### PR TITLE
Fix DuplexClientBaseTests use of Close()

### DIFF
--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/ClientBase/DuplexClientBaseTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/ClientBase/DuplexClientBaseTests.cs
@@ -41,7 +41,7 @@ public static class DuplexClientBaseTests
                 errorBuilder.AppendLine(String.Format("The sent GUID does not match the returned GUID. Sent: {0} Received: {1}", guid, returnedGuid));
             }
 
-            duplexService.Close();
+            ((ICommunicationObject)duplexService).Close();
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
DuplexClientBaseTests used ClientBase<T>.Close() which is public
but not available in the public contract.  So the test fails when
run against NET Native.  This change allows it to function in both
CoreCLR and NET Native.