### PR TITLE
Set BridgeResourceFolder at Bridge startup

### DIFF
--- a/src/System.Private.ServiceModel/tests/Common/Infrastructure/src/testproperties.props
+++ b/src/System.Private.ServiceModel/tests/Common/Infrastructure/src/testproperties.props
@@ -57,7 +57,7 @@
       </TestProperty>
       <TestProperty Include="BridgeMaxIdleTimeSpan">
         <Value>$(BridgeMaxIdleTimeSpan)</Value>
-        <DefaultValue>20:00</DefaultValue>
+        <DefaultValue>24:00:00</DefaultValue>
       </TestProperty>
       <TestProperty Include="MaxTestTimeSpan">
         <Value>$(MaxTestTimeSpan)</Value>

--- a/src/System.Private.ServiceModel/tools/setupfiles/CleanupWCFTestService.cmd
+++ b/src/System.Private.ServiceModel/tools/setupfiles/CleanupWCFTestService.cmd
@@ -5,9 +5,13 @@ echo BridgeKeepRunning=%BridgeKeepRunning%
 if '%BridgeKeepRunning%' neq 'true' (
     echo Stopping the Bridge...
     pushd %~dp0..\..\..\..\bin\wcf\tools\Bridge
-    call Bridge.exe -stopIfLocal %*
+    call Bridge.exe -stopIfLocal -reset %*
     popd
 ) else (
+    echo Releasing Bridge resources but leaving it running...
+    pushd %~dp0..\..\..\..\bin\wcf\tools\Bridge
+    call Bridge.exe -reset %*
+    popd
     echo The Bridge was left running because BridgeKeepRunning is true
 )
 

--- a/src/System.Private.ServiceModel/tools/setupfiles/CleanupWCFTestService.cmd
+++ b/src/System.Private.ServiceModel/tools/setupfiles/CleanupWCFTestService.cmd
@@ -3,13 +3,15 @@ setlocal
 
 echo BridgeKeepRunning=%BridgeKeepRunning%
 if '%BridgeKeepRunning%' neq 'true' (
-    echo Stopping the Bridge...
+    echo Releasing Bridge resources and stopping it if running locally.
     pushd %~dp0..\..\..\..\bin\wcf\tools\Bridge
+    echo Invoking Bridge.exe -stopIfLocal -reset %* ...
     call Bridge.exe -stopIfLocal -reset %*
     popd
 ) else (
-    echo Releasing Bridge resources but leaving it running...
+    echo Releasing Bridge resources but leaving it running.
     pushd %~dp0..\..\..\..\bin\wcf\tools\Bridge
+    echo Invoking Bridge.exe -reset %* ...
     call Bridge.exe -reset %*
     popd
     echo The Bridge was left running because BridgeKeepRunning is true

--- a/src/System.Private.ServiceModel/tools/setupfiles/SetupWCFTestService.cmd
+++ b/src/System.Private.ServiceModel/tools/setupfiles/SetupWCFTestService.cmd
@@ -6,9 +6,9 @@ echo Building the Bridge...
 call BuildWCFTestService.cmd
 popd
 
-echo Starting the Bridge with parameters %*
 pushd %~dp0..\..\..\..\bin\wcf\tools\Bridge
-start /MIN Bridge.exe %*
+echo starting the Bridge with arguments: /BridgeResourceFolder:..\..\Bridge\Resources %*
+start /MIN Bridge.exe /BridgeResourceFolder:..\..\Bridge\Resources %*
 popd
 
 exit /b

--- a/src/System.Private.ServiceModel/tools/test/Bridge.Build.Tasks/Bridge.Build.Tasks/ReleaseBridgeResourcesTask.cs
+++ b/src/System.Private.ServiceModel/tools/test/Bridge.Build.Tasks/Bridge.Build.Tasks/ReleaseBridgeResourcesTask.cs
@@ -61,7 +61,7 @@ namespace Bridge.Build.Tasks
                 bridgeIsRunning = true;
 
                 // A DELETE request to the config endpoint releases all allocated resources.
-                response = httpClient.DeleteAsync(bridgeAddress + "/config/").GetAwaiter().GetResult();
+                response = httpClient.DeleteAsync(bridgeAddress + "/resource/").GetAwaiter().GetResult();
                 if (!response.IsSuccessStatusCode)
                 {
                     string reason = String.Format("Failed to release the resources.  The DELETE request to Bridge returned unexpected status code='{0}', reason='{1}'",

--- a/src/System.Private.ServiceModel/tools/test/Bridge/Bridge/BridgeController.cs
+++ b/src/System.Private.ServiceModel/tools/test/Bridge/Bridge/BridgeController.cs
@@ -80,7 +80,11 @@ namespace Bridge
             }
         }
 
-        public static void ReleaseAllResources()
+        // Release all Bridge resources.
+        // If 'force' is true, it means the Bridge is shutting down
+        // and even the firewall rules necessary to talk to the Bridge
+        // will be removed.
+        public static void ReleaseAllResources(bool force)
         {
             // Cleanly shutdown all AppDomains we own so they have
             // the chance to release resources they've acquired or installed
@@ -99,11 +103,18 @@ namespace Bridge
 
             // Finally remove all firewall rules we added for the ports
             PortManager.RemoveAllBridgeFirewallRules();
+
+            // If the Bridge is not being shutdown, open a port in the firewall to
+            // communicate with the Bridge itself.
+            if (!force)
+            {
+                PortManager.OpenPortInFirewall(ConfigController.BridgeConfiguration.BridgePort);
+            }
         }
 
         public static void StopBridgeProcess(int exitCode)
         {
-            ReleaseAllResources();
+            ReleaseAllResources(force:true);
             Environment.Exit(exitCode);
         }
 

--- a/src/System.Private.ServiceModel/tools/test/Bridge/Bridge/IdleTimeoutManager.cs
+++ b/src/System.Private.ServiceModel/tools/test/Bridge/Bridge/IdleTimeoutManager.cs
@@ -13,7 +13,7 @@ namespace Bridge
 {
     public class IdleTimeoutHandler : DelegatingHandler
     {
-        public static readonly TimeSpan Default_MaxIdleTimeSpan = TimeSpan.FromMinutes(30);
+        public static readonly TimeSpan Default_MaxIdleTimeSpan = TimeSpan.FromHours(24);
         private IdleTimeoutManager _timeoutManager;
 
         private IdleTimeoutHandler(TimeSpan idleTimeout)

--- a/src/System.Private.ServiceModel/tools/test/Bridge/Bridge/Program.cs
+++ b/src/System.Private.ServiceModel/tools/test/Bridge/Bridge/Program.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
+using System.Text;
 using WcfTestBridgeCommon;
 
 namespace Bridge
@@ -21,8 +22,8 @@ namespace Bridge
         {
             CommandLineArguments commandLineArgs = new CommandLineArguments(args);
 
-            Console.WriteLine("Specified BridgeConfiguration is:{0}{1}",
-                                Environment.NewLine, commandLineArgs.BridgeConfiguration.ToString());
+            Console.WriteLine("Bridge.exe was launched with:{0}{1}", 
+                              Environment.NewLine, commandLineArgs.ToString());
 
             // If asked to ping (not the default), just ping and return an exit code indicating its state
             if (commandLineArgs.Ping)
@@ -72,7 +73,7 @@ namespace Bridge
 
             using (HttpClient httpClient = new HttpClient())
             {
-                Console.WriteLine("Testing Bridge at {0}", bridgeUrl);
+                Console.WriteLine("Pinging the Bridge by issuing GET request to {0}", bridgeUrl);
                 try
                 {
                     var response = httpClient.GetAsync(bridgeUrl).GetAwaiter().GetResult();
@@ -137,7 +138,7 @@ namespace Bridge
             // in a different process on this machine.
             using (HttpClient httpClient = new HttpClient())
             {
-                Console.WriteLine("Stopping Bridge at {0}", bridgeUrl);
+                Console.WriteLine("Stopping the Bridge by issuing DELETE request to {0}", bridgeUrl);
                 try
                 {
                     var response = httpClient.DeleteAsync(bridgeUrl).GetAwaiter().GetResult();
@@ -195,10 +196,11 @@ namespace Bridge
             string bridgeUrl = String.Format("http://{0}:{1}/Resource", commandLineArgs.BridgeConfiguration.BridgeHost, commandLineArgs.BridgeConfiguration.BridgePort);
             string problem = null;
 
+            Console.WriteLine("Resetting the Bridge by sending DELETE request to {0}", bridgeUrl);
+
             // We reset the Bridge using a DELETE request to the /resource endpoint.
             using (HttpClient httpClient = new HttpClient())
             {
-                Console.WriteLine("Stopping Bridge at {0}", bridgeUrl);
                 try
                 {
                     var response = httpClient.DeleteAsync(bridgeUrl).GetAwaiter().GetResult();
@@ -371,6 +373,21 @@ namespace Bridge
             public bool Stop { get; private set; }
             public bool StopIfLocal { get; private set; }
             public bool Reset { get; private set; }
+
+            public override string ToString()
+            {
+                StringBuilder sb = new StringBuilder();
+                sb.AppendLine("Options are:")
+                    .AppendLine(String.Format("  -allowRemote = {0}", AllowRemote))
+                    .AppendLine(String.Format("  -remoteAddresses = {0}", RemoteAddresses))
+                    .AppendLine(String.Format("  -ping = {0}", Ping))
+                    .AppendLine(String.Format("  -stop = {0}", Stop))
+                    .AppendLine(String.Format("  -stopIfLocal = {0}", StopIfLocal))
+                    .AppendLine(String.Format("  -reset = {0}", Reset))
+                    .AppendLine(String.Format("BridgeConfiguration is:{0}{1}", 
+                                                Environment.NewLine, BridgeConfiguration.ToString()));
+                return sb.ToString();
+            }
 
             private bool Parse(string[] args)
             {

--- a/startBridge.cmd
+++ b/startBridge.cmd
@@ -4,10 +4,17 @@ set BridgeKeepRunning=true
 
 pushd %~dp0src\System.Private.ServiceModel\tools\setupfiles
 call SetupWCFTestService.cmd %*
+if ERRORLEVEL 1 goto error
 popd
 
 echo Because you started the Bridge manually, it will remain running until you close it manually.
 echo Set the BridgeKeepRunning environment variable to 'false' to allow it to be closed by OuterLoop tests.
+goto done
+
+:error
+echo An error occurred starting the Bridge
+popd
+exit /b l
 
 :done
 popd


### PR DESCRIPTION
Prior to this change, the BridgeResourceFolder was specified by
BridgeClient when tests ran.  However, this was not a valid
strategy for x-platform use, otherwise both client and Bridge
would need to share a x-OS folder.

With this change, Bridge.exe is required to have a BridgeResourceFolder
when it is asked to start, and the BridgeClient no longer alters that.

Also adds a 'reset' option to Bridge.exe so that when tests complete
the Bridge can be asked to release all remote resources.  They will
be reacquired the next time Bridge requests are made.

Also move the Http DELETE handling to the ResourceController where it
really belonged.  An Http DELETE to the /resource endpoint releases all
resources.

Fixes #334