### PR TITLE
Improve exception message reporting from Assert.True checks

### DIFF
--- a/src/System.ServiceModel.Primitives/tests/ServiceModel/DuplexChannelFactoryTest.cs
+++ b/src/System.ServiceModel.Primitives/tests/ServiceModel/DuplexChannelFactoryTest.cs
@@ -172,8 +172,8 @@ public class DuplexChannelFactoryTest
             factory.CreateChannel();
         });
 
-        Assert.True(exception.Message.Contains("IRequestChannel"), 
-            string.Format("InvalidCastException exception string should contain 'IRequestChannel'. Actual message:\r\n" + exception.ToString()));
+        // Can't check that the InvalidCastException message as .NET Native only reports this message for all InvalidCastExceptions:
+        // "System.InvalidCastException: Arg_InvalidCastException"
     }
 
     [Fact]

--- a/src/System.ServiceModel.Primitives/tests/ServiceModel/DuplexChannelFactoryTest.cs
+++ b/src/System.ServiceModel.Primitives/tests/ServiceModel/DuplexChannelFactoryTest.cs
@@ -101,7 +101,8 @@ public class DuplexChannelFactoryTest
             factory.CreateChannel();
         });
 
-        Assert.True(exception.Message.Contains("BasicHttpBinding"), "InvalidOperationException exception string should contain 'BasicHttpBinding'");
+        Assert.True(exception.Message.Contains("BasicHttpBinding"), 
+            string.Format("InvalidOperationException exception string should contain 'BasicHttpBinding'. Actual message:\r\n" + exception.ToString()));
     }
 
     [Fact]
@@ -171,7 +172,8 @@ public class DuplexChannelFactoryTest
             factory.CreateChannel();
         });
 
-        Assert.True(exception.Message.Contains("IRequestChannel"), "InvalidCastException exception string should contain 'IRequestChannel'");
+        Assert.True(exception.Message.Contains("IRequestChannel"), 
+            string.Format("InvalidCastException exception string should contain 'IRequestChannel'. Actual message:\r\n" + exception.ToString()));
     }
 
     [Fact]


### PR DESCRIPTION
When some checks for Assert.True were done to verify the contents of an exception message, the Assert.True statement did not report the full failing exception message. 

Note - for #189 
DuplexChannelFactoryTest.CreateChannel_Using_Http_NoSecurity attempts to check
for the string 'IRequestChannel' inside the exception string of the InvalidCastException.
While CoreCLR reports this string, .NET Native does not report anything meaningful inside
the exception string - only "Arg_InvalidCastException" with no further details.

As such, we need to remove this check as it will never pass in .NET Native - even
though this check will work fine in CoreCLR.