### PR TITLE
Enables the CallbackContractType in ContractDescription

### DIFF
--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Description/TypeLoader.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Description/TypeLoader.cs
@@ -502,8 +502,11 @@ namespace System.ServiceModel.Description
         {
             if (serviceEndpoint.Contract.IsDuplex())
             {
-                // 
-                throw ExceptionHelper.PlatformNotSupported();
+                CallbackBehaviorAttribute attr = serviceEndpoint.Behaviors.Find<CallbackBehaviorAttribute>();
+                if (attr == null)
+                {
+                    serviceEndpoint.Behaviors.Insert(0, new CallbackBehaviorAttribute());
+                }
             }
         }
 

--- a/src/System.ServiceModel.Duplex/tests/ServiceModel/CallbackBehaviorAttributeTest.cs
+++ b/src/System.ServiceModel.Duplex/tests/ServiceModel/CallbackBehaviorAttributeTest.cs
@@ -15,4 +15,24 @@ public static class CallbackBehaviorAttributeTest
         Assert.True(cba.AutomaticSessionShutdown, "AutomaticSessionShutdown should have been true");
         Assert.True(cba.UseSynchronizationContext, "UseSynchronizationContext should have been true");
     }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public static void AutomaticSessionShutdown_Property_Is_Settable(bool value)
+    {
+        CallbackBehaviorAttribute cba = new CallbackBehaviorAttribute();
+        cba.AutomaticSessionShutdown = value;
+        Assert.Equal(value, cba.AutomaticSessionShutdown);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public static void UseSynchronizationContext_Property_Is_Settable(bool value)
+    {
+        CallbackBehaviorAttribute cba = new CallbackBehaviorAttribute();
+        cba.UseSynchronizationContext = value;
+        Assert.Equal(value, cba.UseSynchronizationContext);
+    }
 }

--- a/src/System.ServiceModel.Tests.Common/src/BaseAddress.cs
+++ b/src/System.ServiceModel.Tests.Common/src/BaseAddress.cs
@@ -5,9 +5,10 @@ using System;
 
 public static class BaseAddress
 {
-#if USE_FIDDLER
-    // Base address for testing nonexistent endpoints
+    // base address never used for end-to-end communication
+    public const string FakeServerBaseAddress = "http://localhost/fakeservice.svc";
 
+#if USE_FIDDLER
     public const string HttpServerBaseAddress = "http://localhost.fiddler:8081/";
 
     // Base address for HTTP endpoints
@@ -28,7 +29,6 @@ public static class BaseAddress
     // Base address for HTTPS endpoints with Windows Authentication
     public const string HttpsWindowsBaseAddress = "https://localhost.fiddler:44285/WindowsCommunicationFoundation";
 #else
-    // Base address for testing nonexistent endpoints
 
     public const string HttpServerBaseAddress = "http://localhost:8081/";
 

--- a/src/System.ServiceModel.Tests.Common/src/ServiceInterfaces.cs
+++ b/src/System.ServiceModel.Tests.Common/src/ServiceInterfaces.cs
@@ -209,3 +209,23 @@ public interface IWcfCustomUserNameService
     [OperationContract(Action = "http://tempuri.org/IWcfCustomUserNameService/Echo")]
     String Echo(String message);
 }
+
+[ServiceContract(
+    Name = "SampleDuplexHello",
+    Namespace = "http://microsoft.wcf.test",
+    CallbackContract = typeof(IHelloCallbackContract),
+    SessionMode = SessionMode.Required
+  )]
+public interface IDuplexHello
+{
+    [OperationContract(IsOneWay = true)]
+    void Hello(string greeting);
+}
+
+public interface IHelloCallbackContract
+{
+    [OperationContract(IsOneWay = true)]
+    void Reply(string responseToGreeting);
+}
+
+

--- a/src/System.ServiceModel.Tests.Common/src/TestHelpers.cs
+++ b/src/System.ServiceModel.Tests.Common/src/TestHelpers.cs
@@ -60,9 +60,6 @@ public class MyClientBase : ClientBase<IWcfServiceGenerated>
 // This helper class is used by the ContractDescription tests to validate contracts.
 public class ContractDescriptionTestHelper
 {
-    // Real service endpoint not required for this test because we never open the channel
-    private const string address = "http://localhost/fakeservice.svc";
-
     // Helper method to validate that service contract T is correct.
     // This helper uses ClientBase<T> to construct the ContractDescription.
     // The 'expectedOperations' describes the operations we expect to find in that contract.
@@ -73,13 +70,17 @@ public class ContractDescriptionTestHelper
         StringBuilder errorBuilder = new StringBuilder();
         try
         {
-            CustomBinding customBinding = new CustomBinding();
-            customBinding.Elements.Add(new TextMessageEncodingBindingElement());
-            customBinding.Elements.Add(new HttpTransportBindingElement());
+            // Arrange
+            CustomBinding binding = new CustomBinding();
+            binding.Elements.Add(new TextMessageEncodingBindingElement());
+            binding.Elements.Add(new HttpTransportBindingElement());
+            EndpointAddress address = new EndpointAddress(BaseAddress.FakeServerBaseAddress);
 
-            MyClientBase<T> client = new MyClientBase<T>(customBinding, new EndpointAddress(address));
-            ContractDescription contract = client.Endpoint.Contract;
+            // Act
+            ChannelFactory<T> factory = new ChannelFactory<T>(binding, address);
+            ContractDescription contract = factory.Endpoint.Contract;
 
+            // Assert
             string results = ValidateContractDescription(contract, typeof(T), expectedContract);
             if (results != null)
             {


### PR DESCRIPTION
Adds code to extract the ContractCallbackType property from
ServiceContractAttribute and ensures it is properly initialized
in the ContractDescription.

Adds a unit test for this change and enhances the unit tests of the
CallbackBehaviorAttribute that is instantiated by this change.

Fixes #92