### PR TITLE
Re-enables Duplex unit tests previously disabled

### DIFF
--- a/src/System.Private.ServiceModel/tests/Common/src/BaseAddress.cs
+++ b/src/System.Private.ServiceModel/tests/Common/src/BaseAddress.cs
@@ -47,9 +47,15 @@ public static class BaseAddress
 
     // Base address for HTTPS endpoints with Windows Authentication
     public const string HttpsWindowsBaseAddress = "https://localhost:44285/WindowsCommunicationFoundation";
+
+    public const string HttpBaseAddress_NetHttp = BaseAddress.HttpBaseAddress + "/NetHttp";
+
+    public const string HttpBaseAddress_Basic = BaseAddress.HttpBaseAddress + "/Basic";
+
 #endif
 
     public const string TcpDuplexAddress = "net.tcp://localhost:809/WindowsCommunicationFoundation";
+    public const string Tcp_NoSecurity_Callback_Address = BaseAddress.TcpDuplexAddress + "/tcp-nosecurity-callback";
 }
 
 

--- a/src/System.ServiceModel.Primitives/tests/ServiceModel/DuplexChannelFactoryTest.cs
+++ b/src/System.ServiceModel.Primitives/tests/ServiceModel/DuplexChannelFactoryTest.cs
@@ -157,13 +157,12 @@ public class DuplexChannelFactoryTest
     }
 
     [Fact]
-    [ActiveIssue(178)]
     public static void CreateChannel_Using_Http_NoSecurity()
     {
         WcfDuplexServiceCallback callback = new WcfDuplexServiceCallback();
         InstanceContext context = new InstanceContext(callback);
         Binding binding = new NetHttpBinding(BasicHttpSecurityMode.None);
-        EndpointAddress endpoint = new EndpointAddress(Endpoints.HttpBaseAddress_NetHttp);
+        EndpointAddress endpoint = new EndpointAddress(BaseAddress.HttpBaseAddress_NetHttp);
         DuplexChannelFactory<IWcfDuplexService> factory = new DuplexChannelFactory<IWcfDuplexService>(context, binding, endpoint);
 
         // Can't cast to IDuplexSessionChannel to IRequestChannel on http

--- a/src/System.ServiceModel.Primitives/tests/ServiceModel/DuplexClientBaseTest.cs
+++ b/src/System.ServiceModel.Primitives/tests/ServiceModel/DuplexClientBaseTest.cs
@@ -10,12 +10,11 @@ using Xunit;
 public class DuplexClientBaseTest
 {
     [Fact]
-    [ActiveIssue(178)]
     public static void DuplexClientBase_Ctor_Initializes_State()
     {
         InstanceContext context = new InstanceContext(new WcfDuplexServiceCallback());
         Binding binding = new NetTcpBinding();
-        EndpointAddress endpoint = new EndpointAddress(Endpoints.Tcp_NoSecurity_Callback_Address);
+        EndpointAddress endpoint = new EndpointAddress(BaseAddress.Tcp_NoSecurity_Callback_Address);
         MyDuplexClientBase<IWcfDuplexService> duplexClientBase = new MyDuplexClientBase<IWcfDuplexService>(context, binding, endpoint);
 
         Assert.Equal<EndpointAddress>(endpoint, duplexClientBase.Endpoint.Address);
@@ -25,12 +24,11 @@ public class DuplexClientBaseTest
     }
 
     [Fact]
-    [ActiveIssue(178)]
     public static void DuplexClientBase_Aborts_Changes_CommunicationState()
     {
         InstanceContext context = new InstanceContext(new WcfDuplexServiceCallback());
         Binding binding = new NetTcpBinding();
-        EndpointAddress endpoint = new EndpointAddress(Endpoints.Tcp_NoSecurity_Callback_Address);
+        EndpointAddress endpoint = new EndpointAddress(BaseAddress.Tcp_NoSecurity_Callback_Address);
         MyDuplexClientBase<IWcfDuplexService> duplexClientBase = new MyDuplexClientBase<IWcfDuplexService>(context, binding, endpoint);
 
         Assert.Equal<CommunicationState>(CommunicationState.Created, duplexClientBase.State);
@@ -39,20 +37,18 @@ public class DuplexClientBaseTest
     }
 
     [Fact]
-    [ActiveIssue(178)]
     public static void CreateDuplexClientBase_NullContext_Throws()
     {
         Binding binding = new NetTcpBinding();
-        EndpointAddress endpoint = new EndpointAddress(Endpoints.Tcp_NoSecurity_Callback_Address);
+        EndpointAddress endpoint = new EndpointAddress(BaseAddress.Tcp_NoSecurity_Callback_Address);
         Assert.Throws<ArgumentNullException>("callbackInstance", () => { MyDuplexClientBase<IWcfDuplexService> duplexClientBase = new MyDuplexClientBase<IWcfDuplexService>(null, binding, endpoint); }); 
     }
 
     [Fact]
-    [ActiveIssue(178)]
     public static void CreateDuplexClientBase_NullBinding_Throws()
     {
         InstanceContext context = new InstanceContext(new WcfDuplexServiceCallback());
-        EndpointAddress endpoint = new EndpointAddress(Endpoints.Tcp_NoSecurity_Callback_Address);
+        EndpointAddress endpoint = new EndpointAddress(BaseAddress.Tcp_NoSecurity_Callback_Address);
         Assert.Throws<ArgumentNullException>("binding", () => { MyDuplexClientBase<IWcfDuplexService> duplexClientBase = new MyDuplexClientBase<IWcfDuplexService>(context, null, endpoint); });
     }
 
@@ -65,12 +61,11 @@ public class DuplexClientBaseTest
     }
     
     [Fact]
-    [ActiveIssue(178)]
     public static void CreateDuplexClientBase_Binding_Url_Mismatch_Throws()
     {
         InstanceContext context = new InstanceContext(new WcfDuplexServiceCallback());
         Binding binding = new NetTcpBinding();
-        EndpointAddress endpoint = new EndpointAddress(Endpoints.HttpBaseAddress_Basic);
+        EndpointAddress endpoint = new EndpointAddress(BaseAddress.HttpBaseAddress_Basic);
         Assert.Throws<ArgumentException>("via", () => {
             MyDuplexClientBase<IWcfDuplexService> duplexClientBase = new MyDuplexClientBase<IWcfDuplexService>(context, binding, endpoint);
             ((ICommunicationObject)duplexClientBase).Open(); 


### PR DESCRIPTION
The Duplex unit tests previously disabled with [ActiveIssue(178)]
have been re-enabled and modified to use static BaseAddress URL's

Fixes #178