### PR TITLE
Revert behaviour when adding a null/empty string to a http header 

### DIFF
--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/HttpChannelFactory.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/HttpChannelFactory.cs
@@ -794,18 +794,13 @@ namespace System.ServiceModel.Channels
                             }
                             else
                             {
-                                try
+                                if (!_httpRequestMessage.Headers.TryAddWithoutValidation(name, value))
                                 {
-                                    _httpRequestMessage.Headers.Add(name, value);
-                                }
-                                catch (Exception addHeaderException)
-                                {
-                                    throw FxTrace.Exception.AsError(new InvalidOperationException(SR.Format(
-                                                    SR.CopyHttpHeaderFailed,
-                                                    name,
-                                                    value,
-                                                    HttpChannelUtilities.HttpRequestHeadersTypeName),
-                                                    addHeaderException));
+                                        throw FxTrace.Exception.AsError(new InvalidOperationException(SR.Format(
+                                                SR.CopyHttpHeaderFailed,
+                                                name,
+                                                value,
+                                                _httpRequestMessage.Headers.GetType().Name)));
                                 }
                             }
                         }


### PR DESCRIPTION
This is a regression from commit ddcd6e4. 

App testing found that if we attempt to add a header with a null or empty string value to the _httpRequestMessage.Headers collection, an exception is thrown by
`System.Net.Http.Headers.HttpHeaderParser.ParseValue(...)`

which causes a failure in the app.