### PR TITLE
Enable OuterLoop testing for x-plat

### DIFF
--- a/Documentation/building/cross-platform-testing.md
+++ b/Documentation/building/cross-platform-testing.md
@@ -69,6 +69,8 @@ Then, run the tests.  run-test.sh defaults to wanting to use Windows tests (for
 historical reasons), so we need to pass an explict path to the tests, as well as
 a path to the location of CoreCLR, CoreFx, WCF and mscorlib.dll.
 
+All InnerLoop (aka unit) tests can be run like this:
+
 ```
 cd ~/git/wcf
 ./run-test.sh --coreclr-bins ~/git/coreclr/bin/Product/Linux.x64.Release \
@@ -79,4 +81,44 @@ cd ~/git/wcf
  --wcf-tests ~/git/wcf/bin/tests/Linux.AnyCPU.Debug
 ```
 
-run-test.sh should now invoke all the managed tests.
+The test run can be restricted to only specific tests using "restrict-proj" like this:
+
+```
+cd ~/git/wcf
+./run-test.sh --coreclr-bins ~/git/coreclr/bin/Product/Linux.x64.Release \
+ --mscorlib-bins ~/git/coreclr/bin/Product/Linux.x64.Release \
+ --corefx-bins ~/git/corefx/bin/Linux.AnyCPU.Debug/ \
+ --corefx-native-bins ~/git/corefx/bin/Linux.x64.Debug/Native \
+ --wcf-bins ~/git/wcf/bin/Linux.AnyCPU.Debug \
+ --wcf-tests ~/git/wcf/bin/tests/Linux.AnyCPU.Debug \
+ --restrict-proj System.ServiceModel.Primitives.Tests
+```
+
+To run OuterLoop (aka functional) tests, you need to first start the "Bridge" running on a separate Windows
+machine as described in [The Bridge and cross-machine testing](https://github.com/dotnet/wcf/blob/master/Documentation/cross-machine-test-guide.md).
+On that other machine, start the Bridge and tell it to allow remote access using "/allowRemote".  To lock down the Bridge
+to accept requests from only the test machine, it is a good idea to use "/remoteAddresses" to specify a single valid client
+IP address. On Linux, use 'ifconfig' to determine the IP address of the machine where the tests will run.
+On the machine where you want the Bridge to run, specify that when starting the Bridge, like this:
+
+```
+  StartBridge /allowRemote /remoteAddresses:{Linux-test-machine-IP-address}
+```
+
+Then on the Linux machine where the tests live, run the OuterLoop tests like this:
+
+```
+./run-test.sh --coreclr-bins ~/git/coreclr/bin/Product/Linux.x64.Release \
+ --mscorlib-bins ~/git/coreclr/bin/Product/Linux.x64.Release \
+ --corefx-bins ~/git/corefx/bin/Linux.AnyCPU.Debug/ \
+ --corefx-native-bins ~/git/corefx/bin/Linux.x64.Debug/Native \
+ --wcf-bins ~/git/wcf/bin/Linux.AnyCPU.Debug \
+ --wcf-tests ~/git/wcf/bin/tests/Linux.AnyCPU.Debug \
+ --bridge-host roncain7a \
+ --xunit-args "-notrait category=failing"
+```
+
+In this case, "bridge-host" identifies the machine where the Bridge is running.  The "xunit-args" option tells the test runner
+not to run tests already marked as "failing" with [ActiveIssue].  If "xunit-args is not specified, it defaults to
+"-notrait category=failing -notrait category=OuterLoop", meaning skip both failing and OuterLoop tests.  We allow OuterLoop
+tests to run by omitting that category from the "-notrait" list in the xunit-args option.

--- a/Documentation/building/cross-platform-testing.md
+++ b/Documentation/building/cross-platform-testing.md
@@ -30,7 +30,9 @@ instructions assume you are building for Linux, but are easily modifiable for OS
    CoreCLR (which is exactly what we do in Jenkins).
    
 4. A Linux build of the native CoreFX components.  On Linux, run ./build.sh from
-   src/Native in your CoreFX enlistment.
+   src/Native in your CoreFX enlistment.  Before doing this, ensure the libcurl
+   libraries are are installed using:
+   `apt-get install libcurl4-openssl-dev`
    
 5. A Linux build of WCF.  On Windows, run `build.cmd /p:OSGroup=Linux`. It
    is okay to build a Debug version of WCF and run it on top of a release

--- a/run-test.sh
+++ b/run-test.sh
@@ -33,6 +33,9 @@ usage()
     echo "                                      default: <repo_root>/bin/<OS>.AnyCPU.<Configuration>"
     echo "    --wcf-tests <location>            Location of the root binaries location containing"
     echo "                                      the windows WCF tests"
+    echo "    --bridge-host <machineName>       Machine hosting the Bridge for multi-machine tests"
+    echo
+    echo "    --xunit-args <xunit args>         Additional args to pass to xunit"
     echo
     echo "Flavor/OS options:"
     echo "    --configuration <config>          Configuration to run (Debug/Release)"
@@ -70,6 +73,8 @@ esac
 TestHostVersion="0.0.2-prerelease"
 TestSelection=".*"
 TestsFailed=0
+BridgeHost=""
+XunitArgs="-notrait category=failing -notrait category=OuterLoop"
 OverlayDir="$ProjectRoot/bin/tests/$OS.AnyCPU.$Configuration/TestOverlay/"
 
 create_test_overlay()
@@ -215,9 +220,9 @@ runtest()
 
   echo
   echo "Running tests in $dirName"
-  echo "./corerun xunit.console.netcore.exe $testDllName -xml testResults.xml -notrait category=failing -notrait category=OuterLoop -notrait category=$xunitOSCategory"
+  echo "./corerun xunit.console.netcore.exe $testDllName -xml testResults.xml $XunitArgs -notrait category=$xunitOSCategory"
   echo
-  ./corerun xunit.console.netcore.exe $testDllName -xml testResults.xml -notrait category=failing -notrait category=OuterLoop -notrait category=$xunitOSCategory
+  ./corerun xunit.console.netcore.exe $testDllName -xml testResults.xml $XunitArgs -notrait category=$xunitOSCategory
   exitCode=$?
   popd > /dev/null
   exit $exitCode
@@ -249,6 +254,13 @@ do
         ;;
         --wcf-bins)
         WcfBins=$2
+        ;;
+        --bridge-host)
+        BridgeHost=$2
+        export BridgeHost
+        ;;
+        --xunit-args)
+        XunitArgs=$2
         ;;
         --restrict-proj)
         TestSelection=$2

--- a/run-test.sh
+++ b/run-test.sh
@@ -328,6 +328,11 @@ then
     CoreClrObjs="$ProjectRoot/bin/obj/$OS.x64.$Configuration"
 fi
 
+if [ "$XunitArgs" != *"-notrait category=OuterLoop"* ]
+then
+    echo "OuterLoop tests will be run using the Bridge at $BridgeHost"
+fi
+
 create_test_overlay
 
 # Walk the directory tree rooted at src bin/tests/Windows_NT.AnyCPU.$Configuration/

--- a/src/System.Private.ServiceModel/tools/setupfiles/SetupWCFTestService.cmd
+++ b/src/System.Private.ServiceModel/tools/setupfiles/SetupWCFTestService.cmd
@@ -6,9 +6,14 @@ echo Building the Bridge...
 call BuildWCFTestService.cmd
 popd
 
+if '%BridgeResourceFolder%' == '' (
+   set _bridgeResourceFolder=..\..\Bridge\Resources
+) else (
+   set _bridgeResourceFolder=%BridgeResourceFolder%
+)
 pushd %~dp0..\..\..\..\bin\wcf\tools\Bridge
-echo starting the Bridge with arguments: /BridgeResourceFolder:..\..\Bridge\Resources %*
-start /MIN Bridge.exe /BridgeResourceFolder:..\..\Bridge\Resources %*
+echo Invoking Bridge.exe with arguments: /BridgeResourceFolder:%_bridgeResourceFolder% %*
+start /MIN Bridge.exe /BridgeResourceFolder:%_bridgeResourceFolder% %*
 popd
 
 exit /b

--- a/src/System.Private.ServiceModel/tools/test/Bridge/Bridge/Program.cs
+++ b/src/System.Private.ServiceModel/tools/test/Bridge/Bridge/Program.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Net;
 using System.Net.Http;
 using System.Text;
 using WcfTestBridgeCommon;
@@ -14,7 +15,6 @@ namespace Bridge
 {
     internal class Program
     {
-        internal const int DefaultPortNumber = 44283;
         internal const bool DefaultAllowRemote = false;
         internal const string DefaultRemoteAddresses = "LocalSubnet";
 
@@ -422,9 +422,6 @@ namespace Bridge
                 }
 
                 BridgeConfiguration = new BridgeConfiguration();
-                BridgeConfiguration.BridgePort = DefaultPortNumber;
-                BridgeConfiguration.BridgeHost = "localhost";
-                BridgeConfiguration.BridgeMaxIdleTimeSpan = IdleTimeoutHandler.Default_MaxIdleTimeSpan;
 
                 // If the user specified a configuration file, deserialize it as json
                 // and treat each name-value pair as if it had been on the command line.

--- a/src/System.Private.ServiceModel/tools/test/Bridge/WcfTestBridgeCommon/BridgeConfiguration.cs
+++ b/src/System.Private.ServiceModel/tools/test/Bridge/WcfTestBridgeCommon/BridgeConfiguration.cs
@@ -12,6 +12,14 @@ namespace WcfTestBridgeCommon
     [Serializable]
     public class BridgeConfiguration
     {
+        private static readonly string Default_BridgeHost = "localhost";
+        private static readonly int Default_BridgePort = 44283;
+        private static readonly int Default_BridgeHttpPort = 8081;
+        private static readonly int Default_BridgeHttpsPort = 44285;
+        private static readonly int Default_BridgeTcpPort = 809;
+        private static readonly int Default_BridgeWebSocketPort = 8083;
+        private static readonly TimeSpan Default_BridgeMaxIdleTimeSpan = TimeSpan.FromHours(24);
+        
         // These property names must match the names used in TestProperties because
         // that is the set of name/value pairs from which this type is created.
         private const string BridgeResourceFolder_PropertyName = "BridgeResourceFolder";
@@ -40,6 +48,13 @@ namespace WcfTestBridgeCommon
 
         public BridgeConfiguration()
         {
+            BridgeHost = Default_BridgeHost;
+            BridgePort = Default_BridgePort;
+            BridgeHttpPort = Default_BridgeHttpPort;
+            BridgeHttpsPort = Default_BridgeHttpsPort;
+            BridgeTcpPort = Default_BridgeTcpPort;
+            BridgeWebSocketPort = Default_BridgeWebSocketPort;
+            BridgeMaxIdleTimeSpan = Default_BridgeMaxIdleTimeSpan;
         }
 
         // This ctor accepts an existing BridgeConfiguration and a set of name/value pairs.

--- a/src/System.Private.ServiceModel/tools/test/Bridge/WcfTestBridgeCommon/PortManager.cs
+++ b/src/System.Private.ServiceModel/tools/test/Bridge/WcfTestBridgeCommon/PortManager.cs
@@ -92,6 +92,12 @@ namespace WcfTestBridgeCommon
 
         private static void AddFirewallRule(int port)
         {
+            if (port == 0)
+            {
+                Console.WriteLine("Warning -- request to add firewall rule for port 0 ignored.");
+                return;
+            }
+
             lock (s_portLock)
             {
                 // If we add any rules, register to delete them at process exit.


### PR DESCRIPTION
These changes make it possible to tell the run-test.sh script
that OuterLoop tests should be included.  More work is required
to allow a CI machine to host a 2nd machine, but this PR makes
it possible to test manually.

This PR also enhances the error reporting from BridgeClient to
improve the debugging experience talking x-machine to the WCF
Bridge component.