### PR TITLE
Update build-tools to version 58 to match CoreFx

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -10,7 +10,7 @@
 
   <!-- Build Tools Versions -->
   <PropertyGroup>
-    <BuildToolsVersion>1.0.25-prerelease-00056</BuildToolsVersion>
+    <BuildToolsVersion>1.0.25-prerelease-00058</BuildToolsVersion>
     <DnxVersion>1.0.0-beta5-12101</DnxVersion>
     <DnxPackageName Condition="'$(DnxPackageName)' == '' and '$(OsEnvironment)'!='Unix'">dnx-coreclr-win-x86.$(DnxVersion)</DnxPackageName>
     <DnxPackageName Condition="'$(DnxPackageName)' == '' and '$(OsEnvironment)'=='Unix'">dnx-mono.$(DnxVersion)</DnxPackageName>

--- a/src/.nuget/packages.Windows_NT.config
+++ b/src/.nuget/packages.Windows_NT.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.DotNet.BuildTools" version="1.0.25-prerelease-00056" />
+  <package id="Microsoft.DotNet.BuildTools" version="1.0.25-prerelease-00058" />
   <package id="dnx-coreclr-win-x86" version="1.0.0-beta5-12101" />
   <package id="Microsoft.DotNet.BuildTools.ApiTools" version="1.0.0-prerelease" />
 </packages>

--- a/src/test.props
+++ b/src/test.props
@@ -1,13 +1,4 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-<!-- Handles the test output directory issue for visual studio. Currently we need to do a full build from the command line first.
-     But once - dotnet/buildtools#181 is fixed we might be able to get rid of this. 
-     This property walks up the tree and finds the buildtools computed $(bindir) and $(TestPath)\$(DebugTestFrameworkFolder)
-     and sets the output path to match the start working directory.
-     Currently handles only Windows_NT as the OS_GROUP
--->
-  <PropertyGroup Condition=" $(MSBuildProjectName.EndsWith('.Tests')) AND '$(BuildingInsideVisualStudio)' == 'true' ">
-    <OutputPath>$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), build.proj))\\bin\\tests\\Windows_NT.$(Platform).$(Configuration)\$(MSBuildProjectName)\dnxcore50</OutputPath>
-  </PropertyGroup>  
   <PropertyGroup>
     <WcfSourceProj>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)\System.Private.ServiceModel\src\System.Private.ServiceModel.csproj'))</WcfSourceProj>
     <WcfTestCommonProj>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)\System.Private.ServiceModel\tests\Common\src\System.ServiceModel.Tests.Common.csproj'))</WcfTestCommonProj>


### PR DESCRIPTION
This change to build-tools permits F5 debugging in VS2015
without needing to run build.cmd each time.

It also reverts the work-around we had made to test.props for this.

Fixes #188