### PR TITLE
Enable previously skipped duplex scenario test

### DIFF
--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/ClientBase/DuplexClientBaseTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/ClientBase/DuplexClientBaseTests.cs
@@ -14,7 +14,6 @@ public static class DuplexClientBaseTests
     static TimeSpan maxTestWaitTime = TimeSpan.FromSeconds(10);
 
     [Fact]
-    [ActiveIssue(90)]
     [OuterLoop]
     public static void DuplexClientBaseOfT_OverNetTcp_Call()
     {

--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/TypedClient/TypedProxyTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/TypedClient/TypedProxyTests.cs
@@ -417,7 +417,7 @@ public static class TypedProxyTests
     }
 
     [Fact]
-    [ActiveIssue(90)]
+    [ActiveIssue(157)]
     [OuterLoop]
     public static void ServiceContract_TypedProxy_DuplexCallback()
     {


### PR DESCRIPTION
Enables DuplexClientBaseOfT_OverNetTcp_Call after PR #152 was merged
and enabled duplex operation.

Also updates [ActiveIssue] of ServiceContract_TypedProxy_DuplexCallback
to refer to new issue #157.