### PR TITLE
Improve Bridge firewall support

### DIFF
--- a/Documentation/cross-machine-test-guide.md
+++ b/Documentation/cross-machine-test-guide.md
@@ -1,0 +1,132 @@
+The Bridge and cross-machine testing
+====================================
+
+Bridge overview
+---------------
+The basic OuterLoop scenario tests normally run against locally hosted
+WCF test services.  But some scenarios require running the WCF test
+service(s) on a machine other than the machine running the test
+(example: cross-platform testing).
+
+For this we have developed what we call the "Bridge." This Bridge is
+a WebAPI application meant to run on a Windows OS using the full
+.NET framework.  It offers a REST API that the scenario tests can
+invoke through normal HTTP requests to launch WCF services on other
+machines.
+
+The Bridge itself is agnostic of WCF services. Instead, it is aware
+of types that implement IResource, and it uses reflection to analyze
+a collection of assemblies to discover them.  It then exposes each of these
+as a "resource" to the Bridge REST API.  When a test requests a particular
+resource, the Bridge invokes the appropriate IResource.  In this case, the
+WCF tests provide IResources that know how to create and host WCF services.
+
+When the tests start up, they inform the Bridge where to find these
+resource assemblies.  This folder is known as the "Bridge Resource Folder".
+
+There are several Bridge-specific properties that are meaningful to
+both the Bridge and the tests.  They can be defined either as Environment
+variables or passed into build.cmd as MSBuild properties.  They are:
+
+  - **BuildHost**: the name of the machine on which the Bridge runs (default localhost)
+  - **BridgePort**: the port to use to communicate with the Bridge (default 44283)
+  - **BridgeResourceFolder**: the full path to the folder that contains the Bridge IResource assemblies (default bin\Wcf\Bridge\Resources)
+  - **BridgeAllowRemote**: indicates whether the Bridge will accept requests from machines other than itself (default: false)
+
+Starting the Bridge Locally
+---------------------------
+By default, the Bridge will self-start locally during OuterLoop tests and accept only
+requests from the machine running the tests.  It will shutdown when all the OuterLoop
+tests have completed.
+
+If you want to run the Bridge on a different machine, you must follow the steps below.
+
+Starting the Bridge on a different machine
+------------------------------------------
+On the Bridge where the machine will run, do these things:
+
+cd to the root folder of a local WCF Git repository and run this command:
+
+```
+    startBridge.cmd {options}
+```
+
+The options can be any of these:
+
+    -portNumber NNN
+    -allowRemote true/false
+    -remoteAddresses comma-separated-list
+
+The 'portNumber' option allows you to choose a port other than
+the default 44283.
+
+The 'allowRemote' option tells the Bridge it is allowed to accept
+requests from other machines.  If unspecified, it will accept only
+from localhost.  It must be set to true if the Bridge is running
+on a machine other than where the tests run.
+
+The 'remoteAddresses' is a comma-separated list of IP addresses,
+a range of IP's, or one of the supported predefined terms supported
+for the Scope properties page in the Windows Firewall.
+See https://technet.microsoft.com/en-us/library/dd759059.aspx .
+
+If left unspecified, but 'allowRemote' is true, the 'remoteAddresses'
+will default to "LocalSubnet".  The value "*" allows remote
+access from all addresses, but for security reasons is not recommended.
+
+The purpose of these options is to limit the scope applied to the
+firewall rules the Bridge automatically generates while it is running.
+It does this to open specific ports needed for the WCF test services.
+The Bridge deletes these firewall rules when it exits.
+
+After running 'startBridge.cmd', a PowerShell window will start Bridge.exe in elevated mode.
+You will see a CMD window indicating what URL the Bridge is using and confirmation
+whether it is enbled to receive remote requests.  It will remain running until you manually close it or type "exit" in that CMD window.
+
+Running OuterLoop tests when the Bridge is remote
+------------------------------------------------
+On the machine where you want the tests to run, follow these steps:
+
+Start the OuterLoop tests like this:
+
+ * cd to the root folder
+ * run this CMD
+
+``` 
+    build.cmd /p:WithCategories=OuterLoop /p:BridgeHost=bridge-host-name /p:BridgeResourceFolder=shared-folder-Bridge-can-access
+```
+
+   Alternatively, you could have set these as environment variables to skip passing them as MSBuild properties:
+
+
+    set BridgeHost=bridge-host-name
+    set BridgeResourceFolder=shared-folder-Bridge-can-access
+    [optional] set BridgePort=NNN
+
+
+BridgeHost must match the machine name where the Bridge is running.
+
+BridgeResourceFolder must be the location of a folder that both the client
+and Bridge machines can access.  The WCF services built for the tests will
+be written to that folder, and the Bridge will be asked to read from it.
+
+BridgePort needs to be set only if you started the Bridge on a different port.
+
+After you started 'build.cmd' you will see a PowerShell window execute elevated, 
+and it will ping the remotely running Bridge to verify it is available.  All OuterLoop tests
+will then run against WCF test services running on the Bridge machine.
+
+If you watch the CMD window running on the Bridge machine, you will see it
+write to the console the incoming configuration and resource requests.
+After all tests have run, the Bridge will continue to run for several minutes.
+The timeout interval can be specified on the client test machine by setting
+the BridgeMaxIdleTimeSpan to some valid TimeSpan value (either as an environment
+variable or on the build.cmd line.  Default is "20:00" (twenty minutes).  After
+no activity for this amount of time, the Bridge will close.  Alternatively, you
+can type "exit" in the Bridge CMD window to close it manually.
+
+You can control the amount of time the Bridge will remain alive when idle by setting the environment variable BridgeMaxIdleTimeSpan to any legal TimeSpan string (example: 'set BridgeMaxIdleTimeSpan=1.02:03:04' will allow it to run 1 day, 2 hours, 3 minutes, and 4 seconds).  This value should be set on the machine where the tests run, because they will configure the Bridge machine when they start.
+
+
+
+

--- a/Documentation/developer-guide.md
+++ b/Documentation/developer-guide.md
@@ -28,3 +28,40 @@ The WCF repository can be built from a regular, non-admin command prompt using b
 Microsoft uses this repository to create and publish separate NuGet packages for each library. 
 
 The repository is a work in progress, and not all of the libraries are complete yet.
+
+Running the unit tests
+======================
+Unit tests are those that test aspects of the WCF libraries that don't require network interactions.
+To build the product and run the unit tests, simply execute this CMD from the root of the repository:
+
+```
+    build.cmd
+```
+
+Running the scenario tests
+==========================
+Scenario tests are those tests that involve network activity between the tests and one or
+more running WCF services.  By default, they are not run with the normal build.cmd.
+To run the scenario tests, execute this CMD from the root of the repository:
+
+```
+    build.cmd /p:WithCategories=OuterLoop
+```
+
+Obtaining code coverage
+=======================
+You can also obtain detailed code coverage information by including an additional property
+when you run the build script.  For example, this CMD runs the scenario tests and collects
+code coverage numbers:
+```
+    build.cmd /p:WithCategories=OuterLoop /p:Coverage=true
+```
+
+Running scenario tests across multiple machines
+===============================================
+By default scenario tests run against WCF services that are locally self-hosted.
+To run these tests against WCF services running on a separate machine, see:
+[Cross-machine test guide](https://github.com/dotnet/wcf/blob/master/Documentation/cross-machine-test-guide.md).
+
+
+

--- a/src/System.Private.ServiceModel/tools/setupfiles/RunElevated.vbs
+++ b/src/System.Private.ServiceModel/tools/setupfiles/RunElevated.vbs
@@ -1,15 +1,11 @@
+'Capture command line arguments to forward to program we start
 strName      = WScript.Arguments.Item(0)
-strArgs      = ""
+cmdArgs      = ""
 If WScript.Arguments.Count > 1 Then
     For i = 1 To WScript.Arguments.Count - 1
-        strArgs = strArgs & " " & WScript.Arguments.Item(i)
+        cmdArgs = cmdArgs & " " & WScript.Arguments.Item(i)
     Next
 End If
 
 Set objShell = CreateObject("Shell.Application")
-
-dim fso,currentDirectory,cmdArgs
-Set fso = CreateObject("Scripting.FileSystemObject")
-currentDirectory = fso.GetAbsolutePathName(".")
-cmdArgs = currentDirectory & " " & strArgs
 objShell.ShellExecute WScript.Arguments(0), cmdArgs,"", "runas", 1

--- a/src/System.Private.ServiceModel/tools/setupfiles/SetupWCFTestService.cmd
+++ b/src/System.Private.ServiceModel/tools/setupfiles/SetupWCFTestService.cmd
@@ -21,7 +21,7 @@ if '%BridgeAllowRemote%' neq '' (
    set _bridgeAllowRemoteArg=-allowRemote %BridgeAllowRemote%
 )
 
-echo Executing: start powershell -ExecutionPolicy Bypass -File ..\test\Bridge\bin\ensureBridge.ps1 %_bridgeHostArg% %_bridgePortArg% %_bridgeAllowRemoteArg%
+echo Executing: start powershell -ExecutionPolicy Bypass -File ..\test\Bridge\bin\ensureBridge.ps1 %_bridgeHostArg% %_bridgePortArg% %_bridgeAllowRemoteArg% %2 %3 %4 %5 %6 %7
 
-start powershell -ExecutionPolicy Bypass -File ..\test\Bridge\bin\ensureBridge.ps1 %_bridgeHostArg% %_bridgePortArg% %_bridgeAllowRemoteArg%
+start powershell -ExecutionPolicy Bypass -File ..\test\Bridge\bin\ensureBridge.ps1 %_bridgeHostArg% %_bridgePortArg% %_bridgeAllowRemoteArg% %2 %3 %4 %5 %6 %7
 exit /b

--- a/src/System.Private.ServiceModel/tools/setupfiles/SetupWCFTestService.cmd
+++ b/src/System.Private.ServiceModel/tools/setupfiles/SetupWCFTestService.cmd
@@ -1,9 +1,7 @@
 echo off
 setlocal
 
-REM elevated window does not set current directory correctly. 
-REM Workaround it by passing the current directory as 1st parameter
-pushd %1
+pushd %~dp0
 
 certutil -addstore -f root RootCATest.cer
 certutil -f -p test -importpfx "WcfTestServer.pfx"
@@ -21,7 +19,7 @@ if '%BridgeAllowRemote%' neq '' (
    set _bridgeAllowRemoteArg=-allowRemote %BridgeAllowRemote%
 )
 
-echo Executing: start powershell -ExecutionPolicy Bypass -File ..\test\Bridge\bin\ensureBridge.ps1 %_bridgeHostArg% %_bridgePortArg% %_bridgeAllowRemoteArg% %2 %3 %4 %5 %6 %7
+echo Executing: start powershell -ExecutionPolicy Bypass -File ..\test\Bridge\bin\ensureBridge.ps1 %_bridgeHostArg% %_bridgePortArg% %_bridgeAllowRemoteArg% %*
 
-start powershell -ExecutionPolicy Bypass -File ..\test\Bridge\bin\ensureBridge.ps1 %_bridgeHostArg% %_bridgePortArg% %_bridgeAllowRemoteArg% %2 %3 %4 %5 %6 %7
+start powershell -ExecutionPolicy Bypass -File ..\test\Bridge\bin\ensureBridge.ps1 %_bridgeHostArg% %_bridgePortArg% %_bridgeAllowRemoteArg% %*
 exit /b

--- a/src/System.Private.ServiceModel/tools/test/Bridge/Bridge/ConfigController.cs
+++ b/src/System.Private.ServiceModel/tools/test/Bridge/Bridge/ConfigController.cs
@@ -143,6 +143,9 @@ namespace Bridge
         // and return to an initial state
         public HttpResponseMessage Delete(HttpRequestMessage request)
         {
+            Trace.WriteLine(String.Format("{0:T} - received DELETE request", DateTime.Now),
+                            typeof(ConfigController).Name);
+
             // A configuration change can have wide impact, so we don't allow concurrent use
             lock (ConfigController.BridgeLock)
             {

--- a/src/System.Private.ServiceModel/tools/test/Bridge/Bridge/ensureBridge.ps1
+++ b/src/System.Private.ServiceModel/tools/test/Bridge/Bridge/ensureBridge.ps1
@@ -5,20 +5,24 @@
         [Alias('h')]
         [string]$hostName = 'localhost',
 
+        [Alias('a')]
+        [string]$allowRemote = $false,
+
         [Alias('r')]
-        [string]$allowRemote = $false
+        [string]$remoteAddresses = ''
+
 )
 
 Write-Host
 
 $baseAddress = "http://" + $hostName + ":" + $portNumber
 
-Write-Host portNumber is $portNumber
-Write-Host hostName is $hostName
-Write-Host allowRemote is $allowRemote
+#Write-Host portNumber is $portNumber
+#Write-Host hostName is $hostName
+#Write-Host allowRemote is $allowRemote
+#Write-Host remoteAddresses is $remoteAddresses
 
-
-Write-Host Bridge base address is $baseAddress
+Write-Host Ensuring Bridge is available at $baseAddress
 
 Write-Host
 
@@ -43,6 +47,10 @@ if(!$result)
         if ($allowRemote -eq $true)
         {
             $bridgeArgs = $bridgeArgs + ' -allowRemote'
+        }
+        if ($remoteAddresses -ine '')
+        {
+            $bridgeArgs = $bridgeArgs + ' -remoteAddresses:' + $remoteAddresses
         }
 
 	Write-Host Launching Bridge at $bridgePath $bridgeArgs

--- a/src/System.Private.ServiceModel/tools/test/Bridge/WcfTestBridgeCommon/PortManager.cs
+++ b/src/System.Private.ServiceModel/tools/test/Bridge/WcfTestBridgeCommon/PortManager.cs
@@ -14,11 +14,45 @@ namespace WcfTestBridgeCommon
     // manage which ports are open on behalf of the Bridge.
     public class PortManager
     {
-        private static string s_PortNameFormat = "Bridge auto-rule {0}";
+        // This prefix is used both to name rules and to discover existing
+        // rules created by this class, so it must be unique
+        private static string s_RuleNamePrefix = "Bridge WCF test port rule";
         private static object s_portLock = new object();
-        private static Dictionary<int, string> s_AddedRulesByPort = new Dictionary<int, string>();
         private static bool s_registeredForProcessExit = false;
+        private static INetFwPolicy2 s_netFwPolicy2;
+        private static string s_remoteAddresses = "LocalSubnet";
 
+        private static INetFwPolicy2 NetFwPolicy2
+        {
+            get
+            {
+                lock (s_portLock)
+                {
+                    if (s_netFwPolicy2 == null)
+                    {
+                        Type netFwPolicy2Type = Type.GetTypeFromProgID("HNetCfg.FwPolicy2", false);
+                        s_netFwPolicy2 = (INetFwPolicy2)Activator.CreateInstance(netFwPolicy2Type);
+                    }
+                }
+
+                return s_netFwPolicy2;
+            }
+        }
+
+        public static string RemoteAddresses
+        {
+            get
+            {
+                return s_remoteAddresses;
+            }
+            set
+            {
+                s_remoteAddresses = value;
+            }
+        }
+ 
+        // We listen for ProcessExit so we can delete the firewall
+        // rules we added while the Bridge was running.
         private static void RegisterForProcessExit()
         {
             lock (s_portLock)
@@ -26,82 +60,111 @@ namespace WcfTestBridgeCommon
                 if (!s_registeredForProcessExit)
                 {
                     AppDomain.CurrentDomain.ProcessExit += (s, e) =>
-                        {
-                            CloseAllOpenedPortsInFireWall();
-                        };
+                    {
+                        RemoveAllBridgeFirewallRules();
+                    };
                     s_registeredForProcessExit = true;
                 }
             }
         }
 
-        private static void AddNewFirewallRule(int port)
+        // Searches all existing firewall rules with the given name
+        private static INetFwRule FindRule(string name, int port)
         {
             lock (s_portLock)
             {
-                if (s_AddedRulesByPort.ContainsKey(port))
+                // Match on our special naming pattern and port
+                HashSet<string> ruleSet = new HashSet<string>();
+                foreach (var r in NetFwPolicy2.Rules)
+                {
+                    INetFwRule rule = (INetFwRule)r;
+                    if (String.Equals(name, rule.Name, StringComparison.OrdinalIgnoreCase) &&
+                        String.Equals(rule.LocalPorts, port.ToString(), StringComparison.Ordinal))
+                    {
+                        return rule;
+                    }
+                }
+
+                return null;
+            }
+        }
+
+        private static void AddFirewallRule(int port)
+        {
+            lock (s_portLock)
+            {
+                // If we add any rules, register to delete them at process exit.
+                RegisterForProcessExit();
+
+                // If we already created this rule, we don't create it again.
+                string ruleName = String.Format("{0} {1}", s_RuleNamePrefix, port);
+                if (FindRule(ruleName, port) != null)
                 {
                     return;
                 }
 
-                // If we add any rules, register to delete them at process exit.
-                RegisterForProcessExit();
-
-                // Create the FwPolicy2 object.
-                Type netFwPolicy2Type = Type.GetTypeFromProgID("HNetCfg.FwPolicy2", false);
-                INetFwPolicy2 fwPolicy2 = (INetFwPolicy2)Activator.CreateInstance(netFwPolicy2Type);
-
-                // Get the Rules object
-                INetFwRules rulesObject = fwPolicy2.Rules;
-
-                int CurrentProfiles = fwPolicy2.CurrentProfileTypes;
+                INetFwRules rulesObject = NetFwPolicy2.Rules;
+                int currentProfiles = NetFwPolicy2.CurrentProfileTypes;
 
                 // Create a Rule Object.
                 Type netFwRuleType = Type.GetTypeFromProgID("HNetCfg.FWRule", false);
                 INetFwRule newRule = (INetFwRule)Activator.CreateInstance(netFwRuleType);
 
-                newRule.Name = String.Format(s_PortNameFormat, port);
-                newRule.Description = String.Format("Rule added for Bridge use of port {0}", port);
-                newRule.Protocol = (int)NET_FW_IP_PROTOCOL_.NET_FW_IP_PROTOCOL_TCP;
-                newRule.LocalPorts = port.ToString();
-                newRule.Direction = NET_FW_RULE_DIRECTION_.NET_FW_RULE_DIR_IN;
-                newRule.Enabled = true;
-                newRule.Profiles = CurrentProfiles;
-                newRule.Action = NET_FW_ACTION_.NET_FW_ACTION_ALLOW;
+                try
+                {
+                    newRule.Name = ruleName;
+                    newRule.Description = String.Format("Rule added for Bridge WCF test use of port {0}", port);
+                    newRule.Protocol = (int)NET_FW_IP_PROTOCOL_.NET_FW_IP_PROTOCOL_TCP;
+                    newRule.LocalPorts = port.ToString();
+                    newRule.Direction = NET_FW_RULE_DIRECTION_.NET_FW_RULE_DIR_IN;
+                    newRule.Enabled = true;
+                    newRule.Profiles = currentProfiles;
+                    newRule.Action = NET_FW_ACTION_.NET_FW_ACTION_ALLOW;
+                    newRule.RemoteAddresses = RemoteAddresses;
 
-                // Add a new rule
-                rulesObject.Add(newRule);
+                    // Add a new rule
+                    rulesObject.Add(newRule);
 
-                Trace.WriteLine(String.Format("Added firewall rule {0}", newRule.Name),
-                                typeof(PortManager).Name);
-
-                s_AddedRulesByPort[port] = newRule.Name;
+                    Trace.WriteLine(String.Format("Added firewall rule {0}", newRule.Name),
+                                    typeof(PortManager).Name);
+                }
+                catch (Exception ex)
+                {
+                    string message = String.Format("Failed to add firewall rule name:{0}, port:{1}, remoteAddresses:{2}{3}{4}",
+                                                    newRule.Name, port, RemoteAddresses, Environment.NewLine, ex.ToString());
+                    Console.WriteLine(message);
+                    Trace.TraceWarning(message);
+                }
             }
         }
 
-        private static void CloseAllOpenedPortsInFireWall()
+        public static void RemoveAllBridgeFirewallRules()
         {
-            Type NetFwPolicy2Type = Type.GetTypeFromProgID("HNetCfg.FwPolicy2", false);
-            INetFwPolicy2 fwPolicy2 = (INetFwPolicy2)Activator.CreateInstance(NetFwPolicy2Type);
-
-            // Get the Rules object
-            INetFwRules RulesObject = fwPolicy2.Rules;
-
             lock (s_portLock)
             {
-                foreach (var pair in s_AddedRulesByPort)
+                // Capture Bridge-specific rules into local list so we
+                // don't mutate the rule list during enumeration.
+                HashSet<string> ruleSet = new HashSet<string>();
+                foreach (var r in NetFwPolicy2.Rules)
                 {
-                    RulesObject.Remove(pair.Value);
-                    Trace.WriteLine(String.Format("Removed firewall rule {0}", pair.Value),
-                                    typeof(PortManager).Name);
+                    INetFwRule rule = (INetFwRule)r;
+                    string ruleName = rule.Name;
+                    if (rule.Name.StartsWith(s_RuleNamePrefix, StringComparison.Ordinal) && !ruleSet.Contains(rule.Name))
+                    {
+                        ruleSet.Add(rule.Name);
+                    }
                 }
 
-                s_AddedRulesByPort.Clear();
+                foreach (string ruleName in ruleSet)
+                {
+                    NetFwPolicy2.Rules.Remove(ruleName);
+                }
             }
         }
 
         public static void OpenPortInFirewall(int port)
         {
-            AddNewFirewallRule(port);
+            AddFirewallRule(port);
         }
     }
 }

--- a/startBridge.cmd
+++ b/startBridge.cmd
@@ -1,0 +1,14 @@
+@echo off
+
+pushd %~dp0src\System.Private.ServiceModel\tools\setupfiles
+
+echo Building the Bridge...
+call start /wait BuildWCFTestService.cmd
+
+echo Launching the Bridge (elevated) ...
+start /wait RunElevated.vbs SetupWCFTestService.cmd %*
+
+set BridgeKeepRunning=true
+
+:done
+popd


### PR DESCRIPTION
These changes allow the firewall rules created by the Bridge
to be scoped to specific IP's to allow them to be secured against
unauthorized access.

Remotely starting the Bridge has been made easier with a new script.
and a new markdown file describes how to run the Bridge remotely.