### PR TITLE
Remove use of ServiceContractAttribute.SessionMode

### DIFF
--- a/src/System.ServiceModel.Tests.Common/src/ServiceInterfaces.cs
+++ b/src/System.ServiceModel.Tests.Common/src/ServiceInterfaces.cs
@@ -213,8 +213,7 @@ public interface IWcfCustomUserNameService
 [ServiceContract(
     Name = "SampleDuplexHello",
     Namespace = "http://microsoft.wcf.test",
-    CallbackContract = typeof(IHelloCallbackContract),
-    SessionMode = SessionMode.Required
+    CallbackContract = typeof(IHelloCallbackContract)
   )]
 public interface IDuplexHello
 {


### PR DESCRIPTION
This property is not part of the public contract but was
being used inadvertantly by a unit test.  Removes that usage.