### PR TITLE
Adding APIs to contracts for certificate validation

### DIFF
--- a/src/System.Private.ServiceModel/src/System.Private.ServiceModel.csproj
+++ b/src/System.Private.ServiceModel/src/System.Private.ServiceModel.csproj
@@ -5,7 +5,7 @@
     <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
     <Platform Condition="'$(Platform)' == ''">AnyCPU</Platform>
     <AssemblyName>System.Private.ServiceModel</AssemblyName>
-    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <RootNamespace>System.ServiceModel</RootNamespace>
     <OutputType>Library</OutputType>
     <NoWarn>$(NoWarn);1634;1691;649</NoWarn>

--- a/src/System.ServiceModel.NetTcp/ref/System.ServiceModel.NetTcp.cs
+++ b/src/System.ServiceModel.NetTcp/ref/System.ServiceModel.NetTcp.cs
@@ -51,6 +51,8 @@ namespace System.ServiceModel
         public TcpTransportSecurity() { }
         [System.ComponentModel.DefaultValueAttribute((System.ServiceModel.TcpClientCredentialType)(1))]
         public System.ServiceModel.TcpClientCredentialType ClientCredentialType { get { return default(System.ServiceModel.TcpClientCredentialType); } set { } }
+        [System.ComponentModel.DefaultValueAttribute((System.Security.Authentication.SslProtocols)(4080))]
+        public System.Security.Authentication.SslProtocols SslProtocols { get { return default(System.Security.Authentication.SslProtocols); } set { } }
     }
 }
 namespace System.ServiceModel.Channels
@@ -70,6 +72,8 @@ namespace System.ServiceModel.Channels
     public partial class SslStreamSecurityBindingElement : System.ServiceModel.Channels.BindingElement
     {
         public SslStreamSecurityBindingElement() { }
+        [System.ComponentModel.DefaultValueAttribute((System.Security.Authentication.SslProtocols)(4080))]
+        public System.Security.Authentication.SslProtocols SslProtocols { get { return default(System.Security.Authentication.SslProtocols); } set { } }
         public override System.ServiceModel.Channels.IChannelFactory<TChannel> BuildChannelFactory<TChannel>(System.ServiceModel.Channels.BindingContext context) { return default(System.ServiceModel.Channels.IChannelFactory<TChannel>); }
         public override bool CanBuildChannelFactory<TChannel>(System.ServiceModel.Channels.BindingContext context) { return default(bool); }
         public override System.ServiceModel.Channels.BindingElement Clone() { return default(System.ServiceModel.Channels.BindingElement); }

--- a/src/System.ServiceModel.NetTcp/ref/System.ServiceModel.NetTcp.csproj
+++ b/src/System.ServiceModel.NetTcp/ref/System.ServiceModel.NetTcp.csproj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <OutputType>Library</OutputType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/System.ServiceModel.NetTcp/ref/project.json
+++ b/src/System.ServiceModel.NetTcp/ref/project.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "System.ObjectModel": "4.0.0",
     "System.Runtime": "4.0.0",
-    "System.ServiceModel.Primitives": "4.0.0",
+    "System.ServiceModel.Primitives": "4.1.0",
     "System.Runtime.Serialization.Xml": "4.0.0"
   },
   "frameworks": {

--- a/src/System.ServiceModel.Primitives/ref/System.ServiceModel.Primitives.cs
+++ b/src/System.ServiceModel.Primitives/ref/System.ServiceModel.Primitives.cs
@@ -4,7 +4,12 @@
 // Changes to this file must follow the http://aka.ms/api-review process.
 // ------------------------------------------------------------------------------
 
-
+namespace System.IdentityModel.Selectors {
+  public abstract partial class X509CertificateValidator {
+    protected X509CertificateValidator() { }
+    public abstract void Validate(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate);
+  }
+}
 namespace System.ServiceModel
 {
     public partial class ActionNotSupportedException : System.ServiceModel.CommunicationException
@@ -1160,7 +1165,9 @@ namespace System.ServiceModel.Description
     {
         public ClientCredentials() { }
         protected ClientCredentials(System.ServiceModel.Description.ClientCredentials other) { }
+        public System.ServiceModel.Security.X509CertificateInitiatorClientCredential ClientCertificate { get { return default(System.ServiceModel.Security.X509CertificateInitiatorClientCredential); } }
         public System.ServiceModel.Security.HttpDigestClientCredential HttpDigest { get { return default(System.ServiceModel.Security.HttpDigestClientCredential); } }
+        public System.ServiceModel.Security.X509CertificateRecipientClientCredential ServiceCertificate { get { return default(System.ServiceModel.Security.X509CertificateRecipientClientCredential); } }
         public System.ServiceModel.Security.UserNamePasswordClientCredential UserName { get { return default(System.ServiceModel.Security.UserNamePasswordClientCredential); } }
         public System.ServiceModel.Security.WindowsClientCredential Windows { get { return default(System.ServiceModel.Security.WindowsClientCredential); } }
         public virtual void ApplyClientBehavior(System.ServiceModel.Description.ServiceEndpoint serviceEndpoint, System.ServiceModel.Dispatcher.ClientRuntime behavior) { }
@@ -1436,5 +1443,36 @@ namespace System.ServiceModel.Security
         internal WindowsClientCredential() { }
         public System.Security.Principal.TokenImpersonationLevel AllowedImpersonationLevel { get { return default(System.Security.Principal.TokenImpersonationLevel); } set { } }
         public System.Net.NetworkCredential ClientCredential { get { return default(System.Net.NetworkCredential); } set { } }
+    }
+    public sealed partial class X509ServiceCertificateAuthentication {
+        internal X509ServiceCertificateAuthentication() { }
+        public System.ServiceModel.Security.X509CertificateValidationMode CertificateValidationMode { get { return default(System.ServiceModel.Security.X509CertificateValidationMode); } set { } }
+        public System.IdentityModel.Selectors.X509CertificateValidator CustomCertificateValidator { get { return default(System.IdentityModel.Selectors.X509CertificateValidator); } set { } }
+        public System.Security.Cryptography.X509Certificates.X509RevocationMode RevocationMode { get { return default(System.Security.Cryptography.X509Certificates.X509RevocationMode); } set { } }
+        public System.Security.Cryptography.X509Certificates.StoreLocation TrustedStoreLocation { get { return default(System.Security.Cryptography.X509Certificates.StoreLocation); } set { } }
+    }
+    public sealed partial class X509CertificateInitiatorClientCredential {
+        internal X509CertificateInitiatorClientCredential() { }
+        public System.Security.Cryptography.X509Certificates.X509Certificate2 Certificate { get { return default(System.Security.Cryptography.X509Certificates.X509Certificate2); } set { } }
+        public void SetCertificate(System.Security.Cryptography.X509Certificates.StoreLocation storeLocation, System.Security.Cryptography.X509Certificates.StoreName storeName, System.Security.Cryptography.X509Certificates.X509FindType findType, object findValue) { }
+        public void SetCertificate(string subjectName, System.Security.Cryptography.X509Certificates.StoreLocation storeLocation, System.Security.Cryptography.X509Certificates.StoreName storeName) { }
+    }
+    public sealed partial class X509CertificateRecipientClientCredential {
+        internal X509CertificateRecipientClientCredential() { }
+        public System.ServiceModel.Security.X509ServiceCertificateAuthentication Authentication { get { return default(System.ServiceModel.Security.X509ServiceCertificateAuthentication); } }
+        public System.Security.Cryptography.X509Certificates.X509Certificate2 DefaultCertificate { get { return default(System.Security.Cryptography.X509Certificates.X509Certificate2); } set { } }
+        public System.Collections.Generic.Dictionary<System.Uri, System.Security.Cryptography.X509Certificates.X509Certificate2> ScopedCertificates { get { return default(System.Collections.Generic.Dictionary<System.Uri, System.Security.Cryptography.X509Certificates.X509Certificate2>); } }
+        public System.ServiceModel.Security.X509ServiceCertificateAuthentication SslCertificateAuthentication { get { return default(System.ServiceModel.Security.X509ServiceCertificateAuthentication); } set { } }
+        public void SetDefaultCertificate(System.Security.Cryptography.X509Certificates.StoreLocation storeLocation, System.Security.Cryptography.X509Certificates.StoreName storeName, System.Security.Cryptography.X509Certificates.X509FindType findType, object findValue) { }
+        public void SetDefaultCertificate(string subjectName, System.Security.Cryptography.X509Certificates.StoreLocation storeLocation, System.Security.Cryptography.X509Certificates.StoreName storeName) { }
+        public void SetScopedCertificate(System.Security.Cryptography.X509Certificates.StoreLocation storeLocation, System.Security.Cryptography.X509Certificates.StoreName storeName, System.Security.Cryptography.X509Certificates.X509FindType findType, object findValue, System.Uri targetService) { }
+        public void SetScopedCertificate(string subjectName, System.Security.Cryptography.X509Certificates.StoreLocation storeLocation, System.Security.Cryptography.X509Certificates.StoreName storeName, System.Uri targetService) { }
+    }
+    public enum X509CertificateValidationMode {
+        ChainTrust = 2,
+        Custom = 4,
+        None = 0,
+        PeerOrChainTrust = 3,
+        PeerTrust = 1,
     }
 }

--- a/src/System.ServiceModel.Primitives/ref/System.ServiceModel.Primitives.csproj
+++ b/src/System.ServiceModel.Primitives/ref/System.ServiceModel.Primitives.csproj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <OutputType>Library</OutputType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/System.ServiceModel.Primitives/ref/project.json
+++ b/src/System.ServiceModel.Primitives/ref/project.json
@@ -13,6 +13,8 @@
     "System.Reflection": "4.0.0",
     "System.Net.Primitives": "4.0.0",
     "System.Security.Principal": "4.0.0",
+    "System.Security.Cryptography.X509Certificates" : "4.0.0-beta-*",
+    "System.Collections" : "4.0.0", 
     "System.Runtime.Serialization.Primitives": "4.0.0"
   },
   "frameworks": {


### PR DESCRIPTION
**Please do not merge this PR - it needs to be done in steps as mentioned below** 

Adding APIs to contracts per https://github.com/dotnet/wcf/issues/308

Also for:
https://github.com/dotnet/wcf/issues/39, https://github.com/dotnet/wcf/issues/302, https://github.com/dotnet/wcf/issues/243

These APIs were previously present on desktop and we want to turn these on to enable some certificate (non-)validation scenarios in .NET Core. 

Specifically, these APIs allow for 
* specification of the SslProtocols that are allowed by ssl stream security
* ditto for the NetTcp transport
* specification of the X509 client credential type
* support the specification of the client and server certificate

Note that this change will be split into the following steps over three evenings
1. Bump version of System.Private.ServiceModel
2. Change contract for System.ServiceModel.Primitives 
3. Change contract for System.ServiceModel.NetTcp
... and bump the project.lock.json files for each of the above changes too
Each step will mean we wait for the next packages to be published

cc: @roncain, @mconnew, @weshaggard, @ericstj, @terrajobst 