### PR TITLE
Bump buildtools to version -00093 to fix code coverage

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -10,7 +10,7 @@
 
   <!-- Build Tools Versions -->
   <PropertyGroup>
-    <BuildToolsVersion>1.0.25-prerelease-00092</BuildToolsVersion>
+    <BuildToolsVersion>1.0.25-prerelease-00093</BuildToolsVersion>
     <DnxVersion>1.0.0-beta7</DnxVersion>
     <DnxPackageName Condition="'$(DnxPackageName)' == '' and '$(OsEnvironment)'!='Unix'">dnx-coreclr-win-x86.$(DnxVersion)</DnxPackageName>
     <DnxPackageName Condition="'$(DnxPackageName)' == '' and '$(OsEnvironment)'=='Unix'">dnx-mono.$(DnxVersion)</DnxPackageName>

--- a/src/.nuget/packages.Windows_NT.config
+++ b/src/.nuget/packages.Windows_NT.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.DotNet.BuildTools" version="1.0.25-prerelease-00092" />
+  <package id="Microsoft.DotNet.BuildTools" version="1.0.25-prerelease-00093" />
   <package id="dnx-coreclr-win-x86" version="1.0.0-beta7" />
   <package id="Microsoft.DotNet.BuildTools.ApiTools" version="1.0.0-prerelease" />
 </packages>


### PR DESCRIPTION
Coverage broke with the update to build tools version -00089