### PR TITLE
Scenario test helper for proper cleanup of all communication objects …

### DIFF
--- a/src/System.Private.ServiceModel/tests/Common/Scenarios/ScenarioTestHelpers.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Scenarios/ScenarioTestHelpers.cs
@@ -153,6 +153,44 @@ public static class ScenarioTestHelpers
 
         return compositeObject;
     }
+
+    /// <summary>
+    /// Closes com objects in the order passed in if not already closed.
+    /// If Close fails for Timeout or Communication exception then Aborts.
+    /// </summary>
+    /// <param name="objects">Any communication objects that need to be cleaned up.
+    /// In the order in which they need to be cleaned up.</param>
+    public static void CloseCommunicationObjects(params ICommunicationObject[] objects)
+    {
+        foreach(ICommunicationObject comObj in objects)
+        {
+            try
+            {
+                if(comObj == null)
+                {
+                    continue;
+                }
+                // Only want to call Close if it is in the Opened state
+                if(comObj.State == CommunicationState.Opened)
+                {
+                    comObj.Close();
+                }
+                // Anything not closed by this point should be aborted
+                if(comObj.State != CommunicationState.Closed)
+                {
+                    comObj.Abort();
+                }
+            }
+            catch(TimeoutException)
+            {
+                comObj.Abort();
+            }
+            catch(CommunicationException)
+            {
+                comObj.Abort();
+            }
+        }
+    }
 }
 
 

--- a/src/System.Private.ServiceModel/tests/Scenarios/Binding/Http/BasicHttpBindingTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Binding/Http/BasicHttpBindingTests.cs
@@ -16,32 +16,32 @@ public static class Binding_Http_BasicHttpBindingTests
     [OuterLoop]
     public static void DefaultSettings_Echo_RoundTrips_String()
     {
-        string variationDetails = "Client:: BasicHttpBinding/DefaultValues\nServer:: BasicHttpBinding/DefaultValues";
+        ChannelFactory<IWcfService> factory = null;
+        IWcfService serviceProxy = null;
         string testString = "Hello";
-        StringBuilder errorBuilder = new StringBuilder();
-        bool success = false;
-
-        BasicHttpBinding binding = new BasicHttpBinding(BasicHttpSecurityMode.None);
+        Binding binding = null;
 
         try
         {
-            ChannelFactory<IWcfService> factory = new ChannelFactory<IWcfService>(binding, new EndpointAddress(Endpoints.HttpBaseAddress_Basic));
+            // *** SETUP *** \\
+            binding = new BasicHttpBinding(BasicHttpSecurityMode.None);
+            factory = new ChannelFactory<IWcfService>(binding, new EndpointAddress(Endpoints.HttpBaseAddress_Basic));
+            serviceProxy = factory.CreateChannel();
 
-            IWcfService serviceProxy = factory.CreateChannel();
-
+            // *** EXECUTE *** \\
             string result = serviceProxy.Echo(testString);
-            success = string.Equals(result, testString);
 
-            if (!success)
-            {
-                errorBuilder.AppendLine(String.Format("    Error: expected response from service: '{0}' Actual was: '{1}'", testString, result));
-            }
+            // *** VALIDATE *** \\
+            Assert.True(result == testString, String.Format("Error: expected response from service: '{0}' Actual was: '{1}'", testString, result));
+
+            // *** CLEANUP *** \\
+            factory.Close();
+            ((ICommunicationObject)serviceProxy).Close();
         }
-        catch (Exception ex)
+        finally
         {
-            errorBuilder.AppendLine(String.Format("    Error: Unexpected exception was caught while doing the basic echo test for variation...\n'{0}'\nException: {1}", variationDetails, ex.ToString()));
+            // *** ENSURE CLEANUP *** \\
+            ScenarioTestHelpers.CloseCommunicationObjects((ICommunicationObject)serviceProxy, factory);
         }
-
-        Assert.True(errorBuilder.Length == 0, "Test case FAILED with errors: " + errorBuilder.ToString());
     }
 }


### PR DESCRIPTION
…used in tests.

* We really need to close on Issue 168, this is my attempt at a proposal that takes into account everybodies feedback.
* We should still attempt to Close communication objects in the Try block.
* We should Close after doing validation, if both the scenario being tested and the call to Close Throw we would want to fix the scenario Throw first as it could be the cause for the Close throwing.
* The helper method ensures all com objects have been cleaned up regardless of the test results.
* Fixes #168