### PR TITLE
Adds TestProperties class to capture MSBuild properties

### DIFF
--- a/src/System.Private.ServiceModel/tests/Common/TestPropertiesTest.cs
+++ b/src/System.Private.ServiceModel/tests/Common/TestPropertiesTest.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.ServiceModel.Tests.Common;
+using Xunit;
+
+public static class TestPropertiesTest
+{
+    [Fact]
+    public static void TestProperties_Property_Names_Are_Initialized()
+    {
+        // Test property names are auto-generated.
+        // This test will fail to compile if these names are not generated.
+        Assert.NotNull(TestProperties.BridgeResourceFolder_PropertyName);
+        Assert.NotNull(TestProperties.BridgeUrl_PropertyName);
+        Assert.NotNull(TestProperties.UseFiddlerUrl_PropertyName);
+    }
+
+    [Fact]
+    public static void TestProperties_PropertyNames_Property_Returns_List()
+    {
+        IEnumerable<string> propertyNames = TestProperties.PropertyNames;
+        Assert.NotNull(propertyNames);
+        Assert.True(propertyNames.Any());
+    }
+
+    [Fact]
+    public static void TestProperties_All_Properties_Have_Values()
+    {
+        IEnumerable<string> propertyNames = TestProperties.PropertyNames;
+        foreach(var name in propertyNames)
+        {
+            string value = TestProperties.GetProperty(name);
+            Assert.True(value != null, String.Format("Property '{0}' should not be null.", name));
+        }
+
+    }
+
+    [Fact]
+    public static void TestProperties_Throw_ArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() => TestProperties.GetProperty(null));
+    }
+
+    [Fact]
+    public static void TestProperties_Throw_KeyNotFoundException()
+    {
+        Assert.Throws<KeyNotFoundException>(() => TestProperties.GetProperty("NotAProperty"));
+    }
+}

--- a/src/System.Private.ServiceModel/tests/System.Private.ServiceModel.Tests.csproj
+++ b/src/System.Private.ServiceModel/tests/System.Private.ServiceModel.Tests.csproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{BB3B114D-68D7-4E36-9EBE-127E694E6EC9}</ProjectGuid>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="**\*.cs" Exclude="Scenarios\SelfHostWcfService\*" />
+    <Compile Include="**\*.cs" Exclude="Scenarios\**\*" />
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />

--- a/src/System.ServiceModel.Tests.Common/src/System.ServiceModel.Tests.Common.csproj
+++ b/src/System.ServiceModel.Tests.Common/src/System.ServiceModel.Tests.Common.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="4.0" DefaultTargets="CreateTestProperties;Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
@@ -22,6 +22,8 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />
+    <None Include="testproperties.props" />
+    <None Include="testproperties.targets" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\System.Private.ServiceModel\src\System.Private.ServiceModel.csproj">
@@ -29,5 +31,7 @@
       <Name>System.Private.ServiceModel</Name>
     </ProjectReference>
   </ItemGroup>
+  <Import Project="testproperties.props" />
+  <Import Project="testproperties.targets" />
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.ServiceModel.Tests.Common/src/TestProperties.cs
+++ b/src/System.ServiceModel.Tests.Common/src/TestProperties.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Collections.Generic;
+
+namespace System.ServiceModel.Tests.Common
+{
+    // This type exists to provide name/value pairs for properties
+    // defined at build time and accessible at runtime.
+    // These name/value pairs are auto-generated when this current
+    // project is built.
+    public static partial class TestProperties
+    {
+        // Lazily create the dictionary, and initialize it via a
+        // partial method in generated code.
+        private static Lazy<Dictionary<String, String>> _properties = new Lazy<Dictionary<String, String>>(() =>
+        {
+            Dictionary<String, String> properties = new Dictionary<String, String>();
+            Initialize(properties);
+            return properties;
+        });
+
+        // This partial method will be implemented by code generated at build time.
+        static partial void Initialize(Dictionary<string,string> properties);
+
+        /// <summary>
+        /// Gets the list of available property names.
+        /// </summary>
+        public static IEnumerable<string> PropertyNames
+        {
+            get
+            {
+                return _properties.Value.Keys;
+            }
+        }
+
+        /// <summary>
+        /// Returns the value associated with a given <paramref name="propertyName"/>.
+        /// </summary>
+        /// <param name="propertyName">The name of the property to retrieve.</param>
+        /// <returns>The value associated with that property.</returns>
+        /// <exception cref="ArgumentNullException">propertyName is <c>null</c>.</exception> 
+        /// <exception cref="KeyNotFoundException">The request property is not available.</exception>
+        /// <remarks>Precedence will be given to Environment variables.
+        /// If there is no Environment variable of the request name, the fallback
+        /// is the value in a dictionary created at build time.</remarks>
+        public static string GetProperty(string propertyName)
+        {
+            // Environment variables take precedence, but limit access
+            // to only the environment variables corresponding to known
+            // property names.
+            string result = _properties.Value.ContainsKey(propertyName)
+                                ? Environment.GetEnvironmentVariable(propertyName)
+                                : null;
+            if (String.IsNullOrEmpty(result))
+            {
+                // Throw KeyNotFoundException if caller asks for nonexistent property.
+                result = _properties.Value[propertyName];
+            }
+
+            return result;
+        }
+    }
+}

--- a/src/System.ServiceModel.Tests.Common/src/testproperties.props
+++ b/src/System.ServiceModel.Tests.Common/src/testproperties.props
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <!-- 
+      TestProperty:
+        This item collection gives the name and value for each property to generate
+        into TestProperties.Properties. The included ItemSpec for each item will
+        become the property's key.  The value for the property will be taken from
+        the "Value" metadata, or if it is blank, from the "DefaultValue" metadata.
+        This pattern permits properties to specify their defaults here but to be
+        overridden from the command line.
+        Example: 'msbuild /p:UseFiddlerUrl=true' will override the default false.
+    -->
+    <ItemGroup>
+      <TestProperty Include="BridgeResourceFolder">
+        <Value>$(BridgeResourceFolder)</Value>
+        <DefaultValue>$(OutputPath)</DefaultValue>
+      </TestProperty>
+      <TestProperty Include="BridgeUrl">
+        <Value>$(BridgeUrl)</Value>
+        <DefaultValue>http://localhost/Bridge</DefaultValue>
+      </TestProperty>
+      <TestProperty Include="UseFiddlerUrl">
+        <Value>$(UseFiddlerUrl)</Value>
+        <DefaultValue>false</DefaultValue>
+      </TestProperty>
+    </ItemGroup>
+
+  <!--
+     GeneratedTestPropertiesFileName:
+     The full path of the C# file that will be generated at build time to
+     initialize TestProperties.Properties from the @(TestProperty) items.
+  -->
+  <PropertyGroup>
+    <GeneratedTestPropertiesFileName>$(OutputPath)_ServiceModel.TestProperties.Generated.cs</GeneratedTestPropertiesFileName>
+  </PropertyGroup>
+</Project>
+
+

--- a/src/System.ServiceModel.Tests.Common/src/testproperties.targets
+++ b/src/System.ServiceModel.Tests.Common/src/testproperties.targets
@@ -1,0 +1,135 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <!-- 
+    CreateTestPropertiesFile:
+      This task generates a C# file to initialize the TestProperties.Properties
+      dictionary with the provided name/value pairs.
+      FileName :          the full name of the file to generate
+      TestPropertyItems : item collection of name/value pairs to generate
+                          name = item.ItemSpec
+                          value = item's metadata for "Value" or "DefaultValue" if "Value" is blank
+  -->
+  <UsingTask TaskName="CreateTestPropertiesFile" TaskFactory="CodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.v12.0.dll">
+    <ParameterGroup>
+      <FileName ParameterType="System.String" Required="true" />
+      <TestPropertyItems ParameterType="Microsoft.Build.Framework.ITaskItem[]" Required="true" />
+    </ParameterGroup>
+    <Task>
+      <Reference Include="System" />
+      <Reference Include="System.IO" />
+      <Code Type="Fragment" Language="cs">
+        <![CDATA[
+        
+        // In some build environments, paths such as $(OutputPath) are
+        // not created prior to starting the build.  So we may find
+        // we need to create the folder for the generated file.
+        string outputFolder = Path.GetDirectoryName(FileName);
+        if (!Directory.Exists(outputFolder))
+        {
+            Log.LogMessage("Creating output folder {0}", outputFolder);
+            Directory.CreateDirectory(outputFolder);
+        }
+
+        StringBuilder sb = new StringBuilder();
+	      sb.AppendLine(
+ @"using System.Collections.Generic;
+namespace System.ServiceModel.Tests.Common
+{
+    public static partial class TestProperties
+    {");
+        
+        // Generate a string for each property name.
+        // Code accessing the properties should use these generated names.
+        foreach (var item in TestPropertyItems)
+        {
+            sb.AppendLine(String.Format("        public static readonly string {0}_PropertyName = \"{0}\";", item.ItemSpec));
+        }
+        
+        // Generate the Initialize partial method to populate the dictionary
+        sb.AppendLine(
+@"        static partial void Initialize(Dictionary<string, string> properties)
+        {");
+                
+        foreach (var item in TestPropertyItems)
+        {
+            string propertyName = item.ItemSpec;
+            string propertyValue = item.GetMetadata("Value");
+            if (String.IsNullOrEmpty(propertyValue))
+            {
+                propertyValue = item.GetMetadata("DefaultValue");
+            }
+         
+            // Convert the property value into a legal string literal.     
+            StringBuilder literal = new StringBuilder();       
+            foreach (var c in propertyValue)
+            {
+                switch (c)
+                {
+                    case '\'': literal.Append(@"\'"); break;
+                    case '\"': literal.Append("\\\""); break;
+                    case '\\': literal.Append(@"\\"); break;
+                    default:
+                        if (c >= 0x20 && c <= 0x7e)
+                        {
+                            // ASCII printable character
+                            literal.Append(c);
+                        }
+                        else
+                        {
+                            // As UTF16 escaped character
+                            literal.AppendFormat(@"\u{0:x4}", (int)c);
+                        }
+                        break;
+                }
+            }
+            
+            string setStatement = String.Format("            properties[\"{0}\"] = \"{1}\";", propertyName, literal.ToString());
+            Log.LogMessage(setStatement);
+            sb.AppendLine(setStatement);
+        }
+            
+	      sb.AppendLine(
+ @"        }
+    }
+}");
+        
+        // Do not rewrite file if there are no changes.  This permits incremental builds.
+        string contentsToWrite = sb.ToString();
+        string priorContents = File.Exists(FileName) ? File.ReadAllText(FileName) : String.Empty;
+        if (!String.Equals(contentsToWrite, priorContents))
+        {
+            Log.LogMessage("Test properties were generated to {0}.", FileName);
+            File.WriteAllText(FileName, sb.ToString());
+        }
+        else
+        {
+             Log.LogMessage("No changes were made to the existing file {0}", FileName);
+        }
+        ]]>
+      </Code>
+    </Task>
+  </UsingTask>
+
+  <!--
+    CreateTestProperties:
+      This target generates a file to initialize the TestProperties dictionary
+      with a set of known name/value pairs.  The file will also contain
+      generated static strings for each property name.  Code accessing the
+      properties in TestProperties.Properties should use these generated
+      names rather than separate string literals.
+  -->
+  <Target Name="CreateTestProperties">
+
+    <!-- Generate the file (will be a NOP if file exists and doesn't need to change) -->
+    <CreateTestPropertiesFile FileName ="$(GeneratedTestPropertiesFileName)" TestPropertyItems="@(TestProperty)"/>
+
+    <!-- Add the generated file to the @(Compile) collection so it gets built. -->
+    <ItemGroup>
+      <Compile Include="$(GeneratedTestPropertiesFileName)" />
+    </ItemGroup>
+
+  </Target>
+</Project>
+
+


### PR DESCRIPTION
A new TestProperties class is added together with a custom
task to generate a C# file to populate a dictionary with
MSBuild properties defined at build time.

This makes all the build-time MSBuild properties available
to tests at runtime.  This is necessary because the frameworks
on which these tests run do not support configuration files
or environment variables.

Fixes #29