### PR TITLE
Fixes issue matching wrong localhost certificate

### DIFF
--- a/src/System.Private.ServiceModel/tools/test/Bridge/Bridge/BridgeController.cs
+++ b/src/System.Private.ServiceModel/tools/test/Bridge/Bridge/BridgeController.cs
@@ -86,6 +86,9 @@ namespace Bridge
             // the chance to release resources they've acquired or installed
             AppDomainManager.ShutdownAllAppDomains();
 
+            // Uninstall any certificates added or used by the Bridge itself
+            CertificateManager.UninstallAllCertificates(force: true);
+
             // Force the removal of the SSL cert that may have been added
             // by another AppDomain or left from a prior run
             int httpsPort = ConfigController.BridgeConfiguration.BridgeHttpsPort;
@@ -94,7 +97,7 @@ namespace Bridge
                 CertificateManager.UninstallSslPortCertificate(httpsPort);
             }
 
-            CertificateManager.UninstallAllCertificates();
+            // Finally remove all firewall rules we added for the ports
             PortManager.RemoveAllBridgeFirewallRules();
         }
 

--- a/src/System.Private.ServiceModel/tools/test/Bridge/WcfTestBridgeCommon/AssemblyLoader.cs
+++ b/src/System.Private.ServiceModel/tools/test/Bridge/WcfTestBridgeCommon/AssemblyLoader.cs
@@ -19,8 +19,8 @@ namespace WcfTestBridgeCommon
             {
                 // Uninstall all certificates we explicitly added within this AppDomain
                 CertificateManager.UninstallAllSslPortCertificates();
-                CertificateManager.UninstallAllMyCertificates();
-                CertificateManager.UninstallAllRootCertificates();
+                CertificateManager.UninstallAllMyCertificates(force: false);
+                CertificateManager.UninstallAllRootCertificates(force: false);
             };
         }
 


### PR DESCRIPTION
The Bridge CertificateManager was using too simple
an algorithm to find an existing "localhost" certificate
and accidentally matched one already installed for IIS.
This caused the CI machine to fail OuterLoop https tests.

This change tightens the algorithm to locate only a
"localhost" certificate with a known issuer.