### PR TITLE
Fixing Callback contracts with a Task<T> return type

### DIFF
--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Dispatcher/InvokerUtil.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Dispatcher/InvokerUtil.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 namespace System.ServiceModel.Dispatcher
 {
 
-    delegate Task<object> InvokeDelegate(object target, object[] inputs, object[] outputs);
+    delegate object InvokeDelegate(object target, object[] inputs, object[] outputs);
 
     internal sealed class InvokerUtil
     {
@@ -30,7 +30,7 @@ namespace System.ServiceModel.Dispatcher
             internal InvokeDelegate GenerateInvokeDelegate(MethodInfo method, out int inputParameterCount, out int outputParameterCount)
             {
                 ParameterInfo[] parameters = method.GetParameters();
-                bool returnsValue = method.ReturnType == typeof (void);
+                bool returnsValue = method.ReturnType != typeof (void);
                 var inputCount = parameters.Length;
                 inputParameterCount = inputCount;
 
@@ -70,8 +70,10 @@ namespace System.ServiceModel.Dispatcher
                     {
                         outputs[i] = inputs[outputPos[i]];
                     }
-                    return Task.FromResult(result);
+
+                    return result;
                 };
+
                 return lambda;
             }
         }

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Dispatcher/SyncMethodInvoker.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Dispatcher/SyncMethodInvoker.cs
@@ -71,7 +71,7 @@ namespace System.ServiceModel.Dispatcher
             return tuple.Item1;
         }
 
-        private async Task<Tuple<object,object[]>> InvokeAsync(object instance, object[] inputs)
+        private Task<Tuple<object,object[]>> InvokeAsync(object instance, object[] inputs)
         {
             EnsureIsInitialized();
 
@@ -142,7 +142,7 @@ namespace System.ServiceModel.Dispatcher
                     {
                         TD.OperationInvoked(eventTraceActivity, MethodName, TraceUtility.GetCallerInfo(OperationContext.Current));
                     }
-                    returnValue = await _invokeDelegate(instance, inputs, outputs);
+                    returnValue = _invokeDelegate(instance, inputs, outputs);
                     callSucceeded = true;
                 }
             }
@@ -182,7 +182,7 @@ namespace System.ServiceModel.Dispatcher
                 }
             }
 
-            return Tuple.Create(returnValue, outputs);
+            return Task.FromResult(Tuple.Create(returnValue, outputs));
         }
 
         void EnsureIsInitialized()

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Dispatcher/TaskMethodInvoker.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Dispatcher/TaskMethodInvoker.cs
@@ -99,7 +99,7 @@ namespace System.ServiceModel.Dispatcher
 
             if (_isGenericTask)
             {
-                returnVal = _taskTResultGetMethod.Invoke(result, Type.EmptyTypes);
+                returnVal = _taskTResultGetMethod.Invoke(task, Type.EmptyTypes);
             }
             else
             {
@@ -187,7 +187,13 @@ namespace System.ServiceModel.Dispatcher
                         TD.OperationInvoked(eventTraceActivity, MethodName,
                             TraceUtility.GetCallerInfo(OperationContext.Current));
                     }
-                    returnValue = await _invokeDelegate(instance, inputs, outputs);
+                    returnValue = _invokeDelegate(instance, inputs, outputs);
+                    var returnValueTask = returnValue as Task;
+                    if (returnValueTask != null)
+                    {
+                        await returnValueTask;
+                    }
+
                     callSucceeded = true;
                 }
             }

--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/TypedClient/TypedProxyDuplexTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/TypedClient/TypedProxyDuplexTests.cs
@@ -20,7 +20,6 @@ public static class TypedProxyDuplexTests
     //              IDuplexChannel (for a two-way duplex message exchange pattern)
 
     [Fact]
-    [ActiveIssue(138)]
     [OuterLoop]
     public static void ServiceContract_TypedProxy_AsyncTask_CallbackReturn()
     {


### PR DESCRIPTION
Callback contracts with a return type of simply Task were working, but Task<T> were causing a null ref exception.