### PR TITLE
Enable IResources to receive and return name/value pairs

### DIFF
--- a/src/System.Private.ServiceModel/tests/Common/Infrastructure/src/JsonSerializer.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Infrastructure/src/JsonSerializer.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Infrastructure.Common
+{
+    internal class JsonSerializer
+    {
+        internal static readonly string JsonMediaType = "application/json";
+
+        internal static string SerializeDictionary(IDictionary dictionary)
+        {
+            StringBuilder sb = new StringBuilder();
+            sb.AppendLine("{");
+            foreach (var key in dictionary.Keys)
+            {
+                sb.AppendFormat("   {0} : \"{1}\",\n", key, dictionary[key] == null ? String.Empty : dictionary[key].ToString());
+            }
+
+            sb.Remove(sb.Length - 2, 2);
+            sb.AppendLine("\n}");
+            return sb.ToString();
+        }
+
+        internal static Dictionary<string, string> DeserializeDictionary(string data)
+        {
+            Dictionary<string, string> dictionary = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            data = data.Replace("{", String.Empty)
+                    .Replace("}", String.Empty)
+                    .Trim();
+
+            string[] pairs = data.Split(',');
+            foreach (string pair in pairs)
+            {
+                int colonPos = pair.IndexOf(':');
+                if (colonPos > 0)
+                {
+                    string key = pair.Substring(0, colonPos - 1).Replace("\"", String.Empty).Trim();
+                    string value = pair.Substring(colonPos + 1).Replace("\"", String.Empty).Trim();
+                    dictionary[key] = value;
+                }
+            }
+
+            return dictionary;
+        }
+    }
+}

--- a/src/System.Private.ServiceModel/tools/test/Bridge/Bridge/Program.cs
+++ b/src/System.Private.ServiceModel/tools/test/Bridge/Bridge/Program.cs
@@ -17,6 +17,7 @@ namespace Bridge
     {
         internal const bool DefaultAllowRemote = false;
         internal const string DefaultRemoteAddresses = "LocalSubnet";
+        internal const string BridgeControllerEndpoint = "Bridge";
 
         private static void Main(string[] args)
         {
@@ -69,7 +70,7 @@ namespace Bridge
         {
             errorMessage = null;
 
-            string bridgeUrl = String.Format("http://{0}:{1}/Bridge", host, port);
+            string bridgeUrl = String.Format("http://{0}:{1}/{2}", host, port, BridgeControllerEndpoint);
 
             using (HttpClient httpClient = new HttpClient())
             {
@@ -130,7 +131,10 @@ namespace Bridge
                 Environment.Exit(0);
             }
 
-            string bridgeUrl = String.Format("http://{0}:{1}/Bridge", commandLineArgs.BridgeConfiguration.BridgeHost, commandLineArgs.BridgeConfiguration.BridgePort);
+            string bridgeUrl = String.Format("http://{0}:{1}/{2}", 
+                                             commandLineArgs.BridgeConfiguration.BridgeHost, 
+                                             commandLineArgs.BridgeConfiguration.BridgePort,
+                                             BridgeControllerEndpoint);
             string problem = null;
 
             // We stop the Bridge using a DELETE request.
@@ -312,7 +316,9 @@ namespace Bridge
 
             while (true)
             {
-                Console.WriteLine("The Bridge is running and listening at {0}", visibleAddress);
+                Console.WriteLine("The Bridge is running and listening at {0}/{1}", 
+                                    visibleAddress, BridgeControllerEndpoint);
+
                 if (commandLineArgs.AllowRemote)
                 {
                     Console.WriteLine("Remote access is allowed from '{0}'", commandLineArgs.RemoteAddresses);

--- a/src/System.Private.ServiceModel/tools/test/Bridge/Bridge/ResourceInvoker.cs
+++ b/src/System.Private.ServiceModel/tools/test/Bridge/Bridge/ResourceInvoker.cs
@@ -9,11 +9,11 @@ namespace Bridge
 {
     public class ResourceInvoker
     {
-        public static object DynamicInvokePut(resource resource)
+        public static ResourceResponse DynamicInvokePut(string resourceName, Dictionary<string, string> properties)
         {
-            if (String.IsNullOrEmpty(resource.name))
+            if (String.IsNullOrEmpty(resourceName))
             {
-                throw new ArgumentNullException("resource.name");
+                throw new ArgumentNullException("resourceName");
             }
 
             // Disallow concurrent resource instantation or configuration changes
@@ -38,17 +38,19 @@ namespace Bridge
                 ResourceRequestContext context = new ResourceRequestContext
                 {
                     BridgeConfiguration = ConfigController.BridgeConfiguration,
-                    ResourceName = resource.name
+                    ResourceName = resourceName,
+                    Properties = properties
                 };
-                return loader.IResourceCall(resource.name, "Put", new object[] { context });
+                object result = loader.IResourceCall(resourceName, "Put", new object[] { context });
+                return (ResourceResponse) result;
             }
         }
 
-        public static object DynamicInvokeGet(string name)
+        public static ResourceResponse DynamicInvokeGet(string resourceName, Dictionary<string, string> properties)
         {
-            if (String.IsNullOrWhiteSpace(name))
+            if (String.IsNullOrWhiteSpace(resourceName))
             {
-                throw new ArgumentNullException("name");
+                throw new ArgumentNullException("resourceName");
             }
 
             // Disallow concurrent resource instantation or configuration changes
@@ -69,10 +71,12 @@ namespace Bridge
                 ResourceRequestContext context = new ResourceRequestContext
                 {
                     BridgeConfiguration = ConfigController.BridgeConfiguration,
-                    ResourceName = name
+                    ResourceName = resourceName,
+                    Properties = properties
                 };
 
-                return loader.IResourceCall(name, "Get", new object[] { context });
+                object result = loader.IResourceCall(resourceName, "Get", new object[] { context });
+                return (ResourceResponse) result;
             }
         }
     }

--- a/src/System.Private.ServiceModel/tools/test/Bridge/WcfTestBridgeCommon/AssemblyLoader.cs
+++ b/src/System.Private.ServiceModel/tools/test/Bridge/WcfTestBridgeCommon/AssemblyLoader.cs
@@ -52,6 +52,8 @@ namespace WcfTestBridgeCommon
             AppDomain.CurrentDomain.SetData(TypeList, types);
         }
 
+        // The return is a ResourceResponse but we return as object
+        // to avoid dynamic type casting across AppDomain boundaries.
         public object IResourceCall(string typeName, string verb, object[] arguments)
         {
             var types = AppDomain.CurrentDomain.GetData(TypeList) as Dictionary<string, Type>;

--- a/src/System.Private.ServiceModel/tools/test/Bridge/WcfTestBridgeCommon/IResource.cs
+++ b/src/System.Private.ServiceModel/tools/test/Bridge/WcfTestBridgeCommon/IResource.cs
@@ -5,8 +5,8 @@ namespace WcfTestBridgeCommon
 {
     public interface IResource
     {
-        object Put(ResourceRequestContext context);
+        ResourceResponse Put(ResourceRequestContext context);
 
-        object Get(ResourceRequestContext context);
+        ResourceResponse Get(ResourceRequestContext context);
     }
 }

--- a/src/System.Private.ServiceModel/tools/test/Bridge/WcfTestBridgeCommon/ResourceRequestContext.cs
+++ b/src/System.Private.ServiceModel/tools/test/Bridge/WcfTestBridgeCommon/ResourceRequestContext.cs
@@ -13,5 +13,6 @@ namespace WcfTestBridgeCommon
     {
         public BridgeConfiguration BridgeConfiguration { get; set; }
         public string ResourceName { get; set; }
+        public Dictionary<string, string> Properties { get; set; }
     }
 }

--- a/src/System.Private.ServiceModel/tools/test/Bridge/WcfTestBridgeCommon/ResourceResponse.cs
+++ b/src/System.Private.ServiceModel/tools/test/Bridge/WcfTestBridgeCommon/ResourceResponse.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace WcfTestBridgeCommon
+{
+    [Serializable]
+    public class ResourceResponse
+    {
+        public ResourceResponse()
+        {
+            Properties = new Dictionary<string, string>();
+        }
+
+        public Dictionary<string, string> Properties { get; set; }
+    }
+}

--- a/src/System.Private.ServiceModel/tools/test/Bridge/WcfTestBridgeCommon/WcfTestBridgeCommon.csproj
+++ b/src/System.Private.ServiceModel/tools/test/Bridge/WcfTestBridgeCommon/WcfTestBridgeCommon.csproj
@@ -41,6 +41,7 @@
     <Compile Include="IResource.cs" />
     <Compile Include="PortManager.cs" />
     <Compile Include="ResourceRequestContext.cs" />
+    <Compile Include="ResourceResponse.cs" />
   </ItemGroup>
   <ItemGroup>
     <COMReference Include="NetFwTypeLib">

--- a/src/System.Private.ServiceModel/tools/test/SelfHostWcfService/TestResources/BaseAddressResource.cs
+++ b/src/System.Private.ServiceModel/tools/test/SelfHostWcfService/TestResources/BaseAddressResource.cs
@@ -13,17 +13,17 @@ namespace WcfService.TestResources
         internal const string Https = "https";
         internal const string Tcp = "net.tcp";
 
-        public object Put(ResourceRequestContext context)
+        public ResourceResponse Put(ResourceRequestContext context)
         {
             throw new NotImplementedException("Cannot PUT on this resource");
         }
 
-        public object Get(ResourceRequestContext context)
+        public ResourceResponse Get(ResourceRequestContext context)
         {
             var http = GetHttpProtocol(context) + AppDomain.CurrentDomain.FriendlyName;
             var https = GetHttpsProtocol(context) + AppDomain.CurrentDomain.FriendlyName;
             var tcp = GetTcpProtocol(context) + AppDomain.CurrentDomain.FriendlyName;
-            return new Dictionary<string, string>()
+            Dictionary<string, string> resultDictionary = new Dictionary<string, string>()
             {
                 { "HttpServerBaseAddress", GetHttpProtocol(context) },
                 { "HttpBaseAddress", http },
@@ -33,6 +33,11 @@ namespace WcfService.TestResources
                 { "HttpsNtlmBaseAddress", https },
                 { "HttpsWindowsBaseAddress", https },
                 { "TcpBaseAddress", tcp }
+            };
+
+            return new ResourceResponse
+            {
+                Properties = resultDictionary
             };
         }
 


### PR DESCRIPTION
Prior to these changes, invoking the IResource interface
on the Bridge did not pass any part of the request content
to the IResource.  After this change, the ResourceRequestContext
contains name/value pairs deserialized from the request content.

This change also solidifies the IResource contract so that the
Get and Put methods return a ResourceResponse rather than object.
This permits resources to return name/value pairs as well as to
receive them.

The Bridge Client was updated to expect a response containing
name/value pairs as json instead of the regex match.

The ResourceController was hardened to handle missing or
incomplete request content and to trace the incoming and
outgoing name/value pairs.

Fixes #353