### PR TITLE
Fix broken wiki links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,11 +1,8 @@
 # Contributing
 
-See [Contributing] on the wiki for information about coding styles, source structure, making
+See [Contributing](Documentation/contributing.md) for information about coding styles, source structure, making
 pull requests, and more.
 
-[Contributing]: https://github.com/dotnet/wcf/wiki/Contributing
 # Developers
 
-See the [Developer Guide] for details about developing in this repo.
-
-[Developer Guide]: https://github.com/dotnet/wcf/wiki/Developer-Guide
+See the [Developer Guide](Documentation/developer-guide.md) for details about developing in this repo.

--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ Want to get more familiar with what's going on in the code?
 
 Looking for something to work on? The list of [up-for-grabs issues](https://github.com/dotnet/wcf/labels/up%20for%20grabs) is a great place to start. See some of our guides for more details:
 
-* [Contributing Guide](https://github.com/dotnet/wcf/wiki/Contributing)
-* [Developer Guide](https://github.com/dotnet/wcf/wiki/Developer-Guide)
-* [Issue Guide](https://github.com/dotnet/wcf/wiki/Issue-Guide)
+* [Contributing Guide](Documentation/contributing.md)
+* [Developer Guide](Documentation/developer-guide.md)
+* [Issue Guide](Documentation/issue-guide.md)
 
 You are also encouraged to start a discussion by filing a [New Issue](https://github.com/dotnet/wcf/issues/new).
 


### PR DESCRIPTION
The old links to wiki has been broken after we moved wiki to the documentation folder.
The links are updated to pointing to the new documentation location.