### PR TITLE
This is the initial commit for the stress tests.

### DIFF
--- a/src/System.Private.ServiceModel/tests/Stress/SharedPoolsOfWCFObjects/CallStats.cs
+++ b/src/System.Private.ServiceModel/tests/Stress/SharedPoolsOfWCFObjects/CallStats.cs
@@ -1,0 +1,205 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Collections.Concurrent;
+using System.Threading;
+using System.Diagnostics;
+
+namespace WCFClientStressTests
+{
+    /// <summary>
+    /// This class provides a few Call*AndRecordStats() utility methods which will store and aggregate the timing of the delegates they invoke 
+    /// 
+    /// Note: all Call*AndRecordStats() methods catch all exceptions coming from the delegates
+    /// However we don't want to miss the case when an unexpected exception happens for the calls that should never have exceptions
+    /// </summary>
+    public class CallStats
+    {
+        public CallTimingStatsCollector SunnyDay { get; set; }
+        public CallTimingStatsCollector RainyDay { get; set; }
+
+        public static int SunnyDaySamples = 1000000;
+        public static int RainyDaySamples = 10000;
+
+        public CallStats()
+            : this(SunnyDaySamples, RainyDaySamples, CallTimingStatsCollector.CalculateSomePercentiles, CallTimingStatsCollector.CalculateSomePercentiles)
+        {
+        }
+
+        public CallStats(int samples, int errorSamples)
+            : this(samples, errorSamples, CallTimingStatsCollector.CalculateSomePercentiles, CallTimingStatsCollector.CalculateSomePercentiles)
+        {
+        }
+
+        public CallStats(int samples, int errorSamples, Func<long[], TimingPercentileStats> statsCalculator, Func<long[], TimingPercentileStats> errorStatsCalculator)
+        {
+            SunnyDay = new CallTimingStatsCollector(samples, statsCalculator);
+            RainyDay = new CallTimingStatsCollector(errorSamples, errorStatsCalculator);
+        }
+
+        public void CallActionAndRecordStats(Action action)
+        {
+            Stopwatch sw = new Stopwatch();
+            try
+            {
+                sw.Restart();
+                action();
+                SunnyDay.AddCallTiming(sw.ElapsedTicks);
+            }
+            catch (Exception e)
+            {
+                RainyDay.AddCallTiming(sw.ElapsedTicks);
+            }
+        }
+
+        public T CallFuncAndRecordStats<T>(Func<T> func)
+        {
+            T result = default(T);
+            Stopwatch sw = new Stopwatch();
+            try
+            {
+                sw.Restart();
+                result = func();
+                SunnyDay.AddCallTiming(sw.ElapsedTicks);
+            }
+            catch (Exception e)
+            {
+                RainyDay.AddCallTiming(sw.ElapsedTicks);
+            }
+            return result;
+        }
+
+        public T CallFuncAndRecordStats<T, P>(Func<P, T> func, P param)
+        {
+            T result = default(T);
+            Stopwatch sw = new Stopwatch();
+            try
+            {
+                sw.Restart();
+                result = func(param);
+                SunnyDay.AddCallTiming(sw.ElapsedTicks);
+            }
+            catch (Exception e)
+            {
+                RainyDay.AddCallTiming(sw.ElapsedTicks);
+            }
+            return result;
+        }
+
+        public async Task CallAsyncFuncAndRecordStatsAsync(Func<Task> func)
+        {
+            Stopwatch sw = new Stopwatch();
+            try
+            {
+                sw.Restart();
+                await func();
+                SunnyDay.AddCallTiming(sw.ElapsedTicks);
+            }
+            catch (Exception e)
+            {
+                RainyDay.AddCallTiming(sw.ElapsedTicks);
+            }
+        }
+
+        public async Task CallAsyncFuncAndRecordStatsAsync<P>(Func<P, Task> func, P param)
+        {
+            Stopwatch sw = new Stopwatch();
+            try
+            {
+                sw.Restart();
+                await func(param);
+                SunnyDay.AddCallTiming(sw.ElapsedTicks);
+            }
+            catch (Exception e)
+            {
+                RainyDay.AddCallTiming(sw.ElapsedTicks);
+            }
+        }
+    }
+
+    public class TimingPercentileStats
+    {
+        public DateTime Time;       // Time when the stats were calculated
+        public int[] Centile;       // negative % means take bottom part, positive % means take top part
+        public long[] AvgTiming;    // within this time
+    }
+
+    public class CallTimingStatsCollector
+    {
+        private int _samples;
+        private int _numCalls;
+        private long[] _timings;
+        private Object _lock = new Object();
+        private Func<long[], TimingPercentileStats> _statsCalculator;
+        public ConcurrentQueue<TimingPercentileStats> PercentileStats { get; set; }
+
+        public CallTimingStatsCollector(int samples, Func<long[], TimingPercentileStats> statsCalculator)
+        {
+            _samples = samples;
+            _timings = new long[_samples * 2];
+            _statsCalculator = statsCalculator;
+            PercentileStats = new ConcurrentQueue<TimingPercentileStats>();
+        }
+
+        // For the most part lock-free and isn't particularly thread safe
+        //
+        // However here we use it without any additional synchronization 
+        // since we use a large number of samples and 
+        public void AddCallTiming(long ticks)
+        {
+            int index = Interlocked.Increment(ref _numCalls) % (_samples * 2);
+            _timings[index] = ticks;
+
+            if (index % _samples == 0)
+            {
+                // if we get a context switch here then the data in _timings may get overwritten by other threads calling AddCallTiming()
+                // however no data will be lost if there were fewer than _samples calls while we make a copy of our half of _timings
+                // the copy may land into LOH - before trying to optimize it we'll need to optimize _statsCalculator as well
+                long[] copy = new long[_samples];
+                int timingsIndex = index == 0 ? _samples + 1 : 1;
+                // this almost useless lock will only stop the first thread that wrapped up _samples calls while we copy the data
+                lock (_lock)
+                {
+                    for (int i = 0; i < _samples; i++)
+                    {
+                        int ti = (timingsIndex + i) % (_samples * 2);
+                        copy[i] = _timings[ti];
+                    }
+                }
+                //calculate percentiles
+                PercentileStats.Enqueue(_statsCalculator(copy));
+            }
+        }
+
+        public static TimingPercentileStats CalculateSomePercentiles(long[] timingArr)
+        {
+            var stats = new TimingPercentileStats()
+            {
+                Time = DateTime.Now,
+                Centile = new int[] { -50, 1 },
+                AvgTiming = new long[2]
+            };
+
+            for (int i = 0; i < stats.Centile.Length; i++)
+            {
+                if (stats.Centile[i] < 0)
+                {
+                    int lowestXPctNum = (timingArr.Length * -1 * stats.Centile[i]) / 100;
+                    stats.AvgTiming[i] = timingArr.OrderBy(t1 => t1).Take(lowestXPctNum).Sum(t2 => t2) / lowestXPctNum;
+                }
+                else
+                {
+                    int topXPctNum = (timingArr.Length * stats.Centile[i]) / 100;
+                    stats.AvgTiming[i] = timingArr.OrderByDescending(t1 => t1).Take(topXPctNum).Sum(t2 => t2) / topXPctNum;
+                }
+
+                //Console.WriteLine(String.Format("Percentile {0}, time {1}", stats.Centile[i], stats.AvgTiming[i]));
+            }
+
+            return stats;
+        }
+    }
+}

--- a/src/System.Private.ServiceModel/tests/Stress/SharedPoolsOfWCFObjects/IService1.cs
+++ b/src/System.Private.ServiceModel/tests/Stress/SharedPoolsOfWCFObjects/IService1.cs
@@ -1,0 +1,47 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Threading.Tasks;
+using System.ServiceModel;
+using System.Runtime.Serialization;
+
+
+namespace WcfService1
+{
+    // NOTE: You can use the "Rename" command on the "Refactor" menu to change the interface name "IService1" in both code and config file together.
+    [ServiceContract]
+    public interface IService1
+    {
+        [OperationContract]
+        string GetData(int value);
+
+        [OperationContractAttribute(Name = "GetData")]
+        Task<string> GetDataAsync(int value);
+
+        [OperationContract]
+        CompositeType GetDataUsingDataContract(CompositeType composite);
+    }
+
+
+    // Use a data contract as illustrated in the sample below to add composite types to service operations.
+    [DataContract]
+    public class CompositeType
+    {
+        bool boolValue = true;
+        string stringValue = "Hello ";
+
+        [DataMember]
+        public bool BoolValue
+        {
+            get { return boolValue; }
+            set { boolValue = value; }
+        }
+
+        [DataMember]
+        public string StringValue
+        {
+            get { return stringValue; }
+            set { stringValue = value; }
+        }
+    }
+}

--- a/src/System.Private.ServiceModel/tests/Stress/SharedPoolsOfWCFObjects/PoolOfThings.cs
+++ b/src/System.Private.ServiceModel/tests/Stress/SharedPoolsOfWCFObjects/PoolOfThings.cs
@@ -1,0 +1,374 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace WCFClientStressTests
+{
+    // Pooling of WCF channel factories and channels is a commonly reccomended practice due to its perf benefits.
+    // However with pooling come more race condition-like scenarios such as using an already faulted channel or factory.
+    // 
+    // The number of such scenarios is rather significant:
+    // - create and use a pool of channels using a pool of channel factories
+    // - replace and close channels under stress
+    // - replace and close channel factories under stress
+    // - manipulate a pooled channel or a pooled factory state while others use them
+    // 
+    // PoolOfThings and PoolOfAsyncThings classes help to organize generic pools of objects
+    // FactoryAndPoolOfItsObjects and FactoryAndPoolOfItsAsyncObjects classes help to organize pools of pools of objects
+    // 
+
+    public class PoolOfThings<T> : IDisposable where T : class
+    {
+        private T[] _thePool;
+        private int _maxSize;
+
+        private Func<T> _createInstance;
+        private Action<T> _destroyInstance;
+
+        /// <summary>
+        /// ctor taking sync versions of delegates
+        /// </summary>
+        /// <param name="maxSize"> number of pooled instances </param>
+        /// <param name="createInstance"> delegate to create a new instance; can return null in which case the pool will store null until DestoryAllPooledInstances is called </param>
+        /// <param name="destroyInstance"></param>
+        public PoolOfThings(int maxSize, Func<T> createInstance, Action<T> destroyInstance)
+        {
+            _thePool = new T[maxSize];
+            _maxSize = maxSize;
+            _createInstance = createInstance;
+            _destroyInstance = destroyInstance;
+        }
+
+        public void Dispose()
+        {
+            DestoryAllPooledInstances();
+        }
+
+        // Replaces the pool of channels with a new one and destory all instances in the previous pool
+        public void DestoryAllPooledInstances()
+        {
+            // Get the new pool ready
+            T[] newPool = new T[_maxSize];
+
+            // Replace the pool
+            var oldPool = _thePool;
+            if (Interlocked.CompareExchange(ref _thePool, newPool, oldPool) != oldPool)
+            {
+                // somebody beat us - they will be responsible for closing the old _channelsPool they replaced
+            }
+            else
+            {
+                // we are the one who replaced the old _thePool - we're responsible for cleaning it up
+                DestroyAllPooledInstanciesImpl(oldPool, _destroyInstance);
+            }
+        }
+
+        public IEnumerable<T> GetAllPooledInstances()
+        {
+            return new AllPooledInstancesCollection(this);
+        }
+
+        #region helpers
+
+        private class AllPooledInstancesCollection : IEnumerable<T>
+        {
+            private PoolOfThings<T> _thePool;
+            public AllPooledInstancesCollection(PoolOfThings<T> thePool)
+            {
+                _thePool = thePool;
+            }
+
+            public IEnumerator<T> GetEnumerator()
+            {
+                for (int i = 0; i < _thePool._thePool.Length; i++)
+                {
+                    var instance = _thePool.GetPooledInstance(i);
+                    // skip nulls 
+                    if (instance != default(T))
+                    {
+                        yield return instance;
+                    }
+                }
+            }
+
+            IEnumerator IEnumerable.GetEnumerator()
+            {
+                return GetEnumerator();
+            }
+        }
+
+        private T GetPooledInstance(int i)
+        {
+            var instance = _thePool[i];
+            while (instance == null)
+            {
+                //try
+                {
+                    instance = _createInstance();
+                    if (instance == null)
+                    {
+                        break;
+                    }
+                    if (Interlocked.CompareExchange<T>(ref _thePool[i], instance, null) != null)
+                    {
+                        _destroyInstance(instance);
+                        instance = _thePool[i];
+                        // Somebody stored the new instance before us - dispose ours and re-read theirs
+                        // Since the whole pool can also be replaced we can still get a null from _thePool[index]
+                        // so we retry while (instance == null)
+                        // Note that _destroyInstance(instance) should not throw since nobody uses it yet
+
+                        //Interlocked.Increment(ref _numPoolSetRetries);
+                    }
+                }
+                //catch (Exception)
+                {
+                    //    break;
+                }
+            }
+            return instance;
+        }
+
+        private void DestroyAllPooledInstanciesImpl(T[] instancesPool, Action<T> destroyInstance)
+        {
+            foreach (var instance in instancesPool)
+            {
+                if (instance != null)
+                {
+                    try
+                    {
+                        //Interlocked.Increment(ref _stats.FactoriesClosed);
+                        destroyInstance(instance);
+                    }
+                    catch (Exception e)
+                    {
+                        //Interlocked.Increment(ref _stats.ExceptionsClosingFactories);
+                    }
+                }
+            }
+        }
+        #endregion
+    }
+    public class PoolOfAsyncThings<T> : IDisposable where T : class
+    {
+        private T[] _thePool;
+        private int _maxSize;
+
+        private Func<T> _createInstance;
+        private Func<T, Task> _destroyInstanceAsync;
+
+        /// <summary>
+        /// ctor taking sync versions of delegates
+        /// </summary>
+        /// <param name="maxSize"> number of pooled instances </param>
+        /// <param name="createInstance"> delegate to create a new instance; can return null in which case the pool will store null until DestoryAllPooledInstancesAsync is called </param>
+        /// <param name="destroyInstance"></param>
+        public PoolOfAsyncThings(int maxSize, Func<T> createInstance, Func<T, Task> destroyInstanceAsync)
+        {
+            _thePool = new T[maxSize];
+            _maxSize = maxSize;
+            _createInstance = createInstance;
+            _destroyInstanceAsync = destroyInstanceAsync;
+        }
+
+        public void Dispose()
+        {
+            DestoryAllPooledInstancesAsync().Wait();
+        }
+
+        // Replaces the pool of channels with a new one and destory all instances in the previous pool
+        public async Task DestoryAllPooledInstancesAsync()
+        {
+            // Get the new pool ready
+            T[] newPool = new T[_maxSize];
+
+            // Replace the pool
+            var oldPool = _thePool;
+            if (Interlocked.CompareExchange(ref _thePool, newPool, oldPool) != oldPool)
+            {
+                // somebody beat us - they will be responsible for closing the old _channelsPool they replaced
+            }
+            else
+            {
+                // we are the one who replaced the old _thePool - we're responsible for cleaning it up
+                await DestroyAllPooledInstanciesImplAsync(oldPool, _destroyInstanceAsync);
+            }
+        }
+
+        public IEnumerable<T> GetAllPooledInstances()
+        {
+            return new AllPooledInstancesCollection(this);
+        }
+
+        #region helpers
+
+        private class AllPooledInstancesCollection : IEnumerable<T>
+        {
+            private PoolOfAsyncThings<T> _thePool;
+            public AllPooledInstancesCollection(PoolOfAsyncThings<T> thePool)
+            {
+                _thePool = thePool;
+            }
+
+            public IEnumerator<T> GetEnumerator()
+            {
+                for (int i = 0; i < _thePool._thePool.Length; i++)
+                {
+                    var instance = _thePool.GetPooledInstance(i);
+                    // skip nulls 
+                    if (instance != default(T))
+                    {
+                        yield return instance;
+                    }
+                }
+            }
+
+            IEnumerator IEnumerable.GetEnumerator()
+            {
+                return GetEnumerator();
+            }
+        }
+
+        private T GetPooledInstance(int i)
+        {
+            var instance = _thePool[i];
+            while (instance == null)
+            {
+                instance = _createInstance();
+                if (instance == null)
+                {
+                    break;
+                }
+                if (Interlocked.CompareExchange<T>(ref _thePool[i], instance, null) != null)
+                {
+                    // We're deliberately not awaiting it
+                    _destroyInstanceAsync(instance);
+                    instance = _thePool[i];
+                    // Somebody stored the new instance before us - dispose ours and re-read theirs
+                    // Since the whole pool can also be replaced we can still get a null from _thePool[index]
+                    // so we retry while (instance == null)
+                    // Note that _destroyInstance(instance) should not throw since nobody uses it yet
+
+                    //Interlocked.Increment(ref _numPoolSetRetries);
+                }
+            }
+            return instance;
+        }
+
+        private async Task DestroyAllPooledInstanciesImplAsync(T[] instancesPool, Func<T, Task> destroyInstanceAsync)
+        {
+            foreach (var instance in instancesPool)
+            {
+                if (instance != null)
+                {
+                    try
+                    {
+                        //Interlocked.Increment(ref _stats.FactoriesClosed);
+                        await destroyInstanceAsync(instance);
+                    }
+                    catch (Exception e)
+                    {
+                        //Interlocked.Increment(ref _stats.ExceptionsClosingFactories);
+                    }
+                }
+            }
+        }
+        #endregion
+    }
+
+    /// <summary>
+    /// This helper classes below group a factory F with a pool of objects O created with the help of the factory
+    /// Keeping them together makes it easier to create and cleanup pools of pools of objects
+    /// Unlike the traditional factory patters, rather than demanding the factory F to be able to create/destroy 
+    /// instances of O we take delegates to create/destroy instances of O as constructor parameters.
+    /// This allows us to decouple F and O and makes it easy to introduce additional wrappers around the instances F creates
+    /// </summary>
+    public class FactoryAndPoolOfItsObjects<F, O>
+        where F : class
+        where O : class
+    {
+        private Action<F> _destroyFactoryInstance;
+        public F Factory { get; set; }
+        public PoolOfThings<O> ObjectsPool { get; set; }
+
+        /// <summary>
+        /// The constructor simply creates an empty pool of objects and stores delegates to create/destroy instances
+        /// </summary>
+        /// <param name="createFactoryInstance"> A func to create an instance of F. </param>
+        /// <param name="destroyFactoryInstance"> An action to destroy an instance of F</param>
+        /// <param name="maxPooledObjects"> Max size of the pool of objects O </param>
+        /// <param name="createObject"> A func to create all instances of O </param>
+        /// <param name="destroyObject"> An action to destroy all instances of O</param>
+        public FactoryAndPoolOfItsObjects(Func<F> createFactoryInstance, Action<F> destroyFactoryInstance, int maxPooledObjects, Func<F, O> createObject, Action<O> destroyObject)
+        {
+            _destroyFactoryInstance = destroyFactoryInstance;
+            Factory = createFactoryInstance();
+            ObjectsPool = new PoolOfThings<O>(
+                maxSize: maxPooledObjects,
+                createInstance: () =>
+                {
+                    // PoolOfThings lets us use the instances while destroying them
+                    // Destroy may null Factory out so we save a local copy here
+                    var f = Factory;
+                    return f != null ? createObject(f) : null;
+                },
+                destroyInstance: destroyObject);
+        }
+
+        public void Destroy()
+        {
+            // should never be recycled more than once
+            if (Factory == null)
+            {
+                System.Diagnostics.Debugger.Break();
+            }
+            _destroyFactoryInstance(Factory);
+            Factory = null;
+        }
+    }
+
+    public class FactoryAndPoolOfItsAsyncObjects<F, O>
+        where F : class
+        where O : class
+    {
+        private Func<F, Task> _destroyFactoryInstanceAsync;
+        public F Factory { get; set; }
+        public PoolOfAsyncThings<O> ObjectsPool { get; set; }
+        public FactoryAndPoolOfItsAsyncObjects(
+            Func<F> createFactoryInstance,
+            Func<F, Task> destroyFactoryInstanceAsync,
+            int maxPooledObjects,
+            Func<F, O> createObject,
+            Func<O, Task> destroyObjectAsync)
+        {
+            _destroyFactoryInstanceAsync = destroyFactoryInstanceAsync;
+            Factory = createFactoryInstance();
+            ObjectsPool = new PoolOfAsyncThings<O>(
+                maxSize: maxPooledObjects,
+                createInstance: () =>
+                {
+                    // PoolOfThings lets us use the instances while destroying them
+                    // DestroyAsync may null Factory out so we save a local copy
+                    var f = Factory;
+                    return f != null ? createObject(f) : null;
+                },
+                destroyInstanceAsync: async (o) => await destroyObjectAsync(o));
+        }
+
+        public async Task DestroyAsync()
+        {
+            // should never be recycled more than once
+            if (Factory == null)
+            {
+                System.Diagnostics.Debugger.Break();
+            }
+            await _destroyFactoryInstanceAsync(Factory);
+            Factory = null;
+        }
+    }
+}

--- a/src/System.Private.ServiceModel/tests/Stress/SharedPoolsOfWCFObjects/Program.cs
+++ b/src/System.Private.ServiceModel/tests/Stress/SharedPoolsOfWCFObjects/Program.cs
@@ -1,0 +1,84 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Threading.Tasks;
+
+namespace WCFClientStressTests
+{
+    public class Program
+    {
+        public void Main(string[] args)
+        {
+            ProcessRunOptions(args);
+
+            DoTheRun(3000000);
+
+            Console.WriteLine("Done. Press Enter to GC.");
+            Console.ReadLine();
+            GC.Collect();
+            Console.WriteLine("After GC");
+            Console.ReadLine();
+        }
+
+        private void ProcessRunOptions(string[] args)
+        {
+            // All hardcoded right now, but we need to extract the following from the parameters:
+            //  -   HostName
+            //  -   AppName
+            //  -   TCP/HTTP
+            //  -   duration and/or # of iterations to run
+            //  -   # factories to pool
+            //  -   # channels to pool
+            //  -   etc
+            TestHelpers.SetHostAndProtocol(useHttp: false, hostName: "localhost", appName: "WcfService1");
+        }
+
+        private void DoTheRun(int iterations)
+        {
+            Console.WriteLine("Start");
+            Task[] allTasks = new Task[23];
+            for (int t = 0; t < allTasks.Length; t++)
+            {
+                int tt = t;
+                allTasks[t] = Task.Run(() =>
+                {
+                    var ttt = tt;
+                    for (int i = 0; i < iterations; i++)
+                    {
+                        try
+                        {
+                            RunAllStressTests();
+                        }
+                        catch (Exception e)
+                        {
+                            System.Diagnostics.Debugger.Break();
+                        }
+
+                        if (i % 1000 == 0)
+                        {
+                            Console.WriteLine(ttt + " " + i);
+                        }
+                    }
+                    Console.WriteLine(ttt + ": done");
+                });
+            }
+            Task.WaitAll(allTasks);
+
+            Console.WriteLine("Dispose all");
+            StaticDisposablesHelper.DisposeAll();
+        }
+
+        public void RunAllStressTests()
+        {
+            CreateAndCloseFactoryAndChannelFullCycleTest.CreateFactoriesAndChannelsUseAllOnceCloseAll();
+            PooledFactoriesAndChannels.UseChannelsInPooledFactoriesAndChannels();
+            // will get stuck with wcf/issues/108
+            // RecyclablePooledFactoriesAndChannels.RunAllScenariosWithWeights(100, 1, 1); 
+            RecyclablePooledFactoriesAndChannels_OpenOnce.RunAllScenariosWithWeights(1000, 1, 1);
+            RecyclablePooledFactoriesAndChannelsAsync_OpenOnce.RunAllScenariosWithWeightsAsync(1000, 1, 1).Wait();
+            PooledFactories.CreateUseAndCloseChannels();
+            RecyclablePooledFactories.RunAllScenariosWithWeights(100, 1);
+        }
+    }
+}

--- a/src/System.Private.ServiceModel/tests/Stress/SharedPoolsOfWCFObjects/SharedPoolsOfWCFObjects.cs
+++ b/src/System.Private.ServiceModel/tests/Stress/SharedPoolsOfWCFObjects/SharedPoolsOfWCFObjects.cs
@@ -1,0 +1,612 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using System.ServiceModel;
+using System.Text;
+using System.Threading;
+using System.Collections.Concurrent;
+
+namespace WCFClientStressTests
+{
+    #region Actual tests
+    // A full cycle of creating a pool of channel factories, using each factory to create
+    // a pool of channels, using all channels once and then closing all of them
+    public static class CreateAndCloseFactoryAndChannelFullCycleTest
+    {
+        private static CallStats s_CreateChannelStats = new CallStats();
+        private static CallStats s_CallChannelStats = new CallStats();
+        private static CallStats s_CloseChannelStats = new CallStats();
+        private static CallStats s_CloseFactoryStats = new CallStats();
+
+        static CreateAndCloseFactoryAndChannelFullCycleTest()
+        {
+        }
+        public static void CreateFactoriesAndChannelsUseAllOnceCloseAll()
+        {
+            using (var theOneTimeThing = new PoolOfThings<FactoryAndPoolOfItsObjects<ChannelFactory<WcfService1.IService1>, WcfService1.IService1>>(
+                    maxSize: 3, // # of pooled FactoryAndPoolOfItsObjects
+                    createInstance: () => new FactoryAndPoolOfItsObjects<ChannelFactory<WcfService1.IService1>, WcfService1.IService1>(
+                        createFactoryInstance: () =>
+                            TestHelpers.CreateChannelFactory<WcfService1.IService1>(TestHelpers.CreateEndPointAddress(), TestHelpers.CreateBinding()),
+                        destroyFactoryInstance: (chf) =>
+                            s_CloseFactoryStats.CallActionAndRecordStats(() => TestHelpers.CloseFactory(chf)),
+                        maxPooledObjects: 3, // # of pooled channels within each pooled FactoryAndPoolOfItsObjects
+                        createObject: (chf) =>
+                            s_CreateChannelStats.CallFuncAndRecordStats(TestHelpers.CreateChannel, chf),
+                        destroyObject: (ch) =>
+                            s_CloseChannelStats.CallActionAndRecordStats(() => TestHelpers.CloseChannel(ch))
+                        ),
+                    destroyInstance: (_fapoic) => _fapoic.Destroy()))
+            {
+                foreach (var factoryAndPoolOfItsChannels in theOneTimeThing.GetAllPooledInstances())
+                {
+                    foreach (var channel in factoryAndPoolOfItsChannels.ObjectsPool.GetAllPooledInstances())
+                    {
+                        s_CallChannelStats.CallActionAndRecordStats(() =>
+                        {
+                            channel.GetData(44);
+                        });
+                    }
+                }
+            }
+        }
+    }
+
+    // One of the most common scenario: create a pool of channel factories, use each factory to create a pool of channels,
+    // and then use all pooled channels for the duration of the stress run
+    public class PooledFactoriesAndChannels
+    {
+        private static CallStats s_CreateChannelStats = new CallStats();
+        private static CallStats s_CallChannelStats = new CallStats();
+        private static CallStats s_CloseChannelStats = new CallStats();
+        private static CallStats s_CloseFactoryStats = new CallStats();
+        private static PoolOfThings<
+            FactoryAndPoolOfItsObjects<
+                ChannelFactory<WcfService1.IService1>,
+                WcfService1.IService1>
+            > s_pooledFactoriesAndChannels;
+
+        static PooledFactoriesAndChannels()
+        {
+            s_pooledFactoriesAndChannels = StaticDisposablesHelper.AddDisposable(
+                new PoolOfThings<FactoryAndPoolOfItsObjects<ChannelFactory<WcfService1.IService1>, WcfService1.IService1>>(
+                    maxSize: 3, // # of pooled FactoryAndPoolOfItsObjects
+                    createInstance: () => new FactoryAndPoolOfItsObjects<ChannelFactory<WcfService1.IService1>, WcfService1.IService1>(
+                        createFactoryInstance: () =>
+                            TestHelpers.CreateChannelFactory<WcfService1.IService1>(TestHelpers.CreateEndPointAddress(), TestHelpers.CreateBinding()),
+                        destroyFactoryInstance: (chf) =>
+                            s_CloseFactoryStats.CallActionAndRecordStats(() => TestHelpers.CloseFactory(chf)),
+                        maxPooledObjects: 3, // # of pooled channels within each pooled FactoryAndPoolOfItsObjects
+                        createObject: (chf) =>
+                            s_CreateChannelStats.CallFuncAndRecordStats(TestHelpers.CreateChannel, chf),
+                        destroyObject: (ch) =>
+                            s_CloseChannelStats.CallActionAndRecordStats(() => TestHelpers.CloseChannel(ch))
+                        ),
+                    destroyInstance: (_fapoic) => _fapoic.Destroy()));
+        }
+
+        public static void UseChannelsInPooledFactoriesAndChannels()
+        {
+            foreach (var factoryAndPoolOfItsChannels in s_pooledFactoriesAndChannels.GetAllPooledInstances())
+            {
+                foreach (var channel in factoryAndPoolOfItsChannels.ObjectsPool.GetAllPooledInstances())
+                {
+                    s_CallChannelStats.CallActionAndRecordStats(() =>
+                    {
+                        channel.GetData(44);
+                    });
+                }
+            }
+        }
+    }
+
+    public class RecyclablePooledFactoriesAndChannels
+    {
+        private static int s_iteration = 0;
+        private static CallStats s_CreateChannelStats = new CallStats();
+        private static CallStats s_CallChannelStats = new CallStats();
+        private static CallStats s_CloseChannelStats = new CallStats();
+        private static CallStats s_CloseFactoryStats = new CallStats();
+        private static PoolOfThings<FactoryAndPoolOfItsObjects<
+                ChannelFactory<WcfService1.IService1>,
+                WcfService1.IService1>
+            > s_recyclablePooledFactoriesAndChannels;
+
+        static RecyclablePooledFactoriesAndChannels()
+        {
+            s_recyclablePooledFactoriesAndChannels = StaticDisposablesHelper.AddDisposable(
+                new PoolOfThings<FactoryAndPoolOfItsObjects<ChannelFactory<WcfService1.IService1>, WcfService1.IService1>>(
+                    maxSize: 3, // # of pooled FactoryAndPoolOfItsObjects
+                    createInstance: () => new FactoryAndPoolOfItsObjects<ChannelFactory<WcfService1.IService1>, WcfService1.IService1>(
+                        createFactoryInstance: () =>
+                            TestHelpers.CreateChannelFactory<WcfService1.IService1>(TestHelpers.CreateEndPointAddress(), TestHelpers.CreateBinding()),
+                        destroyFactoryInstance: (chf) =>
+                            s_CloseFactoryStats.CallActionAndRecordStats(() => TestHelpers.CloseFactory(chf)),
+                        maxPooledObjects: 3, // # of pooled channels within each pooled FactoryAndPoolOfItsObjects
+                        createObject: (chf) =>
+                            s_CreateChannelStats.CallFuncAndRecordStats(TestHelpers.CreateChannel, chf),
+                        destroyObject: (ch) =>
+                            s_CloseChannelStats.CallActionAndRecordStats(() => TestHelpers.CloseChannel(ch))
+                        ),
+                    destroyInstance: (_fapoic) => _fapoic.Destroy()));
+        }
+
+        public static void RunAllScenariosWithWeights(int useWeight, int recycleChannelsWeight, int recycleFactoriesWeight)
+        {
+            int seed = Interlocked.Increment(ref s_iteration) % (useWeight + recycleChannelsWeight + recycleFactoriesWeight);
+            if (seed < useWeight)
+            {
+                UsePooledChannels();
+            }
+            else if (seed < useWeight + recycleChannelsWeight)
+            {
+                RecyclePooledChannels();
+            }
+            else if (seed < useWeight + recycleChannelsWeight + recycleFactoriesWeight)
+            {
+                RecyclePooledFactories();
+            }
+        }
+
+        public static void UsePooledChannels()
+        {
+            foreach (var factoryAndPoolOfItsChannels in s_recyclablePooledFactoriesAndChannels.GetAllPooledInstances())
+            {
+                foreach (var channel in factoryAndPoolOfItsChannels.ObjectsPool.GetAllPooledInstances())
+                {
+                    s_CallChannelStats.CallActionAndRecordStats(() =>
+                    {
+                        channel.GetData(44);
+                    });
+                }
+            }
+        }
+
+        public static void RecyclePooledChannels()
+        {
+            Console.WriteLine("RecyclePooledChannels");
+            foreach (var factoryAndPoolOfItsChannels in s_recyclablePooledFactoriesAndChannels.GetAllPooledInstances())
+            {
+                factoryAndPoolOfItsChannels.ObjectsPool.DestoryAllPooledInstances();
+            }
+        }
+
+        public static void RecyclePooledFactories()
+        {
+            Console.WriteLine("RecyclePooledFactories");
+            s_recyclablePooledFactoriesAndChannels.DestoryAllPooledInstances();
+            // additional checks - move to DestoryAllPooledInstances itself
+            foreach (var factoryAndPoolOfItsChannels in s_recyclablePooledFactoriesAndChannels.GetAllPooledInstances())
+            {
+                if (factoryAndPoolOfItsChannels.Factory.State == CommunicationState.Closed)
+                {
+                    System.Diagnostics.Debugger.Break();
+                }
+            }
+        }
+    }
+
+    public class RecyclablePooledFactoriesAndChannels_OpenOnce
+    {
+        private static int s_iteration = 0;
+        private static CallStats s_CreateChannelStats = new CallStats(samples: 1000, errorSamples: 1000);
+        private static CallStats s_CallChannelStats = new CallStats(samples: 1000000, errorSamples: 10000);
+        private static CallStats s_CloseChannelStats = new CallStats(samples: 1000, errorSamples: 1000);
+        private static CallStats s_CloseFactoryStats = new CallStats(samples: 1000, errorSamples: 1000);
+        private static PoolOfThings<FactoryAndPoolOfItsObjects<
+                ChannelFactory<WcfService1.IService1>,
+                OpenOnceChannelWrapper<WcfService1.IService1>>
+            > s_recyclablePooledFactoriesAndChannels;
+
+        static RecyclablePooledFactoriesAndChannels_OpenOnce()
+        {
+            s_recyclablePooledFactoriesAndChannels = StaticDisposablesHelper.AddDisposable(
+                new PoolOfThings<FactoryAndPoolOfItsObjects<ChannelFactory<WcfService1.IService1>, OpenOnceChannelWrapper<WcfService1.IService1>>>(
+                    maxSize: 3, // # of pooled FactoryAndPoolOfItsObjects
+                    createInstance: () => new FactoryAndPoolOfItsObjects<ChannelFactory<WcfService1.IService1>, OpenOnceChannelWrapper<WcfService1.IService1>>(
+                        createFactoryInstance: () =>
+                            TestHelpers.CreateChannelFactory<WcfService1.IService1>(TestHelpers.CreateEndPointAddress(), TestHelpers.CreateBinding()),
+                        destroyFactoryInstance: (chf) =>
+                            s_CloseFactoryStats.CallActionAndRecordStats(() => TestHelpers.CloseFactory(chf)),
+                        maxPooledObjects: 3, // # of pooled channels within each pooled FactoryAndPoolOfItsObjects
+                        createObject: (chf) =>
+                            s_CreateChannelStats.CallFuncAndRecordStats(func: () => new OpenOnceChannelWrapper<WcfService1.IService1>(TestHelpers.CreateChannel(chf))),
+                        destroyObject: (chWr) =>
+                            s_CloseChannelStats.CallActionAndRecordStats(action: () => TestHelpers.CloseChannel(chWr.Channel))
+                        ),
+                    destroyInstance: (_fapoic) => _fapoic.Destroy()));
+        }
+
+        public static void RunAllScenariosWithWeights(int useWeight, int recycleChannelsWeight, int recycleFactoriesWeight)
+        {
+            int seed = new Random(Interlocked.Increment(ref s_iteration)).Next(useWeight + recycleChannelsWeight + recycleFactoriesWeight);
+            if (seed < useWeight)
+            {
+                UsePooledChannels();
+            }
+            else if (seed < useWeight + recycleChannelsWeight)
+            {
+                RecyclePooledChannels();
+            }
+            else if (seed < useWeight + recycleChannelsWeight + recycleFactoriesWeight)
+            {
+                RecyclePooledFactories();
+            }
+
+            // move this outside of the test - an external code should query the test for its call stats
+            if (Interlocked.Increment(ref s_iteration) % 1000000 == 0)
+            {
+                var sb = new StringBuilder();
+                sb.AppendLine("CreateChannelStats: ");
+                PrintStats(s_CreateChannelStats, sb);
+                sb.AppendLine();
+
+                sb.AppendLine("CallChannelStats: ");
+                PrintStats(s_CallChannelStats, sb);
+                sb.AppendLine();
+
+                sb.AppendLine("CloseChannelStats: ");
+                PrintStats(s_CloseChannelStats, sb);
+                sb.AppendLine();
+
+                sb.AppendLine("CloseFactoryStats: ");
+                PrintStats(s_CloseFactoryStats, sb);
+                sb.AppendLine();
+
+                Console.WriteLine(sb.ToString());
+            }
+        }
+
+        // move this outside of the test - an external code should query the test for its call stats
+        private static void PrintStats(CallStats stats, StringBuilder sb)
+        {
+            sb.AppendLine("Sunny:");
+            AppendStats(stats.SunnyDay, sb);
+            sb.AppendLine("Rainy:");
+            AppendStats(stats.RainyDay, sb);
+        }
+
+        // move this outside of the test - an external code should query the test for its call stats
+        private static void AppendStats(CallTimingStatsCollector tstats, StringBuilder sb)
+        {
+            foreach (var stat in tstats.PercentileStats)
+            {
+                sb.AppendLine("Time: " + stat.Time);
+                for (int i = 0; i < stat.Centile.Length; i++)
+                {
+                    sb.AppendLine(stat.Centile[i] + ": " + stat.AvgTiming[i]);
+                }
+            }
+        }
+
+        public static void UsePooledChannels()
+        {
+            foreach (var factoryAndPoolOfItsChannels in s_recyclablePooledFactoriesAndChannels.GetAllPooledInstances())
+            {
+                foreach (var channelWrapper in factoryAndPoolOfItsChannels.ObjectsPool.GetAllPooledInstances())
+                {
+                    s_CallChannelStats.CallActionAndRecordStats(() =>
+                    {
+                        channelWrapper.OpenChannelOnce();
+                        channelWrapper.Channel.GetData(44);
+                    });
+                }
+            }
+        }
+
+        public static void AbortPooledChannels()
+        {
+            foreach (var factoryAndPoolOfItsChannels in s_recyclablePooledFactoriesAndChannels.GetAllPooledInstances())
+            {
+                foreach (var channelWrapper in factoryAndPoolOfItsChannels.ObjectsPool.GetAllPooledInstances())
+                {
+                    s_CallChannelStats.CallActionAndRecordStats(() =>
+                    {
+                        var co = (ICommunicationObject)channelWrapper.Channel;
+                        co.Abort();
+                    });
+                }
+            }
+        }
+
+
+        public static void RecyclePooledChannels()
+        {
+            Console.WriteLine("RecyclePooledChannels");
+            foreach (var factoryAndPoolOfItsChannels in s_recyclablePooledFactoriesAndChannels.GetAllPooledInstances())
+            {
+                factoryAndPoolOfItsChannels.ObjectsPool.DestoryAllPooledInstances();
+            }
+        }
+
+        public static void RecyclePooledFactories()
+        {
+            Console.WriteLine("RecyclePooledFactories");
+            s_recyclablePooledFactoriesAndChannels.DestoryAllPooledInstances();
+            foreach (var factoryAndPoolOfItsChannels in s_recyclablePooledFactoriesAndChannels.GetAllPooledInstances())
+            {
+                if (factoryAndPoolOfItsChannels.Factory.State == CommunicationState.Closed)
+                {
+                    System.Diagnostics.Debugger.Break();
+                }
+            }
+        }
+    }
+
+    public class RecyclablePooledFactoriesAndChannelsAsync_OpenOnce
+    {
+        private static int s_iteration = 0;
+        private static CallStats s_CreateChannelStats = new CallStats();
+        private static CallStats s_CallChannelStats = new CallStats();
+        private static CallStats s_CloseChannelStats = new CallStats();
+        private static CallStats s_CloseFactoryStats = new CallStats();
+        private static PoolOfAsyncThings<
+            FactoryAndPoolOfItsAsyncObjects<
+                ChannelFactory<WcfService1.IService1>,
+                OpenAsyncOnceChannelWrapper<WcfService1.IService1>>
+            > s_recyclablePooledFactoriesAndChannels;
+
+        static RecyclablePooledFactoriesAndChannelsAsync_OpenOnce()
+        {
+            s_recyclablePooledFactoriesAndChannels = StaticDisposablesHelper.AddDisposable(
+                new PoolOfAsyncThings<
+                    FactoryAndPoolOfItsAsyncObjects<ChannelFactory<WcfService1.IService1>, OpenAsyncOnceChannelWrapper<WcfService1.IService1>>>(
+                    maxSize: 3, // # of pooled FactoryAndPoolOfItsChannels
+                    createInstance: () => new FactoryAndPoolOfItsAsyncObjects<ChannelFactory<WcfService1.IService1>, OpenAsyncOnceChannelWrapper<WcfService1.IService1>>(
+                        createFactoryInstance: () =>
+                            TestHelpers.CreateChannelFactory<WcfService1.IService1>(TestHelpers.CreateEndPointAddress(), TestHelpers.CreateBinding()),
+                        destroyFactoryInstanceAsync: async (chf) =>
+                            await s_CloseFactoryStats.CallAsyncFuncAndRecordStatsAsync(TestHelpers.CloseFactoryAsync, chf),
+                        maxPooledObjects: 3, // # of pooled channels within each pooled FactoryAndPoolOfItsAsyncObjects
+                        createObject: (chf) =>
+                            s_CreateChannelStats.CallFuncAndRecordStats(func: () => new OpenAsyncOnceChannelWrapper<WcfService1.IService1>(TestHelpers.CreateChannel(chf))),
+                        destroyObjectAsync: async (chWr) =>
+                            await s_CloseChannelStats.CallAsyncFuncAndRecordStatsAsync(func: () => TestHelpers.CloseChannelAsync(chWr.Channel))
+                    ),
+                    destroyInstanceAsync: async (_fapoic) => await _fapoic.DestroyAsync()));
+        }
+
+
+        public static async Task RunAllScenariosWithWeightsAsync(int useWeight, int recycleChannelsWeight, int recycleFactoriesWeight)
+        {
+            int seed = new Random(Interlocked.Increment(ref s_iteration)).Next(useWeight + recycleChannelsWeight + recycleFactoriesWeight);
+            //int seed = Interlocked.Increment(ref s_iteration) % (useWeight + recycleChannelsWeight + recycleFactoriesWeight);
+            if (seed < useWeight)
+            {
+                await UsePooledChannelsAsync();
+            }
+            else if (seed < useWeight + recycleChannelsWeight)
+            {
+                await RecyclePooledChannelsAsync();
+            }
+            else if (seed < useWeight + recycleChannelsWeight + recycleFactoriesWeight)
+            {
+                await RecyclePooledFactoriesAsync();
+            }
+        }
+
+        public static async Task UsePooledChannelsAsync()
+        {
+            var allTasks = new List<Task>();
+            foreach (var factoryAndPoolOfItsChannels in s_recyclablePooledFactoriesAndChannels.GetAllPooledInstances())
+            {
+                foreach (var channelWrapper in factoryAndPoolOfItsChannels.ObjectsPool.GetAllPooledInstances())
+                {
+                    allTasks.Add(s_CallChannelStats.CallAsyncFuncAndRecordStatsAsync(async () =>
+                    {
+                        if (channelWrapper.Channel != null)
+                        {
+                            await channelWrapper.OpenChannelOnceAsync();
+                            var s = await channelWrapper.Channel.GetDataAsync(44);
+                            //Console.WriteLine(s);
+                        }
+                    }));
+                }
+            }
+            await Task.WhenAll(allTasks);
+        }
+
+        public static async Task RecyclePooledChannelsAsync()
+        {
+            Console.WriteLine("RecyclePooledChannels");
+            var allTasks = new List<Task>();
+            foreach (var factoryAndPoolOfItsChannels in s_recyclablePooledFactoriesAndChannels.GetAllPooledInstances())
+            {
+                allTasks.Add(factoryAndPoolOfItsChannels.ObjectsPool.DestoryAllPooledInstancesAsync());
+            }
+            await Task.WhenAll(allTasks);
+        }
+
+        public static async Task RecyclePooledFactoriesAsync()
+        {
+            Console.WriteLine("RecyclePooledFactories");
+            await s_recyclablePooledFactoriesAndChannels.DestoryAllPooledInstancesAsync();
+        }
+    }
+
+    public class PooledFactories
+    {
+        private static CallStats s_CreateChannelStats = new CallStats();
+        private static CallStats s_CallChannelStats = new CallStats();
+        private static CallStats s_CloseChannelStats = new CallStats();
+        private static CallStats s_CloseFactoryStats = new CallStats();
+        private static PoolOfThings<ChannelFactory<WcfService1.IService1>> s_pooledChannelFactories;
+
+        static PooledFactories()
+        {
+            s_pooledChannelFactories = StaticDisposablesHelper.AddDisposable(
+                new PoolOfThings<ChannelFactory<WcfService1.IService1>>(
+                    maxSize: 10,
+                    createInstance: () =>
+                        TestHelpers.CreateChannelFactory<WcfService1.IService1>(TestHelpers.CreateEndPointAddress(), TestHelpers.CreateBinding()),
+                    destroyInstance: (chf) =>
+                         s_CloseFactoryStats.CallActionAndRecordStats(() => TestHelpers.CloseFactory(chf))));
+        }
+        public static void CreateUseAndCloseChannels()
+        {
+            foreach (var factory in s_pooledChannelFactories.GetAllPooledInstances())
+            {
+                WcfService1.IService1 channel = null;
+                s_CreateChannelStats.CallActionAndRecordStats(() =>
+                       channel = factory.CreateChannel());
+
+                if (channel != null)
+                {
+                    s_CallChannelStats.CallActionAndRecordStats(() =>
+                            channel.GetData(1));
+
+                    s_CloseChannelStats.CallActionAndRecordStats(() =>
+                    {
+                        (channel as IClientChannel).Close();
+                    });
+                }
+            }
+        }
+    }
+
+    public class RecyclablePooledFactories
+    {
+        private static int s_iteration = 0;
+        private static CallStats s_CreateChannelStats = new CallStats();
+        private static CallStats s_CallChannelStats = new CallStats();
+        private static CallStats s_CloseChannelStats = new CallStats();
+        private static CallStats s_CloseFactoryStats = new CallStats();
+
+        private static PoolOfThings<ChannelFactory<WcfService1.IService1>> s_recyclablePooledChannelFactories;
+
+        static RecyclablePooledFactories()
+        {
+            s_recyclablePooledChannelFactories = StaticDisposablesHelper.AddDisposable(
+                new PoolOfThings<ChannelFactory<WcfService1.IService1>>(
+                    maxSize: 10,
+                    createInstance: () =>
+                        TestHelpers.CreateChannelFactory<WcfService1.IService1>(TestHelpers.CreateEndPointAddress(), TestHelpers.CreateBinding()),
+                    destroyInstance: (chf) =>
+                         s_CloseFactoryStats.CallActionAndRecordStats(() => TestHelpers.CloseFactory(chf))));
+        }
+        public static void CreateUseAndCloseChannels()
+        {
+            foreach (var factory in s_recyclablePooledChannelFactories.GetAllPooledInstances())
+            {
+                WcfService1.IService1 channel = null;
+                s_CreateChannelStats.CallActionAndRecordStats(() =>
+                       channel = factory.CreateChannel());
+
+                if (channel != null)
+                {
+                    s_CallChannelStats.CallActionAndRecordStats(() =>
+                            channel.GetData(1));
+
+                    s_CloseChannelStats.CallActionAndRecordStats(() =>
+                    {
+                        (channel as IClientChannel).Close();
+                    });
+                }
+            }
+        }
+
+        public static void RecycleFactories()
+        {
+            s_recyclablePooledChannelFactories.DestoryAllPooledInstances();
+        }
+        public static void RunAllScenariosWithWeights(int createUseAndCloseChannelsWeight, int recycleFactoriesWeight)
+        {
+            int seed = Interlocked.Increment(ref s_iteration) % (createUseAndCloseChannelsWeight + recycleFactoriesWeight);
+            if (seed < createUseAndCloseChannelsWeight)
+            {
+                CreateUseAndCloseChannels();
+            }
+            else if (seed < createUseAndCloseChannelsWeight + recycleFactoriesWeight)
+            {
+                RecycleFactories();
+            }
+        }
+    }
+
+    #endregion
+
+    // Helpers
+    public class OpenOnceChannelWrapper<C>
+    {
+        private bool _openCalled = false;
+        private Object _lock = new Object();
+
+        public C Channel { get; set; }
+
+        public OpenOnceChannelWrapper(C c)
+        {
+            Channel = c;
+        }
+        public void OpenChannelOnce()
+        {
+            lock (_lock)
+            {
+                if (!_openCalled)
+                {
+                    (Channel as ICommunicationObject).Open();
+                    _openCalled = true;
+                }
+            }
+        }
+    }
+
+    public class OpenAsyncOnceChannelWrapper<C>
+    {
+        private Task<Task> _openTask = null;
+
+        public C Channel { get; set; }
+
+        public OpenAsyncOnceChannelWrapper(C c)
+        {
+            Channel = c;
+        }
+        public async Task OpenChannelOnceAsync()
+        {
+            // Channel can be null if the factory is in faulted/closed state
+            if (Channel != null)
+            {
+                var co = Channel as ICommunicationObject;
+                // create a cold task
+                var t = new Task<Task>(async () => await Task.Factory.FromAsync(co.BeginOpen, co.EndOpen, TaskCreationOptions.None));
+                // see if we can save it to _openTask
+                if (Interlocked.CompareExchange(ref _openTask, t, null) == null)
+                {
+                    // then we start
+                    t.Start();
+                    // and await its async action
+                    await t.Unwrap();
+                }
+                else
+                {
+                    await _openTask.Unwrap();
+                }
+            }
+        }
+    }
+
+    public class StaticDisposablesHelper
+    {
+        private static ConcurrentQueue<IDisposable> s_disposables = new ConcurrentQueue<IDisposable>();
+        public static DT AddDisposable<DT>(DT t) where DT : IDisposable
+        {
+            s_disposables.Enqueue(t);
+            return t;
+        }
+
+        public static void DisposeAll()
+        {
+            if (s_disposables != null)
+            {
+                IDisposable d = null;
+                while (s_disposables.TryDequeue(out d))
+                {
+                    d.Dispose();
+                }
+                s_disposables = null;
+            }
+        }
+    }
+}

--- a/src/System.Private.ServiceModel/tests/Stress/SharedPoolsOfWCFObjects/SharedPoolsOfWCFObjects.xproj
+++ b/src/System.Private.ServiceModel/tests/Stress/SharedPoolsOfWCFObjects/SharedPoolsOfWCFObjects.xproj
@@ -1,0 +1,20 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>4904c84b-3ea5-425b-aa82-c444c24b88c9</ProjectGuid>
+    <RootNamespace>WCFClientStressTestsCore</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/src/System.Private.ServiceModel/tests/Stress/SharedPoolsOfWCFObjects/TestHelpers.cs
+++ b/src/System.Private.ServiceModel/tests/Stress/SharedPoolsOfWCFObjects/TestHelpers.cs
@@ -1,0 +1,161 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Threading.Tasks;
+using System.ServiceModel;
+using System.ServiceModel.Channels;
+using System.Threading;
+
+
+namespace WCFClientStressTests
+{
+    public static class TestHelpers
+    {
+        private static bool UseHttp { get; set; }
+        private static string HostName { get; set; }
+
+        private static string s_tcpUrl;
+        private static string s_httpUrl;
+
+        public static void SetHostAndProtocol(bool useHttp, string hostName, string appName)
+        {
+            UseHttp = useHttp;
+            HostName = hostName;
+            s_tcpUrl = "net.tcp://" + hostName + ":808/" + appName + "/Service1.svc";
+            s_httpUrl = "http://" + hostName + "/" + appName + "/Service1.svc";
+        }
+
+        public static EndpointAddress CreateEndPointAddress()
+        {
+            return UseHttp ? CreateHttpEndpointAddress() : CreateNetTcpEndpointAddress();
+        }
+
+        public static EndpointAddress CreateNetTcpEndpointAddress()
+        {
+            //string address = "net.tcp://cspod222-04vm4.corp.microsoft.com/WcfService1/Service1.svc";
+            return new EndpointAddress(s_tcpUrl);
+        }
+
+        public static EndpointAddress CreateHttpEndpointAddress()
+        {
+            return new EndpointAddress(s_httpUrl);
+        }
+
+        public static Binding CreateBinding()
+        {
+            return UseHttp ? CreateHttpBinding() : CreateNetTcpBinding();
+        }
+        public static NetTcpBinding CreateNetTcpBinding()
+        {
+            NetTcpBinding binding = new NetTcpBinding();
+            binding.Security = new NetTcpSecurity();
+            binding.Security.Mode = SecurityMode.None;
+            return binding;
+        }
+
+        public static Binding CreateHttpBinding()
+        {
+            return new BasicHttpBinding();
+        }
+
+        public static ChannelFactory<C> CreateChannelFactory<C>(EndpointAddress a, Binding b)
+        {
+            var factory = new ChannelFactory<C>(b, a);
+            new CommunicationObjectEventVerifier(factory);
+            return factory;
+        }
+
+        public static C CreateChannel<C>(ChannelFactory<C> factory)
+        {
+            var channel = factory.CreateChannel();
+            new CommunicationObjectEventVerifier(channel as ICommunicationObject);
+            return channel;
+        }
+
+        public class CommunicationObjectEventVerifier
+        {
+            private int _openedFired;
+            private int _openingFired;
+            private int _closedFired;
+            private int _closingFired;
+            private int _faultedFired;
+
+            public CommunicationObjectEventVerifier(ICommunicationObject channel)
+            {
+                channel.Opened += (_, __) =>
+                {
+                    if (Interlocked.CompareExchange(ref _openedFired, 1, 0) != 0)
+                    {
+                        System.Diagnostics.Debugger.Break();
+                    }
+                };
+
+                channel.Opening += (_, __) =>
+                {
+                    if (Interlocked.CompareExchange(ref _openingFired, 1, 0) != 0)
+                    {
+                        System.Diagnostics.Debugger.Break();
+                    }
+                };
+
+                channel.Closed += (_, __) =>
+                {
+                    if (Interlocked.CompareExchange(ref _closedFired, 1, 0) != 0)
+                    {
+                        System.Diagnostics.Debugger.Break();
+                    }
+                };
+
+                channel.Closing += (_, __) =>
+                {
+                    if (Interlocked.CompareExchange(ref _closingFired, 1, 0) != 0)
+                    {
+                        System.Diagnostics.Debugger.Break();
+                    }
+                };
+
+                channel.Faulted += (_, __) =>
+                {
+                    if (Interlocked.CompareExchange(ref _faultedFired, 1, 0) != 0)
+                    {
+                        System.Diagnostics.Debugger.Break();
+                    }
+                };
+            }
+        }
+
+        private static long s_closeCalls = 0;
+        public static void CloseChannel<C>(C channel)
+        {
+            Interlocked.Increment(ref s_closeCalls);
+            // Getting a null would indicate an issue in harness
+            if (channel == null)
+            {
+                System.Diagnostics.Debugger.Break();
+            }
+            // Getting a null would indicate an issue in tests
+            if (channel as ICommunicationObject == null)
+            {
+                System.Diagnostics.Debugger.Break();
+            }
+
+            ((ICommunicationObject)channel).Close();
+        }
+
+        public static async Task CloseChannelAsync<C>(C channel)
+        {
+            var cc = (channel as IClientChannel);
+            await Task.Factory.FromAsync(cc.BeginClose, cc.EndClose, TaskCreationOptions.None);
+        }
+
+        public static void CloseFactory<C>(ChannelFactory<C> factory)
+        {
+            factory.Close();
+        }
+
+        public static async Task CloseFactoryAsync<C>(ChannelFactory<C> factory)
+        {
+            await Task.Factory.FromAsync(factory.BeginClose, factory.EndClose, TaskCreationOptions.None);
+        }
+    }
+}

--- a/src/System.Private.ServiceModel/tests/Stress/SharedPoolsOfWCFObjects/project.json
+++ b/src/System.Private.ServiceModel/tests/Stress/SharedPoolsOfWCFObjects/project.json
@@ -1,0 +1,35 @@
+﻿{
+  "version": "1.0.0-*",
+  "description": "",
+  "authors": [ "" ],
+  "tags": [ "" ],
+  "projectUrl": "",
+  "licenseUrl": "",
+
+  "dependencies": {
+    "System.Net.Sockets": "4.0.10-beta-*",
+    "System.ServiceModel.NetTcp": "4.0.0-beta-*",
+    "System.ServiceModel.Http": "4.0.10-beta-*",
+    "System.ServiceModel.Primitives": "4.0.0-beta-*",
+    "System.ServiceModel.Security": "4.0.0-beta-*",
+    "System.Console": "4.0.0-beta-*",
+    "System.Collections": "4.0.10-beta-*",
+    "System.Linq": "4.0.0-beta-*",
+    "System.Threading": "4.0.10-beta-*",
+    "System.Diagnostics.Debug": "4.0.10-beta-*",
+    "System.Collections.Specialized": "4.0.0-beta-*",
+
+  },
+
+  "commands": {
+    "WCFClientStressTestsCore" : "WCFClientStressTestsCore"
+  },
+
+  "frameworks" : {
+    "dnxcore50" : {
+      "dependencies": {
+
+      }
+    }
+  }
+}

--- a/src/System.Private.ServiceModel/tests/Stress/SharedPoolsOfWCFObjects/project.lock.json
+++ b/src/System.Private.ServiceModel/tests/Stress/SharedPoolsOfWCFObjects/project.lock.json
@@ -1,0 +1,3317 @@
+{
+  "locked": true,
+  "version": 1,
+  "targets": {
+    "DNXCore,Version=v5.0": {
+      "Microsoft.Win32.Primitives/4.0.0-beta-23110": {
+        "dependencies": {
+          "System.Runtime": "4.0.20-beta-23110",
+          "System.Runtime.InteropServices": "4.0.20-beta-23110"
+        },
+        "compile": {
+          "ref/dotnet/Microsoft.Win32.Primitives.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/Microsoft.Win32.Primitives.dll": {}
+        }
+      },
+      "System.Collections/4.0.10-beta-23110": {
+        "dependencies": {
+          "System.Runtime": "4.0.20-beta-23110"
+        },
+        "compile": {
+          "ref/dotnet/System.Collections.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Collections.dll": {}
+        }
+      },
+      "System.Collections.Concurrent/4.0.10-beta-23110": {
+        "dependencies": {
+          "System.Collections": "4.0.10-beta-23110",
+          "System.Diagnostics.Debug": "4.0.10-beta-23110",
+          "System.Diagnostics.Tracing": "4.0.20-beta-23110",
+          "System.Globalization": "4.0.10-beta-23110",
+          "System.Resources.ResourceManager": "4.0.0-beta-23110",
+          "System.Runtime": "4.0.20-beta-23110",
+          "System.Runtime.Extensions": "4.0.10-beta-23110",
+          "System.Threading": "4.0.10-beta-23110",
+          "System.Threading.Tasks": "4.0.10-beta-23110"
+        },
+        "compile": {
+          "ref/dotnet/System.Collections.Concurrent.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Collections.Concurrent.dll": {}
+        }
+      },
+      "System.Collections.NonGeneric/4.0.0-beta-23110": {
+        "dependencies": {
+          "System.Diagnostics.Debug": "4.0.10-beta-23110",
+          "System.Globalization": "4.0.10-beta-23110",
+          "System.Resources.ResourceManager": "4.0.0-beta-23110",
+          "System.Runtime": "4.0.20-beta-23110",
+          "System.Runtime.Extensions": "4.0.10-beta-23110",
+          "System.Threading": "4.0.10-beta-23110"
+        },
+        "compile": {
+          "ref/dotnet/System.Collections.NonGeneric.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Collections.NonGeneric.dll": {}
+        }
+      },
+      "System.Collections.Specialized/4.0.0-beta-23110": {
+        "dependencies": {
+          "System.Collections.NonGeneric": "4.0.0-beta-23110",
+          "System.Globalization": "4.0.10-beta-23110",
+          "System.Globalization.Extensions": "4.0.0-beta-23110",
+          "System.Resources.ResourceManager": "4.0.0-beta-23110",
+          "System.Runtime": "4.0.20-beta-23110",
+          "System.Runtime.Extensions": "4.0.10-beta-23110",
+          "System.Threading": "4.0.10-beta-23110"
+        },
+        "compile": {
+          "ref/dotnet/System.Collections.Specialized.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Collections.Specialized.dll": {}
+        }
+      },
+      "System.ComponentModel.EventBasedAsync/4.0.10-beta-23110": {
+        "dependencies": {
+          "System.Resources.ResourceManager": "4.0.0-beta-23110",
+          "System.Runtime": "4.0.20-beta-23110",
+          "System.Threading": "4.0.10-beta-23110",
+          "System.Threading.Tasks": "4.0.10-beta-23110"
+        },
+        "compile": {
+          "ref/dotnet/System.ComponentModel.EventBasedAsync.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.ComponentModel.EventBasedAsync.dll": {}
+        }
+      },
+      "System.Console/4.0.0-beta-23110": {
+        "dependencies": {
+          "System.IO": "4.0.10-beta-23110",
+          "System.IO.FileSystem.Primitives": "4.0.0-beta-23110",
+          "System.Resources.ResourceManager": "4.0.0-beta-23110",
+          "System.Runtime": "4.0.20-beta-23110",
+          "System.Runtime.InteropServices": "4.0.20-beta-23110",
+          "System.Text.Encoding": "4.0.10-beta-23110",
+          "System.Text.Encoding.Extensions": "4.0.10-beta-23110",
+          "System.Threading": "4.0.10-beta-23110",
+          "System.Threading.Tasks": "4.0.10-beta-23110"
+        },
+        "compile": {
+          "ref/dotnet/System.Console.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Console.dll": {}
+        }
+      },
+      "System.Diagnostics.Contracts/4.0.0-beta-23110": {
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Diagnostics.Contracts.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Diagnostics.Contracts.dll": {}
+        }
+      },
+      "System.Diagnostics.Debug/4.0.10-beta-23110": {
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Diagnostics.Debug.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Diagnostics.Debug.dll": {}
+        }
+      },
+      "System.Diagnostics.Tracing/4.0.20-beta-23110": {
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Diagnostics.Tracing.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Diagnostics.Tracing.dll": {}
+        }
+      },
+      "System.Globalization/4.0.10-beta-23110": {
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Globalization.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Globalization.dll": {}
+        }
+      },
+      "System.Globalization.Calendars/4.0.0-beta-23110": {
+        "dependencies": {
+          "System.Globalization": "4.0.0",
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Globalization.Calendars.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Globalization.Calendars.dll": {}
+        }
+      },
+      "System.Globalization.Extensions/4.0.0-beta-23110": {
+        "dependencies": {
+          "System.Globalization": "4.0.10-beta-23110",
+          "System.Resources.ResourceManager": "4.0.0-beta-23110",
+          "System.Runtime": "4.0.20-beta-23110",
+          "System.Runtime.Extensions": "4.0.10-beta-23110",
+          "System.Runtime.InteropServices": "4.0.20-beta-23110"
+        },
+        "compile": {
+          "ref/dotnet/System.Globalization.Extensions.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Globalization.Extensions.dll": {}
+        }
+      },
+      "System.IO/4.0.10-beta-23110": {
+        "dependencies": {
+          "System.Runtime": "4.0.20-beta-23110",
+          "System.Text.Encoding": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.IO.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.IO.dll": {}
+        }
+      },
+      "System.IO.Compression/4.0.0-beta-23110": {
+        "dependencies": {
+          "System.Collections": "4.0.10-beta-23110",
+          "System.Diagnostics.Debug": "4.0.10-beta-23110",
+          "System.IO": "4.0.10-beta-23110",
+          "System.Resources.ResourceManager": "4.0.0-beta-23110",
+          "System.Runtime": "4.0.20-beta-23110",
+          "System.Runtime.Extensions": "4.0.10-beta-23110",
+          "System.Runtime.Handles": "4.0.0-beta-23110",
+          "System.Runtime.InteropServices": "4.0.20-beta-23110",
+          "System.Text.Encoding": "4.0.10-beta-23110",
+          "System.Threading": "4.0.0",
+          "System.Threading.Tasks": "4.0.10-beta-23110"
+        },
+        "compile": {
+          "ref/dotnet/System.IO.Compression.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.IO.Compression.dll": {}
+        }
+      },
+      "System.IO.FileSystem/4.0.0-beta-23110": {
+        "dependencies": {
+          "System.Collections": "4.0.10-beta-23110",
+          "System.IO": "4.0.10-beta-23110",
+          "System.IO.FileSystem.Primitives": "4.0.0-beta-23110",
+          "System.Resources.ResourceManager": "4.0.0-beta-23110",
+          "System.Runtime": "4.0.20-beta-23110",
+          "System.Runtime.Extensions": "4.0.10-beta-23110",
+          "System.Runtime.Handles": "4.0.0-beta-23110",
+          "System.Runtime.InteropServices": "4.0.20-beta-23110",
+          "System.Text.Encoding": "4.0.10-beta-23110",
+          "System.Text.Encoding.Extensions": "4.0.10-beta-23110",
+          "System.Threading": "4.0.10-beta-23110",
+          "System.Threading.Overlapped": "4.0.0-beta-23110",
+          "System.Threading.Tasks": "4.0.10-beta-23110"
+        },
+        "compile": {
+          "ref/dotnet/System.IO.FileSystem.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.IO.FileSystem.dll": {}
+        }
+      },
+      "System.IO.FileSystem.Primitives/4.0.0-beta-23110": {
+        "dependencies": {
+          "System.Runtime": "4.0.20-beta-23110"
+        },
+        "compile": {
+          "ref/dotnet/System.IO.FileSystem.Primitives.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.IO.FileSystem.Primitives.dll": {}
+        }
+      },
+      "System.Linq/4.0.0-beta-23110": {
+        "dependencies": {
+          "System.Collections": "4.0.10-beta-23110",
+          "System.Diagnostics.Debug": "4.0.10-beta-23110",
+          "System.Resources.ResourceManager": "4.0.0-beta-23110",
+          "System.Runtime": "4.0.20-beta-23110",
+          "System.Runtime.Extensions": "4.0.10-beta-23110"
+        },
+        "compile": {
+          "ref/dotnet/System.Linq.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Linq.dll": {}
+        }
+      },
+      "System.Linq.Expressions/4.0.10-beta-23110": {
+        "dependencies": {
+          "System.Collections": "4.0.10-beta-23110",
+          "System.Diagnostics.Debug": "4.0.10-beta-23110",
+          "System.Globalization": "4.0.10-beta-23110",
+          "System.IO": "4.0.10-beta-23110",
+          "System.Linq": "4.0.0-beta-23110",
+          "System.ObjectModel": "4.0.10-beta-23110",
+          "System.Reflection": "4.0.10-beta-23110",
+          "System.Reflection.Emit": "4.0.0-beta-23110",
+          "System.Reflection.Extensions": "4.0.0-beta-23110",
+          "System.Reflection.Primitives": "4.0.0-beta-23110",
+          "System.Reflection.TypeExtensions": "4.0.0-beta-23110",
+          "System.Resources.ResourceManager": "4.0.0-beta-23110",
+          "System.Runtime": "4.0.20-beta-23110",
+          "System.Runtime.Extensions": "4.0.10-beta-23110",
+          "System.Threading": "4.0.10-beta-23110"
+        },
+        "compile": {
+          "ref/dotnet/System.Linq.Expressions.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Linq.Expressions.dll": {}
+        }
+      },
+      "System.Linq.Queryable/4.0.0-beta-23110": {
+        "dependencies": {
+          "System.Collections": "4.0.10-beta-23110",
+          "System.Linq": "4.0.0-beta-23110",
+          "System.Linq.Expressions": "4.0.10-beta-23110",
+          "System.Reflection": "4.0.10-beta-23110",
+          "System.Reflection.Extensions": "4.0.0-beta-23110",
+          "System.Resources.ResourceManager": "4.0.0-beta-23110",
+          "System.Runtime": "4.0.20-beta-23110"
+        },
+        "compile": {
+          "ref/dotnet/System.Linq.Queryable.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Linq.Queryable.dll": {}
+        }
+      },
+      "System.Net.Http/4.0.0-beta-23110": {
+        "dependencies": {
+          "Microsoft.Win32.Primitives": "4.0.0-beta-23110",
+          "System.Collections": "4.0.10-beta-23110",
+          "System.Diagnostics.Debug": "4.0.10-beta-23110",
+          "System.Globalization": "4.0.10-beta-23110",
+          "System.IO": "4.0.10-beta-23110",
+          "System.IO.Compression": "4.0.0-beta-23110",
+          "System.Net.Primitives": "4.0.10-beta-23110",
+          "System.Resources.ResourceManager": "4.0.0-beta-23110",
+          "System.Runtime": "4.0.20-beta-23110",
+          "System.Runtime.Extensions": "4.0.10-beta-23110",
+          "System.Runtime.Handles": "4.0.0-beta-23110",
+          "System.Runtime.InteropServices": "4.0.20-beta-23110",
+          "System.Text.Encoding": "4.0.10-beta-23110",
+          "System.Threading": "4.0.10-beta-23110",
+          "System.Threading.Tasks": "4.0.10-beta-23110"
+        },
+        "compile": {
+          "ref/dotnet/System.Net.Http.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Net.Http.dll": {}
+        }
+      },
+      "System.Net.NameResolution/4.0.0-beta-23110": {
+        "dependencies": {
+          "System.Private.Networking": "4.0.0-beta-23110"
+        },
+        "compile": {
+          "ref/dotnet/System.Net.NameResolution.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Net.NameResolution.dll": {}
+        }
+      },
+      "System.Net.Primitives/4.0.10-beta-23110": {
+        "dependencies": {
+          "System.Private.Networking": "4.0.0-beta-23110"
+        },
+        "compile": {
+          "ref/dotnet/System.Net.Primitives.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Net.Primitives.dll": {}
+        }
+      },
+      "System.Net.Security/4.0.0-beta-23110": {
+        "dependencies": {
+          "System.Private.Networking": "4.0.0-beta-23110"
+        },
+        "compile": {
+          "ref/dotnet/System.Net.Security.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Net.Security.dll": {}
+        }
+      },
+      "System.Net.Sockets/4.0.10-beta-23110": {
+        "dependencies": {
+          "System.Private.Networking": "4.0.0-beta-23110"
+        },
+        "compile": {
+          "ref/dotnet/System.Net.Sockets.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Net.Sockets.dll": {}
+        }
+      },
+      "System.Net.WebHeaderCollection/4.0.0-beta-23110": {
+        "dependencies": {
+          "System.Collections.NonGeneric": "4.0.0-beta-23110",
+          "System.Collections.Specialized": "4.0.0-beta-23110",
+          "System.Resources.ResourceManager": "4.0.0-beta-23110",
+          "System.Runtime": "4.0.20-beta-23110"
+        },
+        "compile": {
+          "ref/dotnet/System.Net.WebHeaderCollection.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Net.WebHeaderCollection.dll": {}
+        }
+      },
+      "System.ObjectModel/4.0.10-beta-23110": {
+        "dependencies": {
+          "System.Collections": "4.0.10-beta-23110",
+          "System.Diagnostics.Debug": "4.0.10-beta-23110",
+          "System.Resources.ResourceManager": "4.0.0-beta-23110",
+          "System.Runtime": "4.0.20-beta-23110",
+          "System.Threading": "4.0.10-beta-23110"
+        },
+        "compile": {
+          "ref/dotnet/System.ObjectModel.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.ObjectModel.dll": {}
+        }
+      },
+      "System.Private.DataContractSerialization/4.0.0-beta-23110": {
+        "dependencies": {
+          "System.Collections": "4.0.10-beta-23110",
+          "System.Globalization": "4.0.10-beta-23110",
+          "System.IO": "4.0.10-beta-23110",
+          "System.Linq": "4.0.0-beta-23110",
+          "System.Reflection": "4.0.10-beta-23110",
+          "System.Reflection.Extensions": "4.0.0-beta-23110",
+          "System.Reflection.Primitives": "4.0.0-beta-23110",
+          "System.Reflection.TypeExtensions": "4.0.0-beta-23110",
+          "System.Resources.ResourceManager": "4.0.0-beta-23110",
+          "System.Runtime": "4.0.20-beta-23110",
+          "System.Runtime.Extensions": "4.0.10-beta-23110",
+          "System.Runtime.Serialization.Primitives": "4.0.10-beta-23110",
+          "System.Text.Encoding": "4.0.10-beta-23110",
+          "System.Text.Encoding.Extensions": "4.0.10-beta-23110",
+          "System.Text.RegularExpressions": "4.0.10-beta-23110",
+          "System.Threading": "4.0.10-beta-23110",
+          "System.Xml.ReaderWriter": "4.0.10-beta-23110",
+          "System.Xml.XmlSerializer": "4.0.10-beta-23110"
+        },
+        "compile": {
+          "ref/dnxcore50/_._": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Private.DataContractSerialization.dll": {}
+        }
+      },
+      "System.Private.Networking/4.0.0-beta-23110": {
+        "dependencies": {
+          "Microsoft.Win32.Primitives": "4.0.0-beta-23110",
+          "System.Collections": "4.0.10-beta-23110",
+          "System.Collections.Concurrent": "4.0.0",
+          "System.Collections.NonGeneric": "4.0.0-beta-23110",
+          "System.ComponentModel.EventBasedAsync": "4.0.10-beta-23110",
+          "System.Diagnostics.Debug": "4.0.10-beta-23110",
+          "System.Diagnostics.Tracing": "4.0.20-beta-23110",
+          "System.Globalization": "4.0.10-beta-23110",
+          "System.IO": "4.0.10-beta-23110",
+          "System.IO.FileSystem": "4.0.0-beta-23110",
+          "System.IO.FileSystem.Primitives": "4.0.0-beta-23110",
+          "System.Resources.ResourceManager": "4.0.0-beta-23110",
+          "System.Runtime": "4.0.20-beta-23110",
+          "System.Runtime.Extensions": "4.0.10-beta-23110",
+          "System.Runtime.Handles": "4.0.0-beta-23110",
+          "System.Runtime.InteropServices": "4.0.20-beta-23110",
+          "System.Security.Cryptography.Encryption": "4.0.0-beta-23110",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23110",
+          "System.Security.Principal.Windows": "4.0.0-beta-23110",
+          "System.Security.SecureString": "4.0.0-beta-23110",
+          "System.Threading": "4.0.10-beta-23110",
+          "System.Threading.Overlapped": "4.0.0-beta-23110",
+          "System.Threading.Tasks": "4.0.10-beta-23110",
+          "System.Threading.ThreadPool": "4.0.10-beta-23110"
+        },
+        "compile": {
+          "ref/dnxcore50/_._": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Private.Networking.dll": {}
+        }
+      },
+      "System.Private.ServiceModel/4.0.0-beta-23110": {
+        "dependencies": {
+          "System.Collections": "4.0.10-beta-23110",
+          "System.Collections.Concurrent": "4.0.10-beta-23110",
+          "System.Collections.NonGeneric": "4.0.0-beta-23110",
+          "System.Collections.Specialized": "4.0.0-beta-23110",
+          "System.ComponentModel.EventBasedAsync": "4.0.10-beta-23110",
+          "System.Diagnostics.Contracts": "4.0.0-beta-23110",
+          "System.Diagnostics.Debug": "4.0.10-beta-23110",
+          "System.Globalization": "4.0.10-beta-23110",
+          "System.IO": "4.0.10-beta-23110",
+          "System.IO.Compression": "4.0.0-beta-23110",
+          "System.Linq": "4.0.0-beta-23110",
+          "System.Linq.Expressions": "4.0.10-beta-23110",
+          "System.Linq.Queryable": "4.0.0-beta-23110",
+          "System.Net.Http": "4.0.0-beta-23110",
+          "System.Net.NameResolution": "4.0.0-beta-23110",
+          "System.Net.Primitives": "4.0.10-beta-23110",
+          "System.Net.Security": "4.0.0-beta-23110",
+          "System.Net.Sockets": "4.0.10-beta-23110",
+          "System.Net.WebHeaderCollection": "4.0.0-beta-23110",
+          "System.ObjectModel": "4.0.10-beta-23110",
+          "System.Reflection": "4.0.10-beta-23110",
+          "System.Reflection.DispatchProxy": "4.0.0-beta-23110",
+          "System.Reflection.Extensions": "4.0.0-beta-23110",
+          "System.Reflection.Primitives": "4.0.0-beta-23110",
+          "System.Reflection.TypeExtensions": "4.0.0-beta-23110",
+          "System.Resources.ResourceManager": "4.0.0-beta-23110",
+          "System.Runtime": "4.0.20-beta-23110",
+          "System.Runtime.Extensions": "4.0.10-beta-23110",
+          "System.Runtime.InteropServices": "4.0.20-beta-23110",
+          "System.Runtime.Serialization.Primitives": "4.0.10-beta-23110",
+          "System.Runtime.Serialization.Xml": "4.0.10-beta-23110",
+          "System.Security.Claims": "4.0.0-beta-23110",
+          "System.Security.Principal": "4.0.0-beta-23110",
+          "System.Security.Principal.Windows": "4.0.0-beta-23110",
+          "System.Text.Encoding": "4.0.10-beta-23110",
+          "System.Threading": "4.0.10-beta-23110",
+          "System.Threading.Tasks": "4.0.10-beta-23110",
+          "System.Threading.Timer": "4.0.0-beta-23110",
+          "System.Xml.ReaderWriter": "4.0.10-beta-23110",
+          "System.Xml.XmlDocument": "4.0.0-beta-23110",
+          "System.Xml.XmlSerializer": "4.0.10-beta-23110"
+        },
+        "compile": {
+          "ref/dnxcore50/_._": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Private.ServiceModel.dll": {}
+        }
+      },
+      "System.Private.Uri/4.0.0-beta-23110": {
+        "compile": {
+          "ref/dnxcore50/_._": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Private.Uri.dll": {}
+        }
+      },
+      "System.Reflection/4.0.10-beta-23110": {
+        "dependencies": {
+          "System.IO": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0-beta-23110",
+          "System.Runtime": "4.0.20-beta-23110"
+        },
+        "compile": {
+          "ref/dotnet/System.Reflection.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Reflection.dll": {}
+        }
+      },
+      "System.Reflection.DispatchProxy/4.0.0-beta-23110": {
+        "dependencies": {
+          "System.Collections": "4.0.10-beta-23110",
+          "System.Linq": "4.0.0-beta-23110",
+          "System.Reflection": "4.0.10-beta-23110",
+          "System.Reflection.Extensions": "4.0.0-beta-23110",
+          "System.Reflection.Primitives": "4.0.0-beta-23110",
+          "System.Resources.ResourceManager": "4.0.0-beta-23110",
+          "System.Runtime": "4.0.20-beta-23110",
+          "System.Threading": "4.0.10-beta-23110"
+        },
+        "compile": {
+          "ref/dotnet/System.Reflection.DispatchProxy.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Reflection.DispatchProxy.dll": {}
+        }
+      },
+      "System.Reflection.Emit/4.0.0-beta-23110": {
+        "dependencies": {
+          "System.IO": "4.0.0",
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Emit.ILGeneration": "4.0.0-beta-23110",
+          "System.Reflection.Primitives": "4.0.0-beta-23110",
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Reflection.Emit.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Reflection.Emit.dll": {}
+        }
+      },
+      "System.Reflection.Emit.ILGeneration/4.0.0-beta-23110": {
+        "dependencies": {
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0-beta-23110",
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Reflection.Emit.ILGeneration.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Reflection.Emit.ILGeneration.dll": {}
+        }
+      },
+      "System.Reflection.Extensions/4.0.0-beta-23110": {
+        "dependencies": {
+          "System.Reflection": "4.0.0",
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Reflection.Extensions.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Reflection.Extensions.dll": {}
+        }
+      },
+      "System.Reflection.Primitives/4.0.0-beta-23110": {
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Reflection.Primitives.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Reflection.Primitives.dll": {}
+        }
+      },
+      "System.Reflection.TypeExtensions/4.0.0-beta-23110": {
+        "dependencies": {
+          "System.Reflection": "4.0.0",
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Reflection.TypeExtensions.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Reflection.TypeExtensions.dll": {}
+        }
+      },
+      "System.Resources.ResourceManager/4.0.0-beta-23110": {
+        "dependencies": {
+          "System.Globalization": "4.0.0",
+          "System.Reflection": "4.0.0",
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Resources.ResourceManager.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Resources.ResourceManager.dll": {}
+        }
+      },
+      "System.Runtime/4.0.20-beta-23110": {
+        "dependencies": {
+          "System.Private.Uri": "4.0.0-beta-23110"
+        },
+        "compile": {
+          "ref/dotnet/System.Runtime.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Runtime.dll": {}
+        }
+      },
+      "System.Runtime.Extensions/4.0.10-beta-23110": {
+        "dependencies": {
+          "System.Runtime": "4.0.20-beta-23110"
+        },
+        "compile": {
+          "ref/dotnet/System.Runtime.Extensions.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Runtime.Extensions.dll": {}
+        }
+      },
+      "System.Runtime.Handles/4.0.0-beta-23110": {
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Runtime.Handles.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Runtime.Handles.dll": {}
+        }
+      },
+      "System.Runtime.InteropServices/4.0.20-beta-23110": {
+        "dependencies": {
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0-beta-23110",
+          "System.Runtime": "4.0.0",
+          "System.Runtime.Handles": "4.0.0-beta-23110"
+        },
+        "compile": {
+          "ref/dotnet/System.Runtime.InteropServices.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Runtime.InteropServices.dll": {}
+        }
+      },
+      "System.Runtime.Numerics/4.0.0-beta-23110": {
+        "dependencies": {
+          "System.Globalization": "4.0.10-beta-23110",
+          "System.Resources.ResourceManager": "4.0.0-beta-23110",
+          "System.Runtime": "4.0.20-beta-23110",
+          "System.Runtime.Extensions": "4.0.10-beta-23110"
+        },
+        "compile": {
+          "ref/dotnet/System.Runtime.Numerics.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Runtime.Numerics.dll": {}
+        }
+      },
+      "System.Runtime.Serialization.Primitives/4.0.10-beta-23110": {
+        "dependencies": {
+          "System.Resources.ResourceManager": "4.0.0-beta-23110",
+          "System.Runtime": "4.0.20-beta-23110"
+        },
+        "compile": {
+          "ref/dotnet/System.Runtime.Serialization.Primitives.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Runtime.Serialization.Primitives.dll": {}
+        }
+      },
+      "System.Runtime.Serialization.Xml/4.0.10-beta-23110": {
+        "dependencies": {
+          "System.Private.DataContractSerialization": "4.0.0-beta-23110",
+          "System.Runtime.Serialization.Primitives": "4.0.10-beta-23110"
+        },
+        "compile": {
+          "ref/dotnet/System.Runtime.Serialization.Xml.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Runtime.Serialization.Xml.dll": {}
+        }
+      },
+      "System.Security.Claims/4.0.0-beta-23110": {
+        "dependencies": {
+          "System.Collections": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.Globalization": "4.0.0",
+          "System.IO": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0-beta-23110",
+          "System.Runtime": "4.0.20-beta-23110",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Security.Principal": "4.0.0-beta-23110"
+        },
+        "compile": {
+          "ref/dotnet/System.Security.Claims.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Security.Claims.dll": {}
+        }
+      },
+      "System.Security.Cryptography.Encoding/4.0.0-beta-23110": {
+        "dependencies": {
+          "System.Diagnostics.Debug": "4.0.10-beta-23110",
+          "System.Resources.ResourceManager": "4.0.0-beta-23110",
+          "System.Runtime": "4.0.20-beta-23110",
+          "System.Runtime.Handles": "4.0.0-beta-23110",
+          "System.Runtime.InteropServices": "4.0.20-beta-23110",
+          "System.Security.Cryptography.Encryption": "4.0.0-beta-23110"
+        },
+        "compile": {
+          "ref/dotnet/System.Security.Cryptography.Encoding.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Security.Cryptography.Encoding.dll": {}
+        }
+      },
+      "System.Security.Cryptography.Encryption/4.0.0-beta-23110": {
+        "dependencies": {
+          "System.Globalization": "4.0.0",
+          "System.IO": "4.0.10-beta-23110",
+          "System.Resources.ResourceManager": "4.0.0-beta-23110",
+          "System.Runtime": "4.0.20-beta-23110",
+          "System.Threading.Tasks": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Security.Cryptography.Encryption.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Security.Cryptography.Encryption.dll": {}
+        }
+      },
+      "System.Security.Cryptography.Hashing/4.0.0-beta-23110": {
+        "dependencies": {
+          "System.IO": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0-beta-23110",
+          "System.Runtime": "4.0.20-beta-23110"
+        },
+        "compile": {
+          "ref/dotnet/System.Security.Cryptography.Hashing.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Security.Cryptography.Hashing.dll": {}
+        }
+      },
+      "System.Security.Cryptography.Hashing.Algorithms/4.0.0-beta-23110": {
+        "dependencies": {
+          "System.Resources.ResourceManager": "4.0.0-beta-23110",
+          "System.Runtime": "4.0.20-beta-23110",
+          "System.Runtime.Handles": "4.0.0-beta-23110",
+          "System.Security.Cryptography.Encryption": "4.0.0-beta-23110",
+          "System.Security.Cryptography.Hashing": "4.0.0-beta-23110",
+          "System.Security.Cryptography.RandomNumberGenerator": "4.0.0-beta-23110"
+        },
+        "compile": {
+          "ref/dotnet/System.Security.Cryptography.Hashing.Algorithms.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Security.Cryptography.Hashing.Algorithms.dll": {}
+        }
+      },
+      "System.Security.Cryptography.RandomNumberGenerator/4.0.0-beta-23110": {
+        "dependencies": {
+          "System.Runtime": "4.0.20-beta-23110",
+          "System.Security.Cryptography.Encryption": "4.0.0-beta-23110"
+        },
+        "compile": {
+          "ref/dotnet/System.Security.Cryptography.RandomNumberGenerator.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Security.Cryptography.RandomNumberGenerator.dll": {}
+        }
+      },
+      "System.Security.Cryptography.RSA/4.0.0-beta-23110": {
+        "dependencies": {
+          "System.IO": "4.0.10-beta-23110",
+          "System.Reflection": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0-beta-23110",
+          "System.Runtime": "4.0.20-beta-23110",
+          "System.Runtime.Extensions": "4.0.10-beta-23110",
+          "System.Runtime.Handles": "4.0.0-beta-23110",
+          "System.Runtime.InteropServices": "4.0.20-beta-23110",
+          "System.Security.Cryptography.Encoding": "4.0.0-beta-23110",
+          "System.Security.Cryptography.Encryption": "4.0.0-beta-23110",
+          "System.Security.Cryptography.Hashing": "4.0.0-beta-23110",
+          "System.Security.Cryptography.Hashing.Algorithms": "4.0.0-beta-23110",
+          "System.Threading": "4.0.10-beta-23110"
+        },
+        "compile": {
+          "ref/dotnet/System.Security.Cryptography.RSA.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Security.Cryptography.RSA.dll": {}
+        }
+      },
+      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23110": {
+        "dependencies": {
+          "System.Collections": "4.0.10-beta-23110",
+          "System.Diagnostics.Debug": "4.0.10-beta-23110",
+          "System.Globalization": "4.0.10-beta-23110",
+          "System.Globalization.Calendars": "4.0.0-beta-23110",
+          "System.IO": "4.0.10-beta-23110",
+          "System.IO.FileSystem": "4.0.0-beta-23110",
+          "System.Resources.ResourceManager": "4.0.0-beta-23110",
+          "System.Runtime": "4.0.20-beta-23110",
+          "System.Runtime.Extensions": "4.0.10-beta-23110",
+          "System.Runtime.Handles": "4.0.0-beta-23110",
+          "System.Runtime.InteropServices": "4.0.20-beta-23110",
+          "System.Runtime.Numerics": "4.0.0-beta-23110",
+          "System.Security.Cryptography.Encoding": "4.0.0-beta-23110",
+          "System.Security.Cryptography.Encryption": "4.0.0-beta-23110",
+          "System.Security.Cryptography.Hashing": "4.0.0-beta-23110",
+          "System.Security.Cryptography.Hashing.Algorithms": "4.0.0-beta-23110",
+          "System.Security.Cryptography.RSA": "4.0.0-beta-23110",
+          "System.Text.Encoding": "4.0.10-beta-23110",
+          "System.Threading": "4.0.10-beta-23110"
+        },
+        "compile": {
+          "ref/dotnet/System.Security.Cryptography.X509Certificates.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Security.Cryptography.X509Certificates.dll": {}
+        }
+      },
+      "System.Security.Principal/4.0.0-beta-23110": {
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Security.Principal.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Security.Principal.dll": {}
+        }
+      },
+      "System.Security.Principal.Windows/4.0.0-beta-23110": {
+        "dependencies": {
+          "System.Collections": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.Reflection": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0-beta-23110",
+          "System.Runtime": "4.0.20-beta-23110",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.0",
+          "System.Security.Claims": "4.0.0-beta-23110",
+          "System.Security.Principal": "4.0.0-beta-23110",
+          "System.Threading": "4.0.10-beta-23110"
+        },
+        "compile": {
+          "ref/dotnet/System.Security.Principal.Windows.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Security.Principal.Windows.dll": {}
+        }
+      },
+      "System.Security.SecureString/4.0.0-beta-23110": {
+        "dependencies": {
+          "System.Resources.ResourceManager": "4.0.0-beta-23110",
+          "System.Runtime": "4.0.20-beta-23110",
+          "System.Runtime.Handles": "4.0.0-beta-23110",
+          "System.Runtime.InteropServices": "4.0.20-beta-23110",
+          "System.Security.Cryptography.Encryption": "4.0.0-beta-23110",
+          "System.Threading": "4.0.10-beta-23110"
+        },
+        "compile": {
+          "ref/dotnet/System.Security.SecureString.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Security.SecureString.dll": {}
+        }
+      },
+      "System.ServiceModel.Http/4.0.10-beta-23110": {
+        "dependencies": {
+          "System.Private.ServiceModel": "4.0.0-beta-23110"
+        },
+        "compile": {
+          "ref/dotnet/System.ServiceModel.Http.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.ServiceModel.Http.dll": {}
+        }
+      },
+      "System.ServiceModel.NetTcp/4.0.0-beta-23110": {
+        "dependencies": {
+          "System.Private.ServiceModel": "4.0.0-beta-23110"
+        },
+        "compile": {
+          "ref/dotnet/System.ServiceModel.NetTcp.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.ServiceModel.NetTcp.dll": {}
+        }
+      },
+      "System.ServiceModel.Primitives/4.0.0-beta-23110": {
+        "dependencies": {
+          "System.Private.ServiceModel": "4.0.0-beta-23110"
+        },
+        "compile": {
+          "ref/dotnet/System.ServiceModel.Primitives.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.ServiceModel.Primitives.dll": {}
+        }
+      },
+      "System.ServiceModel.Security/4.0.0-beta-23109": {
+        "dependencies": {
+          "System.Private.ServiceModel": "4.0.0-beta-23109"
+        },
+        "compile": {
+          "ref/dotnet/System.ServiceModel.Security.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.ServiceModel.Security.dll": {}
+        }
+      },
+      "System.Text.Encoding/4.0.10-beta-23110": {
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Text.Encoding.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Text.Encoding.dll": {}
+        }
+      },
+      "System.Text.Encoding.Extensions/4.0.10-beta-23110": {
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.Text.Encoding": "4.0.10-beta-23110"
+        },
+        "compile": {
+          "ref/dotnet/System.Text.Encoding.Extensions.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Text.Encoding.Extensions.dll": {}
+        }
+      },
+      "System.Text.RegularExpressions/4.0.10-beta-23110": {
+        "dependencies": {
+          "System.Collections": "4.0.10-beta-23110",
+          "System.Globalization": "4.0.10-beta-23110",
+          "System.Resources.ResourceManager": "4.0.0-beta-23110",
+          "System.Runtime": "4.0.20-beta-23110",
+          "System.Runtime.Extensions": "4.0.10-beta-23110",
+          "System.Threading": "4.0.10-beta-23110"
+        },
+        "compile": {
+          "ref/dotnet/System.Text.RegularExpressions.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Text.RegularExpressions.dll": {}
+        }
+      },
+      "System.Threading/4.0.10-beta-23110": {
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Threading.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Threading.dll": {}
+        }
+      },
+      "System.Threading.Overlapped/4.0.0-beta-23110": {
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.Runtime.Handles": "4.0.0-beta-23110"
+        },
+        "compile": {
+          "ref/dotnet/System.Threading.Overlapped.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Threading.Overlapped.dll": {}
+        }
+      },
+      "System.Threading.Tasks/4.0.10-beta-23110": {
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Threading.Tasks.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Threading.Tasks.dll": {}
+        }
+      },
+      "System.Threading.ThreadPool/4.0.10-beta-23110": {
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Threading.ThreadPool.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Threading.ThreadPool.dll": {}
+        }
+      },
+      "System.Threading.Timer/4.0.0-beta-23110": {
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Threading.Timer.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Threading.Timer.dll": {}
+        }
+      },
+      "System.Xml.ReaderWriter/4.0.10-beta-23110": {
+        "dependencies": {
+          "System.Collections": "4.0.10-beta-23110",
+          "System.Diagnostics.Debug": "4.0.10-beta-23110",
+          "System.Globalization": "4.0.10-beta-23110",
+          "System.IO": "4.0.10-beta-23110",
+          "System.IO.FileSystem": "4.0.0-beta-23110",
+          "System.IO.FileSystem.Primitives": "4.0.0-beta-23110",
+          "System.Resources.ResourceManager": "4.0.0-beta-23110",
+          "System.Runtime": "4.0.20-beta-23110",
+          "System.Runtime.Extensions": "4.0.10-beta-23110",
+          "System.Runtime.InteropServices": "4.0.20-beta-23110",
+          "System.Text.Encoding": "4.0.10-beta-23110",
+          "System.Text.Encoding.Extensions": "4.0.10-beta-23110",
+          "System.Text.RegularExpressions": "4.0.10-beta-23110",
+          "System.Threading.Tasks": "4.0.10-beta-23110"
+        },
+        "compile": {
+          "ref/dotnet/System.Xml.ReaderWriter.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Xml.ReaderWriter.dll": {}
+        }
+      },
+      "System.Xml.XmlDocument/4.0.0-beta-23110": {
+        "dependencies": {
+          "System.Collections": "4.0.10-beta-23110",
+          "System.Diagnostics.Debug": "4.0.10-beta-23110",
+          "System.Globalization": "4.0.10-beta-23110",
+          "System.IO": "4.0.10-beta-23110",
+          "System.Resources.ResourceManager": "4.0.0-beta-23110",
+          "System.Runtime": "4.0.20-beta-23110",
+          "System.Runtime.Extensions": "4.0.10-beta-23110",
+          "System.Text.Encoding": "4.0.10-beta-23110",
+          "System.Threading": "4.0.10-beta-23110",
+          "System.Xml.ReaderWriter": "4.0.10-beta-23110"
+        },
+        "compile": {
+          "ref/dotnet/System.Xml.XmlDocument.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Xml.XmlDocument.dll": {}
+        }
+      },
+      "System.Xml.XmlSerializer/4.0.10-beta-23110": {
+        "dependencies": {
+          "System.Collections": "4.0.10-beta-23110",
+          "System.Diagnostics.Debug": "4.0.10-beta-23110",
+          "System.Globalization": "4.0.10-beta-23110",
+          "System.IO": "4.0.10-beta-23110",
+          "System.Linq": "4.0.0-beta-23110",
+          "System.Reflection": "4.0.10-beta-23110",
+          "System.Reflection.Extensions": "4.0.0-beta-23110",
+          "System.Reflection.Primitives": "4.0.0-beta-23110",
+          "System.Reflection.TypeExtensions": "4.0.0-beta-23110",
+          "System.Resources.ResourceManager": "4.0.0-beta-23110",
+          "System.Runtime": "4.0.20-beta-23110",
+          "System.Runtime.Extensions": "4.0.10-beta-23110",
+          "System.Text.RegularExpressions": "4.0.10-beta-23110",
+          "System.Threading": "4.0.10-beta-23110",
+          "System.Xml.ReaderWriter": "4.0.10-beta-23110",
+          "System.Xml.XmlDocument": "4.0.0-beta-23110"
+        },
+        "compile": {
+          "ref/dotnet/System.Xml.XmlSerializer.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Xml.XmlSerializer.dll": {}
+        }
+      }
+    }
+  },
+  "libraries": {
+    "Microsoft.Win32.Primitives/4.0.0-beta-23110": {
+      "serviceable": true,
+      "sha512": "jOJqZRsqnJfEfo49Blvg8pbVdQRK+jt1mNouXzb3wbUxz36BKxNIAE3tloxBI5nVCRw9oJhbEQ9pt4HTmnX6Bg==",
+      "files": [
+        "lib/dotnet/Microsoft.Win32.Primitives.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/Microsoft.Win32.Primitives.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "Microsoft.Win32.Primitives.4.0.0-beta-23110.nupkg",
+        "Microsoft.Win32.Primitives.4.0.0-beta-23110.nupkg.sha512",
+        "Microsoft.Win32.Primitives.nuspec",
+        "ref/dotnet/de/Microsoft.Win32.Primitives.xml",
+        "ref/dotnet/es/Microsoft.Win32.Primitives.xml",
+        "ref/dotnet/fr/Microsoft.Win32.Primitives.xml",
+        "ref/dotnet/it/Microsoft.Win32.Primitives.xml",
+        "ref/dotnet/ja/Microsoft.Win32.Primitives.xml",
+        "ref/dotnet/ko/Microsoft.Win32.Primitives.xml",
+        "ref/dotnet/Microsoft.Win32.Primitives.dll",
+        "ref/dotnet/Microsoft.Win32.Primitives.xml",
+        "ref/dotnet/ru/Microsoft.Win32.Primitives.xml",
+        "ref/dotnet/zh-hans/Microsoft.Win32.Primitives.xml",
+        "ref/dotnet/zh-hant/Microsoft.Win32.Primitives.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/Microsoft.Win32.Primitives.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._"
+      ]
+    },
+    "System.Collections/4.0.10-beta-23110": {
+      "serviceable": true,
+      "sha512": "C+SFurxzh+d1HlrjHLKbp379UIMHTzziguFb0xkDRYOA2na2DnvgoQ12vhEBt264UT3808HfGLoe8BPR4CYA8w==",
+      "files": [
+        "lib/DNXCore50/System.Collections.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/netcore50/System.Collections.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Collections.xml",
+        "ref/dotnet/es/System.Collections.xml",
+        "ref/dotnet/fr/System.Collections.xml",
+        "ref/dotnet/it/System.Collections.xml",
+        "ref/dotnet/ja/System.Collections.xml",
+        "ref/dotnet/ko/System.Collections.xml",
+        "ref/dotnet/ru/System.Collections.xml",
+        "ref/dotnet/System.Collections.dll",
+        "ref/dotnet/System.Collections.xml",
+        "ref/dotnet/zh-hans/System.Collections.xml",
+        "ref/dotnet/zh-hant/System.Collections.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Collections.dll",
+        "System.Collections.4.0.10-beta-23110.nupkg",
+        "System.Collections.4.0.10-beta-23110.nupkg.sha512",
+        "System.Collections.nuspec"
+      ]
+    },
+    "System.Collections.Concurrent/4.0.10-beta-23110": {
+      "serviceable": true,
+      "sha512": "DOl5Ueu7I3i/BCMsF/VNJvRRDkE/zTMKIkRvJl03j+5DnqGqzwJMud3y6zlCsCENEKlZ5aS12HLl9VmP9qy4HQ==",
+      "files": [
+        "lib/dotnet/System.Collections.Concurrent.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Collections.Concurrent.xml",
+        "ref/dotnet/es/System.Collections.Concurrent.xml",
+        "ref/dotnet/fr/System.Collections.Concurrent.xml",
+        "ref/dotnet/it/System.Collections.Concurrent.xml",
+        "ref/dotnet/ja/System.Collections.Concurrent.xml",
+        "ref/dotnet/ko/System.Collections.Concurrent.xml",
+        "ref/dotnet/ru/System.Collections.Concurrent.xml",
+        "ref/dotnet/System.Collections.Concurrent.dll",
+        "ref/dotnet/System.Collections.Concurrent.xml",
+        "ref/dotnet/zh-hans/System.Collections.Concurrent.xml",
+        "ref/dotnet/zh-hant/System.Collections.Concurrent.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Collections.Concurrent.4.0.10-beta-23110.nupkg",
+        "System.Collections.Concurrent.4.0.10-beta-23110.nupkg.sha512",
+        "System.Collections.Concurrent.nuspec"
+      ]
+    },
+    "System.Collections.NonGeneric/4.0.0-beta-23110": {
+      "serviceable": true,
+      "sha512": "wttQXPUjklmOJbKyJv/yrsE25sYjcCuDcugLgyPPk9bjdkxc7O7RtzDHvhk+DYWaxg/+soYMeNxSQ0a0EooBmg==",
+      "files": [
+        "lib/dotnet/System.Collections.NonGeneric.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Collections.NonGeneric.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Collections.NonGeneric.xml",
+        "ref/dotnet/es/System.Collections.NonGeneric.xml",
+        "ref/dotnet/fr/System.Collections.NonGeneric.xml",
+        "ref/dotnet/it/System.Collections.NonGeneric.xml",
+        "ref/dotnet/ja/System.Collections.NonGeneric.xml",
+        "ref/dotnet/ko/System.Collections.NonGeneric.xml",
+        "ref/dotnet/ru/System.Collections.NonGeneric.xml",
+        "ref/dotnet/System.Collections.NonGeneric.dll",
+        "ref/dotnet/System.Collections.NonGeneric.xml",
+        "ref/dotnet/zh-hans/System.Collections.NonGeneric.xml",
+        "ref/dotnet/zh-hant/System.Collections.NonGeneric.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Collections.NonGeneric.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Collections.NonGeneric.4.0.0-beta-23110.nupkg",
+        "System.Collections.NonGeneric.4.0.0-beta-23110.nupkg.sha512",
+        "System.Collections.NonGeneric.nuspec"
+      ]
+    },
+    "System.Collections.Specialized/4.0.0-beta-23110": {
+      "serviceable": true,
+      "sha512": "f/IeaHtnn1HoDFQzjWgFCTCOJ3C/5y5CHBRKC6U2R3/Kz9j1sMu2XN19Tgy1nFt0m7MasQZ0j/cZDMw4/nrLgw==",
+      "files": [
+        "lib/dotnet/System.Collections.Specialized.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Collections.Specialized.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Collections.Specialized.xml",
+        "ref/dotnet/es/System.Collections.Specialized.xml",
+        "ref/dotnet/fr/System.Collections.Specialized.xml",
+        "ref/dotnet/it/System.Collections.Specialized.xml",
+        "ref/dotnet/ja/System.Collections.Specialized.xml",
+        "ref/dotnet/ko/System.Collections.Specialized.xml",
+        "ref/dotnet/ru/System.Collections.Specialized.xml",
+        "ref/dotnet/System.Collections.Specialized.dll",
+        "ref/dotnet/System.Collections.Specialized.xml",
+        "ref/dotnet/zh-hans/System.Collections.Specialized.xml",
+        "ref/dotnet/zh-hant/System.Collections.Specialized.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Collections.Specialized.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Collections.Specialized.4.0.0-beta-23110.nupkg",
+        "System.Collections.Specialized.4.0.0-beta-23110.nupkg.sha512",
+        "System.Collections.Specialized.nuspec"
+      ]
+    },
+    "System.ComponentModel.EventBasedAsync/4.0.10-beta-23110": {
+      "serviceable": true,
+      "sha512": "ryHi9thD2J/ZcpAL7IKpfSG/7DvQzl27bh4d9Sca+zDZBkhyKlhoooJTNqRWru9SiUslTsuFH69cEfVHuI+IIQ==",
+      "files": [
+        "lib/dotnet/System.ComponentModel.EventBasedAsync.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.ComponentModel.EventBasedAsync.xml",
+        "ref/dotnet/es/System.ComponentModel.EventBasedAsync.xml",
+        "ref/dotnet/fr/System.ComponentModel.EventBasedAsync.xml",
+        "ref/dotnet/it/System.ComponentModel.EventBasedAsync.xml",
+        "ref/dotnet/ja/System.ComponentModel.EventBasedAsync.xml",
+        "ref/dotnet/ko/System.ComponentModel.EventBasedAsync.xml",
+        "ref/dotnet/ru/System.ComponentModel.EventBasedAsync.xml",
+        "ref/dotnet/System.ComponentModel.EventBasedAsync.dll",
+        "ref/dotnet/System.ComponentModel.EventBasedAsync.xml",
+        "ref/dotnet/zh-hans/System.ComponentModel.EventBasedAsync.xml",
+        "ref/dotnet/zh-hant/System.ComponentModel.EventBasedAsync.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.ComponentModel.EventBasedAsync.4.0.10-beta-23110.nupkg",
+        "System.ComponentModel.EventBasedAsync.4.0.10-beta-23110.nupkg.sha512",
+        "System.ComponentModel.EventBasedAsync.nuspec"
+      ]
+    },
+    "System.Console/4.0.0-beta-23110": {
+      "serviceable": true,
+      "sha512": "h0dNCBNcS70ZLIWkRYbC0aZe2x3f9zQrE2cvnMQ7sLqftDPiLv1jr9mTqgazrsgqmToQVxTc515V+g4q9TcMGQ==",
+      "files": [
+        "lib/DNXCore50/System.Console.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Console.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Console.xml",
+        "ref/dotnet/es/System.Console.xml",
+        "ref/dotnet/fr/System.Console.xml",
+        "ref/dotnet/it/System.Console.xml",
+        "ref/dotnet/ja/System.Console.xml",
+        "ref/dotnet/ko/System.Console.xml",
+        "ref/dotnet/ru/System.Console.xml",
+        "ref/dotnet/System.Console.dll",
+        "ref/dotnet/System.Console.xml",
+        "ref/dotnet/zh-hans/System.Console.xml",
+        "ref/dotnet/zh-hant/System.Console.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Console.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Console.4.0.0-beta-23110.nupkg",
+        "System.Console.4.0.0-beta-23110.nupkg.sha512",
+        "System.Console.nuspec"
+      ]
+    },
+    "System.Diagnostics.Contracts/4.0.0-beta-23110": {
+      "sha512": "vb2yHEJm5Uv3lzvY29SSaLlJfGkplQK8sVEQXdjUEFV56RtQKStdzkhMaPyduHT7MUnmveXBlNPRIraxebYILg==",
+      "files": [
+        "lib/DNXCore50/System.Diagnostics.Contracts.dll",
+        "lib/net45/_._",
+        "lib/netcore50/System.Diagnostics.Contracts.dll",
+        "lib/win8/_._",
+        "lib/wp80/_._",
+        "lib/wpa81/_._",
+        "ref/dotnet/de/System.Diagnostics.Contracts.xml",
+        "ref/dotnet/es/System.Diagnostics.Contracts.xml",
+        "ref/dotnet/fr/System.Diagnostics.Contracts.xml",
+        "ref/dotnet/it/System.Diagnostics.Contracts.xml",
+        "ref/dotnet/ja/System.Diagnostics.Contracts.xml",
+        "ref/dotnet/ko/System.Diagnostics.Contracts.xml",
+        "ref/dotnet/ru/System.Diagnostics.Contracts.xml",
+        "ref/dotnet/System.Diagnostics.Contracts.dll",
+        "ref/dotnet/System.Diagnostics.Contracts.xml",
+        "ref/dotnet/zh-hans/System.Diagnostics.Contracts.xml",
+        "ref/dotnet/zh-hant/System.Diagnostics.Contracts.xml",
+        "ref/net45/_._",
+        "ref/netcore50/System.Diagnostics.Contracts.dll",
+        "ref/netcore50/System.Diagnostics.Contracts.xml",
+        "ref/win8/_._",
+        "ref/wp80/_._",
+        "ref/wpa81/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Contracts.dll",
+        "System.Diagnostics.Contracts.4.0.0-beta-23110.nupkg",
+        "System.Diagnostics.Contracts.4.0.0-beta-23110.nupkg.sha512",
+        "System.Diagnostics.Contracts.nuspec"
+      ]
+    },
+    "System.Diagnostics.Debug/4.0.10-beta-23110": {
+      "serviceable": true,
+      "sha512": "+rYK/6pR0KwzqkmiheA1Mr3kJBFYsw6tfyK7AFaytgZNzAKdKhdJ5qfDtBtv1BqVAs3IRcaqD5dxl4zHnciAEA==",
+      "files": [
+        "lib/DNXCore50/System.Diagnostics.Debug.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/netcore50/System.Diagnostics.Debug.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Diagnostics.Debug.xml",
+        "ref/dotnet/es/System.Diagnostics.Debug.xml",
+        "ref/dotnet/fr/System.Diagnostics.Debug.xml",
+        "ref/dotnet/it/System.Diagnostics.Debug.xml",
+        "ref/dotnet/ja/System.Diagnostics.Debug.xml",
+        "ref/dotnet/ko/System.Diagnostics.Debug.xml",
+        "ref/dotnet/ru/System.Diagnostics.Debug.xml",
+        "ref/dotnet/System.Diagnostics.Debug.dll",
+        "ref/dotnet/System.Diagnostics.Debug.xml",
+        "ref/dotnet/zh-hans/System.Diagnostics.Debug.xml",
+        "ref/dotnet/zh-hant/System.Diagnostics.Debug.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Debug.dll",
+        "System.Diagnostics.Debug.4.0.10-beta-23110.nupkg",
+        "System.Diagnostics.Debug.4.0.10-beta-23110.nupkg.sha512",
+        "System.Diagnostics.Debug.nuspec"
+      ]
+    },
+    "System.Diagnostics.Tracing/4.0.20-beta-23110": {
+      "serviceable": true,
+      "sha512": "nRaoSigfs+qumT3iCA8UYVJDZo2eOs8Lt2OvFYjQzdE08h7TEpf1AH5bU11wzTSvc6Aa9WlM5w4y4yJWzU24iQ==",
+      "files": [
+        "lib/DNXCore50/System.Diagnostics.Tracing.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/netcore50/System.Diagnostics.Tracing.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Diagnostics.Tracing.xml",
+        "ref/dotnet/es/System.Diagnostics.Tracing.xml",
+        "ref/dotnet/fr/System.Diagnostics.Tracing.xml",
+        "ref/dotnet/it/System.Diagnostics.Tracing.xml",
+        "ref/dotnet/ja/System.Diagnostics.Tracing.xml",
+        "ref/dotnet/ko/System.Diagnostics.Tracing.xml",
+        "ref/dotnet/ru/System.Diagnostics.Tracing.xml",
+        "ref/dotnet/System.Diagnostics.Tracing.dll",
+        "ref/dotnet/System.Diagnostics.Tracing.xml",
+        "ref/dotnet/zh-hans/System.Diagnostics.Tracing.xml",
+        "ref/dotnet/zh-hant/System.Diagnostics.Tracing.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Tracing.dll",
+        "System.Diagnostics.Tracing.4.0.20-beta-23110.nupkg",
+        "System.Diagnostics.Tracing.4.0.20-beta-23110.nupkg.sha512",
+        "System.Diagnostics.Tracing.nuspec"
+      ]
+    },
+    "System.Globalization/4.0.10-beta-23110": {
+      "sha512": "0cpVwpqK923iR+v7bv2DnYjXuunZH+m1WB24ZUJrNN5zWHti4uGQSmYmRCEH8LaiJIUL7xinfrT8UU4/1D1Vmg==",
+      "files": [
+        "lib/DNXCore50/System.Globalization.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/netcore50/System.Globalization.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Globalization.xml",
+        "ref/dotnet/es/System.Globalization.xml",
+        "ref/dotnet/fr/System.Globalization.xml",
+        "ref/dotnet/it/System.Globalization.xml",
+        "ref/dotnet/ja/System.Globalization.xml",
+        "ref/dotnet/ko/System.Globalization.xml",
+        "ref/dotnet/ru/System.Globalization.xml",
+        "ref/dotnet/System.Globalization.dll",
+        "ref/dotnet/System.Globalization.xml",
+        "ref/dotnet/zh-hans/System.Globalization.xml",
+        "ref/dotnet/zh-hant/System.Globalization.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Globalization.dll",
+        "System.Globalization.4.0.10-beta-23110.nupkg",
+        "System.Globalization.4.0.10-beta-23110.nupkg.sha512",
+        "System.Globalization.nuspec"
+      ]
+    },
+    "System.Globalization.Calendars/4.0.0-beta-23110": {
+      "sha512": "p+G17m7+3TRZfJmW1EOSsnTCNVZbYOeM5H7fVhT3hGCRkfxqIL6osedcWrY+npiozPItWV62+1YjHS/TB8BdqA==",
+      "files": [
+        "lib/DNXCore50/System.Globalization.Calendars.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Globalization.Calendars.dll",
+        "lib/netcore50/System.Globalization.Calendars.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Globalization.Calendars.xml",
+        "ref/dotnet/es/System.Globalization.Calendars.xml",
+        "ref/dotnet/fr/System.Globalization.Calendars.xml",
+        "ref/dotnet/it/System.Globalization.Calendars.xml",
+        "ref/dotnet/ja/System.Globalization.Calendars.xml",
+        "ref/dotnet/ko/System.Globalization.Calendars.xml",
+        "ref/dotnet/ru/System.Globalization.Calendars.xml",
+        "ref/dotnet/System.Globalization.Calendars.dll",
+        "ref/dotnet/System.Globalization.Calendars.xml",
+        "ref/dotnet/zh-hans/System.Globalization.Calendars.xml",
+        "ref/dotnet/zh-hant/System.Globalization.Calendars.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Globalization.Calendars.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Globalization.Calendars.dll",
+        "System.Globalization.Calendars.4.0.0-beta-23110.nupkg",
+        "System.Globalization.Calendars.4.0.0-beta-23110.nupkg.sha512",
+        "System.Globalization.Calendars.nuspec"
+      ]
+    },
+    "System.Globalization.Extensions/4.0.0-beta-23110": {
+      "serviceable": true,
+      "sha512": "Edo4Y0ZWcSeo3NXTS380YOhRS16YWLQrDnt3GEH7w7XurWwbP4itP0d4UsNkqZpo9OyDpYjpmNj7o+wFuKj0tQ==",
+      "files": [
+        "lib/dotnet/System.Globalization.Extensions.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Globalization.Extensions.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Globalization.Extensions.xml",
+        "ref/dotnet/es/System.Globalization.Extensions.xml",
+        "ref/dotnet/fr/System.Globalization.Extensions.xml",
+        "ref/dotnet/it/System.Globalization.Extensions.xml",
+        "ref/dotnet/ja/System.Globalization.Extensions.xml",
+        "ref/dotnet/ko/System.Globalization.Extensions.xml",
+        "ref/dotnet/ru/System.Globalization.Extensions.xml",
+        "ref/dotnet/System.Globalization.Extensions.dll",
+        "ref/dotnet/System.Globalization.Extensions.xml",
+        "ref/dotnet/zh-hans/System.Globalization.Extensions.xml",
+        "ref/dotnet/zh-hant/System.Globalization.Extensions.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Globalization.Extensions.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Globalization.Extensions.4.0.0-beta-23110.nupkg",
+        "System.Globalization.Extensions.4.0.0-beta-23110.nupkg.sha512",
+        "System.Globalization.Extensions.nuspec"
+      ]
+    },
+    "System.IO/4.0.10-beta-23110": {
+      "serviceable": true,
+      "sha512": "dAzefr5pHn1l7uQiHwUzgWBAsNO1Pe1EjY7qvcmo7TNdHEUgRaBxsXmguseRdT19YZGMZPFYV0guTOeT5kvu0g==",
+      "files": [
+        "lib/DNXCore50/System.IO.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/netcore50/System.IO.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.IO.xml",
+        "ref/dotnet/es/System.IO.xml",
+        "ref/dotnet/fr/System.IO.xml",
+        "ref/dotnet/it/System.IO.xml",
+        "ref/dotnet/ja/System.IO.xml",
+        "ref/dotnet/ko/System.IO.xml",
+        "ref/dotnet/ru/System.IO.xml",
+        "ref/dotnet/System.IO.dll",
+        "ref/dotnet/System.IO.xml",
+        "ref/dotnet/zh-hans/System.IO.xml",
+        "ref/dotnet/zh-hant/System.IO.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "runtimes/win8-aot/lib/netcore50/System.IO.dll",
+        "System.IO.4.0.10-beta-23110.nupkg",
+        "System.IO.4.0.10-beta-23110.nupkg.sha512",
+        "System.IO.nuspec"
+      ]
+    },
+    "System.IO.Compression/4.0.0-beta-23110": {
+      "serviceable": true,
+      "sha512": "UXbvlombDFI5v5N17D6h2XH6oWvzd9YRKOB4tK+eS1t6iEh8g3fin4JoTKWc3fc7PTWGl5UVQkT3Kd3Ej79YKQ==",
+      "files": [
+        "lib/dotnet/System.IO.Compression.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net45/_._",
+        "lib/netcore50/System.IO.Compression.dll",
+        "lib/win8/_._",
+        "lib/wpa81/_._",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.IO.Compression.xml",
+        "ref/dotnet/es/System.IO.Compression.xml",
+        "ref/dotnet/fr/System.IO.Compression.xml",
+        "ref/dotnet/it/System.IO.Compression.xml",
+        "ref/dotnet/ja/System.IO.Compression.xml",
+        "ref/dotnet/ko/System.IO.Compression.xml",
+        "ref/dotnet/ru/System.IO.Compression.xml",
+        "ref/dotnet/System.IO.Compression.dll",
+        "ref/dotnet/System.IO.Compression.xml",
+        "ref/dotnet/zh-hans/System.IO.Compression.xml",
+        "ref/dotnet/zh-hant/System.IO.Compression.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net45/_._",
+        "ref/netcore50/System.IO.Compression.dll",
+        "ref/netcore50/System.IO.Compression.xml",
+        "ref/win8/_._",
+        "ref/wpa81/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "runtime.json",
+        "System.IO.Compression.4.0.0-beta-23110.nupkg",
+        "System.IO.Compression.4.0.0-beta-23110.nupkg.sha512",
+        "System.IO.Compression.nuspec"
+      ]
+    },
+    "System.IO.FileSystem/4.0.0-beta-23110": {
+      "serviceable": true,
+      "sha512": "vbocv+ZodpVOCoxgLdmIr4z0i9vxmBJp/GWE6LQtO3F4ecak5PBO+2+Toe+DcqWTq/X/TuHqFvl1l6werVkmpA==",
+      "files": [
+        "lib/DNXCore50/System.IO.FileSystem.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.IO.FileSystem.dll",
+        "lib/netcore50/System.IO.FileSystem.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.IO.FileSystem.xml",
+        "ref/dotnet/es/System.IO.FileSystem.xml",
+        "ref/dotnet/fr/System.IO.FileSystem.xml",
+        "ref/dotnet/it/System.IO.FileSystem.xml",
+        "ref/dotnet/ja/System.IO.FileSystem.xml",
+        "ref/dotnet/ko/System.IO.FileSystem.xml",
+        "ref/dotnet/ru/System.IO.FileSystem.xml",
+        "ref/dotnet/System.IO.FileSystem.dll",
+        "ref/dotnet/System.IO.FileSystem.xml",
+        "ref/dotnet/zh-hans/System.IO.FileSystem.xml",
+        "ref/dotnet/zh-hant/System.IO.FileSystem.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.IO.FileSystem.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.IO.FileSystem.4.0.0-beta-23110.nupkg",
+        "System.IO.FileSystem.4.0.0-beta-23110.nupkg.sha512",
+        "System.IO.FileSystem.nuspec"
+      ]
+    },
+    "System.IO.FileSystem.Primitives/4.0.0-beta-23110": {
+      "serviceable": true,
+      "sha512": "a6oWBtw8PvB2NV3L8+CZjV+NVeXfEkW7ApzhfUuxio/vYwYBBULBdOUcQAmL2ohQh4MMe1ZUnz0LM8y6L7ekOQ==",
+      "files": [
+        "lib/dotnet/System.IO.FileSystem.Primitives.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.IO.FileSystem.Primitives.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.IO.FileSystem.Primitives.xml",
+        "ref/dotnet/es/System.IO.FileSystem.Primitives.xml",
+        "ref/dotnet/fr/System.IO.FileSystem.Primitives.xml",
+        "ref/dotnet/it/System.IO.FileSystem.Primitives.xml",
+        "ref/dotnet/ja/System.IO.FileSystem.Primitives.xml",
+        "ref/dotnet/ko/System.IO.FileSystem.Primitives.xml",
+        "ref/dotnet/ru/System.IO.FileSystem.Primitives.xml",
+        "ref/dotnet/System.IO.FileSystem.Primitives.dll",
+        "ref/dotnet/System.IO.FileSystem.Primitives.xml",
+        "ref/dotnet/zh-hans/System.IO.FileSystem.Primitives.xml",
+        "ref/dotnet/zh-hant/System.IO.FileSystem.Primitives.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.IO.FileSystem.Primitives.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.IO.FileSystem.Primitives.4.0.0-beta-23110.nupkg",
+        "System.IO.FileSystem.Primitives.4.0.0-beta-23110.nupkg.sha512",
+        "System.IO.FileSystem.Primitives.nuspec"
+      ]
+    },
+    "System.Linq/4.0.0-beta-23110": {
+      "serviceable": true,
+      "sha512": "OChNNza5YpS5be7qTKf7azxfIX8tJLW/RHgJkEDo0ZIYTSZ+OiAEAmGHUm9syC7bx4K1mp7ufwrsLzQ9K7QB3g==",
+      "files": [
+        "lib/dotnet/System.Linq.dll",
+        "lib/net45/_._",
+        "lib/netcore50/System.Linq.dll",
+        "lib/win8/_._",
+        "lib/wp80/_._",
+        "lib/wpa81/_._",
+        "ref/dotnet/de/System.Linq.xml",
+        "ref/dotnet/es/System.Linq.xml",
+        "ref/dotnet/fr/System.Linq.xml",
+        "ref/dotnet/it/System.Linq.xml",
+        "ref/dotnet/ja/System.Linq.xml",
+        "ref/dotnet/ko/System.Linq.xml",
+        "ref/dotnet/ru/System.Linq.xml",
+        "ref/dotnet/System.Linq.dll",
+        "ref/dotnet/System.Linq.xml",
+        "ref/dotnet/zh-hans/System.Linq.xml",
+        "ref/dotnet/zh-hant/System.Linq.xml",
+        "ref/net45/_._",
+        "ref/netcore50/System.Linq.dll",
+        "ref/netcore50/System.Linq.xml",
+        "ref/win8/_._",
+        "ref/wp80/_._",
+        "ref/wpa81/_._",
+        "System.Linq.4.0.0-beta-23110.nupkg",
+        "System.Linq.4.0.0-beta-23110.nupkg.sha512",
+        "System.Linq.nuspec"
+      ]
+    },
+    "System.Linq.Expressions/4.0.10-beta-23110": {
+      "serviceable": true,
+      "sha512": "vUL3iYmzEyfABg8ERtIYEX04ve1ZDQG9+C7PTLzWaDLRdp6W9yXu+cnbtJ44m0Qmj7GBtnNzj+vGdVWL1ZUXMg==",
+      "files": [
+        "lib/DNXCore50/System.Linq.Expressions.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/netcore50/System.Linq.Expressions.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Linq.Expressions.xml",
+        "ref/dotnet/es/System.Linq.Expressions.xml",
+        "ref/dotnet/fr/System.Linq.Expressions.xml",
+        "ref/dotnet/it/System.Linq.Expressions.xml",
+        "ref/dotnet/ja/System.Linq.Expressions.xml",
+        "ref/dotnet/ko/System.Linq.Expressions.xml",
+        "ref/dotnet/ru/System.Linq.Expressions.xml",
+        "ref/dotnet/System.Linq.Expressions.dll",
+        "ref/dotnet/System.Linq.Expressions.xml",
+        "ref/dotnet/zh-hans/System.Linq.Expressions.xml",
+        "ref/dotnet/zh-hant/System.Linq.Expressions.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "runtime.json",
+        "runtimes/win8-aot/lib/netcore50/System.Linq.Expressions.dll",
+        "System.Linq.Expressions.4.0.10-beta-23110.nupkg",
+        "System.Linq.Expressions.4.0.10-beta-23110.nupkg.sha512",
+        "System.Linq.Expressions.nuspec"
+      ]
+    },
+    "System.Linq.Queryable/4.0.0-beta-23110": {
+      "serviceable": true,
+      "sha512": "Nmkug18cDoD2//pqcYESnwjm3NPYeqaB1O/nk0nBvKEgD4lpNBpTd0/y/JXhVoKU0GE16CPQioLYGAsHRUwJcQ==",
+      "files": [
+        "lib/dotnet/System.Linq.Queryable.dll",
+        "lib/net45/_._",
+        "lib/netcore50/System.Linq.Queryable.dll",
+        "lib/win8/_._",
+        "lib/wp80/_._",
+        "lib/wpa81/_._",
+        "ref/dotnet/de/System.Linq.Queryable.xml",
+        "ref/dotnet/es/System.Linq.Queryable.xml",
+        "ref/dotnet/fr/System.Linq.Queryable.xml",
+        "ref/dotnet/it/System.Linq.Queryable.xml",
+        "ref/dotnet/ja/System.Linq.Queryable.xml",
+        "ref/dotnet/ko/System.Linq.Queryable.xml",
+        "ref/dotnet/ru/System.Linq.Queryable.xml",
+        "ref/dotnet/System.Linq.Queryable.dll",
+        "ref/dotnet/System.Linq.Queryable.xml",
+        "ref/dotnet/zh-hans/System.Linq.Queryable.xml",
+        "ref/dotnet/zh-hant/System.Linq.Queryable.xml",
+        "ref/net45/_._",
+        "ref/netcore50/System.Linq.Queryable.dll",
+        "ref/netcore50/System.Linq.Queryable.xml",
+        "ref/win8/_._",
+        "ref/wp80/_._",
+        "ref/wpa81/_._",
+        "System.Linq.Queryable.4.0.0-beta-23110.nupkg",
+        "System.Linq.Queryable.4.0.0-beta-23110.nupkg.sha512",
+        "System.Linq.Queryable.nuspec"
+      ]
+    },
+    "System.Net.Http/4.0.0-beta-23110": {
+      "serviceable": true,
+      "sha512": "9EJW5LOi8dFAjCLC1DGOyhJVSllq4Zq+vFteiCWO1qKRNWJGzzJgtt/r+PfWQuE7JNQUKJloEeW4kVTnHBYcGQ==",
+      "files": [
+        "lib/DNXCore50/System.Net.Http.dll",
+        "lib/net45/_._",
+        "lib/netcore50/System.Net.Http.dll",
+        "lib/win8/_._",
+        "lib/wpa81/_._",
+        "ref/dotnet/de/System.Net.Http.xml",
+        "ref/dotnet/es/System.Net.Http.xml",
+        "ref/dotnet/fr/System.Net.Http.xml",
+        "ref/dotnet/it/System.Net.Http.xml",
+        "ref/dotnet/ja/System.Net.Http.xml",
+        "ref/dotnet/ko/System.Net.Http.xml",
+        "ref/dotnet/ru/System.Net.Http.xml",
+        "ref/dotnet/System.Net.Http.dll",
+        "ref/dotnet/System.Net.Http.xml",
+        "ref/dotnet/zh-hans/System.Net.Http.xml",
+        "ref/dotnet/zh-hant/System.Net.Http.xml",
+        "ref/net45/_._",
+        "ref/netcore50/System.Net.Http.dll",
+        "ref/netcore50/System.Net.Http.xml",
+        "ref/win8/_._",
+        "ref/wpa81/_._",
+        "System.Net.Http.4.0.0-beta-23110.nupkg",
+        "System.Net.Http.4.0.0-beta-23110.nupkg.sha512",
+        "System.Net.Http.nuspec"
+      ]
+    },
+    "System.Net.NameResolution/4.0.0-beta-23110": {
+      "sha512": "POsyeb9EAB24ka46Sqcb8yoSyyxo8VHC29EMnVmolCXtOAdIIDPUqujt5rFj/cXE9i34AR0QH5X1heGXTzy35Q==",
+      "files": [
+        "lib/DNXCore50/System.Net.NameResolution.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Net.NameResolution.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Net.NameResolution.xml",
+        "ref/dotnet/es/System.Net.NameResolution.xml",
+        "ref/dotnet/fr/System.Net.NameResolution.xml",
+        "ref/dotnet/it/System.Net.NameResolution.xml",
+        "ref/dotnet/ja/System.Net.NameResolution.xml",
+        "ref/dotnet/ko/System.Net.NameResolution.xml",
+        "ref/dotnet/ru/System.Net.NameResolution.xml",
+        "ref/dotnet/System.Net.NameResolution.dll",
+        "ref/dotnet/System.Net.NameResolution.xml",
+        "ref/dotnet/zh-hans/System.Net.NameResolution.xml",
+        "ref/dotnet/zh-hant/System.Net.NameResolution.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Net.NameResolution.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Net.NameResolution.4.0.0-beta-23110.nupkg",
+        "System.Net.NameResolution.4.0.0-beta-23110.nupkg.sha512",
+        "System.Net.NameResolution.nuspec"
+      ]
+    },
+    "System.Net.Primitives/4.0.10-beta-23110": {
+      "serviceable": true,
+      "sha512": "ONQEWvo5dd0l6nDQbG3GKTMY75VGe7Av3ijYcXfeAfq0oHyOkCWjBURj06uhcAk3+AZQz8bmPsr3ILJZ4zUURQ==",
+      "files": [
+        "lib/DNXCore50/System.Net.Primitives.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/netcore50/System.Net.Primitives.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Net.Primitives.xml",
+        "ref/dotnet/es/System.Net.Primitives.xml",
+        "ref/dotnet/fr/System.Net.Primitives.xml",
+        "ref/dotnet/it/System.Net.Primitives.xml",
+        "ref/dotnet/ja/System.Net.Primitives.xml",
+        "ref/dotnet/ko/System.Net.Primitives.xml",
+        "ref/dotnet/ru/System.Net.Primitives.xml",
+        "ref/dotnet/System.Net.Primitives.dll",
+        "ref/dotnet/System.Net.Primitives.xml",
+        "ref/dotnet/zh-hans/System.Net.Primitives.xml",
+        "ref/dotnet/zh-hant/System.Net.Primitives.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Net.Primitives.4.0.10-beta-23110.nupkg",
+        "System.Net.Primitives.4.0.10-beta-23110.nupkg.sha512",
+        "System.Net.Primitives.nuspec"
+      ]
+    },
+    "System.Net.Security/4.0.0-beta-23110": {
+      "sha512": "iYmPZtaPtDQpvoncwpMleMFJV4JtIwpFmHN0YT8kPqi+kRnZSlgKE3nUZPELpGCyqAbLxlJ+rwHbZy++YG/YPw==",
+      "files": [
+        "lib/DNXCore50/System.Net.Security.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Net.Security.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Net.Security.xml",
+        "ref/dotnet/es/System.Net.Security.xml",
+        "ref/dotnet/fr/System.Net.Security.xml",
+        "ref/dotnet/it/System.Net.Security.xml",
+        "ref/dotnet/ja/System.Net.Security.xml",
+        "ref/dotnet/ko/System.Net.Security.xml",
+        "ref/dotnet/ru/System.Net.Security.xml",
+        "ref/dotnet/System.Net.Security.dll",
+        "ref/dotnet/System.Net.Security.xml",
+        "ref/dotnet/zh-hans/System.Net.Security.xml",
+        "ref/dotnet/zh-hant/System.Net.Security.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Net.Security.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Net.Security.4.0.0-beta-23110.nupkg",
+        "System.Net.Security.4.0.0-beta-23110.nupkg.sha512",
+        "System.Net.Security.nuspec"
+      ]
+    },
+    "System.Net.Sockets/4.0.10-beta-23110": {
+      "sha512": "yBP2BtI6ZFPV0v9OMFDhCQ+HGTs5ZjGxZU8RRF6TZoh0VYM15q72gBeAwXH710+ojqMDtB1+uZkmfGaZVxpPIw==",
+      "files": [
+        "lib/DNXCore50/System.Net.Sockets.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Net.Sockets.xml",
+        "ref/dotnet/es/System.Net.Sockets.xml",
+        "ref/dotnet/fr/System.Net.Sockets.xml",
+        "ref/dotnet/it/System.Net.Sockets.xml",
+        "ref/dotnet/ja/System.Net.Sockets.xml",
+        "ref/dotnet/ko/System.Net.Sockets.xml",
+        "ref/dotnet/ru/System.Net.Sockets.xml",
+        "ref/dotnet/System.Net.Sockets.dll",
+        "ref/dotnet/System.Net.Sockets.xml",
+        "ref/dotnet/zh-hans/System.Net.Sockets.xml",
+        "ref/dotnet/zh-hant/System.Net.Sockets.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Net.Sockets.4.0.10-beta-23110.nupkg",
+        "System.Net.Sockets.4.0.10-beta-23110.nupkg.sha512",
+        "System.Net.Sockets.nuspec"
+      ]
+    },
+    "System.Net.WebHeaderCollection/4.0.0-beta-23110": {
+      "serviceable": true,
+      "sha512": "VEaE8UB9O1h0cDTVy9PvlA+FjF3EjFiWtJ7QNohx4G0B1+WW1b6xTCaY4jrlFiSqv/NG8APcifhkjZ3YNpCDpQ==",
+      "files": [
+        "lib/dotnet/System.Net.WebHeaderCollection.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Net.WebHeaderCollection.xml",
+        "ref/dotnet/es/System.Net.WebHeaderCollection.xml",
+        "ref/dotnet/fr/System.Net.WebHeaderCollection.xml",
+        "ref/dotnet/it/System.Net.WebHeaderCollection.xml",
+        "ref/dotnet/ja/System.Net.WebHeaderCollection.xml",
+        "ref/dotnet/ko/System.Net.WebHeaderCollection.xml",
+        "ref/dotnet/ru/System.Net.WebHeaderCollection.xml",
+        "ref/dotnet/System.Net.WebHeaderCollection.dll",
+        "ref/dotnet/System.Net.WebHeaderCollection.xml",
+        "ref/dotnet/zh-hans/System.Net.WebHeaderCollection.xml",
+        "ref/dotnet/zh-hant/System.Net.WebHeaderCollection.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Net.WebHeaderCollection.4.0.0-beta-23110.nupkg",
+        "System.Net.WebHeaderCollection.4.0.0-beta-23110.nupkg.sha512",
+        "System.Net.WebHeaderCollection.nuspec"
+      ]
+    },
+    "System.ObjectModel/4.0.10-beta-23110": {
+      "serviceable": true,
+      "sha512": "Gy9dut90Z7TCB5RbjxKA+jTzvzrAnQqVA5I7d34g7vgF62bpRs0tkndOd9LP7fOMEUBiniFhFCT12pou4U70Lg==",
+      "files": [
+        "lib/dotnet/System.ObjectModel.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.ObjectModel.xml",
+        "ref/dotnet/es/System.ObjectModel.xml",
+        "ref/dotnet/fr/System.ObjectModel.xml",
+        "ref/dotnet/it/System.ObjectModel.xml",
+        "ref/dotnet/ja/System.ObjectModel.xml",
+        "ref/dotnet/ko/System.ObjectModel.xml",
+        "ref/dotnet/ru/System.ObjectModel.xml",
+        "ref/dotnet/System.ObjectModel.dll",
+        "ref/dotnet/System.ObjectModel.xml",
+        "ref/dotnet/zh-hans/System.ObjectModel.xml",
+        "ref/dotnet/zh-hant/System.ObjectModel.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.ObjectModel.4.0.10-beta-23110.nupkg",
+        "System.ObjectModel.4.0.10-beta-23110.nupkg.sha512",
+        "System.ObjectModel.nuspec"
+      ]
+    },
+    "System.Private.DataContractSerialization/4.0.0-beta-23110": {
+      "serviceable": true,
+      "sha512": "dd2xXfvn2voRquK9PPH7a6CnjZkxe+Xnbu0aWG/sxd1QSzIf7/PwtzZUjeV5yfB8TTkCzuQ35bEnFBjUprlRSQ==",
+      "files": [
+        "lib/DNXCore50/System.Private.DataContractSerialization.dll",
+        "lib/netcore50/System.Private.DataContractSerialization.dll",
+        "ref/dnxcore50/_._",
+        "ref/netcore50/_._",
+        "runtime.json",
+        "runtimes/win8-aot/lib/netcore50/System.Private.DataContractSerialization.dll",
+        "System.Private.DataContractSerialization.4.0.0-beta-23110.nupkg",
+        "System.Private.DataContractSerialization.4.0.0-beta-23110.nupkg.sha512",
+        "System.Private.DataContractSerialization.nuspec"
+      ]
+    },
+    "System.Private.Networking/4.0.0-beta-23110": {
+      "serviceable": true,
+      "sha512": "YSQV8XbJPWDgq5GOaL3vcaCDvPq4kkbbjfPggtb3Fk+TSUprA/KbYGjICwOYLJUcaQkNlRww6fb+q+wcOAPM0w==",
+      "files": [
+        "lib/DNXCore50/System.Private.Networking.dll",
+        "lib/netcore50/System.Private.Networking.dll",
+        "ref/dnxcore50/_._",
+        "ref/netcore50/_._",
+        "System.Private.Networking.4.0.0-beta-23110.nupkg",
+        "System.Private.Networking.4.0.0-beta-23110.nupkg.sha512",
+        "System.Private.Networking.nuspec"
+      ]
+    },
+    "System.Private.ServiceModel/4.0.0-beta-23110": {
+      "serviceable": true,
+      "sha512": "pxkmlDt01lluamQNT5UH7qG7TbHopz9ndX0YV5EsLdeSjHaYQxxXH6rwhDQIBvdVtG2A7EfaJfM4po/Wk4gvpw==",
+      "files": [
+        "lib/DNXCore50/System.Private.ServiceModel.dll",
+        "lib/netcore50/System.Private.ServiceModel.dll",
+        "ref/dnxcore50/_._",
+        "ref/netcore50/_._",
+        "System.Private.ServiceModel.4.0.0-beta-23110.nupkg",
+        "System.Private.ServiceModel.4.0.0-beta-23110.nupkg.sha512",
+        "System.Private.ServiceModel.nuspec"
+      ]
+    },
+    "System.Private.Uri/4.0.0-beta-23110": {
+      "serviceable": true,
+      "sha512": "jU3WYx4hJhCID/hYWW6A0t4pGdtI+Obqvsm06AAVCpdKAEJPe5zq6cgLDQVwPWsOaw2IQmQ0nsTKAXtL/CkpCg==",
+      "files": [
+        "lib/DNXCore50/System.Private.Uri.dll",
+        "lib/netcore50/System.Private.Uri.dll",
+        "ref/dnxcore50/_._",
+        "ref/netcore50/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Private.Uri.dll",
+        "System.Private.Uri.4.0.0-beta-23110.nupkg",
+        "System.Private.Uri.4.0.0-beta-23110.nupkg.sha512",
+        "System.Private.Uri.nuspec"
+      ]
+    },
+    "System.Reflection/4.0.10-beta-23110": {
+      "sha512": "WiSln11obIbCrHgZbPz0tYLSpQEO96LIM2pWug//KSUVC0s2I2iZN62KuCyLb8XdCm6PBs8MAigXzAYjt5lXJw==",
+      "files": [
+        "lib/DNXCore50/System.Reflection.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/netcore50/System.Reflection.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Reflection.xml",
+        "ref/dotnet/es/System.Reflection.xml",
+        "ref/dotnet/fr/System.Reflection.xml",
+        "ref/dotnet/it/System.Reflection.xml",
+        "ref/dotnet/ja/System.Reflection.xml",
+        "ref/dotnet/ko/System.Reflection.xml",
+        "ref/dotnet/ru/System.Reflection.xml",
+        "ref/dotnet/System.Reflection.dll",
+        "ref/dotnet/System.Reflection.xml",
+        "ref/dotnet/zh-hans/System.Reflection.xml",
+        "ref/dotnet/zh-hant/System.Reflection.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Reflection.dll",
+        "System.Reflection.4.0.10-beta-23110.nupkg",
+        "System.Reflection.4.0.10-beta-23110.nupkg.sha512",
+        "System.Reflection.nuspec"
+      ]
+    },
+    "System.Reflection.DispatchProxy/4.0.0-beta-23110": {
+      "serviceable": true,
+      "sha512": "soXz3k0IeNX3ZOEFZ7InpWbQ/xYSFfnSSOCITL4Q1CuGRmuoa8Yi5NC7XAU/fR5RtIkvvdb/r0ZaYaW9mmrPKg==",
+      "files": [
+        "lib/DNXCore50/System.Reflection.DispatchProxy.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Reflection.DispatchProxy.dll",
+        "lib/netcore50/System.Reflection.DispatchProxy.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Reflection.DispatchProxy.xml",
+        "ref/dotnet/es/System.Reflection.DispatchProxy.xml",
+        "ref/dotnet/fr/System.Reflection.DispatchProxy.xml",
+        "ref/dotnet/it/System.Reflection.DispatchProxy.xml",
+        "ref/dotnet/ja/System.Reflection.DispatchProxy.xml",
+        "ref/dotnet/ko/System.Reflection.DispatchProxy.xml",
+        "ref/dotnet/ru/System.Reflection.DispatchProxy.xml",
+        "ref/dotnet/System.Reflection.DispatchProxy.dll",
+        "ref/dotnet/System.Reflection.DispatchProxy.xml",
+        "ref/dotnet/zh-hans/System.Reflection.DispatchProxy.xml",
+        "ref/dotnet/zh-hant/System.Reflection.DispatchProxy.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "runtime.json",
+        "runtimes/win8-aot/lib/netcore50/System.Reflection.DispatchProxy.dll",
+        "System.Reflection.DispatchProxy.4.0.0-beta-23110.nupkg",
+        "System.Reflection.DispatchProxy.4.0.0-beta-23110.nupkg.sha512",
+        "System.Reflection.DispatchProxy.nuspec"
+      ]
+    },
+    "System.Reflection.Emit/4.0.0-beta-23110": {
+      "sha512": "S3Y231TTbWSSnucqj3lmG0dDawpNdoD4r8k36t89T2SUMgF+TDRwcORMqZ6CzyK9bJxchjoJgcNIQB7hpZAlzQ==",
+      "files": [
+        "lib/DNXCore50/System.Reflection.Emit.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/net45/_._",
+        "lib/netcore50/System.Reflection.Emit.dll",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Reflection.Emit.xml",
+        "ref/dotnet/es/System.Reflection.Emit.xml",
+        "ref/dotnet/fr/System.Reflection.Emit.xml",
+        "ref/dotnet/it/System.Reflection.Emit.xml",
+        "ref/dotnet/ja/System.Reflection.Emit.xml",
+        "ref/dotnet/ko/System.Reflection.Emit.xml",
+        "ref/dotnet/ru/System.Reflection.Emit.xml",
+        "ref/dotnet/System.Reflection.Emit.dll",
+        "ref/dotnet/System.Reflection.Emit.xml",
+        "ref/dotnet/zh-hans/System.Reflection.Emit.xml",
+        "ref/dotnet/zh-hant/System.Reflection.Emit.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/net45/_._",
+        "ref/xamarinmac20/_._",
+        "System.Reflection.Emit.4.0.0-beta-23110.nupkg",
+        "System.Reflection.Emit.4.0.0-beta-23110.nupkg.sha512",
+        "System.Reflection.Emit.nuspec"
+      ]
+    },
+    "System.Reflection.Emit.ILGeneration/4.0.0-beta-23110": {
+      "sha512": "9M8Kw1gW5d8dFrhYrXEvGtrDG/pKxq5nypEUsGOrZh78yMWPoe86ilD5KZhcCZNy187pWcXAf6EfZJ+1aPp2ug==",
+      "files": [
+        "lib/DNXCore50/System.Reflection.Emit.ILGeneration.dll",
+        "lib/net45/_._",
+        "lib/netcore50/System.Reflection.Emit.ILGeneration.dll",
+        "lib/wp80/_._",
+        "ref/dotnet/de/System.Reflection.Emit.ILGeneration.xml",
+        "ref/dotnet/es/System.Reflection.Emit.ILGeneration.xml",
+        "ref/dotnet/fr/System.Reflection.Emit.ILGeneration.xml",
+        "ref/dotnet/it/System.Reflection.Emit.ILGeneration.xml",
+        "ref/dotnet/ja/System.Reflection.Emit.ILGeneration.xml",
+        "ref/dotnet/ko/System.Reflection.Emit.ILGeneration.xml",
+        "ref/dotnet/ru/System.Reflection.Emit.ILGeneration.xml",
+        "ref/dotnet/System.Reflection.Emit.ILGeneration.dll",
+        "ref/dotnet/System.Reflection.Emit.ILGeneration.xml",
+        "ref/dotnet/zh-hans/System.Reflection.Emit.ILGeneration.xml",
+        "ref/dotnet/zh-hant/System.Reflection.Emit.ILGeneration.xml",
+        "ref/net45/_._",
+        "ref/wp80/_._",
+        "System.Reflection.Emit.ILGeneration.4.0.0-beta-23110.nupkg",
+        "System.Reflection.Emit.ILGeneration.4.0.0-beta-23110.nupkg.sha512",
+        "System.Reflection.Emit.ILGeneration.nuspec"
+      ]
+    },
+    "System.Reflection.Extensions/4.0.0-beta-23110": {
+      "serviceable": true,
+      "sha512": "ZV+0yQlXtKLRSsnA6IBk9vLijHGdbePtRbMf5HC3s3F/Z6ZQ8yLEXHDmWcn7wRPI/RgolxeKNrnVsukyR1VGMA==",
+      "files": [
+        "lib/DNXCore50/System.Reflection.Extensions.dll",
+        "lib/net45/_._",
+        "lib/netcore50/System.Reflection.Extensions.dll",
+        "lib/win8/_._",
+        "lib/wp80/_._",
+        "lib/wpa81/_._",
+        "ref/dotnet/de/System.Reflection.Extensions.xml",
+        "ref/dotnet/es/System.Reflection.Extensions.xml",
+        "ref/dotnet/fr/System.Reflection.Extensions.xml",
+        "ref/dotnet/it/System.Reflection.Extensions.xml",
+        "ref/dotnet/ja/System.Reflection.Extensions.xml",
+        "ref/dotnet/ko/System.Reflection.Extensions.xml",
+        "ref/dotnet/ru/System.Reflection.Extensions.xml",
+        "ref/dotnet/System.Reflection.Extensions.dll",
+        "ref/dotnet/System.Reflection.Extensions.xml",
+        "ref/dotnet/zh-hans/System.Reflection.Extensions.xml",
+        "ref/dotnet/zh-hant/System.Reflection.Extensions.xml",
+        "ref/net45/_._",
+        "ref/netcore50/System.Reflection.Extensions.dll",
+        "ref/netcore50/System.Reflection.Extensions.xml",
+        "ref/win8/_._",
+        "ref/wp80/_._",
+        "ref/wpa81/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Reflection.Extensions.dll",
+        "System.Reflection.Extensions.4.0.0-beta-23110.nupkg",
+        "System.Reflection.Extensions.4.0.0-beta-23110.nupkg.sha512",
+        "System.Reflection.Extensions.nuspec"
+      ]
+    },
+    "System.Reflection.Primitives/4.0.0-beta-23110": {
+      "serviceable": true,
+      "sha512": "QIwLr1xZ3Xg4LB3C+dd7zoE6FAcJCuL60eQFcasA6pC5Nl/0LA7ltcOkq0+DaAIDCD9bH/OFQEZ3F/bdDGtS/Q==",
+      "files": [
+        "lib/DNXCore50/System.Reflection.Primitives.dll",
+        "lib/net45/_._",
+        "lib/netcore50/System.Reflection.Primitives.dll",
+        "lib/win8/_._",
+        "lib/wp80/_._",
+        "lib/wpa81/_._",
+        "ref/dotnet/de/System.Reflection.Primitives.xml",
+        "ref/dotnet/es/System.Reflection.Primitives.xml",
+        "ref/dotnet/fr/System.Reflection.Primitives.xml",
+        "ref/dotnet/it/System.Reflection.Primitives.xml",
+        "ref/dotnet/ja/System.Reflection.Primitives.xml",
+        "ref/dotnet/ko/System.Reflection.Primitives.xml",
+        "ref/dotnet/ru/System.Reflection.Primitives.xml",
+        "ref/dotnet/System.Reflection.Primitives.dll",
+        "ref/dotnet/System.Reflection.Primitives.xml",
+        "ref/dotnet/zh-hans/System.Reflection.Primitives.xml",
+        "ref/dotnet/zh-hant/System.Reflection.Primitives.xml",
+        "ref/net45/_._",
+        "ref/netcore50/System.Reflection.Primitives.dll",
+        "ref/netcore50/System.Reflection.Primitives.xml",
+        "ref/win8/_._",
+        "ref/wp80/_._",
+        "ref/wpa81/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Reflection.Primitives.dll",
+        "System.Reflection.Primitives.4.0.0-beta-23110.nupkg",
+        "System.Reflection.Primitives.4.0.0-beta-23110.nupkg.sha512",
+        "System.Reflection.Primitives.nuspec"
+      ]
+    },
+    "System.Reflection.TypeExtensions/4.0.0-beta-23110": {
+      "serviceable": true,
+      "sha512": "wOpJ1WBQqsnvFu56hA4hyUTpmhtI0vRA1aNsX78TGr3a4fOF/oV/eX2sUF/ZVBhtvBGzfWA4OOLa59k2C1J1Uw==",
+      "files": [
+        "lib/DNXCore50/System.Reflection.TypeExtensions.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Reflection.TypeExtensions.dll",
+        "lib/netcore50/System.Reflection.TypeExtensions.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Reflection.TypeExtensions.xml",
+        "ref/dotnet/es/System.Reflection.TypeExtensions.xml",
+        "ref/dotnet/fr/System.Reflection.TypeExtensions.xml",
+        "ref/dotnet/it/System.Reflection.TypeExtensions.xml",
+        "ref/dotnet/ja/System.Reflection.TypeExtensions.xml",
+        "ref/dotnet/ko/System.Reflection.TypeExtensions.xml",
+        "ref/dotnet/ru/System.Reflection.TypeExtensions.xml",
+        "ref/dotnet/System.Reflection.TypeExtensions.dll",
+        "ref/dotnet/System.Reflection.TypeExtensions.xml",
+        "ref/dotnet/zh-hans/System.Reflection.TypeExtensions.xml",
+        "ref/dotnet/zh-hant/System.Reflection.TypeExtensions.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Reflection.TypeExtensions.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Reflection.TypeExtensions.dll",
+        "System.Reflection.TypeExtensions.4.0.0-beta-23110.nupkg",
+        "System.Reflection.TypeExtensions.4.0.0-beta-23110.nupkg.sha512",
+        "System.Reflection.TypeExtensions.nuspec"
+      ]
+    },
+    "System.Resources.ResourceManager/4.0.0-beta-23110": {
+      "serviceable": true,
+      "sha512": "pv9uEtkJFwZatmwiM3rgs1xoEDAJ3KGghh9E4udg1kirHQ2tvdm2FT8S1gTG1nzpJqBGzg4jl+tubTTGosckeA==",
+      "files": [
+        "lib/DNXCore50/System.Resources.ResourceManager.dll",
+        "lib/net45/_._",
+        "lib/netcore50/System.Resources.ResourceManager.dll",
+        "lib/win8/_._",
+        "lib/wp80/_._",
+        "lib/wpa81/_._",
+        "ref/dotnet/de/System.Resources.ResourceManager.xml",
+        "ref/dotnet/es/System.Resources.ResourceManager.xml",
+        "ref/dotnet/fr/System.Resources.ResourceManager.xml",
+        "ref/dotnet/it/System.Resources.ResourceManager.xml",
+        "ref/dotnet/ja/System.Resources.ResourceManager.xml",
+        "ref/dotnet/ko/System.Resources.ResourceManager.xml",
+        "ref/dotnet/ru/System.Resources.ResourceManager.xml",
+        "ref/dotnet/System.Resources.ResourceManager.dll",
+        "ref/dotnet/System.Resources.ResourceManager.xml",
+        "ref/dotnet/zh-hans/System.Resources.ResourceManager.xml",
+        "ref/dotnet/zh-hant/System.Resources.ResourceManager.xml",
+        "ref/net45/_._",
+        "ref/netcore50/System.Resources.ResourceManager.dll",
+        "ref/netcore50/System.Resources.ResourceManager.xml",
+        "ref/win8/_._",
+        "ref/wp80/_._",
+        "ref/wpa81/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Resources.ResourceManager.dll",
+        "System.Resources.ResourceManager.4.0.0-beta-23110.nupkg",
+        "System.Resources.ResourceManager.4.0.0-beta-23110.nupkg.sha512",
+        "System.Resources.ResourceManager.nuspec"
+      ]
+    },
+    "System.Runtime/4.0.20-beta-23110": {
+      "serviceable": true,
+      "sha512": "MUs0/AsISalHLYKKDcY1oLdIT9a9P6tXjis4Ha/Qa2/t4hZ3rDQ2rcQok20PZ0oo8rrUNRFGVU6RB9PJ/SaK2A==",
+      "files": [
+        "lib/DNXCore50/System.Runtime.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/netcore50/System.Runtime.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Runtime.xml",
+        "ref/dotnet/es/System.Runtime.xml",
+        "ref/dotnet/fr/System.Runtime.xml",
+        "ref/dotnet/it/System.Runtime.xml",
+        "ref/dotnet/ja/System.Runtime.xml",
+        "ref/dotnet/ko/System.Runtime.xml",
+        "ref/dotnet/ru/System.Runtime.xml",
+        "ref/dotnet/System.Runtime.dll",
+        "ref/dotnet/System.Runtime.xml",
+        "ref/dotnet/zh-hans/System.Runtime.xml",
+        "ref/dotnet/zh-hant/System.Runtime.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.dll",
+        "System.Runtime.4.0.20-beta-23110.nupkg",
+        "System.Runtime.4.0.20-beta-23110.nupkg.sha512",
+        "System.Runtime.nuspec"
+      ]
+    },
+    "System.Runtime.Extensions/4.0.10-beta-23110": {
+      "serviceable": true,
+      "sha512": "jWzcMxGSWx06AFLEmTT2pznSavlQIJnFMJKP1xmAnftmrWqkQ7+xZCqU7nCmoUQ+dMwMJFMUJYQI2tj5WPZg7g==",
+      "files": [
+        "lib/DNXCore50/System.Runtime.Extensions.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/netcore50/System.Runtime.Extensions.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Runtime.Extensions.xml",
+        "ref/dotnet/es/System.Runtime.Extensions.xml",
+        "ref/dotnet/fr/System.Runtime.Extensions.xml",
+        "ref/dotnet/it/System.Runtime.Extensions.xml",
+        "ref/dotnet/ja/System.Runtime.Extensions.xml",
+        "ref/dotnet/ko/System.Runtime.Extensions.xml",
+        "ref/dotnet/ru/System.Runtime.Extensions.xml",
+        "ref/dotnet/System.Runtime.Extensions.dll",
+        "ref/dotnet/System.Runtime.Extensions.xml",
+        "ref/dotnet/zh-hans/System.Runtime.Extensions.xml",
+        "ref/dotnet/zh-hant/System.Runtime.Extensions.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.Extensions.dll",
+        "System.Runtime.Extensions.4.0.10-beta-23110.nupkg",
+        "System.Runtime.Extensions.4.0.10-beta-23110.nupkg.sha512",
+        "System.Runtime.Extensions.nuspec"
+      ]
+    },
+    "System.Runtime.Handles/4.0.0-beta-23110": {
+      "serviceable": true,
+      "sha512": "VG4FO4O5CJcO0vKpN37Sgvhw22Hnz+Jh/cw4rcmD74mw8teraymyEANEfHhbUIRccbKfdL+Hm+eyJ+mZGHkjsw==",
+      "files": [
+        "lib/DNXCore50/System.Runtime.Handles.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/netcore50/System.Runtime.Handles.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Runtime.Handles.xml",
+        "ref/dotnet/es/System.Runtime.Handles.xml",
+        "ref/dotnet/fr/System.Runtime.Handles.xml",
+        "ref/dotnet/it/System.Runtime.Handles.xml",
+        "ref/dotnet/ja/System.Runtime.Handles.xml",
+        "ref/dotnet/ko/System.Runtime.Handles.xml",
+        "ref/dotnet/ru/System.Runtime.Handles.xml",
+        "ref/dotnet/System.Runtime.Handles.dll",
+        "ref/dotnet/System.Runtime.Handles.xml",
+        "ref/dotnet/zh-hans/System.Runtime.Handles.xml",
+        "ref/dotnet/zh-hant/System.Runtime.Handles.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.Handles.dll",
+        "System.Runtime.Handles.4.0.0-beta-23110.nupkg",
+        "System.Runtime.Handles.4.0.0-beta-23110.nupkg.sha512",
+        "System.Runtime.Handles.nuspec"
+      ]
+    },
+    "System.Runtime.InteropServices/4.0.20-beta-23110": {
+      "serviceable": true,
+      "sha512": "rRcd68AoRe+BYb9V2/RlsSJcISxbCYQuLbObYdtYRGaAc1qxHbfNzZyQecQjZqzKCEdT64jEca4mNS/mfoYX7Q==",
+      "files": [
+        "lib/DNXCore50/System.Runtime.InteropServices.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/netcore50/System.Runtime.InteropServices.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Runtime.InteropServices.xml",
+        "ref/dotnet/es/System.Runtime.InteropServices.xml",
+        "ref/dotnet/fr/System.Runtime.InteropServices.xml",
+        "ref/dotnet/it/System.Runtime.InteropServices.xml",
+        "ref/dotnet/ja/System.Runtime.InteropServices.xml",
+        "ref/dotnet/ko/System.Runtime.InteropServices.xml",
+        "ref/dotnet/ru/System.Runtime.InteropServices.xml",
+        "ref/dotnet/System.Runtime.InteropServices.dll",
+        "ref/dotnet/System.Runtime.InteropServices.xml",
+        "ref/dotnet/zh-hans/System.Runtime.InteropServices.xml",
+        "ref/dotnet/zh-hant/System.Runtime.InteropServices.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.InteropServices.dll",
+        "System.Runtime.InteropServices.4.0.20-beta-23110.nupkg",
+        "System.Runtime.InteropServices.4.0.20-beta-23110.nupkg.sha512",
+        "System.Runtime.InteropServices.nuspec"
+      ]
+    },
+    "System.Runtime.Numerics/4.0.0-beta-23110": {
+      "serviceable": true,
+      "sha512": "pQaurqp3W3MpvjFgq8zE2urqUeV9dXyrK0lKba5mDJXLGIRxZrEpYIoxiau1aY9a8TT1CI82Guvm3ejk9FcU2Q==",
+      "files": [
+        "lib/dotnet/System.Runtime.Numerics.dll",
+        "lib/net45/_._",
+        "lib/netcore50/System.Runtime.Numerics.dll",
+        "lib/win8/_._",
+        "lib/wpa81/_._",
+        "ref/dotnet/de/System.Runtime.Numerics.xml",
+        "ref/dotnet/es/System.Runtime.Numerics.xml",
+        "ref/dotnet/fr/System.Runtime.Numerics.xml",
+        "ref/dotnet/it/System.Runtime.Numerics.xml",
+        "ref/dotnet/ja/System.Runtime.Numerics.xml",
+        "ref/dotnet/ko/System.Runtime.Numerics.xml",
+        "ref/dotnet/ru/System.Runtime.Numerics.xml",
+        "ref/dotnet/System.Runtime.Numerics.dll",
+        "ref/dotnet/System.Runtime.Numerics.xml",
+        "ref/dotnet/zh-hans/System.Runtime.Numerics.xml",
+        "ref/dotnet/zh-hant/System.Runtime.Numerics.xml",
+        "ref/net45/_._",
+        "ref/netcore50/System.Runtime.Numerics.dll",
+        "ref/netcore50/System.Runtime.Numerics.xml",
+        "ref/win8/_._",
+        "ref/wpa81/_._",
+        "System.Runtime.Numerics.4.0.0-beta-23110.nupkg",
+        "System.Runtime.Numerics.4.0.0-beta-23110.nupkg.sha512",
+        "System.Runtime.Numerics.nuspec"
+      ]
+    },
+    "System.Runtime.Serialization.Primitives/4.0.10-beta-23110": {
+      "serviceable": true,
+      "sha512": "ZbmhJtP/rPcQPogGPUL6FevRb0vEsWn2nCxtEJ3jnIEZkUkQliZr1Ua+9H3/QN79OBmxfqUZRuelSS2vauHM+Q==",
+      "files": [
+        "lib/dotnet/System.Runtime.Serialization.Primitives.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Runtime.Serialization.Primitives.xml",
+        "ref/dotnet/es/System.Runtime.Serialization.Primitives.xml",
+        "ref/dotnet/fr/System.Runtime.Serialization.Primitives.xml",
+        "ref/dotnet/it/System.Runtime.Serialization.Primitives.xml",
+        "ref/dotnet/ja/System.Runtime.Serialization.Primitives.xml",
+        "ref/dotnet/ko/System.Runtime.Serialization.Primitives.xml",
+        "ref/dotnet/ru/System.Runtime.Serialization.Primitives.xml",
+        "ref/dotnet/System.Runtime.Serialization.Primitives.dll",
+        "ref/dotnet/System.Runtime.Serialization.Primitives.xml",
+        "ref/dotnet/zh-hans/System.Runtime.Serialization.Primitives.xml",
+        "ref/dotnet/zh-hant/System.Runtime.Serialization.Primitives.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Runtime.Serialization.Primitives.4.0.10-beta-23110.nupkg",
+        "System.Runtime.Serialization.Primitives.4.0.10-beta-23110.nupkg.sha512",
+        "System.Runtime.Serialization.Primitives.nuspec"
+      ]
+    },
+    "System.Runtime.Serialization.Xml/4.0.10-beta-23110": {
+      "sha512": "hBF/XANozO/x9IR08nmgpg7ZGgoOqjvUDuek+RW2YOQWfqEt7JmZRQyIOqR5Gyw3GU7ydmXm/9+fnkgMPIsHJg==",
+      "files": [
+        "lib/DNXCore50/System.Runtime.Serialization.Xml.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/netcore50/System.Runtime.Serialization.Xml.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Runtime.Serialization.Xml.xml",
+        "ref/dotnet/es/System.Runtime.Serialization.Xml.xml",
+        "ref/dotnet/fr/System.Runtime.Serialization.Xml.xml",
+        "ref/dotnet/it/System.Runtime.Serialization.Xml.xml",
+        "ref/dotnet/ja/System.Runtime.Serialization.Xml.xml",
+        "ref/dotnet/ko/System.Runtime.Serialization.Xml.xml",
+        "ref/dotnet/ru/System.Runtime.Serialization.Xml.xml",
+        "ref/dotnet/System.Runtime.Serialization.Xml.dll",
+        "ref/dotnet/System.Runtime.Serialization.Xml.xml",
+        "ref/dotnet/zh-hans/System.Runtime.Serialization.Xml.xml",
+        "ref/dotnet/zh-hant/System.Runtime.Serialization.Xml.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.Serialization.Xml.dll",
+        "System.Runtime.Serialization.Xml.4.0.10-beta-23110.nupkg",
+        "System.Runtime.Serialization.Xml.4.0.10-beta-23110.nupkg.sha512",
+        "System.Runtime.Serialization.Xml.nuspec"
+      ]
+    },
+    "System.Security.Claims/4.0.0-beta-23110": {
+      "serviceable": true,
+      "sha512": "OPf6O93HVDMlrC6ZW0RPlXRtWSdoK6vL2MDRcdfF8RyWDc9eeX9OOWMMD5Yz/i8Iodsye6Ldn9uFDD3Y8jx4Cg==",
+      "files": [
+        "lib/dotnet/System.Security.Claims.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Security.Claims.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Security.Claims.xml",
+        "ref/dotnet/es/System.Security.Claims.xml",
+        "ref/dotnet/fr/System.Security.Claims.xml",
+        "ref/dotnet/it/System.Security.Claims.xml",
+        "ref/dotnet/ja/System.Security.Claims.xml",
+        "ref/dotnet/ko/System.Security.Claims.xml",
+        "ref/dotnet/ru/System.Security.Claims.xml",
+        "ref/dotnet/System.Security.Claims.dll",
+        "ref/dotnet/System.Security.Claims.xml",
+        "ref/dotnet/zh-hans/System.Security.Claims.xml",
+        "ref/dotnet/zh-hant/System.Security.Claims.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Security.Claims.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Security.Claims.4.0.0-beta-23110.nupkg",
+        "System.Security.Claims.4.0.0-beta-23110.nupkg.sha512",
+        "System.Security.Claims.nuspec"
+      ]
+    },
+    "System.Security.Cryptography.Encoding/4.0.0-beta-23110": {
+      "serviceable": true,
+      "sha512": "EgOJl6XT7/JBntPu8+Irs+Wc1r5vBZ8qRlRck+WES1mxhSm06d+aUbsWwAKVJEtfozycZrgEFSgtRoNFevKKdg==",
+      "files": [
+        "lib/DNXCore50/System.Security.Cryptography.Encoding.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Security.Cryptography.Encoding.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/es/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/fr/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/it/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/ja/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/ko/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/ru/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/System.Security.Cryptography.Encoding.dll",
+        "ref/dotnet/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/zh-hans/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/zh-hant/System.Security.Cryptography.Encoding.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Security.Cryptography.Encoding.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Security.Cryptography.Encoding.4.0.0-beta-23110.nupkg",
+        "System.Security.Cryptography.Encoding.4.0.0-beta-23110.nupkg.sha512",
+        "System.Security.Cryptography.Encoding.nuspec"
+      ]
+    },
+    "System.Security.Cryptography.Encryption/4.0.0-beta-23110": {
+      "serviceable": true,
+      "sha512": "CcPu99yHJvys4B83gUff+WvrmyqhjlvDnNtZ8BSpgxLtP0QU50iaJVL2Z5ohor+JxPfcLi/Kr+KWsabA60yOzw==",
+      "files": [
+        "lib/DNXCore50/System.Security.Cryptography.Encryption.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Security.Cryptography.Encryption.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Security.Cryptography.Encryption.xml",
+        "ref/dotnet/es/System.Security.Cryptography.Encryption.xml",
+        "ref/dotnet/fr/System.Security.Cryptography.Encryption.xml",
+        "ref/dotnet/it/System.Security.Cryptography.Encryption.xml",
+        "ref/dotnet/ja/System.Security.Cryptography.Encryption.xml",
+        "ref/dotnet/ko/System.Security.Cryptography.Encryption.xml",
+        "ref/dotnet/ru/System.Security.Cryptography.Encryption.xml",
+        "ref/dotnet/System.Security.Cryptography.Encryption.dll",
+        "ref/dotnet/System.Security.Cryptography.Encryption.xml",
+        "ref/dotnet/zh-hans/System.Security.Cryptography.Encryption.xml",
+        "ref/dotnet/zh-hant/System.Security.Cryptography.Encryption.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Security.Cryptography.Encryption.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Security.Cryptography.Encryption.4.0.0-beta-23110.nupkg",
+        "System.Security.Cryptography.Encryption.4.0.0-beta-23110.nupkg.sha512",
+        "System.Security.Cryptography.Encryption.nuspec"
+      ]
+    },
+    "System.Security.Cryptography.Hashing/4.0.0-beta-23110": {
+      "serviceable": true,
+      "sha512": "QIAeXCxiewcjPLtLLXY8dZ40KqLJ7gj/JS4i8gJQX0fDdFcjiHFdWPUHJGCfvgoAkapsLR43YZLGFsEDCkViQw==",
+      "files": [
+        "lib/DNXCore50/System.Security.Cryptography.Hashing.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Security.Cryptography.Hashing.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Security.Cryptography.Hashing.xml",
+        "ref/dotnet/es/System.Security.Cryptography.Hashing.xml",
+        "ref/dotnet/fr/System.Security.Cryptography.Hashing.xml",
+        "ref/dotnet/it/System.Security.Cryptography.Hashing.xml",
+        "ref/dotnet/ja/System.Security.Cryptography.Hashing.xml",
+        "ref/dotnet/ko/System.Security.Cryptography.Hashing.xml",
+        "ref/dotnet/ru/System.Security.Cryptography.Hashing.xml",
+        "ref/dotnet/System.Security.Cryptography.Hashing.dll",
+        "ref/dotnet/System.Security.Cryptography.Hashing.xml",
+        "ref/dotnet/zh-hans/System.Security.Cryptography.Hashing.xml",
+        "ref/dotnet/zh-hant/System.Security.Cryptography.Hashing.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Security.Cryptography.Hashing.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Security.Cryptography.Hashing.4.0.0-beta-23110.nupkg",
+        "System.Security.Cryptography.Hashing.4.0.0-beta-23110.nupkg.sha512",
+        "System.Security.Cryptography.Hashing.nuspec"
+      ]
+    },
+    "System.Security.Cryptography.Hashing.Algorithms/4.0.0-beta-23110": {
+      "serviceable": true,
+      "sha512": "ed3W8yDY7l1U8syL7Nklp41G98GJ/yB64gDI+fdncKWnqQI2wpqtbSBvXig9oxnqlsbedXKTwImacRKAQtKo6A==",
+      "files": [
+        "lib/DNXCore50/System.Security.Cryptography.Hashing.Algorithms.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Security.Cryptography.Hashing.Algorithms.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Security.Cryptography.Hashing.Algorithms.xml",
+        "ref/dotnet/es/System.Security.Cryptography.Hashing.Algorithms.xml",
+        "ref/dotnet/fr/System.Security.Cryptography.Hashing.Algorithms.xml",
+        "ref/dotnet/it/System.Security.Cryptography.Hashing.Algorithms.xml",
+        "ref/dotnet/ja/System.Security.Cryptography.Hashing.Algorithms.xml",
+        "ref/dotnet/ko/System.Security.Cryptography.Hashing.Algorithms.xml",
+        "ref/dotnet/ru/System.Security.Cryptography.Hashing.Algorithms.xml",
+        "ref/dotnet/System.Security.Cryptography.Hashing.Algorithms.dll",
+        "ref/dotnet/System.Security.Cryptography.Hashing.Algorithms.xml",
+        "ref/dotnet/zh-hans/System.Security.Cryptography.Hashing.Algorithms.xml",
+        "ref/dotnet/zh-hant/System.Security.Cryptography.Hashing.Algorithms.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Security.Cryptography.Hashing.Algorithms.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Security.Cryptography.Hashing.Algorithms.4.0.0-beta-23110.nupkg",
+        "System.Security.Cryptography.Hashing.Algorithms.4.0.0-beta-23110.nupkg.sha512",
+        "System.Security.Cryptography.Hashing.Algorithms.nuspec"
+      ]
+    },
+    "System.Security.Cryptography.RandomNumberGenerator/4.0.0-beta-23110": {
+      "serviceable": true,
+      "sha512": "GBwlfdsZlKiI4XPX54ZVle+XOKJB9JCYiSlvwSkIzs7HFrIOoeRALmq8otiGItHLVUX+0BG5AICZb3XGNBRtog==",
+      "files": [
+        "lib/DNXCore50/System.Security.Cryptography.RandomNumberGenerator.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Security.Cryptography.RandomNumberGenerator.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Security.Cryptography.RandomNumberGenerator.xml",
+        "ref/dotnet/es/System.Security.Cryptography.RandomNumberGenerator.xml",
+        "ref/dotnet/fr/System.Security.Cryptography.RandomNumberGenerator.xml",
+        "ref/dotnet/it/System.Security.Cryptography.RandomNumberGenerator.xml",
+        "ref/dotnet/ja/System.Security.Cryptography.RandomNumberGenerator.xml",
+        "ref/dotnet/ko/System.Security.Cryptography.RandomNumberGenerator.xml",
+        "ref/dotnet/ru/System.Security.Cryptography.RandomNumberGenerator.xml",
+        "ref/dotnet/System.Security.Cryptography.RandomNumberGenerator.dll",
+        "ref/dotnet/System.Security.Cryptography.RandomNumberGenerator.xml",
+        "ref/dotnet/zh-hans/System.Security.Cryptography.RandomNumberGenerator.xml",
+        "ref/dotnet/zh-hant/System.Security.Cryptography.RandomNumberGenerator.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Security.Cryptography.RandomNumberGenerator.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Security.Cryptography.RandomNumberGenerator.4.0.0-beta-23110.nupkg",
+        "System.Security.Cryptography.RandomNumberGenerator.4.0.0-beta-23110.nupkg.sha512",
+        "System.Security.Cryptography.RandomNumberGenerator.nuspec"
+      ]
+    },
+    "System.Security.Cryptography.RSA/4.0.0-beta-23110": {
+      "serviceable": true,
+      "sha512": "f92pWQoEmnMy5Zetnm00S8r7x+UibhRlJDxczU59Y8pv04dWInLBvdrPk5zg9o836qxkEDL4zShKZ/rKqCfv/g==",
+      "files": [
+        "lib/DNXCore50/System.Security.Cryptography.RSA.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Security.Cryptography.RSA.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Security.Cryptography.RSA.xml",
+        "ref/dotnet/es/System.Security.Cryptography.RSA.xml",
+        "ref/dotnet/fr/System.Security.Cryptography.RSA.xml",
+        "ref/dotnet/it/System.Security.Cryptography.RSA.xml",
+        "ref/dotnet/ja/System.Security.Cryptography.RSA.xml",
+        "ref/dotnet/ko/System.Security.Cryptography.RSA.xml",
+        "ref/dotnet/ru/System.Security.Cryptography.RSA.xml",
+        "ref/dotnet/System.Security.Cryptography.RSA.dll",
+        "ref/dotnet/System.Security.Cryptography.RSA.xml",
+        "ref/dotnet/zh-hans/System.Security.Cryptography.RSA.xml",
+        "ref/dotnet/zh-hant/System.Security.Cryptography.RSA.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Security.Cryptography.RSA.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Security.Cryptography.RSA.4.0.0-beta-23110.nupkg",
+        "System.Security.Cryptography.RSA.4.0.0-beta-23110.nupkg.sha512",
+        "System.Security.Cryptography.RSA.nuspec"
+      ]
+    },
+    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23110": {
+      "serviceable": true,
+      "sha512": "i8I/vRWnb9fCIhmAeTH4M1EXLhpEcaLnt2RIGD7vwNPeXax89OHsEUydr+r6bWaKnVnPrS2G7Zrji57TK/8zog==",
+      "files": [
+        "lib/DNXCore50/System.Security.Cryptography.X509Certificates.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Security.Cryptography.X509Certificates.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/es/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/fr/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/it/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/ja/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/ko/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/ru/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/System.Security.Cryptography.X509Certificates.dll",
+        "ref/dotnet/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/zh-hans/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/zh-hant/System.Security.Cryptography.X509Certificates.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Security.Cryptography.X509Certificates.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23110.nupkg",
+        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23110.nupkg.sha512",
+        "System.Security.Cryptography.X509Certificates.nuspec"
+      ]
+    },
+    "System.Security.Principal/4.0.0-beta-23110": {
+      "serviceable": true,
+      "sha512": "ZQ2xLLZq+FxoweATt3gIqp76KCD8DTPpAxYOGV9Ov8VafQIy7zauJYUgxQohxUjxAw8cidoW2f+RsF+r7Ltw4Q==",
+      "files": [
+        "lib/dotnet/System.Security.Principal.dll",
+        "lib/net45/_._",
+        "lib/netcore50/System.Security.Principal.dll",
+        "lib/win8/_._",
+        "lib/wp80/_._",
+        "lib/wpa81/_._",
+        "ref/dotnet/de/System.Security.Principal.xml",
+        "ref/dotnet/es/System.Security.Principal.xml",
+        "ref/dotnet/fr/System.Security.Principal.xml",
+        "ref/dotnet/it/System.Security.Principal.xml",
+        "ref/dotnet/ja/System.Security.Principal.xml",
+        "ref/dotnet/ko/System.Security.Principal.xml",
+        "ref/dotnet/ru/System.Security.Principal.xml",
+        "ref/dotnet/System.Security.Principal.dll",
+        "ref/dotnet/System.Security.Principal.xml",
+        "ref/dotnet/zh-hans/System.Security.Principal.xml",
+        "ref/dotnet/zh-hant/System.Security.Principal.xml",
+        "ref/net45/_._",
+        "ref/netcore50/System.Security.Principal.dll",
+        "ref/netcore50/System.Security.Principal.xml",
+        "ref/win8/_._",
+        "ref/wp80/_._",
+        "ref/wpa81/_._",
+        "System.Security.Principal.4.0.0-beta-23110.nupkg",
+        "System.Security.Principal.4.0.0-beta-23110.nupkg.sha512",
+        "System.Security.Principal.nuspec"
+      ]
+    },
+    "System.Security.Principal.Windows/4.0.0-beta-23110": {
+      "serviceable": true,
+      "sha512": "UqHjBRdcnFgGOz8B29MjlIwIRjH71unFZk+Q6drP8vt0cYVRN7OVLhDVwvhze1ZcK4nEYchgz3vndxKHSuI/Zw==",
+      "files": [
+        "lib/DNXCore50/System.Security.Principal.Windows.dll",
+        "lib/net46/System.Security.Principal.Windows.dll",
+        "ref/dotnet/de/System.Security.Principal.Windows.xml",
+        "ref/dotnet/es/System.Security.Principal.Windows.xml",
+        "ref/dotnet/fr/System.Security.Principal.Windows.xml",
+        "ref/dotnet/it/System.Security.Principal.Windows.xml",
+        "ref/dotnet/ja/System.Security.Principal.Windows.xml",
+        "ref/dotnet/ko/System.Security.Principal.Windows.xml",
+        "ref/dotnet/ru/System.Security.Principal.Windows.xml",
+        "ref/dotnet/System.Security.Principal.Windows.dll",
+        "ref/dotnet/System.Security.Principal.Windows.xml",
+        "ref/dotnet/zh-hans/System.Security.Principal.Windows.xml",
+        "ref/dotnet/zh-hant/System.Security.Principal.Windows.xml",
+        "ref/net46/System.Security.Principal.Windows.dll",
+        "System.Security.Principal.Windows.4.0.0-beta-23110.nupkg",
+        "System.Security.Principal.Windows.4.0.0-beta-23110.nupkg.sha512",
+        "System.Security.Principal.Windows.nuspec"
+      ]
+    },
+    "System.Security.SecureString/4.0.0-beta-23110": {
+      "serviceable": true,
+      "sha512": "KJEpYYl/tIXkrQcwL7pkG3us/CgOPIX2ZFaLSwgN8uBqQpGN8Kj8wxpEiANRBB0DHfqGxb/8nb74YKS0ETZ6Vg==",
+      "files": [
+        "lib/DNXCore50/System.Security.SecureString.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Security.SecureString.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Security.SecureString.xml",
+        "ref/dotnet/es/System.Security.SecureString.xml",
+        "ref/dotnet/fr/System.Security.SecureString.xml",
+        "ref/dotnet/it/System.Security.SecureString.xml",
+        "ref/dotnet/ja/System.Security.SecureString.xml",
+        "ref/dotnet/ko/System.Security.SecureString.xml",
+        "ref/dotnet/ru/System.Security.SecureString.xml",
+        "ref/dotnet/System.Security.SecureString.dll",
+        "ref/dotnet/System.Security.SecureString.xml",
+        "ref/dotnet/zh-hans/System.Security.SecureString.xml",
+        "ref/dotnet/zh-hant/System.Security.SecureString.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Security.SecureString.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Security.SecureString.4.0.0-beta-23110.nupkg",
+        "System.Security.SecureString.4.0.0-beta-23110.nupkg.sha512",
+        "System.Security.SecureString.nuspec"
+      ]
+    },
+    "System.ServiceModel.Http/4.0.10-beta-23110": {
+      "serviceable": true,
+      "sha512": "K/EWYuxVLqNmaMg2mqPR/YQRhziaXobjjuoGl6RDBPnmYsG58JmctJTZWE18LhXSydAk2Ai8HoqBLfbK3HbFMw==",
+      "files": [
+        "lib/DNXCore50/System.ServiceModel.Http.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/netcore50/System.ServiceModel.Http.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.ServiceModel.Http.xml",
+        "ref/dotnet/es/System.ServiceModel.Http.xml",
+        "ref/dotnet/fr/System.ServiceModel.Http.xml",
+        "ref/dotnet/it/System.ServiceModel.Http.xml",
+        "ref/dotnet/ja/System.ServiceModel.Http.xml",
+        "ref/dotnet/ko/System.ServiceModel.Http.xml",
+        "ref/dotnet/ru/System.ServiceModel.Http.xml",
+        "ref/dotnet/System.ServiceModel.Http.dll",
+        "ref/dotnet/System.ServiceModel.Http.xml",
+        "ref/dotnet/zh-hans/System.ServiceModel.Http.xml",
+        "ref/dotnet/zh-hant/System.ServiceModel.Http.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.ServiceModel.Http.4.0.10-beta-23110.nupkg",
+        "System.ServiceModel.Http.4.0.10-beta-23110.nupkg.sha512",
+        "System.ServiceModel.Http.nuspec"
+      ]
+    },
+    "System.ServiceModel.NetTcp/4.0.0-beta-23110": {
+      "serviceable": true,
+      "sha512": "1MfgVmxFNGsktwrA1/mOB1RFJYqfcfuQ9WEKzMAmzZG78gzraaENIhE8wvGoEW5uQ5wraU6ml4M1pZzlW8NRYw==",
+      "files": [
+        "lib/DNXCore50/System.ServiceModel.NetTcp.dll",
+        "lib/net45/_._",
+        "lib/netcore50/System.ServiceModel.NetTcp.dll",
+        "lib/win8/_._",
+        "ref/dotnet/de/System.ServiceModel.NetTcp.xml",
+        "ref/dotnet/es/System.ServiceModel.NetTcp.xml",
+        "ref/dotnet/fr/System.ServiceModel.NetTcp.xml",
+        "ref/dotnet/it/System.ServiceModel.NetTcp.xml",
+        "ref/dotnet/ja/System.ServiceModel.NetTcp.xml",
+        "ref/dotnet/ko/System.ServiceModel.NetTcp.xml",
+        "ref/dotnet/ru/System.ServiceModel.NetTcp.xml",
+        "ref/dotnet/System.ServiceModel.NetTcp.dll",
+        "ref/dotnet/System.ServiceModel.NetTcp.xml",
+        "ref/dotnet/zh-hans/System.ServiceModel.NetTcp.xml",
+        "ref/dotnet/zh-hant/System.ServiceModel.NetTcp.xml",
+        "ref/net45/_._",
+        "ref/netcore50/System.ServiceModel.NetTcp.dll",
+        "ref/netcore50/System.ServiceModel.NetTcp.xml",
+        "ref/win8/_._",
+        "System.ServiceModel.NetTcp.4.0.0-beta-23110.nupkg",
+        "System.ServiceModel.NetTcp.4.0.0-beta-23110.nupkg.sha512",
+        "System.ServiceModel.NetTcp.nuspec"
+      ]
+    },
+    "System.ServiceModel.Primitives/4.0.0-beta-23110": {
+      "serviceable": true,
+      "sha512": "YmdkPuQDJsyCgw1w/3GW+8yCTrjF6FBvz0ifAmvBshubEPFRShxOq+lBLDdgbDO/S1OpA+SsG9v599fCNrMjxg==",
+      "files": [
+        "lib/DNXCore50/System.ServiceModel.Primitives.dll",
+        "lib/net45/_._",
+        "lib/netcore50/System.ServiceModel.Primitives.dll",
+        "lib/win8/_._",
+        "ref/dotnet/de/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/es/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/fr/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/it/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/ja/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/ko/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/ru/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/System.ServiceModel.Primitives.dll",
+        "ref/dotnet/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/zh-hans/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/zh-hant/System.ServiceModel.Primitives.xml",
+        "ref/net45/_._",
+        "ref/netcore50/System.ServiceModel.Primitives.dll",
+        "ref/netcore50/System.ServiceModel.Primitives.xml",
+        "ref/win8/_._",
+        "System.ServiceModel.Primitives.4.0.0-beta-23110.nupkg",
+        "System.ServiceModel.Primitives.4.0.0-beta-23110.nupkg.sha512",
+        "System.ServiceModel.Primitives.nuspec"
+      ]
+    },
+    "System.ServiceModel.Security/4.0.0-beta-23109": {
+      "serviceable": true,
+      "sha512": "RaOW9Zu8rnw8vnrXAs5M6MsuP/h2CYuXK/Q5PkiaVcECc9xJEZngGzz3Oe0PhXhdFbyikf5h/Vt1mpQ1crS+gg==",
+      "files": [
+        "lib/DNXCore50/System.ServiceModel.Security.dll",
+        "lib/net45/_._",
+        "lib/netcore50/System.ServiceModel.Security.dll",
+        "lib/win8/_._",
+        "ref/dotnet/de/System.ServiceModel.Security.xml",
+        "ref/dotnet/es/System.ServiceModel.Security.xml",
+        "ref/dotnet/fr/System.ServiceModel.Security.xml",
+        "ref/dotnet/it/System.ServiceModel.Security.xml",
+        "ref/dotnet/ja/System.ServiceModel.Security.xml",
+        "ref/dotnet/ko/System.ServiceModel.Security.xml",
+        "ref/dotnet/ru/System.ServiceModel.Security.xml",
+        "ref/dotnet/System.ServiceModel.Security.dll",
+        "ref/dotnet/System.ServiceModel.Security.xml",
+        "ref/dotnet/zh-hans/System.ServiceModel.Security.xml",
+        "ref/dotnet/zh-hant/System.ServiceModel.Security.xml",
+        "ref/net45/_._",
+        "ref/netcore50/System.ServiceModel.Security.dll",
+        "ref/netcore50/System.ServiceModel.Security.xml",
+        "ref/win8/_._",
+        "System.ServiceModel.Security.4.0.0-beta-23109.nupkg",
+        "System.ServiceModel.Security.4.0.0-beta-23109.nupkg.sha512",
+        "System.ServiceModel.Security.nuspec"
+      ]
+    },
+    "System.Text.Encoding/4.0.10-beta-23110": {
+      "sha512": "FlGJ4JtP8G8HSNbYHECdXxEKvCIlbwC7KeYft10HtUAuAwMceKLnYg4gTg7ukaipmgkgB35UfPdW7MJ6BODsiw==",
+      "files": [
+        "lib/DNXCore50/System.Text.Encoding.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/netcore50/System.Text.Encoding.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Text.Encoding.xml",
+        "ref/dotnet/es/System.Text.Encoding.xml",
+        "ref/dotnet/fr/System.Text.Encoding.xml",
+        "ref/dotnet/it/System.Text.Encoding.xml",
+        "ref/dotnet/ja/System.Text.Encoding.xml",
+        "ref/dotnet/ko/System.Text.Encoding.xml",
+        "ref/dotnet/ru/System.Text.Encoding.xml",
+        "ref/dotnet/System.Text.Encoding.dll",
+        "ref/dotnet/System.Text.Encoding.xml",
+        "ref/dotnet/zh-hans/System.Text.Encoding.xml",
+        "ref/dotnet/zh-hant/System.Text.Encoding.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Text.Encoding.dll",
+        "System.Text.Encoding.4.0.10-beta-23110.nupkg",
+        "System.Text.Encoding.4.0.10-beta-23110.nupkg.sha512",
+        "System.Text.Encoding.nuspec"
+      ]
+    },
+    "System.Text.Encoding.Extensions/4.0.10-beta-23110": {
+      "sha512": "W1kKe/AR3pgaZkWlQUk9cmtjm6KfjthuTGgPyscKQkSQeqPSVqbup1j0Ahfi86L+pYGUtOBYvuvGIuf0enRxxg==",
+      "files": [
+        "lib/DNXCore50/System.Text.Encoding.Extensions.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/netcore50/System.Text.Encoding.Extensions.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Text.Encoding.Extensions.xml",
+        "ref/dotnet/es/System.Text.Encoding.Extensions.xml",
+        "ref/dotnet/fr/System.Text.Encoding.Extensions.xml",
+        "ref/dotnet/it/System.Text.Encoding.Extensions.xml",
+        "ref/dotnet/ja/System.Text.Encoding.Extensions.xml",
+        "ref/dotnet/ko/System.Text.Encoding.Extensions.xml",
+        "ref/dotnet/ru/System.Text.Encoding.Extensions.xml",
+        "ref/dotnet/System.Text.Encoding.Extensions.dll",
+        "ref/dotnet/System.Text.Encoding.Extensions.xml",
+        "ref/dotnet/zh-hans/System.Text.Encoding.Extensions.xml",
+        "ref/dotnet/zh-hant/System.Text.Encoding.Extensions.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Text.Encoding.Extensions.dll",
+        "System.Text.Encoding.Extensions.4.0.10-beta-23110.nupkg",
+        "System.Text.Encoding.Extensions.4.0.10-beta-23110.nupkg.sha512",
+        "System.Text.Encoding.Extensions.nuspec"
+      ]
+    },
+    "System.Text.RegularExpressions/4.0.10-beta-23110": {
+      "serviceable": true,
+      "sha512": "VQwjucM32LrqdcZ7PX5PpZFHcNXlCsroyJ37m5DK1/36/q7QER4F2RpmnXiCfVKs7E0PSuyydbIHl9MxdsO/uw==",
+      "files": [
+        "lib/dotnet/System.Text.RegularExpressions.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Text.RegularExpressions.xml",
+        "ref/dotnet/es/System.Text.RegularExpressions.xml",
+        "ref/dotnet/fr/System.Text.RegularExpressions.xml",
+        "ref/dotnet/it/System.Text.RegularExpressions.xml",
+        "ref/dotnet/ja/System.Text.RegularExpressions.xml",
+        "ref/dotnet/ko/System.Text.RegularExpressions.xml",
+        "ref/dotnet/ru/System.Text.RegularExpressions.xml",
+        "ref/dotnet/System.Text.RegularExpressions.dll",
+        "ref/dotnet/System.Text.RegularExpressions.xml",
+        "ref/dotnet/zh-hans/System.Text.RegularExpressions.xml",
+        "ref/dotnet/zh-hant/System.Text.RegularExpressions.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Text.RegularExpressions.4.0.10-beta-23110.nupkg",
+        "System.Text.RegularExpressions.4.0.10-beta-23110.nupkg.sha512",
+        "System.Text.RegularExpressions.nuspec"
+      ]
+    },
+    "System.Threading/4.0.10-beta-23110": {
+      "serviceable": true,
+      "sha512": "vdSth7tUIQk1MXqSSgGLN40M77AcdqkHkLU9RwhnOjMyravqL9P+NlOJotoaw/JKWVJiVCIQ9bND3EFhVHdrsA==",
+      "files": [
+        "lib/DNXCore50/System.Threading.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/netcore50/System.Threading.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Threading.xml",
+        "ref/dotnet/es/System.Threading.xml",
+        "ref/dotnet/fr/System.Threading.xml",
+        "ref/dotnet/it/System.Threading.xml",
+        "ref/dotnet/ja/System.Threading.xml",
+        "ref/dotnet/ko/System.Threading.xml",
+        "ref/dotnet/ru/System.Threading.xml",
+        "ref/dotnet/System.Threading.dll",
+        "ref/dotnet/System.Threading.xml",
+        "ref/dotnet/zh-hans/System.Threading.xml",
+        "ref/dotnet/zh-hant/System.Threading.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Threading.dll",
+        "System.Threading.4.0.10-beta-23110.nupkg",
+        "System.Threading.4.0.10-beta-23110.nupkg.sha512",
+        "System.Threading.nuspec"
+      ]
+    },
+    "System.Threading.Overlapped/4.0.0-beta-23110": {
+      "serviceable": true,
+      "sha512": "WcDzyotEp85Ul6B7T6NHXZmThDn+PVX0IrMLOwzH/PehbStyViKbOORyewpq+RaK4/MSYMXpXV6rvHT10j2Fhw==",
+      "files": [
+        "lib/DNXCore50/System.Threading.Overlapped.dll",
+        "lib/net46/System.Threading.Overlapped.dll",
+        "lib/netcore50/System.Threading.Overlapped.dll",
+        "ref/dotnet/de/System.Threading.Overlapped.xml",
+        "ref/dotnet/es/System.Threading.Overlapped.xml",
+        "ref/dotnet/fr/System.Threading.Overlapped.xml",
+        "ref/dotnet/it/System.Threading.Overlapped.xml",
+        "ref/dotnet/ja/System.Threading.Overlapped.xml",
+        "ref/dotnet/ko/System.Threading.Overlapped.xml",
+        "ref/dotnet/ru/System.Threading.Overlapped.xml",
+        "ref/dotnet/System.Threading.Overlapped.dll",
+        "ref/dotnet/System.Threading.Overlapped.xml",
+        "ref/dotnet/zh-hans/System.Threading.Overlapped.xml",
+        "ref/dotnet/zh-hant/System.Threading.Overlapped.xml",
+        "ref/net46/System.Threading.Overlapped.dll",
+        "System.Threading.Overlapped.4.0.0-beta-23110.nupkg",
+        "System.Threading.Overlapped.4.0.0-beta-23110.nupkg.sha512",
+        "System.Threading.Overlapped.nuspec"
+      ]
+    },
+    "System.Threading.Tasks/4.0.10-beta-23110": {
+      "serviceable": true,
+      "sha512": "/mtUOcDyxKBzs+xhpNM7sMg0pncDPEyM1s6TG0EEX8HKRT8tZnW8KYcv1e03lEf5SXwVmCG52QUimYf0HC7jvA==",
+      "files": [
+        "lib/DNXCore50/System.Threading.Tasks.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/netcore50/System.Threading.Tasks.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Threading.Tasks.xml",
+        "ref/dotnet/es/System.Threading.Tasks.xml",
+        "ref/dotnet/fr/System.Threading.Tasks.xml",
+        "ref/dotnet/it/System.Threading.Tasks.xml",
+        "ref/dotnet/ja/System.Threading.Tasks.xml",
+        "ref/dotnet/ko/System.Threading.Tasks.xml",
+        "ref/dotnet/ru/System.Threading.Tasks.xml",
+        "ref/dotnet/System.Threading.Tasks.dll",
+        "ref/dotnet/System.Threading.Tasks.xml",
+        "ref/dotnet/zh-hans/System.Threading.Tasks.xml",
+        "ref/dotnet/zh-hant/System.Threading.Tasks.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Threading.Tasks.dll",
+        "System.Threading.Tasks.4.0.10-beta-23110.nupkg",
+        "System.Threading.Tasks.4.0.10-beta-23110.nupkg.sha512",
+        "System.Threading.Tasks.nuspec"
+      ]
+    },
+    "System.Threading.ThreadPool/4.0.10-beta-23110": {
+      "sha512": "qmCisRtQrJEoEk9wpQ9KfQ0ypM+3Fpol9Y7Br3JEeyzQ5BTpd/b7Z8R5By+1brGANqajd7q9a1AQpjv9K1PEkg==",
+      "files": [
+        "lib/DNXCore50/System.Threading.ThreadPool.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Threading.ThreadPool.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Threading.ThreadPool.xml",
+        "ref/dotnet/es/System.Threading.ThreadPool.xml",
+        "ref/dotnet/fr/System.Threading.ThreadPool.xml",
+        "ref/dotnet/it/System.Threading.ThreadPool.xml",
+        "ref/dotnet/ja/System.Threading.ThreadPool.xml",
+        "ref/dotnet/ko/System.Threading.ThreadPool.xml",
+        "ref/dotnet/ru/System.Threading.ThreadPool.xml",
+        "ref/dotnet/System.Threading.ThreadPool.dll",
+        "ref/dotnet/System.Threading.ThreadPool.xml",
+        "ref/dotnet/zh-hans/System.Threading.ThreadPool.xml",
+        "ref/dotnet/zh-hant/System.Threading.ThreadPool.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Threading.ThreadPool.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Threading.ThreadPool.4.0.10-beta-23110.nupkg",
+        "System.Threading.ThreadPool.4.0.10-beta-23110.nupkg.sha512",
+        "System.Threading.ThreadPool.nuspec"
+      ]
+    },
+    "System.Threading.Timer/4.0.0-beta-23110": {
+      "sha512": "4ro+Bei549CPcdWBmBxYdSzIbhIDoCVBwgRnejxhzCXrMJBdNctHTjY7VSb8AptZexRzZHcR1lHDz56US1kDwQ==",
+      "files": [
+        "lib/DNXCore50/System.Threading.Timer.dll",
+        "lib/net451/_._",
+        "lib/netcore50/System.Threading.Timer.dll",
+        "lib/win81/_._",
+        "lib/wpa81/_._",
+        "ref/dotnet/de/System.Threading.Timer.xml",
+        "ref/dotnet/es/System.Threading.Timer.xml",
+        "ref/dotnet/fr/System.Threading.Timer.xml",
+        "ref/dotnet/it/System.Threading.Timer.xml",
+        "ref/dotnet/ja/System.Threading.Timer.xml",
+        "ref/dotnet/ko/System.Threading.Timer.xml",
+        "ref/dotnet/ru/System.Threading.Timer.xml",
+        "ref/dotnet/System.Threading.Timer.dll",
+        "ref/dotnet/System.Threading.Timer.xml",
+        "ref/dotnet/zh-hans/System.Threading.Timer.xml",
+        "ref/dotnet/zh-hant/System.Threading.Timer.xml",
+        "ref/net451/_._",
+        "ref/netcore50/System.Threading.Timer.dll",
+        "ref/netcore50/System.Threading.Timer.xml",
+        "ref/win81/_._",
+        "ref/wpa81/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Threading.Timer.dll",
+        "System.Threading.Timer.4.0.0-beta-23110.nupkg",
+        "System.Threading.Timer.4.0.0-beta-23110.nupkg.sha512",
+        "System.Threading.Timer.nuspec"
+      ]
+    },
+    "System.Xml.ReaderWriter/4.0.10-beta-23110": {
+      "serviceable": true,
+      "sha512": "0+VkAfGzuCgyV0KQpacApXjPdZTS/lmMyTI/9gT8Z59traQQRG8Wjg4Rc13NZak1UVHd67Kn5K+2bZ8qBrsNfw==",
+      "files": [
+        "lib/dotnet/System.Xml.ReaderWriter.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Xml.ReaderWriter.xml",
+        "ref/dotnet/es/System.Xml.ReaderWriter.xml",
+        "ref/dotnet/fr/System.Xml.ReaderWriter.xml",
+        "ref/dotnet/it/System.Xml.ReaderWriter.xml",
+        "ref/dotnet/ja/System.Xml.ReaderWriter.xml",
+        "ref/dotnet/ko/System.Xml.ReaderWriter.xml",
+        "ref/dotnet/ru/System.Xml.ReaderWriter.xml",
+        "ref/dotnet/System.Xml.ReaderWriter.dll",
+        "ref/dotnet/System.Xml.ReaderWriter.xml",
+        "ref/dotnet/zh-hans/System.Xml.ReaderWriter.xml",
+        "ref/dotnet/zh-hant/System.Xml.ReaderWriter.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Xml.ReaderWriter.4.0.10-beta-23110.nupkg",
+        "System.Xml.ReaderWriter.4.0.10-beta-23110.nupkg.sha512",
+        "System.Xml.ReaderWriter.nuspec"
+      ]
+    },
+    "System.Xml.XmlDocument/4.0.0-beta-23110": {
+      "serviceable": true,
+      "sha512": "YJC5mvucSOZgyOclW9fpTKvy/GmBmhDzZpvtqi0jDsXfNh0Do1wuWIGN30BujgVKzm2gfyWOCSZ9dr94RTPBLw==",
+      "files": [
+        "lib/dotnet/System.Xml.XmlDocument.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Xml.XmlDocument.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Xml.XmlDocument.xml",
+        "ref/dotnet/es/System.Xml.XmlDocument.xml",
+        "ref/dotnet/fr/System.Xml.XmlDocument.xml",
+        "ref/dotnet/it/System.Xml.XmlDocument.xml",
+        "ref/dotnet/ja/System.Xml.XmlDocument.xml",
+        "ref/dotnet/ko/System.Xml.XmlDocument.xml",
+        "ref/dotnet/ru/System.Xml.XmlDocument.xml",
+        "ref/dotnet/System.Xml.XmlDocument.dll",
+        "ref/dotnet/System.Xml.XmlDocument.xml",
+        "ref/dotnet/zh-hans/System.Xml.XmlDocument.xml",
+        "ref/dotnet/zh-hant/System.Xml.XmlDocument.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Xml.XmlDocument.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Xml.XmlDocument.4.0.0-beta-23110.nupkg",
+        "System.Xml.XmlDocument.4.0.0-beta-23110.nupkg.sha512",
+        "System.Xml.XmlDocument.nuspec"
+      ]
+    },
+    "System.Xml.XmlSerializer/4.0.10-beta-23110": {
+      "serviceable": true,
+      "sha512": "dTzOKBw3xkbmJUbeL1xHcIvgh/o3ON48MgDSyNA2ntrDPzylCmAUL4e/lybEhVjXbi8DpYt4LpRuaUMh65PEyg==",
+      "files": [
+        "lib/DNXCore50/System.Xml.XmlSerializer.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/netcore50/System.Xml.XmlSerializer.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Xml.XmlSerializer.xml",
+        "ref/dotnet/es/System.Xml.XmlSerializer.xml",
+        "ref/dotnet/fr/System.Xml.XmlSerializer.xml",
+        "ref/dotnet/it/System.Xml.XmlSerializer.xml",
+        "ref/dotnet/ja/System.Xml.XmlSerializer.xml",
+        "ref/dotnet/ko/System.Xml.XmlSerializer.xml",
+        "ref/dotnet/ru/System.Xml.XmlSerializer.xml",
+        "ref/dotnet/System.Xml.XmlSerializer.dll",
+        "ref/dotnet/System.Xml.XmlSerializer.xml",
+        "ref/dotnet/zh-hans/System.Xml.XmlSerializer.xml",
+        "ref/dotnet/zh-hant/System.Xml.XmlSerializer.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "runtime.json",
+        "runtimes/win8-aot/lib/netcore50/System.Xml.XmlSerializer.dll",
+        "System.Xml.XmlSerializer.4.0.10-beta-23110.nupkg",
+        "System.Xml.XmlSerializer.4.0.10-beta-23110.nupkg.sha512",
+        "System.Xml.XmlSerializer.nuspec"
+      ]
+    }
+  },
+  "projectFileDependencyGroups": {
+    "": [
+      "System.Net.Sockets >= 4.0.10-beta-*",
+      "System.ServiceModel.NetTcp >= 4.0.0-beta-*",
+      "System.ServiceModel.Http >= 4.0.10-beta-*",
+      "System.ServiceModel.Primitives >= 4.0.0-beta-*",
+      "System.ServiceModel.Security >= 4.0.0-beta-*",
+      "System.Console >= 4.0.0-beta-*",
+      "System.Collections >= 4.0.10-beta-*",
+      "System.Linq >= 4.0.0-beta-*",
+      "System.Threading >= 4.0.10-beta-*",
+      "System.Diagnostics.Debug >= 4.0.10-beta-*",
+      "System.Collections.Specialized >= 4.0.0-beta-*"
+    ],
+    "DNXCore,Version=v5.0": []
+  }
+}


### PR DESCRIPTION
These stress tests focus on using shared instances of WCF channel factories and channels by multiple threads. 

We group those instances in pools, and we group the scenarios that use them in static classes (with public static methods for easy consumption without any preliminary setup from various stress frameworks).

Some scenarios focus on just making WCF calls using a pool of already created channels while other scenarios open/close/recycle/abort channels and factories on some threads while simultaneously invoking service calls over other threads. 

We use a number of helper methods and classes to wrap the actual calls to WCF factories and channels and service calls in order to be able to verify invariants (e.g. events do get fired only once, things do get closed, etc - this list can be greatly extended to provide a safety net for all kinds of scenarios).

The names of the scenarios should be self-explanatory (e.g. RecyclablePooledFactoriesAndChannelsAsync). Some tests ('*openonce') contain workarounds for stress bugs that we already found but haven't fixed yet.

Finally, there is a small sample on how to run the tests (program.cs).

@iamjasonp 
@roncain
@hongdai
@SajayAntony
@zhenlan
@mconnew
@StephenBonikowsky 