### PR TITLE
Temporarily make package restore not run concurrently

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -77,7 +77,11 @@
 
     <DnuRestoreCommand>"$(DnuToolPath)"</DnuRestoreCommand>
     <DnuRestoreCommand>$(DnuRestoreCommand) restore</DnuRestoreCommand>
-    <DnuRestoreCommand>$(DnuRestoreCommand) --parallel</DnuRestoreCommand>
+<!-- temporarily remove the parallel switch to allow package restore.
+     to restore, remove the X from DnuRestoreCommands below.
+-->
+    <DnuRestoreCommandX>$(DnuRestoreCommand) --parallel</DnuRestoreCommandX>
+
     <!-- Dnu doesn't like trailing slashes in the packages directory argument -->
     <DnuRestoreCommand>$(DnuRestoreCommand) --packages "$(PackagesDir.TrimEnd('/\'.ToCharArray()))" $(DnuRestoreSource)</DnuRestoreCommand>
     <DnuRestoreCommand Condition="'$(LockDependencies)' == 'true'">$(DnuRestoreCommand) --lock</DnuRestoreCommand>


### PR DESCRIPTION
An issue with Dnu package restore running concurrently is preventing
builds from working correctly.  This change is temporary and allows
the build to succeed.  An issue will be opened to undo this change
when Dnu is fixed.