### PR TITLE
Bump System.Private.ServiceModel version to 4.1.0

### DIFF
--- a/src/System.Private.ServiceModel/src/System.Private.ServiceModel.csproj
+++ b/src/System.Private.ServiceModel/src/System.Private.ServiceModel.csproj
@@ -5,7 +5,7 @@
     <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
     <Platform Condition="'$(Platform)' == ''">AnyCPU</Platform>
     <AssemblyName>System.Private.ServiceModel</AssemblyName>
-    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <RootNamespace>System.ServiceModel</RootNamespace>
     <OutputType>Library</OutputType>
     <NoWarn>$(NoWarn);1634;1691;649</NoWarn>


### PR DESCRIPTION
Related to #385

In preparation for API changes to System.ServiceModel.Primitives and System.ServiceModel.NetTcp, we need to bump the minor version of System.Private.ServiceModel and wait for the nightly build to push out a new package