### PR TITLE
Make Bridge idle timeout configurable

### DIFF
--- a/src/System.Private.ServiceModel/tests/Common/Infrastructure/src/BridgeClient.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Infrastructure/src/BridgeClient.cs
@@ -13,6 +13,7 @@ namespace Infrastructure.Common
 {
     public static class BridgeClient 
     {
+        private static object s_thisLock = new object();
         private static Dictionary<string, string> _Resources = new Dictionary<string, string>();
         private static BridgeState _BridgeStatus = BridgeState.NotStarted;
         private static readonly Regex regexResource = new Regex(@"details\s*:\s*""([^""]+)""", RegexOptions.IgnoreCase);
@@ -22,20 +23,26 @@ namespace Infrastructure.Common
             get { return TestProperties.GetProperty(TestProperties.BridgeUrl_PropertyName); }
         }
 
-        static BridgeClient()
+        private static void EnsureBridgeIsRunning()
         {
-            if (_BridgeStatus == BridgeState.NotStarted)
+            // Tests run concurrently, so we need the initial configuration
+            // request to finish and set state before the rest continue.
+            lock (s_thisLock)
             {
-                MakeConfigRequest();
-            }
-            else if (_BridgeStatus == BridgeState.Faulted)
-            {
-                throw new Exception("Bridge is not running");
+                if (_BridgeStatus == BridgeState.NotStarted)
+                {
+                    MakeConfigRequest();
+                }
+                else if (_BridgeStatus == BridgeState.Faulted)
+                {
+                    throw new Exception("Bridge is not running");
+                }
             }
         }
-
         public static string GetResourceAddress(string resourceName)
         {
+            EnsureBridgeIsRunning();
+
             string resourceAddress = null;
             if (_BridgeStatus == BridgeState.Started && !_Resources.TryGetValue(resourceName, out resourceAddress))
             {
@@ -59,7 +66,18 @@ namespace Infrastructure.Common
                 {
                     var response = httpClient.PostAsync("/config/", content).Result;
                     if (!response.IsSuccessStatusCode)
-                        throw new Exception("Unexpected status code: " + response.StatusCode);
+                    {
+                        string reason = String.Empty;
+                        if (response.Content != null)
+                        {
+                            string contentAsString = response.Content.ReadAsStringAsync().Result;
+                            reason = String.Format("{0}Bridge returned content:{0}{1}",
+                                                    Environment.NewLine, contentAsString);
+                        }
+                        throw new Exception(
+                            String.Format("Bridge returned unexpected status code {0}{1}", 
+                                            response.StatusCode, reason));
+                    }
                     _BridgeStatus = BridgeState.Started;
                 }
                 catch (Exception exc)
@@ -72,6 +90,8 @@ namespace Infrastructure.Common
 
         private static string CreateConfigRequestContentAsJson()
         {
+            ValidateConfigRequestProperties();
+
             // Create a Json dictionary of name/value pairs from TestProperties
             StringBuilder sb = new StringBuilder("{ ");
             string[] propertyNames = TestProperties.PropertyNames.ToArray();
@@ -88,8 +108,21 @@ namespace Infrastructure.Common
             return sb.ToString();
         }
 
+        // Validates some of the name/value pairs that will be sent to the Bridge
+        // via the /config POST request.
+        private static void ValidateConfigRequestProperties()
+        {
+            string bridgeResourceFolder = TestProperties.GetProperty(TestProperties.BridgeResourceFolder_PropertyName);
+            if (String.IsNullOrEmpty(bridgeResourceFolder) || !Directory.Exists(bridgeResourceFolder))
+            {
+                throw new Exception(String.Format("BridgeResourceFolder '{0}' does not exist", bridgeResourceFolder));
+            }
+        }
+
         private static string MakeResourcePutRequest(string resourceName)
         {
+            EnsureBridgeIsRunning();
+
             using (HttpClient httpClient = new HttpClient())
             {
                 httpClient.BaseAddress = new Uri(BridgeBaseAddress);
@@ -119,6 +152,8 @@ namespace Infrastructure.Common
 
         private static string MakeResourceGetRequest(string resourceName)
         {
+            EnsureBridgeIsRunning();
+
             using (HttpClient httpClient = new HttpClient())
             {
                 httpClient.BaseAddress = new Uri(BridgeBaseAddress);

--- a/src/System.Private.ServiceModel/tests/Common/Infrastructure/src/BridgeClient.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Infrastructure/src/BridgeClient.cs
@@ -64,19 +64,18 @@ namespace Infrastructure.Common
                     "application/json");
                 try
                 {
-                    var response = httpClient.PostAsync("/config/", content).Result;
+                    var response = httpClient.PostAsync("/config/", content).GetAwaiter().GetResult();
                     if (!response.IsSuccessStatusCode)
                     {
-                        string reason = String.Empty;
+                        string reason = String.Format("{0}Bridge returned unexpected status code='{1}', reason='{2}'",
+                                                    Environment.NewLine, response.StatusCode, response.ReasonPhrase);
                         if (response.Content != null)
                         {
-                            string contentAsString = response.Content.ReadAsStringAsync().Result;
-                            reason = String.Format("{0}Bridge returned content:{0}{1}",
-                                                    Environment.NewLine, contentAsString);
+                            string contentAsString = response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
+                            reason = String.Format("{0}, content:{1}{2}",
+                                                    reason, Environment.NewLine, contentAsString);
                         }
-                        throw new Exception(
-                            String.Format("Bridge returned unexpected status code {0}{1}", 
-                                            response.StatusCode, reason));
+                        throw new Exception(reason);
                     }
                     _BridgeStatus = BridgeState.Started;
                 }
@@ -132,11 +131,11 @@ namespace Infrastructure.Common
                         "application/json");
                 try
                 {
-                    var response = httpClient.PutAsync("/resource/", content).Result;
+                    var response = httpClient.PutAsync("/resource/", content).GetAwaiter().GetResult();
                     if (!response.IsSuccessStatusCode)
                         throw new Exception("Unexpected status code: " + response.StatusCode);
 
-                    var responseContent = response.Content.ReadAsStringAsync().Result;
+                    var responseContent = response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
                     var match = regexResource.Match(responseContent);
                     if (!match.Success || match.Groups.Count != 2)
                         throw new Exception("Invalid response from bridge: " + responseContent);
@@ -157,11 +156,11 @@ namespace Infrastructure.Common
             using (HttpClient httpClient = new HttpClient())
             {
                 httpClient.BaseAddress = new Uri(BridgeBaseAddress);
-                var response = httpClient.GetAsync("/resource/" + resourceName).Result;
+                var response = httpClient.GetAsync("/resource/" + resourceName).GetAwaiter().GetResult();
                 if (!response.IsSuccessStatusCode)
                     throw new Exception("Unexpected status code: " + response.StatusCode);
 
-                return response.Content.ReadAsStringAsync().Result;
+                return response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
             }
         }
 

--- a/src/System.Private.ServiceModel/tests/Common/Infrastructure/src/testproperties.props
+++ b/src/System.Private.ServiceModel/tests/Common/Infrastructure/src/testproperties.props
@@ -23,6 +23,10 @@
         <Value>$(UseFiddlerUrl)</Value>
         <DefaultValue>false</DefaultValue>
       </TestProperty>
+      <TestProperty Include="BridgeMaxIdleTimeSpan">
+        <Value>$(BridgeMaxIdleTimeSpan)</Value>
+        <DefaultValue>20:00</DefaultValue>
+      </TestProperty>
     </ItemGroup>
 
   <!--

--- a/src/System.Private.ServiceModel/tools/test/Bridge/Bridge/AppDomainManager.cs
+++ b/src/System.Private.ServiceModel/tools/test/Bridge/Bridge/AppDomainManager.cs
@@ -12,17 +12,11 @@ namespace Bridge
 {
     public static class AppDomainManager
     {
-        public static string UpdateApp(BridgeConfiguration oldConfig, BridgeConfiguration newConfig)
+        public static string OnResourceFolderChanged(string oldFolder, string newFolder)
         {
-            if (!String.Equals(oldConfig.BridgeResourceFolder, newConfig.BridgeResourceFolder, StringComparison.OrdinalIgnoreCase))
-            {
-                var newPath = Path.GetFullPath(newConfig.BridgeResourceFolder);
-                Trace.WriteLine("Adding assemblies in the directory");
-                string friendlyName = CreateAppDomain(newPath);
-                return friendlyName;
-            }
-
-            return "BridgeAppDomain" + (TypeCache.AppDomains.Count - 1);
+            var newPath = Path.GetFullPath(newFolder);
+            Trace.WriteLine(String.Format("Adding assemblies from the resource folder {0}", newPath), typeof(AppDomainManager).Name);
+            return CreateAppDomain(newPath);
         }
 
         [MethodImpl(MethodImplOptions.Synchronized)]

--- a/src/System.Private.ServiceModel/tools/test/Bridge/Bridge/AppDomainManager.cs
+++ b/src/System.Private.ServiceModel/tools/test/Bridge/Bridge/AppDomainManager.cs
@@ -10,16 +10,15 @@ using WcfTestBridgeCommon;
 
 namespace Bridge
 {
-    public static class ConfigurationExtensions
+    public static class AppDomainManager
     {
-        public static string UpdateApp(this BridgeConfiguration config)
+        public static string UpdateApp(BridgeConfiguration oldConfig, BridgeConfiguration newConfig)
         {
-            if (!String.Equals(ConfigController.BridgeConfiguration.BridgeResourceFolder, config.BridgeResourceFolder, StringComparison.OrdinalIgnoreCase))
+            if (!String.Equals(oldConfig.BridgeResourceFolder, newConfig.BridgeResourceFolder, StringComparison.OrdinalIgnoreCase))
             {
-                var newPath = Path.GetFullPath(config.BridgeResourceFolder);
+                var newPath = Path.GetFullPath(newConfig.BridgeResourceFolder);
                 Trace.WriteLine("Adding assemblies in the directory");
                 string friendlyName = CreateAppDomain(newPath);
-                ConfigController.BridgeConfiguration = config;
                 return friendlyName;
             }
 

--- a/src/System.Private.ServiceModel/tools/test/Bridge/Bridge/Bridge.csproj
+++ b/src/System.Private.ServiceModel/tools/test/Bridge/Bridge/Bridge.csproj
@@ -91,6 +91,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AppDomainManager.cs" />
+    <Compile Include="ChangedEventArgs.cs" />
     <Compile Include="ConfigController.cs" />
     <Compile Include="IdleTimeoutManager.cs" />
     <Compile Include="JsonSerializer.cs" />

--- a/src/System.Private.ServiceModel/tools/test/Bridge/Bridge/Bridge.csproj
+++ b/src/System.Private.ServiceModel/tools/test/Bridge/Bridge/Bridge.csproj
@@ -90,8 +90,8 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AppDomainManager.cs" />
     <Compile Include="ConfigController.cs" />
-    <Compile Include="ConfigurationExtensions.cs" />
     <Compile Include="IdleTimeoutManager.cs" />
     <Compile Include="JsonSerializer.cs" />
     <Compile Include="OwinSelfhostStartup.cs" />

--- a/src/System.Private.ServiceModel/tools/test/Bridge/Bridge/ChangedEventArgs.cs
+++ b/src/System.Private.ServiceModel/tools/test/Bridge/Bridge/ChangedEventArgs.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Bridge
+{
+    // General purpose EventArgs used to communicate changes
+    // to an object of a type T.
+    public class ChangedEventArgs<T> : EventArgs
+    {
+        public ChangedEventArgs(T oldValue, T newValue)
+        {
+            OldValue = oldValue;
+            NewValue = newValue;
+        }
+        public T OldValue { get; private set; }
+        public T NewValue { get; private set; }
+    }
+}

--- a/src/System.Private.ServiceModel/tools/test/Bridge/Bridge/ResourceController.cs
+++ b/src/System.Private.ServiceModel/tools/test/Bridge/Bridge/ResourceController.cs
@@ -20,7 +20,7 @@ namespace Bridge
         /// <response code="200">Test initialized.</response>
         public HttpResponseMessage Put(HttpRequestMessage request)
         {
-            string nameValuePairs = request.Content.ReadAsStringAsync().Result;
+            string nameValuePairs = request.Content.ReadAsStringAsync().GetAwaiter().GetResult();
             Dictionary<string, string> resourceInfo = JsonSerializer.DeserializeDictionary(nameValuePairs);
             string resourceName = null;
             resourceInfo.TryGetValue("name", out resourceName);

--- a/src/System.Private.ServiceModel/tools/test/Bridge/Bridge/ResourceInvoker.cs
+++ b/src/System.Private.ServiceModel/tools/test/Bridge/Bridge/ResourceInvoker.cs
@@ -17,7 +17,7 @@ namespace Bridge
             }
 
             AppDomain appDomain;
-            if (!TypeCache.AppDomains.TryGetValue(ConfigController.CurrentAppDomain, out appDomain))
+            if (!TypeCache.AppDomains.TryGetValue(ConfigController.CurrentAppDomainName, out appDomain))
             {
                 throw new ArgumentException("Resource not found");
             }
@@ -43,7 +43,7 @@ namespace Bridge
             }
 
             AppDomain appDomain;
-            if (!TypeCache.AppDomains.TryGetValue(ConfigController.CurrentAppDomain, out appDomain))
+            if (!TypeCache.AppDomains.TryGetValue(ConfigController.CurrentAppDomainName, out appDomain))
             {
                 throw new ArgumentException("Resource not found");
             }

--- a/src/System.Private.ServiceModel/tools/test/Bridge/WcfTestBridgeCommon/BridgeConfiguration.cs
+++ b/src/System.Private.ServiceModel/tools/test/Bridge/WcfTestBridgeCommon/BridgeConfiguration.cs
@@ -13,12 +13,12 @@ namespace WcfTestBridgeCommon
         // that is the set of name/value pairs from which this type is created.
         private const string BridgeResourceFolder_PropertyName = "BridgeResourceFolder";
         private const string BridgeUrl_PropertyName = "BridgeUrl";
-        private const string BridgeIdleTimeoutMinutes_PropertyName = "BridgeIdleTimeoutMinutes";
+        private const string BridgeMaxIdleTimeSpan_PropertyName = "BridgeMaxIdleTimeSpan";
         private const string UseFiddlerUrl_PropertyName = "UseFiddlerUrl";
 
         public string BridgeResourceFolder { get; set; }
         public string BridgeUrl { get; set; }
-        public int BridgeIdleTimeoutMinutes { get; set; }
+        public TimeSpan BridgeMaxIdleTimeSpan { get; set; }
         public bool UseFiddlerUrl { get; set; }
 
         public BridgeConfiguration()
@@ -32,7 +32,7 @@ namespace WcfTestBridgeCommon
         {
             BridgeResourceFolder = configuration.BridgeResourceFolder;
             BridgeUrl = configuration.BridgeUrl;
-            BridgeIdleTimeoutMinutes = configuration.BridgeIdleTimeoutMinutes;
+            BridgeMaxIdleTimeSpan = configuration.BridgeMaxIdleTimeSpan;
             UseFiddlerUrl = configuration.UseFiddlerUrl;
 
             string propertyValue = null;
@@ -53,17 +53,17 @@ namespace WcfTestBridgeCommon
                 BridgeUrl = propertyValue;
             }
 
-            if (properties.TryGetValue(BridgeIdleTimeoutMinutes_PropertyName, out propertyValue))
+            if (properties.TryGetValue(BridgeMaxIdleTimeSpan_PropertyName, out propertyValue))
             {
-                int minutes = 0;
-                if (!int.TryParse(propertyValue, out minutes))
+                TimeSpan span;
+                if (!TimeSpan.TryParse(propertyValue, out span))
                 {
                     throw new ArgumentException(
-                        String.Format("The BridgeIdleTimeoutMinutes value '{0}' is not a valid integer.", propertyValue),
-                        BridgeResourceFolder_PropertyName);
+                        String.Format("The BridgeMaxIdleTimeSpan value '{0}' is not a valid TimeSpan.", propertyValue),
+                        BridgeMaxIdleTimeSpan_PropertyName);
                 }
 
-                BridgeIdleTimeoutMinutes = minutes;
+                BridgeMaxIdleTimeSpan = span;
             }
 
             if (properties.TryGetValue(UseFiddlerUrl_PropertyName, out propertyValue))
@@ -85,7 +85,7 @@ namespace WcfTestBridgeCommon
             StringBuilder sb = new StringBuilder();
             sb.AppendLine(String.Format("{0} : '{1}'", BridgeResourceFolder_PropertyName, BridgeResourceFolder));
             sb.AppendLine(String.Format("{0} : '{1}'", BridgeUrl_PropertyName, BridgeUrl));
-            sb.AppendLine(String.Format("{0} : '{1}'", BridgeIdleTimeoutMinutes_PropertyName, BridgeIdleTimeoutMinutes));
+            sb.AppendLine(String.Format("{0} : '{1}'", BridgeMaxIdleTimeSpan_PropertyName, BridgeMaxIdleTimeSpan));
             sb.AppendLine(String.Format("{0} : '{1}'", UseFiddlerUrl_PropertyName, UseFiddlerUrl));
             return sb.ToString();
         }


### PR DESCRIPTION
This PR allows the Bridge to accept an
idle timeout as one of the properties in
the POST config name/value pairs.  And it
sets the idle timeout manager to use that
as its new idle timeout between requests.

To avoid making the Bridge aware of all its
configuration sensitive types, this PR also adds
a new EventHandler for configuration changes.
Types that care about configuration changes register
to be notified of the change.

The ConfigurationExtensions class was updated to
use this same notification mechanism.  And it was
renamed to reflect its true purpose -- AppDomainManager.

Fixes #198