### PR TITLE
Fix build warnings

### DIFF
--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/MessageContent.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/MessageContent.cs
@@ -15,9 +15,11 @@ namespace System.ServiceModel.Channels
 {
     public abstract class MessageContent : HttpContent
     {
+#pragma warning disable 3008	// not CLS-compliant
         protected Message _message;
         protected MessageEncoder _messageEncoder;
         protected Stream _stream = null;
+#pragma warning restore 3008	// not CLS-compliant
         private bool _disposed;
 
         public MessageContent(Message message, MessageEncoder messageEncoder)
@@ -75,7 +77,6 @@ namespace System.ServiceModel.Channels
                     }
                     else if (string.Compare(name, "content-type", StringComparison.OrdinalIgnoreCase) == 0)
                     {
-                        MediaTypeHeaderValue contentType;
                         if (SetContentType(value))
                         {
                             wasContentTypeSet = true;

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/ProducerConsumerStream.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/ProducerConsumerStream.cs
@@ -190,9 +190,9 @@ namespace System.ServiceModel.Channels
             }
         }
 
-#pragma warning disable 660,661  // Hashcode not needed, Equals overriden for fast path comparison of EmptyContainer
+#pragma warning disable 659,660,661  // Hashcode not needed, Equals overriden for fast path comparison of EmptyContainer
         private struct WriteBufferWrapper : IEquatable<WriteBufferWrapper>
-#pragma warning restore 660,661
+#pragma warning restore 659,660,661
         {
             public static readonly WriteBufferWrapper EmptyContainer = new WriteBufferWrapper(null, -1, -1, true);
 


### PR DESCRIPTION
Build warnings were produced due to fields not being CLS-compliant
and Equals being overridden without overriding GetHashcode.
These warnings caused the build to fail when building the
TFS mirrored sources with warnings treated as errors.