### PR TITLE
Change some pragmas to format supported by internal build tools

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -49,7 +49,8 @@
 
     <NugetRestoreCommand>"$(NuGetToolPath)"</NugetRestoreCommand>
     <NugetRestoreCommand>$(NugetRestoreCommand) install</NugetRestoreCommand>
-    <NugetRestoreCommand>$(NugetRestoreCommand) -OutputDirectory "$(PackagesDir.TrimEnd('/'))"</NugetRestoreCommand>
+    <!-- NuGet.exe doesn't like trailing slashes in the output directory argument -->
+    <NugetRestoreCommand>$(NugetRestoreCommand) -OutputDirectory "$(PackagesDir.TrimEnd('/\'.ToCharArray()))"</NugetRestoreCommand>
     <NugetRestoreCommand>$(NugetRestoreCommand) $(NuGetConfigCommandLine)</NugetRestoreCommand>
     <NugetRestoreCommand>$(NugetRestoreCommand) -Verbosity detailed</NugetRestoreCommand>
     <NugetRestoreCommand Condition="'$(OsEnvironment)'=='Unix'">mono $(NuGetRestoreCommand)</NugetRestoreCommand>
@@ -63,7 +64,8 @@
 
     <DnuRestoreCommand>"$(DnuToolPath)"</DnuRestoreCommand>
     <DnuRestoreCommand>$(DnuRestoreCommand) restore</DnuRestoreCommand>
-    <DnuRestoreCommand>$(DnuRestoreCommand) --packages "$(PackagesDir.TrimEnd('/'))"</DnuRestoreCommand>
+    <!-- Dnu doesn't like trailing slashes in the packages directory argument -->
+    <DnuRestoreCommand>$(DnuRestoreCommand) --packages "$(PackagesDir.TrimEnd('/\'.ToCharArray()))"</DnuRestoreCommand>
     <DnuRestoreCommand Condition="'$(LockDependencies)' == 'true'">$(DnuRestoreCommand) --lock</DnuRestoreCommand>
   </PropertyGroup>
 

--- a/src/System.Private.ServiceModel/src/Mockups/System.cs
+++ b/src/System.Private.ServiceModel/src/Mockups/System.cs
@@ -64,7 +64,7 @@ namespace System.Security.Principal
         internal WindowsIdentity(IntPtr token) { }
         internal WindowsIdentity(IntPtr token, string authType) { }
         public static WindowsIdentity GetCurrent() { return null; }
-        public SecurityIdentifier User { get; }
+        public SecurityIdentifier User { get { return null; } }
 
         void IDisposable.Dispose() { }
     }

--- a/src/System.Private.ServiceModel/src/System/IdentityModel/CryptoHelper.cs
+++ b/src/System.Private.ServiceModel/src/System/IdentityModel/CryptoHelper.cs
@@ -11,9 +11,9 @@ using System.ServiceModel.Security;
 namespace System.Security.Cryptography
 {
     internal abstract class HashAlgorithm {}
-#pragma warning disable CS0436 // HashAlgorithm conflicts with imported types
+#pragma warning disable 0436 // HashAlgorithm conflicts with imported types
     internal abstract class KeyedHashAlgorithm : HashAlgorithm {}
-#pragma warning restore CS0436 
+#pragma warning restore 0436 
     internal interface ICryptoTransform {}
     internal abstract class SymmetricAlgorithm {}
 }
@@ -55,7 +55,7 @@ namespace System.IdentityModel
             throw ExceptionHelper.PlatformNotSupported();
         }
 
-#pragma warning disable CS0436 // ICryptoTransform, KeyedHashAlgorithm, SymmetricAlgorithm conflict with imported types 
+#pragma warning disable 0436 // ICryptoTransform, KeyedHashAlgorithm, SymmetricAlgorithm conflict with imported types 
         internal static ICryptoTransform CreateDecryptor(byte[] key, byte[] iv, string algorithm)
         {
             throw ExceptionHelper.PlatformNotSupported();
@@ -75,7 +75,7 @@ namespace System.IdentityModel
         {
             throw ExceptionHelper.PlatformNotSupported();
         }
-#pragma warning restore CS0436 
+#pragma warning restore 0436 
 
         internal static bool IsAsymmetricAlgorithm(string algorithm)
         {

--- a/src/System.Private.ServiceModel/src/System/IdentityModel/HashStream.cs
+++ b/src/System.Private.ServiceModel/src/System/IdentityModel/HashStream.cs
@@ -13,7 +13,7 @@ namespace System.IdentityModel
 
         private MemoryStream _logStream;
 
-#pragma warning disable CS0436 // HashAlgorithm conflicts with imported types 
+#pragma warning disable 0436 // HashAlgorithm conflicts with imported types 
         /// <summary>
         /// Constructor for HashStream. The HashAlgorithm instance is owned by the caller.
         /// </summary>
@@ -24,7 +24,7 @@ namespace System.IdentityModel
 
             Reset(hash);
         }
-#pragma warning restore CS0436
+#pragma warning restore 0436
 
         public override bool CanRead
         {
@@ -89,12 +89,12 @@ namespace System.IdentityModel
             throw ExceptionHelper.PlatformNotSupported();
         }
 
-#pragma warning disable CS0436 // HashAlgorithm conflicts with imported types 
+#pragma warning disable 0436 // HashAlgorithm conflicts with imported types 
         public void Reset(HashAlgorithm hash)
         {
             throw ExceptionHelper.PlatformNotSupported();
         }
-#pragma warning restore CS0436
+#pragma warning restore 0436
 
         public override void Write(byte[] buffer, int offset, int count)
         {

--- a/src/System.Private.ServiceModel/src/System/IdentityModel/Tokens/SymmetricKey.cs
+++ b/src/System.Private.ServiceModel/src/System/IdentityModel/Tokens/SymmetricKey.cs
@@ -61,7 +61,7 @@ namespace System.IdentityModel.Tokens
             return CryptoHelper.GenerateDerivedKey(_symmetricKey, algorithm, label, nonce, derivedKeyLength, offset);
         }
 
-#pragma warning disable CS0436 // ICryptoTransform conflicts with imported types 
+#pragma warning disable 0436 // ICryptoTransform conflicts with imported types 
         public override ICryptoTransform GetDecryptionTransform(string algorithm, byte[] iv)
         {
             return CryptoHelper.CreateDecryptor(_symmetricKey, iv, algorithm);
@@ -71,14 +71,14 @@ namespace System.IdentityModel.Tokens
         {
             return CryptoHelper.CreateEncryptor(_symmetricKey, iv, algorithm);
         }
-#pragma warning restore CS0436 
+#pragma warning restore 0436 
 
         public override int GetIVSize(string algorithm)
         {
             return CryptoHelper.GetIVSize(algorithm);
         }
 
-#pragma warning disable CS0436 // KeyedHashAlgorithm, SymmetricAlgorithm conflict with imported types 
+#pragma warning disable 0436 // KeyedHashAlgorithm, SymmetricAlgorithm conflict with imported types 
         public override KeyedHashAlgorithm GetKeyedHashAlgorithm(string algorithm)
         {
             return CryptoHelper.CreateKeyedHashAlgorithm(_symmetricKey, algorithm);
@@ -88,7 +88,7 @@ namespace System.IdentityModel.Tokens
         {
             return CryptoHelper.GetSymmetricAlgorithm(_symmetricKey, algorithm);
         }
-#pragma warning restore CS0436
+#pragma warning restore 0436
 
         public override byte[] GetSymmetricKey()
         {

--- a/src/System.Private.ServiceModel/src/System/IdentityModel/Tokens/SymmetricSecurityKey.cs
+++ b/src/System.Private.ServiceModel/src/System/IdentityModel/Tokens/SymmetricSecurityKey.cs
@@ -9,17 +9,17 @@ namespace System.IdentityModel.Tokens
     {
         public abstract byte[] GenerateDerivedKey(string algorithm, byte[] label, byte[] nonce, int derivedKeyLength, int offset);
 
-#pragma warning disable CS0436 // ICryptoTransform conflicts with imported types 
+#pragma warning disable 0436 // ICryptoTransform conflicts with imported types 
         public abstract ICryptoTransform GetDecryptionTransform(string algorithm, byte[] iv);
         public abstract ICryptoTransform GetEncryptionTransform(string algorithm, byte[] iv);
-#pragma warning restore CS0436
+#pragma warning restore 0436
 
         public abstract int GetIVSize(string algorithm);
 
-#pragma warning disable CS0436 // KeyedHashAlgorithm, SymmetricAlgorithm conflict with imported types 
+#pragma warning disable 0436 // KeyedHashAlgorithm, SymmetricAlgorithm conflict with imported types 
         public abstract KeyedHashAlgorithm GetKeyedHashAlgorithm(string algorithm);
         public abstract SymmetricAlgorithm GetSymmetricAlgorithm(string algorithm);
-#pragma warning restore CS0436
+#pragma warning restore 0436
 
         public abstract byte[] GetSymmetricKey();
     }


### PR DESCRIPTION
There are some internal builds that use a slightly different compiler version,
which means that while this code works with build.cmd from Git, it doesn't
work with the toolchain we use for these builds.

These changes will mean that we build on the build systems we're aware of.