### PR TITLE
Disable Duplex unit tests using Endpoints

### DIFF
--- a/src/System.ServiceModel.Primitives/tests/ServiceModel/DuplexChannelFactoryTest.cs
+++ b/src/System.ServiceModel.Primitives/tests/ServiceModel/DuplexChannelFactoryTest.cs
@@ -157,6 +157,7 @@ public class DuplexChannelFactoryTest
     }
 
     [Fact]
+    [ActiveIssue(178)]
     public static void CreateChannel_Using_Http_NoSecurity()
     {
         WcfDuplexServiceCallback callback = new WcfDuplexServiceCallback();

--- a/src/System.ServiceModel.Primitives/tests/ServiceModel/DuplexClientBaseTest.cs
+++ b/src/System.ServiceModel.Primitives/tests/ServiceModel/DuplexClientBaseTest.cs
@@ -10,6 +10,7 @@ using Xunit;
 public class DuplexClientBaseTest
 {
     [Fact]
+    [ActiveIssue(178)]
     public static void DuplexClientBase_Ctor_Initializes_State()
     {
         InstanceContext context = new InstanceContext(new WcfDuplexServiceCallback());
@@ -24,6 +25,7 @@ public class DuplexClientBaseTest
     }
 
     [Fact]
+    [ActiveIssue(178)]
     public static void DuplexClientBase_Aborts_Changes_CommunicationState()
     {
         InstanceContext context = new InstanceContext(new WcfDuplexServiceCallback());
@@ -37,6 +39,7 @@ public class DuplexClientBaseTest
     }
 
     [Fact]
+    [ActiveIssue(178)]
     public static void CreateDuplexClientBase_NullContext_Throws()
     {
         Binding binding = new NetTcpBinding();
@@ -45,6 +48,7 @@ public class DuplexClientBaseTest
     }
 
     [Fact]
+    [ActiveIssue(178)]
     public static void CreateDuplexClientBase_NullBinding_Throws()
     {
         InstanceContext context = new InstanceContext(new WcfDuplexServiceCallback());
@@ -61,6 +65,7 @@ public class DuplexClientBaseTest
     }
     
     [Fact]
+    [ActiveIssue(178)]
     public static void CreateDuplexClientBase_Binding_Url_Mismatch_Throws()
     {
         InstanceContext context = new InstanceContext(new WcfDuplexServiceCallback());


### PR DESCRIPTION
The Endpoints class is reserved for [OuterLoop] tests and
requires a running WCF Service.

This PR adds [ActiveIssue(178)] to all the Duplex unit tests
using Endpoints.  They need to be converted to use BaseAddress only.