### PR TITLE
Verify Server Dns for NetTcp binding

### DIFF
--- a/src/System.Private.ServiceModel/tests/Common/Scenarios/Endpoints.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Scenarios/Endpoints.cs
@@ -99,6 +99,11 @@ public static partial class Endpoints
         get { return BridgeClient.GetResourceAddress("WcfService.TestResources.TcpNoSecurityResource"); }
     }
 
+    public static string Tcp_VerifyDNS_Address
+    {
+        get { return BridgeClient.GetResourceAddress("WcfService.TestResources.TcpVerifyDNSResource"); }
+    }
+
     public static string Tcp_NoSecurity_Callback_Address
     {
         get { return BridgeClient.GetResourceAddress("WcfService.TestResources.DuplexResource"); }

--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Security.TransportSecurity.Tests.csproj
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Security.TransportSecurity.Tests.csproj
@@ -20,6 +20,7 @@
         <Compile Include="Https\ClientCredentialTypeTests.cs" />
         <Compile Include="Https\HttpsTests.cs" />
         <Compile Include="Tcp\ClientCredentialTypeTests.cs" />
+        <Compile Include="Tcp\IdentityTests.cs" />
     </ItemGroup>
     <ItemGroup>
         <None Include="project.json" />

--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Tcp/IdentityTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Tcp/IdentityTests.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.ServiceModel;
+using System.Text;
+using Xunit;
+
+namespace Security.TransportSecurity.Tests.Tcp
+{
+    public static class IdentityTests
+    {
+        [Fact]
+        [ActiveIssue(12)]
+        [OuterLoop]
+        // The product code will check the Dns identity from the server and throw if it does not match what is specified in DnsEndpointIdentity
+        public static void VerifyServiceIdentityMatchDnsEndpointIdentity()
+        {
+            string testString = "Hello";
+
+            NetTcpBinding binding = new NetTcpBinding();
+            //SecurityMode.Transport is not supported yet, we will get an exception here, tracked by issue #81
+            binding.Security.Mode = SecurityMode.Transport;
+            binding.Security.Transport.ClientCredentialType = TcpClientCredentialType.None;
+
+            EndpointAddress endpointAddress = new EndpointAddress(new Uri(Endpoints.Tcp_VerifyDNS_Address),new DnsEndpointIdentity("localhost"));
+            ChannelFactory<IWcfService> factory = new ChannelFactory<IWcfService>(binding, endpointAddress);
+            // factory.Credentials.ServiceCertificate is not availabe currently, tracked by issue 243
+            // We need to change the validation mode as we use a test certificate. It does not affect the purpose of this test
+            // factory.Credentials.ServiceCertificate.Authentication.CertificateValidationMode = X509CertificateValidationMode.None;
+            IWcfService serviceProxy = factory.CreateChannel();
+
+            try
+            {
+                var result = serviceProxy.Echo(testString);
+                Assert.Equal(testString, result);
+            }
+            finally
+            {
+                if (factory != null && factory.State != CommunicationState.Closed)
+                {factory.Abort();
+                }
+            }
+        }
+    }
+}

--- a/src/System.Private.ServiceModel/tools/test/SelfHostWcfService/TestResources/EndpointResource.cs
+++ b/src/System.Private.ServiceModel/tools/test/SelfHostWcfService/TestResources/EndpointResource.cs
@@ -15,6 +15,7 @@ namespace WcfService.TestResources
         private static Dictionary<string, ServiceHost> s_currentHosts = new Dictionary<string, ServiceHost>();
         private static object s_currentHostLock = new object();
         private string _hostName = "localhost";
+        protected string certThumbprint = "1d 85 a3 f6 cd 2c 02 2c 5c a5 4e 5c b2 00 a4 7f 89 ba 0d 3d";
 
         #region Host Listen Uri components
 
@@ -58,6 +59,7 @@ namespace WcfService.TestResources
                             GetBinding(),
                             BuildUri());
                         ModifyBehaviors(host.Description);
+                        ModifyHost(host);
                         host.Open();
                         s_currentHosts.Add(Address, host);
                     }
@@ -79,6 +81,10 @@ namespace WcfService.TestResources
         }
 
         protected abstract Binding GetBinding();
+
+        protected virtual void ModifyHost(ServiceHost serviceHost)
+        {
+        }
 
         private void ModifyBehaviors(ServiceDescription desc)
         {

--- a/src/System.Private.ServiceModel/tools/test/SelfHostWcfService/TestResources/TcpVerifyDNSResource.cs
+++ b/src/System.Private.ServiceModel/tools/test/SelfHostWcfService/TestResources/TcpVerifyDNSResource.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using System;
+using System.ServiceModel;
+using System.ServiceModel.Channels;
+using System.Security.Cryptography.X509Certificates;
+
+namespace WcfService.TestResources
+{
+    internal class TcpVerifyDNSResource : TcpResource
+    {
+        protected override string Address { get { return "tcp-VerifyDNS"; } }
+        protected override string Host
+        {
+            get
+            {
+                return Environment.MachineName;
+            }
+        }
+
+        protected override Binding GetBinding()
+        {
+            NetTcpBinding binding = new NetTcpBinding() { PortSharingEnabled = false };
+            binding.Security.Mode = SecurityMode.Transport;
+            binding.Security.Transport.ClientCredentialType = TcpClientCredentialType.None;
+
+            return binding;
+        }
+
+        protected override void ModifyHost(ServiceHost serviceHost)
+        {
+            serviceHost.Credentials.ServiceCertificate.SetCertificate(StoreLocation.LocalMachine,
+                                                      StoreName.My,
+                                                      X509FindType.FindByThumbprint,
+                                                      certThumbprint);
+        }
+    }
+}

--- a/src/System.Private.ServiceModel/tools/test/SelfHostWcfService/WcfService.csproj
+++ b/src/System.Private.ServiceModel/tools/test/SelfHostWcfService/WcfService.csproj
@@ -73,6 +73,7 @@
     <Compile Include="TestResources\TcpDefaultResource.cs" />
     <Compile Include="TestResources\TcpNoSecurityResource.cs" />
     <Compile Include="TestResources\TcpNoSecurityTextResource.cs" />
+    <Compile Include="TestResources\TcpVerifyDNSResource.cs" />
     <Compile Include="TestResources\HttpsSoap12Resource.cs" />
     <Compile Include="TestResources\HttpSoap12Resource.cs" />
     <Compile Include="TestResources\HttpsSoap11Resource.cs" />


### PR DESCRIPTION
* This is one of the key scenarios for DnsEndpointIdentity
* Note that it will fail until all dependent features mentioned in the test resolved.