### PR TITLE
Make Bridge use configurable location for resources

### DIFF
--- a/src/System.Private.ServiceModel/tests/Common/src/BridgeClient.cs
+++ b/src/System.Private.ServiceModel/tests/Common/src/BridgeClient.cs
@@ -50,8 +50,10 @@ namespace System.ServiceModel.Tests.Common
             using (HttpClient httpClient = new HttpClient())
             {
                 httpClient.BaseAddress = new Uri(BridgeBaseAddress);
+                string resourceFolder = TestProperties.GetProperty(TestProperties.BridgeResourceFolder_PropertyName);
+                string contentPayload = "{ resourcesDirectory : \"" + resourceFolder + "\" }"; 
                 var content = new StringContent(
-                    @"{ resourcesDirectory : ""WcfService"" }",
+                    contentPayload,
                     Encoding.UTF8,
                     "application/json");
                 try

--- a/src/System.Private.ServiceModel/tests/Scenarios/SelfHostWcfService/WcfService.csproj
+++ b/src/System.Private.ServiceModel/tests/Scenarios/SelfHostWcfService/WcfService.csproj
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), wcf.targets))\wcf.targets" Condition=" '$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), wcf.targets))' != '' " />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -11,7 +12,7 @@
     <AssemblyName>WcfService</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <OutputPath>$(SolutionDir)\bin\WcfService\</OutputPath>
+    <OutputPath>$(BridgeResourceFolder)</OutputPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/wcf.targets
+++ b/wcf.targets
@@ -3,12 +3,16 @@
     Overrides for WCF
   -->
 
+  <PropertyGroup>
+     <WcfRootFolder>$(MSBuildThisFileDirectory)</WcfRootFolder>
+  </PropertyGroup>
+
   <PropertyGroup Condition="'$(BridgeResourceFolder)' == ''">
-     <BridgeResourceFolder>$(MSBuildThisFileDirectory)bin\wcf\BridgeResources\</BridgeResourceFolder>
+     <BridgeResourceFolder>$(WcfRootFolder)bin\Wcf\Bridge\Resources\</BridgeResourceFolder>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(WcfToolsOutputPath)' == ''">
-     <WcfToolsOutputPath>$(MSBuildThisFileDirectory)bin\wcf\tools\</WcfToolsOutputPath>
+     <WcfToolsOutputPath>$(WcfRootFolder)bin\Wcf\tools\</WcfToolsOutputPath>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
TestProperties contains a configurable property for the
location of the Bridge's resources.  This PR makes the
WcfService compile to that location, and the Bridge client
configures the Bridge using this location.

Fixes #186