### PR TITLE
Enable conditional building for Net Native

### DIFF
--- a/src/System.Private.ServiceModel/src/Resources/System.Private.ServiceModel.rd.xml
+++ b/src/System.Private.ServiceModel/src/Resources/System.Private.ServiceModel.rd.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Directives xmlns="http://schemas.microsoft.com/netfx/2013/01/metadata">
+  <Library Name="*System.Private.ServiceModel*">
+    <!-- WCF needs to instantiate TaskCompletionSource{T} for all service contract operations that return Task{T} -->
+    <Type Name="System.Threading.Tasks.Task{TResult}" Dynamic="Public">
+      <ImpliesType Name="System.Threading.Tasks.TaskCompletionSource{TResult}" Dynamic="Required Public"/>
+    </Type>
+
+    <!-- WCF needs these to be reflectable to instantate Attribute from CustomAttributeData -->
+    <Type Name="System.Runtime.Serialization.DataContractAttribute" Dynamic="Required All" />
+    <Type Name="System.Runtime.Serialization.DataMemberAttribute" Dynamic="Required All" />
+    
+    <Assembly Name="System.Private.ServiceModel">
+      <Namespace Name="System.ServiceModel">
+        <Type Name="BasicHttpBinding" Dynamic="Required All" />
+        <!-- WCF attributes must be reflectable to instantiate Attribute from CustomAttributeData -->
+        <Type Name="FaultContractAttribute" Dynamic="Required All" >
+          <Method Name=".ctor">
+            <TypeParameter Name="detailType" DataContractSerializer="Public" DataContractJsonSerializer="Public" />
+          </Method>
+        </Type>
+        <Type Name="MessageBodyMemberAttribute" Dynamic="Required All" />
+        <Type Name="MessageContractMemberAttribute" Dynamic="Required All" />
+        <Type Name="MessageParameterAttribute" Dynamic="Required All" />
+        <Type Name="OperationContractAttribute" Dynamic="Required All" />
+        <Type Name="MessageContractAttribute" Dynamic="Required All" >
+          <AttributeImplies Dynamic="Required All" />
+        </Type>
+        <!-- ServiceContractAttribute on a type makes it available for Reflection -->
+        <Type Name="ServiceContractAttribute" Dynamic="Required All" >
+          <AttributeImplies Dynamic="Required All" />
+        </Type>
+        <!-- ExceptionDetail requires serialization for FaultException -->
+        <Type Name="ExceptionDetail" Dynamic="Required All" DataContractJsonSerializer="Public" DataContractSerializer="Public" />
+        <!-- Allowing Reflection on FaultException{Object} permits type instantiation of FaultException{TDetail} -->
+        <Type Name="FaultException{System.Object}" Dynamic="Required All" />
+      </Namespace>
+      <Namespace Name="System.ServiceModel.Channels">
+        <Type Name="Binding" Dynamic="Required All" >
+            <Subtypes Browse="All" />
+        </Type>
+        <Type Name="CustomBinding" Dynamic="Required All" />
+        <Type Name="IRequestChannel" Dynamic="Required All" />
+      </Namespace>
+    </Assembly>
+  </Library>
+</Directives>

--- a/src/System.Private.ServiceModel/src/System.Private.ServiceModel.csproj
+++ b/src/System.Private.ServiceModel/src/System.Private.ServiceModel.csproj
@@ -14,17 +14,25 @@
     <DebugSymbols>true</DebugSymbols>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <ProjectGuid>{9E50E7BF-CD6E-4269-A6DD-59FD0BD6C0FD}</ProjectGuid>
-    <DefineConstants>$(DefineConstants);FEATURE_CORECLR</DefineConstants>
     <CommonPath Condition="'$(CommonPath)' == ''">..\..\Common\src</CommonPath>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(IsNETNativeLibrary)' == 'true'">
+     <DefineConstants>$(DefineConstants);FEATURE_NETNATIVE</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(IsNETNativeLibrary)' != 'true'">
+     <DefineConstants>$(DefineConstants);FEATURE_CORECLR</DefineConstants>
+    </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(CommonPath)\System\NotImplemented.cs">
       <Link>Common\System\NotImplemented.cs</Link>
     </Compile>
-    <Compile Include=".\**\*.cs" />
+    <Compile Include="$(MsBuildThisFileDirectory)\**\*.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(IsNETNativeLibrary)' == 'true'">
+    <EmbeddedResource Include="$(MsBuildThisFileDirectory)Resources\$(AssemblyName).rd.xml" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/CoreClrSocketConnection.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/CoreClrSocketConnection.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if FEATURE_CORECLR
 using System;
 using System.Diagnostics.Contracts;
 using System.Net;
@@ -906,3 +907,4 @@ namespace System.ServiceModel.Channels
         }
     }
 }
+#endif // FEATURE_CORECLR

--- a/src/System.Private.ServiceModel/src/project.json
+++ b/src/System.Private.ServiceModel/src/project.json
@@ -18,7 +18,6 @@
     "System.Net.Http": "4.0.0-beta-22819",
     "System.Net.NameResolution": "4.0.0-beta-22819",
     "System.Net.Primitives": "4.0.10-beta-22819",
-    "System.Net.Security": "4.0.0-beta-22819",
     "System.Net.Sockets": "4.0.0-beta-22819",
     "System.Net.WebHeaderCollection": "4.0.0-beta-22819",
     "System.ObjectModel": "4.0.10-beta-22819",
@@ -35,7 +34,6 @@
     "System.Runtime.Serialization.Xml": "4.0.10-beta-22819",
     "System.Security.Claims": "4.0.0-beta-22819",
     "System.Security.Principal": "4.0.0-beta-22819",
-    "System.Security.Principal.Windows": "4.0.0-beta-22819",
     "System.Text.Encoding": "4.0.10-beta-22819",
     "System.Threading": "4.0.10-beta-22819",
     "System.Threading.Tasks": "4.0.10-beta-22819",
@@ -46,6 +44,16 @@
     "System.Xml.XmlSerializer": "4.0.10-beta-22819"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "dependencies": {
+        "System.Net.Security": "4.0.0-beta-22819",
+        "System.Security.Principal.Windows": "4.0.0-beta-22819",
+      }
+    },
+    "netcore50": {
+      "dependencies": {
+        "System.Runtime.WindowsRuntime": "4.0.10-beta-*"
+      }
+    }
   }
 }

--- a/src/System.Private.ServiceModel/src/project.lock.json
+++ b/src/System.Private.ServiceModel/src/project.lock.json
@@ -1039,6 +1039,682 @@
           "lib/DNXCore50/System.Xml.XmlSerializer.dll"
         ]
       }
+    },
+    ".NETCore,Version=v5.0": {
+      "System.Collections/4.0.10-beta-22819": {
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-22819"
+        },
+        "compile": [
+          "ref/any/System.Collections.dll"
+        ],
+        "runtime": [
+          "lib/netcore50/System.Collections.dll"
+        ]
+      },
+      "System.Collections.Concurrent/4.0.10-beta-22819": {
+        "dependencies": {
+          "System.Runtime": "4.0.20-beta-22819",
+          "System.Threading.Tasks": "4.0.10-beta-22819",
+          "System.Diagnostics.Tracing": "4.0.20-beta-22819",
+          "System.Resources.ResourceManager": "4.0.0-beta-22819",
+          "System.Diagnostics.Debug": "4.0.10-beta-22819",
+          "System.Threading": "4.0.10-beta-22819",
+          "System.Collections": "4.0.10-beta-22819",
+          "System.Runtime.Extensions": "4.0.10-beta-22819",
+          "System.Globalization": "4.0.10-beta-22819"
+        },
+        "compile": [
+          "ref/any/System.Collections.Concurrent.dll"
+        ],
+        "runtime": [
+          "lib/any/System.Collections.Concurrent.dll"
+        ]
+      },
+      "System.Collections.NonGeneric/4.0.0-beta-22819": {
+        "dependencies": {
+          "System.Runtime": "4.0.20-beta-22819",
+          "System.Globalization": "4.0.10-beta-22819",
+          "System.Resources.ResourceManager": "4.0.0-beta-22819",
+          "System.Diagnostics.Debug": "4.0.10-beta-22819",
+          "System.Threading": "4.0.10-beta-22819",
+          "System.Runtime.Extensions": "4.0.10-beta-22819"
+        },
+        "compile": [
+          "ref/any/System.Collections.NonGeneric.dll"
+        ],
+        "runtime": [
+          "lib/any/System.Collections.NonGeneric.dll"
+        ]
+      },
+      "System.Collections.Specialized/4.0.0-beta-22819": {
+        "dependencies": {
+          "System.Runtime": "4.0.20-beta-22819",
+          "System.Resources.ResourceManager": "4.0.0-beta-22819",
+          "System.Collections.NonGeneric": "4.0.0-beta-22819",
+          "System.Globalization.Extensions": "4.0.0-beta-22819",
+          "System.Runtime.Extensions": "4.0.10-beta-22819",
+          "System.Threading": "4.0.10-beta-22819",
+          "System.Globalization": "4.0.10-beta-22819"
+        },
+        "compile": [
+          "ref/any/System.Collections.Specialized.dll"
+        ],
+        "runtime": [
+          "lib/any/System.Collections.Specialized.dll"
+        ]
+      },
+      "System.ComponentModel/4.0.0-beta-22819": {
+        "dependencies": {
+          "System.Runtime": "4.0.20-beta-22819"
+        },
+        "compile": [
+          "ref/any/System.ComponentModel.dll"
+        ],
+        "runtime": [
+          "lib/any/System.ComponentModel.dll"
+        ]
+      },
+      "System.ComponentModel.EventBasedAsync/4.0.10-beta-22819": {
+        "dependencies": {
+          "System.Runtime": "4.0.20-beta-22819",
+          "System.Threading": "4.0.10-beta-22819",
+          "System.Resources.ResourceManager": "4.0.0-beta-22819",
+          "System.Threading.Tasks": "4.0.10-beta-22819"
+        },
+        "compile": [
+          "ref/any/System.ComponentModel.EventBasedAsync.dll"
+        ],
+        "runtime": [
+          "lib/any/System.ComponentModel.EventBasedAsync.dll"
+        ]
+      },
+      "System.Diagnostics.Contracts/4.0.0-beta-22819": {
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-22819"
+        },
+        "compile": [
+          "ref/any/System.Diagnostics.Contracts.dll"
+        ],
+        "runtime": [
+          "lib/netcore50/System.Diagnostics.Contracts.dll"
+        ]
+      },
+      "System.Diagnostics.Debug/4.0.10-beta-22819": {
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-22819"
+        },
+        "compile": [
+          "ref/any/System.Diagnostics.Debug.dll"
+        ]
+      },
+      "System.Diagnostics.Tools/4.0.0-beta-22819": {
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-22819"
+        },
+        "compile": [
+          "ref/any/System.Diagnostics.Tools.dll"
+        ],
+        "runtime": [
+          "lib/netcore50/System.Diagnostics.Tools.dll"
+        ]
+      },
+      "System.Diagnostics.Tracing/4.0.20-beta-22819": {
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-22819"
+        },
+        "compile": [
+          "ref/any/System.Diagnostics.Tracing.dll"
+        ],
+        "runtime": [
+          "lib/netcore50/System.Diagnostics.Tracing.dll"
+        ]
+      },
+      "System.Globalization/4.0.10-beta-22819": {
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-22819"
+        },
+        "compile": [
+          "ref/any/System.Globalization.dll"
+        ],
+        "runtime": [
+          "lib/netcore50/System.Globalization.dll"
+        ]
+      },
+      "System.Globalization.Extensions/4.0.0-beta-22819": {
+        "dependencies": {
+          "System.Runtime": "4.0.20-beta-22819",
+          "System.Runtime.Extensions": "4.0.10-beta-22819",
+          "System.Globalization": "4.0.10-beta-22819",
+          "System.Runtime.InteropServices": "4.0.20-beta-22819",
+          "System.Resources.ResourceManager": "4.0.0-beta-22819"
+        },
+        "compile": [
+          "ref/any/System.Globalization.Extensions.dll"
+        ],
+        "runtime": [
+          "lib/any/System.Globalization.Extensions.dll"
+        ]
+      },
+      "System.IO/4.0.10-beta-22819": {
+        "dependencies": {
+          "System.Runtime": "4.0.20-beta-22819",
+          "System.Text.Encoding": "4.0.0-beta-22819",
+          "System.Threading.Tasks": "4.0.0-beta-22819"
+        },
+        "compile": [
+          "ref/any/System.IO.dll"
+        ],
+        "runtime": [
+          "lib/netcore50/System.IO.dll"
+        ]
+      },
+      "System.IO.Compression/4.0.0-beta-22819": {
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-22819",
+          "System.IO": "4.0.0-beta-22819",
+          "System.Text.Encoding": "4.0.0-beta-22819",
+          "System.Resources.ResourceManager": "4.0.0-beta-22819",
+          "System.Threading.Tasks": "4.0.0-beta-22819",
+          "System.Runtime.InteropServices": "4.0.0-beta-22819",
+          "System.Collections": "4.0.0-beta-22819",
+          "System.Runtime.Extensions": "4.0.0-beta-22819",
+          "System.Threading": "4.0.0-beta-22819"
+        },
+        "compile": [
+          "ref/any/System.IO.Compression.dll"
+        ],
+        "runtime": [
+          "lib/any/System.IO.Compression.dll"
+        ]
+      },
+      "System.IO.FileSystem/4.0.0-beta-22819": {
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-22819",
+          "System.Text.Encoding": "4.0.0-beta-22819",
+          "System.IO": "4.0.0-beta-22819",
+          "System.IO.FileSystem.Primitives": "4.0.0-beta-22819",
+          "System.Threading.Tasks": "4.0.0-beta-22819",
+          "System.Runtime.Handles": "4.0.0-beta-22819"
+        },
+        "compile": [
+          "ref/any/System.IO.FileSystem.dll"
+        ],
+        "runtime": [
+          "lib/netcore50/System.IO.FileSystem.dll"
+        ]
+      },
+      "System.IO.FileSystem.Primitives/4.0.0-beta-22819": {
+        "dependencies": {
+          "System.Runtime": "4.0.20-beta-22819"
+        },
+        "compile": [
+          "ref/any/System.IO.FileSystem.Primitives.dll"
+        ],
+        "runtime": [
+          "lib/any/System.IO.FileSystem.Primitives.dll"
+        ]
+      },
+      "System.Linq/4.0.0-beta-22819": {
+        "dependencies": {
+          "System.Runtime": "4.0.20-beta-22819",
+          "System.Collections": "4.0.10-beta-22819",
+          "System.Resources.ResourceManager": "4.0.0-beta-22819",
+          "System.Diagnostics.Debug": "4.0.10-beta-22819",
+          "System.Runtime.Extensions": "4.0.10-beta-22819"
+        },
+        "compile": [
+          "ref/any/System.Linq.dll"
+        ],
+        "runtime": [
+          "lib/any/System.Linq.dll"
+        ]
+      },
+      "System.Linq.Expressions/4.0.10-beta-22819": {
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-22819",
+          "System.Reflection": "4.0.0-beta-22819"
+        },
+        "compile": [
+          "ref/any/System.Linq.Expressions.dll"
+        ],
+        "runtime": [
+          "lib/netcore50/System.Linq.Expressions.dll"
+        ]
+      },
+      "System.Linq.Queryable/4.0.0-beta-22819": {
+        "dependencies": {
+          "System.Runtime": "4.0.20-beta-22819",
+          "System.Linq.Expressions": "4.0.10-beta-22819",
+          "System.Linq": "4.0.0-beta-22819",
+          "System.Resources.ResourceManager": "4.0.0-beta-22819",
+          "System.Reflection.Extensions": "4.0.0-beta-22819",
+          "System.Reflection": "4.0.10-beta-22819",
+          "System.Collections": "4.0.10-beta-22819"
+        },
+        "compile": [
+          "ref/any/System.Linq.Queryable.dll"
+        ],
+        "runtime": [
+          "lib/any/System.Linq.Queryable.dll"
+        ]
+      },
+      "System.Net.Http/4.0.0-beta-22819": {
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-22819",
+          "System.Threading.Tasks": "4.0.0-beta-22819",
+          "System.IO": "4.0.0-beta-22819",
+          "System.Net.Primitives": "4.0.0-beta-22819",
+          "System.Text.Encoding": "4.0.0-beta-22819"
+        },
+        "compile": [
+          "ref/any/System.Net.Http.dll"
+        ],
+        "runtime": [
+          "lib/netcore50/System.Net.Http.dll"
+        ]
+      },
+      "System.Net.NameResolution/4.0.0-beta-22819": {
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-22819",
+          "System.Threading.Tasks": "4.0.0-beta-22819",
+          "System.Net.Primitives": "4.0.10-beta-22819"
+        },
+        "compile": [
+          "ref/any/System.Net.NameResolution.dll"
+        ]
+      },
+      "System.Net.Primitives/4.0.10-beta-22819": {
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-22819",
+          "System.Runtime.Handles": "4.0.0-beta-22819"
+        },
+        "compile": [
+          "ref/any/System.Net.Primitives.dll"
+        ],
+        "runtime": [
+          "lib/netcore50/System.Net.Primitives.dll"
+        ]
+      },
+      "System.Net.Sockets/4.0.0-beta-22819": {
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-22819",
+          "System.IO": "4.0.0-beta-22819",
+          "System.Threading.Tasks": "4.0.0-beta-22819",
+          "System.Net.Primitives": "4.0.10-beta-22819"
+        },
+        "compile": [
+          "ref/any/System.Net.Sockets.dll"
+        ]
+      },
+      "System.Net.WebHeaderCollection/4.0.0-beta-22819": {
+        "dependencies": {
+          "System.Runtime": "4.0.20-beta-22819",
+          "System.Resources.ResourceManager": "4.0.0-beta-22819",
+          "System.Collections.Specialized": "4.0.0-beta-22819",
+          "System.Collections.NonGeneric": "4.0.0-beta-22819"
+        },
+        "compile": [
+          "ref/any/System.Net.WebHeaderCollection.dll"
+        ],
+        "runtime": [
+          "lib/any/System.Net.WebHeaderCollection.dll"
+        ]
+      },
+      "System.ObjectModel/4.0.10-beta-22819": {
+        "dependencies": {
+          "System.Runtime": "4.0.20-beta-22819",
+          "System.Resources.ResourceManager": "4.0.0-beta-22819",
+          "System.Diagnostics.Debug": "4.0.10-beta-22819",
+          "System.Collections": "4.0.10-beta-22819",
+          "System.Threading": "4.0.10-beta-22819"
+        },
+        "compile": [
+          "ref/any/System.ObjectModel.dll"
+        ],
+        "runtime": [
+          "lib/any/System.ObjectModel.dll"
+        ]
+      },
+      "System.Reflection/4.0.10-beta-22819": {
+        "dependencies": {
+          "System.Runtime": "4.0.20-beta-22819",
+          "System.IO": "4.0.0-beta-22819",
+          "System.Reflection.Primitives": "4.0.0-beta-22819"
+        },
+        "compile": [
+          "ref/any/System.Reflection.dll"
+        ],
+        "runtime": [
+          "lib/netcore50/System.Reflection.dll"
+        ]
+      },
+      "System.Reflection.DispatchProxy/4.0.0-beta-22819": {
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-22819",
+          "System.Reflection": "4.0.0-beta-22819"
+        },
+        "compile": [
+          "ref/any/System.Reflection.DispatchProxy.dll"
+        ],
+        "runtime": [
+          "lib/netcore50/System.Reflection.DispatchProxy.dll"
+        ]
+      },
+      "System.Reflection.Extensions/4.0.0-beta-22819": {
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-22819",
+          "System.Reflection": "4.0.0-beta-22819"
+        },
+        "compile": [
+          "ref/any/System.Reflection.Extensions.dll"
+        ],
+        "runtime": [
+          "lib/netcore50/System.Reflection.Extensions.dll"
+        ]
+      },
+      "System.Reflection.Primitives/4.0.0-beta-22819": {
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-22819"
+        },
+        "compile": [
+          "ref/any/System.Reflection.Primitives.dll"
+        ],
+        "runtime": [
+          "lib/netcore50/System.Reflection.Primitives.dll"
+        ]
+      },
+      "System.Reflection.TypeExtensions/4.0.0-beta-22819": {
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-22819",
+          "System.Reflection": "4.0.0-beta-22819"
+        },
+        "compile": [
+          "ref/any/System.Reflection.TypeExtensions.dll"
+        ],
+        "runtime": [
+          "lib/netcore50/System.Reflection.TypeExtensions.dll"
+        ]
+      },
+      "System.Resources.ResourceManager/4.0.0-beta-22819": {
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-22819",
+          "System.Reflection": "4.0.0-beta-22819",
+          "System.Globalization": "4.0.0-beta-22819"
+        },
+        "compile": [
+          "ref/any/System.Resources.ResourceManager.dll"
+        ],
+        "runtime": [
+          "lib/netcore50/System.Resources.ResourceManager.dll"
+        ]
+      },
+      "System.Runtime/4.0.20-beta-22819": {
+        "compile": [
+          "ref/any/mscorlib.dll",
+          "ref/any/System.Runtime.dll"
+        ],
+        "runtime": [
+          "lib/netcore50/System.Runtime.dll"
+        ]
+      },
+      "System.Runtime.Extensions/4.0.10-beta-22819": {
+        "dependencies": {
+          "System.Runtime": "4.0.20-beta-22819"
+        },
+        "compile": [
+          "ref/any/System.Runtime.Extensions.dll"
+        ],
+        "runtime": [
+          "lib/netcore50/System.Runtime.Extensions.dll"
+        ]
+      },
+      "System.Runtime.Handles/4.0.0-beta-22819": {
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-22819"
+        },
+        "compile": [
+          "ref/any/System.Runtime.Handles.dll"
+        ],
+        "runtime": [
+          "lib/netcore50/System.Runtime.Handles.dll"
+        ]
+      },
+      "System.Runtime.InteropServices/4.0.20-beta-22819": {
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-22819",
+          "System.Reflection": "4.0.0-beta-22819",
+          "System.Reflection.Primitives": "4.0.0-beta-22819",
+          "System.Runtime.Handles": "4.0.0-beta-22819"
+        },
+        "compile": [
+          "ref/any/System.Runtime.InteropServices.dll"
+        ]
+      },
+      "System.Runtime.Serialization.Primitives/4.0.10-beta-22819": {
+        "dependencies": {
+          "System.Runtime": "4.0.20-beta-22819",
+          "System.Resources.ResourceManager": "4.0.0-beta-22819"
+        },
+        "compile": [
+          "ref/any/System.Runtime.Serialization.Primitives.dll"
+        ],
+        "runtime": [
+          "lib/any/System.Runtime.Serialization.Primitives.dll"
+        ]
+      },
+      "System.Runtime.Serialization.Xml/4.0.10-beta-22819": {
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-22819",
+          "System.Xml.ReaderWriter": "4.0.0-beta-22819",
+          "System.IO": "4.0.0-beta-22819",
+          "System.Text.Encoding": "4.0.0-beta-22819",
+          "System.Runtime.Serialization.Primitives": "4.0.10-beta-22819"
+        },
+        "compile": [
+          "ref/any/System.Runtime.Serialization.Xml.dll"
+        ],
+        "runtime": [
+          "lib/netcore50/System.Runtime.Serialization.Xml.dll"
+        ]
+      },
+      "System.Runtime.WindowsRuntime/4.0.10-beta-22927": {
+        "dependencies": {
+          "System.Runtime": "4.0.20-beta-22927",
+          "System.Resources.ResourceManager": "4.0.0-beta-22927",
+          "System.Globalization": "4.0.0-beta-22927",
+          "System.Runtime.Extensions": "4.0.0-beta-22927",
+          "System.Threading": "4.0.0-beta-22927",
+          "System.Diagnostics.Debug": "4.0.0-beta-22927",
+          "System.Runtime.InteropServices": "4.0.0-beta-22927",
+          "System.Threading.Tasks": "4.0.10-beta-22927",
+          "System.IO": "4.0.10-beta-22927",
+          "System.ObjectModel": "4.0.0-beta-22927"
+        },
+        "compile": [
+          "ref/any/System.Runtime.WindowsRuntime.dll"
+        ],
+        "runtime": [
+          "lib/netcore50/System.Runtime.WindowsRuntime.dll"
+        ]
+      },
+      "System.Security.Claims/4.0.0-beta-22819": {
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-22819",
+          "System.Security.Principal": "4.0.0-beta-22819",
+          "System.IO": "4.0.0-beta-22819",
+          "System.Resources.ResourceManager": "4.0.0-beta-22819",
+          "System.Collections": "4.0.0-beta-22819",
+          "System.Diagnostics.Debug": "4.0.0-beta-22819",
+          "System.Globalization": "4.0.0-beta-22819",
+          "System.Runtime.Extensions": "4.0.0-beta-22819"
+        },
+        "compile": [
+          "ref/any/System.Security.Claims.dll"
+        ],
+        "runtime": [
+          "lib/any/System.Security.Claims.dll"
+        ]
+      },
+      "System.Security.Principal/4.0.0-beta-22819": {
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-22819"
+        },
+        "compile": [
+          "ref/any/System.Security.Principal.dll"
+        ],
+        "runtime": [
+          "lib/any/System.Security.Principal.dll"
+        ]
+      },
+      "System.Text.Encoding/4.0.10-beta-22819": {
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-22819"
+        },
+        "compile": [
+          "ref/any/System.Text.Encoding.dll"
+        ],
+        "runtime": [
+          "lib/netcore50/System.Text.Encoding.dll"
+        ]
+      },
+      "System.Text.Encoding.Extensions/4.0.10-beta-22819": {
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-22819",
+          "System.Text.Encoding": "4.0.10-beta-22819"
+        },
+        "compile": [
+          "ref/any/System.Text.Encoding.Extensions.dll"
+        ],
+        "runtime": [
+          "lib/netcore50/System.Text.Encoding.Extensions.dll"
+        ]
+      },
+      "System.Text.RegularExpressions/4.0.10-beta-22819": {
+        "dependencies": {
+          "System.Runtime": "4.0.20-beta-22819",
+          "System.Resources.ResourceManager": "4.0.0-beta-22819",
+          "System.Collections": "4.0.10-beta-22819",
+          "System.Globalization": "4.0.10-beta-22819",
+          "System.Runtime.Extensions": "4.0.10-beta-22819",
+          "System.Threading": "4.0.10-beta-22819"
+        },
+        "compile": [
+          "lib/any/System.Text.RegularExpressions.dll"
+        ],
+        "runtime": [
+          "lib/any/System.Text.RegularExpressions.dll"
+        ]
+      },
+      "System.Threading/4.0.10-beta-22819": {
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-22819",
+          "System.Threading.Tasks": "4.0.0-beta-22819"
+        },
+        "compile": [
+          "ref/any/System.Threading.dll"
+        ]
+      },
+      "System.Threading.Tasks/4.0.10-beta-22819": {
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-22819"
+        },
+        "compile": [
+          "ref/any/System.Threading.Tasks.dll"
+        ],
+        "runtime": [
+          "lib/netcore50/System.Threading.Tasks.dll"
+        ]
+      },
+      "System.Threading.Timer/4.0.0-beta-22819": {
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-22819"
+        },
+        "compile": [
+          "ref/any/System.Threading.Timer.dll"
+        ],
+        "runtime": [
+          "lib/netcore50/System.Threading.Timer.dll"
+        ]
+      },
+      "System.Xml.ReaderWriter/4.0.10-beta-22819": {
+        "dependencies": {
+          "System.Runtime": "4.0.20-beta-22819",
+          "System.Text.Encoding": "4.0.10-beta-22819",
+          "System.IO": "4.0.10-beta-22819",
+          "System.Threading.Tasks": "4.0.10-beta-22819",
+          "System.Runtime.InteropServices": "4.0.20-beta-22819",
+          "System.Resources.ResourceManager": "4.0.0-beta-22819",
+          "System.IO.FileSystem": "4.0.0-beta-22819",
+          "System.IO.FileSystem.Primitives": "4.0.0-beta-22819",
+          "System.Diagnostics.Debug": "4.0.10-beta-22819",
+          "System.Text.RegularExpressions": "4.0.10-beta-22819",
+          "System.Collections": "4.0.10-beta-22819",
+          "System.Runtime.Extensions": "4.0.10-beta-22819",
+          "System.Globalization": "4.0.10-beta-22819",
+          "System.Text.Encoding.Extensions": "4.0.10-beta-22819"
+        },
+        "compile": [
+          "ref/any/System.Xml.ReaderWriter.dll"
+        ],
+        "runtime": [
+          "lib/any/System.Xml.ReaderWriter.dll"
+        ]
+      },
+      "System.Xml.XDocument/4.0.10-beta-22819": {
+        "dependencies": {
+          "System.Runtime": "4.0.20-beta-22819",
+          "System.IO": "4.0.10-beta-22819",
+          "System.Xml.ReaderWriter": "4.0.10-beta-22819",
+          "System.Resources.ResourceManager": "4.0.0-beta-22819",
+          "System.Diagnostics.Debug": "4.0.10-beta-22819",
+          "System.Collections": "4.0.10-beta-22819",
+          "System.Globalization": "4.0.10-beta-22819",
+          "System.Threading": "4.0.10-beta-22819",
+          "System.Text.Encoding": "4.0.10-beta-22819",
+          "System.Reflection": "4.0.10-beta-22819",
+          "System.Runtime.Extensions": "4.0.10-beta-22819"
+        },
+        "compile": [
+          "ref/any/System.Xml.XDocument.dll"
+        ],
+        "runtime": [
+          "lib/any/System.Xml.XDocument.dll"
+        ]
+      },
+      "System.Xml.XmlDocument/4.0.0-beta-22819": {
+        "dependencies": {
+          "System.Runtime": "4.0.20-beta-22819",
+          "System.Xml.ReaderWriter": "4.0.10-beta-22819",
+          "System.IO": "4.0.10-beta-22819",
+          "System.Resources.ResourceManager": "4.0.0-beta-22819",
+          "System.Text.Encoding": "4.0.10-beta-22819",
+          "System.Collections": "4.0.10-beta-22819",
+          "System.Diagnostics.Debug": "4.0.10-beta-22819",
+          "System.Runtime.Extensions": "4.0.10-beta-22819",
+          "System.Globalization": "4.0.10-beta-22819",
+          "System.Threading": "4.0.10-beta-22819"
+        },
+        "compile": [
+          "ref/any/System.Xml.XmlDocument.dll"
+        ],
+        "runtime": [
+          "lib/any/System.Xml.XmlDocument.dll"
+        ]
+      },
+      "System.Xml.XmlSerializer/4.0.10-beta-22819": {
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-22819",
+          "System.IO": "4.0.0-beta-22819",
+          "System.Xml.ReaderWriter": "4.0.10-beta-22819"
+        },
+        "compile": [
+          "ref/any/System.Xml.XmlSerializer.dll"
+        ],
+        "runtime": [
+          "lib/netcore50/System.Xml.XmlSerializer.dll"
+        ]
+      }
     }
   },
   "libraries": {
@@ -1634,6 +2310,17 @@
         "ref/net46/System.Runtime.Serialization.Xml.dll"
       ]
     },
+    "System.Runtime.WindowsRuntime/4.0.10-beta-22927": {
+      "sha512": "xbkYHyYXQ/uHrMenP/+mt5z2s13Ln/WLN7Xvlb+kthNszT4YCqmYZukx8uM3784G1LEL6dqNu192Pck+BcCC0g==",
+      "files": [
+        "System.Runtime.WindowsRuntime.4.0.10-beta-22927.nupkg",
+        "System.Runtime.WindowsRuntime.4.0.10-beta-22927.nupkg.sha512",
+        "System.Runtime.WindowsRuntime.nuspec",
+        "lib/netcore50/System.Runtime.WindowsRuntime.dll",
+        "ref/any/System.Runtime.WindowsRuntime.dll",
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.WindowsRuntime.dll"
+      ]
+    },
     "System.Security.Claims/4.0.0-beta-22819": {
       "sha512": "fO+ncij1ZD/v5sFNgxRbIcN60zDM5BWJ5aWcTmAV6KORiEYOnM+6+LaWVDK0wYgBalhsRNSW3uCSYJJ4qvD7dA==",
       "files": [
@@ -1941,7 +2628,6 @@
       "System.Net.Http >= 4.0.0-beta-22819",
       "System.Net.NameResolution >= 4.0.0-beta-22819",
       "System.Net.Primitives >= 4.0.10-beta-22819",
-      "System.Net.Security >= 4.0.0-beta-22819",
       "System.Net.Sockets >= 4.0.0-beta-22819",
       "System.Net.WebHeaderCollection >= 4.0.0-beta-22819",
       "System.ObjectModel >= 4.0.10-beta-22819",
@@ -1958,7 +2644,6 @@
       "System.Runtime.Serialization.Xml >= 4.0.10-beta-22819",
       "System.Security.Claims >= 4.0.0-beta-22819",
       "System.Security.Principal >= 4.0.0-beta-22819",
-      "System.Security.Principal.Windows >= 4.0.0-beta-22819",
       "System.Text.Encoding >= 4.0.10-beta-22819",
       "System.Threading >= 4.0.10-beta-22819",
       "System.Threading.Tasks >= 4.0.10-beta-22819",
@@ -1968,6 +2653,12 @@
       "System.Xml.XmlDocument >= 4.0.0-beta-22819",
       "System.Xml.XmlSerializer >= 4.0.10-beta-22819"
     ],
-    "DNXCore,Version=v5.0": []
+    "DNXCore,Version=v5.0": [
+      "System.Net.Security >= 4.0.0-beta-22819",
+      "System.Security.Principal.Windows >= 4.0.0-beta-22819"
+    ],
+    ".NETCore,Version=v5.0": [
+      "System.Runtime.WindowsRuntime >= 4.0.10-beta-*"
+    ]
   }
 }


### PR DESCRIPTION
These changes allow the main product to be built for
NET Native conditionally.  This is not the default but
is used when building the NuGet packages in the TFS mirror.

This commit also adds an embedded rd.xml when the project
is compiled for NET Native.

Fixes #60