### PR TITLE
Update dependency on System.Runtime.Serialization.Xml

### DIFF
--- a/src/System.Private.ServiceModel/src/project.json
+++ b/src/System.Private.ServiceModel/src/project.json
@@ -33,7 +33,7 @@
     "System.Runtime.Extensions": "4.0.10",
     "System.Runtime.Handles": "4.0.0",
     "System.Runtime.InteropServices": "4.0.20-beta-*",
-    "System.Runtime.Serialization.Xml": "4.0.10",
+    "System.Runtime.Serialization.Xml": "4.0.11-beta-*",
     "System.Security.Claims": "4.0.0",
     "System.Security.Cryptography.X509Certificates": "4.0.0-beta-*",
     "System.Security.Principal": "4.0.0",

--- a/src/System.Private.ServiceModel/src/project.lock.json
+++ b/src/System.Private.ServiceModel/src/project.lock.json
@@ -316,7 +316,7 @@
           "lib/dotnet/System.Linq.Queryable.dll": {}
         }
       },
-      "System.Net.Http/4.0.1-beta-23324": {
+      "System.Net.Http/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -329,16 +329,15 @@
           "ref/dotnet/System.Net.Http.dll": {}
         }
       },
-      "System.Net.NameResolution/4.0.0-beta-23324": {
+      "System.Net.NameResolution/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.Networking": "4.0.1-beta-23324"
+          "System.Net.Primitives": "4.0.10",
+          "System.Runtime": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Net.NameResolution.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Net.NameResolution.dll": {}
         }
       },
       "System.Net.Primitives/4.0.10": {
@@ -353,10 +352,10 @@
           "lib/DNXCore50/System.Net.Primitives.dll": {}
         }
       },
-      "System.Net.Security/4.0.0-beta-23324": {
+      "System.Net.Security/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.Networking": "4.0.1-beta-23324"
+          "System.Private.Networking": "4.0.1-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.Net.Security.dll": {}
@@ -392,7 +391,7 @@
           "lib/dotnet/System.Net.WebHeaderCollection.dll": {}
         }
       },
-      "System.Net.WebSockets/4.0.0-beta-23324": {
+      "System.Net.WebSockets/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -404,10 +403,10 @@
           "ref/dotnet/System.Net.WebSockets.dll": {}
         },
         "runtime": {
-          "lib/DNXCore50/System.Net.WebSockets.dll": {}
+          "lib/dotnet/System.Net.WebSockets.dll": {}
         }
       },
-      "System.Net.WebSockets.Client/4.0.0-beta-23324": {
+      "System.Net.WebSockets.Client/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -417,13 +416,13 @@
           "System.Globalization": "4.0.10",
           "System.Net.Primitives": "4.0.10",
           "System.Net.WebHeaderCollection": "4.0.0",
-          "System.Net.WebSockets": "4.0.0-beta-23324",
+          "System.Net.WebSockets": "4.0.0-beta-23330",
           "System.Resources.ResourceManager": "4.0.0",
           "System.Runtime": "4.0.20",
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23324",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23330",
           "System.Text.Encoding": "4.0.10",
           "System.Threading": "4.0.10",
           "System.Threading.Tasks": "4.0.10"
@@ -451,10 +450,11 @@
           "lib/dotnet/System.ObjectModel.dll": {}
         }
       },
-      "System.Private.DataContractSerialization/4.0.0": {
+      "System.Private.DataContractSerialization/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
           "System.Globalization": "4.0.10",
           "System.IO": "4.0.10",
           "System.Linq": "4.0.0",
@@ -465,11 +465,12 @@
           "System.Resources.ResourceManager": "4.0.0",
           "System.Runtime": "4.0.20",
           "System.Runtime.Extensions": "4.0.10",
-          "System.Runtime.Serialization.Primitives": "4.0.10",
+          "System.Runtime.Serialization.Primitives": "4.0.11-beta-23330",
           "System.Text.Encoding": "4.0.10",
           "System.Text.Encoding.Extensions": "4.0.10",
           "System.Text.RegularExpressions": "4.0.10",
           "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10",
           "System.Xml.ReaderWriter": "4.0.10",
           "System.Xml.XmlSerializer": "4.0.10"
         },
@@ -480,7 +481,7 @@
           "lib/DNXCore50/System.Private.DataContractSerialization.dll": {}
         }
       },
-      "System.Private.Networking/4.0.1-beta-23324": {
+      "System.Private.Networking/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -499,13 +500,13 @@
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23324",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23324",
-          "System.Security.Principal.Windows": "4.0.0-beta-23324",
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23330",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23330",
+          "System.Security.Principal.Windows": "4.0.0-beta-23330",
           "System.Threading": "4.0.10",
           "System.Threading.Overlapped": "4.0.0",
           "System.Threading.Tasks": "4.0.10",
-          "System.Threading.ThreadPool": "4.0.10-beta-23324"
+          "System.Threading.ThreadPool": "4.0.10-beta-23330"
         },
         "compile": {
           "ref/dnxcore50/_._": {}
@@ -689,7 +690,7 @@
           "lib/DNXCore50/System.Runtime.InteropServices.dll": {}
         }
       },
-      "System.Runtime.Serialization.Primitives/4.0.10": {
+      "System.Runtime.Serialization.Primitives/4.0.11-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Resources.ResourceManager": "4.0.0",
@@ -702,11 +703,11 @@
           "lib/dotnet/System.Runtime.Serialization.Primitives.dll": {}
         }
       },
-      "System.Runtime.Serialization.Xml/4.0.10": {
+      "System.Runtime.Serialization.Xml/4.0.11-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.DataContractSerialization": "4.0.0",
-          "System.Runtime.Serialization.Primitives": "4.0.10"
+          "System.Private.DataContractSerialization": "4.0.1-beta-23330",
+          "System.Runtime.Serialization.Primitives": "4.0.11-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.Runtime.Serialization.Xml.dll": {}
@@ -734,18 +735,18 @@
           "lib/dotnet/System.Security.Claims.dll": {}
         }
       },
-      "System.Security.Cryptography.Algorithms/4.0.0-beta-23324": {
+      "System.Security.Cryptography.Algorithms/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
           "System.Runtime": "4.0.0",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23324"
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.Algorithms.dll": {}
         }
       },
-      "System.Security.Cryptography.Encoding/4.0.0-beta-23324": {
+      "System.Security.Cryptography.Encoding/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -754,7 +755,7 @@
           "ref/dotnet/System.Security.Cryptography.Encoding.dll": {}
         }
       },
-      "System.Security.Cryptography.Primitives/4.0.0-beta-23324": {
+      "System.Security.Cryptography.Primitives/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.0",
@@ -772,13 +773,13 @@
           "lib/dotnet/System.Security.Cryptography.Primitives.dll": {}
         }
       },
-      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23324": {
+      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
           "System.Runtime.Handles": "4.0.0",
-          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23324",
-          "System.Security.Cryptography.Encoding": "4.0.0-beta-23324"
+          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23330",
+          "System.Security.Cryptography.Encoding": "4.0.0-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.X509Certificates.dll": {}
@@ -796,7 +797,7 @@
           "lib/dotnet/System.Security.Principal.dll": {}
         }
       },
-      "System.Security.Principal.Windows/4.0.0-beta-23324": {
+      "System.Security.Principal.Windows/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -899,7 +900,7 @@
           "lib/DNXCore50/System.Threading.Tasks.dll": {}
         }
       },
-      "System.Threading.ThreadPool/4.0.10-beta-23324": {
+      "System.Threading.ThreadPool/4.0.10-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
@@ -1350,29 +1351,20 @@
           "lib/netcore50/System.Linq.Queryable.dll": {}
         }
       },
-      "System.Net.Http/4.0.1-beta-23324": {
+      "System.Net.Http/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Collections": "4.0.10",
-          "System.Diagnostics.Debug": "4.0.10",
-          "System.Globalization": "4.0.10",
-          "System.IO": "4.0.10",
+          "System.IO": "4.0.0",
           "System.Net.Primitives": "4.0.0",
-          "System.Resources.ResourceManager": "4.0.0",
-          "System.Runtime": "4.0.20",
-          "System.Runtime.Extensions": "4.0.10",
-          "System.Runtime.InteropServices": "4.0.20",
-          "System.Runtime.WindowsRuntime": "4.0.10",
-          "System.Text.Encoding": "4.0.10",
-          "System.Text.Encoding.Extensions": "4.0.10",
-          "System.Threading": "4.0.10",
-          "System.Threading.Tasks": "4.0.10"
+          "System.Runtime": "4.0.0",
+          "System.Text.Encoding": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/netcore50/System.Net.Http.dll": {}
         },
         "runtime": {
-          "lib/netcore50/System.Net.Http.dll": {}
+          "lib/win8/_._": {}
         }
       },
       "System.Net.Primitives/4.0.10": {
@@ -1388,13 +1380,13 @@
           "lib/netcore50/System.Net.Primitives.dll": {}
         }
       },
-      "System.Net.Security/4.0.0-beta-23324": {
+      "System.Net.Security/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
           "System.Net.Primitives": "4.0.10",
           "System.Runtime": "4.0.0",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23324",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23330",
           "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
@@ -1416,27 +1408,47 @@
           "lib/dotnet/System.Net.WebHeaderCollection.dll": {}
         }
       },
-      "System.Net.WebSockets/4.0.0-beta-23324": {
+      "System.Net.WebSockets/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Runtime": "4.0.0",
+          "Microsoft.Win32.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
           "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Net.WebSockets.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Net.WebSockets.dll": {}
         }
       },
-      "System.Net.WebSockets.Client/4.0.0-beta-23324": {
+      "System.Net.WebSockets.Client/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Diagnostics.Tracing": "4.0.20",
+          "System.Globalization": "4.0.10",
           "System.Net.Primitives": "4.0.10",
-          "System.Net.WebSockets": "4.0.0-beta-23324",
-          "System.Runtime": "4.0.0",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23324",
-          "System.Threading.Tasks": "4.0.0"
+          "System.Net.WebHeaderCollection": "4.0.0",
+          "System.Net.WebSockets": "4.0.0-beta-23330",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Runtime.InteropServices.WindowsRuntime": "4.0.0",
+          "System.Runtime.WindowsRuntime": "4.0.0",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23330",
+          "System.Text.Encoding": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dotnet/System.Net.WebSockets.Client.dll": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.Net.WebSockets.Client.dll": {}
         }
       },
       "System.ObjectModel/4.0.10": {
@@ -1455,10 +1467,11 @@
           "lib/dotnet/System.ObjectModel.dll": {}
         }
       },
-      "System.Private.DataContractSerialization/4.0.0": {
+      "System.Private.DataContractSerialization/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
           "System.Globalization": "4.0.10",
           "System.IO": "4.0.10",
           "System.Linq": "4.0.0",
@@ -1469,11 +1482,12 @@
           "System.Resources.ResourceManager": "4.0.0",
           "System.Runtime": "4.0.20",
           "System.Runtime.Extensions": "4.0.10",
-          "System.Runtime.Serialization.Primitives": "4.0.10",
+          "System.Runtime.Serialization.Primitives": "4.0.11-beta-23330",
           "System.Text.Encoding": "4.0.10",
           "System.Text.Encoding.Extensions": "4.0.10",
           "System.Text.RegularExpressions": "4.0.10",
           "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10",
           "System.Xml.ReaderWriter": "4.0.10",
           "System.Xml.XmlSerializer": "4.0.10"
         },
@@ -1669,7 +1683,19 @@
           "lib/netcore50/System.Runtime.InteropServices.dll": {}
         }
       },
-      "System.Runtime.Serialization.Primitives/4.0.10": {
+      "System.Runtime.InteropServices.WindowsRuntime/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/netcore50/System.Runtime.InteropServices.WindowsRuntime.dll": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.Runtime.InteropServices.WindowsRuntime.dll": {}
+        }
+      },
+      "System.Runtime.Serialization.Primitives/4.0.11-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Resources.ResourceManager": "4.0.0",
@@ -1682,11 +1708,11 @@
           "lib/dotnet/System.Runtime.Serialization.Primitives.dll": {}
         }
       },
-      "System.Runtime.Serialization.Xml/4.0.10": {
+      "System.Runtime.Serialization.Xml/4.0.11-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.DataContractSerialization": "4.0.0",
-          "System.Runtime.Serialization.Primitives": "4.0.10"
+          "System.Private.DataContractSerialization": "4.0.1-beta-23330",
+          "System.Runtime.Serialization.Primitives": "4.0.11-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.Runtime.Serialization.Xml.dll": {}
@@ -1735,18 +1761,18 @@
           "lib/dotnet/System.Security.Claims.dll": {}
         }
       },
-      "System.Security.Cryptography.Algorithms/4.0.0-beta-23324": {
+      "System.Security.Cryptography.Algorithms/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
           "System.Runtime": "4.0.0",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23324"
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.Algorithms.dll": {}
         }
       },
-      "System.Security.Cryptography.Encoding/4.0.0-beta-23324": {
+      "System.Security.Cryptography.Encoding/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -1755,7 +1781,7 @@
           "ref/dotnet/System.Security.Cryptography.Encoding.dll": {}
         }
       },
-      "System.Security.Cryptography.Primitives/4.0.0-beta-23324": {
+      "System.Security.Cryptography.Primitives/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.0",
@@ -1773,13 +1799,13 @@
           "lib/dotnet/System.Security.Cryptography.Primitives.dll": {}
         }
       },
-      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23324": {
+      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
           "System.Runtime.Handles": "4.0.0",
-          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23324",
-          "System.Security.Cryptography.Encoding": "4.0.0-beta-23324"
+          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23330",
+          "System.Security.Cryptography.Encoding": "4.0.0-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.X509Certificates.dll": {}
@@ -1797,7 +1823,7 @@
           "lib/netcore50/System.Security.Principal.dll": {}
         }
       },
-      "System.Security.Principal.Windows/4.0.0-beta-23324": {
+      "System.Security.Principal.Windows/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
@@ -2670,23 +2696,12 @@
         "System.Linq.Queryable.nuspec"
       ]
     },
-    "System.Net.Http/4.0.1-beta-23324": {
+    "System.Net.Http/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "gXfHlWsiMQDuFqwnQrlQTje9vqMhCFLtm35jX4WqZjcfa3y69DbwueeT0gJbVMK88/UnG8FAYiDBb7AKyu+51w==",
+      "sha512": "itLPx7B7Ac4mX8wQx9V9DQcxqTgkmwDNnQIHuCgAH53Jq2X3XziiRRBbxbmNJlWqBlgPzbseWJmMCtcF/ePhOg==",
       "files": [
         "lib/net45/_._",
-        "lib/netcore50/de/System.Net.Http.xml",
-        "lib/netcore50/es/System.Net.Http.xml",
-        "lib/netcore50/fr/System.Net.Http.xml",
-        "lib/netcore50/it/System.Net.Http.xml",
-        "lib/netcore50/ja/System.Net.Http.xml",
-        "lib/netcore50/ko/System.Net.Http.xml",
-        "lib/netcore50/ru/System.Net.Http.xml",
-        "lib/netcore50/System.Net.Http.dll",
-        "lib/netcore50/System.Net.Http.xml",
-        "lib/netcore50/zh-hans/System.Net.Http.xml",
-        "lib/netcore50/zh-hant/System.Net.Http.xml",
         "lib/win8/_._",
         "lib/wpa81/_._",
         "ref/dotnet/System.Net.Http.dll",
@@ -2695,17 +2710,16 @@
         "ref/win8/_._",
         "ref/wpa81/_._",
         "runtime.json",
-        "System.Net.Http.4.0.1-beta-23324.nupkg",
-        "System.Net.Http.4.0.1-beta-23324.nupkg.sha512",
+        "System.Net.Http.4.0.1-beta-23330.nupkg",
+        "System.Net.Http.4.0.1-beta-23330.nupkg.sha512",
         "System.Net.Http.nuspec"
       ]
     },
-    "System.Net.NameResolution/4.0.0-beta-23324": {
+    "System.Net.NameResolution/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "lNYXUmnSXUtLFY09Rc27zJ6/TxCuGggQzBgiuWHoWrjWxymuuxqPT2Mj7Dn7sUUh0GvF2MOx7Uk+rtCFBiIavg==",
+      "sha512": "d8Am+In/aBgcHpEV6xsi5BCiTEN4y6s9O1V/yIvwX8mDC4CtdZiGsi4DtoB0TLOgp8ky6GxbSF4bKCjFpBO3uw==",
       "files": [
-        "lib/DNXCore50/System.Net.NameResolution.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.NameResolution.dll",
@@ -2717,8 +2731,9 @@
         "ref/net46/System.Net.NameResolution.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.NameResolution.4.0.0-beta-23324.nupkg",
-        "System.Net.NameResolution.4.0.0-beta-23324.nupkg.sha512",
+        "runtime.json",
+        "System.Net.NameResolution.4.0.0-beta-23330.nupkg",
+        "System.Net.NameResolution.4.0.0-beta-23330.nupkg.sha512",
         "System.Net.NameResolution.nuspec"
       ]
     },
@@ -2755,9 +2770,9 @@
         "System.Net.Primitives.nuspec"
       ]
     },
-    "System.Net.Security/4.0.0-beta-23324": {
+    "System.Net.Security/4.0.0-beta-23330": {
       "type": "package",
-      "sha512": "D04RYjxrnR3D+uI9CGmAAFKKQ6T+pPcRHYucc1PIo7/hJK5I/Yu7gAw9yOxHUhQjSGfrKo00lHpBCQMTQt4lSw==",
+      "sha512": "z98dKloNy9DBdyfqQwQvKWA2q8Qj4vgGEVONnlS70c13eh0MolBHJ0wNdplZZK5zYZ5Eu8GTwexbUlpHbsfzVA==",
       "files": [
         "lib/DNXCore50/System.Net.Security.dll",
         "lib/MonoAndroid10/_._",
@@ -2771,8 +2786,8 @@
         "ref/net46/System.Net.Security.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.Security.4.0.0-beta-23324.nupkg",
-        "System.Net.Security.4.0.0-beta-23324.nupkg.sha512",
+        "System.Net.Security.4.0.0-beta-23330.nupkg",
+        "System.Net.Security.4.0.0-beta-23330.nupkg.sha512",
         "System.Net.Security.nuspec"
       ]
     },
@@ -2837,22 +2852,22 @@
         "System.Net.WebHeaderCollection.nuspec"
       ]
     },
-    "System.Net.WebSockets/4.0.0-beta-23324": {
+    "System.Net.WebSockets/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "Yq5jsxarl7rhHGtPx1vpW3a2iUF+4eD6FE5u2IRlBs8YEvoGVN2jzhBtPJw40t1SGidXLCvlsVaB3qyNbk99MQ==",
+      "sha512": "6Q9/uTDcaqbmdbD04MisKmjti4aEpp40i/UzpGaPZ4ItuwzU/pMk9RjiYUBUiCQyZeKNlXcSB1FPN2nFof7tww==",
       "files": [
-        "lib/DNXCore50/de/System.Net.WebSockets.xml",
-        "lib/DNXCore50/es/System.Net.WebSockets.xml",
-        "lib/DNXCore50/fr/System.Net.WebSockets.xml",
-        "lib/DNXCore50/it/System.Net.WebSockets.xml",
-        "lib/DNXCore50/ja/System.Net.WebSockets.xml",
-        "lib/DNXCore50/ko/System.Net.WebSockets.xml",
-        "lib/DNXCore50/ru/System.Net.WebSockets.xml",
-        "lib/DNXCore50/System.Net.WebSockets.dll",
-        "lib/DNXCore50/System.Net.WebSockets.xml",
-        "lib/DNXCore50/zh-hans/System.Net.WebSockets.xml",
-        "lib/DNXCore50/zh-hant/System.Net.WebSockets.xml",
+        "lib/dotnet/de/System.Net.WebSockets.xml",
+        "lib/dotnet/es/System.Net.WebSockets.xml",
+        "lib/dotnet/fr/System.Net.WebSockets.xml",
+        "lib/dotnet/it/System.Net.WebSockets.xml",
+        "lib/dotnet/ja/System.Net.WebSockets.xml",
+        "lib/dotnet/ko/System.Net.WebSockets.xml",
+        "lib/dotnet/ru/System.Net.WebSockets.xml",
+        "lib/dotnet/System.Net.WebSockets.dll",
+        "lib/dotnet/System.Net.WebSockets.xml",
+        "lib/dotnet/zh-hans/System.Net.WebSockets.xml",
+        "lib/dotnet/zh-hant/System.Net.WebSockets.xml",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.WebSockets.dll",
@@ -2864,15 +2879,15 @@
         "ref/net46/System.Net.WebSockets.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.WebSockets.4.0.0-beta-23324.nupkg",
-        "System.Net.WebSockets.4.0.0-beta-23324.nupkg.sha512",
+        "System.Net.WebSockets.4.0.0-beta-23330.nupkg",
+        "System.Net.WebSockets.4.0.0-beta-23330.nupkg.sha512",
         "System.Net.WebSockets.nuspec"
       ]
     },
-    "System.Net.WebSockets.Client/4.0.0-beta-23324": {
+    "System.Net.WebSockets.Client/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "Zgnuyst8Kr37iY1z887R8R8VBFdKFqgHCmBTUIrBa8CUvGOvDocK/tM/b+VmseX0cEgUpodNB47gzGIVV0iM5g==",
+      "sha512": "1NWEqwDkYRyvr1gSKZlY51AaI9w8oD0dC5UNa2Lb+qaeFHSF5KfCSzf7seD+im+sH6uocVo2nppiaabfbXZT4Q==",
       "files": [
         "lib/DNXCore50/de/System.Net.WebSockets.Client.xml",
         "lib/DNXCore50/es/System.Net.WebSockets.Client.xml",
@@ -2888,6 +2903,17 @@
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.WebSockets.Client.dll",
+        "lib/netcore50/de/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/es/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/fr/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/it/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/ja/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/ko/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/ru/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/System.Net.WebSockets.Client.dll",
+        "lib/netcore50/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/zh-hans/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/zh-hant/System.Net.WebSockets.Client.xml",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
         "ref/dotnet/System.Net.WebSockets.Client.dll",
@@ -2896,8 +2922,8 @@
         "ref/net46/System.Net.WebSockets.Client.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.WebSockets.Client.4.0.0-beta-23324.nupkg",
-        "System.Net.WebSockets.Client.4.0.0-beta-23324.nupkg.sha512",
+        "System.Net.WebSockets.Client.4.0.0-beta-23330.nupkg",
+        "System.Net.WebSockets.Client.4.0.0-beta-23330.nupkg.sha512",
         "System.Net.WebSockets.Client.nuspec"
       ]
     },
@@ -2933,10 +2959,10 @@
         "System.ObjectModel.nuspec"
       ]
     },
-    "System.Private.DataContractSerialization/4.0.0": {
+    "System.Private.DataContractSerialization/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "uQvzoXHXHn/9YqUmPtgD8ZPJIlBuuL3QHegbuik97W/umoI28fOnGLnvjRHhju1VMWvFLRQoh7uZkBaoZ+KpVQ==",
+      "sha512": "/5tVyLbNpRC1efSJ2fhoUaiey8vVsxDCkrFATTFkDmQGb4hoFRe1JNATLh/LDvHNB6QNgQmbwyPvVRTEvBVGEQ==",
       "files": [
         "lib/DNXCore50/System.Private.DataContractSerialization.dll",
         "lib/netcore50/System.Private.DataContractSerialization.dll",
@@ -2944,8 +2970,8 @@
         "ref/netcore50/_._",
         "runtime.json",
         "runtimes/win8-aot/lib/netcore50/System.Private.DataContractSerialization.dll",
-        "System.Private.DataContractSerialization.4.0.0.nupkg",
-        "System.Private.DataContractSerialization.4.0.0.nupkg.sha512",
+        "System.Private.DataContractSerialization.4.0.1-beta-23330.nupkg",
+        "System.Private.DataContractSerialization.4.0.1-beta-23330.nupkg.sha512",
         "System.Private.DataContractSerialization.nuspec"
       ]
     },
@@ -2963,17 +2989,17 @@
         "System.Private.Networking.nuspec"
       ]
     },
-    "System.Private.Networking/4.0.1-beta-23324": {
+    "System.Private.Networking/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "OfyxoeCdh1ypzdz1u0h1Clgt+6749vALs2ZPkLwsOPzL0INCG9ISYo+Jhh62ZD8TMkWwLrvyVppMBPHY6M7Upw==",
+      "sha512": "8NZi1gCQaGTKDb2yWplm52HWCLaZnUwVitksJgcXY2dEJau/TBGyZup+yhOngOIe8QzQMxNG4iokY3Ce0/8mbg==",
       "files": [
         "lib/DNXCore50/System.Private.Networking.dll",
         "lib/netcore50/System.Private.Networking.dll",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "System.Private.Networking.4.0.1-beta-23324.nupkg",
-        "System.Private.Networking.4.0.1-beta-23324.nupkg.sha512",
+        "System.Private.Networking.4.0.1-beta-23330.nupkg",
+        "System.Private.Networking.4.0.1-beta-23330.nupkg.sha512",
         "System.Private.Networking.nuspec"
       ]
     },
@@ -3385,41 +3411,75 @@
         "System.Runtime.InteropServices.nuspec"
       ]
     },
-    "System.Runtime.Serialization.Primitives/4.0.10": {
+    "System.Runtime.InteropServices.WindowsRuntime/4.0.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "NPc8DZIomf5tGjYtz/KTHI01IPcVlypfhCux32AbLPDjTotdvL8TpKRwMyQJ6Kh08yprRVH7uBD1PdJiuoFzag==",
+      "sha512": "K5MGSvw/sGPKQYdOVqSpsVbHBE8HccHIDEhUNjM1lui65KGF/slNZfijGU87ggQiVXTI802ebKiOYBkwiLotow==",
       "files": [
+        "lib/net45/_._",
+        "lib/netcore50/System.Runtime.InteropServices.WindowsRuntime.dll",
+        "lib/win8/_._",
+        "lib/wp80/_._",
+        "lib/wpa81/_._",
+        "ref/dotnet/de/System.Runtime.InteropServices.WindowsRuntime.xml",
+        "ref/dotnet/es/System.Runtime.InteropServices.WindowsRuntime.xml",
+        "ref/dotnet/fr/System.Runtime.InteropServices.WindowsRuntime.xml",
+        "ref/dotnet/it/System.Runtime.InteropServices.WindowsRuntime.xml",
+        "ref/dotnet/ja/System.Runtime.InteropServices.WindowsRuntime.xml",
+        "ref/dotnet/ko/System.Runtime.InteropServices.WindowsRuntime.xml",
+        "ref/dotnet/ru/System.Runtime.InteropServices.WindowsRuntime.xml",
+        "ref/dotnet/System.Runtime.InteropServices.WindowsRuntime.dll",
+        "ref/dotnet/System.Runtime.InteropServices.WindowsRuntime.xml",
+        "ref/dotnet/zh-hans/System.Runtime.InteropServices.WindowsRuntime.xml",
+        "ref/dotnet/zh-hant/System.Runtime.InteropServices.WindowsRuntime.xml",
+        "ref/net45/_._",
+        "ref/netcore50/System.Runtime.InteropServices.WindowsRuntime.dll",
+        "ref/netcore50/System.Runtime.InteropServices.WindowsRuntime.xml",
+        "ref/win8/_._",
+        "ref/wp80/_._",
+        "ref/wpa81/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.InteropServices.WindowsRuntime.dll",
+        "System.Runtime.InteropServices.WindowsRuntime.4.0.0.nupkg",
+        "System.Runtime.InteropServices.WindowsRuntime.4.0.0.nupkg.sha512",
+        "System.Runtime.InteropServices.WindowsRuntime.nuspec"
+      ]
+    },
+    "System.Runtime.Serialization.Primitives/4.0.11-beta-23330": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "bxnXaAL2xcwGEiNMKiU6yumv+PE02zt4I6rOVnbqYdrNfvy0mvdeWi02WkQKUj/ride+8Am7/FlQ6vfi2Dz6IA==",
+      "files": [
+        "lib/dotnet/de/System.Runtime.Serialization.Primitives.xml",
+        "lib/dotnet/es/System.Runtime.Serialization.Primitives.xml",
+        "lib/dotnet/fr/System.Runtime.Serialization.Primitives.xml",
+        "lib/dotnet/it/System.Runtime.Serialization.Primitives.xml",
+        "lib/dotnet/ja/System.Runtime.Serialization.Primitives.xml",
+        "lib/dotnet/ko/System.Runtime.Serialization.Primitives.xml",
+        "lib/dotnet/ru/System.Runtime.Serialization.Primitives.xml",
         "lib/dotnet/System.Runtime.Serialization.Primitives.dll",
+        "lib/dotnet/System.Runtime.Serialization.Primitives.xml",
+        "lib/dotnet/zh-hans/System.Runtime.Serialization.Primitives.xml",
+        "lib/dotnet/zh-hant/System.Runtime.Serialization.Primitives.xml",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/de/System.Runtime.Serialization.Primitives.xml",
-        "ref/dotnet/es/System.Runtime.Serialization.Primitives.xml",
-        "ref/dotnet/fr/System.Runtime.Serialization.Primitives.xml",
-        "ref/dotnet/it/System.Runtime.Serialization.Primitives.xml",
-        "ref/dotnet/ja/System.Runtime.Serialization.Primitives.xml",
-        "ref/dotnet/ko/System.Runtime.Serialization.Primitives.xml",
-        "ref/dotnet/ru/System.Runtime.Serialization.Primitives.xml",
         "ref/dotnet/System.Runtime.Serialization.Primitives.dll",
-        "ref/dotnet/System.Runtime.Serialization.Primitives.xml",
-        "ref/dotnet/zh-hans/System.Runtime.Serialization.Primitives.xml",
-        "ref/dotnet/zh-hant/System.Runtime.Serialization.Primitives.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Runtime.Serialization.Primitives.4.0.10.nupkg",
-        "System.Runtime.Serialization.Primitives.4.0.10.nupkg.sha512",
+        "System.Runtime.Serialization.Primitives.4.0.11-beta-23330.nupkg",
+        "System.Runtime.Serialization.Primitives.4.0.11-beta-23330.nupkg.sha512",
         "System.Runtime.Serialization.Primitives.nuspec"
       ]
     },
-    "System.Runtime.Serialization.Xml/4.0.10": {
+    "System.Runtime.Serialization.Xml/4.0.11-beta-23330": {
       "type": "package",
-      "sha512": "xsy7XbH8RTpKoDPNcibSGCOpujsmwUmOWAby3PssqkZFpLBXUbDO2s6JKITRjxejET2g0PK8t+mdIvu3xmUuKA==",
+      "serviceable": true,
+      "sha512": "eBQrA9Kqjgwt5OzKimjWZKPdzcX9n1B8Rr7Wpfup9+6S37Y9FcZRQfpThsD98uttxK112oAAjq2Bs2rpVcK+Tw==",
       "files": [
         "lib/DNXCore50/System.Runtime.Serialization.Xml.dll",
         "lib/MonoAndroid10/_._",
@@ -3428,25 +3488,15 @@
         "lib/netcore50/System.Runtime.Serialization.Xml.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/de/System.Runtime.Serialization.Xml.xml",
-        "ref/dotnet/es/System.Runtime.Serialization.Xml.xml",
-        "ref/dotnet/fr/System.Runtime.Serialization.Xml.xml",
-        "ref/dotnet/it/System.Runtime.Serialization.Xml.xml",
-        "ref/dotnet/ja/System.Runtime.Serialization.Xml.xml",
-        "ref/dotnet/ko/System.Runtime.Serialization.Xml.xml",
-        "ref/dotnet/ru/System.Runtime.Serialization.Xml.xml",
         "ref/dotnet/System.Runtime.Serialization.Xml.dll",
-        "ref/dotnet/System.Runtime.Serialization.Xml.xml",
-        "ref/dotnet/zh-hans/System.Runtime.Serialization.Xml.xml",
-        "ref/dotnet/zh-hant/System.Runtime.Serialization.Xml.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtimes/win8-aot/lib/netcore50/System.Runtime.Serialization.Xml.dll",
-        "System.Runtime.Serialization.Xml.4.0.10.nupkg",
-        "System.Runtime.Serialization.Xml.4.0.10.nupkg.sha512",
+        "System.Runtime.Serialization.Xml.4.0.11-beta-23330.nupkg",
+        "System.Runtime.Serialization.Xml.4.0.11-beta-23330.nupkg.sha512",
         "System.Runtime.Serialization.Xml.nuspec"
       ]
     },
@@ -3511,10 +3561,10 @@
         "System.Security.Claims.nuspec"
       ]
     },
-    "System.Security.Cryptography.Algorithms/4.0.0-beta-23324": {
+    "System.Security.Cryptography.Algorithms/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "Mt6LwMj8hPp0+xZHcV6grZ7wSWhgycGkdZ6DQ9XvUY9NguUsvb/+fu2cMdrC7XsnpvwIROByp+p2dSjqBn3E2Q==",
+      "sha512": "FB4RoTDaV5tBiPSJsiG3A5DydeKz7ErglnkqVjBFjm6wu8kg91j0MxL/Al9iUyu9i/hq53fRs5KE3rjUNYvf5w==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -3528,15 +3578,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.Algorithms.4.0.0-beta-23324.nupkg",
-        "System.Security.Cryptography.Algorithms.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Cryptography.Algorithms.4.0.0-beta-23330.nupkg",
+        "System.Security.Cryptography.Algorithms.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Cryptography.Algorithms.nuspec"
       ]
     },
-    "System.Security.Cryptography.Encoding/4.0.0-beta-23324": {
+    "System.Security.Cryptography.Encoding/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "JHOyknf1eYO6C39Vao6kAGpadq3PBO1L4tuzNEz/HvbH5sfIHPbjhxL11OyAhVKCzLCfEj6+aeClovFqZIRPyw==",
+      "sha512": "zeFdKQT6xjNdiNCaEmEYJMEK59kixkX7jJSoOLw3H+53t9X0F98vr3tS8YlrW/Lk/K9c6L5pYLlkb2dNqvUD/g==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -3550,15 +3600,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.Encoding.4.0.0-beta-23324.nupkg",
-        "System.Security.Cryptography.Encoding.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Cryptography.Encoding.4.0.0-beta-23330.nupkg",
+        "System.Security.Cryptography.Encoding.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Cryptography.Encoding.nuspec"
       ]
     },
-    "System.Security.Cryptography.Primitives/4.0.0-beta-23324": {
+    "System.Security.Cryptography.Primitives/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "ETZxelIX51Di4FTytd8ohSpN6Ym/32aWIX9E2NCFkd91qdexn2Dkysn80b6n4gX6jG+oL0UHQDtD/fYq8C65oQ==",
+      "sha512": "15uVbOD3X0sRQJIxcEH5hasxlFdbA1CmPPZa0Y8pYEuQcWMF2gBswvU8s4qoKtA7x2xhNhzPsXIhsQuKNMTdEA==",
       "files": [
         "lib/dotnet/System.Security.Cryptography.Primitives.dll",
         "lib/MonoAndroid10/_._",
@@ -3572,15 +3622,15 @@
         "ref/net46/System.Security.Cryptography.Primitives.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Security.Cryptography.Primitives.4.0.0-beta-23324.nupkg",
-        "System.Security.Cryptography.Primitives.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Cryptography.Primitives.4.0.0-beta-23330.nupkg",
+        "System.Security.Cryptography.Primitives.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Cryptography.Primitives.nuspec"
       ]
     },
-    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23324": {
+    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "8NaEOxkkNBUECh0cPzGpbXS0uzGDpnvxI0kqQKRGp9uA+9qCyQfxcqAT6ozAYtOuFNVaC1XU3zQnb7T2nfvIDg==",
+      "sha512": "L8mUimdm7+GsORgJ8DFBMGsFnwDJ5YCUdJj3HfXQx4HCoPDPF+vJo3HRiHfcvNA2Zsf0ov2kuerYj/eeVa2/Rw==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -3594,8 +3644,8 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23324.nupkg",
-        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23330.nupkg",
+        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Cryptography.X509Certificates.nuspec"
       ]
     },
@@ -3632,10 +3682,10 @@
         "System.Security.Principal.nuspec"
       ]
     },
-    "System.Security.Principal.Windows/4.0.0-beta-23324": {
+    "System.Security.Principal.Windows/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "csbCKdwBz31T8He7U6XMIc9BiWgwjHs5WDZR4rfhsk48TpdsbKNHX9OX4b+GwvgcsfVuWxre7zqNR0Bc9gWZ7g==",
+      "sha512": "q+3L3aB8bn0HCW52kX9TSJdhbjffBw7QWCOu0yX1SDhPN9MCPmJ4aBBCn1HRWroa5y7UcNUdjL1xwiERycZexw==",
       "files": [
         "lib/DNXCore50/de/System.Security.Principal.Windows.xml",
         "lib/DNXCore50/es/System.Security.Principal.Windows.xml",
@@ -3651,8 +3701,8 @@
         "lib/net46/System.Security.Principal.Windows.dll",
         "ref/dotnet/System.Security.Principal.Windows.dll",
         "ref/net46/System.Security.Principal.Windows.dll",
-        "System.Security.Principal.Windows.4.0.0-beta-23324.nupkg",
-        "System.Security.Principal.Windows.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Principal.Windows.4.0.0-beta-23330.nupkg",
+        "System.Security.Principal.Windows.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Principal.Windows.nuspec"
       ]
     },
@@ -3847,10 +3897,9 @@
         "System.Threading.Tasks.nuspec"
       ]
     },
-    "System.Threading.ThreadPool/4.0.10-beta-23324": {
+    "System.Threading.ThreadPool/4.0.10-beta-23330": {
       "type": "package",
-      "serviceable": true,
-      "sha512": "G4SjGmiV72HBiv8wkfnKFGTieekrACU1m43VaeJ6vDeSyb08eEFusVH1UWZpOsUF25meCuzpda0ezus24b4rKA==",
+      "sha512": "nM5OewUj8NJrye93apbM6KHvPddgPJGzt1IWIXk9lV5HB4NGsn6M5U0gxMQWShQuDp6NF3ya3ULRSvh3dLMbzg==",
       "files": [
         "lib/DNXCore50/System.Threading.ThreadPool.dll",
         "lib/MonoAndroid10/_._",
@@ -3864,8 +3913,8 @@
         "ref/net46/System.Threading.ThreadPool.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Threading.ThreadPool.4.0.10-beta-23324.nupkg",
-        "System.Threading.ThreadPool.4.0.10-beta-23324.nupkg.sha512",
+        "System.Threading.ThreadPool.4.0.10-beta-23330.nupkg",
+        "System.Threading.ThreadPool.4.0.10-beta-23330.nupkg.sha512",
         "System.Threading.ThreadPool.nuspec"
       ]
     },
@@ -4067,7 +4116,7 @@
       "System.Runtime.Extensions >= 4.0.10",
       "System.Runtime.Handles >= 4.0.0",
       "System.Runtime.InteropServices >= 4.0.20-beta-*",
-      "System.Runtime.Serialization.Xml >= 4.0.10",
+      "System.Runtime.Serialization.Xml >= 4.0.11-beta-*",
       "System.Security.Claims >= 4.0.0",
       "System.Security.Cryptography.X509Certificates >= 4.0.0-beta-*",
       "System.Security.Principal >= 4.0.0",

--- a/src/System.Private.ServiceModel/tests/Common/Infrastructure/src/project.lock.json
+++ b/src/System.Private.ServiceModel/tests/Common/Infrastructure/src/project.lock.json
@@ -292,7 +292,7 @@
           "lib/dotnet/System.Linq.Queryable.dll": {}
         }
       },
-      "System.Net.Http/4.0.1-beta-23324": {
+      "System.Net.Http/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -305,16 +305,15 @@
           "ref/dotnet/System.Net.Http.dll": {}
         }
       },
-      "System.Net.NameResolution/4.0.0-beta-23324": {
+      "System.Net.NameResolution/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.Networking": "4.0.1-beta-23324"
+          "System.Net.Primitives": "4.0.10",
+          "System.Runtime": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Net.NameResolution.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Net.NameResolution.dll": {}
         }
       },
       "System.Net.Primitives/4.0.10": {
@@ -329,10 +328,10 @@
           "lib/DNXCore50/System.Net.Primitives.dll": {}
         }
       },
-      "System.Net.Security/4.0.0-beta-23324": {
+      "System.Net.Security/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.Networking": "4.0.1-beta-23324"
+          "System.Private.Networking": "4.0.1-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.Net.Security.dll": {}
@@ -367,6 +366,49 @@
         },
         "runtime": {
           "lib/dotnet/System.Net.WebHeaderCollection.dll": {}
+        }
+      },
+      "System.Net.WebSockets/4.0.0-beta-23330": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.Win32.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Threading.Tasks": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Net.WebSockets.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Net.WebSockets.dll": {}
+        }
+      },
+      "System.Net.WebSockets.Client/4.0.0-beta-23330": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.Win32.Primitives": "4.0.0",
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Diagnostics.Tracing": "4.0.20",
+          "System.Globalization": "4.0.10",
+          "System.Net.Primitives": "4.0.10",
+          "System.Net.WebHeaderCollection": "4.0.0",
+          "System.Net.WebSockets": "4.0.0-beta-23330",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23330",
+          "System.Text.Encoding": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Net.WebSockets.Client.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Net.WebSockets.Client.dll": {}
         }
       },
       "System.ObjectModel/4.0.10": {
@@ -414,7 +456,7 @@
           "lib/DNXCore50/System.Private.DataContractSerialization.dll": {}
         }
       },
-      "System.Private.Networking/4.0.1-beta-23324": {
+      "System.Private.Networking/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -433,13 +475,13 @@
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23324",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23324",
-          "System.Security.Principal.Windows": "4.0.0-beta-23324",
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23330",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23330",
+          "System.Security.Principal.Windows": "4.0.0-beta-23330",
           "System.Threading": "4.0.10",
           "System.Threading.Overlapped": "4.0.0",
           "System.Threading.Tasks": "4.0.10",
-          "System.Threading.ThreadPool": "4.0.10-beta-23324"
+          "System.Threading.ThreadPool": "4.0.10-beta-23330"
         },
         "compile": {
           "ref/dnxcore50/_._": {}
@@ -448,7 +490,7 @@
           "lib/DNXCore50/System.Private.Networking.dll": {}
         }
       },
-      "System.Private.ServiceModel/4.0.1-beta-23324": {
+      "System.Private.ServiceModel/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -465,12 +507,14 @@
           "System.Linq": "4.0.0",
           "System.Linq.Expressions": "4.0.10",
           "System.Linq.Queryable": "4.0.0",
-          "System.Net.Http": "4.0.1-beta-23324",
-          "System.Net.NameResolution": "4.0.0-beta-23324",
+          "System.Net.Http": "4.0.1-beta-23330",
+          "System.Net.NameResolution": "4.0.0-beta-23330",
           "System.Net.Primitives": "4.0.10",
-          "System.Net.Security": "4.0.0-beta-23324",
-          "System.Net.Sockets": "4.0.10-beta-23324",
+          "System.Net.Security": "4.0.0-beta-23330",
+          "System.Net.Sockets": "4.0.10-beta-23330",
           "System.Net.WebHeaderCollection": "4.0.0",
+          "System.Net.WebSockets": "4.0.0-beta-23330",
+          "System.Net.WebSockets.Client": "4.0.0-beta-23330",
           "System.ObjectModel": "4.0.10",
           "System.Reflection": "4.0.10",
           "System.Reflection.DispatchProxy": "4.0.0",
@@ -484,9 +528,9 @@
           "System.Runtime.Serialization.Primitives": "4.0.10",
           "System.Runtime.Serialization.Xml": "4.0.10",
           "System.Security.Claims": "4.0.0",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23324",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23330",
           "System.Security.Principal": "4.0.0",
-          "System.Security.Principal.Windows": "4.0.0-beta-23324",
+          "System.Security.Principal.Windows": "4.0.0-beta-23330",
           "System.Text.Encoding": "4.0.10",
           "System.Threading": "4.0.10",
           "System.Threading.Tasks": "4.0.10",
@@ -722,18 +766,18 @@
           "lib/dotnet/System.Security.Claims.dll": {}
         }
       },
-      "System.Security.Cryptography.Algorithms/4.0.0-beta-23324": {
+      "System.Security.Cryptography.Algorithms/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
           "System.Runtime": "4.0.0",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23324"
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.Algorithms.dll": {}
         }
       },
-      "System.Security.Cryptography.Encoding/4.0.0-beta-23324": {
+      "System.Security.Cryptography.Encoding/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -742,7 +786,7 @@
           "ref/dotnet/System.Security.Cryptography.Encoding.dll": {}
         }
       },
-      "System.Security.Cryptography.Primitives/4.0.0-beta-23324": {
+      "System.Security.Cryptography.Primitives/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.0",
@@ -760,13 +804,13 @@
           "lib/dotnet/System.Security.Cryptography.Primitives.dll": {}
         }
       },
-      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23324": {
+      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
           "System.Runtime.Handles": "4.0.0",
-          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23324",
-          "System.Security.Cryptography.Encoding": "4.0.0-beta-23324"
+          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23330",
+          "System.Security.Cryptography.Encoding": "4.0.0-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.X509Certificates.dll": {}
@@ -784,7 +828,7 @@
           "lib/dotnet/System.Security.Principal.dll": {}
         }
       },
-      "System.Security.Principal.Windows/4.0.0-beta-23324": {
+      "System.Security.Principal.Windows/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -807,10 +851,10 @@
           "lib/DNXCore50/System.Security.Principal.Windows.dll": {}
         }
       },
-      "System.ServiceModel.Duplex/4.0.1-beta-23324": {
+      "System.ServiceModel.Duplex/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.0.1-beta-23324"
+          "System.Private.ServiceModel": "4.0.1-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.ServiceModel.Duplex.dll": {}
@@ -819,10 +863,10 @@
           "lib/DNXCore50/System.ServiceModel.Duplex.dll": {}
         }
       },
-      "System.ServiceModel.Http/4.0.11-beta-23324": {
+      "System.ServiceModel.Http/4.0.11-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.0.1-beta-23324",
+          "System.Private.ServiceModel": "4.0.1-beta-23330",
           "System.Runtime": "4.0.20"
         },
         "compile": {
@@ -832,10 +876,10 @@
           "lib/DNXCore50/System.ServiceModel.Http.dll": {}
         }
       },
-      "System.ServiceModel.Primitives/4.0.1-beta-23324": {
+      "System.ServiceModel.Primitives/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.0.1-beta-23324"
+          "System.Private.ServiceModel": "4.0.1-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.ServiceModel.Primitives.dll": {}
@@ -924,7 +968,7 @@
           "lib/DNXCore50/System.Threading.Tasks.dll": {}
         }
       },
-      "System.Threading.ThreadPool/4.0.10-beta-23324": {
+      "System.Threading.ThreadPool/4.0.10-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
@@ -1625,23 +1669,12 @@
         "System.Linq.Queryable.nuspec"
       ]
     },
-    "System.Net.Http/4.0.1-beta-23324": {
+    "System.Net.Http/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "gXfHlWsiMQDuFqwnQrlQTje9vqMhCFLtm35jX4WqZjcfa3y69DbwueeT0gJbVMK88/UnG8FAYiDBb7AKyu+51w==",
+      "sha512": "itLPx7B7Ac4mX8wQx9V9DQcxqTgkmwDNnQIHuCgAH53Jq2X3XziiRRBbxbmNJlWqBlgPzbseWJmMCtcF/ePhOg==",
       "files": [
         "lib/net45/_._",
-        "lib/netcore50/de/System.Net.Http.xml",
-        "lib/netcore50/es/System.Net.Http.xml",
-        "lib/netcore50/fr/System.Net.Http.xml",
-        "lib/netcore50/it/System.Net.Http.xml",
-        "lib/netcore50/ja/System.Net.Http.xml",
-        "lib/netcore50/ko/System.Net.Http.xml",
-        "lib/netcore50/ru/System.Net.Http.xml",
-        "lib/netcore50/System.Net.Http.dll",
-        "lib/netcore50/System.Net.Http.xml",
-        "lib/netcore50/zh-hans/System.Net.Http.xml",
-        "lib/netcore50/zh-hant/System.Net.Http.xml",
         "lib/win8/_._",
         "lib/wpa81/_._",
         "ref/dotnet/System.Net.Http.dll",
@@ -1650,17 +1683,16 @@
         "ref/win8/_._",
         "ref/wpa81/_._",
         "runtime.json",
-        "System.Net.Http.4.0.1-beta-23324.nupkg",
-        "System.Net.Http.4.0.1-beta-23324.nupkg.sha512",
+        "System.Net.Http.4.0.1-beta-23330.nupkg",
+        "System.Net.Http.4.0.1-beta-23330.nupkg.sha512",
         "System.Net.Http.nuspec"
       ]
     },
-    "System.Net.NameResolution/4.0.0-beta-23324": {
+    "System.Net.NameResolution/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "lNYXUmnSXUtLFY09Rc27zJ6/TxCuGggQzBgiuWHoWrjWxymuuxqPT2Mj7Dn7sUUh0GvF2MOx7Uk+rtCFBiIavg==",
+      "sha512": "d8Am+In/aBgcHpEV6xsi5BCiTEN4y6s9O1V/yIvwX8mDC4CtdZiGsi4DtoB0TLOgp8ky6GxbSF4bKCjFpBO3uw==",
       "files": [
-        "lib/DNXCore50/System.Net.NameResolution.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.NameResolution.dll",
@@ -1672,8 +1704,9 @@
         "ref/net46/System.Net.NameResolution.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.NameResolution.4.0.0-beta-23324.nupkg",
-        "System.Net.NameResolution.4.0.0-beta-23324.nupkg.sha512",
+        "runtime.json",
+        "System.Net.NameResolution.4.0.0-beta-23330.nupkg",
+        "System.Net.NameResolution.4.0.0-beta-23330.nupkg.sha512",
         "System.Net.NameResolution.nuspec"
       ]
     },
@@ -1710,9 +1743,9 @@
         "System.Net.Primitives.nuspec"
       ]
     },
-    "System.Net.Security/4.0.0-beta-23324": {
+    "System.Net.Security/4.0.0-beta-23330": {
       "type": "package",
-      "sha512": "D04RYjxrnR3D+uI9CGmAAFKKQ6T+pPcRHYucc1PIo7/hJK5I/Yu7gAw9yOxHUhQjSGfrKo00lHpBCQMTQt4lSw==",
+      "sha512": "z98dKloNy9DBdyfqQwQvKWA2q8Qj4vgGEVONnlS70c13eh0MolBHJ0wNdplZZK5zYZ5Eu8GTwexbUlpHbsfzVA==",
       "files": [
         "lib/DNXCore50/System.Net.Security.dll",
         "lib/MonoAndroid10/_._",
@@ -1726,8 +1759,8 @@
         "ref/net46/System.Net.Security.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.Security.4.0.0-beta-23324.nupkg",
-        "System.Net.Security.4.0.0-beta-23324.nupkg.sha512",
+        "System.Net.Security.4.0.0-beta-23330.nupkg",
+        "System.Net.Security.4.0.0-beta-23330.nupkg.sha512",
         "System.Net.Security.nuspec"
       ]
     },
@@ -1785,6 +1818,81 @@
         "System.Net.WebHeaderCollection.nuspec"
       ]
     },
+    "System.Net.WebSockets/4.0.0-beta-23330": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "6Q9/uTDcaqbmdbD04MisKmjti4aEpp40i/UzpGaPZ4ItuwzU/pMk9RjiYUBUiCQyZeKNlXcSB1FPN2nFof7tww==",
+      "files": [
+        "lib/dotnet/de/System.Net.WebSockets.xml",
+        "lib/dotnet/es/System.Net.WebSockets.xml",
+        "lib/dotnet/fr/System.Net.WebSockets.xml",
+        "lib/dotnet/it/System.Net.WebSockets.xml",
+        "lib/dotnet/ja/System.Net.WebSockets.xml",
+        "lib/dotnet/ko/System.Net.WebSockets.xml",
+        "lib/dotnet/ru/System.Net.WebSockets.xml",
+        "lib/dotnet/System.Net.WebSockets.dll",
+        "lib/dotnet/System.Net.WebSockets.xml",
+        "lib/dotnet/zh-hans/System.Net.WebSockets.xml",
+        "lib/dotnet/zh-hant/System.Net.WebSockets.xml",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Net.WebSockets.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Net.WebSockets.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Net.WebSockets.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Net.WebSockets.4.0.0-beta-23330.nupkg",
+        "System.Net.WebSockets.4.0.0-beta-23330.nupkg.sha512",
+        "System.Net.WebSockets.nuspec"
+      ]
+    },
+    "System.Net.WebSockets.Client/4.0.0-beta-23330": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "1NWEqwDkYRyvr1gSKZlY51AaI9w8oD0dC5UNa2Lb+qaeFHSF5KfCSzf7seD+im+sH6uocVo2nppiaabfbXZT4Q==",
+      "files": [
+        "lib/DNXCore50/de/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/es/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/fr/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/it/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/ja/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/ko/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/ru/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/System.Net.WebSockets.Client.dll",
+        "lib/DNXCore50/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/zh-hans/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/zh-hant/System.Net.WebSockets.Client.xml",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Net.WebSockets.Client.dll",
+        "lib/netcore50/de/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/es/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/fr/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/it/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/ja/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/ko/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/ru/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/System.Net.WebSockets.Client.dll",
+        "lib/netcore50/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/zh-hans/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/zh-hant/System.Net.WebSockets.Client.xml",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Net.WebSockets.Client.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Net.WebSockets.Client.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Net.WebSockets.Client.4.0.0-beta-23330.nupkg",
+        "System.Net.WebSockets.Client.4.0.0-beta-23330.nupkg.sha512",
+        "System.Net.WebSockets.Client.nuspec"
+      ]
+    },
     "System.ObjectModel/4.0.10": {
       "type": "package",
       "serviceable": true,
@@ -1833,31 +1941,31 @@
         "System.Private.DataContractSerialization.nuspec"
       ]
     },
-    "System.Private.Networking/4.0.1-beta-23324": {
+    "System.Private.Networking/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "OfyxoeCdh1ypzdz1u0h1Clgt+6749vALs2ZPkLwsOPzL0INCG9ISYo+Jhh62ZD8TMkWwLrvyVppMBPHY6M7Upw==",
+      "sha512": "8NZi1gCQaGTKDb2yWplm52HWCLaZnUwVitksJgcXY2dEJau/TBGyZup+yhOngOIe8QzQMxNG4iokY3Ce0/8mbg==",
       "files": [
         "lib/DNXCore50/System.Private.Networking.dll",
         "lib/netcore50/System.Private.Networking.dll",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "System.Private.Networking.4.0.1-beta-23324.nupkg",
-        "System.Private.Networking.4.0.1-beta-23324.nupkg.sha512",
+        "System.Private.Networking.4.0.1-beta-23330.nupkg",
+        "System.Private.Networking.4.0.1-beta-23330.nupkg.sha512",
         "System.Private.Networking.nuspec"
       ]
     },
-    "System.Private.ServiceModel/4.0.1-beta-23324": {
+    "System.Private.ServiceModel/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "Lz3T9V8GnaOFlf8LUmuPznuOIuy92BAFVc9huiMrFKByzPpydGuCvXEe+81rZ1IF2TQcHKO++9otnj96AEJ5BA==",
+      "sha512": "8lENvmHuZdlvmnYN1w98Mv8bDjc0O/YlaNHRRph35T/fLDyaG8LMLMwG3/ut6a/AenLJmbf92snOtNXCuqM+cQ==",
       "files": [
         "lib/DNXCore50/System.Private.ServiceModel.dll",
         "lib/netcore50/System.Private.ServiceModel.dll",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "System.Private.ServiceModel.4.0.1-beta-23324.nupkg",
-        "System.Private.ServiceModel.4.0.1-beta-23324.nupkg.sha512",
+        "System.Private.ServiceModel.4.0.1-beta-23330.nupkg",
+        "System.Private.ServiceModel.4.0.1-beta-23330.nupkg.sha512",
         "System.Private.ServiceModel.nuspec"
       ]
     },
@@ -2366,10 +2474,10 @@
         "System.Security.Claims.nuspec"
       ]
     },
-    "System.Security.Cryptography.Algorithms/4.0.0-beta-23324": {
+    "System.Security.Cryptography.Algorithms/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "Mt6LwMj8hPp0+xZHcV6grZ7wSWhgycGkdZ6DQ9XvUY9NguUsvb/+fu2cMdrC7XsnpvwIROByp+p2dSjqBn3E2Q==",
+      "sha512": "FB4RoTDaV5tBiPSJsiG3A5DydeKz7ErglnkqVjBFjm6wu8kg91j0MxL/Al9iUyu9i/hq53fRs5KE3rjUNYvf5w==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2383,15 +2491,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.Algorithms.4.0.0-beta-23324.nupkg",
-        "System.Security.Cryptography.Algorithms.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Cryptography.Algorithms.4.0.0-beta-23330.nupkg",
+        "System.Security.Cryptography.Algorithms.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Cryptography.Algorithms.nuspec"
       ]
     },
-    "System.Security.Cryptography.Encoding/4.0.0-beta-23324": {
+    "System.Security.Cryptography.Encoding/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "JHOyknf1eYO6C39Vao6kAGpadq3PBO1L4tuzNEz/HvbH5sfIHPbjhxL11OyAhVKCzLCfEj6+aeClovFqZIRPyw==",
+      "sha512": "zeFdKQT6xjNdiNCaEmEYJMEK59kixkX7jJSoOLw3H+53t9X0F98vr3tS8YlrW/Lk/K9c6L5pYLlkb2dNqvUD/g==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2405,15 +2513,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.Encoding.4.0.0-beta-23324.nupkg",
-        "System.Security.Cryptography.Encoding.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Cryptography.Encoding.4.0.0-beta-23330.nupkg",
+        "System.Security.Cryptography.Encoding.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Cryptography.Encoding.nuspec"
       ]
     },
-    "System.Security.Cryptography.Primitives/4.0.0-beta-23324": {
+    "System.Security.Cryptography.Primitives/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "ETZxelIX51Di4FTytd8ohSpN6Ym/32aWIX9E2NCFkd91qdexn2Dkysn80b6n4gX6jG+oL0UHQDtD/fYq8C65oQ==",
+      "sha512": "15uVbOD3X0sRQJIxcEH5hasxlFdbA1CmPPZa0Y8pYEuQcWMF2gBswvU8s4qoKtA7x2xhNhzPsXIhsQuKNMTdEA==",
       "files": [
         "lib/dotnet/System.Security.Cryptography.Primitives.dll",
         "lib/MonoAndroid10/_._",
@@ -2427,15 +2535,15 @@
         "ref/net46/System.Security.Cryptography.Primitives.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Security.Cryptography.Primitives.4.0.0-beta-23324.nupkg",
-        "System.Security.Cryptography.Primitives.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Cryptography.Primitives.4.0.0-beta-23330.nupkg",
+        "System.Security.Cryptography.Primitives.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Cryptography.Primitives.nuspec"
       ]
     },
-    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23324": {
+    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "8NaEOxkkNBUECh0cPzGpbXS0uzGDpnvxI0kqQKRGp9uA+9qCyQfxcqAT6ozAYtOuFNVaC1XU3zQnb7T2nfvIDg==",
+      "sha512": "L8mUimdm7+GsORgJ8DFBMGsFnwDJ5YCUdJj3HfXQx4HCoPDPF+vJo3HRiHfcvNA2Zsf0ov2kuerYj/eeVa2/Rw==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2449,8 +2557,8 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23324.nupkg",
-        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23330.nupkg",
+        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Cryptography.X509Certificates.nuspec"
       ]
     },
@@ -2487,10 +2595,10 @@
         "System.Security.Principal.nuspec"
       ]
     },
-    "System.Security.Principal.Windows/4.0.0-beta-23324": {
+    "System.Security.Principal.Windows/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "csbCKdwBz31T8He7U6XMIc9BiWgwjHs5WDZR4rfhsk48TpdsbKNHX9OX4b+GwvgcsfVuWxre7zqNR0Bc9gWZ7g==",
+      "sha512": "q+3L3aB8bn0HCW52kX9TSJdhbjffBw7QWCOu0yX1SDhPN9MCPmJ4aBBCn1HRWroa5y7UcNUdjL1xwiERycZexw==",
       "files": [
         "lib/DNXCore50/de/System.Security.Principal.Windows.xml",
         "lib/DNXCore50/es/System.Security.Principal.Windows.xml",
@@ -2506,15 +2614,15 @@
         "lib/net46/System.Security.Principal.Windows.dll",
         "ref/dotnet/System.Security.Principal.Windows.dll",
         "ref/net46/System.Security.Principal.Windows.dll",
-        "System.Security.Principal.Windows.4.0.0-beta-23324.nupkg",
-        "System.Security.Principal.Windows.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Principal.Windows.4.0.0-beta-23330.nupkg",
+        "System.Security.Principal.Windows.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Principal.Windows.nuspec"
       ]
     },
-    "System.ServiceModel.Duplex/4.0.1-beta-23324": {
+    "System.ServiceModel.Duplex/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "b+p3u2zee0oAM4AIyM9rev1MaoExxD4d97iNeZFG0Q0bEVFOzK97/5HNcq5FzpTUhxZgfXXCOCmuIYwnYsfU/w==",
+      "sha512": "0k9wL8LeMYj1jfu2wZwTdQhmPBcpMSUgD304cR50CpHOJnrP/NjiQ0Blx3oSURd8Tda5XuXC0PNGWDF+EpW/Lg==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Duplex.dll",
         "lib/net45/_._",
@@ -2534,15 +2642,15 @@
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.Duplex.dll",
         "ref/win8/_._",
-        "System.ServiceModel.Duplex.4.0.1-beta-23324.nupkg",
-        "System.ServiceModel.Duplex.4.0.1-beta-23324.nupkg.sha512",
+        "System.ServiceModel.Duplex.4.0.1-beta-23330.nupkg",
+        "System.ServiceModel.Duplex.4.0.1-beta-23330.nupkg.sha512",
         "System.ServiceModel.Duplex.nuspec"
       ]
     },
-    "System.ServiceModel.Http/4.0.11-beta-23324": {
+    "System.ServiceModel.Http/4.0.11-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "VkTumuCSmXd0NPZZU+nrO7YqznvM+wP96NykXbxFJdNAtCplmqXaQh+YZ/02rjJmfou5qyo2V+ZWVwySBAirOg==",
+      "sha512": "NHKxIIYL0ATDbX18RLCSXtuq26MMoYfAVdpl5K+D0s5AHp7TMPb7LcjZPpg25B2v48x1TwE9LYcYTCiOZcoPzQ==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Http.dll",
         "lib/MonoAndroid10/_._",
@@ -2567,15 +2675,15 @@
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.ServiceModel.Http.4.0.11-beta-23324.nupkg",
-        "System.ServiceModel.Http.4.0.11-beta-23324.nupkg.sha512",
+        "System.ServiceModel.Http.4.0.11-beta-23330.nupkg",
+        "System.ServiceModel.Http.4.0.11-beta-23330.nupkg.sha512",
         "System.ServiceModel.Http.nuspec"
       ]
     },
-    "System.ServiceModel.Primitives/4.0.1-beta-23324": {
+    "System.ServiceModel.Primitives/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "bmU31B4CD5+m9Kt0iDM5Yw2ZXRfv7lpK3Sx1HektcT/HERc+IMPdO38f/Wxtofo5WOA0qmd1fdrMeQcbEkDfJg==",
+      "sha512": "kJ/pcRUf7Ow7s/rX8Kmc9P2k6cvyudIzyUcqr/pn9NwY8DC/2DWkkFvYE2udR4kvBzJJzXl/rsJQlyLIVGMAww==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Primitives.dll",
         "lib/net45/_._",
@@ -2595,8 +2703,8 @@
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.Primitives.dll",
         "ref/win8/_._",
-        "System.ServiceModel.Primitives.4.0.1-beta-23324.nupkg",
-        "System.ServiceModel.Primitives.4.0.1-beta-23324.nupkg.sha512",
+        "System.ServiceModel.Primitives.4.0.1-beta-23330.nupkg",
+        "System.ServiceModel.Primitives.4.0.1-beta-23330.nupkg.sha512",
         "System.ServiceModel.Primitives.nuspec"
       ]
     },
@@ -2791,10 +2899,9 @@
         "System.Threading.Tasks.nuspec"
       ]
     },
-    "System.Threading.ThreadPool/4.0.10-beta-23324": {
+    "System.Threading.ThreadPool/4.0.10-beta-23330": {
       "type": "package",
-      "serviceable": true,
-      "sha512": "G4SjGmiV72HBiv8wkfnKFGTieekrACU1m43VaeJ6vDeSyb08eEFusVH1UWZpOsUF25meCuzpda0ezus24b4rKA==",
+      "sha512": "nM5OewUj8NJrye93apbM6KHvPddgPJGzt1IWIXk9lV5HB4NGsn6M5U0gxMQWShQuDp6NF3ya3ULRSvh3dLMbzg==",
       "files": [
         "lib/DNXCore50/System.Threading.ThreadPool.dll",
         "lib/MonoAndroid10/_._",
@@ -2808,8 +2915,8 @@
         "ref/net46/System.Threading.ThreadPool.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Threading.ThreadPool.4.0.10-beta-23324.nupkg",
-        "System.Threading.ThreadPool.4.0.10-beta-23324.nupkg.sha512",
+        "System.Threading.ThreadPool.4.0.10-beta-23330.nupkg",
+        "System.Threading.ThreadPool.4.0.10-beta-23330.nupkg.sha512",
         "System.Threading.ThreadPool.nuspec"
       ]
     },

--- a/src/System.Private.ServiceModel/tests/Common/Infrastructure/tests/project.lock.json
+++ b/src/System.Private.ServiceModel/tests/Common/Infrastructure/tests/project.lock.json
@@ -292,7 +292,7 @@
           "lib/dotnet/System.Linq.Queryable.dll": {}
         }
       },
-      "System.Net.Http/4.0.1-beta-23324": {
+      "System.Net.Http/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -305,16 +305,15 @@
           "ref/dotnet/System.Net.Http.dll": {}
         }
       },
-      "System.Net.NameResolution/4.0.0-beta-23324": {
+      "System.Net.NameResolution/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.Networking": "4.0.1-beta-23324"
+          "System.Net.Primitives": "4.0.10",
+          "System.Runtime": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Net.NameResolution.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Net.NameResolution.dll": {}
         }
       },
       "System.Net.Primitives/4.0.10": {
@@ -329,10 +328,10 @@
           "lib/DNXCore50/System.Net.Primitives.dll": {}
         }
       },
-      "System.Net.Security/4.0.0-beta-23324": {
+      "System.Net.Security/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.Networking": "4.0.1-beta-23324"
+          "System.Private.Networking": "4.0.1-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.Net.Security.dll": {}
@@ -367,6 +366,49 @@
         },
         "runtime": {
           "lib/dotnet/System.Net.WebHeaderCollection.dll": {}
+        }
+      },
+      "System.Net.WebSockets/4.0.0-beta-23330": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.Win32.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Threading.Tasks": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Net.WebSockets.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Net.WebSockets.dll": {}
+        }
+      },
+      "System.Net.WebSockets.Client/4.0.0-beta-23330": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.Win32.Primitives": "4.0.0",
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Diagnostics.Tracing": "4.0.20",
+          "System.Globalization": "4.0.10",
+          "System.Net.Primitives": "4.0.10",
+          "System.Net.WebHeaderCollection": "4.0.0",
+          "System.Net.WebSockets": "4.0.0-beta-23330",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23330",
+          "System.Text.Encoding": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Net.WebSockets.Client.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Net.WebSockets.Client.dll": {}
         }
       },
       "System.ObjectModel/4.0.10": {
@@ -414,7 +456,7 @@
           "lib/DNXCore50/System.Private.DataContractSerialization.dll": {}
         }
       },
-      "System.Private.Networking/4.0.1-beta-23324": {
+      "System.Private.Networking/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -433,13 +475,13 @@
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23324",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23324",
-          "System.Security.Principal.Windows": "4.0.0-beta-23324",
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23330",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23330",
+          "System.Security.Principal.Windows": "4.0.0-beta-23330",
           "System.Threading": "4.0.10",
           "System.Threading.Overlapped": "4.0.0",
           "System.Threading.Tasks": "4.0.10",
-          "System.Threading.ThreadPool": "4.0.10-beta-23324"
+          "System.Threading.ThreadPool": "4.0.10-beta-23330"
         },
         "compile": {
           "ref/dnxcore50/_._": {}
@@ -448,7 +490,7 @@
           "lib/DNXCore50/System.Private.Networking.dll": {}
         }
       },
-      "System.Private.ServiceModel/4.0.1-beta-23324": {
+      "System.Private.ServiceModel/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -465,12 +507,14 @@
           "System.Linq": "4.0.0",
           "System.Linq.Expressions": "4.0.10",
           "System.Linq.Queryable": "4.0.0",
-          "System.Net.Http": "4.0.1-beta-23324",
-          "System.Net.NameResolution": "4.0.0-beta-23324",
+          "System.Net.Http": "4.0.1-beta-23330",
+          "System.Net.NameResolution": "4.0.0-beta-23330",
           "System.Net.Primitives": "4.0.10",
-          "System.Net.Security": "4.0.0-beta-23324",
-          "System.Net.Sockets": "4.0.10-beta-23324",
+          "System.Net.Security": "4.0.0-beta-23330",
+          "System.Net.Sockets": "4.0.10-beta-23330",
           "System.Net.WebHeaderCollection": "4.0.0",
+          "System.Net.WebSockets": "4.0.0-beta-23330",
+          "System.Net.WebSockets.Client": "4.0.0-beta-23330",
           "System.ObjectModel": "4.0.10",
           "System.Reflection": "4.0.10",
           "System.Reflection.DispatchProxy": "4.0.0",
@@ -484,9 +528,9 @@
           "System.Runtime.Serialization.Primitives": "4.0.10",
           "System.Runtime.Serialization.Xml": "4.0.10",
           "System.Security.Claims": "4.0.0",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23324",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23330",
           "System.Security.Principal": "4.0.0",
-          "System.Security.Principal.Windows": "4.0.0-beta-23324",
+          "System.Security.Principal.Windows": "4.0.0-beta-23330",
           "System.Text.Encoding": "4.0.10",
           "System.Threading": "4.0.10",
           "System.Threading.Tasks": "4.0.10",
@@ -735,18 +779,18 @@
           "lib/dotnet/System.Security.Claims.dll": {}
         }
       },
-      "System.Security.Cryptography.Algorithms/4.0.0-beta-23324": {
+      "System.Security.Cryptography.Algorithms/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
           "System.Runtime": "4.0.0",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23324"
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.Algorithms.dll": {}
         }
       },
-      "System.Security.Cryptography.Encoding/4.0.0-beta-23324": {
+      "System.Security.Cryptography.Encoding/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -755,7 +799,7 @@
           "ref/dotnet/System.Security.Cryptography.Encoding.dll": {}
         }
       },
-      "System.Security.Cryptography.Primitives/4.0.0-beta-23324": {
+      "System.Security.Cryptography.Primitives/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.0",
@@ -773,13 +817,13 @@
           "lib/dotnet/System.Security.Cryptography.Primitives.dll": {}
         }
       },
-      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23324": {
+      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
           "System.Runtime.Handles": "4.0.0",
-          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23324",
-          "System.Security.Cryptography.Encoding": "4.0.0-beta-23324"
+          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23330",
+          "System.Security.Cryptography.Encoding": "4.0.0-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.X509Certificates.dll": {}
@@ -797,7 +841,7 @@
           "lib/dotnet/System.Security.Principal.dll": {}
         }
       },
-      "System.Security.Principal.Windows/4.0.0-beta-23324": {
+      "System.Security.Principal.Windows/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -820,10 +864,10 @@
           "lib/DNXCore50/System.Security.Principal.Windows.dll": {}
         }
       },
-      "System.ServiceModel.Http/4.0.11-beta-23324": {
+      "System.ServiceModel.Http/4.0.11-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.0.1-beta-23324",
+          "System.Private.ServiceModel": "4.0.1-beta-23330",
           "System.Runtime": "4.0.20"
         },
         "compile": {
@@ -833,10 +877,10 @@
           "lib/DNXCore50/System.ServiceModel.Http.dll": {}
         }
       },
-      "System.ServiceModel.NetTcp/4.0.1-beta-23324": {
+      "System.ServiceModel.NetTcp/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.0.1-beta-23324"
+          "System.Private.ServiceModel": "4.0.1-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.ServiceModel.NetTcp.dll": {}
@@ -845,10 +889,10 @@
           "lib/DNXCore50/System.ServiceModel.NetTcp.dll": {}
         }
       },
-      "System.ServiceModel.Primitives/4.0.1-beta-23324": {
+      "System.ServiceModel.Primitives/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.0.1-beta-23324"
+          "System.Private.ServiceModel": "4.0.1-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.ServiceModel.Primitives.dll": {}
@@ -857,10 +901,10 @@
           "lib/DNXCore50/System.ServiceModel.Primitives.dll": {}
         }
       },
-      "System.ServiceModel.Security/4.0.1-beta-23324": {
+      "System.ServiceModel.Security/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.0.1-beta-23324"
+          "System.Private.ServiceModel": "4.0.1-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.ServiceModel.Security.dll": {}
@@ -949,7 +993,7 @@
           "lib/DNXCore50/System.Threading.Tasks.dll": {}
         }
       },
-      "System.Threading.ThreadPool/4.0.10-beta-23324": {
+      "System.Threading.ThreadPool/4.0.10-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
@@ -1142,7 +1186,7 @@
           "lib/dotnet/xunit.execution.dotnet.dll": {}
         }
       },
-      "xunit.netcore.extensions/1.0.0-prerelease-00095": {
+      "xunit.netcore.extensions/1.0.0-prerelease-00098": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.10",
@@ -1770,23 +1814,12 @@
         "System.Linq.Queryable.nuspec"
       ]
     },
-    "System.Net.Http/4.0.1-beta-23324": {
+    "System.Net.Http/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "gXfHlWsiMQDuFqwnQrlQTje9vqMhCFLtm35jX4WqZjcfa3y69DbwueeT0gJbVMK88/UnG8FAYiDBb7AKyu+51w==",
+      "sha512": "itLPx7B7Ac4mX8wQx9V9DQcxqTgkmwDNnQIHuCgAH53Jq2X3XziiRRBbxbmNJlWqBlgPzbseWJmMCtcF/ePhOg==",
       "files": [
         "lib/net45/_._",
-        "lib/netcore50/de/System.Net.Http.xml",
-        "lib/netcore50/es/System.Net.Http.xml",
-        "lib/netcore50/fr/System.Net.Http.xml",
-        "lib/netcore50/it/System.Net.Http.xml",
-        "lib/netcore50/ja/System.Net.Http.xml",
-        "lib/netcore50/ko/System.Net.Http.xml",
-        "lib/netcore50/ru/System.Net.Http.xml",
-        "lib/netcore50/System.Net.Http.dll",
-        "lib/netcore50/System.Net.Http.xml",
-        "lib/netcore50/zh-hans/System.Net.Http.xml",
-        "lib/netcore50/zh-hant/System.Net.Http.xml",
         "lib/win8/_._",
         "lib/wpa81/_._",
         "ref/dotnet/System.Net.Http.dll",
@@ -1795,17 +1828,16 @@
         "ref/win8/_._",
         "ref/wpa81/_._",
         "runtime.json",
-        "System.Net.Http.4.0.1-beta-23324.nupkg",
-        "System.Net.Http.4.0.1-beta-23324.nupkg.sha512",
+        "System.Net.Http.4.0.1-beta-23330.nupkg",
+        "System.Net.Http.4.0.1-beta-23330.nupkg.sha512",
         "System.Net.Http.nuspec"
       ]
     },
-    "System.Net.NameResolution/4.0.0-beta-23324": {
+    "System.Net.NameResolution/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "lNYXUmnSXUtLFY09Rc27zJ6/TxCuGggQzBgiuWHoWrjWxymuuxqPT2Mj7Dn7sUUh0GvF2MOx7Uk+rtCFBiIavg==",
+      "sha512": "d8Am+In/aBgcHpEV6xsi5BCiTEN4y6s9O1V/yIvwX8mDC4CtdZiGsi4DtoB0TLOgp8ky6GxbSF4bKCjFpBO3uw==",
       "files": [
-        "lib/DNXCore50/System.Net.NameResolution.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.NameResolution.dll",
@@ -1817,8 +1849,9 @@
         "ref/net46/System.Net.NameResolution.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.NameResolution.4.0.0-beta-23324.nupkg",
-        "System.Net.NameResolution.4.0.0-beta-23324.nupkg.sha512",
+        "runtime.json",
+        "System.Net.NameResolution.4.0.0-beta-23330.nupkg",
+        "System.Net.NameResolution.4.0.0-beta-23330.nupkg.sha512",
         "System.Net.NameResolution.nuspec"
       ]
     },
@@ -1855,9 +1888,9 @@
         "System.Net.Primitives.nuspec"
       ]
     },
-    "System.Net.Security/4.0.0-beta-23324": {
+    "System.Net.Security/4.0.0-beta-23330": {
       "type": "package",
-      "sha512": "D04RYjxrnR3D+uI9CGmAAFKKQ6T+pPcRHYucc1PIo7/hJK5I/Yu7gAw9yOxHUhQjSGfrKo00lHpBCQMTQt4lSw==",
+      "sha512": "z98dKloNy9DBdyfqQwQvKWA2q8Qj4vgGEVONnlS70c13eh0MolBHJ0wNdplZZK5zYZ5Eu8GTwexbUlpHbsfzVA==",
       "files": [
         "lib/DNXCore50/System.Net.Security.dll",
         "lib/MonoAndroid10/_._",
@@ -1871,8 +1904,8 @@
         "ref/net46/System.Net.Security.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.Security.4.0.0-beta-23324.nupkg",
-        "System.Net.Security.4.0.0-beta-23324.nupkg.sha512",
+        "System.Net.Security.4.0.0-beta-23330.nupkg",
+        "System.Net.Security.4.0.0-beta-23330.nupkg.sha512",
         "System.Net.Security.nuspec"
       ]
     },
@@ -1930,6 +1963,81 @@
         "System.Net.WebHeaderCollection.nuspec"
       ]
     },
+    "System.Net.WebSockets/4.0.0-beta-23330": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "6Q9/uTDcaqbmdbD04MisKmjti4aEpp40i/UzpGaPZ4ItuwzU/pMk9RjiYUBUiCQyZeKNlXcSB1FPN2nFof7tww==",
+      "files": [
+        "lib/dotnet/de/System.Net.WebSockets.xml",
+        "lib/dotnet/es/System.Net.WebSockets.xml",
+        "lib/dotnet/fr/System.Net.WebSockets.xml",
+        "lib/dotnet/it/System.Net.WebSockets.xml",
+        "lib/dotnet/ja/System.Net.WebSockets.xml",
+        "lib/dotnet/ko/System.Net.WebSockets.xml",
+        "lib/dotnet/ru/System.Net.WebSockets.xml",
+        "lib/dotnet/System.Net.WebSockets.dll",
+        "lib/dotnet/System.Net.WebSockets.xml",
+        "lib/dotnet/zh-hans/System.Net.WebSockets.xml",
+        "lib/dotnet/zh-hant/System.Net.WebSockets.xml",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Net.WebSockets.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Net.WebSockets.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Net.WebSockets.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Net.WebSockets.4.0.0-beta-23330.nupkg",
+        "System.Net.WebSockets.4.0.0-beta-23330.nupkg.sha512",
+        "System.Net.WebSockets.nuspec"
+      ]
+    },
+    "System.Net.WebSockets.Client/4.0.0-beta-23330": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "1NWEqwDkYRyvr1gSKZlY51AaI9w8oD0dC5UNa2Lb+qaeFHSF5KfCSzf7seD+im+sH6uocVo2nppiaabfbXZT4Q==",
+      "files": [
+        "lib/DNXCore50/de/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/es/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/fr/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/it/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/ja/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/ko/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/ru/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/System.Net.WebSockets.Client.dll",
+        "lib/DNXCore50/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/zh-hans/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/zh-hant/System.Net.WebSockets.Client.xml",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Net.WebSockets.Client.dll",
+        "lib/netcore50/de/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/es/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/fr/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/it/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/ja/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/ko/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/ru/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/System.Net.WebSockets.Client.dll",
+        "lib/netcore50/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/zh-hans/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/zh-hant/System.Net.WebSockets.Client.xml",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Net.WebSockets.Client.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Net.WebSockets.Client.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Net.WebSockets.Client.4.0.0-beta-23330.nupkg",
+        "System.Net.WebSockets.Client.4.0.0-beta-23330.nupkg.sha512",
+        "System.Net.WebSockets.Client.nuspec"
+      ]
+    },
     "System.ObjectModel/4.0.10": {
       "type": "package",
       "serviceable": true,
@@ -1978,31 +2086,31 @@
         "System.Private.DataContractSerialization.nuspec"
       ]
     },
-    "System.Private.Networking/4.0.1-beta-23324": {
+    "System.Private.Networking/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "OfyxoeCdh1ypzdz1u0h1Clgt+6749vALs2ZPkLwsOPzL0INCG9ISYo+Jhh62ZD8TMkWwLrvyVppMBPHY6M7Upw==",
+      "sha512": "8NZi1gCQaGTKDb2yWplm52HWCLaZnUwVitksJgcXY2dEJau/TBGyZup+yhOngOIe8QzQMxNG4iokY3Ce0/8mbg==",
       "files": [
         "lib/DNXCore50/System.Private.Networking.dll",
         "lib/netcore50/System.Private.Networking.dll",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "System.Private.Networking.4.0.1-beta-23324.nupkg",
-        "System.Private.Networking.4.0.1-beta-23324.nupkg.sha512",
+        "System.Private.Networking.4.0.1-beta-23330.nupkg",
+        "System.Private.Networking.4.0.1-beta-23330.nupkg.sha512",
         "System.Private.Networking.nuspec"
       ]
     },
-    "System.Private.ServiceModel/4.0.1-beta-23324": {
+    "System.Private.ServiceModel/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "Lz3T9V8GnaOFlf8LUmuPznuOIuy92BAFVc9huiMrFKByzPpydGuCvXEe+81rZ1IF2TQcHKO++9otnj96AEJ5BA==",
+      "sha512": "8lENvmHuZdlvmnYN1w98Mv8bDjc0O/YlaNHRRph35T/fLDyaG8LMLMwG3/ut6a/AenLJmbf92snOtNXCuqM+cQ==",
       "files": [
         "lib/DNXCore50/System.Private.ServiceModel.dll",
         "lib/netcore50/System.Private.ServiceModel.dll",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "System.Private.ServiceModel.4.0.1-beta-23324.nupkg",
-        "System.Private.ServiceModel.4.0.1-beta-23324.nupkg.sha512",
+        "System.Private.ServiceModel.4.0.1-beta-23330.nupkg",
+        "System.Private.ServiceModel.4.0.1-beta-23330.nupkg.sha512",
         "System.Private.ServiceModel.nuspec"
       ]
     },
@@ -2531,10 +2639,10 @@
         "System.Security.Claims.nuspec"
       ]
     },
-    "System.Security.Cryptography.Algorithms/4.0.0-beta-23324": {
+    "System.Security.Cryptography.Algorithms/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "Mt6LwMj8hPp0+xZHcV6grZ7wSWhgycGkdZ6DQ9XvUY9NguUsvb/+fu2cMdrC7XsnpvwIROByp+p2dSjqBn3E2Q==",
+      "sha512": "FB4RoTDaV5tBiPSJsiG3A5DydeKz7ErglnkqVjBFjm6wu8kg91j0MxL/Al9iUyu9i/hq53fRs5KE3rjUNYvf5w==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2548,15 +2656,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.Algorithms.4.0.0-beta-23324.nupkg",
-        "System.Security.Cryptography.Algorithms.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Cryptography.Algorithms.4.0.0-beta-23330.nupkg",
+        "System.Security.Cryptography.Algorithms.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Cryptography.Algorithms.nuspec"
       ]
     },
-    "System.Security.Cryptography.Encoding/4.0.0-beta-23324": {
+    "System.Security.Cryptography.Encoding/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "JHOyknf1eYO6C39Vao6kAGpadq3PBO1L4tuzNEz/HvbH5sfIHPbjhxL11OyAhVKCzLCfEj6+aeClovFqZIRPyw==",
+      "sha512": "zeFdKQT6xjNdiNCaEmEYJMEK59kixkX7jJSoOLw3H+53t9X0F98vr3tS8YlrW/Lk/K9c6L5pYLlkb2dNqvUD/g==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2570,15 +2678,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.Encoding.4.0.0-beta-23324.nupkg",
-        "System.Security.Cryptography.Encoding.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Cryptography.Encoding.4.0.0-beta-23330.nupkg",
+        "System.Security.Cryptography.Encoding.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Cryptography.Encoding.nuspec"
       ]
     },
-    "System.Security.Cryptography.Primitives/4.0.0-beta-23324": {
+    "System.Security.Cryptography.Primitives/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "ETZxelIX51Di4FTytd8ohSpN6Ym/32aWIX9E2NCFkd91qdexn2Dkysn80b6n4gX6jG+oL0UHQDtD/fYq8C65oQ==",
+      "sha512": "15uVbOD3X0sRQJIxcEH5hasxlFdbA1CmPPZa0Y8pYEuQcWMF2gBswvU8s4qoKtA7x2xhNhzPsXIhsQuKNMTdEA==",
       "files": [
         "lib/dotnet/System.Security.Cryptography.Primitives.dll",
         "lib/MonoAndroid10/_._",
@@ -2592,15 +2700,15 @@
         "ref/net46/System.Security.Cryptography.Primitives.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Security.Cryptography.Primitives.4.0.0-beta-23324.nupkg",
-        "System.Security.Cryptography.Primitives.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Cryptography.Primitives.4.0.0-beta-23330.nupkg",
+        "System.Security.Cryptography.Primitives.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Cryptography.Primitives.nuspec"
       ]
     },
-    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23324": {
+    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "8NaEOxkkNBUECh0cPzGpbXS0uzGDpnvxI0kqQKRGp9uA+9qCyQfxcqAT6ozAYtOuFNVaC1XU3zQnb7T2nfvIDg==",
+      "sha512": "L8mUimdm7+GsORgJ8DFBMGsFnwDJ5YCUdJj3HfXQx4HCoPDPF+vJo3HRiHfcvNA2Zsf0ov2kuerYj/eeVa2/Rw==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2614,8 +2722,8 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23324.nupkg",
-        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23330.nupkg",
+        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Cryptography.X509Certificates.nuspec"
       ]
     },
@@ -2652,10 +2760,10 @@
         "System.Security.Principal.nuspec"
       ]
     },
-    "System.Security.Principal.Windows/4.0.0-beta-23324": {
+    "System.Security.Principal.Windows/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "csbCKdwBz31T8He7U6XMIc9BiWgwjHs5WDZR4rfhsk48TpdsbKNHX9OX4b+GwvgcsfVuWxre7zqNR0Bc9gWZ7g==",
+      "sha512": "q+3L3aB8bn0HCW52kX9TSJdhbjffBw7QWCOu0yX1SDhPN9MCPmJ4aBBCn1HRWroa5y7UcNUdjL1xwiERycZexw==",
       "files": [
         "lib/DNXCore50/de/System.Security.Principal.Windows.xml",
         "lib/DNXCore50/es/System.Security.Principal.Windows.xml",
@@ -2671,15 +2779,15 @@
         "lib/net46/System.Security.Principal.Windows.dll",
         "ref/dotnet/System.Security.Principal.Windows.dll",
         "ref/net46/System.Security.Principal.Windows.dll",
-        "System.Security.Principal.Windows.4.0.0-beta-23324.nupkg",
-        "System.Security.Principal.Windows.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Principal.Windows.4.0.0-beta-23330.nupkg",
+        "System.Security.Principal.Windows.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Principal.Windows.nuspec"
       ]
     },
-    "System.ServiceModel.Http/4.0.11-beta-23324": {
+    "System.ServiceModel.Http/4.0.11-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "VkTumuCSmXd0NPZZU+nrO7YqznvM+wP96NykXbxFJdNAtCplmqXaQh+YZ/02rjJmfou5qyo2V+ZWVwySBAirOg==",
+      "sha512": "NHKxIIYL0ATDbX18RLCSXtuq26MMoYfAVdpl5K+D0s5AHp7TMPb7LcjZPpg25B2v48x1TwE9LYcYTCiOZcoPzQ==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Http.dll",
         "lib/MonoAndroid10/_._",
@@ -2704,15 +2812,15 @@
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.ServiceModel.Http.4.0.11-beta-23324.nupkg",
-        "System.ServiceModel.Http.4.0.11-beta-23324.nupkg.sha512",
+        "System.ServiceModel.Http.4.0.11-beta-23330.nupkg",
+        "System.ServiceModel.Http.4.0.11-beta-23330.nupkg.sha512",
         "System.ServiceModel.Http.nuspec"
       ]
     },
-    "System.ServiceModel.NetTcp/4.0.1-beta-23324": {
+    "System.ServiceModel.NetTcp/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "xI03xQCdWzqq4H2E29BELQm/e9LJl+IAbD50lcH966Z+JdaYOqeM6RGxAys0sVim59wvCrOv/YaRNxz66YLoog==",
+      "sha512": "Vx0QSKz4BlX/yYqKHET3mofo6RxxaMDLWsEFWDbEBJeCs0Yq19uGiIYwK1mXkWy3Y+jDwi42au3mVhmRbDHavA==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.NetTcp.dll",
         "lib/net45/_._",
@@ -2732,15 +2840,15 @@
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.NetTcp.dll",
         "ref/win8/_._",
-        "System.ServiceModel.NetTcp.4.0.1-beta-23324.nupkg",
-        "System.ServiceModel.NetTcp.4.0.1-beta-23324.nupkg.sha512",
+        "System.ServiceModel.NetTcp.4.0.1-beta-23330.nupkg",
+        "System.ServiceModel.NetTcp.4.0.1-beta-23330.nupkg.sha512",
         "System.ServiceModel.NetTcp.nuspec"
       ]
     },
-    "System.ServiceModel.Primitives/4.0.1-beta-23324": {
+    "System.ServiceModel.Primitives/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "bmU31B4CD5+m9Kt0iDM5Yw2ZXRfv7lpK3Sx1HektcT/HERc+IMPdO38f/Wxtofo5WOA0qmd1fdrMeQcbEkDfJg==",
+      "sha512": "kJ/pcRUf7Ow7s/rX8Kmc9P2k6cvyudIzyUcqr/pn9NwY8DC/2DWkkFvYE2udR4kvBzJJzXl/rsJQlyLIVGMAww==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Primitives.dll",
         "lib/net45/_._",
@@ -2760,15 +2868,15 @@
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.Primitives.dll",
         "ref/win8/_._",
-        "System.ServiceModel.Primitives.4.0.1-beta-23324.nupkg",
-        "System.ServiceModel.Primitives.4.0.1-beta-23324.nupkg.sha512",
+        "System.ServiceModel.Primitives.4.0.1-beta-23330.nupkg",
+        "System.ServiceModel.Primitives.4.0.1-beta-23330.nupkg.sha512",
         "System.ServiceModel.Primitives.nuspec"
       ]
     },
-    "System.ServiceModel.Security/4.0.1-beta-23324": {
+    "System.ServiceModel.Security/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "vZN35yLLzcJXgr56Dds+N98fHb8IzyujOqJNuipkO6GEtUuyybV/g1UvmKbel/HvvoAyjSTNC+3/O95Go+tn0Q==",
+      "sha512": "DkdJSuFiSyHpu5vmqx1DHolDVZCPE1LoTVPFlH3E2AOFUnv7+LddJd02I1l03fhtKrOkJKJACHonhseWDdeIMg==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Security.dll",
         "lib/net45/_._",
@@ -2788,8 +2896,8 @@
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.Security.dll",
         "ref/win8/_._",
-        "System.ServiceModel.Security.4.0.1-beta-23324.nupkg",
-        "System.ServiceModel.Security.4.0.1-beta-23324.nupkg.sha512",
+        "System.ServiceModel.Security.4.0.1-beta-23330.nupkg",
+        "System.ServiceModel.Security.4.0.1-beta-23330.nupkg.sha512",
         "System.ServiceModel.Security.nuspec"
       ]
     },
@@ -2984,10 +3092,9 @@
         "System.Threading.Tasks.nuspec"
       ]
     },
-    "System.Threading.ThreadPool/4.0.10-beta-23324": {
+    "System.Threading.ThreadPool/4.0.10-beta-23330": {
       "type": "package",
-      "serviceable": true,
-      "sha512": "G4SjGmiV72HBiv8wkfnKFGTieekrACU1m43VaeJ6vDeSyb08eEFusVH1UWZpOsUF25meCuzpda0ezus24b4rKA==",
+      "sha512": "nM5OewUj8NJrye93apbM6KHvPddgPJGzt1IWIXk9lV5HB4NGsn6M5U0gxMQWShQuDp6NF3ya3ULRSvh3dLMbzg==",
       "files": [
         "lib/DNXCore50/System.Threading.ThreadPool.dll",
         "lib/MonoAndroid10/_._",
@@ -3001,8 +3108,8 @@
         "ref/net46/System.Threading.ThreadPool.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Threading.ThreadPool.4.0.10-beta-23324.nupkg",
-        "System.Threading.ThreadPool.4.0.10-beta-23324.nupkg.sha512",
+        "System.Threading.ThreadPool.4.0.10-beta-23330.nupkg",
+        "System.Threading.ThreadPool.4.0.10-beta-23330.nupkg.sha512",
         "System.Threading.ThreadPool.nuspec"
       ]
     },
@@ -3253,14 +3360,14 @@
         "xunit.extensibility.execution.nuspec"
       ]
     },
-    "xunit.netcore.extensions/1.0.0-prerelease-00095": {
+    "xunit.netcore.extensions/1.0.0-prerelease-00098": {
       "type": "package",
       "serviceable": true,
-      "sha512": "FuvWmkuxHiqD0cHDggg5MRmBoeM4Uea7OUEmKvZiQu7Fy02hJ6yKKNV7mNW3y4scwSzDNA81Qa+HIS33PeWUog==",
+      "sha512": "3kRPwTbC42YGmsNHpNMKfGVOO5cVfxUD+C7cYbti1aml4UCT/RFZ6lhm5Vym2wNRDxryu0Es78aMf1BaybSrDg==",
       "files": [
         "lib/dotnet/Xunit.NetCore.Extensions.dll",
-        "xunit.netcore.extensions.1.0.0-prerelease-00095.nupkg",
-        "xunit.netcore.extensions.1.0.0-prerelease-00095.nupkg.sha512",
+        "xunit.netcore.extensions.1.0.0-prerelease-00098.nupkg",
+        "xunit.netcore.extensions.1.0.0-prerelease-00098.nupkg.sha512",
         "xunit.netcore.extensions.nuspec"
       ]
     }

--- a/src/System.Private.ServiceModel/tests/Common/Scenarios/project.lock.json
+++ b/src/System.Private.ServiceModel/tests/Common/Scenarios/project.lock.json
@@ -292,7 +292,7 @@
           "lib/dotnet/System.Linq.Queryable.dll": {}
         }
       },
-      "System.Net.Http/4.0.1-beta-23324": {
+      "System.Net.Http/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -305,16 +305,15 @@
           "ref/dotnet/System.Net.Http.dll": {}
         }
       },
-      "System.Net.NameResolution/4.0.0-beta-23324": {
+      "System.Net.NameResolution/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.Networking": "4.0.1-beta-23324"
+          "System.Net.Primitives": "4.0.10",
+          "System.Runtime": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Net.NameResolution.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Net.NameResolution.dll": {}
         }
       },
       "System.Net.Primitives/4.0.10": {
@@ -329,10 +328,10 @@
           "lib/DNXCore50/System.Net.Primitives.dll": {}
         }
       },
-      "System.Net.Security/4.0.0-beta-23324": {
+      "System.Net.Security/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.Networking": "4.0.1-beta-23324"
+          "System.Private.Networking": "4.0.1-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.Net.Security.dll": {}
@@ -367,6 +366,49 @@
         },
         "runtime": {
           "lib/dotnet/System.Net.WebHeaderCollection.dll": {}
+        }
+      },
+      "System.Net.WebSockets/4.0.0-beta-23330": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.Win32.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Threading.Tasks": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Net.WebSockets.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Net.WebSockets.dll": {}
+        }
+      },
+      "System.Net.WebSockets.Client/4.0.0-beta-23330": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.Win32.Primitives": "4.0.0",
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Diagnostics.Tracing": "4.0.20",
+          "System.Globalization": "4.0.10",
+          "System.Net.Primitives": "4.0.10",
+          "System.Net.WebHeaderCollection": "4.0.0",
+          "System.Net.WebSockets": "4.0.0-beta-23330",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23330",
+          "System.Text.Encoding": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Net.WebSockets.Client.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Net.WebSockets.Client.dll": {}
         }
       },
       "System.ObjectModel/4.0.10": {
@@ -414,7 +456,7 @@
           "lib/DNXCore50/System.Private.DataContractSerialization.dll": {}
         }
       },
-      "System.Private.Networking/4.0.1-beta-23324": {
+      "System.Private.Networking/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -433,13 +475,13 @@
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23324",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23324",
-          "System.Security.Principal.Windows": "4.0.0-beta-23324",
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23330",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23330",
+          "System.Security.Principal.Windows": "4.0.0-beta-23330",
           "System.Threading": "4.0.10",
           "System.Threading.Overlapped": "4.0.0",
           "System.Threading.Tasks": "4.0.10",
-          "System.Threading.ThreadPool": "4.0.10-beta-23324"
+          "System.Threading.ThreadPool": "4.0.10-beta-23330"
         },
         "compile": {
           "ref/dnxcore50/_._": {}
@@ -448,7 +490,7 @@
           "lib/DNXCore50/System.Private.Networking.dll": {}
         }
       },
-      "System.Private.ServiceModel/4.0.1-beta-23324": {
+      "System.Private.ServiceModel/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -465,12 +507,14 @@
           "System.Linq": "4.0.0",
           "System.Linq.Expressions": "4.0.10",
           "System.Linq.Queryable": "4.0.0",
-          "System.Net.Http": "4.0.1-beta-23324",
-          "System.Net.NameResolution": "4.0.0-beta-23324",
+          "System.Net.Http": "4.0.1-beta-23330",
+          "System.Net.NameResolution": "4.0.0-beta-23330",
           "System.Net.Primitives": "4.0.10",
-          "System.Net.Security": "4.0.0-beta-23324",
-          "System.Net.Sockets": "4.0.10-beta-23324",
+          "System.Net.Security": "4.0.0-beta-23330",
+          "System.Net.Sockets": "4.0.10-beta-23330",
           "System.Net.WebHeaderCollection": "4.0.0",
+          "System.Net.WebSockets": "4.0.0-beta-23330",
+          "System.Net.WebSockets.Client": "4.0.0-beta-23330",
           "System.ObjectModel": "4.0.10",
           "System.Reflection": "4.0.10",
           "System.Reflection.DispatchProxy": "4.0.0",
@@ -484,9 +528,9 @@
           "System.Runtime.Serialization.Primitives": "4.0.10",
           "System.Runtime.Serialization.Xml": "4.0.10",
           "System.Security.Claims": "4.0.0",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23324",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23330",
           "System.Security.Principal": "4.0.0",
-          "System.Security.Principal.Windows": "4.0.0-beta-23324",
+          "System.Security.Principal.Windows": "4.0.0-beta-23330",
           "System.Text.Encoding": "4.0.10",
           "System.Threading": "4.0.10",
           "System.Threading.Tasks": "4.0.10",
@@ -735,18 +779,18 @@
           "lib/dotnet/System.Security.Claims.dll": {}
         }
       },
-      "System.Security.Cryptography.Algorithms/4.0.0-beta-23324": {
+      "System.Security.Cryptography.Algorithms/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
           "System.Runtime": "4.0.0",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23324"
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.Algorithms.dll": {}
         }
       },
-      "System.Security.Cryptography.Encoding/4.0.0-beta-23324": {
+      "System.Security.Cryptography.Encoding/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -755,7 +799,7 @@
           "ref/dotnet/System.Security.Cryptography.Encoding.dll": {}
         }
       },
-      "System.Security.Cryptography.Primitives/4.0.0-beta-23324": {
+      "System.Security.Cryptography.Primitives/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.0",
@@ -773,13 +817,13 @@
           "lib/dotnet/System.Security.Cryptography.Primitives.dll": {}
         }
       },
-      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23324": {
+      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
           "System.Runtime.Handles": "4.0.0",
-          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23324",
-          "System.Security.Cryptography.Encoding": "4.0.0-beta-23324"
+          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23330",
+          "System.Security.Cryptography.Encoding": "4.0.0-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.X509Certificates.dll": {}
@@ -797,7 +841,7 @@
           "lib/dotnet/System.Security.Principal.dll": {}
         }
       },
-      "System.Security.Principal.Windows/4.0.0-beta-23324": {
+      "System.Security.Principal.Windows/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -820,10 +864,10 @@
           "lib/DNXCore50/System.Security.Principal.Windows.dll": {}
         }
       },
-      "System.ServiceModel.Duplex/4.0.1-beta-23324": {
+      "System.ServiceModel.Duplex/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.0.1-beta-23324"
+          "System.Private.ServiceModel": "4.0.1-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.ServiceModel.Duplex.dll": {}
@@ -832,10 +876,10 @@
           "lib/DNXCore50/System.ServiceModel.Duplex.dll": {}
         }
       },
-      "System.ServiceModel.Http/4.0.11-beta-23324": {
+      "System.ServiceModel.Http/4.0.11-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.0.1-beta-23324",
+          "System.Private.ServiceModel": "4.0.1-beta-23330",
           "System.Runtime": "4.0.20"
         },
         "compile": {
@@ -845,10 +889,10 @@
           "lib/DNXCore50/System.ServiceModel.Http.dll": {}
         }
       },
-      "System.ServiceModel.NetTcp/4.0.1-beta-23324": {
+      "System.ServiceModel.NetTcp/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.0.1-beta-23324"
+          "System.Private.ServiceModel": "4.0.1-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.ServiceModel.NetTcp.dll": {}
@@ -857,10 +901,10 @@
           "lib/DNXCore50/System.ServiceModel.NetTcp.dll": {}
         }
       },
-      "System.ServiceModel.Primitives/4.0.1-beta-23324": {
+      "System.ServiceModel.Primitives/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.0.1-beta-23324"
+          "System.Private.ServiceModel": "4.0.1-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.ServiceModel.Primitives.dll": {}
@@ -869,10 +913,10 @@
           "lib/DNXCore50/System.ServiceModel.Primitives.dll": {}
         }
       },
-      "System.ServiceModel.Security/4.0.1-beta-23324": {
+      "System.ServiceModel.Security/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.0.1-beta-23324"
+          "System.Private.ServiceModel": "4.0.1-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.ServiceModel.Security.dll": {}
@@ -961,7 +1005,7 @@
           "lib/DNXCore50/System.Threading.Tasks.dll": {}
         }
       },
-      "System.Threading.ThreadPool/4.0.10-beta-23324": {
+      "System.Threading.ThreadPool/4.0.10-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
@@ -1154,7 +1198,7 @@
           "lib/dotnet/xunit.execution.dotnet.dll": {}
         }
       },
-      "xunit.netcore.extensions/1.0.0-prerelease-00095": {
+      "xunit.netcore.extensions/1.0.0-prerelease-00098": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.10",
@@ -1782,23 +1826,12 @@
         "System.Linq.Queryable.nuspec"
       ]
     },
-    "System.Net.Http/4.0.1-beta-23324": {
+    "System.Net.Http/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "gXfHlWsiMQDuFqwnQrlQTje9vqMhCFLtm35jX4WqZjcfa3y69DbwueeT0gJbVMK88/UnG8FAYiDBb7AKyu+51w==",
+      "sha512": "itLPx7B7Ac4mX8wQx9V9DQcxqTgkmwDNnQIHuCgAH53Jq2X3XziiRRBbxbmNJlWqBlgPzbseWJmMCtcF/ePhOg==",
       "files": [
         "lib/net45/_._",
-        "lib/netcore50/de/System.Net.Http.xml",
-        "lib/netcore50/es/System.Net.Http.xml",
-        "lib/netcore50/fr/System.Net.Http.xml",
-        "lib/netcore50/it/System.Net.Http.xml",
-        "lib/netcore50/ja/System.Net.Http.xml",
-        "lib/netcore50/ko/System.Net.Http.xml",
-        "lib/netcore50/ru/System.Net.Http.xml",
-        "lib/netcore50/System.Net.Http.dll",
-        "lib/netcore50/System.Net.Http.xml",
-        "lib/netcore50/zh-hans/System.Net.Http.xml",
-        "lib/netcore50/zh-hant/System.Net.Http.xml",
         "lib/win8/_._",
         "lib/wpa81/_._",
         "ref/dotnet/System.Net.Http.dll",
@@ -1807,17 +1840,16 @@
         "ref/win8/_._",
         "ref/wpa81/_._",
         "runtime.json",
-        "System.Net.Http.4.0.1-beta-23324.nupkg",
-        "System.Net.Http.4.0.1-beta-23324.nupkg.sha512",
+        "System.Net.Http.4.0.1-beta-23330.nupkg",
+        "System.Net.Http.4.0.1-beta-23330.nupkg.sha512",
         "System.Net.Http.nuspec"
       ]
     },
-    "System.Net.NameResolution/4.0.0-beta-23324": {
+    "System.Net.NameResolution/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "lNYXUmnSXUtLFY09Rc27zJ6/TxCuGggQzBgiuWHoWrjWxymuuxqPT2Mj7Dn7sUUh0GvF2MOx7Uk+rtCFBiIavg==",
+      "sha512": "d8Am+In/aBgcHpEV6xsi5BCiTEN4y6s9O1V/yIvwX8mDC4CtdZiGsi4DtoB0TLOgp8ky6GxbSF4bKCjFpBO3uw==",
       "files": [
-        "lib/DNXCore50/System.Net.NameResolution.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.NameResolution.dll",
@@ -1829,8 +1861,9 @@
         "ref/net46/System.Net.NameResolution.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.NameResolution.4.0.0-beta-23324.nupkg",
-        "System.Net.NameResolution.4.0.0-beta-23324.nupkg.sha512",
+        "runtime.json",
+        "System.Net.NameResolution.4.0.0-beta-23330.nupkg",
+        "System.Net.NameResolution.4.0.0-beta-23330.nupkg.sha512",
         "System.Net.NameResolution.nuspec"
       ]
     },
@@ -1867,9 +1900,9 @@
         "System.Net.Primitives.nuspec"
       ]
     },
-    "System.Net.Security/4.0.0-beta-23324": {
+    "System.Net.Security/4.0.0-beta-23330": {
       "type": "package",
-      "sha512": "D04RYjxrnR3D+uI9CGmAAFKKQ6T+pPcRHYucc1PIo7/hJK5I/Yu7gAw9yOxHUhQjSGfrKo00lHpBCQMTQt4lSw==",
+      "sha512": "z98dKloNy9DBdyfqQwQvKWA2q8Qj4vgGEVONnlS70c13eh0MolBHJ0wNdplZZK5zYZ5Eu8GTwexbUlpHbsfzVA==",
       "files": [
         "lib/DNXCore50/System.Net.Security.dll",
         "lib/MonoAndroid10/_._",
@@ -1883,8 +1916,8 @@
         "ref/net46/System.Net.Security.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.Security.4.0.0-beta-23324.nupkg",
-        "System.Net.Security.4.0.0-beta-23324.nupkg.sha512",
+        "System.Net.Security.4.0.0-beta-23330.nupkg",
+        "System.Net.Security.4.0.0-beta-23330.nupkg.sha512",
         "System.Net.Security.nuspec"
       ]
     },
@@ -1942,6 +1975,81 @@
         "System.Net.WebHeaderCollection.nuspec"
       ]
     },
+    "System.Net.WebSockets/4.0.0-beta-23330": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "6Q9/uTDcaqbmdbD04MisKmjti4aEpp40i/UzpGaPZ4ItuwzU/pMk9RjiYUBUiCQyZeKNlXcSB1FPN2nFof7tww==",
+      "files": [
+        "lib/dotnet/de/System.Net.WebSockets.xml",
+        "lib/dotnet/es/System.Net.WebSockets.xml",
+        "lib/dotnet/fr/System.Net.WebSockets.xml",
+        "lib/dotnet/it/System.Net.WebSockets.xml",
+        "lib/dotnet/ja/System.Net.WebSockets.xml",
+        "lib/dotnet/ko/System.Net.WebSockets.xml",
+        "lib/dotnet/ru/System.Net.WebSockets.xml",
+        "lib/dotnet/System.Net.WebSockets.dll",
+        "lib/dotnet/System.Net.WebSockets.xml",
+        "lib/dotnet/zh-hans/System.Net.WebSockets.xml",
+        "lib/dotnet/zh-hant/System.Net.WebSockets.xml",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Net.WebSockets.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Net.WebSockets.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Net.WebSockets.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Net.WebSockets.4.0.0-beta-23330.nupkg",
+        "System.Net.WebSockets.4.0.0-beta-23330.nupkg.sha512",
+        "System.Net.WebSockets.nuspec"
+      ]
+    },
+    "System.Net.WebSockets.Client/4.0.0-beta-23330": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "1NWEqwDkYRyvr1gSKZlY51AaI9w8oD0dC5UNa2Lb+qaeFHSF5KfCSzf7seD+im+sH6uocVo2nppiaabfbXZT4Q==",
+      "files": [
+        "lib/DNXCore50/de/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/es/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/fr/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/it/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/ja/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/ko/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/ru/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/System.Net.WebSockets.Client.dll",
+        "lib/DNXCore50/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/zh-hans/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/zh-hant/System.Net.WebSockets.Client.xml",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Net.WebSockets.Client.dll",
+        "lib/netcore50/de/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/es/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/fr/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/it/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/ja/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/ko/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/ru/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/System.Net.WebSockets.Client.dll",
+        "lib/netcore50/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/zh-hans/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/zh-hant/System.Net.WebSockets.Client.xml",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Net.WebSockets.Client.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Net.WebSockets.Client.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Net.WebSockets.Client.4.0.0-beta-23330.nupkg",
+        "System.Net.WebSockets.Client.4.0.0-beta-23330.nupkg.sha512",
+        "System.Net.WebSockets.Client.nuspec"
+      ]
+    },
     "System.ObjectModel/4.0.10": {
       "type": "package",
       "serviceable": true,
@@ -1990,31 +2098,31 @@
         "System.Private.DataContractSerialization.nuspec"
       ]
     },
-    "System.Private.Networking/4.0.1-beta-23324": {
+    "System.Private.Networking/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "OfyxoeCdh1ypzdz1u0h1Clgt+6749vALs2ZPkLwsOPzL0INCG9ISYo+Jhh62ZD8TMkWwLrvyVppMBPHY6M7Upw==",
+      "sha512": "8NZi1gCQaGTKDb2yWplm52HWCLaZnUwVitksJgcXY2dEJau/TBGyZup+yhOngOIe8QzQMxNG4iokY3Ce0/8mbg==",
       "files": [
         "lib/DNXCore50/System.Private.Networking.dll",
         "lib/netcore50/System.Private.Networking.dll",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "System.Private.Networking.4.0.1-beta-23324.nupkg",
-        "System.Private.Networking.4.0.1-beta-23324.nupkg.sha512",
+        "System.Private.Networking.4.0.1-beta-23330.nupkg",
+        "System.Private.Networking.4.0.1-beta-23330.nupkg.sha512",
         "System.Private.Networking.nuspec"
       ]
     },
-    "System.Private.ServiceModel/4.0.1-beta-23324": {
+    "System.Private.ServiceModel/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "Lz3T9V8GnaOFlf8LUmuPznuOIuy92BAFVc9huiMrFKByzPpydGuCvXEe+81rZ1IF2TQcHKO++9otnj96AEJ5BA==",
+      "sha512": "8lENvmHuZdlvmnYN1w98Mv8bDjc0O/YlaNHRRph35T/fLDyaG8LMLMwG3/ut6a/AenLJmbf92snOtNXCuqM+cQ==",
       "files": [
         "lib/DNXCore50/System.Private.ServiceModel.dll",
         "lib/netcore50/System.Private.ServiceModel.dll",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "System.Private.ServiceModel.4.0.1-beta-23324.nupkg",
-        "System.Private.ServiceModel.4.0.1-beta-23324.nupkg.sha512",
+        "System.Private.ServiceModel.4.0.1-beta-23330.nupkg",
+        "System.Private.ServiceModel.4.0.1-beta-23330.nupkg.sha512",
         "System.Private.ServiceModel.nuspec"
       ]
     },
@@ -2543,10 +2651,10 @@
         "System.Security.Claims.nuspec"
       ]
     },
-    "System.Security.Cryptography.Algorithms/4.0.0-beta-23324": {
+    "System.Security.Cryptography.Algorithms/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "Mt6LwMj8hPp0+xZHcV6grZ7wSWhgycGkdZ6DQ9XvUY9NguUsvb/+fu2cMdrC7XsnpvwIROByp+p2dSjqBn3E2Q==",
+      "sha512": "FB4RoTDaV5tBiPSJsiG3A5DydeKz7ErglnkqVjBFjm6wu8kg91j0MxL/Al9iUyu9i/hq53fRs5KE3rjUNYvf5w==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2560,15 +2668,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.Algorithms.4.0.0-beta-23324.nupkg",
-        "System.Security.Cryptography.Algorithms.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Cryptography.Algorithms.4.0.0-beta-23330.nupkg",
+        "System.Security.Cryptography.Algorithms.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Cryptography.Algorithms.nuspec"
       ]
     },
-    "System.Security.Cryptography.Encoding/4.0.0-beta-23324": {
+    "System.Security.Cryptography.Encoding/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "JHOyknf1eYO6C39Vao6kAGpadq3PBO1L4tuzNEz/HvbH5sfIHPbjhxL11OyAhVKCzLCfEj6+aeClovFqZIRPyw==",
+      "sha512": "zeFdKQT6xjNdiNCaEmEYJMEK59kixkX7jJSoOLw3H+53t9X0F98vr3tS8YlrW/Lk/K9c6L5pYLlkb2dNqvUD/g==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2582,15 +2690,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.Encoding.4.0.0-beta-23324.nupkg",
-        "System.Security.Cryptography.Encoding.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Cryptography.Encoding.4.0.0-beta-23330.nupkg",
+        "System.Security.Cryptography.Encoding.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Cryptography.Encoding.nuspec"
       ]
     },
-    "System.Security.Cryptography.Primitives/4.0.0-beta-23324": {
+    "System.Security.Cryptography.Primitives/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "ETZxelIX51Di4FTytd8ohSpN6Ym/32aWIX9E2NCFkd91qdexn2Dkysn80b6n4gX6jG+oL0UHQDtD/fYq8C65oQ==",
+      "sha512": "15uVbOD3X0sRQJIxcEH5hasxlFdbA1CmPPZa0Y8pYEuQcWMF2gBswvU8s4qoKtA7x2xhNhzPsXIhsQuKNMTdEA==",
       "files": [
         "lib/dotnet/System.Security.Cryptography.Primitives.dll",
         "lib/MonoAndroid10/_._",
@@ -2604,15 +2712,15 @@
         "ref/net46/System.Security.Cryptography.Primitives.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Security.Cryptography.Primitives.4.0.0-beta-23324.nupkg",
-        "System.Security.Cryptography.Primitives.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Cryptography.Primitives.4.0.0-beta-23330.nupkg",
+        "System.Security.Cryptography.Primitives.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Cryptography.Primitives.nuspec"
       ]
     },
-    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23324": {
+    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "8NaEOxkkNBUECh0cPzGpbXS0uzGDpnvxI0kqQKRGp9uA+9qCyQfxcqAT6ozAYtOuFNVaC1XU3zQnb7T2nfvIDg==",
+      "sha512": "L8mUimdm7+GsORgJ8DFBMGsFnwDJ5YCUdJj3HfXQx4HCoPDPF+vJo3HRiHfcvNA2Zsf0ov2kuerYj/eeVa2/Rw==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2626,8 +2734,8 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23324.nupkg",
-        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23330.nupkg",
+        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Cryptography.X509Certificates.nuspec"
       ]
     },
@@ -2664,10 +2772,10 @@
         "System.Security.Principal.nuspec"
       ]
     },
-    "System.Security.Principal.Windows/4.0.0-beta-23324": {
+    "System.Security.Principal.Windows/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "csbCKdwBz31T8He7U6XMIc9BiWgwjHs5WDZR4rfhsk48TpdsbKNHX9OX4b+GwvgcsfVuWxre7zqNR0Bc9gWZ7g==",
+      "sha512": "q+3L3aB8bn0HCW52kX9TSJdhbjffBw7QWCOu0yX1SDhPN9MCPmJ4aBBCn1HRWroa5y7UcNUdjL1xwiERycZexw==",
       "files": [
         "lib/DNXCore50/de/System.Security.Principal.Windows.xml",
         "lib/DNXCore50/es/System.Security.Principal.Windows.xml",
@@ -2683,15 +2791,15 @@
         "lib/net46/System.Security.Principal.Windows.dll",
         "ref/dotnet/System.Security.Principal.Windows.dll",
         "ref/net46/System.Security.Principal.Windows.dll",
-        "System.Security.Principal.Windows.4.0.0-beta-23324.nupkg",
-        "System.Security.Principal.Windows.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Principal.Windows.4.0.0-beta-23330.nupkg",
+        "System.Security.Principal.Windows.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Principal.Windows.nuspec"
       ]
     },
-    "System.ServiceModel.Duplex/4.0.1-beta-23324": {
+    "System.ServiceModel.Duplex/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "b+p3u2zee0oAM4AIyM9rev1MaoExxD4d97iNeZFG0Q0bEVFOzK97/5HNcq5FzpTUhxZgfXXCOCmuIYwnYsfU/w==",
+      "sha512": "0k9wL8LeMYj1jfu2wZwTdQhmPBcpMSUgD304cR50CpHOJnrP/NjiQ0Blx3oSURd8Tda5XuXC0PNGWDF+EpW/Lg==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Duplex.dll",
         "lib/net45/_._",
@@ -2711,15 +2819,15 @@
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.Duplex.dll",
         "ref/win8/_._",
-        "System.ServiceModel.Duplex.4.0.1-beta-23324.nupkg",
-        "System.ServiceModel.Duplex.4.0.1-beta-23324.nupkg.sha512",
+        "System.ServiceModel.Duplex.4.0.1-beta-23330.nupkg",
+        "System.ServiceModel.Duplex.4.0.1-beta-23330.nupkg.sha512",
         "System.ServiceModel.Duplex.nuspec"
       ]
     },
-    "System.ServiceModel.Http/4.0.11-beta-23324": {
+    "System.ServiceModel.Http/4.0.11-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "VkTumuCSmXd0NPZZU+nrO7YqznvM+wP96NykXbxFJdNAtCplmqXaQh+YZ/02rjJmfou5qyo2V+ZWVwySBAirOg==",
+      "sha512": "NHKxIIYL0ATDbX18RLCSXtuq26MMoYfAVdpl5K+D0s5AHp7TMPb7LcjZPpg25B2v48x1TwE9LYcYTCiOZcoPzQ==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Http.dll",
         "lib/MonoAndroid10/_._",
@@ -2744,15 +2852,15 @@
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.ServiceModel.Http.4.0.11-beta-23324.nupkg",
-        "System.ServiceModel.Http.4.0.11-beta-23324.nupkg.sha512",
+        "System.ServiceModel.Http.4.0.11-beta-23330.nupkg",
+        "System.ServiceModel.Http.4.0.11-beta-23330.nupkg.sha512",
         "System.ServiceModel.Http.nuspec"
       ]
     },
-    "System.ServiceModel.NetTcp/4.0.1-beta-23324": {
+    "System.ServiceModel.NetTcp/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "xI03xQCdWzqq4H2E29BELQm/e9LJl+IAbD50lcH966Z+JdaYOqeM6RGxAys0sVim59wvCrOv/YaRNxz66YLoog==",
+      "sha512": "Vx0QSKz4BlX/yYqKHET3mofo6RxxaMDLWsEFWDbEBJeCs0Yq19uGiIYwK1mXkWy3Y+jDwi42au3mVhmRbDHavA==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.NetTcp.dll",
         "lib/net45/_._",
@@ -2772,15 +2880,15 @@
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.NetTcp.dll",
         "ref/win8/_._",
-        "System.ServiceModel.NetTcp.4.0.1-beta-23324.nupkg",
-        "System.ServiceModel.NetTcp.4.0.1-beta-23324.nupkg.sha512",
+        "System.ServiceModel.NetTcp.4.0.1-beta-23330.nupkg",
+        "System.ServiceModel.NetTcp.4.0.1-beta-23330.nupkg.sha512",
         "System.ServiceModel.NetTcp.nuspec"
       ]
     },
-    "System.ServiceModel.Primitives/4.0.1-beta-23324": {
+    "System.ServiceModel.Primitives/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "bmU31B4CD5+m9Kt0iDM5Yw2ZXRfv7lpK3Sx1HektcT/HERc+IMPdO38f/Wxtofo5WOA0qmd1fdrMeQcbEkDfJg==",
+      "sha512": "kJ/pcRUf7Ow7s/rX8Kmc9P2k6cvyudIzyUcqr/pn9NwY8DC/2DWkkFvYE2udR4kvBzJJzXl/rsJQlyLIVGMAww==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Primitives.dll",
         "lib/net45/_._",
@@ -2800,15 +2908,15 @@
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.Primitives.dll",
         "ref/win8/_._",
-        "System.ServiceModel.Primitives.4.0.1-beta-23324.nupkg",
-        "System.ServiceModel.Primitives.4.0.1-beta-23324.nupkg.sha512",
+        "System.ServiceModel.Primitives.4.0.1-beta-23330.nupkg",
+        "System.ServiceModel.Primitives.4.0.1-beta-23330.nupkg.sha512",
         "System.ServiceModel.Primitives.nuspec"
       ]
     },
-    "System.ServiceModel.Security/4.0.1-beta-23324": {
+    "System.ServiceModel.Security/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "vZN35yLLzcJXgr56Dds+N98fHb8IzyujOqJNuipkO6GEtUuyybV/g1UvmKbel/HvvoAyjSTNC+3/O95Go+tn0Q==",
+      "sha512": "DkdJSuFiSyHpu5vmqx1DHolDVZCPE1LoTVPFlH3E2AOFUnv7+LddJd02I1l03fhtKrOkJKJACHonhseWDdeIMg==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Security.dll",
         "lib/net45/_._",
@@ -2828,8 +2936,8 @@
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.Security.dll",
         "ref/win8/_._",
-        "System.ServiceModel.Security.4.0.1-beta-23324.nupkg",
-        "System.ServiceModel.Security.4.0.1-beta-23324.nupkg.sha512",
+        "System.ServiceModel.Security.4.0.1-beta-23330.nupkg",
+        "System.ServiceModel.Security.4.0.1-beta-23330.nupkg.sha512",
         "System.ServiceModel.Security.nuspec"
       ]
     },
@@ -3024,10 +3132,9 @@
         "System.Threading.Tasks.nuspec"
       ]
     },
-    "System.Threading.ThreadPool/4.0.10-beta-23324": {
+    "System.Threading.ThreadPool/4.0.10-beta-23330": {
       "type": "package",
-      "serviceable": true,
-      "sha512": "G4SjGmiV72HBiv8wkfnKFGTieekrACU1m43VaeJ6vDeSyb08eEFusVH1UWZpOsUF25meCuzpda0ezus24b4rKA==",
+      "sha512": "nM5OewUj8NJrye93apbM6KHvPddgPJGzt1IWIXk9lV5HB4NGsn6M5U0gxMQWShQuDp6NF3ya3ULRSvh3dLMbzg==",
       "files": [
         "lib/DNXCore50/System.Threading.ThreadPool.dll",
         "lib/MonoAndroid10/_._",
@@ -3041,8 +3148,8 @@
         "ref/net46/System.Threading.ThreadPool.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Threading.ThreadPool.4.0.10-beta-23324.nupkg",
-        "System.Threading.ThreadPool.4.0.10-beta-23324.nupkg.sha512",
+        "System.Threading.ThreadPool.4.0.10-beta-23330.nupkg",
+        "System.Threading.ThreadPool.4.0.10-beta-23330.nupkg.sha512",
         "System.Threading.ThreadPool.nuspec"
       ]
     },
@@ -3293,14 +3400,14 @@
         "xunit.extensibility.execution.nuspec"
       ]
     },
-    "xunit.netcore.extensions/1.0.0-prerelease-00095": {
+    "xunit.netcore.extensions/1.0.0-prerelease-00098": {
       "type": "package",
       "serviceable": true,
-      "sha512": "FuvWmkuxHiqD0cHDggg5MRmBoeM4Uea7OUEmKvZiQu7Fy02hJ6yKKNV7mNW3y4scwSzDNA81Qa+HIS33PeWUog==",
+      "sha512": "3kRPwTbC42YGmsNHpNMKfGVOO5cVfxUD+C7cYbti1aml4UCT/RFZ6lhm5Vym2wNRDxryu0Es78aMf1BaybSrDg==",
       "files": [
         "lib/dotnet/Xunit.NetCore.Extensions.dll",
-        "xunit.netcore.extensions.1.0.0-prerelease-00095.nupkg",
-        "xunit.netcore.extensions.1.0.0-prerelease-00095.nupkg.sha512",
+        "xunit.netcore.extensions.1.0.0-prerelease-00098.nupkg",
+        "xunit.netcore.extensions.1.0.0-prerelease-00098.nupkg.sha512",
         "xunit.netcore.extensions.nuspec"
       ]
     }

--- a/src/System.Private.ServiceModel/tests/Common/Unit/project.lock.json
+++ b/src/System.Private.ServiceModel/tests/Common/Unit/project.lock.json
@@ -292,7 +292,7 @@
           "lib/dotnet/System.Linq.Queryable.dll": {}
         }
       },
-      "System.Net.Http/4.0.1-beta-23324": {
+      "System.Net.Http/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -305,16 +305,15 @@
           "ref/dotnet/System.Net.Http.dll": {}
         }
       },
-      "System.Net.NameResolution/4.0.0-beta-23324": {
+      "System.Net.NameResolution/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.Networking": "4.0.1-beta-23324"
+          "System.Net.Primitives": "4.0.10",
+          "System.Runtime": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Net.NameResolution.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Net.NameResolution.dll": {}
         }
       },
       "System.Net.Primitives/4.0.10": {
@@ -329,10 +328,10 @@
           "lib/DNXCore50/System.Net.Primitives.dll": {}
         }
       },
-      "System.Net.Security/4.0.0-beta-23324": {
+      "System.Net.Security/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.Networking": "4.0.1-beta-23324"
+          "System.Private.Networking": "4.0.1-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.Net.Security.dll": {}
@@ -367,6 +366,49 @@
         },
         "runtime": {
           "lib/dotnet/System.Net.WebHeaderCollection.dll": {}
+        }
+      },
+      "System.Net.WebSockets/4.0.0-beta-23330": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.Win32.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Threading.Tasks": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Net.WebSockets.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Net.WebSockets.dll": {}
+        }
+      },
+      "System.Net.WebSockets.Client/4.0.0-beta-23330": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.Win32.Primitives": "4.0.0",
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Diagnostics.Tracing": "4.0.20",
+          "System.Globalization": "4.0.10",
+          "System.Net.Primitives": "4.0.10",
+          "System.Net.WebHeaderCollection": "4.0.0",
+          "System.Net.WebSockets": "4.0.0-beta-23330",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23330",
+          "System.Text.Encoding": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Net.WebSockets.Client.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Net.WebSockets.Client.dll": {}
         }
       },
       "System.ObjectModel/4.0.10": {
@@ -414,7 +456,7 @@
           "lib/DNXCore50/System.Private.DataContractSerialization.dll": {}
         }
       },
-      "System.Private.Networking/4.0.1-beta-23324": {
+      "System.Private.Networking/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -433,13 +475,13 @@
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23324",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23324",
-          "System.Security.Principal.Windows": "4.0.0-beta-23324",
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23330",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23330",
+          "System.Security.Principal.Windows": "4.0.0-beta-23330",
           "System.Threading": "4.0.10",
           "System.Threading.Overlapped": "4.0.0",
           "System.Threading.Tasks": "4.0.10",
-          "System.Threading.ThreadPool": "4.0.10-beta-23324"
+          "System.Threading.ThreadPool": "4.0.10-beta-23330"
         },
         "compile": {
           "ref/dnxcore50/_._": {}
@@ -448,7 +490,7 @@
           "lib/DNXCore50/System.Private.Networking.dll": {}
         }
       },
-      "System.Private.ServiceModel/4.0.1-beta-23324": {
+      "System.Private.ServiceModel/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -465,12 +507,14 @@
           "System.Linq": "4.0.0",
           "System.Linq.Expressions": "4.0.10",
           "System.Linq.Queryable": "4.0.0",
-          "System.Net.Http": "4.0.1-beta-23324",
-          "System.Net.NameResolution": "4.0.0-beta-23324",
+          "System.Net.Http": "4.0.1-beta-23330",
+          "System.Net.NameResolution": "4.0.0-beta-23330",
           "System.Net.Primitives": "4.0.10",
-          "System.Net.Security": "4.0.0-beta-23324",
-          "System.Net.Sockets": "4.0.10-beta-23324",
+          "System.Net.Security": "4.0.0-beta-23330",
+          "System.Net.Sockets": "4.0.10-beta-23330",
           "System.Net.WebHeaderCollection": "4.0.0",
+          "System.Net.WebSockets": "4.0.0-beta-23330",
+          "System.Net.WebSockets.Client": "4.0.0-beta-23330",
           "System.ObjectModel": "4.0.10",
           "System.Reflection": "4.0.10",
           "System.Reflection.DispatchProxy": "4.0.0",
@@ -484,9 +528,9 @@
           "System.Runtime.Serialization.Primitives": "4.0.10",
           "System.Runtime.Serialization.Xml": "4.0.10",
           "System.Security.Claims": "4.0.0",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23324",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23330",
           "System.Security.Principal": "4.0.0",
-          "System.Security.Principal.Windows": "4.0.0-beta-23324",
+          "System.Security.Principal.Windows": "4.0.0-beta-23330",
           "System.Text.Encoding": "4.0.10",
           "System.Threading": "4.0.10",
           "System.Threading.Tasks": "4.0.10",
@@ -722,18 +766,18 @@
           "lib/dotnet/System.Security.Claims.dll": {}
         }
       },
-      "System.Security.Cryptography.Algorithms/4.0.0-beta-23324": {
+      "System.Security.Cryptography.Algorithms/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
           "System.Runtime": "4.0.0",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23324"
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.Algorithms.dll": {}
         }
       },
-      "System.Security.Cryptography.Encoding/4.0.0-beta-23324": {
+      "System.Security.Cryptography.Encoding/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -742,7 +786,7 @@
           "ref/dotnet/System.Security.Cryptography.Encoding.dll": {}
         }
       },
-      "System.Security.Cryptography.Primitives/4.0.0-beta-23324": {
+      "System.Security.Cryptography.Primitives/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.0",
@@ -760,13 +804,13 @@
           "lib/dotnet/System.Security.Cryptography.Primitives.dll": {}
         }
       },
-      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23324": {
+      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
           "System.Runtime.Handles": "4.0.0",
-          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23324",
-          "System.Security.Cryptography.Encoding": "4.0.0-beta-23324"
+          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23330",
+          "System.Security.Cryptography.Encoding": "4.0.0-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.X509Certificates.dll": {}
@@ -784,7 +828,7 @@
           "lib/dotnet/System.Security.Principal.dll": {}
         }
       },
-      "System.Security.Principal.Windows/4.0.0-beta-23324": {
+      "System.Security.Principal.Windows/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -807,10 +851,10 @@
           "lib/DNXCore50/System.Security.Principal.Windows.dll": {}
         }
       },
-      "System.ServiceModel.Duplex/4.0.1-beta-23324": {
+      "System.ServiceModel.Duplex/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.0.1-beta-23324"
+          "System.Private.ServiceModel": "4.0.1-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.ServiceModel.Duplex.dll": {}
@@ -819,10 +863,10 @@
           "lib/DNXCore50/System.ServiceModel.Duplex.dll": {}
         }
       },
-      "System.ServiceModel.Http/4.0.11-beta-23324": {
+      "System.ServiceModel.Http/4.0.11-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.0.1-beta-23324",
+          "System.Private.ServiceModel": "4.0.1-beta-23330",
           "System.Runtime": "4.0.20"
         },
         "compile": {
@@ -832,10 +876,10 @@
           "lib/DNXCore50/System.ServiceModel.Http.dll": {}
         }
       },
-      "System.ServiceModel.Primitives/4.0.1-beta-23324": {
+      "System.ServiceModel.Primitives/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.0.1-beta-23324"
+          "System.Private.ServiceModel": "4.0.1-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.ServiceModel.Primitives.dll": {}
@@ -924,7 +968,7 @@
           "lib/DNXCore50/System.Threading.Tasks.dll": {}
         }
       },
-      "System.Threading.ThreadPool/4.0.10-beta-23324": {
+      "System.Threading.ThreadPool/4.0.10-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
@@ -1625,23 +1669,12 @@
         "System.Linq.Queryable.nuspec"
       ]
     },
-    "System.Net.Http/4.0.1-beta-23324": {
+    "System.Net.Http/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "gXfHlWsiMQDuFqwnQrlQTje9vqMhCFLtm35jX4WqZjcfa3y69DbwueeT0gJbVMK88/UnG8FAYiDBb7AKyu+51w==",
+      "sha512": "itLPx7B7Ac4mX8wQx9V9DQcxqTgkmwDNnQIHuCgAH53Jq2X3XziiRRBbxbmNJlWqBlgPzbseWJmMCtcF/ePhOg==",
       "files": [
         "lib/net45/_._",
-        "lib/netcore50/de/System.Net.Http.xml",
-        "lib/netcore50/es/System.Net.Http.xml",
-        "lib/netcore50/fr/System.Net.Http.xml",
-        "lib/netcore50/it/System.Net.Http.xml",
-        "lib/netcore50/ja/System.Net.Http.xml",
-        "lib/netcore50/ko/System.Net.Http.xml",
-        "lib/netcore50/ru/System.Net.Http.xml",
-        "lib/netcore50/System.Net.Http.dll",
-        "lib/netcore50/System.Net.Http.xml",
-        "lib/netcore50/zh-hans/System.Net.Http.xml",
-        "lib/netcore50/zh-hant/System.Net.Http.xml",
         "lib/win8/_._",
         "lib/wpa81/_._",
         "ref/dotnet/System.Net.Http.dll",
@@ -1650,17 +1683,16 @@
         "ref/win8/_._",
         "ref/wpa81/_._",
         "runtime.json",
-        "System.Net.Http.4.0.1-beta-23324.nupkg",
-        "System.Net.Http.4.0.1-beta-23324.nupkg.sha512",
+        "System.Net.Http.4.0.1-beta-23330.nupkg",
+        "System.Net.Http.4.0.1-beta-23330.nupkg.sha512",
         "System.Net.Http.nuspec"
       ]
     },
-    "System.Net.NameResolution/4.0.0-beta-23324": {
+    "System.Net.NameResolution/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "lNYXUmnSXUtLFY09Rc27zJ6/TxCuGggQzBgiuWHoWrjWxymuuxqPT2Mj7Dn7sUUh0GvF2MOx7Uk+rtCFBiIavg==",
+      "sha512": "d8Am+In/aBgcHpEV6xsi5BCiTEN4y6s9O1V/yIvwX8mDC4CtdZiGsi4DtoB0TLOgp8ky6GxbSF4bKCjFpBO3uw==",
       "files": [
-        "lib/DNXCore50/System.Net.NameResolution.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.NameResolution.dll",
@@ -1672,8 +1704,9 @@
         "ref/net46/System.Net.NameResolution.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.NameResolution.4.0.0-beta-23324.nupkg",
-        "System.Net.NameResolution.4.0.0-beta-23324.nupkg.sha512",
+        "runtime.json",
+        "System.Net.NameResolution.4.0.0-beta-23330.nupkg",
+        "System.Net.NameResolution.4.0.0-beta-23330.nupkg.sha512",
         "System.Net.NameResolution.nuspec"
       ]
     },
@@ -1710,9 +1743,9 @@
         "System.Net.Primitives.nuspec"
       ]
     },
-    "System.Net.Security/4.0.0-beta-23324": {
+    "System.Net.Security/4.0.0-beta-23330": {
       "type": "package",
-      "sha512": "D04RYjxrnR3D+uI9CGmAAFKKQ6T+pPcRHYucc1PIo7/hJK5I/Yu7gAw9yOxHUhQjSGfrKo00lHpBCQMTQt4lSw==",
+      "sha512": "z98dKloNy9DBdyfqQwQvKWA2q8Qj4vgGEVONnlS70c13eh0MolBHJ0wNdplZZK5zYZ5Eu8GTwexbUlpHbsfzVA==",
       "files": [
         "lib/DNXCore50/System.Net.Security.dll",
         "lib/MonoAndroid10/_._",
@@ -1726,8 +1759,8 @@
         "ref/net46/System.Net.Security.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.Security.4.0.0-beta-23324.nupkg",
-        "System.Net.Security.4.0.0-beta-23324.nupkg.sha512",
+        "System.Net.Security.4.0.0-beta-23330.nupkg",
+        "System.Net.Security.4.0.0-beta-23330.nupkg.sha512",
         "System.Net.Security.nuspec"
       ]
     },
@@ -1785,6 +1818,81 @@
         "System.Net.WebHeaderCollection.nuspec"
       ]
     },
+    "System.Net.WebSockets/4.0.0-beta-23330": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "6Q9/uTDcaqbmdbD04MisKmjti4aEpp40i/UzpGaPZ4ItuwzU/pMk9RjiYUBUiCQyZeKNlXcSB1FPN2nFof7tww==",
+      "files": [
+        "lib/dotnet/de/System.Net.WebSockets.xml",
+        "lib/dotnet/es/System.Net.WebSockets.xml",
+        "lib/dotnet/fr/System.Net.WebSockets.xml",
+        "lib/dotnet/it/System.Net.WebSockets.xml",
+        "lib/dotnet/ja/System.Net.WebSockets.xml",
+        "lib/dotnet/ko/System.Net.WebSockets.xml",
+        "lib/dotnet/ru/System.Net.WebSockets.xml",
+        "lib/dotnet/System.Net.WebSockets.dll",
+        "lib/dotnet/System.Net.WebSockets.xml",
+        "lib/dotnet/zh-hans/System.Net.WebSockets.xml",
+        "lib/dotnet/zh-hant/System.Net.WebSockets.xml",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Net.WebSockets.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Net.WebSockets.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Net.WebSockets.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Net.WebSockets.4.0.0-beta-23330.nupkg",
+        "System.Net.WebSockets.4.0.0-beta-23330.nupkg.sha512",
+        "System.Net.WebSockets.nuspec"
+      ]
+    },
+    "System.Net.WebSockets.Client/4.0.0-beta-23330": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "1NWEqwDkYRyvr1gSKZlY51AaI9w8oD0dC5UNa2Lb+qaeFHSF5KfCSzf7seD+im+sH6uocVo2nppiaabfbXZT4Q==",
+      "files": [
+        "lib/DNXCore50/de/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/es/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/fr/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/it/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/ja/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/ko/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/ru/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/System.Net.WebSockets.Client.dll",
+        "lib/DNXCore50/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/zh-hans/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/zh-hant/System.Net.WebSockets.Client.xml",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Net.WebSockets.Client.dll",
+        "lib/netcore50/de/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/es/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/fr/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/it/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/ja/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/ko/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/ru/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/System.Net.WebSockets.Client.dll",
+        "lib/netcore50/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/zh-hans/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/zh-hant/System.Net.WebSockets.Client.xml",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Net.WebSockets.Client.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Net.WebSockets.Client.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Net.WebSockets.Client.4.0.0-beta-23330.nupkg",
+        "System.Net.WebSockets.Client.4.0.0-beta-23330.nupkg.sha512",
+        "System.Net.WebSockets.Client.nuspec"
+      ]
+    },
     "System.ObjectModel/4.0.10": {
       "type": "package",
       "serviceable": true,
@@ -1833,31 +1941,31 @@
         "System.Private.DataContractSerialization.nuspec"
       ]
     },
-    "System.Private.Networking/4.0.1-beta-23324": {
+    "System.Private.Networking/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "OfyxoeCdh1ypzdz1u0h1Clgt+6749vALs2ZPkLwsOPzL0INCG9ISYo+Jhh62ZD8TMkWwLrvyVppMBPHY6M7Upw==",
+      "sha512": "8NZi1gCQaGTKDb2yWplm52HWCLaZnUwVitksJgcXY2dEJau/TBGyZup+yhOngOIe8QzQMxNG4iokY3Ce0/8mbg==",
       "files": [
         "lib/DNXCore50/System.Private.Networking.dll",
         "lib/netcore50/System.Private.Networking.dll",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "System.Private.Networking.4.0.1-beta-23324.nupkg",
-        "System.Private.Networking.4.0.1-beta-23324.nupkg.sha512",
+        "System.Private.Networking.4.0.1-beta-23330.nupkg",
+        "System.Private.Networking.4.0.1-beta-23330.nupkg.sha512",
         "System.Private.Networking.nuspec"
       ]
     },
-    "System.Private.ServiceModel/4.0.1-beta-23324": {
+    "System.Private.ServiceModel/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "Lz3T9V8GnaOFlf8LUmuPznuOIuy92BAFVc9huiMrFKByzPpydGuCvXEe+81rZ1IF2TQcHKO++9otnj96AEJ5BA==",
+      "sha512": "8lENvmHuZdlvmnYN1w98Mv8bDjc0O/YlaNHRRph35T/fLDyaG8LMLMwG3/ut6a/AenLJmbf92snOtNXCuqM+cQ==",
       "files": [
         "lib/DNXCore50/System.Private.ServiceModel.dll",
         "lib/netcore50/System.Private.ServiceModel.dll",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "System.Private.ServiceModel.4.0.1-beta-23324.nupkg",
-        "System.Private.ServiceModel.4.0.1-beta-23324.nupkg.sha512",
+        "System.Private.ServiceModel.4.0.1-beta-23330.nupkg",
+        "System.Private.ServiceModel.4.0.1-beta-23330.nupkg.sha512",
         "System.Private.ServiceModel.nuspec"
       ]
     },
@@ -2366,10 +2474,10 @@
         "System.Security.Claims.nuspec"
       ]
     },
-    "System.Security.Cryptography.Algorithms/4.0.0-beta-23324": {
+    "System.Security.Cryptography.Algorithms/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "Mt6LwMj8hPp0+xZHcV6grZ7wSWhgycGkdZ6DQ9XvUY9NguUsvb/+fu2cMdrC7XsnpvwIROByp+p2dSjqBn3E2Q==",
+      "sha512": "FB4RoTDaV5tBiPSJsiG3A5DydeKz7ErglnkqVjBFjm6wu8kg91j0MxL/Al9iUyu9i/hq53fRs5KE3rjUNYvf5w==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2383,15 +2491,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.Algorithms.4.0.0-beta-23324.nupkg",
-        "System.Security.Cryptography.Algorithms.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Cryptography.Algorithms.4.0.0-beta-23330.nupkg",
+        "System.Security.Cryptography.Algorithms.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Cryptography.Algorithms.nuspec"
       ]
     },
-    "System.Security.Cryptography.Encoding/4.0.0-beta-23324": {
+    "System.Security.Cryptography.Encoding/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "JHOyknf1eYO6C39Vao6kAGpadq3PBO1L4tuzNEz/HvbH5sfIHPbjhxL11OyAhVKCzLCfEj6+aeClovFqZIRPyw==",
+      "sha512": "zeFdKQT6xjNdiNCaEmEYJMEK59kixkX7jJSoOLw3H+53t9X0F98vr3tS8YlrW/Lk/K9c6L5pYLlkb2dNqvUD/g==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2405,15 +2513,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.Encoding.4.0.0-beta-23324.nupkg",
-        "System.Security.Cryptography.Encoding.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Cryptography.Encoding.4.0.0-beta-23330.nupkg",
+        "System.Security.Cryptography.Encoding.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Cryptography.Encoding.nuspec"
       ]
     },
-    "System.Security.Cryptography.Primitives/4.0.0-beta-23324": {
+    "System.Security.Cryptography.Primitives/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "ETZxelIX51Di4FTytd8ohSpN6Ym/32aWIX9E2NCFkd91qdexn2Dkysn80b6n4gX6jG+oL0UHQDtD/fYq8C65oQ==",
+      "sha512": "15uVbOD3X0sRQJIxcEH5hasxlFdbA1CmPPZa0Y8pYEuQcWMF2gBswvU8s4qoKtA7x2xhNhzPsXIhsQuKNMTdEA==",
       "files": [
         "lib/dotnet/System.Security.Cryptography.Primitives.dll",
         "lib/MonoAndroid10/_._",
@@ -2427,15 +2535,15 @@
         "ref/net46/System.Security.Cryptography.Primitives.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Security.Cryptography.Primitives.4.0.0-beta-23324.nupkg",
-        "System.Security.Cryptography.Primitives.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Cryptography.Primitives.4.0.0-beta-23330.nupkg",
+        "System.Security.Cryptography.Primitives.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Cryptography.Primitives.nuspec"
       ]
     },
-    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23324": {
+    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "8NaEOxkkNBUECh0cPzGpbXS0uzGDpnvxI0kqQKRGp9uA+9qCyQfxcqAT6ozAYtOuFNVaC1XU3zQnb7T2nfvIDg==",
+      "sha512": "L8mUimdm7+GsORgJ8DFBMGsFnwDJ5YCUdJj3HfXQx4HCoPDPF+vJo3HRiHfcvNA2Zsf0ov2kuerYj/eeVa2/Rw==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2449,8 +2557,8 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23324.nupkg",
-        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23330.nupkg",
+        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Cryptography.X509Certificates.nuspec"
       ]
     },
@@ -2487,10 +2595,10 @@
         "System.Security.Principal.nuspec"
       ]
     },
-    "System.Security.Principal.Windows/4.0.0-beta-23324": {
+    "System.Security.Principal.Windows/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "csbCKdwBz31T8He7U6XMIc9BiWgwjHs5WDZR4rfhsk48TpdsbKNHX9OX4b+GwvgcsfVuWxre7zqNR0Bc9gWZ7g==",
+      "sha512": "q+3L3aB8bn0HCW52kX9TSJdhbjffBw7QWCOu0yX1SDhPN9MCPmJ4aBBCn1HRWroa5y7UcNUdjL1xwiERycZexw==",
       "files": [
         "lib/DNXCore50/de/System.Security.Principal.Windows.xml",
         "lib/DNXCore50/es/System.Security.Principal.Windows.xml",
@@ -2506,15 +2614,15 @@
         "lib/net46/System.Security.Principal.Windows.dll",
         "ref/dotnet/System.Security.Principal.Windows.dll",
         "ref/net46/System.Security.Principal.Windows.dll",
-        "System.Security.Principal.Windows.4.0.0-beta-23324.nupkg",
-        "System.Security.Principal.Windows.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Principal.Windows.4.0.0-beta-23330.nupkg",
+        "System.Security.Principal.Windows.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Principal.Windows.nuspec"
       ]
     },
-    "System.ServiceModel.Duplex/4.0.1-beta-23324": {
+    "System.ServiceModel.Duplex/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "b+p3u2zee0oAM4AIyM9rev1MaoExxD4d97iNeZFG0Q0bEVFOzK97/5HNcq5FzpTUhxZgfXXCOCmuIYwnYsfU/w==",
+      "sha512": "0k9wL8LeMYj1jfu2wZwTdQhmPBcpMSUgD304cR50CpHOJnrP/NjiQ0Blx3oSURd8Tda5XuXC0PNGWDF+EpW/Lg==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Duplex.dll",
         "lib/net45/_._",
@@ -2534,15 +2642,15 @@
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.Duplex.dll",
         "ref/win8/_._",
-        "System.ServiceModel.Duplex.4.0.1-beta-23324.nupkg",
-        "System.ServiceModel.Duplex.4.0.1-beta-23324.nupkg.sha512",
+        "System.ServiceModel.Duplex.4.0.1-beta-23330.nupkg",
+        "System.ServiceModel.Duplex.4.0.1-beta-23330.nupkg.sha512",
         "System.ServiceModel.Duplex.nuspec"
       ]
     },
-    "System.ServiceModel.Http/4.0.11-beta-23324": {
+    "System.ServiceModel.Http/4.0.11-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "VkTumuCSmXd0NPZZU+nrO7YqznvM+wP96NykXbxFJdNAtCplmqXaQh+YZ/02rjJmfou5qyo2V+ZWVwySBAirOg==",
+      "sha512": "NHKxIIYL0ATDbX18RLCSXtuq26MMoYfAVdpl5K+D0s5AHp7TMPb7LcjZPpg25B2v48x1TwE9LYcYTCiOZcoPzQ==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Http.dll",
         "lib/MonoAndroid10/_._",
@@ -2567,15 +2675,15 @@
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.ServiceModel.Http.4.0.11-beta-23324.nupkg",
-        "System.ServiceModel.Http.4.0.11-beta-23324.nupkg.sha512",
+        "System.ServiceModel.Http.4.0.11-beta-23330.nupkg",
+        "System.ServiceModel.Http.4.0.11-beta-23330.nupkg.sha512",
         "System.ServiceModel.Http.nuspec"
       ]
     },
-    "System.ServiceModel.Primitives/4.0.1-beta-23324": {
+    "System.ServiceModel.Primitives/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "bmU31B4CD5+m9Kt0iDM5Yw2ZXRfv7lpK3Sx1HektcT/HERc+IMPdO38f/Wxtofo5WOA0qmd1fdrMeQcbEkDfJg==",
+      "sha512": "kJ/pcRUf7Ow7s/rX8Kmc9P2k6cvyudIzyUcqr/pn9NwY8DC/2DWkkFvYE2udR4kvBzJJzXl/rsJQlyLIVGMAww==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Primitives.dll",
         "lib/net45/_._",
@@ -2595,8 +2703,8 @@
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.Primitives.dll",
         "ref/win8/_._",
-        "System.ServiceModel.Primitives.4.0.1-beta-23324.nupkg",
-        "System.ServiceModel.Primitives.4.0.1-beta-23324.nupkg.sha512",
+        "System.ServiceModel.Primitives.4.0.1-beta-23330.nupkg",
+        "System.ServiceModel.Primitives.4.0.1-beta-23330.nupkg.sha512",
         "System.ServiceModel.Primitives.nuspec"
       ]
     },
@@ -2791,10 +2899,9 @@
         "System.Threading.Tasks.nuspec"
       ]
     },
-    "System.Threading.ThreadPool/4.0.10-beta-23324": {
+    "System.Threading.ThreadPool/4.0.10-beta-23330": {
       "type": "package",
-      "serviceable": true,
-      "sha512": "G4SjGmiV72HBiv8wkfnKFGTieekrACU1m43VaeJ6vDeSyb08eEFusVH1UWZpOsUF25meCuzpda0ezus24b4rKA==",
+      "sha512": "nM5OewUj8NJrye93apbM6KHvPddgPJGzt1IWIXk9lV5HB4NGsn6M5U0gxMQWShQuDp6NF3ya3ULRSvh3dLMbzg==",
       "files": [
         "lib/DNXCore50/System.Threading.ThreadPool.dll",
         "lib/MonoAndroid10/_._",
@@ -2808,8 +2915,8 @@
         "ref/net46/System.Threading.ThreadPool.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Threading.ThreadPool.4.0.10-beta-23324.nupkg",
-        "System.Threading.ThreadPool.4.0.10-beta-23324.nupkg.sha512",
+        "System.Threading.ThreadPool.4.0.10-beta-23330.nupkg",
+        "System.Threading.ThreadPool.4.0.10-beta-23330.nupkg.sha512",
         "System.Threading.ThreadPool.nuspec"
       ]
     },

--- a/src/System.Private.ServiceModel/tests/Scenarios/Binding/Custom/project.lock.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Binding/Custom/project.lock.json
@@ -292,7 +292,7 @@
           "lib/dotnet/System.Linq.Queryable.dll": {}
         }
       },
-      "System.Net.Http/4.0.1-beta-23324": {
+      "System.Net.Http/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -305,16 +305,15 @@
           "ref/dotnet/System.Net.Http.dll": {}
         }
       },
-      "System.Net.NameResolution/4.0.0-beta-23324": {
+      "System.Net.NameResolution/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.Networking": "4.0.1-beta-23324"
+          "System.Net.Primitives": "4.0.10",
+          "System.Runtime": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Net.NameResolution.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Net.NameResolution.dll": {}
         }
       },
       "System.Net.Primitives/4.0.10": {
@@ -329,10 +328,10 @@
           "lib/DNXCore50/System.Net.Primitives.dll": {}
         }
       },
-      "System.Net.Security/4.0.0-beta-23324": {
+      "System.Net.Security/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.Networking": "4.0.1-beta-23324"
+          "System.Private.Networking": "4.0.1-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.Net.Security.dll": {}
@@ -367,6 +366,49 @@
         },
         "runtime": {
           "lib/dotnet/System.Net.WebHeaderCollection.dll": {}
+        }
+      },
+      "System.Net.WebSockets/4.0.0-beta-23330": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.Win32.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Threading.Tasks": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Net.WebSockets.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Net.WebSockets.dll": {}
+        }
+      },
+      "System.Net.WebSockets.Client/4.0.0-beta-23330": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.Win32.Primitives": "4.0.0",
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Diagnostics.Tracing": "4.0.20",
+          "System.Globalization": "4.0.10",
+          "System.Net.Primitives": "4.0.10",
+          "System.Net.WebHeaderCollection": "4.0.0",
+          "System.Net.WebSockets": "4.0.0-beta-23330",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23330",
+          "System.Text.Encoding": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Net.WebSockets.Client.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Net.WebSockets.Client.dll": {}
         }
       },
       "System.ObjectModel/4.0.10": {
@@ -414,7 +456,7 @@
           "lib/DNXCore50/System.Private.DataContractSerialization.dll": {}
         }
       },
-      "System.Private.Networking/4.0.1-beta-23324": {
+      "System.Private.Networking/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -433,13 +475,13 @@
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23324",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23324",
-          "System.Security.Principal.Windows": "4.0.0-beta-23324",
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23330",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23330",
+          "System.Security.Principal.Windows": "4.0.0-beta-23330",
           "System.Threading": "4.0.10",
           "System.Threading.Overlapped": "4.0.0",
           "System.Threading.Tasks": "4.0.10",
-          "System.Threading.ThreadPool": "4.0.10-beta-23324"
+          "System.Threading.ThreadPool": "4.0.10-beta-23330"
         },
         "compile": {
           "ref/dnxcore50/_._": {}
@@ -448,7 +490,7 @@
           "lib/DNXCore50/System.Private.Networking.dll": {}
         }
       },
-      "System.Private.ServiceModel/4.0.1-beta-23324": {
+      "System.Private.ServiceModel/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -465,12 +507,14 @@
           "System.Linq": "4.0.0",
           "System.Linq.Expressions": "4.0.10",
           "System.Linq.Queryable": "4.0.0",
-          "System.Net.Http": "4.0.1-beta-23324",
-          "System.Net.NameResolution": "4.0.0-beta-23324",
+          "System.Net.Http": "4.0.1-beta-23330",
+          "System.Net.NameResolution": "4.0.0-beta-23330",
           "System.Net.Primitives": "4.0.10",
-          "System.Net.Security": "4.0.0-beta-23324",
-          "System.Net.Sockets": "4.0.10-beta-23324",
+          "System.Net.Security": "4.0.0-beta-23330",
+          "System.Net.Sockets": "4.0.10-beta-23330",
           "System.Net.WebHeaderCollection": "4.0.0",
+          "System.Net.WebSockets": "4.0.0-beta-23330",
+          "System.Net.WebSockets.Client": "4.0.0-beta-23330",
           "System.ObjectModel": "4.0.10",
           "System.Reflection": "4.0.10",
           "System.Reflection.DispatchProxy": "4.0.0",
@@ -484,9 +528,9 @@
           "System.Runtime.Serialization.Primitives": "4.0.10",
           "System.Runtime.Serialization.Xml": "4.0.10",
           "System.Security.Claims": "4.0.0",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23324",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23330",
           "System.Security.Principal": "4.0.0",
-          "System.Security.Principal.Windows": "4.0.0-beta-23324",
+          "System.Security.Principal.Windows": "4.0.0-beta-23330",
           "System.Text.Encoding": "4.0.10",
           "System.Threading": "4.0.10",
           "System.Threading.Tasks": "4.0.10",
@@ -735,18 +779,18 @@
           "lib/dotnet/System.Security.Claims.dll": {}
         }
       },
-      "System.Security.Cryptography.Algorithms/4.0.0-beta-23324": {
+      "System.Security.Cryptography.Algorithms/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
           "System.Runtime": "4.0.0",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23324"
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.Algorithms.dll": {}
         }
       },
-      "System.Security.Cryptography.Encoding/4.0.0-beta-23324": {
+      "System.Security.Cryptography.Encoding/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -755,7 +799,7 @@
           "ref/dotnet/System.Security.Cryptography.Encoding.dll": {}
         }
       },
-      "System.Security.Cryptography.Primitives/4.0.0-beta-23324": {
+      "System.Security.Cryptography.Primitives/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.0",
@@ -773,13 +817,13 @@
           "lib/dotnet/System.Security.Cryptography.Primitives.dll": {}
         }
       },
-      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23324": {
+      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
           "System.Runtime.Handles": "4.0.0",
-          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23324",
-          "System.Security.Cryptography.Encoding": "4.0.0-beta-23324"
+          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23330",
+          "System.Security.Cryptography.Encoding": "4.0.0-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.X509Certificates.dll": {}
@@ -797,7 +841,7 @@
           "lib/dotnet/System.Security.Principal.dll": {}
         }
       },
-      "System.Security.Principal.Windows/4.0.0-beta-23324": {
+      "System.Security.Principal.Windows/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -820,10 +864,10 @@
           "lib/DNXCore50/System.Security.Principal.Windows.dll": {}
         }
       },
-      "System.ServiceModel.Http/4.0.11-beta-23324": {
+      "System.ServiceModel.Http/4.0.11-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.0.1-beta-23324",
+          "System.Private.ServiceModel": "4.0.1-beta-23330",
           "System.Runtime": "4.0.20"
         },
         "compile": {
@@ -833,10 +877,10 @@
           "lib/DNXCore50/System.ServiceModel.Http.dll": {}
         }
       },
-      "System.ServiceModel.Primitives/4.0.1-beta-23324": {
+      "System.ServiceModel.Primitives/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.0.1-beta-23324"
+          "System.Private.ServiceModel": "4.0.1-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.ServiceModel.Primitives.dll": {}
@@ -925,7 +969,7 @@
           "lib/DNXCore50/System.Threading.Tasks.dll": {}
         }
       },
-      "System.Threading.ThreadPool/4.0.10-beta-23324": {
+      "System.Threading.ThreadPool/4.0.10-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
@@ -1118,7 +1162,7 @@
           "lib/dotnet/xunit.execution.dotnet.dll": {}
         }
       },
-      "xunit.netcore.extensions/1.0.0-prerelease-00095": {
+      "xunit.netcore.extensions/1.0.0-prerelease-00098": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.10",
@@ -1746,23 +1790,12 @@
         "System.Linq.Queryable.nuspec"
       ]
     },
-    "System.Net.Http/4.0.1-beta-23324": {
+    "System.Net.Http/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "gXfHlWsiMQDuFqwnQrlQTje9vqMhCFLtm35jX4WqZjcfa3y69DbwueeT0gJbVMK88/UnG8FAYiDBb7AKyu+51w==",
+      "sha512": "itLPx7B7Ac4mX8wQx9V9DQcxqTgkmwDNnQIHuCgAH53Jq2X3XziiRRBbxbmNJlWqBlgPzbseWJmMCtcF/ePhOg==",
       "files": [
         "lib/net45/_._",
-        "lib/netcore50/de/System.Net.Http.xml",
-        "lib/netcore50/es/System.Net.Http.xml",
-        "lib/netcore50/fr/System.Net.Http.xml",
-        "lib/netcore50/it/System.Net.Http.xml",
-        "lib/netcore50/ja/System.Net.Http.xml",
-        "lib/netcore50/ko/System.Net.Http.xml",
-        "lib/netcore50/ru/System.Net.Http.xml",
-        "lib/netcore50/System.Net.Http.dll",
-        "lib/netcore50/System.Net.Http.xml",
-        "lib/netcore50/zh-hans/System.Net.Http.xml",
-        "lib/netcore50/zh-hant/System.Net.Http.xml",
         "lib/win8/_._",
         "lib/wpa81/_._",
         "ref/dotnet/System.Net.Http.dll",
@@ -1771,17 +1804,16 @@
         "ref/win8/_._",
         "ref/wpa81/_._",
         "runtime.json",
-        "System.Net.Http.4.0.1-beta-23324.nupkg",
-        "System.Net.Http.4.0.1-beta-23324.nupkg.sha512",
+        "System.Net.Http.4.0.1-beta-23330.nupkg",
+        "System.Net.Http.4.0.1-beta-23330.nupkg.sha512",
         "System.Net.Http.nuspec"
       ]
     },
-    "System.Net.NameResolution/4.0.0-beta-23324": {
+    "System.Net.NameResolution/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "lNYXUmnSXUtLFY09Rc27zJ6/TxCuGggQzBgiuWHoWrjWxymuuxqPT2Mj7Dn7sUUh0GvF2MOx7Uk+rtCFBiIavg==",
+      "sha512": "d8Am+In/aBgcHpEV6xsi5BCiTEN4y6s9O1V/yIvwX8mDC4CtdZiGsi4DtoB0TLOgp8ky6GxbSF4bKCjFpBO3uw==",
       "files": [
-        "lib/DNXCore50/System.Net.NameResolution.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.NameResolution.dll",
@@ -1793,8 +1825,9 @@
         "ref/net46/System.Net.NameResolution.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.NameResolution.4.0.0-beta-23324.nupkg",
-        "System.Net.NameResolution.4.0.0-beta-23324.nupkg.sha512",
+        "runtime.json",
+        "System.Net.NameResolution.4.0.0-beta-23330.nupkg",
+        "System.Net.NameResolution.4.0.0-beta-23330.nupkg.sha512",
         "System.Net.NameResolution.nuspec"
       ]
     },
@@ -1831,9 +1864,9 @@
         "System.Net.Primitives.nuspec"
       ]
     },
-    "System.Net.Security/4.0.0-beta-23324": {
+    "System.Net.Security/4.0.0-beta-23330": {
       "type": "package",
-      "sha512": "D04RYjxrnR3D+uI9CGmAAFKKQ6T+pPcRHYucc1PIo7/hJK5I/Yu7gAw9yOxHUhQjSGfrKo00lHpBCQMTQt4lSw==",
+      "sha512": "z98dKloNy9DBdyfqQwQvKWA2q8Qj4vgGEVONnlS70c13eh0MolBHJ0wNdplZZK5zYZ5Eu8GTwexbUlpHbsfzVA==",
       "files": [
         "lib/DNXCore50/System.Net.Security.dll",
         "lib/MonoAndroid10/_._",
@@ -1847,8 +1880,8 @@
         "ref/net46/System.Net.Security.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.Security.4.0.0-beta-23324.nupkg",
-        "System.Net.Security.4.0.0-beta-23324.nupkg.sha512",
+        "System.Net.Security.4.0.0-beta-23330.nupkg",
+        "System.Net.Security.4.0.0-beta-23330.nupkg.sha512",
         "System.Net.Security.nuspec"
       ]
     },
@@ -1906,6 +1939,81 @@
         "System.Net.WebHeaderCollection.nuspec"
       ]
     },
+    "System.Net.WebSockets/4.0.0-beta-23330": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "6Q9/uTDcaqbmdbD04MisKmjti4aEpp40i/UzpGaPZ4ItuwzU/pMk9RjiYUBUiCQyZeKNlXcSB1FPN2nFof7tww==",
+      "files": [
+        "lib/dotnet/de/System.Net.WebSockets.xml",
+        "lib/dotnet/es/System.Net.WebSockets.xml",
+        "lib/dotnet/fr/System.Net.WebSockets.xml",
+        "lib/dotnet/it/System.Net.WebSockets.xml",
+        "lib/dotnet/ja/System.Net.WebSockets.xml",
+        "lib/dotnet/ko/System.Net.WebSockets.xml",
+        "lib/dotnet/ru/System.Net.WebSockets.xml",
+        "lib/dotnet/System.Net.WebSockets.dll",
+        "lib/dotnet/System.Net.WebSockets.xml",
+        "lib/dotnet/zh-hans/System.Net.WebSockets.xml",
+        "lib/dotnet/zh-hant/System.Net.WebSockets.xml",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Net.WebSockets.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Net.WebSockets.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Net.WebSockets.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Net.WebSockets.4.0.0-beta-23330.nupkg",
+        "System.Net.WebSockets.4.0.0-beta-23330.nupkg.sha512",
+        "System.Net.WebSockets.nuspec"
+      ]
+    },
+    "System.Net.WebSockets.Client/4.0.0-beta-23330": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "1NWEqwDkYRyvr1gSKZlY51AaI9w8oD0dC5UNa2Lb+qaeFHSF5KfCSzf7seD+im+sH6uocVo2nppiaabfbXZT4Q==",
+      "files": [
+        "lib/DNXCore50/de/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/es/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/fr/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/it/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/ja/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/ko/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/ru/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/System.Net.WebSockets.Client.dll",
+        "lib/DNXCore50/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/zh-hans/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/zh-hant/System.Net.WebSockets.Client.xml",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Net.WebSockets.Client.dll",
+        "lib/netcore50/de/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/es/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/fr/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/it/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/ja/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/ko/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/ru/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/System.Net.WebSockets.Client.dll",
+        "lib/netcore50/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/zh-hans/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/zh-hant/System.Net.WebSockets.Client.xml",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Net.WebSockets.Client.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Net.WebSockets.Client.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Net.WebSockets.Client.4.0.0-beta-23330.nupkg",
+        "System.Net.WebSockets.Client.4.0.0-beta-23330.nupkg.sha512",
+        "System.Net.WebSockets.Client.nuspec"
+      ]
+    },
     "System.ObjectModel/4.0.10": {
       "type": "package",
       "serviceable": true,
@@ -1954,31 +2062,31 @@
         "System.Private.DataContractSerialization.nuspec"
       ]
     },
-    "System.Private.Networking/4.0.1-beta-23324": {
+    "System.Private.Networking/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "OfyxoeCdh1ypzdz1u0h1Clgt+6749vALs2ZPkLwsOPzL0INCG9ISYo+Jhh62ZD8TMkWwLrvyVppMBPHY6M7Upw==",
+      "sha512": "8NZi1gCQaGTKDb2yWplm52HWCLaZnUwVitksJgcXY2dEJau/TBGyZup+yhOngOIe8QzQMxNG4iokY3Ce0/8mbg==",
       "files": [
         "lib/DNXCore50/System.Private.Networking.dll",
         "lib/netcore50/System.Private.Networking.dll",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "System.Private.Networking.4.0.1-beta-23324.nupkg",
-        "System.Private.Networking.4.0.1-beta-23324.nupkg.sha512",
+        "System.Private.Networking.4.0.1-beta-23330.nupkg",
+        "System.Private.Networking.4.0.1-beta-23330.nupkg.sha512",
         "System.Private.Networking.nuspec"
       ]
     },
-    "System.Private.ServiceModel/4.0.1-beta-23324": {
+    "System.Private.ServiceModel/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "Lz3T9V8GnaOFlf8LUmuPznuOIuy92BAFVc9huiMrFKByzPpydGuCvXEe+81rZ1IF2TQcHKO++9otnj96AEJ5BA==",
+      "sha512": "8lENvmHuZdlvmnYN1w98Mv8bDjc0O/YlaNHRRph35T/fLDyaG8LMLMwG3/ut6a/AenLJmbf92snOtNXCuqM+cQ==",
       "files": [
         "lib/DNXCore50/System.Private.ServiceModel.dll",
         "lib/netcore50/System.Private.ServiceModel.dll",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "System.Private.ServiceModel.4.0.1-beta-23324.nupkg",
-        "System.Private.ServiceModel.4.0.1-beta-23324.nupkg.sha512",
+        "System.Private.ServiceModel.4.0.1-beta-23330.nupkg",
+        "System.Private.ServiceModel.4.0.1-beta-23330.nupkg.sha512",
         "System.Private.ServiceModel.nuspec"
       ]
     },
@@ -2507,10 +2615,10 @@
         "System.Security.Claims.nuspec"
       ]
     },
-    "System.Security.Cryptography.Algorithms/4.0.0-beta-23324": {
+    "System.Security.Cryptography.Algorithms/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "Mt6LwMj8hPp0+xZHcV6grZ7wSWhgycGkdZ6DQ9XvUY9NguUsvb/+fu2cMdrC7XsnpvwIROByp+p2dSjqBn3E2Q==",
+      "sha512": "FB4RoTDaV5tBiPSJsiG3A5DydeKz7ErglnkqVjBFjm6wu8kg91j0MxL/Al9iUyu9i/hq53fRs5KE3rjUNYvf5w==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2524,15 +2632,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.Algorithms.4.0.0-beta-23324.nupkg",
-        "System.Security.Cryptography.Algorithms.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Cryptography.Algorithms.4.0.0-beta-23330.nupkg",
+        "System.Security.Cryptography.Algorithms.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Cryptography.Algorithms.nuspec"
       ]
     },
-    "System.Security.Cryptography.Encoding/4.0.0-beta-23324": {
+    "System.Security.Cryptography.Encoding/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "JHOyknf1eYO6C39Vao6kAGpadq3PBO1L4tuzNEz/HvbH5sfIHPbjhxL11OyAhVKCzLCfEj6+aeClovFqZIRPyw==",
+      "sha512": "zeFdKQT6xjNdiNCaEmEYJMEK59kixkX7jJSoOLw3H+53t9X0F98vr3tS8YlrW/Lk/K9c6L5pYLlkb2dNqvUD/g==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2546,15 +2654,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.Encoding.4.0.0-beta-23324.nupkg",
-        "System.Security.Cryptography.Encoding.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Cryptography.Encoding.4.0.0-beta-23330.nupkg",
+        "System.Security.Cryptography.Encoding.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Cryptography.Encoding.nuspec"
       ]
     },
-    "System.Security.Cryptography.Primitives/4.0.0-beta-23324": {
+    "System.Security.Cryptography.Primitives/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "ETZxelIX51Di4FTytd8ohSpN6Ym/32aWIX9E2NCFkd91qdexn2Dkysn80b6n4gX6jG+oL0UHQDtD/fYq8C65oQ==",
+      "sha512": "15uVbOD3X0sRQJIxcEH5hasxlFdbA1CmPPZa0Y8pYEuQcWMF2gBswvU8s4qoKtA7x2xhNhzPsXIhsQuKNMTdEA==",
       "files": [
         "lib/dotnet/System.Security.Cryptography.Primitives.dll",
         "lib/MonoAndroid10/_._",
@@ -2568,15 +2676,15 @@
         "ref/net46/System.Security.Cryptography.Primitives.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Security.Cryptography.Primitives.4.0.0-beta-23324.nupkg",
-        "System.Security.Cryptography.Primitives.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Cryptography.Primitives.4.0.0-beta-23330.nupkg",
+        "System.Security.Cryptography.Primitives.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Cryptography.Primitives.nuspec"
       ]
     },
-    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23324": {
+    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "8NaEOxkkNBUECh0cPzGpbXS0uzGDpnvxI0kqQKRGp9uA+9qCyQfxcqAT6ozAYtOuFNVaC1XU3zQnb7T2nfvIDg==",
+      "sha512": "L8mUimdm7+GsORgJ8DFBMGsFnwDJ5YCUdJj3HfXQx4HCoPDPF+vJo3HRiHfcvNA2Zsf0ov2kuerYj/eeVa2/Rw==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2590,8 +2698,8 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23324.nupkg",
-        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23330.nupkg",
+        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Cryptography.X509Certificates.nuspec"
       ]
     },
@@ -2628,10 +2736,10 @@
         "System.Security.Principal.nuspec"
       ]
     },
-    "System.Security.Principal.Windows/4.0.0-beta-23324": {
+    "System.Security.Principal.Windows/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "csbCKdwBz31T8He7U6XMIc9BiWgwjHs5WDZR4rfhsk48TpdsbKNHX9OX4b+GwvgcsfVuWxre7zqNR0Bc9gWZ7g==",
+      "sha512": "q+3L3aB8bn0HCW52kX9TSJdhbjffBw7QWCOu0yX1SDhPN9MCPmJ4aBBCn1HRWroa5y7UcNUdjL1xwiERycZexw==",
       "files": [
         "lib/DNXCore50/de/System.Security.Principal.Windows.xml",
         "lib/DNXCore50/es/System.Security.Principal.Windows.xml",
@@ -2647,15 +2755,15 @@
         "lib/net46/System.Security.Principal.Windows.dll",
         "ref/dotnet/System.Security.Principal.Windows.dll",
         "ref/net46/System.Security.Principal.Windows.dll",
-        "System.Security.Principal.Windows.4.0.0-beta-23324.nupkg",
-        "System.Security.Principal.Windows.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Principal.Windows.4.0.0-beta-23330.nupkg",
+        "System.Security.Principal.Windows.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Principal.Windows.nuspec"
       ]
     },
-    "System.ServiceModel.Http/4.0.11-beta-23324": {
+    "System.ServiceModel.Http/4.0.11-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "VkTumuCSmXd0NPZZU+nrO7YqznvM+wP96NykXbxFJdNAtCplmqXaQh+YZ/02rjJmfou5qyo2V+ZWVwySBAirOg==",
+      "sha512": "NHKxIIYL0ATDbX18RLCSXtuq26MMoYfAVdpl5K+D0s5AHp7TMPb7LcjZPpg25B2v48x1TwE9LYcYTCiOZcoPzQ==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Http.dll",
         "lib/MonoAndroid10/_._",
@@ -2680,15 +2788,15 @@
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.ServiceModel.Http.4.0.11-beta-23324.nupkg",
-        "System.ServiceModel.Http.4.0.11-beta-23324.nupkg.sha512",
+        "System.ServiceModel.Http.4.0.11-beta-23330.nupkg",
+        "System.ServiceModel.Http.4.0.11-beta-23330.nupkg.sha512",
         "System.ServiceModel.Http.nuspec"
       ]
     },
-    "System.ServiceModel.Primitives/4.0.1-beta-23324": {
+    "System.ServiceModel.Primitives/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "bmU31B4CD5+m9Kt0iDM5Yw2ZXRfv7lpK3Sx1HektcT/HERc+IMPdO38f/Wxtofo5WOA0qmd1fdrMeQcbEkDfJg==",
+      "sha512": "kJ/pcRUf7Ow7s/rX8Kmc9P2k6cvyudIzyUcqr/pn9NwY8DC/2DWkkFvYE2udR4kvBzJJzXl/rsJQlyLIVGMAww==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Primitives.dll",
         "lib/net45/_._",
@@ -2708,8 +2816,8 @@
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.Primitives.dll",
         "ref/win8/_._",
-        "System.ServiceModel.Primitives.4.0.1-beta-23324.nupkg",
-        "System.ServiceModel.Primitives.4.0.1-beta-23324.nupkg.sha512",
+        "System.ServiceModel.Primitives.4.0.1-beta-23330.nupkg",
+        "System.ServiceModel.Primitives.4.0.1-beta-23330.nupkg.sha512",
         "System.ServiceModel.Primitives.nuspec"
       ]
     },
@@ -2904,10 +3012,9 @@
         "System.Threading.Tasks.nuspec"
       ]
     },
-    "System.Threading.ThreadPool/4.0.10-beta-23324": {
+    "System.Threading.ThreadPool/4.0.10-beta-23330": {
       "type": "package",
-      "serviceable": true,
-      "sha512": "G4SjGmiV72HBiv8wkfnKFGTieekrACU1m43VaeJ6vDeSyb08eEFusVH1UWZpOsUF25meCuzpda0ezus24b4rKA==",
+      "sha512": "nM5OewUj8NJrye93apbM6KHvPddgPJGzt1IWIXk9lV5HB4NGsn6M5U0gxMQWShQuDp6NF3ya3ULRSvh3dLMbzg==",
       "files": [
         "lib/DNXCore50/System.Threading.ThreadPool.dll",
         "lib/MonoAndroid10/_._",
@@ -2921,8 +3028,8 @@
         "ref/net46/System.Threading.ThreadPool.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Threading.ThreadPool.4.0.10-beta-23324.nupkg",
-        "System.Threading.ThreadPool.4.0.10-beta-23324.nupkg.sha512",
+        "System.Threading.ThreadPool.4.0.10-beta-23330.nupkg",
+        "System.Threading.ThreadPool.4.0.10-beta-23330.nupkg.sha512",
         "System.Threading.ThreadPool.nuspec"
       ]
     },
@@ -3173,14 +3280,14 @@
         "xunit.extensibility.execution.nuspec"
       ]
     },
-    "xunit.netcore.extensions/1.0.0-prerelease-00095": {
+    "xunit.netcore.extensions/1.0.0-prerelease-00098": {
       "type": "package",
       "serviceable": true,
-      "sha512": "FuvWmkuxHiqD0cHDggg5MRmBoeM4Uea7OUEmKvZiQu7Fy02hJ6yKKNV7mNW3y4scwSzDNA81Qa+HIS33PeWUog==",
+      "sha512": "3kRPwTbC42YGmsNHpNMKfGVOO5cVfxUD+C7cYbti1aml4UCT/RFZ6lhm5Vym2wNRDxryu0Es78aMf1BaybSrDg==",
       "files": [
         "lib/dotnet/Xunit.NetCore.Extensions.dll",
-        "xunit.netcore.extensions.1.0.0-prerelease-00095.nupkg",
-        "xunit.netcore.extensions.1.0.0-prerelease-00095.nupkg.sha512",
+        "xunit.netcore.extensions.1.0.0-prerelease-00098.nupkg",
+        "xunit.netcore.extensions.1.0.0-prerelease-00098.nupkg.sha512",
         "xunit.netcore.extensions.nuspec"
       ]
     }

--- a/src/System.Private.ServiceModel/tests/Scenarios/Binding/Http/project.lock.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Binding/Http/project.lock.json
@@ -292,7 +292,7 @@
           "lib/dotnet/System.Linq.Queryable.dll": {}
         }
       },
-      "System.Net.Http/4.0.1-beta-23324": {
+      "System.Net.Http/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -305,16 +305,15 @@
           "ref/dotnet/System.Net.Http.dll": {}
         }
       },
-      "System.Net.NameResolution/4.0.0-beta-23324": {
+      "System.Net.NameResolution/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.Networking": "4.0.1-beta-23324"
+          "System.Net.Primitives": "4.0.10",
+          "System.Runtime": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Net.NameResolution.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Net.NameResolution.dll": {}
         }
       },
       "System.Net.Primitives/4.0.10": {
@@ -329,10 +328,10 @@
           "lib/DNXCore50/System.Net.Primitives.dll": {}
         }
       },
-      "System.Net.Security/4.0.0-beta-23324": {
+      "System.Net.Security/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.Networking": "4.0.1-beta-23324"
+          "System.Private.Networking": "4.0.1-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.Net.Security.dll": {}
@@ -367,6 +366,49 @@
         },
         "runtime": {
           "lib/dotnet/System.Net.WebHeaderCollection.dll": {}
+        }
+      },
+      "System.Net.WebSockets/4.0.0-beta-23330": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.Win32.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Threading.Tasks": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Net.WebSockets.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Net.WebSockets.dll": {}
+        }
+      },
+      "System.Net.WebSockets.Client/4.0.0-beta-23330": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.Win32.Primitives": "4.0.0",
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Diagnostics.Tracing": "4.0.20",
+          "System.Globalization": "4.0.10",
+          "System.Net.Primitives": "4.0.10",
+          "System.Net.WebHeaderCollection": "4.0.0",
+          "System.Net.WebSockets": "4.0.0-beta-23330",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23330",
+          "System.Text.Encoding": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Net.WebSockets.Client.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Net.WebSockets.Client.dll": {}
         }
       },
       "System.ObjectModel/4.0.10": {
@@ -414,7 +456,7 @@
           "lib/DNXCore50/System.Private.DataContractSerialization.dll": {}
         }
       },
-      "System.Private.Networking/4.0.1-beta-23324": {
+      "System.Private.Networking/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -433,13 +475,13 @@
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23324",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23324",
-          "System.Security.Principal.Windows": "4.0.0-beta-23324",
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23330",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23330",
+          "System.Security.Principal.Windows": "4.0.0-beta-23330",
           "System.Threading": "4.0.10",
           "System.Threading.Overlapped": "4.0.0",
           "System.Threading.Tasks": "4.0.10",
-          "System.Threading.ThreadPool": "4.0.10-beta-23324"
+          "System.Threading.ThreadPool": "4.0.10-beta-23330"
         },
         "compile": {
           "ref/dnxcore50/_._": {}
@@ -448,7 +490,7 @@
           "lib/DNXCore50/System.Private.Networking.dll": {}
         }
       },
-      "System.Private.ServiceModel/4.0.1-beta-23324": {
+      "System.Private.ServiceModel/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -465,12 +507,14 @@
           "System.Linq": "4.0.0",
           "System.Linq.Expressions": "4.0.10",
           "System.Linq.Queryable": "4.0.0",
-          "System.Net.Http": "4.0.1-beta-23324",
-          "System.Net.NameResolution": "4.0.0-beta-23324",
+          "System.Net.Http": "4.0.1-beta-23330",
+          "System.Net.NameResolution": "4.0.0-beta-23330",
           "System.Net.Primitives": "4.0.10",
-          "System.Net.Security": "4.0.0-beta-23324",
-          "System.Net.Sockets": "4.0.10-beta-23324",
+          "System.Net.Security": "4.0.0-beta-23330",
+          "System.Net.Sockets": "4.0.10-beta-23330",
           "System.Net.WebHeaderCollection": "4.0.0",
+          "System.Net.WebSockets": "4.0.0-beta-23330",
+          "System.Net.WebSockets.Client": "4.0.0-beta-23330",
           "System.ObjectModel": "4.0.10",
           "System.Reflection": "4.0.10",
           "System.Reflection.DispatchProxy": "4.0.0",
@@ -484,9 +528,9 @@
           "System.Runtime.Serialization.Primitives": "4.0.10",
           "System.Runtime.Serialization.Xml": "4.0.10",
           "System.Security.Claims": "4.0.0",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23324",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23330",
           "System.Security.Principal": "4.0.0",
-          "System.Security.Principal.Windows": "4.0.0-beta-23324",
+          "System.Security.Principal.Windows": "4.0.0-beta-23330",
           "System.Text.Encoding": "4.0.10",
           "System.Threading": "4.0.10",
           "System.Threading.Tasks": "4.0.10",
@@ -735,18 +779,18 @@
           "lib/dotnet/System.Security.Claims.dll": {}
         }
       },
-      "System.Security.Cryptography.Algorithms/4.0.0-beta-23324": {
+      "System.Security.Cryptography.Algorithms/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
           "System.Runtime": "4.0.0",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23324"
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.Algorithms.dll": {}
         }
       },
-      "System.Security.Cryptography.Encoding/4.0.0-beta-23324": {
+      "System.Security.Cryptography.Encoding/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -755,7 +799,7 @@
           "ref/dotnet/System.Security.Cryptography.Encoding.dll": {}
         }
       },
-      "System.Security.Cryptography.Primitives/4.0.0-beta-23324": {
+      "System.Security.Cryptography.Primitives/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.0",
@@ -773,13 +817,13 @@
           "lib/dotnet/System.Security.Cryptography.Primitives.dll": {}
         }
       },
-      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23324": {
+      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
           "System.Runtime.Handles": "4.0.0",
-          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23324",
-          "System.Security.Cryptography.Encoding": "4.0.0-beta-23324"
+          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23330",
+          "System.Security.Cryptography.Encoding": "4.0.0-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.X509Certificates.dll": {}
@@ -797,7 +841,7 @@
           "lib/dotnet/System.Security.Principal.dll": {}
         }
       },
-      "System.Security.Principal.Windows/4.0.0-beta-23324": {
+      "System.Security.Principal.Windows/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -820,10 +864,10 @@
           "lib/DNXCore50/System.Security.Principal.Windows.dll": {}
         }
       },
-      "System.ServiceModel.Http/4.0.11-beta-23324": {
+      "System.ServiceModel.Http/4.0.11-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.0.1-beta-23324",
+          "System.Private.ServiceModel": "4.0.1-beta-23330",
           "System.Runtime": "4.0.20"
         },
         "compile": {
@@ -833,10 +877,10 @@
           "lib/DNXCore50/System.ServiceModel.Http.dll": {}
         }
       },
-      "System.ServiceModel.Primitives/4.0.1-beta-23324": {
+      "System.ServiceModel.Primitives/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.0.1-beta-23324"
+          "System.Private.ServiceModel": "4.0.1-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.ServiceModel.Primitives.dll": {}
@@ -925,7 +969,7 @@
           "lib/DNXCore50/System.Threading.Tasks.dll": {}
         }
       },
-      "System.Threading.ThreadPool/4.0.10-beta-23324": {
+      "System.Threading.ThreadPool/4.0.10-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
@@ -1118,7 +1162,7 @@
           "lib/dotnet/xunit.execution.dotnet.dll": {}
         }
       },
-      "xunit.netcore.extensions/1.0.0-prerelease-00095": {
+      "xunit.netcore.extensions/1.0.0-prerelease-00098": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.10",
@@ -1746,23 +1790,12 @@
         "System.Linq.Queryable.nuspec"
       ]
     },
-    "System.Net.Http/4.0.1-beta-23324": {
+    "System.Net.Http/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "gXfHlWsiMQDuFqwnQrlQTje9vqMhCFLtm35jX4WqZjcfa3y69DbwueeT0gJbVMK88/UnG8FAYiDBb7AKyu+51w==",
+      "sha512": "itLPx7B7Ac4mX8wQx9V9DQcxqTgkmwDNnQIHuCgAH53Jq2X3XziiRRBbxbmNJlWqBlgPzbseWJmMCtcF/ePhOg==",
       "files": [
         "lib/net45/_._",
-        "lib/netcore50/de/System.Net.Http.xml",
-        "lib/netcore50/es/System.Net.Http.xml",
-        "lib/netcore50/fr/System.Net.Http.xml",
-        "lib/netcore50/it/System.Net.Http.xml",
-        "lib/netcore50/ja/System.Net.Http.xml",
-        "lib/netcore50/ko/System.Net.Http.xml",
-        "lib/netcore50/ru/System.Net.Http.xml",
-        "lib/netcore50/System.Net.Http.dll",
-        "lib/netcore50/System.Net.Http.xml",
-        "lib/netcore50/zh-hans/System.Net.Http.xml",
-        "lib/netcore50/zh-hant/System.Net.Http.xml",
         "lib/win8/_._",
         "lib/wpa81/_._",
         "ref/dotnet/System.Net.Http.dll",
@@ -1771,17 +1804,16 @@
         "ref/win8/_._",
         "ref/wpa81/_._",
         "runtime.json",
-        "System.Net.Http.4.0.1-beta-23324.nupkg",
-        "System.Net.Http.4.0.1-beta-23324.nupkg.sha512",
+        "System.Net.Http.4.0.1-beta-23330.nupkg",
+        "System.Net.Http.4.0.1-beta-23330.nupkg.sha512",
         "System.Net.Http.nuspec"
       ]
     },
-    "System.Net.NameResolution/4.0.0-beta-23324": {
+    "System.Net.NameResolution/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "lNYXUmnSXUtLFY09Rc27zJ6/TxCuGggQzBgiuWHoWrjWxymuuxqPT2Mj7Dn7sUUh0GvF2MOx7Uk+rtCFBiIavg==",
+      "sha512": "d8Am+In/aBgcHpEV6xsi5BCiTEN4y6s9O1V/yIvwX8mDC4CtdZiGsi4DtoB0TLOgp8ky6GxbSF4bKCjFpBO3uw==",
       "files": [
-        "lib/DNXCore50/System.Net.NameResolution.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.NameResolution.dll",
@@ -1793,8 +1825,9 @@
         "ref/net46/System.Net.NameResolution.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.NameResolution.4.0.0-beta-23324.nupkg",
-        "System.Net.NameResolution.4.0.0-beta-23324.nupkg.sha512",
+        "runtime.json",
+        "System.Net.NameResolution.4.0.0-beta-23330.nupkg",
+        "System.Net.NameResolution.4.0.0-beta-23330.nupkg.sha512",
         "System.Net.NameResolution.nuspec"
       ]
     },
@@ -1831,9 +1864,9 @@
         "System.Net.Primitives.nuspec"
       ]
     },
-    "System.Net.Security/4.0.0-beta-23324": {
+    "System.Net.Security/4.0.0-beta-23330": {
       "type": "package",
-      "sha512": "D04RYjxrnR3D+uI9CGmAAFKKQ6T+pPcRHYucc1PIo7/hJK5I/Yu7gAw9yOxHUhQjSGfrKo00lHpBCQMTQt4lSw==",
+      "sha512": "z98dKloNy9DBdyfqQwQvKWA2q8Qj4vgGEVONnlS70c13eh0MolBHJ0wNdplZZK5zYZ5Eu8GTwexbUlpHbsfzVA==",
       "files": [
         "lib/DNXCore50/System.Net.Security.dll",
         "lib/MonoAndroid10/_._",
@@ -1847,8 +1880,8 @@
         "ref/net46/System.Net.Security.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.Security.4.0.0-beta-23324.nupkg",
-        "System.Net.Security.4.0.0-beta-23324.nupkg.sha512",
+        "System.Net.Security.4.0.0-beta-23330.nupkg",
+        "System.Net.Security.4.0.0-beta-23330.nupkg.sha512",
         "System.Net.Security.nuspec"
       ]
     },
@@ -1906,6 +1939,81 @@
         "System.Net.WebHeaderCollection.nuspec"
       ]
     },
+    "System.Net.WebSockets/4.0.0-beta-23330": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "6Q9/uTDcaqbmdbD04MisKmjti4aEpp40i/UzpGaPZ4ItuwzU/pMk9RjiYUBUiCQyZeKNlXcSB1FPN2nFof7tww==",
+      "files": [
+        "lib/dotnet/de/System.Net.WebSockets.xml",
+        "lib/dotnet/es/System.Net.WebSockets.xml",
+        "lib/dotnet/fr/System.Net.WebSockets.xml",
+        "lib/dotnet/it/System.Net.WebSockets.xml",
+        "lib/dotnet/ja/System.Net.WebSockets.xml",
+        "lib/dotnet/ko/System.Net.WebSockets.xml",
+        "lib/dotnet/ru/System.Net.WebSockets.xml",
+        "lib/dotnet/System.Net.WebSockets.dll",
+        "lib/dotnet/System.Net.WebSockets.xml",
+        "lib/dotnet/zh-hans/System.Net.WebSockets.xml",
+        "lib/dotnet/zh-hant/System.Net.WebSockets.xml",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Net.WebSockets.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Net.WebSockets.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Net.WebSockets.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Net.WebSockets.4.0.0-beta-23330.nupkg",
+        "System.Net.WebSockets.4.0.0-beta-23330.nupkg.sha512",
+        "System.Net.WebSockets.nuspec"
+      ]
+    },
+    "System.Net.WebSockets.Client/4.0.0-beta-23330": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "1NWEqwDkYRyvr1gSKZlY51AaI9w8oD0dC5UNa2Lb+qaeFHSF5KfCSzf7seD+im+sH6uocVo2nppiaabfbXZT4Q==",
+      "files": [
+        "lib/DNXCore50/de/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/es/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/fr/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/it/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/ja/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/ko/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/ru/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/System.Net.WebSockets.Client.dll",
+        "lib/DNXCore50/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/zh-hans/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/zh-hant/System.Net.WebSockets.Client.xml",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Net.WebSockets.Client.dll",
+        "lib/netcore50/de/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/es/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/fr/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/it/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/ja/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/ko/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/ru/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/System.Net.WebSockets.Client.dll",
+        "lib/netcore50/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/zh-hans/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/zh-hant/System.Net.WebSockets.Client.xml",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Net.WebSockets.Client.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Net.WebSockets.Client.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Net.WebSockets.Client.4.0.0-beta-23330.nupkg",
+        "System.Net.WebSockets.Client.4.0.0-beta-23330.nupkg.sha512",
+        "System.Net.WebSockets.Client.nuspec"
+      ]
+    },
     "System.ObjectModel/4.0.10": {
       "type": "package",
       "serviceable": true,
@@ -1954,31 +2062,31 @@
         "System.Private.DataContractSerialization.nuspec"
       ]
     },
-    "System.Private.Networking/4.0.1-beta-23324": {
+    "System.Private.Networking/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "OfyxoeCdh1ypzdz1u0h1Clgt+6749vALs2ZPkLwsOPzL0INCG9ISYo+Jhh62ZD8TMkWwLrvyVppMBPHY6M7Upw==",
+      "sha512": "8NZi1gCQaGTKDb2yWplm52HWCLaZnUwVitksJgcXY2dEJau/TBGyZup+yhOngOIe8QzQMxNG4iokY3Ce0/8mbg==",
       "files": [
         "lib/DNXCore50/System.Private.Networking.dll",
         "lib/netcore50/System.Private.Networking.dll",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "System.Private.Networking.4.0.1-beta-23324.nupkg",
-        "System.Private.Networking.4.0.1-beta-23324.nupkg.sha512",
+        "System.Private.Networking.4.0.1-beta-23330.nupkg",
+        "System.Private.Networking.4.0.1-beta-23330.nupkg.sha512",
         "System.Private.Networking.nuspec"
       ]
     },
-    "System.Private.ServiceModel/4.0.1-beta-23324": {
+    "System.Private.ServiceModel/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "Lz3T9V8GnaOFlf8LUmuPznuOIuy92BAFVc9huiMrFKByzPpydGuCvXEe+81rZ1IF2TQcHKO++9otnj96AEJ5BA==",
+      "sha512": "8lENvmHuZdlvmnYN1w98Mv8bDjc0O/YlaNHRRph35T/fLDyaG8LMLMwG3/ut6a/AenLJmbf92snOtNXCuqM+cQ==",
       "files": [
         "lib/DNXCore50/System.Private.ServiceModel.dll",
         "lib/netcore50/System.Private.ServiceModel.dll",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "System.Private.ServiceModel.4.0.1-beta-23324.nupkg",
-        "System.Private.ServiceModel.4.0.1-beta-23324.nupkg.sha512",
+        "System.Private.ServiceModel.4.0.1-beta-23330.nupkg",
+        "System.Private.ServiceModel.4.0.1-beta-23330.nupkg.sha512",
         "System.Private.ServiceModel.nuspec"
       ]
     },
@@ -2507,10 +2615,10 @@
         "System.Security.Claims.nuspec"
       ]
     },
-    "System.Security.Cryptography.Algorithms/4.0.0-beta-23324": {
+    "System.Security.Cryptography.Algorithms/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "Mt6LwMj8hPp0+xZHcV6grZ7wSWhgycGkdZ6DQ9XvUY9NguUsvb/+fu2cMdrC7XsnpvwIROByp+p2dSjqBn3E2Q==",
+      "sha512": "FB4RoTDaV5tBiPSJsiG3A5DydeKz7ErglnkqVjBFjm6wu8kg91j0MxL/Al9iUyu9i/hq53fRs5KE3rjUNYvf5w==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2524,15 +2632,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.Algorithms.4.0.0-beta-23324.nupkg",
-        "System.Security.Cryptography.Algorithms.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Cryptography.Algorithms.4.0.0-beta-23330.nupkg",
+        "System.Security.Cryptography.Algorithms.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Cryptography.Algorithms.nuspec"
       ]
     },
-    "System.Security.Cryptography.Encoding/4.0.0-beta-23324": {
+    "System.Security.Cryptography.Encoding/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "JHOyknf1eYO6C39Vao6kAGpadq3PBO1L4tuzNEz/HvbH5sfIHPbjhxL11OyAhVKCzLCfEj6+aeClovFqZIRPyw==",
+      "sha512": "zeFdKQT6xjNdiNCaEmEYJMEK59kixkX7jJSoOLw3H+53t9X0F98vr3tS8YlrW/Lk/K9c6L5pYLlkb2dNqvUD/g==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2546,15 +2654,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.Encoding.4.0.0-beta-23324.nupkg",
-        "System.Security.Cryptography.Encoding.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Cryptography.Encoding.4.0.0-beta-23330.nupkg",
+        "System.Security.Cryptography.Encoding.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Cryptography.Encoding.nuspec"
       ]
     },
-    "System.Security.Cryptography.Primitives/4.0.0-beta-23324": {
+    "System.Security.Cryptography.Primitives/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "ETZxelIX51Di4FTytd8ohSpN6Ym/32aWIX9E2NCFkd91qdexn2Dkysn80b6n4gX6jG+oL0UHQDtD/fYq8C65oQ==",
+      "sha512": "15uVbOD3X0sRQJIxcEH5hasxlFdbA1CmPPZa0Y8pYEuQcWMF2gBswvU8s4qoKtA7x2xhNhzPsXIhsQuKNMTdEA==",
       "files": [
         "lib/dotnet/System.Security.Cryptography.Primitives.dll",
         "lib/MonoAndroid10/_._",
@@ -2568,15 +2676,15 @@
         "ref/net46/System.Security.Cryptography.Primitives.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Security.Cryptography.Primitives.4.0.0-beta-23324.nupkg",
-        "System.Security.Cryptography.Primitives.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Cryptography.Primitives.4.0.0-beta-23330.nupkg",
+        "System.Security.Cryptography.Primitives.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Cryptography.Primitives.nuspec"
       ]
     },
-    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23324": {
+    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "8NaEOxkkNBUECh0cPzGpbXS0uzGDpnvxI0kqQKRGp9uA+9qCyQfxcqAT6ozAYtOuFNVaC1XU3zQnb7T2nfvIDg==",
+      "sha512": "L8mUimdm7+GsORgJ8DFBMGsFnwDJ5YCUdJj3HfXQx4HCoPDPF+vJo3HRiHfcvNA2Zsf0ov2kuerYj/eeVa2/Rw==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2590,8 +2698,8 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23324.nupkg",
-        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23330.nupkg",
+        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Cryptography.X509Certificates.nuspec"
       ]
     },
@@ -2628,10 +2736,10 @@
         "System.Security.Principal.nuspec"
       ]
     },
-    "System.Security.Principal.Windows/4.0.0-beta-23324": {
+    "System.Security.Principal.Windows/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "csbCKdwBz31T8He7U6XMIc9BiWgwjHs5WDZR4rfhsk48TpdsbKNHX9OX4b+GwvgcsfVuWxre7zqNR0Bc9gWZ7g==",
+      "sha512": "q+3L3aB8bn0HCW52kX9TSJdhbjffBw7QWCOu0yX1SDhPN9MCPmJ4aBBCn1HRWroa5y7UcNUdjL1xwiERycZexw==",
       "files": [
         "lib/DNXCore50/de/System.Security.Principal.Windows.xml",
         "lib/DNXCore50/es/System.Security.Principal.Windows.xml",
@@ -2647,15 +2755,15 @@
         "lib/net46/System.Security.Principal.Windows.dll",
         "ref/dotnet/System.Security.Principal.Windows.dll",
         "ref/net46/System.Security.Principal.Windows.dll",
-        "System.Security.Principal.Windows.4.0.0-beta-23324.nupkg",
-        "System.Security.Principal.Windows.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Principal.Windows.4.0.0-beta-23330.nupkg",
+        "System.Security.Principal.Windows.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Principal.Windows.nuspec"
       ]
     },
-    "System.ServiceModel.Http/4.0.11-beta-23324": {
+    "System.ServiceModel.Http/4.0.11-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "VkTumuCSmXd0NPZZU+nrO7YqznvM+wP96NykXbxFJdNAtCplmqXaQh+YZ/02rjJmfou5qyo2V+ZWVwySBAirOg==",
+      "sha512": "NHKxIIYL0ATDbX18RLCSXtuq26MMoYfAVdpl5K+D0s5AHp7TMPb7LcjZPpg25B2v48x1TwE9LYcYTCiOZcoPzQ==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Http.dll",
         "lib/MonoAndroid10/_._",
@@ -2680,15 +2788,15 @@
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.ServiceModel.Http.4.0.11-beta-23324.nupkg",
-        "System.ServiceModel.Http.4.0.11-beta-23324.nupkg.sha512",
+        "System.ServiceModel.Http.4.0.11-beta-23330.nupkg",
+        "System.ServiceModel.Http.4.0.11-beta-23330.nupkg.sha512",
         "System.ServiceModel.Http.nuspec"
       ]
     },
-    "System.ServiceModel.Primitives/4.0.1-beta-23324": {
+    "System.ServiceModel.Primitives/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "bmU31B4CD5+m9Kt0iDM5Yw2ZXRfv7lpK3Sx1HektcT/HERc+IMPdO38f/Wxtofo5WOA0qmd1fdrMeQcbEkDfJg==",
+      "sha512": "kJ/pcRUf7Ow7s/rX8Kmc9P2k6cvyudIzyUcqr/pn9NwY8DC/2DWkkFvYE2udR4kvBzJJzXl/rsJQlyLIVGMAww==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Primitives.dll",
         "lib/net45/_._",
@@ -2708,8 +2816,8 @@
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.Primitives.dll",
         "ref/win8/_._",
-        "System.ServiceModel.Primitives.4.0.1-beta-23324.nupkg",
-        "System.ServiceModel.Primitives.4.0.1-beta-23324.nupkg.sha512",
+        "System.ServiceModel.Primitives.4.0.1-beta-23330.nupkg",
+        "System.ServiceModel.Primitives.4.0.1-beta-23330.nupkg.sha512",
         "System.ServiceModel.Primitives.nuspec"
       ]
     },
@@ -2904,10 +3012,9 @@
         "System.Threading.Tasks.nuspec"
       ]
     },
-    "System.Threading.ThreadPool/4.0.10-beta-23324": {
+    "System.Threading.ThreadPool/4.0.10-beta-23330": {
       "type": "package",
-      "serviceable": true,
-      "sha512": "G4SjGmiV72HBiv8wkfnKFGTieekrACU1m43VaeJ6vDeSyb08eEFusVH1UWZpOsUF25meCuzpda0ezus24b4rKA==",
+      "sha512": "nM5OewUj8NJrye93apbM6KHvPddgPJGzt1IWIXk9lV5HB4NGsn6M5U0gxMQWShQuDp6NF3ya3ULRSvh3dLMbzg==",
       "files": [
         "lib/DNXCore50/System.Threading.ThreadPool.dll",
         "lib/MonoAndroid10/_._",
@@ -2921,8 +3028,8 @@
         "ref/net46/System.Threading.ThreadPool.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Threading.ThreadPool.4.0.10-beta-23324.nupkg",
-        "System.Threading.ThreadPool.4.0.10-beta-23324.nupkg.sha512",
+        "System.Threading.ThreadPool.4.0.10-beta-23330.nupkg",
+        "System.Threading.ThreadPool.4.0.10-beta-23330.nupkg.sha512",
         "System.Threading.ThreadPool.nuspec"
       ]
     },
@@ -3173,14 +3280,14 @@
         "xunit.extensibility.execution.nuspec"
       ]
     },
-    "xunit.netcore.extensions/1.0.0-prerelease-00095": {
+    "xunit.netcore.extensions/1.0.0-prerelease-00098": {
       "type": "package",
       "serviceable": true,
-      "sha512": "FuvWmkuxHiqD0cHDggg5MRmBoeM4Uea7OUEmKvZiQu7Fy02hJ6yKKNV7mNW3y4scwSzDNA81Qa+HIS33PeWUog==",
+      "sha512": "3kRPwTbC42YGmsNHpNMKfGVOO5cVfxUD+C7cYbti1aml4UCT/RFZ6lhm5Vym2wNRDxryu0Es78aMf1BaybSrDg==",
       "files": [
         "lib/dotnet/Xunit.NetCore.Extensions.dll",
-        "xunit.netcore.extensions.1.0.0-prerelease-00095.nupkg",
-        "xunit.netcore.extensions.1.0.0-prerelease-00095.nupkg.sha512",
+        "xunit.netcore.extensions.1.0.0-prerelease-00098.nupkg",
+        "xunit.netcore.extensions.1.0.0-prerelease-00098.nupkg.sha512",
         "xunit.netcore.extensions.nuspec"
       ]
     }

--- a/src/System.Private.ServiceModel/tests/Scenarios/Binding/NetHttp/project.lock.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Binding/NetHttp/project.lock.json
@@ -292,7 +292,7 @@
           "lib/dotnet/System.Linq.Queryable.dll": {}
         }
       },
-      "System.Net.Http/4.0.1-beta-23324": {
+      "System.Net.Http/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -305,16 +305,15 @@
           "ref/dotnet/System.Net.Http.dll": {}
         }
       },
-      "System.Net.NameResolution/4.0.0-beta-23324": {
+      "System.Net.NameResolution/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.Networking": "4.0.1-beta-23324"
+          "System.Net.Primitives": "4.0.10",
+          "System.Runtime": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Net.NameResolution.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Net.NameResolution.dll": {}
         }
       },
       "System.Net.Primitives/4.0.10": {
@@ -329,10 +328,10 @@
           "lib/DNXCore50/System.Net.Primitives.dll": {}
         }
       },
-      "System.Net.Security/4.0.0-beta-23324": {
+      "System.Net.Security/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.Networking": "4.0.1-beta-23324"
+          "System.Private.Networking": "4.0.1-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.Net.Security.dll": {}
@@ -369,7 +368,7 @@
           "lib/dotnet/System.Net.WebHeaderCollection.dll": {}
         }
       },
-      "System.Net.WebSockets/4.0.0-beta-23324": {
+      "System.Net.WebSockets/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -381,10 +380,10 @@
           "ref/dotnet/System.Net.WebSockets.dll": {}
         },
         "runtime": {
-          "lib/DNXCore50/System.Net.WebSockets.dll": {}
+          "lib/dotnet/System.Net.WebSockets.dll": {}
         }
       },
-      "System.Net.WebSockets.Client/4.0.0-beta-23324": {
+      "System.Net.WebSockets.Client/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -394,13 +393,13 @@
           "System.Globalization": "4.0.10",
           "System.Net.Primitives": "4.0.10",
           "System.Net.WebHeaderCollection": "4.0.0",
-          "System.Net.WebSockets": "4.0.0-beta-23324",
+          "System.Net.WebSockets": "4.0.0-beta-23330",
           "System.Resources.ResourceManager": "4.0.0",
           "System.Runtime": "4.0.20",
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23324",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23330",
           "System.Text.Encoding": "4.0.10",
           "System.Threading": "4.0.10",
           "System.Threading.Tasks": "4.0.10"
@@ -457,7 +456,7 @@
           "lib/DNXCore50/System.Private.DataContractSerialization.dll": {}
         }
       },
-      "System.Private.Networking/4.0.1-beta-23324": {
+      "System.Private.Networking/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -476,13 +475,13 @@
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23324",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23324",
-          "System.Security.Principal.Windows": "4.0.0-beta-23324",
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23330",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23330",
+          "System.Security.Principal.Windows": "4.0.0-beta-23330",
           "System.Threading": "4.0.10",
           "System.Threading.Overlapped": "4.0.0",
           "System.Threading.Tasks": "4.0.10",
-          "System.Threading.ThreadPool": "4.0.10-beta-23324"
+          "System.Threading.ThreadPool": "4.0.10-beta-23330"
         },
         "compile": {
           "ref/dnxcore50/_._": {}
@@ -491,7 +490,7 @@
           "lib/DNXCore50/System.Private.Networking.dll": {}
         }
       },
-      "System.Private.ServiceModel/4.0.1-beta-23324": {
+      "System.Private.ServiceModel/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -508,12 +507,14 @@
           "System.Linq": "4.0.0",
           "System.Linq.Expressions": "4.0.10",
           "System.Linq.Queryable": "4.0.0",
-          "System.Net.Http": "4.0.1-beta-23324",
-          "System.Net.NameResolution": "4.0.0-beta-23324",
+          "System.Net.Http": "4.0.1-beta-23330",
+          "System.Net.NameResolution": "4.0.0-beta-23330",
           "System.Net.Primitives": "4.0.10",
-          "System.Net.Security": "4.0.0-beta-23324",
-          "System.Net.Sockets": "4.0.10-beta-23324",
+          "System.Net.Security": "4.0.0-beta-23330",
+          "System.Net.Sockets": "4.0.10-beta-23330",
           "System.Net.WebHeaderCollection": "4.0.0",
+          "System.Net.WebSockets": "4.0.0-beta-23330",
+          "System.Net.WebSockets.Client": "4.0.0-beta-23330",
           "System.ObjectModel": "4.0.10",
           "System.Reflection": "4.0.10",
           "System.Reflection.DispatchProxy": "4.0.0",
@@ -527,9 +528,9 @@
           "System.Runtime.Serialization.Primitives": "4.0.10",
           "System.Runtime.Serialization.Xml": "4.0.10",
           "System.Security.Claims": "4.0.0",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23324",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23330",
           "System.Security.Principal": "4.0.0",
-          "System.Security.Principal.Windows": "4.0.0-beta-23324",
+          "System.Security.Principal.Windows": "4.0.0-beta-23330",
           "System.Text.Encoding": "4.0.10",
           "System.Threading": "4.0.10",
           "System.Threading.Tasks": "4.0.10",
@@ -778,18 +779,18 @@
           "lib/dotnet/System.Security.Claims.dll": {}
         }
       },
-      "System.Security.Cryptography.Algorithms/4.0.0-beta-23324": {
+      "System.Security.Cryptography.Algorithms/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
           "System.Runtime": "4.0.0",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23324"
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.Algorithms.dll": {}
         }
       },
-      "System.Security.Cryptography.Encoding/4.0.0-beta-23324": {
+      "System.Security.Cryptography.Encoding/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -798,7 +799,7 @@
           "ref/dotnet/System.Security.Cryptography.Encoding.dll": {}
         }
       },
-      "System.Security.Cryptography.Primitives/4.0.0-beta-23324": {
+      "System.Security.Cryptography.Primitives/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.0",
@@ -816,13 +817,13 @@
           "lib/dotnet/System.Security.Cryptography.Primitives.dll": {}
         }
       },
-      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23324": {
+      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
           "System.Runtime.Handles": "4.0.0",
-          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23324",
-          "System.Security.Cryptography.Encoding": "4.0.0-beta-23324"
+          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23330",
+          "System.Security.Cryptography.Encoding": "4.0.0-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.X509Certificates.dll": {}
@@ -840,7 +841,7 @@
           "lib/dotnet/System.Security.Principal.dll": {}
         }
       },
-      "System.Security.Principal.Windows/4.0.0-beta-23324": {
+      "System.Security.Principal.Windows/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -863,10 +864,10 @@
           "lib/DNXCore50/System.Security.Principal.Windows.dll": {}
         }
       },
-      "System.ServiceModel.Duplex/4.0.1-beta-23324": {
+      "System.ServiceModel.Duplex/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.0.1-beta-23324"
+          "System.Private.ServiceModel": "4.0.1-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.ServiceModel.Duplex.dll": {}
@@ -875,10 +876,10 @@
           "lib/DNXCore50/System.ServiceModel.Duplex.dll": {}
         }
       },
-      "System.ServiceModel.Http/4.0.11-beta-23324": {
+      "System.ServiceModel.Http/4.0.11-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.0.1-beta-23324",
+          "System.Private.ServiceModel": "4.0.1-beta-23330",
           "System.Runtime": "4.0.20"
         },
         "compile": {
@@ -888,10 +889,10 @@
           "lib/DNXCore50/System.ServiceModel.Http.dll": {}
         }
       },
-      "System.ServiceModel.NetTcp/4.0.1-beta-23324": {
+      "System.ServiceModel.NetTcp/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.0.1-beta-23324"
+          "System.Private.ServiceModel": "4.0.1-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.ServiceModel.NetTcp.dll": {}
@@ -900,10 +901,10 @@
           "lib/DNXCore50/System.ServiceModel.NetTcp.dll": {}
         }
       },
-      "System.ServiceModel.Primitives/4.0.1-beta-23324": {
+      "System.ServiceModel.Primitives/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.0.1-beta-23324"
+          "System.Private.ServiceModel": "4.0.1-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.ServiceModel.Primitives.dll": {}
@@ -992,7 +993,7 @@
           "lib/DNXCore50/System.Threading.Tasks.dll": {}
         }
       },
-      "System.Threading.ThreadPool/4.0.10-beta-23324": {
+      "System.Threading.ThreadPool/4.0.10-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
@@ -1185,7 +1186,7 @@
           "lib/dotnet/xunit.execution.dotnet.dll": {}
         }
       },
-      "xunit.netcore.extensions/1.0.0-prerelease-00095": {
+      "xunit.netcore.extensions/1.0.0-prerelease-00098": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.10",
@@ -1813,23 +1814,12 @@
         "System.Linq.Queryable.nuspec"
       ]
     },
-    "System.Net.Http/4.0.1-beta-23324": {
+    "System.Net.Http/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "gXfHlWsiMQDuFqwnQrlQTje9vqMhCFLtm35jX4WqZjcfa3y69DbwueeT0gJbVMK88/UnG8FAYiDBb7AKyu+51w==",
+      "sha512": "itLPx7B7Ac4mX8wQx9V9DQcxqTgkmwDNnQIHuCgAH53Jq2X3XziiRRBbxbmNJlWqBlgPzbseWJmMCtcF/ePhOg==",
       "files": [
         "lib/net45/_._",
-        "lib/netcore50/de/System.Net.Http.xml",
-        "lib/netcore50/es/System.Net.Http.xml",
-        "lib/netcore50/fr/System.Net.Http.xml",
-        "lib/netcore50/it/System.Net.Http.xml",
-        "lib/netcore50/ja/System.Net.Http.xml",
-        "lib/netcore50/ko/System.Net.Http.xml",
-        "lib/netcore50/ru/System.Net.Http.xml",
-        "lib/netcore50/System.Net.Http.dll",
-        "lib/netcore50/System.Net.Http.xml",
-        "lib/netcore50/zh-hans/System.Net.Http.xml",
-        "lib/netcore50/zh-hant/System.Net.Http.xml",
         "lib/win8/_._",
         "lib/wpa81/_._",
         "ref/dotnet/System.Net.Http.dll",
@@ -1838,17 +1828,16 @@
         "ref/win8/_._",
         "ref/wpa81/_._",
         "runtime.json",
-        "System.Net.Http.4.0.1-beta-23324.nupkg",
-        "System.Net.Http.4.0.1-beta-23324.nupkg.sha512",
+        "System.Net.Http.4.0.1-beta-23330.nupkg",
+        "System.Net.Http.4.0.1-beta-23330.nupkg.sha512",
         "System.Net.Http.nuspec"
       ]
     },
-    "System.Net.NameResolution/4.0.0-beta-23324": {
+    "System.Net.NameResolution/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "lNYXUmnSXUtLFY09Rc27zJ6/TxCuGggQzBgiuWHoWrjWxymuuxqPT2Mj7Dn7sUUh0GvF2MOx7Uk+rtCFBiIavg==",
+      "sha512": "d8Am+In/aBgcHpEV6xsi5BCiTEN4y6s9O1V/yIvwX8mDC4CtdZiGsi4DtoB0TLOgp8ky6GxbSF4bKCjFpBO3uw==",
       "files": [
-        "lib/DNXCore50/System.Net.NameResolution.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.NameResolution.dll",
@@ -1860,8 +1849,9 @@
         "ref/net46/System.Net.NameResolution.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.NameResolution.4.0.0-beta-23324.nupkg",
-        "System.Net.NameResolution.4.0.0-beta-23324.nupkg.sha512",
+        "runtime.json",
+        "System.Net.NameResolution.4.0.0-beta-23330.nupkg",
+        "System.Net.NameResolution.4.0.0-beta-23330.nupkg.sha512",
         "System.Net.NameResolution.nuspec"
       ]
     },
@@ -1898,9 +1888,9 @@
         "System.Net.Primitives.nuspec"
       ]
     },
-    "System.Net.Security/4.0.0-beta-23324": {
+    "System.Net.Security/4.0.0-beta-23330": {
       "type": "package",
-      "sha512": "D04RYjxrnR3D+uI9CGmAAFKKQ6T+pPcRHYucc1PIo7/hJK5I/Yu7gAw9yOxHUhQjSGfrKo00lHpBCQMTQt4lSw==",
+      "sha512": "z98dKloNy9DBdyfqQwQvKWA2q8Qj4vgGEVONnlS70c13eh0MolBHJ0wNdplZZK5zYZ5Eu8GTwexbUlpHbsfzVA==",
       "files": [
         "lib/DNXCore50/System.Net.Security.dll",
         "lib/MonoAndroid10/_._",
@@ -1914,8 +1904,8 @@
         "ref/net46/System.Net.Security.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.Security.4.0.0-beta-23324.nupkg",
-        "System.Net.Security.4.0.0-beta-23324.nupkg.sha512",
+        "System.Net.Security.4.0.0-beta-23330.nupkg",
+        "System.Net.Security.4.0.0-beta-23330.nupkg.sha512",
         "System.Net.Security.nuspec"
       ]
     },
@@ -1973,22 +1963,22 @@
         "System.Net.WebHeaderCollection.nuspec"
       ]
     },
-    "System.Net.WebSockets/4.0.0-beta-23324": {
+    "System.Net.WebSockets/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "Yq5jsxarl7rhHGtPx1vpW3a2iUF+4eD6FE5u2IRlBs8YEvoGVN2jzhBtPJw40t1SGidXLCvlsVaB3qyNbk99MQ==",
+      "sha512": "6Q9/uTDcaqbmdbD04MisKmjti4aEpp40i/UzpGaPZ4ItuwzU/pMk9RjiYUBUiCQyZeKNlXcSB1FPN2nFof7tww==",
       "files": [
-        "lib/DNXCore50/de/System.Net.WebSockets.xml",
-        "lib/DNXCore50/es/System.Net.WebSockets.xml",
-        "lib/DNXCore50/fr/System.Net.WebSockets.xml",
-        "lib/DNXCore50/it/System.Net.WebSockets.xml",
-        "lib/DNXCore50/ja/System.Net.WebSockets.xml",
-        "lib/DNXCore50/ko/System.Net.WebSockets.xml",
-        "lib/DNXCore50/ru/System.Net.WebSockets.xml",
-        "lib/DNXCore50/System.Net.WebSockets.dll",
-        "lib/DNXCore50/System.Net.WebSockets.xml",
-        "lib/DNXCore50/zh-hans/System.Net.WebSockets.xml",
-        "lib/DNXCore50/zh-hant/System.Net.WebSockets.xml",
+        "lib/dotnet/de/System.Net.WebSockets.xml",
+        "lib/dotnet/es/System.Net.WebSockets.xml",
+        "lib/dotnet/fr/System.Net.WebSockets.xml",
+        "lib/dotnet/it/System.Net.WebSockets.xml",
+        "lib/dotnet/ja/System.Net.WebSockets.xml",
+        "lib/dotnet/ko/System.Net.WebSockets.xml",
+        "lib/dotnet/ru/System.Net.WebSockets.xml",
+        "lib/dotnet/System.Net.WebSockets.dll",
+        "lib/dotnet/System.Net.WebSockets.xml",
+        "lib/dotnet/zh-hans/System.Net.WebSockets.xml",
+        "lib/dotnet/zh-hant/System.Net.WebSockets.xml",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.WebSockets.dll",
@@ -2000,15 +1990,15 @@
         "ref/net46/System.Net.WebSockets.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.WebSockets.4.0.0-beta-23324.nupkg",
-        "System.Net.WebSockets.4.0.0-beta-23324.nupkg.sha512",
+        "System.Net.WebSockets.4.0.0-beta-23330.nupkg",
+        "System.Net.WebSockets.4.0.0-beta-23330.nupkg.sha512",
         "System.Net.WebSockets.nuspec"
       ]
     },
-    "System.Net.WebSockets.Client/4.0.0-beta-23324": {
+    "System.Net.WebSockets.Client/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "Zgnuyst8Kr37iY1z887R8R8VBFdKFqgHCmBTUIrBa8CUvGOvDocK/tM/b+VmseX0cEgUpodNB47gzGIVV0iM5g==",
+      "sha512": "1NWEqwDkYRyvr1gSKZlY51AaI9w8oD0dC5UNa2Lb+qaeFHSF5KfCSzf7seD+im+sH6uocVo2nppiaabfbXZT4Q==",
       "files": [
         "lib/DNXCore50/de/System.Net.WebSockets.Client.xml",
         "lib/DNXCore50/es/System.Net.WebSockets.Client.xml",
@@ -2024,6 +2014,17 @@
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.WebSockets.Client.dll",
+        "lib/netcore50/de/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/es/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/fr/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/it/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/ja/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/ko/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/ru/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/System.Net.WebSockets.Client.dll",
+        "lib/netcore50/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/zh-hans/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/zh-hant/System.Net.WebSockets.Client.xml",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
         "ref/dotnet/System.Net.WebSockets.Client.dll",
@@ -2032,8 +2033,8 @@
         "ref/net46/System.Net.WebSockets.Client.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.WebSockets.Client.4.0.0-beta-23324.nupkg",
-        "System.Net.WebSockets.Client.4.0.0-beta-23324.nupkg.sha512",
+        "System.Net.WebSockets.Client.4.0.0-beta-23330.nupkg",
+        "System.Net.WebSockets.Client.4.0.0-beta-23330.nupkg.sha512",
         "System.Net.WebSockets.Client.nuspec"
       ]
     },
@@ -2085,31 +2086,31 @@
         "System.Private.DataContractSerialization.nuspec"
       ]
     },
-    "System.Private.Networking/4.0.1-beta-23324": {
+    "System.Private.Networking/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "OfyxoeCdh1ypzdz1u0h1Clgt+6749vALs2ZPkLwsOPzL0INCG9ISYo+Jhh62ZD8TMkWwLrvyVppMBPHY6M7Upw==",
+      "sha512": "8NZi1gCQaGTKDb2yWplm52HWCLaZnUwVitksJgcXY2dEJau/TBGyZup+yhOngOIe8QzQMxNG4iokY3Ce0/8mbg==",
       "files": [
         "lib/DNXCore50/System.Private.Networking.dll",
         "lib/netcore50/System.Private.Networking.dll",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "System.Private.Networking.4.0.1-beta-23324.nupkg",
-        "System.Private.Networking.4.0.1-beta-23324.nupkg.sha512",
+        "System.Private.Networking.4.0.1-beta-23330.nupkg",
+        "System.Private.Networking.4.0.1-beta-23330.nupkg.sha512",
         "System.Private.Networking.nuspec"
       ]
     },
-    "System.Private.ServiceModel/4.0.1-beta-23324": {
+    "System.Private.ServiceModel/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "Lz3T9V8GnaOFlf8LUmuPznuOIuy92BAFVc9huiMrFKByzPpydGuCvXEe+81rZ1IF2TQcHKO++9otnj96AEJ5BA==",
+      "sha512": "8lENvmHuZdlvmnYN1w98Mv8bDjc0O/YlaNHRRph35T/fLDyaG8LMLMwG3/ut6a/AenLJmbf92snOtNXCuqM+cQ==",
       "files": [
         "lib/DNXCore50/System.Private.ServiceModel.dll",
         "lib/netcore50/System.Private.ServiceModel.dll",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "System.Private.ServiceModel.4.0.1-beta-23324.nupkg",
-        "System.Private.ServiceModel.4.0.1-beta-23324.nupkg.sha512",
+        "System.Private.ServiceModel.4.0.1-beta-23330.nupkg",
+        "System.Private.ServiceModel.4.0.1-beta-23330.nupkg.sha512",
         "System.Private.ServiceModel.nuspec"
       ]
     },
@@ -2638,10 +2639,10 @@
         "System.Security.Claims.nuspec"
       ]
     },
-    "System.Security.Cryptography.Algorithms/4.0.0-beta-23324": {
+    "System.Security.Cryptography.Algorithms/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "Mt6LwMj8hPp0+xZHcV6grZ7wSWhgycGkdZ6DQ9XvUY9NguUsvb/+fu2cMdrC7XsnpvwIROByp+p2dSjqBn3E2Q==",
+      "sha512": "FB4RoTDaV5tBiPSJsiG3A5DydeKz7ErglnkqVjBFjm6wu8kg91j0MxL/Al9iUyu9i/hq53fRs5KE3rjUNYvf5w==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2655,15 +2656,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.Algorithms.4.0.0-beta-23324.nupkg",
-        "System.Security.Cryptography.Algorithms.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Cryptography.Algorithms.4.0.0-beta-23330.nupkg",
+        "System.Security.Cryptography.Algorithms.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Cryptography.Algorithms.nuspec"
       ]
     },
-    "System.Security.Cryptography.Encoding/4.0.0-beta-23324": {
+    "System.Security.Cryptography.Encoding/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "JHOyknf1eYO6C39Vao6kAGpadq3PBO1L4tuzNEz/HvbH5sfIHPbjhxL11OyAhVKCzLCfEj6+aeClovFqZIRPyw==",
+      "sha512": "zeFdKQT6xjNdiNCaEmEYJMEK59kixkX7jJSoOLw3H+53t9X0F98vr3tS8YlrW/Lk/K9c6L5pYLlkb2dNqvUD/g==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2677,15 +2678,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.Encoding.4.0.0-beta-23324.nupkg",
-        "System.Security.Cryptography.Encoding.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Cryptography.Encoding.4.0.0-beta-23330.nupkg",
+        "System.Security.Cryptography.Encoding.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Cryptography.Encoding.nuspec"
       ]
     },
-    "System.Security.Cryptography.Primitives/4.0.0-beta-23324": {
+    "System.Security.Cryptography.Primitives/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "ETZxelIX51Di4FTytd8ohSpN6Ym/32aWIX9E2NCFkd91qdexn2Dkysn80b6n4gX6jG+oL0UHQDtD/fYq8C65oQ==",
+      "sha512": "15uVbOD3X0sRQJIxcEH5hasxlFdbA1CmPPZa0Y8pYEuQcWMF2gBswvU8s4qoKtA7x2xhNhzPsXIhsQuKNMTdEA==",
       "files": [
         "lib/dotnet/System.Security.Cryptography.Primitives.dll",
         "lib/MonoAndroid10/_._",
@@ -2699,15 +2700,15 @@
         "ref/net46/System.Security.Cryptography.Primitives.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Security.Cryptography.Primitives.4.0.0-beta-23324.nupkg",
-        "System.Security.Cryptography.Primitives.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Cryptography.Primitives.4.0.0-beta-23330.nupkg",
+        "System.Security.Cryptography.Primitives.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Cryptography.Primitives.nuspec"
       ]
     },
-    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23324": {
+    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "8NaEOxkkNBUECh0cPzGpbXS0uzGDpnvxI0kqQKRGp9uA+9qCyQfxcqAT6ozAYtOuFNVaC1XU3zQnb7T2nfvIDg==",
+      "sha512": "L8mUimdm7+GsORgJ8DFBMGsFnwDJ5YCUdJj3HfXQx4HCoPDPF+vJo3HRiHfcvNA2Zsf0ov2kuerYj/eeVa2/Rw==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2721,8 +2722,8 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23324.nupkg",
-        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23330.nupkg",
+        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Cryptography.X509Certificates.nuspec"
       ]
     },
@@ -2759,10 +2760,10 @@
         "System.Security.Principal.nuspec"
       ]
     },
-    "System.Security.Principal.Windows/4.0.0-beta-23324": {
+    "System.Security.Principal.Windows/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "csbCKdwBz31T8He7U6XMIc9BiWgwjHs5WDZR4rfhsk48TpdsbKNHX9OX4b+GwvgcsfVuWxre7zqNR0Bc9gWZ7g==",
+      "sha512": "q+3L3aB8bn0HCW52kX9TSJdhbjffBw7QWCOu0yX1SDhPN9MCPmJ4aBBCn1HRWroa5y7UcNUdjL1xwiERycZexw==",
       "files": [
         "lib/DNXCore50/de/System.Security.Principal.Windows.xml",
         "lib/DNXCore50/es/System.Security.Principal.Windows.xml",
@@ -2778,15 +2779,15 @@
         "lib/net46/System.Security.Principal.Windows.dll",
         "ref/dotnet/System.Security.Principal.Windows.dll",
         "ref/net46/System.Security.Principal.Windows.dll",
-        "System.Security.Principal.Windows.4.0.0-beta-23324.nupkg",
-        "System.Security.Principal.Windows.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Principal.Windows.4.0.0-beta-23330.nupkg",
+        "System.Security.Principal.Windows.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Principal.Windows.nuspec"
       ]
     },
-    "System.ServiceModel.Duplex/4.0.1-beta-23324": {
+    "System.ServiceModel.Duplex/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "b+p3u2zee0oAM4AIyM9rev1MaoExxD4d97iNeZFG0Q0bEVFOzK97/5HNcq5FzpTUhxZgfXXCOCmuIYwnYsfU/w==",
+      "sha512": "0k9wL8LeMYj1jfu2wZwTdQhmPBcpMSUgD304cR50CpHOJnrP/NjiQ0Blx3oSURd8Tda5XuXC0PNGWDF+EpW/Lg==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Duplex.dll",
         "lib/net45/_._",
@@ -2806,15 +2807,15 @@
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.Duplex.dll",
         "ref/win8/_._",
-        "System.ServiceModel.Duplex.4.0.1-beta-23324.nupkg",
-        "System.ServiceModel.Duplex.4.0.1-beta-23324.nupkg.sha512",
+        "System.ServiceModel.Duplex.4.0.1-beta-23330.nupkg",
+        "System.ServiceModel.Duplex.4.0.1-beta-23330.nupkg.sha512",
         "System.ServiceModel.Duplex.nuspec"
       ]
     },
-    "System.ServiceModel.Http/4.0.11-beta-23324": {
+    "System.ServiceModel.Http/4.0.11-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "VkTumuCSmXd0NPZZU+nrO7YqznvM+wP96NykXbxFJdNAtCplmqXaQh+YZ/02rjJmfou5qyo2V+ZWVwySBAirOg==",
+      "sha512": "NHKxIIYL0ATDbX18RLCSXtuq26MMoYfAVdpl5K+D0s5AHp7TMPb7LcjZPpg25B2v48x1TwE9LYcYTCiOZcoPzQ==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Http.dll",
         "lib/MonoAndroid10/_._",
@@ -2839,15 +2840,15 @@
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.ServiceModel.Http.4.0.11-beta-23324.nupkg",
-        "System.ServiceModel.Http.4.0.11-beta-23324.nupkg.sha512",
+        "System.ServiceModel.Http.4.0.11-beta-23330.nupkg",
+        "System.ServiceModel.Http.4.0.11-beta-23330.nupkg.sha512",
         "System.ServiceModel.Http.nuspec"
       ]
     },
-    "System.ServiceModel.NetTcp/4.0.1-beta-23324": {
+    "System.ServiceModel.NetTcp/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "xI03xQCdWzqq4H2E29BELQm/e9LJl+IAbD50lcH966Z+JdaYOqeM6RGxAys0sVim59wvCrOv/YaRNxz66YLoog==",
+      "sha512": "Vx0QSKz4BlX/yYqKHET3mofo6RxxaMDLWsEFWDbEBJeCs0Yq19uGiIYwK1mXkWy3Y+jDwi42au3mVhmRbDHavA==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.NetTcp.dll",
         "lib/net45/_._",
@@ -2867,15 +2868,15 @@
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.NetTcp.dll",
         "ref/win8/_._",
-        "System.ServiceModel.NetTcp.4.0.1-beta-23324.nupkg",
-        "System.ServiceModel.NetTcp.4.0.1-beta-23324.nupkg.sha512",
+        "System.ServiceModel.NetTcp.4.0.1-beta-23330.nupkg",
+        "System.ServiceModel.NetTcp.4.0.1-beta-23330.nupkg.sha512",
         "System.ServiceModel.NetTcp.nuspec"
       ]
     },
-    "System.ServiceModel.Primitives/4.0.1-beta-23324": {
+    "System.ServiceModel.Primitives/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "bmU31B4CD5+m9Kt0iDM5Yw2ZXRfv7lpK3Sx1HektcT/HERc+IMPdO38f/Wxtofo5WOA0qmd1fdrMeQcbEkDfJg==",
+      "sha512": "kJ/pcRUf7Ow7s/rX8Kmc9P2k6cvyudIzyUcqr/pn9NwY8DC/2DWkkFvYE2udR4kvBzJJzXl/rsJQlyLIVGMAww==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Primitives.dll",
         "lib/net45/_._",
@@ -2895,8 +2896,8 @@
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.Primitives.dll",
         "ref/win8/_._",
-        "System.ServiceModel.Primitives.4.0.1-beta-23324.nupkg",
-        "System.ServiceModel.Primitives.4.0.1-beta-23324.nupkg.sha512",
+        "System.ServiceModel.Primitives.4.0.1-beta-23330.nupkg",
+        "System.ServiceModel.Primitives.4.0.1-beta-23330.nupkg.sha512",
         "System.ServiceModel.Primitives.nuspec"
       ]
     },
@@ -3091,10 +3092,9 @@
         "System.Threading.Tasks.nuspec"
       ]
     },
-    "System.Threading.ThreadPool/4.0.10-beta-23324": {
+    "System.Threading.ThreadPool/4.0.10-beta-23330": {
       "type": "package",
-      "serviceable": true,
-      "sha512": "G4SjGmiV72HBiv8wkfnKFGTieekrACU1m43VaeJ6vDeSyb08eEFusVH1UWZpOsUF25meCuzpda0ezus24b4rKA==",
+      "sha512": "nM5OewUj8NJrye93apbM6KHvPddgPJGzt1IWIXk9lV5HB4NGsn6M5U0gxMQWShQuDp6NF3ya3ULRSvh3dLMbzg==",
       "files": [
         "lib/DNXCore50/System.Threading.ThreadPool.dll",
         "lib/MonoAndroid10/_._",
@@ -3108,8 +3108,8 @@
         "ref/net46/System.Threading.ThreadPool.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Threading.ThreadPool.4.0.10-beta-23324.nupkg",
-        "System.Threading.ThreadPool.4.0.10-beta-23324.nupkg.sha512",
+        "System.Threading.ThreadPool.4.0.10-beta-23330.nupkg",
+        "System.Threading.ThreadPool.4.0.10-beta-23330.nupkg.sha512",
         "System.Threading.ThreadPool.nuspec"
       ]
     },
@@ -3360,14 +3360,14 @@
         "xunit.extensibility.execution.nuspec"
       ]
     },
-    "xunit.netcore.extensions/1.0.0-prerelease-00095": {
+    "xunit.netcore.extensions/1.0.0-prerelease-00098": {
       "type": "package",
       "serviceable": true,
-      "sha512": "FuvWmkuxHiqD0cHDggg5MRmBoeM4Uea7OUEmKvZiQu7Fy02hJ6yKKNV7mNW3y4scwSzDNA81Qa+HIS33PeWUog==",
+      "sha512": "3kRPwTbC42YGmsNHpNMKfGVOO5cVfxUD+C7cYbti1aml4UCT/RFZ6lhm5Vym2wNRDxryu0Es78aMf1BaybSrDg==",
       "files": [
         "lib/dotnet/Xunit.NetCore.Extensions.dll",
-        "xunit.netcore.extensions.1.0.0-prerelease-00095.nupkg",
-        "xunit.netcore.extensions.1.0.0-prerelease-00095.nupkg.sha512",
+        "xunit.netcore.extensions.1.0.0-prerelease-00098.nupkg",
+        "xunit.netcore.extensions.1.0.0-prerelease-00098.nupkg.sha512",
         "xunit.netcore.extensions.nuspec"
       ]
     }

--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/ChannelLayer/project.lock.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/ChannelLayer/project.lock.json
@@ -292,7 +292,7 @@
           "lib/dotnet/System.Linq.Queryable.dll": {}
         }
       },
-      "System.Net.Http/4.0.1-beta-23324": {
+      "System.Net.Http/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -305,16 +305,15 @@
           "ref/dotnet/System.Net.Http.dll": {}
         }
       },
-      "System.Net.NameResolution/4.0.0-beta-23324": {
+      "System.Net.NameResolution/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.Networking": "4.0.1-beta-23324"
+          "System.Net.Primitives": "4.0.10",
+          "System.Runtime": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Net.NameResolution.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Net.NameResolution.dll": {}
         }
       },
       "System.Net.Primitives/4.0.10": {
@@ -329,10 +328,10 @@
           "lib/DNXCore50/System.Net.Primitives.dll": {}
         }
       },
-      "System.Net.Security/4.0.0-beta-23324": {
+      "System.Net.Security/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.Networking": "4.0.1-beta-23324"
+          "System.Private.Networking": "4.0.1-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.Net.Security.dll": {}
@@ -367,6 +366,49 @@
         },
         "runtime": {
           "lib/dotnet/System.Net.WebHeaderCollection.dll": {}
+        }
+      },
+      "System.Net.WebSockets/4.0.0-beta-23330": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.Win32.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Threading.Tasks": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Net.WebSockets.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Net.WebSockets.dll": {}
+        }
+      },
+      "System.Net.WebSockets.Client/4.0.0-beta-23330": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.Win32.Primitives": "4.0.0",
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Diagnostics.Tracing": "4.0.20",
+          "System.Globalization": "4.0.10",
+          "System.Net.Primitives": "4.0.10",
+          "System.Net.WebHeaderCollection": "4.0.0",
+          "System.Net.WebSockets": "4.0.0-beta-23330",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23330",
+          "System.Text.Encoding": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Net.WebSockets.Client.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Net.WebSockets.Client.dll": {}
         }
       },
       "System.ObjectModel/4.0.10": {
@@ -414,7 +456,7 @@
           "lib/DNXCore50/System.Private.DataContractSerialization.dll": {}
         }
       },
-      "System.Private.Networking/4.0.1-beta-23324": {
+      "System.Private.Networking/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -433,13 +475,13 @@
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23324",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23324",
-          "System.Security.Principal.Windows": "4.0.0-beta-23324",
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23330",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23330",
+          "System.Security.Principal.Windows": "4.0.0-beta-23330",
           "System.Threading": "4.0.10",
           "System.Threading.Overlapped": "4.0.0",
           "System.Threading.Tasks": "4.0.10",
-          "System.Threading.ThreadPool": "4.0.10-beta-23324"
+          "System.Threading.ThreadPool": "4.0.10-beta-23330"
         },
         "compile": {
           "ref/dnxcore50/_._": {}
@@ -448,7 +490,7 @@
           "lib/DNXCore50/System.Private.Networking.dll": {}
         }
       },
-      "System.Private.ServiceModel/4.0.1-beta-23324": {
+      "System.Private.ServiceModel/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -465,12 +507,14 @@
           "System.Linq": "4.0.0",
           "System.Linq.Expressions": "4.0.10",
           "System.Linq.Queryable": "4.0.0",
-          "System.Net.Http": "4.0.1-beta-23324",
-          "System.Net.NameResolution": "4.0.0-beta-23324",
+          "System.Net.Http": "4.0.1-beta-23330",
+          "System.Net.NameResolution": "4.0.0-beta-23330",
           "System.Net.Primitives": "4.0.10",
-          "System.Net.Security": "4.0.0-beta-23324",
-          "System.Net.Sockets": "4.0.10-beta-23324",
+          "System.Net.Security": "4.0.0-beta-23330",
+          "System.Net.Sockets": "4.0.10-beta-23330",
           "System.Net.WebHeaderCollection": "4.0.0",
+          "System.Net.WebSockets": "4.0.0-beta-23330",
+          "System.Net.WebSockets.Client": "4.0.0-beta-23330",
           "System.ObjectModel": "4.0.10",
           "System.Reflection": "4.0.10",
           "System.Reflection.DispatchProxy": "4.0.0",
@@ -484,9 +528,9 @@
           "System.Runtime.Serialization.Primitives": "4.0.10",
           "System.Runtime.Serialization.Xml": "4.0.10",
           "System.Security.Claims": "4.0.0",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23324",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23330",
           "System.Security.Principal": "4.0.0",
-          "System.Security.Principal.Windows": "4.0.0-beta-23324",
+          "System.Security.Principal.Windows": "4.0.0-beta-23330",
           "System.Text.Encoding": "4.0.10",
           "System.Threading": "4.0.10",
           "System.Threading.Tasks": "4.0.10",
@@ -735,18 +779,18 @@
           "lib/dotnet/System.Security.Claims.dll": {}
         }
       },
-      "System.Security.Cryptography.Algorithms/4.0.0-beta-23324": {
+      "System.Security.Cryptography.Algorithms/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
           "System.Runtime": "4.0.0",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23324"
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.Algorithms.dll": {}
         }
       },
-      "System.Security.Cryptography.Encoding/4.0.0-beta-23324": {
+      "System.Security.Cryptography.Encoding/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -755,7 +799,7 @@
           "ref/dotnet/System.Security.Cryptography.Encoding.dll": {}
         }
       },
-      "System.Security.Cryptography.Primitives/4.0.0-beta-23324": {
+      "System.Security.Cryptography.Primitives/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.0",
@@ -773,13 +817,13 @@
           "lib/dotnet/System.Security.Cryptography.Primitives.dll": {}
         }
       },
-      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23324": {
+      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
           "System.Runtime.Handles": "4.0.0",
-          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23324",
-          "System.Security.Cryptography.Encoding": "4.0.0-beta-23324"
+          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23330",
+          "System.Security.Cryptography.Encoding": "4.0.0-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.X509Certificates.dll": {}
@@ -797,7 +841,7 @@
           "lib/dotnet/System.Security.Principal.dll": {}
         }
       },
-      "System.Security.Principal.Windows/4.0.0-beta-23324": {
+      "System.Security.Principal.Windows/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -820,10 +864,10 @@
           "lib/DNXCore50/System.Security.Principal.Windows.dll": {}
         }
       },
-      "System.ServiceModel.Http/4.0.11-beta-23324": {
+      "System.ServiceModel.Http/4.0.11-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.0.1-beta-23324",
+          "System.Private.ServiceModel": "4.0.1-beta-23330",
           "System.Runtime": "4.0.20"
         },
         "compile": {
@@ -833,10 +877,10 @@
           "lib/DNXCore50/System.ServiceModel.Http.dll": {}
         }
       },
-      "System.ServiceModel.NetTcp/4.0.1-beta-23324": {
+      "System.ServiceModel.NetTcp/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.0.1-beta-23324"
+          "System.Private.ServiceModel": "4.0.1-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.ServiceModel.NetTcp.dll": {}
@@ -845,10 +889,10 @@
           "lib/DNXCore50/System.ServiceModel.NetTcp.dll": {}
         }
       },
-      "System.ServiceModel.Primitives/4.0.1-beta-23324": {
+      "System.ServiceModel.Primitives/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.0.1-beta-23324"
+          "System.Private.ServiceModel": "4.0.1-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.ServiceModel.Primitives.dll": {}
@@ -937,7 +981,7 @@
           "lib/DNXCore50/System.Threading.Tasks.dll": {}
         }
       },
-      "System.Threading.ThreadPool/4.0.10-beta-23324": {
+      "System.Threading.ThreadPool/4.0.10-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
@@ -1130,7 +1174,7 @@
           "lib/dotnet/xunit.execution.dotnet.dll": {}
         }
       },
-      "xunit.netcore.extensions/1.0.0-prerelease-00095": {
+      "xunit.netcore.extensions/1.0.0-prerelease-00098": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.10",
@@ -1758,23 +1802,12 @@
         "System.Linq.Queryable.nuspec"
       ]
     },
-    "System.Net.Http/4.0.1-beta-23324": {
+    "System.Net.Http/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "gXfHlWsiMQDuFqwnQrlQTje9vqMhCFLtm35jX4WqZjcfa3y69DbwueeT0gJbVMK88/UnG8FAYiDBb7AKyu+51w==",
+      "sha512": "itLPx7B7Ac4mX8wQx9V9DQcxqTgkmwDNnQIHuCgAH53Jq2X3XziiRRBbxbmNJlWqBlgPzbseWJmMCtcF/ePhOg==",
       "files": [
         "lib/net45/_._",
-        "lib/netcore50/de/System.Net.Http.xml",
-        "lib/netcore50/es/System.Net.Http.xml",
-        "lib/netcore50/fr/System.Net.Http.xml",
-        "lib/netcore50/it/System.Net.Http.xml",
-        "lib/netcore50/ja/System.Net.Http.xml",
-        "lib/netcore50/ko/System.Net.Http.xml",
-        "lib/netcore50/ru/System.Net.Http.xml",
-        "lib/netcore50/System.Net.Http.dll",
-        "lib/netcore50/System.Net.Http.xml",
-        "lib/netcore50/zh-hans/System.Net.Http.xml",
-        "lib/netcore50/zh-hant/System.Net.Http.xml",
         "lib/win8/_._",
         "lib/wpa81/_._",
         "ref/dotnet/System.Net.Http.dll",
@@ -1783,17 +1816,16 @@
         "ref/win8/_._",
         "ref/wpa81/_._",
         "runtime.json",
-        "System.Net.Http.4.0.1-beta-23324.nupkg",
-        "System.Net.Http.4.0.1-beta-23324.nupkg.sha512",
+        "System.Net.Http.4.0.1-beta-23330.nupkg",
+        "System.Net.Http.4.0.1-beta-23330.nupkg.sha512",
         "System.Net.Http.nuspec"
       ]
     },
-    "System.Net.NameResolution/4.0.0-beta-23324": {
+    "System.Net.NameResolution/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "lNYXUmnSXUtLFY09Rc27zJ6/TxCuGggQzBgiuWHoWrjWxymuuxqPT2Mj7Dn7sUUh0GvF2MOx7Uk+rtCFBiIavg==",
+      "sha512": "d8Am+In/aBgcHpEV6xsi5BCiTEN4y6s9O1V/yIvwX8mDC4CtdZiGsi4DtoB0TLOgp8ky6GxbSF4bKCjFpBO3uw==",
       "files": [
-        "lib/DNXCore50/System.Net.NameResolution.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.NameResolution.dll",
@@ -1805,8 +1837,9 @@
         "ref/net46/System.Net.NameResolution.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.NameResolution.4.0.0-beta-23324.nupkg",
-        "System.Net.NameResolution.4.0.0-beta-23324.nupkg.sha512",
+        "runtime.json",
+        "System.Net.NameResolution.4.0.0-beta-23330.nupkg",
+        "System.Net.NameResolution.4.0.0-beta-23330.nupkg.sha512",
         "System.Net.NameResolution.nuspec"
       ]
     },
@@ -1843,9 +1876,9 @@
         "System.Net.Primitives.nuspec"
       ]
     },
-    "System.Net.Security/4.0.0-beta-23324": {
+    "System.Net.Security/4.0.0-beta-23330": {
       "type": "package",
-      "sha512": "D04RYjxrnR3D+uI9CGmAAFKKQ6T+pPcRHYucc1PIo7/hJK5I/Yu7gAw9yOxHUhQjSGfrKo00lHpBCQMTQt4lSw==",
+      "sha512": "z98dKloNy9DBdyfqQwQvKWA2q8Qj4vgGEVONnlS70c13eh0MolBHJ0wNdplZZK5zYZ5Eu8GTwexbUlpHbsfzVA==",
       "files": [
         "lib/DNXCore50/System.Net.Security.dll",
         "lib/MonoAndroid10/_._",
@@ -1859,8 +1892,8 @@
         "ref/net46/System.Net.Security.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.Security.4.0.0-beta-23324.nupkg",
-        "System.Net.Security.4.0.0-beta-23324.nupkg.sha512",
+        "System.Net.Security.4.0.0-beta-23330.nupkg",
+        "System.Net.Security.4.0.0-beta-23330.nupkg.sha512",
         "System.Net.Security.nuspec"
       ]
     },
@@ -1918,6 +1951,81 @@
         "System.Net.WebHeaderCollection.nuspec"
       ]
     },
+    "System.Net.WebSockets/4.0.0-beta-23330": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "6Q9/uTDcaqbmdbD04MisKmjti4aEpp40i/UzpGaPZ4ItuwzU/pMk9RjiYUBUiCQyZeKNlXcSB1FPN2nFof7tww==",
+      "files": [
+        "lib/dotnet/de/System.Net.WebSockets.xml",
+        "lib/dotnet/es/System.Net.WebSockets.xml",
+        "lib/dotnet/fr/System.Net.WebSockets.xml",
+        "lib/dotnet/it/System.Net.WebSockets.xml",
+        "lib/dotnet/ja/System.Net.WebSockets.xml",
+        "lib/dotnet/ko/System.Net.WebSockets.xml",
+        "lib/dotnet/ru/System.Net.WebSockets.xml",
+        "lib/dotnet/System.Net.WebSockets.dll",
+        "lib/dotnet/System.Net.WebSockets.xml",
+        "lib/dotnet/zh-hans/System.Net.WebSockets.xml",
+        "lib/dotnet/zh-hant/System.Net.WebSockets.xml",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Net.WebSockets.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Net.WebSockets.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Net.WebSockets.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Net.WebSockets.4.0.0-beta-23330.nupkg",
+        "System.Net.WebSockets.4.0.0-beta-23330.nupkg.sha512",
+        "System.Net.WebSockets.nuspec"
+      ]
+    },
+    "System.Net.WebSockets.Client/4.0.0-beta-23330": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "1NWEqwDkYRyvr1gSKZlY51AaI9w8oD0dC5UNa2Lb+qaeFHSF5KfCSzf7seD+im+sH6uocVo2nppiaabfbXZT4Q==",
+      "files": [
+        "lib/DNXCore50/de/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/es/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/fr/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/it/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/ja/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/ko/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/ru/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/System.Net.WebSockets.Client.dll",
+        "lib/DNXCore50/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/zh-hans/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/zh-hant/System.Net.WebSockets.Client.xml",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Net.WebSockets.Client.dll",
+        "lib/netcore50/de/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/es/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/fr/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/it/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/ja/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/ko/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/ru/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/System.Net.WebSockets.Client.dll",
+        "lib/netcore50/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/zh-hans/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/zh-hant/System.Net.WebSockets.Client.xml",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Net.WebSockets.Client.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Net.WebSockets.Client.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Net.WebSockets.Client.4.0.0-beta-23330.nupkg",
+        "System.Net.WebSockets.Client.4.0.0-beta-23330.nupkg.sha512",
+        "System.Net.WebSockets.Client.nuspec"
+      ]
+    },
     "System.ObjectModel/4.0.10": {
       "type": "package",
       "serviceable": true,
@@ -1966,31 +2074,31 @@
         "System.Private.DataContractSerialization.nuspec"
       ]
     },
-    "System.Private.Networking/4.0.1-beta-23324": {
+    "System.Private.Networking/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "OfyxoeCdh1ypzdz1u0h1Clgt+6749vALs2ZPkLwsOPzL0INCG9ISYo+Jhh62ZD8TMkWwLrvyVppMBPHY6M7Upw==",
+      "sha512": "8NZi1gCQaGTKDb2yWplm52HWCLaZnUwVitksJgcXY2dEJau/TBGyZup+yhOngOIe8QzQMxNG4iokY3Ce0/8mbg==",
       "files": [
         "lib/DNXCore50/System.Private.Networking.dll",
         "lib/netcore50/System.Private.Networking.dll",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "System.Private.Networking.4.0.1-beta-23324.nupkg",
-        "System.Private.Networking.4.0.1-beta-23324.nupkg.sha512",
+        "System.Private.Networking.4.0.1-beta-23330.nupkg",
+        "System.Private.Networking.4.0.1-beta-23330.nupkg.sha512",
         "System.Private.Networking.nuspec"
       ]
     },
-    "System.Private.ServiceModel/4.0.1-beta-23324": {
+    "System.Private.ServiceModel/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "Lz3T9V8GnaOFlf8LUmuPznuOIuy92BAFVc9huiMrFKByzPpydGuCvXEe+81rZ1IF2TQcHKO++9otnj96AEJ5BA==",
+      "sha512": "8lENvmHuZdlvmnYN1w98Mv8bDjc0O/YlaNHRRph35T/fLDyaG8LMLMwG3/ut6a/AenLJmbf92snOtNXCuqM+cQ==",
       "files": [
         "lib/DNXCore50/System.Private.ServiceModel.dll",
         "lib/netcore50/System.Private.ServiceModel.dll",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "System.Private.ServiceModel.4.0.1-beta-23324.nupkg",
-        "System.Private.ServiceModel.4.0.1-beta-23324.nupkg.sha512",
+        "System.Private.ServiceModel.4.0.1-beta-23330.nupkg",
+        "System.Private.ServiceModel.4.0.1-beta-23330.nupkg.sha512",
         "System.Private.ServiceModel.nuspec"
       ]
     },
@@ -2519,10 +2627,10 @@
         "System.Security.Claims.nuspec"
       ]
     },
-    "System.Security.Cryptography.Algorithms/4.0.0-beta-23324": {
+    "System.Security.Cryptography.Algorithms/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "Mt6LwMj8hPp0+xZHcV6grZ7wSWhgycGkdZ6DQ9XvUY9NguUsvb/+fu2cMdrC7XsnpvwIROByp+p2dSjqBn3E2Q==",
+      "sha512": "FB4RoTDaV5tBiPSJsiG3A5DydeKz7ErglnkqVjBFjm6wu8kg91j0MxL/Al9iUyu9i/hq53fRs5KE3rjUNYvf5w==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2536,15 +2644,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.Algorithms.4.0.0-beta-23324.nupkg",
-        "System.Security.Cryptography.Algorithms.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Cryptography.Algorithms.4.0.0-beta-23330.nupkg",
+        "System.Security.Cryptography.Algorithms.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Cryptography.Algorithms.nuspec"
       ]
     },
-    "System.Security.Cryptography.Encoding/4.0.0-beta-23324": {
+    "System.Security.Cryptography.Encoding/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "JHOyknf1eYO6C39Vao6kAGpadq3PBO1L4tuzNEz/HvbH5sfIHPbjhxL11OyAhVKCzLCfEj6+aeClovFqZIRPyw==",
+      "sha512": "zeFdKQT6xjNdiNCaEmEYJMEK59kixkX7jJSoOLw3H+53t9X0F98vr3tS8YlrW/Lk/K9c6L5pYLlkb2dNqvUD/g==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2558,15 +2666,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.Encoding.4.0.0-beta-23324.nupkg",
-        "System.Security.Cryptography.Encoding.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Cryptography.Encoding.4.0.0-beta-23330.nupkg",
+        "System.Security.Cryptography.Encoding.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Cryptography.Encoding.nuspec"
       ]
     },
-    "System.Security.Cryptography.Primitives/4.0.0-beta-23324": {
+    "System.Security.Cryptography.Primitives/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "ETZxelIX51Di4FTytd8ohSpN6Ym/32aWIX9E2NCFkd91qdexn2Dkysn80b6n4gX6jG+oL0UHQDtD/fYq8C65oQ==",
+      "sha512": "15uVbOD3X0sRQJIxcEH5hasxlFdbA1CmPPZa0Y8pYEuQcWMF2gBswvU8s4qoKtA7x2xhNhzPsXIhsQuKNMTdEA==",
       "files": [
         "lib/dotnet/System.Security.Cryptography.Primitives.dll",
         "lib/MonoAndroid10/_._",
@@ -2580,15 +2688,15 @@
         "ref/net46/System.Security.Cryptography.Primitives.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Security.Cryptography.Primitives.4.0.0-beta-23324.nupkg",
-        "System.Security.Cryptography.Primitives.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Cryptography.Primitives.4.0.0-beta-23330.nupkg",
+        "System.Security.Cryptography.Primitives.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Cryptography.Primitives.nuspec"
       ]
     },
-    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23324": {
+    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "8NaEOxkkNBUECh0cPzGpbXS0uzGDpnvxI0kqQKRGp9uA+9qCyQfxcqAT6ozAYtOuFNVaC1XU3zQnb7T2nfvIDg==",
+      "sha512": "L8mUimdm7+GsORgJ8DFBMGsFnwDJ5YCUdJj3HfXQx4HCoPDPF+vJo3HRiHfcvNA2Zsf0ov2kuerYj/eeVa2/Rw==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2602,8 +2710,8 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23324.nupkg",
-        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23330.nupkg",
+        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Cryptography.X509Certificates.nuspec"
       ]
     },
@@ -2640,10 +2748,10 @@
         "System.Security.Principal.nuspec"
       ]
     },
-    "System.Security.Principal.Windows/4.0.0-beta-23324": {
+    "System.Security.Principal.Windows/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "csbCKdwBz31T8He7U6XMIc9BiWgwjHs5WDZR4rfhsk48TpdsbKNHX9OX4b+GwvgcsfVuWxre7zqNR0Bc9gWZ7g==",
+      "sha512": "q+3L3aB8bn0HCW52kX9TSJdhbjffBw7QWCOu0yX1SDhPN9MCPmJ4aBBCn1HRWroa5y7UcNUdjL1xwiERycZexw==",
       "files": [
         "lib/DNXCore50/de/System.Security.Principal.Windows.xml",
         "lib/DNXCore50/es/System.Security.Principal.Windows.xml",
@@ -2659,15 +2767,15 @@
         "lib/net46/System.Security.Principal.Windows.dll",
         "ref/dotnet/System.Security.Principal.Windows.dll",
         "ref/net46/System.Security.Principal.Windows.dll",
-        "System.Security.Principal.Windows.4.0.0-beta-23324.nupkg",
-        "System.Security.Principal.Windows.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Principal.Windows.4.0.0-beta-23330.nupkg",
+        "System.Security.Principal.Windows.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Principal.Windows.nuspec"
       ]
     },
-    "System.ServiceModel.Http/4.0.11-beta-23324": {
+    "System.ServiceModel.Http/4.0.11-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "VkTumuCSmXd0NPZZU+nrO7YqznvM+wP96NykXbxFJdNAtCplmqXaQh+YZ/02rjJmfou5qyo2V+ZWVwySBAirOg==",
+      "sha512": "NHKxIIYL0ATDbX18RLCSXtuq26MMoYfAVdpl5K+D0s5AHp7TMPb7LcjZPpg25B2v48x1TwE9LYcYTCiOZcoPzQ==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Http.dll",
         "lib/MonoAndroid10/_._",
@@ -2692,15 +2800,15 @@
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.ServiceModel.Http.4.0.11-beta-23324.nupkg",
-        "System.ServiceModel.Http.4.0.11-beta-23324.nupkg.sha512",
+        "System.ServiceModel.Http.4.0.11-beta-23330.nupkg",
+        "System.ServiceModel.Http.4.0.11-beta-23330.nupkg.sha512",
         "System.ServiceModel.Http.nuspec"
       ]
     },
-    "System.ServiceModel.NetTcp/4.0.1-beta-23324": {
+    "System.ServiceModel.NetTcp/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "xI03xQCdWzqq4H2E29BELQm/e9LJl+IAbD50lcH966Z+JdaYOqeM6RGxAys0sVim59wvCrOv/YaRNxz66YLoog==",
+      "sha512": "Vx0QSKz4BlX/yYqKHET3mofo6RxxaMDLWsEFWDbEBJeCs0Yq19uGiIYwK1mXkWy3Y+jDwi42au3mVhmRbDHavA==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.NetTcp.dll",
         "lib/net45/_._",
@@ -2720,15 +2828,15 @@
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.NetTcp.dll",
         "ref/win8/_._",
-        "System.ServiceModel.NetTcp.4.0.1-beta-23324.nupkg",
-        "System.ServiceModel.NetTcp.4.0.1-beta-23324.nupkg.sha512",
+        "System.ServiceModel.NetTcp.4.0.1-beta-23330.nupkg",
+        "System.ServiceModel.NetTcp.4.0.1-beta-23330.nupkg.sha512",
         "System.ServiceModel.NetTcp.nuspec"
       ]
     },
-    "System.ServiceModel.Primitives/4.0.1-beta-23324": {
+    "System.ServiceModel.Primitives/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "bmU31B4CD5+m9Kt0iDM5Yw2ZXRfv7lpK3Sx1HektcT/HERc+IMPdO38f/Wxtofo5WOA0qmd1fdrMeQcbEkDfJg==",
+      "sha512": "kJ/pcRUf7Ow7s/rX8Kmc9P2k6cvyudIzyUcqr/pn9NwY8DC/2DWkkFvYE2udR4kvBzJJzXl/rsJQlyLIVGMAww==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Primitives.dll",
         "lib/net45/_._",
@@ -2748,8 +2856,8 @@
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.Primitives.dll",
         "ref/win8/_._",
-        "System.ServiceModel.Primitives.4.0.1-beta-23324.nupkg",
-        "System.ServiceModel.Primitives.4.0.1-beta-23324.nupkg.sha512",
+        "System.ServiceModel.Primitives.4.0.1-beta-23330.nupkg",
+        "System.ServiceModel.Primitives.4.0.1-beta-23330.nupkg.sha512",
         "System.ServiceModel.Primitives.nuspec"
       ]
     },
@@ -2944,10 +3052,9 @@
         "System.Threading.Tasks.nuspec"
       ]
     },
-    "System.Threading.ThreadPool/4.0.10-beta-23324": {
+    "System.Threading.ThreadPool/4.0.10-beta-23330": {
       "type": "package",
-      "serviceable": true,
-      "sha512": "G4SjGmiV72HBiv8wkfnKFGTieekrACU1m43VaeJ6vDeSyb08eEFusVH1UWZpOsUF25meCuzpda0ezus24b4rKA==",
+      "sha512": "nM5OewUj8NJrye93apbM6KHvPddgPJGzt1IWIXk9lV5HB4NGsn6M5U0gxMQWShQuDp6NF3ya3ULRSvh3dLMbzg==",
       "files": [
         "lib/DNXCore50/System.Threading.ThreadPool.dll",
         "lib/MonoAndroid10/_._",
@@ -2961,8 +3068,8 @@
         "ref/net46/System.Threading.ThreadPool.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Threading.ThreadPool.4.0.10-beta-23324.nupkg",
-        "System.Threading.ThreadPool.4.0.10-beta-23324.nupkg.sha512",
+        "System.Threading.ThreadPool.4.0.10-beta-23330.nupkg",
+        "System.Threading.ThreadPool.4.0.10-beta-23330.nupkg.sha512",
         "System.Threading.ThreadPool.nuspec"
       ]
     },
@@ -3213,14 +3320,14 @@
         "xunit.extensibility.execution.nuspec"
       ]
     },
-    "xunit.netcore.extensions/1.0.0-prerelease-00095": {
+    "xunit.netcore.extensions/1.0.0-prerelease-00098": {
       "type": "package",
       "serviceable": true,
-      "sha512": "FuvWmkuxHiqD0cHDggg5MRmBoeM4Uea7OUEmKvZiQu7Fy02hJ6yKKNV7mNW3y4scwSzDNA81Qa+HIS33PeWUog==",
+      "sha512": "3kRPwTbC42YGmsNHpNMKfGVOO5cVfxUD+C7cYbti1aml4UCT/RFZ6lhm5Vym2wNRDxryu0Es78aMf1BaybSrDg==",
       "files": [
         "lib/dotnet/Xunit.NetCore.Extensions.dll",
-        "xunit.netcore.extensions.1.0.0-prerelease-00095.nupkg",
-        "xunit.netcore.extensions.1.0.0-prerelease-00095.nupkg.sha512",
+        "xunit.netcore.extensions.1.0.0-prerelease-00098.nupkg",
+        "xunit.netcore.extensions.1.0.0-prerelease-00098.nupkg.sha512",
         "xunit.netcore.extensions.nuspec"
       ]
     }

--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/ClientBase/project.lock.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/ClientBase/project.lock.json
@@ -292,7 +292,7 @@
           "lib/dotnet/System.Linq.Queryable.dll": {}
         }
       },
-      "System.Net.Http/4.0.1-beta-23324": {
+      "System.Net.Http/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -305,16 +305,15 @@
           "ref/dotnet/System.Net.Http.dll": {}
         }
       },
-      "System.Net.NameResolution/4.0.0-beta-23324": {
+      "System.Net.NameResolution/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.Networking": "4.0.1-beta-23324"
+          "System.Net.Primitives": "4.0.10",
+          "System.Runtime": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Net.NameResolution.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Net.NameResolution.dll": {}
         }
       },
       "System.Net.Primitives/4.0.10": {
@@ -329,10 +328,10 @@
           "lib/DNXCore50/System.Net.Primitives.dll": {}
         }
       },
-      "System.Net.Security/4.0.0-beta-23324": {
+      "System.Net.Security/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.Networking": "4.0.1-beta-23324"
+          "System.Private.Networking": "4.0.1-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.Net.Security.dll": {}
@@ -367,6 +366,49 @@
         },
         "runtime": {
           "lib/dotnet/System.Net.WebHeaderCollection.dll": {}
+        }
+      },
+      "System.Net.WebSockets/4.0.0-beta-23330": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.Win32.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Threading.Tasks": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Net.WebSockets.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Net.WebSockets.dll": {}
+        }
+      },
+      "System.Net.WebSockets.Client/4.0.0-beta-23330": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.Win32.Primitives": "4.0.0",
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Diagnostics.Tracing": "4.0.20",
+          "System.Globalization": "4.0.10",
+          "System.Net.Primitives": "4.0.10",
+          "System.Net.WebHeaderCollection": "4.0.0",
+          "System.Net.WebSockets": "4.0.0-beta-23330",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23330",
+          "System.Text.Encoding": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Net.WebSockets.Client.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Net.WebSockets.Client.dll": {}
         }
       },
       "System.ObjectModel/4.0.10": {
@@ -414,7 +456,7 @@
           "lib/DNXCore50/System.Private.DataContractSerialization.dll": {}
         }
       },
-      "System.Private.Networking/4.0.1-beta-23324": {
+      "System.Private.Networking/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -433,13 +475,13 @@
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23324",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23324",
-          "System.Security.Principal.Windows": "4.0.0-beta-23324",
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23330",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23330",
+          "System.Security.Principal.Windows": "4.0.0-beta-23330",
           "System.Threading": "4.0.10",
           "System.Threading.Overlapped": "4.0.0",
           "System.Threading.Tasks": "4.0.10",
-          "System.Threading.ThreadPool": "4.0.10-beta-23324"
+          "System.Threading.ThreadPool": "4.0.10-beta-23330"
         },
         "compile": {
           "ref/dnxcore50/_._": {}
@@ -448,7 +490,7 @@
           "lib/DNXCore50/System.Private.Networking.dll": {}
         }
       },
-      "System.Private.ServiceModel/4.0.1-beta-23324": {
+      "System.Private.ServiceModel/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -465,12 +507,14 @@
           "System.Linq": "4.0.0",
           "System.Linq.Expressions": "4.0.10",
           "System.Linq.Queryable": "4.0.0",
-          "System.Net.Http": "4.0.1-beta-23324",
-          "System.Net.NameResolution": "4.0.0-beta-23324",
+          "System.Net.Http": "4.0.1-beta-23330",
+          "System.Net.NameResolution": "4.0.0-beta-23330",
           "System.Net.Primitives": "4.0.10",
-          "System.Net.Security": "4.0.0-beta-23324",
-          "System.Net.Sockets": "4.0.10-beta-23324",
+          "System.Net.Security": "4.0.0-beta-23330",
+          "System.Net.Sockets": "4.0.10-beta-23330",
           "System.Net.WebHeaderCollection": "4.0.0",
+          "System.Net.WebSockets": "4.0.0-beta-23330",
+          "System.Net.WebSockets.Client": "4.0.0-beta-23330",
           "System.ObjectModel": "4.0.10",
           "System.Reflection": "4.0.10",
           "System.Reflection.DispatchProxy": "4.0.0",
@@ -484,9 +528,9 @@
           "System.Runtime.Serialization.Primitives": "4.0.10",
           "System.Runtime.Serialization.Xml": "4.0.10",
           "System.Security.Claims": "4.0.0",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23324",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23330",
           "System.Security.Principal": "4.0.0",
-          "System.Security.Principal.Windows": "4.0.0-beta-23324",
+          "System.Security.Principal.Windows": "4.0.0-beta-23330",
           "System.Text.Encoding": "4.0.10",
           "System.Threading": "4.0.10",
           "System.Threading.Tasks": "4.0.10",
@@ -750,18 +794,18 @@
           "lib/dotnet/System.Security.Claims.dll": {}
         }
       },
-      "System.Security.Cryptography.Algorithms/4.0.0-beta-23324": {
+      "System.Security.Cryptography.Algorithms/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
           "System.Runtime": "4.0.0",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23324"
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.Algorithms.dll": {}
         }
       },
-      "System.Security.Cryptography.Encoding/4.0.0-beta-23324": {
+      "System.Security.Cryptography.Encoding/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -770,7 +814,7 @@
           "ref/dotnet/System.Security.Cryptography.Encoding.dll": {}
         }
       },
-      "System.Security.Cryptography.Primitives/4.0.0-beta-23324": {
+      "System.Security.Cryptography.Primitives/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.0",
@@ -788,13 +832,13 @@
           "lib/dotnet/System.Security.Cryptography.Primitives.dll": {}
         }
       },
-      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23324": {
+      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
           "System.Runtime.Handles": "4.0.0",
-          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23324",
-          "System.Security.Cryptography.Encoding": "4.0.0-beta-23324"
+          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23330",
+          "System.Security.Cryptography.Encoding": "4.0.0-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.X509Certificates.dll": {}
@@ -812,7 +856,7 @@
           "lib/dotnet/System.Security.Principal.dll": {}
         }
       },
-      "System.Security.Principal.Windows/4.0.0-beta-23324": {
+      "System.Security.Principal.Windows/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -835,10 +879,10 @@
           "lib/DNXCore50/System.Security.Principal.Windows.dll": {}
         }
       },
-      "System.ServiceModel.Duplex/4.0.1-beta-23324": {
+      "System.ServiceModel.Duplex/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.0.1-beta-23324"
+          "System.Private.ServiceModel": "4.0.1-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.ServiceModel.Duplex.dll": {}
@@ -847,10 +891,10 @@
           "lib/DNXCore50/System.ServiceModel.Duplex.dll": {}
         }
       },
-      "System.ServiceModel.Http/4.0.11-beta-23324": {
+      "System.ServiceModel.Http/4.0.11-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.0.1-beta-23324",
+          "System.Private.ServiceModel": "4.0.1-beta-23330",
           "System.Runtime": "4.0.20"
         },
         "compile": {
@@ -860,10 +904,10 @@
           "lib/DNXCore50/System.ServiceModel.Http.dll": {}
         }
       },
-      "System.ServiceModel.NetTcp/4.0.1-beta-23324": {
+      "System.ServiceModel.NetTcp/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.0.1-beta-23324"
+          "System.Private.ServiceModel": "4.0.1-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.ServiceModel.NetTcp.dll": {}
@@ -872,10 +916,10 @@
           "lib/DNXCore50/System.ServiceModel.NetTcp.dll": {}
         }
       },
-      "System.ServiceModel.Primitives/4.0.1-beta-23324": {
+      "System.ServiceModel.Primitives/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.0.1-beta-23324"
+          "System.Private.ServiceModel": "4.0.1-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.ServiceModel.Primitives.dll": {}
@@ -964,7 +1008,7 @@
           "lib/DNXCore50/System.Threading.Tasks.dll": {}
         }
       },
-      "System.Threading.ThreadPool/4.0.10-beta-23324": {
+      "System.Threading.ThreadPool/4.0.10-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
@@ -1157,7 +1201,7 @@
           "lib/dotnet/xunit.execution.dotnet.dll": {}
         }
       },
-      "xunit.netcore.extensions/1.0.0-prerelease-00095": {
+      "xunit.netcore.extensions/1.0.0-prerelease-00098": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.10",
@@ -1785,23 +1829,12 @@
         "System.Linq.Queryable.nuspec"
       ]
     },
-    "System.Net.Http/4.0.1-beta-23324": {
+    "System.Net.Http/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "gXfHlWsiMQDuFqwnQrlQTje9vqMhCFLtm35jX4WqZjcfa3y69DbwueeT0gJbVMK88/UnG8FAYiDBb7AKyu+51w==",
+      "sha512": "itLPx7B7Ac4mX8wQx9V9DQcxqTgkmwDNnQIHuCgAH53Jq2X3XziiRRBbxbmNJlWqBlgPzbseWJmMCtcF/ePhOg==",
       "files": [
         "lib/net45/_._",
-        "lib/netcore50/de/System.Net.Http.xml",
-        "lib/netcore50/es/System.Net.Http.xml",
-        "lib/netcore50/fr/System.Net.Http.xml",
-        "lib/netcore50/it/System.Net.Http.xml",
-        "lib/netcore50/ja/System.Net.Http.xml",
-        "lib/netcore50/ko/System.Net.Http.xml",
-        "lib/netcore50/ru/System.Net.Http.xml",
-        "lib/netcore50/System.Net.Http.dll",
-        "lib/netcore50/System.Net.Http.xml",
-        "lib/netcore50/zh-hans/System.Net.Http.xml",
-        "lib/netcore50/zh-hant/System.Net.Http.xml",
         "lib/win8/_._",
         "lib/wpa81/_._",
         "ref/dotnet/System.Net.Http.dll",
@@ -1810,17 +1843,16 @@
         "ref/win8/_._",
         "ref/wpa81/_._",
         "runtime.json",
-        "System.Net.Http.4.0.1-beta-23324.nupkg",
-        "System.Net.Http.4.0.1-beta-23324.nupkg.sha512",
+        "System.Net.Http.4.0.1-beta-23330.nupkg",
+        "System.Net.Http.4.0.1-beta-23330.nupkg.sha512",
         "System.Net.Http.nuspec"
       ]
     },
-    "System.Net.NameResolution/4.0.0-beta-23324": {
+    "System.Net.NameResolution/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "lNYXUmnSXUtLFY09Rc27zJ6/TxCuGggQzBgiuWHoWrjWxymuuxqPT2Mj7Dn7sUUh0GvF2MOx7Uk+rtCFBiIavg==",
+      "sha512": "d8Am+In/aBgcHpEV6xsi5BCiTEN4y6s9O1V/yIvwX8mDC4CtdZiGsi4DtoB0TLOgp8ky6GxbSF4bKCjFpBO3uw==",
       "files": [
-        "lib/DNXCore50/System.Net.NameResolution.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.NameResolution.dll",
@@ -1832,8 +1864,9 @@
         "ref/net46/System.Net.NameResolution.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.NameResolution.4.0.0-beta-23324.nupkg",
-        "System.Net.NameResolution.4.0.0-beta-23324.nupkg.sha512",
+        "runtime.json",
+        "System.Net.NameResolution.4.0.0-beta-23330.nupkg",
+        "System.Net.NameResolution.4.0.0-beta-23330.nupkg.sha512",
         "System.Net.NameResolution.nuspec"
       ]
     },
@@ -1870,9 +1903,9 @@
         "System.Net.Primitives.nuspec"
       ]
     },
-    "System.Net.Security/4.0.0-beta-23324": {
+    "System.Net.Security/4.0.0-beta-23330": {
       "type": "package",
-      "sha512": "D04RYjxrnR3D+uI9CGmAAFKKQ6T+pPcRHYucc1PIo7/hJK5I/Yu7gAw9yOxHUhQjSGfrKo00lHpBCQMTQt4lSw==",
+      "sha512": "z98dKloNy9DBdyfqQwQvKWA2q8Qj4vgGEVONnlS70c13eh0MolBHJ0wNdplZZK5zYZ5Eu8GTwexbUlpHbsfzVA==",
       "files": [
         "lib/DNXCore50/System.Net.Security.dll",
         "lib/MonoAndroid10/_._",
@@ -1886,8 +1919,8 @@
         "ref/net46/System.Net.Security.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.Security.4.0.0-beta-23324.nupkg",
-        "System.Net.Security.4.0.0-beta-23324.nupkg.sha512",
+        "System.Net.Security.4.0.0-beta-23330.nupkg",
+        "System.Net.Security.4.0.0-beta-23330.nupkg.sha512",
         "System.Net.Security.nuspec"
       ]
     },
@@ -1945,6 +1978,81 @@
         "System.Net.WebHeaderCollection.nuspec"
       ]
     },
+    "System.Net.WebSockets/4.0.0-beta-23330": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "6Q9/uTDcaqbmdbD04MisKmjti4aEpp40i/UzpGaPZ4ItuwzU/pMk9RjiYUBUiCQyZeKNlXcSB1FPN2nFof7tww==",
+      "files": [
+        "lib/dotnet/de/System.Net.WebSockets.xml",
+        "lib/dotnet/es/System.Net.WebSockets.xml",
+        "lib/dotnet/fr/System.Net.WebSockets.xml",
+        "lib/dotnet/it/System.Net.WebSockets.xml",
+        "lib/dotnet/ja/System.Net.WebSockets.xml",
+        "lib/dotnet/ko/System.Net.WebSockets.xml",
+        "lib/dotnet/ru/System.Net.WebSockets.xml",
+        "lib/dotnet/System.Net.WebSockets.dll",
+        "lib/dotnet/System.Net.WebSockets.xml",
+        "lib/dotnet/zh-hans/System.Net.WebSockets.xml",
+        "lib/dotnet/zh-hant/System.Net.WebSockets.xml",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Net.WebSockets.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Net.WebSockets.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Net.WebSockets.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Net.WebSockets.4.0.0-beta-23330.nupkg",
+        "System.Net.WebSockets.4.0.0-beta-23330.nupkg.sha512",
+        "System.Net.WebSockets.nuspec"
+      ]
+    },
+    "System.Net.WebSockets.Client/4.0.0-beta-23330": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "1NWEqwDkYRyvr1gSKZlY51AaI9w8oD0dC5UNa2Lb+qaeFHSF5KfCSzf7seD+im+sH6uocVo2nppiaabfbXZT4Q==",
+      "files": [
+        "lib/DNXCore50/de/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/es/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/fr/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/it/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/ja/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/ko/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/ru/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/System.Net.WebSockets.Client.dll",
+        "lib/DNXCore50/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/zh-hans/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/zh-hant/System.Net.WebSockets.Client.xml",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Net.WebSockets.Client.dll",
+        "lib/netcore50/de/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/es/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/fr/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/it/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/ja/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/ko/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/ru/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/System.Net.WebSockets.Client.dll",
+        "lib/netcore50/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/zh-hans/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/zh-hant/System.Net.WebSockets.Client.xml",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Net.WebSockets.Client.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Net.WebSockets.Client.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Net.WebSockets.Client.4.0.0-beta-23330.nupkg",
+        "System.Net.WebSockets.Client.4.0.0-beta-23330.nupkg.sha512",
+        "System.Net.WebSockets.Client.nuspec"
+      ]
+    },
     "System.ObjectModel/4.0.10": {
       "type": "package",
       "serviceable": true,
@@ -1993,31 +2101,31 @@
         "System.Private.DataContractSerialization.nuspec"
       ]
     },
-    "System.Private.Networking/4.0.1-beta-23324": {
+    "System.Private.Networking/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "OfyxoeCdh1ypzdz1u0h1Clgt+6749vALs2ZPkLwsOPzL0INCG9ISYo+Jhh62ZD8TMkWwLrvyVppMBPHY6M7Upw==",
+      "sha512": "8NZi1gCQaGTKDb2yWplm52HWCLaZnUwVitksJgcXY2dEJau/TBGyZup+yhOngOIe8QzQMxNG4iokY3Ce0/8mbg==",
       "files": [
         "lib/DNXCore50/System.Private.Networking.dll",
         "lib/netcore50/System.Private.Networking.dll",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "System.Private.Networking.4.0.1-beta-23324.nupkg",
-        "System.Private.Networking.4.0.1-beta-23324.nupkg.sha512",
+        "System.Private.Networking.4.0.1-beta-23330.nupkg",
+        "System.Private.Networking.4.0.1-beta-23330.nupkg.sha512",
         "System.Private.Networking.nuspec"
       ]
     },
-    "System.Private.ServiceModel/4.0.1-beta-23324": {
+    "System.Private.ServiceModel/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "Lz3T9V8GnaOFlf8LUmuPznuOIuy92BAFVc9huiMrFKByzPpydGuCvXEe+81rZ1IF2TQcHKO++9otnj96AEJ5BA==",
+      "sha512": "8lENvmHuZdlvmnYN1w98Mv8bDjc0O/YlaNHRRph35T/fLDyaG8LMLMwG3/ut6a/AenLJmbf92snOtNXCuqM+cQ==",
       "files": [
         "lib/DNXCore50/System.Private.ServiceModel.dll",
         "lib/netcore50/System.Private.ServiceModel.dll",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "System.Private.ServiceModel.4.0.1-beta-23324.nupkg",
-        "System.Private.ServiceModel.4.0.1-beta-23324.nupkg.sha512",
+        "System.Private.ServiceModel.4.0.1-beta-23330.nupkg",
+        "System.Private.ServiceModel.4.0.1-beta-23330.nupkg.sha512",
         "System.Private.ServiceModel.nuspec"
       ]
     },
@@ -2572,10 +2680,10 @@
         "System.Security.Claims.nuspec"
       ]
     },
-    "System.Security.Cryptography.Algorithms/4.0.0-beta-23324": {
+    "System.Security.Cryptography.Algorithms/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "Mt6LwMj8hPp0+xZHcV6grZ7wSWhgycGkdZ6DQ9XvUY9NguUsvb/+fu2cMdrC7XsnpvwIROByp+p2dSjqBn3E2Q==",
+      "sha512": "FB4RoTDaV5tBiPSJsiG3A5DydeKz7ErglnkqVjBFjm6wu8kg91j0MxL/Al9iUyu9i/hq53fRs5KE3rjUNYvf5w==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2589,15 +2697,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.Algorithms.4.0.0-beta-23324.nupkg",
-        "System.Security.Cryptography.Algorithms.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Cryptography.Algorithms.4.0.0-beta-23330.nupkg",
+        "System.Security.Cryptography.Algorithms.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Cryptography.Algorithms.nuspec"
       ]
     },
-    "System.Security.Cryptography.Encoding/4.0.0-beta-23324": {
+    "System.Security.Cryptography.Encoding/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "JHOyknf1eYO6C39Vao6kAGpadq3PBO1L4tuzNEz/HvbH5sfIHPbjhxL11OyAhVKCzLCfEj6+aeClovFqZIRPyw==",
+      "sha512": "zeFdKQT6xjNdiNCaEmEYJMEK59kixkX7jJSoOLw3H+53t9X0F98vr3tS8YlrW/Lk/K9c6L5pYLlkb2dNqvUD/g==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2611,15 +2719,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.Encoding.4.0.0-beta-23324.nupkg",
-        "System.Security.Cryptography.Encoding.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Cryptography.Encoding.4.0.0-beta-23330.nupkg",
+        "System.Security.Cryptography.Encoding.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Cryptography.Encoding.nuspec"
       ]
     },
-    "System.Security.Cryptography.Primitives/4.0.0-beta-23324": {
+    "System.Security.Cryptography.Primitives/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "ETZxelIX51Di4FTytd8ohSpN6Ym/32aWIX9E2NCFkd91qdexn2Dkysn80b6n4gX6jG+oL0UHQDtD/fYq8C65oQ==",
+      "sha512": "15uVbOD3X0sRQJIxcEH5hasxlFdbA1CmPPZa0Y8pYEuQcWMF2gBswvU8s4qoKtA7x2xhNhzPsXIhsQuKNMTdEA==",
       "files": [
         "lib/dotnet/System.Security.Cryptography.Primitives.dll",
         "lib/MonoAndroid10/_._",
@@ -2633,15 +2741,15 @@
         "ref/net46/System.Security.Cryptography.Primitives.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Security.Cryptography.Primitives.4.0.0-beta-23324.nupkg",
-        "System.Security.Cryptography.Primitives.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Cryptography.Primitives.4.0.0-beta-23330.nupkg",
+        "System.Security.Cryptography.Primitives.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Cryptography.Primitives.nuspec"
       ]
     },
-    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23324": {
+    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "8NaEOxkkNBUECh0cPzGpbXS0uzGDpnvxI0kqQKRGp9uA+9qCyQfxcqAT6ozAYtOuFNVaC1XU3zQnb7T2nfvIDg==",
+      "sha512": "L8mUimdm7+GsORgJ8DFBMGsFnwDJ5YCUdJj3HfXQx4HCoPDPF+vJo3HRiHfcvNA2Zsf0ov2kuerYj/eeVa2/Rw==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2655,8 +2763,8 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23324.nupkg",
-        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23330.nupkg",
+        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Cryptography.X509Certificates.nuspec"
       ]
     },
@@ -2693,10 +2801,10 @@
         "System.Security.Principal.nuspec"
       ]
     },
-    "System.Security.Principal.Windows/4.0.0-beta-23324": {
+    "System.Security.Principal.Windows/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "csbCKdwBz31T8He7U6XMIc9BiWgwjHs5WDZR4rfhsk48TpdsbKNHX9OX4b+GwvgcsfVuWxre7zqNR0Bc9gWZ7g==",
+      "sha512": "q+3L3aB8bn0HCW52kX9TSJdhbjffBw7QWCOu0yX1SDhPN9MCPmJ4aBBCn1HRWroa5y7UcNUdjL1xwiERycZexw==",
       "files": [
         "lib/DNXCore50/de/System.Security.Principal.Windows.xml",
         "lib/DNXCore50/es/System.Security.Principal.Windows.xml",
@@ -2712,15 +2820,15 @@
         "lib/net46/System.Security.Principal.Windows.dll",
         "ref/dotnet/System.Security.Principal.Windows.dll",
         "ref/net46/System.Security.Principal.Windows.dll",
-        "System.Security.Principal.Windows.4.0.0-beta-23324.nupkg",
-        "System.Security.Principal.Windows.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Principal.Windows.4.0.0-beta-23330.nupkg",
+        "System.Security.Principal.Windows.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Principal.Windows.nuspec"
       ]
     },
-    "System.ServiceModel.Duplex/4.0.1-beta-23324": {
+    "System.ServiceModel.Duplex/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "b+p3u2zee0oAM4AIyM9rev1MaoExxD4d97iNeZFG0Q0bEVFOzK97/5HNcq5FzpTUhxZgfXXCOCmuIYwnYsfU/w==",
+      "sha512": "0k9wL8LeMYj1jfu2wZwTdQhmPBcpMSUgD304cR50CpHOJnrP/NjiQ0Blx3oSURd8Tda5XuXC0PNGWDF+EpW/Lg==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Duplex.dll",
         "lib/net45/_._",
@@ -2740,15 +2848,15 @@
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.Duplex.dll",
         "ref/win8/_._",
-        "System.ServiceModel.Duplex.4.0.1-beta-23324.nupkg",
-        "System.ServiceModel.Duplex.4.0.1-beta-23324.nupkg.sha512",
+        "System.ServiceModel.Duplex.4.0.1-beta-23330.nupkg",
+        "System.ServiceModel.Duplex.4.0.1-beta-23330.nupkg.sha512",
         "System.ServiceModel.Duplex.nuspec"
       ]
     },
-    "System.ServiceModel.Http/4.0.11-beta-23324": {
+    "System.ServiceModel.Http/4.0.11-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "VkTumuCSmXd0NPZZU+nrO7YqznvM+wP96NykXbxFJdNAtCplmqXaQh+YZ/02rjJmfou5qyo2V+ZWVwySBAirOg==",
+      "sha512": "NHKxIIYL0ATDbX18RLCSXtuq26MMoYfAVdpl5K+D0s5AHp7TMPb7LcjZPpg25B2v48x1TwE9LYcYTCiOZcoPzQ==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Http.dll",
         "lib/MonoAndroid10/_._",
@@ -2773,15 +2881,15 @@
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.ServiceModel.Http.4.0.11-beta-23324.nupkg",
-        "System.ServiceModel.Http.4.0.11-beta-23324.nupkg.sha512",
+        "System.ServiceModel.Http.4.0.11-beta-23330.nupkg",
+        "System.ServiceModel.Http.4.0.11-beta-23330.nupkg.sha512",
         "System.ServiceModel.Http.nuspec"
       ]
     },
-    "System.ServiceModel.NetTcp/4.0.1-beta-23324": {
+    "System.ServiceModel.NetTcp/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "xI03xQCdWzqq4H2E29BELQm/e9LJl+IAbD50lcH966Z+JdaYOqeM6RGxAys0sVim59wvCrOv/YaRNxz66YLoog==",
+      "sha512": "Vx0QSKz4BlX/yYqKHET3mofo6RxxaMDLWsEFWDbEBJeCs0Yq19uGiIYwK1mXkWy3Y+jDwi42au3mVhmRbDHavA==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.NetTcp.dll",
         "lib/net45/_._",
@@ -2801,15 +2909,15 @@
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.NetTcp.dll",
         "ref/win8/_._",
-        "System.ServiceModel.NetTcp.4.0.1-beta-23324.nupkg",
-        "System.ServiceModel.NetTcp.4.0.1-beta-23324.nupkg.sha512",
+        "System.ServiceModel.NetTcp.4.0.1-beta-23330.nupkg",
+        "System.ServiceModel.NetTcp.4.0.1-beta-23330.nupkg.sha512",
         "System.ServiceModel.NetTcp.nuspec"
       ]
     },
-    "System.ServiceModel.Primitives/4.0.1-beta-23324": {
+    "System.ServiceModel.Primitives/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "bmU31B4CD5+m9Kt0iDM5Yw2ZXRfv7lpK3Sx1HektcT/HERc+IMPdO38f/Wxtofo5WOA0qmd1fdrMeQcbEkDfJg==",
+      "sha512": "kJ/pcRUf7Ow7s/rX8Kmc9P2k6cvyudIzyUcqr/pn9NwY8DC/2DWkkFvYE2udR4kvBzJJzXl/rsJQlyLIVGMAww==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Primitives.dll",
         "lib/net45/_._",
@@ -2829,8 +2937,8 @@
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.Primitives.dll",
         "ref/win8/_._",
-        "System.ServiceModel.Primitives.4.0.1-beta-23324.nupkg",
-        "System.ServiceModel.Primitives.4.0.1-beta-23324.nupkg.sha512",
+        "System.ServiceModel.Primitives.4.0.1-beta-23330.nupkg",
+        "System.ServiceModel.Primitives.4.0.1-beta-23330.nupkg.sha512",
         "System.ServiceModel.Primitives.nuspec"
       ]
     },
@@ -3025,10 +3133,9 @@
         "System.Threading.Tasks.nuspec"
       ]
     },
-    "System.Threading.ThreadPool/4.0.10-beta-23324": {
+    "System.Threading.ThreadPool/4.0.10-beta-23330": {
       "type": "package",
-      "serviceable": true,
-      "sha512": "G4SjGmiV72HBiv8wkfnKFGTieekrACU1m43VaeJ6vDeSyb08eEFusVH1UWZpOsUF25meCuzpda0ezus24b4rKA==",
+      "sha512": "nM5OewUj8NJrye93apbM6KHvPddgPJGzt1IWIXk9lV5HB4NGsn6M5U0gxMQWShQuDp6NF3ya3ULRSvh3dLMbzg==",
       "files": [
         "lib/DNXCore50/System.Threading.ThreadPool.dll",
         "lib/MonoAndroid10/_._",
@@ -3042,8 +3149,8 @@
         "ref/net46/System.Threading.ThreadPool.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Threading.ThreadPool.4.0.10-beta-23324.nupkg",
-        "System.Threading.ThreadPool.4.0.10-beta-23324.nupkg.sha512",
+        "System.Threading.ThreadPool.4.0.10-beta-23330.nupkg",
+        "System.Threading.ThreadPool.4.0.10-beta-23330.nupkg.sha512",
         "System.Threading.ThreadPool.nuspec"
       ]
     },
@@ -3294,14 +3401,14 @@
         "xunit.extensibility.execution.nuspec"
       ]
     },
-    "xunit.netcore.extensions/1.0.0-prerelease-00095": {
+    "xunit.netcore.extensions/1.0.0-prerelease-00098": {
       "type": "package",
       "serviceable": true,
-      "sha512": "FuvWmkuxHiqD0cHDggg5MRmBoeM4Uea7OUEmKvZiQu7Fy02hJ6yKKNV7mNW3y4scwSzDNA81Qa+HIS33PeWUog==",
+      "sha512": "3kRPwTbC42YGmsNHpNMKfGVOO5cVfxUD+C7cYbti1aml4UCT/RFZ6lhm5Vym2wNRDxryu0Es78aMf1BaybSrDg==",
       "files": [
         "lib/dotnet/Xunit.NetCore.Extensions.dll",
-        "xunit.netcore.extensions.1.0.0-prerelease-00095.nupkg",
-        "xunit.netcore.extensions.1.0.0-prerelease-00095.nupkg.sha512",
+        "xunit.netcore.extensions.1.0.0-prerelease-00098.nupkg",
+        "xunit.netcore.extensions.1.0.0-prerelease-00098.nupkg.sha512",
         "xunit.netcore.extensions.nuspec"
       ]
     }

--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/ExpectedExceptions/project.lock.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/ExpectedExceptions/project.lock.json
@@ -292,7 +292,7 @@
           "lib/dotnet/System.Linq.Queryable.dll": {}
         }
       },
-      "System.Net.Http/4.0.1-beta-23324": {
+      "System.Net.Http/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -305,16 +305,15 @@
           "ref/dotnet/System.Net.Http.dll": {}
         }
       },
-      "System.Net.NameResolution/4.0.0-beta-23324": {
+      "System.Net.NameResolution/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.Networking": "4.0.1-beta-23324"
+          "System.Net.Primitives": "4.0.10",
+          "System.Runtime": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Net.NameResolution.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Net.NameResolution.dll": {}
         }
       },
       "System.Net.Primitives/4.0.10": {
@@ -329,10 +328,10 @@
           "lib/DNXCore50/System.Net.Primitives.dll": {}
         }
       },
-      "System.Net.Security/4.0.0-beta-23324": {
+      "System.Net.Security/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.Networking": "4.0.1-beta-23324"
+          "System.Private.Networking": "4.0.1-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.Net.Security.dll": {}
@@ -367,6 +366,49 @@
         },
         "runtime": {
           "lib/dotnet/System.Net.WebHeaderCollection.dll": {}
+        }
+      },
+      "System.Net.WebSockets/4.0.0-beta-23330": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.Win32.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Threading.Tasks": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Net.WebSockets.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Net.WebSockets.dll": {}
+        }
+      },
+      "System.Net.WebSockets.Client/4.0.0-beta-23330": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.Win32.Primitives": "4.0.0",
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Diagnostics.Tracing": "4.0.20",
+          "System.Globalization": "4.0.10",
+          "System.Net.Primitives": "4.0.10",
+          "System.Net.WebHeaderCollection": "4.0.0",
+          "System.Net.WebSockets": "4.0.0-beta-23330",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23330",
+          "System.Text.Encoding": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Net.WebSockets.Client.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Net.WebSockets.Client.dll": {}
         }
       },
       "System.ObjectModel/4.0.10": {
@@ -414,7 +456,7 @@
           "lib/DNXCore50/System.Private.DataContractSerialization.dll": {}
         }
       },
-      "System.Private.Networking/4.0.1-beta-23324": {
+      "System.Private.Networking/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -433,13 +475,13 @@
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23324",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23324",
-          "System.Security.Principal.Windows": "4.0.0-beta-23324",
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23330",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23330",
+          "System.Security.Principal.Windows": "4.0.0-beta-23330",
           "System.Threading": "4.0.10",
           "System.Threading.Overlapped": "4.0.0",
           "System.Threading.Tasks": "4.0.10",
-          "System.Threading.ThreadPool": "4.0.10-beta-23324"
+          "System.Threading.ThreadPool": "4.0.10-beta-23330"
         },
         "compile": {
           "ref/dnxcore50/_._": {}
@@ -448,7 +490,7 @@
           "lib/DNXCore50/System.Private.Networking.dll": {}
         }
       },
-      "System.Private.ServiceModel/4.0.1-beta-23324": {
+      "System.Private.ServiceModel/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -465,12 +507,14 @@
           "System.Linq": "4.0.0",
           "System.Linq.Expressions": "4.0.10",
           "System.Linq.Queryable": "4.0.0",
-          "System.Net.Http": "4.0.1-beta-23324",
-          "System.Net.NameResolution": "4.0.0-beta-23324",
+          "System.Net.Http": "4.0.1-beta-23330",
+          "System.Net.NameResolution": "4.0.0-beta-23330",
           "System.Net.Primitives": "4.0.10",
-          "System.Net.Security": "4.0.0-beta-23324",
-          "System.Net.Sockets": "4.0.10-beta-23324",
+          "System.Net.Security": "4.0.0-beta-23330",
+          "System.Net.Sockets": "4.0.10-beta-23330",
           "System.Net.WebHeaderCollection": "4.0.0",
+          "System.Net.WebSockets": "4.0.0-beta-23330",
+          "System.Net.WebSockets.Client": "4.0.0-beta-23330",
           "System.ObjectModel": "4.0.10",
           "System.Reflection": "4.0.10",
           "System.Reflection.DispatchProxy": "4.0.0",
@@ -484,9 +528,9 @@
           "System.Runtime.Serialization.Primitives": "4.0.10",
           "System.Runtime.Serialization.Xml": "4.0.10",
           "System.Security.Claims": "4.0.0",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23324",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23330",
           "System.Security.Principal": "4.0.0",
-          "System.Security.Principal.Windows": "4.0.0-beta-23324",
+          "System.Security.Principal.Windows": "4.0.0-beta-23330",
           "System.Text.Encoding": "4.0.10",
           "System.Threading": "4.0.10",
           "System.Threading.Tasks": "4.0.10",
@@ -750,18 +794,18 @@
           "lib/dotnet/System.Security.Claims.dll": {}
         }
       },
-      "System.Security.Cryptography.Algorithms/4.0.0-beta-23324": {
+      "System.Security.Cryptography.Algorithms/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
           "System.Runtime": "4.0.0",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23324"
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.Algorithms.dll": {}
         }
       },
-      "System.Security.Cryptography.Encoding/4.0.0-beta-23324": {
+      "System.Security.Cryptography.Encoding/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -770,7 +814,7 @@
           "ref/dotnet/System.Security.Cryptography.Encoding.dll": {}
         }
       },
-      "System.Security.Cryptography.Primitives/4.0.0-beta-23324": {
+      "System.Security.Cryptography.Primitives/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.0",
@@ -788,13 +832,13 @@
           "lib/dotnet/System.Security.Cryptography.Primitives.dll": {}
         }
       },
-      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23324": {
+      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
           "System.Runtime.Handles": "4.0.0",
-          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23324",
-          "System.Security.Cryptography.Encoding": "4.0.0-beta-23324"
+          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23330",
+          "System.Security.Cryptography.Encoding": "4.0.0-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.X509Certificates.dll": {}
@@ -812,7 +856,7 @@
           "lib/dotnet/System.Security.Principal.dll": {}
         }
       },
-      "System.Security.Principal.Windows/4.0.0-beta-23324": {
+      "System.Security.Principal.Windows/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -835,10 +879,10 @@
           "lib/DNXCore50/System.Security.Principal.Windows.dll": {}
         }
       },
-      "System.ServiceModel.Duplex/4.0.1-beta-23324": {
+      "System.ServiceModel.Duplex/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.0.1-beta-23324"
+          "System.Private.ServiceModel": "4.0.1-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.ServiceModel.Duplex.dll": {}
@@ -847,10 +891,10 @@
           "lib/DNXCore50/System.ServiceModel.Duplex.dll": {}
         }
       },
-      "System.ServiceModel.Http/4.0.11-beta-23324": {
+      "System.ServiceModel.Http/4.0.11-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.0.1-beta-23324",
+          "System.Private.ServiceModel": "4.0.1-beta-23330",
           "System.Runtime": "4.0.20"
         },
         "compile": {
@@ -860,10 +904,10 @@
           "lib/DNXCore50/System.ServiceModel.Http.dll": {}
         }
       },
-      "System.ServiceModel.NetTcp/4.0.1-beta-23324": {
+      "System.ServiceModel.NetTcp/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.0.1-beta-23324"
+          "System.Private.ServiceModel": "4.0.1-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.ServiceModel.NetTcp.dll": {}
@@ -872,10 +916,10 @@
           "lib/DNXCore50/System.ServiceModel.NetTcp.dll": {}
         }
       },
-      "System.ServiceModel.Primitives/4.0.1-beta-23324": {
+      "System.ServiceModel.Primitives/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.0.1-beta-23324"
+          "System.Private.ServiceModel": "4.0.1-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.ServiceModel.Primitives.dll": {}
@@ -964,7 +1008,7 @@
           "lib/DNXCore50/System.Threading.Tasks.dll": {}
         }
       },
-      "System.Threading.ThreadPool/4.0.10-beta-23324": {
+      "System.Threading.ThreadPool/4.0.10-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
@@ -1157,7 +1201,7 @@
           "lib/dotnet/xunit.execution.dotnet.dll": {}
         }
       },
-      "xunit.netcore.extensions/1.0.0-prerelease-00095": {
+      "xunit.netcore.extensions/1.0.0-prerelease-00098": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.10",
@@ -1785,23 +1829,12 @@
         "System.Linq.Queryable.nuspec"
       ]
     },
-    "System.Net.Http/4.0.1-beta-23324": {
+    "System.Net.Http/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "gXfHlWsiMQDuFqwnQrlQTje9vqMhCFLtm35jX4WqZjcfa3y69DbwueeT0gJbVMK88/UnG8FAYiDBb7AKyu+51w==",
+      "sha512": "itLPx7B7Ac4mX8wQx9V9DQcxqTgkmwDNnQIHuCgAH53Jq2X3XziiRRBbxbmNJlWqBlgPzbseWJmMCtcF/ePhOg==",
       "files": [
         "lib/net45/_._",
-        "lib/netcore50/de/System.Net.Http.xml",
-        "lib/netcore50/es/System.Net.Http.xml",
-        "lib/netcore50/fr/System.Net.Http.xml",
-        "lib/netcore50/it/System.Net.Http.xml",
-        "lib/netcore50/ja/System.Net.Http.xml",
-        "lib/netcore50/ko/System.Net.Http.xml",
-        "lib/netcore50/ru/System.Net.Http.xml",
-        "lib/netcore50/System.Net.Http.dll",
-        "lib/netcore50/System.Net.Http.xml",
-        "lib/netcore50/zh-hans/System.Net.Http.xml",
-        "lib/netcore50/zh-hant/System.Net.Http.xml",
         "lib/win8/_._",
         "lib/wpa81/_._",
         "ref/dotnet/System.Net.Http.dll",
@@ -1810,17 +1843,16 @@
         "ref/win8/_._",
         "ref/wpa81/_._",
         "runtime.json",
-        "System.Net.Http.4.0.1-beta-23324.nupkg",
-        "System.Net.Http.4.0.1-beta-23324.nupkg.sha512",
+        "System.Net.Http.4.0.1-beta-23330.nupkg",
+        "System.Net.Http.4.0.1-beta-23330.nupkg.sha512",
         "System.Net.Http.nuspec"
       ]
     },
-    "System.Net.NameResolution/4.0.0-beta-23324": {
+    "System.Net.NameResolution/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "lNYXUmnSXUtLFY09Rc27zJ6/TxCuGggQzBgiuWHoWrjWxymuuxqPT2Mj7Dn7sUUh0GvF2MOx7Uk+rtCFBiIavg==",
+      "sha512": "d8Am+In/aBgcHpEV6xsi5BCiTEN4y6s9O1V/yIvwX8mDC4CtdZiGsi4DtoB0TLOgp8ky6GxbSF4bKCjFpBO3uw==",
       "files": [
-        "lib/DNXCore50/System.Net.NameResolution.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.NameResolution.dll",
@@ -1832,8 +1864,9 @@
         "ref/net46/System.Net.NameResolution.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.NameResolution.4.0.0-beta-23324.nupkg",
-        "System.Net.NameResolution.4.0.0-beta-23324.nupkg.sha512",
+        "runtime.json",
+        "System.Net.NameResolution.4.0.0-beta-23330.nupkg",
+        "System.Net.NameResolution.4.0.0-beta-23330.nupkg.sha512",
         "System.Net.NameResolution.nuspec"
       ]
     },
@@ -1870,9 +1903,9 @@
         "System.Net.Primitives.nuspec"
       ]
     },
-    "System.Net.Security/4.0.0-beta-23324": {
+    "System.Net.Security/4.0.0-beta-23330": {
       "type": "package",
-      "sha512": "D04RYjxrnR3D+uI9CGmAAFKKQ6T+pPcRHYucc1PIo7/hJK5I/Yu7gAw9yOxHUhQjSGfrKo00lHpBCQMTQt4lSw==",
+      "sha512": "z98dKloNy9DBdyfqQwQvKWA2q8Qj4vgGEVONnlS70c13eh0MolBHJ0wNdplZZK5zYZ5Eu8GTwexbUlpHbsfzVA==",
       "files": [
         "lib/DNXCore50/System.Net.Security.dll",
         "lib/MonoAndroid10/_._",
@@ -1886,8 +1919,8 @@
         "ref/net46/System.Net.Security.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.Security.4.0.0-beta-23324.nupkg",
-        "System.Net.Security.4.0.0-beta-23324.nupkg.sha512",
+        "System.Net.Security.4.0.0-beta-23330.nupkg",
+        "System.Net.Security.4.0.0-beta-23330.nupkg.sha512",
         "System.Net.Security.nuspec"
       ]
     },
@@ -1945,6 +1978,81 @@
         "System.Net.WebHeaderCollection.nuspec"
       ]
     },
+    "System.Net.WebSockets/4.0.0-beta-23330": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "6Q9/uTDcaqbmdbD04MisKmjti4aEpp40i/UzpGaPZ4ItuwzU/pMk9RjiYUBUiCQyZeKNlXcSB1FPN2nFof7tww==",
+      "files": [
+        "lib/dotnet/de/System.Net.WebSockets.xml",
+        "lib/dotnet/es/System.Net.WebSockets.xml",
+        "lib/dotnet/fr/System.Net.WebSockets.xml",
+        "lib/dotnet/it/System.Net.WebSockets.xml",
+        "lib/dotnet/ja/System.Net.WebSockets.xml",
+        "lib/dotnet/ko/System.Net.WebSockets.xml",
+        "lib/dotnet/ru/System.Net.WebSockets.xml",
+        "lib/dotnet/System.Net.WebSockets.dll",
+        "lib/dotnet/System.Net.WebSockets.xml",
+        "lib/dotnet/zh-hans/System.Net.WebSockets.xml",
+        "lib/dotnet/zh-hant/System.Net.WebSockets.xml",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Net.WebSockets.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Net.WebSockets.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Net.WebSockets.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Net.WebSockets.4.0.0-beta-23330.nupkg",
+        "System.Net.WebSockets.4.0.0-beta-23330.nupkg.sha512",
+        "System.Net.WebSockets.nuspec"
+      ]
+    },
+    "System.Net.WebSockets.Client/4.0.0-beta-23330": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "1NWEqwDkYRyvr1gSKZlY51AaI9w8oD0dC5UNa2Lb+qaeFHSF5KfCSzf7seD+im+sH6uocVo2nppiaabfbXZT4Q==",
+      "files": [
+        "lib/DNXCore50/de/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/es/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/fr/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/it/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/ja/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/ko/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/ru/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/System.Net.WebSockets.Client.dll",
+        "lib/DNXCore50/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/zh-hans/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/zh-hant/System.Net.WebSockets.Client.xml",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Net.WebSockets.Client.dll",
+        "lib/netcore50/de/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/es/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/fr/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/it/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/ja/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/ko/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/ru/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/System.Net.WebSockets.Client.dll",
+        "lib/netcore50/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/zh-hans/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/zh-hant/System.Net.WebSockets.Client.xml",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Net.WebSockets.Client.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Net.WebSockets.Client.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Net.WebSockets.Client.4.0.0-beta-23330.nupkg",
+        "System.Net.WebSockets.Client.4.0.0-beta-23330.nupkg.sha512",
+        "System.Net.WebSockets.Client.nuspec"
+      ]
+    },
     "System.ObjectModel/4.0.10": {
       "type": "package",
       "serviceable": true,
@@ -1993,31 +2101,31 @@
         "System.Private.DataContractSerialization.nuspec"
       ]
     },
-    "System.Private.Networking/4.0.1-beta-23324": {
+    "System.Private.Networking/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "OfyxoeCdh1ypzdz1u0h1Clgt+6749vALs2ZPkLwsOPzL0INCG9ISYo+Jhh62ZD8TMkWwLrvyVppMBPHY6M7Upw==",
+      "sha512": "8NZi1gCQaGTKDb2yWplm52HWCLaZnUwVitksJgcXY2dEJau/TBGyZup+yhOngOIe8QzQMxNG4iokY3Ce0/8mbg==",
       "files": [
         "lib/DNXCore50/System.Private.Networking.dll",
         "lib/netcore50/System.Private.Networking.dll",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "System.Private.Networking.4.0.1-beta-23324.nupkg",
-        "System.Private.Networking.4.0.1-beta-23324.nupkg.sha512",
+        "System.Private.Networking.4.0.1-beta-23330.nupkg",
+        "System.Private.Networking.4.0.1-beta-23330.nupkg.sha512",
         "System.Private.Networking.nuspec"
       ]
     },
-    "System.Private.ServiceModel/4.0.1-beta-23324": {
+    "System.Private.ServiceModel/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "Lz3T9V8GnaOFlf8LUmuPznuOIuy92BAFVc9huiMrFKByzPpydGuCvXEe+81rZ1IF2TQcHKO++9otnj96AEJ5BA==",
+      "sha512": "8lENvmHuZdlvmnYN1w98Mv8bDjc0O/YlaNHRRph35T/fLDyaG8LMLMwG3/ut6a/AenLJmbf92snOtNXCuqM+cQ==",
       "files": [
         "lib/DNXCore50/System.Private.ServiceModel.dll",
         "lib/netcore50/System.Private.ServiceModel.dll",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "System.Private.ServiceModel.4.0.1-beta-23324.nupkg",
-        "System.Private.ServiceModel.4.0.1-beta-23324.nupkg.sha512",
+        "System.Private.ServiceModel.4.0.1-beta-23330.nupkg",
+        "System.Private.ServiceModel.4.0.1-beta-23330.nupkg.sha512",
         "System.Private.ServiceModel.nuspec"
       ]
     },
@@ -2572,10 +2680,10 @@
         "System.Security.Claims.nuspec"
       ]
     },
-    "System.Security.Cryptography.Algorithms/4.0.0-beta-23324": {
+    "System.Security.Cryptography.Algorithms/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "Mt6LwMj8hPp0+xZHcV6grZ7wSWhgycGkdZ6DQ9XvUY9NguUsvb/+fu2cMdrC7XsnpvwIROByp+p2dSjqBn3E2Q==",
+      "sha512": "FB4RoTDaV5tBiPSJsiG3A5DydeKz7ErglnkqVjBFjm6wu8kg91j0MxL/Al9iUyu9i/hq53fRs5KE3rjUNYvf5w==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2589,15 +2697,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.Algorithms.4.0.0-beta-23324.nupkg",
-        "System.Security.Cryptography.Algorithms.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Cryptography.Algorithms.4.0.0-beta-23330.nupkg",
+        "System.Security.Cryptography.Algorithms.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Cryptography.Algorithms.nuspec"
       ]
     },
-    "System.Security.Cryptography.Encoding/4.0.0-beta-23324": {
+    "System.Security.Cryptography.Encoding/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "JHOyknf1eYO6C39Vao6kAGpadq3PBO1L4tuzNEz/HvbH5sfIHPbjhxL11OyAhVKCzLCfEj6+aeClovFqZIRPyw==",
+      "sha512": "zeFdKQT6xjNdiNCaEmEYJMEK59kixkX7jJSoOLw3H+53t9X0F98vr3tS8YlrW/Lk/K9c6L5pYLlkb2dNqvUD/g==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2611,15 +2719,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.Encoding.4.0.0-beta-23324.nupkg",
-        "System.Security.Cryptography.Encoding.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Cryptography.Encoding.4.0.0-beta-23330.nupkg",
+        "System.Security.Cryptography.Encoding.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Cryptography.Encoding.nuspec"
       ]
     },
-    "System.Security.Cryptography.Primitives/4.0.0-beta-23324": {
+    "System.Security.Cryptography.Primitives/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "ETZxelIX51Di4FTytd8ohSpN6Ym/32aWIX9E2NCFkd91qdexn2Dkysn80b6n4gX6jG+oL0UHQDtD/fYq8C65oQ==",
+      "sha512": "15uVbOD3X0sRQJIxcEH5hasxlFdbA1CmPPZa0Y8pYEuQcWMF2gBswvU8s4qoKtA7x2xhNhzPsXIhsQuKNMTdEA==",
       "files": [
         "lib/dotnet/System.Security.Cryptography.Primitives.dll",
         "lib/MonoAndroid10/_._",
@@ -2633,15 +2741,15 @@
         "ref/net46/System.Security.Cryptography.Primitives.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Security.Cryptography.Primitives.4.0.0-beta-23324.nupkg",
-        "System.Security.Cryptography.Primitives.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Cryptography.Primitives.4.0.0-beta-23330.nupkg",
+        "System.Security.Cryptography.Primitives.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Cryptography.Primitives.nuspec"
       ]
     },
-    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23324": {
+    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "8NaEOxkkNBUECh0cPzGpbXS0uzGDpnvxI0kqQKRGp9uA+9qCyQfxcqAT6ozAYtOuFNVaC1XU3zQnb7T2nfvIDg==",
+      "sha512": "L8mUimdm7+GsORgJ8DFBMGsFnwDJ5YCUdJj3HfXQx4HCoPDPF+vJo3HRiHfcvNA2Zsf0ov2kuerYj/eeVa2/Rw==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2655,8 +2763,8 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23324.nupkg",
-        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23330.nupkg",
+        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Cryptography.X509Certificates.nuspec"
       ]
     },
@@ -2693,10 +2801,10 @@
         "System.Security.Principal.nuspec"
       ]
     },
-    "System.Security.Principal.Windows/4.0.0-beta-23324": {
+    "System.Security.Principal.Windows/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "csbCKdwBz31T8He7U6XMIc9BiWgwjHs5WDZR4rfhsk48TpdsbKNHX9OX4b+GwvgcsfVuWxre7zqNR0Bc9gWZ7g==",
+      "sha512": "q+3L3aB8bn0HCW52kX9TSJdhbjffBw7QWCOu0yX1SDhPN9MCPmJ4aBBCn1HRWroa5y7UcNUdjL1xwiERycZexw==",
       "files": [
         "lib/DNXCore50/de/System.Security.Principal.Windows.xml",
         "lib/DNXCore50/es/System.Security.Principal.Windows.xml",
@@ -2712,15 +2820,15 @@
         "lib/net46/System.Security.Principal.Windows.dll",
         "ref/dotnet/System.Security.Principal.Windows.dll",
         "ref/net46/System.Security.Principal.Windows.dll",
-        "System.Security.Principal.Windows.4.0.0-beta-23324.nupkg",
-        "System.Security.Principal.Windows.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Principal.Windows.4.0.0-beta-23330.nupkg",
+        "System.Security.Principal.Windows.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Principal.Windows.nuspec"
       ]
     },
-    "System.ServiceModel.Duplex/4.0.1-beta-23324": {
+    "System.ServiceModel.Duplex/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "b+p3u2zee0oAM4AIyM9rev1MaoExxD4d97iNeZFG0Q0bEVFOzK97/5HNcq5FzpTUhxZgfXXCOCmuIYwnYsfU/w==",
+      "sha512": "0k9wL8LeMYj1jfu2wZwTdQhmPBcpMSUgD304cR50CpHOJnrP/NjiQ0Blx3oSURd8Tda5XuXC0PNGWDF+EpW/Lg==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Duplex.dll",
         "lib/net45/_._",
@@ -2740,15 +2848,15 @@
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.Duplex.dll",
         "ref/win8/_._",
-        "System.ServiceModel.Duplex.4.0.1-beta-23324.nupkg",
-        "System.ServiceModel.Duplex.4.0.1-beta-23324.nupkg.sha512",
+        "System.ServiceModel.Duplex.4.0.1-beta-23330.nupkg",
+        "System.ServiceModel.Duplex.4.0.1-beta-23330.nupkg.sha512",
         "System.ServiceModel.Duplex.nuspec"
       ]
     },
-    "System.ServiceModel.Http/4.0.11-beta-23324": {
+    "System.ServiceModel.Http/4.0.11-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "VkTumuCSmXd0NPZZU+nrO7YqznvM+wP96NykXbxFJdNAtCplmqXaQh+YZ/02rjJmfou5qyo2V+ZWVwySBAirOg==",
+      "sha512": "NHKxIIYL0ATDbX18RLCSXtuq26MMoYfAVdpl5K+D0s5AHp7TMPb7LcjZPpg25B2v48x1TwE9LYcYTCiOZcoPzQ==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Http.dll",
         "lib/MonoAndroid10/_._",
@@ -2773,15 +2881,15 @@
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.ServiceModel.Http.4.0.11-beta-23324.nupkg",
-        "System.ServiceModel.Http.4.0.11-beta-23324.nupkg.sha512",
+        "System.ServiceModel.Http.4.0.11-beta-23330.nupkg",
+        "System.ServiceModel.Http.4.0.11-beta-23330.nupkg.sha512",
         "System.ServiceModel.Http.nuspec"
       ]
     },
-    "System.ServiceModel.NetTcp/4.0.1-beta-23324": {
+    "System.ServiceModel.NetTcp/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "xI03xQCdWzqq4H2E29BELQm/e9LJl+IAbD50lcH966Z+JdaYOqeM6RGxAys0sVim59wvCrOv/YaRNxz66YLoog==",
+      "sha512": "Vx0QSKz4BlX/yYqKHET3mofo6RxxaMDLWsEFWDbEBJeCs0Yq19uGiIYwK1mXkWy3Y+jDwi42au3mVhmRbDHavA==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.NetTcp.dll",
         "lib/net45/_._",
@@ -2801,15 +2909,15 @@
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.NetTcp.dll",
         "ref/win8/_._",
-        "System.ServiceModel.NetTcp.4.0.1-beta-23324.nupkg",
-        "System.ServiceModel.NetTcp.4.0.1-beta-23324.nupkg.sha512",
+        "System.ServiceModel.NetTcp.4.0.1-beta-23330.nupkg",
+        "System.ServiceModel.NetTcp.4.0.1-beta-23330.nupkg.sha512",
         "System.ServiceModel.NetTcp.nuspec"
       ]
     },
-    "System.ServiceModel.Primitives/4.0.1-beta-23324": {
+    "System.ServiceModel.Primitives/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "bmU31B4CD5+m9Kt0iDM5Yw2ZXRfv7lpK3Sx1HektcT/HERc+IMPdO38f/Wxtofo5WOA0qmd1fdrMeQcbEkDfJg==",
+      "sha512": "kJ/pcRUf7Ow7s/rX8Kmc9P2k6cvyudIzyUcqr/pn9NwY8DC/2DWkkFvYE2udR4kvBzJJzXl/rsJQlyLIVGMAww==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Primitives.dll",
         "lib/net45/_._",
@@ -2829,8 +2937,8 @@
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.Primitives.dll",
         "ref/win8/_._",
-        "System.ServiceModel.Primitives.4.0.1-beta-23324.nupkg",
-        "System.ServiceModel.Primitives.4.0.1-beta-23324.nupkg.sha512",
+        "System.ServiceModel.Primitives.4.0.1-beta-23330.nupkg",
+        "System.ServiceModel.Primitives.4.0.1-beta-23330.nupkg.sha512",
         "System.ServiceModel.Primitives.nuspec"
       ]
     },
@@ -3025,10 +3133,9 @@
         "System.Threading.Tasks.nuspec"
       ]
     },
-    "System.Threading.ThreadPool/4.0.10-beta-23324": {
+    "System.Threading.ThreadPool/4.0.10-beta-23330": {
       "type": "package",
-      "serviceable": true,
-      "sha512": "G4SjGmiV72HBiv8wkfnKFGTieekrACU1m43VaeJ6vDeSyb08eEFusVH1UWZpOsUF25meCuzpda0ezus24b4rKA==",
+      "sha512": "nM5OewUj8NJrye93apbM6KHvPddgPJGzt1IWIXk9lV5HB4NGsn6M5U0gxMQWShQuDp6NF3ya3ULRSvh3dLMbzg==",
       "files": [
         "lib/DNXCore50/System.Threading.ThreadPool.dll",
         "lib/MonoAndroid10/_._",
@@ -3042,8 +3149,8 @@
         "ref/net46/System.Threading.ThreadPool.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Threading.ThreadPool.4.0.10-beta-23324.nupkg",
-        "System.Threading.ThreadPool.4.0.10-beta-23324.nupkg.sha512",
+        "System.Threading.ThreadPool.4.0.10-beta-23330.nupkg",
+        "System.Threading.ThreadPool.4.0.10-beta-23330.nupkg.sha512",
         "System.Threading.ThreadPool.nuspec"
       ]
     },
@@ -3294,14 +3401,14 @@
         "xunit.extensibility.execution.nuspec"
       ]
     },
-    "xunit.netcore.extensions/1.0.0-prerelease-00095": {
+    "xunit.netcore.extensions/1.0.0-prerelease-00098": {
       "type": "package",
       "serviceable": true,
-      "sha512": "FuvWmkuxHiqD0cHDggg5MRmBoeM4Uea7OUEmKvZiQu7Fy02hJ6yKKNV7mNW3y4scwSzDNA81Qa+HIS33PeWUog==",
+      "sha512": "3kRPwTbC42YGmsNHpNMKfGVOO5cVfxUD+C7cYbti1aml4UCT/RFZ6lhm5Vym2wNRDxryu0Es78aMf1BaybSrDg==",
       "files": [
         "lib/dotnet/Xunit.NetCore.Extensions.dll",
-        "xunit.netcore.extensions.1.0.0-prerelease-00095.nupkg",
-        "xunit.netcore.extensions.1.0.0-prerelease-00095.nupkg.sha512",
+        "xunit.netcore.extensions.1.0.0-prerelease-00098.nupkg",
+        "xunit.netcore.extensions.1.0.0-prerelease-00098.nupkg.sha512",
         "xunit.netcore.extensions.nuspec"
       ]
     }

--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/TypedClient/project.lock.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/TypedClient/project.lock.json
@@ -292,7 +292,7 @@
           "lib/dotnet/System.Linq.Queryable.dll": {}
         }
       },
-      "System.Net.Http/4.0.1-beta-23324": {
+      "System.Net.Http/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -305,16 +305,15 @@
           "ref/dotnet/System.Net.Http.dll": {}
         }
       },
-      "System.Net.NameResolution/4.0.0-beta-23324": {
+      "System.Net.NameResolution/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.Networking": "4.0.1-beta-23324"
+          "System.Net.Primitives": "4.0.10",
+          "System.Runtime": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Net.NameResolution.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Net.NameResolution.dll": {}
         }
       },
       "System.Net.Primitives/4.0.10": {
@@ -329,10 +328,10 @@
           "lib/DNXCore50/System.Net.Primitives.dll": {}
         }
       },
-      "System.Net.Security/4.0.0-beta-23324": {
+      "System.Net.Security/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.Networking": "4.0.1-beta-23324"
+          "System.Private.Networking": "4.0.1-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.Net.Security.dll": {}
@@ -367,6 +366,49 @@
         },
         "runtime": {
           "lib/dotnet/System.Net.WebHeaderCollection.dll": {}
+        }
+      },
+      "System.Net.WebSockets/4.0.0-beta-23330": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.Win32.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Threading.Tasks": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Net.WebSockets.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Net.WebSockets.dll": {}
+        }
+      },
+      "System.Net.WebSockets.Client/4.0.0-beta-23330": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.Win32.Primitives": "4.0.0",
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Diagnostics.Tracing": "4.0.20",
+          "System.Globalization": "4.0.10",
+          "System.Net.Primitives": "4.0.10",
+          "System.Net.WebHeaderCollection": "4.0.0",
+          "System.Net.WebSockets": "4.0.0-beta-23330",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23330",
+          "System.Text.Encoding": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Net.WebSockets.Client.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Net.WebSockets.Client.dll": {}
         }
       },
       "System.ObjectModel/4.0.10": {
@@ -414,7 +456,7 @@
           "lib/DNXCore50/System.Private.DataContractSerialization.dll": {}
         }
       },
-      "System.Private.Networking/4.0.1-beta-23324": {
+      "System.Private.Networking/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -433,13 +475,13 @@
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23324",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23324",
-          "System.Security.Principal.Windows": "4.0.0-beta-23324",
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23330",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23330",
+          "System.Security.Principal.Windows": "4.0.0-beta-23330",
           "System.Threading": "4.0.10",
           "System.Threading.Overlapped": "4.0.0",
           "System.Threading.Tasks": "4.0.10",
-          "System.Threading.ThreadPool": "4.0.10-beta-23324"
+          "System.Threading.ThreadPool": "4.0.10-beta-23330"
         },
         "compile": {
           "ref/dnxcore50/_._": {}
@@ -448,7 +490,7 @@
           "lib/DNXCore50/System.Private.Networking.dll": {}
         }
       },
-      "System.Private.ServiceModel/4.0.1-beta-23324": {
+      "System.Private.ServiceModel/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -465,12 +507,14 @@
           "System.Linq": "4.0.0",
           "System.Linq.Expressions": "4.0.10",
           "System.Linq.Queryable": "4.0.0",
-          "System.Net.Http": "4.0.1-beta-23324",
-          "System.Net.NameResolution": "4.0.0-beta-23324",
+          "System.Net.Http": "4.0.1-beta-23330",
+          "System.Net.NameResolution": "4.0.0-beta-23330",
           "System.Net.Primitives": "4.0.10",
-          "System.Net.Security": "4.0.0-beta-23324",
-          "System.Net.Sockets": "4.0.10-beta-23324",
+          "System.Net.Security": "4.0.0-beta-23330",
+          "System.Net.Sockets": "4.0.10-beta-23330",
           "System.Net.WebHeaderCollection": "4.0.0",
+          "System.Net.WebSockets": "4.0.0-beta-23330",
+          "System.Net.WebSockets.Client": "4.0.0-beta-23330",
           "System.ObjectModel": "4.0.10",
           "System.Reflection": "4.0.10",
           "System.Reflection.DispatchProxy": "4.0.0",
@@ -484,9 +528,9 @@
           "System.Runtime.Serialization.Primitives": "4.0.10",
           "System.Runtime.Serialization.Xml": "4.0.10",
           "System.Security.Claims": "4.0.0",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23324",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23330",
           "System.Security.Principal": "4.0.0",
-          "System.Security.Principal.Windows": "4.0.0-beta-23324",
+          "System.Security.Principal.Windows": "4.0.0-beta-23330",
           "System.Text.Encoding": "4.0.10",
           "System.Threading": "4.0.10",
           "System.Threading.Tasks": "4.0.10",
@@ -735,18 +779,18 @@
           "lib/dotnet/System.Security.Claims.dll": {}
         }
       },
-      "System.Security.Cryptography.Algorithms/4.0.0-beta-23324": {
+      "System.Security.Cryptography.Algorithms/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
           "System.Runtime": "4.0.0",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23324"
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.Algorithms.dll": {}
         }
       },
-      "System.Security.Cryptography.Encoding/4.0.0-beta-23324": {
+      "System.Security.Cryptography.Encoding/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -755,7 +799,7 @@
           "ref/dotnet/System.Security.Cryptography.Encoding.dll": {}
         }
       },
-      "System.Security.Cryptography.Primitives/4.0.0-beta-23324": {
+      "System.Security.Cryptography.Primitives/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.0",
@@ -773,13 +817,13 @@
           "lib/dotnet/System.Security.Cryptography.Primitives.dll": {}
         }
       },
-      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23324": {
+      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
           "System.Runtime.Handles": "4.0.0",
-          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23324",
-          "System.Security.Cryptography.Encoding": "4.0.0-beta-23324"
+          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23330",
+          "System.Security.Cryptography.Encoding": "4.0.0-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.X509Certificates.dll": {}
@@ -797,7 +841,7 @@
           "lib/dotnet/System.Security.Principal.dll": {}
         }
       },
-      "System.Security.Principal.Windows/4.0.0-beta-23324": {
+      "System.Security.Principal.Windows/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -820,10 +864,10 @@
           "lib/DNXCore50/System.Security.Principal.Windows.dll": {}
         }
       },
-      "System.ServiceModel.Duplex/4.0.1-beta-23324": {
+      "System.ServiceModel.Duplex/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.0.1-beta-23324"
+          "System.Private.ServiceModel": "4.0.1-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.ServiceModel.Duplex.dll": {}
@@ -832,10 +876,10 @@
           "lib/DNXCore50/System.ServiceModel.Duplex.dll": {}
         }
       },
-      "System.ServiceModel.Http/4.0.11-beta-23324": {
+      "System.ServiceModel.Http/4.0.11-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.0.1-beta-23324",
+          "System.Private.ServiceModel": "4.0.1-beta-23330",
           "System.Runtime": "4.0.20"
         },
         "compile": {
@@ -845,10 +889,10 @@
           "lib/DNXCore50/System.ServiceModel.Http.dll": {}
         }
       },
-      "System.ServiceModel.NetTcp/4.0.1-beta-23324": {
+      "System.ServiceModel.NetTcp/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.0.1-beta-23324"
+          "System.Private.ServiceModel": "4.0.1-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.ServiceModel.NetTcp.dll": {}
@@ -857,10 +901,10 @@
           "lib/DNXCore50/System.ServiceModel.NetTcp.dll": {}
         }
       },
-      "System.ServiceModel.Primitives/4.0.1-beta-23324": {
+      "System.ServiceModel.Primitives/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.0.1-beta-23324"
+          "System.Private.ServiceModel": "4.0.1-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.ServiceModel.Primitives.dll": {}
@@ -949,7 +993,7 @@
           "lib/DNXCore50/System.Threading.Tasks.dll": {}
         }
       },
-      "System.Threading.ThreadPool/4.0.10-beta-23324": {
+      "System.Threading.ThreadPool/4.0.10-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
@@ -1142,7 +1186,7 @@
           "lib/dotnet/xunit.execution.dotnet.dll": {}
         }
       },
-      "xunit.netcore.extensions/1.0.0-prerelease-00095": {
+      "xunit.netcore.extensions/1.0.0-prerelease-00098": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.10",
@@ -1770,23 +1814,12 @@
         "System.Linq.Queryable.nuspec"
       ]
     },
-    "System.Net.Http/4.0.1-beta-23324": {
+    "System.Net.Http/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "gXfHlWsiMQDuFqwnQrlQTje9vqMhCFLtm35jX4WqZjcfa3y69DbwueeT0gJbVMK88/UnG8FAYiDBb7AKyu+51w==",
+      "sha512": "itLPx7B7Ac4mX8wQx9V9DQcxqTgkmwDNnQIHuCgAH53Jq2X3XziiRRBbxbmNJlWqBlgPzbseWJmMCtcF/ePhOg==",
       "files": [
         "lib/net45/_._",
-        "lib/netcore50/de/System.Net.Http.xml",
-        "lib/netcore50/es/System.Net.Http.xml",
-        "lib/netcore50/fr/System.Net.Http.xml",
-        "lib/netcore50/it/System.Net.Http.xml",
-        "lib/netcore50/ja/System.Net.Http.xml",
-        "lib/netcore50/ko/System.Net.Http.xml",
-        "lib/netcore50/ru/System.Net.Http.xml",
-        "lib/netcore50/System.Net.Http.dll",
-        "lib/netcore50/System.Net.Http.xml",
-        "lib/netcore50/zh-hans/System.Net.Http.xml",
-        "lib/netcore50/zh-hant/System.Net.Http.xml",
         "lib/win8/_._",
         "lib/wpa81/_._",
         "ref/dotnet/System.Net.Http.dll",
@@ -1795,17 +1828,16 @@
         "ref/win8/_._",
         "ref/wpa81/_._",
         "runtime.json",
-        "System.Net.Http.4.0.1-beta-23324.nupkg",
-        "System.Net.Http.4.0.1-beta-23324.nupkg.sha512",
+        "System.Net.Http.4.0.1-beta-23330.nupkg",
+        "System.Net.Http.4.0.1-beta-23330.nupkg.sha512",
         "System.Net.Http.nuspec"
       ]
     },
-    "System.Net.NameResolution/4.0.0-beta-23324": {
+    "System.Net.NameResolution/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "lNYXUmnSXUtLFY09Rc27zJ6/TxCuGggQzBgiuWHoWrjWxymuuxqPT2Mj7Dn7sUUh0GvF2MOx7Uk+rtCFBiIavg==",
+      "sha512": "d8Am+In/aBgcHpEV6xsi5BCiTEN4y6s9O1V/yIvwX8mDC4CtdZiGsi4DtoB0TLOgp8ky6GxbSF4bKCjFpBO3uw==",
       "files": [
-        "lib/DNXCore50/System.Net.NameResolution.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.NameResolution.dll",
@@ -1817,8 +1849,9 @@
         "ref/net46/System.Net.NameResolution.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.NameResolution.4.0.0-beta-23324.nupkg",
-        "System.Net.NameResolution.4.0.0-beta-23324.nupkg.sha512",
+        "runtime.json",
+        "System.Net.NameResolution.4.0.0-beta-23330.nupkg",
+        "System.Net.NameResolution.4.0.0-beta-23330.nupkg.sha512",
         "System.Net.NameResolution.nuspec"
       ]
     },
@@ -1855,9 +1888,9 @@
         "System.Net.Primitives.nuspec"
       ]
     },
-    "System.Net.Security/4.0.0-beta-23324": {
+    "System.Net.Security/4.0.0-beta-23330": {
       "type": "package",
-      "sha512": "D04RYjxrnR3D+uI9CGmAAFKKQ6T+pPcRHYucc1PIo7/hJK5I/Yu7gAw9yOxHUhQjSGfrKo00lHpBCQMTQt4lSw==",
+      "sha512": "z98dKloNy9DBdyfqQwQvKWA2q8Qj4vgGEVONnlS70c13eh0MolBHJ0wNdplZZK5zYZ5Eu8GTwexbUlpHbsfzVA==",
       "files": [
         "lib/DNXCore50/System.Net.Security.dll",
         "lib/MonoAndroid10/_._",
@@ -1871,8 +1904,8 @@
         "ref/net46/System.Net.Security.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.Security.4.0.0-beta-23324.nupkg",
-        "System.Net.Security.4.0.0-beta-23324.nupkg.sha512",
+        "System.Net.Security.4.0.0-beta-23330.nupkg",
+        "System.Net.Security.4.0.0-beta-23330.nupkg.sha512",
         "System.Net.Security.nuspec"
       ]
     },
@@ -1930,6 +1963,81 @@
         "System.Net.WebHeaderCollection.nuspec"
       ]
     },
+    "System.Net.WebSockets/4.0.0-beta-23330": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "6Q9/uTDcaqbmdbD04MisKmjti4aEpp40i/UzpGaPZ4ItuwzU/pMk9RjiYUBUiCQyZeKNlXcSB1FPN2nFof7tww==",
+      "files": [
+        "lib/dotnet/de/System.Net.WebSockets.xml",
+        "lib/dotnet/es/System.Net.WebSockets.xml",
+        "lib/dotnet/fr/System.Net.WebSockets.xml",
+        "lib/dotnet/it/System.Net.WebSockets.xml",
+        "lib/dotnet/ja/System.Net.WebSockets.xml",
+        "lib/dotnet/ko/System.Net.WebSockets.xml",
+        "lib/dotnet/ru/System.Net.WebSockets.xml",
+        "lib/dotnet/System.Net.WebSockets.dll",
+        "lib/dotnet/System.Net.WebSockets.xml",
+        "lib/dotnet/zh-hans/System.Net.WebSockets.xml",
+        "lib/dotnet/zh-hant/System.Net.WebSockets.xml",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Net.WebSockets.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Net.WebSockets.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Net.WebSockets.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Net.WebSockets.4.0.0-beta-23330.nupkg",
+        "System.Net.WebSockets.4.0.0-beta-23330.nupkg.sha512",
+        "System.Net.WebSockets.nuspec"
+      ]
+    },
+    "System.Net.WebSockets.Client/4.0.0-beta-23330": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "1NWEqwDkYRyvr1gSKZlY51AaI9w8oD0dC5UNa2Lb+qaeFHSF5KfCSzf7seD+im+sH6uocVo2nppiaabfbXZT4Q==",
+      "files": [
+        "lib/DNXCore50/de/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/es/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/fr/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/it/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/ja/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/ko/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/ru/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/System.Net.WebSockets.Client.dll",
+        "lib/DNXCore50/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/zh-hans/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/zh-hant/System.Net.WebSockets.Client.xml",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Net.WebSockets.Client.dll",
+        "lib/netcore50/de/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/es/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/fr/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/it/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/ja/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/ko/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/ru/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/System.Net.WebSockets.Client.dll",
+        "lib/netcore50/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/zh-hans/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/zh-hant/System.Net.WebSockets.Client.xml",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Net.WebSockets.Client.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Net.WebSockets.Client.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Net.WebSockets.Client.4.0.0-beta-23330.nupkg",
+        "System.Net.WebSockets.Client.4.0.0-beta-23330.nupkg.sha512",
+        "System.Net.WebSockets.Client.nuspec"
+      ]
+    },
     "System.ObjectModel/4.0.10": {
       "type": "package",
       "serviceable": true,
@@ -1978,31 +2086,31 @@
         "System.Private.DataContractSerialization.nuspec"
       ]
     },
-    "System.Private.Networking/4.0.1-beta-23324": {
+    "System.Private.Networking/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "OfyxoeCdh1ypzdz1u0h1Clgt+6749vALs2ZPkLwsOPzL0INCG9ISYo+Jhh62ZD8TMkWwLrvyVppMBPHY6M7Upw==",
+      "sha512": "8NZi1gCQaGTKDb2yWplm52HWCLaZnUwVitksJgcXY2dEJau/TBGyZup+yhOngOIe8QzQMxNG4iokY3Ce0/8mbg==",
       "files": [
         "lib/DNXCore50/System.Private.Networking.dll",
         "lib/netcore50/System.Private.Networking.dll",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "System.Private.Networking.4.0.1-beta-23324.nupkg",
-        "System.Private.Networking.4.0.1-beta-23324.nupkg.sha512",
+        "System.Private.Networking.4.0.1-beta-23330.nupkg",
+        "System.Private.Networking.4.0.1-beta-23330.nupkg.sha512",
         "System.Private.Networking.nuspec"
       ]
     },
-    "System.Private.ServiceModel/4.0.1-beta-23324": {
+    "System.Private.ServiceModel/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "Lz3T9V8GnaOFlf8LUmuPznuOIuy92BAFVc9huiMrFKByzPpydGuCvXEe+81rZ1IF2TQcHKO++9otnj96AEJ5BA==",
+      "sha512": "8lENvmHuZdlvmnYN1w98Mv8bDjc0O/YlaNHRRph35T/fLDyaG8LMLMwG3/ut6a/AenLJmbf92snOtNXCuqM+cQ==",
       "files": [
         "lib/DNXCore50/System.Private.ServiceModel.dll",
         "lib/netcore50/System.Private.ServiceModel.dll",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "System.Private.ServiceModel.4.0.1-beta-23324.nupkg",
-        "System.Private.ServiceModel.4.0.1-beta-23324.nupkg.sha512",
+        "System.Private.ServiceModel.4.0.1-beta-23330.nupkg",
+        "System.Private.ServiceModel.4.0.1-beta-23330.nupkg.sha512",
         "System.Private.ServiceModel.nuspec"
       ]
     },
@@ -2531,10 +2639,10 @@
         "System.Security.Claims.nuspec"
       ]
     },
-    "System.Security.Cryptography.Algorithms/4.0.0-beta-23324": {
+    "System.Security.Cryptography.Algorithms/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "Mt6LwMj8hPp0+xZHcV6grZ7wSWhgycGkdZ6DQ9XvUY9NguUsvb/+fu2cMdrC7XsnpvwIROByp+p2dSjqBn3E2Q==",
+      "sha512": "FB4RoTDaV5tBiPSJsiG3A5DydeKz7ErglnkqVjBFjm6wu8kg91j0MxL/Al9iUyu9i/hq53fRs5KE3rjUNYvf5w==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2548,15 +2656,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.Algorithms.4.0.0-beta-23324.nupkg",
-        "System.Security.Cryptography.Algorithms.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Cryptography.Algorithms.4.0.0-beta-23330.nupkg",
+        "System.Security.Cryptography.Algorithms.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Cryptography.Algorithms.nuspec"
       ]
     },
-    "System.Security.Cryptography.Encoding/4.0.0-beta-23324": {
+    "System.Security.Cryptography.Encoding/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "JHOyknf1eYO6C39Vao6kAGpadq3PBO1L4tuzNEz/HvbH5sfIHPbjhxL11OyAhVKCzLCfEj6+aeClovFqZIRPyw==",
+      "sha512": "zeFdKQT6xjNdiNCaEmEYJMEK59kixkX7jJSoOLw3H+53t9X0F98vr3tS8YlrW/Lk/K9c6L5pYLlkb2dNqvUD/g==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2570,15 +2678,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.Encoding.4.0.0-beta-23324.nupkg",
-        "System.Security.Cryptography.Encoding.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Cryptography.Encoding.4.0.0-beta-23330.nupkg",
+        "System.Security.Cryptography.Encoding.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Cryptography.Encoding.nuspec"
       ]
     },
-    "System.Security.Cryptography.Primitives/4.0.0-beta-23324": {
+    "System.Security.Cryptography.Primitives/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "ETZxelIX51Di4FTytd8ohSpN6Ym/32aWIX9E2NCFkd91qdexn2Dkysn80b6n4gX6jG+oL0UHQDtD/fYq8C65oQ==",
+      "sha512": "15uVbOD3X0sRQJIxcEH5hasxlFdbA1CmPPZa0Y8pYEuQcWMF2gBswvU8s4qoKtA7x2xhNhzPsXIhsQuKNMTdEA==",
       "files": [
         "lib/dotnet/System.Security.Cryptography.Primitives.dll",
         "lib/MonoAndroid10/_._",
@@ -2592,15 +2700,15 @@
         "ref/net46/System.Security.Cryptography.Primitives.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Security.Cryptography.Primitives.4.0.0-beta-23324.nupkg",
-        "System.Security.Cryptography.Primitives.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Cryptography.Primitives.4.0.0-beta-23330.nupkg",
+        "System.Security.Cryptography.Primitives.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Cryptography.Primitives.nuspec"
       ]
     },
-    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23324": {
+    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "8NaEOxkkNBUECh0cPzGpbXS0uzGDpnvxI0kqQKRGp9uA+9qCyQfxcqAT6ozAYtOuFNVaC1XU3zQnb7T2nfvIDg==",
+      "sha512": "L8mUimdm7+GsORgJ8DFBMGsFnwDJ5YCUdJj3HfXQx4HCoPDPF+vJo3HRiHfcvNA2Zsf0ov2kuerYj/eeVa2/Rw==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2614,8 +2722,8 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23324.nupkg",
-        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23330.nupkg",
+        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Cryptography.X509Certificates.nuspec"
       ]
     },
@@ -2652,10 +2760,10 @@
         "System.Security.Principal.nuspec"
       ]
     },
-    "System.Security.Principal.Windows/4.0.0-beta-23324": {
+    "System.Security.Principal.Windows/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "csbCKdwBz31T8He7U6XMIc9BiWgwjHs5WDZR4rfhsk48TpdsbKNHX9OX4b+GwvgcsfVuWxre7zqNR0Bc9gWZ7g==",
+      "sha512": "q+3L3aB8bn0HCW52kX9TSJdhbjffBw7QWCOu0yX1SDhPN9MCPmJ4aBBCn1HRWroa5y7UcNUdjL1xwiERycZexw==",
       "files": [
         "lib/DNXCore50/de/System.Security.Principal.Windows.xml",
         "lib/DNXCore50/es/System.Security.Principal.Windows.xml",
@@ -2671,15 +2779,15 @@
         "lib/net46/System.Security.Principal.Windows.dll",
         "ref/dotnet/System.Security.Principal.Windows.dll",
         "ref/net46/System.Security.Principal.Windows.dll",
-        "System.Security.Principal.Windows.4.0.0-beta-23324.nupkg",
-        "System.Security.Principal.Windows.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Principal.Windows.4.0.0-beta-23330.nupkg",
+        "System.Security.Principal.Windows.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Principal.Windows.nuspec"
       ]
     },
-    "System.ServiceModel.Duplex/4.0.1-beta-23324": {
+    "System.ServiceModel.Duplex/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "b+p3u2zee0oAM4AIyM9rev1MaoExxD4d97iNeZFG0Q0bEVFOzK97/5HNcq5FzpTUhxZgfXXCOCmuIYwnYsfU/w==",
+      "sha512": "0k9wL8LeMYj1jfu2wZwTdQhmPBcpMSUgD304cR50CpHOJnrP/NjiQ0Blx3oSURd8Tda5XuXC0PNGWDF+EpW/Lg==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Duplex.dll",
         "lib/net45/_._",
@@ -2699,15 +2807,15 @@
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.Duplex.dll",
         "ref/win8/_._",
-        "System.ServiceModel.Duplex.4.0.1-beta-23324.nupkg",
-        "System.ServiceModel.Duplex.4.0.1-beta-23324.nupkg.sha512",
+        "System.ServiceModel.Duplex.4.0.1-beta-23330.nupkg",
+        "System.ServiceModel.Duplex.4.0.1-beta-23330.nupkg.sha512",
         "System.ServiceModel.Duplex.nuspec"
       ]
     },
-    "System.ServiceModel.Http/4.0.11-beta-23324": {
+    "System.ServiceModel.Http/4.0.11-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "VkTumuCSmXd0NPZZU+nrO7YqznvM+wP96NykXbxFJdNAtCplmqXaQh+YZ/02rjJmfou5qyo2V+ZWVwySBAirOg==",
+      "sha512": "NHKxIIYL0ATDbX18RLCSXtuq26MMoYfAVdpl5K+D0s5AHp7TMPb7LcjZPpg25B2v48x1TwE9LYcYTCiOZcoPzQ==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Http.dll",
         "lib/MonoAndroid10/_._",
@@ -2732,15 +2840,15 @@
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.ServiceModel.Http.4.0.11-beta-23324.nupkg",
-        "System.ServiceModel.Http.4.0.11-beta-23324.nupkg.sha512",
+        "System.ServiceModel.Http.4.0.11-beta-23330.nupkg",
+        "System.ServiceModel.Http.4.0.11-beta-23330.nupkg.sha512",
         "System.ServiceModel.Http.nuspec"
       ]
     },
-    "System.ServiceModel.NetTcp/4.0.1-beta-23324": {
+    "System.ServiceModel.NetTcp/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "xI03xQCdWzqq4H2E29BELQm/e9LJl+IAbD50lcH966Z+JdaYOqeM6RGxAys0sVim59wvCrOv/YaRNxz66YLoog==",
+      "sha512": "Vx0QSKz4BlX/yYqKHET3mofo6RxxaMDLWsEFWDbEBJeCs0Yq19uGiIYwK1mXkWy3Y+jDwi42au3mVhmRbDHavA==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.NetTcp.dll",
         "lib/net45/_._",
@@ -2760,15 +2868,15 @@
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.NetTcp.dll",
         "ref/win8/_._",
-        "System.ServiceModel.NetTcp.4.0.1-beta-23324.nupkg",
-        "System.ServiceModel.NetTcp.4.0.1-beta-23324.nupkg.sha512",
+        "System.ServiceModel.NetTcp.4.0.1-beta-23330.nupkg",
+        "System.ServiceModel.NetTcp.4.0.1-beta-23330.nupkg.sha512",
         "System.ServiceModel.NetTcp.nuspec"
       ]
     },
-    "System.ServiceModel.Primitives/4.0.1-beta-23324": {
+    "System.ServiceModel.Primitives/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "bmU31B4CD5+m9Kt0iDM5Yw2ZXRfv7lpK3Sx1HektcT/HERc+IMPdO38f/Wxtofo5WOA0qmd1fdrMeQcbEkDfJg==",
+      "sha512": "kJ/pcRUf7Ow7s/rX8Kmc9P2k6cvyudIzyUcqr/pn9NwY8DC/2DWkkFvYE2udR4kvBzJJzXl/rsJQlyLIVGMAww==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Primitives.dll",
         "lib/net45/_._",
@@ -2788,8 +2896,8 @@
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.Primitives.dll",
         "ref/win8/_._",
-        "System.ServiceModel.Primitives.4.0.1-beta-23324.nupkg",
-        "System.ServiceModel.Primitives.4.0.1-beta-23324.nupkg.sha512",
+        "System.ServiceModel.Primitives.4.0.1-beta-23330.nupkg",
+        "System.ServiceModel.Primitives.4.0.1-beta-23330.nupkg.sha512",
         "System.ServiceModel.Primitives.nuspec"
       ]
     },
@@ -2984,10 +3092,9 @@
         "System.Threading.Tasks.nuspec"
       ]
     },
-    "System.Threading.ThreadPool/4.0.10-beta-23324": {
+    "System.Threading.ThreadPool/4.0.10-beta-23330": {
       "type": "package",
-      "serviceable": true,
-      "sha512": "G4SjGmiV72HBiv8wkfnKFGTieekrACU1m43VaeJ6vDeSyb08eEFusVH1UWZpOsUF25meCuzpda0ezus24b4rKA==",
+      "sha512": "nM5OewUj8NJrye93apbM6KHvPddgPJGzt1IWIXk9lV5HB4NGsn6M5U0gxMQWShQuDp6NF3ya3ULRSvh3dLMbzg==",
       "files": [
         "lib/DNXCore50/System.Threading.ThreadPool.dll",
         "lib/MonoAndroid10/_._",
@@ -3001,8 +3108,8 @@
         "ref/net46/System.Threading.ThreadPool.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Threading.ThreadPool.4.0.10-beta-23324.nupkg",
-        "System.Threading.ThreadPool.4.0.10-beta-23324.nupkg.sha512",
+        "System.Threading.ThreadPool.4.0.10-beta-23330.nupkg",
+        "System.Threading.ThreadPool.4.0.10-beta-23330.nupkg.sha512",
         "System.Threading.ThreadPool.nuspec"
       ]
     },
@@ -3253,14 +3360,14 @@
         "xunit.extensibility.execution.nuspec"
       ]
     },
-    "xunit.netcore.extensions/1.0.0-prerelease-00095": {
+    "xunit.netcore.extensions/1.0.0-prerelease-00098": {
       "type": "package",
       "serviceable": true,
-      "sha512": "FuvWmkuxHiqD0cHDggg5MRmBoeM4Uea7OUEmKvZiQu7Fy02hJ6yKKNV7mNW3y4scwSzDNA81Qa+HIS33PeWUog==",
+      "sha512": "3kRPwTbC42YGmsNHpNMKfGVOO5cVfxUD+C7cYbti1aml4UCT/RFZ6lhm5Vym2wNRDxryu0Es78aMf1BaybSrDg==",
       "files": [
         "lib/dotnet/Xunit.NetCore.Extensions.dll",
-        "xunit.netcore.extensions.1.0.0-prerelease-00095.nupkg",
-        "xunit.netcore.extensions.1.0.0-prerelease-00095.nupkg.sha512",
+        "xunit.netcore.extensions.1.0.0-prerelease-00098.nupkg",
+        "xunit.netcore.extensions.1.0.0-prerelease-00098.nupkg.sha512",
         "xunit.netcore.extensions.nuspec"
       ]
     }

--- a/src/System.Private.ServiceModel/tests/Scenarios/Contract/Data/project.lock.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Contract/Data/project.lock.json
@@ -292,7 +292,7 @@
           "lib/dotnet/System.Linq.Queryable.dll": {}
         }
       },
-      "System.Net.Http/4.0.1-beta-23324": {
+      "System.Net.Http/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -305,16 +305,15 @@
           "ref/dotnet/System.Net.Http.dll": {}
         }
       },
-      "System.Net.NameResolution/4.0.0-beta-23324": {
+      "System.Net.NameResolution/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.Networking": "4.0.1-beta-23324"
+          "System.Net.Primitives": "4.0.10",
+          "System.Runtime": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Net.NameResolution.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Net.NameResolution.dll": {}
         }
       },
       "System.Net.Primitives/4.0.10": {
@@ -329,10 +328,10 @@
           "lib/DNXCore50/System.Net.Primitives.dll": {}
         }
       },
-      "System.Net.Security/4.0.0-beta-23324": {
+      "System.Net.Security/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.Networking": "4.0.1-beta-23324"
+          "System.Private.Networking": "4.0.1-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.Net.Security.dll": {}
@@ -367,6 +366,49 @@
         },
         "runtime": {
           "lib/dotnet/System.Net.WebHeaderCollection.dll": {}
+        }
+      },
+      "System.Net.WebSockets/4.0.0-beta-23330": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.Win32.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Threading.Tasks": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Net.WebSockets.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Net.WebSockets.dll": {}
+        }
+      },
+      "System.Net.WebSockets.Client/4.0.0-beta-23330": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.Win32.Primitives": "4.0.0",
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Diagnostics.Tracing": "4.0.20",
+          "System.Globalization": "4.0.10",
+          "System.Net.Primitives": "4.0.10",
+          "System.Net.WebHeaderCollection": "4.0.0",
+          "System.Net.WebSockets": "4.0.0-beta-23330",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23330",
+          "System.Text.Encoding": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Net.WebSockets.Client.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Net.WebSockets.Client.dll": {}
         }
       },
       "System.ObjectModel/4.0.10": {
@@ -414,7 +456,7 @@
           "lib/DNXCore50/System.Private.DataContractSerialization.dll": {}
         }
       },
-      "System.Private.Networking/4.0.1-beta-23324": {
+      "System.Private.Networking/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -433,13 +475,13 @@
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23324",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23324",
-          "System.Security.Principal.Windows": "4.0.0-beta-23324",
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23330",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23330",
+          "System.Security.Principal.Windows": "4.0.0-beta-23330",
           "System.Threading": "4.0.10",
           "System.Threading.Overlapped": "4.0.0",
           "System.Threading.Tasks": "4.0.10",
-          "System.Threading.ThreadPool": "4.0.10-beta-23324"
+          "System.Threading.ThreadPool": "4.0.10-beta-23330"
         },
         "compile": {
           "ref/dnxcore50/_._": {}
@@ -448,7 +490,7 @@
           "lib/DNXCore50/System.Private.Networking.dll": {}
         }
       },
-      "System.Private.ServiceModel/4.0.1-beta-23324": {
+      "System.Private.ServiceModel/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -465,12 +507,14 @@
           "System.Linq": "4.0.0",
           "System.Linq.Expressions": "4.0.10",
           "System.Linq.Queryable": "4.0.0",
-          "System.Net.Http": "4.0.1-beta-23324",
-          "System.Net.NameResolution": "4.0.0-beta-23324",
+          "System.Net.Http": "4.0.1-beta-23330",
+          "System.Net.NameResolution": "4.0.0-beta-23330",
           "System.Net.Primitives": "4.0.10",
-          "System.Net.Security": "4.0.0-beta-23324",
-          "System.Net.Sockets": "4.0.10-beta-23324",
+          "System.Net.Security": "4.0.0-beta-23330",
+          "System.Net.Sockets": "4.0.10-beta-23330",
           "System.Net.WebHeaderCollection": "4.0.0",
+          "System.Net.WebSockets": "4.0.0-beta-23330",
+          "System.Net.WebSockets.Client": "4.0.0-beta-23330",
           "System.ObjectModel": "4.0.10",
           "System.Reflection": "4.0.10",
           "System.Reflection.DispatchProxy": "4.0.0",
@@ -484,9 +528,9 @@
           "System.Runtime.Serialization.Primitives": "4.0.10",
           "System.Runtime.Serialization.Xml": "4.0.10",
           "System.Security.Claims": "4.0.0",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23324",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23330",
           "System.Security.Principal": "4.0.0",
-          "System.Security.Principal.Windows": "4.0.0-beta-23324",
+          "System.Security.Principal.Windows": "4.0.0-beta-23330",
           "System.Text.Encoding": "4.0.10",
           "System.Threading": "4.0.10",
           "System.Threading.Tasks": "4.0.10",
@@ -750,18 +794,18 @@
           "lib/dotnet/System.Security.Claims.dll": {}
         }
       },
-      "System.Security.Cryptography.Algorithms/4.0.0-beta-23324": {
+      "System.Security.Cryptography.Algorithms/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
           "System.Runtime": "4.0.0",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23324"
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.Algorithms.dll": {}
         }
       },
-      "System.Security.Cryptography.Encoding/4.0.0-beta-23324": {
+      "System.Security.Cryptography.Encoding/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -770,7 +814,7 @@
           "ref/dotnet/System.Security.Cryptography.Encoding.dll": {}
         }
       },
-      "System.Security.Cryptography.Primitives/4.0.0-beta-23324": {
+      "System.Security.Cryptography.Primitives/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.0",
@@ -788,13 +832,13 @@
           "lib/dotnet/System.Security.Cryptography.Primitives.dll": {}
         }
       },
-      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23324": {
+      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
           "System.Runtime.Handles": "4.0.0",
-          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23324",
-          "System.Security.Cryptography.Encoding": "4.0.0-beta-23324"
+          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23330",
+          "System.Security.Cryptography.Encoding": "4.0.0-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.X509Certificates.dll": {}
@@ -812,7 +856,7 @@
           "lib/dotnet/System.Security.Principal.dll": {}
         }
       },
-      "System.Security.Principal.Windows/4.0.0-beta-23324": {
+      "System.Security.Principal.Windows/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -835,10 +879,10 @@
           "lib/DNXCore50/System.Security.Principal.Windows.dll": {}
         }
       },
-      "System.ServiceModel.Duplex/4.0.1-beta-23324": {
+      "System.ServiceModel.Duplex/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.0.1-beta-23324"
+          "System.Private.ServiceModel": "4.0.1-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.ServiceModel.Duplex.dll": {}
@@ -847,10 +891,10 @@
           "lib/DNXCore50/System.ServiceModel.Duplex.dll": {}
         }
       },
-      "System.ServiceModel.Http/4.0.11-beta-23324": {
+      "System.ServiceModel.Http/4.0.11-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.0.1-beta-23324",
+          "System.Private.ServiceModel": "4.0.1-beta-23330",
           "System.Runtime": "4.0.20"
         },
         "compile": {
@@ -860,10 +904,10 @@
           "lib/DNXCore50/System.ServiceModel.Http.dll": {}
         }
       },
-      "System.ServiceModel.NetTcp/4.0.1-beta-23324": {
+      "System.ServiceModel.NetTcp/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.0.1-beta-23324"
+          "System.Private.ServiceModel": "4.0.1-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.ServiceModel.NetTcp.dll": {}
@@ -872,10 +916,10 @@
           "lib/DNXCore50/System.ServiceModel.NetTcp.dll": {}
         }
       },
-      "System.ServiceModel.Primitives/4.0.1-beta-23324": {
+      "System.ServiceModel.Primitives/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.0.1-beta-23324"
+          "System.Private.ServiceModel": "4.0.1-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.ServiceModel.Primitives.dll": {}
@@ -964,7 +1008,7 @@
           "lib/DNXCore50/System.Threading.Tasks.dll": {}
         }
       },
-      "System.Threading.ThreadPool/4.0.10-beta-23324": {
+      "System.Threading.ThreadPool/4.0.10-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
@@ -1157,7 +1201,7 @@
           "lib/dotnet/xunit.execution.dotnet.dll": {}
         }
       },
-      "xunit.netcore.extensions/1.0.0-prerelease-00095": {
+      "xunit.netcore.extensions/1.0.0-prerelease-00098": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.10",
@@ -1785,23 +1829,12 @@
         "System.Linq.Queryable.nuspec"
       ]
     },
-    "System.Net.Http/4.0.1-beta-23324": {
+    "System.Net.Http/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "gXfHlWsiMQDuFqwnQrlQTje9vqMhCFLtm35jX4WqZjcfa3y69DbwueeT0gJbVMK88/UnG8FAYiDBb7AKyu+51w==",
+      "sha512": "itLPx7B7Ac4mX8wQx9V9DQcxqTgkmwDNnQIHuCgAH53Jq2X3XziiRRBbxbmNJlWqBlgPzbseWJmMCtcF/ePhOg==",
       "files": [
         "lib/net45/_._",
-        "lib/netcore50/de/System.Net.Http.xml",
-        "lib/netcore50/es/System.Net.Http.xml",
-        "lib/netcore50/fr/System.Net.Http.xml",
-        "lib/netcore50/it/System.Net.Http.xml",
-        "lib/netcore50/ja/System.Net.Http.xml",
-        "lib/netcore50/ko/System.Net.Http.xml",
-        "lib/netcore50/ru/System.Net.Http.xml",
-        "lib/netcore50/System.Net.Http.dll",
-        "lib/netcore50/System.Net.Http.xml",
-        "lib/netcore50/zh-hans/System.Net.Http.xml",
-        "lib/netcore50/zh-hant/System.Net.Http.xml",
         "lib/win8/_._",
         "lib/wpa81/_._",
         "ref/dotnet/System.Net.Http.dll",
@@ -1810,17 +1843,16 @@
         "ref/win8/_._",
         "ref/wpa81/_._",
         "runtime.json",
-        "System.Net.Http.4.0.1-beta-23324.nupkg",
-        "System.Net.Http.4.0.1-beta-23324.nupkg.sha512",
+        "System.Net.Http.4.0.1-beta-23330.nupkg",
+        "System.Net.Http.4.0.1-beta-23330.nupkg.sha512",
         "System.Net.Http.nuspec"
       ]
     },
-    "System.Net.NameResolution/4.0.0-beta-23324": {
+    "System.Net.NameResolution/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "lNYXUmnSXUtLFY09Rc27zJ6/TxCuGggQzBgiuWHoWrjWxymuuxqPT2Mj7Dn7sUUh0GvF2MOx7Uk+rtCFBiIavg==",
+      "sha512": "d8Am+In/aBgcHpEV6xsi5BCiTEN4y6s9O1V/yIvwX8mDC4CtdZiGsi4DtoB0TLOgp8ky6GxbSF4bKCjFpBO3uw==",
       "files": [
-        "lib/DNXCore50/System.Net.NameResolution.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.NameResolution.dll",
@@ -1832,8 +1864,9 @@
         "ref/net46/System.Net.NameResolution.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.NameResolution.4.0.0-beta-23324.nupkg",
-        "System.Net.NameResolution.4.0.0-beta-23324.nupkg.sha512",
+        "runtime.json",
+        "System.Net.NameResolution.4.0.0-beta-23330.nupkg",
+        "System.Net.NameResolution.4.0.0-beta-23330.nupkg.sha512",
         "System.Net.NameResolution.nuspec"
       ]
     },
@@ -1870,9 +1903,9 @@
         "System.Net.Primitives.nuspec"
       ]
     },
-    "System.Net.Security/4.0.0-beta-23324": {
+    "System.Net.Security/4.0.0-beta-23330": {
       "type": "package",
-      "sha512": "D04RYjxrnR3D+uI9CGmAAFKKQ6T+pPcRHYucc1PIo7/hJK5I/Yu7gAw9yOxHUhQjSGfrKo00lHpBCQMTQt4lSw==",
+      "sha512": "z98dKloNy9DBdyfqQwQvKWA2q8Qj4vgGEVONnlS70c13eh0MolBHJ0wNdplZZK5zYZ5Eu8GTwexbUlpHbsfzVA==",
       "files": [
         "lib/DNXCore50/System.Net.Security.dll",
         "lib/MonoAndroid10/_._",
@@ -1886,8 +1919,8 @@
         "ref/net46/System.Net.Security.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.Security.4.0.0-beta-23324.nupkg",
-        "System.Net.Security.4.0.0-beta-23324.nupkg.sha512",
+        "System.Net.Security.4.0.0-beta-23330.nupkg",
+        "System.Net.Security.4.0.0-beta-23330.nupkg.sha512",
         "System.Net.Security.nuspec"
       ]
     },
@@ -1945,6 +1978,81 @@
         "System.Net.WebHeaderCollection.nuspec"
       ]
     },
+    "System.Net.WebSockets/4.0.0-beta-23330": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "6Q9/uTDcaqbmdbD04MisKmjti4aEpp40i/UzpGaPZ4ItuwzU/pMk9RjiYUBUiCQyZeKNlXcSB1FPN2nFof7tww==",
+      "files": [
+        "lib/dotnet/de/System.Net.WebSockets.xml",
+        "lib/dotnet/es/System.Net.WebSockets.xml",
+        "lib/dotnet/fr/System.Net.WebSockets.xml",
+        "lib/dotnet/it/System.Net.WebSockets.xml",
+        "lib/dotnet/ja/System.Net.WebSockets.xml",
+        "lib/dotnet/ko/System.Net.WebSockets.xml",
+        "lib/dotnet/ru/System.Net.WebSockets.xml",
+        "lib/dotnet/System.Net.WebSockets.dll",
+        "lib/dotnet/System.Net.WebSockets.xml",
+        "lib/dotnet/zh-hans/System.Net.WebSockets.xml",
+        "lib/dotnet/zh-hant/System.Net.WebSockets.xml",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Net.WebSockets.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Net.WebSockets.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Net.WebSockets.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Net.WebSockets.4.0.0-beta-23330.nupkg",
+        "System.Net.WebSockets.4.0.0-beta-23330.nupkg.sha512",
+        "System.Net.WebSockets.nuspec"
+      ]
+    },
+    "System.Net.WebSockets.Client/4.0.0-beta-23330": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "1NWEqwDkYRyvr1gSKZlY51AaI9w8oD0dC5UNa2Lb+qaeFHSF5KfCSzf7seD+im+sH6uocVo2nppiaabfbXZT4Q==",
+      "files": [
+        "lib/DNXCore50/de/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/es/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/fr/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/it/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/ja/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/ko/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/ru/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/System.Net.WebSockets.Client.dll",
+        "lib/DNXCore50/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/zh-hans/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/zh-hant/System.Net.WebSockets.Client.xml",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Net.WebSockets.Client.dll",
+        "lib/netcore50/de/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/es/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/fr/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/it/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/ja/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/ko/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/ru/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/System.Net.WebSockets.Client.dll",
+        "lib/netcore50/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/zh-hans/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/zh-hant/System.Net.WebSockets.Client.xml",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Net.WebSockets.Client.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Net.WebSockets.Client.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Net.WebSockets.Client.4.0.0-beta-23330.nupkg",
+        "System.Net.WebSockets.Client.4.0.0-beta-23330.nupkg.sha512",
+        "System.Net.WebSockets.Client.nuspec"
+      ]
+    },
     "System.ObjectModel/4.0.10": {
       "type": "package",
       "serviceable": true,
@@ -1993,31 +2101,31 @@
         "System.Private.DataContractSerialization.nuspec"
       ]
     },
-    "System.Private.Networking/4.0.1-beta-23324": {
+    "System.Private.Networking/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "OfyxoeCdh1ypzdz1u0h1Clgt+6749vALs2ZPkLwsOPzL0INCG9ISYo+Jhh62ZD8TMkWwLrvyVppMBPHY6M7Upw==",
+      "sha512": "8NZi1gCQaGTKDb2yWplm52HWCLaZnUwVitksJgcXY2dEJau/TBGyZup+yhOngOIe8QzQMxNG4iokY3Ce0/8mbg==",
       "files": [
         "lib/DNXCore50/System.Private.Networking.dll",
         "lib/netcore50/System.Private.Networking.dll",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "System.Private.Networking.4.0.1-beta-23324.nupkg",
-        "System.Private.Networking.4.0.1-beta-23324.nupkg.sha512",
+        "System.Private.Networking.4.0.1-beta-23330.nupkg",
+        "System.Private.Networking.4.0.1-beta-23330.nupkg.sha512",
         "System.Private.Networking.nuspec"
       ]
     },
-    "System.Private.ServiceModel/4.0.1-beta-23324": {
+    "System.Private.ServiceModel/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "Lz3T9V8GnaOFlf8LUmuPznuOIuy92BAFVc9huiMrFKByzPpydGuCvXEe+81rZ1IF2TQcHKO++9otnj96AEJ5BA==",
+      "sha512": "8lENvmHuZdlvmnYN1w98Mv8bDjc0O/YlaNHRRph35T/fLDyaG8LMLMwG3/ut6a/AenLJmbf92snOtNXCuqM+cQ==",
       "files": [
         "lib/DNXCore50/System.Private.ServiceModel.dll",
         "lib/netcore50/System.Private.ServiceModel.dll",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "System.Private.ServiceModel.4.0.1-beta-23324.nupkg",
-        "System.Private.ServiceModel.4.0.1-beta-23324.nupkg.sha512",
+        "System.Private.ServiceModel.4.0.1-beta-23330.nupkg",
+        "System.Private.ServiceModel.4.0.1-beta-23330.nupkg.sha512",
         "System.Private.ServiceModel.nuspec"
       ]
     },
@@ -2572,10 +2680,10 @@
         "System.Security.Claims.nuspec"
       ]
     },
-    "System.Security.Cryptography.Algorithms/4.0.0-beta-23324": {
+    "System.Security.Cryptography.Algorithms/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "Mt6LwMj8hPp0+xZHcV6grZ7wSWhgycGkdZ6DQ9XvUY9NguUsvb/+fu2cMdrC7XsnpvwIROByp+p2dSjqBn3E2Q==",
+      "sha512": "FB4RoTDaV5tBiPSJsiG3A5DydeKz7ErglnkqVjBFjm6wu8kg91j0MxL/Al9iUyu9i/hq53fRs5KE3rjUNYvf5w==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2589,15 +2697,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.Algorithms.4.0.0-beta-23324.nupkg",
-        "System.Security.Cryptography.Algorithms.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Cryptography.Algorithms.4.0.0-beta-23330.nupkg",
+        "System.Security.Cryptography.Algorithms.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Cryptography.Algorithms.nuspec"
       ]
     },
-    "System.Security.Cryptography.Encoding/4.0.0-beta-23324": {
+    "System.Security.Cryptography.Encoding/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "JHOyknf1eYO6C39Vao6kAGpadq3PBO1L4tuzNEz/HvbH5sfIHPbjhxL11OyAhVKCzLCfEj6+aeClovFqZIRPyw==",
+      "sha512": "zeFdKQT6xjNdiNCaEmEYJMEK59kixkX7jJSoOLw3H+53t9X0F98vr3tS8YlrW/Lk/K9c6L5pYLlkb2dNqvUD/g==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2611,15 +2719,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.Encoding.4.0.0-beta-23324.nupkg",
-        "System.Security.Cryptography.Encoding.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Cryptography.Encoding.4.0.0-beta-23330.nupkg",
+        "System.Security.Cryptography.Encoding.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Cryptography.Encoding.nuspec"
       ]
     },
-    "System.Security.Cryptography.Primitives/4.0.0-beta-23324": {
+    "System.Security.Cryptography.Primitives/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "ETZxelIX51Di4FTytd8ohSpN6Ym/32aWIX9E2NCFkd91qdexn2Dkysn80b6n4gX6jG+oL0UHQDtD/fYq8C65oQ==",
+      "sha512": "15uVbOD3X0sRQJIxcEH5hasxlFdbA1CmPPZa0Y8pYEuQcWMF2gBswvU8s4qoKtA7x2xhNhzPsXIhsQuKNMTdEA==",
       "files": [
         "lib/dotnet/System.Security.Cryptography.Primitives.dll",
         "lib/MonoAndroid10/_._",
@@ -2633,15 +2741,15 @@
         "ref/net46/System.Security.Cryptography.Primitives.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Security.Cryptography.Primitives.4.0.0-beta-23324.nupkg",
-        "System.Security.Cryptography.Primitives.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Cryptography.Primitives.4.0.0-beta-23330.nupkg",
+        "System.Security.Cryptography.Primitives.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Cryptography.Primitives.nuspec"
       ]
     },
-    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23324": {
+    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "8NaEOxkkNBUECh0cPzGpbXS0uzGDpnvxI0kqQKRGp9uA+9qCyQfxcqAT6ozAYtOuFNVaC1XU3zQnb7T2nfvIDg==",
+      "sha512": "L8mUimdm7+GsORgJ8DFBMGsFnwDJ5YCUdJj3HfXQx4HCoPDPF+vJo3HRiHfcvNA2Zsf0ov2kuerYj/eeVa2/Rw==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2655,8 +2763,8 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23324.nupkg",
-        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23330.nupkg",
+        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Cryptography.X509Certificates.nuspec"
       ]
     },
@@ -2693,10 +2801,10 @@
         "System.Security.Principal.nuspec"
       ]
     },
-    "System.Security.Principal.Windows/4.0.0-beta-23324": {
+    "System.Security.Principal.Windows/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "csbCKdwBz31T8He7U6XMIc9BiWgwjHs5WDZR4rfhsk48TpdsbKNHX9OX4b+GwvgcsfVuWxre7zqNR0Bc9gWZ7g==",
+      "sha512": "q+3L3aB8bn0HCW52kX9TSJdhbjffBw7QWCOu0yX1SDhPN9MCPmJ4aBBCn1HRWroa5y7UcNUdjL1xwiERycZexw==",
       "files": [
         "lib/DNXCore50/de/System.Security.Principal.Windows.xml",
         "lib/DNXCore50/es/System.Security.Principal.Windows.xml",
@@ -2712,15 +2820,15 @@
         "lib/net46/System.Security.Principal.Windows.dll",
         "ref/dotnet/System.Security.Principal.Windows.dll",
         "ref/net46/System.Security.Principal.Windows.dll",
-        "System.Security.Principal.Windows.4.0.0-beta-23324.nupkg",
-        "System.Security.Principal.Windows.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Principal.Windows.4.0.0-beta-23330.nupkg",
+        "System.Security.Principal.Windows.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Principal.Windows.nuspec"
       ]
     },
-    "System.ServiceModel.Duplex/4.0.1-beta-23324": {
+    "System.ServiceModel.Duplex/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "b+p3u2zee0oAM4AIyM9rev1MaoExxD4d97iNeZFG0Q0bEVFOzK97/5HNcq5FzpTUhxZgfXXCOCmuIYwnYsfU/w==",
+      "sha512": "0k9wL8LeMYj1jfu2wZwTdQhmPBcpMSUgD304cR50CpHOJnrP/NjiQ0Blx3oSURd8Tda5XuXC0PNGWDF+EpW/Lg==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Duplex.dll",
         "lib/net45/_._",
@@ -2740,15 +2848,15 @@
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.Duplex.dll",
         "ref/win8/_._",
-        "System.ServiceModel.Duplex.4.0.1-beta-23324.nupkg",
-        "System.ServiceModel.Duplex.4.0.1-beta-23324.nupkg.sha512",
+        "System.ServiceModel.Duplex.4.0.1-beta-23330.nupkg",
+        "System.ServiceModel.Duplex.4.0.1-beta-23330.nupkg.sha512",
         "System.ServiceModel.Duplex.nuspec"
       ]
     },
-    "System.ServiceModel.Http/4.0.11-beta-23324": {
+    "System.ServiceModel.Http/4.0.11-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "VkTumuCSmXd0NPZZU+nrO7YqznvM+wP96NykXbxFJdNAtCplmqXaQh+YZ/02rjJmfou5qyo2V+ZWVwySBAirOg==",
+      "sha512": "NHKxIIYL0ATDbX18RLCSXtuq26MMoYfAVdpl5K+D0s5AHp7TMPb7LcjZPpg25B2v48x1TwE9LYcYTCiOZcoPzQ==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Http.dll",
         "lib/MonoAndroid10/_._",
@@ -2773,15 +2881,15 @@
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.ServiceModel.Http.4.0.11-beta-23324.nupkg",
-        "System.ServiceModel.Http.4.0.11-beta-23324.nupkg.sha512",
+        "System.ServiceModel.Http.4.0.11-beta-23330.nupkg",
+        "System.ServiceModel.Http.4.0.11-beta-23330.nupkg.sha512",
         "System.ServiceModel.Http.nuspec"
       ]
     },
-    "System.ServiceModel.NetTcp/4.0.1-beta-23324": {
+    "System.ServiceModel.NetTcp/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "xI03xQCdWzqq4H2E29BELQm/e9LJl+IAbD50lcH966Z+JdaYOqeM6RGxAys0sVim59wvCrOv/YaRNxz66YLoog==",
+      "sha512": "Vx0QSKz4BlX/yYqKHET3mofo6RxxaMDLWsEFWDbEBJeCs0Yq19uGiIYwK1mXkWy3Y+jDwi42au3mVhmRbDHavA==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.NetTcp.dll",
         "lib/net45/_._",
@@ -2801,15 +2909,15 @@
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.NetTcp.dll",
         "ref/win8/_._",
-        "System.ServiceModel.NetTcp.4.0.1-beta-23324.nupkg",
-        "System.ServiceModel.NetTcp.4.0.1-beta-23324.nupkg.sha512",
+        "System.ServiceModel.NetTcp.4.0.1-beta-23330.nupkg",
+        "System.ServiceModel.NetTcp.4.0.1-beta-23330.nupkg.sha512",
         "System.ServiceModel.NetTcp.nuspec"
       ]
     },
-    "System.ServiceModel.Primitives/4.0.1-beta-23324": {
+    "System.ServiceModel.Primitives/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "bmU31B4CD5+m9Kt0iDM5Yw2ZXRfv7lpK3Sx1HektcT/HERc+IMPdO38f/Wxtofo5WOA0qmd1fdrMeQcbEkDfJg==",
+      "sha512": "kJ/pcRUf7Ow7s/rX8Kmc9P2k6cvyudIzyUcqr/pn9NwY8DC/2DWkkFvYE2udR4kvBzJJzXl/rsJQlyLIVGMAww==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Primitives.dll",
         "lib/net45/_._",
@@ -2829,8 +2937,8 @@
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.Primitives.dll",
         "ref/win8/_._",
-        "System.ServiceModel.Primitives.4.0.1-beta-23324.nupkg",
-        "System.ServiceModel.Primitives.4.0.1-beta-23324.nupkg.sha512",
+        "System.ServiceModel.Primitives.4.0.1-beta-23330.nupkg",
+        "System.ServiceModel.Primitives.4.0.1-beta-23330.nupkg.sha512",
         "System.ServiceModel.Primitives.nuspec"
       ]
     },
@@ -3025,10 +3133,9 @@
         "System.Threading.Tasks.nuspec"
       ]
     },
-    "System.Threading.ThreadPool/4.0.10-beta-23324": {
+    "System.Threading.ThreadPool/4.0.10-beta-23330": {
       "type": "package",
-      "serviceable": true,
-      "sha512": "G4SjGmiV72HBiv8wkfnKFGTieekrACU1m43VaeJ6vDeSyb08eEFusVH1UWZpOsUF25meCuzpda0ezus24b4rKA==",
+      "sha512": "nM5OewUj8NJrye93apbM6KHvPddgPJGzt1IWIXk9lV5HB4NGsn6M5U0gxMQWShQuDp6NF3ya3ULRSvh3dLMbzg==",
       "files": [
         "lib/DNXCore50/System.Threading.ThreadPool.dll",
         "lib/MonoAndroid10/_._",
@@ -3042,8 +3149,8 @@
         "ref/net46/System.Threading.ThreadPool.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Threading.ThreadPool.4.0.10-beta-23324.nupkg",
-        "System.Threading.ThreadPool.4.0.10-beta-23324.nupkg.sha512",
+        "System.Threading.ThreadPool.4.0.10-beta-23330.nupkg",
+        "System.Threading.ThreadPool.4.0.10-beta-23330.nupkg.sha512",
         "System.Threading.ThreadPool.nuspec"
       ]
     },
@@ -3294,14 +3401,14 @@
         "xunit.extensibility.execution.nuspec"
       ]
     },
-    "xunit.netcore.extensions/1.0.0-prerelease-00095": {
+    "xunit.netcore.extensions/1.0.0-prerelease-00098": {
       "type": "package",
       "serviceable": true,
-      "sha512": "FuvWmkuxHiqD0cHDggg5MRmBoeM4Uea7OUEmKvZiQu7Fy02hJ6yKKNV7mNW3y4scwSzDNA81Qa+HIS33PeWUog==",
+      "sha512": "3kRPwTbC42YGmsNHpNMKfGVOO5cVfxUD+C7cYbti1aml4UCT/RFZ6lhm5Vym2wNRDxryu0Es78aMf1BaybSrDg==",
       "files": [
         "lib/dotnet/Xunit.NetCore.Extensions.dll",
-        "xunit.netcore.extensions.1.0.0-prerelease-00095.nupkg",
-        "xunit.netcore.extensions.1.0.0-prerelease-00095.nupkg.sha512",
+        "xunit.netcore.extensions.1.0.0-prerelease-00098.nupkg",
+        "xunit.netcore.extensions.1.0.0-prerelease-00098.nupkg.sha512",
         "xunit.netcore.extensions.nuspec"
       ]
     }

--- a/src/System.Private.ServiceModel/tests/Scenarios/Contract/Fault/project.lock.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Contract/Fault/project.lock.json
@@ -292,7 +292,7 @@
           "lib/dotnet/System.Linq.Queryable.dll": {}
         }
       },
-      "System.Net.Http/4.0.1-beta-23324": {
+      "System.Net.Http/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -305,16 +305,15 @@
           "ref/dotnet/System.Net.Http.dll": {}
         }
       },
-      "System.Net.NameResolution/4.0.0-beta-23324": {
+      "System.Net.NameResolution/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.Networking": "4.0.1-beta-23324"
+          "System.Net.Primitives": "4.0.10",
+          "System.Runtime": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Net.NameResolution.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Net.NameResolution.dll": {}
         }
       },
       "System.Net.Primitives/4.0.10": {
@@ -329,10 +328,10 @@
           "lib/DNXCore50/System.Net.Primitives.dll": {}
         }
       },
-      "System.Net.Security/4.0.0-beta-23324": {
+      "System.Net.Security/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.Networking": "4.0.1-beta-23324"
+          "System.Private.Networking": "4.0.1-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.Net.Security.dll": {}
@@ -367,6 +366,49 @@
         },
         "runtime": {
           "lib/dotnet/System.Net.WebHeaderCollection.dll": {}
+        }
+      },
+      "System.Net.WebSockets/4.0.0-beta-23330": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.Win32.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Threading.Tasks": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Net.WebSockets.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Net.WebSockets.dll": {}
+        }
+      },
+      "System.Net.WebSockets.Client/4.0.0-beta-23330": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.Win32.Primitives": "4.0.0",
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Diagnostics.Tracing": "4.0.20",
+          "System.Globalization": "4.0.10",
+          "System.Net.Primitives": "4.0.10",
+          "System.Net.WebHeaderCollection": "4.0.0",
+          "System.Net.WebSockets": "4.0.0-beta-23330",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23330",
+          "System.Text.Encoding": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Net.WebSockets.Client.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Net.WebSockets.Client.dll": {}
         }
       },
       "System.ObjectModel/4.0.10": {
@@ -414,7 +456,7 @@
           "lib/DNXCore50/System.Private.DataContractSerialization.dll": {}
         }
       },
-      "System.Private.Networking/4.0.1-beta-23324": {
+      "System.Private.Networking/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -433,13 +475,13 @@
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23324",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23324",
-          "System.Security.Principal.Windows": "4.0.0-beta-23324",
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23330",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23330",
+          "System.Security.Principal.Windows": "4.0.0-beta-23330",
           "System.Threading": "4.0.10",
           "System.Threading.Overlapped": "4.0.0",
           "System.Threading.Tasks": "4.0.10",
-          "System.Threading.ThreadPool": "4.0.10-beta-23324"
+          "System.Threading.ThreadPool": "4.0.10-beta-23330"
         },
         "compile": {
           "ref/dnxcore50/_._": {}
@@ -448,7 +490,7 @@
           "lib/DNXCore50/System.Private.Networking.dll": {}
         }
       },
-      "System.Private.ServiceModel/4.0.1-beta-23324": {
+      "System.Private.ServiceModel/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -465,12 +507,14 @@
           "System.Linq": "4.0.0",
           "System.Linq.Expressions": "4.0.10",
           "System.Linq.Queryable": "4.0.0",
-          "System.Net.Http": "4.0.1-beta-23324",
-          "System.Net.NameResolution": "4.0.0-beta-23324",
+          "System.Net.Http": "4.0.1-beta-23330",
+          "System.Net.NameResolution": "4.0.0-beta-23330",
           "System.Net.Primitives": "4.0.10",
-          "System.Net.Security": "4.0.0-beta-23324",
-          "System.Net.Sockets": "4.0.10-beta-23324",
+          "System.Net.Security": "4.0.0-beta-23330",
+          "System.Net.Sockets": "4.0.10-beta-23330",
           "System.Net.WebHeaderCollection": "4.0.0",
+          "System.Net.WebSockets": "4.0.0-beta-23330",
+          "System.Net.WebSockets.Client": "4.0.0-beta-23330",
           "System.ObjectModel": "4.0.10",
           "System.Reflection": "4.0.10",
           "System.Reflection.DispatchProxy": "4.0.0",
@@ -484,9 +528,9 @@
           "System.Runtime.Serialization.Primitives": "4.0.10",
           "System.Runtime.Serialization.Xml": "4.0.10",
           "System.Security.Claims": "4.0.0",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23324",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23330",
           "System.Security.Principal": "4.0.0",
-          "System.Security.Principal.Windows": "4.0.0-beta-23324",
+          "System.Security.Principal.Windows": "4.0.0-beta-23330",
           "System.Text.Encoding": "4.0.10",
           "System.Threading": "4.0.10",
           "System.Threading.Tasks": "4.0.10",
@@ -750,18 +794,18 @@
           "lib/dotnet/System.Security.Claims.dll": {}
         }
       },
-      "System.Security.Cryptography.Algorithms/4.0.0-beta-23324": {
+      "System.Security.Cryptography.Algorithms/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
           "System.Runtime": "4.0.0",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23324"
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.Algorithms.dll": {}
         }
       },
-      "System.Security.Cryptography.Encoding/4.0.0-beta-23324": {
+      "System.Security.Cryptography.Encoding/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -770,7 +814,7 @@
           "ref/dotnet/System.Security.Cryptography.Encoding.dll": {}
         }
       },
-      "System.Security.Cryptography.Primitives/4.0.0-beta-23324": {
+      "System.Security.Cryptography.Primitives/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.0",
@@ -788,13 +832,13 @@
           "lib/dotnet/System.Security.Cryptography.Primitives.dll": {}
         }
       },
-      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23324": {
+      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
           "System.Runtime.Handles": "4.0.0",
-          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23324",
-          "System.Security.Cryptography.Encoding": "4.0.0-beta-23324"
+          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23330",
+          "System.Security.Cryptography.Encoding": "4.0.0-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.X509Certificates.dll": {}
@@ -812,7 +856,7 @@
           "lib/dotnet/System.Security.Principal.dll": {}
         }
       },
-      "System.Security.Principal.Windows/4.0.0-beta-23324": {
+      "System.Security.Principal.Windows/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -835,10 +879,10 @@
           "lib/DNXCore50/System.Security.Principal.Windows.dll": {}
         }
       },
-      "System.ServiceModel.Http/4.0.11-beta-23324": {
+      "System.ServiceModel.Http/4.0.11-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.0.1-beta-23324",
+          "System.Private.ServiceModel": "4.0.1-beta-23330",
           "System.Runtime": "4.0.20"
         },
         "compile": {
@@ -848,10 +892,10 @@
           "lib/DNXCore50/System.ServiceModel.Http.dll": {}
         }
       },
-      "System.ServiceModel.Primitives/4.0.1-beta-23324": {
+      "System.ServiceModel.Primitives/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.0.1-beta-23324"
+          "System.Private.ServiceModel": "4.0.1-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.ServiceModel.Primitives.dll": {}
@@ -940,7 +984,7 @@
           "lib/DNXCore50/System.Threading.Tasks.dll": {}
         }
       },
-      "System.Threading.ThreadPool/4.0.10-beta-23324": {
+      "System.Threading.ThreadPool/4.0.10-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
@@ -1133,7 +1177,7 @@
           "lib/dotnet/xunit.execution.dotnet.dll": {}
         }
       },
-      "xunit.netcore.extensions/1.0.0-prerelease-00095": {
+      "xunit.netcore.extensions/1.0.0-prerelease-00098": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.10",
@@ -1761,23 +1805,12 @@
         "System.Linq.Queryable.nuspec"
       ]
     },
-    "System.Net.Http/4.0.1-beta-23324": {
+    "System.Net.Http/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "gXfHlWsiMQDuFqwnQrlQTje9vqMhCFLtm35jX4WqZjcfa3y69DbwueeT0gJbVMK88/UnG8FAYiDBb7AKyu+51w==",
+      "sha512": "itLPx7B7Ac4mX8wQx9V9DQcxqTgkmwDNnQIHuCgAH53Jq2X3XziiRRBbxbmNJlWqBlgPzbseWJmMCtcF/ePhOg==",
       "files": [
         "lib/net45/_._",
-        "lib/netcore50/de/System.Net.Http.xml",
-        "lib/netcore50/es/System.Net.Http.xml",
-        "lib/netcore50/fr/System.Net.Http.xml",
-        "lib/netcore50/it/System.Net.Http.xml",
-        "lib/netcore50/ja/System.Net.Http.xml",
-        "lib/netcore50/ko/System.Net.Http.xml",
-        "lib/netcore50/ru/System.Net.Http.xml",
-        "lib/netcore50/System.Net.Http.dll",
-        "lib/netcore50/System.Net.Http.xml",
-        "lib/netcore50/zh-hans/System.Net.Http.xml",
-        "lib/netcore50/zh-hant/System.Net.Http.xml",
         "lib/win8/_._",
         "lib/wpa81/_._",
         "ref/dotnet/System.Net.Http.dll",
@@ -1786,17 +1819,16 @@
         "ref/win8/_._",
         "ref/wpa81/_._",
         "runtime.json",
-        "System.Net.Http.4.0.1-beta-23324.nupkg",
-        "System.Net.Http.4.0.1-beta-23324.nupkg.sha512",
+        "System.Net.Http.4.0.1-beta-23330.nupkg",
+        "System.Net.Http.4.0.1-beta-23330.nupkg.sha512",
         "System.Net.Http.nuspec"
       ]
     },
-    "System.Net.NameResolution/4.0.0-beta-23324": {
+    "System.Net.NameResolution/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "lNYXUmnSXUtLFY09Rc27zJ6/TxCuGggQzBgiuWHoWrjWxymuuxqPT2Mj7Dn7sUUh0GvF2MOx7Uk+rtCFBiIavg==",
+      "sha512": "d8Am+In/aBgcHpEV6xsi5BCiTEN4y6s9O1V/yIvwX8mDC4CtdZiGsi4DtoB0TLOgp8ky6GxbSF4bKCjFpBO3uw==",
       "files": [
-        "lib/DNXCore50/System.Net.NameResolution.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.NameResolution.dll",
@@ -1808,8 +1840,9 @@
         "ref/net46/System.Net.NameResolution.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.NameResolution.4.0.0-beta-23324.nupkg",
-        "System.Net.NameResolution.4.0.0-beta-23324.nupkg.sha512",
+        "runtime.json",
+        "System.Net.NameResolution.4.0.0-beta-23330.nupkg",
+        "System.Net.NameResolution.4.0.0-beta-23330.nupkg.sha512",
         "System.Net.NameResolution.nuspec"
       ]
     },
@@ -1846,9 +1879,9 @@
         "System.Net.Primitives.nuspec"
       ]
     },
-    "System.Net.Security/4.0.0-beta-23324": {
+    "System.Net.Security/4.0.0-beta-23330": {
       "type": "package",
-      "sha512": "D04RYjxrnR3D+uI9CGmAAFKKQ6T+pPcRHYucc1PIo7/hJK5I/Yu7gAw9yOxHUhQjSGfrKo00lHpBCQMTQt4lSw==",
+      "sha512": "z98dKloNy9DBdyfqQwQvKWA2q8Qj4vgGEVONnlS70c13eh0MolBHJ0wNdplZZK5zYZ5Eu8GTwexbUlpHbsfzVA==",
       "files": [
         "lib/DNXCore50/System.Net.Security.dll",
         "lib/MonoAndroid10/_._",
@@ -1862,8 +1895,8 @@
         "ref/net46/System.Net.Security.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.Security.4.0.0-beta-23324.nupkg",
-        "System.Net.Security.4.0.0-beta-23324.nupkg.sha512",
+        "System.Net.Security.4.0.0-beta-23330.nupkg",
+        "System.Net.Security.4.0.0-beta-23330.nupkg.sha512",
         "System.Net.Security.nuspec"
       ]
     },
@@ -1921,6 +1954,81 @@
         "System.Net.WebHeaderCollection.nuspec"
       ]
     },
+    "System.Net.WebSockets/4.0.0-beta-23330": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "6Q9/uTDcaqbmdbD04MisKmjti4aEpp40i/UzpGaPZ4ItuwzU/pMk9RjiYUBUiCQyZeKNlXcSB1FPN2nFof7tww==",
+      "files": [
+        "lib/dotnet/de/System.Net.WebSockets.xml",
+        "lib/dotnet/es/System.Net.WebSockets.xml",
+        "lib/dotnet/fr/System.Net.WebSockets.xml",
+        "lib/dotnet/it/System.Net.WebSockets.xml",
+        "lib/dotnet/ja/System.Net.WebSockets.xml",
+        "lib/dotnet/ko/System.Net.WebSockets.xml",
+        "lib/dotnet/ru/System.Net.WebSockets.xml",
+        "lib/dotnet/System.Net.WebSockets.dll",
+        "lib/dotnet/System.Net.WebSockets.xml",
+        "lib/dotnet/zh-hans/System.Net.WebSockets.xml",
+        "lib/dotnet/zh-hant/System.Net.WebSockets.xml",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Net.WebSockets.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Net.WebSockets.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Net.WebSockets.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Net.WebSockets.4.0.0-beta-23330.nupkg",
+        "System.Net.WebSockets.4.0.0-beta-23330.nupkg.sha512",
+        "System.Net.WebSockets.nuspec"
+      ]
+    },
+    "System.Net.WebSockets.Client/4.0.0-beta-23330": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "1NWEqwDkYRyvr1gSKZlY51AaI9w8oD0dC5UNa2Lb+qaeFHSF5KfCSzf7seD+im+sH6uocVo2nppiaabfbXZT4Q==",
+      "files": [
+        "lib/DNXCore50/de/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/es/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/fr/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/it/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/ja/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/ko/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/ru/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/System.Net.WebSockets.Client.dll",
+        "lib/DNXCore50/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/zh-hans/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/zh-hant/System.Net.WebSockets.Client.xml",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Net.WebSockets.Client.dll",
+        "lib/netcore50/de/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/es/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/fr/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/it/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/ja/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/ko/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/ru/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/System.Net.WebSockets.Client.dll",
+        "lib/netcore50/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/zh-hans/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/zh-hant/System.Net.WebSockets.Client.xml",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Net.WebSockets.Client.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Net.WebSockets.Client.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Net.WebSockets.Client.4.0.0-beta-23330.nupkg",
+        "System.Net.WebSockets.Client.4.0.0-beta-23330.nupkg.sha512",
+        "System.Net.WebSockets.Client.nuspec"
+      ]
+    },
     "System.ObjectModel/4.0.10": {
       "type": "package",
       "serviceable": true,
@@ -1969,31 +2077,31 @@
         "System.Private.DataContractSerialization.nuspec"
       ]
     },
-    "System.Private.Networking/4.0.1-beta-23324": {
+    "System.Private.Networking/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "OfyxoeCdh1ypzdz1u0h1Clgt+6749vALs2ZPkLwsOPzL0INCG9ISYo+Jhh62ZD8TMkWwLrvyVppMBPHY6M7Upw==",
+      "sha512": "8NZi1gCQaGTKDb2yWplm52HWCLaZnUwVitksJgcXY2dEJau/TBGyZup+yhOngOIe8QzQMxNG4iokY3Ce0/8mbg==",
       "files": [
         "lib/DNXCore50/System.Private.Networking.dll",
         "lib/netcore50/System.Private.Networking.dll",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "System.Private.Networking.4.0.1-beta-23324.nupkg",
-        "System.Private.Networking.4.0.1-beta-23324.nupkg.sha512",
+        "System.Private.Networking.4.0.1-beta-23330.nupkg",
+        "System.Private.Networking.4.0.1-beta-23330.nupkg.sha512",
         "System.Private.Networking.nuspec"
       ]
     },
-    "System.Private.ServiceModel/4.0.1-beta-23324": {
+    "System.Private.ServiceModel/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "Lz3T9V8GnaOFlf8LUmuPznuOIuy92BAFVc9huiMrFKByzPpydGuCvXEe+81rZ1IF2TQcHKO++9otnj96AEJ5BA==",
+      "sha512": "8lENvmHuZdlvmnYN1w98Mv8bDjc0O/YlaNHRRph35T/fLDyaG8LMLMwG3/ut6a/AenLJmbf92snOtNXCuqM+cQ==",
       "files": [
         "lib/DNXCore50/System.Private.ServiceModel.dll",
         "lib/netcore50/System.Private.ServiceModel.dll",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "System.Private.ServiceModel.4.0.1-beta-23324.nupkg",
-        "System.Private.ServiceModel.4.0.1-beta-23324.nupkg.sha512",
+        "System.Private.ServiceModel.4.0.1-beta-23330.nupkg",
+        "System.Private.ServiceModel.4.0.1-beta-23330.nupkg.sha512",
         "System.Private.ServiceModel.nuspec"
       ]
     },
@@ -2548,10 +2656,10 @@
         "System.Security.Claims.nuspec"
       ]
     },
-    "System.Security.Cryptography.Algorithms/4.0.0-beta-23324": {
+    "System.Security.Cryptography.Algorithms/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "Mt6LwMj8hPp0+xZHcV6grZ7wSWhgycGkdZ6DQ9XvUY9NguUsvb/+fu2cMdrC7XsnpvwIROByp+p2dSjqBn3E2Q==",
+      "sha512": "FB4RoTDaV5tBiPSJsiG3A5DydeKz7ErglnkqVjBFjm6wu8kg91j0MxL/Al9iUyu9i/hq53fRs5KE3rjUNYvf5w==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2565,15 +2673,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.Algorithms.4.0.0-beta-23324.nupkg",
-        "System.Security.Cryptography.Algorithms.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Cryptography.Algorithms.4.0.0-beta-23330.nupkg",
+        "System.Security.Cryptography.Algorithms.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Cryptography.Algorithms.nuspec"
       ]
     },
-    "System.Security.Cryptography.Encoding/4.0.0-beta-23324": {
+    "System.Security.Cryptography.Encoding/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "JHOyknf1eYO6C39Vao6kAGpadq3PBO1L4tuzNEz/HvbH5sfIHPbjhxL11OyAhVKCzLCfEj6+aeClovFqZIRPyw==",
+      "sha512": "zeFdKQT6xjNdiNCaEmEYJMEK59kixkX7jJSoOLw3H+53t9X0F98vr3tS8YlrW/Lk/K9c6L5pYLlkb2dNqvUD/g==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2587,15 +2695,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.Encoding.4.0.0-beta-23324.nupkg",
-        "System.Security.Cryptography.Encoding.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Cryptography.Encoding.4.0.0-beta-23330.nupkg",
+        "System.Security.Cryptography.Encoding.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Cryptography.Encoding.nuspec"
       ]
     },
-    "System.Security.Cryptography.Primitives/4.0.0-beta-23324": {
+    "System.Security.Cryptography.Primitives/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "ETZxelIX51Di4FTytd8ohSpN6Ym/32aWIX9E2NCFkd91qdexn2Dkysn80b6n4gX6jG+oL0UHQDtD/fYq8C65oQ==",
+      "sha512": "15uVbOD3X0sRQJIxcEH5hasxlFdbA1CmPPZa0Y8pYEuQcWMF2gBswvU8s4qoKtA7x2xhNhzPsXIhsQuKNMTdEA==",
       "files": [
         "lib/dotnet/System.Security.Cryptography.Primitives.dll",
         "lib/MonoAndroid10/_._",
@@ -2609,15 +2717,15 @@
         "ref/net46/System.Security.Cryptography.Primitives.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Security.Cryptography.Primitives.4.0.0-beta-23324.nupkg",
-        "System.Security.Cryptography.Primitives.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Cryptography.Primitives.4.0.0-beta-23330.nupkg",
+        "System.Security.Cryptography.Primitives.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Cryptography.Primitives.nuspec"
       ]
     },
-    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23324": {
+    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "8NaEOxkkNBUECh0cPzGpbXS0uzGDpnvxI0kqQKRGp9uA+9qCyQfxcqAT6ozAYtOuFNVaC1XU3zQnb7T2nfvIDg==",
+      "sha512": "L8mUimdm7+GsORgJ8DFBMGsFnwDJ5YCUdJj3HfXQx4HCoPDPF+vJo3HRiHfcvNA2Zsf0ov2kuerYj/eeVa2/Rw==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2631,8 +2739,8 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23324.nupkg",
-        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23330.nupkg",
+        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Cryptography.X509Certificates.nuspec"
       ]
     },
@@ -2669,10 +2777,10 @@
         "System.Security.Principal.nuspec"
       ]
     },
-    "System.Security.Principal.Windows/4.0.0-beta-23324": {
+    "System.Security.Principal.Windows/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "csbCKdwBz31T8He7U6XMIc9BiWgwjHs5WDZR4rfhsk48TpdsbKNHX9OX4b+GwvgcsfVuWxre7zqNR0Bc9gWZ7g==",
+      "sha512": "q+3L3aB8bn0HCW52kX9TSJdhbjffBw7QWCOu0yX1SDhPN9MCPmJ4aBBCn1HRWroa5y7UcNUdjL1xwiERycZexw==",
       "files": [
         "lib/DNXCore50/de/System.Security.Principal.Windows.xml",
         "lib/DNXCore50/es/System.Security.Principal.Windows.xml",
@@ -2688,15 +2796,15 @@
         "lib/net46/System.Security.Principal.Windows.dll",
         "ref/dotnet/System.Security.Principal.Windows.dll",
         "ref/net46/System.Security.Principal.Windows.dll",
-        "System.Security.Principal.Windows.4.0.0-beta-23324.nupkg",
-        "System.Security.Principal.Windows.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Principal.Windows.4.0.0-beta-23330.nupkg",
+        "System.Security.Principal.Windows.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Principal.Windows.nuspec"
       ]
     },
-    "System.ServiceModel.Http/4.0.11-beta-23324": {
+    "System.ServiceModel.Http/4.0.11-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "VkTumuCSmXd0NPZZU+nrO7YqznvM+wP96NykXbxFJdNAtCplmqXaQh+YZ/02rjJmfou5qyo2V+ZWVwySBAirOg==",
+      "sha512": "NHKxIIYL0ATDbX18RLCSXtuq26MMoYfAVdpl5K+D0s5AHp7TMPb7LcjZPpg25B2v48x1TwE9LYcYTCiOZcoPzQ==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Http.dll",
         "lib/MonoAndroid10/_._",
@@ -2721,15 +2829,15 @@
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.ServiceModel.Http.4.0.11-beta-23324.nupkg",
-        "System.ServiceModel.Http.4.0.11-beta-23324.nupkg.sha512",
+        "System.ServiceModel.Http.4.0.11-beta-23330.nupkg",
+        "System.ServiceModel.Http.4.0.11-beta-23330.nupkg.sha512",
         "System.ServiceModel.Http.nuspec"
       ]
     },
-    "System.ServiceModel.Primitives/4.0.1-beta-23324": {
+    "System.ServiceModel.Primitives/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "bmU31B4CD5+m9Kt0iDM5Yw2ZXRfv7lpK3Sx1HektcT/HERc+IMPdO38f/Wxtofo5WOA0qmd1fdrMeQcbEkDfJg==",
+      "sha512": "kJ/pcRUf7Ow7s/rX8Kmc9P2k6cvyudIzyUcqr/pn9NwY8DC/2DWkkFvYE2udR4kvBzJJzXl/rsJQlyLIVGMAww==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Primitives.dll",
         "lib/net45/_._",
@@ -2749,8 +2857,8 @@
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.Primitives.dll",
         "ref/win8/_._",
-        "System.ServiceModel.Primitives.4.0.1-beta-23324.nupkg",
-        "System.ServiceModel.Primitives.4.0.1-beta-23324.nupkg.sha512",
+        "System.ServiceModel.Primitives.4.0.1-beta-23330.nupkg",
+        "System.ServiceModel.Primitives.4.0.1-beta-23330.nupkg.sha512",
         "System.ServiceModel.Primitives.nuspec"
       ]
     },
@@ -2945,10 +3053,9 @@
         "System.Threading.Tasks.nuspec"
       ]
     },
-    "System.Threading.ThreadPool/4.0.10-beta-23324": {
+    "System.Threading.ThreadPool/4.0.10-beta-23330": {
       "type": "package",
-      "serviceable": true,
-      "sha512": "G4SjGmiV72HBiv8wkfnKFGTieekrACU1m43VaeJ6vDeSyb08eEFusVH1UWZpOsUF25meCuzpda0ezus24b4rKA==",
+      "sha512": "nM5OewUj8NJrye93apbM6KHvPddgPJGzt1IWIXk9lV5HB4NGsn6M5U0gxMQWShQuDp6NF3ya3ULRSvh3dLMbzg==",
       "files": [
         "lib/DNXCore50/System.Threading.ThreadPool.dll",
         "lib/MonoAndroid10/_._",
@@ -2962,8 +3069,8 @@
         "ref/net46/System.Threading.ThreadPool.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Threading.ThreadPool.4.0.10-beta-23324.nupkg",
-        "System.Threading.ThreadPool.4.0.10-beta-23324.nupkg.sha512",
+        "System.Threading.ThreadPool.4.0.10-beta-23330.nupkg",
+        "System.Threading.ThreadPool.4.0.10-beta-23330.nupkg.sha512",
         "System.Threading.ThreadPool.nuspec"
       ]
     },
@@ -3214,14 +3321,14 @@
         "xunit.extensibility.execution.nuspec"
       ]
     },
-    "xunit.netcore.extensions/1.0.0-prerelease-00095": {
+    "xunit.netcore.extensions/1.0.0-prerelease-00098": {
       "type": "package",
       "serviceable": true,
-      "sha512": "FuvWmkuxHiqD0cHDggg5MRmBoeM4Uea7OUEmKvZiQu7Fy02hJ6yKKNV7mNW3y4scwSzDNA81Qa+HIS33PeWUog==",
+      "sha512": "3kRPwTbC42YGmsNHpNMKfGVOO5cVfxUD+C7cYbti1aml4UCT/RFZ6lhm5Vym2wNRDxryu0Es78aMf1BaybSrDg==",
       "files": [
         "lib/dotnet/Xunit.NetCore.Extensions.dll",
-        "xunit.netcore.extensions.1.0.0-prerelease-00095.nupkg",
-        "xunit.netcore.extensions.1.0.0-prerelease-00095.nupkg.sha512",
+        "xunit.netcore.extensions.1.0.0-prerelease-00098.nupkg",
+        "xunit.netcore.extensions.1.0.0-prerelease-00098.nupkg.sha512",
         "xunit.netcore.extensions.nuspec"
       ]
     }

--- a/src/System.Private.ServiceModel/tests/Scenarios/Contract/Message/project.lock.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Contract/Message/project.lock.json
@@ -292,7 +292,7 @@
           "lib/dotnet/System.Linq.Queryable.dll": {}
         }
       },
-      "System.Net.Http/4.0.1-beta-23324": {
+      "System.Net.Http/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -305,16 +305,15 @@
           "ref/dotnet/System.Net.Http.dll": {}
         }
       },
-      "System.Net.NameResolution/4.0.0-beta-23324": {
+      "System.Net.NameResolution/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.Networking": "4.0.1-beta-23324"
+          "System.Net.Primitives": "4.0.10",
+          "System.Runtime": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Net.NameResolution.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Net.NameResolution.dll": {}
         }
       },
       "System.Net.Primitives/4.0.10": {
@@ -329,10 +328,10 @@
           "lib/DNXCore50/System.Net.Primitives.dll": {}
         }
       },
-      "System.Net.Security/4.0.0-beta-23324": {
+      "System.Net.Security/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.Networking": "4.0.1-beta-23324"
+          "System.Private.Networking": "4.0.1-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.Net.Security.dll": {}
@@ -367,6 +366,49 @@
         },
         "runtime": {
           "lib/dotnet/System.Net.WebHeaderCollection.dll": {}
+        }
+      },
+      "System.Net.WebSockets/4.0.0-beta-23330": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.Win32.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Threading.Tasks": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Net.WebSockets.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Net.WebSockets.dll": {}
+        }
+      },
+      "System.Net.WebSockets.Client/4.0.0-beta-23330": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.Win32.Primitives": "4.0.0",
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Diagnostics.Tracing": "4.0.20",
+          "System.Globalization": "4.0.10",
+          "System.Net.Primitives": "4.0.10",
+          "System.Net.WebHeaderCollection": "4.0.0",
+          "System.Net.WebSockets": "4.0.0-beta-23330",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23330",
+          "System.Text.Encoding": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Net.WebSockets.Client.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Net.WebSockets.Client.dll": {}
         }
       },
       "System.ObjectModel/4.0.10": {
@@ -414,7 +456,7 @@
           "lib/DNXCore50/System.Private.DataContractSerialization.dll": {}
         }
       },
-      "System.Private.Networking/4.0.1-beta-23324": {
+      "System.Private.Networking/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -433,13 +475,13 @@
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23324",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23324",
-          "System.Security.Principal.Windows": "4.0.0-beta-23324",
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23330",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23330",
+          "System.Security.Principal.Windows": "4.0.0-beta-23330",
           "System.Threading": "4.0.10",
           "System.Threading.Overlapped": "4.0.0",
           "System.Threading.Tasks": "4.0.10",
-          "System.Threading.ThreadPool": "4.0.10-beta-23324"
+          "System.Threading.ThreadPool": "4.0.10-beta-23330"
         },
         "compile": {
           "ref/dnxcore50/_._": {}
@@ -448,7 +490,7 @@
           "lib/DNXCore50/System.Private.Networking.dll": {}
         }
       },
-      "System.Private.ServiceModel/4.0.1-beta-23324": {
+      "System.Private.ServiceModel/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -465,12 +507,14 @@
           "System.Linq": "4.0.0",
           "System.Linq.Expressions": "4.0.10",
           "System.Linq.Queryable": "4.0.0",
-          "System.Net.Http": "4.0.1-beta-23324",
-          "System.Net.NameResolution": "4.0.0-beta-23324",
+          "System.Net.Http": "4.0.1-beta-23330",
+          "System.Net.NameResolution": "4.0.0-beta-23330",
           "System.Net.Primitives": "4.0.10",
-          "System.Net.Security": "4.0.0-beta-23324",
-          "System.Net.Sockets": "4.0.10-beta-23324",
+          "System.Net.Security": "4.0.0-beta-23330",
+          "System.Net.Sockets": "4.0.10-beta-23330",
           "System.Net.WebHeaderCollection": "4.0.0",
+          "System.Net.WebSockets": "4.0.0-beta-23330",
+          "System.Net.WebSockets.Client": "4.0.0-beta-23330",
           "System.ObjectModel": "4.0.10",
           "System.Reflection": "4.0.10",
           "System.Reflection.DispatchProxy": "4.0.0",
@@ -484,9 +528,9 @@
           "System.Runtime.Serialization.Primitives": "4.0.10",
           "System.Runtime.Serialization.Xml": "4.0.10",
           "System.Security.Claims": "4.0.0",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23324",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23330",
           "System.Security.Principal": "4.0.0",
-          "System.Security.Principal.Windows": "4.0.0-beta-23324",
+          "System.Security.Principal.Windows": "4.0.0-beta-23330",
           "System.Text.Encoding": "4.0.10",
           "System.Threading": "4.0.10",
           "System.Threading.Tasks": "4.0.10",
@@ -735,18 +779,18 @@
           "lib/dotnet/System.Security.Claims.dll": {}
         }
       },
-      "System.Security.Cryptography.Algorithms/4.0.0-beta-23324": {
+      "System.Security.Cryptography.Algorithms/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
           "System.Runtime": "4.0.0",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23324"
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.Algorithms.dll": {}
         }
       },
-      "System.Security.Cryptography.Encoding/4.0.0-beta-23324": {
+      "System.Security.Cryptography.Encoding/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -755,7 +799,7 @@
           "ref/dotnet/System.Security.Cryptography.Encoding.dll": {}
         }
       },
-      "System.Security.Cryptography.Primitives/4.0.0-beta-23324": {
+      "System.Security.Cryptography.Primitives/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.0",
@@ -773,13 +817,13 @@
           "lib/dotnet/System.Security.Cryptography.Primitives.dll": {}
         }
       },
-      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23324": {
+      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
           "System.Runtime.Handles": "4.0.0",
-          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23324",
-          "System.Security.Cryptography.Encoding": "4.0.0-beta-23324"
+          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23330",
+          "System.Security.Cryptography.Encoding": "4.0.0-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.X509Certificates.dll": {}
@@ -797,7 +841,7 @@
           "lib/dotnet/System.Security.Principal.dll": {}
         }
       },
-      "System.Security.Principal.Windows/4.0.0-beta-23324": {
+      "System.Security.Principal.Windows/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -820,10 +864,10 @@
           "lib/DNXCore50/System.Security.Principal.Windows.dll": {}
         }
       },
-      "System.ServiceModel.Http/4.0.11-beta-23324": {
+      "System.ServiceModel.Http/4.0.11-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.0.1-beta-23324",
+          "System.Private.ServiceModel": "4.0.1-beta-23330",
           "System.Runtime": "4.0.20"
         },
         "compile": {
@@ -833,10 +877,10 @@
           "lib/DNXCore50/System.ServiceModel.Http.dll": {}
         }
       },
-      "System.ServiceModel.Primitives/4.0.1-beta-23324": {
+      "System.ServiceModel.Primitives/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.0.1-beta-23324"
+          "System.Private.ServiceModel": "4.0.1-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.ServiceModel.Primitives.dll": {}
@@ -925,7 +969,7 @@
           "lib/DNXCore50/System.Threading.Tasks.dll": {}
         }
       },
-      "System.Threading.ThreadPool/4.0.10-beta-23324": {
+      "System.Threading.ThreadPool/4.0.10-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
@@ -1118,7 +1162,7 @@
           "lib/dotnet/xunit.execution.dotnet.dll": {}
         }
       },
-      "xunit.netcore.extensions/1.0.0-prerelease-00095": {
+      "xunit.netcore.extensions/1.0.0-prerelease-00098": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.10",
@@ -1746,23 +1790,12 @@
         "System.Linq.Queryable.nuspec"
       ]
     },
-    "System.Net.Http/4.0.1-beta-23324": {
+    "System.Net.Http/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "gXfHlWsiMQDuFqwnQrlQTje9vqMhCFLtm35jX4WqZjcfa3y69DbwueeT0gJbVMK88/UnG8FAYiDBb7AKyu+51w==",
+      "sha512": "itLPx7B7Ac4mX8wQx9V9DQcxqTgkmwDNnQIHuCgAH53Jq2X3XziiRRBbxbmNJlWqBlgPzbseWJmMCtcF/ePhOg==",
       "files": [
         "lib/net45/_._",
-        "lib/netcore50/de/System.Net.Http.xml",
-        "lib/netcore50/es/System.Net.Http.xml",
-        "lib/netcore50/fr/System.Net.Http.xml",
-        "lib/netcore50/it/System.Net.Http.xml",
-        "lib/netcore50/ja/System.Net.Http.xml",
-        "lib/netcore50/ko/System.Net.Http.xml",
-        "lib/netcore50/ru/System.Net.Http.xml",
-        "lib/netcore50/System.Net.Http.dll",
-        "lib/netcore50/System.Net.Http.xml",
-        "lib/netcore50/zh-hans/System.Net.Http.xml",
-        "lib/netcore50/zh-hant/System.Net.Http.xml",
         "lib/win8/_._",
         "lib/wpa81/_._",
         "ref/dotnet/System.Net.Http.dll",
@@ -1771,17 +1804,16 @@
         "ref/win8/_._",
         "ref/wpa81/_._",
         "runtime.json",
-        "System.Net.Http.4.0.1-beta-23324.nupkg",
-        "System.Net.Http.4.0.1-beta-23324.nupkg.sha512",
+        "System.Net.Http.4.0.1-beta-23330.nupkg",
+        "System.Net.Http.4.0.1-beta-23330.nupkg.sha512",
         "System.Net.Http.nuspec"
       ]
     },
-    "System.Net.NameResolution/4.0.0-beta-23324": {
+    "System.Net.NameResolution/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "lNYXUmnSXUtLFY09Rc27zJ6/TxCuGggQzBgiuWHoWrjWxymuuxqPT2Mj7Dn7sUUh0GvF2MOx7Uk+rtCFBiIavg==",
+      "sha512": "d8Am+In/aBgcHpEV6xsi5BCiTEN4y6s9O1V/yIvwX8mDC4CtdZiGsi4DtoB0TLOgp8ky6GxbSF4bKCjFpBO3uw==",
       "files": [
-        "lib/DNXCore50/System.Net.NameResolution.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.NameResolution.dll",
@@ -1793,8 +1825,9 @@
         "ref/net46/System.Net.NameResolution.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.NameResolution.4.0.0-beta-23324.nupkg",
-        "System.Net.NameResolution.4.0.0-beta-23324.nupkg.sha512",
+        "runtime.json",
+        "System.Net.NameResolution.4.0.0-beta-23330.nupkg",
+        "System.Net.NameResolution.4.0.0-beta-23330.nupkg.sha512",
         "System.Net.NameResolution.nuspec"
       ]
     },
@@ -1831,9 +1864,9 @@
         "System.Net.Primitives.nuspec"
       ]
     },
-    "System.Net.Security/4.0.0-beta-23324": {
+    "System.Net.Security/4.0.0-beta-23330": {
       "type": "package",
-      "sha512": "D04RYjxrnR3D+uI9CGmAAFKKQ6T+pPcRHYucc1PIo7/hJK5I/Yu7gAw9yOxHUhQjSGfrKo00lHpBCQMTQt4lSw==",
+      "sha512": "z98dKloNy9DBdyfqQwQvKWA2q8Qj4vgGEVONnlS70c13eh0MolBHJ0wNdplZZK5zYZ5Eu8GTwexbUlpHbsfzVA==",
       "files": [
         "lib/DNXCore50/System.Net.Security.dll",
         "lib/MonoAndroid10/_._",
@@ -1847,8 +1880,8 @@
         "ref/net46/System.Net.Security.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.Security.4.0.0-beta-23324.nupkg",
-        "System.Net.Security.4.0.0-beta-23324.nupkg.sha512",
+        "System.Net.Security.4.0.0-beta-23330.nupkg",
+        "System.Net.Security.4.0.0-beta-23330.nupkg.sha512",
         "System.Net.Security.nuspec"
       ]
     },
@@ -1906,6 +1939,81 @@
         "System.Net.WebHeaderCollection.nuspec"
       ]
     },
+    "System.Net.WebSockets/4.0.0-beta-23330": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "6Q9/uTDcaqbmdbD04MisKmjti4aEpp40i/UzpGaPZ4ItuwzU/pMk9RjiYUBUiCQyZeKNlXcSB1FPN2nFof7tww==",
+      "files": [
+        "lib/dotnet/de/System.Net.WebSockets.xml",
+        "lib/dotnet/es/System.Net.WebSockets.xml",
+        "lib/dotnet/fr/System.Net.WebSockets.xml",
+        "lib/dotnet/it/System.Net.WebSockets.xml",
+        "lib/dotnet/ja/System.Net.WebSockets.xml",
+        "lib/dotnet/ko/System.Net.WebSockets.xml",
+        "lib/dotnet/ru/System.Net.WebSockets.xml",
+        "lib/dotnet/System.Net.WebSockets.dll",
+        "lib/dotnet/System.Net.WebSockets.xml",
+        "lib/dotnet/zh-hans/System.Net.WebSockets.xml",
+        "lib/dotnet/zh-hant/System.Net.WebSockets.xml",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Net.WebSockets.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Net.WebSockets.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Net.WebSockets.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Net.WebSockets.4.0.0-beta-23330.nupkg",
+        "System.Net.WebSockets.4.0.0-beta-23330.nupkg.sha512",
+        "System.Net.WebSockets.nuspec"
+      ]
+    },
+    "System.Net.WebSockets.Client/4.0.0-beta-23330": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "1NWEqwDkYRyvr1gSKZlY51AaI9w8oD0dC5UNa2Lb+qaeFHSF5KfCSzf7seD+im+sH6uocVo2nppiaabfbXZT4Q==",
+      "files": [
+        "lib/DNXCore50/de/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/es/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/fr/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/it/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/ja/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/ko/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/ru/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/System.Net.WebSockets.Client.dll",
+        "lib/DNXCore50/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/zh-hans/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/zh-hant/System.Net.WebSockets.Client.xml",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Net.WebSockets.Client.dll",
+        "lib/netcore50/de/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/es/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/fr/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/it/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/ja/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/ko/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/ru/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/System.Net.WebSockets.Client.dll",
+        "lib/netcore50/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/zh-hans/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/zh-hant/System.Net.WebSockets.Client.xml",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Net.WebSockets.Client.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Net.WebSockets.Client.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Net.WebSockets.Client.4.0.0-beta-23330.nupkg",
+        "System.Net.WebSockets.Client.4.0.0-beta-23330.nupkg.sha512",
+        "System.Net.WebSockets.Client.nuspec"
+      ]
+    },
     "System.ObjectModel/4.0.10": {
       "type": "package",
       "serviceable": true,
@@ -1954,31 +2062,31 @@
         "System.Private.DataContractSerialization.nuspec"
       ]
     },
-    "System.Private.Networking/4.0.1-beta-23324": {
+    "System.Private.Networking/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "OfyxoeCdh1ypzdz1u0h1Clgt+6749vALs2ZPkLwsOPzL0INCG9ISYo+Jhh62ZD8TMkWwLrvyVppMBPHY6M7Upw==",
+      "sha512": "8NZi1gCQaGTKDb2yWplm52HWCLaZnUwVitksJgcXY2dEJau/TBGyZup+yhOngOIe8QzQMxNG4iokY3Ce0/8mbg==",
       "files": [
         "lib/DNXCore50/System.Private.Networking.dll",
         "lib/netcore50/System.Private.Networking.dll",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "System.Private.Networking.4.0.1-beta-23324.nupkg",
-        "System.Private.Networking.4.0.1-beta-23324.nupkg.sha512",
+        "System.Private.Networking.4.0.1-beta-23330.nupkg",
+        "System.Private.Networking.4.0.1-beta-23330.nupkg.sha512",
         "System.Private.Networking.nuspec"
       ]
     },
-    "System.Private.ServiceModel/4.0.1-beta-23324": {
+    "System.Private.ServiceModel/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "Lz3T9V8GnaOFlf8LUmuPznuOIuy92BAFVc9huiMrFKByzPpydGuCvXEe+81rZ1IF2TQcHKO++9otnj96AEJ5BA==",
+      "sha512": "8lENvmHuZdlvmnYN1w98Mv8bDjc0O/YlaNHRRph35T/fLDyaG8LMLMwG3/ut6a/AenLJmbf92snOtNXCuqM+cQ==",
       "files": [
         "lib/DNXCore50/System.Private.ServiceModel.dll",
         "lib/netcore50/System.Private.ServiceModel.dll",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "System.Private.ServiceModel.4.0.1-beta-23324.nupkg",
-        "System.Private.ServiceModel.4.0.1-beta-23324.nupkg.sha512",
+        "System.Private.ServiceModel.4.0.1-beta-23330.nupkg",
+        "System.Private.ServiceModel.4.0.1-beta-23330.nupkg.sha512",
         "System.Private.ServiceModel.nuspec"
       ]
     },
@@ -2507,10 +2615,10 @@
         "System.Security.Claims.nuspec"
       ]
     },
-    "System.Security.Cryptography.Algorithms/4.0.0-beta-23324": {
+    "System.Security.Cryptography.Algorithms/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "Mt6LwMj8hPp0+xZHcV6grZ7wSWhgycGkdZ6DQ9XvUY9NguUsvb/+fu2cMdrC7XsnpvwIROByp+p2dSjqBn3E2Q==",
+      "sha512": "FB4RoTDaV5tBiPSJsiG3A5DydeKz7ErglnkqVjBFjm6wu8kg91j0MxL/Al9iUyu9i/hq53fRs5KE3rjUNYvf5w==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2524,15 +2632,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.Algorithms.4.0.0-beta-23324.nupkg",
-        "System.Security.Cryptography.Algorithms.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Cryptography.Algorithms.4.0.0-beta-23330.nupkg",
+        "System.Security.Cryptography.Algorithms.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Cryptography.Algorithms.nuspec"
       ]
     },
-    "System.Security.Cryptography.Encoding/4.0.0-beta-23324": {
+    "System.Security.Cryptography.Encoding/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "JHOyknf1eYO6C39Vao6kAGpadq3PBO1L4tuzNEz/HvbH5sfIHPbjhxL11OyAhVKCzLCfEj6+aeClovFqZIRPyw==",
+      "sha512": "zeFdKQT6xjNdiNCaEmEYJMEK59kixkX7jJSoOLw3H+53t9X0F98vr3tS8YlrW/Lk/K9c6L5pYLlkb2dNqvUD/g==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2546,15 +2654,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.Encoding.4.0.0-beta-23324.nupkg",
-        "System.Security.Cryptography.Encoding.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Cryptography.Encoding.4.0.0-beta-23330.nupkg",
+        "System.Security.Cryptography.Encoding.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Cryptography.Encoding.nuspec"
       ]
     },
-    "System.Security.Cryptography.Primitives/4.0.0-beta-23324": {
+    "System.Security.Cryptography.Primitives/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "ETZxelIX51Di4FTytd8ohSpN6Ym/32aWIX9E2NCFkd91qdexn2Dkysn80b6n4gX6jG+oL0UHQDtD/fYq8C65oQ==",
+      "sha512": "15uVbOD3X0sRQJIxcEH5hasxlFdbA1CmPPZa0Y8pYEuQcWMF2gBswvU8s4qoKtA7x2xhNhzPsXIhsQuKNMTdEA==",
       "files": [
         "lib/dotnet/System.Security.Cryptography.Primitives.dll",
         "lib/MonoAndroid10/_._",
@@ -2568,15 +2676,15 @@
         "ref/net46/System.Security.Cryptography.Primitives.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Security.Cryptography.Primitives.4.0.0-beta-23324.nupkg",
-        "System.Security.Cryptography.Primitives.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Cryptography.Primitives.4.0.0-beta-23330.nupkg",
+        "System.Security.Cryptography.Primitives.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Cryptography.Primitives.nuspec"
       ]
     },
-    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23324": {
+    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "8NaEOxkkNBUECh0cPzGpbXS0uzGDpnvxI0kqQKRGp9uA+9qCyQfxcqAT6ozAYtOuFNVaC1XU3zQnb7T2nfvIDg==",
+      "sha512": "L8mUimdm7+GsORgJ8DFBMGsFnwDJ5YCUdJj3HfXQx4HCoPDPF+vJo3HRiHfcvNA2Zsf0ov2kuerYj/eeVa2/Rw==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2590,8 +2698,8 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23324.nupkg",
-        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23330.nupkg",
+        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Cryptography.X509Certificates.nuspec"
       ]
     },
@@ -2628,10 +2736,10 @@
         "System.Security.Principal.nuspec"
       ]
     },
-    "System.Security.Principal.Windows/4.0.0-beta-23324": {
+    "System.Security.Principal.Windows/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "csbCKdwBz31T8He7U6XMIc9BiWgwjHs5WDZR4rfhsk48TpdsbKNHX9OX4b+GwvgcsfVuWxre7zqNR0Bc9gWZ7g==",
+      "sha512": "q+3L3aB8bn0HCW52kX9TSJdhbjffBw7QWCOu0yX1SDhPN9MCPmJ4aBBCn1HRWroa5y7UcNUdjL1xwiERycZexw==",
       "files": [
         "lib/DNXCore50/de/System.Security.Principal.Windows.xml",
         "lib/DNXCore50/es/System.Security.Principal.Windows.xml",
@@ -2647,15 +2755,15 @@
         "lib/net46/System.Security.Principal.Windows.dll",
         "ref/dotnet/System.Security.Principal.Windows.dll",
         "ref/net46/System.Security.Principal.Windows.dll",
-        "System.Security.Principal.Windows.4.0.0-beta-23324.nupkg",
-        "System.Security.Principal.Windows.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Principal.Windows.4.0.0-beta-23330.nupkg",
+        "System.Security.Principal.Windows.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Principal.Windows.nuspec"
       ]
     },
-    "System.ServiceModel.Http/4.0.11-beta-23324": {
+    "System.ServiceModel.Http/4.0.11-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "VkTumuCSmXd0NPZZU+nrO7YqznvM+wP96NykXbxFJdNAtCplmqXaQh+YZ/02rjJmfou5qyo2V+ZWVwySBAirOg==",
+      "sha512": "NHKxIIYL0ATDbX18RLCSXtuq26MMoYfAVdpl5K+D0s5AHp7TMPb7LcjZPpg25B2v48x1TwE9LYcYTCiOZcoPzQ==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Http.dll",
         "lib/MonoAndroid10/_._",
@@ -2680,15 +2788,15 @@
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.ServiceModel.Http.4.0.11-beta-23324.nupkg",
-        "System.ServiceModel.Http.4.0.11-beta-23324.nupkg.sha512",
+        "System.ServiceModel.Http.4.0.11-beta-23330.nupkg",
+        "System.ServiceModel.Http.4.0.11-beta-23330.nupkg.sha512",
         "System.ServiceModel.Http.nuspec"
       ]
     },
-    "System.ServiceModel.Primitives/4.0.1-beta-23324": {
+    "System.ServiceModel.Primitives/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "bmU31B4CD5+m9Kt0iDM5Yw2ZXRfv7lpK3Sx1HektcT/HERc+IMPdO38f/Wxtofo5WOA0qmd1fdrMeQcbEkDfJg==",
+      "sha512": "kJ/pcRUf7Ow7s/rX8Kmc9P2k6cvyudIzyUcqr/pn9NwY8DC/2DWkkFvYE2udR4kvBzJJzXl/rsJQlyLIVGMAww==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Primitives.dll",
         "lib/net45/_._",
@@ -2708,8 +2816,8 @@
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.Primitives.dll",
         "ref/win8/_._",
-        "System.ServiceModel.Primitives.4.0.1-beta-23324.nupkg",
-        "System.ServiceModel.Primitives.4.0.1-beta-23324.nupkg.sha512",
+        "System.ServiceModel.Primitives.4.0.1-beta-23330.nupkg",
+        "System.ServiceModel.Primitives.4.0.1-beta-23330.nupkg.sha512",
         "System.ServiceModel.Primitives.nuspec"
       ]
     },
@@ -2904,10 +3012,9 @@
         "System.Threading.Tasks.nuspec"
       ]
     },
-    "System.Threading.ThreadPool/4.0.10-beta-23324": {
+    "System.Threading.ThreadPool/4.0.10-beta-23330": {
       "type": "package",
-      "serviceable": true,
-      "sha512": "G4SjGmiV72HBiv8wkfnKFGTieekrACU1m43VaeJ6vDeSyb08eEFusVH1UWZpOsUF25meCuzpda0ezus24b4rKA==",
+      "sha512": "nM5OewUj8NJrye93apbM6KHvPddgPJGzt1IWIXk9lV5HB4NGsn6M5U0gxMQWShQuDp6NF3ya3ULRSvh3dLMbzg==",
       "files": [
         "lib/DNXCore50/System.Threading.ThreadPool.dll",
         "lib/MonoAndroid10/_._",
@@ -2921,8 +3028,8 @@
         "ref/net46/System.Threading.ThreadPool.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Threading.ThreadPool.4.0.10-beta-23324.nupkg",
-        "System.Threading.ThreadPool.4.0.10-beta-23324.nupkg.sha512",
+        "System.Threading.ThreadPool.4.0.10-beta-23330.nupkg",
+        "System.Threading.ThreadPool.4.0.10-beta-23330.nupkg.sha512",
         "System.Threading.ThreadPool.nuspec"
       ]
     },
@@ -3173,14 +3280,14 @@
         "xunit.extensibility.execution.nuspec"
       ]
     },
-    "xunit.netcore.extensions/1.0.0-prerelease-00095": {
+    "xunit.netcore.extensions/1.0.0-prerelease-00098": {
       "type": "package",
       "serviceable": true,
-      "sha512": "FuvWmkuxHiqD0cHDggg5MRmBoeM4Uea7OUEmKvZiQu7Fy02hJ6yKKNV7mNW3y4scwSzDNA81Qa+HIS33PeWUog==",
+      "sha512": "3kRPwTbC42YGmsNHpNMKfGVOO5cVfxUD+C7cYbti1aml4UCT/RFZ6lhm5Vym2wNRDxryu0Es78aMf1BaybSrDg==",
       "files": [
         "lib/dotnet/Xunit.NetCore.Extensions.dll",
-        "xunit.netcore.extensions.1.0.0-prerelease-00095.nupkg",
-        "xunit.netcore.extensions.1.0.0-prerelease-00095.nupkg.sha512",
+        "xunit.netcore.extensions.1.0.0-prerelease-00098.nupkg",
+        "xunit.netcore.extensions.1.0.0-prerelease-00098.nupkg.sha512",
         "xunit.netcore.extensions.nuspec"
       ]
     }

--- a/src/System.Private.ServiceModel/tests/Scenarios/Contract/Service/project.lock.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Contract/Service/project.lock.json
@@ -292,7 +292,7 @@
           "lib/dotnet/System.Linq.Queryable.dll": {}
         }
       },
-      "System.Net.Http/4.0.1-beta-23324": {
+      "System.Net.Http/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -305,16 +305,15 @@
           "ref/dotnet/System.Net.Http.dll": {}
         }
       },
-      "System.Net.NameResolution/4.0.0-beta-23324": {
+      "System.Net.NameResolution/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.Networking": "4.0.1-beta-23324"
+          "System.Net.Primitives": "4.0.10",
+          "System.Runtime": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Net.NameResolution.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Net.NameResolution.dll": {}
         }
       },
       "System.Net.Primitives/4.0.10": {
@@ -329,10 +328,10 @@
           "lib/DNXCore50/System.Net.Primitives.dll": {}
         }
       },
-      "System.Net.Security/4.0.0-beta-23324": {
+      "System.Net.Security/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.Networking": "4.0.1-beta-23324"
+          "System.Private.Networking": "4.0.1-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.Net.Security.dll": {}
@@ -367,6 +366,49 @@
         },
         "runtime": {
           "lib/dotnet/System.Net.WebHeaderCollection.dll": {}
+        }
+      },
+      "System.Net.WebSockets/4.0.0-beta-23330": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.Win32.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Threading.Tasks": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Net.WebSockets.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Net.WebSockets.dll": {}
+        }
+      },
+      "System.Net.WebSockets.Client/4.0.0-beta-23330": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.Win32.Primitives": "4.0.0",
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Diagnostics.Tracing": "4.0.20",
+          "System.Globalization": "4.0.10",
+          "System.Net.Primitives": "4.0.10",
+          "System.Net.WebHeaderCollection": "4.0.0",
+          "System.Net.WebSockets": "4.0.0-beta-23330",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23330",
+          "System.Text.Encoding": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Net.WebSockets.Client.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Net.WebSockets.Client.dll": {}
         }
       },
       "System.ObjectModel/4.0.10": {
@@ -414,7 +456,7 @@
           "lib/DNXCore50/System.Private.DataContractSerialization.dll": {}
         }
       },
-      "System.Private.Networking/4.0.1-beta-23324": {
+      "System.Private.Networking/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -433,13 +475,13 @@
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23324",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23324",
-          "System.Security.Principal.Windows": "4.0.0-beta-23324",
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23330",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23330",
+          "System.Security.Principal.Windows": "4.0.0-beta-23330",
           "System.Threading": "4.0.10",
           "System.Threading.Overlapped": "4.0.0",
           "System.Threading.Tasks": "4.0.10",
-          "System.Threading.ThreadPool": "4.0.10-beta-23324"
+          "System.Threading.ThreadPool": "4.0.10-beta-23330"
         },
         "compile": {
           "ref/dnxcore50/_._": {}
@@ -448,7 +490,7 @@
           "lib/DNXCore50/System.Private.Networking.dll": {}
         }
       },
-      "System.Private.ServiceModel/4.0.1-beta-23324": {
+      "System.Private.ServiceModel/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -465,12 +507,14 @@
           "System.Linq": "4.0.0",
           "System.Linq.Expressions": "4.0.10",
           "System.Linq.Queryable": "4.0.0",
-          "System.Net.Http": "4.0.1-beta-23324",
-          "System.Net.NameResolution": "4.0.0-beta-23324",
+          "System.Net.Http": "4.0.1-beta-23330",
+          "System.Net.NameResolution": "4.0.0-beta-23330",
           "System.Net.Primitives": "4.0.10",
-          "System.Net.Security": "4.0.0-beta-23324",
-          "System.Net.Sockets": "4.0.10-beta-23324",
+          "System.Net.Security": "4.0.0-beta-23330",
+          "System.Net.Sockets": "4.0.10-beta-23330",
           "System.Net.WebHeaderCollection": "4.0.0",
+          "System.Net.WebSockets": "4.0.0-beta-23330",
+          "System.Net.WebSockets.Client": "4.0.0-beta-23330",
           "System.ObjectModel": "4.0.10",
           "System.Reflection": "4.0.10",
           "System.Reflection.DispatchProxy": "4.0.0",
@@ -484,9 +528,9 @@
           "System.Runtime.Serialization.Primitives": "4.0.10",
           "System.Runtime.Serialization.Xml": "4.0.10",
           "System.Security.Claims": "4.0.0",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23324",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23330",
           "System.Security.Principal": "4.0.0",
-          "System.Security.Principal.Windows": "4.0.0-beta-23324",
+          "System.Security.Principal.Windows": "4.0.0-beta-23330",
           "System.Text.Encoding": "4.0.10",
           "System.Threading": "4.0.10",
           "System.Threading.Tasks": "4.0.10",
@@ -735,18 +779,18 @@
           "lib/dotnet/System.Security.Claims.dll": {}
         }
       },
-      "System.Security.Cryptography.Algorithms/4.0.0-beta-23324": {
+      "System.Security.Cryptography.Algorithms/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
           "System.Runtime": "4.0.0",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23324"
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.Algorithms.dll": {}
         }
       },
-      "System.Security.Cryptography.Encoding/4.0.0-beta-23324": {
+      "System.Security.Cryptography.Encoding/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -755,7 +799,7 @@
           "ref/dotnet/System.Security.Cryptography.Encoding.dll": {}
         }
       },
-      "System.Security.Cryptography.Primitives/4.0.0-beta-23324": {
+      "System.Security.Cryptography.Primitives/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.0",
@@ -773,13 +817,13 @@
           "lib/dotnet/System.Security.Cryptography.Primitives.dll": {}
         }
       },
-      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23324": {
+      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
           "System.Runtime.Handles": "4.0.0",
-          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23324",
-          "System.Security.Cryptography.Encoding": "4.0.0-beta-23324"
+          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23330",
+          "System.Security.Cryptography.Encoding": "4.0.0-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.X509Certificates.dll": {}
@@ -797,7 +841,7 @@
           "lib/dotnet/System.Security.Principal.dll": {}
         }
       },
-      "System.Security.Principal.Windows/4.0.0-beta-23324": {
+      "System.Security.Principal.Windows/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -820,10 +864,10 @@
           "lib/DNXCore50/System.Security.Principal.Windows.dll": {}
         }
       },
-      "System.ServiceModel.Http/4.0.11-beta-23324": {
+      "System.ServiceModel.Http/4.0.11-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.0.1-beta-23324",
+          "System.Private.ServiceModel": "4.0.1-beta-23330",
           "System.Runtime": "4.0.20"
         },
         "compile": {
@@ -833,10 +877,10 @@
           "lib/DNXCore50/System.ServiceModel.Http.dll": {}
         }
       },
-      "System.ServiceModel.Primitives/4.0.1-beta-23324": {
+      "System.ServiceModel.Primitives/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.0.1-beta-23324"
+          "System.Private.ServiceModel": "4.0.1-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.ServiceModel.Primitives.dll": {}
@@ -925,7 +969,7 @@
           "lib/DNXCore50/System.Threading.Tasks.dll": {}
         }
       },
-      "System.Threading.ThreadPool/4.0.10-beta-23324": {
+      "System.Threading.ThreadPool/4.0.10-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
@@ -1118,7 +1162,7 @@
           "lib/dotnet/xunit.execution.dotnet.dll": {}
         }
       },
-      "xunit.netcore.extensions/1.0.0-prerelease-00095": {
+      "xunit.netcore.extensions/1.0.0-prerelease-00098": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.10",
@@ -1746,23 +1790,12 @@
         "System.Linq.Queryable.nuspec"
       ]
     },
-    "System.Net.Http/4.0.1-beta-23324": {
+    "System.Net.Http/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "gXfHlWsiMQDuFqwnQrlQTje9vqMhCFLtm35jX4WqZjcfa3y69DbwueeT0gJbVMK88/UnG8FAYiDBb7AKyu+51w==",
+      "sha512": "itLPx7B7Ac4mX8wQx9V9DQcxqTgkmwDNnQIHuCgAH53Jq2X3XziiRRBbxbmNJlWqBlgPzbseWJmMCtcF/ePhOg==",
       "files": [
         "lib/net45/_._",
-        "lib/netcore50/de/System.Net.Http.xml",
-        "lib/netcore50/es/System.Net.Http.xml",
-        "lib/netcore50/fr/System.Net.Http.xml",
-        "lib/netcore50/it/System.Net.Http.xml",
-        "lib/netcore50/ja/System.Net.Http.xml",
-        "lib/netcore50/ko/System.Net.Http.xml",
-        "lib/netcore50/ru/System.Net.Http.xml",
-        "lib/netcore50/System.Net.Http.dll",
-        "lib/netcore50/System.Net.Http.xml",
-        "lib/netcore50/zh-hans/System.Net.Http.xml",
-        "lib/netcore50/zh-hant/System.Net.Http.xml",
         "lib/win8/_._",
         "lib/wpa81/_._",
         "ref/dotnet/System.Net.Http.dll",
@@ -1771,17 +1804,16 @@
         "ref/win8/_._",
         "ref/wpa81/_._",
         "runtime.json",
-        "System.Net.Http.4.0.1-beta-23324.nupkg",
-        "System.Net.Http.4.0.1-beta-23324.nupkg.sha512",
+        "System.Net.Http.4.0.1-beta-23330.nupkg",
+        "System.Net.Http.4.0.1-beta-23330.nupkg.sha512",
         "System.Net.Http.nuspec"
       ]
     },
-    "System.Net.NameResolution/4.0.0-beta-23324": {
+    "System.Net.NameResolution/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "lNYXUmnSXUtLFY09Rc27zJ6/TxCuGggQzBgiuWHoWrjWxymuuxqPT2Mj7Dn7sUUh0GvF2MOx7Uk+rtCFBiIavg==",
+      "sha512": "d8Am+In/aBgcHpEV6xsi5BCiTEN4y6s9O1V/yIvwX8mDC4CtdZiGsi4DtoB0TLOgp8ky6GxbSF4bKCjFpBO3uw==",
       "files": [
-        "lib/DNXCore50/System.Net.NameResolution.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.NameResolution.dll",
@@ -1793,8 +1825,9 @@
         "ref/net46/System.Net.NameResolution.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.NameResolution.4.0.0-beta-23324.nupkg",
-        "System.Net.NameResolution.4.0.0-beta-23324.nupkg.sha512",
+        "runtime.json",
+        "System.Net.NameResolution.4.0.0-beta-23330.nupkg",
+        "System.Net.NameResolution.4.0.0-beta-23330.nupkg.sha512",
         "System.Net.NameResolution.nuspec"
       ]
     },
@@ -1831,9 +1864,9 @@
         "System.Net.Primitives.nuspec"
       ]
     },
-    "System.Net.Security/4.0.0-beta-23324": {
+    "System.Net.Security/4.0.0-beta-23330": {
       "type": "package",
-      "sha512": "D04RYjxrnR3D+uI9CGmAAFKKQ6T+pPcRHYucc1PIo7/hJK5I/Yu7gAw9yOxHUhQjSGfrKo00lHpBCQMTQt4lSw==",
+      "sha512": "z98dKloNy9DBdyfqQwQvKWA2q8Qj4vgGEVONnlS70c13eh0MolBHJ0wNdplZZK5zYZ5Eu8GTwexbUlpHbsfzVA==",
       "files": [
         "lib/DNXCore50/System.Net.Security.dll",
         "lib/MonoAndroid10/_._",
@@ -1847,8 +1880,8 @@
         "ref/net46/System.Net.Security.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.Security.4.0.0-beta-23324.nupkg",
-        "System.Net.Security.4.0.0-beta-23324.nupkg.sha512",
+        "System.Net.Security.4.0.0-beta-23330.nupkg",
+        "System.Net.Security.4.0.0-beta-23330.nupkg.sha512",
         "System.Net.Security.nuspec"
       ]
     },
@@ -1906,6 +1939,81 @@
         "System.Net.WebHeaderCollection.nuspec"
       ]
     },
+    "System.Net.WebSockets/4.0.0-beta-23330": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "6Q9/uTDcaqbmdbD04MisKmjti4aEpp40i/UzpGaPZ4ItuwzU/pMk9RjiYUBUiCQyZeKNlXcSB1FPN2nFof7tww==",
+      "files": [
+        "lib/dotnet/de/System.Net.WebSockets.xml",
+        "lib/dotnet/es/System.Net.WebSockets.xml",
+        "lib/dotnet/fr/System.Net.WebSockets.xml",
+        "lib/dotnet/it/System.Net.WebSockets.xml",
+        "lib/dotnet/ja/System.Net.WebSockets.xml",
+        "lib/dotnet/ko/System.Net.WebSockets.xml",
+        "lib/dotnet/ru/System.Net.WebSockets.xml",
+        "lib/dotnet/System.Net.WebSockets.dll",
+        "lib/dotnet/System.Net.WebSockets.xml",
+        "lib/dotnet/zh-hans/System.Net.WebSockets.xml",
+        "lib/dotnet/zh-hant/System.Net.WebSockets.xml",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Net.WebSockets.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Net.WebSockets.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Net.WebSockets.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Net.WebSockets.4.0.0-beta-23330.nupkg",
+        "System.Net.WebSockets.4.0.0-beta-23330.nupkg.sha512",
+        "System.Net.WebSockets.nuspec"
+      ]
+    },
+    "System.Net.WebSockets.Client/4.0.0-beta-23330": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "1NWEqwDkYRyvr1gSKZlY51AaI9w8oD0dC5UNa2Lb+qaeFHSF5KfCSzf7seD+im+sH6uocVo2nppiaabfbXZT4Q==",
+      "files": [
+        "lib/DNXCore50/de/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/es/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/fr/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/it/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/ja/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/ko/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/ru/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/System.Net.WebSockets.Client.dll",
+        "lib/DNXCore50/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/zh-hans/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/zh-hant/System.Net.WebSockets.Client.xml",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Net.WebSockets.Client.dll",
+        "lib/netcore50/de/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/es/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/fr/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/it/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/ja/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/ko/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/ru/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/System.Net.WebSockets.Client.dll",
+        "lib/netcore50/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/zh-hans/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/zh-hant/System.Net.WebSockets.Client.xml",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Net.WebSockets.Client.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Net.WebSockets.Client.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Net.WebSockets.Client.4.0.0-beta-23330.nupkg",
+        "System.Net.WebSockets.Client.4.0.0-beta-23330.nupkg.sha512",
+        "System.Net.WebSockets.Client.nuspec"
+      ]
+    },
     "System.ObjectModel/4.0.10": {
       "type": "package",
       "serviceable": true,
@@ -1954,31 +2062,31 @@
         "System.Private.DataContractSerialization.nuspec"
       ]
     },
-    "System.Private.Networking/4.0.1-beta-23324": {
+    "System.Private.Networking/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "OfyxoeCdh1ypzdz1u0h1Clgt+6749vALs2ZPkLwsOPzL0INCG9ISYo+Jhh62ZD8TMkWwLrvyVppMBPHY6M7Upw==",
+      "sha512": "8NZi1gCQaGTKDb2yWplm52HWCLaZnUwVitksJgcXY2dEJau/TBGyZup+yhOngOIe8QzQMxNG4iokY3Ce0/8mbg==",
       "files": [
         "lib/DNXCore50/System.Private.Networking.dll",
         "lib/netcore50/System.Private.Networking.dll",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "System.Private.Networking.4.0.1-beta-23324.nupkg",
-        "System.Private.Networking.4.0.1-beta-23324.nupkg.sha512",
+        "System.Private.Networking.4.0.1-beta-23330.nupkg",
+        "System.Private.Networking.4.0.1-beta-23330.nupkg.sha512",
         "System.Private.Networking.nuspec"
       ]
     },
-    "System.Private.ServiceModel/4.0.1-beta-23324": {
+    "System.Private.ServiceModel/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "Lz3T9V8GnaOFlf8LUmuPznuOIuy92BAFVc9huiMrFKByzPpydGuCvXEe+81rZ1IF2TQcHKO++9otnj96AEJ5BA==",
+      "sha512": "8lENvmHuZdlvmnYN1w98Mv8bDjc0O/YlaNHRRph35T/fLDyaG8LMLMwG3/ut6a/AenLJmbf92snOtNXCuqM+cQ==",
       "files": [
         "lib/DNXCore50/System.Private.ServiceModel.dll",
         "lib/netcore50/System.Private.ServiceModel.dll",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "System.Private.ServiceModel.4.0.1-beta-23324.nupkg",
-        "System.Private.ServiceModel.4.0.1-beta-23324.nupkg.sha512",
+        "System.Private.ServiceModel.4.0.1-beta-23330.nupkg",
+        "System.Private.ServiceModel.4.0.1-beta-23330.nupkg.sha512",
         "System.Private.ServiceModel.nuspec"
       ]
     },
@@ -2507,10 +2615,10 @@
         "System.Security.Claims.nuspec"
       ]
     },
-    "System.Security.Cryptography.Algorithms/4.0.0-beta-23324": {
+    "System.Security.Cryptography.Algorithms/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "Mt6LwMj8hPp0+xZHcV6grZ7wSWhgycGkdZ6DQ9XvUY9NguUsvb/+fu2cMdrC7XsnpvwIROByp+p2dSjqBn3E2Q==",
+      "sha512": "FB4RoTDaV5tBiPSJsiG3A5DydeKz7ErglnkqVjBFjm6wu8kg91j0MxL/Al9iUyu9i/hq53fRs5KE3rjUNYvf5w==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2524,15 +2632,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.Algorithms.4.0.0-beta-23324.nupkg",
-        "System.Security.Cryptography.Algorithms.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Cryptography.Algorithms.4.0.0-beta-23330.nupkg",
+        "System.Security.Cryptography.Algorithms.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Cryptography.Algorithms.nuspec"
       ]
     },
-    "System.Security.Cryptography.Encoding/4.0.0-beta-23324": {
+    "System.Security.Cryptography.Encoding/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "JHOyknf1eYO6C39Vao6kAGpadq3PBO1L4tuzNEz/HvbH5sfIHPbjhxL11OyAhVKCzLCfEj6+aeClovFqZIRPyw==",
+      "sha512": "zeFdKQT6xjNdiNCaEmEYJMEK59kixkX7jJSoOLw3H+53t9X0F98vr3tS8YlrW/Lk/K9c6L5pYLlkb2dNqvUD/g==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2546,15 +2654,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.Encoding.4.0.0-beta-23324.nupkg",
-        "System.Security.Cryptography.Encoding.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Cryptography.Encoding.4.0.0-beta-23330.nupkg",
+        "System.Security.Cryptography.Encoding.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Cryptography.Encoding.nuspec"
       ]
     },
-    "System.Security.Cryptography.Primitives/4.0.0-beta-23324": {
+    "System.Security.Cryptography.Primitives/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "ETZxelIX51Di4FTytd8ohSpN6Ym/32aWIX9E2NCFkd91qdexn2Dkysn80b6n4gX6jG+oL0UHQDtD/fYq8C65oQ==",
+      "sha512": "15uVbOD3X0sRQJIxcEH5hasxlFdbA1CmPPZa0Y8pYEuQcWMF2gBswvU8s4qoKtA7x2xhNhzPsXIhsQuKNMTdEA==",
       "files": [
         "lib/dotnet/System.Security.Cryptography.Primitives.dll",
         "lib/MonoAndroid10/_._",
@@ -2568,15 +2676,15 @@
         "ref/net46/System.Security.Cryptography.Primitives.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Security.Cryptography.Primitives.4.0.0-beta-23324.nupkg",
-        "System.Security.Cryptography.Primitives.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Cryptography.Primitives.4.0.0-beta-23330.nupkg",
+        "System.Security.Cryptography.Primitives.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Cryptography.Primitives.nuspec"
       ]
     },
-    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23324": {
+    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "8NaEOxkkNBUECh0cPzGpbXS0uzGDpnvxI0kqQKRGp9uA+9qCyQfxcqAT6ozAYtOuFNVaC1XU3zQnb7T2nfvIDg==",
+      "sha512": "L8mUimdm7+GsORgJ8DFBMGsFnwDJ5YCUdJj3HfXQx4HCoPDPF+vJo3HRiHfcvNA2Zsf0ov2kuerYj/eeVa2/Rw==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2590,8 +2698,8 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23324.nupkg",
-        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23330.nupkg",
+        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Cryptography.X509Certificates.nuspec"
       ]
     },
@@ -2628,10 +2736,10 @@
         "System.Security.Principal.nuspec"
       ]
     },
-    "System.Security.Principal.Windows/4.0.0-beta-23324": {
+    "System.Security.Principal.Windows/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "csbCKdwBz31T8He7U6XMIc9BiWgwjHs5WDZR4rfhsk48TpdsbKNHX9OX4b+GwvgcsfVuWxre7zqNR0Bc9gWZ7g==",
+      "sha512": "q+3L3aB8bn0HCW52kX9TSJdhbjffBw7QWCOu0yX1SDhPN9MCPmJ4aBBCn1HRWroa5y7UcNUdjL1xwiERycZexw==",
       "files": [
         "lib/DNXCore50/de/System.Security.Principal.Windows.xml",
         "lib/DNXCore50/es/System.Security.Principal.Windows.xml",
@@ -2647,15 +2755,15 @@
         "lib/net46/System.Security.Principal.Windows.dll",
         "ref/dotnet/System.Security.Principal.Windows.dll",
         "ref/net46/System.Security.Principal.Windows.dll",
-        "System.Security.Principal.Windows.4.0.0-beta-23324.nupkg",
-        "System.Security.Principal.Windows.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Principal.Windows.4.0.0-beta-23330.nupkg",
+        "System.Security.Principal.Windows.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Principal.Windows.nuspec"
       ]
     },
-    "System.ServiceModel.Http/4.0.11-beta-23324": {
+    "System.ServiceModel.Http/4.0.11-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "VkTumuCSmXd0NPZZU+nrO7YqznvM+wP96NykXbxFJdNAtCplmqXaQh+YZ/02rjJmfou5qyo2V+ZWVwySBAirOg==",
+      "sha512": "NHKxIIYL0ATDbX18RLCSXtuq26MMoYfAVdpl5K+D0s5AHp7TMPb7LcjZPpg25B2v48x1TwE9LYcYTCiOZcoPzQ==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Http.dll",
         "lib/MonoAndroid10/_._",
@@ -2680,15 +2788,15 @@
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.ServiceModel.Http.4.0.11-beta-23324.nupkg",
-        "System.ServiceModel.Http.4.0.11-beta-23324.nupkg.sha512",
+        "System.ServiceModel.Http.4.0.11-beta-23330.nupkg",
+        "System.ServiceModel.Http.4.0.11-beta-23330.nupkg.sha512",
         "System.ServiceModel.Http.nuspec"
       ]
     },
-    "System.ServiceModel.Primitives/4.0.1-beta-23324": {
+    "System.ServiceModel.Primitives/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "bmU31B4CD5+m9Kt0iDM5Yw2ZXRfv7lpK3Sx1HektcT/HERc+IMPdO38f/Wxtofo5WOA0qmd1fdrMeQcbEkDfJg==",
+      "sha512": "kJ/pcRUf7Ow7s/rX8Kmc9P2k6cvyudIzyUcqr/pn9NwY8DC/2DWkkFvYE2udR4kvBzJJzXl/rsJQlyLIVGMAww==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Primitives.dll",
         "lib/net45/_._",
@@ -2708,8 +2816,8 @@
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.Primitives.dll",
         "ref/win8/_._",
-        "System.ServiceModel.Primitives.4.0.1-beta-23324.nupkg",
-        "System.ServiceModel.Primitives.4.0.1-beta-23324.nupkg.sha512",
+        "System.ServiceModel.Primitives.4.0.1-beta-23330.nupkg",
+        "System.ServiceModel.Primitives.4.0.1-beta-23330.nupkg.sha512",
         "System.ServiceModel.Primitives.nuspec"
       ]
     },
@@ -2904,10 +3012,9 @@
         "System.Threading.Tasks.nuspec"
       ]
     },
-    "System.Threading.ThreadPool/4.0.10-beta-23324": {
+    "System.Threading.ThreadPool/4.0.10-beta-23330": {
       "type": "package",
-      "serviceable": true,
-      "sha512": "G4SjGmiV72HBiv8wkfnKFGTieekrACU1m43VaeJ6vDeSyb08eEFusVH1UWZpOsUF25meCuzpda0ezus24b4rKA==",
+      "sha512": "nM5OewUj8NJrye93apbM6KHvPddgPJGzt1IWIXk9lV5HB4NGsn6M5U0gxMQWShQuDp6NF3ya3ULRSvh3dLMbzg==",
       "files": [
         "lib/DNXCore50/System.Threading.ThreadPool.dll",
         "lib/MonoAndroid10/_._",
@@ -2921,8 +3028,8 @@
         "ref/net46/System.Threading.ThreadPool.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Threading.ThreadPool.4.0.10-beta-23324.nupkg",
-        "System.Threading.ThreadPool.4.0.10-beta-23324.nupkg.sha512",
+        "System.Threading.ThreadPool.4.0.10-beta-23330.nupkg",
+        "System.Threading.ThreadPool.4.0.10-beta-23330.nupkg.sha512",
         "System.Threading.ThreadPool.nuspec"
       ]
     },
@@ -3173,14 +3280,14 @@
         "xunit.extensibility.execution.nuspec"
       ]
     },
-    "xunit.netcore.extensions/1.0.0-prerelease-00095": {
+    "xunit.netcore.extensions/1.0.0-prerelease-00098": {
       "type": "package",
       "serviceable": true,
-      "sha512": "FuvWmkuxHiqD0cHDggg5MRmBoeM4Uea7OUEmKvZiQu7Fy02hJ6yKKNV7mNW3y4scwSzDNA81Qa+HIS33PeWUog==",
+      "sha512": "3kRPwTbC42YGmsNHpNMKfGVOO5cVfxUD+C7cYbti1aml4UCT/RFZ6lhm5Vym2wNRDxryu0Es78aMf1BaybSrDg==",
       "files": [
         "lib/dotnet/Xunit.NetCore.Extensions.dll",
-        "xunit.netcore.extensions.1.0.0-prerelease-00095.nupkg",
-        "xunit.netcore.extensions.1.0.0-prerelease-00095.nupkg.sha512",
+        "xunit.netcore.extensions.1.0.0-prerelease-00098.nupkg",
+        "xunit.netcore.extensions.1.0.0-prerelease-00098.nupkg.sha512",
         "xunit.netcore.extensions.nuspec"
       ]
     }

--- a/src/System.Private.ServiceModel/tests/Scenarios/Contract/XmlSerializer/project.lock.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Contract/XmlSerializer/project.lock.json
@@ -292,7 +292,7 @@
           "lib/dotnet/System.Linq.Queryable.dll": {}
         }
       },
-      "System.Net.Http/4.0.1-beta-23324": {
+      "System.Net.Http/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -305,16 +305,15 @@
           "ref/dotnet/System.Net.Http.dll": {}
         }
       },
-      "System.Net.NameResolution/4.0.0-beta-23324": {
+      "System.Net.NameResolution/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.Networking": "4.0.1-beta-23324"
+          "System.Net.Primitives": "4.0.10",
+          "System.Runtime": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Net.NameResolution.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Net.NameResolution.dll": {}
         }
       },
       "System.Net.Primitives/4.0.10": {
@@ -329,10 +328,10 @@
           "lib/DNXCore50/System.Net.Primitives.dll": {}
         }
       },
-      "System.Net.Security/4.0.0-beta-23324": {
+      "System.Net.Security/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.Networking": "4.0.1-beta-23324"
+          "System.Private.Networking": "4.0.1-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.Net.Security.dll": {}
@@ -367,6 +366,49 @@
         },
         "runtime": {
           "lib/dotnet/System.Net.WebHeaderCollection.dll": {}
+        }
+      },
+      "System.Net.WebSockets/4.0.0-beta-23330": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.Win32.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Threading.Tasks": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Net.WebSockets.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Net.WebSockets.dll": {}
+        }
+      },
+      "System.Net.WebSockets.Client/4.0.0-beta-23330": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.Win32.Primitives": "4.0.0",
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Diagnostics.Tracing": "4.0.20",
+          "System.Globalization": "4.0.10",
+          "System.Net.Primitives": "4.0.10",
+          "System.Net.WebHeaderCollection": "4.0.0",
+          "System.Net.WebSockets": "4.0.0-beta-23330",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23330",
+          "System.Text.Encoding": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Net.WebSockets.Client.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Net.WebSockets.Client.dll": {}
         }
       },
       "System.ObjectModel/4.0.10": {
@@ -414,7 +456,7 @@
           "lib/DNXCore50/System.Private.DataContractSerialization.dll": {}
         }
       },
-      "System.Private.Networking/4.0.1-beta-23324": {
+      "System.Private.Networking/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -433,13 +475,13 @@
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23324",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23324",
-          "System.Security.Principal.Windows": "4.0.0-beta-23324",
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23330",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23330",
+          "System.Security.Principal.Windows": "4.0.0-beta-23330",
           "System.Threading": "4.0.10",
           "System.Threading.Overlapped": "4.0.0",
           "System.Threading.Tasks": "4.0.10",
-          "System.Threading.ThreadPool": "4.0.10-beta-23324"
+          "System.Threading.ThreadPool": "4.0.10-beta-23330"
         },
         "compile": {
           "ref/dnxcore50/_._": {}
@@ -448,7 +490,7 @@
           "lib/DNXCore50/System.Private.Networking.dll": {}
         }
       },
-      "System.Private.ServiceModel/4.0.1-beta-23324": {
+      "System.Private.ServiceModel/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -465,12 +507,14 @@
           "System.Linq": "4.0.0",
           "System.Linq.Expressions": "4.0.10",
           "System.Linq.Queryable": "4.0.0",
-          "System.Net.Http": "4.0.1-beta-23324",
-          "System.Net.NameResolution": "4.0.0-beta-23324",
+          "System.Net.Http": "4.0.1-beta-23330",
+          "System.Net.NameResolution": "4.0.0-beta-23330",
           "System.Net.Primitives": "4.0.10",
-          "System.Net.Security": "4.0.0-beta-23324",
-          "System.Net.Sockets": "4.0.10-beta-23324",
+          "System.Net.Security": "4.0.0-beta-23330",
+          "System.Net.Sockets": "4.0.10-beta-23330",
           "System.Net.WebHeaderCollection": "4.0.0",
+          "System.Net.WebSockets": "4.0.0-beta-23330",
+          "System.Net.WebSockets.Client": "4.0.0-beta-23330",
           "System.ObjectModel": "4.0.10",
           "System.Reflection": "4.0.10",
           "System.Reflection.DispatchProxy": "4.0.0",
@@ -484,9 +528,9 @@
           "System.Runtime.Serialization.Primitives": "4.0.10",
           "System.Runtime.Serialization.Xml": "4.0.10",
           "System.Security.Claims": "4.0.0",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23324",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23330",
           "System.Security.Principal": "4.0.0",
-          "System.Security.Principal.Windows": "4.0.0-beta-23324",
+          "System.Security.Principal.Windows": "4.0.0-beta-23330",
           "System.Text.Encoding": "4.0.10",
           "System.Threading": "4.0.10",
           "System.Threading.Tasks": "4.0.10",
@@ -750,18 +794,18 @@
           "lib/dotnet/System.Security.Claims.dll": {}
         }
       },
-      "System.Security.Cryptography.Algorithms/4.0.0-beta-23324": {
+      "System.Security.Cryptography.Algorithms/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
           "System.Runtime": "4.0.0",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23324"
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.Algorithms.dll": {}
         }
       },
-      "System.Security.Cryptography.Encoding/4.0.0-beta-23324": {
+      "System.Security.Cryptography.Encoding/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -770,7 +814,7 @@
           "ref/dotnet/System.Security.Cryptography.Encoding.dll": {}
         }
       },
-      "System.Security.Cryptography.Primitives/4.0.0-beta-23324": {
+      "System.Security.Cryptography.Primitives/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.0",
@@ -788,13 +832,13 @@
           "lib/dotnet/System.Security.Cryptography.Primitives.dll": {}
         }
       },
-      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23324": {
+      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
           "System.Runtime.Handles": "4.0.0",
-          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23324",
-          "System.Security.Cryptography.Encoding": "4.0.0-beta-23324"
+          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23330",
+          "System.Security.Cryptography.Encoding": "4.0.0-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.X509Certificates.dll": {}
@@ -812,7 +856,7 @@
           "lib/dotnet/System.Security.Principal.dll": {}
         }
       },
-      "System.Security.Principal.Windows/4.0.0-beta-23324": {
+      "System.Security.Principal.Windows/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -835,10 +879,10 @@
           "lib/DNXCore50/System.Security.Principal.Windows.dll": {}
         }
       },
-      "System.ServiceModel.Http/4.0.11-beta-23324": {
+      "System.ServiceModel.Http/4.0.11-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.0.1-beta-23324",
+          "System.Private.ServiceModel": "4.0.1-beta-23330",
           "System.Runtime": "4.0.20"
         },
         "compile": {
@@ -848,10 +892,10 @@
           "lib/DNXCore50/System.ServiceModel.Http.dll": {}
         }
       },
-      "System.ServiceModel.Primitives/4.0.1-beta-23324": {
+      "System.ServiceModel.Primitives/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.0.1-beta-23324"
+          "System.Private.ServiceModel": "4.0.1-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.ServiceModel.Primitives.dll": {}
@@ -940,7 +984,7 @@
           "lib/DNXCore50/System.Threading.Tasks.dll": {}
         }
       },
-      "System.Threading.ThreadPool/4.0.10-beta-23324": {
+      "System.Threading.ThreadPool/4.0.10-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
@@ -1133,7 +1177,7 @@
           "lib/dotnet/xunit.execution.dotnet.dll": {}
         }
       },
-      "xunit.netcore.extensions/1.0.0-prerelease-00095": {
+      "xunit.netcore.extensions/1.0.0-prerelease-00098": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.10",
@@ -1761,23 +1805,12 @@
         "System.Linq.Queryable.nuspec"
       ]
     },
-    "System.Net.Http/4.0.1-beta-23324": {
+    "System.Net.Http/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "gXfHlWsiMQDuFqwnQrlQTje9vqMhCFLtm35jX4WqZjcfa3y69DbwueeT0gJbVMK88/UnG8FAYiDBb7AKyu+51w==",
+      "sha512": "itLPx7B7Ac4mX8wQx9V9DQcxqTgkmwDNnQIHuCgAH53Jq2X3XziiRRBbxbmNJlWqBlgPzbseWJmMCtcF/ePhOg==",
       "files": [
         "lib/net45/_._",
-        "lib/netcore50/de/System.Net.Http.xml",
-        "lib/netcore50/es/System.Net.Http.xml",
-        "lib/netcore50/fr/System.Net.Http.xml",
-        "lib/netcore50/it/System.Net.Http.xml",
-        "lib/netcore50/ja/System.Net.Http.xml",
-        "lib/netcore50/ko/System.Net.Http.xml",
-        "lib/netcore50/ru/System.Net.Http.xml",
-        "lib/netcore50/System.Net.Http.dll",
-        "lib/netcore50/System.Net.Http.xml",
-        "lib/netcore50/zh-hans/System.Net.Http.xml",
-        "lib/netcore50/zh-hant/System.Net.Http.xml",
         "lib/win8/_._",
         "lib/wpa81/_._",
         "ref/dotnet/System.Net.Http.dll",
@@ -1786,17 +1819,16 @@
         "ref/win8/_._",
         "ref/wpa81/_._",
         "runtime.json",
-        "System.Net.Http.4.0.1-beta-23324.nupkg",
-        "System.Net.Http.4.0.1-beta-23324.nupkg.sha512",
+        "System.Net.Http.4.0.1-beta-23330.nupkg",
+        "System.Net.Http.4.0.1-beta-23330.nupkg.sha512",
         "System.Net.Http.nuspec"
       ]
     },
-    "System.Net.NameResolution/4.0.0-beta-23324": {
+    "System.Net.NameResolution/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "lNYXUmnSXUtLFY09Rc27zJ6/TxCuGggQzBgiuWHoWrjWxymuuxqPT2Mj7Dn7sUUh0GvF2MOx7Uk+rtCFBiIavg==",
+      "sha512": "d8Am+In/aBgcHpEV6xsi5BCiTEN4y6s9O1V/yIvwX8mDC4CtdZiGsi4DtoB0TLOgp8ky6GxbSF4bKCjFpBO3uw==",
       "files": [
-        "lib/DNXCore50/System.Net.NameResolution.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.NameResolution.dll",
@@ -1808,8 +1840,9 @@
         "ref/net46/System.Net.NameResolution.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.NameResolution.4.0.0-beta-23324.nupkg",
-        "System.Net.NameResolution.4.0.0-beta-23324.nupkg.sha512",
+        "runtime.json",
+        "System.Net.NameResolution.4.0.0-beta-23330.nupkg",
+        "System.Net.NameResolution.4.0.0-beta-23330.nupkg.sha512",
         "System.Net.NameResolution.nuspec"
       ]
     },
@@ -1846,9 +1879,9 @@
         "System.Net.Primitives.nuspec"
       ]
     },
-    "System.Net.Security/4.0.0-beta-23324": {
+    "System.Net.Security/4.0.0-beta-23330": {
       "type": "package",
-      "sha512": "D04RYjxrnR3D+uI9CGmAAFKKQ6T+pPcRHYucc1PIo7/hJK5I/Yu7gAw9yOxHUhQjSGfrKo00lHpBCQMTQt4lSw==",
+      "sha512": "z98dKloNy9DBdyfqQwQvKWA2q8Qj4vgGEVONnlS70c13eh0MolBHJ0wNdplZZK5zYZ5Eu8GTwexbUlpHbsfzVA==",
       "files": [
         "lib/DNXCore50/System.Net.Security.dll",
         "lib/MonoAndroid10/_._",
@@ -1862,8 +1895,8 @@
         "ref/net46/System.Net.Security.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.Security.4.0.0-beta-23324.nupkg",
-        "System.Net.Security.4.0.0-beta-23324.nupkg.sha512",
+        "System.Net.Security.4.0.0-beta-23330.nupkg",
+        "System.Net.Security.4.0.0-beta-23330.nupkg.sha512",
         "System.Net.Security.nuspec"
       ]
     },
@@ -1921,6 +1954,81 @@
         "System.Net.WebHeaderCollection.nuspec"
       ]
     },
+    "System.Net.WebSockets/4.0.0-beta-23330": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "6Q9/uTDcaqbmdbD04MisKmjti4aEpp40i/UzpGaPZ4ItuwzU/pMk9RjiYUBUiCQyZeKNlXcSB1FPN2nFof7tww==",
+      "files": [
+        "lib/dotnet/de/System.Net.WebSockets.xml",
+        "lib/dotnet/es/System.Net.WebSockets.xml",
+        "lib/dotnet/fr/System.Net.WebSockets.xml",
+        "lib/dotnet/it/System.Net.WebSockets.xml",
+        "lib/dotnet/ja/System.Net.WebSockets.xml",
+        "lib/dotnet/ko/System.Net.WebSockets.xml",
+        "lib/dotnet/ru/System.Net.WebSockets.xml",
+        "lib/dotnet/System.Net.WebSockets.dll",
+        "lib/dotnet/System.Net.WebSockets.xml",
+        "lib/dotnet/zh-hans/System.Net.WebSockets.xml",
+        "lib/dotnet/zh-hant/System.Net.WebSockets.xml",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Net.WebSockets.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Net.WebSockets.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Net.WebSockets.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Net.WebSockets.4.0.0-beta-23330.nupkg",
+        "System.Net.WebSockets.4.0.0-beta-23330.nupkg.sha512",
+        "System.Net.WebSockets.nuspec"
+      ]
+    },
+    "System.Net.WebSockets.Client/4.0.0-beta-23330": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "1NWEqwDkYRyvr1gSKZlY51AaI9w8oD0dC5UNa2Lb+qaeFHSF5KfCSzf7seD+im+sH6uocVo2nppiaabfbXZT4Q==",
+      "files": [
+        "lib/DNXCore50/de/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/es/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/fr/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/it/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/ja/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/ko/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/ru/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/System.Net.WebSockets.Client.dll",
+        "lib/DNXCore50/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/zh-hans/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/zh-hant/System.Net.WebSockets.Client.xml",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Net.WebSockets.Client.dll",
+        "lib/netcore50/de/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/es/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/fr/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/it/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/ja/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/ko/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/ru/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/System.Net.WebSockets.Client.dll",
+        "lib/netcore50/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/zh-hans/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/zh-hant/System.Net.WebSockets.Client.xml",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Net.WebSockets.Client.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Net.WebSockets.Client.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Net.WebSockets.Client.4.0.0-beta-23330.nupkg",
+        "System.Net.WebSockets.Client.4.0.0-beta-23330.nupkg.sha512",
+        "System.Net.WebSockets.Client.nuspec"
+      ]
+    },
     "System.ObjectModel/4.0.10": {
       "type": "package",
       "serviceable": true,
@@ -1969,31 +2077,31 @@
         "System.Private.DataContractSerialization.nuspec"
       ]
     },
-    "System.Private.Networking/4.0.1-beta-23324": {
+    "System.Private.Networking/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "OfyxoeCdh1ypzdz1u0h1Clgt+6749vALs2ZPkLwsOPzL0INCG9ISYo+Jhh62ZD8TMkWwLrvyVppMBPHY6M7Upw==",
+      "sha512": "8NZi1gCQaGTKDb2yWplm52HWCLaZnUwVitksJgcXY2dEJau/TBGyZup+yhOngOIe8QzQMxNG4iokY3Ce0/8mbg==",
       "files": [
         "lib/DNXCore50/System.Private.Networking.dll",
         "lib/netcore50/System.Private.Networking.dll",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "System.Private.Networking.4.0.1-beta-23324.nupkg",
-        "System.Private.Networking.4.0.1-beta-23324.nupkg.sha512",
+        "System.Private.Networking.4.0.1-beta-23330.nupkg",
+        "System.Private.Networking.4.0.1-beta-23330.nupkg.sha512",
         "System.Private.Networking.nuspec"
       ]
     },
-    "System.Private.ServiceModel/4.0.1-beta-23324": {
+    "System.Private.ServiceModel/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "Lz3T9V8GnaOFlf8LUmuPznuOIuy92BAFVc9huiMrFKByzPpydGuCvXEe+81rZ1IF2TQcHKO++9otnj96AEJ5BA==",
+      "sha512": "8lENvmHuZdlvmnYN1w98Mv8bDjc0O/YlaNHRRph35T/fLDyaG8LMLMwG3/ut6a/AenLJmbf92snOtNXCuqM+cQ==",
       "files": [
         "lib/DNXCore50/System.Private.ServiceModel.dll",
         "lib/netcore50/System.Private.ServiceModel.dll",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "System.Private.ServiceModel.4.0.1-beta-23324.nupkg",
-        "System.Private.ServiceModel.4.0.1-beta-23324.nupkg.sha512",
+        "System.Private.ServiceModel.4.0.1-beta-23330.nupkg",
+        "System.Private.ServiceModel.4.0.1-beta-23330.nupkg.sha512",
         "System.Private.ServiceModel.nuspec"
       ]
     },
@@ -2548,10 +2656,10 @@
         "System.Security.Claims.nuspec"
       ]
     },
-    "System.Security.Cryptography.Algorithms/4.0.0-beta-23324": {
+    "System.Security.Cryptography.Algorithms/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "Mt6LwMj8hPp0+xZHcV6grZ7wSWhgycGkdZ6DQ9XvUY9NguUsvb/+fu2cMdrC7XsnpvwIROByp+p2dSjqBn3E2Q==",
+      "sha512": "FB4RoTDaV5tBiPSJsiG3A5DydeKz7ErglnkqVjBFjm6wu8kg91j0MxL/Al9iUyu9i/hq53fRs5KE3rjUNYvf5w==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2565,15 +2673,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.Algorithms.4.0.0-beta-23324.nupkg",
-        "System.Security.Cryptography.Algorithms.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Cryptography.Algorithms.4.0.0-beta-23330.nupkg",
+        "System.Security.Cryptography.Algorithms.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Cryptography.Algorithms.nuspec"
       ]
     },
-    "System.Security.Cryptography.Encoding/4.0.0-beta-23324": {
+    "System.Security.Cryptography.Encoding/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "JHOyknf1eYO6C39Vao6kAGpadq3PBO1L4tuzNEz/HvbH5sfIHPbjhxL11OyAhVKCzLCfEj6+aeClovFqZIRPyw==",
+      "sha512": "zeFdKQT6xjNdiNCaEmEYJMEK59kixkX7jJSoOLw3H+53t9X0F98vr3tS8YlrW/Lk/K9c6L5pYLlkb2dNqvUD/g==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2587,15 +2695,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.Encoding.4.0.0-beta-23324.nupkg",
-        "System.Security.Cryptography.Encoding.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Cryptography.Encoding.4.0.0-beta-23330.nupkg",
+        "System.Security.Cryptography.Encoding.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Cryptography.Encoding.nuspec"
       ]
     },
-    "System.Security.Cryptography.Primitives/4.0.0-beta-23324": {
+    "System.Security.Cryptography.Primitives/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "ETZxelIX51Di4FTytd8ohSpN6Ym/32aWIX9E2NCFkd91qdexn2Dkysn80b6n4gX6jG+oL0UHQDtD/fYq8C65oQ==",
+      "sha512": "15uVbOD3X0sRQJIxcEH5hasxlFdbA1CmPPZa0Y8pYEuQcWMF2gBswvU8s4qoKtA7x2xhNhzPsXIhsQuKNMTdEA==",
       "files": [
         "lib/dotnet/System.Security.Cryptography.Primitives.dll",
         "lib/MonoAndroid10/_._",
@@ -2609,15 +2717,15 @@
         "ref/net46/System.Security.Cryptography.Primitives.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Security.Cryptography.Primitives.4.0.0-beta-23324.nupkg",
-        "System.Security.Cryptography.Primitives.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Cryptography.Primitives.4.0.0-beta-23330.nupkg",
+        "System.Security.Cryptography.Primitives.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Cryptography.Primitives.nuspec"
       ]
     },
-    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23324": {
+    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "8NaEOxkkNBUECh0cPzGpbXS0uzGDpnvxI0kqQKRGp9uA+9qCyQfxcqAT6ozAYtOuFNVaC1XU3zQnb7T2nfvIDg==",
+      "sha512": "L8mUimdm7+GsORgJ8DFBMGsFnwDJ5YCUdJj3HfXQx4HCoPDPF+vJo3HRiHfcvNA2Zsf0ov2kuerYj/eeVa2/Rw==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2631,8 +2739,8 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23324.nupkg",
-        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23330.nupkg",
+        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Cryptography.X509Certificates.nuspec"
       ]
     },
@@ -2669,10 +2777,10 @@
         "System.Security.Principal.nuspec"
       ]
     },
-    "System.Security.Principal.Windows/4.0.0-beta-23324": {
+    "System.Security.Principal.Windows/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "csbCKdwBz31T8He7U6XMIc9BiWgwjHs5WDZR4rfhsk48TpdsbKNHX9OX4b+GwvgcsfVuWxre7zqNR0Bc9gWZ7g==",
+      "sha512": "q+3L3aB8bn0HCW52kX9TSJdhbjffBw7QWCOu0yX1SDhPN9MCPmJ4aBBCn1HRWroa5y7UcNUdjL1xwiERycZexw==",
       "files": [
         "lib/DNXCore50/de/System.Security.Principal.Windows.xml",
         "lib/DNXCore50/es/System.Security.Principal.Windows.xml",
@@ -2688,15 +2796,15 @@
         "lib/net46/System.Security.Principal.Windows.dll",
         "ref/dotnet/System.Security.Principal.Windows.dll",
         "ref/net46/System.Security.Principal.Windows.dll",
-        "System.Security.Principal.Windows.4.0.0-beta-23324.nupkg",
-        "System.Security.Principal.Windows.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Principal.Windows.4.0.0-beta-23330.nupkg",
+        "System.Security.Principal.Windows.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Principal.Windows.nuspec"
       ]
     },
-    "System.ServiceModel.Http/4.0.11-beta-23324": {
+    "System.ServiceModel.Http/4.0.11-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "VkTumuCSmXd0NPZZU+nrO7YqznvM+wP96NykXbxFJdNAtCplmqXaQh+YZ/02rjJmfou5qyo2V+ZWVwySBAirOg==",
+      "sha512": "NHKxIIYL0ATDbX18RLCSXtuq26MMoYfAVdpl5K+D0s5AHp7TMPb7LcjZPpg25B2v48x1TwE9LYcYTCiOZcoPzQ==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Http.dll",
         "lib/MonoAndroid10/_._",
@@ -2721,15 +2829,15 @@
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.ServiceModel.Http.4.0.11-beta-23324.nupkg",
-        "System.ServiceModel.Http.4.0.11-beta-23324.nupkg.sha512",
+        "System.ServiceModel.Http.4.0.11-beta-23330.nupkg",
+        "System.ServiceModel.Http.4.0.11-beta-23330.nupkg.sha512",
         "System.ServiceModel.Http.nuspec"
       ]
     },
-    "System.ServiceModel.Primitives/4.0.1-beta-23324": {
+    "System.ServiceModel.Primitives/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "bmU31B4CD5+m9Kt0iDM5Yw2ZXRfv7lpK3Sx1HektcT/HERc+IMPdO38f/Wxtofo5WOA0qmd1fdrMeQcbEkDfJg==",
+      "sha512": "kJ/pcRUf7Ow7s/rX8Kmc9P2k6cvyudIzyUcqr/pn9NwY8DC/2DWkkFvYE2udR4kvBzJJzXl/rsJQlyLIVGMAww==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Primitives.dll",
         "lib/net45/_._",
@@ -2749,8 +2857,8 @@
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.Primitives.dll",
         "ref/win8/_._",
-        "System.ServiceModel.Primitives.4.0.1-beta-23324.nupkg",
-        "System.ServiceModel.Primitives.4.0.1-beta-23324.nupkg.sha512",
+        "System.ServiceModel.Primitives.4.0.1-beta-23330.nupkg",
+        "System.ServiceModel.Primitives.4.0.1-beta-23330.nupkg.sha512",
         "System.ServiceModel.Primitives.nuspec"
       ]
     },
@@ -2945,10 +3053,9 @@
         "System.Threading.Tasks.nuspec"
       ]
     },
-    "System.Threading.ThreadPool/4.0.10-beta-23324": {
+    "System.Threading.ThreadPool/4.0.10-beta-23330": {
       "type": "package",
-      "serviceable": true,
-      "sha512": "G4SjGmiV72HBiv8wkfnKFGTieekrACU1m43VaeJ6vDeSyb08eEFusVH1UWZpOsUF25meCuzpda0ezus24b4rKA==",
+      "sha512": "nM5OewUj8NJrye93apbM6KHvPddgPJGzt1IWIXk9lV5HB4NGsn6M5U0gxMQWShQuDp6NF3ya3ULRSvh3dLMbzg==",
       "files": [
         "lib/DNXCore50/System.Threading.ThreadPool.dll",
         "lib/MonoAndroid10/_._",
@@ -2962,8 +3069,8 @@
         "ref/net46/System.Threading.ThreadPool.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Threading.ThreadPool.4.0.10-beta-23324.nupkg",
-        "System.Threading.ThreadPool.4.0.10-beta-23324.nupkg.sha512",
+        "System.Threading.ThreadPool.4.0.10-beta-23330.nupkg",
+        "System.Threading.ThreadPool.4.0.10-beta-23330.nupkg.sha512",
         "System.Threading.ThreadPool.nuspec"
       ]
     },
@@ -3214,14 +3321,14 @@
         "xunit.extensibility.execution.nuspec"
       ]
     },
-    "xunit.netcore.extensions/1.0.0-prerelease-00095": {
+    "xunit.netcore.extensions/1.0.0-prerelease-00098": {
       "type": "package",
       "serviceable": true,
-      "sha512": "FuvWmkuxHiqD0cHDggg5MRmBoeM4Uea7OUEmKvZiQu7Fy02hJ6yKKNV7mNW3y4scwSzDNA81Qa+HIS33PeWUog==",
+      "sha512": "3kRPwTbC42YGmsNHpNMKfGVOO5cVfxUD+C7cYbti1aml4UCT/RFZ6lhm5Vym2wNRDxryu0Es78aMf1BaybSrDg==",
       "files": [
         "lib/dotnet/Xunit.NetCore.Extensions.dll",
-        "xunit.netcore.extensions.1.0.0-prerelease-00095.nupkg",
-        "xunit.netcore.extensions.1.0.0-prerelease-00095.nupkg.sha512",
+        "xunit.netcore.extensions.1.0.0-prerelease-00098.nupkg",
+        "xunit.netcore.extensions.1.0.0-prerelease-00098.nupkg.sha512",
         "xunit.netcore.extensions.nuspec"
       ]
     }

--- a/src/System.Private.ServiceModel/tests/Scenarios/Encoding/Encoders/project.lock.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Encoding/Encoders/project.lock.json
@@ -292,7 +292,7 @@
           "lib/dotnet/System.Linq.Queryable.dll": {}
         }
       },
-      "System.Net.Http/4.0.1-beta-23324": {
+      "System.Net.Http/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -305,16 +305,15 @@
           "ref/dotnet/System.Net.Http.dll": {}
         }
       },
-      "System.Net.NameResolution/4.0.0-beta-23324": {
+      "System.Net.NameResolution/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.Networking": "4.0.1-beta-23324"
+          "System.Net.Primitives": "4.0.10",
+          "System.Runtime": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Net.NameResolution.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Net.NameResolution.dll": {}
         }
       },
       "System.Net.Primitives/4.0.10": {
@@ -329,10 +328,10 @@
           "lib/DNXCore50/System.Net.Primitives.dll": {}
         }
       },
-      "System.Net.Security/4.0.0-beta-23324": {
+      "System.Net.Security/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.Networking": "4.0.1-beta-23324"
+          "System.Private.Networking": "4.0.1-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.Net.Security.dll": {}
@@ -367,6 +366,49 @@
         },
         "runtime": {
           "lib/dotnet/System.Net.WebHeaderCollection.dll": {}
+        }
+      },
+      "System.Net.WebSockets/4.0.0-beta-23330": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.Win32.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Threading.Tasks": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Net.WebSockets.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Net.WebSockets.dll": {}
+        }
+      },
+      "System.Net.WebSockets.Client/4.0.0-beta-23330": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.Win32.Primitives": "4.0.0",
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Diagnostics.Tracing": "4.0.20",
+          "System.Globalization": "4.0.10",
+          "System.Net.Primitives": "4.0.10",
+          "System.Net.WebHeaderCollection": "4.0.0",
+          "System.Net.WebSockets": "4.0.0-beta-23330",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23330",
+          "System.Text.Encoding": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Net.WebSockets.Client.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Net.WebSockets.Client.dll": {}
         }
       },
       "System.ObjectModel/4.0.10": {
@@ -414,7 +456,7 @@
           "lib/DNXCore50/System.Private.DataContractSerialization.dll": {}
         }
       },
-      "System.Private.Networking/4.0.1-beta-23324": {
+      "System.Private.Networking/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -433,13 +475,13 @@
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23324",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23324",
-          "System.Security.Principal.Windows": "4.0.0-beta-23324",
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23330",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23330",
+          "System.Security.Principal.Windows": "4.0.0-beta-23330",
           "System.Threading": "4.0.10",
           "System.Threading.Overlapped": "4.0.0",
           "System.Threading.Tasks": "4.0.10",
-          "System.Threading.ThreadPool": "4.0.10-beta-23324"
+          "System.Threading.ThreadPool": "4.0.10-beta-23330"
         },
         "compile": {
           "ref/dnxcore50/_._": {}
@@ -448,7 +490,7 @@
           "lib/DNXCore50/System.Private.Networking.dll": {}
         }
       },
-      "System.Private.ServiceModel/4.0.1-beta-23324": {
+      "System.Private.ServiceModel/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -465,12 +507,14 @@
           "System.Linq": "4.0.0",
           "System.Linq.Expressions": "4.0.10",
           "System.Linq.Queryable": "4.0.0",
-          "System.Net.Http": "4.0.1-beta-23324",
-          "System.Net.NameResolution": "4.0.0-beta-23324",
+          "System.Net.Http": "4.0.1-beta-23330",
+          "System.Net.NameResolution": "4.0.0-beta-23330",
           "System.Net.Primitives": "4.0.10",
-          "System.Net.Security": "4.0.0-beta-23324",
-          "System.Net.Sockets": "4.0.10-beta-23324",
+          "System.Net.Security": "4.0.0-beta-23330",
+          "System.Net.Sockets": "4.0.10-beta-23330",
           "System.Net.WebHeaderCollection": "4.0.0",
+          "System.Net.WebSockets": "4.0.0-beta-23330",
+          "System.Net.WebSockets.Client": "4.0.0-beta-23330",
           "System.ObjectModel": "4.0.10",
           "System.Reflection": "4.0.10",
           "System.Reflection.DispatchProxy": "4.0.0",
@@ -484,9 +528,9 @@
           "System.Runtime.Serialization.Primitives": "4.0.10",
           "System.Runtime.Serialization.Xml": "4.0.10",
           "System.Security.Claims": "4.0.0",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23324",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23330",
           "System.Security.Principal": "4.0.0",
-          "System.Security.Principal.Windows": "4.0.0-beta-23324",
+          "System.Security.Principal.Windows": "4.0.0-beta-23330",
           "System.Text.Encoding": "4.0.10",
           "System.Threading": "4.0.10",
           "System.Threading.Tasks": "4.0.10",
@@ -750,18 +794,18 @@
           "lib/dotnet/System.Security.Claims.dll": {}
         }
       },
-      "System.Security.Cryptography.Algorithms/4.0.0-beta-23324": {
+      "System.Security.Cryptography.Algorithms/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
           "System.Runtime": "4.0.0",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23324"
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.Algorithms.dll": {}
         }
       },
-      "System.Security.Cryptography.Encoding/4.0.0-beta-23324": {
+      "System.Security.Cryptography.Encoding/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -770,7 +814,7 @@
           "ref/dotnet/System.Security.Cryptography.Encoding.dll": {}
         }
       },
-      "System.Security.Cryptography.Primitives/4.0.0-beta-23324": {
+      "System.Security.Cryptography.Primitives/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.0",
@@ -788,13 +832,13 @@
           "lib/dotnet/System.Security.Cryptography.Primitives.dll": {}
         }
       },
-      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23324": {
+      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
           "System.Runtime.Handles": "4.0.0",
-          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23324",
-          "System.Security.Cryptography.Encoding": "4.0.0-beta-23324"
+          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23330",
+          "System.Security.Cryptography.Encoding": "4.0.0-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.X509Certificates.dll": {}
@@ -812,7 +856,7 @@
           "lib/dotnet/System.Security.Principal.dll": {}
         }
       },
-      "System.Security.Principal.Windows/4.0.0-beta-23324": {
+      "System.Security.Principal.Windows/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -835,10 +879,10 @@
           "lib/DNXCore50/System.Security.Principal.Windows.dll": {}
         }
       },
-      "System.ServiceModel.Http/4.0.11-beta-23324": {
+      "System.ServiceModel.Http/4.0.11-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.0.1-beta-23324",
+          "System.Private.ServiceModel": "4.0.1-beta-23330",
           "System.Runtime": "4.0.20"
         },
         "compile": {
@@ -848,10 +892,10 @@
           "lib/DNXCore50/System.ServiceModel.Http.dll": {}
         }
       },
-      "System.ServiceModel.NetTcp/4.0.1-beta-23324": {
+      "System.ServiceModel.NetTcp/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.0.1-beta-23324"
+          "System.Private.ServiceModel": "4.0.1-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.ServiceModel.NetTcp.dll": {}
@@ -860,10 +904,10 @@
           "lib/DNXCore50/System.ServiceModel.NetTcp.dll": {}
         }
       },
-      "System.ServiceModel.Primitives/4.0.1-beta-23324": {
+      "System.ServiceModel.Primitives/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.0.1-beta-23324"
+          "System.Private.ServiceModel": "4.0.1-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.ServiceModel.Primitives.dll": {}
@@ -952,7 +996,7 @@
           "lib/DNXCore50/System.Threading.Tasks.dll": {}
         }
       },
-      "System.Threading.ThreadPool/4.0.10-beta-23324": {
+      "System.Threading.ThreadPool/4.0.10-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
@@ -1145,7 +1189,7 @@
           "lib/dotnet/xunit.execution.dotnet.dll": {}
         }
       },
-      "xunit.netcore.extensions/1.0.0-prerelease-00095": {
+      "xunit.netcore.extensions/1.0.0-prerelease-00098": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.10",
@@ -1773,23 +1817,12 @@
         "System.Linq.Queryable.nuspec"
       ]
     },
-    "System.Net.Http/4.0.1-beta-23324": {
+    "System.Net.Http/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "gXfHlWsiMQDuFqwnQrlQTje9vqMhCFLtm35jX4WqZjcfa3y69DbwueeT0gJbVMK88/UnG8FAYiDBb7AKyu+51w==",
+      "sha512": "itLPx7B7Ac4mX8wQx9V9DQcxqTgkmwDNnQIHuCgAH53Jq2X3XziiRRBbxbmNJlWqBlgPzbseWJmMCtcF/ePhOg==",
       "files": [
         "lib/net45/_._",
-        "lib/netcore50/de/System.Net.Http.xml",
-        "lib/netcore50/es/System.Net.Http.xml",
-        "lib/netcore50/fr/System.Net.Http.xml",
-        "lib/netcore50/it/System.Net.Http.xml",
-        "lib/netcore50/ja/System.Net.Http.xml",
-        "lib/netcore50/ko/System.Net.Http.xml",
-        "lib/netcore50/ru/System.Net.Http.xml",
-        "lib/netcore50/System.Net.Http.dll",
-        "lib/netcore50/System.Net.Http.xml",
-        "lib/netcore50/zh-hans/System.Net.Http.xml",
-        "lib/netcore50/zh-hant/System.Net.Http.xml",
         "lib/win8/_._",
         "lib/wpa81/_._",
         "ref/dotnet/System.Net.Http.dll",
@@ -1798,17 +1831,16 @@
         "ref/win8/_._",
         "ref/wpa81/_._",
         "runtime.json",
-        "System.Net.Http.4.0.1-beta-23324.nupkg",
-        "System.Net.Http.4.0.1-beta-23324.nupkg.sha512",
+        "System.Net.Http.4.0.1-beta-23330.nupkg",
+        "System.Net.Http.4.0.1-beta-23330.nupkg.sha512",
         "System.Net.Http.nuspec"
       ]
     },
-    "System.Net.NameResolution/4.0.0-beta-23324": {
+    "System.Net.NameResolution/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "lNYXUmnSXUtLFY09Rc27zJ6/TxCuGggQzBgiuWHoWrjWxymuuxqPT2Mj7Dn7sUUh0GvF2MOx7Uk+rtCFBiIavg==",
+      "sha512": "d8Am+In/aBgcHpEV6xsi5BCiTEN4y6s9O1V/yIvwX8mDC4CtdZiGsi4DtoB0TLOgp8ky6GxbSF4bKCjFpBO3uw==",
       "files": [
-        "lib/DNXCore50/System.Net.NameResolution.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.NameResolution.dll",
@@ -1820,8 +1852,9 @@
         "ref/net46/System.Net.NameResolution.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.NameResolution.4.0.0-beta-23324.nupkg",
-        "System.Net.NameResolution.4.0.0-beta-23324.nupkg.sha512",
+        "runtime.json",
+        "System.Net.NameResolution.4.0.0-beta-23330.nupkg",
+        "System.Net.NameResolution.4.0.0-beta-23330.nupkg.sha512",
         "System.Net.NameResolution.nuspec"
       ]
     },
@@ -1858,9 +1891,9 @@
         "System.Net.Primitives.nuspec"
       ]
     },
-    "System.Net.Security/4.0.0-beta-23324": {
+    "System.Net.Security/4.0.0-beta-23330": {
       "type": "package",
-      "sha512": "D04RYjxrnR3D+uI9CGmAAFKKQ6T+pPcRHYucc1PIo7/hJK5I/Yu7gAw9yOxHUhQjSGfrKo00lHpBCQMTQt4lSw==",
+      "sha512": "z98dKloNy9DBdyfqQwQvKWA2q8Qj4vgGEVONnlS70c13eh0MolBHJ0wNdplZZK5zYZ5Eu8GTwexbUlpHbsfzVA==",
       "files": [
         "lib/DNXCore50/System.Net.Security.dll",
         "lib/MonoAndroid10/_._",
@@ -1874,8 +1907,8 @@
         "ref/net46/System.Net.Security.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.Security.4.0.0-beta-23324.nupkg",
-        "System.Net.Security.4.0.0-beta-23324.nupkg.sha512",
+        "System.Net.Security.4.0.0-beta-23330.nupkg",
+        "System.Net.Security.4.0.0-beta-23330.nupkg.sha512",
         "System.Net.Security.nuspec"
       ]
     },
@@ -1933,6 +1966,81 @@
         "System.Net.WebHeaderCollection.nuspec"
       ]
     },
+    "System.Net.WebSockets/4.0.0-beta-23330": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "6Q9/uTDcaqbmdbD04MisKmjti4aEpp40i/UzpGaPZ4ItuwzU/pMk9RjiYUBUiCQyZeKNlXcSB1FPN2nFof7tww==",
+      "files": [
+        "lib/dotnet/de/System.Net.WebSockets.xml",
+        "lib/dotnet/es/System.Net.WebSockets.xml",
+        "lib/dotnet/fr/System.Net.WebSockets.xml",
+        "lib/dotnet/it/System.Net.WebSockets.xml",
+        "lib/dotnet/ja/System.Net.WebSockets.xml",
+        "lib/dotnet/ko/System.Net.WebSockets.xml",
+        "lib/dotnet/ru/System.Net.WebSockets.xml",
+        "lib/dotnet/System.Net.WebSockets.dll",
+        "lib/dotnet/System.Net.WebSockets.xml",
+        "lib/dotnet/zh-hans/System.Net.WebSockets.xml",
+        "lib/dotnet/zh-hant/System.Net.WebSockets.xml",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Net.WebSockets.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Net.WebSockets.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Net.WebSockets.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Net.WebSockets.4.0.0-beta-23330.nupkg",
+        "System.Net.WebSockets.4.0.0-beta-23330.nupkg.sha512",
+        "System.Net.WebSockets.nuspec"
+      ]
+    },
+    "System.Net.WebSockets.Client/4.0.0-beta-23330": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "1NWEqwDkYRyvr1gSKZlY51AaI9w8oD0dC5UNa2Lb+qaeFHSF5KfCSzf7seD+im+sH6uocVo2nppiaabfbXZT4Q==",
+      "files": [
+        "lib/DNXCore50/de/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/es/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/fr/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/it/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/ja/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/ko/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/ru/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/System.Net.WebSockets.Client.dll",
+        "lib/DNXCore50/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/zh-hans/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/zh-hant/System.Net.WebSockets.Client.xml",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Net.WebSockets.Client.dll",
+        "lib/netcore50/de/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/es/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/fr/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/it/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/ja/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/ko/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/ru/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/System.Net.WebSockets.Client.dll",
+        "lib/netcore50/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/zh-hans/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/zh-hant/System.Net.WebSockets.Client.xml",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Net.WebSockets.Client.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Net.WebSockets.Client.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Net.WebSockets.Client.4.0.0-beta-23330.nupkg",
+        "System.Net.WebSockets.Client.4.0.0-beta-23330.nupkg.sha512",
+        "System.Net.WebSockets.Client.nuspec"
+      ]
+    },
     "System.ObjectModel/4.0.10": {
       "type": "package",
       "serviceable": true,
@@ -1981,31 +2089,31 @@
         "System.Private.DataContractSerialization.nuspec"
       ]
     },
-    "System.Private.Networking/4.0.1-beta-23324": {
+    "System.Private.Networking/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "OfyxoeCdh1ypzdz1u0h1Clgt+6749vALs2ZPkLwsOPzL0INCG9ISYo+Jhh62ZD8TMkWwLrvyVppMBPHY6M7Upw==",
+      "sha512": "8NZi1gCQaGTKDb2yWplm52HWCLaZnUwVitksJgcXY2dEJau/TBGyZup+yhOngOIe8QzQMxNG4iokY3Ce0/8mbg==",
       "files": [
         "lib/DNXCore50/System.Private.Networking.dll",
         "lib/netcore50/System.Private.Networking.dll",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "System.Private.Networking.4.0.1-beta-23324.nupkg",
-        "System.Private.Networking.4.0.1-beta-23324.nupkg.sha512",
+        "System.Private.Networking.4.0.1-beta-23330.nupkg",
+        "System.Private.Networking.4.0.1-beta-23330.nupkg.sha512",
         "System.Private.Networking.nuspec"
       ]
     },
-    "System.Private.ServiceModel/4.0.1-beta-23324": {
+    "System.Private.ServiceModel/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "Lz3T9V8GnaOFlf8LUmuPznuOIuy92BAFVc9huiMrFKByzPpydGuCvXEe+81rZ1IF2TQcHKO++9otnj96AEJ5BA==",
+      "sha512": "8lENvmHuZdlvmnYN1w98Mv8bDjc0O/YlaNHRRph35T/fLDyaG8LMLMwG3/ut6a/AenLJmbf92snOtNXCuqM+cQ==",
       "files": [
         "lib/DNXCore50/System.Private.ServiceModel.dll",
         "lib/netcore50/System.Private.ServiceModel.dll",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "System.Private.ServiceModel.4.0.1-beta-23324.nupkg",
-        "System.Private.ServiceModel.4.0.1-beta-23324.nupkg.sha512",
+        "System.Private.ServiceModel.4.0.1-beta-23330.nupkg",
+        "System.Private.ServiceModel.4.0.1-beta-23330.nupkg.sha512",
         "System.Private.ServiceModel.nuspec"
       ]
     },
@@ -2560,10 +2668,10 @@
         "System.Security.Claims.nuspec"
       ]
     },
-    "System.Security.Cryptography.Algorithms/4.0.0-beta-23324": {
+    "System.Security.Cryptography.Algorithms/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "Mt6LwMj8hPp0+xZHcV6grZ7wSWhgycGkdZ6DQ9XvUY9NguUsvb/+fu2cMdrC7XsnpvwIROByp+p2dSjqBn3E2Q==",
+      "sha512": "FB4RoTDaV5tBiPSJsiG3A5DydeKz7ErglnkqVjBFjm6wu8kg91j0MxL/Al9iUyu9i/hq53fRs5KE3rjUNYvf5w==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2577,15 +2685,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.Algorithms.4.0.0-beta-23324.nupkg",
-        "System.Security.Cryptography.Algorithms.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Cryptography.Algorithms.4.0.0-beta-23330.nupkg",
+        "System.Security.Cryptography.Algorithms.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Cryptography.Algorithms.nuspec"
       ]
     },
-    "System.Security.Cryptography.Encoding/4.0.0-beta-23324": {
+    "System.Security.Cryptography.Encoding/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "JHOyknf1eYO6C39Vao6kAGpadq3PBO1L4tuzNEz/HvbH5sfIHPbjhxL11OyAhVKCzLCfEj6+aeClovFqZIRPyw==",
+      "sha512": "zeFdKQT6xjNdiNCaEmEYJMEK59kixkX7jJSoOLw3H+53t9X0F98vr3tS8YlrW/Lk/K9c6L5pYLlkb2dNqvUD/g==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2599,15 +2707,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.Encoding.4.0.0-beta-23324.nupkg",
-        "System.Security.Cryptography.Encoding.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Cryptography.Encoding.4.0.0-beta-23330.nupkg",
+        "System.Security.Cryptography.Encoding.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Cryptography.Encoding.nuspec"
       ]
     },
-    "System.Security.Cryptography.Primitives/4.0.0-beta-23324": {
+    "System.Security.Cryptography.Primitives/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "ETZxelIX51Di4FTytd8ohSpN6Ym/32aWIX9E2NCFkd91qdexn2Dkysn80b6n4gX6jG+oL0UHQDtD/fYq8C65oQ==",
+      "sha512": "15uVbOD3X0sRQJIxcEH5hasxlFdbA1CmPPZa0Y8pYEuQcWMF2gBswvU8s4qoKtA7x2xhNhzPsXIhsQuKNMTdEA==",
       "files": [
         "lib/dotnet/System.Security.Cryptography.Primitives.dll",
         "lib/MonoAndroid10/_._",
@@ -2621,15 +2729,15 @@
         "ref/net46/System.Security.Cryptography.Primitives.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Security.Cryptography.Primitives.4.0.0-beta-23324.nupkg",
-        "System.Security.Cryptography.Primitives.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Cryptography.Primitives.4.0.0-beta-23330.nupkg",
+        "System.Security.Cryptography.Primitives.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Cryptography.Primitives.nuspec"
       ]
     },
-    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23324": {
+    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "8NaEOxkkNBUECh0cPzGpbXS0uzGDpnvxI0kqQKRGp9uA+9qCyQfxcqAT6ozAYtOuFNVaC1XU3zQnb7T2nfvIDg==",
+      "sha512": "L8mUimdm7+GsORgJ8DFBMGsFnwDJ5YCUdJj3HfXQx4HCoPDPF+vJo3HRiHfcvNA2Zsf0ov2kuerYj/eeVa2/Rw==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2643,8 +2751,8 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23324.nupkg",
-        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23330.nupkg",
+        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Cryptography.X509Certificates.nuspec"
       ]
     },
@@ -2681,10 +2789,10 @@
         "System.Security.Principal.nuspec"
       ]
     },
-    "System.Security.Principal.Windows/4.0.0-beta-23324": {
+    "System.Security.Principal.Windows/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "csbCKdwBz31T8He7U6XMIc9BiWgwjHs5WDZR4rfhsk48TpdsbKNHX9OX4b+GwvgcsfVuWxre7zqNR0Bc9gWZ7g==",
+      "sha512": "q+3L3aB8bn0HCW52kX9TSJdhbjffBw7QWCOu0yX1SDhPN9MCPmJ4aBBCn1HRWroa5y7UcNUdjL1xwiERycZexw==",
       "files": [
         "lib/DNXCore50/de/System.Security.Principal.Windows.xml",
         "lib/DNXCore50/es/System.Security.Principal.Windows.xml",
@@ -2700,15 +2808,15 @@
         "lib/net46/System.Security.Principal.Windows.dll",
         "ref/dotnet/System.Security.Principal.Windows.dll",
         "ref/net46/System.Security.Principal.Windows.dll",
-        "System.Security.Principal.Windows.4.0.0-beta-23324.nupkg",
-        "System.Security.Principal.Windows.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Principal.Windows.4.0.0-beta-23330.nupkg",
+        "System.Security.Principal.Windows.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Principal.Windows.nuspec"
       ]
     },
-    "System.ServiceModel.Http/4.0.11-beta-23324": {
+    "System.ServiceModel.Http/4.0.11-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "VkTumuCSmXd0NPZZU+nrO7YqznvM+wP96NykXbxFJdNAtCplmqXaQh+YZ/02rjJmfou5qyo2V+ZWVwySBAirOg==",
+      "sha512": "NHKxIIYL0ATDbX18RLCSXtuq26MMoYfAVdpl5K+D0s5AHp7TMPb7LcjZPpg25B2v48x1TwE9LYcYTCiOZcoPzQ==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Http.dll",
         "lib/MonoAndroid10/_._",
@@ -2733,15 +2841,15 @@
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.ServiceModel.Http.4.0.11-beta-23324.nupkg",
-        "System.ServiceModel.Http.4.0.11-beta-23324.nupkg.sha512",
+        "System.ServiceModel.Http.4.0.11-beta-23330.nupkg",
+        "System.ServiceModel.Http.4.0.11-beta-23330.nupkg.sha512",
         "System.ServiceModel.Http.nuspec"
       ]
     },
-    "System.ServiceModel.NetTcp/4.0.1-beta-23324": {
+    "System.ServiceModel.NetTcp/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "xI03xQCdWzqq4H2E29BELQm/e9LJl+IAbD50lcH966Z+JdaYOqeM6RGxAys0sVim59wvCrOv/YaRNxz66YLoog==",
+      "sha512": "Vx0QSKz4BlX/yYqKHET3mofo6RxxaMDLWsEFWDbEBJeCs0Yq19uGiIYwK1mXkWy3Y+jDwi42au3mVhmRbDHavA==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.NetTcp.dll",
         "lib/net45/_._",
@@ -2761,15 +2869,15 @@
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.NetTcp.dll",
         "ref/win8/_._",
-        "System.ServiceModel.NetTcp.4.0.1-beta-23324.nupkg",
-        "System.ServiceModel.NetTcp.4.0.1-beta-23324.nupkg.sha512",
+        "System.ServiceModel.NetTcp.4.0.1-beta-23330.nupkg",
+        "System.ServiceModel.NetTcp.4.0.1-beta-23330.nupkg.sha512",
         "System.ServiceModel.NetTcp.nuspec"
       ]
     },
-    "System.ServiceModel.Primitives/4.0.1-beta-23324": {
+    "System.ServiceModel.Primitives/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "bmU31B4CD5+m9Kt0iDM5Yw2ZXRfv7lpK3Sx1HektcT/HERc+IMPdO38f/Wxtofo5WOA0qmd1fdrMeQcbEkDfJg==",
+      "sha512": "kJ/pcRUf7Ow7s/rX8Kmc9P2k6cvyudIzyUcqr/pn9NwY8DC/2DWkkFvYE2udR4kvBzJJzXl/rsJQlyLIVGMAww==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Primitives.dll",
         "lib/net45/_._",
@@ -2789,8 +2897,8 @@
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.Primitives.dll",
         "ref/win8/_._",
-        "System.ServiceModel.Primitives.4.0.1-beta-23324.nupkg",
-        "System.ServiceModel.Primitives.4.0.1-beta-23324.nupkg.sha512",
+        "System.ServiceModel.Primitives.4.0.1-beta-23330.nupkg",
+        "System.ServiceModel.Primitives.4.0.1-beta-23330.nupkg.sha512",
         "System.ServiceModel.Primitives.nuspec"
       ]
     },
@@ -2985,10 +3093,9 @@
         "System.Threading.Tasks.nuspec"
       ]
     },
-    "System.Threading.ThreadPool/4.0.10-beta-23324": {
+    "System.Threading.ThreadPool/4.0.10-beta-23330": {
       "type": "package",
-      "serviceable": true,
-      "sha512": "G4SjGmiV72HBiv8wkfnKFGTieekrACU1m43VaeJ6vDeSyb08eEFusVH1UWZpOsUF25meCuzpda0ezus24b4rKA==",
+      "sha512": "nM5OewUj8NJrye93apbM6KHvPddgPJGzt1IWIXk9lV5HB4NGsn6M5U0gxMQWShQuDp6NF3ya3ULRSvh3dLMbzg==",
       "files": [
         "lib/DNXCore50/System.Threading.ThreadPool.dll",
         "lib/MonoAndroid10/_._",
@@ -3002,8 +3109,8 @@
         "ref/net46/System.Threading.ThreadPool.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Threading.ThreadPool.4.0.10-beta-23324.nupkg",
-        "System.Threading.ThreadPool.4.0.10-beta-23324.nupkg.sha512",
+        "System.Threading.ThreadPool.4.0.10-beta-23330.nupkg",
+        "System.Threading.ThreadPool.4.0.10-beta-23330.nupkg.sha512",
         "System.Threading.ThreadPool.nuspec"
       ]
     },
@@ -3254,14 +3361,14 @@
         "xunit.extensibility.execution.nuspec"
       ]
     },
-    "xunit.netcore.extensions/1.0.0-prerelease-00095": {
+    "xunit.netcore.extensions/1.0.0-prerelease-00098": {
       "type": "package",
       "serviceable": true,
-      "sha512": "FuvWmkuxHiqD0cHDggg5MRmBoeM4Uea7OUEmKvZiQu7Fy02hJ6yKKNV7mNW3y4scwSzDNA81Qa+HIS33PeWUog==",
+      "sha512": "3kRPwTbC42YGmsNHpNMKfGVOO5cVfxUD+C7cYbti1aml4UCT/RFZ6lhm5Vym2wNRDxryu0Es78aMf1BaybSrDg==",
       "files": [
         "lib/dotnet/Xunit.NetCore.Extensions.dll",
-        "xunit.netcore.extensions.1.0.0-prerelease-00095.nupkg",
-        "xunit.netcore.extensions.1.0.0-prerelease-00095.nupkg.sha512",
+        "xunit.netcore.extensions.1.0.0-prerelease-00098.nupkg",
+        "xunit.netcore.extensions.1.0.0-prerelease-00098.nupkg.sha512",
         "xunit.netcore.extensions.nuspec"
       ]
     }

--- a/src/System.Private.ServiceModel/tests/Scenarios/Encoding/MessageVersion/project.lock.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Encoding/MessageVersion/project.lock.json
@@ -292,7 +292,7 @@
           "lib/dotnet/System.Linq.Queryable.dll": {}
         }
       },
-      "System.Net.Http/4.0.1-beta-23324": {
+      "System.Net.Http/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -305,16 +305,15 @@
           "ref/dotnet/System.Net.Http.dll": {}
         }
       },
-      "System.Net.NameResolution/4.0.0-beta-23324": {
+      "System.Net.NameResolution/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.Networking": "4.0.1-beta-23324"
+          "System.Net.Primitives": "4.0.10",
+          "System.Runtime": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Net.NameResolution.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Net.NameResolution.dll": {}
         }
       },
       "System.Net.Primitives/4.0.10": {
@@ -329,10 +328,10 @@
           "lib/DNXCore50/System.Net.Primitives.dll": {}
         }
       },
-      "System.Net.Security/4.0.0-beta-23324": {
+      "System.Net.Security/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.Networking": "4.0.1-beta-23324"
+          "System.Private.Networking": "4.0.1-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.Net.Security.dll": {}
@@ -367,6 +366,49 @@
         },
         "runtime": {
           "lib/dotnet/System.Net.WebHeaderCollection.dll": {}
+        }
+      },
+      "System.Net.WebSockets/4.0.0-beta-23330": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.Win32.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Threading.Tasks": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Net.WebSockets.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Net.WebSockets.dll": {}
+        }
+      },
+      "System.Net.WebSockets.Client/4.0.0-beta-23330": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.Win32.Primitives": "4.0.0",
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Diagnostics.Tracing": "4.0.20",
+          "System.Globalization": "4.0.10",
+          "System.Net.Primitives": "4.0.10",
+          "System.Net.WebHeaderCollection": "4.0.0",
+          "System.Net.WebSockets": "4.0.0-beta-23330",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23330",
+          "System.Text.Encoding": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Net.WebSockets.Client.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Net.WebSockets.Client.dll": {}
         }
       },
       "System.ObjectModel/4.0.10": {
@@ -414,7 +456,7 @@
           "lib/DNXCore50/System.Private.DataContractSerialization.dll": {}
         }
       },
-      "System.Private.Networking/4.0.1-beta-23324": {
+      "System.Private.Networking/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -433,13 +475,13 @@
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23324",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23324",
-          "System.Security.Principal.Windows": "4.0.0-beta-23324",
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23330",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23330",
+          "System.Security.Principal.Windows": "4.0.0-beta-23330",
           "System.Threading": "4.0.10",
           "System.Threading.Overlapped": "4.0.0",
           "System.Threading.Tasks": "4.0.10",
-          "System.Threading.ThreadPool": "4.0.10-beta-23324"
+          "System.Threading.ThreadPool": "4.0.10-beta-23330"
         },
         "compile": {
           "ref/dnxcore50/_._": {}
@@ -448,7 +490,7 @@
           "lib/DNXCore50/System.Private.Networking.dll": {}
         }
       },
-      "System.Private.ServiceModel/4.0.1-beta-23324": {
+      "System.Private.ServiceModel/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -465,12 +507,14 @@
           "System.Linq": "4.0.0",
           "System.Linq.Expressions": "4.0.10",
           "System.Linq.Queryable": "4.0.0",
-          "System.Net.Http": "4.0.1-beta-23324",
-          "System.Net.NameResolution": "4.0.0-beta-23324",
+          "System.Net.Http": "4.0.1-beta-23330",
+          "System.Net.NameResolution": "4.0.0-beta-23330",
           "System.Net.Primitives": "4.0.10",
-          "System.Net.Security": "4.0.0-beta-23324",
-          "System.Net.Sockets": "4.0.10-beta-23324",
+          "System.Net.Security": "4.0.0-beta-23330",
+          "System.Net.Sockets": "4.0.10-beta-23330",
           "System.Net.WebHeaderCollection": "4.0.0",
+          "System.Net.WebSockets": "4.0.0-beta-23330",
+          "System.Net.WebSockets.Client": "4.0.0-beta-23330",
           "System.ObjectModel": "4.0.10",
           "System.Reflection": "4.0.10",
           "System.Reflection.DispatchProxy": "4.0.0",
@@ -484,9 +528,9 @@
           "System.Runtime.Serialization.Primitives": "4.0.10",
           "System.Runtime.Serialization.Xml": "4.0.10",
           "System.Security.Claims": "4.0.0",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23324",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23330",
           "System.Security.Principal": "4.0.0",
-          "System.Security.Principal.Windows": "4.0.0-beta-23324",
+          "System.Security.Principal.Windows": "4.0.0-beta-23330",
           "System.Text.Encoding": "4.0.10",
           "System.Threading": "4.0.10",
           "System.Threading.Tasks": "4.0.10",
@@ -735,18 +779,18 @@
           "lib/dotnet/System.Security.Claims.dll": {}
         }
       },
-      "System.Security.Cryptography.Algorithms/4.0.0-beta-23324": {
+      "System.Security.Cryptography.Algorithms/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
           "System.Runtime": "4.0.0",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23324"
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.Algorithms.dll": {}
         }
       },
-      "System.Security.Cryptography.Encoding/4.0.0-beta-23324": {
+      "System.Security.Cryptography.Encoding/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -755,7 +799,7 @@
           "ref/dotnet/System.Security.Cryptography.Encoding.dll": {}
         }
       },
-      "System.Security.Cryptography.Primitives/4.0.0-beta-23324": {
+      "System.Security.Cryptography.Primitives/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.0",
@@ -773,13 +817,13 @@
           "lib/dotnet/System.Security.Cryptography.Primitives.dll": {}
         }
       },
-      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23324": {
+      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
           "System.Runtime.Handles": "4.0.0",
-          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23324",
-          "System.Security.Cryptography.Encoding": "4.0.0-beta-23324"
+          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23330",
+          "System.Security.Cryptography.Encoding": "4.0.0-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.X509Certificates.dll": {}
@@ -797,7 +841,7 @@
           "lib/dotnet/System.Security.Principal.dll": {}
         }
       },
-      "System.Security.Principal.Windows/4.0.0-beta-23324": {
+      "System.Security.Principal.Windows/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -820,10 +864,10 @@
           "lib/DNXCore50/System.Security.Principal.Windows.dll": {}
         }
       },
-      "System.ServiceModel.Http/4.0.11-beta-23324": {
+      "System.ServiceModel.Http/4.0.11-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.0.1-beta-23324",
+          "System.Private.ServiceModel": "4.0.1-beta-23330",
           "System.Runtime": "4.0.20"
         },
         "compile": {
@@ -833,10 +877,10 @@
           "lib/DNXCore50/System.ServiceModel.Http.dll": {}
         }
       },
-      "System.ServiceModel.Primitives/4.0.1-beta-23324": {
+      "System.ServiceModel.Primitives/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.0.1-beta-23324"
+          "System.Private.ServiceModel": "4.0.1-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.ServiceModel.Primitives.dll": {}
@@ -925,7 +969,7 @@
           "lib/DNXCore50/System.Threading.Tasks.dll": {}
         }
       },
-      "System.Threading.ThreadPool/4.0.10-beta-23324": {
+      "System.Threading.ThreadPool/4.0.10-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
@@ -1118,7 +1162,7 @@
           "lib/dotnet/xunit.execution.dotnet.dll": {}
         }
       },
-      "xunit.netcore.extensions/1.0.0-prerelease-00095": {
+      "xunit.netcore.extensions/1.0.0-prerelease-00098": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.10",
@@ -1746,23 +1790,12 @@
         "System.Linq.Queryable.nuspec"
       ]
     },
-    "System.Net.Http/4.0.1-beta-23324": {
+    "System.Net.Http/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "gXfHlWsiMQDuFqwnQrlQTje9vqMhCFLtm35jX4WqZjcfa3y69DbwueeT0gJbVMK88/UnG8FAYiDBb7AKyu+51w==",
+      "sha512": "itLPx7B7Ac4mX8wQx9V9DQcxqTgkmwDNnQIHuCgAH53Jq2X3XziiRRBbxbmNJlWqBlgPzbseWJmMCtcF/ePhOg==",
       "files": [
         "lib/net45/_._",
-        "lib/netcore50/de/System.Net.Http.xml",
-        "lib/netcore50/es/System.Net.Http.xml",
-        "lib/netcore50/fr/System.Net.Http.xml",
-        "lib/netcore50/it/System.Net.Http.xml",
-        "lib/netcore50/ja/System.Net.Http.xml",
-        "lib/netcore50/ko/System.Net.Http.xml",
-        "lib/netcore50/ru/System.Net.Http.xml",
-        "lib/netcore50/System.Net.Http.dll",
-        "lib/netcore50/System.Net.Http.xml",
-        "lib/netcore50/zh-hans/System.Net.Http.xml",
-        "lib/netcore50/zh-hant/System.Net.Http.xml",
         "lib/win8/_._",
         "lib/wpa81/_._",
         "ref/dotnet/System.Net.Http.dll",
@@ -1771,17 +1804,16 @@
         "ref/win8/_._",
         "ref/wpa81/_._",
         "runtime.json",
-        "System.Net.Http.4.0.1-beta-23324.nupkg",
-        "System.Net.Http.4.0.1-beta-23324.nupkg.sha512",
+        "System.Net.Http.4.0.1-beta-23330.nupkg",
+        "System.Net.Http.4.0.1-beta-23330.nupkg.sha512",
         "System.Net.Http.nuspec"
       ]
     },
-    "System.Net.NameResolution/4.0.0-beta-23324": {
+    "System.Net.NameResolution/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "lNYXUmnSXUtLFY09Rc27zJ6/TxCuGggQzBgiuWHoWrjWxymuuxqPT2Mj7Dn7sUUh0GvF2MOx7Uk+rtCFBiIavg==",
+      "sha512": "d8Am+In/aBgcHpEV6xsi5BCiTEN4y6s9O1V/yIvwX8mDC4CtdZiGsi4DtoB0TLOgp8ky6GxbSF4bKCjFpBO3uw==",
       "files": [
-        "lib/DNXCore50/System.Net.NameResolution.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.NameResolution.dll",
@@ -1793,8 +1825,9 @@
         "ref/net46/System.Net.NameResolution.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.NameResolution.4.0.0-beta-23324.nupkg",
-        "System.Net.NameResolution.4.0.0-beta-23324.nupkg.sha512",
+        "runtime.json",
+        "System.Net.NameResolution.4.0.0-beta-23330.nupkg",
+        "System.Net.NameResolution.4.0.0-beta-23330.nupkg.sha512",
         "System.Net.NameResolution.nuspec"
       ]
     },
@@ -1831,9 +1864,9 @@
         "System.Net.Primitives.nuspec"
       ]
     },
-    "System.Net.Security/4.0.0-beta-23324": {
+    "System.Net.Security/4.0.0-beta-23330": {
       "type": "package",
-      "sha512": "D04RYjxrnR3D+uI9CGmAAFKKQ6T+pPcRHYucc1PIo7/hJK5I/Yu7gAw9yOxHUhQjSGfrKo00lHpBCQMTQt4lSw==",
+      "sha512": "z98dKloNy9DBdyfqQwQvKWA2q8Qj4vgGEVONnlS70c13eh0MolBHJ0wNdplZZK5zYZ5Eu8GTwexbUlpHbsfzVA==",
       "files": [
         "lib/DNXCore50/System.Net.Security.dll",
         "lib/MonoAndroid10/_._",
@@ -1847,8 +1880,8 @@
         "ref/net46/System.Net.Security.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.Security.4.0.0-beta-23324.nupkg",
-        "System.Net.Security.4.0.0-beta-23324.nupkg.sha512",
+        "System.Net.Security.4.0.0-beta-23330.nupkg",
+        "System.Net.Security.4.0.0-beta-23330.nupkg.sha512",
         "System.Net.Security.nuspec"
       ]
     },
@@ -1906,6 +1939,81 @@
         "System.Net.WebHeaderCollection.nuspec"
       ]
     },
+    "System.Net.WebSockets/4.0.0-beta-23330": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "6Q9/uTDcaqbmdbD04MisKmjti4aEpp40i/UzpGaPZ4ItuwzU/pMk9RjiYUBUiCQyZeKNlXcSB1FPN2nFof7tww==",
+      "files": [
+        "lib/dotnet/de/System.Net.WebSockets.xml",
+        "lib/dotnet/es/System.Net.WebSockets.xml",
+        "lib/dotnet/fr/System.Net.WebSockets.xml",
+        "lib/dotnet/it/System.Net.WebSockets.xml",
+        "lib/dotnet/ja/System.Net.WebSockets.xml",
+        "lib/dotnet/ko/System.Net.WebSockets.xml",
+        "lib/dotnet/ru/System.Net.WebSockets.xml",
+        "lib/dotnet/System.Net.WebSockets.dll",
+        "lib/dotnet/System.Net.WebSockets.xml",
+        "lib/dotnet/zh-hans/System.Net.WebSockets.xml",
+        "lib/dotnet/zh-hant/System.Net.WebSockets.xml",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Net.WebSockets.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Net.WebSockets.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Net.WebSockets.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Net.WebSockets.4.0.0-beta-23330.nupkg",
+        "System.Net.WebSockets.4.0.0-beta-23330.nupkg.sha512",
+        "System.Net.WebSockets.nuspec"
+      ]
+    },
+    "System.Net.WebSockets.Client/4.0.0-beta-23330": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "1NWEqwDkYRyvr1gSKZlY51AaI9w8oD0dC5UNa2Lb+qaeFHSF5KfCSzf7seD+im+sH6uocVo2nppiaabfbXZT4Q==",
+      "files": [
+        "lib/DNXCore50/de/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/es/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/fr/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/it/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/ja/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/ko/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/ru/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/System.Net.WebSockets.Client.dll",
+        "lib/DNXCore50/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/zh-hans/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/zh-hant/System.Net.WebSockets.Client.xml",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Net.WebSockets.Client.dll",
+        "lib/netcore50/de/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/es/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/fr/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/it/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/ja/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/ko/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/ru/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/System.Net.WebSockets.Client.dll",
+        "lib/netcore50/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/zh-hans/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/zh-hant/System.Net.WebSockets.Client.xml",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Net.WebSockets.Client.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Net.WebSockets.Client.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Net.WebSockets.Client.4.0.0-beta-23330.nupkg",
+        "System.Net.WebSockets.Client.4.0.0-beta-23330.nupkg.sha512",
+        "System.Net.WebSockets.Client.nuspec"
+      ]
+    },
     "System.ObjectModel/4.0.10": {
       "type": "package",
       "serviceable": true,
@@ -1954,31 +2062,31 @@
         "System.Private.DataContractSerialization.nuspec"
       ]
     },
-    "System.Private.Networking/4.0.1-beta-23324": {
+    "System.Private.Networking/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "OfyxoeCdh1ypzdz1u0h1Clgt+6749vALs2ZPkLwsOPzL0INCG9ISYo+Jhh62ZD8TMkWwLrvyVppMBPHY6M7Upw==",
+      "sha512": "8NZi1gCQaGTKDb2yWplm52HWCLaZnUwVitksJgcXY2dEJau/TBGyZup+yhOngOIe8QzQMxNG4iokY3Ce0/8mbg==",
       "files": [
         "lib/DNXCore50/System.Private.Networking.dll",
         "lib/netcore50/System.Private.Networking.dll",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "System.Private.Networking.4.0.1-beta-23324.nupkg",
-        "System.Private.Networking.4.0.1-beta-23324.nupkg.sha512",
+        "System.Private.Networking.4.0.1-beta-23330.nupkg",
+        "System.Private.Networking.4.0.1-beta-23330.nupkg.sha512",
         "System.Private.Networking.nuspec"
       ]
     },
-    "System.Private.ServiceModel/4.0.1-beta-23324": {
+    "System.Private.ServiceModel/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "Lz3T9V8GnaOFlf8LUmuPznuOIuy92BAFVc9huiMrFKByzPpydGuCvXEe+81rZ1IF2TQcHKO++9otnj96AEJ5BA==",
+      "sha512": "8lENvmHuZdlvmnYN1w98Mv8bDjc0O/YlaNHRRph35T/fLDyaG8LMLMwG3/ut6a/AenLJmbf92snOtNXCuqM+cQ==",
       "files": [
         "lib/DNXCore50/System.Private.ServiceModel.dll",
         "lib/netcore50/System.Private.ServiceModel.dll",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "System.Private.ServiceModel.4.0.1-beta-23324.nupkg",
-        "System.Private.ServiceModel.4.0.1-beta-23324.nupkg.sha512",
+        "System.Private.ServiceModel.4.0.1-beta-23330.nupkg",
+        "System.Private.ServiceModel.4.0.1-beta-23330.nupkg.sha512",
         "System.Private.ServiceModel.nuspec"
       ]
     },
@@ -2507,10 +2615,10 @@
         "System.Security.Claims.nuspec"
       ]
     },
-    "System.Security.Cryptography.Algorithms/4.0.0-beta-23324": {
+    "System.Security.Cryptography.Algorithms/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "Mt6LwMj8hPp0+xZHcV6grZ7wSWhgycGkdZ6DQ9XvUY9NguUsvb/+fu2cMdrC7XsnpvwIROByp+p2dSjqBn3E2Q==",
+      "sha512": "FB4RoTDaV5tBiPSJsiG3A5DydeKz7ErglnkqVjBFjm6wu8kg91j0MxL/Al9iUyu9i/hq53fRs5KE3rjUNYvf5w==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2524,15 +2632,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.Algorithms.4.0.0-beta-23324.nupkg",
-        "System.Security.Cryptography.Algorithms.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Cryptography.Algorithms.4.0.0-beta-23330.nupkg",
+        "System.Security.Cryptography.Algorithms.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Cryptography.Algorithms.nuspec"
       ]
     },
-    "System.Security.Cryptography.Encoding/4.0.0-beta-23324": {
+    "System.Security.Cryptography.Encoding/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "JHOyknf1eYO6C39Vao6kAGpadq3PBO1L4tuzNEz/HvbH5sfIHPbjhxL11OyAhVKCzLCfEj6+aeClovFqZIRPyw==",
+      "sha512": "zeFdKQT6xjNdiNCaEmEYJMEK59kixkX7jJSoOLw3H+53t9X0F98vr3tS8YlrW/Lk/K9c6L5pYLlkb2dNqvUD/g==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2546,15 +2654,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.Encoding.4.0.0-beta-23324.nupkg",
-        "System.Security.Cryptography.Encoding.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Cryptography.Encoding.4.0.0-beta-23330.nupkg",
+        "System.Security.Cryptography.Encoding.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Cryptography.Encoding.nuspec"
       ]
     },
-    "System.Security.Cryptography.Primitives/4.0.0-beta-23324": {
+    "System.Security.Cryptography.Primitives/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "ETZxelIX51Di4FTytd8ohSpN6Ym/32aWIX9E2NCFkd91qdexn2Dkysn80b6n4gX6jG+oL0UHQDtD/fYq8C65oQ==",
+      "sha512": "15uVbOD3X0sRQJIxcEH5hasxlFdbA1CmPPZa0Y8pYEuQcWMF2gBswvU8s4qoKtA7x2xhNhzPsXIhsQuKNMTdEA==",
       "files": [
         "lib/dotnet/System.Security.Cryptography.Primitives.dll",
         "lib/MonoAndroid10/_._",
@@ -2568,15 +2676,15 @@
         "ref/net46/System.Security.Cryptography.Primitives.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Security.Cryptography.Primitives.4.0.0-beta-23324.nupkg",
-        "System.Security.Cryptography.Primitives.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Cryptography.Primitives.4.0.0-beta-23330.nupkg",
+        "System.Security.Cryptography.Primitives.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Cryptography.Primitives.nuspec"
       ]
     },
-    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23324": {
+    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "8NaEOxkkNBUECh0cPzGpbXS0uzGDpnvxI0kqQKRGp9uA+9qCyQfxcqAT6ozAYtOuFNVaC1XU3zQnb7T2nfvIDg==",
+      "sha512": "L8mUimdm7+GsORgJ8DFBMGsFnwDJ5YCUdJj3HfXQx4HCoPDPF+vJo3HRiHfcvNA2Zsf0ov2kuerYj/eeVa2/Rw==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2590,8 +2698,8 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23324.nupkg",
-        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23330.nupkg",
+        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Cryptography.X509Certificates.nuspec"
       ]
     },
@@ -2628,10 +2736,10 @@
         "System.Security.Principal.nuspec"
       ]
     },
-    "System.Security.Principal.Windows/4.0.0-beta-23324": {
+    "System.Security.Principal.Windows/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "csbCKdwBz31T8He7U6XMIc9BiWgwjHs5WDZR4rfhsk48TpdsbKNHX9OX4b+GwvgcsfVuWxre7zqNR0Bc9gWZ7g==",
+      "sha512": "q+3L3aB8bn0HCW52kX9TSJdhbjffBw7QWCOu0yX1SDhPN9MCPmJ4aBBCn1HRWroa5y7UcNUdjL1xwiERycZexw==",
       "files": [
         "lib/DNXCore50/de/System.Security.Principal.Windows.xml",
         "lib/DNXCore50/es/System.Security.Principal.Windows.xml",
@@ -2647,15 +2755,15 @@
         "lib/net46/System.Security.Principal.Windows.dll",
         "ref/dotnet/System.Security.Principal.Windows.dll",
         "ref/net46/System.Security.Principal.Windows.dll",
-        "System.Security.Principal.Windows.4.0.0-beta-23324.nupkg",
-        "System.Security.Principal.Windows.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Principal.Windows.4.0.0-beta-23330.nupkg",
+        "System.Security.Principal.Windows.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Principal.Windows.nuspec"
       ]
     },
-    "System.ServiceModel.Http/4.0.11-beta-23324": {
+    "System.ServiceModel.Http/4.0.11-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "VkTumuCSmXd0NPZZU+nrO7YqznvM+wP96NykXbxFJdNAtCplmqXaQh+YZ/02rjJmfou5qyo2V+ZWVwySBAirOg==",
+      "sha512": "NHKxIIYL0ATDbX18RLCSXtuq26MMoYfAVdpl5K+D0s5AHp7TMPb7LcjZPpg25B2v48x1TwE9LYcYTCiOZcoPzQ==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Http.dll",
         "lib/MonoAndroid10/_._",
@@ -2680,15 +2788,15 @@
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.ServiceModel.Http.4.0.11-beta-23324.nupkg",
-        "System.ServiceModel.Http.4.0.11-beta-23324.nupkg.sha512",
+        "System.ServiceModel.Http.4.0.11-beta-23330.nupkg",
+        "System.ServiceModel.Http.4.0.11-beta-23330.nupkg.sha512",
         "System.ServiceModel.Http.nuspec"
       ]
     },
-    "System.ServiceModel.Primitives/4.0.1-beta-23324": {
+    "System.ServiceModel.Primitives/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "bmU31B4CD5+m9Kt0iDM5Yw2ZXRfv7lpK3Sx1HektcT/HERc+IMPdO38f/Wxtofo5WOA0qmd1fdrMeQcbEkDfJg==",
+      "sha512": "kJ/pcRUf7Ow7s/rX8Kmc9P2k6cvyudIzyUcqr/pn9NwY8DC/2DWkkFvYE2udR4kvBzJJzXl/rsJQlyLIVGMAww==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Primitives.dll",
         "lib/net45/_._",
@@ -2708,8 +2816,8 @@
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.Primitives.dll",
         "ref/win8/_._",
-        "System.ServiceModel.Primitives.4.0.1-beta-23324.nupkg",
-        "System.ServiceModel.Primitives.4.0.1-beta-23324.nupkg.sha512",
+        "System.ServiceModel.Primitives.4.0.1-beta-23330.nupkg",
+        "System.ServiceModel.Primitives.4.0.1-beta-23330.nupkg.sha512",
         "System.ServiceModel.Primitives.nuspec"
       ]
     },
@@ -2904,10 +3012,9 @@
         "System.Threading.Tasks.nuspec"
       ]
     },
-    "System.Threading.ThreadPool/4.0.10-beta-23324": {
+    "System.Threading.ThreadPool/4.0.10-beta-23330": {
       "type": "package",
-      "serviceable": true,
-      "sha512": "G4SjGmiV72HBiv8wkfnKFGTieekrACU1m43VaeJ6vDeSyb08eEFusVH1UWZpOsUF25meCuzpda0ezus24b4rKA==",
+      "sha512": "nM5OewUj8NJrye93apbM6KHvPddgPJGzt1IWIXk9lV5HB4NGsn6M5U0gxMQWShQuDp6NF3ya3ULRSvh3dLMbzg==",
       "files": [
         "lib/DNXCore50/System.Threading.ThreadPool.dll",
         "lib/MonoAndroid10/_._",
@@ -2921,8 +3028,8 @@
         "ref/net46/System.Threading.ThreadPool.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Threading.ThreadPool.4.0.10-beta-23324.nupkg",
-        "System.Threading.ThreadPool.4.0.10-beta-23324.nupkg.sha512",
+        "System.Threading.ThreadPool.4.0.10-beta-23330.nupkg",
+        "System.Threading.ThreadPool.4.0.10-beta-23330.nupkg.sha512",
         "System.Threading.ThreadPool.nuspec"
       ]
     },
@@ -3173,14 +3280,14 @@
         "xunit.extensibility.execution.nuspec"
       ]
     },
-    "xunit.netcore.extensions/1.0.0-prerelease-00095": {
+    "xunit.netcore.extensions/1.0.0-prerelease-00098": {
       "type": "package",
       "serviceable": true,
-      "sha512": "FuvWmkuxHiqD0cHDggg5MRmBoeM4Uea7OUEmKvZiQu7Fy02hJ6yKKNV7mNW3y4scwSzDNA81Qa+HIS33PeWUog==",
+      "sha512": "3kRPwTbC42YGmsNHpNMKfGVOO5cVfxUD+C7cYbti1aml4UCT/RFZ6lhm5Vym2wNRDxryu0Es78aMf1BaybSrDg==",
       "files": [
         "lib/dotnet/Xunit.NetCore.Extensions.dll",
-        "xunit.netcore.extensions.1.0.0-prerelease-00095.nupkg",
-        "xunit.netcore.extensions.1.0.0-prerelease-00095.nupkg.sha512",
+        "xunit.netcore.extensions.1.0.0-prerelease-00098.nupkg",
+        "xunit.netcore.extensions.1.0.0-prerelease-00098.nupkg.sha512",
         "xunit.netcore.extensions.nuspec"
       ]
     }

--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/project.lock.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/project.lock.json
@@ -292,7 +292,7 @@
           "lib/dotnet/System.Linq.Queryable.dll": {}
         }
       },
-      "System.Net.Http/4.0.1-beta-23324": {
+      "System.Net.Http/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -305,16 +305,15 @@
           "ref/dotnet/System.Net.Http.dll": {}
         }
       },
-      "System.Net.NameResolution/4.0.0-beta-23324": {
+      "System.Net.NameResolution/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.Networking": "4.0.1-beta-23324"
+          "System.Net.Primitives": "4.0.10",
+          "System.Runtime": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Net.NameResolution.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Net.NameResolution.dll": {}
         }
       },
       "System.Net.Primitives/4.0.10": {
@@ -329,10 +328,10 @@
           "lib/DNXCore50/System.Net.Primitives.dll": {}
         }
       },
-      "System.Net.Security/4.0.0-beta-23324": {
+      "System.Net.Security/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.Networking": "4.0.1-beta-23324"
+          "System.Private.Networking": "4.0.1-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.Net.Security.dll": {}
@@ -367,6 +366,49 @@
         },
         "runtime": {
           "lib/dotnet/System.Net.WebHeaderCollection.dll": {}
+        }
+      },
+      "System.Net.WebSockets/4.0.0-beta-23330": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.Win32.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Threading.Tasks": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Net.WebSockets.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Net.WebSockets.dll": {}
+        }
+      },
+      "System.Net.WebSockets.Client/4.0.0-beta-23330": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.Win32.Primitives": "4.0.0",
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Diagnostics.Tracing": "4.0.20",
+          "System.Globalization": "4.0.10",
+          "System.Net.Primitives": "4.0.10",
+          "System.Net.WebHeaderCollection": "4.0.0",
+          "System.Net.WebSockets": "4.0.0-beta-23330",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23330",
+          "System.Text.Encoding": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Net.WebSockets.Client.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Net.WebSockets.Client.dll": {}
         }
       },
       "System.ObjectModel/4.0.10": {
@@ -414,7 +456,7 @@
           "lib/DNXCore50/System.Private.DataContractSerialization.dll": {}
         }
       },
-      "System.Private.Networking/4.0.1-beta-23324": {
+      "System.Private.Networking/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -433,13 +475,13 @@
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23324",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23324",
-          "System.Security.Principal.Windows": "4.0.0-beta-23324",
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23330",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23330",
+          "System.Security.Principal.Windows": "4.0.0-beta-23330",
           "System.Threading": "4.0.10",
           "System.Threading.Overlapped": "4.0.0",
           "System.Threading.Tasks": "4.0.10",
-          "System.Threading.ThreadPool": "4.0.10-beta-23324"
+          "System.Threading.ThreadPool": "4.0.10-beta-23330"
         },
         "compile": {
           "ref/dnxcore50/_._": {}
@@ -448,7 +490,7 @@
           "lib/DNXCore50/System.Private.Networking.dll": {}
         }
       },
-      "System.Private.ServiceModel/4.0.1-beta-23324": {
+      "System.Private.ServiceModel/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -465,12 +507,14 @@
           "System.Linq": "4.0.0",
           "System.Linq.Expressions": "4.0.10",
           "System.Linq.Queryable": "4.0.0",
-          "System.Net.Http": "4.0.1-beta-23324",
-          "System.Net.NameResolution": "4.0.0-beta-23324",
+          "System.Net.Http": "4.0.1-beta-23330",
+          "System.Net.NameResolution": "4.0.0-beta-23330",
           "System.Net.Primitives": "4.0.10",
-          "System.Net.Security": "4.0.0-beta-23324",
-          "System.Net.Sockets": "4.0.10-beta-23324",
+          "System.Net.Security": "4.0.0-beta-23330",
+          "System.Net.Sockets": "4.0.10-beta-23330",
           "System.Net.WebHeaderCollection": "4.0.0",
+          "System.Net.WebSockets": "4.0.0-beta-23330",
+          "System.Net.WebSockets.Client": "4.0.0-beta-23330",
           "System.ObjectModel": "4.0.10",
           "System.Reflection": "4.0.10",
           "System.Reflection.DispatchProxy": "4.0.0",
@@ -484,9 +528,9 @@
           "System.Runtime.Serialization.Primitives": "4.0.10",
           "System.Runtime.Serialization.Xml": "4.0.10",
           "System.Security.Claims": "4.0.0",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23324",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23330",
           "System.Security.Principal": "4.0.0",
-          "System.Security.Principal.Windows": "4.0.0-beta-23324",
+          "System.Security.Principal.Windows": "4.0.0-beta-23330",
           "System.Text.Encoding": "4.0.10",
           "System.Threading": "4.0.10",
           "System.Threading.Tasks": "4.0.10",
@@ -735,18 +779,18 @@
           "lib/dotnet/System.Security.Claims.dll": {}
         }
       },
-      "System.Security.Cryptography.Algorithms/4.0.0-beta-23324": {
+      "System.Security.Cryptography.Algorithms/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
           "System.Runtime": "4.0.0",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23324"
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.Algorithms.dll": {}
         }
       },
-      "System.Security.Cryptography.Encoding/4.0.0-beta-23324": {
+      "System.Security.Cryptography.Encoding/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -755,7 +799,7 @@
           "ref/dotnet/System.Security.Cryptography.Encoding.dll": {}
         }
       },
-      "System.Security.Cryptography.Primitives/4.0.0-beta-23324": {
+      "System.Security.Cryptography.Primitives/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.0",
@@ -773,13 +817,13 @@
           "lib/dotnet/System.Security.Cryptography.Primitives.dll": {}
         }
       },
-      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23324": {
+      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
           "System.Runtime.Handles": "4.0.0",
-          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23324",
-          "System.Security.Cryptography.Encoding": "4.0.0-beta-23324"
+          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23330",
+          "System.Security.Cryptography.Encoding": "4.0.0-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.X509Certificates.dll": {}
@@ -797,7 +841,7 @@
           "lib/dotnet/System.Security.Principal.dll": {}
         }
       },
-      "System.Security.Principal.Windows/4.0.0-beta-23324": {
+      "System.Security.Principal.Windows/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -820,10 +864,10 @@
           "lib/DNXCore50/System.Security.Principal.Windows.dll": {}
         }
       },
-      "System.ServiceModel.Http/4.0.11-beta-23324": {
+      "System.ServiceModel.Http/4.0.11-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.0.1-beta-23324",
+          "System.Private.ServiceModel": "4.0.1-beta-23330",
           "System.Runtime": "4.0.20"
         },
         "compile": {
@@ -833,10 +877,10 @@
           "lib/DNXCore50/System.ServiceModel.Http.dll": {}
         }
       },
-      "System.ServiceModel.NetTcp/4.0.1-beta-23324": {
+      "System.ServiceModel.NetTcp/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.0.1-beta-23324"
+          "System.Private.ServiceModel": "4.0.1-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.ServiceModel.NetTcp.dll": {}
@@ -845,10 +889,10 @@
           "lib/DNXCore50/System.ServiceModel.NetTcp.dll": {}
         }
       },
-      "System.ServiceModel.Primitives/4.0.1-beta-23324": {
+      "System.ServiceModel.Primitives/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.0.1-beta-23324"
+          "System.Private.ServiceModel": "4.0.1-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.ServiceModel.Primitives.dll": {}
@@ -857,10 +901,10 @@
           "lib/DNXCore50/System.ServiceModel.Primitives.dll": {}
         }
       },
-      "System.ServiceModel.Security/4.0.1-beta-23324": {
+      "System.ServiceModel.Security/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.0.1-beta-23324"
+          "System.Private.ServiceModel": "4.0.1-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.ServiceModel.Security.dll": {}
@@ -949,7 +993,7 @@
           "lib/DNXCore50/System.Threading.Tasks.dll": {}
         }
       },
-      "System.Threading.ThreadPool/4.0.10-beta-23324": {
+      "System.Threading.ThreadPool/4.0.10-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
@@ -1142,7 +1186,7 @@
           "lib/dotnet/xunit.execution.dotnet.dll": {}
         }
       },
-      "xunit.netcore.extensions/1.0.0-prerelease-00095": {
+      "xunit.netcore.extensions/1.0.0-prerelease-00098": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.10",
@@ -1770,23 +1814,12 @@
         "System.Linq.Queryable.nuspec"
       ]
     },
-    "System.Net.Http/4.0.1-beta-23324": {
+    "System.Net.Http/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "gXfHlWsiMQDuFqwnQrlQTje9vqMhCFLtm35jX4WqZjcfa3y69DbwueeT0gJbVMK88/UnG8FAYiDBb7AKyu+51w==",
+      "sha512": "itLPx7B7Ac4mX8wQx9V9DQcxqTgkmwDNnQIHuCgAH53Jq2X3XziiRRBbxbmNJlWqBlgPzbseWJmMCtcF/ePhOg==",
       "files": [
         "lib/net45/_._",
-        "lib/netcore50/de/System.Net.Http.xml",
-        "lib/netcore50/es/System.Net.Http.xml",
-        "lib/netcore50/fr/System.Net.Http.xml",
-        "lib/netcore50/it/System.Net.Http.xml",
-        "lib/netcore50/ja/System.Net.Http.xml",
-        "lib/netcore50/ko/System.Net.Http.xml",
-        "lib/netcore50/ru/System.Net.Http.xml",
-        "lib/netcore50/System.Net.Http.dll",
-        "lib/netcore50/System.Net.Http.xml",
-        "lib/netcore50/zh-hans/System.Net.Http.xml",
-        "lib/netcore50/zh-hant/System.Net.Http.xml",
         "lib/win8/_._",
         "lib/wpa81/_._",
         "ref/dotnet/System.Net.Http.dll",
@@ -1795,17 +1828,16 @@
         "ref/win8/_._",
         "ref/wpa81/_._",
         "runtime.json",
-        "System.Net.Http.4.0.1-beta-23324.nupkg",
-        "System.Net.Http.4.0.1-beta-23324.nupkg.sha512",
+        "System.Net.Http.4.0.1-beta-23330.nupkg",
+        "System.Net.Http.4.0.1-beta-23330.nupkg.sha512",
         "System.Net.Http.nuspec"
       ]
     },
-    "System.Net.NameResolution/4.0.0-beta-23324": {
+    "System.Net.NameResolution/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "lNYXUmnSXUtLFY09Rc27zJ6/TxCuGggQzBgiuWHoWrjWxymuuxqPT2Mj7Dn7sUUh0GvF2MOx7Uk+rtCFBiIavg==",
+      "sha512": "d8Am+In/aBgcHpEV6xsi5BCiTEN4y6s9O1V/yIvwX8mDC4CtdZiGsi4DtoB0TLOgp8ky6GxbSF4bKCjFpBO3uw==",
       "files": [
-        "lib/DNXCore50/System.Net.NameResolution.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.NameResolution.dll",
@@ -1817,8 +1849,9 @@
         "ref/net46/System.Net.NameResolution.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.NameResolution.4.0.0-beta-23324.nupkg",
-        "System.Net.NameResolution.4.0.0-beta-23324.nupkg.sha512",
+        "runtime.json",
+        "System.Net.NameResolution.4.0.0-beta-23330.nupkg",
+        "System.Net.NameResolution.4.0.0-beta-23330.nupkg.sha512",
         "System.Net.NameResolution.nuspec"
       ]
     },
@@ -1855,9 +1888,9 @@
         "System.Net.Primitives.nuspec"
       ]
     },
-    "System.Net.Security/4.0.0-beta-23324": {
+    "System.Net.Security/4.0.0-beta-23330": {
       "type": "package",
-      "sha512": "D04RYjxrnR3D+uI9CGmAAFKKQ6T+pPcRHYucc1PIo7/hJK5I/Yu7gAw9yOxHUhQjSGfrKo00lHpBCQMTQt4lSw==",
+      "sha512": "z98dKloNy9DBdyfqQwQvKWA2q8Qj4vgGEVONnlS70c13eh0MolBHJ0wNdplZZK5zYZ5Eu8GTwexbUlpHbsfzVA==",
       "files": [
         "lib/DNXCore50/System.Net.Security.dll",
         "lib/MonoAndroid10/_._",
@@ -1871,8 +1904,8 @@
         "ref/net46/System.Net.Security.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.Security.4.0.0-beta-23324.nupkg",
-        "System.Net.Security.4.0.0-beta-23324.nupkg.sha512",
+        "System.Net.Security.4.0.0-beta-23330.nupkg",
+        "System.Net.Security.4.0.0-beta-23330.nupkg.sha512",
         "System.Net.Security.nuspec"
       ]
     },
@@ -1930,6 +1963,81 @@
         "System.Net.WebHeaderCollection.nuspec"
       ]
     },
+    "System.Net.WebSockets/4.0.0-beta-23330": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "6Q9/uTDcaqbmdbD04MisKmjti4aEpp40i/UzpGaPZ4ItuwzU/pMk9RjiYUBUiCQyZeKNlXcSB1FPN2nFof7tww==",
+      "files": [
+        "lib/dotnet/de/System.Net.WebSockets.xml",
+        "lib/dotnet/es/System.Net.WebSockets.xml",
+        "lib/dotnet/fr/System.Net.WebSockets.xml",
+        "lib/dotnet/it/System.Net.WebSockets.xml",
+        "lib/dotnet/ja/System.Net.WebSockets.xml",
+        "lib/dotnet/ko/System.Net.WebSockets.xml",
+        "lib/dotnet/ru/System.Net.WebSockets.xml",
+        "lib/dotnet/System.Net.WebSockets.dll",
+        "lib/dotnet/System.Net.WebSockets.xml",
+        "lib/dotnet/zh-hans/System.Net.WebSockets.xml",
+        "lib/dotnet/zh-hant/System.Net.WebSockets.xml",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Net.WebSockets.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Net.WebSockets.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Net.WebSockets.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Net.WebSockets.4.0.0-beta-23330.nupkg",
+        "System.Net.WebSockets.4.0.0-beta-23330.nupkg.sha512",
+        "System.Net.WebSockets.nuspec"
+      ]
+    },
+    "System.Net.WebSockets.Client/4.0.0-beta-23330": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "1NWEqwDkYRyvr1gSKZlY51AaI9w8oD0dC5UNa2Lb+qaeFHSF5KfCSzf7seD+im+sH6uocVo2nppiaabfbXZT4Q==",
+      "files": [
+        "lib/DNXCore50/de/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/es/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/fr/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/it/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/ja/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/ko/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/ru/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/System.Net.WebSockets.Client.dll",
+        "lib/DNXCore50/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/zh-hans/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/zh-hant/System.Net.WebSockets.Client.xml",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Net.WebSockets.Client.dll",
+        "lib/netcore50/de/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/es/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/fr/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/it/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/ja/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/ko/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/ru/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/System.Net.WebSockets.Client.dll",
+        "lib/netcore50/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/zh-hans/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/zh-hant/System.Net.WebSockets.Client.xml",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Net.WebSockets.Client.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Net.WebSockets.Client.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Net.WebSockets.Client.4.0.0-beta-23330.nupkg",
+        "System.Net.WebSockets.Client.4.0.0-beta-23330.nupkg.sha512",
+        "System.Net.WebSockets.Client.nuspec"
+      ]
+    },
     "System.ObjectModel/4.0.10": {
       "type": "package",
       "serviceable": true,
@@ -1978,31 +2086,31 @@
         "System.Private.DataContractSerialization.nuspec"
       ]
     },
-    "System.Private.Networking/4.0.1-beta-23324": {
+    "System.Private.Networking/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "OfyxoeCdh1ypzdz1u0h1Clgt+6749vALs2ZPkLwsOPzL0INCG9ISYo+Jhh62ZD8TMkWwLrvyVppMBPHY6M7Upw==",
+      "sha512": "8NZi1gCQaGTKDb2yWplm52HWCLaZnUwVitksJgcXY2dEJau/TBGyZup+yhOngOIe8QzQMxNG4iokY3Ce0/8mbg==",
       "files": [
         "lib/DNXCore50/System.Private.Networking.dll",
         "lib/netcore50/System.Private.Networking.dll",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "System.Private.Networking.4.0.1-beta-23324.nupkg",
-        "System.Private.Networking.4.0.1-beta-23324.nupkg.sha512",
+        "System.Private.Networking.4.0.1-beta-23330.nupkg",
+        "System.Private.Networking.4.0.1-beta-23330.nupkg.sha512",
         "System.Private.Networking.nuspec"
       ]
     },
-    "System.Private.ServiceModel/4.0.1-beta-23324": {
+    "System.Private.ServiceModel/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "Lz3T9V8GnaOFlf8LUmuPznuOIuy92BAFVc9huiMrFKByzPpydGuCvXEe+81rZ1IF2TQcHKO++9otnj96AEJ5BA==",
+      "sha512": "8lENvmHuZdlvmnYN1w98Mv8bDjc0O/YlaNHRRph35T/fLDyaG8LMLMwG3/ut6a/AenLJmbf92snOtNXCuqM+cQ==",
       "files": [
         "lib/DNXCore50/System.Private.ServiceModel.dll",
         "lib/netcore50/System.Private.ServiceModel.dll",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "System.Private.ServiceModel.4.0.1-beta-23324.nupkg",
-        "System.Private.ServiceModel.4.0.1-beta-23324.nupkg.sha512",
+        "System.Private.ServiceModel.4.0.1-beta-23330.nupkg",
+        "System.Private.ServiceModel.4.0.1-beta-23330.nupkg.sha512",
         "System.Private.ServiceModel.nuspec"
       ]
     },
@@ -2531,10 +2639,10 @@
         "System.Security.Claims.nuspec"
       ]
     },
-    "System.Security.Cryptography.Algorithms/4.0.0-beta-23324": {
+    "System.Security.Cryptography.Algorithms/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "Mt6LwMj8hPp0+xZHcV6grZ7wSWhgycGkdZ6DQ9XvUY9NguUsvb/+fu2cMdrC7XsnpvwIROByp+p2dSjqBn3E2Q==",
+      "sha512": "FB4RoTDaV5tBiPSJsiG3A5DydeKz7ErglnkqVjBFjm6wu8kg91j0MxL/Al9iUyu9i/hq53fRs5KE3rjUNYvf5w==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2548,15 +2656,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.Algorithms.4.0.0-beta-23324.nupkg",
-        "System.Security.Cryptography.Algorithms.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Cryptography.Algorithms.4.0.0-beta-23330.nupkg",
+        "System.Security.Cryptography.Algorithms.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Cryptography.Algorithms.nuspec"
       ]
     },
-    "System.Security.Cryptography.Encoding/4.0.0-beta-23324": {
+    "System.Security.Cryptography.Encoding/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "JHOyknf1eYO6C39Vao6kAGpadq3PBO1L4tuzNEz/HvbH5sfIHPbjhxL11OyAhVKCzLCfEj6+aeClovFqZIRPyw==",
+      "sha512": "zeFdKQT6xjNdiNCaEmEYJMEK59kixkX7jJSoOLw3H+53t9X0F98vr3tS8YlrW/Lk/K9c6L5pYLlkb2dNqvUD/g==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2570,15 +2678,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.Encoding.4.0.0-beta-23324.nupkg",
-        "System.Security.Cryptography.Encoding.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Cryptography.Encoding.4.0.0-beta-23330.nupkg",
+        "System.Security.Cryptography.Encoding.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Cryptography.Encoding.nuspec"
       ]
     },
-    "System.Security.Cryptography.Primitives/4.0.0-beta-23324": {
+    "System.Security.Cryptography.Primitives/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "ETZxelIX51Di4FTytd8ohSpN6Ym/32aWIX9E2NCFkd91qdexn2Dkysn80b6n4gX6jG+oL0UHQDtD/fYq8C65oQ==",
+      "sha512": "15uVbOD3X0sRQJIxcEH5hasxlFdbA1CmPPZa0Y8pYEuQcWMF2gBswvU8s4qoKtA7x2xhNhzPsXIhsQuKNMTdEA==",
       "files": [
         "lib/dotnet/System.Security.Cryptography.Primitives.dll",
         "lib/MonoAndroid10/_._",
@@ -2592,15 +2700,15 @@
         "ref/net46/System.Security.Cryptography.Primitives.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Security.Cryptography.Primitives.4.0.0-beta-23324.nupkg",
-        "System.Security.Cryptography.Primitives.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Cryptography.Primitives.4.0.0-beta-23330.nupkg",
+        "System.Security.Cryptography.Primitives.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Cryptography.Primitives.nuspec"
       ]
     },
-    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23324": {
+    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "8NaEOxkkNBUECh0cPzGpbXS0uzGDpnvxI0kqQKRGp9uA+9qCyQfxcqAT6ozAYtOuFNVaC1XU3zQnb7T2nfvIDg==",
+      "sha512": "L8mUimdm7+GsORgJ8DFBMGsFnwDJ5YCUdJj3HfXQx4HCoPDPF+vJo3HRiHfcvNA2Zsf0ov2kuerYj/eeVa2/Rw==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2614,8 +2722,8 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23324.nupkg",
-        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23330.nupkg",
+        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Cryptography.X509Certificates.nuspec"
       ]
     },
@@ -2652,10 +2760,10 @@
         "System.Security.Principal.nuspec"
       ]
     },
-    "System.Security.Principal.Windows/4.0.0-beta-23324": {
+    "System.Security.Principal.Windows/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "csbCKdwBz31T8He7U6XMIc9BiWgwjHs5WDZR4rfhsk48TpdsbKNHX9OX4b+GwvgcsfVuWxre7zqNR0Bc9gWZ7g==",
+      "sha512": "q+3L3aB8bn0HCW52kX9TSJdhbjffBw7QWCOu0yX1SDhPN9MCPmJ4aBBCn1HRWroa5y7UcNUdjL1xwiERycZexw==",
       "files": [
         "lib/DNXCore50/de/System.Security.Principal.Windows.xml",
         "lib/DNXCore50/es/System.Security.Principal.Windows.xml",
@@ -2671,15 +2779,15 @@
         "lib/net46/System.Security.Principal.Windows.dll",
         "ref/dotnet/System.Security.Principal.Windows.dll",
         "ref/net46/System.Security.Principal.Windows.dll",
-        "System.Security.Principal.Windows.4.0.0-beta-23324.nupkg",
-        "System.Security.Principal.Windows.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Principal.Windows.4.0.0-beta-23330.nupkg",
+        "System.Security.Principal.Windows.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Principal.Windows.nuspec"
       ]
     },
-    "System.ServiceModel.Http/4.0.11-beta-23324": {
+    "System.ServiceModel.Http/4.0.11-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "VkTumuCSmXd0NPZZU+nrO7YqznvM+wP96NykXbxFJdNAtCplmqXaQh+YZ/02rjJmfou5qyo2V+ZWVwySBAirOg==",
+      "sha512": "NHKxIIYL0ATDbX18RLCSXtuq26MMoYfAVdpl5K+D0s5AHp7TMPb7LcjZPpg25B2v48x1TwE9LYcYTCiOZcoPzQ==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Http.dll",
         "lib/MonoAndroid10/_._",
@@ -2704,15 +2812,15 @@
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.ServiceModel.Http.4.0.11-beta-23324.nupkg",
-        "System.ServiceModel.Http.4.0.11-beta-23324.nupkg.sha512",
+        "System.ServiceModel.Http.4.0.11-beta-23330.nupkg",
+        "System.ServiceModel.Http.4.0.11-beta-23330.nupkg.sha512",
         "System.ServiceModel.Http.nuspec"
       ]
     },
-    "System.ServiceModel.NetTcp/4.0.1-beta-23324": {
+    "System.ServiceModel.NetTcp/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "xI03xQCdWzqq4H2E29BELQm/e9LJl+IAbD50lcH966Z+JdaYOqeM6RGxAys0sVim59wvCrOv/YaRNxz66YLoog==",
+      "sha512": "Vx0QSKz4BlX/yYqKHET3mofo6RxxaMDLWsEFWDbEBJeCs0Yq19uGiIYwK1mXkWy3Y+jDwi42au3mVhmRbDHavA==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.NetTcp.dll",
         "lib/net45/_._",
@@ -2732,15 +2840,15 @@
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.NetTcp.dll",
         "ref/win8/_._",
-        "System.ServiceModel.NetTcp.4.0.1-beta-23324.nupkg",
-        "System.ServiceModel.NetTcp.4.0.1-beta-23324.nupkg.sha512",
+        "System.ServiceModel.NetTcp.4.0.1-beta-23330.nupkg",
+        "System.ServiceModel.NetTcp.4.0.1-beta-23330.nupkg.sha512",
         "System.ServiceModel.NetTcp.nuspec"
       ]
     },
-    "System.ServiceModel.Primitives/4.0.1-beta-23324": {
+    "System.ServiceModel.Primitives/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "bmU31B4CD5+m9Kt0iDM5Yw2ZXRfv7lpK3Sx1HektcT/HERc+IMPdO38f/Wxtofo5WOA0qmd1fdrMeQcbEkDfJg==",
+      "sha512": "kJ/pcRUf7Ow7s/rX8Kmc9P2k6cvyudIzyUcqr/pn9NwY8DC/2DWkkFvYE2udR4kvBzJJzXl/rsJQlyLIVGMAww==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Primitives.dll",
         "lib/net45/_._",
@@ -2760,15 +2868,15 @@
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.Primitives.dll",
         "ref/win8/_._",
-        "System.ServiceModel.Primitives.4.0.1-beta-23324.nupkg",
-        "System.ServiceModel.Primitives.4.0.1-beta-23324.nupkg.sha512",
+        "System.ServiceModel.Primitives.4.0.1-beta-23330.nupkg",
+        "System.ServiceModel.Primitives.4.0.1-beta-23330.nupkg.sha512",
         "System.ServiceModel.Primitives.nuspec"
       ]
     },
-    "System.ServiceModel.Security/4.0.1-beta-23324": {
+    "System.ServiceModel.Security/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "vZN35yLLzcJXgr56Dds+N98fHb8IzyujOqJNuipkO6GEtUuyybV/g1UvmKbel/HvvoAyjSTNC+3/O95Go+tn0Q==",
+      "sha512": "DkdJSuFiSyHpu5vmqx1DHolDVZCPE1LoTVPFlH3E2AOFUnv7+LddJd02I1l03fhtKrOkJKJACHonhseWDdeIMg==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Security.dll",
         "lib/net45/_._",
@@ -2788,8 +2896,8 @@
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.Security.dll",
         "ref/win8/_._",
-        "System.ServiceModel.Security.4.0.1-beta-23324.nupkg",
-        "System.ServiceModel.Security.4.0.1-beta-23324.nupkg.sha512",
+        "System.ServiceModel.Security.4.0.1-beta-23330.nupkg",
+        "System.ServiceModel.Security.4.0.1-beta-23330.nupkg.sha512",
         "System.ServiceModel.Security.nuspec"
       ]
     },
@@ -2984,10 +3092,9 @@
         "System.Threading.Tasks.nuspec"
       ]
     },
-    "System.Threading.ThreadPool/4.0.10-beta-23324": {
+    "System.Threading.ThreadPool/4.0.10-beta-23330": {
       "type": "package",
-      "serviceable": true,
-      "sha512": "G4SjGmiV72HBiv8wkfnKFGTieekrACU1m43VaeJ6vDeSyb08eEFusVH1UWZpOsUF25meCuzpda0ezus24b4rKA==",
+      "sha512": "nM5OewUj8NJrye93apbM6KHvPddgPJGzt1IWIXk9lV5HB4NGsn6M5U0gxMQWShQuDp6NF3ya3ULRSvh3dLMbzg==",
       "files": [
         "lib/DNXCore50/System.Threading.ThreadPool.dll",
         "lib/MonoAndroid10/_._",
@@ -3001,8 +3108,8 @@
         "ref/net46/System.Threading.ThreadPool.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Threading.ThreadPool.4.0.10-beta-23324.nupkg",
-        "System.Threading.ThreadPool.4.0.10-beta-23324.nupkg.sha512",
+        "System.Threading.ThreadPool.4.0.10-beta-23330.nupkg",
+        "System.Threading.ThreadPool.4.0.10-beta-23330.nupkg.sha512",
         "System.Threading.ThreadPool.nuspec"
       ]
     },
@@ -3253,14 +3360,14 @@
         "xunit.extensibility.execution.nuspec"
       ]
     },
-    "xunit.netcore.extensions/1.0.0-prerelease-00095": {
+    "xunit.netcore.extensions/1.0.0-prerelease-00098": {
       "type": "package",
       "serviceable": true,
-      "sha512": "FuvWmkuxHiqD0cHDggg5MRmBoeM4Uea7OUEmKvZiQu7Fy02hJ6yKKNV7mNW3y4scwSzDNA81Qa+HIS33PeWUog==",
+      "sha512": "3kRPwTbC42YGmsNHpNMKfGVOO5cVfxUD+C7cYbti1aml4UCT/RFZ6lhm5Vym2wNRDxryu0Es78aMf1BaybSrDg==",
       "files": [
         "lib/dotnet/Xunit.NetCore.Extensions.dll",
-        "xunit.netcore.extensions.1.0.0-prerelease-00095.nupkg",
-        "xunit.netcore.extensions.1.0.0-prerelease-00095.nupkg.sha512",
+        "xunit.netcore.extensions.1.0.0-prerelease-00098.nupkg",
+        "xunit.netcore.extensions.1.0.0-prerelease-00098.nupkg.sha512",
         "xunit.netcore.extensions.nuspec"
       ]
     }

--- a/src/System.Private.ServiceModel/tests/Stress/SharedPoolsOfWCFObjects/project.lock.json
+++ b/src/System.Private.ServiceModel/tests/Stress/SharedPoolsOfWCFObjects/project.lock.json
@@ -16,10 +16,10 @@
           "lib/dotnet/Microsoft.Win32.Primitives.dll": {}
         }
       },
-      "System.Collections/4.0.11-beta-23323": {
+      "System.Collections/4.0.11-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Runtime": "4.0.21-beta-23323"
+          "System.Runtime": "4.0.21-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.Collections.dll": {}
@@ -65,7 +65,7 @@
           "lib/dotnet/System.Collections.NonGeneric.dll": {}
         }
       },
-      "System.Collections.Specialized/4.0.1-beta-23323": {
+      "System.Collections.Specialized/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Collections.NonGeneric": "4.0.0",
@@ -98,7 +98,7 @@
           "lib/dotnet/System.ComponentModel.EventBasedAsync.dll": {}
         }
       },
-      "System.Console/4.0.0-beta-23323": {
+      "System.Console/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -120,7 +120,7 @@
           "lib/DNXCore50/System.Diagnostics.Contracts.dll": {}
         }
       },
-      "System.Diagnostics.Debug/4.0.11-beta-23323": {
+      "System.Diagnostics.Debug/4.0.11-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -129,7 +129,7 @@
           "ref/dotnet/System.Diagnostics.Debug.dll": {}
         }
       },
-      "System.Diagnostics.Tools/4.0.1-beta-23323": {
+      "System.Diagnostics.Tools/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -251,7 +251,7 @@
           "lib/dotnet/System.IO.FileSystem.Primitives.dll": {}
         }
       },
-      "System.Linq/4.0.1-beta-23323": {
+      "System.Linq/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -311,7 +311,7 @@
           "lib/dotnet/System.Linq.Queryable.dll": {}
         }
       },
-      "System.Net.Http/4.0.1-beta-23323": {
+      "System.Net.Http/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -324,16 +324,15 @@
           "ref/dotnet/System.Net.Http.dll": {}
         }
       },
-      "System.Net.NameResolution/4.0.0-beta-23323": {
+      "System.Net.NameResolution/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.Networking": "4.0.1-beta-23323"
+          "System.Net.Primitives": "4.0.10",
+          "System.Runtime": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Net.NameResolution.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Net.NameResolution.dll": {}
         }
       },
       "System.Net.Primitives/4.0.10": {
@@ -348,10 +347,10 @@
           "lib/DNXCore50/System.Net.Primitives.dll": {}
         }
       },
-      "System.Net.Security/4.0.0-beta-23323": {
+      "System.Net.Security/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.Networking": "4.0.1-beta-23323"
+          "System.Private.Networking": "4.0.1-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.Net.Security.dll": {}
@@ -386,6 +385,49 @@
         },
         "runtime": {
           "lib/dotnet/System.Net.WebHeaderCollection.dll": {}
+        }
+      },
+      "System.Net.WebSockets/4.0.0-beta-23330": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.Win32.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Threading.Tasks": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Net.WebSockets.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Net.WebSockets.dll": {}
+        }
+      },
+      "System.Net.WebSockets.Client/4.0.0-beta-23330": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.Win32.Primitives": "4.0.0",
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Diagnostics.Tracing": "4.0.20",
+          "System.Globalization": "4.0.10",
+          "System.Net.Primitives": "4.0.10",
+          "System.Net.WebHeaderCollection": "4.0.0",
+          "System.Net.WebSockets": "4.0.0-beta-23330",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23330",
+          "System.Text.Encoding": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Net.WebSockets.Client.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Net.WebSockets.Client.dll": {}
         }
       },
       "System.ObjectModel/4.0.10": {
@@ -433,7 +475,7 @@
           "lib/DNXCore50/System.Private.DataContractSerialization.dll": {}
         }
       },
-      "System.Private.Networking/4.0.1-beta-23323": {
+      "System.Private.Networking/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -452,13 +494,13 @@
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23323",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23323",
-          "System.Security.Principal.Windows": "4.0.0-beta-23323",
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23330",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23330",
+          "System.Security.Principal.Windows": "4.0.0-beta-23330",
           "System.Threading": "4.0.10",
           "System.Threading.Overlapped": "4.0.0",
           "System.Threading.Tasks": "4.0.10",
-          "System.Threading.ThreadPool": "4.0.10-beta-23323"
+          "System.Threading.ThreadPool": "4.0.10-beta-23330"
         },
         "compile": {
           "ref/dnxcore50/_._": {}
@@ -467,7 +509,7 @@
           "lib/DNXCore50/System.Private.Networking.dll": {}
         }
       },
-      "System.Private.ServiceModel/4.0.1-beta-23323": {
+      "System.Private.ServiceModel/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -484,12 +526,14 @@
           "System.Linq": "4.0.0",
           "System.Linq.Expressions": "4.0.10",
           "System.Linq.Queryable": "4.0.0",
-          "System.Net.Http": "4.0.1-beta-23323",
-          "System.Net.NameResolution": "4.0.0-beta-23323",
+          "System.Net.Http": "4.0.1-beta-23330",
+          "System.Net.NameResolution": "4.0.0-beta-23330",
           "System.Net.Primitives": "4.0.10",
-          "System.Net.Security": "4.0.0-beta-23323",
-          "System.Net.Sockets": "4.0.10-beta-23323",
+          "System.Net.Security": "4.0.0-beta-23330",
+          "System.Net.Sockets": "4.0.10-beta-23330",
           "System.Net.WebHeaderCollection": "4.0.0",
+          "System.Net.WebSockets": "4.0.0-beta-23330",
+          "System.Net.WebSockets.Client": "4.0.0-beta-23330",
           "System.ObjectModel": "4.0.10",
           "System.Reflection": "4.0.10",
           "System.Reflection.DispatchProxy": "4.0.0",
@@ -503,9 +547,9 @@
           "System.Runtime.Serialization.Primitives": "4.0.10",
           "System.Runtime.Serialization.Xml": "4.0.10",
           "System.Security.Claims": "4.0.0",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23323",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23330",
           "System.Security.Principal": "4.0.0",
-          "System.Security.Principal.Windows": "4.0.0-beta-23323",
+          "System.Security.Principal.Windows": "4.0.0-beta-23330",
           "System.Text.Encoding": "4.0.10",
           "System.Threading": "4.0.10",
           "System.Threading.Tasks": "4.0.10",
@@ -521,7 +565,7 @@
           "lib/DNXCore50/System.Private.ServiceModel.dll": {}
         }
       },
-      "System.Private.Uri/4.0.1-beta-23323": {
+      "System.Private.Uri/4.0.1-beta-23330": {
         "type": "package",
         "compile": {
           "ref/dnxcore50/_._": {}
@@ -642,10 +686,10 @@
           "lib/DNXCore50/System.Resources.ResourceManager.dll": {}
         }
       },
-      "System.Runtime/4.0.21-beta-23323": {
+      "System.Runtime/4.0.21-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.Uri": "4.0.1-beta-23323"
+          "System.Private.Uri": "4.0.1-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.Runtime.dll": {}
@@ -738,18 +782,18 @@
           "lib/dotnet/System.Security.Claims.dll": {}
         }
       },
-      "System.Security.Cryptography.Algorithms/4.0.0-beta-23323": {
+      "System.Security.Cryptography.Algorithms/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
           "System.Runtime": "4.0.0",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23323"
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.Algorithms.dll": {}
         }
       },
-      "System.Security.Cryptography.Encoding/4.0.0-beta-23323": {
+      "System.Security.Cryptography.Encoding/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -758,7 +802,7 @@
           "ref/dotnet/System.Security.Cryptography.Encoding.dll": {}
         }
       },
-      "System.Security.Cryptography.Primitives/4.0.0-beta-23323": {
+      "System.Security.Cryptography.Primitives/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.0",
@@ -776,13 +820,13 @@
           "lib/dotnet/System.Security.Cryptography.Primitives.dll": {}
         }
       },
-      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23323": {
+      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
           "System.Runtime.Handles": "4.0.0",
-          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23323",
-          "System.Security.Cryptography.Encoding": "4.0.0-beta-23323"
+          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23330",
+          "System.Security.Cryptography.Encoding": "4.0.0-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.X509Certificates.dll": {}
@@ -800,7 +844,7 @@
           "lib/dotnet/System.Security.Principal.dll": {}
         }
       },
-      "System.Security.Principal.Windows/4.0.0-beta-23323": {
+      "System.Security.Principal.Windows/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -823,10 +867,10 @@
           "lib/DNXCore50/System.Security.Principal.Windows.dll": {}
         }
       },
-      "System.ServiceModel.Duplex/4.0.1-beta-23323": {
+      "System.ServiceModel.Duplex/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.0.1-beta-23323"
+          "System.Private.ServiceModel": "4.0.1-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.ServiceModel.Duplex.dll": {}
@@ -835,10 +879,10 @@
           "lib/DNXCore50/System.ServiceModel.Duplex.dll": {}
         }
       },
-      "System.ServiceModel.Http/4.0.11-beta-23323": {
+      "System.ServiceModel.Http/4.0.11-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.0.1-beta-23323",
+          "System.Private.ServiceModel": "4.0.1-beta-23330",
           "System.Runtime": "4.0.20"
         },
         "compile": {
@@ -848,10 +892,10 @@
           "lib/DNXCore50/System.ServiceModel.Http.dll": {}
         }
       },
-      "System.ServiceModel.NetTcp/4.0.1-beta-23323": {
+      "System.ServiceModel.NetTcp/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.0.1-beta-23323"
+          "System.Private.ServiceModel": "4.0.1-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.ServiceModel.NetTcp.dll": {}
@@ -860,10 +904,10 @@
           "lib/DNXCore50/System.ServiceModel.NetTcp.dll": {}
         }
       },
-      "System.ServiceModel.Primitives/4.0.1-beta-23323": {
+      "System.ServiceModel.Primitives/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.0.1-beta-23323"
+          "System.Private.ServiceModel": "4.0.1-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.ServiceModel.Primitives.dll": {}
@@ -872,10 +916,10 @@
           "lib/DNXCore50/System.ServiceModel.Primitives.dll": {}
         }
       },
-      "System.ServiceModel.Security/4.0.1-beta-23323": {
+      "System.ServiceModel.Security/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.0.1-beta-23323"
+          "System.Private.ServiceModel": "4.0.1-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.ServiceModel.Security.dll": {}
@@ -926,7 +970,7 @@
           "lib/dotnet/System.Text.RegularExpressions.dll": {}
         }
       },
-      "System.Threading/4.0.11-beta-23323": {
+      "System.Threading/4.0.11-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
@@ -961,7 +1005,7 @@
           "lib/DNXCore50/System.Threading.Tasks.dll": {}
         }
       },
-      "System.Threading.ThreadPool/4.0.10-beta-23323": {
+      "System.Threading.ThreadPool/4.0.10-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
@@ -1094,10 +1138,10 @@
         "ref/xamarinmac20/_._"
       ]
     },
-    "System.Collections/4.0.11-beta-23323": {
+    "System.Collections/4.0.11-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "cq6jwtL7r7FMUecRpeVB5dibtgHJn1uIg+j7Kgi/WjjmAlwuz3/xFTIUOxc/ZyvC54wa0gg9gH/jH8GPTW569w==",
+      "sha512": "OlKgcJcVObSKRdCJiRDSvIa1GA8pbMzNS5DoOFuGypzD39namEQIPprwY5DaWn3KM4gsl1vXOgcpRwiXaCyHpQ==",
       "files": [
         "lib/DNXCore50/de/System.Collections.xml",
         "lib/DNXCore50/es/System.Collections.xml",
@@ -1143,8 +1187,8 @@
         "runtimes/win8-aot/lib/netcore50/System.Collections.xml",
         "runtimes/win8-aot/lib/netcore50/zh-hans/System.Collections.xml",
         "runtimes/win8-aot/lib/netcore50/zh-hant/System.Collections.xml",
-        "System.Collections.4.0.11-beta-23323.nupkg",
-        "System.Collections.4.0.11-beta-23323.nupkg.sha512",
+        "System.Collections.4.0.11-beta-23330.nupkg",
+        "System.Collections.4.0.11-beta-23330.nupkg.sha512",
         "System.Collections.nuspec"
       ]
     },
@@ -1212,10 +1256,10 @@
         "System.Collections.NonGeneric.nuspec"
       ]
     },
-    "System.Collections.Specialized/4.0.1-beta-23323": {
+    "System.Collections.Specialized/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "/xUxkMLBrJKWhO62Ruk0sUHQkxdueeedf3rs/tgLZb/TzuDy+erwjYeSr6yTwThl93pqo57MGv6LtDvSwvs/xw==",
+      "sha512": "kHJ+R6/r7vCt7wZGKaK0O4QCnv3++6cSlg/qJkMq1x2zgnvtc7A4OwXGyy6vRkWYHRATFlabbgpfPce4TZBBlA==",
       "files": [
         "lib/dotnet/de/System.Collections.Specialized.xml",
         "lib/dotnet/es/System.Collections.Specialized.xml",
@@ -1239,8 +1283,8 @@
         "ref/net46/System.Collections.Specialized.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Collections.Specialized.4.0.1-beta-23323.nupkg",
-        "System.Collections.Specialized.4.0.1-beta-23323.nupkg.sha512",
+        "System.Collections.Specialized.4.0.1-beta-23330.nupkg",
+        "System.Collections.Specialized.4.0.1-beta-23330.nupkg.sha512",
         "System.Collections.Specialized.nuspec"
       ]
     },
@@ -1276,10 +1320,10 @@
         "System.ComponentModel.EventBasedAsync.nuspec"
       ]
     },
-    "System.Console/4.0.0-beta-23323": {
+    "System.Console/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "kSjxLIwLxdfWbg0VEXEmwXPfaE4TERzbhigI/+yJkMqRgL2u0Pmp2AgNI8zEfSQEMFMHN+8KzYmDsyYBQKEAXQ==",
+      "sha512": "zsvCt5wo0eTkZXwzGLfJ5arE1gt4Be4HDPbl1k6Z3ajBOI/ez0BtCJLZCTWdGMTeIDpFoMKjJRaotp1DFQ39og==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -1293,8 +1337,8 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Console.4.0.0-beta-23323.nupkg",
-        "System.Console.4.0.0-beta-23323.nupkg.sha512",
+        "System.Console.4.0.0-beta-23330.nupkg",
+        "System.Console.4.0.0-beta-23330.nupkg.sha512",
         "System.Console.nuspec"
       ]
     },
@@ -1331,10 +1375,10 @@
         "System.Diagnostics.Contracts.nuspec"
       ]
     },
-    "System.Diagnostics.Debug/4.0.11-beta-23323": {
+    "System.Diagnostics.Debug/4.0.11-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "rfVya0ZLPB2OYa3kOoxK7HtDuLIKsZm3lVW5Kb4RS909GIVqEvGdlLMCwZPjyGuY21NBRZ2EZ9GkuowGumbBBA==",
+      "sha512": "Bgfqh/XHLUhHcTrR+JGffqkYU34DgCvmG+1/HM8eG4H4NCsWOtfREhK2SEzs2qkDJgQJ5XeWa00/Fh34F6Xq1g==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -1348,16 +1392,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Debug.dll",
-        "System.Diagnostics.Debug.4.0.11-beta-23323.nupkg",
-        "System.Diagnostics.Debug.4.0.11-beta-23323.nupkg.sha512",
+        "System.Diagnostics.Debug.4.0.11-beta-23330.nupkg",
+        "System.Diagnostics.Debug.4.0.11-beta-23330.nupkg.sha512",
         "System.Diagnostics.Debug.nuspec"
       ]
     },
-    "System.Diagnostics.Tools/4.0.1-beta-23323": {
+    "System.Diagnostics.Tools/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "LTpqXAgBDnpp3W6E+RZ/rb5RiBetsJmhpN5I93Asi3GatRFw6HIMypiqvNRX0qH75Lfz7jkg2ERcHESvNkM5Yw==",
+      "sha512": "5hgxNI+0gP6/joJw0l5iGtsL1Lh2RsIOVh9Js9fg3rVu0rIGLTfZuaZLtgRumVh+znAjXtFHKdKL8BMjFqKP2Q==",
       "files": [
         "lib/DNXCore50/de/System.Diagnostics.Tools.xml",
         "lib/DNXCore50/es/System.Diagnostics.Tools.xml",
@@ -1402,8 +1445,8 @@
         "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Tools.xml",
         "runtimes/win8-aot/lib/netcore50/zh-hans/System.Diagnostics.Tools.xml",
         "runtimes/win8-aot/lib/netcore50/zh-hant/System.Diagnostics.Tools.xml",
-        "System.Diagnostics.Tools.4.0.1-beta-23323.nupkg",
-        "System.Diagnostics.Tools.4.0.1-beta-23323.nupkg.sha512",
+        "System.Diagnostics.Tools.4.0.1-beta-23330.nupkg",
+        "System.Diagnostics.Tools.4.0.1-beta-23330.nupkg.sha512",
         "System.Diagnostics.Tools.nuspec"
       ]
     },
@@ -1645,10 +1688,10 @@
         "System.IO.FileSystem.Primitives.nuspec"
       ]
     },
-    "System.Linq/4.0.1-beta-23323": {
+    "System.Linq/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "jQI5UEXB7mysfE3v3jh3pz1DYQlmJI27J6E87gCYKgDViNIDzNGFq4IYjFr4AXI6r1RwbSIh6rpxAiiIxQef2Q==",
+      "sha512": "g/wPmqz0p2qkAr3tjUP5GsCTqY4cMh08KtRpiUat7vXiSFQVgC2u9bZrJKyPV0JWSmtpl6X0xppsS/z1YvYEZw==",
       "files": [
         "lib/dotnet/de/System.Linq.xml",
         "lib/dotnet/es/System.Linq.xml",
@@ -1673,8 +1716,8 @@
         "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "System.Linq.4.0.1-beta-23323.nupkg",
-        "System.Linq.4.0.1-beta-23323.nupkg.sha512",
+        "System.Linq.4.0.1-beta-23330.nupkg",
+        "System.Linq.4.0.1-beta-23330.nupkg.sha512",
         "System.Linq.nuspec"
       ]
     },
@@ -1746,23 +1789,12 @@
         "System.Linq.Queryable.nuspec"
       ]
     },
-    "System.Net.Http/4.0.1-beta-23323": {
+    "System.Net.Http/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "vX/9YzKFrLjki3bAA8cVi0BjIyPrEA1ylS5ODQNqrV/duyqsV83j3gXYqljUDJ7vdptARkbji8U8OwIz7GHxKA==",
+      "sha512": "itLPx7B7Ac4mX8wQx9V9DQcxqTgkmwDNnQIHuCgAH53Jq2X3XziiRRBbxbmNJlWqBlgPzbseWJmMCtcF/ePhOg==",
       "files": [
         "lib/net45/_._",
-        "lib/netcore50/de/System.Net.Http.xml",
-        "lib/netcore50/es/System.Net.Http.xml",
-        "lib/netcore50/fr/System.Net.Http.xml",
-        "lib/netcore50/it/System.Net.Http.xml",
-        "lib/netcore50/ja/System.Net.Http.xml",
-        "lib/netcore50/ko/System.Net.Http.xml",
-        "lib/netcore50/ru/System.Net.Http.xml",
-        "lib/netcore50/System.Net.Http.dll",
-        "lib/netcore50/System.Net.Http.xml",
-        "lib/netcore50/zh-hans/System.Net.Http.xml",
-        "lib/netcore50/zh-hant/System.Net.Http.xml",
         "lib/win8/_._",
         "lib/wpa81/_._",
         "ref/dotnet/System.Net.Http.dll",
@@ -1771,17 +1803,16 @@
         "ref/win8/_._",
         "ref/wpa81/_._",
         "runtime.json",
-        "System.Net.Http.4.0.1-beta-23323.nupkg",
-        "System.Net.Http.4.0.1-beta-23323.nupkg.sha512",
+        "System.Net.Http.4.0.1-beta-23330.nupkg",
+        "System.Net.Http.4.0.1-beta-23330.nupkg.sha512",
         "System.Net.Http.nuspec"
       ]
     },
-    "System.Net.NameResolution/4.0.0-beta-23323": {
+    "System.Net.NameResolution/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "xv2vf6VS5GcCkSMJtCGpJJQ/6grDMwmChTYAUXiEsLZRRUceVPqqkaMw3a1VN3EcUoQx+HvBOGFJ41QmCB3zcQ==",
+      "sha512": "d8Am+In/aBgcHpEV6xsi5BCiTEN4y6s9O1V/yIvwX8mDC4CtdZiGsi4DtoB0TLOgp8ky6GxbSF4bKCjFpBO3uw==",
       "files": [
-        "lib/DNXCore50/System.Net.NameResolution.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.NameResolution.dll",
@@ -1793,8 +1824,9 @@
         "ref/net46/System.Net.NameResolution.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.NameResolution.4.0.0-beta-23323.nupkg",
-        "System.Net.NameResolution.4.0.0-beta-23323.nupkg.sha512",
+        "runtime.json",
+        "System.Net.NameResolution.4.0.0-beta-23330.nupkg",
+        "System.Net.NameResolution.4.0.0-beta-23330.nupkg.sha512",
         "System.Net.NameResolution.nuspec"
       ]
     },
@@ -1831,9 +1863,9 @@
         "System.Net.Primitives.nuspec"
       ]
     },
-    "System.Net.Security/4.0.0-beta-23323": {
+    "System.Net.Security/4.0.0-beta-23330": {
       "type": "package",
-      "sha512": "C/HTkvWZSE4x5JYWHlqaTbJt67+GltNPVaP9mPr/5J/xtaN21Uqo4hfKuDSHA4Iws+6QKcxSUvRW5GxRb6kxCg==",
+      "sha512": "z98dKloNy9DBdyfqQwQvKWA2q8Qj4vgGEVONnlS70c13eh0MolBHJ0wNdplZZK5zYZ5Eu8GTwexbUlpHbsfzVA==",
       "files": [
         "lib/DNXCore50/System.Net.Security.dll",
         "lib/MonoAndroid10/_._",
@@ -1847,8 +1879,8 @@
         "ref/net46/System.Net.Security.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.Security.4.0.0-beta-23323.nupkg",
-        "System.Net.Security.4.0.0-beta-23323.nupkg.sha512",
+        "System.Net.Security.4.0.0-beta-23330.nupkg",
+        "System.Net.Security.4.0.0-beta-23330.nupkg.sha512",
         "System.Net.Security.nuspec"
       ]
     },
@@ -1906,6 +1938,81 @@
         "System.Net.WebHeaderCollection.nuspec"
       ]
     },
+    "System.Net.WebSockets/4.0.0-beta-23330": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "6Q9/uTDcaqbmdbD04MisKmjti4aEpp40i/UzpGaPZ4ItuwzU/pMk9RjiYUBUiCQyZeKNlXcSB1FPN2nFof7tww==",
+      "files": [
+        "lib/dotnet/de/System.Net.WebSockets.xml",
+        "lib/dotnet/es/System.Net.WebSockets.xml",
+        "lib/dotnet/fr/System.Net.WebSockets.xml",
+        "lib/dotnet/it/System.Net.WebSockets.xml",
+        "lib/dotnet/ja/System.Net.WebSockets.xml",
+        "lib/dotnet/ko/System.Net.WebSockets.xml",
+        "lib/dotnet/ru/System.Net.WebSockets.xml",
+        "lib/dotnet/System.Net.WebSockets.dll",
+        "lib/dotnet/System.Net.WebSockets.xml",
+        "lib/dotnet/zh-hans/System.Net.WebSockets.xml",
+        "lib/dotnet/zh-hant/System.Net.WebSockets.xml",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Net.WebSockets.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Net.WebSockets.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Net.WebSockets.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Net.WebSockets.4.0.0-beta-23330.nupkg",
+        "System.Net.WebSockets.4.0.0-beta-23330.nupkg.sha512",
+        "System.Net.WebSockets.nuspec"
+      ]
+    },
+    "System.Net.WebSockets.Client/4.0.0-beta-23330": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "1NWEqwDkYRyvr1gSKZlY51AaI9w8oD0dC5UNa2Lb+qaeFHSF5KfCSzf7seD+im+sH6uocVo2nppiaabfbXZT4Q==",
+      "files": [
+        "lib/DNXCore50/de/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/es/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/fr/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/it/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/ja/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/ko/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/ru/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/System.Net.WebSockets.Client.dll",
+        "lib/DNXCore50/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/zh-hans/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/zh-hant/System.Net.WebSockets.Client.xml",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Net.WebSockets.Client.dll",
+        "lib/netcore50/de/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/es/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/fr/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/it/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/ja/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/ko/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/ru/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/System.Net.WebSockets.Client.dll",
+        "lib/netcore50/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/zh-hans/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/zh-hant/System.Net.WebSockets.Client.xml",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Net.WebSockets.Client.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Net.WebSockets.Client.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Net.WebSockets.Client.4.0.0-beta-23330.nupkg",
+        "System.Net.WebSockets.Client.4.0.0-beta-23330.nupkg.sha512",
+        "System.Net.WebSockets.Client.nuspec"
+      ]
+    },
     "System.ObjectModel/4.0.10": {
       "type": "package",
       "serviceable": true,
@@ -1954,45 +2061,43 @@
         "System.Private.DataContractSerialization.nuspec"
       ]
     },
-    "System.Private.Networking/4.0.1-beta-23323": {
+    "System.Private.Networking/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "K+ZZTnDPQq3Ed091zU8hS/Se7r/ww7MLRbtulYW5eTv1GlFWRpwT1aT/u82xIKZzTJN3yMwUwbnv6yWeuMMK2Q==",
+      "sha512": "8NZi1gCQaGTKDb2yWplm52HWCLaZnUwVitksJgcXY2dEJau/TBGyZup+yhOngOIe8QzQMxNG4iokY3Ce0/8mbg==",
       "files": [
         "lib/DNXCore50/System.Private.Networking.dll",
         "lib/netcore50/System.Private.Networking.dll",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "System.Private.Networking.4.0.1-beta-23323.nupkg",
-        "System.Private.Networking.4.0.1-beta-23323.nupkg.sha512",
+        "System.Private.Networking.4.0.1-beta-23330.nupkg",
+        "System.Private.Networking.4.0.1-beta-23330.nupkg.sha512",
         "System.Private.Networking.nuspec"
       ]
     },
-    "System.Private.ServiceModel/4.0.1-beta-23323": {
+    "System.Private.ServiceModel/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "ygchOYK4nVb+GEyxy5HLOq5K7yIw4o5eOlZ8utBHjgAehWmBa5fk4QJnvmNQA6QdXdCBDBuJq6FSzDp+2SHjtA==",
+      "sha512": "8lENvmHuZdlvmnYN1w98Mv8bDjc0O/YlaNHRRph35T/fLDyaG8LMLMwG3/ut6a/AenLJmbf92snOtNXCuqM+cQ==",
       "files": [
         "lib/DNXCore50/System.Private.ServiceModel.dll",
         "lib/netcore50/System.Private.ServiceModel.dll",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "System.Private.ServiceModel.4.0.1-beta-23323.nupkg",
-        "System.Private.ServiceModel.4.0.1-beta-23323.nupkg.sha512",
+        "System.Private.ServiceModel.4.0.1-beta-23330.nupkg",
+        "System.Private.ServiceModel.4.0.1-beta-23330.nupkg.sha512",
         "System.Private.ServiceModel.nuspec"
       ]
     },
-    "System.Private.Uri/4.0.1-beta-23323": {
+    "System.Private.Uri/4.0.1-beta-23330": {
       "type": "package",
-      "serviceable": true,
-      "sha512": "eLspsxqTeemqNyeY5lI2qTUHU75xVhoI6+rzaE0WQkiRn5YkwBxmV5AAkwH/goVf5crDIEDEryKqssbEPN8BYg==",
+      "sha512": "PsVKlgXVovVjU7RhaC++BONWL/dT4vef220q4JD6BcFoL8l1K98hh3SGnFTfyOZPgKJwZbDfp5AqABn8txpl2Q==",
       "files": [
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
         "runtime.json",
-        "runtimes/win8-aot/lib/netcore50/System.Private.Uri.dll",
-        "System.Private.Uri.4.0.1-beta-23323.nupkg",
-        "System.Private.Uri.4.0.1-beta-23323.nupkg.sha512",
+        "System.Private.Uri.4.0.1-beta-23330.nupkg",
+        "System.Private.Uri.4.0.1-beta-23330.nupkg.sha512",
         "System.Private.Uri.nuspec"
       ]
     },
@@ -2253,10 +2358,10 @@
         "System.Resources.ResourceManager.nuspec"
       ]
     },
-    "System.Runtime/4.0.21-beta-23323": {
+    "System.Runtime/4.0.21-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "QXA+/kwMkkUU48SYyJsEeY12A0vFYBfT8LBlZ0o6BcoxNOjlPq68zbfbPEywpZW+86gYUdK8md3GjIh8WQQ+aA==",
+      "sha512": "yOw8Qm5gDsoMtG0Ml5/IJhsZQ4nR769UZVzpe+N0rdiSuITDKjXj9cpcFzmWnOUBdfuZjpOG+/GHMj5vJznQiQ==",
       "files": [
         "lib/DNXCore50/de/System.Runtime.xml",
         "lib/DNXCore50/es/System.Runtime.xml",
@@ -2302,8 +2407,8 @@
         "runtimes/win8-aot/lib/netcore50/System.Runtime.xml",
         "runtimes/win8-aot/lib/netcore50/zh-hans/System.Runtime.xml",
         "runtimes/win8-aot/lib/netcore50/zh-hant/System.Runtime.xml",
-        "System.Runtime.4.0.21-beta-23323.nupkg",
-        "System.Runtime.4.0.21-beta-23323.nupkg.sha512",
+        "System.Runtime.4.0.21-beta-23330.nupkg",
+        "System.Runtime.4.0.21-beta-23330.nupkg.sha512",
         "System.Runtime.nuspec"
       ]
     },
@@ -2506,10 +2611,10 @@
         "System.Security.Claims.nuspec"
       ]
     },
-    "System.Security.Cryptography.Algorithms/4.0.0-beta-23323": {
+    "System.Security.Cryptography.Algorithms/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "+++XXXxuTq5M3hDvDHEGF3Vwr5XdNUSUNn8PQAbZarK9kDCeHvwPd5U4e7TuPhYRkp6QktnQwhrBSHhuwbkW8A==",
+      "sha512": "FB4RoTDaV5tBiPSJsiG3A5DydeKz7ErglnkqVjBFjm6wu8kg91j0MxL/Al9iUyu9i/hq53fRs5KE3rjUNYvf5w==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2523,15 +2628,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.Algorithms.4.0.0-beta-23323.nupkg",
-        "System.Security.Cryptography.Algorithms.4.0.0-beta-23323.nupkg.sha512",
+        "System.Security.Cryptography.Algorithms.4.0.0-beta-23330.nupkg",
+        "System.Security.Cryptography.Algorithms.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Cryptography.Algorithms.nuspec"
       ]
     },
-    "System.Security.Cryptography.Encoding/4.0.0-beta-23323": {
+    "System.Security.Cryptography.Encoding/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "1pk8IM9/BDUASr9dpQUegaCWpGVFApxHMxKP9gbGvhWeZclbgDFiKbnAEuOHi7fXdwlVHeZD7t99y/9I/nXA6A==",
+      "sha512": "zeFdKQT6xjNdiNCaEmEYJMEK59kixkX7jJSoOLw3H+53t9X0F98vr3tS8YlrW/Lk/K9c6L5pYLlkb2dNqvUD/g==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2545,15 +2650,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.Encoding.4.0.0-beta-23323.nupkg",
-        "System.Security.Cryptography.Encoding.4.0.0-beta-23323.nupkg.sha512",
+        "System.Security.Cryptography.Encoding.4.0.0-beta-23330.nupkg",
+        "System.Security.Cryptography.Encoding.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Cryptography.Encoding.nuspec"
       ]
     },
-    "System.Security.Cryptography.Primitives/4.0.0-beta-23323": {
+    "System.Security.Cryptography.Primitives/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "Wy16m2oGsrgG4l42Kma49DdRiNdr1liepDXcf1LKqh907yvSQgybLb0yl6Y1u+kNQQ5TVUz3B5pocQwrJNZHRg==",
+      "sha512": "15uVbOD3X0sRQJIxcEH5hasxlFdbA1CmPPZa0Y8pYEuQcWMF2gBswvU8s4qoKtA7x2xhNhzPsXIhsQuKNMTdEA==",
       "files": [
         "lib/dotnet/System.Security.Cryptography.Primitives.dll",
         "lib/MonoAndroid10/_._",
@@ -2567,15 +2672,15 @@
         "ref/net46/System.Security.Cryptography.Primitives.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Security.Cryptography.Primitives.4.0.0-beta-23323.nupkg",
-        "System.Security.Cryptography.Primitives.4.0.0-beta-23323.nupkg.sha512",
+        "System.Security.Cryptography.Primitives.4.0.0-beta-23330.nupkg",
+        "System.Security.Cryptography.Primitives.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Cryptography.Primitives.nuspec"
       ]
     },
-    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23323": {
+    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "PFD+4dnmMb7idGhvkUCAs2sGVacTxhjSY05YNJ4LBOnkhUsNeQLBEYjQSidsSqglLgs+qjkUQ326CHFpgUQaTQ==",
+      "sha512": "L8mUimdm7+GsORgJ8DFBMGsFnwDJ5YCUdJj3HfXQx4HCoPDPF+vJo3HRiHfcvNA2Zsf0ov2kuerYj/eeVa2/Rw==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2589,8 +2694,8 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23323.nupkg",
-        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23323.nupkg.sha512",
+        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23330.nupkg",
+        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Cryptography.X509Certificates.nuspec"
       ]
     },
@@ -2627,10 +2732,10 @@
         "System.Security.Principal.nuspec"
       ]
     },
-    "System.Security.Principal.Windows/4.0.0-beta-23323": {
+    "System.Security.Principal.Windows/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "QfKN/OrRuNlZN5yZMTjr4WnEgtqs94ZIJhUF8pXrBW3zAkKmj91PuogTHUHntjbRKsuUsq4gbdmSb6tHX9vwYg==",
+      "sha512": "q+3L3aB8bn0HCW52kX9TSJdhbjffBw7QWCOu0yX1SDhPN9MCPmJ4aBBCn1HRWroa5y7UcNUdjL1xwiERycZexw==",
       "files": [
         "lib/DNXCore50/de/System.Security.Principal.Windows.xml",
         "lib/DNXCore50/es/System.Security.Principal.Windows.xml",
@@ -2646,15 +2751,15 @@
         "lib/net46/System.Security.Principal.Windows.dll",
         "ref/dotnet/System.Security.Principal.Windows.dll",
         "ref/net46/System.Security.Principal.Windows.dll",
-        "System.Security.Principal.Windows.4.0.0-beta-23323.nupkg",
-        "System.Security.Principal.Windows.4.0.0-beta-23323.nupkg.sha512",
+        "System.Security.Principal.Windows.4.0.0-beta-23330.nupkg",
+        "System.Security.Principal.Windows.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Principal.Windows.nuspec"
       ]
     },
-    "System.ServiceModel.Duplex/4.0.1-beta-23323": {
+    "System.ServiceModel.Duplex/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "Vs/HC+DjrVBaBzn+nTfm42/PchwfVChMh3ClN25kDar5Azp+FMAEoAURN0BO4maa2+JWBa0EI7Ug/oGqZVK4hw==",
+      "sha512": "0k9wL8LeMYj1jfu2wZwTdQhmPBcpMSUgD304cR50CpHOJnrP/NjiQ0Blx3oSURd8Tda5XuXC0PNGWDF+EpW/Lg==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Duplex.dll",
         "lib/net45/_._",
@@ -2674,15 +2779,15 @@
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.Duplex.dll",
         "ref/win8/_._",
-        "System.ServiceModel.Duplex.4.0.1-beta-23323.nupkg",
-        "System.ServiceModel.Duplex.4.0.1-beta-23323.nupkg.sha512",
+        "System.ServiceModel.Duplex.4.0.1-beta-23330.nupkg",
+        "System.ServiceModel.Duplex.4.0.1-beta-23330.nupkg.sha512",
         "System.ServiceModel.Duplex.nuspec"
       ]
     },
-    "System.ServiceModel.Http/4.0.11-beta-23323": {
+    "System.ServiceModel.Http/4.0.11-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "8Xe5DJDZKoSM0CsAQJVT42NvcawVHE5B9mFUPmkpCyHRUPcg9g53tymp50pQEZ1VAMvsuGTxeIjaiIIF8lhDgA==",
+      "sha512": "NHKxIIYL0ATDbX18RLCSXtuq26MMoYfAVdpl5K+D0s5AHp7TMPb7LcjZPpg25B2v48x1TwE9LYcYTCiOZcoPzQ==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Http.dll",
         "lib/MonoAndroid10/_._",
@@ -2707,15 +2812,15 @@
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.ServiceModel.Http.4.0.11-beta-23323.nupkg",
-        "System.ServiceModel.Http.4.0.11-beta-23323.nupkg.sha512",
+        "System.ServiceModel.Http.4.0.11-beta-23330.nupkg",
+        "System.ServiceModel.Http.4.0.11-beta-23330.nupkg.sha512",
         "System.ServiceModel.Http.nuspec"
       ]
     },
-    "System.ServiceModel.NetTcp/4.0.1-beta-23323": {
+    "System.ServiceModel.NetTcp/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "xVSY5S+3BqlT7FdYnTaS6FGXgw1XJe/k2m9iw9ww8BAsK1+yFSpnss5uBVJ9f8oTw5SKVYhFvul6TizbBV/AkQ==",
+      "sha512": "Vx0QSKz4BlX/yYqKHET3mofo6RxxaMDLWsEFWDbEBJeCs0Yq19uGiIYwK1mXkWy3Y+jDwi42au3mVhmRbDHavA==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.NetTcp.dll",
         "lib/net45/_._",
@@ -2735,15 +2840,15 @@
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.NetTcp.dll",
         "ref/win8/_._",
-        "System.ServiceModel.NetTcp.4.0.1-beta-23323.nupkg",
-        "System.ServiceModel.NetTcp.4.0.1-beta-23323.nupkg.sha512",
+        "System.ServiceModel.NetTcp.4.0.1-beta-23330.nupkg",
+        "System.ServiceModel.NetTcp.4.0.1-beta-23330.nupkg.sha512",
         "System.ServiceModel.NetTcp.nuspec"
       ]
     },
-    "System.ServiceModel.Primitives/4.0.1-beta-23323": {
+    "System.ServiceModel.Primitives/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "btLNE4sQgc6F93k+EIjYE+OEblqPdHdEz6keTgUSxnre+GcjXYwNmsnnYoH4FS8jTvmA1Cyb/fHIVRMMY9nIfw==",
+      "sha512": "kJ/pcRUf7Ow7s/rX8Kmc9P2k6cvyudIzyUcqr/pn9NwY8DC/2DWkkFvYE2udR4kvBzJJzXl/rsJQlyLIVGMAww==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Primitives.dll",
         "lib/net45/_._",
@@ -2763,15 +2868,15 @@
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.Primitives.dll",
         "ref/win8/_._",
-        "System.ServiceModel.Primitives.4.0.1-beta-23323.nupkg",
-        "System.ServiceModel.Primitives.4.0.1-beta-23323.nupkg.sha512",
+        "System.ServiceModel.Primitives.4.0.1-beta-23330.nupkg",
+        "System.ServiceModel.Primitives.4.0.1-beta-23330.nupkg.sha512",
         "System.ServiceModel.Primitives.nuspec"
       ]
     },
-    "System.ServiceModel.Security/4.0.1-beta-23323": {
+    "System.ServiceModel.Security/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "myPgo4jRIqTcHk8NBvf+mxG2ARJ7LT7t73bM2MDj+fBAPesmLqz4rd+/FBwJlJiSddTT4SWSgJ8SD6Z+hb1NpQ==",
+      "sha512": "DkdJSuFiSyHpu5vmqx1DHolDVZCPE1LoTVPFlH3E2AOFUnv7+LddJd02I1l03fhtKrOkJKJACHonhseWDdeIMg==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Security.dll",
         "lib/net45/_._",
@@ -2791,8 +2896,8 @@
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.Security.dll",
         "ref/win8/_._",
-        "System.ServiceModel.Security.4.0.1-beta-23323.nupkg",
-        "System.ServiceModel.Security.4.0.1-beta-23323.nupkg.sha512",
+        "System.ServiceModel.Security.4.0.1-beta-23330.nupkg",
+        "System.ServiceModel.Security.4.0.1-beta-23330.nupkg.sha512",
         "System.ServiceModel.Security.nuspec"
       ]
     },
@@ -2894,10 +2999,10 @@
         "System.Text.RegularExpressions.nuspec"
       ]
     },
-    "System.Threading/4.0.11-beta-23323": {
+    "System.Threading/4.0.11-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "g6nir/AeQ4/T9HWs7rmd8/6PWYvOqYfV8MthNVsN8d/rr/FzWy9sZGIufri8fhKc/ocROJu8uS8d88BuToOWlA==",
+      "sha512": "ro8NNFu7OQKgsFGtB1qYHw1FgAu2yNC0nuQlbM8SfCNk9ddnyIetwo3kHT3C7JY3cUff/SsbzKgiU4eBubO1vQ==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2911,9 +3016,8 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "runtimes/win8-aot/lib/netcore50/System.Threading.dll",
-        "System.Threading.4.0.11-beta-23323.nupkg",
-        "System.Threading.4.0.11-beta-23323.nupkg.sha512",
+        "System.Threading.4.0.11-beta-23330.nupkg",
+        "System.Threading.4.0.11-beta-23330.nupkg.sha512",
         "System.Threading.nuspec"
       ]
     },
@@ -2976,10 +3080,9 @@
         "System.Threading.Tasks.nuspec"
       ]
     },
-    "System.Threading.ThreadPool/4.0.10-beta-23323": {
+    "System.Threading.ThreadPool/4.0.10-beta-23330": {
       "type": "package",
-      "serviceable": true,
-      "sha512": "z1pLtZ9i5Q3qbrYlfExbwQJ5WVyiXwiQEGnO2jgyjgsYKtRSGSpR+F/4YOKPAiFXHyQpgtcdqvmBoMltBlRHLg==",
+      "sha512": "nM5OewUj8NJrye93apbM6KHvPddgPJGzt1IWIXk9lV5HB4NGsn6M5U0gxMQWShQuDp6NF3ya3ULRSvh3dLMbzg==",
       "files": [
         "lib/DNXCore50/System.Threading.ThreadPool.dll",
         "lib/MonoAndroid10/_._",
@@ -2993,8 +3096,8 @@
         "ref/net46/System.Threading.ThreadPool.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Threading.ThreadPool.4.0.10-beta-23323.nupkg",
-        "System.Threading.ThreadPool.4.0.10-beta-23323.nupkg.sha512",
+        "System.Threading.ThreadPool.4.0.10-beta-23330.nupkg",
+        "System.Threading.ThreadPool.4.0.10-beta-23330.nupkg.sha512",
         "System.Threading.ThreadPool.nuspec"
       ]
     },

--- a/src/System.Private.ServiceModel/tests/Unit/project.lock.json
+++ b/src/System.Private.ServiceModel/tests/Unit/project.lock.json
@@ -316,7 +316,7 @@
           "lib/dotnet/System.Linq.Queryable.dll": {}
         }
       },
-      "System.Net.Http/4.0.1-beta-23324": {
+      "System.Net.Http/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -329,16 +329,15 @@
           "ref/dotnet/System.Net.Http.dll": {}
         }
       },
-      "System.Net.NameResolution/4.0.0-beta-23324": {
+      "System.Net.NameResolution/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.Networking": "4.0.1-beta-23324"
+          "System.Net.Primitives": "4.0.10",
+          "System.Runtime": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Net.NameResolution.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Net.NameResolution.dll": {}
         }
       },
       "System.Net.Primitives/4.0.10": {
@@ -353,10 +352,10 @@
           "lib/DNXCore50/System.Net.Primitives.dll": {}
         }
       },
-      "System.Net.Security/4.0.0-beta-23324": {
+      "System.Net.Security/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.Networking": "4.0.1-beta-23324"
+          "System.Private.Networking": "4.0.1-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.Net.Security.dll": {}
@@ -392,7 +391,7 @@
           "lib/dotnet/System.Net.WebHeaderCollection.dll": {}
         }
       },
-      "System.Net.WebSockets/4.0.0-beta-23324": {
+      "System.Net.WebSockets/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -404,10 +403,10 @@
           "ref/dotnet/System.Net.WebSockets.dll": {}
         },
         "runtime": {
-          "lib/DNXCore50/System.Net.WebSockets.dll": {}
+          "lib/dotnet/System.Net.WebSockets.dll": {}
         }
       },
-      "System.Net.WebSockets.Client/4.0.0-beta-23324": {
+      "System.Net.WebSockets.Client/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -417,13 +416,13 @@
           "System.Globalization": "4.0.10",
           "System.Net.Primitives": "4.0.10",
           "System.Net.WebHeaderCollection": "4.0.0",
-          "System.Net.WebSockets": "4.0.0-beta-23324",
+          "System.Net.WebSockets": "4.0.0-beta-23330",
           "System.Resources.ResourceManager": "4.0.0",
           "System.Runtime": "4.0.20",
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23324",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23330",
           "System.Text.Encoding": "4.0.10",
           "System.Threading": "4.0.10",
           "System.Threading.Tasks": "4.0.10"
@@ -480,7 +479,7 @@
           "lib/DNXCore50/System.Private.DataContractSerialization.dll": {}
         }
       },
-      "System.Private.Networking/4.0.1-beta-23324": {
+      "System.Private.Networking/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -499,13 +498,13 @@
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23324",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23324",
-          "System.Security.Principal.Windows": "4.0.0-beta-23324",
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23330",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23330",
+          "System.Security.Principal.Windows": "4.0.0-beta-23330",
           "System.Threading": "4.0.10",
           "System.Threading.Overlapped": "4.0.0",
           "System.Threading.Tasks": "4.0.10",
-          "System.Threading.ThreadPool": "4.0.10-beta-23324"
+          "System.Threading.ThreadPool": "4.0.10-beta-23330"
         },
         "compile": {
           "ref/dnxcore50/_._": {}
@@ -747,18 +746,18 @@
           "lib/dotnet/System.Security.Claims.dll": {}
         }
       },
-      "System.Security.Cryptography.Algorithms/4.0.0-beta-23324": {
+      "System.Security.Cryptography.Algorithms/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
           "System.Runtime": "4.0.0",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23324"
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.Algorithms.dll": {}
         }
       },
-      "System.Security.Cryptography.Encoding/4.0.0-beta-23324": {
+      "System.Security.Cryptography.Encoding/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -767,7 +766,7 @@
           "ref/dotnet/System.Security.Cryptography.Encoding.dll": {}
         }
       },
-      "System.Security.Cryptography.Primitives/4.0.0-beta-23324": {
+      "System.Security.Cryptography.Primitives/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.0",
@@ -785,13 +784,13 @@
           "lib/dotnet/System.Security.Cryptography.Primitives.dll": {}
         }
       },
-      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23324": {
+      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
           "System.Runtime.Handles": "4.0.0",
-          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23324",
-          "System.Security.Cryptography.Encoding": "4.0.0-beta-23324"
+          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23330",
+          "System.Security.Cryptography.Encoding": "4.0.0-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.X509Certificates.dll": {}
@@ -809,7 +808,7 @@
           "lib/dotnet/System.Security.Principal.dll": {}
         }
       },
-      "System.Security.Principal.Windows/4.0.0-beta-23324": {
+      "System.Security.Principal.Windows/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -912,7 +911,7 @@
           "lib/DNXCore50/System.Threading.Tasks.dll": {}
         }
       },
-      "System.Threading.ThreadPool/4.0.10-beta-23324": {
+      "System.Threading.ThreadPool/4.0.10-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
@@ -1127,7 +1126,7 @@
           "lib/dotnet/xunit.execution.dotnet.dll": {}
         }
       },
-      "xunit.netcore.extensions/1.0.0-prerelease-00095": {
+      "xunit.netcore.extensions/1.0.0-prerelease-00098": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.10",
@@ -1822,23 +1821,12 @@
         "System.Linq.Queryable.nuspec"
       ]
     },
-    "System.Net.Http/4.0.1-beta-23324": {
+    "System.Net.Http/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "gXfHlWsiMQDuFqwnQrlQTje9vqMhCFLtm35jX4WqZjcfa3y69DbwueeT0gJbVMK88/UnG8FAYiDBb7AKyu+51w==",
+      "sha512": "itLPx7B7Ac4mX8wQx9V9DQcxqTgkmwDNnQIHuCgAH53Jq2X3XziiRRBbxbmNJlWqBlgPzbseWJmMCtcF/ePhOg==",
       "files": [
         "lib/net45/_._",
-        "lib/netcore50/de/System.Net.Http.xml",
-        "lib/netcore50/es/System.Net.Http.xml",
-        "lib/netcore50/fr/System.Net.Http.xml",
-        "lib/netcore50/it/System.Net.Http.xml",
-        "lib/netcore50/ja/System.Net.Http.xml",
-        "lib/netcore50/ko/System.Net.Http.xml",
-        "lib/netcore50/ru/System.Net.Http.xml",
-        "lib/netcore50/System.Net.Http.dll",
-        "lib/netcore50/System.Net.Http.xml",
-        "lib/netcore50/zh-hans/System.Net.Http.xml",
-        "lib/netcore50/zh-hant/System.Net.Http.xml",
         "lib/win8/_._",
         "lib/wpa81/_._",
         "ref/dotnet/System.Net.Http.dll",
@@ -1847,17 +1835,16 @@
         "ref/win8/_._",
         "ref/wpa81/_._",
         "runtime.json",
-        "System.Net.Http.4.0.1-beta-23324.nupkg",
-        "System.Net.Http.4.0.1-beta-23324.nupkg.sha512",
+        "System.Net.Http.4.0.1-beta-23330.nupkg",
+        "System.Net.Http.4.0.1-beta-23330.nupkg.sha512",
         "System.Net.Http.nuspec"
       ]
     },
-    "System.Net.NameResolution/4.0.0-beta-23324": {
+    "System.Net.NameResolution/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "lNYXUmnSXUtLFY09Rc27zJ6/TxCuGggQzBgiuWHoWrjWxymuuxqPT2Mj7Dn7sUUh0GvF2MOx7Uk+rtCFBiIavg==",
+      "sha512": "d8Am+In/aBgcHpEV6xsi5BCiTEN4y6s9O1V/yIvwX8mDC4CtdZiGsi4DtoB0TLOgp8ky6GxbSF4bKCjFpBO3uw==",
       "files": [
-        "lib/DNXCore50/System.Net.NameResolution.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.NameResolution.dll",
@@ -1869,8 +1856,9 @@
         "ref/net46/System.Net.NameResolution.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.NameResolution.4.0.0-beta-23324.nupkg",
-        "System.Net.NameResolution.4.0.0-beta-23324.nupkg.sha512",
+        "runtime.json",
+        "System.Net.NameResolution.4.0.0-beta-23330.nupkg",
+        "System.Net.NameResolution.4.0.0-beta-23330.nupkg.sha512",
         "System.Net.NameResolution.nuspec"
       ]
     },
@@ -1907,9 +1895,9 @@
         "System.Net.Primitives.nuspec"
       ]
     },
-    "System.Net.Security/4.0.0-beta-23324": {
+    "System.Net.Security/4.0.0-beta-23330": {
       "type": "package",
-      "sha512": "D04RYjxrnR3D+uI9CGmAAFKKQ6T+pPcRHYucc1PIo7/hJK5I/Yu7gAw9yOxHUhQjSGfrKo00lHpBCQMTQt4lSw==",
+      "sha512": "z98dKloNy9DBdyfqQwQvKWA2q8Qj4vgGEVONnlS70c13eh0MolBHJ0wNdplZZK5zYZ5Eu8GTwexbUlpHbsfzVA==",
       "files": [
         "lib/DNXCore50/System.Net.Security.dll",
         "lib/MonoAndroid10/_._",
@@ -1923,8 +1911,8 @@
         "ref/net46/System.Net.Security.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.Security.4.0.0-beta-23324.nupkg",
-        "System.Net.Security.4.0.0-beta-23324.nupkg.sha512",
+        "System.Net.Security.4.0.0-beta-23330.nupkg",
+        "System.Net.Security.4.0.0-beta-23330.nupkg.sha512",
         "System.Net.Security.nuspec"
       ]
     },
@@ -1989,22 +1977,22 @@
         "System.Net.WebHeaderCollection.nuspec"
       ]
     },
-    "System.Net.WebSockets/4.0.0-beta-23324": {
+    "System.Net.WebSockets/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "Yq5jsxarl7rhHGtPx1vpW3a2iUF+4eD6FE5u2IRlBs8YEvoGVN2jzhBtPJw40t1SGidXLCvlsVaB3qyNbk99MQ==",
+      "sha512": "6Q9/uTDcaqbmdbD04MisKmjti4aEpp40i/UzpGaPZ4ItuwzU/pMk9RjiYUBUiCQyZeKNlXcSB1FPN2nFof7tww==",
       "files": [
-        "lib/DNXCore50/de/System.Net.WebSockets.xml",
-        "lib/DNXCore50/es/System.Net.WebSockets.xml",
-        "lib/DNXCore50/fr/System.Net.WebSockets.xml",
-        "lib/DNXCore50/it/System.Net.WebSockets.xml",
-        "lib/DNXCore50/ja/System.Net.WebSockets.xml",
-        "lib/DNXCore50/ko/System.Net.WebSockets.xml",
-        "lib/DNXCore50/ru/System.Net.WebSockets.xml",
-        "lib/DNXCore50/System.Net.WebSockets.dll",
-        "lib/DNXCore50/System.Net.WebSockets.xml",
-        "lib/DNXCore50/zh-hans/System.Net.WebSockets.xml",
-        "lib/DNXCore50/zh-hant/System.Net.WebSockets.xml",
+        "lib/dotnet/de/System.Net.WebSockets.xml",
+        "lib/dotnet/es/System.Net.WebSockets.xml",
+        "lib/dotnet/fr/System.Net.WebSockets.xml",
+        "lib/dotnet/it/System.Net.WebSockets.xml",
+        "lib/dotnet/ja/System.Net.WebSockets.xml",
+        "lib/dotnet/ko/System.Net.WebSockets.xml",
+        "lib/dotnet/ru/System.Net.WebSockets.xml",
+        "lib/dotnet/System.Net.WebSockets.dll",
+        "lib/dotnet/System.Net.WebSockets.xml",
+        "lib/dotnet/zh-hans/System.Net.WebSockets.xml",
+        "lib/dotnet/zh-hant/System.Net.WebSockets.xml",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.WebSockets.dll",
@@ -2016,15 +2004,15 @@
         "ref/net46/System.Net.WebSockets.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.WebSockets.4.0.0-beta-23324.nupkg",
-        "System.Net.WebSockets.4.0.0-beta-23324.nupkg.sha512",
+        "System.Net.WebSockets.4.0.0-beta-23330.nupkg",
+        "System.Net.WebSockets.4.0.0-beta-23330.nupkg.sha512",
         "System.Net.WebSockets.nuspec"
       ]
     },
-    "System.Net.WebSockets.Client/4.0.0-beta-23324": {
+    "System.Net.WebSockets.Client/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "Zgnuyst8Kr37iY1z887R8R8VBFdKFqgHCmBTUIrBa8CUvGOvDocK/tM/b+VmseX0cEgUpodNB47gzGIVV0iM5g==",
+      "sha512": "1NWEqwDkYRyvr1gSKZlY51AaI9w8oD0dC5UNa2Lb+qaeFHSF5KfCSzf7seD+im+sH6uocVo2nppiaabfbXZT4Q==",
       "files": [
         "lib/DNXCore50/de/System.Net.WebSockets.Client.xml",
         "lib/DNXCore50/es/System.Net.WebSockets.Client.xml",
@@ -2040,6 +2028,17 @@
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.WebSockets.Client.dll",
+        "lib/netcore50/de/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/es/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/fr/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/it/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/ja/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/ko/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/ru/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/System.Net.WebSockets.Client.dll",
+        "lib/netcore50/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/zh-hans/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/zh-hant/System.Net.WebSockets.Client.xml",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
         "ref/dotnet/System.Net.WebSockets.Client.dll",
@@ -2048,8 +2047,8 @@
         "ref/net46/System.Net.WebSockets.Client.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.WebSockets.Client.4.0.0-beta-23324.nupkg",
-        "System.Net.WebSockets.Client.4.0.0-beta-23324.nupkg.sha512",
+        "System.Net.WebSockets.Client.4.0.0-beta-23330.nupkg",
+        "System.Net.WebSockets.Client.4.0.0-beta-23330.nupkg.sha512",
         "System.Net.WebSockets.Client.nuspec"
       ]
     },
@@ -2101,17 +2100,17 @@
         "System.Private.DataContractSerialization.nuspec"
       ]
     },
-    "System.Private.Networking/4.0.1-beta-23324": {
+    "System.Private.Networking/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "OfyxoeCdh1ypzdz1u0h1Clgt+6749vALs2ZPkLwsOPzL0INCG9ISYo+Jhh62ZD8TMkWwLrvyVppMBPHY6M7Upw==",
+      "sha512": "8NZi1gCQaGTKDb2yWplm52HWCLaZnUwVitksJgcXY2dEJau/TBGyZup+yhOngOIe8QzQMxNG4iokY3Ce0/8mbg==",
       "files": [
         "lib/DNXCore50/System.Private.Networking.dll",
         "lib/netcore50/System.Private.Networking.dll",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "System.Private.Networking.4.0.1-beta-23324.nupkg",
-        "System.Private.Networking.4.0.1-beta-23324.nupkg.sha512",
+        "System.Private.Networking.4.0.1-beta-23330.nupkg",
+        "System.Private.Networking.4.0.1-beta-23330.nupkg.sha512",
         "System.Private.Networking.nuspec"
       ]
     },
@@ -2640,10 +2639,10 @@
         "System.Security.Claims.nuspec"
       ]
     },
-    "System.Security.Cryptography.Algorithms/4.0.0-beta-23324": {
+    "System.Security.Cryptography.Algorithms/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "Mt6LwMj8hPp0+xZHcV6grZ7wSWhgycGkdZ6DQ9XvUY9NguUsvb/+fu2cMdrC7XsnpvwIROByp+p2dSjqBn3E2Q==",
+      "sha512": "FB4RoTDaV5tBiPSJsiG3A5DydeKz7ErglnkqVjBFjm6wu8kg91j0MxL/Al9iUyu9i/hq53fRs5KE3rjUNYvf5w==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2657,15 +2656,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.Algorithms.4.0.0-beta-23324.nupkg",
-        "System.Security.Cryptography.Algorithms.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Cryptography.Algorithms.4.0.0-beta-23330.nupkg",
+        "System.Security.Cryptography.Algorithms.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Cryptography.Algorithms.nuspec"
       ]
     },
-    "System.Security.Cryptography.Encoding/4.0.0-beta-23324": {
+    "System.Security.Cryptography.Encoding/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "JHOyknf1eYO6C39Vao6kAGpadq3PBO1L4tuzNEz/HvbH5sfIHPbjhxL11OyAhVKCzLCfEj6+aeClovFqZIRPyw==",
+      "sha512": "zeFdKQT6xjNdiNCaEmEYJMEK59kixkX7jJSoOLw3H+53t9X0F98vr3tS8YlrW/Lk/K9c6L5pYLlkb2dNqvUD/g==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2679,15 +2678,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.Encoding.4.0.0-beta-23324.nupkg",
-        "System.Security.Cryptography.Encoding.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Cryptography.Encoding.4.0.0-beta-23330.nupkg",
+        "System.Security.Cryptography.Encoding.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Cryptography.Encoding.nuspec"
       ]
     },
-    "System.Security.Cryptography.Primitives/4.0.0-beta-23324": {
+    "System.Security.Cryptography.Primitives/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "ETZxelIX51Di4FTytd8ohSpN6Ym/32aWIX9E2NCFkd91qdexn2Dkysn80b6n4gX6jG+oL0UHQDtD/fYq8C65oQ==",
+      "sha512": "15uVbOD3X0sRQJIxcEH5hasxlFdbA1CmPPZa0Y8pYEuQcWMF2gBswvU8s4qoKtA7x2xhNhzPsXIhsQuKNMTdEA==",
       "files": [
         "lib/dotnet/System.Security.Cryptography.Primitives.dll",
         "lib/MonoAndroid10/_._",
@@ -2701,15 +2700,15 @@
         "ref/net46/System.Security.Cryptography.Primitives.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Security.Cryptography.Primitives.4.0.0-beta-23324.nupkg",
-        "System.Security.Cryptography.Primitives.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Cryptography.Primitives.4.0.0-beta-23330.nupkg",
+        "System.Security.Cryptography.Primitives.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Cryptography.Primitives.nuspec"
       ]
     },
-    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23324": {
+    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "8NaEOxkkNBUECh0cPzGpbXS0uzGDpnvxI0kqQKRGp9uA+9qCyQfxcqAT6ozAYtOuFNVaC1XU3zQnb7T2nfvIDg==",
+      "sha512": "L8mUimdm7+GsORgJ8DFBMGsFnwDJ5YCUdJj3HfXQx4HCoPDPF+vJo3HRiHfcvNA2Zsf0ov2kuerYj/eeVa2/Rw==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2723,8 +2722,8 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23324.nupkg",
-        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23330.nupkg",
+        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Cryptography.X509Certificates.nuspec"
       ]
     },
@@ -2761,10 +2760,10 @@
         "System.Security.Principal.nuspec"
       ]
     },
-    "System.Security.Principal.Windows/4.0.0-beta-23324": {
+    "System.Security.Principal.Windows/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "csbCKdwBz31T8He7U6XMIc9BiWgwjHs5WDZR4rfhsk48TpdsbKNHX9OX4b+GwvgcsfVuWxre7zqNR0Bc9gWZ7g==",
+      "sha512": "q+3L3aB8bn0HCW52kX9TSJdhbjffBw7QWCOu0yX1SDhPN9MCPmJ4aBBCn1HRWroa5y7UcNUdjL1xwiERycZexw==",
       "files": [
         "lib/DNXCore50/de/System.Security.Principal.Windows.xml",
         "lib/DNXCore50/es/System.Security.Principal.Windows.xml",
@@ -2780,8 +2779,8 @@
         "lib/net46/System.Security.Principal.Windows.dll",
         "ref/dotnet/System.Security.Principal.Windows.dll",
         "ref/net46/System.Security.Principal.Windows.dll",
-        "System.Security.Principal.Windows.4.0.0-beta-23324.nupkg",
-        "System.Security.Principal.Windows.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Principal.Windows.4.0.0-beta-23330.nupkg",
+        "System.Security.Principal.Windows.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Principal.Windows.nuspec"
       ]
     },
@@ -2976,10 +2975,9 @@
         "System.Threading.Tasks.nuspec"
       ]
     },
-    "System.Threading.ThreadPool/4.0.10-beta-23324": {
+    "System.Threading.ThreadPool/4.0.10-beta-23330": {
       "type": "package",
-      "serviceable": true,
-      "sha512": "G4SjGmiV72HBiv8wkfnKFGTieekrACU1m43VaeJ6vDeSyb08eEFusVH1UWZpOsUF25meCuzpda0ezus24b4rKA==",
+      "sha512": "nM5OewUj8NJrye93apbM6KHvPddgPJGzt1IWIXk9lV5HB4NGsn6M5U0gxMQWShQuDp6NF3ya3ULRSvh3dLMbzg==",
       "files": [
         "lib/DNXCore50/System.Threading.ThreadPool.dll",
         "lib/MonoAndroid10/_._",
@@ -2993,8 +2991,8 @@
         "ref/net46/System.Threading.ThreadPool.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Threading.ThreadPool.4.0.10-beta-23324.nupkg",
-        "System.Threading.ThreadPool.4.0.10-beta-23324.nupkg.sha512",
+        "System.Threading.ThreadPool.4.0.10-beta-23330.nupkg",
+        "System.Threading.ThreadPool.4.0.10-beta-23330.nupkg.sha512",
         "System.Threading.ThreadPool.nuspec"
       ]
     },
@@ -3277,14 +3275,14 @@
         "xunit.extensibility.execution.nuspec"
       ]
     },
-    "xunit.netcore.extensions/1.0.0-prerelease-00095": {
+    "xunit.netcore.extensions/1.0.0-prerelease-00098": {
       "type": "package",
       "serviceable": true,
-      "sha512": "FuvWmkuxHiqD0cHDggg5MRmBoeM4Uea7OUEmKvZiQu7Fy02hJ6yKKNV7mNW3y4scwSzDNA81Qa+HIS33PeWUog==",
+      "sha512": "3kRPwTbC42YGmsNHpNMKfGVOO5cVfxUD+C7cYbti1aml4UCT/RFZ6lhm5Vym2wNRDxryu0Es78aMf1BaybSrDg==",
       "files": [
         "lib/dotnet/Xunit.NetCore.Extensions.dll",
-        "xunit.netcore.extensions.1.0.0-prerelease-00095.nupkg",
-        "xunit.netcore.extensions.1.0.0-prerelease-00095.nupkg.sha512",
+        "xunit.netcore.extensions.1.0.0-prerelease-00098.nupkg",
+        "xunit.netcore.extensions.1.0.0-prerelease-00098.nupkg.sha512",
         "xunit.netcore.extensions.nuspec"
       ]
     }

--- a/src/System.ServiceModel.Duplex/tests/project.lock.json
+++ b/src/System.ServiceModel.Duplex/tests/project.lock.json
@@ -1045,7 +1045,7 @@
           "lib/dotnet/xunit.execution.dotnet.dll": {}
         }
       },
-      "xunit.netcore.extensions/1.0.0-prerelease-00095": {
+      "xunit.netcore.extensions/1.0.0-prerelease-00098": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.10",
@@ -3022,14 +3022,14 @@
         "xunit.extensibility.execution.nuspec"
       ]
     },
-    "xunit.netcore.extensions/1.0.0-prerelease-00095": {
+    "xunit.netcore.extensions/1.0.0-prerelease-00098": {
       "type": "package",
       "serviceable": true,
-      "sha512": "FuvWmkuxHiqD0cHDggg5MRmBoeM4Uea7OUEmKvZiQu7Fy02hJ6yKKNV7mNW3y4scwSzDNA81Qa+HIS33PeWUog==",
+      "sha512": "3kRPwTbC42YGmsNHpNMKfGVOO5cVfxUD+C7cYbti1aml4UCT/RFZ6lhm5Vym2wNRDxryu0Es78aMf1BaybSrDg==",
       "files": [
         "lib/dotnet/Xunit.NetCore.Extensions.dll",
-        "xunit.netcore.extensions.1.0.0-prerelease-00095.nupkg",
-        "xunit.netcore.extensions.1.0.0-prerelease-00095.nupkg.sha512",
+        "xunit.netcore.extensions.1.0.0-prerelease-00098.nupkg",
+        "xunit.netcore.extensions.1.0.0-prerelease-00098.nupkg.sha512",
         "xunit.netcore.extensions.nuspec"
       ]
     }

--- a/src/System.ServiceModel.Http/tests/project.lock.json
+++ b/src/System.ServiceModel.Http/tests/project.lock.json
@@ -292,7 +292,7 @@
           "lib/dotnet/System.Linq.Queryable.dll": {}
         }
       },
-      "System.Net.Http/4.0.1-beta-23324": {
+      "System.Net.Http/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -305,16 +305,15 @@
           "ref/dotnet/System.Net.Http.dll": {}
         }
       },
-      "System.Net.NameResolution/4.0.0-beta-23324": {
+      "System.Net.NameResolution/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.Networking": "4.0.1-beta-23324"
+          "System.Net.Primitives": "4.0.10",
+          "System.Runtime": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Net.NameResolution.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Net.NameResolution.dll": {}
         }
       },
       "System.Net.Primitives/4.0.10": {
@@ -329,10 +328,10 @@
           "lib/DNXCore50/System.Net.Primitives.dll": {}
         }
       },
-      "System.Net.Security/4.0.0-beta-23324": {
+      "System.Net.Security/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.Networking": "4.0.1-beta-23324"
+          "System.Private.Networking": "4.0.1-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.Net.Security.dll": {}
@@ -367,6 +366,49 @@
         },
         "runtime": {
           "lib/dotnet/System.Net.WebHeaderCollection.dll": {}
+        }
+      },
+      "System.Net.WebSockets/4.0.0-beta-23330": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.Win32.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Threading.Tasks": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Net.WebSockets.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Net.WebSockets.dll": {}
+        }
+      },
+      "System.Net.WebSockets.Client/4.0.0-beta-23330": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.Win32.Primitives": "4.0.0",
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Diagnostics.Tracing": "4.0.20",
+          "System.Globalization": "4.0.10",
+          "System.Net.Primitives": "4.0.10",
+          "System.Net.WebHeaderCollection": "4.0.0",
+          "System.Net.WebSockets": "4.0.0-beta-23330",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23330",
+          "System.Text.Encoding": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Net.WebSockets.Client.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Net.WebSockets.Client.dll": {}
         }
       },
       "System.ObjectModel/4.0.10": {
@@ -414,7 +456,7 @@
           "lib/DNXCore50/System.Private.DataContractSerialization.dll": {}
         }
       },
-      "System.Private.Networking/4.0.1-beta-23324": {
+      "System.Private.Networking/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -433,13 +475,13 @@
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23324",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23324",
-          "System.Security.Principal.Windows": "4.0.0-beta-23324",
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23330",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23330",
+          "System.Security.Principal.Windows": "4.0.0-beta-23330",
           "System.Threading": "4.0.10",
           "System.Threading.Overlapped": "4.0.0",
           "System.Threading.Tasks": "4.0.10",
-          "System.Threading.ThreadPool": "4.0.10-beta-23324"
+          "System.Threading.ThreadPool": "4.0.10-beta-23330"
         },
         "compile": {
           "ref/dnxcore50/_._": {}
@@ -448,7 +490,7 @@
           "lib/DNXCore50/System.Private.Networking.dll": {}
         }
       },
-      "System.Private.ServiceModel/4.0.1-beta-23324": {
+      "System.Private.ServiceModel/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -465,12 +507,14 @@
           "System.Linq": "4.0.0",
           "System.Linq.Expressions": "4.0.10",
           "System.Linq.Queryable": "4.0.0",
-          "System.Net.Http": "4.0.1-beta-23324",
-          "System.Net.NameResolution": "4.0.0-beta-23324",
+          "System.Net.Http": "4.0.1-beta-23330",
+          "System.Net.NameResolution": "4.0.0-beta-23330",
           "System.Net.Primitives": "4.0.10",
-          "System.Net.Security": "4.0.0-beta-23324",
-          "System.Net.Sockets": "4.0.10-beta-23324",
+          "System.Net.Security": "4.0.0-beta-23330",
+          "System.Net.Sockets": "4.0.10-beta-23330",
           "System.Net.WebHeaderCollection": "4.0.0",
+          "System.Net.WebSockets": "4.0.0-beta-23330",
+          "System.Net.WebSockets.Client": "4.0.0-beta-23330",
           "System.ObjectModel": "4.0.10",
           "System.Reflection": "4.0.10",
           "System.Reflection.DispatchProxy": "4.0.0",
@@ -484,9 +528,9 @@
           "System.Runtime.Serialization.Primitives": "4.0.10",
           "System.Runtime.Serialization.Xml": "4.0.10",
           "System.Security.Claims": "4.0.0",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23324",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23330",
           "System.Security.Principal": "4.0.0",
-          "System.Security.Principal.Windows": "4.0.0-beta-23324",
+          "System.Security.Principal.Windows": "4.0.0-beta-23330",
           "System.Text.Encoding": "4.0.10",
           "System.Threading": "4.0.10",
           "System.Threading.Tasks": "4.0.10",
@@ -735,18 +779,18 @@
           "lib/dotnet/System.Security.Claims.dll": {}
         }
       },
-      "System.Security.Cryptography.Algorithms/4.0.0-beta-23324": {
+      "System.Security.Cryptography.Algorithms/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
           "System.Runtime": "4.0.0",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23324"
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.Algorithms.dll": {}
         }
       },
-      "System.Security.Cryptography.Encoding/4.0.0-beta-23324": {
+      "System.Security.Cryptography.Encoding/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -755,7 +799,7 @@
           "ref/dotnet/System.Security.Cryptography.Encoding.dll": {}
         }
       },
-      "System.Security.Cryptography.Primitives/4.0.0-beta-23324": {
+      "System.Security.Cryptography.Primitives/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.0",
@@ -773,13 +817,13 @@
           "lib/dotnet/System.Security.Cryptography.Primitives.dll": {}
         }
       },
-      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23324": {
+      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
           "System.Runtime.Handles": "4.0.0",
-          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23324",
-          "System.Security.Cryptography.Encoding": "4.0.0-beta-23324"
+          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23330",
+          "System.Security.Cryptography.Encoding": "4.0.0-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.X509Certificates.dll": {}
@@ -797,7 +841,7 @@
           "lib/dotnet/System.Security.Principal.dll": {}
         }
       },
-      "System.Security.Principal.Windows/4.0.0-beta-23324": {
+      "System.Security.Principal.Windows/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -820,10 +864,10 @@
           "lib/DNXCore50/System.Security.Principal.Windows.dll": {}
         }
       },
-      "System.ServiceModel.Http/4.0.11-beta-23324": {
+      "System.ServiceModel.Http/4.0.11-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.0.1-beta-23324",
+          "System.Private.ServiceModel": "4.0.1-beta-23330",
           "System.Runtime": "4.0.20"
         },
         "compile": {
@@ -833,10 +877,10 @@
           "lib/DNXCore50/System.ServiceModel.Http.dll": {}
         }
       },
-      "System.ServiceModel.Primitives/4.0.1-beta-23324": {
+      "System.ServiceModel.Primitives/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.0.1-beta-23324"
+          "System.Private.ServiceModel": "4.0.1-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.ServiceModel.Primitives.dll": {}
@@ -925,7 +969,7 @@
           "lib/DNXCore50/System.Threading.Tasks.dll": {}
         }
       },
-      "System.Threading.ThreadPool/4.0.10-beta-23324": {
+      "System.Threading.ThreadPool/4.0.10-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
@@ -1118,7 +1162,7 @@
           "lib/dotnet/xunit.execution.dotnet.dll": {}
         }
       },
-      "xunit.netcore.extensions/1.0.0-prerelease-00095": {
+      "xunit.netcore.extensions/1.0.0-prerelease-00098": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.10",
@@ -1746,23 +1790,12 @@
         "System.Linq.Queryable.nuspec"
       ]
     },
-    "System.Net.Http/4.0.1-beta-23324": {
+    "System.Net.Http/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "gXfHlWsiMQDuFqwnQrlQTje9vqMhCFLtm35jX4WqZjcfa3y69DbwueeT0gJbVMK88/UnG8FAYiDBb7AKyu+51w==",
+      "sha512": "itLPx7B7Ac4mX8wQx9V9DQcxqTgkmwDNnQIHuCgAH53Jq2X3XziiRRBbxbmNJlWqBlgPzbseWJmMCtcF/ePhOg==",
       "files": [
         "lib/net45/_._",
-        "lib/netcore50/de/System.Net.Http.xml",
-        "lib/netcore50/es/System.Net.Http.xml",
-        "lib/netcore50/fr/System.Net.Http.xml",
-        "lib/netcore50/it/System.Net.Http.xml",
-        "lib/netcore50/ja/System.Net.Http.xml",
-        "lib/netcore50/ko/System.Net.Http.xml",
-        "lib/netcore50/ru/System.Net.Http.xml",
-        "lib/netcore50/System.Net.Http.dll",
-        "lib/netcore50/System.Net.Http.xml",
-        "lib/netcore50/zh-hans/System.Net.Http.xml",
-        "lib/netcore50/zh-hant/System.Net.Http.xml",
         "lib/win8/_._",
         "lib/wpa81/_._",
         "ref/dotnet/System.Net.Http.dll",
@@ -1771,17 +1804,16 @@
         "ref/win8/_._",
         "ref/wpa81/_._",
         "runtime.json",
-        "System.Net.Http.4.0.1-beta-23324.nupkg",
-        "System.Net.Http.4.0.1-beta-23324.nupkg.sha512",
+        "System.Net.Http.4.0.1-beta-23330.nupkg",
+        "System.Net.Http.4.0.1-beta-23330.nupkg.sha512",
         "System.Net.Http.nuspec"
       ]
     },
-    "System.Net.NameResolution/4.0.0-beta-23324": {
+    "System.Net.NameResolution/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "lNYXUmnSXUtLFY09Rc27zJ6/TxCuGggQzBgiuWHoWrjWxymuuxqPT2Mj7Dn7sUUh0GvF2MOx7Uk+rtCFBiIavg==",
+      "sha512": "d8Am+In/aBgcHpEV6xsi5BCiTEN4y6s9O1V/yIvwX8mDC4CtdZiGsi4DtoB0TLOgp8ky6GxbSF4bKCjFpBO3uw==",
       "files": [
-        "lib/DNXCore50/System.Net.NameResolution.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.NameResolution.dll",
@@ -1793,8 +1825,9 @@
         "ref/net46/System.Net.NameResolution.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.NameResolution.4.0.0-beta-23324.nupkg",
-        "System.Net.NameResolution.4.0.0-beta-23324.nupkg.sha512",
+        "runtime.json",
+        "System.Net.NameResolution.4.0.0-beta-23330.nupkg",
+        "System.Net.NameResolution.4.0.0-beta-23330.nupkg.sha512",
         "System.Net.NameResolution.nuspec"
       ]
     },
@@ -1831,9 +1864,9 @@
         "System.Net.Primitives.nuspec"
       ]
     },
-    "System.Net.Security/4.0.0-beta-23324": {
+    "System.Net.Security/4.0.0-beta-23330": {
       "type": "package",
-      "sha512": "D04RYjxrnR3D+uI9CGmAAFKKQ6T+pPcRHYucc1PIo7/hJK5I/Yu7gAw9yOxHUhQjSGfrKo00lHpBCQMTQt4lSw==",
+      "sha512": "z98dKloNy9DBdyfqQwQvKWA2q8Qj4vgGEVONnlS70c13eh0MolBHJ0wNdplZZK5zYZ5Eu8GTwexbUlpHbsfzVA==",
       "files": [
         "lib/DNXCore50/System.Net.Security.dll",
         "lib/MonoAndroid10/_._",
@@ -1847,8 +1880,8 @@
         "ref/net46/System.Net.Security.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.Security.4.0.0-beta-23324.nupkg",
-        "System.Net.Security.4.0.0-beta-23324.nupkg.sha512",
+        "System.Net.Security.4.0.0-beta-23330.nupkg",
+        "System.Net.Security.4.0.0-beta-23330.nupkg.sha512",
         "System.Net.Security.nuspec"
       ]
     },
@@ -1906,6 +1939,81 @@
         "System.Net.WebHeaderCollection.nuspec"
       ]
     },
+    "System.Net.WebSockets/4.0.0-beta-23330": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "6Q9/uTDcaqbmdbD04MisKmjti4aEpp40i/UzpGaPZ4ItuwzU/pMk9RjiYUBUiCQyZeKNlXcSB1FPN2nFof7tww==",
+      "files": [
+        "lib/dotnet/de/System.Net.WebSockets.xml",
+        "lib/dotnet/es/System.Net.WebSockets.xml",
+        "lib/dotnet/fr/System.Net.WebSockets.xml",
+        "lib/dotnet/it/System.Net.WebSockets.xml",
+        "lib/dotnet/ja/System.Net.WebSockets.xml",
+        "lib/dotnet/ko/System.Net.WebSockets.xml",
+        "lib/dotnet/ru/System.Net.WebSockets.xml",
+        "lib/dotnet/System.Net.WebSockets.dll",
+        "lib/dotnet/System.Net.WebSockets.xml",
+        "lib/dotnet/zh-hans/System.Net.WebSockets.xml",
+        "lib/dotnet/zh-hant/System.Net.WebSockets.xml",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Net.WebSockets.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Net.WebSockets.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Net.WebSockets.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Net.WebSockets.4.0.0-beta-23330.nupkg",
+        "System.Net.WebSockets.4.0.0-beta-23330.nupkg.sha512",
+        "System.Net.WebSockets.nuspec"
+      ]
+    },
+    "System.Net.WebSockets.Client/4.0.0-beta-23330": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "1NWEqwDkYRyvr1gSKZlY51AaI9w8oD0dC5UNa2Lb+qaeFHSF5KfCSzf7seD+im+sH6uocVo2nppiaabfbXZT4Q==",
+      "files": [
+        "lib/DNXCore50/de/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/es/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/fr/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/it/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/ja/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/ko/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/ru/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/System.Net.WebSockets.Client.dll",
+        "lib/DNXCore50/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/zh-hans/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/zh-hant/System.Net.WebSockets.Client.xml",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Net.WebSockets.Client.dll",
+        "lib/netcore50/de/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/es/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/fr/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/it/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/ja/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/ko/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/ru/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/System.Net.WebSockets.Client.dll",
+        "lib/netcore50/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/zh-hans/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/zh-hant/System.Net.WebSockets.Client.xml",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Net.WebSockets.Client.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Net.WebSockets.Client.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Net.WebSockets.Client.4.0.0-beta-23330.nupkg",
+        "System.Net.WebSockets.Client.4.0.0-beta-23330.nupkg.sha512",
+        "System.Net.WebSockets.Client.nuspec"
+      ]
+    },
     "System.ObjectModel/4.0.10": {
       "type": "package",
       "serviceable": true,
@@ -1954,31 +2062,31 @@
         "System.Private.DataContractSerialization.nuspec"
       ]
     },
-    "System.Private.Networking/4.0.1-beta-23324": {
+    "System.Private.Networking/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "OfyxoeCdh1ypzdz1u0h1Clgt+6749vALs2ZPkLwsOPzL0INCG9ISYo+Jhh62ZD8TMkWwLrvyVppMBPHY6M7Upw==",
+      "sha512": "8NZi1gCQaGTKDb2yWplm52HWCLaZnUwVitksJgcXY2dEJau/TBGyZup+yhOngOIe8QzQMxNG4iokY3Ce0/8mbg==",
       "files": [
         "lib/DNXCore50/System.Private.Networking.dll",
         "lib/netcore50/System.Private.Networking.dll",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "System.Private.Networking.4.0.1-beta-23324.nupkg",
-        "System.Private.Networking.4.0.1-beta-23324.nupkg.sha512",
+        "System.Private.Networking.4.0.1-beta-23330.nupkg",
+        "System.Private.Networking.4.0.1-beta-23330.nupkg.sha512",
         "System.Private.Networking.nuspec"
       ]
     },
-    "System.Private.ServiceModel/4.0.1-beta-23324": {
+    "System.Private.ServiceModel/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "Lz3T9V8GnaOFlf8LUmuPznuOIuy92BAFVc9huiMrFKByzPpydGuCvXEe+81rZ1IF2TQcHKO++9otnj96AEJ5BA==",
+      "sha512": "8lENvmHuZdlvmnYN1w98Mv8bDjc0O/YlaNHRRph35T/fLDyaG8LMLMwG3/ut6a/AenLJmbf92snOtNXCuqM+cQ==",
       "files": [
         "lib/DNXCore50/System.Private.ServiceModel.dll",
         "lib/netcore50/System.Private.ServiceModel.dll",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "System.Private.ServiceModel.4.0.1-beta-23324.nupkg",
-        "System.Private.ServiceModel.4.0.1-beta-23324.nupkg.sha512",
+        "System.Private.ServiceModel.4.0.1-beta-23330.nupkg",
+        "System.Private.ServiceModel.4.0.1-beta-23330.nupkg.sha512",
         "System.Private.ServiceModel.nuspec"
       ]
     },
@@ -2507,10 +2615,10 @@
         "System.Security.Claims.nuspec"
       ]
     },
-    "System.Security.Cryptography.Algorithms/4.0.0-beta-23324": {
+    "System.Security.Cryptography.Algorithms/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "Mt6LwMj8hPp0+xZHcV6grZ7wSWhgycGkdZ6DQ9XvUY9NguUsvb/+fu2cMdrC7XsnpvwIROByp+p2dSjqBn3E2Q==",
+      "sha512": "FB4RoTDaV5tBiPSJsiG3A5DydeKz7ErglnkqVjBFjm6wu8kg91j0MxL/Al9iUyu9i/hq53fRs5KE3rjUNYvf5w==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2524,15 +2632,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.Algorithms.4.0.0-beta-23324.nupkg",
-        "System.Security.Cryptography.Algorithms.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Cryptography.Algorithms.4.0.0-beta-23330.nupkg",
+        "System.Security.Cryptography.Algorithms.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Cryptography.Algorithms.nuspec"
       ]
     },
-    "System.Security.Cryptography.Encoding/4.0.0-beta-23324": {
+    "System.Security.Cryptography.Encoding/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "JHOyknf1eYO6C39Vao6kAGpadq3PBO1L4tuzNEz/HvbH5sfIHPbjhxL11OyAhVKCzLCfEj6+aeClovFqZIRPyw==",
+      "sha512": "zeFdKQT6xjNdiNCaEmEYJMEK59kixkX7jJSoOLw3H+53t9X0F98vr3tS8YlrW/Lk/K9c6L5pYLlkb2dNqvUD/g==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2546,15 +2654,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.Encoding.4.0.0-beta-23324.nupkg",
-        "System.Security.Cryptography.Encoding.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Cryptography.Encoding.4.0.0-beta-23330.nupkg",
+        "System.Security.Cryptography.Encoding.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Cryptography.Encoding.nuspec"
       ]
     },
-    "System.Security.Cryptography.Primitives/4.0.0-beta-23324": {
+    "System.Security.Cryptography.Primitives/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "ETZxelIX51Di4FTytd8ohSpN6Ym/32aWIX9E2NCFkd91qdexn2Dkysn80b6n4gX6jG+oL0UHQDtD/fYq8C65oQ==",
+      "sha512": "15uVbOD3X0sRQJIxcEH5hasxlFdbA1CmPPZa0Y8pYEuQcWMF2gBswvU8s4qoKtA7x2xhNhzPsXIhsQuKNMTdEA==",
       "files": [
         "lib/dotnet/System.Security.Cryptography.Primitives.dll",
         "lib/MonoAndroid10/_._",
@@ -2568,15 +2676,15 @@
         "ref/net46/System.Security.Cryptography.Primitives.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Security.Cryptography.Primitives.4.0.0-beta-23324.nupkg",
-        "System.Security.Cryptography.Primitives.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Cryptography.Primitives.4.0.0-beta-23330.nupkg",
+        "System.Security.Cryptography.Primitives.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Cryptography.Primitives.nuspec"
       ]
     },
-    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23324": {
+    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "8NaEOxkkNBUECh0cPzGpbXS0uzGDpnvxI0kqQKRGp9uA+9qCyQfxcqAT6ozAYtOuFNVaC1XU3zQnb7T2nfvIDg==",
+      "sha512": "L8mUimdm7+GsORgJ8DFBMGsFnwDJ5YCUdJj3HfXQx4HCoPDPF+vJo3HRiHfcvNA2Zsf0ov2kuerYj/eeVa2/Rw==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2590,8 +2698,8 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23324.nupkg",
-        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23330.nupkg",
+        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Cryptography.X509Certificates.nuspec"
       ]
     },
@@ -2628,10 +2736,10 @@
         "System.Security.Principal.nuspec"
       ]
     },
-    "System.Security.Principal.Windows/4.0.0-beta-23324": {
+    "System.Security.Principal.Windows/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "csbCKdwBz31T8He7U6XMIc9BiWgwjHs5WDZR4rfhsk48TpdsbKNHX9OX4b+GwvgcsfVuWxre7zqNR0Bc9gWZ7g==",
+      "sha512": "q+3L3aB8bn0HCW52kX9TSJdhbjffBw7QWCOu0yX1SDhPN9MCPmJ4aBBCn1HRWroa5y7UcNUdjL1xwiERycZexw==",
       "files": [
         "lib/DNXCore50/de/System.Security.Principal.Windows.xml",
         "lib/DNXCore50/es/System.Security.Principal.Windows.xml",
@@ -2647,15 +2755,15 @@
         "lib/net46/System.Security.Principal.Windows.dll",
         "ref/dotnet/System.Security.Principal.Windows.dll",
         "ref/net46/System.Security.Principal.Windows.dll",
-        "System.Security.Principal.Windows.4.0.0-beta-23324.nupkg",
-        "System.Security.Principal.Windows.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Principal.Windows.4.0.0-beta-23330.nupkg",
+        "System.Security.Principal.Windows.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Principal.Windows.nuspec"
       ]
     },
-    "System.ServiceModel.Http/4.0.11-beta-23324": {
+    "System.ServiceModel.Http/4.0.11-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "VkTumuCSmXd0NPZZU+nrO7YqznvM+wP96NykXbxFJdNAtCplmqXaQh+YZ/02rjJmfou5qyo2V+ZWVwySBAirOg==",
+      "sha512": "NHKxIIYL0ATDbX18RLCSXtuq26MMoYfAVdpl5K+D0s5AHp7TMPb7LcjZPpg25B2v48x1TwE9LYcYTCiOZcoPzQ==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Http.dll",
         "lib/MonoAndroid10/_._",
@@ -2680,15 +2788,15 @@
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.ServiceModel.Http.4.0.11-beta-23324.nupkg",
-        "System.ServiceModel.Http.4.0.11-beta-23324.nupkg.sha512",
+        "System.ServiceModel.Http.4.0.11-beta-23330.nupkg",
+        "System.ServiceModel.Http.4.0.11-beta-23330.nupkg.sha512",
         "System.ServiceModel.Http.nuspec"
       ]
     },
-    "System.ServiceModel.Primitives/4.0.1-beta-23324": {
+    "System.ServiceModel.Primitives/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "bmU31B4CD5+m9Kt0iDM5Yw2ZXRfv7lpK3Sx1HektcT/HERc+IMPdO38f/Wxtofo5WOA0qmd1fdrMeQcbEkDfJg==",
+      "sha512": "kJ/pcRUf7Ow7s/rX8Kmc9P2k6cvyudIzyUcqr/pn9NwY8DC/2DWkkFvYE2udR4kvBzJJzXl/rsJQlyLIVGMAww==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Primitives.dll",
         "lib/net45/_._",
@@ -2708,8 +2816,8 @@
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.Primitives.dll",
         "ref/win8/_._",
-        "System.ServiceModel.Primitives.4.0.1-beta-23324.nupkg",
-        "System.ServiceModel.Primitives.4.0.1-beta-23324.nupkg.sha512",
+        "System.ServiceModel.Primitives.4.0.1-beta-23330.nupkg",
+        "System.ServiceModel.Primitives.4.0.1-beta-23330.nupkg.sha512",
         "System.ServiceModel.Primitives.nuspec"
       ]
     },
@@ -2904,10 +3012,9 @@
         "System.Threading.Tasks.nuspec"
       ]
     },
-    "System.Threading.ThreadPool/4.0.10-beta-23324": {
+    "System.Threading.ThreadPool/4.0.10-beta-23330": {
       "type": "package",
-      "serviceable": true,
-      "sha512": "G4SjGmiV72HBiv8wkfnKFGTieekrACU1m43VaeJ6vDeSyb08eEFusVH1UWZpOsUF25meCuzpda0ezus24b4rKA==",
+      "sha512": "nM5OewUj8NJrye93apbM6KHvPddgPJGzt1IWIXk9lV5HB4NGsn6M5U0gxMQWShQuDp6NF3ya3ULRSvh3dLMbzg==",
       "files": [
         "lib/DNXCore50/System.Threading.ThreadPool.dll",
         "lib/MonoAndroid10/_._",
@@ -2921,8 +3028,8 @@
         "ref/net46/System.Threading.ThreadPool.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Threading.ThreadPool.4.0.10-beta-23324.nupkg",
-        "System.Threading.ThreadPool.4.0.10-beta-23324.nupkg.sha512",
+        "System.Threading.ThreadPool.4.0.10-beta-23330.nupkg",
+        "System.Threading.ThreadPool.4.0.10-beta-23330.nupkg.sha512",
         "System.Threading.ThreadPool.nuspec"
       ]
     },
@@ -3173,14 +3280,14 @@
         "xunit.extensibility.execution.nuspec"
       ]
     },
-    "xunit.netcore.extensions/1.0.0-prerelease-00095": {
+    "xunit.netcore.extensions/1.0.0-prerelease-00098": {
       "type": "package",
       "serviceable": true,
-      "sha512": "FuvWmkuxHiqD0cHDggg5MRmBoeM4Uea7OUEmKvZiQu7Fy02hJ6yKKNV7mNW3y4scwSzDNA81Qa+HIS33PeWUog==",
+      "sha512": "3kRPwTbC42YGmsNHpNMKfGVOO5cVfxUD+C7cYbti1aml4UCT/RFZ6lhm5Vym2wNRDxryu0Es78aMf1BaybSrDg==",
       "files": [
         "lib/dotnet/Xunit.NetCore.Extensions.dll",
-        "xunit.netcore.extensions.1.0.0-prerelease-00095.nupkg",
-        "xunit.netcore.extensions.1.0.0-prerelease-00095.nupkg.sha512",
+        "xunit.netcore.extensions.1.0.0-prerelease-00098.nupkg",
+        "xunit.netcore.extensions.1.0.0-prerelease-00098.nupkg.sha512",
         "xunit.netcore.extensions.nuspec"
       ]
     }

--- a/src/System.ServiceModel.NetTcp/tests/project.lock.json
+++ b/src/System.ServiceModel.NetTcp/tests/project.lock.json
@@ -292,7 +292,7 @@
           "lib/dotnet/System.Linq.Queryable.dll": {}
         }
       },
-      "System.Net.Http/4.0.1-beta-23324": {
+      "System.Net.Http/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -305,16 +305,15 @@
           "ref/dotnet/System.Net.Http.dll": {}
         }
       },
-      "System.Net.NameResolution/4.0.0-beta-23324": {
+      "System.Net.NameResolution/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.Networking": "4.0.1-beta-23324"
+          "System.Net.Primitives": "4.0.10",
+          "System.Runtime": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Net.NameResolution.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Net.NameResolution.dll": {}
         }
       },
       "System.Net.Primitives/4.0.10": {
@@ -329,10 +328,10 @@
           "lib/DNXCore50/System.Net.Primitives.dll": {}
         }
       },
-      "System.Net.Security/4.0.0-beta-23324": {
+      "System.Net.Security/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.Networking": "4.0.1-beta-23324"
+          "System.Private.Networking": "4.0.1-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.Net.Security.dll": {}
@@ -367,6 +366,49 @@
         },
         "runtime": {
           "lib/dotnet/System.Net.WebHeaderCollection.dll": {}
+        }
+      },
+      "System.Net.WebSockets/4.0.0-beta-23330": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.Win32.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Threading.Tasks": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Net.WebSockets.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Net.WebSockets.dll": {}
+        }
+      },
+      "System.Net.WebSockets.Client/4.0.0-beta-23330": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.Win32.Primitives": "4.0.0",
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Diagnostics.Tracing": "4.0.20",
+          "System.Globalization": "4.0.10",
+          "System.Net.Primitives": "4.0.10",
+          "System.Net.WebHeaderCollection": "4.0.0",
+          "System.Net.WebSockets": "4.0.0-beta-23330",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23330",
+          "System.Text.Encoding": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Net.WebSockets.Client.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Net.WebSockets.Client.dll": {}
         }
       },
       "System.ObjectModel/4.0.10": {
@@ -414,7 +456,7 @@
           "lib/DNXCore50/System.Private.DataContractSerialization.dll": {}
         }
       },
-      "System.Private.Networking/4.0.1-beta-23324": {
+      "System.Private.Networking/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -433,13 +475,13 @@
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23324",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23324",
-          "System.Security.Principal.Windows": "4.0.0-beta-23324",
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23330",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23330",
+          "System.Security.Principal.Windows": "4.0.0-beta-23330",
           "System.Threading": "4.0.10",
           "System.Threading.Overlapped": "4.0.0",
           "System.Threading.Tasks": "4.0.10",
-          "System.Threading.ThreadPool": "4.0.10-beta-23324"
+          "System.Threading.ThreadPool": "4.0.10-beta-23330"
         },
         "compile": {
           "ref/dnxcore50/_._": {}
@@ -448,7 +490,7 @@
           "lib/DNXCore50/System.Private.Networking.dll": {}
         }
       },
-      "System.Private.ServiceModel/4.0.1-beta-23324": {
+      "System.Private.ServiceModel/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -465,12 +507,14 @@
           "System.Linq": "4.0.0",
           "System.Linq.Expressions": "4.0.10",
           "System.Linq.Queryable": "4.0.0",
-          "System.Net.Http": "4.0.1-beta-23324",
-          "System.Net.NameResolution": "4.0.0-beta-23324",
+          "System.Net.Http": "4.0.1-beta-23330",
+          "System.Net.NameResolution": "4.0.0-beta-23330",
           "System.Net.Primitives": "4.0.10",
-          "System.Net.Security": "4.0.0-beta-23324",
-          "System.Net.Sockets": "4.0.10-beta-23324",
+          "System.Net.Security": "4.0.0-beta-23330",
+          "System.Net.Sockets": "4.0.10-beta-23330",
           "System.Net.WebHeaderCollection": "4.0.0",
+          "System.Net.WebSockets": "4.0.0-beta-23330",
+          "System.Net.WebSockets.Client": "4.0.0-beta-23330",
           "System.ObjectModel": "4.0.10",
           "System.Reflection": "4.0.10",
           "System.Reflection.DispatchProxy": "4.0.0",
@@ -484,9 +528,9 @@
           "System.Runtime.Serialization.Primitives": "4.0.10",
           "System.Runtime.Serialization.Xml": "4.0.10",
           "System.Security.Claims": "4.0.0",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23324",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23330",
           "System.Security.Principal": "4.0.0",
-          "System.Security.Principal.Windows": "4.0.0-beta-23324",
+          "System.Security.Principal.Windows": "4.0.0-beta-23330",
           "System.Text.Encoding": "4.0.10",
           "System.Threading": "4.0.10",
           "System.Threading.Tasks": "4.0.10",
@@ -735,18 +779,18 @@
           "lib/dotnet/System.Security.Claims.dll": {}
         }
       },
-      "System.Security.Cryptography.Algorithms/4.0.0-beta-23324": {
+      "System.Security.Cryptography.Algorithms/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
           "System.Runtime": "4.0.0",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23324"
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.Algorithms.dll": {}
         }
       },
-      "System.Security.Cryptography.Encoding/4.0.0-beta-23324": {
+      "System.Security.Cryptography.Encoding/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -755,7 +799,7 @@
           "ref/dotnet/System.Security.Cryptography.Encoding.dll": {}
         }
       },
-      "System.Security.Cryptography.Primitives/4.0.0-beta-23324": {
+      "System.Security.Cryptography.Primitives/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.0",
@@ -773,13 +817,13 @@
           "lib/dotnet/System.Security.Cryptography.Primitives.dll": {}
         }
       },
-      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23324": {
+      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
           "System.Runtime.Handles": "4.0.0",
-          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23324",
-          "System.Security.Cryptography.Encoding": "4.0.0-beta-23324"
+          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23330",
+          "System.Security.Cryptography.Encoding": "4.0.0-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.X509Certificates.dll": {}
@@ -797,7 +841,7 @@
           "lib/dotnet/System.Security.Principal.dll": {}
         }
       },
-      "System.Security.Principal.Windows/4.0.0-beta-23324": {
+      "System.Security.Principal.Windows/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -820,10 +864,10 @@
           "lib/DNXCore50/System.Security.Principal.Windows.dll": {}
         }
       },
-      "System.ServiceModel.NetTcp/4.0.1-beta-23324": {
+      "System.ServiceModel.NetTcp/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.0.1-beta-23324"
+          "System.Private.ServiceModel": "4.0.1-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.ServiceModel.NetTcp.dll": {}
@@ -832,10 +876,10 @@
           "lib/DNXCore50/System.ServiceModel.NetTcp.dll": {}
         }
       },
-      "System.ServiceModel.Primitives/4.0.1-beta-23324": {
+      "System.ServiceModel.Primitives/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.0.1-beta-23324"
+          "System.Private.ServiceModel": "4.0.1-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.ServiceModel.Primitives.dll": {}
@@ -924,7 +968,7 @@
           "lib/DNXCore50/System.Threading.Tasks.dll": {}
         }
       },
-      "System.Threading.ThreadPool/4.0.10-beta-23324": {
+      "System.Threading.ThreadPool/4.0.10-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
@@ -1117,7 +1161,7 @@
           "lib/dotnet/xunit.execution.dotnet.dll": {}
         }
       },
-      "xunit.netcore.extensions/1.0.0-prerelease-00095": {
+      "xunit.netcore.extensions/1.0.0-prerelease-00098": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.10",
@@ -1745,23 +1789,12 @@
         "System.Linq.Queryable.nuspec"
       ]
     },
-    "System.Net.Http/4.0.1-beta-23324": {
+    "System.Net.Http/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "gXfHlWsiMQDuFqwnQrlQTje9vqMhCFLtm35jX4WqZjcfa3y69DbwueeT0gJbVMK88/UnG8FAYiDBb7AKyu+51w==",
+      "sha512": "itLPx7B7Ac4mX8wQx9V9DQcxqTgkmwDNnQIHuCgAH53Jq2X3XziiRRBbxbmNJlWqBlgPzbseWJmMCtcF/ePhOg==",
       "files": [
         "lib/net45/_._",
-        "lib/netcore50/de/System.Net.Http.xml",
-        "lib/netcore50/es/System.Net.Http.xml",
-        "lib/netcore50/fr/System.Net.Http.xml",
-        "lib/netcore50/it/System.Net.Http.xml",
-        "lib/netcore50/ja/System.Net.Http.xml",
-        "lib/netcore50/ko/System.Net.Http.xml",
-        "lib/netcore50/ru/System.Net.Http.xml",
-        "lib/netcore50/System.Net.Http.dll",
-        "lib/netcore50/System.Net.Http.xml",
-        "lib/netcore50/zh-hans/System.Net.Http.xml",
-        "lib/netcore50/zh-hant/System.Net.Http.xml",
         "lib/win8/_._",
         "lib/wpa81/_._",
         "ref/dotnet/System.Net.Http.dll",
@@ -1770,17 +1803,16 @@
         "ref/win8/_._",
         "ref/wpa81/_._",
         "runtime.json",
-        "System.Net.Http.4.0.1-beta-23324.nupkg",
-        "System.Net.Http.4.0.1-beta-23324.nupkg.sha512",
+        "System.Net.Http.4.0.1-beta-23330.nupkg",
+        "System.Net.Http.4.0.1-beta-23330.nupkg.sha512",
         "System.Net.Http.nuspec"
       ]
     },
-    "System.Net.NameResolution/4.0.0-beta-23324": {
+    "System.Net.NameResolution/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "lNYXUmnSXUtLFY09Rc27zJ6/TxCuGggQzBgiuWHoWrjWxymuuxqPT2Mj7Dn7sUUh0GvF2MOx7Uk+rtCFBiIavg==",
+      "sha512": "d8Am+In/aBgcHpEV6xsi5BCiTEN4y6s9O1V/yIvwX8mDC4CtdZiGsi4DtoB0TLOgp8ky6GxbSF4bKCjFpBO3uw==",
       "files": [
-        "lib/DNXCore50/System.Net.NameResolution.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.NameResolution.dll",
@@ -1792,8 +1824,9 @@
         "ref/net46/System.Net.NameResolution.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.NameResolution.4.0.0-beta-23324.nupkg",
-        "System.Net.NameResolution.4.0.0-beta-23324.nupkg.sha512",
+        "runtime.json",
+        "System.Net.NameResolution.4.0.0-beta-23330.nupkg",
+        "System.Net.NameResolution.4.0.0-beta-23330.nupkg.sha512",
         "System.Net.NameResolution.nuspec"
       ]
     },
@@ -1830,9 +1863,9 @@
         "System.Net.Primitives.nuspec"
       ]
     },
-    "System.Net.Security/4.0.0-beta-23324": {
+    "System.Net.Security/4.0.0-beta-23330": {
       "type": "package",
-      "sha512": "D04RYjxrnR3D+uI9CGmAAFKKQ6T+pPcRHYucc1PIo7/hJK5I/Yu7gAw9yOxHUhQjSGfrKo00lHpBCQMTQt4lSw==",
+      "sha512": "z98dKloNy9DBdyfqQwQvKWA2q8Qj4vgGEVONnlS70c13eh0MolBHJ0wNdplZZK5zYZ5Eu8GTwexbUlpHbsfzVA==",
       "files": [
         "lib/DNXCore50/System.Net.Security.dll",
         "lib/MonoAndroid10/_._",
@@ -1846,8 +1879,8 @@
         "ref/net46/System.Net.Security.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.Security.4.0.0-beta-23324.nupkg",
-        "System.Net.Security.4.0.0-beta-23324.nupkg.sha512",
+        "System.Net.Security.4.0.0-beta-23330.nupkg",
+        "System.Net.Security.4.0.0-beta-23330.nupkg.sha512",
         "System.Net.Security.nuspec"
       ]
     },
@@ -1905,6 +1938,81 @@
         "System.Net.WebHeaderCollection.nuspec"
       ]
     },
+    "System.Net.WebSockets/4.0.0-beta-23330": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "6Q9/uTDcaqbmdbD04MisKmjti4aEpp40i/UzpGaPZ4ItuwzU/pMk9RjiYUBUiCQyZeKNlXcSB1FPN2nFof7tww==",
+      "files": [
+        "lib/dotnet/de/System.Net.WebSockets.xml",
+        "lib/dotnet/es/System.Net.WebSockets.xml",
+        "lib/dotnet/fr/System.Net.WebSockets.xml",
+        "lib/dotnet/it/System.Net.WebSockets.xml",
+        "lib/dotnet/ja/System.Net.WebSockets.xml",
+        "lib/dotnet/ko/System.Net.WebSockets.xml",
+        "lib/dotnet/ru/System.Net.WebSockets.xml",
+        "lib/dotnet/System.Net.WebSockets.dll",
+        "lib/dotnet/System.Net.WebSockets.xml",
+        "lib/dotnet/zh-hans/System.Net.WebSockets.xml",
+        "lib/dotnet/zh-hant/System.Net.WebSockets.xml",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Net.WebSockets.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Net.WebSockets.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Net.WebSockets.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Net.WebSockets.4.0.0-beta-23330.nupkg",
+        "System.Net.WebSockets.4.0.0-beta-23330.nupkg.sha512",
+        "System.Net.WebSockets.nuspec"
+      ]
+    },
+    "System.Net.WebSockets.Client/4.0.0-beta-23330": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "1NWEqwDkYRyvr1gSKZlY51AaI9w8oD0dC5UNa2Lb+qaeFHSF5KfCSzf7seD+im+sH6uocVo2nppiaabfbXZT4Q==",
+      "files": [
+        "lib/DNXCore50/de/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/es/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/fr/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/it/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/ja/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/ko/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/ru/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/System.Net.WebSockets.Client.dll",
+        "lib/DNXCore50/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/zh-hans/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/zh-hant/System.Net.WebSockets.Client.xml",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Net.WebSockets.Client.dll",
+        "lib/netcore50/de/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/es/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/fr/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/it/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/ja/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/ko/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/ru/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/System.Net.WebSockets.Client.dll",
+        "lib/netcore50/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/zh-hans/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/zh-hant/System.Net.WebSockets.Client.xml",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Net.WebSockets.Client.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Net.WebSockets.Client.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Net.WebSockets.Client.4.0.0-beta-23330.nupkg",
+        "System.Net.WebSockets.Client.4.0.0-beta-23330.nupkg.sha512",
+        "System.Net.WebSockets.Client.nuspec"
+      ]
+    },
     "System.ObjectModel/4.0.10": {
       "type": "package",
       "serviceable": true,
@@ -1953,31 +2061,31 @@
         "System.Private.DataContractSerialization.nuspec"
       ]
     },
-    "System.Private.Networking/4.0.1-beta-23324": {
+    "System.Private.Networking/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "OfyxoeCdh1ypzdz1u0h1Clgt+6749vALs2ZPkLwsOPzL0INCG9ISYo+Jhh62ZD8TMkWwLrvyVppMBPHY6M7Upw==",
+      "sha512": "8NZi1gCQaGTKDb2yWplm52HWCLaZnUwVitksJgcXY2dEJau/TBGyZup+yhOngOIe8QzQMxNG4iokY3Ce0/8mbg==",
       "files": [
         "lib/DNXCore50/System.Private.Networking.dll",
         "lib/netcore50/System.Private.Networking.dll",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "System.Private.Networking.4.0.1-beta-23324.nupkg",
-        "System.Private.Networking.4.0.1-beta-23324.nupkg.sha512",
+        "System.Private.Networking.4.0.1-beta-23330.nupkg",
+        "System.Private.Networking.4.0.1-beta-23330.nupkg.sha512",
         "System.Private.Networking.nuspec"
       ]
     },
-    "System.Private.ServiceModel/4.0.1-beta-23324": {
+    "System.Private.ServiceModel/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "Lz3T9V8GnaOFlf8LUmuPznuOIuy92BAFVc9huiMrFKByzPpydGuCvXEe+81rZ1IF2TQcHKO++9otnj96AEJ5BA==",
+      "sha512": "8lENvmHuZdlvmnYN1w98Mv8bDjc0O/YlaNHRRph35T/fLDyaG8LMLMwG3/ut6a/AenLJmbf92snOtNXCuqM+cQ==",
       "files": [
         "lib/DNXCore50/System.Private.ServiceModel.dll",
         "lib/netcore50/System.Private.ServiceModel.dll",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "System.Private.ServiceModel.4.0.1-beta-23324.nupkg",
-        "System.Private.ServiceModel.4.0.1-beta-23324.nupkg.sha512",
+        "System.Private.ServiceModel.4.0.1-beta-23330.nupkg",
+        "System.Private.ServiceModel.4.0.1-beta-23330.nupkg.sha512",
         "System.Private.ServiceModel.nuspec"
       ]
     },
@@ -2506,10 +2614,10 @@
         "System.Security.Claims.nuspec"
       ]
     },
-    "System.Security.Cryptography.Algorithms/4.0.0-beta-23324": {
+    "System.Security.Cryptography.Algorithms/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "Mt6LwMj8hPp0+xZHcV6grZ7wSWhgycGkdZ6DQ9XvUY9NguUsvb/+fu2cMdrC7XsnpvwIROByp+p2dSjqBn3E2Q==",
+      "sha512": "FB4RoTDaV5tBiPSJsiG3A5DydeKz7ErglnkqVjBFjm6wu8kg91j0MxL/Al9iUyu9i/hq53fRs5KE3rjUNYvf5w==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2523,15 +2631,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.Algorithms.4.0.0-beta-23324.nupkg",
-        "System.Security.Cryptography.Algorithms.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Cryptography.Algorithms.4.0.0-beta-23330.nupkg",
+        "System.Security.Cryptography.Algorithms.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Cryptography.Algorithms.nuspec"
       ]
     },
-    "System.Security.Cryptography.Encoding/4.0.0-beta-23324": {
+    "System.Security.Cryptography.Encoding/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "JHOyknf1eYO6C39Vao6kAGpadq3PBO1L4tuzNEz/HvbH5sfIHPbjhxL11OyAhVKCzLCfEj6+aeClovFqZIRPyw==",
+      "sha512": "zeFdKQT6xjNdiNCaEmEYJMEK59kixkX7jJSoOLw3H+53t9X0F98vr3tS8YlrW/Lk/K9c6L5pYLlkb2dNqvUD/g==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2545,15 +2653,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.Encoding.4.0.0-beta-23324.nupkg",
-        "System.Security.Cryptography.Encoding.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Cryptography.Encoding.4.0.0-beta-23330.nupkg",
+        "System.Security.Cryptography.Encoding.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Cryptography.Encoding.nuspec"
       ]
     },
-    "System.Security.Cryptography.Primitives/4.0.0-beta-23324": {
+    "System.Security.Cryptography.Primitives/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "ETZxelIX51Di4FTytd8ohSpN6Ym/32aWIX9E2NCFkd91qdexn2Dkysn80b6n4gX6jG+oL0UHQDtD/fYq8C65oQ==",
+      "sha512": "15uVbOD3X0sRQJIxcEH5hasxlFdbA1CmPPZa0Y8pYEuQcWMF2gBswvU8s4qoKtA7x2xhNhzPsXIhsQuKNMTdEA==",
       "files": [
         "lib/dotnet/System.Security.Cryptography.Primitives.dll",
         "lib/MonoAndroid10/_._",
@@ -2567,15 +2675,15 @@
         "ref/net46/System.Security.Cryptography.Primitives.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Security.Cryptography.Primitives.4.0.0-beta-23324.nupkg",
-        "System.Security.Cryptography.Primitives.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Cryptography.Primitives.4.0.0-beta-23330.nupkg",
+        "System.Security.Cryptography.Primitives.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Cryptography.Primitives.nuspec"
       ]
     },
-    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23324": {
+    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "8NaEOxkkNBUECh0cPzGpbXS0uzGDpnvxI0kqQKRGp9uA+9qCyQfxcqAT6ozAYtOuFNVaC1XU3zQnb7T2nfvIDg==",
+      "sha512": "L8mUimdm7+GsORgJ8DFBMGsFnwDJ5YCUdJj3HfXQx4HCoPDPF+vJo3HRiHfcvNA2Zsf0ov2kuerYj/eeVa2/Rw==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2589,8 +2697,8 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23324.nupkg",
-        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23330.nupkg",
+        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Cryptography.X509Certificates.nuspec"
       ]
     },
@@ -2627,10 +2735,10 @@
         "System.Security.Principal.nuspec"
       ]
     },
-    "System.Security.Principal.Windows/4.0.0-beta-23324": {
+    "System.Security.Principal.Windows/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "csbCKdwBz31T8He7U6XMIc9BiWgwjHs5WDZR4rfhsk48TpdsbKNHX9OX4b+GwvgcsfVuWxre7zqNR0Bc9gWZ7g==",
+      "sha512": "q+3L3aB8bn0HCW52kX9TSJdhbjffBw7QWCOu0yX1SDhPN9MCPmJ4aBBCn1HRWroa5y7UcNUdjL1xwiERycZexw==",
       "files": [
         "lib/DNXCore50/de/System.Security.Principal.Windows.xml",
         "lib/DNXCore50/es/System.Security.Principal.Windows.xml",
@@ -2646,15 +2754,15 @@
         "lib/net46/System.Security.Principal.Windows.dll",
         "ref/dotnet/System.Security.Principal.Windows.dll",
         "ref/net46/System.Security.Principal.Windows.dll",
-        "System.Security.Principal.Windows.4.0.0-beta-23324.nupkg",
-        "System.Security.Principal.Windows.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Principal.Windows.4.0.0-beta-23330.nupkg",
+        "System.Security.Principal.Windows.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Principal.Windows.nuspec"
       ]
     },
-    "System.ServiceModel.NetTcp/4.0.1-beta-23324": {
+    "System.ServiceModel.NetTcp/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "xI03xQCdWzqq4H2E29BELQm/e9LJl+IAbD50lcH966Z+JdaYOqeM6RGxAys0sVim59wvCrOv/YaRNxz66YLoog==",
+      "sha512": "Vx0QSKz4BlX/yYqKHET3mofo6RxxaMDLWsEFWDbEBJeCs0Yq19uGiIYwK1mXkWy3Y+jDwi42au3mVhmRbDHavA==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.NetTcp.dll",
         "lib/net45/_._",
@@ -2674,15 +2782,15 @@
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.NetTcp.dll",
         "ref/win8/_._",
-        "System.ServiceModel.NetTcp.4.0.1-beta-23324.nupkg",
-        "System.ServiceModel.NetTcp.4.0.1-beta-23324.nupkg.sha512",
+        "System.ServiceModel.NetTcp.4.0.1-beta-23330.nupkg",
+        "System.ServiceModel.NetTcp.4.0.1-beta-23330.nupkg.sha512",
         "System.ServiceModel.NetTcp.nuspec"
       ]
     },
-    "System.ServiceModel.Primitives/4.0.1-beta-23324": {
+    "System.ServiceModel.Primitives/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "bmU31B4CD5+m9Kt0iDM5Yw2ZXRfv7lpK3Sx1HektcT/HERc+IMPdO38f/Wxtofo5WOA0qmd1fdrMeQcbEkDfJg==",
+      "sha512": "kJ/pcRUf7Ow7s/rX8Kmc9P2k6cvyudIzyUcqr/pn9NwY8DC/2DWkkFvYE2udR4kvBzJJzXl/rsJQlyLIVGMAww==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Primitives.dll",
         "lib/net45/_._",
@@ -2702,8 +2810,8 @@
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.Primitives.dll",
         "ref/win8/_._",
-        "System.ServiceModel.Primitives.4.0.1-beta-23324.nupkg",
-        "System.ServiceModel.Primitives.4.0.1-beta-23324.nupkg.sha512",
+        "System.ServiceModel.Primitives.4.0.1-beta-23330.nupkg",
+        "System.ServiceModel.Primitives.4.0.1-beta-23330.nupkg.sha512",
         "System.ServiceModel.Primitives.nuspec"
       ]
     },
@@ -2898,10 +3006,9 @@
         "System.Threading.Tasks.nuspec"
       ]
     },
-    "System.Threading.ThreadPool/4.0.10-beta-23324": {
+    "System.Threading.ThreadPool/4.0.10-beta-23330": {
       "type": "package",
-      "serviceable": true,
-      "sha512": "G4SjGmiV72HBiv8wkfnKFGTieekrACU1m43VaeJ6vDeSyb08eEFusVH1UWZpOsUF25meCuzpda0ezus24b4rKA==",
+      "sha512": "nM5OewUj8NJrye93apbM6KHvPddgPJGzt1IWIXk9lV5HB4NGsn6M5U0gxMQWShQuDp6NF3ya3ULRSvh3dLMbzg==",
       "files": [
         "lib/DNXCore50/System.Threading.ThreadPool.dll",
         "lib/MonoAndroid10/_._",
@@ -2915,8 +3022,8 @@
         "ref/net46/System.Threading.ThreadPool.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Threading.ThreadPool.4.0.10-beta-23324.nupkg",
-        "System.Threading.ThreadPool.4.0.10-beta-23324.nupkg.sha512",
+        "System.Threading.ThreadPool.4.0.10-beta-23330.nupkg",
+        "System.Threading.ThreadPool.4.0.10-beta-23330.nupkg.sha512",
         "System.Threading.ThreadPool.nuspec"
       ]
     },
@@ -3167,14 +3274,14 @@
         "xunit.extensibility.execution.nuspec"
       ]
     },
-    "xunit.netcore.extensions/1.0.0-prerelease-00095": {
+    "xunit.netcore.extensions/1.0.0-prerelease-00098": {
       "type": "package",
       "serviceable": true,
-      "sha512": "FuvWmkuxHiqD0cHDggg5MRmBoeM4Uea7OUEmKvZiQu7Fy02hJ6yKKNV7mNW3y4scwSzDNA81Qa+HIS33PeWUog==",
+      "sha512": "3kRPwTbC42YGmsNHpNMKfGVOO5cVfxUD+C7cYbti1aml4UCT/RFZ6lhm5Vym2wNRDxryu0Es78aMf1BaybSrDg==",
       "files": [
         "lib/dotnet/Xunit.NetCore.Extensions.dll",
-        "xunit.netcore.extensions.1.0.0-prerelease-00095.nupkg",
-        "xunit.netcore.extensions.1.0.0-prerelease-00095.nupkg.sha512",
+        "xunit.netcore.extensions.1.0.0-prerelease-00098.nupkg",
+        "xunit.netcore.extensions.1.0.0-prerelease-00098.nupkg.sha512",
         "xunit.netcore.extensions.nuspec"
       ]
     }

--- a/src/System.ServiceModel.Primitives/tests/project.lock.json
+++ b/src/System.ServiceModel.Primitives/tests/project.lock.json
@@ -383,7 +383,7 @@
           "lib/dotnet/System.Net.WebHeaderCollection.dll": {}
         }
       },
-      "System.Net.WebSockets/4.0.0-beta-23324": {
+      "System.Net.WebSockets/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -395,10 +395,10 @@
           "ref/dotnet/System.Net.WebSockets.dll": {}
         },
         "runtime": {
-          "lib/DNXCore50/System.Net.WebSockets.dll": {}
+          "lib/dotnet/System.Net.WebSockets.dll": {}
         }
       },
-      "System.Net.WebSockets.Client/4.0.0-beta-23324": {
+      "System.Net.WebSockets.Client/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -408,13 +408,13 @@
           "System.Globalization": "4.0.10",
           "System.Net.Primitives": "4.0.10",
           "System.Net.WebHeaderCollection": "4.0.0",
-          "System.Net.WebSockets": "4.0.0-beta-23324",
+          "System.Net.WebSockets": "4.0.0-beta-23330",
           "System.Resources.ResourceManager": "4.0.0",
           "System.Runtime": "4.0.20",
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23324",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23330",
           "System.Text.Encoding": "4.0.10",
           "System.Threading": "4.0.10",
           "System.Threading.Tasks": "4.0.10"
@@ -786,18 +786,18 @@
           "lib/dotnet/System.Security.Claims.dll": {}
         }
       },
-      "System.Security.Cryptography.Algorithms/4.0.0-beta-23324": {
+      "System.Security.Cryptography.Algorithms/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
           "System.Runtime": "4.0.0",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23324"
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.Algorithms.dll": {}
         }
       },
-      "System.Security.Cryptography.Encoding/4.0.0-beta-23324": {
+      "System.Security.Cryptography.Encoding/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -806,7 +806,7 @@
           "ref/dotnet/System.Security.Cryptography.Encoding.dll": {}
         }
       },
-      "System.Security.Cryptography.Primitives/4.0.0-beta-23324": {
+      "System.Security.Cryptography.Primitives/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.0",
@@ -824,13 +824,13 @@
           "lib/dotnet/System.Security.Cryptography.Primitives.dll": {}
         }
       },
-      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23324": {
+      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
           "System.Runtime.Handles": "4.0.0",
-          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23324",
-          "System.Security.Cryptography.Encoding": "4.0.0-beta-23324"
+          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23330",
+          "System.Security.Cryptography.Encoding": "4.0.0-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.X509Certificates.dll": {}
@@ -1190,7 +1190,7 @@
           "lib/dotnet/xunit.execution.dotnet.dll": {}
         }
       },
-      "xunit.netcore.extensions/1.0.0-prerelease-00095": {
+      "xunit.netcore.extensions/1.0.0-prerelease-00098": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.10",
@@ -2005,22 +2005,22 @@
         "System.Net.WebHeaderCollection.nuspec"
       ]
     },
-    "System.Net.WebSockets/4.0.0-beta-23324": {
+    "System.Net.WebSockets/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "Yq5jsxarl7rhHGtPx1vpW3a2iUF+4eD6FE5u2IRlBs8YEvoGVN2jzhBtPJw40t1SGidXLCvlsVaB3qyNbk99MQ==",
+      "sha512": "6Q9/uTDcaqbmdbD04MisKmjti4aEpp40i/UzpGaPZ4ItuwzU/pMk9RjiYUBUiCQyZeKNlXcSB1FPN2nFof7tww==",
       "files": [
-        "lib/DNXCore50/de/System.Net.WebSockets.xml",
-        "lib/DNXCore50/es/System.Net.WebSockets.xml",
-        "lib/DNXCore50/fr/System.Net.WebSockets.xml",
-        "lib/DNXCore50/it/System.Net.WebSockets.xml",
-        "lib/DNXCore50/ja/System.Net.WebSockets.xml",
-        "lib/DNXCore50/ko/System.Net.WebSockets.xml",
-        "lib/DNXCore50/ru/System.Net.WebSockets.xml",
-        "lib/DNXCore50/System.Net.WebSockets.dll",
-        "lib/DNXCore50/System.Net.WebSockets.xml",
-        "lib/DNXCore50/zh-hans/System.Net.WebSockets.xml",
-        "lib/DNXCore50/zh-hant/System.Net.WebSockets.xml",
+        "lib/dotnet/de/System.Net.WebSockets.xml",
+        "lib/dotnet/es/System.Net.WebSockets.xml",
+        "lib/dotnet/fr/System.Net.WebSockets.xml",
+        "lib/dotnet/it/System.Net.WebSockets.xml",
+        "lib/dotnet/ja/System.Net.WebSockets.xml",
+        "lib/dotnet/ko/System.Net.WebSockets.xml",
+        "lib/dotnet/ru/System.Net.WebSockets.xml",
+        "lib/dotnet/System.Net.WebSockets.dll",
+        "lib/dotnet/System.Net.WebSockets.xml",
+        "lib/dotnet/zh-hans/System.Net.WebSockets.xml",
+        "lib/dotnet/zh-hant/System.Net.WebSockets.xml",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.WebSockets.dll",
@@ -2032,15 +2032,15 @@
         "ref/net46/System.Net.WebSockets.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.WebSockets.4.0.0-beta-23324.nupkg",
-        "System.Net.WebSockets.4.0.0-beta-23324.nupkg.sha512",
+        "System.Net.WebSockets.4.0.0-beta-23330.nupkg",
+        "System.Net.WebSockets.4.0.0-beta-23330.nupkg.sha512",
         "System.Net.WebSockets.nuspec"
       ]
     },
-    "System.Net.WebSockets.Client/4.0.0-beta-23324": {
+    "System.Net.WebSockets.Client/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "Zgnuyst8Kr37iY1z887R8R8VBFdKFqgHCmBTUIrBa8CUvGOvDocK/tM/b+VmseX0cEgUpodNB47gzGIVV0iM5g==",
+      "sha512": "1NWEqwDkYRyvr1gSKZlY51AaI9w8oD0dC5UNa2Lb+qaeFHSF5KfCSzf7seD+im+sH6uocVo2nppiaabfbXZT4Q==",
       "files": [
         "lib/DNXCore50/de/System.Net.WebSockets.Client.xml",
         "lib/DNXCore50/es/System.Net.WebSockets.Client.xml",
@@ -2056,6 +2056,17 @@
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.WebSockets.Client.dll",
+        "lib/netcore50/de/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/es/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/fr/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/it/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/ja/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/ko/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/ru/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/System.Net.WebSockets.Client.dll",
+        "lib/netcore50/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/zh-hans/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/zh-hant/System.Net.WebSockets.Client.xml",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
         "ref/dotnet/System.Net.WebSockets.Client.dll",
@@ -2064,8 +2075,8 @@
         "ref/net46/System.Net.WebSockets.Client.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.WebSockets.Client.4.0.0-beta-23324.nupkg",
-        "System.Net.WebSockets.Client.4.0.0-beta-23324.nupkg.sha512",
+        "System.Net.WebSockets.Client.4.0.0-beta-23330.nupkg",
+        "System.Net.WebSockets.Client.4.0.0-beta-23330.nupkg.sha512",
         "System.Net.WebSockets.Client.nuspec"
       ]
     },
@@ -2670,10 +2681,10 @@
         "System.Security.Claims.nuspec"
       ]
     },
-    "System.Security.Cryptography.Algorithms/4.0.0-beta-23324": {
+    "System.Security.Cryptography.Algorithms/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "Mt6LwMj8hPp0+xZHcV6grZ7wSWhgycGkdZ6DQ9XvUY9NguUsvb/+fu2cMdrC7XsnpvwIROByp+p2dSjqBn3E2Q==",
+      "sha512": "FB4RoTDaV5tBiPSJsiG3A5DydeKz7ErglnkqVjBFjm6wu8kg91j0MxL/Al9iUyu9i/hq53fRs5KE3rjUNYvf5w==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2687,15 +2698,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.Algorithms.4.0.0-beta-23324.nupkg",
-        "System.Security.Cryptography.Algorithms.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Cryptography.Algorithms.4.0.0-beta-23330.nupkg",
+        "System.Security.Cryptography.Algorithms.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Cryptography.Algorithms.nuspec"
       ]
     },
-    "System.Security.Cryptography.Encoding/4.0.0-beta-23324": {
+    "System.Security.Cryptography.Encoding/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "JHOyknf1eYO6C39Vao6kAGpadq3PBO1L4tuzNEz/HvbH5sfIHPbjhxL11OyAhVKCzLCfEj6+aeClovFqZIRPyw==",
+      "sha512": "zeFdKQT6xjNdiNCaEmEYJMEK59kixkX7jJSoOLw3H+53t9X0F98vr3tS8YlrW/Lk/K9c6L5pYLlkb2dNqvUD/g==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2709,15 +2720,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.Encoding.4.0.0-beta-23324.nupkg",
-        "System.Security.Cryptography.Encoding.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Cryptography.Encoding.4.0.0-beta-23330.nupkg",
+        "System.Security.Cryptography.Encoding.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Cryptography.Encoding.nuspec"
       ]
     },
-    "System.Security.Cryptography.Primitives/4.0.0-beta-23324": {
+    "System.Security.Cryptography.Primitives/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "ETZxelIX51Di4FTytd8ohSpN6Ym/32aWIX9E2NCFkd91qdexn2Dkysn80b6n4gX6jG+oL0UHQDtD/fYq8C65oQ==",
+      "sha512": "15uVbOD3X0sRQJIxcEH5hasxlFdbA1CmPPZa0Y8pYEuQcWMF2gBswvU8s4qoKtA7x2xhNhzPsXIhsQuKNMTdEA==",
       "files": [
         "lib/dotnet/System.Security.Cryptography.Primitives.dll",
         "lib/MonoAndroid10/_._",
@@ -2731,15 +2742,15 @@
         "ref/net46/System.Security.Cryptography.Primitives.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Security.Cryptography.Primitives.4.0.0-beta-23324.nupkg",
-        "System.Security.Cryptography.Primitives.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Cryptography.Primitives.4.0.0-beta-23330.nupkg",
+        "System.Security.Cryptography.Primitives.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Cryptography.Primitives.nuspec"
       ]
     },
-    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23324": {
+    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "8NaEOxkkNBUECh0cPzGpbXS0uzGDpnvxI0kqQKRGp9uA+9qCyQfxcqAT6ozAYtOuFNVaC1XU3zQnb7T2nfvIDg==",
+      "sha512": "L8mUimdm7+GsORgJ8DFBMGsFnwDJ5YCUdJj3HfXQx4HCoPDPF+vJo3HRiHfcvNA2Zsf0ov2kuerYj/eeVa2/Rw==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2753,8 +2764,8 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23324.nupkg",
-        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23330.nupkg",
+        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Cryptography.X509Certificates.nuspec"
       ]
     },
@@ -3402,14 +3413,14 @@
         "xunit.extensibility.execution.nuspec"
       ]
     },
-    "xunit.netcore.extensions/1.0.0-prerelease-00095": {
+    "xunit.netcore.extensions/1.0.0-prerelease-00098": {
       "type": "package",
       "serviceable": true,
-      "sha512": "FuvWmkuxHiqD0cHDggg5MRmBoeM4Uea7OUEmKvZiQu7Fy02hJ6yKKNV7mNW3y4scwSzDNA81Qa+HIS33PeWUog==",
+      "sha512": "3kRPwTbC42YGmsNHpNMKfGVOO5cVfxUD+C7cYbti1aml4UCT/RFZ6lhm5Vym2wNRDxryu0Es78aMf1BaybSrDg==",
       "files": [
         "lib/dotnet/Xunit.NetCore.Extensions.dll",
-        "xunit.netcore.extensions.1.0.0-prerelease-00095.nupkg",
-        "xunit.netcore.extensions.1.0.0-prerelease-00095.nupkg.sha512",
+        "xunit.netcore.extensions.1.0.0-prerelease-00098.nupkg",
+        "xunit.netcore.extensions.1.0.0-prerelease-00098.nupkg.sha512",
         "xunit.netcore.extensions.nuspec"
       ]
     }

--- a/src/System.ServiceModel.Security/tests/project.lock.json
+++ b/src/System.ServiceModel.Security/tests/project.lock.json
@@ -292,7 +292,7 @@
           "lib/dotnet/System.Linq.Queryable.dll": {}
         }
       },
-      "System.Net.Http/4.0.1-beta-23324": {
+      "System.Net.Http/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -305,16 +305,15 @@
           "ref/dotnet/System.Net.Http.dll": {}
         }
       },
-      "System.Net.NameResolution/4.0.0-beta-23324": {
+      "System.Net.NameResolution/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.Networking": "4.0.1-beta-23324"
+          "System.Net.Primitives": "4.0.10",
+          "System.Runtime": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Net.NameResolution.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Net.NameResolution.dll": {}
         }
       },
       "System.Net.Primitives/4.0.10": {
@@ -329,10 +328,10 @@
           "lib/DNXCore50/System.Net.Primitives.dll": {}
         }
       },
-      "System.Net.Security/4.0.0-beta-23324": {
+      "System.Net.Security/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.Networking": "4.0.1-beta-23324"
+          "System.Private.Networking": "4.0.1-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.Net.Security.dll": {}
@@ -367,6 +366,49 @@
         },
         "runtime": {
           "lib/dotnet/System.Net.WebHeaderCollection.dll": {}
+        }
+      },
+      "System.Net.WebSockets/4.0.0-beta-23330": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.Win32.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Threading.Tasks": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Net.WebSockets.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Net.WebSockets.dll": {}
+        }
+      },
+      "System.Net.WebSockets.Client/4.0.0-beta-23330": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.Win32.Primitives": "4.0.0",
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Diagnostics.Tracing": "4.0.20",
+          "System.Globalization": "4.0.10",
+          "System.Net.Primitives": "4.0.10",
+          "System.Net.WebHeaderCollection": "4.0.0",
+          "System.Net.WebSockets": "4.0.0-beta-23330",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23330",
+          "System.Text.Encoding": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Net.WebSockets.Client.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Net.WebSockets.Client.dll": {}
         }
       },
       "System.ObjectModel/4.0.10": {
@@ -414,7 +456,7 @@
           "lib/DNXCore50/System.Private.DataContractSerialization.dll": {}
         }
       },
-      "System.Private.Networking/4.0.1-beta-23324": {
+      "System.Private.Networking/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -433,13 +475,13 @@
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23324",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23324",
-          "System.Security.Principal.Windows": "4.0.0-beta-23324",
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23330",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23330",
+          "System.Security.Principal.Windows": "4.0.0-beta-23330",
           "System.Threading": "4.0.10",
           "System.Threading.Overlapped": "4.0.0",
           "System.Threading.Tasks": "4.0.10",
-          "System.Threading.ThreadPool": "4.0.10-beta-23324"
+          "System.Threading.ThreadPool": "4.0.10-beta-23330"
         },
         "compile": {
           "ref/dnxcore50/_._": {}
@@ -448,7 +490,7 @@
           "lib/DNXCore50/System.Private.Networking.dll": {}
         }
       },
-      "System.Private.ServiceModel/4.0.1-beta-23324": {
+      "System.Private.ServiceModel/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -465,12 +507,14 @@
           "System.Linq": "4.0.0",
           "System.Linq.Expressions": "4.0.10",
           "System.Linq.Queryable": "4.0.0",
-          "System.Net.Http": "4.0.1-beta-23324",
-          "System.Net.NameResolution": "4.0.0-beta-23324",
+          "System.Net.Http": "4.0.1-beta-23330",
+          "System.Net.NameResolution": "4.0.0-beta-23330",
           "System.Net.Primitives": "4.0.10",
-          "System.Net.Security": "4.0.0-beta-23324",
-          "System.Net.Sockets": "4.0.10-beta-23324",
+          "System.Net.Security": "4.0.0-beta-23330",
+          "System.Net.Sockets": "4.0.10-beta-23330",
           "System.Net.WebHeaderCollection": "4.0.0",
+          "System.Net.WebSockets": "4.0.0-beta-23330",
+          "System.Net.WebSockets.Client": "4.0.0-beta-23330",
           "System.ObjectModel": "4.0.10",
           "System.Reflection": "4.0.10",
           "System.Reflection.DispatchProxy": "4.0.0",
@@ -484,9 +528,9 @@
           "System.Runtime.Serialization.Primitives": "4.0.10",
           "System.Runtime.Serialization.Xml": "4.0.10",
           "System.Security.Claims": "4.0.0",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23324",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23330",
           "System.Security.Principal": "4.0.0",
-          "System.Security.Principal.Windows": "4.0.0-beta-23324",
+          "System.Security.Principal.Windows": "4.0.0-beta-23330",
           "System.Text.Encoding": "4.0.10",
           "System.Threading": "4.0.10",
           "System.Threading.Tasks": "4.0.10",
@@ -735,18 +779,18 @@
           "lib/dotnet/System.Security.Claims.dll": {}
         }
       },
-      "System.Security.Cryptography.Algorithms/4.0.0-beta-23324": {
+      "System.Security.Cryptography.Algorithms/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
           "System.Runtime": "4.0.0",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23324"
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.Algorithms.dll": {}
         }
       },
-      "System.Security.Cryptography.Encoding/4.0.0-beta-23324": {
+      "System.Security.Cryptography.Encoding/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -755,7 +799,7 @@
           "ref/dotnet/System.Security.Cryptography.Encoding.dll": {}
         }
       },
-      "System.Security.Cryptography.Primitives/4.0.0-beta-23324": {
+      "System.Security.Cryptography.Primitives/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.0",
@@ -773,13 +817,13 @@
           "lib/dotnet/System.Security.Cryptography.Primitives.dll": {}
         }
       },
-      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23324": {
+      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
           "System.Runtime.Handles": "4.0.0",
-          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23324",
-          "System.Security.Cryptography.Encoding": "4.0.0-beta-23324"
+          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23330",
+          "System.Security.Cryptography.Encoding": "4.0.0-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.X509Certificates.dll": {}
@@ -797,7 +841,7 @@
           "lib/dotnet/System.Security.Principal.dll": {}
         }
       },
-      "System.Security.Principal.Windows/4.0.0-beta-23324": {
+      "System.Security.Principal.Windows/4.0.0-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -820,10 +864,10 @@
           "lib/DNXCore50/System.Security.Principal.Windows.dll": {}
         }
       },
-      "System.ServiceModel.Http/4.0.11-beta-23324": {
+      "System.ServiceModel.Http/4.0.11-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.0.1-beta-23324",
+          "System.Private.ServiceModel": "4.0.1-beta-23330",
           "System.Runtime": "4.0.20"
         },
         "compile": {
@@ -833,10 +877,10 @@
           "lib/DNXCore50/System.ServiceModel.Http.dll": {}
         }
       },
-      "System.ServiceModel.Primitives/4.0.1-beta-23324": {
+      "System.ServiceModel.Primitives/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.0.1-beta-23324"
+          "System.Private.ServiceModel": "4.0.1-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.ServiceModel.Primitives.dll": {}
@@ -845,10 +889,10 @@
           "lib/DNXCore50/System.ServiceModel.Primitives.dll": {}
         }
       },
-      "System.ServiceModel.Security/4.0.1-beta-23324": {
+      "System.ServiceModel.Security/4.0.1-beta-23330": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.0.1-beta-23324"
+          "System.Private.ServiceModel": "4.0.1-beta-23330"
         },
         "compile": {
           "ref/dotnet/System.ServiceModel.Security.dll": {}
@@ -937,7 +981,7 @@
           "lib/DNXCore50/System.Threading.Tasks.dll": {}
         }
       },
-      "System.Threading.ThreadPool/4.0.10-beta-23324": {
+      "System.Threading.ThreadPool/4.0.10-beta-23330": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
@@ -1130,7 +1174,7 @@
           "lib/dotnet/xunit.execution.dotnet.dll": {}
         }
       },
-      "xunit.netcore.extensions/1.0.0-prerelease-00095": {
+      "xunit.netcore.extensions/1.0.0-prerelease-00098": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.10",
@@ -1758,23 +1802,12 @@
         "System.Linq.Queryable.nuspec"
       ]
     },
-    "System.Net.Http/4.0.1-beta-23324": {
+    "System.Net.Http/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "gXfHlWsiMQDuFqwnQrlQTje9vqMhCFLtm35jX4WqZjcfa3y69DbwueeT0gJbVMK88/UnG8FAYiDBb7AKyu+51w==",
+      "sha512": "itLPx7B7Ac4mX8wQx9V9DQcxqTgkmwDNnQIHuCgAH53Jq2X3XziiRRBbxbmNJlWqBlgPzbseWJmMCtcF/ePhOg==",
       "files": [
         "lib/net45/_._",
-        "lib/netcore50/de/System.Net.Http.xml",
-        "lib/netcore50/es/System.Net.Http.xml",
-        "lib/netcore50/fr/System.Net.Http.xml",
-        "lib/netcore50/it/System.Net.Http.xml",
-        "lib/netcore50/ja/System.Net.Http.xml",
-        "lib/netcore50/ko/System.Net.Http.xml",
-        "lib/netcore50/ru/System.Net.Http.xml",
-        "lib/netcore50/System.Net.Http.dll",
-        "lib/netcore50/System.Net.Http.xml",
-        "lib/netcore50/zh-hans/System.Net.Http.xml",
-        "lib/netcore50/zh-hant/System.Net.Http.xml",
         "lib/win8/_._",
         "lib/wpa81/_._",
         "ref/dotnet/System.Net.Http.dll",
@@ -1783,17 +1816,16 @@
         "ref/win8/_._",
         "ref/wpa81/_._",
         "runtime.json",
-        "System.Net.Http.4.0.1-beta-23324.nupkg",
-        "System.Net.Http.4.0.1-beta-23324.nupkg.sha512",
+        "System.Net.Http.4.0.1-beta-23330.nupkg",
+        "System.Net.Http.4.0.1-beta-23330.nupkg.sha512",
         "System.Net.Http.nuspec"
       ]
     },
-    "System.Net.NameResolution/4.0.0-beta-23324": {
+    "System.Net.NameResolution/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "lNYXUmnSXUtLFY09Rc27zJ6/TxCuGggQzBgiuWHoWrjWxymuuxqPT2Mj7Dn7sUUh0GvF2MOx7Uk+rtCFBiIavg==",
+      "sha512": "d8Am+In/aBgcHpEV6xsi5BCiTEN4y6s9O1V/yIvwX8mDC4CtdZiGsi4DtoB0TLOgp8ky6GxbSF4bKCjFpBO3uw==",
       "files": [
-        "lib/DNXCore50/System.Net.NameResolution.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.NameResolution.dll",
@@ -1805,8 +1837,9 @@
         "ref/net46/System.Net.NameResolution.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.NameResolution.4.0.0-beta-23324.nupkg",
-        "System.Net.NameResolution.4.0.0-beta-23324.nupkg.sha512",
+        "runtime.json",
+        "System.Net.NameResolution.4.0.0-beta-23330.nupkg",
+        "System.Net.NameResolution.4.0.0-beta-23330.nupkg.sha512",
         "System.Net.NameResolution.nuspec"
       ]
     },
@@ -1843,9 +1876,9 @@
         "System.Net.Primitives.nuspec"
       ]
     },
-    "System.Net.Security/4.0.0-beta-23324": {
+    "System.Net.Security/4.0.0-beta-23330": {
       "type": "package",
-      "sha512": "D04RYjxrnR3D+uI9CGmAAFKKQ6T+pPcRHYucc1PIo7/hJK5I/Yu7gAw9yOxHUhQjSGfrKo00lHpBCQMTQt4lSw==",
+      "sha512": "z98dKloNy9DBdyfqQwQvKWA2q8Qj4vgGEVONnlS70c13eh0MolBHJ0wNdplZZK5zYZ5Eu8GTwexbUlpHbsfzVA==",
       "files": [
         "lib/DNXCore50/System.Net.Security.dll",
         "lib/MonoAndroid10/_._",
@@ -1859,8 +1892,8 @@
         "ref/net46/System.Net.Security.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.Security.4.0.0-beta-23324.nupkg",
-        "System.Net.Security.4.0.0-beta-23324.nupkg.sha512",
+        "System.Net.Security.4.0.0-beta-23330.nupkg",
+        "System.Net.Security.4.0.0-beta-23330.nupkg.sha512",
         "System.Net.Security.nuspec"
       ]
     },
@@ -1918,6 +1951,81 @@
         "System.Net.WebHeaderCollection.nuspec"
       ]
     },
+    "System.Net.WebSockets/4.0.0-beta-23330": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "6Q9/uTDcaqbmdbD04MisKmjti4aEpp40i/UzpGaPZ4ItuwzU/pMk9RjiYUBUiCQyZeKNlXcSB1FPN2nFof7tww==",
+      "files": [
+        "lib/dotnet/de/System.Net.WebSockets.xml",
+        "lib/dotnet/es/System.Net.WebSockets.xml",
+        "lib/dotnet/fr/System.Net.WebSockets.xml",
+        "lib/dotnet/it/System.Net.WebSockets.xml",
+        "lib/dotnet/ja/System.Net.WebSockets.xml",
+        "lib/dotnet/ko/System.Net.WebSockets.xml",
+        "lib/dotnet/ru/System.Net.WebSockets.xml",
+        "lib/dotnet/System.Net.WebSockets.dll",
+        "lib/dotnet/System.Net.WebSockets.xml",
+        "lib/dotnet/zh-hans/System.Net.WebSockets.xml",
+        "lib/dotnet/zh-hant/System.Net.WebSockets.xml",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Net.WebSockets.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Net.WebSockets.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Net.WebSockets.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Net.WebSockets.4.0.0-beta-23330.nupkg",
+        "System.Net.WebSockets.4.0.0-beta-23330.nupkg.sha512",
+        "System.Net.WebSockets.nuspec"
+      ]
+    },
+    "System.Net.WebSockets.Client/4.0.0-beta-23330": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "1NWEqwDkYRyvr1gSKZlY51AaI9w8oD0dC5UNa2Lb+qaeFHSF5KfCSzf7seD+im+sH6uocVo2nppiaabfbXZT4Q==",
+      "files": [
+        "lib/DNXCore50/de/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/es/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/fr/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/it/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/ja/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/ko/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/ru/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/System.Net.WebSockets.Client.dll",
+        "lib/DNXCore50/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/zh-hans/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/zh-hant/System.Net.WebSockets.Client.xml",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Net.WebSockets.Client.dll",
+        "lib/netcore50/de/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/es/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/fr/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/it/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/ja/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/ko/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/ru/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/System.Net.WebSockets.Client.dll",
+        "lib/netcore50/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/zh-hans/System.Net.WebSockets.Client.xml",
+        "lib/netcore50/zh-hant/System.Net.WebSockets.Client.xml",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Net.WebSockets.Client.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Net.WebSockets.Client.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Net.WebSockets.Client.4.0.0-beta-23330.nupkg",
+        "System.Net.WebSockets.Client.4.0.0-beta-23330.nupkg.sha512",
+        "System.Net.WebSockets.Client.nuspec"
+      ]
+    },
     "System.ObjectModel/4.0.10": {
       "type": "package",
       "serviceable": true,
@@ -1966,31 +2074,31 @@
         "System.Private.DataContractSerialization.nuspec"
       ]
     },
-    "System.Private.Networking/4.0.1-beta-23324": {
+    "System.Private.Networking/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "OfyxoeCdh1ypzdz1u0h1Clgt+6749vALs2ZPkLwsOPzL0INCG9ISYo+Jhh62ZD8TMkWwLrvyVppMBPHY6M7Upw==",
+      "sha512": "8NZi1gCQaGTKDb2yWplm52HWCLaZnUwVitksJgcXY2dEJau/TBGyZup+yhOngOIe8QzQMxNG4iokY3Ce0/8mbg==",
       "files": [
         "lib/DNXCore50/System.Private.Networking.dll",
         "lib/netcore50/System.Private.Networking.dll",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "System.Private.Networking.4.0.1-beta-23324.nupkg",
-        "System.Private.Networking.4.0.1-beta-23324.nupkg.sha512",
+        "System.Private.Networking.4.0.1-beta-23330.nupkg",
+        "System.Private.Networking.4.0.1-beta-23330.nupkg.sha512",
         "System.Private.Networking.nuspec"
       ]
     },
-    "System.Private.ServiceModel/4.0.1-beta-23324": {
+    "System.Private.ServiceModel/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "Lz3T9V8GnaOFlf8LUmuPznuOIuy92BAFVc9huiMrFKByzPpydGuCvXEe+81rZ1IF2TQcHKO++9otnj96AEJ5BA==",
+      "sha512": "8lENvmHuZdlvmnYN1w98Mv8bDjc0O/YlaNHRRph35T/fLDyaG8LMLMwG3/ut6a/AenLJmbf92snOtNXCuqM+cQ==",
       "files": [
         "lib/DNXCore50/System.Private.ServiceModel.dll",
         "lib/netcore50/System.Private.ServiceModel.dll",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "System.Private.ServiceModel.4.0.1-beta-23324.nupkg",
-        "System.Private.ServiceModel.4.0.1-beta-23324.nupkg.sha512",
+        "System.Private.ServiceModel.4.0.1-beta-23330.nupkg",
+        "System.Private.ServiceModel.4.0.1-beta-23330.nupkg.sha512",
         "System.Private.ServiceModel.nuspec"
       ]
     },
@@ -2519,10 +2627,10 @@
         "System.Security.Claims.nuspec"
       ]
     },
-    "System.Security.Cryptography.Algorithms/4.0.0-beta-23324": {
+    "System.Security.Cryptography.Algorithms/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "Mt6LwMj8hPp0+xZHcV6grZ7wSWhgycGkdZ6DQ9XvUY9NguUsvb/+fu2cMdrC7XsnpvwIROByp+p2dSjqBn3E2Q==",
+      "sha512": "FB4RoTDaV5tBiPSJsiG3A5DydeKz7ErglnkqVjBFjm6wu8kg91j0MxL/Al9iUyu9i/hq53fRs5KE3rjUNYvf5w==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2536,15 +2644,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.Algorithms.4.0.0-beta-23324.nupkg",
-        "System.Security.Cryptography.Algorithms.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Cryptography.Algorithms.4.0.0-beta-23330.nupkg",
+        "System.Security.Cryptography.Algorithms.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Cryptography.Algorithms.nuspec"
       ]
     },
-    "System.Security.Cryptography.Encoding/4.0.0-beta-23324": {
+    "System.Security.Cryptography.Encoding/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "JHOyknf1eYO6C39Vao6kAGpadq3PBO1L4tuzNEz/HvbH5sfIHPbjhxL11OyAhVKCzLCfEj6+aeClovFqZIRPyw==",
+      "sha512": "zeFdKQT6xjNdiNCaEmEYJMEK59kixkX7jJSoOLw3H+53t9X0F98vr3tS8YlrW/Lk/K9c6L5pYLlkb2dNqvUD/g==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2558,15 +2666,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.Encoding.4.0.0-beta-23324.nupkg",
-        "System.Security.Cryptography.Encoding.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Cryptography.Encoding.4.0.0-beta-23330.nupkg",
+        "System.Security.Cryptography.Encoding.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Cryptography.Encoding.nuspec"
       ]
     },
-    "System.Security.Cryptography.Primitives/4.0.0-beta-23324": {
+    "System.Security.Cryptography.Primitives/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "ETZxelIX51Di4FTytd8ohSpN6Ym/32aWIX9E2NCFkd91qdexn2Dkysn80b6n4gX6jG+oL0UHQDtD/fYq8C65oQ==",
+      "sha512": "15uVbOD3X0sRQJIxcEH5hasxlFdbA1CmPPZa0Y8pYEuQcWMF2gBswvU8s4qoKtA7x2xhNhzPsXIhsQuKNMTdEA==",
       "files": [
         "lib/dotnet/System.Security.Cryptography.Primitives.dll",
         "lib/MonoAndroid10/_._",
@@ -2580,15 +2688,15 @@
         "ref/net46/System.Security.Cryptography.Primitives.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Security.Cryptography.Primitives.4.0.0-beta-23324.nupkg",
-        "System.Security.Cryptography.Primitives.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Cryptography.Primitives.4.0.0-beta-23330.nupkg",
+        "System.Security.Cryptography.Primitives.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Cryptography.Primitives.nuspec"
       ]
     },
-    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23324": {
+    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "8NaEOxkkNBUECh0cPzGpbXS0uzGDpnvxI0kqQKRGp9uA+9qCyQfxcqAT6ozAYtOuFNVaC1XU3zQnb7T2nfvIDg==",
+      "sha512": "L8mUimdm7+GsORgJ8DFBMGsFnwDJ5YCUdJj3HfXQx4HCoPDPF+vJo3HRiHfcvNA2Zsf0ov2kuerYj/eeVa2/Rw==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2602,8 +2710,8 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23324.nupkg",
-        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23330.nupkg",
+        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Cryptography.X509Certificates.nuspec"
       ]
     },
@@ -2640,10 +2748,10 @@
         "System.Security.Principal.nuspec"
       ]
     },
-    "System.Security.Principal.Windows/4.0.0-beta-23324": {
+    "System.Security.Principal.Windows/4.0.0-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "csbCKdwBz31T8He7U6XMIc9BiWgwjHs5WDZR4rfhsk48TpdsbKNHX9OX4b+GwvgcsfVuWxre7zqNR0Bc9gWZ7g==",
+      "sha512": "q+3L3aB8bn0HCW52kX9TSJdhbjffBw7QWCOu0yX1SDhPN9MCPmJ4aBBCn1HRWroa5y7UcNUdjL1xwiERycZexw==",
       "files": [
         "lib/DNXCore50/de/System.Security.Principal.Windows.xml",
         "lib/DNXCore50/es/System.Security.Principal.Windows.xml",
@@ -2659,15 +2767,15 @@
         "lib/net46/System.Security.Principal.Windows.dll",
         "ref/dotnet/System.Security.Principal.Windows.dll",
         "ref/net46/System.Security.Principal.Windows.dll",
-        "System.Security.Principal.Windows.4.0.0-beta-23324.nupkg",
-        "System.Security.Principal.Windows.4.0.0-beta-23324.nupkg.sha512",
+        "System.Security.Principal.Windows.4.0.0-beta-23330.nupkg",
+        "System.Security.Principal.Windows.4.0.0-beta-23330.nupkg.sha512",
         "System.Security.Principal.Windows.nuspec"
       ]
     },
-    "System.ServiceModel.Http/4.0.11-beta-23324": {
+    "System.ServiceModel.Http/4.0.11-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "VkTumuCSmXd0NPZZU+nrO7YqznvM+wP96NykXbxFJdNAtCplmqXaQh+YZ/02rjJmfou5qyo2V+ZWVwySBAirOg==",
+      "sha512": "NHKxIIYL0ATDbX18RLCSXtuq26MMoYfAVdpl5K+D0s5AHp7TMPb7LcjZPpg25B2v48x1TwE9LYcYTCiOZcoPzQ==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Http.dll",
         "lib/MonoAndroid10/_._",
@@ -2692,15 +2800,15 @@
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.ServiceModel.Http.4.0.11-beta-23324.nupkg",
-        "System.ServiceModel.Http.4.0.11-beta-23324.nupkg.sha512",
+        "System.ServiceModel.Http.4.0.11-beta-23330.nupkg",
+        "System.ServiceModel.Http.4.0.11-beta-23330.nupkg.sha512",
         "System.ServiceModel.Http.nuspec"
       ]
     },
-    "System.ServiceModel.Primitives/4.0.1-beta-23324": {
+    "System.ServiceModel.Primitives/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "bmU31B4CD5+m9Kt0iDM5Yw2ZXRfv7lpK3Sx1HektcT/HERc+IMPdO38f/Wxtofo5WOA0qmd1fdrMeQcbEkDfJg==",
+      "sha512": "kJ/pcRUf7Ow7s/rX8Kmc9P2k6cvyudIzyUcqr/pn9NwY8DC/2DWkkFvYE2udR4kvBzJJzXl/rsJQlyLIVGMAww==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Primitives.dll",
         "lib/net45/_._",
@@ -2720,15 +2828,15 @@
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.Primitives.dll",
         "ref/win8/_._",
-        "System.ServiceModel.Primitives.4.0.1-beta-23324.nupkg",
-        "System.ServiceModel.Primitives.4.0.1-beta-23324.nupkg.sha512",
+        "System.ServiceModel.Primitives.4.0.1-beta-23330.nupkg",
+        "System.ServiceModel.Primitives.4.0.1-beta-23330.nupkg.sha512",
         "System.ServiceModel.Primitives.nuspec"
       ]
     },
-    "System.ServiceModel.Security/4.0.1-beta-23324": {
+    "System.ServiceModel.Security/4.0.1-beta-23330": {
       "type": "package",
       "serviceable": true,
-      "sha512": "vZN35yLLzcJXgr56Dds+N98fHb8IzyujOqJNuipkO6GEtUuyybV/g1UvmKbel/HvvoAyjSTNC+3/O95Go+tn0Q==",
+      "sha512": "DkdJSuFiSyHpu5vmqx1DHolDVZCPE1LoTVPFlH3E2AOFUnv7+LddJd02I1l03fhtKrOkJKJACHonhseWDdeIMg==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Security.dll",
         "lib/net45/_._",
@@ -2748,8 +2856,8 @@
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.Security.dll",
         "ref/win8/_._",
-        "System.ServiceModel.Security.4.0.1-beta-23324.nupkg",
-        "System.ServiceModel.Security.4.0.1-beta-23324.nupkg.sha512",
+        "System.ServiceModel.Security.4.0.1-beta-23330.nupkg",
+        "System.ServiceModel.Security.4.0.1-beta-23330.nupkg.sha512",
         "System.ServiceModel.Security.nuspec"
       ]
     },
@@ -2944,10 +3052,9 @@
         "System.Threading.Tasks.nuspec"
       ]
     },
-    "System.Threading.ThreadPool/4.0.10-beta-23324": {
+    "System.Threading.ThreadPool/4.0.10-beta-23330": {
       "type": "package",
-      "serviceable": true,
-      "sha512": "G4SjGmiV72HBiv8wkfnKFGTieekrACU1m43VaeJ6vDeSyb08eEFusVH1UWZpOsUF25meCuzpda0ezus24b4rKA==",
+      "sha512": "nM5OewUj8NJrye93apbM6KHvPddgPJGzt1IWIXk9lV5HB4NGsn6M5U0gxMQWShQuDp6NF3ya3ULRSvh3dLMbzg==",
       "files": [
         "lib/DNXCore50/System.Threading.ThreadPool.dll",
         "lib/MonoAndroid10/_._",
@@ -2961,8 +3068,8 @@
         "ref/net46/System.Threading.ThreadPool.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Threading.ThreadPool.4.0.10-beta-23324.nupkg",
-        "System.Threading.ThreadPool.4.0.10-beta-23324.nupkg.sha512",
+        "System.Threading.ThreadPool.4.0.10-beta-23330.nupkg",
+        "System.Threading.ThreadPool.4.0.10-beta-23330.nupkg.sha512",
         "System.Threading.ThreadPool.nuspec"
       ]
     },
@@ -3213,14 +3320,14 @@
         "xunit.extensibility.execution.nuspec"
       ]
     },
-    "xunit.netcore.extensions/1.0.0-prerelease-00095": {
+    "xunit.netcore.extensions/1.0.0-prerelease-00098": {
       "type": "package",
       "serviceable": true,
-      "sha512": "FuvWmkuxHiqD0cHDggg5MRmBoeM4Uea7OUEmKvZiQu7Fy02hJ6yKKNV7mNW3y4scwSzDNA81Qa+HIS33PeWUog==",
+      "sha512": "3kRPwTbC42YGmsNHpNMKfGVOO5cVfxUD+C7cYbti1aml4UCT/RFZ6lhm5Vym2wNRDxryu0Es78aMf1BaybSrDg==",
       "files": [
         "lib/dotnet/Xunit.NetCore.Extensions.dll",
-        "xunit.netcore.extensions.1.0.0-prerelease-00095.nupkg",
-        "xunit.netcore.extensions.1.0.0-prerelease-00095.nupkg.sha512",
+        "xunit.netcore.extensions.1.0.0-prerelease-00098.nupkg",
+        "xunit.netcore.extensions.1.0.0-prerelease-00098.nupkg.sha512",
         "xunit.netcore.extensions.nuspec"
       ]
     }


### PR DESCRIPTION
This change updates the version dependency to 4.0.11-beta-*
so that WCF uses the version containing the fixes added
by PR https://github.com/dotnet/corefx/pull/2596.

Fixes #341