### PR TITLE
Add support for tests to use fiddler proxy

### DIFF
--- a/src/System.ServiceModel.Tests.Common/src/BaseAddress.cs
+++ b/src/System.ServiceModel.Tests.Common/src/BaseAddress.cs
@@ -5,6 +5,29 @@ using System;
 
 public static class BaseAddress
 {
+#if USE_FIDDLER
+    // Base address for testing nonexistent endpoints
+
+    public const string HttpServerBaseAddress = "http://localhost.fiddler:8081/";
+
+    // Base address for HTTP endpoints
+    public const string HttpBaseAddress = "http://localhost.fiddler:8081/WindowsCommunicationFoundation";
+
+    // Base address for HTTPS endpoints
+    public const string HttpsBaseAddress = "https://localhost.fiddler:44285/WindowsCommunicationFoundation";
+
+    // Base address for HTTPS endpoints with Basic Authentication 
+    public const string HttpsBasicBaseAddress = "https://localhost.fiddler:44285/WindowsCommunicationFoundation";
+
+    // Base address for HTTPS endpoints with Digest Authentication
+    public const string HttpsDigestBaseAddress = "https://localhost.fiddler:44285/WindowsCommunicationFoundation";
+
+    // Base address for HTTPS endpoints with NT Authentication
+    public const string HttpsNtlmBaseAddress = "https://localhost.fiddler:44285/WindowsCommunicationFoundation";
+
+    // Base address for HTTPS endpoints with Windows Authentication
+    public const string HttpsWindowsBaseAddress = "https://localhost.fiddler:44285/WindowsCommunicationFoundation";
+#else
     // Base address for testing nonexistent endpoints
 
     public const string HttpServerBaseAddress = "http://localhost:8081/";
@@ -26,6 +49,7 @@ public static class BaseAddress
 
     // Base address for HTTPS endpoints with Windows Authentication
     public const string HttpsWindowsBaseAddress = "https://localhost:44285/WindowsCommunicationFoundation";
+#endif
 
     // Base address for Net.TCP endpoints
     public const string TcpBaseAddress = "net.tcp://localhost:809/WindowsCommunicationFoundation";

--- a/src/System.ServiceModel.Tests.Common/src/System.ServiceModel.Tests.Common.csproj
+++ b/src/System.ServiceModel.Tests.Common/src/System.ServiceModel.Tests.Common.csproj
@@ -14,6 +14,9 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ProjectGuid>{E896294A-AB4A-4AF5-A01C-A19E3972EFF9}</ProjectGuid>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(UseFiddler)' == 'true'">
+     <DefineConstants>$(DefineConstants);USE_FIDDLER</DefineConstants>
+  </PropertyGroup>
   <ItemGroup>
     <Compile Include="**\*.cs" />
   </ItemGroup>


### PR DESCRIPTION
With this change, you can specify /p:UseFiddler=true to build.cmd and the special hostname
localhost.fiddler will be used. This causes the localhost proxy bypass to be skipped and the
requests will be put through the defined proxy server. Fiddler then strips off the .fiddler
from the hostname and passes on the request with the Host being just localhost.
Some tests fail when using fiddler as the failure mode changes and there's not a lot we can
do about that, but this does give greater flexibility to debugging product/test issues.