### PR TITLE
Enable duplex callback usage in NET Native

### DIFF
--- a/src/System.Private.ServiceModel/src/Resources/System.Private.ServiceModel.rd.xml
+++ b/src/System.Private.ServiceModel/src/Resources/System.Private.ServiceModel.rd.xml
@@ -19,6 +19,12 @@
             <TypeParameter Name="detailType" DataContractSerializer="Public" DataContractJsonSerializer="Public" />
           </Method>
         </Type>
+         <!-- Objects passed to the InstanceContext ctor require reflection for duplex contracts -->
+        <Type Name="InstanceContext" Dynamic="Required All" >  
+          <Method Name=".ctor">  
+            <Parameter Name="implementation" Dynamic="Required All" />  
+          </Method>  
+        </Type>  
         <Type Name="MessageBodyMemberAttribute" Dynamic="Required All" />
         <Type Name="MessageContractMemberAttribute" Dynamic="Required All" />
         <Type Name="MessageParameterAttribute" Dynamic="Required All" />
@@ -29,6 +35,10 @@
         <!-- ServiceContractAttribute on a type makes it available for Reflection -->
         <Type Name="ServiceContractAttribute" Dynamic="Required All" >
           <AttributeImplies Dynamic="Required All" />
+          <!-- Type in CallbackContract named property requires reflection -->
+          <Method Name=".ctor">
+             <TypeParameter Name="CallbackContract" Dynamic="Required All" />
+          </Method>
         </Type>
         <!-- ExceptionDetail requires serialization for FaultException -->
         <Type Name="ExceptionDetail" Dynamic="Required All" DataContractJsonSerializer="Public" DataContractSerializer="Public" />


### PR DESCRIPTION
Prior to this change, using Reflection on the concrete duplex
callback type failed in NET Native because its metadata was not
available.

The modification to the rd.xml file allows the NET Native version
of System.Private.ServiceModel to use Reflection on any interface
type specified in [ServiceContract(CallbackContractType)]. This is
necessary to build OperationDescriptions for the callback type.

But this alone does not enable Reflection for the concrete type.
And TypeLoader analyzes the concrete type to locate custom
attributes that implement IOperationBehavior to add them to the
operation's behaviors.

The change to TypeLoader allows it to tolerate missing metadata
when it analyzes these custom attributes. Because the
[OperationBehavior] attribute is not available in a public contract,
these would occur only if the developers create their own custom
attributes that implement IOperationBehavior and apply them to the
concrete type for the callback contract. In that edge-case, these
attributes will not be found in NET Native unless the developer
enables Reflection for that concrete type via an rd.xml file in the app.

Fixes #110