### PR TITLE
Fix async channel open so that continuations don't use the current sync context

### DIFF
--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/CommunicationObject.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/CommunicationObject.cs
@@ -119,7 +119,7 @@ namespace System.ServiceModel.Channels
 
         public IAsyncResult BeginClose(TimeSpan timeout, AsyncCallback callback, object state)
         {
-            return ((IAsyncCommunicationObject)this).CloseAsync(timeout).ToApm(callback, state);
+            return CloseAsyncInternal(timeout).ToApm(callback, state);
         }
 
         public IAsyncResult BeginOpen(AsyncCallback callback, object state)
@@ -129,7 +129,7 @@ namespace System.ServiceModel.Channels
 
         public IAsyncResult BeginOpen(TimeSpan timeout, AsyncCallback callback, object state)
         {
-            return ((IAsyncCommunicationObject)this).OpenAsync(timeout).ToApm(callback, state);
+            return OpenAsyncInternal(timeout).ToApm(callback, state);
         }
 
         public void Close()

--- a/src/System.Private.ServiceModel/tests/Common/src/TestHelpers.cs
+++ b/src/System.Private.ServiceModel/tests/Common/src/TestHelpers.cs
@@ -8,6 +8,7 @@ using System.ServiceModel.Channels;
 using System.ServiceModel.Description;
 using System.ServiceModel.Dispatcher;
 using System.Text;
+using System.Threading;
 using System.Xml;
 
 public static class TestHelpers

--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/TypedClient/TypedProxyTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/TypedClient/TypedProxyTests.cs
@@ -34,7 +34,6 @@ public static class TypedProxyTests
     }
 
     [Fact]
-    [ActiveIssue(78)]
     [OuterLoop]
     public static void ServiceContract_TypedProxy_NetTcpBinding_AsyncBeginEnd_Call()
     {
@@ -54,7 +53,6 @@ public static class TypedProxyTests
     }
 
     [Fact]
-    [ActiveIssue(78)]
     [OuterLoop]
     public static void ServiceContract_TypedProxy_NetTcpBinding_AsyncBeginEnd_Call_WithNoCallback()
     {
@@ -77,7 +75,6 @@ public static class TypedProxyTests
     }
 
     [Fact]
-    [ActiveIssue(78)]
     [OuterLoop]
     public static void ServiceContract_TypedProxy_NetTcpBinding_AsyncBeginEnd_Call_WithSingleThreadedSyncContext()
     {
@@ -103,11 +100,11 @@ public static class TypedProxyTests
     }
 
     [Fact]
-    [ActiveIssue(78)]
     [OuterLoop]
     public static void ServiceContract_TypedProxy_NetTcpBinding_AsyncTask_Call()
     {
         NetTcpBinding netTcpBinding = new NetTcpBinding();
+        netTcpBinding.Security.Mode = SecurityMode.None;
         ServiceContract_TypedProxy_AsyncTask_Call(netTcpBinding, Endpoints.Tcp_NoSecurity_Address, "ServiceContract_TypedProxy_NetTcpBinding_AsyncTask_Call");
     }
 
@@ -127,7 +124,6 @@ public static class TypedProxyTests
     }
 
     [Fact]
-    [ActiveIssue(78)]
     [OuterLoop]
     public static void ServiceContract_TypedProxy__NetTcpBinding_AsyncTask_Call_WithSingleThreadedSyncContext()
     {
@@ -209,7 +205,7 @@ public static class TypedProxyTests
             {
                 SingleThreadSynchronizationContext.Run(async delegate
                 {
-                    int startThread = Environment.CurrentManagedThreadId; //!!!! Use of System.Environment pulls in the contract "System.Runtime.Extensions", is this really needed?
+                    int startThread = Environment.CurrentManagedThreadId;
                     result = await serviceProxy.EchoAsync("Hello");
                     if (startThread != Environment.CurrentManagedThreadId)
                     {


### PR DESCRIPTION
This was causing deadlocks when calling a Task based client synchronously, e.g. FooAsync().Result.
Fixes #78