### PR TITLE
Modify the stress test project.*.json files

### DIFF
--- a/src/System.Private.ServiceModel/tests/Stress/SharedPoolsOfWCFObjects/project.json
+++ b/src/System.Private.ServiceModel/tests/Stress/SharedPoolsOfWCFObjects/project.json
@@ -1,11 +1,4 @@
 ﻿{
-  "version": "1.0.0-*",
-  "description": "",
-  "authors": [ "" ],
-  "tags": [ "" ],
-  "projectUrl": "",
-  "licenseUrl": "",
-
   "dependencies": {
     "System.Net.Sockets": "4.0.10-beta-*",
     "System.ServiceModel.NetTcp": "4.0.0-beta-*",
@@ -17,19 +10,9 @@
     "System.Linq": "4.0.0-beta-*",
     "System.Threading": "4.0.10-beta-*",
     "System.Diagnostics.Debug": "4.0.10-beta-*",
-    "System.Collections.Specialized": "4.0.0-beta-*",
-
+    "System.Collections.Specialized": "4.0.0-beta-*"
   },
-
-  "commands": {
-    "WCFClientStressTestsCore" : "WCFClientStressTestsCore"
-  },
-
   "frameworks" : {
-    "dnxcore50" : {
-      "dependencies": {
-
-      }
-    }
+    "dnxcore50" : {}
   }
 }

--- a/src/System.Private.ServiceModel/tests/Stress/SharedPoolsOfWCFObjects/project.lock.json
+++ b/src/System.Private.ServiceModel/tests/Stress/SharedPoolsOfWCFObjects/project.lock.json
@@ -1,12 +1,12 @@
 {
   "locked": true,
-  "version": 1,
+  "version": -9996,
   "targets": {
     "DNXCore,Version=v5.0": {
-      "Microsoft.Win32.Primitives/4.0.0-beta-23110": {
+      "Microsoft.Win32.Primitives/4.0.0-beta-23121": {
         "dependencies": {
-          "System.Runtime": "4.0.20-beta-23110",
-          "System.Runtime.InteropServices": "4.0.20-beta-23110"
+          "System.Runtime": "4.0.20-beta-23121",
+          "System.Runtime.InteropServices": "4.0.20-beta-23121"
         },
         "compile": {
           "ref/dotnet/Microsoft.Win32.Primitives.dll": {}
@@ -15,9 +15,9 @@
           "lib/dotnet/Microsoft.Win32.Primitives.dll": {}
         }
       },
-      "System.Collections/4.0.10-beta-23110": {
+      "System.Collections/4.0.10-beta-23121": {
         "dependencies": {
-          "System.Runtime": "4.0.20-beta-23110"
+          "System.Runtime": "4.0.20-beta-23121"
         },
         "compile": {
           "ref/dotnet/System.Collections.dll": {}
@@ -26,17 +26,17 @@
           "lib/DNXCore50/System.Collections.dll": {}
         }
       },
-      "System.Collections.Concurrent/4.0.10-beta-23110": {
+      "System.Collections.Concurrent/4.0.10-beta-23121": {
         "dependencies": {
-          "System.Collections": "4.0.10-beta-23110",
-          "System.Diagnostics.Debug": "4.0.10-beta-23110",
-          "System.Diagnostics.Tracing": "4.0.20-beta-23110",
-          "System.Globalization": "4.0.10-beta-23110",
-          "System.Resources.ResourceManager": "4.0.0-beta-23110",
-          "System.Runtime": "4.0.20-beta-23110",
-          "System.Runtime.Extensions": "4.0.10-beta-23110",
-          "System.Threading": "4.0.10-beta-23110",
-          "System.Threading.Tasks": "4.0.10-beta-23110"
+          "System.Runtime": "4.0.20-beta-23121",
+          "System.Threading.Tasks": "4.0.10-beta-23121",
+          "System.Diagnostics.Tracing": "4.0.20-beta-23121",
+          "System.Resources.ResourceManager": "4.0.0-beta-23121",
+          "System.Diagnostics.Debug": "4.0.10-beta-23121",
+          "System.Threading": "4.0.10-beta-23121",
+          "System.Collections": "4.0.10-beta-23121",
+          "System.Runtime.Extensions": "4.0.10-beta-23121",
+          "System.Globalization": "4.0.10-beta-23121"
         },
         "compile": {
           "ref/dotnet/System.Collections.Concurrent.dll": {}
@@ -45,14 +45,14 @@
           "lib/dotnet/System.Collections.Concurrent.dll": {}
         }
       },
-      "System.Collections.NonGeneric/4.0.0-beta-23110": {
+      "System.Collections.NonGeneric/4.0.0-beta-23121": {
         "dependencies": {
-          "System.Diagnostics.Debug": "4.0.10-beta-23110",
-          "System.Globalization": "4.0.10-beta-23110",
-          "System.Resources.ResourceManager": "4.0.0-beta-23110",
-          "System.Runtime": "4.0.20-beta-23110",
-          "System.Runtime.Extensions": "4.0.10-beta-23110",
-          "System.Threading": "4.0.10-beta-23110"
+          "System.Runtime": "4.0.20-beta-23121",
+          "System.Globalization": "4.0.10-beta-23121",
+          "System.Resources.ResourceManager": "4.0.0-beta-23121",
+          "System.Diagnostics.Debug": "4.0.10-beta-23121",
+          "System.Threading": "4.0.10-beta-23121",
+          "System.Runtime.Extensions": "4.0.10-beta-23121"
         },
         "compile": {
           "ref/dotnet/System.Collections.NonGeneric.dll": {}
@@ -61,15 +61,15 @@
           "lib/dotnet/System.Collections.NonGeneric.dll": {}
         }
       },
-      "System.Collections.Specialized/4.0.0-beta-23110": {
+      "System.Collections.Specialized/4.0.0-beta-23121": {
         "dependencies": {
-          "System.Collections.NonGeneric": "4.0.0-beta-23110",
-          "System.Globalization": "4.0.10-beta-23110",
-          "System.Globalization.Extensions": "4.0.0-beta-23110",
-          "System.Resources.ResourceManager": "4.0.0-beta-23110",
-          "System.Runtime": "4.0.20-beta-23110",
-          "System.Runtime.Extensions": "4.0.10-beta-23110",
-          "System.Threading": "4.0.10-beta-23110"
+          "System.Runtime": "4.0.20-beta-23121",
+          "System.Resources.ResourceManager": "4.0.0-beta-23121",
+          "System.Collections.NonGeneric": "4.0.0-beta-23121",
+          "System.Globalization.Extensions": "4.0.0-beta-23121",
+          "System.Runtime.Extensions": "4.0.10-beta-23121",
+          "System.Threading": "4.0.10-beta-23121",
+          "System.Globalization": "4.0.10-beta-23121"
         },
         "compile": {
           "ref/dotnet/System.Collections.Specialized.dll": {}
@@ -78,12 +78,12 @@
           "lib/dotnet/System.Collections.Specialized.dll": {}
         }
       },
-      "System.ComponentModel.EventBasedAsync/4.0.10-beta-23110": {
+      "System.ComponentModel.EventBasedAsync/4.0.10-beta-23121": {
         "dependencies": {
-          "System.Resources.ResourceManager": "4.0.0-beta-23110",
-          "System.Runtime": "4.0.20-beta-23110",
-          "System.Threading": "4.0.10-beta-23110",
-          "System.Threading.Tasks": "4.0.10-beta-23110"
+          "System.Runtime": "4.0.20-beta-23121",
+          "System.Threading": "4.0.10-beta-23121",
+          "System.Resources.ResourceManager": "4.0.0-beta-23121",
+          "System.Threading.Tasks": "4.0.10-beta-23121"
         },
         "compile": {
           "ref/dotnet/System.ComponentModel.EventBasedAsync.dll": {}
@@ -92,17 +92,17 @@
           "lib/dotnet/System.ComponentModel.EventBasedAsync.dll": {}
         }
       },
-      "System.Console/4.0.0-beta-23110": {
+      "System.Console/4.0.0-beta-23121": {
         "dependencies": {
-          "System.IO": "4.0.10-beta-23110",
-          "System.IO.FileSystem.Primitives": "4.0.0-beta-23110",
-          "System.Resources.ResourceManager": "4.0.0-beta-23110",
-          "System.Runtime": "4.0.20-beta-23110",
-          "System.Runtime.InteropServices": "4.0.20-beta-23110",
-          "System.Text.Encoding": "4.0.10-beta-23110",
-          "System.Text.Encoding.Extensions": "4.0.10-beta-23110",
-          "System.Threading": "4.0.10-beta-23110",
-          "System.Threading.Tasks": "4.0.10-beta-23110"
+          "System.Runtime": "4.0.20-beta-23121",
+          "System.Runtime.InteropServices": "4.0.20-beta-23121",
+          "System.Resources.ResourceManager": "4.0.0-beta-23121",
+          "System.IO.FileSystem.Primitives": "4.0.0-beta-23121",
+          "System.IO": "4.0.10-beta-23121",
+          "System.Threading.Tasks": "4.0.10-beta-23121",
+          "System.Text.Encoding": "4.0.10-beta-23121",
+          "System.Threading": "4.0.10-beta-23121",
+          "System.Text.Encoding.Extensions": "4.0.10-beta-23121"
         },
         "compile": {
           "ref/dotnet/System.Console.dll": {}
@@ -111,9 +111,9 @@
           "lib/DNXCore50/System.Console.dll": {}
         }
       },
-      "System.Diagnostics.Contracts/4.0.0-beta-23110": {
+      "System.Diagnostics.Contracts/4.0.0-beta-23121": {
         "dependencies": {
-          "System.Runtime": "4.0.0"
+          "System.Runtime": "4.0.0-beta-23121"
         },
         "compile": {
           "ref/dotnet/System.Diagnostics.Contracts.dll": {}
@@ -122,9 +122,9 @@
           "lib/DNXCore50/System.Diagnostics.Contracts.dll": {}
         }
       },
-      "System.Diagnostics.Debug/4.0.10-beta-23110": {
+      "System.Diagnostics.Debug/4.0.10-beta-23121": {
         "dependencies": {
-          "System.Runtime": "4.0.0"
+          "System.Runtime": "4.0.0-beta-23121"
         },
         "compile": {
           "ref/dotnet/System.Diagnostics.Debug.dll": {}
@@ -133,9 +133,9 @@
           "lib/DNXCore50/System.Diagnostics.Debug.dll": {}
         }
       },
-      "System.Diagnostics.Tracing/4.0.20-beta-23110": {
+      "System.Diagnostics.Tracing/4.0.20-beta-23121": {
         "dependencies": {
-          "System.Runtime": "4.0.0"
+          "System.Runtime": "4.0.0-beta-23121"
         },
         "compile": {
           "ref/dotnet/System.Diagnostics.Tracing.dll": {}
@@ -144,9 +144,9 @@
           "lib/DNXCore50/System.Diagnostics.Tracing.dll": {}
         }
       },
-      "System.Globalization/4.0.10-beta-23110": {
+      "System.Globalization/4.0.10-beta-23121": {
         "dependencies": {
-          "System.Runtime": "4.0.0"
+          "System.Runtime": "4.0.0-beta-23121"
         },
         "compile": {
           "ref/dotnet/System.Globalization.dll": {}
@@ -155,10 +155,10 @@
           "lib/DNXCore50/System.Globalization.dll": {}
         }
       },
-      "System.Globalization.Calendars/4.0.0-beta-23110": {
+      "System.Globalization.Calendars/4.0.0-beta-23121": {
         "dependencies": {
-          "System.Globalization": "4.0.0",
-          "System.Runtime": "4.0.0"
+          "System.Runtime": "4.0.0-beta-23121",
+          "System.Globalization": "4.0.0-beta-23121"
         },
         "compile": {
           "ref/dotnet/System.Globalization.Calendars.dll": {}
@@ -167,13 +167,13 @@
           "lib/DNXCore50/System.Globalization.Calendars.dll": {}
         }
       },
-      "System.Globalization.Extensions/4.0.0-beta-23110": {
+      "System.Globalization.Extensions/4.0.0-beta-23121": {
         "dependencies": {
-          "System.Globalization": "4.0.10-beta-23110",
-          "System.Resources.ResourceManager": "4.0.0-beta-23110",
-          "System.Runtime": "4.0.20-beta-23110",
-          "System.Runtime.Extensions": "4.0.10-beta-23110",
-          "System.Runtime.InteropServices": "4.0.20-beta-23110"
+          "System.Runtime": "4.0.20-beta-23121",
+          "System.Runtime.Extensions": "4.0.10-beta-23121",
+          "System.Globalization": "4.0.10-beta-23121",
+          "System.Runtime.InteropServices": "4.0.20-beta-23121",
+          "System.Resources.ResourceManager": "4.0.0-beta-23121"
         },
         "compile": {
           "ref/dotnet/System.Globalization.Extensions.dll": {}
@@ -182,11 +182,11 @@
           "lib/dotnet/System.Globalization.Extensions.dll": {}
         }
       },
-      "System.IO/4.0.10-beta-23110": {
+      "System.IO/4.0.10-beta-23121": {
         "dependencies": {
-          "System.Runtime": "4.0.20-beta-23110",
-          "System.Text.Encoding": "4.0.0",
-          "System.Threading.Tasks": "4.0.0"
+          "System.Runtime": "4.0.20-beta-23121",
+          "System.Text.Encoding": "4.0.0-beta-23121",
+          "System.Threading.Tasks": "4.0.0-beta-23121"
         },
         "compile": {
           "ref/dotnet/System.IO.dll": {}
@@ -195,19 +195,19 @@
           "lib/DNXCore50/System.IO.dll": {}
         }
       },
-      "System.IO.Compression/4.0.0-beta-23110": {
+      "System.IO.Compression/4.0.0-beta-23121": {
         "dependencies": {
-          "System.Collections": "4.0.10-beta-23110",
-          "System.Diagnostics.Debug": "4.0.10-beta-23110",
-          "System.IO": "4.0.10-beta-23110",
-          "System.Resources.ResourceManager": "4.0.0-beta-23110",
-          "System.Runtime": "4.0.20-beta-23110",
-          "System.Runtime.Extensions": "4.0.10-beta-23110",
-          "System.Runtime.Handles": "4.0.0-beta-23110",
-          "System.Runtime.InteropServices": "4.0.20-beta-23110",
-          "System.Text.Encoding": "4.0.10-beta-23110",
-          "System.Threading": "4.0.0",
-          "System.Threading.Tasks": "4.0.10-beta-23110"
+          "System.Runtime": "4.0.20-beta-23121",
+          "System.IO": "4.0.10-beta-23121",
+          "System.Text.Encoding": "4.0.10-beta-23121",
+          "System.Runtime.InteropServices": "4.0.20-beta-23121",
+          "System.Resources.ResourceManager": "4.0.0-beta-23121",
+          "System.Runtime.Handles": "4.0.0-beta-23121",
+          "System.Threading": "4.0.0-beta-23121",
+          "System.Threading.Tasks": "4.0.10-beta-23121",
+          "System.Diagnostics.Debug": "4.0.10-beta-23121",
+          "System.Collections": "4.0.10-beta-23121",
+          "System.Runtime.Extensions": "4.0.10-beta-23121"
         },
         "compile": {
           "ref/dotnet/System.IO.Compression.dll": {}
@@ -216,21 +216,21 @@
           "lib/dotnet/System.IO.Compression.dll": {}
         }
       },
-      "System.IO.FileSystem/4.0.0-beta-23110": {
+      "System.IO.FileSystem/4.0.0-beta-23121": {
         "dependencies": {
-          "System.Collections": "4.0.10-beta-23110",
-          "System.IO": "4.0.10-beta-23110",
-          "System.IO.FileSystem.Primitives": "4.0.0-beta-23110",
-          "System.Resources.ResourceManager": "4.0.0-beta-23110",
-          "System.Runtime": "4.0.20-beta-23110",
-          "System.Runtime.Extensions": "4.0.10-beta-23110",
-          "System.Runtime.Handles": "4.0.0-beta-23110",
-          "System.Runtime.InteropServices": "4.0.20-beta-23110",
-          "System.Text.Encoding": "4.0.10-beta-23110",
-          "System.Text.Encoding.Extensions": "4.0.10-beta-23110",
-          "System.Threading": "4.0.10-beta-23110",
-          "System.Threading.Overlapped": "4.0.0-beta-23110",
-          "System.Threading.Tasks": "4.0.10-beta-23110"
+          "System.Runtime": "4.0.20-beta-23121",
+          "System.Runtime.InteropServices": "4.0.20-beta-23121",
+          "System.Resources.ResourceManager": "4.0.0-beta-23121",
+          "System.Runtime.Handles": "4.0.0-beta-23121",
+          "System.Threading.Overlapped": "4.0.0-beta-23121",
+          "System.IO.FileSystem.Primitives": "4.0.0-beta-23121",
+          "System.Text.Encoding": "4.0.10-beta-23121",
+          "System.IO": "4.0.10-beta-23121",
+          "System.Collections": "4.0.10-beta-23121",
+          "System.Threading.Tasks": "4.0.10-beta-23121",
+          "System.Runtime.Extensions": "4.0.10-beta-23121",
+          "System.Text.Encoding.Extensions": "4.0.10-beta-23121",
+          "System.Threading": "4.0.10-beta-23121"
         },
         "compile": {
           "ref/dotnet/System.IO.FileSystem.dll": {}
@@ -239,9 +239,9 @@
           "lib/DNXCore50/System.IO.FileSystem.dll": {}
         }
       },
-      "System.IO.FileSystem.Primitives/4.0.0-beta-23110": {
+      "System.IO.FileSystem.Primitives/4.0.0-beta-23121": {
         "dependencies": {
-          "System.Runtime": "4.0.20-beta-23110"
+          "System.Runtime": "4.0.20-beta-23121"
         },
         "compile": {
           "ref/dotnet/System.IO.FileSystem.Primitives.dll": {}
@@ -250,13 +250,13 @@
           "lib/dotnet/System.IO.FileSystem.Primitives.dll": {}
         }
       },
-      "System.Linq/4.0.0-beta-23110": {
+      "System.Linq/4.0.0-beta-23121": {
         "dependencies": {
-          "System.Collections": "4.0.10-beta-23110",
-          "System.Diagnostics.Debug": "4.0.10-beta-23110",
-          "System.Resources.ResourceManager": "4.0.0-beta-23110",
-          "System.Runtime": "4.0.20-beta-23110",
-          "System.Runtime.Extensions": "4.0.10-beta-23110"
+          "System.Runtime": "4.0.20-beta-23121",
+          "System.Collections": "4.0.10-beta-23121",
+          "System.Resources.ResourceManager": "4.0.0-beta-23121",
+          "System.Diagnostics.Debug": "4.0.10-beta-23121",
+          "System.Runtime.Extensions": "4.0.10-beta-23121"
         },
         "compile": {
           "ref/dotnet/System.Linq.dll": {}
@@ -265,23 +265,23 @@
           "lib/dotnet/System.Linq.dll": {}
         }
       },
-      "System.Linq.Expressions/4.0.10-beta-23110": {
+      "System.Linq.Expressions/4.0.10-beta-23121": {
         "dependencies": {
-          "System.Collections": "4.0.10-beta-23110",
-          "System.Diagnostics.Debug": "4.0.10-beta-23110",
-          "System.Globalization": "4.0.10-beta-23110",
-          "System.IO": "4.0.10-beta-23110",
-          "System.Linq": "4.0.0-beta-23110",
-          "System.ObjectModel": "4.0.10-beta-23110",
-          "System.Reflection": "4.0.10-beta-23110",
-          "System.Reflection.Emit": "4.0.0-beta-23110",
-          "System.Reflection.Extensions": "4.0.0-beta-23110",
-          "System.Reflection.Primitives": "4.0.0-beta-23110",
-          "System.Reflection.TypeExtensions": "4.0.0-beta-23110",
-          "System.Resources.ResourceManager": "4.0.0-beta-23110",
-          "System.Runtime": "4.0.20-beta-23110",
-          "System.Runtime.Extensions": "4.0.10-beta-23110",
-          "System.Threading": "4.0.10-beta-23110"
+          "System.Runtime": "4.0.20-beta-23121",
+          "System.Resources.ResourceManager": "4.0.0-beta-23121",
+          "System.Reflection.TypeExtensions": "4.0.0-beta-23121",
+          "System.Reflection.Primitives": "4.0.0-beta-23121",
+          "System.Reflection.Emit": "4.0.0-beta-23121",
+          "System.Linq": "4.0.0-beta-23121",
+          "System.Reflection.Extensions": "4.0.0-beta-23121",
+          "System.Collections": "4.0.10-beta-23121",
+          "System.Diagnostics.Debug": "4.0.10-beta-23121",
+          "System.Reflection": "4.0.10-beta-23121",
+          "System.IO": "4.0.10-beta-23121",
+          "System.ObjectModel": "4.0.10-beta-23121",
+          "System.Threading": "4.0.10-beta-23121",
+          "System.Runtime.Extensions": "4.0.10-beta-23121",
+          "System.Globalization": "4.0.10-beta-23121"
         },
         "compile": {
           "ref/dotnet/System.Linq.Expressions.dll": {}
@@ -290,15 +290,15 @@
           "lib/DNXCore50/System.Linq.Expressions.dll": {}
         }
       },
-      "System.Linq.Queryable/4.0.0-beta-23110": {
+      "System.Linq.Queryable/4.0.0-beta-23121": {
         "dependencies": {
-          "System.Collections": "4.0.10-beta-23110",
-          "System.Linq": "4.0.0-beta-23110",
-          "System.Linq.Expressions": "4.0.10-beta-23110",
-          "System.Reflection": "4.0.10-beta-23110",
-          "System.Reflection.Extensions": "4.0.0-beta-23110",
-          "System.Resources.ResourceManager": "4.0.0-beta-23110",
-          "System.Runtime": "4.0.20-beta-23110"
+          "System.Runtime": "4.0.20-beta-23121",
+          "System.Linq.Expressions": "4.0.10-beta-23121",
+          "System.Linq": "4.0.0-beta-23121",
+          "System.Resources.ResourceManager": "4.0.0-beta-23121",
+          "System.Reflection.Extensions": "4.0.0-beta-23121",
+          "System.Reflection": "4.0.10-beta-23121",
+          "System.Collections": "4.0.10-beta-23121"
         },
         "compile": {
           "ref/dotnet/System.Linq.Queryable.dll": {}
@@ -307,23 +307,23 @@
           "lib/dotnet/System.Linq.Queryable.dll": {}
         }
       },
-      "System.Net.Http/4.0.0-beta-23110": {
+      "System.Net.Http/4.0.0-beta-23121": {
         "dependencies": {
-          "Microsoft.Win32.Primitives": "4.0.0-beta-23110",
-          "System.Collections": "4.0.10-beta-23110",
-          "System.Diagnostics.Debug": "4.0.10-beta-23110",
-          "System.Globalization": "4.0.10-beta-23110",
-          "System.IO": "4.0.10-beta-23110",
-          "System.IO.Compression": "4.0.0-beta-23110",
-          "System.Net.Primitives": "4.0.10-beta-23110",
-          "System.Resources.ResourceManager": "4.0.0-beta-23110",
-          "System.Runtime": "4.0.20-beta-23110",
-          "System.Runtime.Extensions": "4.0.10-beta-23110",
-          "System.Runtime.Handles": "4.0.0-beta-23110",
-          "System.Runtime.InteropServices": "4.0.20-beta-23110",
-          "System.Text.Encoding": "4.0.10-beta-23110",
-          "System.Threading": "4.0.10-beta-23110",
-          "System.Threading.Tasks": "4.0.10-beta-23110"
+          "System.Runtime": "4.0.20-beta-23121",
+          "System.Runtime.InteropServices": "4.0.20-beta-23121",
+          "System.Runtime.Handles": "4.0.0-beta-23121",
+          "System.Resources.ResourceManager": "4.0.0-beta-23121",
+          "Microsoft.Win32.Primitives": "4.0.0-beta-23121",
+          "System.IO.Compression": "4.0.0-beta-23121",
+          "System.Net.Primitives": "4.0.10-beta-23121",
+          "System.Threading.Tasks": "4.0.10-beta-23121",
+          "System.IO": "4.0.10-beta-23121",
+          "System.Diagnostics.Debug": "4.0.10-beta-23121",
+          "System.Text.Encoding": "4.0.10-beta-23121",
+          "System.Collections": "4.0.10-beta-23121",
+          "System.Runtime.Extensions": "4.0.10-beta-23121",
+          "System.Globalization": "4.0.10-beta-23121",
+          "System.Threading": "4.0.10-beta-23121"
         },
         "compile": {
           "ref/dotnet/System.Net.Http.dll": {}
@@ -332,9 +332,9 @@
           "lib/DNXCore50/System.Net.Http.dll": {}
         }
       },
-      "System.Net.NameResolution/4.0.0-beta-23110": {
+      "System.Net.NameResolution/4.0.0-beta-23121": {
         "dependencies": {
-          "System.Private.Networking": "4.0.0-beta-23110"
+          "System.Private.Networking": "4.0.0-beta-23121"
         },
         "compile": {
           "ref/dotnet/System.Net.NameResolution.dll": {}
@@ -343,9 +343,9 @@
           "lib/DNXCore50/System.Net.NameResolution.dll": {}
         }
       },
-      "System.Net.Primitives/4.0.10-beta-23110": {
+      "System.Net.Primitives/4.0.10-beta-23121": {
         "dependencies": {
-          "System.Private.Networking": "4.0.0-beta-23110"
+          "System.Private.Networking": "4.0.0-beta-23121"
         },
         "compile": {
           "ref/dotnet/System.Net.Primitives.dll": {}
@@ -354,9 +354,9 @@
           "lib/DNXCore50/System.Net.Primitives.dll": {}
         }
       },
-      "System.Net.Security/4.0.0-beta-23110": {
+      "System.Net.Security/4.0.0-beta-23121": {
         "dependencies": {
-          "System.Private.Networking": "4.0.0-beta-23110"
+          "System.Private.Networking": "4.0.0-beta-23121"
         },
         "compile": {
           "ref/dotnet/System.Net.Security.dll": {}
@@ -365,9 +365,9 @@
           "lib/DNXCore50/System.Net.Security.dll": {}
         }
       },
-      "System.Net.Sockets/4.0.10-beta-23110": {
+      "System.Net.Sockets/4.0.10-beta-23121": {
         "dependencies": {
-          "System.Private.Networking": "4.0.0-beta-23110"
+          "System.Private.Networking": "4.0.0-beta-23121"
         },
         "compile": {
           "ref/dotnet/System.Net.Sockets.dll": {}
@@ -376,12 +376,12 @@
           "lib/DNXCore50/System.Net.Sockets.dll": {}
         }
       },
-      "System.Net.WebHeaderCollection/4.0.0-beta-23110": {
+      "System.Net.WebHeaderCollection/4.0.0-beta-23121": {
         "dependencies": {
-          "System.Collections.NonGeneric": "4.0.0-beta-23110",
-          "System.Collections.Specialized": "4.0.0-beta-23110",
-          "System.Resources.ResourceManager": "4.0.0-beta-23110",
-          "System.Runtime": "4.0.20-beta-23110"
+          "System.Runtime": "4.0.20-beta-23121",
+          "System.Resources.ResourceManager": "4.0.0-beta-23121",
+          "System.Collections.NonGeneric": "4.0.0-beta-23121",
+          "System.Collections.Specialized": "4.0.0-beta-23121"
         },
         "compile": {
           "ref/dotnet/System.Net.WebHeaderCollection.dll": {}
@@ -390,13 +390,13 @@
           "lib/dotnet/System.Net.WebHeaderCollection.dll": {}
         }
       },
-      "System.ObjectModel/4.0.10-beta-23110": {
+      "System.ObjectModel/4.0.10-beta-23121": {
         "dependencies": {
-          "System.Collections": "4.0.10-beta-23110",
-          "System.Diagnostics.Debug": "4.0.10-beta-23110",
-          "System.Resources.ResourceManager": "4.0.0-beta-23110",
-          "System.Runtime": "4.0.20-beta-23110",
-          "System.Threading": "4.0.10-beta-23110"
+          "System.Runtime": "4.0.20-beta-23121",
+          "System.Resources.ResourceManager": "4.0.0-beta-23121",
+          "System.Diagnostics.Debug": "4.0.10-beta-23121",
+          "System.Collections": "4.0.10-beta-23121",
+          "System.Threading": "4.0.10-beta-23121"
         },
         "compile": {
           "ref/dotnet/System.ObjectModel.dll": {}
@@ -405,132 +405,120 @@
           "lib/dotnet/System.ObjectModel.dll": {}
         }
       },
-      "System.Private.DataContractSerialization/4.0.0-beta-23110": {
+      "System.Private.DataContractSerialization/4.0.0-beta-23121": {
         "dependencies": {
-          "System.Collections": "4.0.10-beta-23110",
-          "System.Globalization": "4.0.10-beta-23110",
-          "System.IO": "4.0.10-beta-23110",
-          "System.Linq": "4.0.0-beta-23110",
-          "System.Reflection": "4.0.10-beta-23110",
-          "System.Reflection.Extensions": "4.0.0-beta-23110",
-          "System.Reflection.Primitives": "4.0.0-beta-23110",
-          "System.Reflection.TypeExtensions": "4.0.0-beta-23110",
-          "System.Resources.ResourceManager": "4.0.0-beta-23110",
-          "System.Runtime": "4.0.20-beta-23110",
-          "System.Runtime.Extensions": "4.0.10-beta-23110",
-          "System.Runtime.Serialization.Primitives": "4.0.10-beta-23110",
-          "System.Text.Encoding": "4.0.10-beta-23110",
-          "System.Text.Encoding.Extensions": "4.0.10-beta-23110",
-          "System.Text.RegularExpressions": "4.0.10-beta-23110",
-          "System.Threading": "4.0.10-beta-23110",
-          "System.Xml.ReaderWriter": "4.0.10-beta-23110",
-          "System.Xml.XmlSerializer": "4.0.10-beta-23110"
-        },
-        "compile": {
-          "ref/dnxcore50/_._": {}
+          "System.Runtime": "4.0.20-beta-23121",
+          "System.Resources.ResourceManager": "4.0.0-beta-23121",
+          "System.Reflection.Primitives": "4.0.0-beta-23121",
+          "System.Reflection.TypeExtensions": "4.0.0-beta-23121",
+          "System.Reflection.Extensions": "4.0.0-beta-23121",
+          "System.Linq": "4.0.0-beta-23121",
+          "System.Text.Encoding": "4.0.10-beta-23121",
+          "System.IO": "4.0.10-beta-23121",
+          "System.Xml.ReaderWriter": "4.0.10-beta-23121",
+          "System.Text.Encoding.Extensions": "4.0.10-beta-23121",
+          "System.Collections": "4.0.10-beta-23121",
+          "System.Reflection": "4.0.10-beta-23121",
+          "System.Runtime.Serialization.Primitives": "4.0.10-beta-23121",
+          "System.Globalization": "4.0.10-beta-23121",
+          "System.Runtime.Extensions": "4.0.10-beta-23121",
+          "System.Threading": "4.0.10-beta-23121",
+          "System.Text.RegularExpressions": "4.0.10-beta-23121",
+          "System.Xml.XmlSerializer": "4.0.10-beta-23121"
         },
         "runtime": {
           "lib/DNXCore50/System.Private.DataContractSerialization.dll": {}
         }
       },
-      "System.Private.Networking/4.0.0-beta-23110": {
+      "System.Private.Networking/4.0.0-beta-23121": {
         "dependencies": {
-          "Microsoft.Win32.Primitives": "4.0.0-beta-23110",
-          "System.Collections": "4.0.10-beta-23110",
-          "System.Collections.Concurrent": "4.0.0",
-          "System.Collections.NonGeneric": "4.0.0-beta-23110",
-          "System.ComponentModel.EventBasedAsync": "4.0.10-beta-23110",
-          "System.Diagnostics.Debug": "4.0.10-beta-23110",
-          "System.Diagnostics.Tracing": "4.0.20-beta-23110",
-          "System.Globalization": "4.0.10-beta-23110",
-          "System.IO": "4.0.10-beta-23110",
-          "System.IO.FileSystem": "4.0.0-beta-23110",
-          "System.IO.FileSystem.Primitives": "4.0.0-beta-23110",
-          "System.Resources.ResourceManager": "4.0.0-beta-23110",
-          "System.Runtime": "4.0.20-beta-23110",
-          "System.Runtime.Extensions": "4.0.10-beta-23110",
-          "System.Runtime.Handles": "4.0.0-beta-23110",
-          "System.Runtime.InteropServices": "4.0.20-beta-23110",
-          "System.Security.Cryptography.Encryption": "4.0.0-beta-23110",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23110",
-          "System.Security.Principal.Windows": "4.0.0-beta-23110",
-          "System.Security.SecureString": "4.0.0-beta-23110",
-          "System.Threading": "4.0.10-beta-23110",
-          "System.Threading.Overlapped": "4.0.0-beta-23110",
-          "System.Threading.Tasks": "4.0.10-beta-23110",
-          "System.Threading.ThreadPool": "4.0.10-beta-23110"
-        },
-        "compile": {
-          "ref/dnxcore50/_._": {}
+          "System.Runtime": "4.0.20-beta-23121",
+          "System.Runtime.InteropServices": "4.0.20-beta-23121",
+          "System.Diagnostics.Tracing": "4.0.20-beta-23121",
+          "System.Resources.ResourceManager": "4.0.0-beta-23121",
+          "System.Runtime.Handles": "4.0.0-beta-23121",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23121",
+          "System.Collections.Concurrent": "4.0.0-beta-23121",
+          "System.Collections.NonGeneric": "4.0.0-beta-23121",
+          "System.Security.SecureString": "4.0.0-beta-23121",
+          "System.Security.Principal.Windows": "4.0.0-beta-23121",
+          "Microsoft.Win32.Primitives": "4.0.0-beta-23121",
+          "System.IO.FileSystem": "4.0.0-beta-23121",
+          "System.Threading.Overlapped": "4.0.0-beta-23121",
+          "System.Security.Cryptography.Encryption": "4.0.0-beta-23121",
+          "System.IO.FileSystem.Primitives": "4.0.0-beta-23121",
+          "System.Collections": "4.0.10-beta-23121",
+          "System.Threading": "4.0.10-beta-23121",
+          "System.Threading.Tasks": "4.0.10-beta-23121",
+          "System.IO": "4.0.10-beta-23121",
+          "System.Diagnostics.Debug": "4.0.10-beta-23121",
+          "System.Threading.ThreadPool": "4.0.10-beta-23121",
+          "System.ComponentModel.EventBasedAsync": "4.0.10-beta-23121",
+          "System.Runtime.Extensions": "4.0.10-beta-23121",
+          "System.Globalization": "4.0.10-beta-23121"
         },
         "runtime": {
           "lib/DNXCore50/System.Private.Networking.dll": {}
         }
       },
-      "System.Private.ServiceModel/4.0.0-beta-23110": {
+      "System.Private.ServiceModel/4.0.0-beta-23121": {
         "dependencies": {
-          "System.Collections": "4.0.10-beta-23110",
-          "System.Collections.Concurrent": "4.0.10-beta-23110",
-          "System.Collections.NonGeneric": "4.0.0-beta-23110",
-          "System.Collections.Specialized": "4.0.0-beta-23110",
-          "System.ComponentModel.EventBasedAsync": "4.0.10-beta-23110",
-          "System.Diagnostics.Contracts": "4.0.0-beta-23110",
-          "System.Diagnostics.Debug": "4.0.10-beta-23110",
-          "System.Globalization": "4.0.10-beta-23110",
-          "System.IO": "4.0.10-beta-23110",
-          "System.IO.Compression": "4.0.0-beta-23110",
-          "System.Linq": "4.0.0-beta-23110",
-          "System.Linq.Expressions": "4.0.10-beta-23110",
-          "System.Linq.Queryable": "4.0.0-beta-23110",
-          "System.Net.Http": "4.0.0-beta-23110",
-          "System.Net.NameResolution": "4.0.0-beta-23110",
-          "System.Net.Primitives": "4.0.10-beta-23110",
-          "System.Net.Security": "4.0.0-beta-23110",
-          "System.Net.Sockets": "4.0.10-beta-23110",
-          "System.Net.WebHeaderCollection": "4.0.0-beta-23110",
-          "System.ObjectModel": "4.0.10-beta-23110",
-          "System.Reflection": "4.0.10-beta-23110",
-          "System.Reflection.DispatchProxy": "4.0.0-beta-23110",
-          "System.Reflection.Extensions": "4.0.0-beta-23110",
-          "System.Reflection.Primitives": "4.0.0-beta-23110",
-          "System.Reflection.TypeExtensions": "4.0.0-beta-23110",
-          "System.Resources.ResourceManager": "4.0.0-beta-23110",
-          "System.Runtime": "4.0.20-beta-23110",
-          "System.Runtime.Extensions": "4.0.10-beta-23110",
-          "System.Runtime.InteropServices": "4.0.20-beta-23110",
-          "System.Runtime.Serialization.Primitives": "4.0.10-beta-23110",
-          "System.Runtime.Serialization.Xml": "4.0.10-beta-23110",
-          "System.Security.Claims": "4.0.0-beta-23110",
-          "System.Security.Principal": "4.0.0-beta-23110",
-          "System.Security.Principal.Windows": "4.0.0-beta-23110",
-          "System.Text.Encoding": "4.0.10-beta-23110",
-          "System.Threading": "4.0.10-beta-23110",
-          "System.Threading.Tasks": "4.0.10-beta-23110",
-          "System.Threading.Timer": "4.0.0-beta-23110",
-          "System.Xml.ReaderWriter": "4.0.10-beta-23110",
-          "System.Xml.XmlDocument": "4.0.0-beta-23110",
-          "System.Xml.XmlSerializer": "4.0.10-beta-23110"
-        },
-        "compile": {
-          "ref/dnxcore50/_._": {}
+          "System.Runtime": "4.0.20-beta-23121",
+          "System.Runtime.InteropServices": "4.0.20-beta-23121",
+          "System.Resources.ResourceManager": "4.0.0-beta-23121",
+          "System.Security.Principal": "4.0.0-beta-23121",
+          "System.Xml.XmlDocument": "4.0.0-beta-23121",
+          "System.Security.Principal.Windows": "4.0.0-beta-23121",
+          "System.Threading.Timer": "4.0.0-beta-23121",
+          "System.Collections.Specialized": "4.0.0-beta-23121",
+          "System.Collections.NonGeneric": "4.0.0-beta-23121",
+          "System.Reflection.TypeExtensions": "4.0.0-beta-23121",
+          "System.Reflection.Extensions": "4.0.0-beta-23121",
+          "System.Security.Claims": "4.0.0-beta-23121",
+          "System.Net.Security": "4.0.0-beta-23121",
+          "System.Net.Http": "4.0.0-beta-23121",
+          "System.Net.NameResolution": "4.0.0-beta-23121",
+          "System.Net.WebHeaderCollection": "4.0.0-beta-23121",
+          "System.Reflection.DispatchProxy": "4.0.0-beta-23121",
+          "System.Linq": "4.0.0-beta-23121",
+          "System.Linq.Queryable": "4.0.0-beta-23121",
+          "System.Reflection.Primitives": "4.0.0-beta-23121",
+          "System.Diagnostics.Contracts": "4.0.0-beta-23121",
+          "System.IO.Compression": "4.0.0-beta-23121",
+          "System.ObjectModel": "4.0.10-beta-23121",
+          "System.Collections": "4.0.10-beta-23121",
+          "System.Text.Encoding": "4.0.10-beta-23121",
+          "System.IO": "4.0.10-beta-23121",
+          "System.Runtime.Serialization.Xml": "4.0.10-beta-23121",
+          "System.Threading.Tasks": "4.0.10-beta-23121",
+          "System.Diagnostics.Debug": "4.0.10-beta-23121",
+          "System.Xml.ReaderWriter": "4.0.10-beta-23121",
+          "System.Runtime.Serialization.Primitives": "4.0.10-beta-23121",
+          "System.Reflection": "4.0.10-beta-23121",
+          "System.Xml.XmlSerializer": "4.0.10-beta-23121",
+          "System.Threading": "4.0.10-beta-23121",
+          "System.Globalization": "4.0.10-beta-23121",
+          "System.Collections.Concurrent": "4.0.10-beta-23121",
+          "System.ComponentModel.EventBasedAsync": "4.0.10-beta-23121",
+          "System.Net.Primitives": "4.0.10-beta-23121",
+          "System.Net.Sockets": "4.0.10-beta-23121",
+          "System.Runtime.Extensions": "4.0.10-beta-23121",
+          "System.Linq.Expressions": "4.0.10-beta-23121"
         },
         "runtime": {
           "lib/DNXCore50/System.Private.ServiceModel.dll": {}
         }
       },
-      "System.Private.Uri/4.0.0-beta-23110": {
-        "compile": {
-          "ref/dnxcore50/_._": {}
-        },
+      "System.Private.Uri/4.0.0-beta-23121": {
         "runtime": {
           "lib/DNXCore50/System.Private.Uri.dll": {}
         }
       },
-      "System.Reflection/4.0.10-beta-23110": {
+      "System.Reflection/4.0.10-beta-23121": {
         "dependencies": {
-          "System.IO": "4.0.0",
-          "System.Reflection.Primitives": "4.0.0-beta-23110",
-          "System.Runtime": "4.0.20-beta-23110"
+          "System.Runtime": "4.0.20-beta-23121",
+          "System.IO": "4.0.0-beta-23121",
+          "System.Reflection.Primitives": "4.0.0-beta-23121"
         },
         "compile": {
           "ref/dotnet/System.Reflection.dll": {}
@@ -539,16 +527,16 @@
           "lib/DNXCore50/System.Reflection.dll": {}
         }
       },
-      "System.Reflection.DispatchProxy/4.0.0-beta-23110": {
+      "System.Reflection.DispatchProxy/4.0.0-beta-23121": {
         "dependencies": {
-          "System.Collections": "4.0.10-beta-23110",
-          "System.Linq": "4.0.0-beta-23110",
-          "System.Reflection": "4.0.10-beta-23110",
-          "System.Reflection.Extensions": "4.0.0-beta-23110",
-          "System.Reflection.Primitives": "4.0.0-beta-23110",
-          "System.Resources.ResourceManager": "4.0.0-beta-23110",
-          "System.Runtime": "4.0.20-beta-23110",
-          "System.Threading": "4.0.10-beta-23110"
+          "System.Runtime": "4.0.20-beta-23121",
+          "System.Resources.ResourceManager": "4.0.0-beta-23121",
+          "System.Reflection.Primitives": "4.0.0-beta-23121",
+          "System.Linq": "4.0.0-beta-23121",
+          "System.Reflection.Extensions": "4.0.0-beta-23121",
+          "System.Reflection": "4.0.10-beta-23121",
+          "System.Collections": "4.0.10-beta-23121",
+          "System.Threading": "4.0.10-beta-23121"
         },
         "compile": {
           "ref/dotnet/System.Reflection.DispatchProxy.dll": {}
@@ -557,13 +545,13 @@
           "lib/DNXCore50/System.Reflection.DispatchProxy.dll": {}
         }
       },
-      "System.Reflection.Emit/4.0.0-beta-23110": {
+      "System.Reflection.Emit/4.0.0-beta-23121": {
         "dependencies": {
-          "System.IO": "4.0.0",
-          "System.Reflection": "4.0.0",
-          "System.Reflection.Emit.ILGeneration": "4.0.0-beta-23110",
-          "System.Reflection.Primitives": "4.0.0-beta-23110",
-          "System.Runtime": "4.0.0"
+          "System.Runtime": "4.0.0-beta-23121",
+          "System.Reflection": "4.0.0-beta-23121",
+          "System.Reflection.Emit.ILGeneration": "4.0.0-beta-23121",
+          "System.IO": "4.0.0-beta-23121",
+          "System.Reflection.Primitives": "4.0.0-beta-23121"
         },
         "compile": {
           "ref/dotnet/System.Reflection.Emit.dll": {}
@@ -572,11 +560,11 @@
           "lib/DNXCore50/System.Reflection.Emit.dll": {}
         }
       },
-      "System.Reflection.Emit.ILGeneration/4.0.0-beta-23110": {
+      "System.Reflection.Emit.ILGeneration/4.0.0-beta-23121": {
         "dependencies": {
-          "System.Reflection": "4.0.0",
-          "System.Reflection.Primitives": "4.0.0-beta-23110",
-          "System.Runtime": "4.0.0"
+          "System.Runtime": "4.0.0-beta-23121",
+          "System.Reflection": "4.0.0-beta-23121",
+          "System.Reflection.Primitives": "4.0.0-beta-23121"
         },
         "compile": {
           "ref/dotnet/System.Reflection.Emit.ILGeneration.dll": {}
@@ -585,10 +573,10 @@
           "lib/DNXCore50/System.Reflection.Emit.ILGeneration.dll": {}
         }
       },
-      "System.Reflection.Extensions/4.0.0-beta-23110": {
+      "System.Reflection.Extensions/4.0.0-beta-23121": {
         "dependencies": {
-          "System.Reflection": "4.0.0",
-          "System.Runtime": "4.0.0"
+          "System.Runtime": "4.0.0-beta-23121",
+          "System.Reflection": "4.0.0-beta-23121"
         },
         "compile": {
           "ref/dotnet/System.Reflection.Extensions.dll": {}
@@ -597,9 +585,9 @@
           "lib/DNXCore50/System.Reflection.Extensions.dll": {}
         }
       },
-      "System.Reflection.Primitives/4.0.0-beta-23110": {
+      "System.Reflection.Primitives/4.0.0-beta-23121": {
         "dependencies": {
-          "System.Runtime": "4.0.0"
+          "System.Runtime": "4.0.0-beta-23121"
         },
         "compile": {
           "ref/dotnet/System.Reflection.Primitives.dll": {}
@@ -608,10 +596,10 @@
           "lib/DNXCore50/System.Reflection.Primitives.dll": {}
         }
       },
-      "System.Reflection.TypeExtensions/4.0.0-beta-23110": {
+      "System.Reflection.TypeExtensions/4.0.0-beta-23121": {
         "dependencies": {
-          "System.Reflection": "4.0.0",
-          "System.Runtime": "4.0.0"
+          "System.Runtime": "4.0.0-beta-23121",
+          "System.Reflection": "4.0.0-beta-23121"
         },
         "compile": {
           "ref/dotnet/System.Reflection.TypeExtensions.dll": {}
@@ -620,11 +608,11 @@
           "lib/DNXCore50/System.Reflection.TypeExtensions.dll": {}
         }
       },
-      "System.Resources.ResourceManager/4.0.0-beta-23110": {
+      "System.Resources.ResourceManager/4.0.0-beta-23121": {
         "dependencies": {
-          "System.Globalization": "4.0.0",
-          "System.Reflection": "4.0.0",
-          "System.Runtime": "4.0.0"
+          "System.Runtime": "4.0.0-beta-23121",
+          "System.Reflection": "4.0.0-beta-23121",
+          "System.Globalization": "4.0.0-beta-23121"
         },
         "compile": {
           "ref/dotnet/System.Resources.ResourceManager.dll": {}
@@ -633,9 +621,9 @@
           "lib/DNXCore50/System.Resources.ResourceManager.dll": {}
         }
       },
-      "System.Runtime/4.0.20-beta-23110": {
+      "System.Runtime/4.0.20-beta-23121": {
         "dependencies": {
-          "System.Private.Uri": "4.0.0-beta-23110"
+          "System.Private.Uri": "4.0.0-beta-23121"
         },
         "compile": {
           "ref/dotnet/System.Runtime.dll": {}
@@ -644,9 +632,9 @@
           "lib/DNXCore50/System.Runtime.dll": {}
         }
       },
-      "System.Runtime.Extensions/4.0.10-beta-23110": {
+      "System.Runtime.Extensions/4.0.10-beta-23121": {
         "dependencies": {
-          "System.Runtime": "4.0.20-beta-23110"
+          "System.Runtime": "4.0.20-beta-23121"
         },
         "compile": {
           "ref/dotnet/System.Runtime.Extensions.dll": {}
@@ -655,9 +643,9 @@
           "lib/DNXCore50/System.Runtime.Extensions.dll": {}
         }
       },
-      "System.Runtime.Handles/4.0.0-beta-23110": {
+      "System.Runtime.Handles/4.0.0-beta-23121": {
         "dependencies": {
-          "System.Runtime": "4.0.0"
+          "System.Runtime": "4.0.0-beta-23121"
         },
         "compile": {
           "ref/dotnet/System.Runtime.Handles.dll": {}
@@ -666,12 +654,12 @@
           "lib/DNXCore50/System.Runtime.Handles.dll": {}
         }
       },
-      "System.Runtime.InteropServices/4.0.20-beta-23110": {
+      "System.Runtime.InteropServices/4.0.20-beta-23121": {
         "dependencies": {
-          "System.Reflection": "4.0.0",
-          "System.Reflection.Primitives": "4.0.0-beta-23110",
-          "System.Runtime": "4.0.0",
-          "System.Runtime.Handles": "4.0.0-beta-23110"
+          "System.Runtime": "4.0.0-beta-23121",
+          "System.Reflection": "4.0.0-beta-23121",
+          "System.Reflection.Primitives": "4.0.0-beta-23121",
+          "System.Runtime.Handles": "4.0.0-beta-23121"
         },
         "compile": {
           "ref/dotnet/System.Runtime.InteropServices.dll": {}
@@ -680,12 +668,12 @@
           "lib/DNXCore50/System.Runtime.InteropServices.dll": {}
         }
       },
-      "System.Runtime.Numerics/4.0.0-beta-23110": {
+      "System.Runtime.Numerics/4.0.0-beta-23121": {
         "dependencies": {
-          "System.Globalization": "4.0.10-beta-23110",
-          "System.Resources.ResourceManager": "4.0.0-beta-23110",
-          "System.Runtime": "4.0.20-beta-23110",
-          "System.Runtime.Extensions": "4.0.10-beta-23110"
+          "System.Runtime": "4.0.20-beta-23121",
+          "System.Resources.ResourceManager": "4.0.0-beta-23121",
+          "System.Globalization": "4.0.10-beta-23121",
+          "System.Runtime.Extensions": "4.0.10-beta-23121"
         },
         "compile": {
           "ref/dotnet/System.Runtime.Numerics.dll": {}
@@ -694,10 +682,10 @@
           "lib/dotnet/System.Runtime.Numerics.dll": {}
         }
       },
-      "System.Runtime.Serialization.Primitives/4.0.10-beta-23110": {
+      "System.Runtime.Serialization.Primitives/4.0.10-beta-23121": {
         "dependencies": {
-          "System.Resources.ResourceManager": "4.0.0-beta-23110",
-          "System.Runtime": "4.0.20-beta-23110"
+          "System.Runtime": "4.0.20-beta-23121",
+          "System.Resources.ResourceManager": "4.0.0-beta-23121"
         },
         "compile": {
           "ref/dotnet/System.Runtime.Serialization.Primitives.dll": {}
@@ -706,10 +694,10 @@
           "lib/dotnet/System.Runtime.Serialization.Primitives.dll": {}
         }
       },
-      "System.Runtime.Serialization.Xml/4.0.10-beta-23110": {
+      "System.Runtime.Serialization.Xml/4.0.10-beta-23121": {
         "dependencies": {
-          "System.Private.DataContractSerialization": "4.0.0-beta-23110",
-          "System.Runtime.Serialization.Primitives": "4.0.10-beta-23110"
+          "System.Runtime.Serialization.Primitives": "4.0.10-beta-23121",
+          "System.Private.DataContractSerialization": "4.0.0-beta-23121"
         },
         "compile": {
           "ref/dotnet/System.Runtime.Serialization.Xml.dll": {}
@@ -718,16 +706,16 @@
           "lib/DNXCore50/System.Runtime.Serialization.Xml.dll": {}
         }
       },
-      "System.Security.Claims/4.0.0-beta-23110": {
+      "System.Security.Claims/4.0.0-beta-23121": {
         "dependencies": {
-          "System.Collections": "4.0.0",
-          "System.Diagnostics.Debug": "4.0.0",
-          "System.Globalization": "4.0.0",
-          "System.IO": "4.0.0",
-          "System.Resources.ResourceManager": "4.0.0-beta-23110",
-          "System.Runtime": "4.0.20-beta-23110",
-          "System.Runtime.Extensions": "4.0.0",
-          "System.Security.Principal": "4.0.0-beta-23110"
+          "System.Runtime": "4.0.20-beta-23121",
+          "System.Security.Principal": "4.0.0-beta-23121",
+          "System.IO": "4.0.0-beta-23121",
+          "System.Resources.ResourceManager": "4.0.0-beta-23121",
+          "System.Collections": "4.0.0-beta-23121",
+          "System.Diagnostics.Debug": "4.0.0-beta-23121",
+          "System.Globalization": "4.0.0-beta-23121",
+          "System.Runtime.Extensions": "4.0.0-beta-23121"
         },
         "compile": {
           "ref/dotnet/System.Security.Claims.dll": {}
@@ -736,14 +724,14 @@
           "lib/dotnet/System.Security.Claims.dll": {}
         }
       },
-      "System.Security.Cryptography.Encoding/4.0.0-beta-23110": {
+      "System.Security.Cryptography.Encoding/4.0.0-beta-23121": {
         "dependencies": {
-          "System.Diagnostics.Debug": "4.0.10-beta-23110",
-          "System.Resources.ResourceManager": "4.0.0-beta-23110",
-          "System.Runtime": "4.0.20-beta-23110",
-          "System.Runtime.Handles": "4.0.0-beta-23110",
-          "System.Runtime.InteropServices": "4.0.20-beta-23110",
-          "System.Security.Cryptography.Encryption": "4.0.0-beta-23110"
+          "System.Runtime": "4.0.20-beta-23121",
+          "System.Runtime.InteropServices": "4.0.20-beta-23121",
+          "System.Resources.ResourceManager": "4.0.0-beta-23121",
+          "System.Security.Cryptography.Encryption": "4.0.0-beta-23121",
+          "System.Runtime.Handles": "4.0.0-beta-23121",
+          "System.Diagnostics.Debug": "4.0.10-beta-23121"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.Encoding.dll": {}
@@ -752,13 +740,12 @@
           "lib/DNXCore50/System.Security.Cryptography.Encoding.dll": {}
         }
       },
-      "System.Security.Cryptography.Encryption/4.0.0-beta-23110": {
+      "System.Security.Cryptography.Encryption/4.0.0-beta-23121": {
         "dependencies": {
-          "System.Globalization": "4.0.0",
-          "System.IO": "4.0.10-beta-23110",
-          "System.Resources.ResourceManager": "4.0.0-beta-23110",
-          "System.Runtime": "4.0.20-beta-23110",
-          "System.Threading.Tasks": "4.0.0"
+          "System.Runtime": "4.0.20-beta-23121",
+          "System.Resources.ResourceManager": "4.0.0-beta-23121",
+          "System.Globalization": "4.0.0-beta-23121",
+          "System.IO": "4.0.10-beta-23121"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.Encryption.dll": {}
@@ -767,11 +754,11 @@
           "lib/DNXCore50/System.Security.Cryptography.Encryption.dll": {}
         }
       },
-      "System.Security.Cryptography.Hashing/4.0.0-beta-23110": {
+      "System.Security.Cryptography.Hashing/4.0.0-beta-23121": {
         "dependencies": {
-          "System.IO": "4.0.0",
-          "System.Resources.ResourceManager": "4.0.0-beta-23110",
-          "System.Runtime": "4.0.20-beta-23110"
+          "System.Runtime": "4.0.20-beta-23121",
+          "System.Resources.ResourceManager": "4.0.0-beta-23121",
+          "System.IO": "4.0.0-beta-23121"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.Hashing.dll": {}
@@ -780,14 +767,14 @@
           "lib/DNXCore50/System.Security.Cryptography.Hashing.dll": {}
         }
       },
-      "System.Security.Cryptography.Hashing.Algorithms/4.0.0-beta-23110": {
+      "System.Security.Cryptography.Hashing.Algorithms/4.0.0-beta-23121": {
         "dependencies": {
-          "System.Resources.ResourceManager": "4.0.0-beta-23110",
-          "System.Runtime": "4.0.20-beta-23110",
-          "System.Runtime.Handles": "4.0.0-beta-23110",
-          "System.Security.Cryptography.Encryption": "4.0.0-beta-23110",
-          "System.Security.Cryptography.Hashing": "4.0.0-beta-23110",
-          "System.Security.Cryptography.RandomNumberGenerator": "4.0.0-beta-23110"
+          "System.Runtime": "4.0.20-beta-23121",
+          "System.Resources.ResourceManager": "4.0.0-beta-23121",
+          "System.Security.Cryptography.Encryption": "4.0.0-beta-23121",
+          "System.Runtime.Handles": "4.0.0-beta-23121",
+          "System.Security.Cryptography.RandomNumberGenerator": "4.0.0-beta-23121",
+          "System.Security.Cryptography.Hashing": "4.0.0-beta-23121"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.Hashing.Algorithms.dll": {}
@@ -796,10 +783,10 @@
           "lib/DNXCore50/System.Security.Cryptography.Hashing.Algorithms.dll": {}
         }
       },
-      "System.Security.Cryptography.RandomNumberGenerator/4.0.0-beta-23110": {
+      "System.Security.Cryptography.RandomNumberGenerator/4.0.0-beta-23121": {
         "dependencies": {
-          "System.Runtime": "4.0.20-beta-23110",
-          "System.Security.Cryptography.Encryption": "4.0.0-beta-23110"
+          "System.Runtime": "4.0.20-beta-23121",
+          "System.Security.Cryptography.Encryption": "4.0.0-beta-23121"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.RandomNumberGenerator.dll": {}
@@ -808,20 +795,20 @@
           "lib/DNXCore50/System.Security.Cryptography.RandomNumberGenerator.dll": {}
         }
       },
-      "System.Security.Cryptography.RSA/4.0.0-beta-23110": {
+      "System.Security.Cryptography.RSA/4.0.0-beta-23121": {
         "dependencies": {
-          "System.IO": "4.0.10-beta-23110",
-          "System.Reflection": "4.0.0",
-          "System.Resources.ResourceManager": "4.0.0-beta-23110",
-          "System.Runtime": "4.0.20-beta-23110",
-          "System.Runtime.Extensions": "4.0.10-beta-23110",
-          "System.Runtime.Handles": "4.0.0-beta-23110",
-          "System.Runtime.InteropServices": "4.0.20-beta-23110",
-          "System.Security.Cryptography.Encoding": "4.0.0-beta-23110",
-          "System.Security.Cryptography.Encryption": "4.0.0-beta-23110",
-          "System.Security.Cryptography.Hashing": "4.0.0-beta-23110",
-          "System.Security.Cryptography.Hashing.Algorithms": "4.0.0-beta-23110",
-          "System.Threading": "4.0.10-beta-23110"
+          "System.Runtime": "4.0.20-beta-23121",
+          "System.Runtime.InteropServices": "4.0.20-beta-23121",
+          "System.Resources.ResourceManager": "4.0.0-beta-23121",
+          "System.Security.Cryptography.Encryption": "4.0.0-beta-23121",
+          "System.Runtime.Handles": "4.0.0-beta-23121",
+          "System.Security.Cryptography.Encoding": "4.0.0-beta-23121",
+          "System.Reflection": "4.0.0-beta-23121",
+          "System.Security.Cryptography.Hashing": "4.0.0-beta-23121",
+          "System.Security.Cryptography.Hashing.Algorithms": "4.0.0-beta-23121",
+          "System.IO": "4.0.10-beta-23121",
+          "System.Threading": "4.0.10-beta-23121",
+          "System.Runtime.Extensions": "4.0.10-beta-23121"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.RSA.dll": {}
@@ -830,27 +817,27 @@
           "lib/DNXCore50/System.Security.Cryptography.RSA.dll": {}
         }
       },
-      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23110": {
+      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23121": {
         "dependencies": {
-          "System.Collections": "4.0.10-beta-23110",
-          "System.Diagnostics.Debug": "4.0.10-beta-23110",
-          "System.Globalization": "4.0.10-beta-23110",
-          "System.Globalization.Calendars": "4.0.0-beta-23110",
-          "System.IO": "4.0.10-beta-23110",
-          "System.IO.FileSystem": "4.0.0-beta-23110",
-          "System.Resources.ResourceManager": "4.0.0-beta-23110",
-          "System.Runtime": "4.0.20-beta-23110",
-          "System.Runtime.Extensions": "4.0.10-beta-23110",
-          "System.Runtime.Handles": "4.0.0-beta-23110",
-          "System.Runtime.InteropServices": "4.0.20-beta-23110",
-          "System.Runtime.Numerics": "4.0.0-beta-23110",
-          "System.Security.Cryptography.Encoding": "4.0.0-beta-23110",
-          "System.Security.Cryptography.Encryption": "4.0.0-beta-23110",
-          "System.Security.Cryptography.Hashing": "4.0.0-beta-23110",
-          "System.Security.Cryptography.Hashing.Algorithms": "4.0.0-beta-23110",
-          "System.Security.Cryptography.RSA": "4.0.0-beta-23110",
-          "System.Text.Encoding": "4.0.10-beta-23110",
-          "System.Threading": "4.0.10-beta-23110"
+          "System.Runtime": "4.0.20-beta-23121",
+          "System.Runtime.InteropServices": "4.0.20-beta-23121",
+          "System.Resources.ResourceManager": "4.0.0-beta-23121",
+          "System.Runtime.Handles": "4.0.0-beta-23121",
+          "System.Security.Cryptography.Encryption": "4.0.0-beta-23121",
+          "System.Security.Cryptography.RSA": "4.0.0-beta-23121",
+          "System.Security.Cryptography.Encoding": "4.0.0-beta-23121",
+          "System.Runtime.Numerics": "4.0.0-beta-23121",
+          "System.Globalization.Calendars": "4.0.0-beta-23121",
+          "System.Security.Cryptography.Hashing.Algorithms": "4.0.0-beta-23121",
+          "System.Security.Cryptography.Hashing": "4.0.0-beta-23121",
+          "System.IO.FileSystem": "4.0.0-beta-23121",
+          "System.Globalization": "4.0.10-beta-23121",
+          "System.Diagnostics.Debug": "4.0.10-beta-23121",
+          "System.Collections": "4.0.10-beta-23121",
+          "System.IO": "4.0.10-beta-23121",
+          "System.Threading": "4.0.10-beta-23121",
+          "System.Runtime.Extensions": "4.0.10-beta-23121",
+          "System.Text.Encoding": "4.0.10-beta-23121"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.X509Certificates.dll": {}
@@ -859,9 +846,9 @@
           "lib/DNXCore50/System.Security.Cryptography.X509Certificates.dll": {}
         }
       },
-      "System.Security.Principal/4.0.0-beta-23110": {
+      "System.Security.Principal/4.0.0-beta-23121": {
         "dependencies": {
-          "System.Runtime": "4.0.0"
+          "System.Runtime": "4.0.0-beta-23121"
         },
         "compile": {
           "ref/dotnet/System.Security.Principal.dll": {}
@@ -870,18 +857,18 @@
           "lib/dotnet/System.Security.Principal.dll": {}
         }
       },
-      "System.Security.Principal.Windows/4.0.0-beta-23110": {
+      "System.Security.Principal.Windows/4.0.0-beta-23121": {
         "dependencies": {
-          "System.Collections": "4.0.0",
-          "System.Diagnostics.Debug": "4.0.0",
-          "System.Reflection": "4.0.0",
-          "System.Resources.ResourceManager": "4.0.0-beta-23110",
-          "System.Runtime": "4.0.20-beta-23110",
-          "System.Runtime.Extensions": "4.0.0",
-          "System.Runtime.InteropServices": "4.0.0",
-          "System.Security.Claims": "4.0.0-beta-23110",
-          "System.Security.Principal": "4.0.0-beta-23110",
-          "System.Threading": "4.0.10-beta-23110"
+          "System.Runtime": "4.0.20-beta-23121",
+          "System.Resources.ResourceManager": "4.0.0-beta-23121",
+          "System.Collections": "4.0.0-beta-23121",
+          "System.Runtime.InteropServices": "4.0.0-beta-23121",
+          "System.Security.Claims": "4.0.0-beta-23121",
+          "System.Security.Principal": "4.0.0-beta-23121",
+          "System.Diagnostics.Debug": "4.0.0-beta-23121",
+          "System.Reflection": "4.0.0-beta-23121",
+          "System.Runtime.Extensions": "4.0.0-beta-23121",
+          "System.Threading": "4.0.10-beta-23121"
         },
         "compile": {
           "ref/dotnet/System.Security.Principal.Windows.dll": {}
@@ -890,14 +877,14 @@
           "lib/DNXCore50/System.Security.Principal.Windows.dll": {}
         }
       },
-      "System.Security.SecureString/4.0.0-beta-23110": {
+      "System.Security.SecureString/4.0.0-beta-23121": {
         "dependencies": {
-          "System.Resources.ResourceManager": "4.0.0-beta-23110",
-          "System.Runtime": "4.0.20-beta-23110",
-          "System.Runtime.Handles": "4.0.0-beta-23110",
-          "System.Runtime.InteropServices": "4.0.20-beta-23110",
-          "System.Security.Cryptography.Encryption": "4.0.0-beta-23110",
-          "System.Threading": "4.0.10-beta-23110"
+          "System.Runtime": "4.0.20-beta-23121",
+          "System.Runtime.InteropServices": "4.0.20-beta-23121",
+          "System.Resources.ResourceManager": "4.0.0-beta-23121",
+          "System.Runtime.Handles": "4.0.0-beta-23121",
+          "System.Security.Cryptography.Encryption": "4.0.0-beta-23121",
+          "System.Threading": "4.0.10-beta-23121"
         },
         "compile": {
           "ref/dotnet/System.Security.SecureString.dll": {}
@@ -906,9 +893,10 @@
           "lib/DNXCore50/System.Security.SecureString.dll": {}
         }
       },
-      "System.ServiceModel.Http/4.0.10-beta-23110": {
+      "System.ServiceModel.Http/4.0.10-beta-23121": {
         "dependencies": {
-          "System.Private.ServiceModel": "4.0.0-beta-23110"
+          "System.Runtime": "4.0.20-beta-23121",
+          "System.Private.ServiceModel": "4.0.0-beta-23121"
         },
         "compile": {
           "ref/dotnet/System.ServiceModel.Http.dll": {}
@@ -917,9 +905,9 @@
           "lib/DNXCore50/System.ServiceModel.Http.dll": {}
         }
       },
-      "System.ServiceModel.NetTcp/4.0.0-beta-23110": {
+      "System.ServiceModel.NetTcp/4.0.0-beta-23121": {
         "dependencies": {
-          "System.Private.ServiceModel": "4.0.0-beta-23110"
+          "System.Private.ServiceModel": "4.0.0-beta-23121"
         },
         "compile": {
           "ref/dotnet/System.ServiceModel.NetTcp.dll": {}
@@ -928,9 +916,9 @@
           "lib/DNXCore50/System.ServiceModel.NetTcp.dll": {}
         }
       },
-      "System.ServiceModel.Primitives/4.0.0-beta-23110": {
+      "System.ServiceModel.Primitives/4.0.0-beta-23121": {
         "dependencies": {
-          "System.Private.ServiceModel": "4.0.0-beta-23110"
+          "System.Private.ServiceModel": "4.0.0-beta-23121"
         },
         "compile": {
           "ref/dotnet/System.ServiceModel.Primitives.dll": {}
@@ -939,9 +927,9 @@
           "lib/DNXCore50/System.ServiceModel.Primitives.dll": {}
         }
       },
-      "System.ServiceModel.Security/4.0.0-beta-23109": {
+      "System.ServiceModel.Security/4.0.0-beta-23121": {
         "dependencies": {
-          "System.Private.ServiceModel": "4.0.0-beta-23109"
+          "System.Private.ServiceModel": "4.0.0-beta-23121"
         },
         "compile": {
           "ref/dotnet/System.ServiceModel.Security.dll": {}
@@ -950,9 +938,9 @@
           "lib/DNXCore50/System.ServiceModel.Security.dll": {}
         }
       },
-      "System.Text.Encoding/4.0.10-beta-23110": {
+      "System.Text.Encoding/4.0.10-beta-23121": {
         "dependencies": {
-          "System.Runtime": "4.0.0"
+          "System.Runtime": "4.0.0-beta-23121"
         },
         "compile": {
           "ref/dotnet/System.Text.Encoding.dll": {}
@@ -961,10 +949,10 @@
           "lib/DNXCore50/System.Text.Encoding.dll": {}
         }
       },
-      "System.Text.Encoding.Extensions/4.0.10-beta-23110": {
+      "System.Text.Encoding.Extensions/4.0.10-beta-23121": {
         "dependencies": {
-          "System.Runtime": "4.0.0",
-          "System.Text.Encoding": "4.0.10-beta-23110"
+          "System.Runtime": "4.0.0-beta-23121",
+          "System.Text.Encoding": "4.0.10-beta-23121"
         },
         "compile": {
           "ref/dotnet/System.Text.Encoding.Extensions.dll": {}
@@ -973,14 +961,14 @@
           "lib/DNXCore50/System.Text.Encoding.Extensions.dll": {}
         }
       },
-      "System.Text.RegularExpressions/4.0.10-beta-23110": {
+      "System.Text.RegularExpressions/4.0.10-beta-23121": {
         "dependencies": {
-          "System.Collections": "4.0.10-beta-23110",
-          "System.Globalization": "4.0.10-beta-23110",
-          "System.Resources.ResourceManager": "4.0.0-beta-23110",
-          "System.Runtime": "4.0.20-beta-23110",
-          "System.Runtime.Extensions": "4.0.10-beta-23110",
-          "System.Threading": "4.0.10-beta-23110"
+          "System.Runtime": "4.0.20-beta-23121",
+          "System.Resources.ResourceManager": "4.0.0-beta-23121",
+          "System.Collections": "4.0.10-beta-23121",
+          "System.Globalization": "4.0.10-beta-23121",
+          "System.Runtime.Extensions": "4.0.10-beta-23121",
+          "System.Threading": "4.0.10-beta-23121"
         },
         "compile": {
           "ref/dotnet/System.Text.RegularExpressions.dll": {}
@@ -989,10 +977,10 @@
           "lib/dotnet/System.Text.RegularExpressions.dll": {}
         }
       },
-      "System.Threading/4.0.10-beta-23110": {
+      "System.Threading/4.0.10-beta-23121": {
         "dependencies": {
-          "System.Runtime": "4.0.0",
-          "System.Threading.Tasks": "4.0.0"
+          "System.Runtime": "4.0.0-beta-23121",
+          "System.Threading.Tasks": "4.0.0-beta-23121"
         },
         "compile": {
           "ref/dotnet/System.Threading.dll": {}
@@ -1001,10 +989,10 @@
           "lib/DNXCore50/System.Threading.dll": {}
         }
       },
-      "System.Threading.Overlapped/4.0.0-beta-23110": {
+      "System.Threading.Overlapped/4.0.0-beta-23121": {
         "dependencies": {
-          "System.Runtime": "4.0.0",
-          "System.Runtime.Handles": "4.0.0-beta-23110"
+          "System.Runtime": "4.0.0-beta-23121",
+          "System.Runtime.Handles": "4.0.0-beta-23121"
         },
         "compile": {
           "ref/dotnet/System.Threading.Overlapped.dll": {}
@@ -1013,9 +1001,9 @@
           "lib/DNXCore50/System.Threading.Overlapped.dll": {}
         }
       },
-      "System.Threading.Tasks/4.0.10-beta-23110": {
+      "System.Threading.Tasks/4.0.10-beta-23121": {
         "dependencies": {
-          "System.Runtime": "4.0.0"
+          "System.Runtime": "4.0.0-beta-23121"
         },
         "compile": {
           "ref/dotnet/System.Threading.Tasks.dll": {}
@@ -1024,10 +1012,10 @@
           "lib/DNXCore50/System.Threading.Tasks.dll": {}
         }
       },
-      "System.Threading.ThreadPool/4.0.10-beta-23110": {
+      "System.Threading.ThreadPool/4.0.10-beta-23121": {
         "dependencies": {
-          "System.Runtime": "4.0.0",
-          "System.Runtime.InteropServices": "4.0.0"
+          "System.Runtime": "4.0.0-beta-23121",
+          "System.Runtime.InteropServices": "4.0.0-beta-23121"
         },
         "compile": {
           "ref/dotnet/System.Threading.ThreadPool.dll": {}
@@ -1036,9 +1024,9 @@
           "lib/DNXCore50/System.Threading.ThreadPool.dll": {}
         }
       },
-      "System.Threading.Timer/4.0.0-beta-23110": {
+      "System.Threading.Timer/4.0.0-beta-23121": {
         "dependencies": {
-          "System.Runtime": "4.0.0"
+          "System.Runtime": "4.0.0-beta-23121"
         },
         "compile": {
           "ref/dotnet/System.Threading.Timer.dll": {}
@@ -1047,22 +1035,22 @@
           "lib/DNXCore50/System.Threading.Timer.dll": {}
         }
       },
-      "System.Xml.ReaderWriter/4.0.10-beta-23110": {
+      "System.Xml.ReaderWriter/4.0.10-beta-23121": {
         "dependencies": {
-          "System.Collections": "4.0.10-beta-23110",
-          "System.Diagnostics.Debug": "4.0.10-beta-23110",
-          "System.Globalization": "4.0.10-beta-23110",
-          "System.IO": "4.0.10-beta-23110",
-          "System.IO.FileSystem": "4.0.0-beta-23110",
-          "System.IO.FileSystem.Primitives": "4.0.0-beta-23110",
-          "System.Resources.ResourceManager": "4.0.0-beta-23110",
-          "System.Runtime": "4.0.20-beta-23110",
-          "System.Runtime.Extensions": "4.0.10-beta-23110",
-          "System.Runtime.InteropServices": "4.0.20-beta-23110",
-          "System.Text.Encoding": "4.0.10-beta-23110",
-          "System.Text.Encoding.Extensions": "4.0.10-beta-23110",
-          "System.Text.RegularExpressions": "4.0.10-beta-23110",
-          "System.Threading.Tasks": "4.0.10-beta-23110"
+          "System.Runtime": "4.0.20-beta-23121",
+          "System.Text.Encoding": "4.0.10-beta-23121",
+          "System.IO": "4.0.10-beta-23121",
+          "System.Threading.Tasks": "4.0.10-beta-23121",
+          "System.Runtime.InteropServices": "4.0.20-beta-23121",
+          "System.Resources.ResourceManager": "4.0.0-beta-23121",
+          "System.IO.FileSystem": "4.0.0-beta-23121",
+          "System.IO.FileSystem.Primitives": "4.0.0-beta-23121",
+          "System.Diagnostics.Debug": "4.0.10-beta-23121",
+          "System.Text.RegularExpressions": "4.0.10-beta-23121",
+          "System.Collections": "4.0.10-beta-23121",
+          "System.Runtime.Extensions": "4.0.10-beta-23121",
+          "System.Globalization": "4.0.10-beta-23121",
+          "System.Text.Encoding.Extensions": "4.0.10-beta-23121"
         },
         "compile": {
           "ref/dotnet/System.Xml.ReaderWriter.dll": {}
@@ -1071,18 +1059,18 @@
           "lib/dotnet/System.Xml.ReaderWriter.dll": {}
         }
       },
-      "System.Xml.XmlDocument/4.0.0-beta-23110": {
+      "System.Xml.XmlDocument/4.0.0-beta-23121": {
         "dependencies": {
-          "System.Collections": "4.0.10-beta-23110",
-          "System.Diagnostics.Debug": "4.0.10-beta-23110",
-          "System.Globalization": "4.0.10-beta-23110",
-          "System.IO": "4.0.10-beta-23110",
-          "System.Resources.ResourceManager": "4.0.0-beta-23110",
-          "System.Runtime": "4.0.20-beta-23110",
-          "System.Runtime.Extensions": "4.0.10-beta-23110",
-          "System.Text.Encoding": "4.0.10-beta-23110",
-          "System.Threading": "4.0.10-beta-23110",
-          "System.Xml.ReaderWriter": "4.0.10-beta-23110"
+          "System.Runtime": "4.0.20-beta-23121",
+          "System.Xml.ReaderWriter": "4.0.10-beta-23121",
+          "System.IO": "4.0.10-beta-23121",
+          "System.Resources.ResourceManager": "4.0.0-beta-23121",
+          "System.Text.Encoding": "4.0.10-beta-23121",
+          "System.Collections": "4.0.10-beta-23121",
+          "System.Diagnostics.Debug": "4.0.10-beta-23121",
+          "System.Runtime.Extensions": "4.0.10-beta-23121",
+          "System.Globalization": "4.0.10-beta-23121",
+          "System.Threading": "4.0.10-beta-23121"
         },
         "compile": {
           "ref/dotnet/System.Xml.XmlDocument.dll": {}
@@ -1091,24 +1079,24 @@
           "lib/dotnet/System.Xml.XmlDocument.dll": {}
         }
       },
-      "System.Xml.XmlSerializer/4.0.10-beta-23110": {
+      "System.Xml.XmlSerializer/4.0.10-beta-23121": {
         "dependencies": {
-          "System.Collections": "4.0.10-beta-23110",
-          "System.Diagnostics.Debug": "4.0.10-beta-23110",
-          "System.Globalization": "4.0.10-beta-23110",
-          "System.IO": "4.0.10-beta-23110",
-          "System.Linq": "4.0.0-beta-23110",
-          "System.Reflection": "4.0.10-beta-23110",
-          "System.Reflection.Extensions": "4.0.0-beta-23110",
-          "System.Reflection.Primitives": "4.0.0-beta-23110",
-          "System.Reflection.TypeExtensions": "4.0.0-beta-23110",
-          "System.Resources.ResourceManager": "4.0.0-beta-23110",
-          "System.Runtime": "4.0.20-beta-23110",
-          "System.Runtime.Extensions": "4.0.10-beta-23110",
-          "System.Text.RegularExpressions": "4.0.10-beta-23110",
-          "System.Threading": "4.0.10-beta-23110",
-          "System.Xml.ReaderWriter": "4.0.10-beta-23110",
-          "System.Xml.XmlDocument": "4.0.0-beta-23110"
+          "System.Runtime": "4.0.20-beta-23121",
+          "System.Resources.ResourceManager": "4.0.0-beta-23121",
+          "System.Xml.XmlDocument": "4.0.0-beta-23121",
+          "System.Reflection.TypeExtensions": "4.0.0-beta-23121",
+          "System.Reflection.Primitives": "4.0.0-beta-23121",
+          "System.Reflection.Extensions": "4.0.0-beta-23121",
+          "System.Linq": "4.0.0-beta-23121",
+          "System.Collections": "4.0.10-beta-23121",
+          "System.Diagnostics.Debug": "4.0.10-beta-23121",
+          "System.Globalization": "4.0.10-beta-23121",
+          "System.Reflection": "4.0.10-beta-23121",
+          "System.Xml.ReaderWriter": "4.0.10-beta-23121",
+          "System.IO": "4.0.10-beta-23121",
+          "System.Text.RegularExpressions": "4.0.10-beta-23121",
+          "System.Threading": "4.0.10-beta-23121",
+          "System.Runtime.Extensions": "4.0.10-beta-23121"
         },
         "compile": {
           "ref/dotnet/System.Xml.XmlSerializer.dll": {}
@@ -1120,27 +1108,27 @@
     }
   },
   "libraries": {
-    "Microsoft.Win32.Primitives/4.0.0-beta-23110": {
+    "Microsoft.Win32.Primitives/4.0.0-beta-23121": {
       "serviceable": true,
-      "sha512": "jOJqZRsqnJfEfo49Blvg8pbVdQRK+jt1mNouXzb3wbUxz36BKxNIAE3tloxBI5nVCRw9oJhbEQ9pt4HTmnX6Bg==",
+      "sha512": "0Nm9nu/oG9pd6R9F/S60Symr4FVkxcfCwcEa/uNvlnfjUEDScaUghFTZK4FvLwWj6rh9d6Qye70qJvi3E9gRXw==",
       "files": [
+        "Microsoft.Win32.Primitives.4.0.0-beta-23121.nupkg",
+        "Microsoft.Win32.Primitives.4.0.0-beta-23121.nupkg.sha512",
+        "Microsoft.Win32.Primitives.nuspec",
         "lib/dotnet/Microsoft.Win32.Primitives.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/Microsoft.Win32.Primitives.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "Microsoft.Win32.Primitives.4.0.0-beta-23110.nupkg",
-        "Microsoft.Win32.Primitives.4.0.0-beta-23110.nupkg.sha512",
-        "Microsoft.Win32.Primitives.nuspec",
+        "ref/dotnet/Microsoft.Win32.Primitives.dll",
+        "ref/dotnet/Microsoft.Win32.Primitives.xml",
         "ref/dotnet/de/Microsoft.Win32.Primitives.xml",
         "ref/dotnet/es/Microsoft.Win32.Primitives.xml",
         "ref/dotnet/fr/Microsoft.Win32.Primitives.xml",
         "ref/dotnet/it/Microsoft.Win32.Primitives.xml",
         "ref/dotnet/ja/Microsoft.Win32.Primitives.xml",
         "ref/dotnet/ko/Microsoft.Win32.Primitives.xml",
-        "ref/dotnet/Microsoft.Win32.Primitives.dll",
-        "ref/dotnet/Microsoft.Win32.Primitives.xml",
         "ref/dotnet/ru/Microsoft.Win32.Primitives.xml",
         "ref/dotnet/zh-hans/Microsoft.Win32.Primitives.xml",
         "ref/dotnet/zh-hant/Microsoft.Win32.Primitives.xml",
@@ -1151,10 +1139,13 @@
         "ref/xamarinmac20/_._"
       ]
     },
-    "System.Collections/4.0.10-beta-23110": {
+    "System.Collections/4.0.10-beta-23121": {
       "serviceable": true,
-      "sha512": "C+SFurxzh+d1HlrjHLKbp379UIMHTzziguFb0xkDRYOA2na2DnvgoQ12vhEBt264UT3808HfGLoe8BPR4CYA8w==",
+      "sha512": "YPG80auFnHcYJGj9bSil3RHD8fcGKJOXlO+hRt3FAkShL9tgHisTcMxRqRFsC39D+WKPS7AkldGe1ihHRMZCgw==",
       "files": [
+        "System.Collections.4.0.10-beta-23121.nupkg",
+        "System.Collections.4.0.10-beta-23121.nupkg.sha512",
+        "System.Collections.nuspec",
         "lib/DNXCore50/System.Collections.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -1162,6 +1153,8 @@
         "lib/netcore50/System.Collections.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Collections.dll",
+        "ref/dotnet/System.Collections.xml",
         "ref/dotnet/de/System.Collections.xml",
         "ref/dotnet/es/System.Collections.xml",
         "ref/dotnet/fr/System.Collections.xml",
@@ -1169,8 +1162,6 @@
         "ref/dotnet/ja/System.Collections.xml",
         "ref/dotnet/ko/System.Collections.xml",
         "ref/dotnet/ru/System.Collections.xml",
-        "ref/dotnet/System.Collections.dll",
-        "ref/dotnet/System.Collections.xml",
         "ref/dotnet/zh-hans/System.Collections.xml",
         "ref/dotnet/zh-hant/System.Collections.xml",
         "ref/MonoAndroid10/_._",
@@ -1178,22 +1169,24 @@
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Collections.dll",
-        "System.Collections.4.0.10-beta-23110.nupkg",
-        "System.Collections.4.0.10-beta-23110.nupkg.sha512",
-        "System.Collections.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Collections.dll"
       ]
     },
-    "System.Collections.Concurrent/4.0.10-beta-23110": {
+    "System.Collections.Concurrent/4.0.10-beta-23121": {
       "serviceable": true,
-      "sha512": "DOl5Ueu7I3i/BCMsF/VNJvRRDkE/zTMKIkRvJl03j+5DnqGqzwJMud3y6zlCsCENEKlZ5aS12HLl9VmP9qy4HQ==",
+      "sha512": "EfUn8QtN3Udmr9kW+H0dPoezG5VlzqFAErBb7SM3qXX5Vx0RthsNwGSwGJJM2n6qBpF+DXRXYWWjV6ugfBm+cw==",
       "files": [
+        "System.Collections.Concurrent.4.0.10-beta-23121.nupkg",
+        "System.Collections.Concurrent.4.0.10-beta-23121.nupkg.sha512",
+        "System.Collections.Concurrent.nuspec",
         "lib/dotnet/System.Collections.Concurrent.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Collections.Concurrent.dll",
+        "ref/dotnet/System.Collections.Concurrent.xml",
         "ref/dotnet/de/System.Collections.Concurrent.xml",
         "ref/dotnet/es/System.Collections.Concurrent.xml",
         "ref/dotnet/fr/System.Collections.Concurrent.xml",
@@ -1201,30 +1194,30 @@
         "ref/dotnet/ja/System.Collections.Concurrent.xml",
         "ref/dotnet/ko/System.Collections.Concurrent.xml",
         "ref/dotnet/ru/System.Collections.Concurrent.xml",
-        "ref/dotnet/System.Collections.Concurrent.dll",
-        "ref/dotnet/System.Collections.Concurrent.xml",
         "ref/dotnet/zh-hans/System.Collections.Concurrent.xml",
         "ref/dotnet/zh-hant/System.Collections.Concurrent.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.Collections.Concurrent.4.0.10-beta-23110.nupkg",
-        "System.Collections.Concurrent.4.0.10-beta-23110.nupkg.sha512",
-        "System.Collections.Concurrent.nuspec"
+        "ref/xamarinmac20/_._"
       ]
     },
-    "System.Collections.NonGeneric/4.0.0-beta-23110": {
+    "System.Collections.NonGeneric/4.0.0-beta-23121": {
       "serviceable": true,
-      "sha512": "wttQXPUjklmOJbKyJv/yrsE25sYjcCuDcugLgyPPk9bjdkxc7O7RtzDHvhk+DYWaxg/+soYMeNxSQ0a0EooBmg==",
+      "sha512": "v1Wpthx9Jxc6EBPuRi05XWCu7jI85j31YJJZvprIguKJxcEZR2c0nqcFmkfB4jJOspGlYML2BJ6mgsJ4kGEytw==",
       "files": [
+        "System.Collections.NonGeneric.4.0.0-beta-23121.nupkg",
+        "System.Collections.NonGeneric.4.0.0-beta-23121.nupkg.sha512",
+        "System.Collections.NonGeneric.nuspec",
         "lib/dotnet/System.Collections.NonGeneric.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Collections.NonGeneric.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Collections.NonGeneric.dll",
+        "ref/dotnet/System.Collections.NonGeneric.xml",
         "ref/dotnet/de/System.Collections.NonGeneric.xml",
         "ref/dotnet/es/System.Collections.NonGeneric.xml",
         "ref/dotnet/fr/System.Collections.NonGeneric.xml",
@@ -1232,30 +1225,30 @@
         "ref/dotnet/ja/System.Collections.NonGeneric.xml",
         "ref/dotnet/ko/System.Collections.NonGeneric.xml",
         "ref/dotnet/ru/System.Collections.NonGeneric.xml",
-        "ref/dotnet/System.Collections.NonGeneric.dll",
-        "ref/dotnet/System.Collections.NonGeneric.xml",
         "ref/dotnet/zh-hans/System.Collections.NonGeneric.xml",
         "ref/dotnet/zh-hant/System.Collections.NonGeneric.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Collections.NonGeneric.dll",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.Collections.NonGeneric.4.0.0-beta-23110.nupkg",
-        "System.Collections.NonGeneric.4.0.0-beta-23110.nupkg.sha512",
-        "System.Collections.NonGeneric.nuspec"
+        "ref/xamarinmac20/_._"
       ]
     },
-    "System.Collections.Specialized/4.0.0-beta-23110": {
+    "System.Collections.Specialized/4.0.0-beta-23121": {
       "serviceable": true,
-      "sha512": "f/IeaHtnn1HoDFQzjWgFCTCOJ3C/5y5CHBRKC6U2R3/Kz9j1sMu2XN19Tgy1nFt0m7MasQZ0j/cZDMw4/nrLgw==",
+      "sha512": "BFrG50XJubnBO9D0IDlJ7/oDEsri7XCpm30VcgYMvT/R6bS2MQyo4aVbc0REGgzo46hGTDy+CHbyqVsGTg4nng==",
       "files": [
+        "System.Collections.Specialized.4.0.0-beta-23121.nupkg",
+        "System.Collections.Specialized.4.0.0-beta-23121.nupkg.sha512",
+        "System.Collections.Specialized.nuspec",
         "lib/dotnet/System.Collections.Specialized.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Collections.Specialized.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Collections.Specialized.dll",
+        "ref/dotnet/System.Collections.Specialized.xml",
         "ref/dotnet/de/System.Collections.Specialized.xml",
         "ref/dotnet/es/System.Collections.Specialized.xml",
         "ref/dotnet/fr/System.Collections.Specialized.xml",
@@ -1263,30 +1256,30 @@
         "ref/dotnet/ja/System.Collections.Specialized.xml",
         "ref/dotnet/ko/System.Collections.Specialized.xml",
         "ref/dotnet/ru/System.Collections.Specialized.xml",
-        "ref/dotnet/System.Collections.Specialized.dll",
-        "ref/dotnet/System.Collections.Specialized.xml",
         "ref/dotnet/zh-hans/System.Collections.Specialized.xml",
         "ref/dotnet/zh-hant/System.Collections.Specialized.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Collections.Specialized.dll",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.Collections.Specialized.4.0.0-beta-23110.nupkg",
-        "System.Collections.Specialized.4.0.0-beta-23110.nupkg.sha512",
-        "System.Collections.Specialized.nuspec"
+        "ref/xamarinmac20/_._"
       ]
     },
-    "System.ComponentModel.EventBasedAsync/4.0.10-beta-23110": {
+    "System.ComponentModel.EventBasedAsync/4.0.10-beta-23121": {
       "serviceable": true,
-      "sha512": "ryHi9thD2J/ZcpAL7IKpfSG/7DvQzl27bh4d9Sca+zDZBkhyKlhoooJTNqRWru9SiUslTsuFH69cEfVHuI+IIQ==",
+      "sha512": "8MiRr10Md8YgaoJ5iorHIbj3LeDhVKfF9Ij+f0PK7DV8X7jiFznQy+igw7eXlyw5bb51U8nttR99QGPxDRtjPw==",
       "files": [
+        "System.ComponentModel.EventBasedAsync.4.0.10-beta-23121.nupkg",
+        "System.ComponentModel.EventBasedAsync.4.0.10-beta-23121.nupkg.sha512",
+        "System.ComponentModel.EventBasedAsync.nuspec",
         "lib/dotnet/System.ComponentModel.EventBasedAsync.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/System.ComponentModel.EventBasedAsync.dll",
+        "ref/dotnet/System.ComponentModel.EventBasedAsync.xml",
         "ref/dotnet/de/System.ComponentModel.EventBasedAsync.xml",
         "ref/dotnet/es/System.ComponentModel.EventBasedAsync.xml",
         "ref/dotnet/fr/System.ComponentModel.EventBasedAsync.xml",
@@ -1294,30 +1287,30 @@
         "ref/dotnet/ja/System.ComponentModel.EventBasedAsync.xml",
         "ref/dotnet/ko/System.ComponentModel.EventBasedAsync.xml",
         "ref/dotnet/ru/System.ComponentModel.EventBasedAsync.xml",
-        "ref/dotnet/System.ComponentModel.EventBasedAsync.dll",
-        "ref/dotnet/System.ComponentModel.EventBasedAsync.xml",
         "ref/dotnet/zh-hans/System.ComponentModel.EventBasedAsync.xml",
         "ref/dotnet/zh-hant/System.ComponentModel.EventBasedAsync.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.ComponentModel.EventBasedAsync.4.0.10-beta-23110.nupkg",
-        "System.ComponentModel.EventBasedAsync.4.0.10-beta-23110.nupkg.sha512",
-        "System.ComponentModel.EventBasedAsync.nuspec"
+        "ref/xamarinmac20/_._"
       ]
     },
-    "System.Console/4.0.0-beta-23110": {
+    "System.Console/4.0.0-beta-23121": {
       "serviceable": true,
-      "sha512": "h0dNCBNcS70ZLIWkRYbC0aZe2x3f9zQrE2cvnMQ7sLqftDPiLv1jr9mTqgazrsgqmToQVxTc515V+g4q9TcMGQ==",
+      "sha512": "EdBTgjjS2r04JXf/DgNKsyOliJeUi2Fzhb9yXR0SMYMPqRmIjmslP1dZf0aOdyZFvztZChm1o6DKUNxQ5UTFMA==",
       "files": [
+        "System.Console.4.0.0-beta-23121.nupkg",
+        "System.Console.4.0.0-beta-23121.nupkg.sha512",
+        "System.Console.nuspec",
         "lib/DNXCore50/System.Console.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Console.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Console.dll",
+        "ref/dotnet/System.Console.xml",
         "ref/dotnet/de/System.Console.xml",
         "ref/dotnet/es/System.Console.xml",
         "ref/dotnet/fr/System.Console.xml",
@@ -1325,29 +1318,29 @@
         "ref/dotnet/ja/System.Console.xml",
         "ref/dotnet/ko/System.Console.xml",
         "ref/dotnet/ru/System.Console.xml",
-        "ref/dotnet/System.Console.dll",
-        "ref/dotnet/System.Console.xml",
         "ref/dotnet/zh-hans/System.Console.xml",
         "ref/dotnet/zh-hant/System.Console.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Console.dll",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.Console.4.0.0-beta-23110.nupkg",
-        "System.Console.4.0.0-beta-23110.nupkg.sha512",
-        "System.Console.nuspec"
+        "ref/xamarinmac20/_._"
       ]
     },
-    "System.Diagnostics.Contracts/4.0.0-beta-23110": {
-      "sha512": "vb2yHEJm5Uv3lzvY29SSaLlJfGkplQK8sVEQXdjUEFV56RtQKStdzkhMaPyduHT7MUnmveXBlNPRIraxebYILg==",
+    "System.Diagnostics.Contracts/4.0.0-beta-23121": {
+      "sha512": "vIla9TxmFeEUTS97JR5PMsFipgAcUD+Ups00IPcdjtoCEGqYxqdQKwhWUTYjgpKVMyP8jxHekFlxqdR9/5FrqA==",
       "files": [
+        "System.Diagnostics.Contracts.4.0.0-beta-23121.nupkg",
+        "System.Diagnostics.Contracts.4.0.0-beta-23121.nupkg.sha512",
+        "System.Diagnostics.Contracts.nuspec",
         "lib/DNXCore50/System.Diagnostics.Contracts.dll",
         "lib/net45/_._",
         "lib/netcore50/System.Diagnostics.Contracts.dll",
         "lib/win8/_._",
         "lib/wp80/_._",
         "lib/wpa81/_._",
+        "ref/dotnet/System.Diagnostics.Contracts.dll",
+        "ref/dotnet/System.Diagnostics.Contracts.xml",
         "ref/dotnet/de/System.Diagnostics.Contracts.xml",
         "ref/dotnet/es/System.Diagnostics.Contracts.xml",
         "ref/dotnet/fr/System.Diagnostics.Contracts.xml",
@@ -1355,8 +1348,6 @@
         "ref/dotnet/ja/System.Diagnostics.Contracts.xml",
         "ref/dotnet/ko/System.Diagnostics.Contracts.xml",
         "ref/dotnet/ru/System.Diagnostics.Contracts.xml",
-        "ref/dotnet/System.Diagnostics.Contracts.dll",
-        "ref/dotnet/System.Diagnostics.Contracts.xml",
         "ref/dotnet/zh-hans/System.Diagnostics.Contracts.xml",
         "ref/dotnet/zh-hant/System.Diagnostics.Contracts.xml",
         "ref/net45/_._",
@@ -1365,16 +1356,16 @@
         "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Contracts.dll",
-        "System.Diagnostics.Contracts.4.0.0-beta-23110.nupkg",
-        "System.Diagnostics.Contracts.4.0.0-beta-23110.nupkg.sha512",
-        "System.Diagnostics.Contracts.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Contracts.dll"
       ]
     },
-    "System.Diagnostics.Debug/4.0.10-beta-23110": {
+    "System.Diagnostics.Debug/4.0.10-beta-23121": {
       "serviceable": true,
-      "sha512": "+rYK/6pR0KwzqkmiheA1Mr3kJBFYsw6tfyK7AFaytgZNzAKdKhdJ5qfDtBtv1BqVAs3IRcaqD5dxl4zHnciAEA==",
+      "sha512": "HOHZVr/MTwc17U7egKHe4oTyjoQlVtJ5HaRFTHBplb8vScWBaj07AgR40nZ9m7lTnoaUzmOYokfmAdqXapbn5A==",
       "files": [
+        "System.Diagnostics.Debug.4.0.10-beta-23121.nupkg",
+        "System.Diagnostics.Debug.4.0.10-beta-23121.nupkg.sha512",
+        "System.Diagnostics.Debug.nuspec",
         "lib/DNXCore50/System.Diagnostics.Debug.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -1382,6 +1373,8 @@
         "lib/netcore50/System.Diagnostics.Debug.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Diagnostics.Debug.dll",
+        "ref/dotnet/System.Diagnostics.Debug.xml",
         "ref/dotnet/de/System.Diagnostics.Debug.xml",
         "ref/dotnet/es/System.Diagnostics.Debug.xml",
         "ref/dotnet/fr/System.Diagnostics.Debug.xml",
@@ -1389,8 +1382,6 @@
         "ref/dotnet/ja/System.Diagnostics.Debug.xml",
         "ref/dotnet/ko/System.Diagnostics.Debug.xml",
         "ref/dotnet/ru/System.Diagnostics.Debug.xml",
-        "ref/dotnet/System.Diagnostics.Debug.dll",
-        "ref/dotnet/System.Diagnostics.Debug.xml",
         "ref/dotnet/zh-hans/System.Diagnostics.Debug.xml",
         "ref/dotnet/zh-hant/System.Diagnostics.Debug.xml",
         "ref/MonoAndroid10/_._",
@@ -1398,16 +1389,16 @@
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Debug.dll",
-        "System.Diagnostics.Debug.4.0.10-beta-23110.nupkg",
-        "System.Diagnostics.Debug.4.0.10-beta-23110.nupkg.sha512",
-        "System.Diagnostics.Debug.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Debug.dll"
       ]
     },
-    "System.Diagnostics.Tracing/4.0.20-beta-23110": {
+    "System.Diagnostics.Tracing/4.0.20-beta-23121": {
       "serviceable": true,
-      "sha512": "nRaoSigfs+qumT3iCA8UYVJDZo2eOs8Lt2OvFYjQzdE08h7TEpf1AH5bU11wzTSvc6Aa9WlM5w4y4yJWzU24iQ==",
+      "sha512": "QXdBwMJE3mr4bcmvIyidgghR3AZbKD5FLOwSt2Si1HvkTjuHMe4C0TXsY4qmaF+muMsK2uqnXwj6bAU+++Mjsg==",
       "files": [
+        "System.Diagnostics.Tracing.4.0.20-beta-23121.nupkg",
+        "System.Diagnostics.Tracing.4.0.20-beta-23121.nupkg.sha512",
+        "System.Diagnostics.Tracing.nuspec",
         "lib/DNXCore50/System.Diagnostics.Tracing.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -1415,6 +1406,8 @@
         "lib/netcore50/System.Diagnostics.Tracing.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Diagnostics.Tracing.dll",
+        "ref/dotnet/System.Diagnostics.Tracing.xml",
         "ref/dotnet/de/System.Diagnostics.Tracing.xml",
         "ref/dotnet/es/System.Diagnostics.Tracing.xml",
         "ref/dotnet/fr/System.Diagnostics.Tracing.xml",
@@ -1422,8 +1415,6 @@
         "ref/dotnet/ja/System.Diagnostics.Tracing.xml",
         "ref/dotnet/ko/System.Diagnostics.Tracing.xml",
         "ref/dotnet/ru/System.Diagnostics.Tracing.xml",
-        "ref/dotnet/System.Diagnostics.Tracing.dll",
-        "ref/dotnet/System.Diagnostics.Tracing.xml",
         "ref/dotnet/zh-hans/System.Diagnostics.Tracing.xml",
         "ref/dotnet/zh-hant/System.Diagnostics.Tracing.xml",
         "ref/MonoAndroid10/_._",
@@ -1431,15 +1422,15 @@
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Tracing.dll",
-        "System.Diagnostics.Tracing.4.0.20-beta-23110.nupkg",
-        "System.Diagnostics.Tracing.4.0.20-beta-23110.nupkg.sha512",
-        "System.Diagnostics.Tracing.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Tracing.dll"
       ]
     },
-    "System.Globalization/4.0.10-beta-23110": {
-      "sha512": "0cpVwpqK923iR+v7bv2DnYjXuunZH+m1WB24ZUJrNN5zWHti4uGQSmYmRCEH8LaiJIUL7xinfrT8UU4/1D1Vmg==",
+    "System.Globalization/4.0.10-beta-23121": {
+      "sha512": "Zm/txqK7ySY3A2dWhF73YwMVJP7n5Q+h9LTbMUtp50ztLVogW/09K01v3LU8nZCsKPQB0uMtU7oy3f//hT3q1g==",
       "files": [
+        "System.Globalization.4.0.10-beta-23121.nupkg",
+        "System.Globalization.4.0.10-beta-23121.nupkg.sha512",
+        "System.Globalization.nuspec",
         "lib/DNXCore50/System.Globalization.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -1447,6 +1438,8 @@
         "lib/netcore50/System.Globalization.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Globalization.dll",
+        "ref/dotnet/System.Globalization.xml",
         "ref/dotnet/de/System.Globalization.xml",
         "ref/dotnet/es/System.Globalization.xml",
         "ref/dotnet/fr/System.Globalization.xml",
@@ -1454,8 +1447,6 @@
         "ref/dotnet/ja/System.Globalization.xml",
         "ref/dotnet/ko/System.Globalization.xml",
         "ref/dotnet/ru/System.Globalization.xml",
-        "ref/dotnet/System.Globalization.dll",
-        "ref/dotnet/System.Globalization.xml",
         "ref/dotnet/zh-hans/System.Globalization.xml",
         "ref/dotnet/zh-hant/System.Globalization.xml",
         "ref/MonoAndroid10/_._",
@@ -1463,15 +1454,15 @@
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Globalization.dll",
-        "System.Globalization.4.0.10-beta-23110.nupkg",
-        "System.Globalization.4.0.10-beta-23110.nupkg.sha512",
-        "System.Globalization.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Globalization.dll"
       ]
     },
-    "System.Globalization.Calendars/4.0.0-beta-23110": {
-      "sha512": "p+G17m7+3TRZfJmW1EOSsnTCNVZbYOeM5H7fVhT3hGCRkfxqIL6osedcWrY+npiozPItWV62+1YjHS/TB8BdqA==",
+    "System.Globalization.Calendars/4.0.0-beta-23121": {
+      "sha512": "mLKiuU2x8hRGxcRVXcYlP0o80gSsmLPWnSpo4wyLhfoa+gh8hLSGD/P4geucohzQqhQYjjiYyGyvkcrcFFosVw==",
       "files": [
+        "System.Globalization.Calendars.4.0.0-beta-23121.nupkg",
+        "System.Globalization.Calendars.4.0.0-beta-23121.nupkg.sha512",
+        "System.Globalization.Calendars.nuspec",
         "lib/DNXCore50/System.Globalization.Calendars.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -1479,6 +1470,8 @@
         "lib/netcore50/System.Globalization.Calendars.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Globalization.Calendars.dll",
+        "ref/dotnet/System.Globalization.Calendars.xml",
         "ref/dotnet/de/System.Globalization.Calendars.xml",
         "ref/dotnet/es/System.Globalization.Calendars.xml",
         "ref/dotnet/fr/System.Globalization.Calendars.xml",
@@ -1486,8 +1479,6 @@
         "ref/dotnet/ja/System.Globalization.Calendars.xml",
         "ref/dotnet/ko/System.Globalization.Calendars.xml",
         "ref/dotnet/ru/System.Globalization.Calendars.xml",
-        "ref/dotnet/System.Globalization.Calendars.dll",
-        "ref/dotnet/System.Globalization.Calendars.xml",
         "ref/dotnet/zh-hans/System.Globalization.Calendars.xml",
         "ref/dotnet/zh-hant/System.Globalization.Calendars.xml",
         "ref/MonoAndroid10/_._",
@@ -1495,22 +1486,24 @@
         "ref/net46/System.Globalization.Calendars.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Globalization.Calendars.dll",
-        "System.Globalization.Calendars.4.0.0-beta-23110.nupkg",
-        "System.Globalization.Calendars.4.0.0-beta-23110.nupkg.sha512",
-        "System.Globalization.Calendars.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Globalization.Calendars.dll"
       ]
     },
-    "System.Globalization.Extensions/4.0.0-beta-23110": {
+    "System.Globalization.Extensions/4.0.0-beta-23121": {
       "serviceable": true,
-      "sha512": "Edo4Y0ZWcSeo3NXTS380YOhRS16YWLQrDnt3GEH7w7XurWwbP4itP0d4UsNkqZpo9OyDpYjpmNj7o+wFuKj0tQ==",
+      "sha512": "V1nAj3T1KqB7ea3mjKwzqKQrhh28eenWKGTI+SQ0zEzBBNslevEUK0OvNZ46thM/9u2zJTUKhx4n7lVStzdwMw==",
       "files": [
+        "System.Globalization.Extensions.4.0.0-beta-23121.nupkg",
+        "System.Globalization.Extensions.4.0.0-beta-23121.nupkg.sha512",
+        "System.Globalization.Extensions.nuspec",
         "lib/dotnet/System.Globalization.Extensions.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Globalization.Extensions.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Globalization.Extensions.dll",
+        "ref/dotnet/System.Globalization.Extensions.xml",
         "ref/dotnet/de/System.Globalization.Extensions.xml",
         "ref/dotnet/es/System.Globalization.Extensions.xml",
         "ref/dotnet/fr/System.Globalization.Extensions.xml",
@@ -1518,24 +1511,22 @@
         "ref/dotnet/ja/System.Globalization.Extensions.xml",
         "ref/dotnet/ko/System.Globalization.Extensions.xml",
         "ref/dotnet/ru/System.Globalization.Extensions.xml",
-        "ref/dotnet/System.Globalization.Extensions.dll",
-        "ref/dotnet/System.Globalization.Extensions.xml",
         "ref/dotnet/zh-hans/System.Globalization.Extensions.xml",
         "ref/dotnet/zh-hant/System.Globalization.Extensions.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Globalization.Extensions.dll",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.Globalization.Extensions.4.0.0-beta-23110.nupkg",
-        "System.Globalization.Extensions.4.0.0-beta-23110.nupkg.sha512",
-        "System.Globalization.Extensions.nuspec"
+        "ref/xamarinmac20/_._"
       ]
     },
-    "System.IO/4.0.10-beta-23110": {
+    "System.IO/4.0.10-beta-23121": {
       "serviceable": true,
-      "sha512": "dAzefr5pHn1l7uQiHwUzgWBAsNO1Pe1EjY7qvcmo7TNdHEUgRaBxsXmguseRdT19YZGMZPFYV0guTOeT5kvu0g==",
+      "sha512": "rh3XszxG+23xUxhPJTZYGLuuzeIuRRwRsCjg/kCTExbPpMJWNk9lV+u/Dsh5I0WArrEG9bdqVTvskSm7yVqaFg==",
       "files": [
+        "System.IO.4.0.10-beta-23121.nupkg",
+        "System.IO.4.0.10-beta-23121.nupkg.sha512",
+        "System.IO.nuspec",
         "lib/DNXCore50/System.IO.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -1543,6 +1534,8 @@
         "lib/netcore50/System.IO.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/System.IO.dll",
+        "ref/dotnet/System.IO.xml",
         "ref/dotnet/de/System.IO.xml",
         "ref/dotnet/es/System.IO.xml",
         "ref/dotnet/fr/System.IO.xml",
@@ -1550,8 +1543,6 @@
         "ref/dotnet/ja/System.IO.xml",
         "ref/dotnet/ko/System.IO.xml",
         "ref/dotnet/ru/System.IO.xml",
-        "ref/dotnet/System.IO.dll",
-        "ref/dotnet/System.IO.xml",
         "ref/dotnet/zh-hans/System.IO.xml",
         "ref/dotnet/zh-hant/System.IO.xml",
         "ref/MonoAndroid10/_._",
@@ -1559,16 +1550,17 @@
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.IO.dll",
-        "System.IO.4.0.10-beta-23110.nupkg",
-        "System.IO.4.0.10-beta-23110.nupkg.sha512",
-        "System.IO.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.IO.dll"
       ]
     },
-    "System.IO.Compression/4.0.0-beta-23110": {
+    "System.IO.Compression/4.0.0-beta-23121": {
       "serviceable": true,
-      "sha512": "UXbvlombDFI5v5N17D6h2XH6oWvzd9YRKOB4tK+eS1t6iEh8g3fin4JoTKWc3fc7PTWGl5UVQkT3Kd3Ej79YKQ==",
+      "sha512": "XJPjfSLUzTHijqQu2Tx30D8qrc8BnLg30cC1k8ZPCnduYZivrR4J6GAk5c/1JYh7EZZxq1FNPx7213Tugg6aFg==",
       "files": [
+        "runtime.json",
+        "System.IO.Compression.4.0.0-beta-23121.nupkg",
+        "System.IO.Compression.4.0.0-beta-23121.nupkg.sha512",
+        "System.IO.Compression.nuspec",
         "lib/dotnet/System.IO.Compression.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -1578,6 +1570,8 @@
         "lib/wpa81/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/System.IO.Compression.dll",
+        "ref/dotnet/System.IO.Compression.xml",
         "ref/dotnet/de/System.IO.Compression.xml",
         "ref/dotnet/es/System.IO.Compression.xml",
         "ref/dotnet/fr/System.IO.Compression.xml",
@@ -1585,8 +1579,6 @@
         "ref/dotnet/ja/System.IO.Compression.xml",
         "ref/dotnet/ko/System.IO.Compression.xml",
         "ref/dotnet/ru/System.IO.Compression.xml",
-        "ref/dotnet/System.IO.Compression.dll",
-        "ref/dotnet/System.IO.Compression.xml",
         "ref/dotnet/zh-hans/System.IO.Compression.xml",
         "ref/dotnet/zh-hant/System.IO.Compression.xml",
         "ref/MonoAndroid10/_._",
@@ -1597,17 +1589,16 @@
         "ref/win8/_._",
         "ref/wpa81/_._",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "runtime.json",
-        "System.IO.Compression.4.0.0-beta-23110.nupkg",
-        "System.IO.Compression.4.0.0-beta-23110.nupkg.sha512",
-        "System.IO.Compression.nuspec"
+        "ref/xamarinmac20/_._"
       ]
     },
-    "System.IO.FileSystem/4.0.0-beta-23110": {
+    "System.IO.FileSystem/4.0.0-beta-23121": {
       "serviceable": true,
-      "sha512": "vbocv+ZodpVOCoxgLdmIr4z0i9vxmBJp/GWE6LQtO3F4ecak5PBO+2+Toe+DcqWTq/X/TuHqFvl1l6werVkmpA==",
+      "sha512": "20Z7wSjuQyIsXJtXGVh3bHBJPKIT4mC7FRlnKTzNYrxZTtTbiQCwtEJbry1lon3hxQv3lDnwSukGtqgh+I99yQ==",
       "files": [
+        "System.IO.FileSystem.4.0.0-beta-23121.nupkg",
+        "System.IO.FileSystem.4.0.0-beta-23121.nupkg.sha512",
+        "System.IO.FileSystem.nuspec",
         "lib/DNXCore50/System.IO.FileSystem.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -1615,6 +1606,8 @@
         "lib/netcore50/System.IO.FileSystem.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/System.IO.FileSystem.dll",
+        "ref/dotnet/System.IO.FileSystem.xml",
         "ref/dotnet/de/System.IO.FileSystem.xml",
         "ref/dotnet/es/System.IO.FileSystem.xml",
         "ref/dotnet/fr/System.IO.FileSystem.xml",
@@ -1622,30 +1615,30 @@
         "ref/dotnet/ja/System.IO.FileSystem.xml",
         "ref/dotnet/ko/System.IO.FileSystem.xml",
         "ref/dotnet/ru/System.IO.FileSystem.xml",
-        "ref/dotnet/System.IO.FileSystem.dll",
-        "ref/dotnet/System.IO.FileSystem.xml",
         "ref/dotnet/zh-hans/System.IO.FileSystem.xml",
         "ref/dotnet/zh-hant/System.IO.FileSystem.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.IO.FileSystem.dll",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.IO.FileSystem.4.0.0-beta-23110.nupkg",
-        "System.IO.FileSystem.4.0.0-beta-23110.nupkg.sha512",
-        "System.IO.FileSystem.nuspec"
+        "ref/xamarinmac20/_._"
       ]
     },
-    "System.IO.FileSystem.Primitives/4.0.0-beta-23110": {
+    "System.IO.FileSystem.Primitives/4.0.0-beta-23121": {
       "serviceable": true,
-      "sha512": "a6oWBtw8PvB2NV3L8+CZjV+NVeXfEkW7ApzhfUuxio/vYwYBBULBdOUcQAmL2ohQh4MMe1ZUnz0LM8y6L7ekOQ==",
+      "sha512": "sM9nEh5RVqkfxr2JMJzXXSqM2ZoxpWCucpuX8aweac70x23FMRgzDZj7pSt8W+dEGDRCxp5eVoiywMvLeSnuXQ==",
       "files": [
+        "System.IO.FileSystem.Primitives.4.0.0-beta-23121.nupkg",
+        "System.IO.FileSystem.Primitives.4.0.0-beta-23121.nupkg.sha512",
+        "System.IO.FileSystem.Primitives.nuspec",
         "lib/dotnet/System.IO.FileSystem.Primitives.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.IO.FileSystem.Primitives.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/System.IO.FileSystem.Primitives.dll",
+        "ref/dotnet/System.IO.FileSystem.Primitives.xml",
         "ref/dotnet/de/System.IO.FileSystem.Primitives.xml",
         "ref/dotnet/es/System.IO.FileSystem.Primitives.xml",
         "ref/dotnet/fr/System.IO.FileSystem.Primitives.xml",
@@ -1653,30 +1646,30 @@
         "ref/dotnet/ja/System.IO.FileSystem.Primitives.xml",
         "ref/dotnet/ko/System.IO.FileSystem.Primitives.xml",
         "ref/dotnet/ru/System.IO.FileSystem.Primitives.xml",
-        "ref/dotnet/System.IO.FileSystem.Primitives.dll",
-        "ref/dotnet/System.IO.FileSystem.Primitives.xml",
         "ref/dotnet/zh-hans/System.IO.FileSystem.Primitives.xml",
         "ref/dotnet/zh-hant/System.IO.FileSystem.Primitives.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.IO.FileSystem.Primitives.dll",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.IO.FileSystem.Primitives.4.0.0-beta-23110.nupkg",
-        "System.IO.FileSystem.Primitives.4.0.0-beta-23110.nupkg.sha512",
-        "System.IO.FileSystem.Primitives.nuspec"
+        "ref/xamarinmac20/_._"
       ]
     },
-    "System.Linq/4.0.0-beta-23110": {
+    "System.Linq/4.0.0-beta-23121": {
       "serviceable": true,
-      "sha512": "OChNNza5YpS5be7qTKf7azxfIX8tJLW/RHgJkEDo0ZIYTSZ+OiAEAmGHUm9syC7bx4K1mp7ufwrsLzQ9K7QB3g==",
+      "sha512": "nReSL6kOJorYhZ+As4UJaKBd/rx11LoPQ4sZ1Pc104uo/UwGPhGvyv1Xfm1a80r+0ybMFNyBug9OX8q+QI+k8A==",
       "files": [
+        "System.Linq.4.0.0-beta-23121.nupkg",
+        "System.Linq.4.0.0-beta-23121.nupkg.sha512",
+        "System.Linq.nuspec",
         "lib/dotnet/System.Linq.dll",
         "lib/net45/_._",
         "lib/netcore50/System.Linq.dll",
         "lib/win8/_._",
         "lib/wp80/_._",
         "lib/wpa81/_._",
+        "ref/dotnet/System.Linq.dll",
+        "ref/dotnet/System.Linq.xml",
         "ref/dotnet/de/System.Linq.xml",
         "ref/dotnet/es/System.Linq.xml",
         "ref/dotnet/fr/System.Linq.xml",
@@ -1684,8 +1677,6 @@
         "ref/dotnet/ja/System.Linq.xml",
         "ref/dotnet/ko/System.Linq.xml",
         "ref/dotnet/ru/System.Linq.xml",
-        "ref/dotnet/System.Linq.dll",
-        "ref/dotnet/System.Linq.xml",
         "ref/dotnet/zh-hans/System.Linq.xml",
         "ref/dotnet/zh-hant/System.Linq.xml",
         "ref/net45/_._",
@@ -1693,16 +1684,17 @@
         "ref/netcore50/System.Linq.xml",
         "ref/win8/_._",
         "ref/wp80/_._",
-        "ref/wpa81/_._",
-        "System.Linq.4.0.0-beta-23110.nupkg",
-        "System.Linq.4.0.0-beta-23110.nupkg.sha512",
-        "System.Linq.nuspec"
+        "ref/wpa81/_._"
       ]
     },
-    "System.Linq.Expressions/4.0.10-beta-23110": {
+    "System.Linq.Expressions/4.0.10-beta-23121": {
       "serviceable": true,
-      "sha512": "vUL3iYmzEyfABg8ERtIYEX04ve1ZDQG9+C7PTLzWaDLRdp6W9yXu+cnbtJ44m0Qmj7GBtnNzj+vGdVWL1ZUXMg==",
+      "sha512": "l1HVGvt8k0wv6fKd5LKo3Du6RTcet3aM3/D9AcFX708dTx/o9mb6BLVTWUTDMYBvhhcoVJ8afs4Ffs9VjTjraw==",
       "files": [
+        "runtime.json",
+        "System.Linq.Expressions.4.0.10-beta-23121.nupkg",
+        "System.Linq.Expressions.4.0.10-beta-23121.nupkg.sha512",
+        "System.Linq.Expressions.nuspec",
         "lib/DNXCore50/System.Linq.Expressions.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -1710,6 +1702,8 @@
         "lib/netcore50/System.Linq.Expressions.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Linq.Expressions.dll",
+        "ref/dotnet/System.Linq.Expressions.xml",
         "ref/dotnet/de/System.Linq.Expressions.xml",
         "ref/dotnet/es/System.Linq.Expressions.xml",
         "ref/dotnet/fr/System.Linq.Expressions.xml",
@@ -1717,8 +1711,6 @@
         "ref/dotnet/ja/System.Linq.Expressions.xml",
         "ref/dotnet/ko/System.Linq.Expressions.xml",
         "ref/dotnet/ru/System.Linq.Expressions.xml",
-        "ref/dotnet/System.Linq.Expressions.dll",
-        "ref/dotnet/System.Linq.Expressions.xml",
         "ref/dotnet/zh-hans/System.Linq.Expressions.xml",
         "ref/dotnet/zh-hant/System.Linq.Expressions.xml",
         "ref/MonoAndroid10/_._",
@@ -1726,23 +1718,24 @@
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtime.json",
-        "runtimes/win8-aot/lib/netcore50/System.Linq.Expressions.dll",
-        "System.Linq.Expressions.4.0.10-beta-23110.nupkg",
-        "System.Linq.Expressions.4.0.10-beta-23110.nupkg.sha512",
-        "System.Linq.Expressions.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Linq.Expressions.dll"
       ]
     },
-    "System.Linq.Queryable/4.0.0-beta-23110": {
+    "System.Linq.Queryable/4.0.0-beta-23121": {
       "serviceable": true,
-      "sha512": "Nmkug18cDoD2//pqcYESnwjm3NPYeqaB1O/nk0nBvKEgD4lpNBpTd0/y/JXhVoKU0GE16CPQioLYGAsHRUwJcQ==",
+      "sha512": "QY4Lc6mtaSELemuUUGEqSAmQ2ZFhBcc4JLXsQVlsUOJTI2EFje+8YyDiljNajSEUEPsqWM3tpilFpv+bR3KD7A==",
       "files": [
+        "System.Linq.Queryable.4.0.0-beta-23121.nupkg",
+        "System.Linq.Queryable.4.0.0-beta-23121.nupkg.sha512",
+        "System.Linq.Queryable.nuspec",
         "lib/dotnet/System.Linq.Queryable.dll",
         "lib/net45/_._",
         "lib/netcore50/System.Linq.Queryable.dll",
         "lib/win8/_._",
         "lib/wp80/_._",
         "lib/wpa81/_._",
+        "ref/dotnet/System.Linq.Queryable.dll",
+        "ref/dotnet/System.Linq.Queryable.xml",
         "ref/dotnet/de/System.Linq.Queryable.xml",
         "ref/dotnet/es/System.Linq.Queryable.xml",
         "ref/dotnet/fr/System.Linq.Queryable.xml",
@@ -1750,8 +1743,6 @@
         "ref/dotnet/ja/System.Linq.Queryable.xml",
         "ref/dotnet/ko/System.Linq.Queryable.xml",
         "ref/dotnet/ru/System.Linq.Queryable.xml",
-        "ref/dotnet/System.Linq.Queryable.dll",
-        "ref/dotnet/System.Linq.Queryable.xml",
         "ref/dotnet/zh-hans/System.Linq.Queryable.xml",
         "ref/dotnet/zh-hant/System.Linq.Queryable.xml",
         "ref/net45/_._",
@@ -1759,21 +1750,23 @@
         "ref/netcore50/System.Linq.Queryable.xml",
         "ref/win8/_._",
         "ref/wp80/_._",
-        "ref/wpa81/_._",
-        "System.Linq.Queryable.4.0.0-beta-23110.nupkg",
-        "System.Linq.Queryable.4.0.0-beta-23110.nupkg.sha512",
-        "System.Linq.Queryable.nuspec"
+        "ref/wpa81/_._"
       ]
     },
-    "System.Net.Http/4.0.0-beta-23110": {
+    "System.Net.Http/4.0.0-beta-23121": {
       "serviceable": true,
-      "sha512": "9EJW5LOi8dFAjCLC1DGOyhJVSllq4Zq+vFteiCWO1qKRNWJGzzJgtt/r+PfWQuE7JNQUKJloEeW4kVTnHBYcGQ==",
+      "sha512": "kGyPHZ2CVrXEWvkG2JJlPzne7o+NOCK+MN8mPfaq9vQmz4uonucvKaWDx5kZqvUiNMflVQEmf2NfOUnJOOYF3g==",
       "files": [
+        "System.Net.Http.4.0.0-beta-23121.nupkg",
+        "System.Net.Http.4.0.0-beta-23121.nupkg.sha512",
+        "System.Net.Http.nuspec",
         "lib/DNXCore50/System.Net.Http.dll",
         "lib/net45/_._",
         "lib/netcore50/System.Net.Http.dll",
         "lib/win8/_._",
         "lib/wpa81/_._",
+        "ref/dotnet/System.Net.Http.dll",
+        "ref/dotnet/System.Net.Http.xml",
         "ref/dotnet/de/System.Net.Http.xml",
         "ref/dotnet/es/System.Net.Http.xml",
         "ref/dotnet/fr/System.Net.Http.xml",
@@ -1781,29 +1774,29 @@
         "ref/dotnet/ja/System.Net.Http.xml",
         "ref/dotnet/ko/System.Net.Http.xml",
         "ref/dotnet/ru/System.Net.Http.xml",
-        "ref/dotnet/System.Net.Http.dll",
-        "ref/dotnet/System.Net.Http.xml",
         "ref/dotnet/zh-hans/System.Net.Http.xml",
         "ref/dotnet/zh-hant/System.Net.Http.xml",
         "ref/net45/_._",
         "ref/netcore50/System.Net.Http.dll",
         "ref/netcore50/System.Net.Http.xml",
         "ref/win8/_._",
-        "ref/wpa81/_._",
-        "System.Net.Http.4.0.0-beta-23110.nupkg",
-        "System.Net.Http.4.0.0-beta-23110.nupkg.sha512",
-        "System.Net.Http.nuspec"
+        "ref/wpa81/_._"
       ]
     },
-    "System.Net.NameResolution/4.0.0-beta-23110": {
-      "sha512": "POsyeb9EAB24ka46Sqcb8yoSyyxo8VHC29EMnVmolCXtOAdIIDPUqujt5rFj/cXE9i34AR0QH5X1heGXTzy35Q==",
+    "System.Net.NameResolution/4.0.0-beta-23121": {
+      "sha512": "C71k2GwUEurcr2sH03zojcUqV4XvhTTCs6AcGbBGp4pOwofriIXCJvT8nvxiUQ25Cwh0dO5PVILWW0HDrmL9Tw==",
       "files": [
+        "System.Net.NameResolution.4.0.0-beta-23121.nupkg",
+        "System.Net.NameResolution.4.0.0-beta-23121.nupkg.sha512",
+        "System.Net.NameResolution.nuspec",
         "lib/DNXCore50/System.Net.NameResolution.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.NameResolution.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Net.NameResolution.dll",
+        "ref/dotnet/System.Net.NameResolution.xml",
         "ref/dotnet/de/System.Net.NameResolution.xml",
         "ref/dotnet/es/System.Net.NameResolution.xml",
         "ref/dotnet/fr/System.Net.NameResolution.xml",
@@ -1811,24 +1804,22 @@
         "ref/dotnet/ja/System.Net.NameResolution.xml",
         "ref/dotnet/ko/System.Net.NameResolution.xml",
         "ref/dotnet/ru/System.Net.NameResolution.xml",
-        "ref/dotnet/System.Net.NameResolution.dll",
-        "ref/dotnet/System.Net.NameResolution.xml",
         "ref/dotnet/zh-hans/System.Net.NameResolution.xml",
         "ref/dotnet/zh-hant/System.Net.NameResolution.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Net.NameResolution.dll",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.Net.NameResolution.4.0.0-beta-23110.nupkg",
-        "System.Net.NameResolution.4.0.0-beta-23110.nupkg.sha512",
-        "System.Net.NameResolution.nuspec"
+        "ref/xamarinmac20/_._"
       ]
     },
-    "System.Net.Primitives/4.0.10-beta-23110": {
+    "System.Net.Primitives/4.0.10-beta-23121": {
       "serviceable": true,
-      "sha512": "ONQEWvo5dd0l6nDQbG3GKTMY75VGe7Av3ijYcXfeAfq0oHyOkCWjBURj06uhcAk3+AZQz8bmPsr3ILJZ4zUURQ==",
+      "sha512": "LUFV8Ykt0ZdE7IdBlqn7ytK2S+VlTwgztCit364RKI6Mh5JgN/ixRuGwdB06K4jh4AZ3R9YqOXLmWyLXfATZhA==",
       "files": [
+        "System.Net.Primitives.4.0.10-beta-23121.nupkg",
+        "System.Net.Primitives.4.0.10-beta-23121.nupkg.sha512",
+        "System.Net.Primitives.nuspec",
         "lib/DNXCore50/System.Net.Primitives.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -1836,6 +1827,8 @@
         "lib/netcore50/System.Net.Primitives.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Net.Primitives.dll",
+        "ref/dotnet/System.Net.Primitives.xml",
         "ref/dotnet/de/System.Net.Primitives.xml",
         "ref/dotnet/es/System.Net.Primitives.xml",
         "ref/dotnet/fr/System.Net.Primitives.xml",
@@ -1843,29 +1836,29 @@
         "ref/dotnet/ja/System.Net.Primitives.xml",
         "ref/dotnet/ko/System.Net.Primitives.xml",
         "ref/dotnet/ru/System.Net.Primitives.xml",
-        "ref/dotnet/System.Net.Primitives.dll",
-        "ref/dotnet/System.Net.Primitives.xml",
         "ref/dotnet/zh-hans/System.Net.Primitives.xml",
         "ref/dotnet/zh-hant/System.Net.Primitives.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.Net.Primitives.4.0.10-beta-23110.nupkg",
-        "System.Net.Primitives.4.0.10-beta-23110.nupkg.sha512",
-        "System.Net.Primitives.nuspec"
+        "ref/xamarinmac20/_._"
       ]
     },
-    "System.Net.Security/4.0.0-beta-23110": {
-      "sha512": "iYmPZtaPtDQpvoncwpMleMFJV4JtIwpFmHN0YT8kPqi+kRnZSlgKE3nUZPELpGCyqAbLxlJ+rwHbZy++YG/YPw==",
+    "System.Net.Security/4.0.0-beta-23121": {
+      "sha512": "RGxhsgY4ncQow88o1x/gljO1ZqzmKsKrxl8l9PN3jNrmUZvTyNW5HEBwktZP6i9OFCKRFV/MJ6Vn75rCnmxhzw==",
       "files": [
+        "System.Net.Security.4.0.0-beta-23121.nupkg",
+        "System.Net.Security.4.0.0-beta-23121.nupkg.sha512",
+        "System.Net.Security.nuspec",
         "lib/DNXCore50/System.Net.Security.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.Security.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Net.Security.dll",
+        "ref/dotnet/System.Net.Security.xml",
         "ref/dotnet/de/System.Net.Security.xml",
         "ref/dotnet/es/System.Net.Security.xml",
         "ref/dotnet/fr/System.Net.Security.xml",
@@ -1873,28 +1866,28 @@
         "ref/dotnet/ja/System.Net.Security.xml",
         "ref/dotnet/ko/System.Net.Security.xml",
         "ref/dotnet/ru/System.Net.Security.xml",
-        "ref/dotnet/System.Net.Security.dll",
-        "ref/dotnet/System.Net.Security.xml",
         "ref/dotnet/zh-hans/System.Net.Security.xml",
         "ref/dotnet/zh-hant/System.Net.Security.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Net.Security.dll",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.Net.Security.4.0.0-beta-23110.nupkg",
-        "System.Net.Security.4.0.0-beta-23110.nupkg.sha512",
-        "System.Net.Security.nuspec"
+        "ref/xamarinmac20/_._"
       ]
     },
-    "System.Net.Sockets/4.0.10-beta-23110": {
-      "sha512": "yBP2BtI6ZFPV0v9OMFDhCQ+HGTs5ZjGxZU8RRF6TZoh0VYM15q72gBeAwXH710+ojqMDtB1+uZkmfGaZVxpPIw==",
+    "System.Net.Sockets/4.0.10-beta-23121": {
+      "sha512": "hvsevoS3DJ7+a/g9u+Rg/+TB4/wv2sFFGYALDUbplm1vTAgNr3UTnWy0WZ1DiNNBNY02HNjX0c/avyPjT/KTLA==",
       "files": [
+        "System.Net.Sockets.4.0.10-beta-23121.nupkg",
+        "System.Net.Sockets.4.0.10-beta-23121.nupkg.sha512",
+        "System.Net.Sockets.nuspec",
         "lib/DNXCore50/System.Net.Sockets.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Net.Sockets.dll",
+        "ref/dotnet/System.Net.Sockets.xml",
         "ref/dotnet/de/System.Net.Sockets.xml",
         "ref/dotnet/es/System.Net.Sockets.xml",
         "ref/dotnet/fr/System.Net.Sockets.xml",
@@ -1902,29 +1895,29 @@
         "ref/dotnet/ja/System.Net.Sockets.xml",
         "ref/dotnet/ko/System.Net.Sockets.xml",
         "ref/dotnet/ru/System.Net.Sockets.xml",
-        "ref/dotnet/System.Net.Sockets.dll",
-        "ref/dotnet/System.Net.Sockets.xml",
         "ref/dotnet/zh-hans/System.Net.Sockets.xml",
         "ref/dotnet/zh-hant/System.Net.Sockets.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.Net.Sockets.4.0.10-beta-23110.nupkg",
-        "System.Net.Sockets.4.0.10-beta-23110.nupkg.sha512",
-        "System.Net.Sockets.nuspec"
+        "ref/xamarinmac20/_._"
       ]
     },
-    "System.Net.WebHeaderCollection/4.0.0-beta-23110": {
+    "System.Net.WebHeaderCollection/4.0.0-beta-23121": {
       "serviceable": true,
-      "sha512": "VEaE8UB9O1h0cDTVy9PvlA+FjF3EjFiWtJ7QNohx4G0B1+WW1b6xTCaY4jrlFiSqv/NG8APcifhkjZ3YNpCDpQ==",
+      "sha512": "3T49d7qPn78j2IFqZs39q6LlZaEKaxBBJukvtjoadjHEXVLUSdnpvLnyQy+v+RhOEPIFOrSPH4YNXB9lOFxdgQ==",
       "files": [
+        "System.Net.WebHeaderCollection.4.0.0-beta-23121.nupkg",
+        "System.Net.WebHeaderCollection.4.0.0-beta-23121.nupkg.sha512",
+        "System.Net.WebHeaderCollection.nuspec",
         "lib/dotnet/System.Net.WebHeaderCollection.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Net.WebHeaderCollection.dll",
+        "ref/dotnet/System.Net.WebHeaderCollection.xml",
         "ref/dotnet/de/System.Net.WebHeaderCollection.xml",
         "ref/dotnet/es/System.Net.WebHeaderCollection.xml",
         "ref/dotnet/fr/System.Net.WebHeaderCollection.xml",
@@ -1932,30 +1925,30 @@
         "ref/dotnet/ja/System.Net.WebHeaderCollection.xml",
         "ref/dotnet/ko/System.Net.WebHeaderCollection.xml",
         "ref/dotnet/ru/System.Net.WebHeaderCollection.xml",
-        "ref/dotnet/System.Net.WebHeaderCollection.dll",
-        "ref/dotnet/System.Net.WebHeaderCollection.xml",
         "ref/dotnet/zh-hans/System.Net.WebHeaderCollection.xml",
         "ref/dotnet/zh-hant/System.Net.WebHeaderCollection.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.Net.WebHeaderCollection.4.0.0-beta-23110.nupkg",
-        "System.Net.WebHeaderCollection.4.0.0-beta-23110.nupkg.sha512",
-        "System.Net.WebHeaderCollection.nuspec"
+        "ref/xamarinmac20/_._"
       ]
     },
-    "System.ObjectModel/4.0.10-beta-23110": {
+    "System.ObjectModel/4.0.10-beta-23121": {
       "serviceable": true,
-      "sha512": "Gy9dut90Z7TCB5RbjxKA+jTzvzrAnQqVA5I7d34g7vgF62bpRs0tkndOd9LP7fOMEUBiniFhFCT12pou4U70Lg==",
+      "sha512": "Sd0Iljjqx5GKxEiITCt9A6Rq5Tj15oh267+jHCURxSf4GDLGg3ViYKBzHFN+flx+dYSLu3bjqkHT2ngi+fps7w==",
       "files": [
+        "System.ObjectModel.4.0.10-beta-23121.nupkg",
+        "System.ObjectModel.4.0.10-beta-23121.nupkg.sha512",
+        "System.ObjectModel.nuspec",
         "lib/dotnet/System.ObjectModel.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/System.ObjectModel.dll",
+        "ref/dotnet/System.ObjectModel.xml",
         "ref/dotnet/de/System.ObjectModel.xml",
         "ref/dotnet/es/System.ObjectModel.xml",
         "ref/dotnet/fr/System.ObjectModel.xml",
@@ -1963,78 +1956,76 @@
         "ref/dotnet/ja/System.ObjectModel.xml",
         "ref/dotnet/ko/System.ObjectModel.xml",
         "ref/dotnet/ru/System.ObjectModel.xml",
-        "ref/dotnet/System.ObjectModel.dll",
-        "ref/dotnet/System.ObjectModel.xml",
         "ref/dotnet/zh-hans/System.ObjectModel.xml",
         "ref/dotnet/zh-hant/System.ObjectModel.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.ObjectModel.4.0.10-beta-23110.nupkg",
-        "System.ObjectModel.4.0.10-beta-23110.nupkg.sha512",
-        "System.ObjectModel.nuspec"
+        "ref/xamarinmac20/_._"
       ]
     },
-    "System.Private.DataContractSerialization/4.0.0-beta-23110": {
+    "System.Private.DataContractSerialization/4.0.0-beta-23121": {
       "serviceable": true,
-      "sha512": "dd2xXfvn2voRquK9PPH7a6CnjZkxe+Xnbu0aWG/sxd1QSzIf7/PwtzZUjeV5yfB8TTkCzuQ35bEnFBjUprlRSQ==",
+      "sha512": "5TkMgqkOxDPZpQpNnhgDNjTBRK10kVRSbgl+xloncxZl82OOAGluN8L2Fx4rS6aA4ae/irQoirz7IicAxHsB/A==",
       "files": [
+        "runtime.json",
+        "System.Private.DataContractSerialization.4.0.0-beta-23121.nupkg",
+        "System.Private.DataContractSerialization.4.0.0-beta-23121.nupkg.sha512",
+        "System.Private.DataContractSerialization.nuspec",
         "lib/DNXCore50/System.Private.DataContractSerialization.dll",
         "lib/netcore50/System.Private.DataContractSerialization.dll",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "runtime.json",
-        "runtimes/win8-aot/lib/netcore50/System.Private.DataContractSerialization.dll",
-        "System.Private.DataContractSerialization.4.0.0-beta-23110.nupkg",
-        "System.Private.DataContractSerialization.4.0.0-beta-23110.nupkg.sha512",
-        "System.Private.DataContractSerialization.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Private.DataContractSerialization.dll"
       ]
     },
-    "System.Private.Networking/4.0.0-beta-23110": {
+    "System.Private.Networking/4.0.0-beta-23121": {
       "serviceable": true,
-      "sha512": "YSQV8XbJPWDgq5GOaL3vcaCDvPq4kkbbjfPggtb3Fk+TSUprA/KbYGjICwOYLJUcaQkNlRww6fb+q+wcOAPM0w==",
+      "sha512": "QQudkuBjJIBUa2T0hjAXUy30iOyly1XiD/ves4cahSIkG7DVki7ObNTZ0nnnQfDghdYt2nXtbuY7BeuWGsTZHA==",
       "files": [
+        "System.Private.Networking.4.0.0-beta-23121.nupkg",
+        "System.Private.Networking.4.0.0-beta-23121.nupkg.sha512",
+        "System.Private.Networking.nuspec",
         "lib/DNXCore50/System.Private.Networking.dll",
         "lib/netcore50/System.Private.Networking.dll",
         "ref/dnxcore50/_._",
-        "ref/netcore50/_._",
-        "System.Private.Networking.4.0.0-beta-23110.nupkg",
-        "System.Private.Networking.4.0.0-beta-23110.nupkg.sha512",
-        "System.Private.Networking.nuspec"
+        "ref/netcore50/_._"
       ]
     },
-    "System.Private.ServiceModel/4.0.0-beta-23110": {
+    "System.Private.ServiceModel/4.0.0-beta-23121": {
       "serviceable": true,
-      "sha512": "pxkmlDt01lluamQNT5UH7qG7TbHopz9ndX0YV5EsLdeSjHaYQxxXH6rwhDQIBvdVtG2A7EfaJfM4po/Wk4gvpw==",
+      "sha512": "+cuoOIWBkGB62zUmDZFYMzu/pDLwLeLh7tXrwoaRVpbgZEfkxeaH60UWgEhQ6IRdbGvBYc6s/AWia/VAdSsZ2A==",
       "files": [
+        "System.Private.ServiceModel.4.0.0-beta-23121.nupkg",
+        "System.Private.ServiceModel.4.0.0-beta-23121.nupkg.sha512",
+        "System.Private.ServiceModel.nuspec",
         "lib/DNXCore50/System.Private.ServiceModel.dll",
         "lib/netcore50/System.Private.ServiceModel.dll",
         "ref/dnxcore50/_._",
-        "ref/netcore50/_._",
-        "System.Private.ServiceModel.4.0.0-beta-23110.nupkg",
-        "System.Private.ServiceModel.4.0.0-beta-23110.nupkg.sha512",
-        "System.Private.ServiceModel.nuspec"
+        "ref/netcore50/_._"
       ]
     },
-    "System.Private.Uri/4.0.0-beta-23110": {
+    "System.Private.Uri/4.0.0-beta-23121": {
       "serviceable": true,
-      "sha512": "jU3WYx4hJhCID/hYWW6A0t4pGdtI+Obqvsm06AAVCpdKAEJPe5zq6cgLDQVwPWsOaw2IQmQ0nsTKAXtL/CkpCg==",
+      "sha512": "O3PltcDfri8QgJJHZh8w+8/lnjMQUnF8EtdOm3XkyUfDtoEvg0ri8OjEPhXJjU5CXGYew8bBhV74Gjl8GU68XQ==",
       "files": [
+        "System.Private.Uri.4.0.0-beta-23121.nupkg",
+        "System.Private.Uri.4.0.0-beta-23121.nupkg.sha512",
+        "System.Private.Uri.nuspec",
         "lib/DNXCore50/System.Private.Uri.dll",
         "lib/netcore50/System.Private.Uri.dll",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Private.Uri.dll",
-        "System.Private.Uri.4.0.0-beta-23110.nupkg",
-        "System.Private.Uri.4.0.0-beta-23110.nupkg.sha512",
-        "System.Private.Uri.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Private.Uri.dll"
       ]
     },
-    "System.Reflection/4.0.10-beta-23110": {
-      "sha512": "WiSln11obIbCrHgZbPz0tYLSpQEO96LIM2pWug//KSUVC0s2I2iZN62KuCyLb8XdCm6PBs8MAigXzAYjt5lXJw==",
+    "System.Reflection/4.0.10-beta-23121": {
+      "sha512": "CXa2XuLMasixnUGgAvGSCyyJBUMBawyapijKjsjUnGBdZuPfefaCw+TVmvYZRqmyVf5pNIZbD2Qg1t/TRRKqog==",
       "files": [
+        "System.Reflection.4.0.10-beta-23121.nupkg",
+        "System.Reflection.4.0.10-beta-23121.nupkg.sha512",
+        "System.Reflection.nuspec",
         "lib/DNXCore50/System.Reflection.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2042,6 +2033,8 @@
         "lib/netcore50/System.Reflection.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Reflection.dll",
+        "ref/dotnet/System.Reflection.xml",
         "ref/dotnet/de/System.Reflection.xml",
         "ref/dotnet/es/System.Reflection.xml",
         "ref/dotnet/fr/System.Reflection.xml",
@@ -2049,8 +2042,6 @@
         "ref/dotnet/ja/System.Reflection.xml",
         "ref/dotnet/ko/System.Reflection.xml",
         "ref/dotnet/ru/System.Reflection.xml",
-        "ref/dotnet/System.Reflection.dll",
-        "ref/dotnet/System.Reflection.xml",
         "ref/dotnet/zh-hans/System.Reflection.xml",
         "ref/dotnet/zh-hant/System.Reflection.xml",
         "ref/MonoAndroid10/_._",
@@ -2058,16 +2049,17 @@
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Reflection.dll",
-        "System.Reflection.4.0.10-beta-23110.nupkg",
-        "System.Reflection.4.0.10-beta-23110.nupkg.sha512",
-        "System.Reflection.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Reflection.dll"
       ]
     },
-    "System.Reflection.DispatchProxy/4.0.0-beta-23110": {
+    "System.Reflection.DispatchProxy/4.0.0-beta-23121": {
       "serviceable": true,
-      "sha512": "soXz3k0IeNX3ZOEFZ7InpWbQ/xYSFfnSSOCITL4Q1CuGRmuoa8Yi5NC7XAU/fR5RtIkvvdb/r0ZaYaW9mmrPKg==",
+      "sha512": "CeX+j2TV+x29qSfwyHFuumKnSdUq54egZGpGqfv6ya1BonHL7WE79vDhqxXvmuUceHBmSO3WJOZ53y1I9rL+hg==",
       "files": [
+        "runtime.json",
+        "System.Reflection.DispatchProxy.4.0.0-beta-23121.nupkg",
+        "System.Reflection.DispatchProxy.4.0.0-beta-23121.nupkg.sha512",
+        "System.Reflection.DispatchProxy.nuspec",
         "lib/DNXCore50/System.Reflection.DispatchProxy.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2075,6 +2067,8 @@
         "lib/netcore50/System.Reflection.DispatchProxy.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Reflection.DispatchProxy.dll",
+        "ref/dotnet/System.Reflection.DispatchProxy.xml",
         "ref/dotnet/de/System.Reflection.DispatchProxy.xml",
         "ref/dotnet/es/System.Reflection.DispatchProxy.xml",
         "ref/dotnet/fr/System.Reflection.DispatchProxy.xml",
@@ -2082,29 +2076,28 @@
         "ref/dotnet/ja/System.Reflection.DispatchProxy.xml",
         "ref/dotnet/ko/System.Reflection.DispatchProxy.xml",
         "ref/dotnet/ru/System.Reflection.DispatchProxy.xml",
-        "ref/dotnet/System.Reflection.DispatchProxy.dll",
-        "ref/dotnet/System.Reflection.DispatchProxy.xml",
         "ref/dotnet/zh-hans/System.Reflection.DispatchProxy.xml",
         "ref/dotnet/zh-hant/System.Reflection.DispatchProxy.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtime.json",
-        "runtimes/win8-aot/lib/netcore50/System.Reflection.DispatchProxy.dll",
-        "System.Reflection.DispatchProxy.4.0.0-beta-23110.nupkg",
-        "System.Reflection.DispatchProxy.4.0.0-beta-23110.nupkg.sha512",
-        "System.Reflection.DispatchProxy.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Reflection.DispatchProxy.dll"
       ]
     },
-    "System.Reflection.Emit/4.0.0-beta-23110": {
-      "sha512": "S3Y231TTbWSSnucqj3lmG0dDawpNdoD4r8k36t89T2SUMgF+TDRwcORMqZ6CzyK9bJxchjoJgcNIQB7hpZAlzQ==",
+    "System.Reflection.Emit/4.0.0-beta-23121": {
+      "sha512": "lh/F6y/TwokKeg3QpyJV7mYSQeU0LWQwc9+I5c4VQlLxziX1dehSV4bSK5YNs/BVkWu+Hh7QYqbHXYRf+NqDqw==",
       "files": [
+        "System.Reflection.Emit.4.0.0-beta-23121.nupkg",
+        "System.Reflection.Emit.4.0.0-beta-23121.nupkg.sha512",
+        "System.Reflection.Emit.nuspec",
         "lib/DNXCore50/System.Reflection.Emit.dll",
         "lib/MonoAndroid10/_._",
         "lib/net45/_._",
         "lib/netcore50/System.Reflection.Emit.dll",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Reflection.Emit.dll",
+        "ref/dotnet/System.Reflection.Emit.xml",
         "ref/dotnet/de/System.Reflection.Emit.xml",
         "ref/dotnet/es/System.Reflection.Emit.xml",
         "ref/dotnet/fr/System.Reflection.Emit.xml",
@@ -2112,25 +2105,25 @@
         "ref/dotnet/ja/System.Reflection.Emit.xml",
         "ref/dotnet/ko/System.Reflection.Emit.xml",
         "ref/dotnet/ru/System.Reflection.Emit.xml",
-        "ref/dotnet/System.Reflection.Emit.dll",
-        "ref/dotnet/System.Reflection.Emit.xml",
         "ref/dotnet/zh-hans/System.Reflection.Emit.xml",
         "ref/dotnet/zh-hant/System.Reflection.Emit.xml",
         "ref/MonoAndroid10/_._",
         "ref/net45/_._",
-        "ref/xamarinmac20/_._",
-        "System.Reflection.Emit.4.0.0-beta-23110.nupkg",
-        "System.Reflection.Emit.4.0.0-beta-23110.nupkg.sha512",
-        "System.Reflection.Emit.nuspec"
+        "ref/xamarinmac20/_._"
       ]
     },
-    "System.Reflection.Emit.ILGeneration/4.0.0-beta-23110": {
-      "sha512": "9M8Kw1gW5d8dFrhYrXEvGtrDG/pKxq5nypEUsGOrZh78yMWPoe86ilD5KZhcCZNy187pWcXAf6EfZJ+1aPp2ug==",
+    "System.Reflection.Emit.ILGeneration/4.0.0-beta-23121": {
+      "sha512": "+EZfwWmWxTdqmXHf9bD02kXmxOjCMGcaluHSQQJIb/6SR3hMLvkmDyNxqprHIt0c3hbXIWnJaI92XgrBZane1Q==",
       "files": [
+        "System.Reflection.Emit.ILGeneration.4.0.0-beta-23121.nupkg",
+        "System.Reflection.Emit.ILGeneration.4.0.0-beta-23121.nupkg.sha512",
+        "System.Reflection.Emit.ILGeneration.nuspec",
         "lib/DNXCore50/System.Reflection.Emit.ILGeneration.dll",
         "lib/net45/_._",
         "lib/netcore50/System.Reflection.Emit.ILGeneration.dll",
         "lib/wp80/_._",
+        "ref/dotnet/System.Reflection.Emit.ILGeneration.dll",
+        "ref/dotnet/System.Reflection.Emit.ILGeneration.xml",
         "ref/dotnet/de/System.Reflection.Emit.ILGeneration.xml",
         "ref/dotnet/es/System.Reflection.Emit.ILGeneration.xml",
         "ref/dotnet/fr/System.Reflection.Emit.ILGeneration.xml",
@@ -2138,27 +2131,27 @@
         "ref/dotnet/ja/System.Reflection.Emit.ILGeneration.xml",
         "ref/dotnet/ko/System.Reflection.Emit.ILGeneration.xml",
         "ref/dotnet/ru/System.Reflection.Emit.ILGeneration.xml",
-        "ref/dotnet/System.Reflection.Emit.ILGeneration.dll",
-        "ref/dotnet/System.Reflection.Emit.ILGeneration.xml",
         "ref/dotnet/zh-hans/System.Reflection.Emit.ILGeneration.xml",
         "ref/dotnet/zh-hant/System.Reflection.Emit.ILGeneration.xml",
         "ref/net45/_._",
-        "ref/wp80/_._",
-        "System.Reflection.Emit.ILGeneration.4.0.0-beta-23110.nupkg",
-        "System.Reflection.Emit.ILGeneration.4.0.0-beta-23110.nupkg.sha512",
-        "System.Reflection.Emit.ILGeneration.nuspec"
+        "ref/wp80/_._"
       ]
     },
-    "System.Reflection.Extensions/4.0.0-beta-23110": {
+    "System.Reflection.Extensions/4.0.0-beta-23121": {
       "serviceable": true,
-      "sha512": "ZV+0yQlXtKLRSsnA6IBk9vLijHGdbePtRbMf5HC3s3F/Z6ZQ8yLEXHDmWcn7wRPI/RgolxeKNrnVsukyR1VGMA==",
+      "sha512": "8WOXeu9Sy+WZ8UojBsZ11gzaPryKEG90GXE/WYsYRRlrCS+dsAjS0a8bGqGdKrbkTucWYYGdwOH/5jsvfmK7sA==",
       "files": [
+        "System.Reflection.Extensions.4.0.0-beta-23121.nupkg",
+        "System.Reflection.Extensions.4.0.0-beta-23121.nupkg.sha512",
+        "System.Reflection.Extensions.nuspec",
         "lib/DNXCore50/System.Reflection.Extensions.dll",
         "lib/net45/_._",
         "lib/netcore50/System.Reflection.Extensions.dll",
         "lib/win8/_._",
         "lib/wp80/_._",
         "lib/wpa81/_._",
+        "ref/dotnet/System.Reflection.Extensions.dll",
+        "ref/dotnet/System.Reflection.Extensions.xml",
         "ref/dotnet/de/System.Reflection.Extensions.xml",
         "ref/dotnet/es/System.Reflection.Extensions.xml",
         "ref/dotnet/fr/System.Reflection.Extensions.xml",
@@ -2166,8 +2159,6 @@
         "ref/dotnet/ja/System.Reflection.Extensions.xml",
         "ref/dotnet/ko/System.Reflection.Extensions.xml",
         "ref/dotnet/ru/System.Reflection.Extensions.xml",
-        "ref/dotnet/System.Reflection.Extensions.dll",
-        "ref/dotnet/System.Reflection.Extensions.xml",
         "ref/dotnet/zh-hans/System.Reflection.Extensions.xml",
         "ref/dotnet/zh-hant/System.Reflection.Extensions.xml",
         "ref/net45/_._",
@@ -2176,22 +2167,24 @@
         "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Reflection.Extensions.dll",
-        "System.Reflection.Extensions.4.0.0-beta-23110.nupkg",
-        "System.Reflection.Extensions.4.0.0-beta-23110.nupkg.sha512",
-        "System.Reflection.Extensions.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Reflection.Extensions.dll"
       ]
     },
-    "System.Reflection.Primitives/4.0.0-beta-23110": {
+    "System.Reflection.Primitives/4.0.0-beta-23121": {
       "serviceable": true,
-      "sha512": "QIwLr1xZ3Xg4LB3C+dd7zoE6FAcJCuL60eQFcasA6pC5Nl/0LA7ltcOkq0+DaAIDCD9bH/OFQEZ3F/bdDGtS/Q==",
+      "sha512": "l/c1/9ddoTKbjBxG0H0VGy1P82kqFyQmDDmioteA+lSy+BAsfA9RKfjmBuebvwBN6w01FVY3twGHPyRbjm5k0w==",
       "files": [
+        "System.Reflection.Primitives.4.0.0-beta-23121.nupkg",
+        "System.Reflection.Primitives.4.0.0-beta-23121.nupkg.sha512",
+        "System.Reflection.Primitives.nuspec",
         "lib/DNXCore50/System.Reflection.Primitives.dll",
         "lib/net45/_._",
         "lib/netcore50/System.Reflection.Primitives.dll",
         "lib/win8/_._",
         "lib/wp80/_._",
         "lib/wpa81/_._",
+        "ref/dotnet/System.Reflection.Primitives.dll",
+        "ref/dotnet/System.Reflection.Primitives.xml",
         "ref/dotnet/de/System.Reflection.Primitives.xml",
         "ref/dotnet/es/System.Reflection.Primitives.xml",
         "ref/dotnet/fr/System.Reflection.Primitives.xml",
@@ -2199,8 +2192,6 @@
         "ref/dotnet/ja/System.Reflection.Primitives.xml",
         "ref/dotnet/ko/System.Reflection.Primitives.xml",
         "ref/dotnet/ru/System.Reflection.Primitives.xml",
-        "ref/dotnet/System.Reflection.Primitives.dll",
-        "ref/dotnet/System.Reflection.Primitives.xml",
         "ref/dotnet/zh-hans/System.Reflection.Primitives.xml",
         "ref/dotnet/zh-hant/System.Reflection.Primitives.xml",
         "ref/net45/_._",
@@ -2209,16 +2200,16 @@
         "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Reflection.Primitives.dll",
-        "System.Reflection.Primitives.4.0.0-beta-23110.nupkg",
-        "System.Reflection.Primitives.4.0.0-beta-23110.nupkg.sha512",
-        "System.Reflection.Primitives.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Reflection.Primitives.dll"
       ]
     },
-    "System.Reflection.TypeExtensions/4.0.0-beta-23110": {
+    "System.Reflection.TypeExtensions/4.0.0-beta-23121": {
       "serviceable": true,
-      "sha512": "wOpJ1WBQqsnvFu56hA4hyUTpmhtI0vRA1aNsX78TGr3a4fOF/oV/eX2sUF/ZVBhtvBGzfWA4OOLa59k2C1J1Uw==",
+      "sha512": "bK1zCVYpKlCKCJSZQMy5HpicVeXY660E2aw+bT+EMr8YppN6B9WjS96NKj3NWONJ8kF4EjBjpY4SxUl/PXmY+g==",
       "files": [
+        "System.Reflection.TypeExtensions.4.0.0-beta-23121.nupkg",
+        "System.Reflection.TypeExtensions.4.0.0-beta-23121.nupkg.sha512",
+        "System.Reflection.TypeExtensions.nuspec",
         "lib/DNXCore50/System.Reflection.TypeExtensions.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2226,6 +2217,8 @@
         "lib/netcore50/System.Reflection.TypeExtensions.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Reflection.TypeExtensions.dll",
+        "ref/dotnet/System.Reflection.TypeExtensions.xml",
         "ref/dotnet/de/System.Reflection.TypeExtensions.xml",
         "ref/dotnet/es/System.Reflection.TypeExtensions.xml",
         "ref/dotnet/fr/System.Reflection.TypeExtensions.xml",
@@ -2233,8 +2226,6 @@
         "ref/dotnet/ja/System.Reflection.TypeExtensions.xml",
         "ref/dotnet/ko/System.Reflection.TypeExtensions.xml",
         "ref/dotnet/ru/System.Reflection.TypeExtensions.xml",
-        "ref/dotnet/System.Reflection.TypeExtensions.dll",
-        "ref/dotnet/System.Reflection.TypeExtensions.xml",
         "ref/dotnet/zh-hans/System.Reflection.TypeExtensions.xml",
         "ref/dotnet/zh-hant/System.Reflection.TypeExtensions.xml",
         "ref/MonoAndroid10/_._",
@@ -2242,22 +2233,24 @@
         "ref/net46/System.Reflection.TypeExtensions.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Reflection.TypeExtensions.dll",
-        "System.Reflection.TypeExtensions.4.0.0-beta-23110.nupkg",
-        "System.Reflection.TypeExtensions.4.0.0-beta-23110.nupkg.sha512",
-        "System.Reflection.TypeExtensions.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Reflection.TypeExtensions.dll"
       ]
     },
-    "System.Resources.ResourceManager/4.0.0-beta-23110": {
+    "System.Resources.ResourceManager/4.0.0-beta-23121": {
       "serviceable": true,
-      "sha512": "pv9uEtkJFwZatmwiM3rgs1xoEDAJ3KGghh9E4udg1kirHQ2tvdm2FT8S1gTG1nzpJqBGzg4jl+tubTTGosckeA==",
+      "sha512": "wh60Qfrz3R6eIsH3ILXIZCmCryuNmGo5xvARF5CNZ0/fBgyHnX1yYED4ETgTsCuVfvHpitoH7ZJ9ixaMbsHocg==",
       "files": [
+        "System.Resources.ResourceManager.4.0.0-beta-23121.nupkg",
+        "System.Resources.ResourceManager.4.0.0-beta-23121.nupkg.sha512",
+        "System.Resources.ResourceManager.nuspec",
         "lib/DNXCore50/System.Resources.ResourceManager.dll",
         "lib/net45/_._",
         "lib/netcore50/System.Resources.ResourceManager.dll",
         "lib/win8/_._",
         "lib/wp80/_._",
         "lib/wpa81/_._",
+        "ref/dotnet/System.Resources.ResourceManager.dll",
+        "ref/dotnet/System.Resources.ResourceManager.xml",
         "ref/dotnet/de/System.Resources.ResourceManager.xml",
         "ref/dotnet/es/System.Resources.ResourceManager.xml",
         "ref/dotnet/fr/System.Resources.ResourceManager.xml",
@@ -2265,8 +2258,6 @@
         "ref/dotnet/ja/System.Resources.ResourceManager.xml",
         "ref/dotnet/ko/System.Resources.ResourceManager.xml",
         "ref/dotnet/ru/System.Resources.ResourceManager.xml",
-        "ref/dotnet/System.Resources.ResourceManager.dll",
-        "ref/dotnet/System.Resources.ResourceManager.xml",
         "ref/dotnet/zh-hans/System.Resources.ResourceManager.xml",
         "ref/dotnet/zh-hant/System.Resources.ResourceManager.xml",
         "ref/net45/_._",
@@ -2275,16 +2266,16 @@
         "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Resources.ResourceManager.dll",
-        "System.Resources.ResourceManager.4.0.0-beta-23110.nupkg",
-        "System.Resources.ResourceManager.4.0.0-beta-23110.nupkg.sha512",
-        "System.Resources.ResourceManager.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Resources.ResourceManager.dll"
       ]
     },
-    "System.Runtime/4.0.20-beta-23110": {
+    "System.Runtime/4.0.20-beta-23121": {
       "serviceable": true,
-      "sha512": "MUs0/AsISalHLYKKDcY1oLdIT9a9P6tXjis4Ha/Qa2/t4hZ3rDQ2rcQok20PZ0oo8rrUNRFGVU6RB9PJ/SaK2A==",
+      "sha512": "QorDOTUeGhg98jG0YG7r2Sz1eQA+hNcr23JAK01td0opWWdmEFh//hD6OHfDBGFLZlCLImo0/JeAWW6GahvEMQ==",
       "files": [
+        "System.Runtime.4.0.20-beta-23121.nupkg",
+        "System.Runtime.4.0.20-beta-23121.nupkg.sha512",
+        "System.Runtime.nuspec",
         "lib/DNXCore50/System.Runtime.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2292,6 +2283,8 @@
         "lib/netcore50/System.Runtime.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Runtime.dll",
+        "ref/dotnet/System.Runtime.xml",
         "ref/dotnet/de/System.Runtime.xml",
         "ref/dotnet/es/System.Runtime.xml",
         "ref/dotnet/fr/System.Runtime.xml",
@@ -2299,8 +2292,6 @@
         "ref/dotnet/ja/System.Runtime.xml",
         "ref/dotnet/ko/System.Runtime.xml",
         "ref/dotnet/ru/System.Runtime.xml",
-        "ref/dotnet/System.Runtime.dll",
-        "ref/dotnet/System.Runtime.xml",
         "ref/dotnet/zh-hans/System.Runtime.xml",
         "ref/dotnet/zh-hant/System.Runtime.xml",
         "ref/MonoAndroid10/_._",
@@ -2308,16 +2299,16 @@
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Runtime.dll",
-        "System.Runtime.4.0.20-beta-23110.nupkg",
-        "System.Runtime.4.0.20-beta-23110.nupkg.sha512",
-        "System.Runtime.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.dll"
       ]
     },
-    "System.Runtime.Extensions/4.0.10-beta-23110": {
+    "System.Runtime.Extensions/4.0.10-beta-23121": {
       "serviceable": true,
-      "sha512": "jWzcMxGSWx06AFLEmTT2pznSavlQIJnFMJKP1xmAnftmrWqkQ7+xZCqU7nCmoUQ+dMwMJFMUJYQI2tj5WPZg7g==",
+      "sha512": "nl7gUoFapz7cSwHY9Sb9s2zMghyYHWtAHg5HXn7u9wWbaeVpAIzBlvrNk20XoMVCwuroLvRbE3VzWnwqMsvdzg==",
       "files": [
+        "System.Runtime.Extensions.4.0.10-beta-23121.nupkg",
+        "System.Runtime.Extensions.4.0.10-beta-23121.nupkg.sha512",
+        "System.Runtime.Extensions.nuspec",
         "lib/DNXCore50/System.Runtime.Extensions.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2325,6 +2316,8 @@
         "lib/netcore50/System.Runtime.Extensions.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Runtime.Extensions.dll",
+        "ref/dotnet/System.Runtime.Extensions.xml",
         "ref/dotnet/de/System.Runtime.Extensions.xml",
         "ref/dotnet/es/System.Runtime.Extensions.xml",
         "ref/dotnet/fr/System.Runtime.Extensions.xml",
@@ -2332,8 +2325,6 @@
         "ref/dotnet/ja/System.Runtime.Extensions.xml",
         "ref/dotnet/ko/System.Runtime.Extensions.xml",
         "ref/dotnet/ru/System.Runtime.Extensions.xml",
-        "ref/dotnet/System.Runtime.Extensions.dll",
-        "ref/dotnet/System.Runtime.Extensions.xml",
         "ref/dotnet/zh-hans/System.Runtime.Extensions.xml",
         "ref/dotnet/zh-hant/System.Runtime.Extensions.xml",
         "ref/MonoAndroid10/_._",
@@ -2341,16 +2332,16 @@
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Runtime.Extensions.dll",
-        "System.Runtime.Extensions.4.0.10-beta-23110.nupkg",
-        "System.Runtime.Extensions.4.0.10-beta-23110.nupkg.sha512",
-        "System.Runtime.Extensions.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.Extensions.dll"
       ]
     },
-    "System.Runtime.Handles/4.0.0-beta-23110": {
+    "System.Runtime.Handles/4.0.0-beta-23121": {
       "serviceable": true,
-      "sha512": "VG4FO4O5CJcO0vKpN37Sgvhw22Hnz+Jh/cw4rcmD74mw8teraymyEANEfHhbUIRccbKfdL+Hm+eyJ+mZGHkjsw==",
+      "sha512": "EzW4nPvEtEUWTmchG1URE7jMXtxRoLT5f8t5QHj0s8hzuCWk7+ey1TI/1+8AvKmmwtwYTu5+mvbgOcmsbQvkGg==",
       "files": [
+        "System.Runtime.Handles.4.0.0-beta-23121.nupkg",
+        "System.Runtime.Handles.4.0.0-beta-23121.nupkg.sha512",
+        "System.Runtime.Handles.nuspec",
         "lib/DNXCore50/System.Runtime.Handles.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2358,6 +2349,8 @@
         "lib/netcore50/System.Runtime.Handles.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Runtime.Handles.dll",
+        "ref/dotnet/System.Runtime.Handles.xml",
         "ref/dotnet/de/System.Runtime.Handles.xml",
         "ref/dotnet/es/System.Runtime.Handles.xml",
         "ref/dotnet/fr/System.Runtime.Handles.xml",
@@ -2365,8 +2358,6 @@
         "ref/dotnet/ja/System.Runtime.Handles.xml",
         "ref/dotnet/ko/System.Runtime.Handles.xml",
         "ref/dotnet/ru/System.Runtime.Handles.xml",
-        "ref/dotnet/System.Runtime.Handles.dll",
-        "ref/dotnet/System.Runtime.Handles.xml",
         "ref/dotnet/zh-hans/System.Runtime.Handles.xml",
         "ref/dotnet/zh-hant/System.Runtime.Handles.xml",
         "ref/MonoAndroid10/_._",
@@ -2374,16 +2365,16 @@
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Runtime.Handles.dll",
-        "System.Runtime.Handles.4.0.0-beta-23110.nupkg",
-        "System.Runtime.Handles.4.0.0-beta-23110.nupkg.sha512",
-        "System.Runtime.Handles.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.Handles.dll"
       ]
     },
-    "System.Runtime.InteropServices/4.0.20-beta-23110": {
+    "System.Runtime.InteropServices/4.0.20-beta-23121": {
       "serviceable": true,
-      "sha512": "rRcd68AoRe+BYb9V2/RlsSJcISxbCYQuLbObYdtYRGaAc1qxHbfNzZyQecQjZqzKCEdT64jEca4mNS/mfoYX7Q==",
+      "sha512": "7FvgWR3IW+zgGPLDxbsowuASbgspcbYRn0fpwT8c/v417i6904bqvZUXEi65T85tBM+PkbutVzJIsPc1bBEd/A==",
       "files": [
+        "System.Runtime.InteropServices.4.0.20-beta-23121.nupkg",
+        "System.Runtime.InteropServices.4.0.20-beta-23121.nupkg.sha512",
+        "System.Runtime.InteropServices.nuspec",
         "lib/DNXCore50/System.Runtime.InteropServices.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2391,6 +2382,8 @@
         "lib/netcore50/System.Runtime.InteropServices.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Runtime.InteropServices.dll",
+        "ref/dotnet/System.Runtime.InteropServices.xml",
         "ref/dotnet/de/System.Runtime.InteropServices.xml",
         "ref/dotnet/es/System.Runtime.InteropServices.xml",
         "ref/dotnet/fr/System.Runtime.InteropServices.xml",
@@ -2398,8 +2391,6 @@
         "ref/dotnet/ja/System.Runtime.InteropServices.xml",
         "ref/dotnet/ko/System.Runtime.InteropServices.xml",
         "ref/dotnet/ru/System.Runtime.InteropServices.xml",
-        "ref/dotnet/System.Runtime.InteropServices.dll",
-        "ref/dotnet/System.Runtime.InteropServices.xml",
         "ref/dotnet/zh-hans/System.Runtime.InteropServices.xml",
         "ref/dotnet/zh-hant/System.Runtime.InteropServices.xml",
         "ref/MonoAndroid10/_._",
@@ -2407,21 +2398,23 @@
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Runtime.InteropServices.dll",
-        "System.Runtime.InteropServices.4.0.20-beta-23110.nupkg",
-        "System.Runtime.InteropServices.4.0.20-beta-23110.nupkg.sha512",
-        "System.Runtime.InteropServices.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.InteropServices.dll"
       ]
     },
-    "System.Runtime.Numerics/4.0.0-beta-23110": {
+    "System.Runtime.Numerics/4.0.0-beta-23121": {
       "serviceable": true,
-      "sha512": "pQaurqp3W3MpvjFgq8zE2urqUeV9dXyrK0lKba5mDJXLGIRxZrEpYIoxiau1aY9a8TT1CI82Guvm3ejk9FcU2Q==",
+      "sha512": "nLEm2Sc8kgGHhlMRewmFxkRnQK26qE/sjOsx06yW7DGx5TSjn8kKXChye1C3Ss86L1pysmHxnWvcOSz9o2KWTA==",
       "files": [
+        "System.Runtime.Numerics.4.0.0-beta-23121.nupkg",
+        "System.Runtime.Numerics.4.0.0-beta-23121.nupkg.sha512",
+        "System.Runtime.Numerics.nuspec",
         "lib/dotnet/System.Runtime.Numerics.dll",
         "lib/net45/_._",
         "lib/netcore50/System.Runtime.Numerics.dll",
         "lib/win8/_._",
         "lib/wpa81/_._",
+        "ref/dotnet/System.Runtime.Numerics.dll",
+        "ref/dotnet/System.Runtime.Numerics.xml",
         "ref/dotnet/de/System.Runtime.Numerics.xml",
         "ref/dotnet/es/System.Runtime.Numerics.xml",
         "ref/dotnet/fr/System.Runtime.Numerics.xml",
@@ -2429,30 +2422,30 @@
         "ref/dotnet/ja/System.Runtime.Numerics.xml",
         "ref/dotnet/ko/System.Runtime.Numerics.xml",
         "ref/dotnet/ru/System.Runtime.Numerics.xml",
-        "ref/dotnet/System.Runtime.Numerics.dll",
-        "ref/dotnet/System.Runtime.Numerics.xml",
         "ref/dotnet/zh-hans/System.Runtime.Numerics.xml",
         "ref/dotnet/zh-hant/System.Runtime.Numerics.xml",
         "ref/net45/_._",
         "ref/netcore50/System.Runtime.Numerics.dll",
         "ref/netcore50/System.Runtime.Numerics.xml",
         "ref/win8/_._",
-        "ref/wpa81/_._",
-        "System.Runtime.Numerics.4.0.0-beta-23110.nupkg",
-        "System.Runtime.Numerics.4.0.0-beta-23110.nupkg.sha512",
-        "System.Runtime.Numerics.nuspec"
+        "ref/wpa81/_._"
       ]
     },
-    "System.Runtime.Serialization.Primitives/4.0.10-beta-23110": {
+    "System.Runtime.Serialization.Primitives/4.0.10-beta-23121": {
       "serviceable": true,
-      "sha512": "ZbmhJtP/rPcQPogGPUL6FevRb0vEsWn2nCxtEJ3jnIEZkUkQliZr1Ua+9H3/QN79OBmxfqUZRuelSS2vauHM+Q==",
+      "sha512": "GGDxEt+0YAQK03pka2RrrFnLU4tuAMbiYjzH1joPExAoO0QgijyTmouh5zxyZRVxjjwMXYG1WZmey8Gs2RaqdA==",
       "files": [
+        "System.Runtime.Serialization.Primitives.4.0.10-beta-23121.nupkg",
+        "System.Runtime.Serialization.Primitives.4.0.10-beta-23121.nupkg.sha512",
+        "System.Runtime.Serialization.Primitives.nuspec",
         "lib/dotnet/System.Runtime.Serialization.Primitives.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Runtime.Serialization.Primitives.dll",
+        "ref/dotnet/System.Runtime.Serialization.Primitives.xml",
         "ref/dotnet/de/System.Runtime.Serialization.Primitives.xml",
         "ref/dotnet/es/System.Runtime.Serialization.Primitives.xml",
         "ref/dotnet/fr/System.Runtime.Serialization.Primitives.xml",
@@ -2460,23 +2453,21 @@
         "ref/dotnet/ja/System.Runtime.Serialization.Primitives.xml",
         "ref/dotnet/ko/System.Runtime.Serialization.Primitives.xml",
         "ref/dotnet/ru/System.Runtime.Serialization.Primitives.xml",
-        "ref/dotnet/System.Runtime.Serialization.Primitives.dll",
-        "ref/dotnet/System.Runtime.Serialization.Primitives.xml",
         "ref/dotnet/zh-hans/System.Runtime.Serialization.Primitives.xml",
         "ref/dotnet/zh-hant/System.Runtime.Serialization.Primitives.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.Runtime.Serialization.Primitives.4.0.10-beta-23110.nupkg",
-        "System.Runtime.Serialization.Primitives.4.0.10-beta-23110.nupkg.sha512",
-        "System.Runtime.Serialization.Primitives.nuspec"
+        "ref/xamarinmac20/_._"
       ]
     },
-    "System.Runtime.Serialization.Xml/4.0.10-beta-23110": {
-      "sha512": "hBF/XANozO/x9IR08nmgpg7ZGgoOqjvUDuek+RW2YOQWfqEt7JmZRQyIOqR5Gyw3GU7ydmXm/9+fnkgMPIsHJg==",
+    "System.Runtime.Serialization.Xml/4.0.10-beta-23121": {
+      "sha512": "HrG+5NX5ztZzkq6ptegumBneNrsr+xnaIgpXccem/9ePKtZWevqrp4CoKnW8Jek6O97gmuhzrbp3BhwyCqrWbA==",
       "files": [
+        "System.Runtime.Serialization.Xml.4.0.10-beta-23121.nupkg",
+        "System.Runtime.Serialization.Xml.4.0.10-beta-23121.nupkg.sha512",
+        "System.Runtime.Serialization.Xml.nuspec",
         "lib/DNXCore50/System.Runtime.Serialization.Xml.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2484,6 +2475,8 @@
         "lib/netcore50/System.Runtime.Serialization.Xml.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Runtime.Serialization.Xml.dll",
+        "ref/dotnet/System.Runtime.Serialization.Xml.xml",
         "ref/dotnet/de/System.Runtime.Serialization.Xml.xml",
         "ref/dotnet/es/System.Runtime.Serialization.Xml.xml",
         "ref/dotnet/fr/System.Runtime.Serialization.Xml.xml",
@@ -2491,8 +2484,6 @@
         "ref/dotnet/ja/System.Runtime.Serialization.Xml.xml",
         "ref/dotnet/ko/System.Runtime.Serialization.Xml.xml",
         "ref/dotnet/ru/System.Runtime.Serialization.Xml.xml",
-        "ref/dotnet/System.Runtime.Serialization.Xml.dll",
-        "ref/dotnet/System.Runtime.Serialization.Xml.xml",
         "ref/dotnet/zh-hans/System.Runtime.Serialization.Xml.xml",
         "ref/dotnet/zh-hant/System.Runtime.Serialization.Xml.xml",
         "ref/MonoAndroid10/_._",
@@ -2500,22 +2491,24 @@
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Runtime.Serialization.Xml.dll",
-        "System.Runtime.Serialization.Xml.4.0.10-beta-23110.nupkg",
-        "System.Runtime.Serialization.Xml.4.0.10-beta-23110.nupkg.sha512",
-        "System.Runtime.Serialization.Xml.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.Serialization.Xml.dll"
       ]
     },
-    "System.Security.Claims/4.0.0-beta-23110": {
+    "System.Security.Claims/4.0.0-beta-23121": {
       "serviceable": true,
-      "sha512": "OPf6O93HVDMlrC6ZW0RPlXRtWSdoK6vL2MDRcdfF8RyWDc9eeX9OOWMMD5Yz/i8Iodsye6Ldn9uFDD3Y8jx4Cg==",
+      "sha512": "Yq/az95Q01wcm/kU+U9B45zS1jxT0kDalR4pa3vaVIUbULOaeqkcGYOPytDJ7aRUXIaPNu2z4kX+TcW2bavG7A==",
       "files": [
+        "System.Security.Claims.4.0.0-beta-23121.nupkg",
+        "System.Security.Claims.4.0.0-beta-23121.nupkg.sha512",
+        "System.Security.Claims.nuspec",
         "lib/dotnet/System.Security.Claims.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Security.Claims.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Security.Claims.dll",
+        "ref/dotnet/System.Security.Claims.xml",
         "ref/dotnet/de/System.Security.Claims.xml",
         "ref/dotnet/es/System.Security.Claims.xml",
         "ref/dotnet/fr/System.Security.Claims.xml",
@@ -2523,30 +2516,30 @@
         "ref/dotnet/ja/System.Security.Claims.xml",
         "ref/dotnet/ko/System.Security.Claims.xml",
         "ref/dotnet/ru/System.Security.Claims.xml",
-        "ref/dotnet/System.Security.Claims.dll",
-        "ref/dotnet/System.Security.Claims.xml",
         "ref/dotnet/zh-hans/System.Security.Claims.xml",
         "ref/dotnet/zh-hant/System.Security.Claims.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Security.Claims.dll",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.Security.Claims.4.0.0-beta-23110.nupkg",
-        "System.Security.Claims.4.0.0-beta-23110.nupkg.sha512",
-        "System.Security.Claims.nuspec"
+        "ref/xamarinmac20/_._"
       ]
     },
-    "System.Security.Cryptography.Encoding/4.0.0-beta-23110": {
+    "System.Security.Cryptography.Encoding/4.0.0-beta-23121": {
       "serviceable": true,
-      "sha512": "EgOJl6XT7/JBntPu8+Irs+Wc1r5vBZ8qRlRck+WES1mxhSm06d+aUbsWwAKVJEtfozycZrgEFSgtRoNFevKKdg==",
+      "sha512": "v2rbnXR7lH4QpJTN/Rh0ctOF0VnKh3iYWuOBKeAMFJPcwoueAnnbDJFlGBqpHeIZprWQuLMPA3LuLbrO+wy38g==",
       "files": [
+        "System.Security.Cryptography.Encoding.4.0.0-beta-23121.nupkg",
+        "System.Security.Cryptography.Encoding.4.0.0-beta-23121.nupkg.sha512",
+        "System.Security.Cryptography.Encoding.nuspec",
         "lib/DNXCore50/System.Security.Cryptography.Encoding.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Security.Cryptography.Encoding.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Security.Cryptography.Encoding.dll",
+        "ref/dotnet/System.Security.Cryptography.Encoding.xml",
         "ref/dotnet/de/System.Security.Cryptography.Encoding.xml",
         "ref/dotnet/es/System.Security.Cryptography.Encoding.xml",
         "ref/dotnet/fr/System.Security.Cryptography.Encoding.xml",
@@ -2554,30 +2547,30 @@
         "ref/dotnet/ja/System.Security.Cryptography.Encoding.xml",
         "ref/dotnet/ko/System.Security.Cryptography.Encoding.xml",
         "ref/dotnet/ru/System.Security.Cryptography.Encoding.xml",
-        "ref/dotnet/System.Security.Cryptography.Encoding.dll",
-        "ref/dotnet/System.Security.Cryptography.Encoding.xml",
         "ref/dotnet/zh-hans/System.Security.Cryptography.Encoding.xml",
         "ref/dotnet/zh-hant/System.Security.Cryptography.Encoding.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Security.Cryptography.Encoding.dll",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.Security.Cryptography.Encoding.4.0.0-beta-23110.nupkg",
-        "System.Security.Cryptography.Encoding.4.0.0-beta-23110.nupkg.sha512",
-        "System.Security.Cryptography.Encoding.nuspec"
+        "ref/xamarinmac20/_._"
       ]
     },
-    "System.Security.Cryptography.Encryption/4.0.0-beta-23110": {
+    "System.Security.Cryptography.Encryption/4.0.0-beta-23121": {
       "serviceable": true,
-      "sha512": "CcPu99yHJvys4B83gUff+WvrmyqhjlvDnNtZ8BSpgxLtP0QU50iaJVL2Z5ohor+JxPfcLi/Kr+KWsabA60yOzw==",
+      "sha512": "5K3Pl/bm+ex7F+9tY+XROP5NMPPkqA+tsI17IHKwp0vsjfVROlKuy/yjwSibse0Sj9BhpV7peHkZ72RxsFnvpg==",
       "files": [
+        "System.Security.Cryptography.Encryption.4.0.0-beta-23121.nupkg",
+        "System.Security.Cryptography.Encryption.4.0.0-beta-23121.nupkg.sha512",
+        "System.Security.Cryptography.Encryption.nuspec",
         "lib/DNXCore50/System.Security.Cryptography.Encryption.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Security.Cryptography.Encryption.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Security.Cryptography.Encryption.dll",
+        "ref/dotnet/System.Security.Cryptography.Encryption.xml",
         "ref/dotnet/de/System.Security.Cryptography.Encryption.xml",
         "ref/dotnet/es/System.Security.Cryptography.Encryption.xml",
         "ref/dotnet/fr/System.Security.Cryptography.Encryption.xml",
@@ -2585,30 +2578,30 @@
         "ref/dotnet/ja/System.Security.Cryptography.Encryption.xml",
         "ref/dotnet/ko/System.Security.Cryptography.Encryption.xml",
         "ref/dotnet/ru/System.Security.Cryptography.Encryption.xml",
-        "ref/dotnet/System.Security.Cryptography.Encryption.dll",
-        "ref/dotnet/System.Security.Cryptography.Encryption.xml",
         "ref/dotnet/zh-hans/System.Security.Cryptography.Encryption.xml",
         "ref/dotnet/zh-hant/System.Security.Cryptography.Encryption.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Security.Cryptography.Encryption.dll",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.Security.Cryptography.Encryption.4.0.0-beta-23110.nupkg",
-        "System.Security.Cryptography.Encryption.4.0.0-beta-23110.nupkg.sha512",
-        "System.Security.Cryptography.Encryption.nuspec"
+        "ref/xamarinmac20/_._"
       ]
     },
-    "System.Security.Cryptography.Hashing/4.0.0-beta-23110": {
+    "System.Security.Cryptography.Hashing/4.0.0-beta-23121": {
       "serviceable": true,
-      "sha512": "QIAeXCxiewcjPLtLLXY8dZ40KqLJ7gj/JS4i8gJQX0fDdFcjiHFdWPUHJGCfvgoAkapsLR43YZLGFsEDCkViQw==",
+      "sha512": "PfCKxfC41/gFxYhEgIHXmeV8EgKkC90GJdQs5TS3la7gOlFzEJFkiUDVP3xD0Ap/gZNp6uswxVRa2Fpa71I39w==",
       "files": [
+        "System.Security.Cryptography.Hashing.4.0.0-beta-23121.nupkg",
+        "System.Security.Cryptography.Hashing.4.0.0-beta-23121.nupkg.sha512",
+        "System.Security.Cryptography.Hashing.nuspec",
         "lib/DNXCore50/System.Security.Cryptography.Hashing.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Security.Cryptography.Hashing.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Security.Cryptography.Hashing.dll",
+        "ref/dotnet/System.Security.Cryptography.Hashing.xml",
         "ref/dotnet/de/System.Security.Cryptography.Hashing.xml",
         "ref/dotnet/es/System.Security.Cryptography.Hashing.xml",
         "ref/dotnet/fr/System.Security.Cryptography.Hashing.xml",
@@ -2616,30 +2609,30 @@
         "ref/dotnet/ja/System.Security.Cryptography.Hashing.xml",
         "ref/dotnet/ko/System.Security.Cryptography.Hashing.xml",
         "ref/dotnet/ru/System.Security.Cryptography.Hashing.xml",
-        "ref/dotnet/System.Security.Cryptography.Hashing.dll",
-        "ref/dotnet/System.Security.Cryptography.Hashing.xml",
         "ref/dotnet/zh-hans/System.Security.Cryptography.Hashing.xml",
         "ref/dotnet/zh-hant/System.Security.Cryptography.Hashing.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Security.Cryptography.Hashing.dll",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.Security.Cryptography.Hashing.4.0.0-beta-23110.nupkg",
-        "System.Security.Cryptography.Hashing.4.0.0-beta-23110.nupkg.sha512",
-        "System.Security.Cryptography.Hashing.nuspec"
+        "ref/xamarinmac20/_._"
       ]
     },
-    "System.Security.Cryptography.Hashing.Algorithms/4.0.0-beta-23110": {
+    "System.Security.Cryptography.Hashing.Algorithms/4.0.0-beta-23121": {
       "serviceable": true,
-      "sha512": "ed3W8yDY7l1U8syL7Nklp41G98GJ/yB64gDI+fdncKWnqQI2wpqtbSBvXig9oxnqlsbedXKTwImacRKAQtKo6A==",
+      "sha512": "6/hii5xJ2ZCR0ohcPkB2GVjmOFeWZTA03972G7Ogof3Y6KqUUYqKOxSZSkU62GBhWuV2kTTuwP69bOejY0Er1g==",
       "files": [
+        "System.Security.Cryptography.Hashing.Algorithms.4.0.0-beta-23121.nupkg",
+        "System.Security.Cryptography.Hashing.Algorithms.4.0.0-beta-23121.nupkg.sha512",
+        "System.Security.Cryptography.Hashing.Algorithms.nuspec",
         "lib/DNXCore50/System.Security.Cryptography.Hashing.Algorithms.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Security.Cryptography.Hashing.Algorithms.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Security.Cryptography.Hashing.Algorithms.dll",
+        "ref/dotnet/System.Security.Cryptography.Hashing.Algorithms.xml",
         "ref/dotnet/de/System.Security.Cryptography.Hashing.Algorithms.xml",
         "ref/dotnet/es/System.Security.Cryptography.Hashing.Algorithms.xml",
         "ref/dotnet/fr/System.Security.Cryptography.Hashing.Algorithms.xml",
@@ -2647,30 +2640,30 @@
         "ref/dotnet/ja/System.Security.Cryptography.Hashing.Algorithms.xml",
         "ref/dotnet/ko/System.Security.Cryptography.Hashing.Algorithms.xml",
         "ref/dotnet/ru/System.Security.Cryptography.Hashing.Algorithms.xml",
-        "ref/dotnet/System.Security.Cryptography.Hashing.Algorithms.dll",
-        "ref/dotnet/System.Security.Cryptography.Hashing.Algorithms.xml",
         "ref/dotnet/zh-hans/System.Security.Cryptography.Hashing.Algorithms.xml",
         "ref/dotnet/zh-hant/System.Security.Cryptography.Hashing.Algorithms.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Security.Cryptography.Hashing.Algorithms.dll",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.Security.Cryptography.Hashing.Algorithms.4.0.0-beta-23110.nupkg",
-        "System.Security.Cryptography.Hashing.Algorithms.4.0.0-beta-23110.nupkg.sha512",
-        "System.Security.Cryptography.Hashing.Algorithms.nuspec"
+        "ref/xamarinmac20/_._"
       ]
     },
-    "System.Security.Cryptography.RandomNumberGenerator/4.0.0-beta-23110": {
+    "System.Security.Cryptography.RandomNumberGenerator/4.0.0-beta-23121": {
       "serviceable": true,
-      "sha512": "GBwlfdsZlKiI4XPX54ZVle+XOKJB9JCYiSlvwSkIzs7HFrIOoeRALmq8otiGItHLVUX+0BG5AICZb3XGNBRtog==",
+      "sha512": "pRgKGZERBZpYK5YfJBuVvkSGSlXXxz6g0F9/fV2bhvAKR6REBJwHXteSxOvyDCRuERGgl3HkO9yv2BxjwHiY9Q==",
       "files": [
+        "System.Security.Cryptography.RandomNumberGenerator.4.0.0-beta-23121.nupkg",
+        "System.Security.Cryptography.RandomNumberGenerator.4.0.0-beta-23121.nupkg.sha512",
+        "System.Security.Cryptography.RandomNumberGenerator.nuspec",
         "lib/DNXCore50/System.Security.Cryptography.RandomNumberGenerator.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Security.Cryptography.RandomNumberGenerator.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Security.Cryptography.RandomNumberGenerator.dll",
+        "ref/dotnet/System.Security.Cryptography.RandomNumberGenerator.xml",
         "ref/dotnet/de/System.Security.Cryptography.RandomNumberGenerator.xml",
         "ref/dotnet/es/System.Security.Cryptography.RandomNumberGenerator.xml",
         "ref/dotnet/fr/System.Security.Cryptography.RandomNumberGenerator.xml",
@@ -2678,30 +2671,30 @@
         "ref/dotnet/ja/System.Security.Cryptography.RandomNumberGenerator.xml",
         "ref/dotnet/ko/System.Security.Cryptography.RandomNumberGenerator.xml",
         "ref/dotnet/ru/System.Security.Cryptography.RandomNumberGenerator.xml",
-        "ref/dotnet/System.Security.Cryptography.RandomNumberGenerator.dll",
-        "ref/dotnet/System.Security.Cryptography.RandomNumberGenerator.xml",
         "ref/dotnet/zh-hans/System.Security.Cryptography.RandomNumberGenerator.xml",
         "ref/dotnet/zh-hant/System.Security.Cryptography.RandomNumberGenerator.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Security.Cryptography.RandomNumberGenerator.dll",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.Security.Cryptography.RandomNumberGenerator.4.0.0-beta-23110.nupkg",
-        "System.Security.Cryptography.RandomNumberGenerator.4.0.0-beta-23110.nupkg.sha512",
-        "System.Security.Cryptography.RandomNumberGenerator.nuspec"
+        "ref/xamarinmac20/_._"
       ]
     },
-    "System.Security.Cryptography.RSA/4.0.0-beta-23110": {
+    "System.Security.Cryptography.RSA/4.0.0-beta-23121": {
       "serviceable": true,
-      "sha512": "f92pWQoEmnMy5Zetnm00S8r7x+UibhRlJDxczU59Y8pv04dWInLBvdrPk5zg9o836qxkEDL4zShKZ/rKqCfv/g==",
+      "sha512": "/0KJHNW/eYLj8VniQRLzfKszes1F54mtO01VPGPM32Hb+qAnbAf0HWVJ4F/XaHDSLAXkip6vPFtgTNTkR/i+hw==",
       "files": [
+        "System.Security.Cryptography.RSA.4.0.0-beta-23121.nupkg",
+        "System.Security.Cryptography.RSA.4.0.0-beta-23121.nupkg.sha512",
+        "System.Security.Cryptography.RSA.nuspec",
         "lib/DNXCore50/System.Security.Cryptography.RSA.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Security.Cryptography.RSA.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Security.Cryptography.RSA.dll",
+        "ref/dotnet/System.Security.Cryptography.RSA.xml",
         "ref/dotnet/de/System.Security.Cryptography.RSA.xml",
         "ref/dotnet/es/System.Security.Cryptography.RSA.xml",
         "ref/dotnet/fr/System.Security.Cryptography.RSA.xml",
@@ -2709,30 +2702,30 @@
         "ref/dotnet/ja/System.Security.Cryptography.RSA.xml",
         "ref/dotnet/ko/System.Security.Cryptography.RSA.xml",
         "ref/dotnet/ru/System.Security.Cryptography.RSA.xml",
-        "ref/dotnet/System.Security.Cryptography.RSA.dll",
-        "ref/dotnet/System.Security.Cryptography.RSA.xml",
         "ref/dotnet/zh-hans/System.Security.Cryptography.RSA.xml",
         "ref/dotnet/zh-hant/System.Security.Cryptography.RSA.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Security.Cryptography.RSA.dll",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.Security.Cryptography.RSA.4.0.0-beta-23110.nupkg",
-        "System.Security.Cryptography.RSA.4.0.0-beta-23110.nupkg.sha512",
-        "System.Security.Cryptography.RSA.nuspec"
+        "ref/xamarinmac20/_._"
       ]
     },
-    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23110": {
+    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23121": {
       "serviceable": true,
-      "sha512": "i8I/vRWnb9fCIhmAeTH4M1EXLhpEcaLnt2RIGD7vwNPeXax89OHsEUydr+r6bWaKnVnPrS2G7Zrji57TK/8zog==",
+      "sha512": "RZOhxEFkTl9UCCsEK7yqUeiN4v7q1uJmY62QWNhZmQs7mmwdpOgs7rUIxq5JHdkySkW4j61DGz4isUuLecb/0w==",
       "files": [
+        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23121.nupkg",
+        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23121.nupkg.sha512",
+        "System.Security.Cryptography.X509Certificates.nuspec",
         "lib/DNXCore50/System.Security.Cryptography.X509Certificates.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Security.Cryptography.X509Certificates.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Security.Cryptography.X509Certificates.dll",
+        "ref/dotnet/System.Security.Cryptography.X509Certificates.xml",
         "ref/dotnet/de/System.Security.Cryptography.X509Certificates.xml",
         "ref/dotnet/es/System.Security.Cryptography.X509Certificates.xml",
         "ref/dotnet/fr/System.Security.Cryptography.X509Certificates.xml",
@@ -2740,30 +2733,30 @@
         "ref/dotnet/ja/System.Security.Cryptography.X509Certificates.xml",
         "ref/dotnet/ko/System.Security.Cryptography.X509Certificates.xml",
         "ref/dotnet/ru/System.Security.Cryptography.X509Certificates.xml",
-        "ref/dotnet/System.Security.Cryptography.X509Certificates.dll",
-        "ref/dotnet/System.Security.Cryptography.X509Certificates.xml",
         "ref/dotnet/zh-hans/System.Security.Cryptography.X509Certificates.xml",
         "ref/dotnet/zh-hant/System.Security.Cryptography.X509Certificates.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Security.Cryptography.X509Certificates.dll",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23110.nupkg",
-        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23110.nupkg.sha512",
-        "System.Security.Cryptography.X509Certificates.nuspec"
+        "ref/xamarinmac20/_._"
       ]
     },
-    "System.Security.Principal/4.0.0-beta-23110": {
+    "System.Security.Principal/4.0.0-beta-23121": {
       "serviceable": true,
-      "sha512": "ZQ2xLLZq+FxoweATt3gIqp76KCD8DTPpAxYOGV9Ov8VafQIy7zauJYUgxQohxUjxAw8cidoW2f+RsF+r7Ltw4Q==",
+      "sha512": "LVKsWbG0gtTRqQekzE3NlKAbZaXs4ODfv0lEmItQuHeeqsf5Dx9uqomtvh+hq2LYWaqLHx5bsJMn4MseU0/Vaw==",
       "files": [
+        "System.Security.Principal.4.0.0-beta-23121.nupkg",
+        "System.Security.Principal.4.0.0-beta-23121.nupkg.sha512",
+        "System.Security.Principal.nuspec",
         "lib/dotnet/System.Security.Principal.dll",
         "lib/net45/_._",
         "lib/netcore50/System.Security.Principal.dll",
         "lib/win8/_._",
         "lib/wp80/_._",
         "lib/wpa81/_._",
+        "ref/dotnet/System.Security.Principal.dll",
+        "ref/dotnet/System.Security.Principal.xml",
         "ref/dotnet/de/System.Security.Principal.xml",
         "ref/dotnet/es/System.Security.Principal.xml",
         "ref/dotnet/fr/System.Security.Principal.xml",
@@ -2771,8 +2764,6 @@
         "ref/dotnet/ja/System.Security.Principal.xml",
         "ref/dotnet/ko/System.Security.Principal.xml",
         "ref/dotnet/ru/System.Security.Principal.xml",
-        "ref/dotnet/System.Security.Principal.dll",
-        "ref/dotnet/System.Security.Principal.xml",
         "ref/dotnet/zh-hans/System.Security.Principal.xml",
         "ref/dotnet/zh-hant/System.Security.Principal.xml",
         "ref/net45/_._",
@@ -2780,18 +2771,20 @@
         "ref/netcore50/System.Security.Principal.xml",
         "ref/win8/_._",
         "ref/wp80/_._",
-        "ref/wpa81/_._",
-        "System.Security.Principal.4.0.0-beta-23110.nupkg",
-        "System.Security.Principal.4.0.0-beta-23110.nupkg.sha512",
-        "System.Security.Principal.nuspec"
+        "ref/wpa81/_._"
       ]
     },
-    "System.Security.Principal.Windows/4.0.0-beta-23110": {
+    "System.Security.Principal.Windows/4.0.0-beta-23121": {
       "serviceable": true,
-      "sha512": "UqHjBRdcnFgGOz8B29MjlIwIRjH71unFZk+Q6drP8vt0cYVRN7OVLhDVwvhze1ZcK4nEYchgz3vndxKHSuI/Zw==",
+      "sha512": "fKZj+VTHgEtYykL7wd7sYKl+AlzvpzVOuLXxOiNeAHoM3jNcKUsY/UCvdjooeg7f3xLL9b3do5vP/oBRXahsXA==",
       "files": [
+        "System.Security.Principal.Windows.4.0.0-beta-23121.nupkg",
+        "System.Security.Principal.Windows.4.0.0-beta-23121.nupkg.sha512",
+        "System.Security.Principal.Windows.nuspec",
         "lib/DNXCore50/System.Security.Principal.Windows.dll",
         "lib/net46/System.Security.Principal.Windows.dll",
+        "ref/dotnet/System.Security.Principal.Windows.dll",
+        "ref/dotnet/System.Security.Principal.Windows.xml",
         "ref/dotnet/de/System.Security.Principal.Windows.xml",
         "ref/dotnet/es/System.Security.Principal.Windows.xml",
         "ref/dotnet/fr/System.Security.Principal.Windows.xml",
@@ -2799,26 +2792,26 @@
         "ref/dotnet/ja/System.Security.Principal.Windows.xml",
         "ref/dotnet/ko/System.Security.Principal.Windows.xml",
         "ref/dotnet/ru/System.Security.Principal.Windows.xml",
-        "ref/dotnet/System.Security.Principal.Windows.dll",
-        "ref/dotnet/System.Security.Principal.Windows.xml",
         "ref/dotnet/zh-hans/System.Security.Principal.Windows.xml",
         "ref/dotnet/zh-hant/System.Security.Principal.Windows.xml",
-        "ref/net46/System.Security.Principal.Windows.dll",
-        "System.Security.Principal.Windows.4.0.0-beta-23110.nupkg",
-        "System.Security.Principal.Windows.4.0.0-beta-23110.nupkg.sha512",
-        "System.Security.Principal.Windows.nuspec"
+        "ref/net46/System.Security.Principal.Windows.dll"
       ]
     },
-    "System.Security.SecureString/4.0.0-beta-23110": {
+    "System.Security.SecureString/4.0.0-beta-23121": {
       "serviceable": true,
-      "sha512": "KJEpYYl/tIXkrQcwL7pkG3us/CgOPIX2ZFaLSwgN8uBqQpGN8Kj8wxpEiANRBB0DHfqGxb/8nb74YKS0ETZ6Vg==",
+      "sha512": "UU4KPS7088XXe2n0Di1MjH/gsDplmnTTs6NaCK7SM+n2X/k0TK4xiPlkNmpU/JA2v7gioA+cdLOYtlWtkwf9SQ==",
       "files": [
+        "System.Security.SecureString.4.0.0-beta-23121.nupkg",
+        "System.Security.SecureString.4.0.0-beta-23121.nupkg.sha512",
+        "System.Security.SecureString.nuspec",
         "lib/DNXCore50/System.Security.SecureString.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Security.SecureString.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Security.SecureString.dll",
+        "ref/dotnet/System.Security.SecureString.xml",
         "ref/dotnet/de/System.Security.SecureString.xml",
         "ref/dotnet/es/System.Security.SecureString.xml",
         "ref/dotnet/fr/System.Security.SecureString.xml",
@@ -2826,24 +2819,22 @@
         "ref/dotnet/ja/System.Security.SecureString.xml",
         "ref/dotnet/ko/System.Security.SecureString.xml",
         "ref/dotnet/ru/System.Security.SecureString.xml",
-        "ref/dotnet/System.Security.SecureString.dll",
-        "ref/dotnet/System.Security.SecureString.xml",
         "ref/dotnet/zh-hans/System.Security.SecureString.xml",
         "ref/dotnet/zh-hant/System.Security.SecureString.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Security.SecureString.dll",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.Security.SecureString.4.0.0-beta-23110.nupkg",
-        "System.Security.SecureString.4.0.0-beta-23110.nupkg.sha512",
-        "System.Security.SecureString.nuspec"
+        "ref/xamarinmac20/_._"
       ]
     },
-    "System.ServiceModel.Http/4.0.10-beta-23110": {
+    "System.ServiceModel.Http/4.0.10-beta-23121": {
       "serviceable": true,
-      "sha512": "K/EWYuxVLqNmaMg2mqPR/YQRhziaXobjjuoGl6RDBPnmYsG58JmctJTZWE18LhXSydAk2Ai8HoqBLfbK3HbFMw==",
+      "sha512": "aiT3l/Q2n24t1IT1Qy2a4pimRrZzKGWJuYDNwTWNF7oAT3oE5iU/jpxVk0sK84c9UEohW1/F80f/QBbC3oE06Q==",
       "files": [
+        "System.ServiceModel.Http.4.0.10-beta-23121.nupkg",
+        "System.ServiceModel.Http.4.0.10-beta-23121.nupkg.sha512",
+        "System.ServiceModel.Http.nuspec",
         "lib/DNXCore50/System.ServiceModel.Http.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2851,6 +2842,8 @@
         "lib/netcore50/System.ServiceModel.Http.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/System.ServiceModel.Http.dll",
+        "ref/dotnet/System.ServiceModel.Http.xml",
         "ref/dotnet/de/System.ServiceModel.Http.xml",
         "ref/dotnet/es/System.ServiceModel.Http.xml",
         "ref/dotnet/fr/System.ServiceModel.Http.xml",
@@ -2858,28 +2851,28 @@
         "ref/dotnet/ja/System.ServiceModel.Http.xml",
         "ref/dotnet/ko/System.ServiceModel.Http.xml",
         "ref/dotnet/ru/System.ServiceModel.Http.xml",
-        "ref/dotnet/System.ServiceModel.Http.dll",
-        "ref/dotnet/System.ServiceModel.Http.xml",
         "ref/dotnet/zh-hans/System.ServiceModel.Http.xml",
         "ref/dotnet/zh-hant/System.ServiceModel.Http.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.ServiceModel.Http.4.0.10-beta-23110.nupkg",
-        "System.ServiceModel.Http.4.0.10-beta-23110.nupkg.sha512",
-        "System.ServiceModel.Http.nuspec"
+        "ref/xamarinmac20/_._"
       ]
     },
-    "System.ServiceModel.NetTcp/4.0.0-beta-23110": {
+    "System.ServiceModel.NetTcp/4.0.0-beta-23121": {
       "serviceable": true,
-      "sha512": "1MfgVmxFNGsktwrA1/mOB1RFJYqfcfuQ9WEKzMAmzZG78gzraaENIhE8wvGoEW5uQ5wraU6ml4M1pZzlW8NRYw==",
+      "sha512": "cJbDudVZ3B3PZZEtEC++/q2bHCwZ72/Jwpo4S4Rji2IKQooZpivJCyGPNaeYjt7udgso205yb2BggfSu+TLSzA==",
       "files": [
+        "System.ServiceModel.NetTcp.4.0.0-beta-23121.nupkg",
+        "System.ServiceModel.NetTcp.4.0.0-beta-23121.nupkg.sha512",
+        "System.ServiceModel.NetTcp.nuspec",
         "lib/DNXCore50/System.ServiceModel.NetTcp.dll",
         "lib/net45/_._",
         "lib/netcore50/System.ServiceModel.NetTcp.dll",
         "lib/win8/_._",
+        "ref/dotnet/System.ServiceModel.NetTcp.dll",
+        "ref/dotnet/System.ServiceModel.NetTcp.xml",
         "ref/dotnet/de/System.ServiceModel.NetTcp.xml",
         "ref/dotnet/es/System.ServiceModel.NetTcp.xml",
         "ref/dotnet/fr/System.ServiceModel.NetTcp.xml",
@@ -2887,27 +2880,27 @@
         "ref/dotnet/ja/System.ServiceModel.NetTcp.xml",
         "ref/dotnet/ko/System.ServiceModel.NetTcp.xml",
         "ref/dotnet/ru/System.ServiceModel.NetTcp.xml",
-        "ref/dotnet/System.ServiceModel.NetTcp.dll",
-        "ref/dotnet/System.ServiceModel.NetTcp.xml",
         "ref/dotnet/zh-hans/System.ServiceModel.NetTcp.xml",
         "ref/dotnet/zh-hant/System.ServiceModel.NetTcp.xml",
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.NetTcp.dll",
         "ref/netcore50/System.ServiceModel.NetTcp.xml",
-        "ref/win8/_._",
-        "System.ServiceModel.NetTcp.4.0.0-beta-23110.nupkg",
-        "System.ServiceModel.NetTcp.4.0.0-beta-23110.nupkg.sha512",
-        "System.ServiceModel.NetTcp.nuspec"
+        "ref/win8/_._"
       ]
     },
-    "System.ServiceModel.Primitives/4.0.0-beta-23110": {
+    "System.ServiceModel.Primitives/4.0.0-beta-23121": {
       "serviceable": true,
-      "sha512": "YmdkPuQDJsyCgw1w/3GW+8yCTrjF6FBvz0ifAmvBshubEPFRShxOq+lBLDdgbDO/S1OpA+SsG9v599fCNrMjxg==",
+      "sha512": "xijY8WaB2PD5iQz+B+ntvBc5+ZhHb3hbO2gnHRaZ5cHZx2Ja2d1vYoShO6Y1FeOIBqkAlzXmi0lWYyNkM6QluA==",
       "files": [
+        "System.ServiceModel.Primitives.4.0.0-beta-23121.nupkg",
+        "System.ServiceModel.Primitives.4.0.0-beta-23121.nupkg.sha512",
+        "System.ServiceModel.Primitives.nuspec",
         "lib/DNXCore50/System.ServiceModel.Primitives.dll",
         "lib/net45/_._",
         "lib/netcore50/System.ServiceModel.Primitives.dll",
         "lib/win8/_._",
+        "ref/dotnet/System.ServiceModel.Primitives.dll",
+        "ref/dotnet/System.ServiceModel.Primitives.xml",
         "ref/dotnet/de/System.ServiceModel.Primitives.xml",
         "ref/dotnet/es/System.ServiceModel.Primitives.xml",
         "ref/dotnet/fr/System.ServiceModel.Primitives.xml",
@@ -2915,27 +2908,27 @@
         "ref/dotnet/ja/System.ServiceModel.Primitives.xml",
         "ref/dotnet/ko/System.ServiceModel.Primitives.xml",
         "ref/dotnet/ru/System.ServiceModel.Primitives.xml",
-        "ref/dotnet/System.ServiceModel.Primitives.dll",
-        "ref/dotnet/System.ServiceModel.Primitives.xml",
         "ref/dotnet/zh-hans/System.ServiceModel.Primitives.xml",
         "ref/dotnet/zh-hant/System.ServiceModel.Primitives.xml",
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.Primitives.dll",
         "ref/netcore50/System.ServiceModel.Primitives.xml",
-        "ref/win8/_._",
-        "System.ServiceModel.Primitives.4.0.0-beta-23110.nupkg",
-        "System.ServiceModel.Primitives.4.0.0-beta-23110.nupkg.sha512",
-        "System.ServiceModel.Primitives.nuspec"
+        "ref/win8/_._"
       ]
     },
-    "System.ServiceModel.Security/4.0.0-beta-23109": {
+    "System.ServiceModel.Security/4.0.0-beta-23121": {
       "serviceable": true,
-      "sha512": "RaOW9Zu8rnw8vnrXAs5M6MsuP/h2CYuXK/Q5PkiaVcECc9xJEZngGzz3Oe0PhXhdFbyikf5h/Vt1mpQ1crS+gg==",
+      "sha512": "Ie8+pgkzU64L9Jc3Wj5qjbd5I4G9z05F0LRWJyPDuvF9zmNE5k8PZm23kJKUTXwhjhQOtpZt2tH8qQTyU/hrGA==",
       "files": [
+        "System.ServiceModel.Security.4.0.0-beta-23121.nupkg",
+        "System.ServiceModel.Security.4.0.0-beta-23121.nupkg.sha512",
+        "System.ServiceModel.Security.nuspec",
         "lib/DNXCore50/System.ServiceModel.Security.dll",
         "lib/net45/_._",
         "lib/netcore50/System.ServiceModel.Security.dll",
         "lib/win8/_._",
+        "ref/dotnet/System.ServiceModel.Security.dll",
+        "ref/dotnet/System.ServiceModel.Security.xml",
         "ref/dotnet/de/System.ServiceModel.Security.xml",
         "ref/dotnet/es/System.ServiceModel.Security.xml",
         "ref/dotnet/fr/System.ServiceModel.Security.xml",
@@ -2943,22 +2936,20 @@
         "ref/dotnet/ja/System.ServiceModel.Security.xml",
         "ref/dotnet/ko/System.ServiceModel.Security.xml",
         "ref/dotnet/ru/System.ServiceModel.Security.xml",
-        "ref/dotnet/System.ServiceModel.Security.dll",
-        "ref/dotnet/System.ServiceModel.Security.xml",
         "ref/dotnet/zh-hans/System.ServiceModel.Security.xml",
         "ref/dotnet/zh-hant/System.ServiceModel.Security.xml",
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.Security.dll",
         "ref/netcore50/System.ServiceModel.Security.xml",
-        "ref/win8/_._",
-        "System.ServiceModel.Security.4.0.0-beta-23109.nupkg",
-        "System.ServiceModel.Security.4.0.0-beta-23109.nupkg.sha512",
-        "System.ServiceModel.Security.nuspec"
+        "ref/win8/_._"
       ]
     },
-    "System.Text.Encoding/4.0.10-beta-23110": {
-      "sha512": "FlGJ4JtP8G8HSNbYHECdXxEKvCIlbwC7KeYft10HtUAuAwMceKLnYg4gTg7ukaipmgkgB35UfPdW7MJ6BODsiw==",
+    "System.Text.Encoding/4.0.10-beta-23121": {
+      "sha512": "MHGrPGQrkgilRupDn8/VRDxLryTRHwDq+PaTefBTu5VOtCC6f1+Ld0t+tdSlJDnjWvWbWTxuLoIVtiq0fNzbiQ==",
       "files": [
+        "System.Text.Encoding.4.0.10-beta-23121.nupkg",
+        "System.Text.Encoding.4.0.10-beta-23121.nupkg.sha512",
+        "System.Text.Encoding.nuspec",
         "lib/DNXCore50/System.Text.Encoding.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2966,6 +2957,8 @@
         "lib/netcore50/System.Text.Encoding.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Text.Encoding.dll",
+        "ref/dotnet/System.Text.Encoding.xml",
         "ref/dotnet/de/System.Text.Encoding.xml",
         "ref/dotnet/es/System.Text.Encoding.xml",
         "ref/dotnet/fr/System.Text.Encoding.xml",
@@ -2973,8 +2966,6 @@
         "ref/dotnet/ja/System.Text.Encoding.xml",
         "ref/dotnet/ko/System.Text.Encoding.xml",
         "ref/dotnet/ru/System.Text.Encoding.xml",
-        "ref/dotnet/System.Text.Encoding.dll",
-        "ref/dotnet/System.Text.Encoding.xml",
         "ref/dotnet/zh-hans/System.Text.Encoding.xml",
         "ref/dotnet/zh-hant/System.Text.Encoding.xml",
         "ref/MonoAndroid10/_._",
@@ -2982,15 +2973,15 @@
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Text.Encoding.dll",
-        "System.Text.Encoding.4.0.10-beta-23110.nupkg",
-        "System.Text.Encoding.4.0.10-beta-23110.nupkg.sha512",
-        "System.Text.Encoding.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Text.Encoding.dll"
       ]
     },
-    "System.Text.Encoding.Extensions/4.0.10-beta-23110": {
-      "sha512": "W1kKe/AR3pgaZkWlQUk9cmtjm6KfjthuTGgPyscKQkSQeqPSVqbup1j0Ahfi86L+pYGUtOBYvuvGIuf0enRxxg==",
+    "System.Text.Encoding.Extensions/4.0.10-beta-23121": {
+      "sha512": "9BrSiuf/NvEdhayNAYhf+5pT4V51vZ/sx9nM8fC1ULUyePlvJR+MHla5yQ+g6HmhLV4JbczJaVGj3Tes4ufp5w==",
       "files": [
+        "System.Text.Encoding.Extensions.4.0.10-beta-23121.nupkg",
+        "System.Text.Encoding.Extensions.4.0.10-beta-23121.nupkg.sha512",
+        "System.Text.Encoding.Extensions.nuspec",
         "lib/DNXCore50/System.Text.Encoding.Extensions.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2998,6 +2989,8 @@
         "lib/netcore50/System.Text.Encoding.Extensions.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Text.Encoding.Extensions.dll",
+        "ref/dotnet/System.Text.Encoding.Extensions.xml",
         "ref/dotnet/de/System.Text.Encoding.Extensions.xml",
         "ref/dotnet/es/System.Text.Encoding.Extensions.xml",
         "ref/dotnet/fr/System.Text.Encoding.Extensions.xml",
@@ -3005,8 +2998,6 @@
         "ref/dotnet/ja/System.Text.Encoding.Extensions.xml",
         "ref/dotnet/ko/System.Text.Encoding.Extensions.xml",
         "ref/dotnet/ru/System.Text.Encoding.Extensions.xml",
-        "ref/dotnet/System.Text.Encoding.Extensions.dll",
-        "ref/dotnet/System.Text.Encoding.Extensions.xml",
         "ref/dotnet/zh-hans/System.Text.Encoding.Extensions.xml",
         "ref/dotnet/zh-hant/System.Text.Encoding.Extensions.xml",
         "ref/MonoAndroid10/_._",
@@ -3014,22 +3005,24 @@
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Text.Encoding.Extensions.dll",
-        "System.Text.Encoding.Extensions.4.0.10-beta-23110.nupkg",
-        "System.Text.Encoding.Extensions.4.0.10-beta-23110.nupkg.sha512",
-        "System.Text.Encoding.Extensions.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Text.Encoding.Extensions.dll"
       ]
     },
-    "System.Text.RegularExpressions/4.0.10-beta-23110": {
+    "System.Text.RegularExpressions/4.0.10-beta-23121": {
       "serviceable": true,
-      "sha512": "VQwjucM32LrqdcZ7PX5PpZFHcNXlCsroyJ37m5DK1/36/q7QER4F2RpmnXiCfVKs7E0PSuyydbIHl9MxdsO/uw==",
+      "sha512": "rK0jgnO7n2FfHP3mVPfv4U8+gmJPs0a9vbt/RbNSinDN2tHJwgQF8qb/foHWHXAB45H7XViGxfico5lAue+7Yg==",
       "files": [
+        "System.Text.RegularExpressions.4.0.10-beta-23121.nupkg",
+        "System.Text.RegularExpressions.4.0.10-beta-23121.nupkg.sha512",
+        "System.Text.RegularExpressions.nuspec",
         "lib/dotnet/System.Text.RegularExpressions.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Text.RegularExpressions.dll",
+        "ref/dotnet/System.Text.RegularExpressions.xml",
         "ref/dotnet/de/System.Text.RegularExpressions.xml",
         "ref/dotnet/es/System.Text.RegularExpressions.xml",
         "ref/dotnet/fr/System.Text.RegularExpressions.xml",
@@ -3037,24 +3030,22 @@
         "ref/dotnet/ja/System.Text.RegularExpressions.xml",
         "ref/dotnet/ko/System.Text.RegularExpressions.xml",
         "ref/dotnet/ru/System.Text.RegularExpressions.xml",
-        "ref/dotnet/System.Text.RegularExpressions.dll",
-        "ref/dotnet/System.Text.RegularExpressions.xml",
         "ref/dotnet/zh-hans/System.Text.RegularExpressions.xml",
         "ref/dotnet/zh-hant/System.Text.RegularExpressions.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.Text.RegularExpressions.4.0.10-beta-23110.nupkg",
-        "System.Text.RegularExpressions.4.0.10-beta-23110.nupkg.sha512",
-        "System.Text.RegularExpressions.nuspec"
+        "ref/xamarinmac20/_._"
       ]
     },
-    "System.Threading/4.0.10-beta-23110": {
+    "System.Threading/4.0.10-beta-23121": {
       "serviceable": true,
-      "sha512": "vdSth7tUIQk1MXqSSgGLN40M77AcdqkHkLU9RwhnOjMyravqL9P+NlOJotoaw/JKWVJiVCIQ9bND3EFhVHdrsA==",
+      "sha512": "Xxi0SqD/88zE5zX1zG5uL/1TbBnhT8y3g+s2llsKKMtpMeMVjvTCQJxFAkmGlCGZB/R0mA22GwSFQhHHJQjjcw==",
       "files": [
+        "System.Threading.4.0.10-beta-23121.nupkg",
+        "System.Threading.4.0.10-beta-23121.nupkg.sha512",
+        "System.Threading.nuspec",
         "lib/DNXCore50/System.Threading.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -3062,6 +3053,8 @@
         "lib/netcore50/System.Threading.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Threading.dll",
+        "ref/dotnet/System.Threading.xml",
         "ref/dotnet/de/System.Threading.xml",
         "ref/dotnet/es/System.Threading.xml",
         "ref/dotnet/fr/System.Threading.xml",
@@ -3069,8 +3062,6 @@
         "ref/dotnet/ja/System.Threading.xml",
         "ref/dotnet/ko/System.Threading.xml",
         "ref/dotnet/ru/System.Threading.xml",
-        "ref/dotnet/System.Threading.dll",
-        "ref/dotnet/System.Threading.xml",
         "ref/dotnet/zh-hans/System.Threading.xml",
         "ref/dotnet/zh-hant/System.Threading.xml",
         "ref/MonoAndroid10/_._",
@@ -3078,19 +3069,21 @@
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Threading.dll",
-        "System.Threading.4.0.10-beta-23110.nupkg",
-        "System.Threading.4.0.10-beta-23110.nupkg.sha512",
-        "System.Threading.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Threading.dll"
       ]
     },
-    "System.Threading.Overlapped/4.0.0-beta-23110": {
+    "System.Threading.Overlapped/4.0.0-beta-23121": {
       "serviceable": true,
-      "sha512": "WcDzyotEp85Ul6B7T6NHXZmThDn+PVX0IrMLOwzH/PehbStyViKbOORyewpq+RaK4/MSYMXpXV6rvHT10j2Fhw==",
+      "sha512": "/FmCaisSajMFdd2+9HDclfu6vupXIlo0Xc7rn0sjvypcYWD+GcLKcqvM9PHbS9pNgL1wHUqrfEVnv9eeYMth8g==",
       "files": [
+        "System.Threading.Overlapped.4.0.0-beta-23121.nupkg",
+        "System.Threading.Overlapped.4.0.0-beta-23121.nupkg.sha512",
+        "System.Threading.Overlapped.nuspec",
         "lib/DNXCore50/System.Threading.Overlapped.dll",
         "lib/net46/System.Threading.Overlapped.dll",
         "lib/netcore50/System.Threading.Overlapped.dll",
+        "ref/dotnet/System.Threading.Overlapped.dll",
+        "ref/dotnet/System.Threading.Overlapped.xml",
         "ref/dotnet/de/System.Threading.Overlapped.xml",
         "ref/dotnet/es/System.Threading.Overlapped.xml",
         "ref/dotnet/fr/System.Threading.Overlapped.xml",
@@ -3098,20 +3091,18 @@
         "ref/dotnet/ja/System.Threading.Overlapped.xml",
         "ref/dotnet/ko/System.Threading.Overlapped.xml",
         "ref/dotnet/ru/System.Threading.Overlapped.xml",
-        "ref/dotnet/System.Threading.Overlapped.dll",
-        "ref/dotnet/System.Threading.Overlapped.xml",
         "ref/dotnet/zh-hans/System.Threading.Overlapped.xml",
         "ref/dotnet/zh-hant/System.Threading.Overlapped.xml",
-        "ref/net46/System.Threading.Overlapped.dll",
-        "System.Threading.Overlapped.4.0.0-beta-23110.nupkg",
-        "System.Threading.Overlapped.4.0.0-beta-23110.nupkg.sha512",
-        "System.Threading.Overlapped.nuspec"
+        "ref/net46/System.Threading.Overlapped.dll"
       ]
     },
-    "System.Threading.Tasks/4.0.10-beta-23110": {
+    "System.Threading.Tasks/4.0.10-beta-23121": {
       "serviceable": true,
-      "sha512": "/mtUOcDyxKBzs+xhpNM7sMg0pncDPEyM1s6TG0EEX8HKRT8tZnW8KYcv1e03lEf5SXwVmCG52QUimYf0HC7jvA==",
+      "sha512": "97UfpiN4WOuvbUN3fqk3zsaGLVuLFjsYcMHL/N3wB3mM3/l0qmDlC0dlI07yY0T5wfpJsLNFyGEcGgCgd54dpw==",
       "files": [
+        "System.Threading.Tasks.4.0.10-beta-23121.nupkg",
+        "System.Threading.Tasks.4.0.10-beta-23121.nupkg.sha512",
+        "System.Threading.Tasks.nuspec",
         "lib/DNXCore50/System.Threading.Tasks.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -3119,6 +3110,8 @@
         "lib/netcore50/System.Threading.Tasks.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Threading.Tasks.dll",
+        "ref/dotnet/System.Threading.Tasks.xml",
         "ref/dotnet/de/System.Threading.Tasks.xml",
         "ref/dotnet/es/System.Threading.Tasks.xml",
         "ref/dotnet/fr/System.Threading.Tasks.xml",
@@ -3126,8 +3119,6 @@
         "ref/dotnet/ja/System.Threading.Tasks.xml",
         "ref/dotnet/ko/System.Threading.Tasks.xml",
         "ref/dotnet/ru/System.Threading.Tasks.xml",
-        "ref/dotnet/System.Threading.Tasks.dll",
-        "ref/dotnet/System.Threading.Tasks.xml",
         "ref/dotnet/zh-hans/System.Threading.Tasks.xml",
         "ref/dotnet/zh-hant/System.Threading.Tasks.xml",
         "ref/MonoAndroid10/_._",
@@ -3135,21 +3126,23 @@
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Threading.Tasks.dll",
-        "System.Threading.Tasks.4.0.10-beta-23110.nupkg",
-        "System.Threading.Tasks.4.0.10-beta-23110.nupkg.sha512",
-        "System.Threading.Tasks.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Threading.Tasks.dll"
       ]
     },
-    "System.Threading.ThreadPool/4.0.10-beta-23110": {
-      "sha512": "qmCisRtQrJEoEk9wpQ9KfQ0ypM+3Fpol9Y7Br3JEeyzQ5BTpd/b7Z8R5By+1brGANqajd7q9a1AQpjv9K1PEkg==",
+    "System.Threading.ThreadPool/4.0.10-beta-23121": {
+      "sha512": "8ijvogwG1fR81JyrVkqvkTKC7X8Y4BIRVtfaqAfkA7PENJDTjPmxAdenUmGPbBw47oxSC8/V8wpdgIaRvHUgbQ==",
       "files": [
+        "System.Threading.ThreadPool.4.0.10-beta-23121.nupkg",
+        "System.Threading.ThreadPool.4.0.10-beta-23121.nupkg.sha512",
+        "System.Threading.ThreadPool.nuspec",
         "lib/DNXCore50/System.Threading.ThreadPool.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Threading.ThreadPool.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Threading.ThreadPool.dll",
+        "ref/dotnet/System.Threading.ThreadPool.xml",
         "ref/dotnet/de/System.Threading.ThreadPool.xml",
         "ref/dotnet/es/System.Threading.ThreadPool.xml",
         "ref/dotnet/fr/System.Threading.ThreadPool.xml",
@@ -3157,28 +3150,28 @@
         "ref/dotnet/ja/System.Threading.ThreadPool.xml",
         "ref/dotnet/ko/System.Threading.ThreadPool.xml",
         "ref/dotnet/ru/System.Threading.ThreadPool.xml",
-        "ref/dotnet/System.Threading.ThreadPool.dll",
-        "ref/dotnet/System.Threading.ThreadPool.xml",
         "ref/dotnet/zh-hans/System.Threading.ThreadPool.xml",
         "ref/dotnet/zh-hant/System.Threading.ThreadPool.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Threading.ThreadPool.dll",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.Threading.ThreadPool.4.0.10-beta-23110.nupkg",
-        "System.Threading.ThreadPool.4.0.10-beta-23110.nupkg.sha512",
-        "System.Threading.ThreadPool.nuspec"
+        "ref/xamarinmac20/_._"
       ]
     },
-    "System.Threading.Timer/4.0.0-beta-23110": {
-      "sha512": "4ro+Bei549CPcdWBmBxYdSzIbhIDoCVBwgRnejxhzCXrMJBdNctHTjY7VSb8AptZexRzZHcR1lHDz56US1kDwQ==",
+    "System.Threading.Timer/4.0.0-beta-23121": {
+      "sha512": "SjCELx6OBlpDaVBWoaiLvbCou3dipaeTGW75iaO7Y0HguoplW5ZV1gDxY2WhKClSq6glblnlazoVvuXDl1RUvQ==",
       "files": [
+        "System.Threading.Timer.4.0.0-beta-23121.nupkg",
+        "System.Threading.Timer.4.0.0-beta-23121.nupkg.sha512",
+        "System.Threading.Timer.nuspec",
         "lib/DNXCore50/System.Threading.Timer.dll",
         "lib/net451/_._",
         "lib/netcore50/System.Threading.Timer.dll",
         "lib/win81/_._",
         "lib/wpa81/_._",
+        "ref/dotnet/System.Threading.Timer.dll",
+        "ref/dotnet/System.Threading.Timer.xml",
         "ref/dotnet/de/System.Threading.Timer.xml",
         "ref/dotnet/es/System.Threading.Timer.xml",
         "ref/dotnet/fr/System.Threading.Timer.xml",
@@ -3186,8 +3179,6 @@
         "ref/dotnet/ja/System.Threading.Timer.xml",
         "ref/dotnet/ko/System.Threading.Timer.xml",
         "ref/dotnet/ru/System.Threading.Timer.xml",
-        "ref/dotnet/System.Threading.Timer.dll",
-        "ref/dotnet/System.Threading.Timer.xml",
         "ref/dotnet/zh-hans/System.Threading.Timer.xml",
         "ref/dotnet/zh-hant/System.Threading.Timer.xml",
         "ref/net451/_._",
@@ -3195,22 +3186,24 @@
         "ref/netcore50/System.Threading.Timer.xml",
         "ref/win81/_._",
         "ref/wpa81/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Threading.Timer.dll",
-        "System.Threading.Timer.4.0.0-beta-23110.nupkg",
-        "System.Threading.Timer.4.0.0-beta-23110.nupkg.sha512",
-        "System.Threading.Timer.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Threading.Timer.dll"
       ]
     },
-    "System.Xml.ReaderWriter/4.0.10-beta-23110": {
+    "System.Xml.ReaderWriter/4.0.10-beta-23121": {
       "serviceable": true,
-      "sha512": "0+VkAfGzuCgyV0KQpacApXjPdZTS/lmMyTI/9gT8Z59traQQRG8Wjg4Rc13NZak1UVHd67Kn5K+2bZ8qBrsNfw==",
+      "sha512": "cGz+TwaUxCbKEnzfnIBh7wbdoNkKoYqiT+9crFseqxAtC5DrxFCrBUXaxZVLv+V205SxkBDfMdkaLnJ8MVv3qA==",
       "files": [
+        "System.Xml.ReaderWriter.4.0.10-beta-23121.nupkg",
+        "System.Xml.ReaderWriter.4.0.10-beta-23121.nupkg.sha512",
+        "System.Xml.ReaderWriter.nuspec",
         "lib/dotnet/System.Xml.ReaderWriter.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Xml.ReaderWriter.dll",
+        "ref/dotnet/System.Xml.ReaderWriter.xml",
         "ref/dotnet/de/System.Xml.ReaderWriter.xml",
         "ref/dotnet/es/System.Xml.ReaderWriter.xml",
         "ref/dotnet/fr/System.Xml.ReaderWriter.xml",
@@ -3218,30 +3211,30 @@
         "ref/dotnet/ja/System.Xml.ReaderWriter.xml",
         "ref/dotnet/ko/System.Xml.ReaderWriter.xml",
         "ref/dotnet/ru/System.Xml.ReaderWriter.xml",
-        "ref/dotnet/System.Xml.ReaderWriter.dll",
-        "ref/dotnet/System.Xml.ReaderWriter.xml",
         "ref/dotnet/zh-hans/System.Xml.ReaderWriter.xml",
         "ref/dotnet/zh-hant/System.Xml.ReaderWriter.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.Xml.ReaderWriter.4.0.10-beta-23110.nupkg",
-        "System.Xml.ReaderWriter.4.0.10-beta-23110.nupkg.sha512",
-        "System.Xml.ReaderWriter.nuspec"
+        "ref/xamarinmac20/_._"
       ]
     },
-    "System.Xml.XmlDocument/4.0.0-beta-23110": {
+    "System.Xml.XmlDocument/4.0.0-beta-23121": {
       "serviceable": true,
-      "sha512": "YJC5mvucSOZgyOclW9fpTKvy/GmBmhDzZpvtqi0jDsXfNh0Do1wuWIGN30BujgVKzm2gfyWOCSZ9dr94RTPBLw==",
+      "sha512": "OsHaY74BDIwZmwkIphpZnGslR2JowCXiFNM4Qywgfj6ioWdGBFPf+2i9+0T6tT5nYL6u9YD0X1gLw/Wp6A7m+w==",
       "files": [
+        "System.Xml.XmlDocument.4.0.0-beta-23121.nupkg",
+        "System.Xml.XmlDocument.4.0.0-beta-23121.nupkg.sha512",
+        "System.Xml.XmlDocument.nuspec",
         "lib/dotnet/System.Xml.XmlDocument.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Xml.XmlDocument.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Xml.XmlDocument.dll",
+        "ref/dotnet/System.Xml.XmlDocument.xml",
         "ref/dotnet/de/System.Xml.XmlDocument.xml",
         "ref/dotnet/es/System.Xml.XmlDocument.xml",
         "ref/dotnet/fr/System.Xml.XmlDocument.xml",
@@ -3249,24 +3242,23 @@
         "ref/dotnet/ja/System.Xml.XmlDocument.xml",
         "ref/dotnet/ko/System.Xml.XmlDocument.xml",
         "ref/dotnet/ru/System.Xml.XmlDocument.xml",
-        "ref/dotnet/System.Xml.XmlDocument.dll",
-        "ref/dotnet/System.Xml.XmlDocument.xml",
         "ref/dotnet/zh-hans/System.Xml.XmlDocument.xml",
         "ref/dotnet/zh-hant/System.Xml.XmlDocument.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Xml.XmlDocument.dll",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.Xml.XmlDocument.4.0.0-beta-23110.nupkg",
-        "System.Xml.XmlDocument.4.0.0-beta-23110.nupkg.sha512",
-        "System.Xml.XmlDocument.nuspec"
+        "ref/xamarinmac20/_._"
       ]
     },
-    "System.Xml.XmlSerializer/4.0.10-beta-23110": {
+    "System.Xml.XmlSerializer/4.0.10-beta-23121": {
       "serviceable": true,
-      "sha512": "dTzOKBw3xkbmJUbeL1xHcIvgh/o3ON48MgDSyNA2ntrDPzylCmAUL4e/lybEhVjXbi8DpYt4LpRuaUMh65PEyg==",
+      "sha512": "TDSMkU3CijLTPQL6W9f/UxCTqREkcY0SZHi6+dlOeHI5I190mEyN4hFY+CsmcH4Tq+JVQuSQyGLsNFaGL0cNGQ==",
       "files": [
+        "runtime.json",
+        "System.Xml.XmlSerializer.4.0.10-beta-23121.nupkg",
+        "System.Xml.XmlSerializer.4.0.10-beta-23121.nupkg.sha512",
+        "System.Xml.XmlSerializer.nuspec",
         "lib/DNXCore50/System.Xml.XmlSerializer.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -3274,6 +3266,8 @@
         "lib/netcore50/System.Xml.XmlSerializer.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Xml.XmlSerializer.dll",
+        "ref/dotnet/System.Xml.XmlSerializer.xml",
         "ref/dotnet/de/System.Xml.XmlSerializer.xml",
         "ref/dotnet/es/System.Xml.XmlSerializer.xml",
         "ref/dotnet/fr/System.Xml.XmlSerializer.xml",
@@ -3281,8 +3275,6 @@
         "ref/dotnet/ja/System.Xml.XmlSerializer.xml",
         "ref/dotnet/ko/System.Xml.XmlSerializer.xml",
         "ref/dotnet/ru/System.Xml.XmlSerializer.xml",
-        "ref/dotnet/System.Xml.XmlSerializer.dll",
-        "ref/dotnet/System.Xml.XmlSerializer.xml",
         "ref/dotnet/zh-hans/System.Xml.XmlSerializer.xml",
         "ref/dotnet/zh-hant/System.Xml.XmlSerializer.xml",
         "ref/MonoAndroid10/_._",
@@ -3290,11 +3282,7 @@
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtime.json",
-        "runtimes/win8-aot/lib/netcore50/System.Xml.XmlSerializer.dll",
-        "System.Xml.XmlSerializer.4.0.10-beta-23110.nupkg",
-        "System.Xml.XmlSerializer.4.0.10-beta-23110.nupkg.sha512",
-        "System.Xml.XmlSerializer.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Xml.XmlSerializer.dll"
       ]
     }
   },


### PR DESCRIPTION
The prior versions of the .json files in
the stress folder were considered invalid
and caused a 'dnu restore' which updated
multiple project.lock.json files during the
build.

This change changes the project.json file to
resemble the other project.json's and also
adds the project.lock.json file produced by
the dnu restore.

This prevents dnu restore from running during
the build due to what it considered an invalid
lock file.