### PR TITLE
Support more than one parameter to build.cmd for OuterLoop Tests

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -6,8 +6,26 @@ setlocal
 ::       means that that rebuilding cannot successfully delete the task
 ::       assembly. 
 
-echo %2 | find /I "outerloop"
-if "%errorlevel%" equ "0" (
+set outloop=false
+
+:START_CMDLINE_PARSE
+set SWITCH=%1
+if {%SWITCH%} == {} goto :END_CMDLINE_PARSE
+set VALUE=%2
+
+if /i "%SWITCH%" == "/p:WithCategories" (
+  if /i "%VALUE%" == "OuterLoop" (
+      set outloop=true
+      goto :END_CMDLINE_PARSE
+  )
+)
+
+SHIFT
+SHIFT
+goto :START_CMDLINE_PARSE
+:END_CMDLINE_PARSE
+
+if "%outloop%" equ "true" (
 	start /wait BuildWCFTestService.cmd
 )
 
@@ -36,8 +54,7 @@ set _buildlog=%~dp0msbuild.log
 set _buildprefix=echo
 set _buildpostfix=^> "%_buildlog%"
 
-echo %2 | find /I "outerloop"
-if "%errorlevel%" equ "0" (
+if "%outloop%" equ "true"  (
         pushd setupfiles
         start /wait RunElevated.vbs SetupWCFTestService.cmd
         popd
@@ -63,8 +80,7 @@ echo.
 findstr /ir /c:".*Warning(s)" /c:".*Error(s)" /c:"Time Elapsed.*" "%_buildlog%"
 echo Build Exit Code = %BUILDERRORLEVEL%
 
-echo %2 | find /I "outerloop"
-if "%errorlevel%" equ "0" (
+if "%outloop%" equ "true"  (
 	pushd setupfiles
 	start /wait RunElevated.vbs CleanupWCFTestService.cmd
 	popd

--- a/build.cmd
+++ b/build.cmd
@@ -8,25 +8,14 @@ setlocal
 
 set outloop=false
 
-REM this command line processing is a temporary step until the build tools provide a proper hook. 
+REM this is a temporary step until the build tools provide a proper hook. 
 REM it will need to deal with multiple include and exclude categories.
 REM See dotnet/corefx#1477
-:START_CMDLINE_PARSE
-set SWITCH=%1
-if {%SWITCH%} == {} goto :END_CMDLINE_PARSE
-set VALUE=%2
 
-if /i "%SWITCH%" == "/p:WithCategories" (
-  if /i "%VALUE%" == "OuterLoop" (
-      set outloop=true
-      goto :END_CMDLINE_PARSE
-  )
+echo %* | findstr /i /C:"/p:WithCategories=OuterLoop"  1>nul
+if %errorlevel% equ 0 (
+  set outloop=true
 )
-
-SHIFT
-SHIFT
-goto :START_CMDLINE_PARSE
-:END_CMDLINE_PARSE
 
 if "%outloop%" equ "true" (
 	start /wait BuildWCFTestService.cmd

--- a/build.cmd
+++ b/build.cmd
@@ -12,7 +12,7 @@ REM this is a temporary step until the build tools provide a proper hook.
 REM it will need to deal with multiple include and exclude categories.
 REM See dotnet/corefx#1477
 
-echo %* | findstr /i /C:"/p:WithCategories=OuterLoop"  1>nul
+echo %* | findstr /i /C:"OuterLoop"  1>nul
 if %errorlevel% equ 0 (
   set outloop=true
 )

--- a/build.cmd
+++ b/build.cmd
@@ -8,6 +8,9 @@ setlocal
 
 set outloop=false
 
+REM this command line processing is a temporary step until the build tools provide a proper hook. 
+REM it will need to deal with multiple include and exclude categories.
+REM See dotnet/corefx#1477
 :START_CMDLINE_PARSE
 set SWITCH=%1
 if {%SWITCH%} == {} goto :END_CMDLINE_PARSE


### PR DESCRIPTION
*Previously we only support passing OuterLoop parameter:
       /p:WithCategories=OuterLoop
* The change adds parsing command line parameters.
   We will be able to pass more than one parameter, such as
   build /p:Coverage=true /p:WithCategories=OuterLoop