### PR TITLE
Add override.targets and wcf.targets

### DIFF
--- a/src/dir.targets
+++ b/src/dir.targets
@@ -16,5 +16,6 @@
           Returns="$(DocumentationFile)"/>
 
   <Import Project="$(ToolsDir)Build.Common.targets" Condition="Exists('$(ToolsDir)Build.Common.targets')" />
+  <Import Project="..\wcf.targets" Condition="Exists('..\wcf.targets')"/>
 
 </Project>

--- a/wcf.targets
+++ b/wcf.targets
@@ -1,0 +1,14 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <!--
+    Overrides for WCF
+  -->
+
+  <PropertyGroup Condition="'$(BridgeResourceFolder)' == ''">
+     <BridgeResourceFolder>$(MSBuildThisFileDirectory)bin\wcf\BridgeResources\</BridgeResourceFolder>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(WcfToolsOutputPath)' == ''">
+     <WcfToolsOutputPath>$(MSBuildThisFileDirectory)bin\wcf\tools\</WcfToolsOutputPath>
+  </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
Adds override.targets to resemble how CoreFx includes multiple
product specific targets at build time.

Also adds wcf.targets that defines common properties and targets
necessary for wcf projects.