### PR TITLE
Rename DLL generated by Infrstructure.Common.Tests

### DIFF
--- a/src/System.Private.ServiceModel/tests/Common/Infrastructure/tests/Infrastructure.Common.Tests.csproj
+++ b/src/System.Private.ServiceModel/tests/Common/Infrastructure/tests/Infrastructure.Common.Tests.csproj
@@ -7,8 +7,8 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>System.ServiceModel.Common.Tests</RootNamespace>
-    <AssemblyName>System.ServiceModel.Common.Tests</AssemblyName>
+    <RootNamespace>Infrastructure.Common.Tests</RootNamespace>
+    <AssemblyName>Infrastructure.Common.Tests</AssemblyName>
     <SignAssembly>false</SignAssembly>
     <CLSCompliant>false</CLSCompliant>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>


### PR DESCRIPTION
Renames the DLL generated by this project to match the
name of the folder and project.  This is necessary to
accommodate the run-test.sh conventions that assume the
DLL's match their folder and project names.

Fixes #376