### PR TITLE
Disable failing negative Encoding tests on Linux

### DIFF
--- a/run-test.sh
+++ b/run-test.sh
@@ -145,7 +145,7 @@ create_test_overlay()
 	echo "Corefx binaries not found at $CoreFxBins"
 	exit 1
   fi
-  find $CoreFxBins -name '*.dll' -and -not -name "*Test*" -exec cp '{}' "$OverlayDir" ";"
+  find $CoreFxBins -name '*.dll' -and -not -name "*Test*" -and -not -wholename "*/ToolRuntime/*"  -exec cp '{}' "$OverlayDir" ";"
 
   # Then the native CoreFX binaries
   if [ ! -d $CoreFxNativeBins ]

--- a/src/System.ServiceModel.Http/tests/ServiceModel/BasicHttpBindingTest.cs
+++ b/src/System.ServiceModel.Http/tests/ServiceModel/BasicHttpBindingTest.cs
@@ -349,6 +349,7 @@ public static class BasicHttpBindingTest
 
     [Theory]
     [MemberData("InvalidEncodings", MemberType = typeof(TestData))]
+    [ActiveIssue(333, PlatformID.AnyUnix)]
     public static void TextEncoding_Property_Set_Invalid_Value_Throws(Encoding encoding)
     {
         var binding = new BasicHttpBinding();

--- a/src/System.ServiceModel.Primitives/tests/Channels/TextMessageEncodingBindingElementTest.cs
+++ b/src/System.ServiceModel.Primitives/tests/Channels/TextMessageEncodingBindingElementTest.cs
@@ -28,6 +28,7 @@ public static class TextMessageEncodingBindingElementTest
 
     [Theory]
     [MemberData("InvalidEncodings", MemberType = typeof(TestData))]
+    [ActiveIssue(333, PlatformID.AnyUnix)]
     public static void WriteEncoding_Property_Set_Throws_For_Invalid_Encodings(Encoding encoding)
     {
         TextMessageEncodingBindingElement element = new TextMessageEncodingBindingElement();


### PR DESCRIPTION
Two negative tests using known-unsupported Encodings were
failing due to issue https://github.com/dotnet/corefx/issues/2774
which returned UTF-8 for every unrecognized encoding.

Adds [ActiveIssue] to these tests using issue #333 which tracks
https://github.com/dotnet/corefx/issues/2774.  The [ActiveIssue]
disables these tests only on Linux.  They still execute on Windows.

Also modifies run-test.sh to exclude the TestRuntime folder from
CoreFx binaries when preparing the tests. The binaries in the WCF
test folders already contain the correct dependent binaries, and
allowing the TestRuntime folder to overwrite them gives out-of-date
or platform-incorrect binaries.

With these 2 changes, all unit tests not marked with [ActiveIssue]
pass on Linux.