### PR TITLE
Enable building and debugging of test projects from visual studio

### DIFF
--- a/src/dir.props
+++ b/src/dir.props
@@ -1,3 +1,4 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\dir.props" />
+  <Import Project=".\test.props" />
 </Project>

--- a/src/test.props
+++ b/src/test.props
@@ -1,0 +1,12 @@
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+<!-- Handles the test output directory issue for visual studio. Currently we need to do a full build from the command line first.
+     But once - dotnet/buildtools#181 is fixed we might be able to get rid of this. 
+     This property walks up the tree and finds the buildtools computed $(bindir) and $(TestPath)\$(DebugTestFrameworkFolder)
+     and sets the output path to match the start working directory.
+     Currently handles only Windows_NT as the OS_GROUP
+-->
+  <PropertyGroup Condition=" $(MSBuildProjectName.EndsWith('.Tests')) AND '$(BuildingInsideVisualStudio)' == 'true' ">
+    <OutputPath>$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), build.proj))\\bin\\tests\\Windows_NT.$(Platform).$(Configuration)\$(MSBuildProjectName)\dnxcore50</OutputPath>
+  </PropertyGroup>  
+</Project>


### PR DESCRIPTION
Once dotnet/buildtools#181 is fixed we should be able to remove this.