### PR TITLE
Fix read bug in content properties in BridgeClient

### DIFF
--- a/src/System.Private.ServiceModel/tests/Common/Infrastructure/src/BridgeClient.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Infrastructure/src/BridgeClient.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using System.Net.Http;
 using System.Text;
 
@@ -74,6 +75,7 @@ namespace Infrastructure.Common
                 }
             }
         }
+
         public static string GetResourceAddress(string resourceName)
         {
             EnsureBridgeIsRunning();
@@ -83,7 +85,7 @@ namespace Infrastructure.Common
             {
                 if (s_BridgeStatus == BridgeState.Started && !_Resources.TryGetValue(resourceName, out resourceAddress))
                 {
-                    resourceAddress = MakeResourcePutRequest(resourceName);
+                    resourceAddress = MakeEndpointResourcePutRequest(resourceName);
                     _Resources.Add(resourceName, resourceAddress);
                 }
             }
@@ -190,28 +192,64 @@ namespace Infrastructure.Common
             return sb.ToString();
         }
 
-        private static string MakeResourcePutRequest(string resourceName)
+        private static string MakeEndpointResourcePutRequest(string resourceName)
+        {
+            var responseContent = MakeResourcePutRequest(resourceName, null);
+
+            string uri = null;
+            if (!responseContent.TryGetValue(EndpointResourceResponseUriKeyName, out uri) || String.IsNullOrWhiteSpace(uri))
+            {
+                StringBuilder sb = new StringBuilder();
+                foreach (var pair in responseContent)
+                {
+                    sb.AppendFormat("{0}  {1} : {2}", Environment.NewLine, pair.Key, pair.Value);
+                }
+
+                throw new Exception("Invalid response from bridge: " + sb.ToString());
+            }
+
+            return uri;
+        }
+        
+
+        internal static Dictionary<string,string> MakeResourcePutRequest(string resourceName, Dictionary<string, string> requestParameters)
         {
             EnsureBridgeIsRunning();
 
+            string requestParametersResourceName; 
+            if (requestParameters != null 
+                && requestParameters.TryGetValue(EndpointResourceRequestNameKeyName, out requestParametersResourceName) 
+                && !string.Equals(resourceName, requestParametersResourceName))
+            {
+                throw new ArgumentException(
+                    string.Format("A PUT request to the bridge included parameter 'name' = '{0}' in its requestParameters, but the 'resourceName' = '{1}' specified was different", requestParametersResourceName, resourceName),
+                    "requestParameters");
+            }
+
             using (HttpClient httpClient = new HttpClient())
             {
-                var emptyContent = new StringContent("{}", Encoding.UTF8, "application/json");
+                StringContent content; 
+                if (requestParameters != null)
+                {
+                    content = new StringContent(
+                            JsonSerializer.SerializeDictionary(requestParameters),
+                            Encoding.UTF8,
+                            "application/json");
+                }
+                else
+                {
+                    content  = new StringContent("{}", Encoding.UTF8, "application/json");
+                }
 
                 try
-                {                    
-                    var response = httpClient.PutAsync(BridgeResourceEndpointAddress + resourceName, emptyContent).GetAwaiter().GetResult();
+                {
+                    var response = httpClient.PutAsync(BridgeResourceEndpointAddress + resourceName, content).GetAwaiter().GetResult();
                     EnsureSuccessfulResponse(response);
 
                     var responseContent = response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
                     Dictionary<string, string> properties = JsonSerializer.DeserializeDictionary(responseContent);
-                    string uri = null;
-                    if (!properties.TryGetValue(EndpointResourceResponseUriKeyName, out uri) || String.IsNullOrWhiteSpace(uri))
-                    {
-                        throw new Exception("Invalid response from bridge: " + responseContent);
-                    }
 
-                    return uri;
+                    return properties;
                 }
                 catch (Exception exc)
                 {
@@ -222,30 +260,48 @@ namespace Infrastructure.Common
             }
         }
 
-        private static string MakeResourceGetRequest(string resourceName)
+        internal static Dictionary<string, string> MakeResourceGetRequest(string resourceName, Dictionary<string, string> requestParameters)
         {
             EnsureBridgeIsRunning();
 
+            string requestParametersResourceName;
+            if (requestParameters != null
+                && requestParameters.TryGetValue(EndpointResourceRequestNameKeyName, out requestParametersResourceName)
+                && !string.Equals(resourceName, requestParametersResourceName))
+            {
+                throw new ArgumentException(
+                    string.Format("A GET request to the bridge included parameter 'name' = '{0}' in its requestParameters, but the 'resourceName' = '{1}' specified was different", requestParametersResourceName, resourceName),
+                    "requestParameters");
+            }
+
             using (HttpClient httpClient = new HttpClient())
             {
+                StringBuilder uriBuilder = new StringBuilder(BridgeResourceEndpointAddress + resourceName);
+                if (requestParameters != null)
+                {
+                    uriBuilder.Append("?");
+                    foreach (var kvp in requestParameters)
+                    {
+                        // we currently rely on the caller to do any URLEncoding
+                        uriBuilder.AppendFormat("{0}={1}&", kvp.Key, kvp.Value);
+                    }
+                }
+                var uri = uriBuilder.ToString().TrimEnd('&');
+
                 try
                 {
-                    var response = httpClient.GetAsync(BridgeResourceEndpointAddress + resourceName).GetAwaiter().GetResult();
+                    var response = httpClient.GetAsync(uri).GetAwaiter().GetResult();
                     EnsureSuccessfulResponse(response);
-                    string responseContent = response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
-                    Dictionary<string, string> properties = JsonSerializer.DeserializeDictionary(responseContent);
-                    string uri = null;
-                    if (!properties.TryGetValue(EndpointResourceResponseUriKeyName, out uri) || String.IsNullOrWhiteSpace(uri))
-                    {
-                        throw new Exception("Invalid response from bridge: " + responseContent);
-                    }
 
-                    return uri;
+                    var responseContent = response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
+                    Dictionary<string, string> properties = JsonSerializer.DeserializeDictionary(responseContent);
+
+                    return properties;
                 }
                 catch (Exception exc)
                 {
-                    string failureMessage = String.Format("A Get request was issued to '{0}{1}' but encountered exception {2}",
-                                                           BridgeResourceEndpointAddress, resourceName, exc.Message);
+                    string failureMessage = String.Format("A GET request was issued to '{0}' for resource '{1}' but encountered exception {2}",
+                    uri, resourceName, exc.Message);
                     throw new Exception(failureMessage, exc);
                 }
             }


### PR DESCRIPTION
Change a260b68 (PR #377) introduced a change to BridgeClient, which changed the way resources were addressed. 

This change allows us to put more content into the PUT request other than just putting to the resource only.

This needs to be introduced either prior to, or as part of the dynamic cert generation change