### PR TITLE
Integrate recent CoreFx changes to props and targets files

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -21,7 +21,7 @@
     <Message Importance="High" Text="Restoring all packages..." />
     <!-- restore all project.jsons in one pass for perf & to avoid concurrency problems with dnu -->
     <!-- include ToolsDir to restore test-runtime\project.json as well -->
-    <Exec Command="$(DnuRestoreCommand) &quot;$(MSBuildProjectDirectory)\src&quot; &quot;$(ToolsDir)&quot;" StandardOutputImportance="Low" CustomErrorRegularExpression="^Unable to locate .*" />
+    <Exec Command="$(DnuRestoreCommand) $(DnuRestoreDirs)" StandardOutputImportance="Low" CustomErrorRegularExpression="^Unable to locate .*" />
 
     <ItemGroup>
       <_allPackagesConfigs Include="$(MSBuildProjectDirectory)\src\**\packages.config"/>

--- a/dir.props
+++ b/dir.props
@@ -66,6 +66,7 @@
 
   <!-- list of nuget package sources passed to dnu -->
   <ItemGroup>
+    <!-- Need to escape double forward slash (%2F) or MSBuild will normalize to one slash on Unix. -->
     <DnuSourceList Include="https:%2F%2Fwww.myget.org/F/dotnet-core/" />
     <DnuSourceList Include="https:%2F%2Fwww.myget.org/F/dotnet-coreclr/" />
     <DnuSourceList Include="https:%2F%2Fwww.myget.org/F/dotnet-corefx/" />
@@ -74,12 +75,19 @@
     <DnuSourceList Include="https:%2F%2Fwww.nuget.org/api/v2/" />
   </ItemGroup>
 
+    <!-- list of directories to perform batch restore -->
+  <ItemGroup>
+    <DnuRestoreDir Include="&quot;$(MSBuildProjectDirectory)\src&quot;" />
+    <DnuRestoreDir Include="&quot;$(ToolsDir)&quot;" />
+  </ItemGroup>
+
   <PropertyGroup>
     <DnxPackageDir Condition="'$(DnxPackageDir)'==''">$(PackagesDir)/$(DnxPackageName)/</DnxPackageDir>
     <DnuToolPath Condition="'$(DnuToolPath)'=='' and '$(OsEnvironment)'!='Unix'">$(DnxPackageDir)\bin\dnu.cmd</DnuToolPath>
     <DnuToolPath Condition="'$(DnuToolPath)'=='' and '$(OsEnvironment)'=='Unix'">$(DnxPackageDir)/bin/dnu</DnuToolPath>
 
     <DnuRestoreSource>@(DnuSourceList -> '--source %(Identity)', ' ')</DnuRestoreSource>
+    <DnuRestoreDirs>@(DnuRestoreDir -> '%(Identity)', ' ')</DnuRestoreDirs>
 
     <DnuRestoreCommand>"$(DnuToolPath)"</DnuRestoreCommand>
     <DnuRestoreCommand>$(DnuRestoreCommand) restore</DnuRestoreCommand>
@@ -88,10 +96,10 @@
     <DnuRestoreCommand Condition="'$(LockDependencies)' == 'true'">$(DnuRestoreCommand) --lock</DnuRestoreCommand>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(BuildAllProjects)'=='true'">  
-    <!-- When we do a traversal build we get all packages up front, don't restore them again -->  
-    <RestorePackages>false</RestorePackages>  
-  </PropertyGroup>  
+  <PropertyGroup Condition="'$(BuildAllProjects)'=='true'">
+    <!-- When we do a traversal build we get all packages up front, don't restore them again -->
+    <RestorePackages>false</RestorePackages>
+  </PropertyGroup>
 
   <!--
     Set up Roslyn predefines
@@ -119,11 +127,6 @@
       https://github.com/dotnet/corefx/issues/1609
     -->
     <ExcludeProjects Include="System.Diagnostics.Debug/tests/System.Diagnostics.Debug.Tests.csproj" />
-    <!--
-      The OpenSourceSign target complains about System.Diagnostics.FileVersionInfo.TestAssembly.dll not being delay signed.
-      https://github.com/dotnet/corefx/issues/1610
-    -->
-    <ExcludeProjects Include="System.Diagnostics.FileVersionInfo/tests/System.Diagnostics.FileVersionInfo.Tests.csproj" />
   </ItemGroup>
 
   <PropertyGroup Condition="'$(OsEnvironment)'=='Unix'">
@@ -163,6 +166,7 @@
     <OSGroup Condition="'$(OSGroup)'=='' and $(Configuration.StartsWith('Windows'))">Windows_NT</OSGroup>
     <OSGroup Condition="'$(OSGroup)'=='' and $(Configuration.StartsWith('Linux'))">Linux</OSGroup>
     <OSGroup Condition="'$(OSGroup)'=='' and $(Configuration.StartsWith('OSX'))">OSX</OSGroup>
+    <OSGroup Condition="'$(OSGroup)'=='' and $(Configuration.StartsWith('FreeBSD'))">FreeBSD</OSGroup>
     <OSGroup Condition="'$(OSGroup)'==''">Windows_NT</OSGroup>
   </PropertyGroup>
 
@@ -186,6 +190,12 @@
     <NoExplicitReferenceToStdLib>true</NoExplicitReferenceToStdLib>
     <AddAdditionalExplicitAssemblyReferences>false</AddAdditionalExplicitAssemblyReferences>
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
+  </PropertyGroup>
+
+  <!-- Set up handling of build warnings -->
+  <PropertyGroup>
+    <WarningLevel>4</WarningLevel>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <!-- Set up some common paths -->
@@ -215,8 +225,9 @@
     <TargetsWindows Condition="'$(OSGroup)' == 'Windows_NT'">true</TargetsWindows>
     <TargetsLinux Condition="'$(OSGroup)' == 'Linux'">true</TargetsLinux>
     <TargetsOSX Condition="'$(OSGroup)' == 'OSX'">true</TargetsOSX>
+    <TargetsFreeBSD Condition="'$(OSGroup)' == 'FreeBSD'">true</TargetsFreeBSD>
 
-    <TargetsUnix Condition="'$(TargetsLinux)' == 'true' or '$(TargetsOSX)' == 'true'">true</TargetsUnix>
+    <TargetsUnix Condition="'$(TargetsLinux)' == 'true' or '$(TargetsOSX)' == 'true' or '$(TargetsFreeBSD)' == 'true'">true</TargetsUnix>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/dir.targets
+++ b/dir.targets
@@ -115,8 +115,8 @@
            Text="The build tools package was just restored and so we cannot continue the build of an individual project because targets from the build tools package were not able to be imported. Please retry the build the individual project again." />
   </Target>
 
-  <!-- Provide default empty targets for BuildAndTest and Test which can be hooked onto or overridden as necessary -->
+  <!-- Provide default targets which can be hooked onto or overridden as necessary -->
   <Target Name="BuildAndTest" DependsOnTargets="Build;Test" />
-
+  <Target Name="RebuildAndTest" DependsOnTargets="Rebuild;Test" />
   <Target Name="Test" />
 </Project>

--- a/src/System.Private.ServiceModel/tests/Scenarios/ServiceModel.Scenarios.Common/ServiceModel.Scenarios.Common.csproj
+++ b/src/System.Private.ServiceModel/tests/Scenarios/ServiceModel.Scenarios.Common/ServiceModel.Scenarios.Common.csproj
@@ -12,6 +12,7 @@
     <SignAssembly>false</SignAssembly>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ProjectGuid>{C2210035-AAB0-4DBB-9A42-6A23C0BD763B}</ProjectGuid>
+    <CLSCompliant>false</CLSCompliant>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="**\*.cs" />


### PR DESCRIPTION
CoreFx made some changes to alter how the DnuRestore worked
and to enable warnings as errors (which is how the projects
are built in the TFS mirrored location).  This PR brings those
changes to WCF.

It also fixes the one warning we had that caused the build to fail.