### PR TITLE
Adding ActiveIssue for SendTimeout negative test.

### DIFF
--- a/src/System.Private.ServiceModel/tests/Common/Scenarios/ServiceInterfaces.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Scenarios/ServiceInterfaces.cs
@@ -4,11 +4,8 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Runtime.Serialization;
 using System.ServiceModel;
 using System.ServiceModel.Channels;
-using System.Text;
 using System.Threading.Tasks;
 using TestTypes;
 
@@ -25,7 +22,7 @@ public interface IWcfService
     ComplexCompositeType EchoComplex(ComplexCompositeType message);
 
     [OperationContract(Action = "http://tempuri.org/IWcfService/EchoWithTimeout")]
-    String EchoWithTimeout(String message);
+    String EchoWithTimeout(String message, TimeSpan timeout);
 
     [OperationContract(Action = "http://tempuri.org/IWcfService/GetDataUsingDataContract")]
     CompositeType GetDataUsingDataContract(CompositeType composite);

--- a/src/System.Private.ServiceModel/tests/Common/Scenarios/ServiceInterfaces.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Scenarios/ServiceInterfaces.cs
@@ -22,7 +22,7 @@ public interface IWcfService
     ComplexCompositeType EchoComplex(ComplexCompositeType message);
 
     [OperationContract(Action = "http://tempuri.org/IWcfService/EchoWithTimeout")]
-    String EchoWithTimeout(String message, TimeSpan timeout);
+    String EchoWithTimeout(String message, TimeSpan serviceOperationTimeout);
 
     [OperationContract(Action = "http://tempuri.org/IWcfService/GetDataUsingDataContract")]
     CompositeType GetDataUsingDataContract(CompositeType composite);

--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/ExpectedExceptions/ExpectedExceptionTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/ExpectedExceptions/ExpectedExceptionTests.cs
@@ -139,7 +139,7 @@ public static class ExpectedExceptionTests
     // The client should throw a TimeoutException
     [Fact]
     [OuterLoop]
-    [ActiveIssue(3464)]// Issue is in the corefx repo
+    [ActiveIssue(273)]
     public static void SendTimeout_For_Long_Running_Operation_Throws_TimeoutException()
     {
         TimeSpan serviceOperationTimeout = TimeSpan.FromMilliseconds(10000);
@@ -164,7 +164,7 @@ public static class ExpectedExceptionTests
 
         // want to assert that this completed in > 5 s as an upper bound since the SendTimeout is 5 sec
         // (usual case is around 5001-5005 ms) 
-        Assert.InRange<long>(watch.ElapsedMilliseconds, 5000, 10000);
+        Assert.InRange<long>(watch.ElapsedMilliseconds, 4985, 6000);
     }
 
     // SendTimeout is set to 0, this should trigger a TimeoutException before even attempting to call the service.
@@ -172,7 +172,7 @@ public static class ExpectedExceptionTests
     [OuterLoop]
     public static void SendTimeout_Zero_Throws_TimeoutException_Immediately()
     {
-        TimeSpan serviceOperationTimeout = TimeSpan.FromMilliseconds(10000);
+        TimeSpan serviceOperationTimeout = TimeSpan.FromMilliseconds(5000);
         BasicHttpBinding binding = new BasicHttpBinding();
         binding.SendTimeout = TimeSpan.FromMilliseconds(0);
         ChannelFactory<IWcfService> factory = new ChannelFactory<IWcfService>(binding, new EndpointAddress(Endpoints.HttpBaseAddress_Basic));

--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/ExpectedExceptions/ExpectedExceptionTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/ExpectedExceptions/ExpectedExceptionTests.cs
@@ -139,8 +139,10 @@ public static class ExpectedExceptionTests
     // The client should throw a TimeoutException
     [Fact]
     [OuterLoop]
+    [ActiveIssue(3464)]// Issue is in the corefx repo
     public static void SendTimeout_For_Long_Running_Operation_Throws_TimeoutException()
     {
+        TimeSpan serviceOperationTimeout = TimeSpan.FromMilliseconds(10000);
         BasicHttpBinding binding = new BasicHttpBinding();
         binding.SendTimeout = TimeSpan.FromMilliseconds(5000);
         ChannelFactory<IWcfService> factory = new ChannelFactory<IWcfService>(binding, new EndpointAddress(Endpoints.HttpBaseAddress_Basic));
@@ -152,7 +154,7 @@ public static class ExpectedExceptionTests
             {
                 IWcfService proxy = factory.CreateChannel();
                 watch.Start();
-                proxy.EchoWithTimeout("Hello");
+                proxy.EchoWithTimeout("Hello", serviceOperationTimeout);
             });
         }
         finally
@@ -170,6 +172,7 @@ public static class ExpectedExceptionTests
     [OuterLoop]
     public static void SendTimeout_Zero_Throws_TimeoutException_Immediately()
     {
+        TimeSpan serviceOperationTimeout = TimeSpan.FromMilliseconds(10000);
         BasicHttpBinding binding = new BasicHttpBinding();
         binding.SendTimeout = TimeSpan.FromMilliseconds(0);
         ChannelFactory<IWcfService> factory = new ChannelFactory<IWcfService>(binding, new EndpointAddress(Endpoints.HttpBaseAddress_Basic));
@@ -181,7 +184,7 @@ public static class ExpectedExceptionTests
             {
                 IWcfService proxy = factory.CreateChannel();
                 watch.Start();
-                proxy.EchoWithTimeout("Hello");
+                proxy.EchoWithTimeout("Hello", serviceOperationTimeout);
             });
         }
         finally

--- a/src/System.Private.ServiceModel/tools/test/SelfHostWcfService/IWcfService.cs
+++ b/src/System.Private.ServiceModel/tools/test/SelfHostWcfService/IWcfService.cs
@@ -13,7 +13,7 @@ namespace WcfService
     internal interface IWcfService
     {
         [OperationContract]
-        String EchoWithTimeout(String message);
+        String EchoWithTimeout(String message, TimeSpan timeout);
 
         [OperationContract]
         Message MessageRequestReply(Message message);

--- a/src/System.Private.ServiceModel/tools/test/SelfHostWcfService/IWcfService.cs
+++ b/src/System.Private.ServiceModel/tools/test/SelfHostWcfService/IWcfService.cs
@@ -13,7 +13,7 @@ namespace WcfService
     internal interface IWcfService
     {
         [OperationContract]
-        String EchoWithTimeout(String message, TimeSpan timeout);
+        String EchoWithTimeout(String message, TimeSpan serviceOperationTimeout);
 
         [OperationContract]
         Message MessageRequestReply(Message message);

--- a/src/System.Private.ServiceModel/tools/test/SelfHostWcfService/WcfService.cs
+++ b/src/System.Private.ServiceModel/tools/test/SelfHostWcfService/WcfService.cs
@@ -13,9 +13,9 @@ namespace WcfService
 {
     internal class WcfService : IWcfService
     {
-        public String EchoWithTimeout(String message, TimeSpan timeout)
+        public String EchoWithTimeout(String message, TimeSpan serviceOperationTimeout)
         {
-            System.Threading.Thread.Sleep(timeout);
+            System.Threading.Thread.Sleep(serviceOperationTimeout);
             return message;
         }
 

--- a/src/System.Private.ServiceModel/tools/test/SelfHostWcfService/WcfService.cs
+++ b/src/System.Private.ServiceModel/tools/test/SelfHostWcfService/WcfService.cs
@@ -13,9 +13,9 @@ namespace WcfService
 {
     internal class WcfService : IWcfService
     {
-        public String EchoWithTimeout(String message)
+        public String EchoWithTimeout(String message, TimeSpan timeout)
         {
-            System.Threading.Thread.Sleep(10000);
+            System.Threading.Thread.Sleep(timeout);
             return message;
         }
 


### PR DESCRIPTION
* Test case name: SendTimeout_For_Long_Running_Operation_Throws_TimeoutException
* Updated it to provide the service operation with the timeout value to use on the server.
* Checking the elapsed time against an expected range still seems like the right thing to do.
* Fixes #273