### PR TITLE
Escape URLs in dir.props

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -66,12 +66,12 @@
 
   <!-- list of nuget package sources passed to dnu -->
   <ItemGroup>
-    <DnuSourceList Include="https://www.myget.org/F/dotnet-core/" />
-    <DnuSourceList Include="https://www.myget.org/F/dotnet-coreclr/" />
-    <DnuSourceList Include="https://www.myget.org/F/dotnet-corefx/" />
-    <DnuSourceList Include="https://www.myget.org/F/dotnet-corefxtestdata/" />
-    <DnuSourceList Include="https://www.myget.org/F/dotnet-buildtools/" />
-    <DnuSourceList Include="https://www.nuget.org/api/v2/" />
+    <DnuSourceList Include="https:%2F%2Fwww.myget.org/F/dotnet-core/" />
+    <DnuSourceList Include="https:%2F%2Fwww.myget.org/F/dotnet-coreclr/" />
+    <DnuSourceList Include="https:%2F%2Fwww.myget.org/F/dotnet-corefx/" />
+    <DnuSourceList Include="https:%2F%2Fwww.myget.org/F/dotnet-corefxtestdata/" />
+    <DnuSourceList Include="https:%2F%2Fwww.myget.org/F/dotnet-buildtools/" />
+    <DnuSourceList Include="https:%2F%2Fwww.nuget.org/api/v2/" />
   </ItemGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
The double-slashes for URL's in dir.props needed
to be escaped to match CoreFx's changes.