### PR TITLE
Move System.Private.ServiceModel to use new S.Security.Claims version

### DIFF
--- a/src/System.Private.ServiceModel/src/project.json
+++ b/src/System.Private.ServiceModel/src/project.json
@@ -33,7 +33,7 @@
     "System.Runtime.Handles": "4.0.0",
     "System.Runtime.InteropServices": "4.0.20-beta-*",
     "System.Runtime.Serialization.Xml": "4.0.10",
-    "System.Security.Claims": "4.0.0",
+    "System.Security.Claims": "4.0.1-beta-*",
     "System.Security.Cryptography.X509Certificates": "4.0.0-beta-*",
     "System.Security.Principal": "4.0.0",
     "System.Security.Principal.Windows": "4.0.0-beta-*",

--- a/src/System.Private.ServiceModel/src/project.lock.json
+++ b/src/System.Private.ServiceModel/src/project.lock.json
@@ -716,7 +716,7 @@
           "lib/DNXCore50/System.Runtime.Serialization.Xml.dll": {}
         }
       },
-      "System.Security.Claims/4.0.0": {
+      "System.Security.Claims/4.0.1-beta-23408": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -1744,7 +1744,7 @@
           "lib/netcore50/System.Runtime.WindowsRuntime.dll": {}
         }
       },
-      "System.Security.Claims/4.0.0": {
+      "System.Security.Claims/4.0.1-beta-23408": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -3561,35 +3561,35 @@
         "System.Runtime.WindowsRuntime.nuspec"
       ]
     },
-    "System.Security.Claims/4.0.0": {
+    "System.Security.Claims/4.0.1-beta-23408": {
       "type": "package",
       "serviceable": true,
-      "sha512": "94NFR/7JN3YdyTH7hl2iSvYmdA8aqShriTHectcK+EbizT71YczMaG6LuqJBQP/HWo66AQyikYYM9aw+4EzGXg==",
+      "sha512": "9rsYgMq/0OqUX9xKlNUkOvaBaZETICCGd7SPcFPv+/bMYte2+PMD/tZpxFrbiXpB2211mHYk/wBVwejEyZuGcQ==",
       "files": [
+        "lib/dotnet/de/System.Security.Claims.xml",
+        "lib/dotnet/es/System.Security.Claims.xml",
+        "lib/dotnet/fr/System.Security.Claims.xml",
+        "lib/dotnet/it/System.Security.Claims.xml",
+        "lib/dotnet/ja/System.Security.Claims.xml",
+        "lib/dotnet/ko/System.Security.Claims.xml",
+        "lib/dotnet/ru/System.Security.Claims.xml",
         "lib/dotnet/System.Security.Claims.dll",
+        "lib/dotnet/System.Security.Claims.xml",
+        "lib/dotnet/zh-hans/System.Security.Claims.xml",
+        "lib/dotnet/zh-hant/System.Security.Claims.xml",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Security.Claims.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/de/System.Security.Claims.xml",
-        "ref/dotnet/es/System.Security.Claims.xml",
-        "ref/dotnet/fr/System.Security.Claims.xml",
-        "ref/dotnet/it/System.Security.Claims.xml",
-        "ref/dotnet/ja/System.Security.Claims.xml",
-        "ref/dotnet/ko/System.Security.Claims.xml",
-        "ref/dotnet/ru/System.Security.Claims.xml",
         "ref/dotnet/System.Security.Claims.dll",
-        "ref/dotnet/System.Security.Claims.xml",
-        "ref/dotnet/zh-hans/System.Security.Claims.xml",
-        "ref/dotnet/zh-hant/System.Security.Claims.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Security.Claims.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Security.Claims.4.0.0.nupkg",
-        "System.Security.Claims.4.0.0.nupkg.sha512",
+        "System.Security.Claims.4.0.1-beta-23408.nupkg",
+        "System.Security.Claims.4.0.1-beta-23408.nupkg.sha512",
         "System.Security.Claims.nuspec"
       ]
     },
@@ -4210,7 +4210,7 @@
       "System.Runtime.Handles >= 4.0.0",
       "System.Runtime.InteropServices >= 4.0.20-beta-*",
       "System.Runtime.Serialization.Xml >= 4.0.10",
-      "System.Security.Claims >= 4.0.0",
+      "System.Security.Claims >= 4.0.1-beta-*",
       "System.Security.Cryptography.X509Certificates >= 4.0.0-beta-*",
       "System.Security.Principal >= 4.0.0",
       "System.Security.Principal.Windows >= 4.0.0-beta-*",

--- a/src/System.Private.ServiceModel/src/project.lock.json
+++ b/src/System.Private.ServiceModel/src/project.lock.json
@@ -316,7 +316,7 @@
           "lib/dotnet/System.Linq.Queryable.dll": {}
         }
       },
-      "System.Net.Http/4.0.1-beta-23409": {
+      "System.Net.Http/4.0.1-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -329,7 +329,7 @@
           "ref/dotnet/System.Net.Http.dll": {}
         }
       },
-      "System.Net.NameResolution/4.0.0-beta-23409": {
+      "System.Net.NameResolution/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Net.Primitives": "4.0.10",
@@ -352,13 +352,13 @@
           "lib/DNXCore50/System.Net.Primitives.dll": {}
         }
       },
-      "System.Net.Security/4.0.0-beta-23409": {
+      "System.Net.Security/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
           "System.Net.Primitives": "4.0.10",
           "System.Runtime": "4.0.0",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23409",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23412",
           "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
@@ -392,7 +392,7 @@
           "lib/dotnet/System.Net.WebHeaderCollection.dll": {}
         }
       },
-      "System.Net.WebSockets/4.0.0-beta-23409": {
+      "System.Net.WebSockets/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -407,7 +407,7 @@
           "lib/dotnet/System.Net.WebSockets.dll": {}
         }
       },
-      "System.Net.WebSockets.Client/4.0.0-beta-23409": {
+      "System.Net.WebSockets.Client/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -417,13 +417,13 @@
           "System.Globalization": "4.0.10",
           "System.Net.Primitives": "4.0.10",
           "System.Net.WebHeaderCollection": "4.0.0",
-          "System.Net.WebSockets": "4.0.0-beta-23409",
+          "System.Net.WebSockets": "4.0.0-beta-23412",
           "System.Resources.ResourceManager": "4.0.0",
           "System.Runtime": "4.0.20",
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23409",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23412",
           "System.Text.Encoding": "4.0.10",
           "System.Threading": "4.0.10",
           "System.Threading.Tasks": "4.0.10"
@@ -716,7 +716,7 @@
           "lib/DNXCore50/System.Runtime.Serialization.Xml.dll": {}
         }
       },
-      "System.Security.Claims/4.0.1-beta-23408": {
+      "System.Security.Claims/4.0.1-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -735,18 +735,18 @@
           "lib/dotnet/System.Security.Claims.dll": {}
         }
       },
-      "System.Security.Cryptography.Algorithms/4.0.0-beta-23409": {
+      "System.Security.Cryptography.Algorithms/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
           "System.Runtime": "4.0.0",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23409"
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23412"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.Algorithms.dll": {}
         }
       },
-      "System.Security.Cryptography.Encoding/4.0.0-beta-23409": {
+      "System.Security.Cryptography.Encoding/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -755,7 +755,7 @@
           "ref/dotnet/System.Security.Cryptography.Encoding.dll": {}
         }
       },
-      "System.Security.Cryptography.Primitives/4.0.0-beta-23409": {
+      "System.Security.Cryptography.Primitives/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.0",
@@ -773,13 +773,13 @@
           "lib/dotnet/System.Security.Cryptography.Primitives.dll": {}
         }
       },
-      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23409": {
+      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
           "System.Runtime.Handles": "4.0.0",
-          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23409",
-          "System.Security.Cryptography.Encoding": "4.0.0-beta-23409"
+          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23412",
+          "System.Security.Cryptography.Encoding": "4.0.0-beta-23412"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.X509Certificates.dll": {}
@@ -797,7 +797,7 @@
           "lib/dotnet/System.Security.Principal.dll": {}
         }
       },
-      "System.Security.Principal.Windows/4.0.0-beta-23409": {
+      "System.Security.Principal.Windows/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -1368,7 +1368,7 @@
           "lib/netcore50/System.Linq.Queryable.dll": {}
         }
       },
-      "System.Net.Http/4.0.1-beta-23409": {
+      "System.Net.Http/4.0.1-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -1412,7 +1412,7 @@
           "lib/dotnet/System.Net.WebHeaderCollection.dll": {}
         }
       },
-      "System.Net.WebSockets/4.0.0-beta-23409": {
+      "System.Net.WebSockets/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -1427,7 +1427,7 @@
           "lib/dotnet/System.Net.WebSockets.dll": {}
         }
       },
-      "System.Net.WebSockets.Client/4.0.0-beta-23409": {
+      "System.Net.WebSockets.Client/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -1436,14 +1436,14 @@
           "System.Globalization": "4.0.10",
           "System.Net.Primitives": "4.0.10",
           "System.Net.WebHeaderCollection": "4.0.0",
-          "System.Net.WebSockets": "4.0.0-beta-23409",
+          "System.Net.WebSockets": "4.0.0-beta-23412",
           "System.Resources.ResourceManager": "4.0.0",
           "System.Runtime": "4.0.20",
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.InteropServices": "4.0.20",
           "System.Runtime.InteropServices.WindowsRuntime": "4.0.0",
           "System.Runtime.WindowsRuntime": "4.0.0",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23409",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23412",
           "System.Text.Encoding": "4.0.10",
           "System.Threading": "4.0.10",
           "System.Threading.Tasks": "4.0.10"
@@ -1744,7 +1744,7 @@
           "lib/netcore50/System.Runtime.WindowsRuntime.dll": {}
         }
       },
-      "System.Security.Claims/4.0.1-beta-23408": {
+      "System.Security.Claims/4.0.1-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -1763,18 +1763,18 @@
           "lib/dotnet/System.Security.Claims.dll": {}
         }
       },
-      "System.Security.Cryptography.Algorithms/4.0.0-beta-23409": {
+      "System.Security.Cryptography.Algorithms/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
           "System.Runtime": "4.0.0",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23409"
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23412"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.Algorithms.dll": {}
         }
       },
-      "System.Security.Cryptography.Encoding/4.0.0-beta-23409": {
+      "System.Security.Cryptography.Encoding/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -1783,7 +1783,7 @@
           "ref/dotnet/System.Security.Cryptography.Encoding.dll": {}
         }
       },
-      "System.Security.Cryptography.Primitives/4.0.0-beta-23409": {
+      "System.Security.Cryptography.Primitives/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.0",
@@ -1801,13 +1801,13 @@
           "lib/dotnet/System.Security.Cryptography.Primitives.dll": {}
         }
       },
-      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23409": {
+      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
           "System.Runtime.Handles": "4.0.0",
-          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23409",
-          "System.Security.Cryptography.Encoding": "4.0.0-beta-23409"
+          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23412",
+          "System.Security.Cryptography.Encoding": "4.0.0-beta-23412"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.X509Certificates.dll": {}
@@ -1825,7 +1825,7 @@
           "lib/netcore50/System.Security.Principal.dll": {}
         }
       },
-      "System.Security.Principal.Windows/4.0.0-beta-23409": {
+      "System.Security.Principal.Windows/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
@@ -2698,10 +2698,10 @@
         "System.Linq.Queryable.nuspec"
       ]
     },
-    "System.Net.Http/4.0.1-beta-23409": {
+    "System.Net.Http/4.0.1-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "O3kwJt8OEdR6c0NLHBemp0OMQFSQLNHtNMC7Hm7daoHp9aju/+SGsj+xQRIErb9be7lWnVjBLKwf71OcAfvsUg==",
+      "sha512": "F7Yej+6QdRVzWg+qbkayRMcmf/7k7YfNFoVSA67wIsG9t5u7Wj4Go8FW72HL8qb9d7YjIsVB/5hA7g9MUT31Aw==",
       "files": [
         "lib/net45/_._",
         "lib/win8/_._",
@@ -2723,15 +2723,15 @@
         "ref/win8/_._",
         "ref/wpa81/_._",
         "runtime.json",
-        "System.Net.Http.4.0.1-beta-23409.nupkg",
-        "System.Net.Http.4.0.1-beta-23409.nupkg.sha512",
+        "System.Net.Http.4.0.1-beta-23412.nupkg",
+        "System.Net.Http.4.0.1-beta-23412.nupkg.sha512",
         "System.Net.Http.nuspec"
       ]
     },
-    "System.Net.NameResolution/4.0.0-beta-23409": {
+    "System.Net.NameResolution/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "g2ErHzffXH9MefxX2eaG58g6gFCZyXavpAmQiOu5CpDjAmDbBt6ixMgOfHN17Km88EE10iTaFA9B/0gBuFiMng==",
+      "sha512": "HCF1zhFYBT+w/Ik+JuTzFJgj83Jfc+eA8VcgvIzdPiGMXfrZeXOogjgSCkCoJmFtKVz2DSfmISoEmiXB1oaLNQ==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2755,8 +2755,8 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Net.NameResolution.4.0.0-beta-23409.nupkg",
-        "System.Net.NameResolution.4.0.0-beta-23409.nupkg.sha512",
+        "System.Net.NameResolution.4.0.0-beta-23412.nupkg",
+        "System.Net.NameResolution.4.0.0-beta-23412.nupkg.sha512",
         "System.Net.NameResolution.nuspec"
       ]
     },
@@ -2793,9 +2793,9 @@
         "System.Net.Primitives.nuspec"
       ]
     },
-    "System.Net.Security/4.0.0-beta-23409": {
+    "System.Net.Security/4.0.0-beta-23412": {
       "type": "package",
-      "sha512": "cGfAjgloAeG5XSPJFPw3R1VOhwZDmwUGu/evyssEwXiCsf9tfD0uo5EO95nGlTsSThHpfRDpH4qzzBAfSve/Vg==",
+      "sha512": "Kcjne7jnvF5aTbRJsAT8kuP+1mxryUF2qYv8f3jnR19wtEjswSIOVU0XzuWc9YObEQcb+kEdzN71HTOm+ssv+w==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2819,8 +2819,8 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Net.Security.4.0.0-beta-23409.nupkg",
-        "System.Net.Security.4.0.0-beta-23409.nupkg.sha512",
+        "System.Net.Security.4.0.0-beta-23412.nupkg",
+        "System.Net.Security.4.0.0-beta-23412.nupkg.sha512",
         "System.Net.Security.nuspec"
       ]
     },
@@ -2885,10 +2885,10 @@
         "System.Net.WebHeaderCollection.nuspec"
       ]
     },
-    "System.Net.WebSockets/4.0.0-beta-23409": {
+    "System.Net.WebSockets/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "iVYL/Ok4yVDukkBI+Juk4GIa70G8DKGqm4xGbbSEDm3n7h2cqaLUpGm3Kj+GUEGOX4aXzP1ixyJQ7PCz0lNGeg==",
+      "sha512": "EvXAa0yd1RM8ROyLl1T0xC94F04Su8YMHnd4/w6j0Z/+4lKHZOU7bQPZ3odDN8WdPGKa/ZNJJGwiapydEWKzwQ==",
       "files": [
         "lib/dotnet/System.Net.WebSockets.dll",
         "lib/MonoAndroid10/_._",
@@ -2912,15 +2912,15 @@
         "ref/net46/System.Net.WebSockets.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.WebSockets.4.0.0-beta-23409.nupkg",
-        "System.Net.WebSockets.4.0.0-beta-23409.nupkg.sha512",
+        "System.Net.WebSockets.4.0.0-beta-23412.nupkg",
+        "System.Net.WebSockets.4.0.0-beta-23412.nupkg.sha512",
         "System.Net.WebSockets.nuspec"
       ]
     },
-    "System.Net.WebSockets.Client/4.0.0-beta-23409": {
+    "System.Net.WebSockets.Client/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "h4cDjk/jlU3V+WEP3fABIYQN70iF/UftFMx/2d2hsIsaxt/o9FCUcNenhQiCeNVMC+pAxUkwUxb1742vfXDoXw==",
+      "sha512": "uaO7c/81sK90605UtThSX9KVmzsJDA1vD4GMW7FsKKntymlkolJsprDekWblQ4A5YbhqxHv+ngXX2kIU0B3Fdw==",
       "files": [
         "lib/DNXCore50/System.Net.WebSockets.Client.dll",
         "lib/MonoAndroid10/_._",
@@ -2945,8 +2945,8 @@
         "ref/net46/System.Net.WebSockets.Client.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.WebSockets.Client.4.0.0-beta-23409.nupkg",
-        "System.Net.WebSockets.Client.4.0.0-beta-23409.nupkg.sha512",
+        "System.Net.WebSockets.Client.4.0.0-beta-23412.nupkg",
+        "System.Net.WebSockets.Client.4.0.0-beta-23412.nupkg.sha512",
         "System.Net.WebSockets.Client.nuspec"
       ]
     },
@@ -3561,42 +3561,42 @@
         "System.Runtime.WindowsRuntime.nuspec"
       ]
     },
-    "System.Security.Claims/4.0.1-beta-23408": {
+    "System.Security.Claims/4.0.1-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "9rsYgMq/0OqUX9xKlNUkOvaBaZETICCGd7SPcFPv+/bMYte2+PMD/tZpxFrbiXpB2211mHYk/wBVwejEyZuGcQ==",
+      "sha512": "Uu9h4cMBVr8DvFgRGxnTjd2fJkMmL3JApUxL82Bf333NHH5S0F85TGizF2kZkX0TOsySJ8TJUSJSQT+yq3m5Kg==",
       "files": [
-        "lib/dotnet/de/System.Security.Claims.xml",
-        "lib/dotnet/es/System.Security.Claims.xml",
-        "lib/dotnet/fr/System.Security.Claims.xml",
-        "lib/dotnet/it/System.Security.Claims.xml",
-        "lib/dotnet/ja/System.Security.Claims.xml",
-        "lib/dotnet/ko/System.Security.Claims.xml",
-        "lib/dotnet/ru/System.Security.Claims.xml",
         "lib/dotnet/System.Security.Claims.dll",
-        "lib/dotnet/System.Security.Claims.xml",
-        "lib/dotnet/zh-hans/System.Security.Claims.xml",
-        "lib/dotnet/zh-hant/System.Security.Claims.xml",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Security.Claims.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Security.Claims.xml",
+        "ref/dotnet/es/System.Security.Claims.xml",
+        "ref/dotnet/fr/System.Security.Claims.xml",
+        "ref/dotnet/it/System.Security.Claims.xml",
+        "ref/dotnet/ja/System.Security.Claims.xml",
+        "ref/dotnet/ko/System.Security.Claims.xml",
+        "ref/dotnet/ru/System.Security.Claims.xml",
         "ref/dotnet/System.Security.Claims.dll",
+        "ref/dotnet/System.Security.Claims.xml",
+        "ref/dotnet/zh-hans/System.Security.Claims.xml",
+        "ref/dotnet/zh-hant/System.Security.Claims.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Security.Claims.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Security.Claims.4.0.1-beta-23408.nupkg",
-        "System.Security.Claims.4.0.1-beta-23408.nupkg.sha512",
+        "System.Security.Claims.4.0.1-beta-23412.nupkg",
+        "System.Security.Claims.4.0.1-beta-23412.nupkg.sha512",
         "System.Security.Claims.nuspec"
       ]
     },
-    "System.Security.Cryptography.Algorithms/4.0.0-beta-23409": {
+    "System.Security.Cryptography.Algorithms/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "+fTP36jzRYPFFG6j3iLDhCp1t7uOg6q7urwe1XAh1JNhqoRPKassTV2FABKzwx1L8LIQXEYIlbK2tb/SOeLcug==",
+      "sha512": "nBjoiqJQiMD3cJgOVrqjIVDqEEPZeIqT+mrBIxjLE+YMQcjEyDuSyOG65Ntoopby5LH4onTLMM4zfXh8JRt9NQ==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -3610,15 +3610,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.Algorithms.4.0.0-beta-23409.nupkg",
-        "System.Security.Cryptography.Algorithms.4.0.0-beta-23409.nupkg.sha512",
+        "System.Security.Cryptography.Algorithms.4.0.0-beta-23412.nupkg",
+        "System.Security.Cryptography.Algorithms.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Cryptography.Algorithms.nuspec"
       ]
     },
-    "System.Security.Cryptography.Encoding/4.0.0-beta-23409": {
+    "System.Security.Cryptography.Encoding/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "Nw4bCWshkW6UTpKag/IJj3/IDkT5x42fRAyGoKjhBXykI6izLz3IocOSHVkBgI8KlMaezhV4+2QCFCD7s+cbGw==",
+      "sha512": "SR1zCARNdeyLoUKYH2SNMm1He7Lr3NR/l7yW3K135L44T6PS3YB8SfXpVoZdMpb22X2G07BZAHVz2x7e4AA1Cg==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -3642,15 +3642,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.Encoding.4.0.0-beta-23409.nupkg",
-        "System.Security.Cryptography.Encoding.4.0.0-beta-23409.nupkg.sha512",
+        "System.Security.Cryptography.Encoding.4.0.0-beta-23412.nupkg",
+        "System.Security.Cryptography.Encoding.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Cryptography.Encoding.nuspec"
       ]
     },
-    "System.Security.Cryptography.Primitives/4.0.0-beta-23409": {
+    "System.Security.Cryptography.Primitives/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "A9uRLcec2cnppupdLyiU3AJCCphk2MQe37Kfm3rA6Oi00mFTfy/fD6SsBjKzJsE6rtx1IjpJUqrNe0dp+r32cg==",
+      "sha512": "H9EBNe0ahjAYjlVn0TnT18PSgZBrtROSQH1RRIKwAjzxQHt8zwDhO4yN0Q5QaaUIoSXgxVmgtWWk62wDvpy+QA==",
       "files": [
         "lib/dotnet/System.Security.Cryptography.Primitives.dll",
         "lib/MonoAndroid10/_._",
@@ -3664,15 +3664,15 @@
         "ref/net46/System.Security.Cryptography.Primitives.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Security.Cryptography.Primitives.4.0.0-beta-23409.nupkg",
-        "System.Security.Cryptography.Primitives.4.0.0-beta-23409.nupkg.sha512",
+        "System.Security.Cryptography.Primitives.4.0.0-beta-23412.nupkg",
+        "System.Security.Cryptography.Primitives.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Cryptography.Primitives.nuspec"
       ]
     },
-    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23409": {
+    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "rKzrKqyWNTP8EYgmlkzOb9Qdi8LrBQ6dJ2k4Uka900ax+iSoiQ2b9osfnBgk1XFPnRUUf1Z4PF4txeOndZOpew==",
+      "sha512": "SfpMjvrfRaRjG42uynLugb3YgpXdpnU7X8vNAU7stIR5/4uW9m1SvWHvBjirjHRBtOpbKB86uD5ODQWX+tWDNA==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -3696,8 +3696,8 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23409.nupkg",
-        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23409.nupkg.sha512",
+        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23412.nupkg",
+        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Cryptography.X509Certificates.nuspec"
       ]
     },
@@ -3734,10 +3734,10 @@
         "System.Security.Principal.nuspec"
       ]
     },
-    "System.Security.Principal.Windows/4.0.0-beta-23409": {
+    "System.Security.Principal.Windows/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "l24CzvkR0FUSmojdk/cXkvPKRqZ2jIJ8h2d440kFwG6yyyJwvOcZkzYDR/XV2npEmls13HcA+KvMsXxmprLn6A==",
+      "sha512": "Zvb/LzT+GjGNV1t8i5KVieilL+8P5LcQykIbJHw5aJxLPFEIQ4Y2hTJXdEkeKvZ4TCF5dlwY1jYyUrJkcqpxzw==",
       "files": [
         "lib/DNXCore50/System.Security.Principal.Windows.dll",
         "lib/net46/System.Security.Principal.Windows.dll",
@@ -3753,8 +3753,8 @@
         "ref/dotnet/zh-hans/System.Security.Principal.Windows.xml",
         "ref/dotnet/zh-hant/System.Security.Principal.Windows.xml",
         "ref/net46/System.Security.Principal.Windows.dll",
-        "System.Security.Principal.Windows.4.0.0-beta-23409.nupkg",
-        "System.Security.Principal.Windows.4.0.0-beta-23409.nupkg.sha512",
+        "System.Security.Principal.Windows.4.0.0-beta-23412.nupkg",
+        "System.Security.Principal.Windows.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Principal.Windows.nuspec"
       ]
     },

--- a/src/System.Private.ServiceModel/tests/Common/Infrastructure/src/project.lock.json
+++ b/src/System.Private.ServiceModel/tests/Common/Infrastructure/src/project.lock.json
@@ -292,7 +292,7 @@
           "lib/dotnet/System.Linq.Queryable.dll": {}
         }
       },
-      "System.Net.Http/4.0.1-beta-23408": {
+      "System.Net.Http/4.0.1-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -305,7 +305,7 @@
           "ref/dotnet/System.Net.Http.dll": {}
         }
       },
-      "System.Net.NameResolution/4.0.0-beta-23408": {
+      "System.Net.NameResolution/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Net.Primitives": "4.0.10",
@@ -328,16 +328,17 @@
           "lib/DNXCore50/System.Net.Primitives.dll": {}
         }
       },
-      "System.Net.Security/4.0.0-beta-23408": {
+      "System.Net.Security/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
-          "System.Private.Networking": "4.0.1-beta-23408"
+          "System.IO": "4.0.0",
+          "System.Net.Primitives": "4.0.10",
+          "System.Runtime": "4.0.0",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23412",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Net.Security.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Net.Security.dll": {}
         }
       },
       "System.Net.Sockets/4.1.0-beta-23225": {
@@ -368,7 +369,7 @@
           "lib/dotnet/System.Net.WebHeaderCollection.dll": {}
         }
       },
-      "System.Net.WebSockets/4.0.0-beta-23408": {
+      "System.Net.WebSockets/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -383,7 +384,7 @@
           "lib/dotnet/System.Net.WebSockets.dll": {}
         }
       },
-      "System.Net.WebSockets.Client/4.0.0-beta-23408": {
+      "System.Net.WebSockets.Client/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -393,13 +394,13 @@
           "System.Globalization": "4.0.10",
           "System.Net.Primitives": "4.0.10",
           "System.Net.WebHeaderCollection": "4.0.0",
-          "System.Net.WebSockets": "4.0.0-beta-23408",
+          "System.Net.WebSockets": "4.0.0-beta-23412",
           "System.Resources.ResourceManager": "4.0.0",
           "System.Runtime": "4.0.20",
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23408",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23412",
           "System.Text.Encoding": "4.0.10",
           "System.Threading": "4.0.10",
           "System.Threading.Tasks": "4.0.10"
@@ -456,7 +457,7 @@
           "lib/DNXCore50/System.Private.DataContractSerialization.dll": {}
         }
       },
-      "System.Private.Networking/4.0.1-beta-23408": {
+      "System.Private.Networking/4.0.1-beta-23225": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -475,13 +476,10 @@
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23408",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23408",
-          "System.Security.Principal.Windows": "4.0.0-beta-23408",
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23225",
           "System.Threading": "4.0.10",
           "System.Threading.Overlapped": "4.0.0",
-          "System.Threading.Tasks": "4.0.10",
-          "System.Threading.ThreadPool": "4.0.10-beta-23408"
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dnxcore50/_._": {}
@@ -490,7 +488,7 @@
           "lib/DNXCore50/System.Private.Networking.dll": {}
         }
       },
-      "System.Private.ServiceModel/4.1.0-beta-23408": {
+      "System.Private.ServiceModel/4.1.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -507,14 +505,14 @@
           "System.Linq": "4.0.0",
           "System.Linq.Expressions": "4.0.10",
           "System.Linq.Queryable": "4.0.0",
-          "System.Net.Http": "4.0.1-beta-23408",
-          "System.Net.NameResolution": "4.0.0-beta-23408",
+          "System.Net.Http": "4.0.1-beta-23412",
+          "System.Net.NameResolution": "4.0.0-beta-23412",
           "System.Net.Primitives": "4.0.10",
-          "System.Net.Security": "4.0.0-beta-23408",
-          "System.Net.Sockets": "4.0.10-beta-23408",
+          "System.Net.Security": "4.0.0-beta-23412",
+          "System.Net.Sockets": "4.0.10-beta-23412",
           "System.Net.WebHeaderCollection": "4.0.0",
-          "System.Net.WebSockets": "4.0.0-beta-23408",
-          "System.Net.WebSockets.Client": "4.0.0-beta-23408",
+          "System.Net.WebSockets": "4.0.0-beta-23412",
+          "System.Net.WebSockets.Client": "4.0.0-beta-23412",
           "System.ObjectModel": "4.0.10",
           "System.Reflection": "4.0.10",
           "System.Reflection.DispatchProxy": "4.0.0",
@@ -528,9 +526,9 @@
           "System.Runtime.Serialization.Primitives": "4.0.10",
           "System.Runtime.Serialization.Xml": "4.0.10",
           "System.Security.Claims": "4.0.0",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23408",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23412",
           "System.Security.Principal": "4.0.0",
-          "System.Security.Principal.Windows": "4.0.0-beta-23408",
+          "System.Security.Principal.Windows": "4.0.0-beta-23412",
           "System.Text.Encoding": "4.0.10",
           "System.Threading": "4.0.10",
           "System.Threading.Tasks": "4.0.10",
@@ -766,18 +764,18 @@
           "lib/dotnet/System.Security.Claims.dll": {}
         }
       },
-      "System.Security.Cryptography.Algorithms/4.0.0-beta-23408": {
+      "System.Security.Cryptography.Algorithms/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
           "System.Runtime": "4.0.0",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23408"
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23412"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.Algorithms.dll": {}
         }
       },
-      "System.Security.Cryptography.Encoding/4.0.0-beta-23408": {
+      "System.Security.Cryptography.Encoding/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -786,7 +784,7 @@
           "ref/dotnet/System.Security.Cryptography.Encoding.dll": {}
         }
       },
-      "System.Security.Cryptography.Primitives/4.0.0-beta-23408": {
+      "System.Security.Cryptography.Primitives/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.0",
@@ -804,13 +802,13 @@
           "lib/dotnet/System.Security.Cryptography.Primitives.dll": {}
         }
       },
-      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23408": {
+      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
           "System.Runtime.Handles": "4.0.0",
-          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23408",
-          "System.Security.Cryptography.Encoding": "4.0.0-beta-23408"
+          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23412",
+          "System.Security.Cryptography.Encoding": "4.0.0-beta-23412"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.X509Certificates.dll": {}
@@ -828,7 +826,7 @@
           "lib/dotnet/System.Security.Principal.dll": {}
         }
       },
-      "System.Security.Principal.Windows/4.0.0-beta-23408": {
+      "System.Security.Principal.Windows/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -851,10 +849,10 @@
           "lib/DNXCore50/System.Security.Principal.Windows.dll": {}
         }
       },
-      "System.ServiceModel.Duplex/4.0.1-beta-23408": {
+      "System.ServiceModel.Duplex/4.0.1-beta-23412": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-beta-23408"
+          "System.Private.ServiceModel": "4.1.0-beta-23412"
         },
         "compile": {
           "ref/dotnet/System.ServiceModel.Duplex.dll": {}
@@ -863,10 +861,10 @@
           "lib/DNXCore50/System.ServiceModel.Duplex.dll": {}
         }
       },
-      "System.ServiceModel.Http/4.0.11-beta-23408": {
+      "System.ServiceModel.Http/4.0.11-beta-23412": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-beta-23408",
+          "System.Private.ServiceModel": "4.1.0-beta-23412",
           "System.Runtime": "4.0.20"
         },
         "compile": {
@@ -876,10 +874,10 @@
           "lib/DNXCore50/System.ServiceModel.Http.dll": {}
         }
       },
-      "System.ServiceModel.Primitives/4.0.1-beta-23408": {
+      "System.ServiceModel.Primitives/4.0.1-beta-23412": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-beta-23408"
+          "System.Private.ServiceModel": "4.1.0-beta-23412"
         },
         "compile": {
           "ref/dotnet/System.ServiceModel.Primitives.dll": {}
@@ -966,19 +964,6 @@
         },
         "runtime": {
           "lib/DNXCore50/System.Threading.Tasks.dll": {}
-        }
-      },
-      "System.Threading.ThreadPool/4.0.10-beta-23408": {
-        "type": "package",
-        "dependencies": {
-          "System.Runtime": "4.0.0",
-          "System.Runtime.InteropServices": "4.0.0"
-        },
-        "compile": {
-          "ref/dotnet/System.Threading.ThreadPool.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Threading.ThreadPool.dll": {}
         }
       },
       "System.Threading.Timer/4.0.0": {
@@ -1669,44 +1654,65 @@
         "System.Linq.Queryable.nuspec"
       ]
     },
-    "System.Net.Http/4.0.1-beta-23408": {
+    "System.Net.Http/4.0.1-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "n+tnV1VgCjbDKKnbgrvgUgxkPDwUFvSv9lTgH882rVzjbWyliVgbBflVzoAUjUSlga/Tr1XQIrfTLMRD5HfYGw==",
+      "sha512": "F7Yej+6QdRVzWg+qbkayRMcmf/7k7YfNFoVSA67wIsG9t5u7Wj4Go8FW72HL8qb9d7YjIsVB/5hA7g9MUT31Aw==",
       "files": [
         "lib/net45/_._",
         "lib/win8/_._",
         "lib/wpa81/_._",
+        "ref/dotnet/de/System.Net.Http.xml",
+        "ref/dotnet/es/System.Net.Http.xml",
+        "ref/dotnet/fr/System.Net.Http.xml",
+        "ref/dotnet/it/System.Net.Http.xml",
+        "ref/dotnet/ja/System.Net.Http.xml",
+        "ref/dotnet/ko/System.Net.Http.xml",
+        "ref/dotnet/ru/System.Net.Http.xml",
         "ref/dotnet/System.Net.Http.dll",
+        "ref/dotnet/System.Net.Http.xml",
+        "ref/dotnet/zh-hans/System.Net.Http.xml",
+        "ref/dotnet/zh-hant/System.Net.Http.xml",
         "ref/net45/_._",
         "ref/netcore50/System.Net.Http.dll",
+        "ref/netcore50/System.Net.Http.xml",
         "ref/win8/_._",
         "ref/wpa81/_._",
         "runtime.json",
-        "System.Net.Http.4.0.1-beta-23408.nupkg",
-        "System.Net.Http.4.0.1-beta-23408.nupkg.sha512",
+        "System.Net.Http.4.0.1-beta-23412.nupkg",
+        "System.Net.Http.4.0.1-beta-23412.nupkg.sha512",
         "System.Net.Http.nuspec"
       ]
     },
-    "System.Net.NameResolution/4.0.0-beta-23408": {
+    "System.Net.NameResolution/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "2A562VFL8GUL/jLCJ3mbQHhwwAIXzPyjxMpdtas1LVM8QLuP1OcHwV3z7ajWnYdGcPc7ZxPEGJQWicuaPD+0nA==",
+      "sha512": "HCF1zhFYBT+w/Ik+JuTzFJgj83Jfc+eA8VcgvIzdPiGMXfrZeXOogjgSCkCoJmFtKVz2DSfmISoEmiXB1oaLNQ==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.NameResolution.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Net.NameResolution.xml",
+        "ref/dotnet/es/System.Net.NameResolution.xml",
+        "ref/dotnet/fr/System.Net.NameResolution.xml",
+        "ref/dotnet/it/System.Net.NameResolution.xml",
+        "ref/dotnet/ja/System.Net.NameResolution.xml",
+        "ref/dotnet/ko/System.Net.NameResolution.xml",
+        "ref/dotnet/ru/System.Net.NameResolution.xml",
         "ref/dotnet/System.Net.NameResolution.dll",
+        "ref/dotnet/System.Net.NameResolution.xml",
+        "ref/dotnet/zh-hans/System.Net.NameResolution.xml",
+        "ref/dotnet/zh-hant/System.Net.NameResolution.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Net.NameResolution.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Net.NameResolution.4.0.0-beta-23408.nupkg",
-        "System.Net.NameResolution.4.0.0-beta-23408.nupkg.sha512",
+        "System.Net.NameResolution.4.0.0-beta-23412.nupkg",
+        "System.Net.NameResolution.4.0.0-beta-23412.nupkg.sha512",
         "System.Net.NameResolution.nuspec"
       ]
     },
@@ -1743,24 +1749,34 @@
         "System.Net.Primitives.nuspec"
       ]
     },
-    "System.Net.Security/4.0.0-beta-23408": {
+    "System.Net.Security/4.0.0-beta-23412": {
       "type": "package",
-      "sha512": "kEkunODO2t/VlBIsC80YFDG0KtY/FyIbtBApNyJQv+LYGEs5IFvEhpi9+p0/jHmhyRMKwbjajNedbXo+VMkt1A==",
+      "sha512": "Kcjne7jnvF5aTbRJsAT8kuP+1mxryUF2qYv8f3jnR19wtEjswSIOVU0XzuWc9YObEQcb+kEdzN71HTOm+ssv+w==",
       "files": [
-        "lib/DNXCore50/System.Net.Security.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.Security.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Net.Security.xml",
+        "ref/dotnet/es/System.Net.Security.xml",
+        "ref/dotnet/fr/System.Net.Security.xml",
+        "ref/dotnet/it/System.Net.Security.xml",
+        "ref/dotnet/ja/System.Net.Security.xml",
+        "ref/dotnet/ko/System.Net.Security.xml",
+        "ref/dotnet/ru/System.Net.Security.xml",
         "ref/dotnet/System.Net.Security.dll",
+        "ref/dotnet/System.Net.Security.xml",
+        "ref/dotnet/zh-hans/System.Net.Security.xml",
+        "ref/dotnet/zh-hant/System.Net.Security.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Net.Security.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.Security.4.0.0-beta-23408.nupkg",
-        "System.Net.Security.4.0.0-beta-23408.nupkg.sha512",
+        "runtime.json",
+        "System.Net.Security.4.0.0-beta-23412.nupkg",
+        "System.Net.Security.4.0.0-beta-23412.nupkg.sha512",
         "System.Net.Security.nuspec"
       ]
     },
@@ -1818,78 +1834,68 @@
         "System.Net.WebHeaderCollection.nuspec"
       ]
     },
-    "System.Net.WebSockets/4.0.0-beta-23408": {
+    "System.Net.WebSockets/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "BXy22/bNVtrXXsG76zXyhjcQnCjSYxQIFF37xWifqPRWmvzsCYSLQpNCTPQUCp7rjB7qWc5yLhC9bThaEx7MHQ==",
+      "sha512": "EvXAa0yd1RM8ROyLl1T0xC94F04Su8YMHnd4/w6j0Z/+4lKHZOU7bQPZ3odDN8WdPGKa/ZNJJGwiapydEWKzwQ==",
       "files": [
-        "lib/dotnet/de/System.Net.WebSockets.xml",
-        "lib/dotnet/es/System.Net.WebSockets.xml",
-        "lib/dotnet/fr/System.Net.WebSockets.xml",
-        "lib/dotnet/it/System.Net.WebSockets.xml",
-        "lib/dotnet/ja/System.Net.WebSockets.xml",
-        "lib/dotnet/ko/System.Net.WebSockets.xml",
-        "lib/dotnet/ru/System.Net.WebSockets.xml",
         "lib/dotnet/System.Net.WebSockets.dll",
-        "lib/dotnet/System.Net.WebSockets.xml",
-        "lib/dotnet/zh-hans/System.Net.WebSockets.xml",
-        "lib/dotnet/zh-hant/System.Net.WebSockets.xml",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.WebSockets.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Net.WebSockets.xml",
+        "ref/dotnet/es/System.Net.WebSockets.xml",
+        "ref/dotnet/fr/System.Net.WebSockets.xml",
+        "ref/dotnet/it/System.Net.WebSockets.xml",
+        "ref/dotnet/ja/System.Net.WebSockets.xml",
+        "ref/dotnet/ko/System.Net.WebSockets.xml",
+        "ref/dotnet/ru/System.Net.WebSockets.xml",
         "ref/dotnet/System.Net.WebSockets.dll",
+        "ref/dotnet/System.Net.WebSockets.xml",
+        "ref/dotnet/zh-hans/System.Net.WebSockets.xml",
+        "ref/dotnet/zh-hant/System.Net.WebSockets.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Net.WebSockets.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.WebSockets.4.0.0-beta-23408.nupkg",
-        "System.Net.WebSockets.4.0.0-beta-23408.nupkg.sha512",
+        "System.Net.WebSockets.4.0.0-beta-23412.nupkg",
+        "System.Net.WebSockets.4.0.0-beta-23412.nupkg.sha512",
         "System.Net.WebSockets.nuspec"
       ]
     },
-    "System.Net.WebSockets.Client/4.0.0-beta-23408": {
+    "System.Net.WebSockets.Client/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "smmvhCkcU0c4RNWc6NZwnN5EFktX58jf8+TJ6enfuXxWrpJ/2NRI5/2yT/okjFSngGK1g0MBrljZsfs2EJ7+Yw==",
+      "sha512": "uaO7c/81sK90605UtThSX9KVmzsJDA1vD4GMW7FsKKntymlkolJsprDekWblQ4A5YbhqxHv+ngXX2kIU0B3Fdw==",
       "files": [
-        "lib/DNXCore50/de/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/es/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/fr/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/it/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/ja/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/ko/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/ru/System.Net.WebSockets.Client.xml",
         "lib/DNXCore50/System.Net.WebSockets.Client.dll",
-        "lib/DNXCore50/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/zh-hans/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/zh-hant/System.Net.WebSockets.Client.xml",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.WebSockets.Client.dll",
-        "lib/netcore50/de/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/es/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/fr/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/it/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/ja/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/ko/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/ru/System.Net.WebSockets.Client.xml",
         "lib/netcore50/System.Net.WebSockets.Client.dll",
-        "lib/netcore50/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/zh-hans/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/zh-hant/System.Net.WebSockets.Client.xml",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/es/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/fr/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/it/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/ja/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/ko/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/ru/System.Net.WebSockets.Client.xml",
         "ref/dotnet/System.Net.WebSockets.Client.dll",
+        "ref/dotnet/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/zh-hans/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/zh-hant/System.Net.WebSockets.Client.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Net.WebSockets.Client.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.WebSockets.Client.4.0.0-beta-23408.nupkg",
-        "System.Net.WebSockets.Client.4.0.0-beta-23408.nupkg.sha512",
+        "System.Net.WebSockets.Client.4.0.0-beta-23412.nupkg",
+        "System.Net.WebSockets.Client.4.0.0-beta-23412.nupkg.sha512",
         "System.Net.WebSockets.Client.nuspec"
       ]
     },
@@ -1941,31 +1947,31 @@
         "System.Private.DataContractSerialization.nuspec"
       ]
     },
-    "System.Private.Networking/4.0.1-beta-23408": {
+    "System.Private.Networking/4.0.1-beta-23225": {
       "type": "package",
       "serviceable": true,
-      "sha512": "i2fRDRqM8Px3CP26C//deF/tCNR1AwqlPEr9+MYiXxNZtgGcSPBfqOJJ5CJdfmDb9Ap0hPG2MiPG7CinaSH7+Q==",
+      "sha512": "oVSynIrR3mIU0b/goscsaZDywr3RLxQijQnaFRKfl/VB3F9rKi5mdr0vHcGVWuq5ALSrG0OLwM8PRA4tM5e3rQ==",
       "files": [
         "lib/DNXCore50/System.Private.Networking.dll",
         "lib/netcore50/System.Private.Networking.dll",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "System.Private.Networking.4.0.1-beta-23408.nupkg",
-        "System.Private.Networking.4.0.1-beta-23408.nupkg.sha512",
+        "System.Private.Networking.4.0.1-beta-23225.nupkg",
+        "System.Private.Networking.4.0.1-beta-23225.nupkg.sha512",
         "System.Private.Networking.nuspec"
       ]
     },
-    "System.Private.ServiceModel/4.1.0-beta-23408": {
+    "System.Private.ServiceModel/4.1.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "l/2192yKa6uXhjKOWeukFJy3hoj9Zq1p55pTGe+Y28r8/5jlvgYxfunP9UyXJRo9W1u3UBtGfV/5R71ULzusGQ==",
+      "sha512": "Wm+8LcQ04YeAvYqu9faHsMZ/L8l/WvPPsqziBfifYB4jXIPXk1/kUxuAryjbLChghZDXvkDN0hv/IHSVPZGgBA==",
       "files": [
         "lib/DNXCore50/System.Private.ServiceModel.dll",
         "lib/netcore50/System.Private.ServiceModel.dll",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "System.Private.ServiceModel.4.1.0-beta-23408.nupkg",
-        "System.Private.ServiceModel.4.1.0-beta-23408.nupkg.sha512",
+        "System.Private.ServiceModel.4.1.0-beta-23412.nupkg",
+        "System.Private.ServiceModel.4.1.0-beta-23412.nupkg.sha512",
         "System.Private.ServiceModel.nuspec"
       ]
     },
@@ -2474,10 +2480,10 @@
         "System.Security.Claims.nuspec"
       ]
     },
-    "System.Security.Cryptography.Algorithms/4.0.0-beta-23408": {
+    "System.Security.Cryptography.Algorithms/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "G6eEqi8mZRrWftcwilcnllE4xJ/53JQlk3VVuJ+9qrX+DHvWz8itYJRUZX357JY4DgEEKQNOJzuRGrOBTUeoPg==",
+      "sha512": "nBjoiqJQiMD3cJgOVrqjIVDqEEPZeIqT+mrBIxjLE+YMQcjEyDuSyOG65Ntoopby5LH4onTLMM4zfXh8JRt9NQ==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2491,37 +2497,47 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.Algorithms.4.0.0-beta-23408.nupkg",
-        "System.Security.Cryptography.Algorithms.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Cryptography.Algorithms.4.0.0-beta-23412.nupkg",
+        "System.Security.Cryptography.Algorithms.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Cryptography.Algorithms.nuspec"
       ]
     },
-    "System.Security.Cryptography.Encoding/4.0.0-beta-23408": {
+    "System.Security.Cryptography.Encoding/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "fPsAK3vyMjnJ6nT4YchdS7KzfGca/6uVVAPCBO08ZpTRGhMGx30vq1MiIqAUrfsFMnot3Ub2jimnAFWkqY6g0Q==",
+      "sha512": "SR1zCARNdeyLoUKYH2SNMm1He7Lr3NR/l7yW3K135L44T6PS3YB8SfXpVoZdMpb22X2G07BZAHVz2x7e4AA1Cg==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Security.Cryptography.Encoding.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/es/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/fr/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/it/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/ja/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/ko/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/ru/System.Security.Cryptography.Encoding.xml",
         "ref/dotnet/System.Security.Cryptography.Encoding.dll",
+        "ref/dotnet/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/zh-hans/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/zh-hant/System.Security.Cryptography.Encoding.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Security.Cryptography.Encoding.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.Encoding.4.0.0-beta-23408.nupkg",
-        "System.Security.Cryptography.Encoding.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Cryptography.Encoding.4.0.0-beta-23412.nupkg",
+        "System.Security.Cryptography.Encoding.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Cryptography.Encoding.nuspec"
       ]
     },
-    "System.Security.Cryptography.Primitives/4.0.0-beta-23408": {
+    "System.Security.Cryptography.Primitives/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "A336dWYEIQxm1rEJCaE5ZZrUWHPUkBGTRH8uAj8qrTqg4/qRc2yN2wZxeGXaZauhI35QwDmOutK7oVb2Cd+4TA==",
+      "sha512": "H9EBNe0ahjAYjlVn0TnT18PSgZBrtROSQH1RRIKwAjzxQHt8zwDhO4yN0Q5QaaUIoSXgxVmgtWWk62wDvpy+QA==",
       "files": [
         "lib/dotnet/System.Security.Cryptography.Primitives.dll",
         "lib/MonoAndroid10/_._",
@@ -2535,30 +2551,40 @@
         "ref/net46/System.Security.Cryptography.Primitives.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Security.Cryptography.Primitives.4.0.0-beta-23408.nupkg",
-        "System.Security.Cryptography.Primitives.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Cryptography.Primitives.4.0.0-beta-23412.nupkg",
+        "System.Security.Cryptography.Primitives.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Cryptography.Primitives.nuspec"
       ]
     },
-    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23408": {
+    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "JSNf5d1V5Y47MIdf7QxZCuGnR5heM4UKbrsdXiWD5lfqu0mnNjebPIclMUXlTw/6IykuDsUpompV/DtsaLLHig==",
+      "sha512": "SfpMjvrfRaRjG42uynLugb3YgpXdpnU7X8vNAU7stIR5/4uW9m1SvWHvBjirjHRBtOpbKB86uD5ODQWX+tWDNA==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Security.Cryptography.X509Certificates.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/es/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/fr/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/it/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/ja/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/ko/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/ru/System.Security.Cryptography.X509Certificates.xml",
         "ref/dotnet/System.Security.Cryptography.X509Certificates.dll",
+        "ref/dotnet/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/zh-hans/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/zh-hant/System.Security.Cryptography.X509Certificates.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Security.Cryptography.X509Certificates.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23408.nupkg",
-        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23412.nupkg",
+        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Cryptography.X509Certificates.nuspec"
       ]
     },
@@ -2595,116 +2621,118 @@
         "System.Security.Principal.nuspec"
       ]
     },
-    "System.Security.Principal.Windows/4.0.0-beta-23408": {
+    "System.Security.Principal.Windows/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "xmjpZJvsT1AW23UkjqUkF/VrOh7DA1cagYY272UQmO8ei227TFD4C7j3ofatL/63hR3CXkLkoephuE4f2Z9fGA==",
+      "sha512": "Zvb/LzT+GjGNV1t8i5KVieilL+8P5LcQykIbJHw5aJxLPFEIQ4Y2hTJXdEkeKvZ4TCF5dlwY1jYyUrJkcqpxzw==",
       "files": [
-        "lib/DNXCore50/de/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/es/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/fr/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/it/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/ja/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/ko/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/ru/System.Security.Principal.Windows.xml",
         "lib/DNXCore50/System.Security.Principal.Windows.dll",
-        "lib/DNXCore50/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/zh-hans/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/zh-hant/System.Security.Principal.Windows.xml",
         "lib/net46/System.Security.Principal.Windows.dll",
+        "ref/dotnet/de/System.Security.Principal.Windows.xml",
+        "ref/dotnet/es/System.Security.Principal.Windows.xml",
+        "ref/dotnet/fr/System.Security.Principal.Windows.xml",
+        "ref/dotnet/it/System.Security.Principal.Windows.xml",
+        "ref/dotnet/ja/System.Security.Principal.Windows.xml",
+        "ref/dotnet/ko/System.Security.Principal.Windows.xml",
+        "ref/dotnet/ru/System.Security.Principal.Windows.xml",
         "ref/dotnet/System.Security.Principal.Windows.dll",
+        "ref/dotnet/System.Security.Principal.Windows.xml",
+        "ref/dotnet/zh-hans/System.Security.Principal.Windows.xml",
+        "ref/dotnet/zh-hant/System.Security.Principal.Windows.xml",
         "ref/net46/System.Security.Principal.Windows.dll",
-        "System.Security.Principal.Windows.4.0.0-beta-23408.nupkg",
-        "System.Security.Principal.Windows.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Principal.Windows.4.0.0-beta-23412.nupkg",
+        "System.Security.Principal.Windows.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Principal.Windows.nuspec"
       ]
     },
-    "System.ServiceModel.Duplex/4.0.1-beta-23408": {
+    "System.ServiceModel.Duplex/4.0.1-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "ZJ3aN/aEg801Rw+aVbBFZ+I9J51FyQVCoWOvSqTSh5i4qZuWuenCxmxahby43teIqNcCrCtHPoyRan2GfY8Vyg==",
+      "sha512": "o5w/amLOdG4NIfER18/TI69QL11pboppiBgH2fIwjzasKZ1OIlxE+KJPbvHJ5vt554reZYCcA+jY4CIx7/pkiw==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Duplex.dll",
         "lib/net45/_._",
-        "lib/netcore50/de/System.ServiceModel.Duplex.xml",
-        "lib/netcore50/es/System.ServiceModel.Duplex.xml",
-        "lib/netcore50/fr/System.ServiceModel.Duplex.xml",
-        "lib/netcore50/it/System.ServiceModel.Duplex.xml",
-        "lib/netcore50/ja/System.ServiceModel.Duplex.xml",
-        "lib/netcore50/ko/System.ServiceModel.Duplex.xml",
-        "lib/netcore50/ru/System.ServiceModel.Duplex.xml",
         "lib/netcore50/System.ServiceModel.Duplex.dll",
-        "lib/netcore50/System.ServiceModel.Duplex.xml",
-        "lib/netcore50/zh-hans/System.ServiceModel.Duplex.xml",
-        "lib/netcore50/zh-hant/System.ServiceModel.Duplex.xml",
         "lib/win8/_._",
+        "ref/dotnet/de/System.ServiceModel.Duplex.xml",
+        "ref/dotnet/es/System.ServiceModel.Duplex.xml",
+        "ref/dotnet/fr/System.ServiceModel.Duplex.xml",
+        "ref/dotnet/it/System.ServiceModel.Duplex.xml",
+        "ref/dotnet/ja/System.ServiceModel.Duplex.xml",
+        "ref/dotnet/ko/System.ServiceModel.Duplex.xml",
+        "ref/dotnet/ru/System.ServiceModel.Duplex.xml",
         "ref/dotnet/System.ServiceModel.Duplex.dll",
+        "ref/dotnet/System.ServiceModel.Duplex.xml",
+        "ref/dotnet/zh-hans/System.ServiceModel.Duplex.xml",
+        "ref/dotnet/zh-hant/System.ServiceModel.Duplex.xml",
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.Duplex.dll",
+        "ref/netcore50/System.ServiceModel.Duplex.xml",
         "ref/win8/_._",
-        "System.ServiceModel.Duplex.4.0.1-beta-23408.nupkg",
-        "System.ServiceModel.Duplex.4.0.1-beta-23408.nupkg.sha512",
+        "System.ServiceModel.Duplex.4.0.1-beta-23412.nupkg",
+        "System.ServiceModel.Duplex.4.0.1-beta-23412.nupkg.sha512",
         "System.ServiceModel.Duplex.nuspec"
       ]
     },
-    "System.ServiceModel.Http/4.0.11-beta-23408": {
+    "System.ServiceModel.Http/4.0.11-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "RScHZ1A3CfjumaP1Vh/xfOp/ga6T3nA8YLkjFOYcIcZm/LILL+yCh+PhIrJOEfz1Js8bLSQC6xbxwYlW6BNmYg==",
+      "sha512": "hKMGQbu/l2gv/PgPvm2ViLVElnVSwAPiv4cXKjinS+UHBf02uPF2m7lN13SCkJDNTBctwHav1rQnMYb1LUJHvw==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Http.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
-        "lib/netcore50/de/System.ServiceModel.Http.xml",
-        "lib/netcore50/es/System.ServiceModel.Http.xml",
-        "lib/netcore50/fr/System.ServiceModel.Http.xml",
-        "lib/netcore50/it/System.ServiceModel.Http.xml",
-        "lib/netcore50/ja/System.ServiceModel.Http.xml",
-        "lib/netcore50/ko/System.ServiceModel.Http.xml",
-        "lib/netcore50/ru/System.ServiceModel.Http.xml",
         "lib/netcore50/System.ServiceModel.Http.dll",
-        "lib/netcore50/System.ServiceModel.Http.xml",
-        "lib/netcore50/zh-hans/System.ServiceModel.Http.xml",
-        "lib/netcore50/zh-hant/System.ServiceModel.Http.xml",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.ServiceModel.Http.xml",
+        "ref/dotnet/es/System.ServiceModel.Http.xml",
+        "ref/dotnet/fr/System.ServiceModel.Http.xml",
+        "ref/dotnet/it/System.ServiceModel.Http.xml",
+        "ref/dotnet/ja/System.ServiceModel.Http.xml",
+        "ref/dotnet/ko/System.ServiceModel.Http.xml",
+        "ref/dotnet/ru/System.ServiceModel.Http.xml",
         "ref/dotnet/System.ServiceModel.Http.dll",
+        "ref/dotnet/System.ServiceModel.Http.xml",
+        "ref/dotnet/zh-hans/System.ServiceModel.Http.xml",
+        "ref/dotnet/zh-hant/System.ServiceModel.Http.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.ServiceModel.Http.4.0.11-beta-23408.nupkg",
-        "System.ServiceModel.Http.4.0.11-beta-23408.nupkg.sha512",
+        "System.ServiceModel.Http.4.0.11-beta-23412.nupkg",
+        "System.ServiceModel.Http.4.0.11-beta-23412.nupkg.sha512",
         "System.ServiceModel.Http.nuspec"
       ]
     },
-    "System.ServiceModel.Primitives/4.0.1-beta-23408": {
+    "System.ServiceModel.Primitives/4.0.1-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "bjXzg+V3Oq/tBXpMY5FwcERN2CQsFXoL4BMoURlwiBMkgwN2CPvBIaK45Moh7nc21jNTVukNayDtURetGzK6aA==",
+      "sha512": "dkCUkNtXb2m9Wf+DY7dc5B4J8DpaWtX4wpFfT3cYLpChxAnjQR85N+tJfMEHLfZNNerKgDRyGyaKa7uSHfvb5g==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Primitives.dll",
         "lib/net45/_._",
-        "lib/netcore50/de/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/es/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/fr/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/it/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/ja/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/ko/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/ru/System.ServiceModel.Primitives.xml",
         "lib/netcore50/System.ServiceModel.Primitives.dll",
-        "lib/netcore50/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/zh-hans/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/zh-hant/System.ServiceModel.Primitives.xml",
         "lib/win8/_._",
+        "ref/dotnet/de/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/es/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/fr/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/it/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/ja/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/ko/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/ru/System.ServiceModel.Primitives.xml",
         "ref/dotnet/System.ServiceModel.Primitives.dll",
+        "ref/dotnet/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/zh-hans/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/zh-hant/System.ServiceModel.Primitives.xml",
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.Primitives.dll",
+        "ref/netcore50/System.ServiceModel.Primitives.xml",
         "ref/win8/_._",
-        "System.ServiceModel.Primitives.4.0.1-beta-23408.nupkg",
-        "System.ServiceModel.Primitives.4.0.1-beta-23408.nupkg.sha512",
+        "System.ServiceModel.Primitives.4.0.1-beta-23412.nupkg",
+        "System.ServiceModel.Primitives.4.0.1-beta-23412.nupkg.sha512",
         "System.ServiceModel.Primitives.nuspec"
       ]
     },
@@ -2897,28 +2925,6 @@
         "System.Threading.Tasks.4.0.10.nupkg",
         "System.Threading.Tasks.4.0.10.nupkg.sha512",
         "System.Threading.Tasks.nuspec"
-      ]
-    },
-    "System.Threading.ThreadPool/4.0.10-beta-23408": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "ahdsVyj+WFj8/iSDwX/G7hkEU4jZmmvWzPS2ajZKdp0Crb0vZJOlM0LQYVASQgbimrUZHQ50o93JYEi8RFdh/Q==",
-      "files": [
-        "lib/DNXCore50/System.Threading.ThreadPool.dll",
-        "lib/MonoAndroid10/_._",
-        "lib/MonoTouch10/_._",
-        "lib/net46/System.Threading.ThreadPool.dll",
-        "lib/xamarinios10/_._",
-        "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Threading.ThreadPool.dll",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
-        "ref/net46/System.Threading.ThreadPool.dll",
-        "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.Threading.ThreadPool.4.0.10-beta-23408.nupkg",
-        "System.Threading.ThreadPool.4.0.10-beta-23408.nupkg.sha512",
-        "System.Threading.ThreadPool.nuspec"
       ]
     },
     "System.Threading.Timer/4.0.0": {

--- a/src/System.Private.ServiceModel/tests/Common/Infrastructure/tests/project.lock.json
+++ b/src/System.Private.ServiceModel/tests/Common/Infrastructure/tests/project.lock.json
@@ -292,7 +292,7 @@
           "lib/dotnet/System.Linq.Queryable.dll": {}
         }
       },
-      "System.Net.Http/4.0.1-beta-23408": {
+      "System.Net.Http/4.0.1-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -305,7 +305,7 @@
           "ref/dotnet/System.Net.Http.dll": {}
         }
       },
-      "System.Net.NameResolution/4.0.0-beta-23408": {
+      "System.Net.NameResolution/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Net.Primitives": "4.0.10",
@@ -328,16 +328,17 @@
           "lib/DNXCore50/System.Net.Primitives.dll": {}
         }
       },
-      "System.Net.Security/4.0.0-beta-23408": {
+      "System.Net.Security/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
-          "System.Private.Networking": "4.0.1-beta-23408"
+          "System.IO": "4.0.0",
+          "System.Net.Primitives": "4.0.10",
+          "System.Runtime": "4.0.0",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23412",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Net.Security.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Net.Security.dll": {}
         }
       },
       "System.Net.Sockets/4.1.0-beta-23225": {
@@ -368,7 +369,7 @@
           "lib/dotnet/System.Net.WebHeaderCollection.dll": {}
         }
       },
-      "System.Net.WebSockets/4.0.0-beta-23408": {
+      "System.Net.WebSockets/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -383,7 +384,7 @@
           "lib/dotnet/System.Net.WebSockets.dll": {}
         }
       },
-      "System.Net.WebSockets.Client/4.0.0-beta-23408": {
+      "System.Net.WebSockets.Client/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -393,13 +394,13 @@
           "System.Globalization": "4.0.10",
           "System.Net.Primitives": "4.0.10",
           "System.Net.WebHeaderCollection": "4.0.0",
-          "System.Net.WebSockets": "4.0.0-beta-23408",
+          "System.Net.WebSockets": "4.0.0-beta-23412",
           "System.Resources.ResourceManager": "4.0.0",
           "System.Runtime": "4.0.20",
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23408",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23412",
           "System.Text.Encoding": "4.0.10",
           "System.Threading": "4.0.10",
           "System.Threading.Tasks": "4.0.10"
@@ -456,7 +457,7 @@
           "lib/DNXCore50/System.Private.DataContractSerialization.dll": {}
         }
       },
-      "System.Private.Networking/4.0.1-beta-23408": {
+      "System.Private.Networking/4.0.1-beta-23225": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -475,13 +476,10 @@
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23408",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23408",
-          "System.Security.Principal.Windows": "4.0.0-beta-23408",
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23225",
           "System.Threading": "4.0.10",
           "System.Threading.Overlapped": "4.0.0",
-          "System.Threading.Tasks": "4.0.10",
-          "System.Threading.ThreadPool": "4.0.10-beta-23408"
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dnxcore50/_._": {}
@@ -490,7 +488,7 @@
           "lib/DNXCore50/System.Private.Networking.dll": {}
         }
       },
-      "System.Private.ServiceModel/4.1.0-beta-23408": {
+      "System.Private.ServiceModel/4.1.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -507,14 +505,14 @@
           "System.Linq": "4.0.0",
           "System.Linq.Expressions": "4.0.10",
           "System.Linq.Queryable": "4.0.0",
-          "System.Net.Http": "4.0.1-beta-23408",
-          "System.Net.NameResolution": "4.0.0-beta-23408",
+          "System.Net.Http": "4.0.1-beta-23412",
+          "System.Net.NameResolution": "4.0.0-beta-23412",
           "System.Net.Primitives": "4.0.10",
-          "System.Net.Security": "4.0.0-beta-23408",
-          "System.Net.Sockets": "4.0.10-beta-23408",
+          "System.Net.Security": "4.0.0-beta-23412",
+          "System.Net.Sockets": "4.0.10-beta-23412",
           "System.Net.WebHeaderCollection": "4.0.0",
-          "System.Net.WebSockets": "4.0.0-beta-23408",
-          "System.Net.WebSockets.Client": "4.0.0-beta-23408",
+          "System.Net.WebSockets": "4.0.0-beta-23412",
+          "System.Net.WebSockets.Client": "4.0.0-beta-23412",
           "System.ObjectModel": "4.0.10",
           "System.Reflection": "4.0.10",
           "System.Reflection.DispatchProxy": "4.0.0",
@@ -528,9 +526,9 @@
           "System.Runtime.Serialization.Primitives": "4.0.10",
           "System.Runtime.Serialization.Xml": "4.0.10",
           "System.Security.Claims": "4.0.0",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23408",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23412",
           "System.Security.Principal": "4.0.0",
-          "System.Security.Principal.Windows": "4.0.0-beta-23408",
+          "System.Security.Principal.Windows": "4.0.0-beta-23412",
           "System.Text.Encoding": "4.0.10",
           "System.Threading": "4.0.10",
           "System.Threading.Tasks": "4.0.10",
@@ -779,18 +777,18 @@
           "lib/dotnet/System.Security.Claims.dll": {}
         }
       },
-      "System.Security.Cryptography.Algorithms/4.0.0-beta-23408": {
+      "System.Security.Cryptography.Algorithms/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
           "System.Runtime": "4.0.0",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23408"
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23412"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.Algorithms.dll": {}
         }
       },
-      "System.Security.Cryptography.Encoding/4.0.0-beta-23408": {
+      "System.Security.Cryptography.Encoding/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -799,7 +797,7 @@
           "ref/dotnet/System.Security.Cryptography.Encoding.dll": {}
         }
       },
-      "System.Security.Cryptography.Primitives/4.0.0-beta-23408": {
+      "System.Security.Cryptography.Primitives/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.0",
@@ -817,13 +815,13 @@
           "lib/dotnet/System.Security.Cryptography.Primitives.dll": {}
         }
       },
-      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23408": {
+      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
           "System.Runtime.Handles": "4.0.0",
-          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23408",
-          "System.Security.Cryptography.Encoding": "4.0.0-beta-23408"
+          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23412",
+          "System.Security.Cryptography.Encoding": "4.0.0-beta-23412"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.X509Certificates.dll": {}
@@ -841,7 +839,7 @@
           "lib/dotnet/System.Security.Principal.dll": {}
         }
       },
-      "System.Security.Principal.Windows/4.0.0-beta-23408": {
+      "System.Security.Principal.Windows/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -864,10 +862,10 @@
           "lib/DNXCore50/System.Security.Principal.Windows.dll": {}
         }
       },
-      "System.ServiceModel.Http/4.0.11-beta-23408": {
+      "System.ServiceModel.Http/4.0.11-beta-23412": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-beta-23408",
+          "System.Private.ServiceModel": "4.1.0-beta-23412",
           "System.Runtime": "4.0.20"
         },
         "compile": {
@@ -877,10 +875,10 @@
           "lib/DNXCore50/System.ServiceModel.Http.dll": {}
         }
       },
-      "System.ServiceModel.NetTcp/4.0.1-beta-23408": {
+      "System.ServiceModel.NetTcp/4.0.1-beta-23412": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-beta-23408"
+          "System.Private.ServiceModel": "4.1.0-beta-23412"
         },
         "compile": {
           "ref/dotnet/System.ServiceModel.NetTcp.dll": {}
@@ -889,10 +887,10 @@
           "lib/DNXCore50/System.ServiceModel.NetTcp.dll": {}
         }
       },
-      "System.ServiceModel.Primitives/4.0.1-beta-23408": {
+      "System.ServiceModel.Primitives/4.0.1-beta-23412": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-beta-23408"
+          "System.Private.ServiceModel": "4.1.0-beta-23412"
         },
         "compile": {
           "ref/dotnet/System.ServiceModel.Primitives.dll": {}
@@ -901,10 +899,10 @@
           "lib/DNXCore50/System.ServiceModel.Primitives.dll": {}
         }
       },
-      "System.ServiceModel.Security/4.0.1-beta-23408": {
+      "System.ServiceModel.Security/4.0.1-beta-23412": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-beta-23408"
+          "System.Private.ServiceModel": "4.1.0-beta-23412"
         },
         "compile": {
           "ref/dotnet/System.ServiceModel.Security.dll": {}
@@ -991,19 +989,6 @@
         },
         "runtime": {
           "lib/DNXCore50/System.Threading.Tasks.dll": {}
-        }
-      },
-      "System.Threading.ThreadPool/4.0.10-beta-23408": {
-        "type": "package",
-        "dependencies": {
-          "System.Runtime": "4.0.0",
-          "System.Runtime.InteropServices": "4.0.0"
-        },
-        "compile": {
-          "ref/dotnet/System.Threading.ThreadPool.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Threading.ThreadPool.dll": {}
         }
       },
       "System.Threading.Timer/4.0.0": {
@@ -1186,7 +1171,7 @@
           "lib/dotnet/xunit.execution.dotnet.dll": {}
         }
       },
-      "xunit.netcore.extensions/1.0.0-prerelease-00104": {
+      "xunit.netcore.extensions/1.0.0-prerelease-00105": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.10",
@@ -1814,44 +1799,65 @@
         "System.Linq.Queryable.nuspec"
       ]
     },
-    "System.Net.Http/4.0.1-beta-23408": {
+    "System.Net.Http/4.0.1-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "n+tnV1VgCjbDKKnbgrvgUgxkPDwUFvSv9lTgH882rVzjbWyliVgbBflVzoAUjUSlga/Tr1XQIrfTLMRD5HfYGw==",
+      "sha512": "F7Yej+6QdRVzWg+qbkayRMcmf/7k7YfNFoVSA67wIsG9t5u7Wj4Go8FW72HL8qb9d7YjIsVB/5hA7g9MUT31Aw==",
       "files": [
         "lib/net45/_._",
         "lib/win8/_._",
         "lib/wpa81/_._",
+        "ref/dotnet/de/System.Net.Http.xml",
+        "ref/dotnet/es/System.Net.Http.xml",
+        "ref/dotnet/fr/System.Net.Http.xml",
+        "ref/dotnet/it/System.Net.Http.xml",
+        "ref/dotnet/ja/System.Net.Http.xml",
+        "ref/dotnet/ko/System.Net.Http.xml",
+        "ref/dotnet/ru/System.Net.Http.xml",
         "ref/dotnet/System.Net.Http.dll",
+        "ref/dotnet/System.Net.Http.xml",
+        "ref/dotnet/zh-hans/System.Net.Http.xml",
+        "ref/dotnet/zh-hant/System.Net.Http.xml",
         "ref/net45/_._",
         "ref/netcore50/System.Net.Http.dll",
+        "ref/netcore50/System.Net.Http.xml",
         "ref/win8/_._",
         "ref/wpa81/_._",
         "runtime.json",
-        "System.Net.Http.4.0.1-beta-23408.nupkg",
-        "System.Net.Http.4.0.1-beta-23408.nupkg.sha512",
+        "System.Net.Http.4.0.1-beta-23412.nupkg",
+        "System.Net.Http.4.0.1-beta-23412.nupkg.sha512",
         "System.Net.Http.nuspec"
       ]
     },
-    "System.Net.NameResolution/4.0.0-beta-23408": {
+    "System.Net.NameResolution/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "2A562VFL8GUL/jLCJ3mbQHhwwAIXzPyjxMpdtas1LVM8QLuP1OcHwV3z7ajWnYdGcPc7ZxPEGJQWicuaPD+0nA==",
+      "sha512": "HCF1zhFYBT+w/Ik+JuTzFJgj83Jfc+eA8VcgvIzdPiGMXfrZeXOogjgSCkCoJmFtKVz2DSfmISoEmiXB1oaLNQ==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.NameResolution.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Net.NameResolution.xml",
+        "ref/dotnet/es/System.Net.NameResolution.xml",
+        "ref/dotnet/fr/System.Net.NameResolution.xml",
+        "ref/dotnet/it/System.Net.NameResolution.xml",
+        "ref/dotnet/ja/System.Net.NameResolution.xml",
+        "ref/dotnet/ko/System.Net.NameResolution.xml",
+        "ref/dotnet/ru/System.Net.NameResolution.xml",
         "ref/dotnet/System.Net.NameResolution.dll",
+        "ref/dotnet/System.Net.NameResolution.xml",
+        "ref/dotnet/zh-hans/System.Net.NameResolution.xml",
+        "ref/dotnet/zh-hant/System.Net.NameResolution.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Net.NameResolution.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Net.NameResolution.4.0.0-beta-23408.nupkg",
-        "System.Net.NameResolution.4.0.0-beta-23408.nupkg.sha512",
+        "System.Net.NameResolution.4.0.0-beta-23412.nupkg",
+        "System.Net.NameResolution.4.0.0-beta-23412.nupkg.sha512",
         "System.Net.NameResolution.nuspec"
       ]
     },
@@ -1888,24 +1894,34 @@
         "System.Net.Primitives.nuspec"
       ]
     },
-    "System.Net.Security/4.0.0-beta-23408": {
+    "System.Net.Security/4.0.0-beta-23412": {
       "type": "package",
-      "sha512": "kEkunODO2t/VlBIsC80YFDG0KtY/FyIbtBApNyJQv+LYGEs5IFvEhpi9+p0/jHmhyRMKwbjajNedbXo+VMkt1A==",
+      "sha512": "Kcjne7jnvF5aTbRJsAT8kuP+1mxryUF2qYv8f3jnR19wtEjswSIOVU0XzuWc9YObEQcb+kEdzN71HTOm+ssv+w==",
       "files": [
-        "lib/DNXCore50/System.Net.Security.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.Security.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Net.Security.xml",
+        "ref/dotnet/es/System.Net.Security.xml",
+        "ref/dotnet/fr/System.Net.Security.xml",
+        "ref/dotnet/it/System.Net.Security.xml",
+        "ref/dotnet/ja/System.Net.Security.xml",
+        "ref/dotnet/ko/System.Net.Security.xml",
+        "ref/dotnet/ru/System.Net.Security.xml",
         "ref/dotnet/System.Net.Security.dll",
+        "ref/dotnet/System.Net.Security.xml",
+        "ref/dotnet/zh-hans/System.Net.Security.xml",
+        "ref/dotnet/zh-hant/System.Net.Security.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Net.Security.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.Security.4.0.0-beta-23408.nupkg",
-        "System.Net.Security.4.0.0-beta-23408.nupkg.sha512",
+        "runtime.json",
+        "System.Net.Security.4.0.0-beta-23412.nupkg",
+        "System.Net.Security.4.0.0-beta-23412.nupkg.sha512",
         "System.Net.Security.nuspec"
       ]
     },
@@ -1963,78 +1979,68 @@
         "System.Net.WebHeaderCollection.nuspec"
       ]
     },
-    "System.Net.WebSockets/4.0.0-beta-23408": {
+    "System.Net.WebSockets/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "BXy22/bNVtrXXsG76zXyhjcQnCjSYxQIFF37xWifqPRWmvzsCYSLQpNCTPQUCp7rjB7qWc5yLhC9bThaEx7MHQ==",
+      "sha512": "EvXAa0yd1RM8ROyLl1T0xC94F04Su8YMHnd4/w6j0Z/+4lKHZOU7bQPZ3odDN8WdPGKa/ZNJJGwiapydEWKzwQ==",
       "files": [
-        "lib/dotnet/de/System.Net.WebSockets.xml",
-        "lib/dotnet/es/System.Net.WebSockets.xml",
-        "lib/dotnet/fr/System.Net.WebSockets.xml",
-        "lib/dotnet/it/System.Net.WebSockets.xml",
-        "lib/dotnet/ja/System.Net.WebSockets.xml",
-        "lib/dotnet/ko/System.Net.WebSockets.xml",
-        "lib/dotnet/ru/System.Net.WebSockets.xml",
         "lib/dotnet/System.Net.WebSockets.dll",
-        "lib/dotnet/System.Net.WebSockets.xml",
-        "lib/dotnet/zh-hans/System.Net.WebSockets.xml",
-        "lib/dotnet/zh-hant/System.Net.WebSockets.xml",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.WebSockets.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Net.WebSockets.xml",
+        "ref/dotnet/es/System.Net.WebSockets.xml",
+        "ref/dotnet/fr/System.Net.WebSockets.xml",
+        "ref/dotnet/it/System.Net.WebSockets.xml",
+        "ref/dotnet/ja/System.Net.WebSockets.xml",
+        "ref/dotnet/ko/System.Net.WebSockets.xml",
+        "ref/dotnet/ru/System.Net.WebSockets.xml",
         "ref/dotnet/System.Net.WebSockets.dll",
+        "ref/dotnet/System.Net.WebSockets.xml",
+        "ref/dotnet/zh-hans/System.Net.WebSockets.xml",
+        "ref/dotnet/zh-hant/System.Net.WebSockets.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Net.WebSockets.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.WebSockets.4.0.0-beta-23408.nupkg",
-        "System.Net.WebSockets.4.0.0-beta-23408.nupkg.sha512",
+        "System.Net.WebSockets.4.0.0-beta-23412.nupkg",
+        "System.Net.WebSockets.4.0.0-beta-23412.nupkg.sha512",
         "System.Net.WebSockets.nuspec"
       ]
     },
-    "System.Net.WebSockets.Client/4.0.0-beta-23408": {
+    "System.Net.WebSockets.Client/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "smmvhCkcU0c4RNWc6NZwnN5EFktX58jf8+TJ6enfuXxWrpJ/2NRI5/2yT/okjFSngGK1g0MBrljZsfs2EJ7+Yw==",
+      "sha512": "uaO7c/81sK90605UtThSX9KVmzsJDA1vD4GMW7FsKKntymlkolJsprDekWblQ4A5YbhqxHv+ngXX2kIU0B3Fdw==",
       "files": [
-        "lib/DNXCore50/de/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/es/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/fr/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/it/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/ja/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/ko/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/ru/System.Net.WebSockets.Client.xml",
         "lib/DNXCore50/System.Net.WebSockets.Client.dll",
-        "lib/DNXCore50/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/zh-hans/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/zh-hant/System.Net.WebSockets.Client.xml",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.WebSockets.Client.dll",
-        "lib/netcore50/de/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/es/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/fr/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/it/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/ja/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/ko/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/ru/System.Net.WebSockets.Client.xml",
         "lib/netcore50/System.Net.WebSockets.Client.dll",
-        "lib/netcore50/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/zh-hans/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/zh-hant/System.Net.WebSockets.Client.xml",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/es/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/fr/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/it/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/ja/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/ko/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/ru/System.Net.WebSockets.Client.xml",
         "ref/dotnet/System.Net.WebSockets.Client.dll",
+        "ref/dotnet/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/zh-hans/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/zh-hant/System.Net.WebSockets.Client.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Net.WebSockets.Client.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.WebSockets.Client.4.0.0-beta-23408.nupkg",
-        "System.Net.WebSockets.Client.4.0.0-beta-23408.nupkg.sha512",
+        "System.Net.WebSockets.Client.4.0.0-beta-23412.nupkg",
+        "System.Net.WebSockets.Client.4.0.0-beta-23412.nupkg.sha512",
         "System.Net.WebSockets.Client.nuspec"
       ]
     },
@@ -2086,31 +2092,31 @@
         "System.Private.DataContractSerialization.nuspec"
       ]
     },
-    "System.Private.Networking/4.0.1-beta-23408": {
+    "System.Private.Networking/4.0.1-beta-23225": {
       "type": "package",
       "serviceable": true,
-      "sha512": "i2fRDRqM8Px3CP26C//deF/tCNR1AwqlPEr9+MYiXxNZtgGcSPBfqOJJ5CJdfmDb9Ap0hPG2MiPG7CinaSH7+Q==",
+      "sha512": "oVSynIrR3mIU0b/goscsaZDywr3RLxQijQnaFRKfl/VB3F9rKi5mdr0vHcGVWuq5ALSrG0OLwM8PRA4tM5e3rQ==",
       "files": [
         "lib/DNXCore50/System.Private.Networking.dll",
         "lib/netcore50/System.Private.Networking.dll",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "System.Private.Networking.4.0.1-beta-23408.nupkg",
-        "System.Private.Networking.4.0.1-beta-23408.nupkg.sha512",
+        "System.Private.Networking.4.0.1-beta-23225.nupkg",
+        "System.Private.Networking.4.0.1-beta-23225.nupkg.sha512",
         "System.Private.Networking.nuspec"
       ]
     },
-    "System.Private.ServiceModel/4.1.0-beta-23408": {
+    "System.Private.ServiceModel/4.1.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "l/2192yKa6uXhjKOWeukFJy3hoj9Zq1p55pTGe+Y28r8/5jlvgYxfunP9UyXJRo9W1u3UBtGfV/5R71ULzusGQ==",
+      "sha512": "Wm+8LcQ04YeAvYqu9faHsMZ/L8l/WvPPsqziBfifYB4jXIPXk1/kUxuAryjbLChghZDXvkDN0hv/IHSVPZGgBA==",
       "files": [
         "lib/DNXCore50/System.Private.ServiceModel.dll",
         "lib/netcore50/System.Private.ServiceModel.dll",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "System.Private.ServiceModel.4.1.0-beta-23408.nupkg",
-        "System.Private.ServiceModel.4.1.0-beta-23408.nupkg.sha512",
+        "System.Private.ServiceModel.4.1.0-beta-23412.nupkg",
+        "System.Private.ServiceModel.4.1.0-beta-23412.nupkg.sha512",
         "System.Private.ServiceModel.nuspec"
       ]
     },
@@ -2639,10 +2645,10 @@
         "System.Security.Claims.nuspec"
       ]
     },
-    "System.Security.Cryptography.Algorithms/4.0.0-beta-23408": {
+    "System.Security.Cryptography.Algorithms/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "G6eEqi8mZRrWftcwilcnllE4xJ/53JQlk3VVuJ+9qrX+DHvWz8itYJRUZX357JY4DgEEKQNOJzuRGrOBTUeoPg==",
+      "sha512": "nBjoiqJQiMD3cJgOVrqjIVDqEEPZeIqT+mrBIxjLE+YMQcjEyDuSyOG65Ntoopby5LH4onTLMM4zfXh8JRt9NQ==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2656,37 +2662,47 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.Algorithms.4.0.0-beta-23408.nupkg",
-        "System.Security.Cryptography.Algorithms.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Cryptography.Algorithms.4.0.0-beta-23412.nupkg",
+        "System.Security.Cryptography.Algorithms.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Cryptography.Algorithms.nuspec"
       ]
     },
-    "System.Security.Cryptography.Encoding/4.0.0-beta-23408": {
+    "System.Security.Cryptography.Encoding/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "fPsAK3vyMjnJ6nT4YchdS7KzfGca/6uVVAPCBO08ZpTRGhMGx30vq1MiIqAUrfsFMnot3Ub2jimnAFWkqY6g0Q==",
+      "sha512": "SR1zCARNdeyLoUKYH2SNMm1He7Lr3NR/l7yW3K135L44T6PS3YB8SfXpVoZdMpb22X2G07BZAHVz2x7e4AA1Cg==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Security.Cryptography.Encoding.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/es/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/fr/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/it/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/ja/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/ko/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/ru/System.Security.Cryptography.Encoding.xml",
         "ref/dotnet/System.Security.Cryptography.Encoding.dll",
+        "ref/dotnet/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/zh-hans/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/zh-hant/System.Security.Cryptography.Encoding.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Security.Cryptography.Encoding.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.Encoding.4.0.0-beta-23408.nupkg",
-        "System.Security.Cryptography.Encoding.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Cryptography.Encoding.4.0.0-beta-23412.nupkg",
+        "System.Security.Cryptography.Encoding.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Cryptography.Encoding.nuspec"
       ]
     },
-    "System.Security.Cryptography.Primitives/4.0.0-beta-23408": {
+    "System.Security.Cryptography.Primitives/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "A336dWYEIQxm1rEJCaE5ZZrUWHPUkBGTRH8uAj8qrTqg4/qRc2yN2wZxeGXaZauhI35QwDmOutK7oVb2Cd+4TA==",
+      "sha512": "H9EBNe0ahjAYjlVn0TnT18PSgZBrtROSQH1RRIKwAjzxQHt8zwDhO4yN0Q5QaaUIoSXgxVmgtWWk62wDvpy+QA==",
       "files": [
         "lib/dotnet/System.Security.Cryptography.Primitives.dll",
         "lib/MonoAndroid10/_._",
@@ -2700,30 +2716,40 @@
         "ref/net46/System.Security.Cryptography.Primitives.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Security.Cryptography.Primitives.4.0.0-beta-23408.nupkg",
-        "System.Security.Cryptography.Primitives.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Cryptography.Primitives.4.0.0-beta-23412.nupkg",
+        "System.Security.Cryptography.Primitives.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Cryptography.Primitives.nuspec"
       ]
     },
-    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23408": {
+    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "JSNf5d1V5Y47MIdf7QxZCuGnR5heM4UKbrsdXiWD5lfqu0mnNjebPIclMUXlTw/6IykuDsUpompV/DtsaLLHig==",
+      "sha512": "SfpMjvrfRaRjG42uynLugb3YgpXdpnU7X8vNAU7stIR5/4uW9m1SvWHvBjirjHRBtOpbKB86uD5ODQWX+tWDNA==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Security.Cryptography.X509Certificates.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/es/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/fr/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/it/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/ja/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/ko/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/ru/System.Security.Cryptography.X509Certificates.xml",
         "ref/dotnet/System.Security.Cryptography.X509Certificates.dll",
+        "ref/dotnet/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/zh-hans/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/zh-hant/System.Security.Cryptography.X509Certificates.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Security.Cryptography.X509Certificates.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23408.nupkg",
-        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23412.nupkg",
+        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Cryptography.X509Certificates.nuspec"
       ]
     },
@@ -2760,144 +2786,147 @@
         "System.Security.Principal.nuspec"
       ]
     },
-    "System.Security.Principal.Windows/4.0.0-beta-23408": {
+    "System.Security.Principal.Windows/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "xmjpZJvsT1AW23UkjqUkF/VrOh7DA1cagYY272UQmO8ei227TFD4C7j3ofatL/63hR3CXkLkoephuE4f2Z9fGA==",
+      "sha512": "Zvb/LzT+GjGNV1t8i5KVieilL+8P5LcQykIbJHw5aJxLPFEIQ4Y2hTJXdEkeKvZ4TCF5dlwY1jYyUrJkcqpxzw==",
       "files": [
-        "lib/DNXCore50/de/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/es/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/fr/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/it/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/ja/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/ko/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/ru/System.Security.Principal.Windows.xml",
         "lib/DNXCore50/System.Security.Principal.Windows.dll",
-        "lib/DNXCore50/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/zh-hans/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/zh-hant/System.Security.Principal.Windows.xml",
         "lib/net46/System.Security.Principal.Windows.dll",
+        "ref/dotnet/de/System.Security.Principal.Windows.xml",
+        "ref/dotnet/es/System.Security.Principal.Windows.xml",
+        "ref/dotnet/fr/System.Security.Principal.Windows.xml",
+        "ref/dotnet/it/System.Security.Principal.Windows.xml",
+        "ref/dotnet/ja/System.Security.Principal.Windows.xml",
+        "ref/dotnet/ko/System.Security.Principal.Windows.xml",
+        "ref/dotnet/ru/System.Security.Principal.Windows.xml",
         "ref/dotnet/System.Security.Principal.Windows.dll",
+        "ref/dotnet/System.Security.Principal.Windows.xml",
+        "ref/dotnet/zh-hans/System.Security.Principal.Windows.xml",
+        "ref/dotnet/zh-hant/System.Security.Principal.Windows.xml",
         "ref/net46/System.Security.Principal.Windows.dll",
-        "System.Security.Principal.Windows.4.0.0-beta-23408.nupkg",
-        "System.Security.Principal.Windows.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Principal.Windows.4.0.0-beta-23412.nupkg",
+        "System.Security.Principal.Windows.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Principal.Windows.nuspec"
       ]
     },
-    "System.ServiceModel.Http/4.0.11-beta-23408": {
+    "System.ServiceModel.Http/4.0.11-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "RScHZ1A3CfjumaP1Vh/xfOp/ga6T3nA8YLkjFOYcIcZm/LILL+yCh+PhIrJOEfz1Js8bLSQC6xbxwYlW6BNmYg==",
+      "sha512": "hKMGQbu/l2gv/PgPvm2ViLVElnVSwAPiv4cXKjinS+UHBf02uPF2m7lN13SCkJDNTBctwHav1rQnMYb1LUJHvw==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Http.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
-        "lib/netcore50/de/System.ServiceModel.Http.xml",
-        "lib/netcore50/es/System.ServiceModel.Http.xml",
-        "lib/netcore50/fr/System.ServiceModel.Http.xml",
-        "lib/netcore50/it/System.ServiceModel.Http.xml",
-        "lib/netcore50/ja/System.ServiceModel.Http.xml",
-        "lib/netcore50/ko/System.ServiceModel.Http.xml",
-        "lib/netcore50/ru/System.ServiceModel.Http.xml",
         "lib/netcore50/System.ServiceModel.Http.dll",
-        "lib/netcore50/System.ServiceModel.Http.xml",
-        "lib/netcore50/zh-hans/System.ServiceModel.Http.xml",
-        "lib/netcore50/zh-hant/System.ServiceModel.Http.xml",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.ServiceModel.Http.xml",
+        "ref/dotnet/es/System.ServiceModel.Http.xml",
+        "ref/dotnet/fr/System.ServiceModel.Http.xml",
+        "ref/dotnet/it/System.ServiceModel.Http.xml",
+        "ref/dotnet/ja/System.ServiceModel.Http.xml",
+        "ref/dotnet/ko/System.ServiceModel.Http.xml",
+        "ref/dotnet/ru/System.ServiceModel.Http.xml",
         "ref/dotnet/System.ServiceModel.Http.dll",
+        "ref/dotnet/System.ServiceModel.Http.xml",
+        "ref/dotnet/zh-hans/System.ServiceModel.Http.xml",
+        "ref/dotnet/zh-hant/System.ServiceModel.Http.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.ServiceModel.Http.4.0.11-beta-23408.nupkg",
-        "System.ServiceModel.Http.4.0.11-beta-23408.nupkg.sha512",
+        "System.ServiceModel.Http.4.0.11-beta-23412.nupkg",
+        "System.ServiceModel.Http.4.0.11-beta-23412.nupkg.sha512",
         "System.ServiceModel.Http.nuspec"
       ]
     },
-    "System.ServiceModel.NetTcp/4.0.1-beta-23408": {
+    "System.ServiceModel.NetTcp/4.0.1-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "ppruBpqoE6AngTs6fABV67r1ic6rKCgr6tw+4lMoRucrNWNfKgX5vWlONOqSd8bQXmQLZ/ftEhDGXYY5CLRUTQ==",
+      "sha512": "9I2iOpoYB8DtVy1Sw6BmOj6NGoxt9cKwOOds4q6G1JLzyyWErsv/FMeGAJT07bgLr8vnMx4s8GXxjCfkUwNtTw==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.NetTcp.dll",
         "lib/net45/_._",
-        "lib/netcore50/de/System.ServiceModel.NetTcp.xml",
-        "lib/netcore50/es/System.ServiceModel.NetTcp.xml",
-        "lib/netcore50/fr/System.ServiceModel.NetTcp.xml",
-        "lib/netcore50/it/System.ServiceModel.NetTcp.xml",
-        "lib/netcore50/ja/System.ServiceModel.NetTcp.xml",
-        "lib/netcore50/ko/System.ServiceModel.NetTcp.xml",
-        "lib/netcore50/ru/System.ServiceModel.NetTcp.xml",
         "lib/netcore50/System.ServiceModel.NetTcp.dll",
-        "lib/netcore50/System.ServiceModel.NetTcp.xml",
-        "lib/netcore50/zh-hans/System.ServiceModel.NetTcp.xml",
-        "lib/netcore50/zh-hant/System.ServiceModel.NetTcp.xml",
         "lib/win8/_._",
+        "ref/dotnet/de/System.ServiceModel.NetTcp.xml",
+        "ref/dotnet/es/System.ServiceModel.NetTcp.xml",
+        "ref/dotnet/fr/System.ServiceModel.NetTcp.xml",
+        "ref/dotnet/it/System.ServiceModel.NetTcp.xml",
+        "ref/dotnet/ja/System.ServiceModel.NetTcp.xml",
+        "ref/dotnet/ko/System.ServiceModel.NetTcp.xml",
+        "ref/dotnet/ru/System.ServiceModel.NetTcp.xml",
         "ref/dotnet/System.ServiceModel.NetTcp.dll",
+        "ref/dotnet/System.ServiceModel.NetTcp.xml",
+        "ref/dotnet/zh-hans/System.ServiceModel.NetTcp.xml",
+        "ref/dotnet/zh-hant/System.ServiceModel.NetTcp.xml",
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.NetTcp.dll",
+        "ref/netcore50/System.ServiceModel.NetTcp.xml",
         "ref/win8/_._",
-        "System.ServiceModel.NetTcp.4.0.1-beta-23408.nupkg",
-        "System.ServiceModel.NetTcp.4.0.1-beta-23408.nupkg.sha512",
+        "System.ServiceModel.NetTcp.4.0.1-beta-23412.nupkg",
+        "System.ServiceModel.NetTcp.4.0.1-beta-23412.nupkg.sha512",
         "System.ServiceModel.NetTcp.nuspec"
       ]
     },
-    "System.ServiceModel.Primitives/4.0.1-beta-23408": {
+    "System.ServiceModel.Primitives/4.0.1-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "bjXzg+V3Oq/tBXpMY5FwcERN2CQsFXoL4BMoURlwiBMkgwN2CPvBIaK45Moh7nc21jNTVukNayDtURetGzK6aA==",
+      "sha512": "dkCUkNtXb2m9Wf+DY7dc5B4J8DpaWtX4wpFfT3cYLpChxAnjQR85N+tJfMEHLfZNNerKgDRyGyaKa7uSHfvb5g==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Primitives.dll",
         "lib/net45/_._",
-        "lib/netcore50/de/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/es/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/fr/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/it/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/ja/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/ko/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/ru/System.ServiceModel.Primitives.xml",
         "lib/netcore50/System.ServiceModel.Primitives.dll",
-        "lib/netcore50/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/zh-hans/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/zh-hant/System.ServiceModel.Primitives.xml",
         "lib/win8/_._",
+        "ref/dotnet/de/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/es/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/fr/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/it/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/ja/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/ko/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/ru/System.ServiceModel.Primitives.xml",
         "ref/dotnet/System.ServiceModel.Primitives.dll",
+        "ref/dotnet/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/zh-hans/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/zh-hant/System.ServiceModel.Primitives.xml",
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.Primitives.dll",
+        "ref/netcore50/System.ServiceModel.Primitives.xml",
         "ref/win8/_._",
-        "System.ServiceModel.Primitives.4.0.1-beta-23408.nupkg",
-        "System.ServiceModel.Primitives.4.0.1-beta-23408.nupkg.sha512",
+        "System.ServiceModel.Primitives.4.0.1-beta-23412.nupkg",
+        "System.ServiceModel.Primitives.4.0.1-beta-23412.nupkg.sha512",
         "System.ServiceModel.Primitives.nuspec"
       ]
     },
-    "System.ServiceModel.Security/4.0.1-beta-23408": {
+    "System.ServiceModel.Security/4.0.1-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "rWTUEu+P30ytvkAGX051GEj9Rqj0Zk2ildyC748zdJE5qO89ZXOdC2WnMVrnQJlFcTASFOmT9BFcym4U2EzLGg==",
+      "sha512": "X+TJPs0+TVaHtDcrgw+QYtRUea0OHyy8VRzWKLL0nls52THNfeZZeTecd3eQnb6lQKpDIU42gl6tP0uePUpvMA==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Security.dll",
         "lib/net45/_._",
-        "lib/netcore50/de/System.ServiceModel.Security.xml",
-        "lib/netcore50/es/System.ServiceModel.Security.xml",
-        "lib/netcore50/fr/System.ServiceModel.Security.xml",
-        "lib/netcore50/it/System.ServiceModel.Security.xml",
-        "lib/netcore50/ja/System.ServiceModel.Security.xml",
-        "lib/netcore50/ko/System.ServiceModel.Security.xml",
-        "lib/netcore50/ru/System.ServiceModel.Security.xml",
         "lib/netcore50/System.ServiceModel.Security.dll",
-        "lib/netcore50/System.ServiceModel.Security.xml",
-        "lib/netcore50/zh-hans/System.ServiceModel.Security.xml",
-        "lib/netcore50/zh-hant/System.ServiceModel.Security.xml",
         "lib/win8/_._",
+        "ref/dotnet/de/System.ServiceModel.Security.xml",
+        "ref/dotnet/es/System.ServiceModel.Security.xml",
+        "ref/dotnet/fr/System.ServiceModel.Security.xml",
+        "ref/dotnet/it/System.ServiceModel.Security.xml",
+        "ref/dotnet/ja/System.ServiceModel.Security.xml",
+        "ref/dotnet/ko/System.ServiceModel.Security.xml",
+        "ref/dotnet/ru/System.ServiceModel.Security.xml",
         "ref/dotnet/System.ServiceModel.Security.dll",
+        "ref/dotnet/System.ServiceModel.Security.xml",
+        "ref/dotnet/zh-hans/System.ServiceModel.Security.xml",
+        "ref/dotnet/zh-hant/System.ServiceModel.Security.xml",
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.Security.dll",
+        "ref/netcore50/System.ServiceModel.Security.xml",
         "ref/win8/_._",
-        "System.ServiceModel.Security.4.0.1-beta-23408.nupkg",
-        "System.ServiceModel.Security.4.0.1-beta-23408.nupkg.sha512",
+        "System.ServiceModel.Security.4.0.1-beta-23412.nupkg",
+        "System.ServiceModel.Security.4.0.1-beta-23412.nupkg.sha512",
         "System.ServiceModel.Security.nuspec"
       ]
     },
@@ -3090,28 +3119,6 @@
         "System.Threading.Tasks.4.0.10.nupkg",
         "System.Threading.Tasks.4.0.10.nupkg.sha512",
         "System.Threading.Tasks.nuspec"
-      ]
-    },
-    "System.Threading.ThreadPool/4.0.10-beta-23408": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "ahdsVyj+WFj8/iSDwX/G7hkEU4jZmmvWzPS2ajZKdp0Crb0vZJOlM0LQYVASQgbimrUZHQ50o93JYEi8RFdh/Q==",
-      "files": [
-        "lib/DNXCore50/System.Threading.ThreadPool.dll",
-        "lib/MonoAndroid10/_._",
-        "lib/MonoTouch10/_._",
-        "lib/net46/System.Threading.ThreadPool.dll",
-        "lib/xamarinios10/_._",
-        "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Threading.ThreadPool.dll",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
-        "ref/net46/System.Threading.ThreadPool.dll",
-        "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.Threading.ThreadPool.4.0.10-beta-23408.nupkg",
-        "System.Threading.ThreadPool.4.0.10-beta-23408.nupkg.sha512",
-        "System.Threading.ThreadPool.nuspec"
       ]
     },
     "System.Threading.Timer/4.0.0": {
@@ -3361,14 +3368,14 @@
         "xunit.extensibility.execution.nuspec"
       ]
     },
-    "xunit.netcore.extensions/1.0.0-prerelease-00104": {
+    "xunit.netcore.extensions/1.0.0-prerelease-00105": {
       "type": "package",
       "serviceable": true,
-      "sha512": "ZMXxEBpGP7krXtvqbPMOWavd2u83w77ghtD254wfj5+d+7GmYYqP9pX1iRIxJK9CBa8Zc2cOrcYsmCLQgYriAQ==",
+      "sha512": "EnnGcy9rmSdQ8izHWvYSYVyjQGhbeFH7JeM/L35ZrrPGtYvq5XD3hc1cJPCs+43mXdF9cdqhkt5uTlXYzC+Z8g==",
       "files": [
         "lib/dotnet/Xunit.NetCore.Extensions.dll",
-        "xunit.netcore.extensions.1.0.0-prerelease-00104.nupkg",
-        "xunit.netcore.extensions.1.0.0-prerelease-00104.nupkg.sha512",
+        "xunit.netcore.extensions.1.0.0-prerelease-00105.nupkg",
+        "xunit.netcore.extensions.1.0.0-prerelease-00105.nupkg.sha512",
         "xunit.netcore.extensions.nuspec"
       ]
     }

--- a/src/System.Private.ServiceModel/tests/Common/Scenarios/project.lock.json
+++ b/src/System.Private.ServiceModel/tests/Common/Scenarios/project.lock.json
@@ -292,7 +292,7 @@
           "lib/dotnet/System.Linq.Queryable.dll": {}
         }
       },
-      "System.Net.Http/4.0.1-beta-23408": {
+      "System.Net.Http/4.0.1-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -305,7 +305,7 @@
           "ref/dotnet/System.Net.Http.dll": {}
         }
       },
-      "System.Net.NameResolution/4.0.0-beta-23408": {
+      "System.Net.NameResolution/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Net.Primitives": "4.0.10",
@@ -328,16 +328,17 @@
           "lib/DNXCore50/System.Net.Primitives.dll": {}
         }
       },
-      "System.Net.Security/4.0.0-beta-23408": {
+      "System.Net.Security/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
-          "System.Private.Networking": "4.0.1-beta-23408"
+          "System.IO": "4.0.0",
+          "System.Net.Primitives": "4.0.10",
+          "System.Runtime": "4.0.0",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23412",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Net.Security.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Net.Security.dll": {}
         }
       },
       "System.Net.Sockets/4.1.0-beta-23225": {
@@ -368,7 +369,7 @@
           "lib/dotnet/System.Net.WebHeaderCollection.dll": {}
         }
       },
-      "System.Net.WebSockets/4.0.0-beta-23408": {
+      "System.Net.WebSockets/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -383,7 +384,7 @@
           "lib/dotnet/System.Net.WebSockets.dll": {}
         }
       },
-      "System.Net.WebSockets.Client/4.0.0-beta-23408": {
+      "System.Net.WebSockets.Client/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -393,13 +394,13 @@
           "System.Globalization": "4.0.10",
           "System.Net.Primitives": "4.0.10",
           "System.Net.WebHeaderCollection": "4.0.0",
-          "System.Net.WebSockets": "4.0.0-beta-23408",
+          "System.Net.WebSockets": "4.0.0-beta-23412",
           "System.Resources.ResourceManager": "4.0.0",
           "System.Runtime": "4.0.20",
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23408",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23412",
           "System.Text.Encoding": "4.0.10",
           "System.Threading": "4.0.10",
           "System.Threading.Tasks": "4.0.10"
@@ -456,7 +457,7 @@
           "lib/DNXCore50/System.Private.DataContractSerialization.dll": {}
         }
       },
-      "System.Private.Networking/4.0.1-beta-23408": {
+      "System.Private.Networking/4.0.1-beta-23225": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -475,13 +476,10 @@
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23408",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23408",
-          "System.Security.Principal.Windows": "4.0.0-beta-23408",
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23225",
           "System.Threading": "4.0.10",
           "System.Threading.Overlapped": "4.0.0",
-          "System.Threading.Tasks": "4.0.10",
-          "System.Threading.ThreadPool": "4.0.10-beta-23408"
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dnxcore50/_._": {}
@@ -490,7 +488,7 @@
           "lib/DNXCore50/System.Private.Networking.dll": {}
         }
       },
-      "System.Private.ServiceModel/4.1.0-beta-23408": {
+      "System.Private.ServiceModel/4.1.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -507,14 +505,14 @@
           "System.Linq": "4.0.0",
           "System.Linq.Expressions": "4.0.10",
           "System.Linq.Queryable": "4.0.0",
-          "System.Net.Http": "4.0.1-beta-23408",
-          "System.Net.NameResolution": "4.0.0-beta-23408",
+          "System.Net.Http": "4.0.1-beta-23412",
+          "System.Net.NameResolution": "4.0.0-beta-23412",
           "System.Net.Primitives": "4.0.10",
-          "System.Net.Security": "4.0.0-beta-23408",
-          "System.Net.Sockets": "4.0.10-beta-23408",
+          "System.Net.Security": "4.0.0-beta-23412",
+          "System.Net.Sockets": "4.0.10-beta-23412",
           "System.Net.WebHeaderCollection": "4.0.0",
-          "System.Net.WebSockets": "4.0.0-beta-23408",
-          "System.Net.WebSockets.Client": "4.0.0-beta-23408",
+          "System.Net.WebSockets": "4.0.0-beta-23412",
+          "System.Net.WebSockets.Client": "4.0.0-beta-23412",
           "System.ObjectModel": "4.0.10",
           "System.Reflection": "4.0.10",
           "System.Reflection.DispatchProxy": "4.0.0",
@@ -528,9 +526,9 @@
           "System.Runtime.Serialization.Primitives": "4.0.10",
           "System.Runtime.Serialization.Xml": "4.0.10",
           "System.Security.Claims": "4.0.0",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23408",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23412",
           "System.Security.Principal": "4.0.0",
-          "System.Security.Principal.Windows": "4.0.0-beta-23408",
+          "System.Security.Principal.Windows": "4.0.0-beta-23412",
           "System.Text.Encoding": "4.0.10",
           "System.Threading": "4.0.10",
           "System.Threading.Tasks": "4.0.10",
@@ -779,18 +777,18 @@
           "lib/dotnet/System.Security.Claims.dll": {}
         }
       },
-      "System.Security.Cryptography.Algorithms/4.0.0-beta-23408": {
+      "System.Security.Cryptography.Algorithms/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
           "System.Runtime": "4.0.0",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23408"
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23412"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.Algorithms.dll": {}
         }
       },
-      "System.Security.Cryptography.Encoding/4.0.0-beta-23408": {
+      "System.Security.Cryptography.Encoding/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -799,7 +797,7 @@
           "ref/dotnet/System.Security.Cryptography.Encoding.dll": {}
         }
       },
-      "System.Security.Cryptography.Primitives/4.0.0-beta-23408": {
+      "System.Security.Cryptography.Primitives/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.0",
@@ -817,13 +815,13 @@
           "lib/dotnet/System.Security.Cryptography.Primitives.dll": {}
         }
       },
-      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23408": {
+      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
           "System.Runtime.Handles": "4.0.0",
-          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23408",
-          "System.Security.Cryptography.Encoding": "4.0.0-beta-23408"
+          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23412",
+          "System.Security.Cryptography.Encoding": "4.0.0-beta-23412"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.X509Certificates.dll": {}
@@ -841,7 +839,7 @@
           "lib/dotnet/System.Security.Principal.dll": {}
         }
       },
-      "System.Security.Principal.Windows/4.0.0-beta-23408": {
+      "System.Security.Principal.Windows/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -864,10 +862,10 @@
           "lib/DNXCore50/System.Security.Principal.Windows.dll": {}
         }
       },
-      "System.ServiceModel.Duplex/4.0.1-beta-23408": {
+      "System.ServiceModel.Duplex/4.0.1-beta-23412": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-beta-23408"
+          "System.Private.ServiceModel": "4.1.0-beta-23412"
         },
         "compile": {
           "ref/dotnet/System.ServiceModel.Duplex.dll": {}
@@ -876,10 +874,10 @@
           "lib/DNXCore50/System.ServiceModel.Duplex.dll": {}
         }
       },
-      "System.ServiceModel.Http/4.0.11-beta-23408": {
+      "System.ServiceModel.Http/4.0.11-beta-23412": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-beta-23408",
+          "System.Private.ServiceModel": "4.1.0-beta-23412",
           "System.Runtime": "4.0.20"
         },
         "compile": {
@@ -889,10 +887,10 @@
           "lib/DNXCore50/System.ServiceModel.Http.dll": {}
         }
       },
-      "System.ServiceModel.NetTcp/4.0.1-beta-23408": {
+      "System.ServiceModel.NetTcp/4.0.1-beta-23412": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-beta-23408"
+          "System.Private.ServiceModel": "4.1.0-beta-23412"
         },
         "compile": {
           "ref/dotnet/System.ServiceModel.NetTcp.dll": {}
@@ -901,10 +899,10 @@
           "lib/DNXCore50/System.ServiceModel.NetTcp.dll": {}
         }
       },
-      "System.ServiceModel.Primitives/4.0.1-beta-23408": {
+      "System.ServiceModel.Primitives/4.0.1-beta-23412": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-beta-23408"
+          "System.Private.ServiceModel": "4.1.0-beta-23412"
         },
         "compile": {
           "ref/dotnet/System.ServiceModel.Primitives.dll": {}
@@ -913,10 +911,10 @@
           "lib/DNXCore50/System.ServiceModel.Primitives.dll": {}
         }
       },
-      "System.ServiceModel.Security/4.0.1-beta-23408": {
+      "System.ServiceModel.Security/4.0.1-beta-23412": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-beta-23408"
+          "System.Private.ServiceModel": "4.1.0-beta-23412"
         },
         "compile": {
           "ref/dotnet/System.ServiceModel.Security.dll": {}
@@ -1003,19 +1001,6 @@
         },
         "runtime": {
           "lib/DNXCore50/System.Threading.Tasks.dll": {}
-        }
-      },
-      "System.Threading.ThreadPool/4.0.10-beta-23408": {
-        "type": "package",
-        "dependencies": {
-          "System.Runtime": "4.0.0",
-          "System.Runtime.InteropServices": "4.0.0"
-        },
-        "compile": {
-          "ref/dotnet/System.Threading.ThreadPool.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Threading.ThreadPool.dll": {}
         }
       },
       "System.Threading.Timer/4.0.0": {
@@ -1198,7 +1183,7 @@
           "lib/dotnet/xunit.execution.dotnet.dll": {}
         }
       },
-      "xunit.netcore.extensions/1.0.0-prerelease-00104": {
+      "xunit.netcore.extensions/1.0.0-prerelease-00105": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.10",
@@ -1826,44 +1811,65 @@
         "System.Linq.Queryable.nuspec"
       ]
     },
-    "System.Net.Http/4.0.1-beta-23408": {
+    "System.Net.Http/4.0.1-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "n+tnV1VgCjbDKKnbgrvgUgxkPDwUFvSv9lTgH882rVzjbWyliVgbBflVzoAUjUSlga/Tr1XQIrfTLMRD5HfYGw==",
+      "sha512": "F7Yej+6QdRVzWg+qbkayRMcmf/7k7YfNFoVSA67wIsG9t5u7Wj4Go8FW72HL8qb9d7YjIsVB/5hA7g9MUT31Aw==",
       "files": [
         "lib/net45/_._",
         "lib/win8/_._",
         "lib/wpa81/_._",
+        "ref/dotnet/de/System.Net.Http.xml",
+        "ref/dotnet/es/System.Net.Http.xml",
+        "ref/dotnet/fr/System.Net.Http.xml",
+        "ref/dotnet/it/System.Net.Http.xml",
+        "ref/dotnet/ja/System.Net.Http.xml",
+        "ref/dotnet/ko/System.Net.Http.xml",
+        "ref/dotnet/ru/System.Net.Http.xml",
         "ref/dotnet/System.Net.Http.dll",
+        "ref/dotnet/System.Net.Http.xml",
+        "ref/dotnet/zh-hans/System.Net.Http.xml",
+        "ref/dotnet/zh-hant/System.Net.Http.xml",
         "ref/net45/_._",
         "ref/netcore50/System.Net.Http.dll",
+        "ref/netcore50/System.Net.Http.xml",
         "ref/win8/_._",
         "ref/wpa81/_._",
         "runtime.json",
-        "System.Net.Http.4.0.1-beta-23408.nupkg",
-        "System.Net.Http.4.0.1-beta-23408.nupkg.sha512",
+        "System.Net.Http.4.0.1-beta-23412.nupkg",
+        "System.Net.Http.4.0.1-beta-23412.nupkg.sha512",
         "System.Net.Http.nuspec"
       ]
     },
-    "System.Net.NameResolution/4.0.0-beta-23408": {
+    "System.Net.NameResolution/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "2A562VFL8GUL/jLCJ3mbQHhwwAIXzPyjxMpdtas1LVM8QLuP1OcHwV3z7ajWnYdGcPc7ZxPEGJQWicuaPD+0nA==",
+      "sha512": "HCF1zhFYBT+w/Ik+JuTzFJgj83Jfc+eA8VcgvIzdPiGMXfrZeXOogjgSCkCoJmFtKVz2DSfmISoEmiXB1oaLNQ==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.NameResolution.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Net.NameResolution.xml",
+        "ref/dotnet/es/System.Net.NameResolution.xml",
+        "ref/dotnet/fr/System.Net.NameResolution.xml",
+        "ref/dotnet/it/System.Net.NameResolution.xml",
+        "ref/dotnet/ja/System.Net.NameResolution.xml",
+        "ref/dotnet/ko/System.Net.NameResolution.xml",
+        "ref/dotnet/ru/System.Net.NameResolution.xml",
         "ref/dotnet/System.Net.NameResolution.dll",
+        "ref/dotnet/System.Net.NameResolution.xml",
+        "ref/dotnet/zh-hans/System.Net.NameResolution.xml",
+        "ref/dotnet/zh-hant/System.Net.NameResolution.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Net.NameResolution.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Net.NameResolution.4.0.0-beta-23408.nupkg",
-        "System.Net.NameResolution.4.0.0-beta-23408.nupkg.sha512",
+        "System.Net.NameResolution.4.0.0-beta-23412.nupkg",
+        "System.Net.NameResolution.4.0.0-beta-23412.nupkg.sha512",
         "System.Net.NameResolution.nuspec"
       ]
     },
@@ -1900,24 +1906,34 @@
         "System.Net.Primitives.nuspec"
       ]
     },
-    "System.Net.Security/4.0.0-beta-23408": {
+    "System.Net.Security/4.0.0-beta-23412": {
       "type": "package",
-      "sha512": "kEkunODO2t/VlBIsC80YFDG0KtY/FyIbtBApNyJQv+LYGEs5IFvEhpi9+p0/jHmhyRMKwbjajNedbXo+VMkt1A==",
+      "sha512": "Kcjne7jnvF5aTbRJsAT8kuP+1mxryUF2qYv8f3jnR19wtEjswSIOVU0XzuWc9YObEQcb+kEdzN71HTOm+ssv+w==",
       "files": [
-        "lib/DNXCore50/System.Net.Security.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.Security.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Net.Security.xml",
+        "ref/dotnet/es/System.Net.Security.xml",
+        "ref/dotnet/fr/System.Net.Security.xml",
+        "ref/dotnet/it/System.Net.Security.xml",
+        "ref/dotnet/ja/System.Net.Security.xml",
+        "ref/dotnet/ko/System.Net.Security.xml",
+        "ref/dotnet/ru/System.Net.Security.xml",
         "ref/dotnet/System.Net.Security.dll",
+        "ref/dotnet/System.Net.Security.xml",
+        "ref/dotnet/zh-hans/System.Net.Security.xml",
+        "ref/dotnet/zh-hant/System.Net.Security.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Net.Security.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.Security.4.0.0-beta-23408.nupkg",
-        "System.Net.Security.4.0.0-beta-23408.nupkg.sha512",
+        "runtime.json",
+        "System.Net.Security.4.0.0-beta-23412.nupkg",
+        "System.Net.Security.4.0.0-beta-23412.nupkg.sha512",
         "System.Net.Security.nuspec"
       ]
     },
@@ -1975,78 +1991,68 @@
         "System.Net.WebHeaderCollection.nuspec"
       ]
     },
-    "System.Net.WebSockets/4.0.0-beta-23408": {
+    "System.Net.WebSockets/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "BXy22/bNVtrXXsG76zXyhjcQnCjSYxQIFF37xWifqPRWmvzsCYSLQpNCTPQUCp7rjB7qWc5yLhC9bThaEx7MHQ==",
+      "sha512": "EvXAa0yd1RM8ROyLl1T0xC94F04Su8YMHnd4/w6j0Z/+4lKHZOU7bQPZ3odDN8WdPGKa/ZNJJGwiapydEWKzwQ==",
       "files": [
-        "lib/dotnet/de/System.Net.WebSockets.xml",
-        "lib/dotnet/es/System.Net.WebSockets.xml",
-        "lib/dotnet/fr/System.Net.WebSockets.xml",
-        "lib/dotnet/it/System.Net.WebSockets.xml",
-        "lib/dotnet/ja/System.Net.WebSockets.xml",
-        "lib/dotnet/ko/System.Net.WebSockets.xml",
-        "lib/dotnet/ru/System.Net.WebSockets.xml",
         "lib/dotnet/System.Net.WebSockets.dll",
-        "lib/dotnet/System.Net.WebSockets.xml",
-        "lib/dotnet/zh-hans/System.Net.WebSockets.xml",
-        "lib/dotnet/zh-hant/System.Net.WebSockets.xml",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.WebSockets.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Net.WebSockets.xml",
+        "ref/dotnet/es/System.Net.WebSockets.xml",
+        "ref/dotnet/fr/System.Net.WebSockets.xml",
+        "ref/dotnet/it/System.Net.WebSockets.xml",
+        "ref/dotnet/ja/System.Net.WebSockets.xml",
+        "ref/dotnet/ko/System.Net.WebSockets.xml",
+        "ref/dotnet/ru/System.Net.WebSockets.xml",
         "ref/dotnet/System.Net.WebSockets.dll",
+        "ref/dotnet/System.Net.WebSockets.xml",
+        "ref/dotnet/zh-hans/System.Net.WebSockets.xml",
+        "ref/dotnet/zh-hant/System.Net.WebSockets.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Net.WebSockets.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.WebSockets.4.0.0-beta-23408.nupkg",
-        "System.Net.WebSockets.4.0.0-beta-23408.nupkg.sha512",
+        "System.Net.WebSockets.4.0.0-beta-23412.nupkg",
+        "System.Net.WebSockets.4.0.0-beta-23412.nupkg.sha512",
         "System.Net.WebSockets.nuspec"
       ]
     },
-    "System.Net.WebSockets.Client/4.0.0-beta-23408": {
+    "System.Net.WebSockets.Client/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "smmvhCkcU0c4RNWc6NZwnN5EFktX58jf8+TJ6enfuXxWrpJ/2NRI5/2yT/okjFSngGK1g0MBrljZsfs2EJ7+Yw==",
+      "sha512": "uaO7c/81sK90605UtThSX9KVmzsJDA1vD4GMW7FsKKntymlkolJsprDekWblQ4A5YbhqxHv+ngXX2kIU0B3Fdw==",
       "files": [
-        "lib/DNXCore50/de/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/es/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/fr/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/it/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/ja/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/ko/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/ru/System.Net.WebSockets.Client.xml",
         "lib/DNXCore50/System.Net.WebSockets.Client.dll",
-        "lib/DNXCore50/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/zh-hans/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/zh-hant/System.Net.WebSockets.Client.xml",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.WebSockets.Client.dll",
-        "lib/netcore50/de/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/es/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/fr/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/it/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/ja/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/ko/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/ru/System.Net.WebSockets.Client.xml",
         "lib/netcore50/System.Net.WebSockets.Client.dll",
-        "lib/netcore50/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/zh-hans/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/zh-hant/System.Net.WebSockets.Client.xml",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/es/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/fr/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/it/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/ja/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/ko/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/ru/System.Net.WebSockets.Client.xml",
         "ref/dotnet/System.Net.WebSockets.Client.dll",
+        "ref/dotnet/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/zh-hans/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/zh-hant/System.Net.WebSockets.Client.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Net.WebSockets.Client.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.WebSockets.Client.4.0.0-beta-23408.nupkg",
-        "System.Net.WebSockets.Client.4.0.0-beta-23408.nupkg.sha512",
+        "System.Net.WebSockets.Client.4.0.0-beta-23412.nupkg",
+        "System.Net.WebSockets.Client.4.0.0-beta-23412.nupkg.sha512",
         "System.Net.WebSockets.Client.nuspec"
       ]
     },
@@ -2098,31 +2104,31 @@
         "System.Private.DataContractSerialization.nuspec"
       ]
     },
-    "System.Private.Networking/4.0.1-beta-23408": {
+    "System.Private.Networking/4.0.1-beta-23225": {
       "type": "package",
       "serviceable": true,
-      "sha512": "i2fRDRqM8Px3CP26C//deF/tCNR1AwqlPEr9+MYiXxNZtgGcSPBfqOJJ5CJdfmDb9Ap0hPG2MiPG7CinaSH7+Q==",
+      "sha512": "oVSynIrR3mIU0b/goscsaZDywr3RLxQijQnaFRKfl/VB3F9rKi5mdr0vHcGVWuq5ALSrG0OLwM8PRA4tM5e3rQ==",
       "files": [
         "lib/DNXCore50/System.Private.Networking.dll",
         "lib/netcore50/System.Private.Networking.dll",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "System.Private.Networking.4.0.1-beta-23408.nupkg",
-        "System.Private.Networking.4.0.1-beta-23408.nupkg.sha512",
+        "System.Private.Networking.4.0.1-beta-23225.nupkg",
+        "System.Private.Networking.4.0.1-beta-23225.nupkg.sha512",
         "System.Private.Networking.nuspec"
       ]
     },
-    "System.Private.ServiceModel/4.1.0-beta-23408": {
+    "System.Private.ServiceModel/4.1.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "l/2192yKa6uXhjKOWeukFJy3hoj9Zq1p55pTGe+Y28r8/5jlvgYxfunP9UyXJRo9W1u3UBtGfV/5R71ULzusGQ==",
+      "sha512": "Wm+8LcQ04YeAvYqu9faHsMZ/L8l/WvPPsqziBfifYB4jXIPXk1/kUxuAryjbLChghZDXvkDN0hv/IHSVPZGgBA==",
       "files": [
         "lib/DNXCore50/System.Private.ServiceModel.dll",
         "lib/netcore50/System.Private.ServiceModel.dll",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "System.Private.ServiceModel.4.1.0-beta-23408.nupkg",
-        "System.Private.ServiceModel.4.1.0-beta-23408.nupkg.sha512",
+        "System.Private.ServiceModel.4.1.0-beta-23412.nupkg",
+        "System.Private.ServiceModel.4.1.0-beta-23412.nupkg.sha512",
         "System.Private.ServiceModel.nuspec"
       ]
     },
@@ -2651,10 +2657,10 @@
         "System.Security.Claims.nuspec"
       ]
     },
-    "System.Security.Cryptography.Algorithms/4.0.0-beta-23408": {
+    "System.Security.Cryptography.Algorithms/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "G6eEqi8mZRrWftcwilcnllE4xJ/53JQlk3VVuJ+9qrX+DHvWz8itYJRUZX357JY4DgEEKQNOJzuRGrOBTUeoPg==",
+      "sha512": "nBjoiqJQiMD3cJgOVrqjIVDqEEPZeIqT+mrBIxjLE+YMQcjEyDuSyOG65Ntoopby5LH4onTLMM4zfXh8JRt9NQ==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2668,37 +2674,47 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.Algorithms.4.0.0-beta-23408.nupkg",
-        "System.Security.Cryptography.Algorithms.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Cryptography.Algorithms.4.0.0-beta-23412.nupkg",
+        "System.Security.Cryptography.Algorithms.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Cryptography.Algorithms.nuspec"
       ]
     },
-    "System.Security.Cryptography.Encoding/4.0.0-beta-23408": {
+    "System.Security.Cryptography.Encoding/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "fPsAK3vyMjnJ6nT4YchdS7KzfGca/6uVVAPCBO08ZpTRGhMGx30vq1MiIqAUrfsFMnot3Ub2jimnAFWkqY6g0Q==",
+      "sha512": "SR1zCARNdeyLoUKYH2SNMm1He7Lr3NR/l7yW3K135L44T6PS3YB8SfXpVoZdMpb22X2G07BZAHVz2x7e4AA1Cg==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Security.Cryptography.Encoding.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/es/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/fr/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/it/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/ja/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/ko/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/ru/System.Security.Cryptography.Encoding.xml",
         "ref/dotnet/System.Security.Cryptography.Encoding.dll",
+        "ref/dotnet/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/zh-hans/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/zh-hant/System.Security.Cryptography.Encoding.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Security.Cryptography.Encoding.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.Encoding.4.0.0-beta-23408.nupkg",
-        "System.Security.Cryptography.Encoding.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Cryptography.Encoding.4.0.0-beta-23412.nupkg",
+        "System.Security.Cryptography.Encoding.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Cryptography.Encoding.nuspec"
       ]
     },
-    "System.Security.Cryptography.Primitives/4.0.0-beta-23408": {
+    "System.Security.Cryptography.Primitives/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "A336dWYEIQxm1rEJCaE5ZZrUWHPUkBGTRH8uAj8qrTqg4/qRc2yN2wZxeGXaZauhI35QwDmOutK7oVb2Cd+4TA==",
+      "sha512": "H9EBNe0ahjAYjlVn0TnT18PSgZBrtROSQH1RRIKwAjzxQHt8zwDhO4yN0Q5QaaUIoSXgxVmgtWWk62wDvpy+QA==",
       "files": [
         "lib/dotnet/System.Security.Cryptography.Primitives.dll",
         "lib/MonoAndroid10/_._",
@@ -2712,30 +2728,40 @@
         "ref/net46/System.Security.Cryptography.Primitives.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Security.Cryptography.Primitives.4.0.0-beta-23408.nupkg",
-        "System.Security.Cryptography.Primitives.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Cryptography.Primitives.4.0.0-beta-23412.nupkg",
+        "System.Security.Cryptography.Primitives.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Cryptography.Primitives.nuspec"
       ]
     },
-    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23408": {
+    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "JSNf5d1V5Y47MIdf7QxZCuGnR5heM4UKbrsdXiWD5lfqu0mnNjebPIclMUXlTw/6IykuDsUpompV/DtsaLLHig==",
+      "sha512": "SfpMjvrfRaRjG42uynLugb3YgpXdpnU7X8vNAU7stIR5/4uW9m1SvWHvBjirjHRBtOpbKB86uD5ODQWX+tWDNA==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Security.Cryptography.X509Certificates.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/es/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/fr/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/it/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/ja/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/ko/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/ru/System.Security.Cryptography.X509Certificates.xml",
         "ref/dotnet/System.Security.Cryptography.X509Certificates.dll",
+        "ref/dotnet/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/zh-hans/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/zh-hant/System.Security.Cryptography.X509Certificates.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Security.Cryptography.X509Certificates.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23408.nupkg",
-        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23412.nupkg",
+        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Cryptography.X509Certificates.nuspec"
       ]
     },
@@ -2772,172 +2798,176 @@
         "System.Security.Principal.nuspec"
       ]
     },
-    "System.Security.Principal.Windows/4.0.0-beta-23408": {
+    "System.Security.Principal.Windows/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "xmjpZJvsT1AW23UkjqUkF/VrOh7DA1cagYY272UQmO8ei227TFD4C7j3ofatL/63hR3CXkLkoephuE4f2Z9fGA==",
+      "sha512": "Zvb/LzT+GjGNV1t8i5KVieilL+8P5LcQykIbJHw5aJxLPFEIQ4Y2hTJXdEkeKvZ4TCF5dlwY1jYyUrJkcqpxzw==",
       "files": [
-        "lib/DNXCore50/de/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/es/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/fr/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/it/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/ja/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/ko/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/ru/System.Security.Principal.Windows.xml",
         "lib/DNXCore50/System.Security.Principal.Windows.dll",
-        "lib/DNXCore50/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/zh-hans/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/zh-hant/System.Security.Principal.Windows.xml",
         "lib/net46/System.Security.Principal.Windows.dll",
+        "ref/dotnet/de/System.Security.Principal.Windows.xml",
+        "ref/dotnet/es/System.Security.Principal.Windows.xml",
+        "ref/dotnet/fr/System.Security.Principal.Windows.xml",
+        "ref/dotnet/it/System.Security.Principal.Windows.xml",
+        "ref/dotnet/ja/System.Security.Principal.Windows.xml",
+        "ref/dotnet/ko/System.Security.Principal.Windows.xml",
+        "ref/dotnet/ru/System.Security.Principal.Windows.xml",
         "ref/dotnet/System.Security.Principal.Windows.dll",
+        "ref/dotnet/System.Security.Principal.Windows.xml",
+        "ref/dotnet/zh-hans/System.Security.Principal.Windows.xml",
+        "ref/dotnet/zh-hant/System.Security.Principal.Windows.xml",
         "ref/net46/System.Security.Principal.Windows.dll",
-        "System.Security.Principal.Windows.4.0.0-beta-23408.nupkg",
-        "System.Security.Principal.Windows.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Principal.Windows.4.0.0-beta-23412.nupkg",
+        "System.Security.Principal.Windows.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Principal.Windows.nuspec"
       ]
     },
-    "System.ServiceModel.Duplex/4.0.1-beta-23408": {
+    "System.ServiceModel.Duplex/4.0.1-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "ZJ3aN/aEg801Rw+aVbBFZ+I9J51FyQVCoWOvSqTSh5i4qZuWuenCxmxahby43teIqNcCrCtHPoyRan2GfY8Vyg==",
+      "sha512": "o5w/amLOdG4NIfER18/TI69QL11pboppiBgH2fIwjzasKZ1OIlxE+KJPbvHJ5vt554reZYCcA+jY4CIx7/pkiw==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Duplex.dll",
         "lib/net45/_._",
-        "lib/netcore50/de/System.ServiceModel.Duplex.xml",
-        "lib/netcore50/es/System.ServiceModel.Duplex.xml",
-        "lib/netcore50/fr/System.ServiceModel.Duplex.xml",
-        "lib/netcore50/it/System.ServiceModel.Duplex.xml",
-        "lib/netcore50/ja/System.ServiceModel.Duplex.xml",
-        "lib/netcore50/ko/System.ServiceModel.Duplex.xml",
-        "lib/netcore50/ru/System.ServiceModel.Duplex.xml",
         "lib/netcore50/System.ServiceModel.Duplex.dll",
-        "lib/netcore50/System.ServiceModel.Duplex.xml",
-        "lib/netcore50/zh-hans/System.ServiceModel.Duplex.xml",
-        "lib/netcore50/zh-hant/System.ServiceModel.Duplex.xml",
         "lib/win8/_._",
+        "ref/dotnet/de/System.ServiceModel.Duplex.xml",
+        "ref/dotnet/es/System.ServiceModel.Duplex.xml",
+        "ref/dotnet/fr/System.ServiceModel.Duplex.xml",
+        "ref/dotnet/it/System.ServiceModel.Duplex.xml",
+        "ref/dotnet/ja/System.ServiceModel.Duplex.xml",
+        "ref/dotnet/ko/System.ServiceModel.Duplex.xml",
+        "ref/dotnet/ru/System.ServiceModel.Duplex.xml",
         "ref/dotnet/System.ServiceModel.Duplex.dll",
+        "ref/dotnet/System.ServiceModel.Duplex.xml",
+        "ref/dotnet/zh-hans/System.ServiceModel.Duplex.xml",
+        "ref/dotnet/zh-hant/System.ServiceModel.Duplex.xml",
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.Duplex.dll",
+        "ref/netcore50/System.ServiceModel.Duplex.xml",
         "ref/win8/_._",
-        "System.ServiceModel.Duplex.4.0.1-beta-23408.nupkg",
-        "System.ServiceModel.Duplex.4.0.1-beta-23408.nupkg.sha512",
+        "System.ServiceModel.Duplex.4.0.1-beta-23412.nupkg",
+        "System.ServiceModel.Duplex.4.0.1-beta-23412.nupkg.sha512",
         "System.ServiceModel.Duplex.nuspec"
       ]
     },
-    "System.ServiceModel.Http/4.0.11-beta-23408": {
+    "System.ServiceModel.Http/4.0.11-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "RScHZ1A3CfjumaP1Vh/xfOp/ga6T3nA8YLkjFOYcIcZm/LILL+yCh+PhIrJOEfz1Js8bLSQC6xbxwYlW6BNmYg==",
+      "sha512": "hKMGQbu/l2gv/PgPvm2ViLVElnVSwAPiv4cXKjinS+UHBf02uPF2m7lN13SCkJDNTBctwHav1rQnMYb1LUJHvw==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Http.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
-        "lib/netcore50/de/System.ServiceModel.Http.xml",
-        "lib/netcore50/es/System.ServiceModel.Http.xml",
-        "lib/netcore50/fr/System.ServiceModel.Http.xml",
-        "lib/netcore50/it/System.ServiceModel.Http.xml",
-        "lib/netcore50/ja/System.ServiceModel.Http.xml",
-        "lib/netcore50/ko/System.ServiceModel.Http.xml",
-        "lib/netcore50/ru/System.ServiceModel.Http.xml",
         "lib/netcore50/System.ServiceModel.Http.dll",
-        "lib/netcore50/System.ServiceModel.Http.xml",
-        "lib/netcore50/zh-hans/System.ServiceModel.Http.xml",
-        "lib/netcore50/zh-hant/System.ServiceModel.Http.xml",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.ServiceModel.Http.xml",
+        "ref/dotnet/es/System.ServiceModel.Http.xml",
+        "ref/dotnet/fr/System.ServiceModel.Http.xml",
+        "ref/dotnet/it/System.ServiceModel.Http.xml",
+        "ref/dotnet/ja/System.ServiceModel.Http.xml",
+        "ref/dotnet/ko/System.ServiceModel.Http.xml",
+        "ref/dotnet/ru/System.ServiceModel.Http.xml",
         "ref/dotnet/System.ServiceModel.Http.dll",
+        "ref/dotnet/System.ServiceModel.Http.xml",
+        "ref/dotnet/zh-hans/System.ServiceModel.Http.xml",
+        "ref/dotnet/zh-hant/System.ServiceModel.Http.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.ServiceModel.Http.4.0.11-beta-23408.nupkg",
-        "System.ServiceModel.Http.4.0.11-beta-23408.nupkg.sha512",
+        "System.ServiceModel.Http.4.0.11-beta-23412.nupkg",
+        "System.ServiceModel.Http.4.0.11-beta-23412.nupkg.sha512",
         "System.ServiceModel.Http.nuspec"
       ]
     },
-    "System.ServiceModel.NetTcp/4.0.1-beta-23408": {
+    "System.ServiceModel.NetTcp/4.0.1-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "ppruBpqoE6AngTs6fABV67r1ic6rKCgr6tw+4lMoRucrNWNfKgX5vWlONOqSd8bQXmQLZ/ftEhDGXYY5CLRUTQ==",
+      "sha512": "9I2iOpoYB8DtVy1Sw6BmOj6NGoxt9cKwOOds4q6G1JLzyyWErsv/FMeGAJT07bgLr8vnMx4s8GXxjCfkUwNtTw==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.NetTcp.dll",
         "lib/net45/_._",
-        "lib/netcore50/de/System.ServiceModel.NetTcp.xml",
-        "lib/netcore50/es/System.ServiceModel.NetTcp.xml",
-        "lib/netcore50/fr/System.ServiceModel.NetTcp.xml",
-        "lib/netcore50/it/System.ServiceModel.NetTcp.xml",
-        "lib/netcore50/ja/System.ServiceModel.NetTcp.xml",
-        "lib/netcore50/ko/System.ServiceModel.NetTcp.xml",
-        "lib/netcore50/ru/System.ServiceModel.NetTcp.xml",
         "lib/netcore50/System.ServiceModel.NetTcp.dll",
-        "lib/netcore50/System.ServiceModel.NetTcp.xml",
-        "lib/netcore50/zh-hans/System.ServiceModel.NetTcp.xml",
-        "lib/netcore50/zh-hant/System.ServiceModel.NetTcp.xml",
         "lib/win8/_._",
+        "ref/dotnet/de/System.ServiceModel.NetTcp.xml",
+        "ref/dotnet/es/System.ServiceModel.NetTcp.xml",
+        "ref/dotnet/fr/System.ServiceModel.NetTcp.xml",
+        "ref/dotnet/it/System.ServiceModel.NetTcp.xml",
+        "ref/dotnet/ja/System.ServiceModel.NetTcp.xml",
+        "ref/dotnet/ko/System.ServiceModel.NetTcp.xml",
+        "ref/dotnet/ru/System.ServiceModel.NetTcp.xml",
         "ref/dotnet/System.ServiceModel.NetTcp.dll",
+        "ref/dotnet/System.ServiceModel.NetTcp.xml",
+        "ref/dotnet/zh-hans/System.ServiceModel.NetTcp.xml",
+        "ref/dotnet/zh-hant/System.ServiceModel.NetTcp.xml",
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.NetTcp.dll",
+        "ref/netcore50/System.ServiceModel.NetTcp.xml",
         "ref/win8/_._",
-        "System.ServiceModel.NetTcp.4.0.1-beta-23408.nupkg",
-        "System.ServiceModel.NetTcp.4.0.1-beta-23408.nupkg.sha512",
+        "System.ServiceModel.NetTcp.4.0.1-beta-23412.nupkg",
+        "System.ServiceModel.NetTcp.4.0.1-beta-23412.nupkg.sha512",
         "System.ServiceModel.NetTcp.nuspec"
       ]
     },
-    "System.ServiceModel.Primitives/4.0.1-beta-23408": {
+    "System.ServiceModel.Primitives/4.0.1-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "bjXzg+V3Oq/tBXpMY5FwcERN2CQsFXoL4BMoURlwiBMkgwN2CPvBIaK45Moh7nc21jNTVukNayDtURetGzK6aA==",
+      "sha512": "dkCUkNtXb2m9Wf+DY7dc5B4J8DpaWtX4wpFfT3cYLpChxAnjQR85N+tJfMEHLfZNNerKgDRyGyaKa7uSHfvb5g==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Primitives.dll",
         "lib/net45/_._",
-        "lib/netcore50/de/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/es/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/fr/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/it/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/ja/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/ko/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/ru/System.ServiceModel.Primitives.xml",
         "lib/netcore50/System.ServiceModel.Primitives.dll",
-        "lib/netcore50/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/zh-hans/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/zh-hant/System.ServiceModel.Primitives.xml",
         "lib/win8/_._",
+        "ref/dotnet/de/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/es/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/fr/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/it/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/ja/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/ko/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/ru/System.ServiceModel.Primitives.xml",
         "ref/dotnet/System.ServiceModel.Primitives.dll",
+        "ref/dotnet/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/zh-hans/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/zh-hant/System.ServiceModel.Primitives.xml",
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.Primitives.dll",
+        "ref/netcore50/System.ServiceModel.Primitives.xml",
         "ref/win8/_._",
-        "System.ServiceModel.Primitives.4.0.1-beta-23408.nupkg",
-        "System.ServiceModel.Primitives.4.0.1-beta-23408.nupkg.sha512",
+        "System.ServiceModel.Primitives.4.0.1-beta-23412.nupkg",
+        "System.ServiceModel.Primitives.4.0.1-beta-23412.nupkg.sha512",
         "System.ServiceModel.Primitives.nuspec"
       ]
     },
-    "System.ServiceModel.Security/4.0.1-beta-23408": {
+    "System.ServiceModel.Security/4.0.1-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "rWTUEu+P30ytvkAGX051GEj9Rqj0Zk2ildyC748zdJE5qO89ZXOdC2WnMVrnQJlFcTASFOmT9BFcym4U2EzLGg==",
+      "sha512": "X+TJPs0+TVaHtDcrgw+QYtRUea0OHyy8VRzWKLL0nls52THNfeZZeTecd3eQnb6lQKpDIU42gl6tP0uePUpvMA==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Security.dll",
         "lib/net45/_._",
-        "lib/netcore50/de/System.ServiceModel.Security.xml",
-        "lib/netcore50/es/System.ServiceModel.Security.xml",
-        "lib/netcore50/fr/System.ServiceModel.Security.xml",
-        "lib/netcore50/it/System.ServiceModel.Security.xml",
-        "lib/netcore50/ja/System.ServiceModel.Security.xml",
-        "lib/netcore50/ko/System.ServiceModel.Security.xml",
-        "lib/netcore50/ru/System.ServiceModel.Security.xml",
         "lib/netcore50/System.ServiceModel.Security.dll",
-        "lib/netcore50/System.ServiceModel.Security.xml",
-        "lib/netcore50/zh-hans/System.ServiceModel.Security.xml",
-        "lib/netcore50/zh-hant/System.ServiceModel.Security.xml",
         "lib/win8/_._",
+        "ref/dotnet/de/System.ServiceModel.Security.xml",
+        "ref/dotnet/es/System.ServiceModel.Security.xml",
+        "ref/dotnet/fr/System.ServiceModel.Security.xml",
+        "ref/dotnet/it/System.ServiceModel.Security.xml",
+        "ref/dotnet/ja/System.ServiceModel.Security.xml",
+        "ref/dotnet/ko/System.ServiceModel.Security.xml",
+        "ref/dotnet/ru/System.ServiceModel.Security.xml",
         "ref/dotnet/System.ServiceModel.Security.dll",
+        "ref/dotnet/System.ServiceModel.Security.xml",
+        "ref/dotnet/zh-hans/System.ServiceModel.Security.xml",
+        "ref/dotnet/zh-hant/System.ServiceModel.Security.xml",
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.Security.dll",
+        "ref/netcore50/System.ServiceModel.Security.xml",
         "ref/win8/_._",
-        "System.ServiceModel.Security.4.0.1-beta-23408.nupkg",
-        "System.ServiceModel.Security.4.0.1-beta-23408.nupkg.sha512",
+        "System.ServiceModel.Security.4.0.1-beta-23412.nupkg",
+        "System.ServiceModel.Security.4.0.1-beta-23412.nupkg.sha512",
         "System.ServiceModel.Security.nuspec"
       ]
     },
@@ -3130,28 +3160,6 @@
         "System.Threading.Tasks.4.0.10.nupkg",
         "System.Threading.Tasks.4.0.10.nupkg.sha512",
         "System.Threading.Tasks.nuspec"
-      ]
-    },
-    "System.Threading.ThreadPool/4.0.10-beta-23408": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "ahdsVyj+WFj8/iSDwX/G7hkEU4jZmmvWzPS2ajZKdp0Crb0vZJOlM0LQYVASQgbimrUZHQ50o93JYEi8RFdh/Q==",
-      "files": [
-        "lib/DNXCore50/System.Threading.ThreadPool.dll",
-        "lib/MonoAndroid10/_._",
-        "lib/MonoTouch10/_._",
-        "lib/net46/System.Threading.ThreadPool.dll",
-        "lib/xamarinios10/_._",
-        "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Threading.ThreadPool.dll",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
-        "ref/net46/System.Threading.ThreadPool.dll",
-        "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.Threading.ThreadPool.4.0.10-beta-23408.nupkg",
-        "System.Threading.ThreadPool.4.0.10-beta-23408.nupkg.sha512",
-        "System.Threading.ThreadPool.nuspec"
       ]
     },
     "System.Threading.Timer/4.0.0": {
@@ -3401,14 +3409,14 @@
         "xunit.extensibility.execution.nuspec"
       ]
     },
-    "xunit.netcore.extensions/1.0.0-prerelease-00104": {
+    "xunit.netcore.extensions/1.0.0-prerelease-00105": {
       "type": "package",
       "serviceable": true,
-      "sha512": "ZMXxEBpGP7krXtvqbPMOWavd2u83w77ghtD254wfj5+d+7GmYYqP9pX1iRIxJK9CBa8Zc2cOrcYsmCLQgYriAQ==",
+      "sha512": "EnnGcy9rmSdQ8izHWvYSYVyjQGhbeFH7JeM/L35ZrrPGtYvq5XD3hc1cJPCs+43mXdF9cdqhkt5uTlXYzC+Z8g==",
       "files": [
         "lib/dotnet/Xunit.NetCore.Extensions.dll",
-        "xunit.netcore.extensions.1.0.0-prerelease-00104.nupkg",
-        "xunit.netcore.extensions.1.0.0-prerelease-00104.nupkg.sha512",
+        "xunit.netcore.extensions.1.0.0-prerelease-00105.nupkg",
+        "xunit.netcore.extensions.1.0.0-prerelease-00105.nupkg.sha512",
         "xunit.netcore.extensions.nuspec"
       ]
     }

--- a/src/System.Private.ServiceModel/tests/Common/Unit/project.lock.json
+++ b/src/System.Private.ServiceModel/tests/Common/Unit/project.lock.json
@@ -292,7 +292,7 @@
           "lib/dotnet/System.Linq.Queryable.dll": {}
         }
       },
-      "System.Net.Http/4.0.1-beta-23408": {
+      "System.Net.Http/4.0.1-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -305,7 +305,7 @@
           "ref/dotnet/System.Net.Http.dll": {}
         }
       },
-      "System.Net.NameResolution/4.0.0-beta-23408": {
+      "System.Net.NameResolution/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Net.Primitives": "4.0.10",
@@ -328,16 +328,17 @@
           "lib/DNXCore50/System.Net.Primitives.dll": {}
         }
       },
-      "System.Net.Security/4.0.0-beta-23408": {
+      "System.Net.Security/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
-          "System.Private.Networking": "4.0.1-beta-23408"
+          "System.IO": "4.0.0",
+          "System.Net.Primitives": "4.0.10",
+          "System.Runtime": "4.0.0",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23412",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Net.Security.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Net.Security.dll": {}
         }
       },
       "System.Net.Sockets/4.1.0-beta-23225": {
@@ -368,7 +369,7 @@
           "lib/dotnet/System.Net.WebHeaderCollection.dll": {}
         }
       },
-      "System.Net.WebSockets/4.0.0-beta-23408": {
+      "System.Net.WebSockets/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -383,7 +384,7 @@
           "lib/dotnet/System.Net.WebSockets.dll": {}
         }
       },
-      "System.Net.WebSockets.Client/4.0.0-beta-23408": {
+      "System.Net.WebSockets.Client/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -393,13 +394,13 @@
           "System.Globalization": "4.0.10",
           "System.Net.Primitives": "4.0.10",
           "System.Net.WebHeaderCollection": "4.0.0",
-          "System.Net.WebSockets": "4.0.0-beta-23408",
+          "System.Net.WebSockets": "4.0.0-beta-23412",
           "System.Resources.ResourceManager": "4.0.0",
           "System.Runtime": "4.0.20",
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23408",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23412",
           "System.Text.Encoding": "4.0.10",
           "System.Threading": "4.0.10",
           "System.Threading.Tasks": "4.0.10"
@@ -456,7 +457,7 @@
           "lib/DNXCore50/System.Private.DataContractSerialization.dll": {}
         }
       },
-      "System.Private.Networking/4.0.1-beta-23408": {
+      "System.Private.Networking/4.0.1-beta-23225": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -475,13 +476,10 @@
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23408",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23408",
-          "System.Security.Principal.Windows": "4.0.0-beta-23408",
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23225",
           "System.Threading": "4.0.10",
           "System.Threading.Overlapped": "4.0.0",
-          "System.Threading.Tasks": "4.0.10",
-          "System.Threading.ThreadPool": "4.0.10-beta-23408"
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dnxcore50/_._": {}
@@ -490,7 +488,7 @@
           "lib/DNXCore50/System.Private.Networking.dll": {}
         }
       },
-      "System.Private.ServiceModel/4.1.0-beta-23408": {
+      "System.Private.ServiceModel/4.1.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -507,14 +505,14 @@
           "System.Linq": "4.0.0",
           "System.Linq.Expressions": "4.0.10",
           "System.Linq.Queryable": "4.0.0",
-          "System.Net.Http": "4.0.1-beta-23408",
-          "System.Net.NameResolution": "4.0.0-beta-23408",
+          "System.Net.Http": "4.0.1-beta-23412",
+          "System.Net.NameResolution": "4.0.0-beta-23412",
           "System.Net.Primitives": "4.0.10",
-          "System.Net.Security": "4.0.0-beta-23408",
-          "System.Net.Sockets": "4.0.10-beta-23408",
+          "System.Net.Security": "4.0.0-beta-23412",
+          "System.Net.Sockets": "4.0.10-beta-23412",
           "System.Net.WebHeaderCollection": "4.0.0",
-          "System.Net.WebSockets": "4.0.0-beta-23408",
-          "System.Net.WebSockets.Client": "4.0.0-beta-23408",
+          "System.Net.WebSockets": "4.0.0-beta-23412",
+          "System.Net.WebSockets.Client": "4.0.0-beta-23412",
           "System.ObjectModel": "4.0.10",
           "System.Reflection": "4.0.10",
           "System.Reflection.DispatchProxy": "4.0.0",
@@ -528,9 +526,9 @@
           "System.Runtime.Serialization.Primitives": "4.0.10",
           "System.Runtime.Serialization.Xml": "4.0.10",
           "System.Security.Claims": "4.0.0",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23408",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23412",
           "System.Security.Principal": "4.0.0",
-          "System.Security.Principal.Windows": "4.0.0-beta-23408",
+          "System.Security.Principal.Windows": "4.0.0-beta-23412",
           "System.Text.Encoding": "4.0.10",
           "System.Threading": "4.0.10",
           "System.Threading.Tasks": "4.0.10",
@@ -766,18 +764,18 @@
           "lib/dotnet/System.Security.Claims.dll": {}
         }
       },
-      "System.Security.Cryptography.Algorithms/4.0.0-beta-23408": {
+      "System.Security.Cryptography.Algorithms/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
           "System.Runtime": "4.0.0",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23408"
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23412"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.Algorithms.dll": {}
         }
       },
-      "System.Security.Cryptography.Encoding/4.0.0-beta-23408": {
+      "System.Security.Cryptography.Encoding/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -786,7 +784,7 @@
           "ref/dotnet/System.Security.Cryptography.Encoding.dll": {}
         }
       },
-      "System.Security.Cryptography.Primitives/4.0.0-beta-23408": {
+      "System.Security.Cryptography.Primitives/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.0",
@@ -804,13 +802,13 @@
           "lib/dotnet/System.Security.Cryptography.Primitives.dll": {}
         }
       },
-      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23408": {
+      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
           "System.Runtime.Handles": "4.0.0",
-          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23408",
-          "System.Security.Cryptography.Encoding": "4.0.0-beta-23408"
+          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23412",
+          "System.Security.Cryptography.Encoding": "4.0.0-beta-23412"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.X509Certificates.dll": {}
@@ -828,7 +826,7 @@
           "lib/dotnet/System.Security.Principal.dll": {}
         }
       },
-      "System.Security.Principal.Windows/4.0.0-beta-23408": {
+      "System.Security.Principal.Windows/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -851,10 +849,10 @@
           "lib/DNXCore50/System.Security.Principal.Windows.dll": {}
         }
       },
-      "System.ServiceModel.Duplex/4.0.1-beta-23408": {
+      "System.ServiceModel.Duplex/4.0.1-beta-23412": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-beta-23408"
+          "System.Private.ServiceModel": "4.1.0-beta-23412"
         },
         "compile": {
           "ref/dotnet/System.ServiceModel.Duplex.dll": {}
@@ -863,10 +861,10 @@
           "lib/DNXCore50/System.ServiceModel.Duplex.dll": {}
         }
       },
-      "System.ServiceModel.Http/4.0.11-beta-23408": {
+      "System.ServiceModel.Http/4.0.11-beta-23412": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-beta-23408",
+          "System.Private.ServiceModel": "4.1.0-beta-23412",
           "System.Runtime": "4.0.20"
         },
         "compile": {
@@ -876,10 +874,10 @@
           "lib/DNXCore50/System.ServiceModel.Http.dll": {}
         }
       },
-      "System.ServiceModel.Primitives/4.0.1-beta-23408": {
+      "System.ServiceModel.Primitives/4.0.1-beta-23412": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-beta-23408"
+          "System.Private.ServiceModel": "4.1.0-beta-23412"
         },
         "compile": {
           "ref/dotnet/System.ServiceModel.Primitives.dll": {}
@@ -966,19 +964,6 @@
         },
         "runtime": {
           "lib/DNXCore50/System.Threading.Tasks.dll": {}
-        }
-      },
-      "System.Threading.ThreadPool/4.0.10-beta-23408": {
-        "type": "package",
-        "dependencies": {
-          "System.Runtime": "4.0.0",
-          "System.Runtime.InteropServices": "4.0.0"
-        },
-        "compile": {
-          "ref/dotnet/System.Threading.ThreadPool.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Threading.ThreadPool.dll": {}
         }
       },
       "System.Threading.Timer/4.0.0": {
@@ -1669,44 +1654,65 @@
         "System.Linq.Queryable.nuspec"
       ]
     },
-    "System.Net.Http/4.0.1-beta-23408": {
+    "System.Net.Http/4.0.1-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "n+tnV1VgCjbDKKnbgrvgUgxkPDwUFvSv9lTgH882rVzjbWyliVgbBflVzoAUjUSlga/Tr1XQIrfTLMRD5HfYGw==",
+      "sha512": "F7Yej+6QdRVzWg+qbkayRMcmf/7k7YfNFoVSA67wIsG9t5u7Wj4Go8FW72HL8qb9d7YjIsVB/5hA7g9MUT31Aw==",
       "files": [
         "lib/net45/_._",
         "lib/win8/_._",
         "lib/wpa81/_._",
+        "ref/dotnet/de/System.Net.Http.xml",
+        "ref/dotnet/es/System.Net.Http.xml",
+        "ref/dotnet/fr/System.Net.Http.xml",
+        "ref/dotnet/it/System.Net.Http.xml",
+        "ref/dotnet/ja/System.Net.Http.xml",
+        "ref/dotnet/ko/System.Net.Http.xml",
+        "ref/dotnet/ru/System.Net.Http.xml",
         "ref/dotnet/System.Net.Http.dll",
+        "ref/dotnet/System.Net.Http.xml",
+        "ref/dotnet/zh-hans/System.Net.Http.xml",
+        "ref/dotnet/zh-hant/System.Net.Http.xml",
         "ref/net45/_._",
         "ref/netcore50/System.Net.Http.dll",
+        "ref/netcore50/System.Net.Http.xml",
         "ref/win8/_._",
         "ref/wpa81/_._",
         "runtime.json",
-        "System.Net.Http.4.0.1-beta-23408.nupkg",
-        "System.Net.Http.4.0.1-beta-23408.nupkg.sha512",
+        "System.Net.Http.4.0.1-beta-23412.nupkg",
+        "System.Net.Http.4.0.1-beta-23412.nupkg.sha512",
         "System.Net.Http.nuspec"
       ]
     },
-    "System.Net.NameResolution/4.0.0-beta-23408": {
+    "System.Net.NameResolution/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "2A562VFL8GUL/jLCJ3mbQHhwwAIXzPyjxMpdtas1LVM8QLuP1OcHwV3z7ajWnYdGcPc7ZxPEGJQWicuaPD+0nA==",
+      "sha512": "HCF1zhFYBT+w/Ik+JuTzFJgj83Jfc+eA8VcgvIzdPiGMXfrZeXOogjgSCkCoJmFtKVz2DSfmISoEmiXB1oaLNQ==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.NameResolution.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Net.NameResolution.xml",
+        "ref/dotnet/es/System.Net.NameResolution.xml",
+        "ref/dotnet/fr/System.Net.NameResolution.xml",
+        "ref/dotnet/it/System.Net.NameResolution.xml",
+        "ref/dotnet/ja/System.Net.NameResolution.xml",
+        "ref/dotnet/ko/System.Net.NameResolution.xml",
+        "ref/dotnet/ru/System.Net.NameResolution.xml",
         "ref/dotnet/System.Net.NameResolution.dll",
+        "ref/dotnet/System.Net.NameResolution.xml",
+        "ref/dotnet/zh-hans/System.Net.NameResolution.xml",
+        "ref/dotnet/zh-hant/System.Net.NameResolution.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Net.NameResolution.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Net.NameResolution.4.0.0-beta-23408.nupkg",
-        "System.Net.NameResolution.4.0.0-beta-23408.nupkg.sha512",
+        "System.Net.NameResolution.4.0.0-beta-23412.nupkg",
+        "System.Net.NameResolution.4.0.0-beta-23412.nupkg.sha512",
         "System.Net.NameResolution.nuspec"
       ]
     },
@@ -1743,24 +1749,34 @@
         "System.Net.Primitives.nuspec"
       ]
     },
-    "System.Net.Security/4.0.0-beta-23408": {
+    "System.Net.Security/4.0.0-beta-23412": {
       "type": "package",
-      "sha512": "kEkunODO2t/VlBIsC80YFDG0KtY/FyIbtBApNyJQv+LYGEs5IFvEhpi9+p0/jHmhyRMKwbjajNedbXo+VMkt1A==",
+      "sha512": "Kcjne7jnvF5aTbRJsAT8kuP+1mxryUF2qYv8f3jnR19wtEjswSIOVU0XzuWc9YObEQcb+kEdzN71HTOm+ssv+w==",
       "files": [
-        "lib/DNXCore50/System.Net.Security.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.Security.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Net.Security.xml",
+        "ref/dotnet/es/System.Net.Security.xml",
+        "ref/dotnet/fr/System.Net.Security.xml",
+        "ref/dotnet/it/System.Net.Security.xml",
+        "ref/dotnet/ja/System.Net.Security.xml",
+        "ref/dotnet/ko/System.Net.Security.xml",
+        "ref/dotnet/ru/System.Net.Security.xml",
         "ref/dotnet/System.Net.Security.dll",
+        "ref/dotnet/System.Net.Security.xml",
+        "ref/dotnet/zh-hans/System.Net.Security.xml",
+        "ref/dotnet/zh-hant/System.Net.Security.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Net.Security.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.Security.4.0.0-beta-23408.nupkg",
-        "System.Net.Security.4.0.0-beta-23408.nupkg.sha512",
+        "runtime.json",
+        "System.Net.Security.4.0.0-beta-23412.nupkg",
+        "System.Net.Security.4.0.0-beta-23412.nupkg.sha512",
         "System.Net.Security.nuspec"
       ]
     },
@@ -1818,78 +1834,68 @@
         "System.Net.WebHeaderCollection.nuspec"
       ]
     },
-    "System.Net.WebSockets/4.0.0-beta-23408": {
+    "System.Net.WebSockets/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "BXy22/bNVtrXXsG76zXyhjcQnCjSYxQIFF37xWifqPRWmvzsCYSLQpNCTPQUCp7rjB7qWc5yLhC9bThaEx7MHQ==",
+      "sha512": "EvXAa0yd1RM8ROyLl1T0xC94F04Su8YMHnd4/w6j0Z/+4lKHZOU7bQPZ3odDN8WdPGKa/ZNJJGwiapydEWKzwQ==",
       "files": [
-        "lib/dotnet/de/System.Net.WebSockets.xml",
-        "lib/dotnet/es/System.Net.WebSockets.xml",
-        "lib/dotnet/fr/System.Net.WebSockets.xml",
-        "lib/dotnet/it/System.Net.WebSockets.xml",
-        "lib/dotnet/ja/System.Net.WebSockets.xml",
-        "lib/dotnet/ko/System.Net.WebSockets.xml",
-        "lib/dotnet/ru/System.Net.WebSockets.xml",
         "lib/dotnet/System.Net.WebSockets.dll",
-        "lib/dotnet/System.Net.WebSockets.xml",
-        "lib/dotnet/zh-hans/System.Net.WebSockets.xml",
-        "lib/dotnet/zh-hant/System.Net.WebSockets.xml",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.WebSockets.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Net.WebSockets.xml",
+        "ref/dotnet/es/System.Net.WebSockets.xml",
+        "ref/dotnet/fr/System.Net.WebSockets.xml",
+        "ref/dotnet/it/System.Net.WebSockets.xml",
+        "ref/dotnet/ja/System.Net.WebSockets.xml",
+        "ref/dotnet/ko/System.Net.WebSockets.xml",
+        "ref/dotnet/ru/System.Net.WebSockets.xml",
         "ref/dotnet/System.Net.WebSockets.dll",
+        "ref/dotnet/System.Net.WebSockets.xml",
+        "ref/dotnet/zh-hans/System.Net.WebSockets.xml",
+        "ref/dotnet/zh-hant/System.Net.WebSockets.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Net.WebSockets.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.WebSockets.4.0.0-beta-23408.nupkg",
-        "System.Net.WebSockets.4.0.0-beta-23408.nupkg.sha512",
+        "System.Net.WebSockets.4.0.0-beta-23412.nupkg",
+        "System.Net.WebSockets.4.0.0-beta-23412.nupkg.sha512",
         "System.Net.WebSockets.nuspec"
       ]
     },
-    "System.Net.WebSockets.Client/4.0.0-beta-23408": {
+    "System.Net.WebSockets.Client/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "smmvhCkcU0c4RNWc6NZwnN5EFktX58jf8+TJ6enfuXxWrpJ/2NRI5/2yT/okjFSngGK1g0MBrljZsfs2EJ7+Yw==",
+      "sha512": "uaO7c/81sK90605UtThSX9KVmzsJDA1vD4GMW7FsKKntymlkolJsprDekWblQ4A5YbhqxHv+ngXX2kIU0B3Fdw==",
       "files": [
-        "lib/DNXCore50/de/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/es/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/fr/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/it/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/ja/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/ko/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/ru/System.Net.WebSockets.Client.xml",
         "lib/DNXCore50/System.Net.WebSockets.Client.dll",
-        "lib/DNXCore50/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/zh-hans/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/zh-hant/System.Net.WebSockets.Client.xml",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.WebSockets.Client.dll",
-        "lib/netcore50/de/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/es/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/fr/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/it/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/ja/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/ko/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/ru/System.Net.WebSockets.Client.xml",
         "lib/netcore50/System.Net.WebSockets.Client.dll",
-        "lib/netcore50/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/zh-hans/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/zh-hant/System.Net.WebSockets.Client.xml",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/es/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/fr/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/it/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/ja/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/ko/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/ru/System.Net.WebSockets.Client.xml",
         "ref/dotnet/System.Net.WebSockets.Client.dll",
+        "ref/dotnet/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/zh-hans/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/zh-hant/System.Net.WebSockets.Client.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Net.WebSockets.Client.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.WebSockets.Client.4.0.0-beta-23408.nupkg",
-        "System.Net.WebSockets.Client.4.0.0-beta-23408.nupkg.sha512",
+        "System.Net.WebSockets.Client.4.0.0-beta-23412.nupkg",
+        "System.Net.WebSockets.Client.4.0.0-beta-23412.nupkg.sha512",
         "System.Net.WebSockets.Client.nuspec"
       ]
     },
@@ -1941,31 +1947,31 @@
         "System.Private.DataContractSerialization.nuspec"
       ]
     },
-    "System.Private.Networking/4.0.1-beta-23408": {
+    "System.Private.Networking/4.0.1-beta-23225": {
       "type": "package",
       "serviceable": true,
-      "sha512": "i2fRDRqM8Px3CP26C//deF/tCNR1AwqlPEr9+MYiXxNZtgGcSPBfqOJJ5CJdfmDb9Ap0hPG2MiPG7CinaSH7+Q==",
+      "sha512": "oVSynIrR3mIU0b/goscsaZDywr3RLxQijQnaFRKfl/VB3F9rKi5mdr0vHcGVWuq5ALSrG0OLwM8PRA4tM5e3rQ==",
       "files": [
         "lib/DNXCore50/System.Private.Networking.dll",
         "lib/netcore50/System.Private.Networking.dll",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "System.Private.Networking.4.0.1-beta-23408.nupkg",
-        "System.Private.Networking.4.0.1-beta-23408.nupkg.sha512",
+        "System.Private.Networking.4.0.1-beta-23225.nupkg",
+        "System.Private.Networking.4.0.1-beta-23225.nupkg.sha512",
         "System.Private.Networking.nuspec"
       ]
     },
-    "System.Private.ServiceModel/4.1.0-beta-23408": {
+    "System.Private.ServiceModel/4.1.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "l/2192yKa6uXhjKOWeukFJy3hoj9Zq1p55pTGe+Y28r8/5jlvgYxfunP9UyXJRo9W1u3UBtGfV/5R71ULzusGQ==",
+      "sha512": "Wm+8LcQ04YeAvYqu9faHsMZ/L8l/WvPPsqziBfifYB4jXIPXk1/kUxuAryjbLChghZDXvkDN0hv/IHSVPZGgBA==",
       "files": [
         "lib/DNXCore50/System.Private.ServiceModel.dll",
         "lib/netcore50/System.Private.ServiceModel.dll",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "System.Private.ServiceModel.4.1.0-beta-23408.nupkg",
-        "System.Private.ServiceModel.4.1.0-beta-23408.nupkg.sha512",
+        "System.Private.ServiceModel.4.1.0-beta-23412.nupkg",
+        "System.Private.ServiceModel.4.1.0-beta-23412.nupkg.sha512",
         "System.Private.ServiceModel.nuspec"
       ]
     },
@@ -2474,10 +2480,10 @@
         "System.Security.Claims.nuspec"
       ]
     },
-    "System.Security.Cryptography.Algorithms/4.0.0-beta-23408": {
+    "System.Security.Cryptography.Algorithms/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "G6eEqi8mZRrWftcwilcnllE4xJ/53JQlk3VVuJ+9qrX+DHvWz8itYJRUZX357JY4DgEEKQNOJzuRGrOBTUeoPg==",
+      "sha512": "nBjoiqJQiMD3cJgOVrqjIVDqEEPZeIqT+mrBIxjLE+YMQcjEyDuSyOG65Ntoopby5LH4onTLMM4zfXh8JRt9NQ==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2491,37 +2497,47 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.Algorithms.4.0.0-beta-23408.nupkg",
-        "System.Security.Cryptography.Algorithms.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Cryptography.Algorithms.4.0.0-beta-23412.nupkg",
+        "System.Security.Cryptography.Algorithms.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Cryptography.Algorithms.nuspec"
       ]
     },
-    "System.Security.Cryptography.Encoding/4.0.0-beta-23408": {
+    "System.Security.Cryptography.Encoding/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "fPsAK3vyMjnJ6nT4YchdS7KzfGca/6uVVAPCBO08ZpTRGhMGx30vq1MiIqAUrfsFMnot3Ub2jimnAFWkqY6g0Q==",
+      "sha512": "SR1zCARNdeyLoUKYH2SNMm1He7Lr3NR/l7yW3K135L44T6PS3YB8SfXpVoZdMpb22X2G07BZAHVz2x7e4AA1Cg==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Security.Cryptography.Encoding.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/es/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/fr/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/it/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/ja/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/ko/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/ru/System.Security.Cryptography.Encoding.xml",
         "ref/dotnet/System.Security.Cryptography.Encoding.dll",
+        "ref/dotnet/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/zh-hans/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/zh-hant/System.Security.Cryptography.Encoding.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Security.Cryptography.Encoding.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.Encoding.4.0.0-beta-23408.nupkg",
-        "System.Security.Cryptography.Encoding.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Cryptography.Encoding.4.0.0-beta-23412.nupkg",
+        "System.Security.Cryptography.Encoding.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Cryptography.Encoding.nuspec"
       ]
     },
-    "System.Security.Cryptography.Primitives/4.0.0-beta-23408": {
+    "System.Security.Cryptography.Primitives/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "A336dWYEIQxm1rEJCaE5ZZrUWHPUkBGTRH8uAj8qrTqg4/qRc2yN2wZxeGXaZauhI35QwDmOutK7oVb2Cd+4TA==",
+      "sha512": "H9EBNe0ahjAYjlVn0TnT18PSgZBrtROSQH1RRIKwAjzxQHt8zwDhO4yN0Q5QaaUIoSXgxVmgtWWk62wDvpy+QA==",
       "files": [
         "lib/dotnet/System.Security.Cryptography.Primitives.dll",
         "lib/MonoAndroid10/_._",
@@ -2535,30 +2551,40 @@
         "ref/net46/System.Security.Cryptography.Primitives.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Security.Cryptography.Primitives.4.0.0-beta-23408.nupkg",
-        "System.Security.Cryptography.Primitives.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Cryptography.Primitives.4.0.0-beta-23412.nupkg",
+        "System.Security.Cryptography.Primitives.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Cryptography.Primitives.nuspec"
       ]
     },
-    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23408": {
+    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "JSNf5d1V5Y47MIdf7QxZCuGnR5heM4UKbrsdXiWD5lfqu0mnNjebPIclMUXlTw/6IykuDsUpompV/DtsaLLHig==",
+      "sha512": "SfpMjvrfRaRjG42uynLugb3YgpXdpnU7X8vNAU7stIR5/4uW9m1SvWHvBjirjHRBtOpbKB86uD5ODQWX+tWDNA==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Security.Cryptography.X509Certificates.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/es/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/fr/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/it/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/ja/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/ko/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/ru/System.Security.Cryptography.X509Certificates.xml",
         "ref/dotnet/System.Security.Cryptography.X509Certificates.dll",
+        "ref/dotnet/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/zh-hans/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/zh-hant/System.Security.Cryptography.X509Certificates.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Security.Cryptography.X509Certificates.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23408.nupkg",
-        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23412.nupkg",
+        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Cryptography.X509Certificates.nuspec"
       ]
     },
@@ -2595,116 +2621,118 @@
         "System.Security.Principal.nuspec"
       ]
     },
-    "System.Security.Principal.Windows/4.0.0-beta-23408": {
+    "System.Security.Principal.Windows/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "xmjpZJvsT1AW23UkjqUkF/VrOh7DA1cagYY272UQmO8ei227TFD4C7j3ofatL/63hR3CXkLkoephuE4f2Z9fGA==",
+      "sha512": "Zvb/LzT+GjGNV1t8i5KVieilL+8P5LcQykIbJHw5aJxLPFEIQ4Y2hTJXdEkeKvZ4TCF5dlwY1jYyUrJkcqpxzw==",
       "files": [
-        "lib/DNXCore50/de/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/es/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/fr/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/it/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/ja/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/ko/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/ru/System.Security.Principal.Windows.xml",
         "lib/DNXCore50/System.Security.Principal.Windows.dll",
-        "lib/DNXCore50/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/zh-hans/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/zh-hant/System.Security.Principal.Windows.xml",
         "lib/net46/System.Security.Principal.Windows.dll",
+        "ref/dotnet/de/System.Security.Principal.Windows.xml",
+        "ref/dotnet/es/System.Security.Principal.Windows.xml",
+        "ref/dotnet/fr/System.Security.Principal.Windows.xml",
+        "ref/dotnet/it/System.Security.Principal.Windows.xml",
+        "ref/dotnet/ja/System.Security.Principal.Windows.xml",
+        "ref/dotnet/ko/System.Security.Principal.Windows.xml",
+        "ref/dotnet/ru/System.Security.Principal.Windows.xml",
         "ref/dotnet/System.Security.Principal.Windows.dll",
+        "ref/dotnet/System.Security.Principal.Windows.xml",
+        "ref/dotnet/zh-hans/System.Security.Principal.Windows.xml",
+        "ref/dotnet/zh-hant/System.Security.Principal.Windows.xml",
         "ref/net46/System.Security.Principal.Windows.dll",
-        "System.Security.Principal.Windows.4.0.0-beta-23408.nupkg",
-        "System.Security.Principal.Windows.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Principal.Windows.4.0.0-beta-23412.nupkg",
+        "System.Security.Principal.Windows.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Principal.Windows.nuspec"
       ]
     },
-    "System.ServiceModel.Duplex/4.0.1-beta-23408": {
+    "System.ServiceModel.Duplex/4.0.1-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "ZJ3aN/aEg801Rw+aVbBFZ+I9J51FyQVCoWOvSqTSh5i4qZuWuenCxmxahby43teIqNcCrCtHPoyRan2GfY8Vyg==",
+      "sha512": "o5w/amLOdG4NIfER18/TI69QL11pboppiBgH2fIwjzasKZ1OIlxE+KJPbvHJ5vt554reZYCcA+jY4CIx7/pkiw==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Duplex.dll",
         "lib/net45/_._",
-        "lib/netcore50/de/System.ServiceModel.Duplex.xml",
-        "lib/netcore50/es/System.ServiceModel.Duplex.xml",
-        "lib/netcore50/fr/System.ServiceModel.Duplex.xml",
-        "lib/netcore50/it/System.ServiceModel.Duplex.xml",
-        "lib/netcore50/ja/System.ServiceModel.Duplex.xml",
-        "lib/netcore50/ko/System.ServiceModel.Duplex.xml",
-        "lib/netcore50/ru/System.ServiceModel.Duplex.xml",
         "lib/netcore50/System.ServiceModel.Duplex.dll",
-        "lib/netcore50/System.ServiceModel.Duplex.xml",
-        "lib/netcore50/zh-hans/System.ServiceModel.Duplex.xml",
-        "lib/netcore50/zh-hant/System.ServiceModel.Duplex.xml",
         "lib/win8/_._",
+        "ref/dotnet/de/System.ServiceModel.Duplex.xml",
+        "ref/dotnet/es/System.ServiceModel.Duplex.xml",
+        "ref/dotnet/fr/System.ServiceModel.Duplex.xml",
+        "ref/dotnet/it/System.ServiceModel.Duplex.xml",
+        "ref/dotnet/ja/System.ServiceModel.Duplex.xml",
+        "ref/dotnet/ko/System.ServiceModel.Duplex.xml",
+        "ref/dotnet/ru/System.ServiceModel.Duplex.xml",
         "ref/dotnet/System.ServiceModel.Duplex.dll",
+        "ref/dotnet/System.ServiceModel.Duplex.xml",
+        "ref/dotnet/zh-hans/System.ServiceModel.Duplex.xml",
+        "ref/dotnet/zh-hant/System.ServiceModel.Duplex.xml",
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.Duplex.dll",
+        "ref/netcore50/System.ServiceModel.Duplex.xml",
         "ref/win8/_._",
-        "System.ServiceModel.Duplex.4.0.1-beta-23408.nupkg",
-        "System.ServiceModel.Duplex.4.0.1-beta-23408.nupkg.sha512",
+        "System.ServiceModel.Duplex.4.0.1-beta-23412.nupkg",
+        "System.ServiceModel.Duplex.4.0.1-beta-23412.nupkg.sha512",
         "System.ServiceModel.Duplex.nuspec"
       ]
     },
-    "System.ServiceModel.Http/4.0.11-beta-23408": {
+    "System.ServiceModel.Http/4.0.11-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "RScHZ1A3CfjumaP1Vh/xfOp/ga6T3nA8YLkjFOYcIcZm/LILL+yCh+PhIrJOEfz1Js8bLSQC6xbxwYlW6BNmYg==",
+      "sha512": "hKMGQbu/l2gv/PgPvm2ViLVElnVSwAPiv4cXKjinS+UHBf02uPF2m7lN13SCkJDNTBctwHav1rQnMYb1LUJHvw==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Http.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
-        "lib/netcore50/de/System.ServiceModel.Http.xml",
-        "lib/netcore50/es/System.ServiceModel.Http.xml",
-        "lib/netcore50/fr/System.ServiceModel.Http.xml",
-        "lib/netcore50/it/System.ServiceModel.Http.xml",
-        "lib/netcore50/ja/System.ServiceModel.Http.xml",
-        "lib/netcore50/ko/System.ServiceModel.Http.xml",
-        "lib/netcore50/ru/System.ServiceModel.Http.xml",
         "lib/netcore50/System.ServiceModel.Http.dll",
-        "lib/netcore50/System.ServiceModel.Http.xml",
-        "lib/netcore50/zh-hans/System.ServiceModel.Http.xml",
-        "lib/netcore50/zh-hant/System.ServiceModel.Http.xml",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.ServiceModel.Http.xml",
+        "ref/dotnet/es/System.ServiceModel.Http.xml",
+        "ref/dotnet/fr/System.ServiceModel.Http.xml",
+        "ref/dotnet/it/System.ServiceModel.Http.xml",
+        "ref/dotnet/ja/System.ServiceModel.Http.xml",
+        "ref/dotnet/ko/System.ServiceModel.Http.xml",
+        "ref/dotnet/ru/System.ServiceModel.Http.xml",
         "ref/dotnet/System.ServiceModel.Http.dll",
+        "ref/dotnet/System.ServiceModel.Http.xml",
+        "ref/dotnet/zh-hans/System.ServiceModel.Http.xml",
+        "ref/dotnet/zh-hant/System.ServiceModel.Http.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.ServiceModel.Http.4.0.11-beta-23408.nupkg",
-        "System.ServiceModel.Http.4.0.11-beta-23408.nupkg.sha512",
+        "System.ServiceModel.Http.4.0.11-beta-23412.nupkg",
+        "System.ServiceModel.Http.4.0.11-beta-23412.nupkg.sha512",
         "System.ServiceModel.Http.nuspec"
       ]
     },
-    "System.ServiceModel.Primitives/4.0.1-beta-23408": {
+    "System.ServiceModel.Primitives/4.0.1-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "bjXzg+V3Oq/tBXpMY5FwcERN2CQsFXoL4BMoURlwiBMkgwN2CPvBIaK45Moh7nc21jNTVukNayDtURetGzK6aA==",
+      "sha512": "dkCUkNtXb2m9Wf+DY7dc5B4J8DpaWtX4wpFfT3cYLpChxAnjQR85N+tJfMEHLfZNNerKgDRyGyaKa7uSHfvb5g==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Primitives.dll",
         "lib/net45/_._",
-        "lib/netcore50/de/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/es/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/fr/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/it/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/ja/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/ko/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/ru/System.ServiceModel.Primitives.xml",
         "lib/netcore50/System.ServiceModel.Primitives.dll",
-        "lib/netcore50/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/zh-hans/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/zh-hant/System.ServiceModel.Primitives.xml",
         "lib/win8/_._",
+        "ref/dotnet/de/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/es/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/fr/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/it/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/ja/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/ko/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/ru/System.ServiceModel.Primitives.xml",
         "ref/dotnet/System.ServiceModel.Primitives.dll",
+        "ref/dotnet/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/zh-hans/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/zh-hant/System.ServiceModel.Primitives.xml",
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.Primitives.dll",
+        "ref/netcore50/System.ServiceModel.Primitives.xml",
         "ref/win8/_._",
-        "System.ServiceModel.Primitives.4.0.1-beta-23408.nupkg",
-        "System.ServiceModel.Primitives.4.0.1-beta-23408.nupkg.sha512",
+        "System.ServiceModel.Primitives.4.0.1-beta-23412.nupkg",
+        "System.ServiceModel.Primitives.4.0.1-beta-23412.nupkg.sha512",
         "System.ServiceModel.Primitives.nuspec"
       ]
     },
@@ -2897,28 +2925,6 @@
         "System.Threading.Tasks.4.0.10.nupkg",
         "System.Threading.Tasks.4.0.10.nupkg.sha512",
         "System.Threading.Tasks.nuspec"
-      ]
-    },
-    "System.Threading.ThreadPool/4.0.10-beta-23408": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "ahdsVyj+WFj8/iSDwX/G7hkEU4jZmmvWzPS2ajZKdp0Crb0vZJOlM0LQYVASQgbimrUZHQ50o93JYEi8RFdh/Q==",
-      "files": [
-        "lib/DNXCore50/System.Threading.ThreadPool.dll",
-        "lib/MonoAndroid10/_._",
-        "lib/MonoTouch10/_._",
-        "lib/net46/System.Threading.ThreadPool.dll",
-        "lib/xamarinios10/_._",
-        "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Threading.ThreadPool.dll",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
-        "ref/net46/System.Threading.ThreadPool.dll",
-        "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.Threading.ThreadPool.4.0.10-beta-23408.nupkg",
-        "System.Threading.ThreadPool.4.0.10-beta-23408.nupkg.sha512",
-        "System.Threading.ThreadPool.nuspec"
       ]
     },
     "System.Threading.Timer/4.0.0": {

--- a/src/System.Private.ServiceModel/tests/Scenarios/Binding/Custom/project.lock.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Binding/Custom/project.lock.json
@@ -292,7 +292,7 @@
           "lib/dotnet/System.Linq.Queryable.dll": {}
         }
       },
-      "System.Net.Http/4.0.1-beta-23408": {
+      "System.Net.Http/4.0.1-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -305,7 +305,7 @@
           "ref/dotnet/System.Net.Http.dll": {}
         }
       },
-      "System.Net.NameResolution/4.0.0-beta-23408": {
+      "System.Net.NameResolution/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Net.Primitives": "4.0.10",
@@ -328,16 +328,17 @@
           "lib/DNXCore50/System.Net.Primitives.dll": {}
         }
       },
-      "System.Net.Security/4.0.0-beta-23408": {
+      "System.Net.Security/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
-          "System.Private.Networking": "4.0.1-beta-23408"
+          "System.IO": "4.0.0",
+          "System.Net.Primitives": "4.0.10",
+          "System.Runtime": "4.0.0",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23412",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Net.Security.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Net.Security.dll": {}
         }
       },
       "System.Net.Sockets/4.1.0-beta-23225": {
@@ -368,7 +369,7 @@
           "lib/dotnet/System.Net.WebHeaderCollection.dll": {}
         }
       },
-      "System.Net.WebSockets/4.0.0-beta-23408": {
+      "System.Net.WebSockets/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -383,7 +384,7 @@
           "lib/dotnet/System.Net.WebSockets.dll": {}
         }
       },
-      "System.Net.WebSockets.Client/4.0.0-beta-23408": {
+      "System.Net.WebSockets.Client/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -393,13 +394,13 @@
           "System.Globalization": "4.0.10",
           "System.Net.Primitives": "4.0.10",
           "System.Net.WebHeaderCollection": "4.0.0",
-          "System.Net.WebSockets": "4.0.0-beta-23408",
+          "System.Net.WebSockets": "4.0.0-beta-23412",
           "System.Resources.ResourceManager": "4.0.0",
           "System.Runtime": "4.0.20",
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23408",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23412",
           "System.Text.Encoding": "4.0.10",
           "System.Threading": "4.0.10",
           "System.Threading.Tasks": "4.0.10"
@@ -456,7 +457,7 @@
           "lib/DNXCore50/System.Private.DataContractSerialization.dll": {}
         }
       },
-      "System.Private.Networking/4.0.1-beta-23408": {
+      "System.Private.Networking/4.0.1-beta-23225": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -475,13 +476,10 @@
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23408",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23408",
-          "System.Security.Principal.Windows": "4.0.0-beta-23408",
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23225",
           "System.Threading": "4.0.10",
           "System.Threading.Overlapped": "4.0.0",
-          "System.Threading.Tasks": "4.0.10",
-          "System.Threading.ThreadPool": "4.0.10-beta-23408"
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dnxcore50/_._": {}
@@ -490,7 +488,7 @@
           "lib/DNXCore50/System.Private.Networking.dll": {}
         }
       },
-      "System.Private.ServiceModel/4.1.0-beta-23408": {
+      "System.Private.ServiceModel/4.1.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -507,14 +505,14 @@
           "System.Linq": "4.0.0",
           "System.Linq.Expressions": "4.0.10",
           "System.Linq.Queryable": "4.0.0",
-          "System.Net.Http": "4.0.1-beta-23408",
-          "System.Net.NameResolution": "4.0.0-beta-23408",
+          "System.Net.Http": "4.0.1-beta-23412",
+          "System.Net.NameResolution": "4.0.0-beta-23412",
           "System.Net.Primitives": "4.0.10",
-          "System.Net.Security": "4.0.0-beta-23408",
-          "System.Net.Sockets": "4.0.10-beta-23408",
+          "System.Net.Security": "4.0.0-beta-23412",
+          "System.Net.Sockets": "4.0.10-beta-23412",
           "System.Net.WebHeaderCollection": "4.0.0",
-          "System.Net.WebSockets": "4.0.0-beta-23408",
-          "System.Net.WebSockets.Client": "4.0.0-beta-23408",
+          "System.Net.WebSockets": "4.0.0-beta-23412",
+          "System.Net.WebSockets.Client": "4.0.0-beta-23412",
           "System.ObjectModel": "4.0.10",
           "System.Reflection": "4.0.10",
           "System.Reflection.DispatchProxy": "4.0.0",
@@ -528,9 +526,9 @@
           "System.Runtime.Serialization.Primitives": "4.0.10",
           "System.Runtime.Serialization.Xml": "4.0.10",
           "System.Security.Claims": "4.0.0",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23408",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23412",
           "System.Security.Principal": "4.0.0",
-          "System.Security.Principal.Windows": "4.0.0-beta-23408",
+          "System.Security.Principal.Windows": "4.0.0-beta-23412",
           "System.Text.Encoding": "4.0.10",
           "System.Threading": "4.0.10",
           "System.Threading.Tasks": "4.0.10",
@@ -779,18 +777,18 @@
           "lib/dotnet/System.Security.Claims.dll": {}
         }
       },
-      "System.Security.Cryptography.Algorithms/4.0.0-beta-23408": {
+      "System.Security.Cryptography.Algorithms/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
           "System.Runtime": "4.0.0",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23408"
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23412"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.Algorithms.dll": {}
         }
       },
-      "System.Security.Cryptography.Encoding/4.0.0-beta-23408": {
+      "System.Security.Cryptography.Encoding/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -799,7 +797,7 @@
           "ref/dotnet/System.Security.Cryptography.Encoding.dll": {}
         }
       },
-      "System.Security.Cryptography.Primitives/4.0.0-beta-23408": {
+      "System.Security.Cryptography.Primitives/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.0",
@@ -817,13 +815,13 @@
           "lib/dotnet/System.Security.Cryptography.Primitives.dll": {}
         }
       },
-      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23408": {
+      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
           "System.Runtime.Handles": "4.0.0",
-          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23408",
-          "System.Security.Cryptography.Encoding": "4.0.0-beta-23408"
+          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23412",
+          "System.Security.Cryptography.Encoding": "4.0.0-beta-23412"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.X509Certificates.dll": {}
@@ -841,7 +839,7 @@
           "lib/dotnet/System.Security.Principal.dll": {}
         }
       },
-      "System.Security.Principal.Windows/4.0.0-beta-23408": {
+      "System.Security.Principal.Windows/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -864,10 +862,10 @@
           "lib/DNXCore50/System.Security.Principal.Windows.dll": {}
         }
       },
-      "System.ServiceModel.Http/4.0.11-beta-23408": {
+      "System.ServiceModel.Http/4.0.11-beta-23412": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-beta-23408",
+          "System.Private.ServiceModel": "4.1.0-beta-23412",
           "System.Runtime": "4.0.20"
         },
         "compile": {
@@ -877,10 +875,10 @@
           "lib/DNXCore50/System.ServiceModel.Http.dll": {}
         }
       },
-      "System.ServiceModel.Primitives/4.0.1-beta-23408": {
+      "System.ServiceModel.Primitives/4.0.1-beta-23412": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-beta-23408"
+          "System.Private.ServiceModel": "4.1.0-beta-23412"
         },
         "compile": {
           "ref/dotnet/System.ServiceModel.Primitives.dll": {}
@@ -967,19 +965,6 @@
         },
         "runtime": {
           "lib/DNXCore50/System.Threading.Tasks.dll": {}
-        }
-      },
-      "System.Threading.ThreadPool/4.0.10-beta-23408": {
-        "type": "package",
-        "dependencies": {
-          "System.Runtime": "4.0.0",
-          "System.Runtime.InteropServices": "4.0.0"
-        },
-        "compile": {
-          "ref/dotnet/System.Threading.ThreadPool.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Threading.ThreadPool.dll": {}
         }
       },
       "System.Threading.Timer/4.0.0": {
@@ -1162,7 +1147,7 @@
           "lib/dotnet/xunit.execution.dotnet.dll": {}
         }
       },
-      "xunit.netcore.extensions/1.0.0-prerelease-00104": {
+      "xunit.netcore.extensions/1.0.0-prerelease-00105": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.10",
@@ -1790,44 +1775,65 @@
         "System.Linq.Queryable.nuspec"
       ]
     },
-    "System.Net.Http/4.0.1-beta-23408": {
+    "System.Net.Http/4.0.1-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "n+tnV1VgCjbDKKnbgrvgUgxkPDwUFvSv9lTgH882rVzjbWyliVgbBflVzoAUjUSlga/Tr1XQIrfTLMRD5HfYGw==",
+      "sha512": "F7Yej+6QdRVzWg+qbkayRMcmf/7k7YfNFoVSA67wIsG9t5u7Wj4Go8FW72HL8qb9d7YjIsVB/5hA7g9MUT31Aw==",
       "files": [
         "lib/net45/_._",
         "lib/win8/_._",
         "lib/wpa81/_._",
+        "ref/dotnet/de/System.Net.Http.xml",
+        "ref/dotnet/es/System.Net.Http.xml",
+        "ref/dotnet/fr/System.Net.Http.xml",
+        "ref/dotnet/it/System.Net.Http.xml",
+        "ref/dotnet/ja/System.Net.Http.xml",
+        "ref/dotnet/ko/System.Net.Http.xml",
+        "ref/dotnet/ru/System.Net.Http.xml",
         "ref/dotnet/System.Net.Http.dll",
+        "ref/dotnet/System.Net.Http.xml",
+        "ref/dotnet/zh-hans/System.Net.Http.xml",
+        "ref/dotnet/zh-hant/System.Net.Http.xml",
         "ref/net45/_._",
         "ref/netcore50/System.Net.Http.dll",
+        "ref/netcore50/System.Net.Http.xml",
         "ref/win8/_._",
         "ref/wpa81/_._",
         "runtime.json",
-        "System.Net.Http.4.0.1-beta-23408.nupkg",
-        "System.Net.Http.4.0.1-beta-23408.nupkg.sha512",
+        "System.Net.Http.4.0.1-beta-23412.nupkg",
+        "System.Net.Http.4.0.1-beta-23412.nupkg.sha512",
         "System.Net.Http.nuspec"
       ]
     },
-    "System.Net.NameResolution/4.0.0-beta-23408": {
+    "System.Net.NameResolution/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "2A562VFL8GUL/jLCJ3mbQHhwwAIXzPyjxMpdtas1LVM8QLuP1OcHwV3z7ajWnYdGcPc7ZxPEGJQWicuaPD+0nA==",
+      "sha512": "HCF1zhFYBT+w/Ik+JuTzFJgj83Jfc+eA8VcgvIzdPiGMXfrZeXOogjgSCkCoJmFtKVz2DSfmISoEmiXB1oaLNQ==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.NameResolution.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Net.NameResolution.xml",
+        "ref/dotnet/es/System.Net.NameResolution.xml",
+        "ref/dotnet/fr/System.Net.NameResolution.xml",
+        "ref/dotnet/it/System.Net.NameResolution.xml",
+        "ref/dotnet/ja/System.Net.NameResolution.xml",
+        "ref/dotnet/ko/System.Net.NameResolution.xml",
+        "ref/dotnet/ru/System.Net.NameResolution.xml",
         "ref/dotnet/System.Net.NameResolution.dll",
+        "ref/dotnet/System.Net.NameResolution.xml",
+        "ref/dotnet/zh-hans/System.Net.NameResolution.xml",
+        "ref/dotnet/zh-hant/System.Net.NameResolution.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Net.NameResolution.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Net.NameResolution.4.0.0-beta-23408.nupkg",
-        "System.Net.NameResolution.4.0.0-beta-23408.nupkg.sha512",
+        "System.Net.NameResolution.4.0.0-beta-23412.nupkg",
+        "System.Net.NameResolution.4.0.0-beta-23412.nupkg.sha512",
         "System.Net.NameResolution.nuspec"
       ]
     },
@@ -1864,24 +1870,34 @@
         "System.Net.Primitives.nuspec"
       ]
     },
-    "System.Net.Security/4.0.0-beta-23408": {
+    "System.Net.Security/4.0.0-beta-23412": {
       "type": "package",
-      "sha512": "kEkunODO2t/VlBIsC80YFDG0KtY/FyIbtBApNyJQv+LYGEs5IFvEhpi9+p0/jHmhyRMKwbjajNedbXo+VMkt1A==",
+      "sha512": "Kcjne7jnvF5aTbRJsAT8kuP+1mxryUF2qYv8f3jnR19wtEjswSIOVU0XzuWc9YObEQcb+kEdzN71HTOm+ssv+w==",
       "files": [
-        "lib/DNXCore50/System.Net.Security.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.Security.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Net.Security.xml",
+        "ref/dotnet/es/System.Net.Security.xml",
+        "ref/dotnet/fr/System.Net.Security.xml",
+        "ref/dotnet/it/System.Net.Security.xml",
+        "ref/dotnet/ja/System.Net.Security.xml",
+        "ref/dotnet/ko/System.Net.Security.xml",
+        "ref/dotnet/ru/System.Net.Security.xml",
         "ref/dotnet/System.Net.Security.dll",
+        "ref/dotnet/System.Net.Security.xml",
+        "ref/dotnet/zh-hans/System.Net.Security.xml",
+        "ref/dotnet/zh-hant/System.Net.Security.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Net.Security.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.Security.4.0.0-beta-23408.nupkg",
-        "System.Net.Security.4.0.0-beta-23408.nupkg.sha512",
+        "runtime.json",
+        "System.Net.Security.4.0.0-beta-23412.nupkg",
+        "System.Net.Security.4.0.0-beta-23412.nupkg.sha512",
         "System.Net.Security.nuspec"
       ]
     },
@@ -1939,78 +1955,68 @@
         "System.Net.WebHeaderCollection.nuspec"
       ]
     },
-    "System.Net.WebSockets/4.0.0-beta-23408": {
+    "System.Net.WebSockets/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "BXy22/bNVtrXXsG76zXyhjcQnCjSYxQIFF37xWifqPRWmvzsCYSLQpNCTPQUCp7rjB7qWc5yLhC9bThaEx7MHQ==",
+      "sha512": "EvXAa0yd1RM8ROyLl1T0xC94F04Su8YMHnd4/w6j0Z/+4lKHZOU7bQPZ3odDN8WdPGKa/ZNJJGwiapydEWKzwQ==",
       "files": [
-        "lib/dotnet/de/System.Net.WebSockets.xml",
-        "lib/dotnet/es/System.Net.WebSockets.xml",
-        "lib/dotnet/fr/System.Net.WebSockets.xml",
-        "lib/dotnet/it/System.Net.WebSockets.xml",
-        "lib/dotnet/ja/System.Net.WebSockets.xml",
-        "lib/dotnet/ko/System.Net.WebSockets.xml",
-        "lib/dotnet/ru/System.Net.WebSockets.xml",
         "lib/dotnet/System.Net.WebSockets.dll",
-        "lib/dotnet/System.Net.WebSockets.xml",
-        "lib/dotnet/zh-hans/System.Net.WebSockets.xml",
-        "lib/dotnet/zh-hant/System.Net.WebSockets.xml",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.WebSockets.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Net.WebSockets.xml",
+        "ref/dotnet/es/System.Net.WebSockets.xml",
+        "ref/dotnet/fr/System.Net.WebSockets.xml",
+        "ref/dotnet/it/System.Net.WebSockets.xml",
+        "ref/dotnet/ja/System.Net.WebSockets.xml",
+        "ref/dotnet/ko/System.Net.WebSockets.xml",
+        "ref/dotnet/ru/System.Net.WebSockets.xml",
         "ref/dotnet/System.Net.WebSockets.dll",
+        "ref/dotnet/System.Net.WebSockets.xml",
+        "ref/dotnet/zh-hans/System.Net.WebSockets.xml",
+        "ref/dotnet/zh-hant/System.Net.WebSockets.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Net.WebSockets.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.WebSockets.4.0.0-beta-23408.nupkg",
-        "System.Net.WebSockets.4.0.0-beta-23408.nupkg.sha512",
+        "System.Net.WebSockets.4.0.0-beta-23412.nupkg",
+        "System.Net.WebSockets.4.0.0-beta-23412.nupkg.sha512",
         "System.Net.WebSockets.nuspec"
       ]
     },
-    "System.Net.WebSockets.Client/4.0.0-beta-23408": {
+    "System.Net.WebSockets.Client/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "smmvhCkcU0c4RNWc6NZwnN5EFktX58jf8+TJ6enfuXxWrpJ/2NRI5/2yT/okjFSngGK1g0MBrljZsfs2EJ7+Yw==",
+      "sha512": "uaO7c/81sK90605UtThSX9KVmzsJDA1vD4GMW7FsKKntymlkolJsprDekWblQ4A5YbhqxHv+ngXX2kIU0B3Fdw==",
       "files": [
-        "lib/DNXCore50/de/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/es/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/fr/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/it/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/ja/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/ko/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/ru/System.Net.WebSockets.Client.xml",
         "lib/DNXCore50/System.Net.WebSockets.Client.dll",
-        "lib/DNXCore50/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/zh-hans/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/zh-hant/System.Net.WebSockets.Client.xml",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.WebSockets.Client.dll",
-        "lib/netcore50/de/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/es/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/fr/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/it/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/ja/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/ko/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/ru/System.Net.WebSockets.Client.xml",
         "lib/netcore50/System.Net.WebSockets.Client.dll",
-        "lib/netcore50/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/zh-hans/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/zh-hant/System.Net.WebSockets.Client.xml",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/es/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/fr/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/it/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/ja/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/ko/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/ru/System.Net.WebSockets.Client.xml",
         "ref/dotnet/System.Net.WebSockets.Client.dll",
+        "ref/dotnet/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/zh-hans/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/zh-hant/System.Net.WebSockets.Client.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Net.WebSockets.Client.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.WebSockets.Client.4.0.0-beta-23408.nupkg",
-        "System.Net.WebSockets.Client.4.0.0-beta-23408.nupkg.sha512",
+        "System.Net.WebSockets.Client.4.0.0-beta-23412.nupkg",
+        "System.Net.WebSockets.Client.4.0.0-beta-23412.nupkg.sha512",
         "System.Net.WebSockets.Client.nuspec"
       ]
     },
@@ -2062,31 +2068,31 @@
         "System.Private.DataContractSerialization.nuspec"
       ]
     },
-    "System.Private.Networking/4.0.1-beta-23408": {
+    "System.Private.Networking/4.0.1-beta-23225": {
       "type": "package",
       "serviceable": true,
-      "sha512": "i2fRDRqM8Px3CP26C//deF/tCNR1AwqlPEr9+MYiXxNZtgGcSPBfqOJJ5CJdfmDb9Ap0hPG2MiPG7CinaSH7+Q==",
+      "sha512": "oVSynIrR3mIU0b/goscsaZDywr3RLxQijQnaFRKfl/VB3F9rKi5mdr0vHcGVWuq5ALSrG0OLwM8PRA4tM5e3rQ==",
       "files": [
         "lib/DNXCore50/System.Private.Networking.dll",
         "lib/netcore50/System.Private.Networking.dll",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "System.Private.Networking.4.0.1-beta-23408.nupkg",
-        "System.Private.Networking.4.0.1-beta-23408.nupkg.sha512",
+        "System.Private.Networking.4.0.1-beta-23225.nupkg",
+        "System.Private.Networking.4.0.1-beta-23225.nupkg.sha512",
         "System.Private.Networking.nuspec"
       ]
     },
-    "System.Private.ServiceModel/4.1.0-beta-23408": {
+    "System.Private.ServiceModel/4.1.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "l/2192yKa6uXhjKOWeukFJy3hoj9Zq1p55pTGe+Y28r8/5jlvgYxfunP9UyXJRo9W1u3UBtGfV/5R71ULzusGQ==",
+      "sha512": "Wm+8LcQ04YeAvYqu9faHsMZ/L8l/WvPPsqziBfifYB4jXIPXk1/kUxuAryjbLChghZDXvkDN0hv/IHSVPZGgBA==",
       "files": [
         "lib/DNXCore50/System.Private.ServiceModel.dll",
         "lib/netcore50/System.Private.ServiceModel.dll",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "System.Private.ServiceModel.4.1.0-beta-23408.nupkg",
-        "System.Private.ServiceModel.4.1.0-beta-23408.nupkg.sha512",
+        "System.Private.ServiceModel.4.1.0-beta-23412.nupkg",
+        "System.Private.ServiceModel.4.1.0-beta-23412.nupkg.sha512",
         "System.Private.ServiceModel.nuspec"
       ]
     },
@@ -2615,10 +2621,10 @@
         "System.Security.Claims.nuspec"
       ]
     },
-    "System.Security.Cryptography.Algorithms/4.0.0-beta-23408": {
+    "System.Security.Cryptography.Algorithms/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "G6eEqi8mZRrWftcwilcnllE4xJ/53JQlk3VVuJ+9qrX+DHvWz8itYJRUZX357JY4DgEEKQNOJzuRGrOBTUeoPg==",
+      "sha512": "nBjoiqJQiMD3cJgOVrqjIVDqEEPZeIqT+mrBIxjLE+YMQcjEyDuSyOG65Ntoopby5LH4onTLMM4zfXh8JRt9NQ==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2632,37 +2638,47 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.Algorithms.4.0.0-beta-23408.nupkg",
-        "System.Security.Cryptography.Algorithms.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Cryptography.Algorithms.4.0.0-beta-23412.nupkg",
+        "System.Security.Cryptography.Algorithms.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Cryptography.Algorithms.nuspec"
       ]
     },
-    "System.Security.Cryptography.Encoding/4.0.0-beta-23408": {
+    "System.Security.Cryptography.Encoding/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "fPsAK3vyMjnJ6nT4YchdS7KzfGca/6uVVAPCBO08ZpTRGhMGx30vq1MiIqAUrfsFMnot3Ub2jimnAFWkqY6g0Q==",
+      "sha512": "SR1zCARNdeyLoUKYH2SNMm1He7Lr3NR/l7yW3K135L44T6PS3YB8SfXpVoZdMpb22X2G07BZAHVz2x7e4AA1Cg==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Security.Cryptography.Encoding.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/es/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/fr/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/it/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/ja/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/ko/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/ru/System.Security.Cryptography.Encoding.xml",
         "ref/dotnet/System.Security.Cryptography.Encoding.dll",
+        "ref/dotnet/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/zh-hans/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/zh-hant/System.Security.Cryptography.Encoding.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Security.Cryptography.Encoding.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.Encoding.4.0.0-beta-23408.nupkg",
-        "System.Security.Cryptography.Encoding.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Cryptography.Encoding.4.0.0-beta-23412.nupkg",
+        "System.Security.Cryptography.Encoding.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Cryptography.Encoding.nuspec"
       ]
     },
-    "System.Security.Cryptography.Primitives/4.0.0-beta-23408": {
+    "System.Security.Cryptography.Primitives/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "A336dWYEIQxm1rEJCaE5ZZrUWHPUkBGTRH8uAj8qrTqg4/qRc2yN2wZxeGXaZauhI35QwDmOutK7oVb2Cd+4TA==",
+      "sha512": "H9EBNe0ahjAYjlVn0TnT18PSgZBrtROSQH1RRIKwAjzxQHt8zwDhO4yN0Q5QaaUIoSXgxVmgtWWk62wDvpy+QA==",
       "files": [
         "lib/dotnet/System.Security.Cryptography.Primitives.dll",
         "lib/MonoAndroid10/_._",
@@ -2676,30 +2692,40 @@
         "ref/net46/System.Security.Cryptography.Primitives.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Security.Cryptography.Primitives.4.0.0-beta-23408.nupkg",
-        "System.Security.Cryptography.Primitives.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Cryptography.Primitives.4.0.0-beta-23412.nupkg",
+        "System.Security.Cryptography.Primitives.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Cryptography.Primitives.nuspec"
       ]
     },
-    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23408": {
+    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "JSNf5d1V5Y47MIdf7QxZCuGnR5heM4UKbrsdXiWD5lfqu0mnNjebPIclMUXlTw/6IykuDsUpompV/DtsaLLHig==",
+      "sha512": "SfpMjvrfRaRjG42uynLugb3YgpXdpnU7X8vNAU7stIR5/4uW9m1SvWHvBjirjHRBtOpbKB86uD5ODQWX+tWDNA==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Security.Cryptography.X509Certificates.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/es/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/fr/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/it/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/ja/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/ko/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/ru/System.Security.Cryptography.X509Certificates.xml",
         "ref/dotnet/System.Security.Cryptography.X509Certificates.dll",
+        "ref/dotnet/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/zh-hans/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/zh-hant/System.Security.Cryptography.X509Certificates.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Security.Cryptography.X509Certificates.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23408.nupkg",
-        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23412.nupkg",
+        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Cryptography.X509Certificates.nuspec"
       ]
     },
@@ -2736,88 +2762,89 @@
         "System.Security.Principal.nuspec"
       ]
     },
-    "System.Security.Principal.Windows/4.0.0-beta-23408": {
+    "System.Security.Principal.Windows/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "xmjpZJvsT1AW23UkjqUkF/VrOh7DA1cagYY272UQmO8ei227TFD4C7j3ofatL/63hR3CXkLkoephuE4f2Z9fGA==",
+      "sha512": "Zvb/LzT+GjGNV1t8i5KVieilL+8P5LcQykIbJHw5aJxLPFEIQ4Y2hTJXdEkeKvZ4TCF5dlwY1jYyUrJkcqpxzw==",
       "files": [
-        "lib/DNXCore50/de/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/es/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/fr/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/it/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/ja/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/ko/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/ru/System.Security.Principal.Windows.xml",
         "lib/DNXCore50/System.Security.Principal.Windows.dll",
-        "lib/DNXCore50/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/zh-hans/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/zh-hant/System.Security.Principal.Windows.xml",
         "lib/net46/System.Security.Principal.Windows.dll",
+        "ref/dotnet/de/System.Security.Principal.Windows.xml",
+        "ref/dotnet/es/System.Security.Principal.Windows.xml",
+        "ref/dotnet/fr/System.Security.Principal.Windows.xml",
+        "ref/dotnet/it/System.Security.Principal.Windows.xml",
+        "ref/dotnet/ja/System.Security.Principal.Windows.xml",
+        "ref/dotnet/ko/System.Security.Principal.Windows.xml",
+        "ref/dotnet/ru/System.Security.Principal.Windows.xml",
         "ref/dotnet/System.Security.Principal.Windows.dll",
+        "ref/dotnet/System.Security.Principal.Windows.xml",
+        "ref/dotnet/zh-hans/System.Security.Principal.Windows.xml",
+        "ref/dotnet/zh-hant/System.Security.Principal.Windows.xml",
         "ref/net46/System.Security.Principal.Windows.dll",
-        "System.Security.Principal.Windows.4.0.0-beta-23408.nupkg",
-        "System.Security.Principal.Windows.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Principal.Windows.4.0.0-beta-23412.nupkg",
+        "System.Security.Principal.Windows.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Principal.Windows.nuspec"
       ]
     },
-    "System.ServiceModel.Http/4.0.11-beta-23408": {
+    "System.ServiceModel.Http/4.0.11-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "RScHZ1A3CfjumaP1Vh/xfOp/ga6T3nA8YLkjFOYcIcZm/LILL+yCh+PhIrJOEfz1Js8bLSQC6xbxwYlW6BNmYg==",
+      "sha512": "hKMGQbu/l2gv/PgPvm2ViLVElnVSwAPiv4cXKjinS+UHBf02uPF2m7lN13SCkJDNTBctwHav1rQnMYb1LUJHvw==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Http.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
-        "lib/netcore50/de/System.ServiceModel.Http.xml",
-        "lib/netcore50/es/System.ServiceModel.Http.xml",
-        "lib/netcore50/fr/System.ServiceModel.Http.xml",
-        "lib/netcore50/it/System.ServiceModel.Http.xml",
-        "lib/netcore50/ja/System.ServiceModel.Http.xml",
-        "lib/netcore50/ko/System.ServiceModel.Http.xml",
-        "lib/netcore50/ru/System.ServiceModel.Http.xml",
         "lib/netcore50/System.ServiceModel.Http.dll",
-        "lib/netcore50/System.ServiceModel.Http.xml",
-        "lib/netcore50/zh-hans/System.ServiceModel.Http.xml",
-        "lib/netcore50/zh-hant/System.ServiceModel.Http.xml",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.ServiceModel.Http.xml",
+        "ref/dotnet/es/System.ServiceModel.Http.xml",
+        "ref/dotnet/fr/System.ServiceModel.Http.xml",
+        "ref/dotnet/it/System.ServiceModel.Http.xml",
+        "ref/dotnet/ja/System.ServiceModel.Http.xml",
+        "ref/dotnet/ko/System.ServiceModel.Http.xml",
+        "ref/dotnet/ru/System.ServiceModel.Http.xml",
         "ref/dotnet/System.ServiceModel.Http.dll",
+        "ref/dotnet/System.ServiceModel.Http.xml",
+        "ref/dotnet/zh-hans/System.ServiceModel.Http.xml",
+        "ref/dotnet/zh-hant/System.ServiceModel.Http.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.ServiceModel.Http.4.0.11-beta-23408.nupkg",
-        "System.ServiceModel.Http.4.0.11-beta-23408.nupkg.sha512",
+        "System.ServiceModel.Http.4.0.11-beta-23412.nupkg",
+        "System.ServiceModel.Http.4.0.11-beta-23412.nupkg.sha512",
         "System.ServiceModel.Http.nuspec"
       ]
     },
-    "System.ServiceModel.Primitives/4.0.1-beta-23408": {
+    "System.ServiceModel.Primitives/4.0.1-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "bjXzg+V3Oq/tBXpMY5FwcERN2CQsFXoL4BMoURlwiBMkgwN2CPvBIaK45Moh7nc21jNTVukNayDtURetGzK6aA==",
+      "sha512": "dkCUkNtXb2m9Wf+DY7dc5B4J8DpaWtX4wpFfT3cYLpChxAnjQR85N+tJfMEHLfZNNerKgDRyGyaKa7uSHfvb5g==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Primitives.dll",
         "lib/net45/_._",
-        "lib/netcore50/de/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/es/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/fr/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/it/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/ja/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/ko/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/ru/System.ServiceModel.Primitives.xml",
         "lib/netcore50/System.ServiceModel.Primitives.dll",
-        "lib/netcore50/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/zh-hans/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/zh-hant/System.ServiceModel.Primitives.xml",
         "lib/win8/_._",
+        "ref/dotnet/de/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/es/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/fr/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/it/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/ja/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/ko/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/ru/System.ServiceModel.Primitives.xml",
         "ref/dotnet/System.ServiceModel.Primitives.dll",
+        "ref/dotnet/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/zh-hans/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/zh-hant/System.ServiceModel.Primitives.xml",
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.Primitives.dll",
+        "ref/netcore50/System.ServiceModel.Primitives.xml",
         "ref/win8/_._",
-        "System.ServiceModel.Primitives.4.0.1-beta-23408.nupkg",
-        "System.ServiceModel.Primitives.4.0.1-beta-23408.nupkg.sha512",
+        "System.ServiceModel.Primitives.4.0.1-beta-23412.nupkg",
+        "System.ServiceModel.Primitives.4.0.1-beta-23412.nupkg.sha512",
         "System.ServiceModel.Primitives.nuspec"
       ]
     },
@@ -3010,28 +3037,6 @@
         "System.Threading.Tasks.4.0.10.nupkg",
         "System.Threading.Tasks.4.0.10.nupkg.sha512",
         "System.Threading.Tasks.nuspec"
-      ]
-    },
-    "System.Threading.ThreadPool/4.0.10-beta-23408": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "ahdsVyj+WFj8/iSDwX/G7hkEU4jZmmvWzPS2ajZKdp0Crb0vZJOlM0LQYVASQgbimrUZHQ50o93JYEi8RFdh/Q==",
-      "files": [
-        "lib/DNXCore50/System.Threading.ThreadPool.dll",
-        "lib/MonoAndroid10/_._",
-        "lib/MonoTouch10/_._",
-        "lib/net46/System.Threading.ThreadPool.dll",
-        "lib/xamarinios10/_._",
-        "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Threading.ThreadPool.dll",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
-        "ref/net46/System.Threading.ThreadPool.dll",
-        "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.Threading.ThreadPool.4.0.10-beta-23408.nupkg",
-        "System.Threading.ThreadPool.4.0.10-beta-23408.nupkg.sha512",
-        "System.Threading.ThreadPool.nuspec"
       ]
     },
     "System.Threading.Timer/4.0.0": {
@@ -3281,14 +3286,14 @@
         "xunit.extensibility.execution.nuspec"
       ]
     },
-    "xunit.netcore.extensions/1.0.0-prerelease-00104": {
+    "xunit.netcore.extensions/1.0.0-prerelease-00105": {
       "type": "package",
       "serviceable": true,
-      "sha512": "ZMXxEBpGP7krXtvqbPMOWavd2u83w77ghtD254wfj5+d+7GmYYqP9pX1iRIxJK9CBa8Zc2cOrcYsmCLQgYriAQ==",
+      "sha512": "EnnGcy9rmSdQ8izHWvYSYVyjQGhbeFH7JeM/L35ZrrPGtYvq5XD3hc1cJPCs+43mXdF9cdqhkt5uTlXYzC+Z8g==",
       "files": [
         "lib/dotnet/Xunit.NetCore.Extensions.dll",
-        "xunit.netcore.extensions.1.0.0-prerelease-00104.nupkg",
-        "xunit.netcore.extensions.1.0.0-prerelease-00104.nupkg.sha512",
+        "xunit.netcore.extensions.1.0.0-prerelease-00105.nupkg",
+        "xunit.netcore.extensions.1.0.0-prerelease-00105.nupkg.sha512",
         "xunit.netcore.extensions.nuspec"
       ]
     }

--- a/src/System.Private.ServiceModel/tests/Scenarios/Binding/Http/project.lock.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Binding/Http/project.lock.json
@@ -292,7 +292,7 @@
           "lib/dotnet/System.Linq.Queryable.dll": {}
         }
       },
-      "System.Net.Http/4.0.1-beta-23408": {
+      "System.Net.Http/4.0.1-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -305,7 +305,7 @@
           "ref/dotnet/System.Net.Http.dll": {}
         }
       },
-      "System.Net.NameResolution/4.0.0-beta-23408": {
+      "System.Net.NameResolution/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Net.Primitives": "4.0.10",
@@ -328,16 +328,17 @@
           "lib/DNXCore50/System.Net.Primitives.dll": {}
         }
       },
-      "System.Net.Security/4.0.0-beta-23408": {
+      "System.Net.Security/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
-          "System.Private.Networking": "4.0.1-beta-23408"
+          "System.IO": "4.0.0",
+          "System.Net.Primitives": "4.0.10",
+          "System.Runtime": "4.0.0",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23412",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Net.Security.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Net.Security.dll": {}
         }
       },
       "System.Net.Sockets/4.1.0-beta-23225": {
@@ -368,7 +369,7 @@
           "lib/dotnet/System.Net.WebHeaderCollection.dll": {}
         }
       },
-      "System.Net.WebSockets/4.0.0-beta-23408": {
+      "System.Net.WebSockets/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -383,7 +384,7 @@
           "lib/dotnet/System.Net.WebSockets.dll": {}
         }
       },
-      "System.Net.WebSockets.Client/4.0.0-beta-23408": {
+      "System.Net.WebSockets.Client/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -393,13 +394,13 @@
           "System.Globalization": "4.0.10",
           "System.Net.Primitives": "4.0.10",
           "System.Net.WebHeaderCollection": "4.0.0",
-          "System.Net.WebSockets": "4.0.0-beta-23408",
+          "System.Net.WebSockets": "4.0.0-beta-23412",
           "System.Resources.ResourceManager": "4.0.0",
           "System.Runtime": "4.0.20",
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23408",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23412",
           "System.Text.Encoding": "4.0.10",
           "System.Threading": "4.0.10",
           "System.Threading.Tasks": "4.0.10"
@@ -456,7 +457,7 @@
           "lib/DNXCore50/System.Private.DataContractSerialization.dll": {}
         }
       },
-      "System.Private.Networking/4.0.1-beta-23408": {
+      "System.Private.Networking/4.0.1-beta-23225": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -475,13 +476,10 @@
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23408",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23408",
-          "System.Security.Principal.Windows": "4.0.0-beta-23408",
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23225",
           "System.Threading": "4.0.10",
           "System.Threading.Overlapped": "4.0.0",
-          "System.Threading.Tasks": "4.0.10",
-          "System.Threading.ThreadPool": "4.0.10-beta-23408"
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dnxcore50/_._": {}
@@ -490,7 +488,7 @@
           "lib/DNXCore50/System.Private.Networking.dll": {}
         }
       },
-      "System.Private.ServiceModel/4.1.0-beta-23408": {
+      "System.Private.ServiceModel/4.1.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -507,14 +505,14 @@
           "System.Linq": "4.0.0",
           "System.Linq.Expressions": "4.0.10",
           "System.Linq.Queryable": "4.0.0",
-          "System.Net.Http": "4.0.1-beta-23408",
-          "System.Net.NameResolution": "4.0.0-beta-23408",
+          "System.Net.Http": "4.0.1-beta-23412",
+          "System.Net.NameResolution": "4.0.0-beta-23412",
           "System.Net.Primitives": "4.0.10",
-          "System.Net.Security": "4.0.0-beta-23408",
-          "System.Net.Sockets": "4.0.10-beta-23408",
+          "System.Net.Security": "4.0.0-beta-23412",
+          "System.Net.Sockets": "4.0.10-beta-23412",
           "System.Net.WebHeaderCollection": "4.0.0",
-          "System.Net.WebSockets": "4.0.0-beta-23408",
-          "System.Net.WebSockets.Client": "4.0.0-beta-23408",
+          "System.Net.WebSockets": "4.0.0-beta-23412",
+          "System.Net.WebSockets.Client": "4.0.0-beta-23412",
           "System.ObjectModel": "4.0.10",
           "System.Reflection": "4.0.10",
           "System.Reflection.DispatchProxy": "4.0.0",
@@ -528,9 +526,9 @@
           "System.Runtime.Serialization.Primitives": "4.0.10",
           "System.Runtime.Serialization.Xml": "4.0.10",
           "System.Security.Claims": "4.0.0",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23408",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23412",
           "System.Security.Principal": "4.0.0",
-          "System.Security.Principal.Windows": "4.0.0-beta-23408",
+          "System.Security.Principal.Windows": "4.0.0-beta-23412",
           "System.Text.Encoding": "4.0.10",
           "System.Threading": "4.0.10",
           "System.Threading.Tasks": "4.0.10",
@@ -779,18 +777,18 @@
           "lib/dotnet/System.Security.Claims.dll": {}
         }
       },
-      "System.Security.Cryptography.Algorithms/4.0.0-beta-23408": {
+      "System.Security.Cryptography.Algorithms/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
           "System.Runtime": "4.0.0",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23408"
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23412"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.Algorithms.dll": {}
         }
       },
-      "System.Security.Cryptography.Encoding/4.0.0-beta-23408": {
+      "System.Security.Cryptography.Encoding/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -799,7 +797,7 @@
           "ref/dotnet/System.Security.Cryptography.Encoding.dll": {}
         }
       },
-      "System.Security.Cryptography.Primitives/4.0.0-beta-23408": {
+      "System.Security.Cryptography.Primitives/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.0",
@@ -817,13 +815,13 @@
           "lib/dotnet/System.Security.Cryptography.Primitives.dll": {}
         }
       },
-      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23408": {
+      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
           "System.Runtime.Handles": "4.0.0",
-          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23408",
-          "System.Security.Cryptography.Encoding": "4.0.0-beta-23408"
+          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23412",
+          "System.Security.Cryptography.Encoding": "4.0.0-beta-23412"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.X509Certificates.dll": {}
@@ -841,7 +839,7 @@
           "lib/dotnet/System.Security.Principal.dll": {}
         }
       },
-      "System.Security.Principal.Windows/4.0.0-beta-23408": {
+      "System.Security.Principal.Windows/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -864,10 +862,10 @@
           "lib/DNXCore50/System.Security.Principal.Windows.dll": {}
         }
       },
-      "System.ServiceModel.Http/4.0.11-beta-23408": {
+      "System.ServiceModel.Http/4.0.11-beta-23412": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-beta-23408",
+          "System.Private.ServiceModel": "4.1.0-beta-23412",
           "System.Runtime": "4.0.20"
         },
         "compile": {
@@ -877,10 +875,10 @@
           "lib/DNXCore50/System.ServiceModel.Http.dll": {}
         }
       },
-      "System.ServiceModel.Primitives/4.0.1-beta-23408": {
+      "System.ServiceModel.Primitives/4.0.1-beta-23412": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-beta-23408"
+          "System.Private.ServiceModel": "4.1.0-beta-23412"
         },
         "compile": {
           "ref/dotnet/System.ServiceModel.Primitives.dll": {}
@@ -967,19 +965,6 @@
         },
         "runtime": {
           "lib/DNXCore50/System.Threading.Tasks.dll": {}
-        }
-      },
-      "System.Threading.ThreadPool/4.0.10-beta-23408": {
-        "type": "package",
-        "dependencies": {
-          "System.Runtime": "4.0.0",
-          "System.Runtime.InteropServices": "4.0.0"
-        },
-        "compile": {
-          "ref/dotnet/System.Threading.ThreadPool.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Threading.ThreadPool.dll": {}
         }
       },
       "System.Threading.Timer/4.0.0": {
@@ -1162,7 +1147,7 @@
           "lib/dotnet/xunit.execution.dotnet.dll": {}
         }
       },
-      "xunit.netcore.extensions/1.0.0-prerelease-00104": {
+      "xunit.netcore.extensions/1.0.0-prerelease-00105": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.10",
@@ -1790,44 +1775,65 @@
         "System.Linq.Queryable.nuspec"
       ]
     },
-    "System.Net.Http/4.0.1-beta-23408": {
+    "System.Net.Http/4.0.1-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "n+tnV1VgCjbDKKnbgrvgUgxkPDwUFvSv9lTgH882rVzjbWyliVgbBflVzoAUjUSlga/Tr1XQIrfTLMRD5HfYGw==",
+      "sha512": "F7Yej+6QdRVzWg+qbkayRMcmf/7k7YfNFoVSA67wIsG9t5u7Wj4Go8FW72HL8qb9d7YjIsVB/5hA7g9MUT31Aw==",
       "files": [
         "lib/net45/_._",
         "lib/win8/_._",
         "lib/wpa81/_._",
+        "ref/dotnet/de/System.Net.Http.xml",
+        "ref/dotnet/es/System.Net.Http.xml",
+        "ref/dotnet/fr/System.Net.Http.xml",
+        "ref/dotnet/it/System.Net.Http.xml",
+        "ref/dotnet/ja/System.Net.Http.xml",
+        "ref/dotnet/ko/System.Net.Http.xml",
+        "ref/dotnet/ru/System.Net.Http.xml",
         "ref/dotnet/System.Net.Http.dll",
+        "ref/dotnet/System.Net.Http.xml",
+        "ref/dotnet/zh-hans/System.Net.Http.xml",
+        "ref/dotnet/zh-hant/System.Net.Http.xml",
         "ref/net45/_._",
         "ref/netcore50/System.Net.Http.dll",
+        "ref/netcore50/System.Net.Http.xml",
         "ref/win8/_._",
         "ref/wpa81/_._",
         "runtime.json",
-        "System.Net.Http.4.0.1-beta-23408.nupkg",
-        "System.Net.Http.4.0.1-beta-23408.nupkg.sha512",
+        "System.Net.Http.4.0.1-beta-23412.nupkg",
+        "System.Net.Http.4.0.1-beta-23412.nupkg.sha512",
         "System.Net.Http.nuspec"
       ]
     },
-    "System.Net.NameResolution/4.0.0-beta-23408": {
+    "System.Net.NameResolution/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "2A562VFL8GUL/jLCJ3mbQHhwwAIXzPyjxMpdtas1LVM8QLuP1OcHwV3z7ajWnYdGcPc7ZxPEGJQWicuaPD+0nA==",
+      "sha512": "HCF1zhFYBT+w/Ik+JuTzFJgj83Jfc+eA8VcgvIzdPiGMXfrZeXOogjgSCkCoJmFtKVz2DSfmISoEmiXB1oaLNQ==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.NameResolution.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Net.NameResolution.xml",
+        "ref/dotnet/es/System.Net.NameResolution.xml",
+        "ref/dotnet/fr/System.Net.NameResolution.xml",
+        "ref/dotnet/it/System.Net.NameResolution.xml",
+        "ref/dotnet/ja/System.Net.NameResolution.xml",
+        "ref/dotnet/ko/System.Net.NameResolution.xml",
+        "ref/dotnet/ru/System.Net.NameResolution.xml",
         "ref/dotnet/System.Net.NameResolution.dll",
+        "ref/dotnet/System.Net.NameResolution.xml",
+        "ref/dotnet/zh-hans/System.Net.NameResolution.xml",
+        "ref/dotnet/zh-hant/System.Net.NameResolution.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Net.NameResolution.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Net.NameResolution.4.0.0-beta-23408.nupkg",
-        "System.Net.NameResolution.4.0.0-beta-23408.nupkg.sha512",
+        "System.Net.NameResolution.4.0.0-beta-23412.nupkg",
+        "System.Net.NameResolution.4.0.0-beta-23412.nupkg.sha512",
         "System.Net.NameResolution.nuspec"
       ]
     },
@@ -1864,24 +1870,34 @@
         "System.Net.Primitives.nuspec"
       ]
     },
-    "System.Net.Security/4.0.0-beta-23408": {
+    "System.Net.Security/4.0.0-beta-23412": {
       "type": "package",
-      "sha512": "kEkunODO2t/VlBIsC80YFDG0KtY/FyIbtBApNyJQv+LYGEs5IFvEhpi9+p0/jHmhyRMKwbjajNedbXo+VMkt1A==",
+      "sha512": "Kcjne7jnvF5aTbRJsAT8kuP+1mxryUF2qYv8f3jnR19wtEjswSIOVU0XzuWc9YObEQcb+kEdzN71HTOm+ssv+w==",
       "files": [
-        "lib/DNXCore50/System.Net.Security.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.Security.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Net.Security.xml",
+        "ref/dotnet/es/System.Net.Security.xml",
+        "ref/dotnet/fr/System.Net.Security.xml",
+        "ref/dotnet/it/System.Net.Security.xml",
+        "ref/dotnet/ja/System.Net.Security.xml",
+        "ref/dotnet/ko/System.Net.Security.xml",
+        "ref/dotnet/ru/System.Net.Security.xml",
         "ref/dotnet/System.Net.Security.dll",
+        "ref/dotnet/System.Net.Security.xml",
+        "ref/dotnet/zh-hans/System.Net.Security.xml",
+        "ref/dotnet/zh-hant/System.Net.Security.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Net.Security.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.Security.4.0.0-beta-23408.nupkg",
-        "System.Net.Security.4.0.0-beta-23408.nupkg.sha512",
+        "runtime.json",
+        "System.Net.Security.4.0.0-beta-23412.nupkg",
+        "System.Net.Security.4.0.0-beta-23412.nupkg.sha512",
         "System.Net.Security.nuspec"
       ]
     },
@@ -1939,78 +1955,68 @@
         "System.Net.WebHeaderCollection.nuspec"
       ]
     },
-    "System.Net.WebSockets/4.0.0-beta-23408": {
+    "System.Net.WebSockets/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "BXy22/bNVtrXXsG76zXyhjcQnCjSYxQIFF37xWifqPRWmvzsCYSLQpNCTPQUCp7rjB7qWc5yLhC9bThaEx7MHQ==",
+      "sha512": "EvXAa0yd1RM8ROyLl1T0xC94F04Su8YMHnd4/w6j0Z/+4lKHZOU7bQPZ3odDN8WdPGKa/ZNJJGwiapydEWKzwQ==",
       "files": [
-        "lib/dotnet/de/System.Net.WebSockets.xml",
-        "lib/dotnet/es/System.Net.WebSockets.xml",
-        "lib/dotnet/fr/System.Net.WebSockets.xml",
-        "lib/dotnet/it/System.Net.WebSockets.xml",
-        "lib/dotnet/ja/System.Net.WebSockets.xml",
-        "lib/dotnet/ko/System.Net.WebSockets.xml",
-        "lib/dotnet/ru/System.Net.WebSockets.xml",
         "lib/dotnet/System.Net.WebSockets.dll",
-        "lib/dotnet/System.Net.WebSockets.xml",
-        "lib/dotnet/zh-hans/System.Net.WebSockets.xml",
-        "lib/dotnet/zh-hant/System.Net.WebSockets.xml",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.WebSockets.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Net.WebSockets.xml",
+        "ref/dotnet/es/System.Net.WebSockets.xml",
+        "ref/dotnet/fr/System.Net.WebSockets.xml",
+        "ref/dotnet/it/System.Net.WebSockets.xml",
+        "ref/dotnet/ja/System.Net.WebSockets.xml",
+        "ref/dotnet/ko/System.Net.WebSockets.xml",
+        "ref/dotnet/ru/System.Net.WebSockets.xml",
         "ref/dotnet/System.Net.WebSockets.dll",
+        "ref/dotnet/System.Net.WebSockets.xml",
+        "ref/dotnet/zh-hans/System.Net.WebSockets.xml",
+        "ref/dotnet/zh-hant/System.Net.WebSockets.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Net.WebSockets.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.WebSockets.4.0.0-beta-23408.nupkg",
-        "System.Net.WebSockets.4.0.0-beta-23408.nupkg.sha512",
+        "System.Net.WebSockets.4.0.0-beta-23412.nupkg",
+        "System.Net.WebSockets.4.0.0-beta-23412.nupkg.sha512",
         "System.Net.WebSockets.nuspec"
       ]
     },
-    "System.Net.WebSockets.Client/4.0.0-beta-23408": {
+    "System.Net.WebSockets.Client/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "smmvhCkcU0c4RNWc6NZwnN5EFktX58jf8+TJ6enfuXxWrpJ/2NRI5/2yT/okjFSngGK1g0MBrljZsfs2EJ7+Yw==",
+      "sha512": "uaO7c/81sK90605UtThSX9KVmzsJDA1vD4GMW7FsKKntymlkolJsprDekWblQ4A5YbhqxHv+ngXX2kIU0B3Fdw==",
       "files": [
-        "lib/DNXCore50/de/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/es/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/fr/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/it/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/ja/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/ko/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/ru/System.Net.WebSockets.Client.xml",
         "lib/DNXCore50/System.Net.WebSockets.Client.dll",
-        "lib/DNXCore50/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/zh-hans/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/zh-hant/System.Net.WebSockets.Client.xml",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.WebSockets.Client.dll",
-        "lib/netcore50/de/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/es/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/fr/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/it/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/ja/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/ko/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/ru/System.Net.WebSockets.Client.xml",
         "lib/netcore50/System.Net.WebSockets.Client.dll",
-        "lib/netcore50/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/zh-hans/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/zh-hant/System.Net.WebSockets.Client.xml",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/es/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/fr/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/it/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/ja/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/ko/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/ru/System.Net.WebSockets.Client.xml",
         "ref/dotnet/System.Net.WebSockets.Client.dll",
+        "ref/dotnet/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/zh-hans/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/zh-hant/System.Net.WebSockets.Client.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Net.WebSockets.Client.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.WebSockets.Client.4.0.0-beta-23408.nupkg",
-        "System.Net.WebSockets.Client.4.0.0-beta-23408.nupkg.sha512",
+        "System.Net.WebSockets.Client.4.0.0-beta-23412.nupkg",
+        "System.Net.WebSockets.Client.4.0.0-beta-23412.nupkg.sha512",
         "System.Net.WebSockets.Client.nuspec"
       ]
     },
@@ -2062,31 +2068,31 @@
         "System.Private.DataContractSerialization.nuspec"
       ]
     },
-    "System.Private.Networking/4.0.1-beta-23408": {
+    "System.Private.Networking/4.0.1-beta-23225": {
       "type": "package",
       "serviceable": true,
-      "sha512": "i2fRDRqM8Px3CP26C//deF/tCNR1AwqlPEr9+MYiXxNZtgGcSPBfqOJJ5CJdfmDb9Ap0hPG2MiPG7CinaSH7+Q==",
+      "sha512": "oVSynIrR3mIU0b/goscsaZDywr3RLxQijQnaFRKfl/VB3F9rKi5mdr0vHcGVWuq5ALSrG0OLwM8PRA4tM5e3rQ==",
       "files": [
         "lib/DNXCore50/System.Private.Networking.dll",
         "lib/netcore50/System.Private.Networking.dll",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "System.Private.Networking.4.0.1-beta-23408.nupkg",
-        "System.Private.Networking.4.0.1-beta-23408.nupkg.sha512",
+        "System.Private.Networking.4.0.1-beta-23225.nupkg",
+        "System.Private.Networking.4.0.1-beta-23225.nupkg.sha512",
         "System.Private.Networking.nuspec"
       ]
     },
-    "System.Private.ServiceModel/4.1.0-beta-23408": {
+    "System.Private.ServiceModel/4.1.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "l/2192yKa6uXhjKOWeukFJy3hoj9Zq1p55pTGe+Y28r8/5jlvgYxfunP9UyXJRo9W1u3UBtGfV/5R71ULzusGQ==",
+      "sha512": "Wm+8LcQ04YeAvYqu9faHsMZ/L8l/WvPPsqziBfifYB4jXIPXk1/kUxuAryjbLChghZDXvkDN0hv/IHSVPZGgBA==",
       "files": [
         "lib/DNXCore50/System.Private.ServiceModel.dll",
         "lib/netcore50/System.Private.ServiceModel.dll",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "System.Private.ServiceModel.4.1.0-beta-23408.nupkg",
-        "System.Private.ServiceModel.4.1.0-beta-23408.nupkg.sha512",
+        "System.Private.ServiceModel.4.1.0-beta-23412.nupkg",
+        "System.Private.ServiceModel.4.1.0-beta-23412.nupkg.sha512",
         "System.Private.ServiceModel.nuspec"
       ]
     },
@@ -2615,10 +2621,10 @@
         "System.Security.Claims.nuspec"
       ]
     },
-    "System.Security.Cryptography.Algorithms/4.0.0-beta-23408": {
+    "System.Security.Cryptography.Algorithms/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "G6eEqi8mZRrWftcwilcnllE4xJ/53JQlk3VVuJ+9qrX+DHvWz8itYJRUZX357JY4DgEEKQNOJzuRGrOBTUeoPg==",
+      "sha512": "nBjoiqJQiMD3cJgOVrqjIVDqEEPZeIqT+mrBIxjLE+YMQcjEyDuSyOG65Ntoopby5LH4onTLMM4zfXh8JRt9NQ==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2632,37 +2638,47 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.Algorithms.4.0.0-beta-23408.nupkg",
-        "System.Security.Cryptography.Algorithms.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Cryptography.Algorithms.4.0.0-beta-23412.nupkg",
+        "System.Security.Cryptography.Algorithms.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Cryptography.Algorithms.nuspec"
       ]
     },
-    "System.Security.Cryptography.Encoding/4.0.0-beta-23408": {
+    "System.Security.Cryptography.Encoding/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "fPsAK3vyMjnJ6nT4YchdS7KzfGca/6uVVAPCBO08ZpTRGhMGx30vq1MiIqAUrfsFMnot3Ub2jimnAFWkqY6g0Q==",
+      "sha512": "SR1zCARNdeyLoUKYH2SNMm1He7Lr3NR/l7yW3K135L44T6PS3YB8SfXpVoZdMpb22X2G07BZAHVz2x7e4AA1Cg==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Security.Cryptography.Encoding.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/es/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/fr/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/it/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/ja/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/ko/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/ru/System.Security.Cryptography.Encoding.xml",
         "ref/dotnet/System.Security.Cryptography.Encoding.dll",
+        "ref/dotnet/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/zh-hans/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/zh-hant/System.Security.Cryptography.Encoding.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Security.Cryptography.Encoding.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.Encoding.4.0.0-beta-23408.nupkg",
-        "System.Security.Cryptography.Encoding.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Cryptography.Encoding.4.0.0-beta-23412.nupkg",
+        "System.Security.Cryptography.Encoding.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Cryptography.Encoding.nuspec"
       ]
     },
-    "System.Security.Cryptography.Primitives/4.0.0-beta-23408": {
+    "System.Security.Cryptography.Primitives/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "A336dWYEIQxm1rEJCaE5ZZrUWHPUkBGTRH8uAj8qrTqg4/qRc2yN2wZxeGXaZauhI35QwDmOutK7oVb2Cd+4TA==",
+      "sha512": "H9EBNe0ahjAYjlVn0TnT18PSgZBrtROSQH1RRIKwAjzxQHt8zwDhO4yN0Q5QaaUIoSXgxVmgtWWk62wDvpy+QA==",
       "files": [
         "lib/dotnet/System.Security.Cryptography.Primitives.dll",
         "lib/MonoAndroid10/_._",
@@ -2676,30 +2692,40 @@
         "ref/net46/System.Security.Cryptography.Primitives.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Security.Cryptography.Primitives.4.0.0-beta-23408.nupkg",
-        "System.Security.Cryptography.Primitives.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Cryptography.Primitives.4.0.0-beta-23412.nupkg",
+        "System.Security.Cryptography.Primitives.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Cryptography.Primitives.nuspec"
       ]
     },
-    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23408": {
+    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "JSNf5d1V5Y47MIdf7QxZCuGnR5heM4UKbrsdXiWD5lfqu0mnNjebPIclMUXlTw/6IykuDsUpompV/DtsaLLHig==",
+      "sha512": "SfpMjvrfRaRjG42uynLugb3YgpXdpnU7X8vNAU7stIR5/4uW9m1SvWHvBjirjHRBtOpbKB86uD5ODQWX+tWDNA==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Security.Cryptography.X509Certificates.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/es/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/fr/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/it/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/ja/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/ko/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/ru/System.Security.Cryptography.X509Certificates.xml",
         "ref/dotnet/System.Security.Cryptography.X509Certificates.dll",
+        "ref/dotnet/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/zh-hans/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/zh-hant/System.Security.Cryptography.X509Certificates.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Security.Cryptography.X509Certificates.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23408.nupkg",
-        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23412.nupkg",
+        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Cryptography.X509Certificates.nuspec"
       ]
     },
@@ -2736,88 +2762,89 @@
         "System.Security.Principal.nuspec"
       ]
     },
-    "System.Security.Principal.Windows/4.0.0-beta-23408": {
+    "System.Security.Principal.Windows/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "xmjpZJvsT1AW23UkjqUkF/VrOh7DA1cagYY272UQmO8ei227TFD4C7j3ofatL/63hR3CXkLkoephuE4f2Z9fGA==",
+      "sha512": "Zvb/LzT+GjGNV1t8i5KVieilL+8P5LcQykIbJHw5aJxLPFEIQ4Y2hTJXdEkeKvZ4TCF5dlwY1jYyUrJkcqpxzw==",
       "files": [
-        "lib/DNXCore50/de/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/es/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/fr/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/it/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/ja/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/ko/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/ru/System.Security.Principal.Windows.xml",
         "lib/DNXCore50/System.Security.Principal.Windows.dll",
-        "lib/DNXCore50/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/zh-hans/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/zh-hant/System.Security.Principal.Windows.xml",
         "lib/net46/System.Security.Principal.Windows.dll",
+        "ref/dotnet/de/System.Security.Principal.Windows.xml",
+        "ref/dotnet/es/System.Security.Principal.Windows.xml",
+        "ref/dotnet/fr/System.Security.Principal.Windows.xml",
+        "ref/dotnet/it/System.Security.Principal.Windows.xml",
+        "ref/dotnet/ja/System.Security.Principal.Windows.xml",
+        "ref/dotnet/ko/System.Security.Principal.Windows.xml",
+        "ref/dotnet/ru/System.Security.Principal.Windows.xml",
         "ref/dotnet/System.Security.Principal.Windows.dll",
+        "ref/dotnet/System.Security.Principal.Windows.xml",
+        "ref/dotnet/zh-hans/System.Security.Principal.Windows.xml",
+        "ref/dotnet/zh-hant/System.Security.Principal.Windows.xml",
         "ref/net46/System.Security.Principal.Windows.dll",
-        "System.Security.Principal.Windows.4.0.0-beta-23408.nupkg",
-        "System.Security.Principal.Windows.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Principal.Windows.4.0.0-beta-23412.nupkg",
+        "System.Security.Principal.Windows.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Principal.Windows.nuspec"
       ]
     },
-    "System.ServiceModel.Http/4.0.11-beta-23408": {
+    "System.ServiceModel.Http/4.0.11-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "RScHZ1A3CfjumaP1Vh/xfOp/ga6T3nA8YLkjFOYcIcZm/LILL+yCh+PhIrJOEfz1Js8bLSQC6xbxwYlW6BNmYg==",
+      "sha512": "hKMGQbu/l2gv/PgPvm2ViLVElnVSwAPiv4cXKjinS+UHBf02uPF2m7lN13SCkJDNTBctwHav1rQnMYb1LUJHvw==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Http.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
-        "lib/netcore50/de/System.ServiceModel.Http.xml",
-        "lib/netcore50/es/System.ServiceModel.Http.xml",
-        "lib/netcore50/fr/System.ServiceModel.Http.xml",
-        "lib/netcore50/it/System.ServiceModel.Http.xml",
-        "lib/netcore50/ja/System.ServiceModel.Http.xml",
-        "lib/netcore50/ko/System.ServiceModel.Http.xml",
-        "lib/netcore50/ru/System.ServiceModel.Http.xml",
         "lib/netcore50/System.ServiceModel.Http.dll",
-        "lib/netcore50/System.ServiceModel.Http.xml",
-        "lib/netcore50/zh-hans/System.ServiceModel.Http.xml",
-        "lib/netcore50/zh-hant/System.ServiceModel.Http.xml",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.ServiceModel.Http.xml",
+        "ref/dotnet/es/System.ServiceModel.Http.xml",
+        "ref/dotnet/fr/System.ServiceModel.Http.xml",
+        "ref/dotnet/it/System.ServiceModel.Http.xml",
+        "ref/dotnet/ja/System.ServiceModel.Http.xml",
+        "ref/dotnet/ko/System.ServiceModel.Http.xml",
+        "ref/dotnet/ru/System.ServiceModel.Http.xml",
         "ref/dotnet/System.ServiceModel.Http.dll",
+        "ref/dotnet/System.ServiceModel.Http.xml",
+        "ref/dotnet/zh-hans/System.ServiceModel.Http.xml",
+        "ref/dotnet/zh-hant/System.ServiceModel.Http.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.ServiceModel.Http.4.0.11-beta-23408.nupkg",
-        "System.ServiceModel.Http.4.0.11-beta-23408.nupkg.sha512",
+        "System.ServiceModel.Http.4.0.11-beta-23412.nupkg",
+        "System.ServiceModel.Http.4.0.11-beta-23412.nupkg.sha512",
         "System.ServiceModel.Http.nuspec"
       ]
     },
-    "System.ServiceModel.Primitives/4.0.1-beta-23408": {
+    "System.ServiceModel.Primitives/4.0.1-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "bjXzg+V3Oq/tBXpMY5FwcERN2CQsFXoL4BMoURlwiBMkgwN2CPvBIaK45Moh7nc21jNTVukNayDtURetGzK6aA==",
+      "sha512": "dkCUkNtXb2m9Wf+DY7dc5B4J8DpaWtX4wpFfT3cYLpChxAnjQR85N+tJfMEHLfZNNerKgDRyGyaKa7uSHfvb5g==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Primitives.dll",
         "lib/net45/_._",
-        "lib/netcore50/de/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/es/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/fr/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/it/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/ja/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/ko/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/ru/System.ServiceModel.Primitives.xml",
         "lib/netcore50/System.ServiceModel.Primitives.dll",
-        "lib/netcore50/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/zh-hans/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/zh-hant/System.ServiceModel.Primitives.xml",
         "lib/win8/_._",
+        "ref/dotnet/de/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/es/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/fr/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/it/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/ja/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/ko/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/ru/System.ServiceModel.Primitives.xml",
         "ref/dotnet/System.ServiceModel.Primitives.dll",
+        "ref/dotnet/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/zh-hans/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/zh-hant/System.ServiceModel.Primitives.xml",
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.Primitives.dll",
+        "ref/netcore50/System.ServiceModel.Primitives.xml",
         "ref/win8/_._",
-        "System.ServiceModel.Primitives.4.0.1-beta-23408.nupkg",
-        "System.ServiceModel.Primitives.4.0.1-beta-23408.nupkg.sha512",
+        "System.ServiceModel.Primitives.4.0.1-beta-23412.nupkg",
+        "System.ServiceModel.Primitives.4.0.1-beta-23412.nupkg.sha512",
         "System.ServiceModel.Primitives.nuspec"
       ]
     },
@@ -3010,28 +3037,6 @@
         "System.Threading.Tasks.4.0.10.nupkg",
         "System.Threading.Tasks.4.0.10.nupkg.sha512",
         "System.Threading.Tasks.nuspec"
-      ]
-    },
-    "System.Threading.ThreadPool/4.0.10-beta-23408": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "ahdsVyj+WFj8/iSDwX/G7hkEU4jZmmvWzPS2ajZKdp0Crb0vZJOlM0LQYVASQgbimrUZHQ50o93JYEi8RFdh/Q==",
-      "files": [
-        "lib/DNXCore50/System.Threading.ThreadPool.dll",
-        "lib/MonoAndroid10/_._",
-        "lib/MonoTouch10/_._",
-        "lib/net46/System.Threading.ThreadPool.dll",
-        "lib/xamarinios10/_._",
-        "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Threading.ThreadPool.dll",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
-        "ref/net46/System.Threading.ThreadPool.dll",
-        "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.Threading.ThreadPool.4.0.10-beta-23408.nupkg",
-        "System.Threading.ThreadPool.4.0.10-beta-23408.nupkg.sha512",
-        "System.Threading.ThreadPool.nuspec"
       ]
     },
     "System.Threading.Timer/4.0.0": {
@@ -3281,14 +3286,14 @@
         "xunit.extensibility.execution.nuspec"
       ]
     },
-    "xunit.netcore.extensions/1.0.0-prerelease-00104": {
+    "xunit.netcore.extensions/1.0.0-prerelease-00105": {
       "type": "package",
       "serviceable": true,
-      "sha512": "ZMXxEBpGP7krXtvqbPMOWavd2u83w77ghtD254wfj5+d+7GmYYqP9pX1iRIxJK9CBa8Zc2cOrcYsmCLQgYriAQ==",
+      "sha512": "EnnGcy9rmSdQ8izHWvYSYVyjQGhbeFH7JeM/L35ZrrPGtYvq5XD3hc1cJPCs+43mXdF9cdqhkt5uTlXYzC+Z8g==",
       "files": [
         "lib/dotnet/Xunit.NetCore.Extensions.dll",
-        "xunit.netcore.extensions.1.0.0-prerelease-00104.nupkg",
-        "xunit.netcore.extensions.1.0.0-prerelease-00104.nupkg.sha512",
+        "xunit.netcore.extensions.1.0.0-prerelease-00105.nupkg",
+        "xunit.netcore.extensions.1.0.0-prerelease-00105.nupkg.sha512",
         "xunit.netcore.extensions.nuspec"
       ]
     }

--- a/src/System.Private.ServiceModel/tests/Scenarios/Binding/NetHttp/project.lock.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Binding/NetHttp/project.lock.json
@@ -292,7 +292,7 @@
           "lib/dotnet/System.Linq.Queryable.dll": {}
         }
       },
-      "System.Net.Http/4.0.1-beta-23408": {
+      "System.Net.Http/4.0.1-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -305,7 +305,7 @@
           "ref/dotnet/System.Net.Http.dll": {}
         }
       },
-      "System.Net.NameResolution/4.0.0-beta-23408": {
+      "System.Net.NameResolution/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Net.Primitives": "4.0.10",
@@ -328,16 +328,17 @@
           "lib/DNXCore50/System.Net.Primitives.dll": {}
         }
       },
-      "System.Net.Security/4.0.0-beta-23408": {
+      "System.Net.Security/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
-          "System.Private.Networking": "4.0.1-beta-23408"
+          "System.IO": "4.0.0",
+          "System.Net.Primitives": "4.0.10",
+          "System.Runtime": "4.0.0",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23412",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Net.Security.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Net.Security.dll": {}
         }
       },
       "System.Net.Sockets/4.1.0-beta-23225": {
@@ -368,7 +369,7 @@
           "lib/dotnet/System.Net.WebHeaderCollection.dll": {}
         }
       },
-      "System.Net.WebSockets/4.0.0-beta-23408": {
+      "System.Net.WebSockets/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -383,7 +384,7 @@
           "lib/dotnet/System.Net.WebSockets.dll": {}
         }
       },
-      "System.Net.WebSockets.Client/4.0.0-beta-23408": {
+      "System.Net.WebSockets.Client/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -393,13 +394,13 @@
           "System.Globalization": "4.0.10",
           "System.Net.Primitives": "4.0.10",
           "System.Net.WebHeaderCollection": "4.0.0",
-          "System.Net.WebSockets": "4.0.0-beta-23408",
+          "System.Net.WebSockets": "4.0.0-beta-23412",
           "System.Resources.ResourceManager": "4.0.0",
           "System.Runtime": "4.0.20",
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23408",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23412",
           "System.Text.Encoding": "4.0.10",
           "System.Threading": "4.0.10",
           "System.Threading.Tasks": "4.0.10"
@@ -456,7 +457,7 @@
           "lib/DNXCore50/System.Private.DataContractSerialization.dll": {}
         }
       },
-      "System.Private.Networking/4.0.1-beta-23408": {
+      "System.Private.Networking/4.0.1-beta-23225": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -475,13 +476,10 @@
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23408",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23408",
-          "System.Security.Principal.Windows": "4.0.0-beta-23408",
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23225",
           "System.Threading": "4.0.10",
           "System.Threading.Overlapped": "4.0.0",
-          "System.Threading.Tasks": "4.0.10",
-          "System.Threading.ThreadPool": "4.0.10-beta-23408"
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dnxcore50/_._": {}
@@ -490,7 +488,7 @@
           "lib/DNXCore50/System.Private.Networking.dll": {}
         }
       },
-      "System.Private.ServiceModel/4.1.0-beta-23408": {
+      "System.Private.ServiceModel/4.1.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -507,14 +505,14 @@
           "System.Linq": "4.0.0",
           "System.Linq.Expressions": "4.0.10",
           "System.Linq.Queryable": "4.0.0",
-          "System.Net.Http": "4.0.1-beta-23408",
-          "System.Net.NameResolution": "4.0.0-beta-23408",
+          "System.Net.Http": "4.0.1-beta-23412",
+          "System.Net.NameResolution": "4.0.0-beta-23412",
           "System.Net.Primitives": "4.0.10",
-          "System.Net.Security": "4.0.0-beta-23408",
-          "System.Net.Sockets": "4.0.10-beta-23408",
+          "System.Net.Security": "4.0.0-beta-23412",
+          "System.Net.Sockets": "4.0.10-beta-23412",
           "System.Net.WebHeaderCollection": "4.0.0",
-          "System.Net.WebSockets": "4.0.0-beta-23408",
-          "System.Net.WebSockets.Client": "4.0.0-beta-23408",
+          "System.Net.WebSockets": "4.0.0-beta-23412",
+          "System.Net.WebSockets.Client": "4.0.0-beta-23412",
           "System.ObjectModel": "4.0.10",
           "System.Reflection": "4.0.10",
           "System.Reflection.DispatchProxy": "4.0.0",
@@ -528,9 +526,9 @@
           "System.Runtime.Serialization.Primitives": "4.0.10",
           "System.Runtime.Serialization.Xml": "4.0.10",
           "System.Security.Claims": "4.0.0",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23408",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23412",
           "System.Security.Principal": "4.0.0",
-          "System.Security.Principal.Windows": "4.0.0-beta-23408",
+          "System.Security.Principal.Windows": "4.0.0-beta-23412",
           "System.Text.Encoding": "4.0.10",
           "System.Threading": "4.0.10",
           "System.Threading.Tasks": "4.0.10",
@@ -779,18 +777,18 @@
           "lib/dotnet/System.Security.Claims.dll": {}
         }
       },
-      "System.Security.Cryptography.Algorithms/4.0.0-beta-23408": {
+      "System.Security.Cryptography.Algorithms/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
           "System.Runtime": "4.0.0",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23408"
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23412"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.Algorithms.dll": {}
         }
       },
-      "System.Security.Cryptography.Encoding/4.0.0-beta-23408": {
+      "System.Security.Cryptography.Encoding/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -799,7 +797,7 @@
           "ref/dotnet/System.Security.Cryptography.Encoding.dll": {}
         }
       },
-      "System.Security.Cryptography.Primitives/4.0.0-beta-23408": {
+      "System.Security.Cryptography.Primitives/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.0",
@@ -817,13 +815,13 @@
           "lib/dotnet/System.Security.Cryptography.Primitives.dll": {}
         }
       },
-      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23408": {
+      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
           "System.Runtime.Handles": "4.0.0",
-          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23408",
-          "System.Security.Cryptography.Encoding": "4.0.0-beta-23408"
+          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23412",
+          "System.Security.Cryptography.Encoding": "4.0.0-beta-23412"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.X509Certificates.dll": {}
@@ -841,7 +839,7 @@
           "lib/dotnet/System.Security.Principal.dll": {}
         }
       },
-      "System.Security.Principal.Windows/4.0.0-beta-23408": {
+      "System.Security.Principal.Windows/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -864,10 +862,10 @@
           "lib/DNXCore50/System.Security.Principal.Windows.dll": {}
         }
       },
-      "System.ServiceModel.Duplex/4.0.1-beta-23408": {
+      "System.ServiceModel.Duplex/4.0.1-beta-23412": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-beta-23408"
+          "System.Private.ServiceModel": "4.1.0-beta-23412"
         },
         "compile": {
           "ref/dotnet/System.ServiceModel.Duplex.dll": {}
@@ -876,10 +874,10 @@
           "lib/DNXCore50/System.ServiceModel.Duplex.dll": {}
         }
       },
-      "System.ServiceModel.Http/4.0.11-beta-23408": {
+      "System.ServiceModel.Http/4.0.11-beta-23412": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-beta-23408",
+          "System.Private.ServiceModel": "4.1.0-beta-23412",
           "System.Runtime": "4.0.20"
         },
         "compile": {
@@ -889,10 +887,10 @@
           "lib/DNXCore50/System.ServiceModel.Http.dll": {}
         }
       },
-      "System.ServiceModel.NetTcp/4.0.1-beta-23408": {
+      "System.ServiceModel.NetTcp/4.0.1-beta-23412": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-beta-23408"
+          "System.Private.ServiceModel": "4.1.0-beta-23412"
         },
         "compile": {
           "ref/dotnet/System.ServiceModel.NetTcp.dll": {}
@@ -901,10 +899,10 @@
           "lib/DNXCore50/System.ServiceModel.NetTcp.dll": {}
         }
       },
-      "System.ServiceModel.Primitives/4.0.1-beta-23408": {
+      "System.ServiceModel.Primitives/4.0.1-beta-23412": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-beta-23408"
+          "System.Private.ServiceModel": "4.1.0-beta-23412"
         },
         "compile": {
           "ref/dotnet/System.ServiceModel.Primitives.dll": {}
@@ -991,19 +989,6 @@
         },
         "runtime": {
           "lib/DNXCore50/System.Threading.Tasks.dll": {}
-        }
-      },
-      "System.Threading.ThreadPool/4.0.10-beta-23408": {
-        "type": "package",
-        "dependencies": {
-          "System.Runtime": "4.0.0",
-          "System.Runtime.InteropServices": "4.0.0"
-        },
-        "compile": {
-          "ref/dotnet/System.Threading.ThreadPool.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Threading.ThreadPool.dll": {}
         }
       },
       "System.Threading.Timer/4.0.0": {
@@ -1186,7 +1171,7 @@
           "lib/dotnet/xunit.execution.dotnet.dll": {}
         }
       },
-      "xunit.netcore.extensions/1.0.0-prerelease-00104": {
+      "xunit.netcore.extensions/1.0.0-prerelease-00105": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.10",
@@ -1814,44 +1799,65 @@
         "System.Linq.Queryable.nuspec"
       ]
     },
-    "System.Net.Http/4.0.1-beta-23408": {
+    "System.Net.Http/4.0.1-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "n+tnV1VgCjbDKKnbgrvgUgxkPDwUFvSv9lTgH882rVzjbWyliVgbBflVzoAUjUSlga/Tr1XQIrfTLMRD5HfYGw==",
+      "sha512": "F7Yej+6QdRVzWg+qbkayRMcmf/7k7YfNFoVSA67wIsG9t5u7Wj4Go8FW72HL8qb9d7YjIsVB/5hA7g9MUT31Aw==",
       "files": [
         "lib/net45/_._",
         "lib/win8/_._",
         "lib/wpa81/_._",
+        "ref/dotnet/de/System.Net.Http.xml",
+        "ref/dotnet/es/System.Net.Http.xml",
+        "ref/dotnet/fr/System.Net.Http.xml",
+        "ref/dotnet/it/System.Net.Http.xml",
+        "ref/dotnet/ja/System.Net.Http.xml",
+        "ref/dotnet/ko/System.Net.Http.xml",
+        "ref/dotnet/ru/System.Net.Http.xml",
         "ref/dotnet/System.Net.Http.dll",
+        "ref/dotnet/System.Net.Http.xml",
+        "ref/dotnet/zh-hans/System.Net.Http.xml",
+        "ref/dotnet/zh-hant/System.Net.Http.xml",
         "ref/net45/_._",
         "ref/netcore50/System.Net.Http.dll",
+        "ref/netcore50/System.Net.Http.xml",
         "ref/win8/_._",
         "ref/wpa81/_._",
         "runtime.json",
-        "System.Net.Http.4.0.1-beta-23408.nupkg",
-        "System.Net.Http.4.0.1-beta-23408.nupkg.sha512",
+        "System.Net.Http.4.0.1-beta-23412.nupkg",
+        "System.Net.Http.4.0.1-beta-23412.nupkg.sha512",
         "System.Net.Http.nuspec"
       ]
     },
-    "System.Net.NameResolution/4.0.0-beta-23408": {
+    "System.Net.NameResolution/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "2A562VFL8GUL/jLCJ3mbQHhwwAIXzPyjxMpdtas1LVM8QLuP1OcHwV3z7ajWnYdGcPc7ZxPEGJQWicuaPD+0nA==",
+      "sha512": "HCF1zhFYBT+w/Ik+JuTzFJgj83Jfc+eA8VcgvIzdPiGMXfrZeXOogjgSCkCoJmFtKVz2DSfmISoEmiXB1oaLNQ==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.NameResolution.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Net.NameResolution.xml",
+        "ref/dotnet/es/System.Net.NameResolution.xml",
+        "ref/dotnet/fr/System.Net.NameResolution.xml",
+        "ref/dotnet/it/System.Net.NameResolution.xml",
+        "ref/dotnet/ja/System.Net.NameResolution.xml",
+        "ref/dotnet/ko/System.Net.NameResolution.xml",
+        "ref/dotnet/ru/System.Net.NameResolution.xml",
         "ref/dotnet/System.Net.NameResolution.dll",
+        "ref/dotnet/System.Net.NameResolution.xml",
+        "ref/dotnet/zh-hans/System.Net.NameResolution.xml",
+        "ref/dotnet/zh-hant/System.Net.NameResolution.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Net.NameResolution.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Net.NameResolution.4.0.0-beta-23408.nupkg",
-        "System.Net.NameResolution.4.0.0-beta-23408.nupkg.sha512",
+        "System.Net.NameResolution.4.0.0-beta-23412.nupkg",
+        "System.Net.NameResolution.4.0.0-beta-23412.nupkg.sha512",
         "System.Net.NameResolution.nuspec"
       ]
     },
@@ -1888,24 +1894,34 @@
         "System.Net.Primitives.nuspec"
       ]
     },
-    "System.Net.Security/4.0.0-beta-23408": {
+    "System.Net.Security/4.0.0-beta-23412": {
       "type": "package",
-      "sha512": "kEkunODO2t/VlBIsC80YFDG0KtY/FyIbtBApNyJQv+LYGEs5IFvEhpi9+p0/jHmhyRMKwbjajNedbXo+VMkt1A==",
+      "sha512": "Kcjne7jnvF5aTbRJsAT8kuP+1mxryUF2qYv8f3jnR19wtEjswSIOVU0XzuWc9YObEQcb+kEdzN71HTOm+ssv+w==",
       "files": [
-        "lib/DNXCore50/System.Net.Security.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.Security.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Net.Security.xml",
+        "ref/dotnet/es/System.Net.Security.xml",
+        "ref/dotnet/fr/System.Net.Security.xml",
+        "ref/dotnet/it/System.Net.Security.xml",
+        "ref/dotnet/ja/System.Net.Security.xml",
+        "ref/dotnet/ko/System.Net.Security.xml",
+        "ref/dotnet/ru/System.Net.Security.xml",
         "ref/dotnet/System.Net.Security.dll",
+        "ref/dotnet/System.Net.Security.xml",
+        "ref/dotnet/zh-hans/System.Net.Security.xml",
+        "ref/dotnet/zh-hant/System.Net.Security.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Net.Security.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.Security.4.0.0-beta-23408.nupkg",
-        "System.Net.Security.4.0.0-beta-23408.nupkg.sha512",
+        "runtime.json",
+        "System.Net.Security.4.0.0-beta-23412.nupkg",
+        "System.Net.Security.4.0.0-beta-23412.nupkg.sha512",
         "System.Net.Security.nuspec"
       ]
     },
@@ -1963,78 +1979,68 @@
         "System.Net.WebHeaderCollection.nuspec"
       ]
     },
-    "System.Net.WebSockets/4.0.0-beta-23408": {
+    "System.Net.WebSockets/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "BXy22/bNVtrXXsG76zXyhjcQnCjSYxQIFF37xWifqPRWmvzsCYSLQpNCTPQUCp7rjB7qWc5yLhC9bThaEx7MHQ==",
+      "sha512": "EvXAa0yd1RM8ROyLl1T0xC94F04Su8YMHnd4/w6j0Z/+4lKHZOU7bQPZ3odDN8WdPGKa/ZNJJGwiapydEWKzwQ==",
       "files": [
-        "lib/dotnet/de/System.Net.WebSockets.xml",
-        "lib/dotnet/es/System.Net.WebSockets.xml",
-        "lib/dotnet/fr/System.Net.WebSockets.xml",
-        "lib/dotnet/it/System.Net.WebSockets.xml",
-        "lib/dotnet/ja/System.Net.WebSockets.xml",
-        "lib/dotnet/ko/System.Net.WebSockets.xml",
-        "lib/dotnet/ru/System.Net.WebSockets.xml",
         "lib/dotnet/System.Net.WebSockets.dll",
-        "lib/dotnet/System.Net.WebSockets.xml",
-        "lib/dotnet/zh-hans/System.Net.WebSockets.xml",
-        "lib/dotnet/zh-hant/System.Net.WebSockets.xml",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.WebSockets.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Net.WebSockets.xml",
+        "ref/dotnet/es/System.Net.WebSockets.xml",
+        "ref/dotnet/fr/System.Net.WebSockets.xml",
+        "ref/dotnet/it/System.Net.WebSockets.xml",
+        "ref/dotnet/ja/System.Net.WebSockets.xml",
+        "ref/dotnet/ko/System.Net.WebSockets.xml",
+        "ref/dotnet/ru/System.Net.WebSockets.xml",
         "ref/dotnet/System.Net.WebSockets.dll",
+        "ref/dotnet/System.Net.WebSockets.xml",
+        "ref/dotnet/zh-hans/System.Net.WebSockets.xml",
+        "ref/dotnet/zh-hant/System.Net.WebSockets.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Net.WebSockets.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.WebSockets.4.0.0-beta-23408.nupkg",
-        "System.Net.WebSockets.4.0.0-beta-23408.nupkg.sha512",
+        "System.Net.WebSockets.4.0.0-beta-23412.nupkg",
+        "System.Net.WebSockets.4.0.0-beta-23412.nupkg.sha512",
         "System.Net.WebSockets.nuspec"
       ]
     },
-    "System.Net.WebSockets.Client/4.0.0-beta-23408": {
+    "System.Net.WebSockets.Client/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "smmvhCkcU0c4RNWc6NZwnN5EFktX58jf8+TJ6enfuXxWrpJ/2NRI5/2yT/okjFSngGK1g0MBrljZsfs2EJ7+Yw==",
+      "sha512": "uaO7c/81sK90605UtThSX9KVmzsJDA1vD4GMW7FsKKntymlkolJsprDekWblQ4A5YbhqxHv+ngXX2kIU0B3Fdw==",
       "files": [
-        "lib/DNXCore50/de/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/es/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/fr/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/it/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/ja/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/ko/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/ru/System.Net.WebSockets.Client.xml",
         "lib/DNXCore50/System.Net.WebSockets.Client.dll",
-        "lib/DNXCore50/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/zh-hans/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/zh-hant/System.Net.WebSockets.Client.xml",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.WebSockets.Client.dll",
-        "lib/netcore50/de/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/es/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/fr/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/it/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/ja/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/ko/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/ru/System.Net.WebSockets.Client.xml",
         "lib/netcore50/System.Net.WebSockets.Client.dll",
-        "lib/netcore50/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/zh-hans/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/zh-hant/System.Net.WebSockets.Client.xml",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/es/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/fr/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/it/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/ja/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/ko/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/ru/System.Net.WebSockets.Client.xml",
         "ref/dotnet/System.Net.WebSockets.Client.dll",
+        "ref/dotnet/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/zh-hans/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/zh-hant/System.Net.WebSockets.Client.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Net.WebSockets.Client.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.WebSockets.Client.4.0.0-beta-23408.nupkg",
-        "System.Net.WebSockets.Client.4.0.0-beta-23408.nupkg.sha512",
+        "System.Net.WebSockets.Client.4.0.0-beta-23412.nupkg",
+        "System.Net.WebSockets.Client.4.0.0-beta-23412.nupkg.sha512",
         "System.Net.WebSockets.Client.nuspec"
       ]
     },
@@ -2086,31 +2092,31 @@
         "System.Private.DataContractSerialization.nuspec"
       ]
     },
-    "System.Private.Networking/4.0.1-beta-23408": {
+    "System.Private.Networking/4.0.1-beta-23225": {
       "type": "package",
       "serviceable": true,
-      "sha512": "i2fRDRqM8Px3CP26C//deF/tCNR1AwqlPEr9+MYiXxNZtgGcSPBfqOJJ5CJdfmDb9Ap0hPG2MiPG7CinaSH7+Q==",
+      "sha512": "oVSynIrR3mIU0b/goscsaZDywr3RLxQijQnaFRKfl/VB3F9rKi5mdr0vHcGVWuq5ALSrG0OLwM8PRA4tM5e3rQ==",
       "files": [
         "lib/DNXCore50/System.Private.Networking.dll",
         "lib/netcore50/System.Private.Networking.dll",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "System.Private.Networking.4.0.1-beta-23408.nupkg",
-        "System.Private.Networking.4.0.1-beta-23408.nupkg.sha512",
+        "System.Private.Networking.4.0.1-beta-23225.nupkg",
+        "System.Private.Networking.4.0.1-beta-23225.nupkg.sha512",
         "System.Private.Networking.nuspec"
       ]
     },
-    "System.Private.ServiceModel/4.1.0-beta-23408": {
+    "System.Private.ServiceModel/4.1.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "l/2192yKa6uXhjKOWeukFJy3hoj9Zq1p55pTGe+Y28r8/5jlvgYxfunP9UyXJRo9W1u3UBtGfV/5R71ULzusGQ==",
+      "sha512": "Wm+8LcQ04YeAvYqu9faHsMZ/L8l/WvPPsqziBfifYB4jXIPXk1/kUxuAryjbLChghZDXvkDN0hv/IHSVPZGgBA==",
       "files": [
         "lib/DNXCore50/System.Private.ServiceModel.dll",
         "lib/netcore50/System.Private.ServiceModel.dll",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "System.Private.ServiceModel.4.1.0-beta-23408.nupkg",
-        "System.Private.ServiceModel.4.1.0-beta-23408.nupkg.sha512",
+        "System.Private.ServiceModel.4.1.0-beta-23412.nupkg",
+        "System.Private.ServiceModel.4.1.0-beta-23412.nupkg.sha512",
         "System.Private.ServiceModel.nuspec"
       ]
     },
@@ -2639,10 +2645,10 @@
         "System.Security.Claims.nuspec"
       ]
     },
-    "System.Security.Cryptography.Algorithms/4.0.0-beta-23408": {
+    "System.Security.Cryptography.Algorithms/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "G6eEqi8mZRrWftcwilcnllE4xJ/53JQlk3VVuJ+9qrX+DHvWz8itYJRUZX357JY4DgEEKQNOJzuRGrOBTUeoPg==",
+      "sha512": "nBjoiqJQiMD3cJgOVrqjIVDqEEPZeIqT+mrBIxjLE+YMQcjEyDuSyOG65Ntoopby5LH4onTLMM4zfXh8JRt9NQ==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2656,37 +2662,47 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.Algorithms.4.0.0-beta-23408.nupkg",
-        "System.Security.Cryptography.Algorithms.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Cryptography.Algorithms.4.0.0-beta-23412.nupkg",
+        "System.Security.Cryptography.Algorithms.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Cryptography.Algorithms.nuspec"
       ]
     },
-    "System.Security.Cryptography.Encoding/4.0.0-beta-23408": {
+    "System.Security.Cryptography.Encoding/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "fPsAK3vyMjnJ6nT4YchdS7KzfGca/6uVVAPCBO08ZpTRGhMGx30vq1MiIqAUrfsFMnot3Ub2jimnAFWkqY6g0Q==",
+      "sha512": "SR1zCARNdeyLoUKYH2SNMm1He7Lr3NR/l7yW3K135L44T6PS3YB8SfXpVoZdMpb22X2G07BZAHVz2x7e4AA1Cg==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Security.Cryptography.Encoding.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/es/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/fr/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/it/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/ja/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/ko/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/ru/System.Security.Cryptography.Encoding.xml",
         "ref/dotnet/System.Security.Cryptography.Encoding.dll",
+        "ref/dotnet/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/zh-hans/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/zh-hant/System.Security.Cryptography.Encoding.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Security.Cryptography.Encoding.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.Encoding.4.0.0-beta-23408.nupkg",
-        "System.Security.Cryptography.Encoding.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Cryptography.Encoding.4.0.0-beta-23412.nupkg",
+        "System.Security.Cryptography.Encoding.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Cryptography.Encoding.nuspec"
       ]
     },
-    "System.Security.Cryptography.Primitives/4.0.0-beta-23408": {
+    "System.Security.Cryptography.Primitives/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "A336dWYEIQxm1rEJCaE5ZZrUWHPUkBGTRH8uAj8qrTqg4/qRc2yN2wZxeGXaZauhI35QwDmOutK7oVb2Cd+4TA==",
+      "sha512": "H9EBNe0ahjAYjlVn0TnT18PSgZBrtROSQH1RRIKwAjzxQHt8zwDhO4yN0Q5QaaUIoSXgxVmgtWWk62wDvpy+QA==",
       "files": [
         "lib/dotnet/System.Security.Cryptography.Primitives.dll",
         "lib/MonoAndroid10/_._",
@@ -2700,30 +2716,40 @@
         "ref/net46/System.Security.Cryptography.Primitives.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Security.Cryptography.Primitives.4.0.0-beta-23408.nupkg",
-        "System.Security.Cryptography.Primitives.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Cryptography.Primitives.4.0.0-beta-23412.nupkg",
+        "System.Security.Cryptography.Primitives.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Cryptography.Primitives.nuspec"
       ]
     },
-    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23408": {
+    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "JSNf5d1V5Y47MIdf7QxZCuGnR5heM4UKbrsdXiWD5lfqu0mnNjebPIclMUXlTw/6IykuDsUpompV/DtsaLLHig==",
+      "sha512": "SfpMjvrfRaRjG42uynLugb3YgpXdpnU7X8vNAU7stIR5/4uW9m1SvWHvBjirjHRBtOpbKB86uD5ODQWX+tWDNA==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Security.Cryptography.X509Certificates.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/es/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/fr/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/it/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/ja/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/ko/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/ru/System.Security.Cryptography.X509Certificates.xml",
         "ref/dotnet/System.Security.Cryptography.X509Certificates.dll",
+        "ref/dotnet/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/zh-hans/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/zh-hant/System.Security.Cryptography.X509Certificates.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Security.Cryptography.X509Certificates.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23408.nupkg",
-        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23412.nupkg",
+        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Cryptography.X509Certificates.nuspec"
       ]
     },
@@ -2760,144 +2786,147 @@
         "System.Security.Principal.nuspec"
       ]
     },
-    "System.Security.Principal.Windows/4.0.0-beta-23408": {
+    "System.Security.Principal.Windows/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "xmjpZJvsT1AW23UkjqUkF/VrOh7DA1cagYY272UQmO8ei227TFD4C7j3ofatL/63hR3CXkLkoephuE4f2Z9fGA==",
+      "sha512": "Zvb/LzT+GjGNV1t8i5KVieilL+8P5LcQykIbJHw5aJxLPFEIQ4Y2hTJXdEkeKvZ4TCF5dlwY1jYyUrJkcqpxzw==",
       "files": [
-        "lib/DNXCore50/de/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/es/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/fr/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/it/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/ja/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/ko/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/ru/System.Security.Principal.Windows.xml",
         "lib/DNXCore50/System.Security.Principal.Windows.dll",
-        "lib/DNXCore50/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/zh-hans/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/zh-hant/System.Security.Principal.Windows.xml",
         "lib/net46/System.Security.Principal.Windows.dll",
+        "ref/dotnet/de/System.Security.Principal.Windows.xml",
+        "ref/dotnet/es/System.Security.Principal.Windows.xml",
+        "ref/dotnet/fr/System.Security.Principal.Windows.xml",
+        "ref/dotnet/it/System.Security.Principal.Windows.xml",
+        "ref/dotnet/ja/System.Security.Principal.Windows.xml",
+        "ref/dotnet/ko/System.Security.Principal.Windows.xml",
+        "ref/dotnet/ru/System.Security.Principal.Windows.xml",
         "ref/dotnet/System.Security.Principal.Windows.dll",
+        "ref/dotnet/System.Security.Principal.Windows.xml",
+        "ref/dotnet/zh-hans/System.Security.Principal.Windows.xml",
+        "ref/dotnet/zh-hant/System.Security.Principal.Windows.xml",
         "ref/net46/System.Security.Principal.Windows.dll",
-        "System.Security.Principal.Windows.4.0.0-beta-23408.nupkg",
-        "System.Security.Principal.Windows.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Principal.Windows.4.0.0-beta-23412.nupkg",
+        "System.Security.Principal.Windows.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Principal.Windows.nuspec"
       ]
     },
-    "System.ServiceModel.Duplex/4.0.1-beta-23408": {
+    "System.ServiceModel.Duplex/4.0.1-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "ZJ3aN/aEg801Rw+aVbBFZ+I9J51FyQVCoWOvSqTSh5i4qZuWuenCxmxahby43teIqNcCrCtHPoyRan2GfY8Vyg==",
+      "sha512": "o5w/amLOdG4NIfER18/TI69QL11pboppiBgH2fIwjzasKZ1OIlxE+KJPbvHJ5vt554reZYCcA+jY4CIx7/pkiw==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Duplex.dll",
         "lib/net45/_._",
-        "lib/netcore50/de/System.ServiceModel.Duplex.xml",
-        "lib/netcore50/es/System.ServiceModel.Duplex.xml",
-        "lib/netcore50/fr/System.ServiceModel.Duplex.xml",
-        "lib/netcore50/it/System.ServiceModel.Duplex.xml",
-        "lib/netcore50/ja/System.ServiceModel.Duplex.xml",
-        "lib/netcore50/ko/System.ServiceModel.Duplex.xml",
-        "lib/netcore50/ru/System.ServiceModel.Duplex.xml",
         "lib/netcore50/System.ServiceModel.Duplex.dll",
-        "lib/netcore50/System.ServiceModel.Duplex.xml",
-        "lib/netcore50/zh-hans/System.ServiceModel.Duplex.xml",
-        "lib/netcore50/zh-hant/System.ServiceModel.Duplex.xml",
         "lib/win8/_._",
+        "ref/dotnet/de/System.ServiceModel.Duplex.xml",
+        "ref/dotnet/es/System.ServiceModel.Duplex.xml",
+        "ref/dotnet/fr/System.ServiceModel.Duplex.xml",
+        "ref/dotnet/it/System.ServiceModel.Duplex.xml",
+        "ref/dotnet/ja/System.ServiceModel.Duplex.xml",
+        "ref/dotnet/ko/System.ServiceModel.Duplex.xml",
+        "ref/dotnet/ru/System.ServiceModel.Duplex.xml",
         "ref/dotnet/System.ServiceModel.Duplex.dll",
+        "ref/dotnet/System.ServiceModel.Duplex.xml",
+        "ref/dotnet/zh-hans/System.ServiceModel.Duplex.xml",
+        "ref/dotnet/zh-hant/System.ServiceModel.Duplex.xml",
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.Duplex.dll",
+        "ref/netcore50/System.ServiceModel.Duplex.xml",
         "ref/win8/_._",
-        "System.ServiceModel.Duplex.4.0.1-beta-23408.nupkg",
-        "System.ServiceModel.Duplex.4.0.1-beta-23408.nupkg.sha512",
+        "System.ServiceModel.Duplex.4.0.1-beta-23412.nupkg",
+        "System.ServiceModel.Duplex.4.0.1-beta-23412.nupkg.sha512",
         "System.ServiceModel.Duplex.nuspec"
       ]
     },
-    "System.ServiceModel.Http/4.0.11-beta-23408": {
+    "System.ServiceModel.Http/4.0.11-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "RScHZ1A3CfjumaP1Vh/xfOp/ga6T3nA8YLkjFOYcIcZm/LILL+yCh+PhIrJOEfz1Js8bLSQC6xbxwYlW6BNmYg==",
+      "sha512": "hKMGQbu/l2gv/PgPvm2ViLVElnVSwAPiv4cXKjinS+UHBf02uPF2m7lN13SCkJDNTBctwHav1rQnMYb1LUJHvw==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Http.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
-        "lib/netcore50/de/System.ServiceModel.Http.xml",
-        "lib/netcore50/es/System.ServiceModel.Http.xml",
-        "lib/netcore50/fr/System.ServiceModel.Http.xml",
-        "lib/netcore50/it/System.ServiceModel.Http.xml",
-        "lib/netcore50/ja/System.ServiceModel.Http.xml",
-        "lib/netcore50/ko/System.ServiceModel.Http.xml",
-        "lib/netcore50/ru/System.ServiceModel.Http.xml",
         "lib/netcore50/System.ServiceModel.Http.dll",
-        "lib/netcore50/System.ServiceModel.Http.xml",
-        "lib/netcore50/zh-hans/System.ServiceModel.Http.xml",
-        "lib/netcore50/zh-hant/System.ServiceModel.Http.xml",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.ServiceModel.Http.xml",
+        "ref/dotnet/es/System.ServiceModel.Http.xml",
+        "ref/dotnet/fr/System.ServiceModel.Http.xml",
+        "ref/dotnet/it/System.ServiceModel.Http.xml",
+        "ref/dotnet/ja/System.ServiceModel.Http.xml",
+        "ref/dotnet/ko/System.ServiceModel.Http.xml",
+        "ref/dotnet/ru/System.ServiceModel.Http.xml",
         "ref/dotnet/System.ServiceModel.Http.dll",
+        "ref/dotnet/System.ServiceModel.Http.xml",
+        "ref/dotnet/zh-hans/System.ServiceModel.Http.xml",
+        "ref/dotnet/zh-hant/System.ServiceModel.Http.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.ServiceModel.Http.4.0.11-beta-23408.nupkg",
-        "System.ServiceModel.Http.4.0.11-beta-23408.nupkg.sha512",
+        "System.ServiceModel.Http.4.0.11-beta-23412.nupkg",
+        "System.ServiceModel.Http.4.0.11-beta-23412.nupkg.sha512",
         "System.ServiceModel.Http.nuspec"
       ]
     },
-    "System.ServiceModel.NetTcp/4.0.1-beta-23408": {
+    "System.ServiceModel.NetTcp/4.0.1-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "ppruBpqoE6AngTs6fABV67r1ic6rKCgr6tw+4lMoRucrNWNfKgX5vWlONOqSd8bQXmQLZ/ftEhDGXYY5CLRUTQ==",
+      "sha512": "9I2iOpoYB8DtVy1Sw6BmOj6NGoxt9cKwOOds4q6G1JLzyyWErsv/FMeGAJT07bgLr8vnMx4s8GXxjCfkUwNtTw==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.NetTcp.dll",
         "lib/net45/_._",
-        "lib/netcore50/de/System.ServiceModel.NetTcp.xml",
-        "lib/netcore50/es/System.ServiceModel.NetTcp.xml",
-        "lib/netcore50/fr/System.ServiceModel.NetTcp.xml",
-        "lib/netcore50/it/System.ServiceModel.NetTcp.xml",
-        "lib/netcore50/ja/System.ServiceModel.NetTcp.xml",
-        "lib/netcore50/ko/System.ServiceModel.NetTcp.xml",
-        "lib/netcore50/ru/System.ServiceModel.NetTcp.xml",
         "lib/netcore50/System.ServiceModel.NetTcp.dll",
-        "lib/netcore50/System.ServiceModel.NetTcp.xml",
-        "lib/netcore50/zh-hans/System.ServiceModel.NetTcp.xml",
-        "lib/netcore50/zh-hant/System.ServiceModel.NetTcp.xml",
         "lib/win8/_._",
+        "ref/dotnet/de/System.ServiceModel.NetTcp.xml",
+        "ref/dotnet/es/System.ServiceModel.NetTcp.xml",
+        "ref/dotnet/fr/System.ServiceModel.NetTcp.xml",
+        "ref/dotnet/it/System.ServiceModel.NetTcp.xml",
+        "ref/dotnet/ja/System.ServiceModel.NetTcp.xml",
+        "ref/dotnet/ko/System.ServiceModel.NetTcp.xml",
+        "ref/dotnet/ru/System.ServiceModel.NetTcp.xml",
         "ref/dotnet/System.ServiceModel.NetTcp.dll",
+        "ref/dotnet/System.ServiceModel.NetTcp.xml",
+        "ref/dotnet/zh-hans/System.ServiceModel.NetTcp.xml",
+        "ref/dotnet/zh-hant/System.ServiceModel.NetTcp.xml",
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.NetTcp.dll",
+        "ref/netcore50/System.ServiceModel.NetTcp.xml",
         "ref/win8/_._",
-        "System.ServiceModel.NetTcp.4.0.1-beta-23408.nupkg",
-        "System.ServiceModel.NetTcp.4.0.1-beta-23408.nupkg.sha512",
+        "System.ServiceModel.NetTcp.4.0.1-beta-23412.nupkg",
+        "System.ServiceModel.NetTcp.4.0.1-beta-23412.nupkg.sha512",
         "System.ServiceModel.NetTcp.nuspec"
       ]
     },
-    "System.ServiceModel.Primitives/4.0.1-beta-23408": {
+    "System.ServiceModel.Primitives/4.0.1-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "bjXzg+V3Oq/tBXpMY5FwcERN2CQsFXoL4BMoURlwiBMkgwN2CPvBIaK45Moh7nc21jNTVukNayDtURetGzK6aA==",
+      "sha512": "dkCUkNtXb2m9Wf+DY7dc5B4J8DpaWtX4wpFfT3cYLpChxAnjQR85N+tJfMEHLfZNNerKgDRyGyaKa7uSHfvb5g==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Primitives.dll",
         "lib/net45/_._",
-        "lib/netcore50/de/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/es/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/fr/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/it/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/ja/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/ko/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/ru/System.ServiceModel.Primitives.xml",
         "lib/netcore50/System.ServiceModel.Primitives.dll",
-        "lib/netcore50/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/zh-hans/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/zh-hant/System.ServiceModel.Primitives.xml",
         "lib/win8/_._",
+        "ref/dotnet/de/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/es/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/fr/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/it/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/ja/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/ko/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/ru/System.ServiceModel.Primitives.xml",
         "ref/dotnet/System.ServiceModel.Primitives.dll",
+        "ref/dotnet/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/zh-hans/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/zh-hant/System.ServiceModel.Primitives.xml",
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.Primitives.dll",
+        "ref/netcore50/System.ServiceModel.Primitives.xml",
         "ref/win8/_._",
-        "System.ServiceModel.Primitives.4.0.1-beta-23408.nupkg",
-        "System.ServiceModel.Primitives.4.0.1-beta-23408.nupkg.sha512",
+        "System.ServiceModel.Primitives.4.0.1-beta-23412.nupkg",
+        "System.ServiceModel.Primitives.4.0.1-beta-23412.nupkg.sha512",
         "System.ServiceModel.Primitives.nuspec"
       ]
     },
@@ -3090,28 +3119,6 @@
         "System.Threading.Tasks.4.0.10.nupkg",
         "System.Threading.Tasks.4.0.10.nupkg.sha512",
         "System.Threading.Tasks.nuspec"
-      ]
-    },
-    "System.Threading.ThreadPool/4.0.10-beta-23408": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "ahdsVyj+WFj8/iSDwX/G7hkEU4jZmmvWzPS2ajZKdp0Crb0vZJOlM0LQYVASQgbimrUZHQ50o93JYEi8RFdh/Q==",
-      "files": [
-        "lib/DNXCore50/System.Threading.ThreadPool.dll",
-        "lib/MonoAndroid10/_._",
-        "lib/MonoTouch10/_._",
-        "lib/net46/System.Threading.ThreadPool.dll",
-        "lib/xamarinios10/_._",
-        "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Threading.ThreadPool.dll",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
-        "ref/net46/System.Threading.ThreadPool.dll",
-        "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.Threading.ThreadPool.4.0.10-beta-23408.nupkg",
-        "System.Threading.ThreadPool.4.0.10-beta-23408.nupkg.sha512",
-        "System.Threading.ThreadPool.nuspec"
       ]
     },
     "System.Threading.Timer/4.0.0": {
@@ -3361,14 +3368,14 @@
         "xunit.extensibility.execution.nuspec"
       ]
     },
-    "xunit.netcore.extensions/1.0.0-prerelease-00104": {
+    "xunit.netcore.extensions/1.0.0-prerelease-00105": {
       "type": "package",
       "serviceable": true,
-      "sha512": "ZMXxEBpGP7krXtvqbPMOWavd2u83w77ghtD254wfj5+d+7GmYYqP9pX1iRIxJK9CBa8Zc2cOrcYsmCLQgYriAQ==",
+      "sha512": "EnnGcy9rmSdQ8izHWvYSYVyjQGhbeFH7JeM/L35ZrrPGtYvq5XD3hc1cJPCs+43mXdF9cdqhkt5uTlXYzC+Z8g==",
       "files": [
         "lib/dotnet/Xunit.NetCore.Extensions.dll",
-        "xunit.netcore.extensions.1.0.0-prerelease-00104.nupkg",
-        "xunit.netcore.extensions.1.0.0-prerelease-00104.nupkg.sha512",
+        "xunit.netcore.extensions.1.0.0-prerelease-00105.nupkg",
+        "xunit.netcore.extensions.1.0.0-prerelease-00105.nupkg.sha512",
         "xunit.netcore.extensions.nuspec"
       ]
     }

--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/ChannelLayer/project.lock.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/ChannelLayer/project.lock.json
@@ -292,7 +292,7 @@
           "lib/dotnet/System.Linq.Queryable.dll": {}
         }
       },
-      "System.Net.Http/4.0.1-beta-23408": {
+      "System.Net.Http/4.0.1-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -305,7 +305,7 @@
           "ref/dotnet/System.Net.Http.dll": {}
         }
       },
-      "System.Net.NameResolution/4.0.0-beta-23408": {
+      "System.Net.NameResolution/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Net.Primitives": "4.0.10",
@@ -328,16 +328,17 @@
           "lib/DNXCore50/System.Net.Primitives.dll": {}
         }
       },
-      "System.Net.Security/4.0.0-beta-23408": {
+      "System.Net.Security/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
-          "System.Private.Networking": "4.0.1-beta-23408"
+          "System.IO": "4.0.0",
+          "System.Net.Primitives": "4.0.10",
+          "System.Runtime": "4.0.0",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23412",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Net.Security.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Net.Security.dll": {}
         }
       },
       "System.Net.Sockets/4.1.0-beta-23225": {
@@ -368,7 +369,7 @@
           "lib/dotnet/System.Net.WebHeaderCollection.dll": {}
         }
       },
-      "System.Net.WebSockets/4.0.0-beta-23408": {
+      "System.Net.WebSockets/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -383,7 +384,7 @@
           "lib/dotnet/System.Net.WebSockets.dll": {}
         }
       },
-      "System.Net.WebSockets.Client/4.0.0-beta-23408": {
+      "System.Net.WebSockets.Client/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -393,13 +394,13 @@
           "System.Globalization": "4.0.10",
           "System.Net.Primitives": "4.0.10",
           "System.Net.WebHeaderCollection": "4.0.0",
-          "System.Net.WebSockets": "4.0.0-beta-23408",
+          "System.Net.WebSockets": "4.0.0-beta-23412",
           "System.Resources.ResourceManager": "4.0.0",
           "System.Runtime": "4.0.20",
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23408",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23412",
           "System.Text.Encoding": "4.0.10",
           "System.Threading": "4.0.10",
           "System.Threading.Tasks": "4.0.10"
@@ -456,7 +457,7 @@
           "lib/DNXCore50/System.Private.DataContractSerialization.dll": {}
         }
       },
-      "System.Private.Networking/4.0.1-beta-23408": {
+      "System.Private.Networking/4.0.1-beta-23225": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -475,13 +476,10 @@
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23408",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23408",
-          "System.Security.Principal.Windows": "4.0.0-beta-23408",
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23225",
           "System.Threading": "4.0.10",
           "System.Threading.Overlapped": "4.0.0",
-          "System.Threading.Tasks": "4.0.10",
-          "System.Threading.ThreadPool": "4.0.10-beta-23408"
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dnxcore50/_._": {}
@@ -490,7 +488,7 @@
           "lib/DNXCore50/System.Private.Networking.dll": {}
         }
       },
-      "System.Private.ServiceModel/4.1.0-beta-23408": {
+      "System.Private.ServiceModel/4.1.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -507,14 +505,14 @@
           "System.Linq": "4.0.0",
           "System.Linq.Expressions": "4.0.10",
           "System.Linq.Queryable": "4.0.0",
-          "System.Net.Http": "4.0.1-beta-23408",
-          "System.Net.NameResolution": "4.0.0-beta-23408",
+          "System.Net.Http": "4.0.1-beta-23412",
+          "System.Net.NameResolution": "4.0.0-beta-23412",
           "System.Net.Primitives": "4.0.10",
-          "System.Net.Security": "4.0.0-beta-23408",
-          "System.Net.Sockets": "4.0.10-beta-23408",
+          "System.Net.Security": "4.0.0-beta-23412",
+          "System.Net.Sockets": "4.0.10-beta-23412",
           "System.Net.WebHeaderCollection": "4.0.0",
-          "System.Net.WebSockets": "4.0.0-beta-23408",
-          "System.Net.WebSockets.Client": "4.0.0-beta-23408",
+          "System.Net.WebSockets": "4.0.0-beta-23412",
+          "System.Net.WebSockets.Client": "4.0.0-beta-23412",
           "System.ObjectModel": "4.0.10",
           "System.Reflection": "4.0.10",
           "System.Reflection.DispatchProxy": "4.0.0",
@@ -528,9 +526,9 @@
           "System.Runtime.Serialization.Primitives": "4.0.10",
           "System.Runtime.Serialization.Xml": "4.0.10",
           "System.Security.Claims": "4.0.0",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23408",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23412",
           "System.Security.Principal": "4.0.0",
-          "System.Security.Principal.Windows": "4.0.0-beta-23408",
+          "System.Security.Principal.Windows": "4.0.0-beta-23412",
           "System.Text.Encoding": "4.0.10",
           "System.Threading": "4.0.10",
           "System.Threading.Tasks": "4.0.10",
@@ -779,18 +777,18 @@
           "lib/dotnet/System.Security.Claims.dll": {}
         }
       },
-      "System.Security.Cryptography.Algorithms/4.0.0-beta-23408": {
+      "System.Security.Cryptography.Algorithms/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
           "System.Runtime": "4.0.0",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23408"
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23412"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.Algorithms.dll": {}
         }
       },
-      "System.Security.Cryptography.Encoding/4.0.0-beta-23408": {
+      "System.Security.Cryptography.Encoding/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -799,7 +797,7 @@
           "ref/dotnet/System.Security.Cryptography.Encoding.dll": {}
         }
       },
-      "System.Security.Cryptography.Primitives/4.0.0-beta-23408": {
+      "System.Security.Cryptography.Primitives/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.0",
@@ -817,13 +815,13 @@
           "lib/dotnet/System.Security.Cryptography.Primitives.dll": {}
         }
       },
-      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23408": {
+      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
           "System.Runtime.Handles": "4.0.0",
-          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23408",
-          "System.Security.Cryptography.Encoding": "4.0.0-beta-23408"
+          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23412",
+          "System.Security.Cryptography.Encoding": "4.0.0-beta-23412"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.X509Certificates.dll": {}
@@ -841,7 +839,7 @@
           "lib/dotnet/System.Security.Principal.dll": {}
         }
       },
-      "System.Security.Principal.Windows/4.0.0-beta-23408": {
+      "System.Security.Principal.Windows/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -864,10 +862,10 @@
           "lib/DNXCore50/System.Security.Principal.Windows.dll": {}
         }
       },
-      "System.ServiceModel.Http/4.0.11-beta-23408": {
+      "System.ServiceModel.Http/4.0.11-beta-23412": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-beta-23408",
+          "System.Private.ServiceModel": "4.1.0-beta-23412",
           "System.Runtime": "4.0.20"
         },
         "compile": {
@@ -877,10 +875,10 @@
           "lib/DNXCore50/System.ServiceModel.Http.dll": {}
         }
       },
-      "System.ServiceModel.NetTcp/4.0.1-beta-23408": {
+      "System.ServiceModel.NetTcp/4.0.1-beta-23412": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-beta-23408"
+          "System.Private.ServiceModel": "4.1.0-beta-23412"
         },
         "compile": {
           "ref/dotnet/System.ServiceModel.NetTcp.dll": {}
@@ -889,10 +887,10 @@
           "lib/DNXCore50/System.ServiceModel.NetTcp.dll": {}
         }
       },
-      "System.ServiceModel.Primitives/4.0.1-beta-23408": {
+      "System.ServiceModel.Primitives/4.0.1-beta-23412": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-beta-23408"
+          "System.Private.ServiceModel": "4.1.0-beta-23412"
         },
         "compile": {
           "ref/dotnet/System.ServiceModel.Primitives.dll": {}
@@ -979,19 +977,6 @@
         },
         "runtime": {
           "lib/DNXCore50/System.Threading.Tasks.dll": {}
-        }
-      },
-      "System.Threading.ThreadPool/4.0.10-beta-23408": {
-        "type": "package",
-        "dependencies": {
-          "System.Runtime": "4.0.0",
-          "System.Runtime.InteropServices": "4.0.0"
-        },
-        "compile": {
-          "ref/dotnet/System.Threading.ThreadPool.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Threading.ThreadPool.dll": {}
         }
       },
       "System.Threading.Timer/4.0.0": {
@@ -1174,7 +1159,7 @@
           "lib/dotnet/xunit.execution.dotnet.dll": {}
         }
       },
-      "xunit.netcore.extensions/1.0.0-prerelease-00104": {
+      "xunit.netcore.extensions/1.0.0-prerelease-00105": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.10",
@@ -1802,44 +1787,65 @@
         "System.Linq.Queryable.nuspec"
       ]
     },
-    "System.Net.Http/4.0.1-beta-23408": {
+    "System.Net.Http/4.0.1-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "n+tnV1VgCjbDKKnbgrvgUgxkPDwUFvSv9lTgH882rVzjbWyliVgbBflVzoAUjUSlga/Tr1XQIrfTLMRD5HfYGw==",
+      "sha512": "F7Yej+6QdRVzWg+qbkayRMcmf/7k7YfNFoVSA67wIsG9t5u7Wj4Go8FW72HL8qb9d7YjIsVB/5hA7g9MUT31Aw==",
       "files": [
         "lib/net45/_._",
         "lib/win8/_._",
         "lib/wpa81/_._",
+        "ref/dotnet/de/System.Net.Http.xml",
+        "ref/dotnet/es/System.Net.Http.xml",
+        "ref/dotnet/fr/System.Net.Http.xml",
+        "ref/dotnet/it/System.Net.Http.xml",
+        "ref/dotnet/ja/System.Net.Http.xml",
+        "ref/dotnet/ko/System.Net.Http.xml",
+        "ref/dotnet/ru/System.Net.Http.xml",
         "ref/dotnet/System.Net.Http.dll",
+        "ref/dotnet/System.Net.Http.xml",
+        "ref/dotnet/zh-hans/System.Net.Http.xml",
+        "ref/dotnet/zh-hant/System.Net.Http.xml",
         "ref/net45/_._",
         "ref/netcore50/System.Net.Http.dll",
+        "ref/netcore50/System.Net.Http.xml",
         "ref/win8/_._",
         "ref/wpa81/_._",
         "runtime.json",
-        "System.Net.Http.4.0.1-beta-23408.nupkg",
-        "System.Net.Http.4.0.1-beta-23408.nupkg.sha512",
+        "System.Net.Http.4.0.1-beta-23412.nupkg",
+        "System.Net.Http.4.0.1-beta-23412.nupkg.sha512",
         "System.Net.Http.nuspec"
       ]
     },
-    "System.Net.NameResolution/4.0.0-beta-23408": {
+    "System.Net.NameResolution/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "2A562VFL8GUL/jLCJ3mbQHhwwAIXzPyjxMpdtas1LVM8QLuP1OcHwV3z7ajWnYdGcPc7ZxPEGJQWicuaPD+0nA==",
+      "sha512": "HCF1zhFYBT+w/Ik+JuTzFJgj83Jfc+eA8VcgvIzdPiGMXfrZeXOogjgSCkCoJmFtKVz2DSfmISoEmiXB1oaLNQ==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.NameResolution.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Net.NameResolution.xml",
+        "ref/dotnet/es/System.Net.NameResolution.xml",
+        "ref/dotnet/fr/System.Net.NameResolution.xml",
+        "ref/dotnet/it/System.Net.NameResolution.xml",
+        "ref/dotnet/ja/System.Net.NameResolution.xml",
+        "ref/dotnet/ko/System.Net.NameResolution.xml",
+        "ref/dotnet/ru/System.Net.NameResolution.xml",
         "ref/dotnet/System.Net.NameResolution.dll",
+        "ref/dotnet/System.Net.NameResolution.xml",
+        "ref/dotnet/zh-hans/System.Net.NameResolution.xml",
+        "ref/dotnet/zh-hant/System.Net.NameResolution.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Net.NameResolution.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Net.NameResolution.4.0.0-beta-23408.nupkg",
-        "System.Net.NameResolution.4.0.0-beta-23408.nupkg.sha512",
+        "System.Net.NameResolution.4.0.0-beta-23412.nupkg",
+        "System.Net.NameResolution.4.0.0-beta-23412.nupkg.sha512",
         "System.Net.NameResolution.nuspec"
       ]
     },
@@ -1876,24 +1882,34 @@
         "System.Net.Primitives.nuspec"
       ]
     },
-    "System.Net.Security/4.0.0-beta-23408": {
+    "System.Net.Security/4.0.0-beta-23412": {
       "type": "package",
-      "sha512": "kEkunODO2t/VlBIsC80YFDG0KtY/FyIbtBApNyJQv+LYGEs5IFvEhpi9+p0/jHmhyRMKwbjajNedbXo+VMkt1A==",
+      "sha512": "Kcjne7jnvF5aTbRJsAT8kuP+1mxryUF2qYv8f3jnR19wtEjswSIOVU0XzuWc9YObEQcb+kEdzN71HTOm+ssv+w==",
       "files": [
-        "lib/DNXCore50/System.Net.Security.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.Security.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Net.Security.xml",
+        "ref/dotnet/es/System.Net.Security.xml",
+        "ref/dotnet/fr/System.Net.Security.xml",
+        "ref/dotnet/it/System.Net.Security.xml",
+        "ref/dotnet/ja/System.Net.Security.xml",
+        "ref/dotnet/ko/System.Net.Security.xml",
+        "ref/dotnet/ru/System.Net.Security.xml",
         "ref/dotnet/System.Net.Security.dll",
+        "ref/dotnet/System.Net.Security.xml",
+        "ref/dotnet/zh-hans/System.Net.Security.xml",
+        "ref/dotnet/zh-hant/System.Net.Security.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Net.Security.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.Security.4.0.0-beta-23408.nupkg",
-        "System.Net.Security.4.0.0-beta-23408.nupkg.sha512",
+        "runtime.json",
+        "System.Net.Security.4.0.0-beta-23412.nupkg",
+        "System.Net.Security.4.0.0-beta-23412.nupkg.sha512",
         "System.Net.Security.nuspec"
       ]
     },
@@ -1951,78 +1967,68 @@
         "System.Net.WebHeaderCollection.nuspec"
       ]
     },
-    "System.Net.WebSockets/4.0.0-beta-23408": {
+    "System.Net.WebSockets/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "BXy22/bNVtrXXsG76zXyhjcQnCjSYxQIFF37xWifqPRWmvzsCYSLQpNCTPQUCp7rjB7qWc5yLhC9bThaEx7MHQ==",
+      "sha512": "EvXAa0yd1RM8ROyLl1T0xC94F04Su8YMHnd4/w6j0Z/+4lKHZOU7bQPZ3odDN8WdPGKa/ZNJJGwiapydEWKzwQ==",
       "files": [
-        "lib/dotnet/de/System.Net.WebSockets.xml",
-        "lib/dotnet/es/System.Net.WebSockets.xml",
-        "lib/dotnet/fr/System.Net.WebSockets.xml",
-        "lib/dotnet/it/System.Net.WebSockets.xml",
-        "lib/dotnet/ja/System.Net.WebSockets.xml",
-        "lib/dotnet/ko/System.Net.WebSockets.xml",
-        "lib/dotnet/ru/System.Net.WebSockets.xml",
         "lib/dotnet/System.Net.WebSockets.dll",
-        "lib/dotnet/System.Net.WebSockets.xml",
-        "lib/dotnet/zh-hans/System.Net.WebSockets.xml",
-        "lib/dotnet/zh-hant/System.Net.WebSockets.xml",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.WebSockets.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Net.WebSockets.xml",
+        "ref/dotnet/es/System.Net.WebSockets.xml",
+        "ref/dotnet/fr/System.Net.WebSockets.xml",
+        "ref/dotnet/it/System.Net.WebSockets.xml",
+        "ref/dotnet/ja/System.Net.WebSockets.xml",
+        "ref/dotnet/ko/System.Net.WebSockets.xml",
+        "ref/dotnet/ru/System.Net.WebSockets.xml",
         "ref/dotnet/System.Net.WebSockets.dll",
+        "ref/dotnet/System.Net.WebSockets.xml",
+        "ref/dotnet/zh-hans/System.Net.WebSockets.xml",
+        "ref/dotnet/zh-hant/System.Net.WebSockets.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Net.WebSockets.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.WebSockets.4.0.0-beta-23408.nupkg",
-        "System.Net.WebSockets.4.0.0-beta-23408.nupkg.sha512",
+        "System.Net.WebSockets.4.0.0-beta-23412.nupkg",
+        "System.Net.WebSockets.4.0.0-beta-23412.nupkg.sha512",
         "System.Net.WebSockets.nuspec"
       ]
     },
-    "System.Net.WebSockets.Client/4.0.0-beta-23408": {
+    "System.Net.WebSockets.Client/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "smmvhCkcU0c4RNWc6NZwnN5EFktX58jf8+TJ6enfuXxWrpJ/2NRI5/2yT/okjFSngGK1g0MBrljZsfs2EJ7+Yw==",
+      "sha512": "uaO7c/81sK90605UtThSX9KVmzsJDA1vD4GMW7FsKKntymlkolJsprDekWblQ4A5YbhqxHv+ngXX2kIU0B3Fdw==",
       "files": [
-        "lib/DNXCore50/de/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/es/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/fr/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/it/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/ja/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/ko/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/ru/System.Net.WebSockets.Client.xml",
         "lib/DNXCore50/System.Net.WebSockets.Client.dll",
-        "lib/DNXCore50/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/zh-hans/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/zh-hant/System.Net.WebSockets.Client.xml",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.WebSockets.Client.dll",
-        "lib/netcore50/de/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/es/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/fr/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/it/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/ja/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/ko/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/ru/System.Net.WebSockets.Client.xml",
         "lib/netcore50/System.Net.WebSockets.Client.dll",
-        "lib/netcore50/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/zh-hans/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/zh-hant/System.Net.WebSockets.Client.xml",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/es/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/fr/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/it/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/ja/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/ko/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/ru/System.Net.WebSockets.Client.xml",
         "ref/dotnet/System.Net.WebSockets.Client.dll",
+        "ref/dotnet/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/zh-hans/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/zh-hant/System.Net.WebSockets.Client.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Net.WebSockets.Client.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.WebSockets.Client.4.0.0-beta-23408.nupkg",
-        "System.Net.WebSockets.Client.4.0.0-beta-23408.nupkg.sha512",
+        "System.Net.WebSockets.Client.4.0.0-beta-23412.nupkg",
+        "System.Net.WebSockets.Client.4.0.0-beta-23412.nupkg.sha512",
         "System.Net.WebSockets.Client.nuspec"
       ]
     },
@@ -2074,31 +2080,31 @@
         "System.Private.DataContractSerialization.nuspec"
       ]
     },
-    "System.Private.Networking/4.0.1-beta-23408": {
+    "System.Private.Networking/4.0.1-beta-23225": {
       "type": "package",
       "serviceable": true,
-      "sha512": "i2fRDRqM8Px3CP26C//deF/tCNR1AwqlPEr9+MYiXxNZtgGcSPBfqOJJ5CJdfmDb9Ap0hPG2MiPG7CinaSH7+Q==",
+      "sha512": "oVSynIrR3mIU0b/goscsaZDywr3RLxQijQnaFRKfl/VB3F9rKi5mdr0vHcGVWuq5ALSrG0OLwM8PRA4tM5e3rQ==",
       "files": [
         "lib/DNXCore50/System.Private.Networking.dll",
         "lib/netcore50/System.Private.Networking.dll",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "System.Private.Networking.4.0.1-beta-23408.nupkg",
-        "System.Private.Networking.4.0.1-beta-23408.nupkg.sha512",
+        "System.Private.Networking.4.0.1-beta-23225.nupkg",
+        "System.Private.Networking.4.0.1-beta-23225.nupkg.sha512",
         "System.Private.Networking.nuspec"
       ]
     },
-    "System.Private.ServiceModel/4.1.0-beta-23408": {
+    "System.Private.ServiceModel/4.1.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "l/2192yKa6uXhjKOWeukFJy3hoj9Zq1p55pTGe+Y28r8/5jlvgYxfunP9UyXJRo9W1u3UBtGfV/5R71ULzusGQ==",
+      "sha512": "Wm+8LcQ04YeAvYqu9faHsMZ/L8l/WvPPsqziBfifYB4jXIPXk1/kUxuAryjbLChghZDXvkDN0hv/IHSVPZGgBA==",
       "files": [
         "lib/DNXCore50/System.Private.ServiceModel.dll",
         "lib/netcore50/System.Private.ServiceModel.dll",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "System.Private.ServiceModel.4.1.0-beta-23408.nupkg",
-        "System.Private.ServiceModel.4.1.0-beta-23408.nupkg.sha512",
+        "System.Private.ServiceModel.4.1.0-beta-23412.nupkg",
+        "System.Private.ServiceModel.4.1.0-beta-23412.nupkg.sha512",
         "System.Private.ServiceModel.nuspec"
       ]
     },
@@ -2627,10 +2633,10 @@
         "System.Security.Claims.nuspec"
       ]
     },
-    "System.Security.Cryptography.Algorithms/4.0.0-beta-23408": {
+    "System.Security.Cryptography.Algorithms/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "G6eEqi8mZRrWftcwilcnllE4xJ/53JQlk3VVuJ+9qrX+DHvWz8itYJRUZX357JY4DgEEKQNOJzuRGrOBTUeoPg==",
+      "sha512": "nBjoiqJQiMD3cJgOVrqjIVDqEEPZeIqT+mrBIxjLE+YMQcjEyDuSyOG65Ntoopby5LH4onTLMM4zfXh8JRt9NQ==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2644,37 +2650,47 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.Algorithms.4.0.0-beta-23408.nupkg",
-        "System.Security.Cryptography.Algorithms.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Cryptography.Algorithms.4.0.0-beta-23412.nupkg",
+        "System.Security.Cryptography.Algorithms.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Cryptography.Algorithms.nuspec"
       ]
     },
-    "System.Security.Cryptography.Encoding/4.0.0-beta-23408": {
+    "System.Security.Cryptography.Encoding/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "fPsAK3vyMjnJ6nT4YchdS7KzfGca/6uVVAPCBO08ZpTRGhMGx30vq1MiIqAUrfsFMnot3Ub2jimnAFWkqY6g0Q==",
+      "sha512": "SR1zCARNdeyLoUKYH2SNMm1He7Lr3NR/l7yW3K135L44T6PS3YB8SfXpVoZdMpb22X2G07BZAHVz2x7e4AA1Cg==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Security.Cryptography.Encoding.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/es/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/fr/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/it/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/ja/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/ko/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/ru/System.Security.Cryptography.Encoding.xml",
         "ref/dotnet/System.Security.Cryptography.Encoding.dll",
+        "ref/dotnet/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/zh-hans/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/zh-hant/System.Security.Cryptography.Encoding.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Security.Cryptography.Encoding.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.Encoding.4.0.0-beta-23408.nupkg",
-        "System.Security.Cryptography.Encoding.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Cryptography.Encoding.4.0.0-beta-23412.nupkg",
+        "System.Security.Cryptography.Encoding.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Cryptography.Encoding.nuspec"
       ]
     },
-    "System.Security.Cryptography.Primitives/4.0.0-beta-23408": {
+    "System.Security.Cryptography.Primitives/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "A336dWYEIQxm1rEJCaE5ZZrUWHPUkBGTRH8uAj8qrTqg4/qRc2yN2wZxeGXaZauhI35QwDmOutK7oVb2Cd+4TA==",
+      "sha512": "H9EBNe0ahjAYjlVn0TnT18PSgZBrtROSQH1RRIKwAjzxQHt8zwDhO4yN0Q5QaaUIoSXgxVmgtWWk62wDvpy+QA==",
       "files": [
         "lib/dotnet/System.Security.Cryptography.Primitives.dll",
         "lib/MonoAndroid10/_._",
@@ -2688,30 +2704,40 @@
         "ref/net46/System.Security.Cryptography.Primitives.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Security.Cryptography.Primitives.4.0.0-beta-23408.nupkg",
-        "System.Security.Cryptography.Primitives.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Cryptography.Primitives.4.0.0-beta-23412.nupkg",
+        "System.Security.Cryptography.Primitives.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Cryptography.Primitives.nuspec"
       ]
     },
-    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23408": {
+    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "JSNf5d1V5Y47MIdf7QxZCuGnR5heM4UKbrsdXiWD5lfqu0mnNjebPIclMUXlTw/6IykuDsUpompV/DtsaLLHig==",
+      "sha512": "SfpMjvrfRaRjG42uynLugb3YgpXdpnU7X8vNAU7stIR5/4uW9m1SvWHvBjirjHRBtOpbKB86uD5ODQWX+tWDNA==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Security.Cryptography.X509Certificates.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/es/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/fr/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/it/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/ja/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/ko/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/ru/System.Security.Cryptography.X509Certificates.xml",
         "ref/dotnet/System.Security.Cryptography.X509Certificates.dll",
+        "ref/dotnet/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/zh-hans/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/zh-hant/System.Security.Cryptography.X509Certificates.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Security.Cryptography.X509Certificates.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23408.nupkg",
-        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23412.nupkg",
+        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Cryptography.X509Certificates.nuspec"
       ]
     },
@@ -2748,116 +2774,118 @@
         "System.Security.Principal.nuspec"
       ]
     },
-    "System.Security.Principal.Windows/4.0.0-beta-23408": {
+    "System.Security.Principal.Windows/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "xmjpZJvsT1AW23UkjqUkF/VrOh7DA1cagYY272UQmO8ei227TFD4C7j3ofatL/63hR3CXkLkoephuE4f2Z9fGA==",
+      "sha512": "Zvb/LzT+GjGNV1t8i5KVieilL+8P5LcQykIbJHw5aJxLPFEIQ4Y2hTJXdEkeKvZ4TCF5dlwY1jYyUrJkcqpxzw==",
       "files": [
-        "lib/DNXCore50/de/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/es/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/fr/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/it/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/ja/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/ko/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/ru/System.Security.Principal.Windows.xml",
         "lib/DNXCore50/System.Security.Principal.Windows.dll",
-        "lib/DNXCore50/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/zh-hans/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/zh-hant/System.Security.Principal.Windows.xml",
         "lib/net46/System.Security.Principal.Windows.dll",
+        "ref/dotnet/de/System.Security.Principal.Windows.xml",
+        "ref/dotnet/es/System.Security.Principal.Windows.xml",
+        "ref/dotnet/fr/System.Security.Principal.Windows.xml",
+        "ref/dotnet/it/System.Security.Principal.Windows.xml",
+        "ref/dotnet/ja/System.Security.Principal.Windows.xml",
+        "ref/dotnet/ko/System.Security.Principal.Windows.xml",
+        "ref/dotnet/ru/System.Security.Principal.Windows.xml",
         "ref/dotnet/System.Security.Principal.Windows.dll",
+        "ref/dotnet/System.Security.Principal.Windows.xml",
+        "ref/dotnet/zh-hans/System.Security.Principal.Windows.xml",
+        "ref/dotnet/zh-hant/System.Security.Principal.Windows.xml",
         "ref/net46/System.Security.Principal.Windows.dll",
-        "System.Security.Principal.Windows.4.0.0-beta-23408.nupkg",
-        "System.Security.Principal.Windows.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Principal.Windows.4.0.0-beta-23412.nupkg",
+        "System.Security.Principal.Windows.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Principal.Windows.nuspec"
       ]
     },
-    "System.ServiceModel.Http/4.0.11-beta-23408": {
+    "System.ServiceModel.Http/4.0.11-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "RScHZ1A3CfjumaP1Vh/xfOp/ga6T3nA8YLkjFOYcIcZm/LILL+yCh+PhIrJOEfz1Js8bLSQC6xbxwYlW6BNmYg==",
+      "sha512": "hKMGQbu/l2gv/PgPvm2ViLVElnVSwAPiv4cXKjinS+UHBf02uPF2m7lN13SCkJDNTBctwHav1rQnMYb1LUJHvw==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Http.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
-        "lib/netcore50/de/System.ServiceModel.Http.xml",
-        "lib/netcore50/es/System.ServiceModel.Http.xml",
-        "lib/netcore50/fr/System.ServiceModel.Http.xml",
-        "lib/netcore50/it/System.ServiceModel.Http.xml",
-        "lib/netcore50/ja/System.ServiceModel.Http.xml",
-        "lib/netcore50/ko/System.ServiceModel.Http.xml",
-        "lib/netcore50/ru/System.ServiceModel.Http.xml",
         "lib/netcore50/System.ServiceModel.Http.dll",
-        "lib/netcore50/System.ServiceModel.Http.xml",
-        "lib/netcore50/zh-hans/System.ServiceModel.Http.xml",
-        "lib/netcore50/zh-hant/System.ServiceModel.Http.xml",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.ServiceModel.Http.xml",
+        "ref/dotnet/es/System.ServiceModel.Http.xml",
+        "ref/dotnet/fr/System.ServiceModel.Http.xml",
+        "ref/dotnet/it/System.ServiceModel.Http.xml",
+        "ref/dotnet/ja/System.ServiceModel.Http.xml",
+        "ref/dotnet/ko/System.ServiceModel.Http.xml",
+        "ref/dotnet/ru/System.ServiceModel.Http.xml",
         "ref/dotnet/System.ServiceModel.Http.dll",
+        "ref/dotnet/System.ServiceModel.Http.xml",
+        "ref/dotnet/zh-hans/System.ServiceModel.Http.xml",
+        "ref/dotnet/zh-hant/System.ServiceModel.Http.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.ServiceModel.Http.4.0.11-beta-23408.nupkg",
-        "System.ServiceModel.Http.4.0.11-beta-23408.nupkg.sha512",
+        "System.ServiceModel.Http.4.0.11-beta-23412.nupkg",
+        "System.ServiceModel.Http.4.0.11-beta-23412.nupkg.sha512",
         "System.ServiceModel.Http.nuspec"
       ]
     },
-    "System.ServiceModel.NetTcp/4.0.1-beta-23408": {
+    "System.ServiceModel.NetTcp/4.0.1-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "ppruBpqoE6AngTs6fABV67r1ic6rKCgr6tw+4lMoRucrNWNfKgX5vWlONOqSd8bQXmQLZ/ftEhDGXYY5CLRUTQ==",
+      "sha512": "9I2iOpoYB8DtVy1Sw6BmOj6NGoxt9cKwOOds4q6G1JLzyyWErsv/FMeGAJT07bgLr8vnMx4s8GXxjCfkUwNtTw==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.NetTcp.dll",
         "lib/net45/_._",
-        "lib/netcore50/de/System.ServiceModel.NetTcp.xml",
-        "lib/netcore50/es/System.ServiceModel.NetTcp.xml",
-        "lib/netcore50/fr/System.ServiceModel.NetTcp.xml",
-        "lib/netcore50/it/System.ServiceModel.NetTcp.xml",
-        "lib/netcore50/ja/System.ServiceModel.NetTcp.xml",
-        "lib/netcore50/ko/System.ServiceModel.NetTcp.xml",
-        "lib/netcore50/ru/System.ServiceModel.NetTcp.xml",
         "lib/netcore50/System.ServiceModel.NetTcp.dll",
-        "lib/netcore50/System.ServiceModel.NetTcp.xml",
-        "lib/netcore50/zh-hans/System.ServiceModel.NetTcp.xml",
-        "lib/netcore50/zh-hant/System.ServiceModel.NetTcp.xml",
         "lib/win8/_._",
+        "ref/dotnet/de/System.ServiceModel.NetTcp.xml",
+        "ref/dotnet/es/System.ServiceModel.NetTcp.xml",
+        "ref/dotnet/fr/System.ServiceModel.NetTcp.xml",
+        "ref/dotnet/it/System.ServiceModel.NetTcp.xml",
+        "ref/dotnet/ja/System.ServiceModel.NetTcp.xml",
+        "ref/dotnet/ko/System.ServiceModel.NetTcp.xml",
+        "ref/dotnet/ru/System.ServiceModel.NetTcp.xml",
         "ref/dotnet/System.ServiceModel.NetTcp.dll",
+        "ref/dotnet/System.ServiceModel.NetTcp.xml",
+        "ref/dotnet/zh-hans/System.ServiceModel.NetTcp.xml",
+        "ref/dotnet/zh-hant/System.ServiceModel.NetTcp.xml",
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.NetTcp.dll",
+        "ref/netcore50/System.ServiceModel.NetTcp.xml",
         "ref/win8/_._",
-        "System.ServiceModel.NetTcp.4.0.1-beta-23408.nupkg",
-        "System.ServiceModel.NetTcp.4.0.1-beta-23408.nupkg.sha512",
+        "System.ServiceModel.NetTcp.4.0.1-beta-23412.nupkg",
+        "System.ServiceModel.NetTcp.4.0.1-beta-23412.nupkg.sha512",
         "System.ServiceModel.NetTcp.nuspec"
       ]
     },
-    "System.ServiceModel.Primitives/4.0.1-beta-23408": {
+    "System.ServiceModel.Primitives/4.0.1-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "bjXzg+V3Oq/tBXpMY5FwcERN2CQsFXoL4BMoURlwiBMkgwN2CPvBIaK45Moh7nc21jNTVukNayDtURetGzK6aA==",
+      "sha512": "dkCUkNtXb2m9Wf+DY7dc5B4J8DpaWtX4wpFfT3cYLpChxAnjQR85N+tJfMEHLfZNNerKgDRyGyaKa7uSHfvb5g==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Primitives.dll",
         "lib/net45/_._",
-        "lib/netcore50/de/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/es/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/fr/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/it/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/ja/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/ko/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/ru/System.ServiceModel.Primitives.xml",
         "lib/netcore50/System.ServiceModel.Primitives.dll",
-        "lib/netcore50/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/zh-hans/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/zh-hant/System.ServiceModel.Primitives.xml",
         "lib/win8/_._",
+        "ref/dotnet/de/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/es/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/fr/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/it/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/ja/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/ko/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/ru/System.ServiceModel.Primitives.xml",
         "ref/dotnet/System.ServiceModel.Primitives.dll",
+        "ref/dotnet/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/zh-hans/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/zh-hant/System.ServiceModel.Primitives.xml",
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.Primitives.dll",
+        "ref/netcore50/System.ServiceModel.Primitives.xml",
         "ref/win8/_._",
-        "System.ServiceModel.Primitives.4.0.1-beta-23408.nupkg",
-        "System.ServiceModel.Primitives.4.0.1-beta-23408.nupkg.sha512",
+        "System.ServiceModel.Primitives.4.0.1-beta-23412.nupkg",
+        "System.ServiceModel.Primitives.4.0.1-beta-23412.nupkg.sha512",
         "System.ServiceModel.Primitives.nuspec"
       ]
     },
@@ -3050,28 +3078,6 @@
         "System.Threading.Tasks.4.0.10.nupkg",
         "System.Threading.Tasks.4.0.10.nupkg.sha512",
         "System.Threading.Tasks.nuspec"
-      ]
-    },
-    "System.Threading.ThreadPool/4.0.10-beta-23408": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "ahdsVyj+WFj8/iSDwX/G7hkEU4jZmmvWzPS2ajZKdp0Crb0vZJOlM0LQYVASQgbimrUZHQ50o93JYEi8RFdh/Q==",
-      "files": [
-        "lib/DNXCore50/System.Threading.ThreadPool.dll",
-        "lib/MonoAndroid10/_._",
-        "lib/MonoTouch10/_._",
-        "lib/net46/System.Threading.ThreadPool.dll",
-        "lib/xamarinios10/_._",
-        "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Threading.ThreadPool.dll",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
-        "ref/net46/System.Threading.ThreadPool.dll",
-        "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.Threading.ThreadPool.4.0.10-beta-23408.nupkg",
-        "System.Threading.ThreadPool.4.0.10-beta-23408.nupkg.sha512",
-        "System.Threading.ThreadPool.nuspec"
       ]
     },
     "System.Threading.Timer/4.0.0": {
@@ -3321,14 +3327,14 @@
         "xunit.extensibility.execution.nuspec"
       ]
     },
-    "xunit.netcore.extensions/1.0.0-prerelease-00104": {
+    "xunit.netcore.extensions/1.0.0-prerelease-00105": {
       "type": "package",
       "serviceable": true,
-      "sha512": "ZMXxEBpGP7krXtvqbPMOWavd2u83w77ghtD254wfj5+d+7GmYYqP9pX1iRIxJK9CBa8Zc2cOrcYsmCLQgYriAQ==",
+      "sha512": "EnnGcy9rmSdQ8izHWvYSYVyjQGhbeFH7JeM/L35ZrrPGtYvq5XD3hc1cJPCs+43mXdF9cdqhkt5uTlXYzC+Z8g==",
       "files": [
         "lib/dotnet/Xunit.NetCore.Extensions.dll",
-        "xunit.netcore.extensions.1.0.0-prerelease-00104.nupkg",
-        "xunit.netcore.extensions.1.0.0-prerelease-00104.nupkg.sha512",
+        "xunit.netcore.extensions.1.0.0-prerelease-00105.nupkg",
+        "xunit.netcore.extensions.1.0.0-prerelease-00105.nupkg.sha512",
         "xunit.netcore.extensions.nuspec"
       ]
     }

--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/ClientBase/project.lock.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/ClientBase/project.lock.json
@@ -292,7 +292,7 @@
           "lib/dotnet/System.Linq.Queryable.dll": {}
         }
       },
-      "System.Net.Http/4.0.1-beta-23408": {
+      "System.Net.Http/4.0.1-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -305,7 +305,7 @@
           "ref/dotnet/System.Net.Http.dll": {}
         }
       },
-      "System.Net.NameResolution/4.0.0-beta-23408": {
+      "System.Net.NameResolution/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Net.Primitives": "4.0.10",
@@ -328,16 +328,17 @@
           "lib/DNXCore50/System.Net.Primitives.dll": {}
         }
       },
-      "System.Net.Security/4.0.0-beta-23408": {
+      "System.Net.Security/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
-          "System.Private.Networking": "4.0.1-beta-23408"
+          "System.IO": "4.0.0",
+          "System.Net.Primitives": "4.0.10",
+          "System.Runtime": "4.0.0",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23412",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Net.Security.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Net.Security.dll": {}
         }
       },
       "System.Net.Sockets/4.1.0-beta-23225": {
@@ -368,7 +369,7 @@
           "lib/dotnet/System.Net.WebHeaderCollection.dll": {}
         }
       },
-      "System.Net.WebSockets/4.0.0-beta-23408": {
+      "System.Net.WebSockets/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -383,7 +384,7 @@
           "lib/dotnet/System.Net.WebSockets.dll": {}
         }
       },
-      "System.Net.WebSockets.Client/4.0.0-beta-23408": {
+      "System.Net.WebSockets.Client/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -393,13 +394,13 @@
           "System.Globalization": "4.0.10",
           "System.Net.Primitives": "4.0.10",
           "System.Net.WebHeaderCollection": "4.0.0",
-          "System.Net.WebSockets": "4.0.0-beta-23408",
+          "System.Net.WebSockets": "4.0.0-beta-23412",
           "System.Resources.ResourceManager": "4.0.0",
           "System.Runtime": "4.0.20",
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23408",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23412",
           "System.Text.Encoding": "4.0.10",
           "System.Threading": "4.0.10",
           "System.Threading.Tasks": "4.0.10"
@@ -456,7 +457,7 @@
           "lib/DNXCore50/System.Private.DataContractSerialization.dll": {}
         }
       },
-      "System.Private.Networking/4.0.1-beta-23408": {
+      "System.Private.Networking/4.0.1-beta-23225": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -475,13 +476,10 @@
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23408",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23408",
-          "System.Security.Principal.Windows": "4.0.0-beta-23408",
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23225",
           "System.Threading": "4.0.10",
           "System.Threading.Overlapped": "4.0.0",
-          "System.Threading.Tasks": "4.0.10",
-          "System.Threading.ThreadPool": "4.0.10-beta-23408"
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dnxcore50/_._": {}
@@ -490,7 +488,7 @@
           "lib/DNXCore50/System.Private.Networking.dll": {}
         }
       },
-      "System.Private.ServiceModel/4.1.0-beta-23408": {
+      "System.Private.ServiceModel/4.1.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -507,14 +505,14 @@
           "System.Linq": "4.0.0",
           "System.Linq.Expressions": "4.0.10",
           "System.Linq.Queryable": "4.0.0",
-          "System.Net.Http": "4.0.1-beta-23408",
-          "System.Net.NameResolution": "4.0.0-beta-23408",
+          "System.Net.Http": "4.0.1-beta-23412",
+          "System.Net.NameResolution": "4.0.0-beta-23412",
           "System.Net.Primitives": "4.0.10",
-          "System.Net.Security": "4.0.0-beta-23408",
-          "System.Net.Sockets": "4.0.10-beta-23408",
+          "System.Net.Security": "4.0.0-beta-23412",
+          "System.Net.Sockets": "4.0.10-beta-23412",
           "System.Net.WebHeaderCollection": "4.0.0",
-          "System.Net.WebSockets": "4.0.0-beta-23408",
-          "System.Net.WebSockets.Client": "4.0.0-beta-23408",
+          "System.Net.WebSockets": "4.0.0-beta-23412",
+          "System.Net.WebSockets.Client": "4.0.0-beta-23412",
           "System.ObjectModel": "4.0.10",
           "System.Reflection": "4.0.10",
           "System.Reflection.DispatchProxy": "4.0.0",
@@ -528,9 +526,9 @@
           "System.Runtime.Serialization.Primitives": "4.0.10",
           "System.Runtime.Serialization.Xml": "4.0.10",
           "System.Security.Claims": "4.0.0",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23408",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23412",
           "System.Security.Principal": "4.0.0",
-          "System.Security.Principal.Windows": "4.0.0-beta-23408",
+          "System.Security.Principal.Windows": "4.0.0-beta-23412",
           "System.Text.Encoding": "4.0.10",
           "System.Threading": "4.0.10",
           "System.Threading.Tasks": "4.0.10",
@@ -794,18 +792,18 @@
           "lib/dotnet/System.Security.Claims.dll": {}
         }
       },
-      "System.Security.Cryptography.Algorithms/4.0.0-beta-23408": {
+      "System.Security.Cryptography.Algorithms/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
           "System.Runtime": "4.0.0",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23408"
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23412"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.Algorithms.dll": {}
         }
       },
-      "System.Security.Cryptography.Encoding/4.0.0-beta-23408": {
+      "System.Security.Cryptography.Encoding/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -814,7 +812,7 @@
           "ref/dotnet/System.Security.Cryptography.Encoding.dll": {}
         }
       },
-      "System.Security.Cryptography.Primitives/4.0.0-beta-23408": {
+      "System.Security.Cryptography.Primitives/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.0",
@@ -832,13 +830,13 @@
           "lib/dotnet/System.Security.Cryptography.Primitives.dll": {}
         }
       },
-      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23408": {
+      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
           "System.Runtime.Handles": "4.0.0",
-          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23408",
-          "System.Security.Cryptography.Encoding": "4.0.0-beta-23408"
+          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23412",
+          "System.Security.Cryptography.Encoding": "4.0.0-beta-23412"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.X509Certificates.dll": {}
@@ -856,7 +854,7 @@
           "lib/dotnet/System.Security.Principal.dll": {}
         }
       },
-      "System.Security.Principal.Windows/4.0.0-beta-23408": {
+      "System.Security.Principal.Windows/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -879,10 +877,10 @@
           "lib/DNXCore50/System.Security.Principal.Windows.dll": {}
         }
       },
-      "System.ServiceModel.Duplex/4.0.1-beta-23408": {
+      "System.ServiceModel.Duplex/4.0.1-beta-23412": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-beta-23408"
+          "System.Private.ServiceModel": "4.1.0-beta-23412"
         },
         "compile": {
           "ref/dotnet/System.ServiceModel.Duplex.dll": {}
@@ -891,10 +889,10 @@
           "lib/DNXCore50/System.ServiceModel.Duplex.dll": {}
         }
       },
-      "System.ServiceModel.Http/4.0.11-beta-23408": {
+      "System.ServiceModel.Http/4.0.11-beta-23412": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-beta-23408",
+          "System.Private.ServiceModel": "4.1.0-beta-23412",
           "System.Runtime": "4.0.20"
         },
         "compile": {
@@ -904,10 +902,10 @@
           "lib/DNXCore50/System.ServiceModel.Http.dll": {}
         }
       },
-      "System.ServiceModel.NetTcp/4.0.1-beta-23408": {
+      "System.ServiceModel.NetTcp/4.0.1-beta-23412": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-beta-23408"
+          "System.Private.ServiceModel": "4.1.0-beta-23412"
         },
         "compile": {
           "ref/dotnet/System.ServiceModel.NetTcp.dll": {}
@@ -916,10 +914,10 @@
           "lib/DNXCore50/System.ServiceModel.NetTcp.dll": {}
         }
       },
-      "System.ServiceModel.Primitives/4.0.1-beta-23408": {
+      "System.ServiceModel.Primitives/4.0.1-beta-23412": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-beta-23408"
+          "System.Private.ServiceModel": "4.1.0-beta-23412"
         },
         "compile": {
           "ref/dotnet/System.ServiceModel.Primitives.dll": {}
@@ -1006,19 +1004,6 @@
         },
         "runtime": {
           "lib/DNXCore50/System.Threading.Tasks.dll": {}
-        }
-      },
-      "System.Threading.ThreadPool/4.0.10-beta-23408": {
-        "type": "package",
-        "dependencies": {
-          "System.Runtime": "4.0.0",
-          "System.Runtime.InteropServices": "4.0.0"
-        },
-        "compile": {
-          "ref/dotnet/System.Threading.ThreadPool.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Threading.ThreadPool.dll": {}
         }
       },
       "System.Threading.Timer/4.0.0": {
@@ -1201,7 +1186,7 @@
           "lib/dotnet/xunit.execution.dotnet.dll": {}
         }
       },
-      "xunit.netcore.extensions/1.0.0-prerelease-00104": {
+      "xunit.netcore.extensions/1.0.0-prerelease-00105": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.10",
@@ -1829,44 +1814,65 @@
         "System.Linq.Queryable.nuspec"
       ]
     },
-    "System.Net.Http/4.0.1-beta-23408": {
+    "System.Net.Http/4.0.1-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "n+tnV1VgCjbDKKnbgrvgUgxkPDwUFvSv9lTgH882rVzjbWyliVgbBflVzoAUjUSlga/Tr1XQIrfTLMRD5HfYGw==",
+      "sha512": "F7Yej+6QdRVzWg+qbkayRMcmf/7k7YfNFoVSA67wIsG9t5u7Wj4Go8FW72HL8qb9d7YjIsVB/5hA7g9MUT31Aw==",
       "files": [
         "lib/net45/_._",
         "lib/win8/_._",
         "lib/wpa81/_._",
+        "ref/dotnet/de/System.Net.Http.xml",
+        "ref/dotnet/es/System.Net.Http.xml",
+        "ref/dotnet/fr/System.Net.Http.xml",
+        "ref/dotnet/it/System.Net.Http.xml",
+        "ref/dotnet/ja/System.Net.Http.xml",
+        "ref/dotnet/ko/System.Net.Http.xml",
+        "ref/dotnet/ru/System.Net.Http.xml",
         "ref/dotnet/System.Net.Http.dll",
+        "ref/dotnet/System.Net.Http.xml",
+        "ref/dotnet/zh-hans/System.Net.Http.xml",
+        "ref/dotnet/zh-hant/System.Net.Http.xml",
         "ref/net45/_._",
         "ref/netcore50/System.Net.Http.dll",
+        "ref/netcore50/System.Net.Http.xml",
         "ref/win8/_._",
         "ref/wpa81/_._",
         "runtime.json",
-        "System.Net.Http.4.0.1-beta-23408.nupkg",
-        "System.Net.Http.4.0.1-beta-23408.nupkg.sha512",
+        "System.Net.Http.4.0.1-beta-23412.nupkg",
+        "System.Net.Http.4.0.1-beta-23412.nupkg.sha512",
         "System.Net.Http.nuspec"
       ]
     },
-    "System.Net.NameResolution/4.0.0-beta-23408": {
+    "System.Net.NameResolution/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "2A562VFL8GUL/jLCJ3mbQHhwwAIXzPyjxMpdtas1LVM8QLuP1OcHwV3z7ajWnYdGcPc7ZxPEGJQWicuaPD+0nA==",
+      "sha512": "HCF1zhFYBT+w/Ik+JuTzFJgj83Jfc+eA8VcgvIzdPiGMXfrZeXOogjgSCkCoJmFtKVz2DSfmISoEmiXB1oaLNQ==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.NameResolution.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Net.NameResolution.xml",
+        "ref/dotnet/es/System.Net.NameResolution.xml",
+        "ref/dotnet/fr/System.Net.NameResolution.xml",
+        "ref/dotnet/it/System.Net.NameResolution.xml",
+        "ref/dotnet/ja/System.Net.NameResolution.xml",
+        "ref/dotnet/ko/System.Net.NameResolution.xml",
+        "ref/dotnet/ru/System.Net.NameResolution.xml",
         "ref/dotnet/System.Net.NameResolution.dll",
+        "ref/dotnet/System.Net.NameResolution.xml",
+        "ref/dotnet/zh-hans/System.Net.NameResolution.xml",
+        "ref/dotnet/zh-hant/System.Net.NameResolution.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Net.NameResolution.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Net.NameResolution.4.0.0-beta-23408.nupkg",
-        "System.Net.NameResolution.4.0.0-beta-23408.nupkg.sha512",
+        "System.Net.NameResolution.4.0.0-beta-23412.nupkg",
+        "System.Net.NameResolution.4.0.0-beta-23412.nupkg.sha512",
         "System.Net.NameResolution.nuspec"
       ]
     },
@@ -1903,24 +1909,34 @@
         "System.Net.Primitives.nuspec"
       ]
     },
-    "System.Net.Security/4.0.0-beta-23408": {
+    "System.Net.Security/4.0.0-beta-23412": {
       "type": "package",
-      "sha512": "kEkunODO2t/VlBIsC80YFDG0KtY/FyIbtBApNyJQv+LYGEs5IFvEhpi9+p0/jHmhyRMKwbjajNedbXo+VMkt1A==",
+      "sha512": "Kcjne7jnvF5aTbRJsAT8kuP+1mxryUF2qYv8f3jnR19wtEjswSIOVU0XzuWc9YObEQcb+kEdzN71HTOm+ssv+w==",
       "files": [
-        "lib/DNXCore50/System.Net.Security.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.Security.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Net.Security.xml",
+        "ref/dotnet/es/System.Net.Security.xml",
+        "ref/dotnet/fr/System.Net.Security.xml",
+        "ref/dotnet/it/System.Net.Security.xml",
+        "ref/dotnet/ja/System.Net.Security.xml",
+        "ref/dotnet/ko/System.Net.Security.xml",
+        "ref/dotnet/ru/System.Net.Security.xml",
         "ref/dotnet/System.Net.Security.dll",
+        "ref/dotnet/System.Net.Security.xml",
+        "ref/dotnet/zh-hans/System.Net.Security.xml",
+        "ref/dotnet/zh-hant/System.Net.Security.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Net.Security.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.Security.4.0.0-beta-23408.nupkg",
-        "System.Net.Security.4.0.0-beta-23408.nupkg.sha512",
+        "runtime.json",
+        "System.Net.Security.4.0.0-beta-23412.nupkg",
+        "System.Net.Security.4.0.0-beta-23412.nupkg.sha512",
         "System.Net.Security.nuspec"
       ]
     },
@@ -1978,78 +1994,68 @@
         "System.Net.WebHeaderCollection.nuspec"
       ]
     },
-    "System.Net.WebSockets/4.0.0-beta-23408": {
+    "System.Net.WebSockets/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "BXy22/bNVtrXXsG76zXyhjcQnCjSYxQIFF37xWifqPRWmvzsCYSLQpNCTPQUCp7rjB7qWc5yLhC9bThaEx7MHQ==",
+      "sha512": "EvXAa0yd1RM8ROyLl1T0xC94F04Su8YMHnd4/w6j0Z/+4lKHZOU7bQPZ3odDN8WdPGKa/ZNJJGwiapydEWKzwQ==",
       "files": [
-        "lib/dotnet/de/System.Net.WebSockets.xml",
-        "lib/dotnet/es/System.Net.WebSockets.xml",
-        "lib/dotnet/fr/System.Net.WebSockets.xml",
-        "lib/dotnet/it/System.Net.WebSockets.xml",
-        "lib/dotnet/ja/System.Net.WebSockets.xml",
-        "lib/dotnet/ko/System.Net.WebSockets.xml",
-        "lib/dotnet/ru/System.Net.WebSockets.xml",
         "lib/dotnet/System.Net.WebSockets.dll",
-        "lib/dotnet/System.Net.WebSockets.xml",
-        "lib/dotnet/zh-hans/System.Net.WebSockets.xml",
-        "lib/dotnet/zh-hant/System.Net.WebSockets.xml",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.WebSockets.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Net.WebSockets.xml",
+        "ref/dotnet/es/System.Net.WebSockets.xml",
+        "ref/dotnet/fr/System.Net.WebSockets.xml",
+        "ref/dotnet/it/System.Net.WebSockets.xml",
+        "ref/dotnet/ja/System.Net.WebSockets.xml",
+        "ref/dotnet/ko/System.Net.WebSockets.xml",
+        "ref/dotnet/ru/System.Net.WebSockets.xml",
         "ref/dotnet/System.Net.WebSockets.dll",
+        "ref/dotnet/System.Net.WebSockets.xml",
+        "ref/dotnet/zh-hans/System.Net.WebSockets.xml",
+        "ref/dotnet/zh-hant/System.Net.WebSockets.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Net.WebSockets.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.WebSockets.4.0.0-beta-23408.nupkg",
-        "System.Net.WebSockets.4.0.0-beta-23408.nupkg.sha512",
+        "System.Net.WebSockets.4.0.0-beta-23412.nupkg",
+        "System.Net.WebSockets.4.0.0-beta-23412.nupkg.sha512",
         "System.Net.WebSockets.nuspec"
       ]
     },
-    "System.Net.WebSockets.Client/4.0.0-beta-23408": {
+    "System.Net.WebSockets.Client/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "smmvhCkcU0c4RNWc6NZwnN5EFktX58jf8+TJ6enfuXxWrpJ/2NRI5/2yT/okjFSngGK1g0MBrljZsfs2EJ7+Yw==",
+      "sha512": "uaO7c/81sK90605UtThSX9KVmzsJDA1vD4GMW7FsKKntymlkolJsprDekWblQ4A5YbhqxHv+ngXX2kIU0B3Fdw==",
       "files": [
-        "lib/DNXCore50/de/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/es/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/fr/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/it/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/ja/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/ko/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/ru/System.Net.WebSockets.Client.xml",
         "lib/DNXCore50/System.Net.WebSockets.Client.dll",
-        "lib/DNXCore50/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/zh-hans/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/zh-hant/System.Net.WebSockets.Client.xml",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.WebSockets.Client.dll",
-        "lib/netcore50/de/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/es/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/fr/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/it/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/ja/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/ko/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/ru/System.Net.WebSockets.Client.xml",
         "lib/netcore50/System.Net.WebSockets.Client.dll",
-        "lib/netcore50/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/zh-hans/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/zh-hant/System.Net.WebSockets.Client.xml",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/es/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/fr/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/it/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/ja/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/ko/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/ru/System.Net.WebSockets.Client.xml",
         "ref/dotnet/System.Net.WebSockets.Client.dll",
+        "ref/dotnet/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/zh-hans/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/zh-hant/System.Net.WebSockets.Client.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Net.WebSockets.Client.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.WebSockets.Client.4.0.0-beta-23408.nupkg",
-        "System.Net.WebSockets.Client.4.0.0-beta-23408.nupkg.sha512",
+        "System.Net.WebSockets.Client.4.0.0-beta-23412.nupkg",
+        "System.Net.WebSockets.Client.4.0.0-beta-23412.nupkg.sha512",
         "System.Net.WebSockets.Client.nuspec"
       ]
     },
@@ -2101,31 +2107,31 @@
         "System.Private.DataContractSerialization.nuspec"
       ]
     },
-    "System.Private.Networking/4.0.1-beta-23408": {
+    "System.Private.Networking/4.0.1-beta-23225": {
       "type": "package",
       "serviceable": true,
-      "sha512": "i2fRDRqM8Px3CP26C//deF/tCNR1AwqlPEr9+MYiXxNZtgGcSPBfqOJJ5CJdfmDb9Ap0hPG2MiPG7CinaSH7+Q==",
+      "sha512": "oVSynIrR3mIU0b/goscsaZDywr3RLxQijQnaFRKfl/VB3F9rKi5mdr0vHcGVWuq5ALSrG0OLwM8PRA4tM5e3rQ==",
       "files": [
         "lib/DNXCore50/System.Private.Networking.dll",
         "lib/netcore50/System.Private.Networking.dll",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "System.Private.Networking.4.0.1-beta-23408.nupkg",
-        "System.Private.Networking.4.0.1-beta-23408.nupkg.sha512",
+        "System.Private.Networking.4.0.1-beta-23225.nupkg",
+        "System.Private.Networking.4.0.1-beta-23225.nupkg.sha512",
         "System.Private.Networking.nuspec"
       ]
     },
-    "System.Private.ServiceModel/4.1.0-beta-23408": {
+    "System.Private.ServiceModel/4.1.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "l/2192yKa6uXhjKOWeukFJy3hoj9Zq1p55pTGe+Y28r8/5jlvgYxfunP9UyXJRo9W1u3UBtGfV/5R71ULzusGQ==",
+      "sha512": "Wm+8LcQ04YeAvYqu9faHsMZ/L8l/WvPPsqziBfifYB4jXIPXk1/kUxuAryjbLChghZDXvkDN0hv/IHSVPZGgBA==",
       "files": [
         "lib/DNXCore50/System.Private.ServiceModel.dll",
         "lib/netcore50/System.Private.ServiceModel.dll",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "System.Private.ServiceModel.4.1.0-beta-23408.nupkg",
-        "System.Private.ServiceModel.4.1.0-beta-23408.nupkg.sha512",
+        "System.Private.ServiceModel.4.1.0-beta-23412.nupkg",
+        "System.Private.ServiceModel.4.1.0-beta-23412.nupkg.sha512",
         "System.Private.ServiceModel.nuspec"
       ]
     },
@@ -2680,10 +2686,10 @@
         "System.Security.Claims.nuspec"
       ]
     },
-    "System.Security.Cryptography.Algorithms/4.0.0-beta-23408": {
+    "System.Security.Cryptography.Algorithms/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "G6eEqi8mZRrWftcwilcnllE4xJ/53JQlk3VVuJ+9qrX+DHvWz8itYJRUZX357JY4DgEEKQNOJzuRGrOBTUeoPg==",
+      "sha512": "nBjoiqJQiMD3cJgOVrqjIVDqEEPZeIqT+mrBIxjLE+YMQcjEyDuSyOG65Ntoopby5LH4onTLMM4zfXh8JRt9NQ==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2697,37 +2703,47 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.Algorithms.4.0.0-beta-23408.nupkg",
-        "System.Security.Cryptography.Algorithms.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Cryptography.Algorithms.4.0.0-beta-23412.nupkg",
+        "System.Security.Cryptography.Algorithms.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Cryptography.Algorithms.nuspec"
       ]
     },
-    "System.Security.Cryptography.Encoding/4.0.0-beta-23408": {
+    "System.Security.Cryptography.Encoding/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "fPsAK3vyMjnJ6nT4YchdS7KzfGca/6uVVAPCBO08ZpTRGhMGx30vq1MiIqAUrfsFMnot3Ub2jimnAFWkqY6g0Q==",
+      "sha512": "SR1zCARNdeyLoUKYH2SNMm1He7Lr3NR/l7yW3K135L44T6PS3YB8SfXpVoZdMpb22X2G07BZAHVz2x7e4AA1Cg==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Security.Cryptography.Encoding.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/es/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/fr/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/it/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/ja/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/ko/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/ru/System.Security.Cryptography.Encoding.xml",
         "ref/dotnet/System.Security.Cryptography.Encoding.dll",
+        "ref/dotnet/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/zh-hans/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/zh-hant/System.Security.Cryptography.Encoding.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Security.Cryptography.Encoding.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.Encoding.4.0.0-beta-23408.nupkg",
-        "System.Security.Cryptography.Encoding.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Cryptography.Encoding.4.0.0-beta-23412.nupkg",
+        "System.Security.Cryptography.Encoding.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Cryptography.Encoding.nuspec"
       ]
     },
-    "System.Security.Cryptography.Primitives/4.0.0-beta-23408": {
+    "System.Security.Cryptography.Primitives/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "A336dWYEIQxm1rEJCaE5ZZrUWHPUkBGTRH8uAj8qrTqg4/qRc2yN2wZxeGXaZauhI35QwDmOutK7oVb2Cd+4TA==",
+      "sha512": "H9EBNe0ahjAYjlVn0TnT18PSgZBrtROSQH1RRIKwAjzxQHt8zwDhO4yN0Q5QaaUIoSXgxVmgtWWk62wDvpy+QA==",
       "files": [
         "lib/dotnet/System.Security.Cryptography.Primitives.dll",
         "lib/MonoAndroid10/_._",
@@ -2741,30 +2757,40 @@
         "ref/net46/System.Security.Cryptography.Primitives.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Security.Cryptography.Primitives.4.0.0-beta-23408.nupkg",
-        "System.Security.Cryptography.Primitives.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Cryptography.Primitives.4.0.0-beta-23412.nupkg",
+        "System.Security.Cryptography.Primitives.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Cryptography.Primitives.nuspec"
       ]
     },
-    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23408": {
+    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "JSNf5d1V5Y47MIdf7QxZCuGnR5heM4UKbrsdXiWD5lfqu0mnNjebPIclMUXlTw/6IykuDsUpompV/DtsaLLHig==",
+      "sha512": "SfpMjvrfRaRjG42uynLugb3YgpXdpnU7X8vNAU7stIR5/4uW9m1SvWHvBjirjHRBtOpbKB86uD5ODQWX+tWDNA==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Security.Cryptography.X509Certificates.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/es/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/fr/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/it/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/ja/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/ko/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/ru/System.Security.Cryptography.X509Certificates.xml",
         "ref/dotnet/System.Security.Cryptography.X509Certificates.dll",
+        "ref/dotnet/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/zh-hans/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/zh-hant/System.Security.Cryptography.X509Certificates.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Security.Cryptography.X509Certificates.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23408.nupkg",
-        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23412.nupkg",
+        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Cryptography.X509Certificates.nuspec"
       ]
     },
@@ -2801,144 +2827,147 @@
         "System.Security.Principal.nuspec"
       ]
     },
-    "System.Security.Principal.Windows/4.0.0-beta-23408": {
+    "System.Security.Principal.Windows/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "xmjpZJvsT1AW23UkjqUkF/VrOh7DA1cagYY272UQmO8ei227TFD4C7j3ofatL/63hR3CXkLkoephuE4f2Z9fGA==",
+      "sha512": "Zvb/LzT+GjGNV1t8i5KVieilL+8P5LcQykIbJHw5aJxLPFEIQ4Y2hTJXdEkeKvZ4TCF5dlwY1jYyUrJkcqpxzw==",
       "files": [
-        "lib/DNXCore50/de/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/es/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/fr/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/it/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/ja/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/ko/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/ru/System.Security.Principal.Windows.xml",
         "lib/DNXCore50/System.Security.Principal.Windows.dll",
-        "lib/DNXCore50/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/zh-hans/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/zh-hant/System.Security.Principal.Windows.xml",
         "lib/net46/System.Security.Principal.Windows.dll",
+        "ref/dotnet/de/System.Security.Principal.Windows.xml",
+        "ref/dotnet/es/System.Security.Principal.Windows.xml",
+        "ref/dotnet/fr/System.Security.Principal.Windows.xml",
+        "ref/dotnet/it/System.Security.Principal.Windows.xml",
+        "ref/dotnet/ja/System.Security.Principal.Windows.xml",
+        "ref/dotnet/ko/System.Security.Principal.Windows.xml",
+        "ref/dotnet/ru/System.Security.Principal.Windows.xml",
         "ref/dotnet/System.Security.Principal.Windows.dll",
+        "ref/dotnet/System.Security.Principal.Windows.xml",
+        "ref/dotnet/zh-hans/System.Security.Principal.Windows.xml",
+        "ref/dotnet/zh-hant/System.Security.Principal.Windows.xml",
         "ref/net46/System.Security.Principal.Windows.dll",
-        "System.Security.Principal.Windows.4.0.0-beta-23408.nupkg",
-        "System.Security.Principal.Windows.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Principal.Windows.4.0.0-beta-23412.nupkg",
+        "System.Security.Principal.Windows.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Principal.Windows.nuspec"
       ]
     },
-    "System.ServiceModel.Duplex/4.0.1-beta-23408": {
+    "System.ServiceModel.Duplex/4.0.1-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "ZJ3aN/aEg801Rw+aVbBFZ+I9J51FyQVCoWOvSqTSh5i4qZuWuenCxmxahby43teIqNcCrCtHPoyRan2GfY8Vyg==",
+      "sha512": "o5w/amLOdG4NIfER18/TI69QL11pboppiBgH2fIwjzasKZ1OIlxE+KJPbvHJ5vt554reZYCcA+jY4CIx7/pkiw==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Duplex.dll",
         "lib/net45/_._",
-        "lib/netcore50/de/System.ServiceModel.Duplex.xml",
-        "lib/netcore50/es/System.ServiceModel.Duplex.xml",
-        "lib/netcore50/fr/System.ServiceModel.Duplex.xml",
-        "lib/netcore50/it/System.ServiceModel.Duplex.xml",
-        "lib/netcore50/ja/System.ServiceModel.Duplex.xml",
-        "lib/netcore50/ko/System.ServiceModel.Duplex.xml",
-        "lib/netcore50/ru/System.ServiceModel.Duplex.xml",
         "lib/netcore50/System.ServiceModel.Duplex.dll",
-        "lib/netcore50/System.ServiceModel.Duplex.xml",
-        "lib/netcore50/zh-hans/System.ServiceModel.Duplex.xml",
-        "lib/netcore50/zh-hant/System.ServiceModel.Duplex.xml",
         "lib/win8/_._",
+        "ref/dotnet/de/System.ServiceModel.Duplex.xml",
+        "ref/dotnet/es/System.ServiceModel.Duplex.xml",
+        "ref/dotnet/fr/System.ServiceModel.Duplex.xml",
+        "ref/dotnet/it/System.ServiceModel.Duplex.xml",
+        "ref/dotnet/ja/System.ServiceModel.Duplex.xml",
+        "ref/dotnet/ko/System.ServiceModel.Duplex.xml",
+        "ref/dotnet/ru/System.ServiceModel.Duplex.xml",
         "ref/dotnet/System.ServiceModel.Duplex.dll",
+        "ref/dotnet/System.ServiceModel.Duplex.xml",
+        "ref/dotnet/zh-hans/System.ServiceModel.Duplex.xml",
+        "ref/dotnet/zh-hant/System.ServiceModel.Duplex.xml",
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.Duplex.dll",
+        "ref/netcore50/System.ServiceModel.Duplex.xml",
         "ref/win8/_._",
-        "System.ServiceModel.Duplex.4.0.1-beta-23408.nupkg",
-        "System.ServiceModel.Duplex.4.0.1-beta-23408.nupkg.sha512",
+        "System.ServiceModel.Duplex.4.0.1-beta-23412.nupkg",
+        "System.ServiceModel.Duplex.4.0.1-beta-23412.nupkg.sha512",
         "System.ServiceModel.Duplex.nuspec"
       ]
     },
-    "System.ServiceModel.Http/4.0.11-beta-23408": {
+    "System.ServiceModel.Http/4.0.11-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "RScHZ1A3CfjumaP1Vh/xfOp/ga6T3nA8YLkjFOYcIcZm/LILL+yCh+PhIrJOEfz1Js8bLSQC6xbxwYlW6BNmYg==",
+      "sha512": "hKMGQbu/l2gv/PgPvm2ViLVElnVSwAPiv4cXKjinS+UHBf02uPF2m7lN13SCkJDNTBctwHav1rQnMYb1LUJHvw==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Http.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
-        "lib/netcore50/de/System.ServiceModel.Http.xml",
-        "lib/netcore50/es/System.ServiceModel.Http.xml",
-        "lib/netcore50/fr/System.ServiceModel.Http.xml",
-        "lib/netcore50/it/System.ServiceModel.Http.xml",
-        "lib/netcore50/ja/System.ServiceModel.Http.xml",
-        "lib/netcore50/ko/System.ServiceModel.Http.xml",
-        "lib/netcore50/ru/System.ServiceModel.Http.xml",
         "lib/netcore50/System.ServiceModel.Http.dll",
-        "lib/netcore50/System.ServiceModel.Http.xml",
-        "lib/netcore50/zh-hans/System.ServiceModel.Http.xml",
-        "lib/netcore50/zh-hant/System.ServiceModel.Http.xml",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.ServiceModel.Http.xml",
+        "ref/dotnet/es/System.ServiceModel.Http.xml",
+        "ref/dotnet/fr/System.ServiceModel.Http.xml",
+        "ref/dotnet/it/System.ServiceModel.Http.xml",
+        "ref/dotnet/ja/System.ServiceModel.Http.xml",
+        "ref/dotnet/ko/System.ServiceModel.Http.xml",
+        "ref/dotnet/ru/System.ServiceModel.Http.xml",
         "ref/dotnet/System.ServiceModel.Http.dll",
+        "ref/dotnet/System.ServiceModel.Http.xml",
+        "ref/dotnet/zh-hans/System.ServiceModel.Http.xml",
+        "ref/dotnet/zh-hant/System.ServiceModel.Http.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.ServiceModel.Http.4.0.11-beta-23408.nupkg",
-        "System.ServiceModel.Http.4.0.11-beta-23408.nupkg.sha512",
+        "System.ServiceModel.Http.4.0.11-beta-23412.nupkg",
+        "System.ServiceModel.Http.4.0.11-beta-23412.nupkg.sha512",
         "System.ServiceModel.Http.nuspec"
       ]
     },
-    "System.ServiceModel.NetTcp/4.0.1-beta-23408": {
+    "System.ServiceModel.NetTcp/4.0.1-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "ppruBpqoE6AngTs6fABV67r1ic6rKCgr6tw+4lMoRucrNWNfKgX5vWlONOqSd8bQXmQLZ/ftEhDGXYY5CLRUTQ==",
+      "sha512": "9I2iOpoYB8DtVy1Sw6BmOj6NGoxt9cKwOOds4q6G1JLzyyWErsv/FMeGAJT07bgLr8vnMx4s8GXxjCfkUwNtTw==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.NetTcp.dll",
         "lib/net45/_._",
-        "lib/netcore50/de/System.ServiceModel.NetTcp.xml",
-        "lib/netcore50/es/System.ServiceModel.NetTcp.xml",
-        "lib/netcore50/fr/System.ServiceModel.NetTcp.xml",
-        "lib/netcore50/it/System.ServiceModel.NetTcp.xml",
-        "lib/netcore50/ja/System.ServiceModel.NetTcp.xml",
-        "lib/netcore50/ko/System.ServiceModel.NetTcp.xml",
-        "lib/netcore50/ru/System.ServiceModel.NetTcp.xml",
         "lib/netcore50/System.ServiceModel.NetTcp.dll",
-        "lib/netcore50/System.ServiceModel.NetTcp.xml",
-        "lib/netcore50/zh-hans/System.ServiceModel.NetTcp.xml",
-        "lib/netcore50/zh-hant/System.ServiceModel.NetTcp.xml",
         "lib/win8/_._",
+        "ref/dotnet/de/System.ServiceModel.NetTcp.xml",
+        "ref/dotnet/es/System.ServiceModel.NetTcp.xml",
+        "ref/dotnet/fr/System.ServiceModel.NetTcp.xml",
+        "ref/dotnet/it/System.ServiceModel.NetTcp.xml",
+        "ref/dotnet/ja/System.ServiceModel.NetTcp.xml",
+        "ref/dotnet/ko/System.ServiceModel.NetTcp.xml",
+        "ref/dotnet/ru/System.ServiceModel.NetTcp.xml",
         "ref/dotnet/System.ServiceModel.NetTcp.dll",
+        "ref/dotnet/System.ServiceModel.NetTcp.xml",
+        "ref/dotnet/zh-hans/System.ServiceModel.NetTcp.xml",
+        "ref/dotnet/zh-hant/System.ServiceModel.NetTcp.xml",
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.NetTcp.dll",
+        "ref/netcore50/System.ServiceModel.NetTcp.xml",
         "ref/win8/_._",
-        "System.ServiceModel.NetTcp.4.0.1-beta-23408.nupkg",
-        "System.ServiceModel.NetTcp.4.0.1-beta-23408.nupkg.sha512",
+        "System.ServiceModel.NetTcp.4.0.1-beta-23412.nupkg",
+        "System.ServiceModel.NetTcp.4.0.1-beta-23412.nupkg.sha512",
         "System.ServiceModel.NetTcp.nuspec"
       ]
     },
-    "System.ServiceModel.Primitives/4.0.1-beta-23408": {
+    "System.ServiceModel.Primitives/4.0.1-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "bjXzg+V3Oq/tBXpMY5FwcERN2CQsFXoL4BMoURlwiBMkgwN2CPvBIaK45Moh7nc21jNTVukNayDtURetGzK6aA==",
+      "sha512": "dkCUkNtXb2m9Wf+DY7dc5B4J8DpaWtX4wpFfT3cYLpChxAnjQR85N+tJfMEHLfZNNerKgDRyGyaKa7uSHfvb5g==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Primitives.dll",
         "lib/net45/_._",
-        "lib/netcore50/de/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/es/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/fr/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/it/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/ja/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/ko/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/ru/System.ServiceModel.Primitives.xml",
         "lib/netcore50/System.ServiceModel.Primitives.dll",
-        "lib/netcore50/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/zh-hans/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/zh-hant/System.ServiceModel.Primitives.xml",
         "lib/win8/_._",
+        "ref/dotnet/de/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/es/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/fr/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/it/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/ja/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/ko/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/ru/System.ServiceModel.Primitives.xml",
         "ref/dotnet/System.ServiceModel.Primitives.dll",
+        "ref/dotnet/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/zh-hans/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/zh-hant/System.ServiceModel.Primitives.xml",
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.Primitives.dll",
+        "ref/netcore50/System.ServiceModel.Primitives.xml",
         "ref/win8/_._",
-        "System.ServiceModel.Primitives.4.0.1-beta-23408.nupkg",
-        "System.ServiceModel.Primitives.4.0.1-beta-23408.nupkg.sha512",
+        "System.ServiceModel.Primitives.4.0.1-beta-23412.nupkg",
+        "System.ServiceModel.Primitives.4.0.1-beta-23412.nupkg.sha512",
         "System.ServiceModel.Primitives.nuspec"
       ]
     },
@@ -3131,28 +3160,6 @@
         "System.Threading.Tasks.4.0.10.nupkg",
         "System.Threading.Tasks.4.0.10.nupkg.sha512",
         "System.Threading.Tasks.nuspec"
-      ]
-    },
-    "System.Threading.ThreadPool/4.0.10-beta-23408": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "ahdsVyj+WFj8/iSDwX/G7hkEU4jZmmvWzPS2ajZKdp0Crb0vZJOlM0LQYVASQgbimrUZHQ50o93JYEi8RFdh/Q==",
-      "files": [
-        "lib/DNXCore50/System.Threading.ThreadPool.dll",
-        "lib/MonoAndroid10/_._",
-        "lib/MonoTouch10/_._",
-        "lib/net46/System.Threading.ThreadPool.dll",
-        "lib/xamarinios10/_._",
-        "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Threading.ThreadPool.dll",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
-        "ref/net46/System.Threading.ThreadPool.dll",
-        "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.Threading.ThreadPool.4.0.10-beta-23408.nupkg",
-        "System.Threading.ThreadPool.4.0.10-beta-23408.nupkg.sha512",
-        "System.Threading.ThreadPool.nuspec"
       ]
     },
     "System.Threading.Timer/4.0.0": {
@@ -3402,14 +3409,14 @@
         "xunit.extensibility.execution.nuspec"
       ]
     },
-    "xunit.netcore.extensions/1.0.0-prerelease-00104": {
+    "xunit.netcore.extensions/1.0.0-prerelease-00105": {
       "type": "package",
       "serviceable": true,
-      "sha512": "ZMXxEBpGP7krXtvqbPMOWavd2u83w77ghtD254wfj5+d+7GmYYqP9pX1iRIxJK9CBa8Zc2cOrcYsmCLQgYriAQ==",
+      "sha512": "EnnGcy9rmSdQ8izHWvYSYVyjQGhbeFH7JeM/L35ZrrPGtYvq5XD3hc1cJPCs+43mXdF9cdqhkt5uTlXYzC+Z8g==",
       "files": [
         "lib/dotnet/Xunit.NetCore.Extensions.dll",
-        "xunit.netcore.extensions.1.0.0-prerelease-00104.nupkg",
-        "xunit.netcore.extensions.1.0.0-prerelease-00104.nupkg.sha512",
+        "xunit.netcore.extensions.1.0.0-prerelease-00105.nupkg",
+        "xunit.netcore.extensions.1.0.0-prerelease-00105.nupkg.sha512",
         "xunit.netcore.extensions.nuspec"
       ]
     }

--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/ExpectedExceptions/project.lock.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/ExpectedExceptions/project.lock.json
@@ -292,7 +292,7 @@
           "lib/dotnet/System.Linq.Queryable.dll": {}
         }
       },
-      "System.Net.Http/4.0.1-beta-23408": {
+      "System.Net.Http/4.0.1-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -305,7 +305,7 @@
           "ref/dotnet/System.Net.Http.dll": {}
         }
       },
-      "System.Net.NameResolution/4.0.0-beta-23408": {
+      "System.Net.NameResolution/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Net.Primitives": "4.0.10",
@@ -328,16 +328,17 @@
           "lib/DNXCore50/System.Net.Primitives.dll": {}
         }
       },
-      "System.Net.Security/4.0.0-beta-23408": {
+      "System.Net.Security/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
-          "System.Private.Networking": "4.0.1-beta-23408"
+          "System.IO": "4.0.0",
+          "System.Net.Primitives": "4.0.10",
+          "System.Runtime": "4.0.0",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23412",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Net.Security.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Net.Security.dll": {}
         }
       },
       "System.Net.Sockets/4.1.0-beta-23225": {
@@ -368,7 +369,7 @@
           "lib/dotnet/System.Net.WebHeaderCollection.dll": {}
         }
       },
-      "System.Net.WebSockets/4.0.0-beta-23408": {
+      "System.Net.WebSockets/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -383,7 +384,7 @@
           "lib/dotnet/System.Net.WebSockets.dll": {}
         }
       },
-      "System.Net.WebSockets.Client/4.0.0-beta-23408": {
+      "System.Net.WebSockets.Client/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -393,13 +394,13 @@
           "System.Globalization": "4.0.10",
           "System.Net.Primitives": "4.0.10",
           "System.Net.WebHeaderCollection": "4.0.0",
-          "System.Net.WebSockets": "4.0.0-beta-23408",
+          "System.Net.WebSockets": "4.0.0-beta-23412",
           "System.Resources.ResourceManager": "4.0.0",
           "System.Runtime": "4.0.20",
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23408",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23412",
           "System.Text.Encoding": "4.0.10",
           "System.Threading": "4.0.10",
           "System.Threading.Tasks": "4.0.10"
@@ -456,7 +457,7 @@
           "lib/DNXCore50/System.Private.DataContractSerialization.dll": {}
         }
       },
-      "System.Private.Networking/4.0.1-beta-23408": {
+      "System.Private.Networking/4.0.1-beta-23225": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -475,13 +476,10 @@
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23408",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23408",
-          "System.Security.Principal.Windows": "4.0.0-beta-23408",
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23225",
           "System.Threading": "4.0.10",
           "System.Threading.Overlapped": "4.0.0",
-          "System.Threading.Tasks": "4.0.10",
-          "System.Threading.ThreadPool": "4.0.10-beta-23408"
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dnxcore50/_._": {}
@@ -490,7 +488,7 @@
           "lib/DNXCore50/System.Private.Networking.dll": {}
         }
       },
-      "System.Private.ServiceModel/4.1.0-beta-23408": {
+      "System.Private.ServiceModel/4.1.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -507,14 +505,14 @@
           "System.Linq": "4.0.0",
           "System.Linq.Expressions": "4.0.10",
           "System.Linq.Queryable": "4.0.0",
-          "System.Net.Http": "4.0.1-beta-23408",
-          "System.Net.NameResolution": "4.0.0-beta-23408",
+          "System.Net.Http": "4.0.1-beta-23412",
+          "System.Net.NameResolution": "4.0.0-beta-23412",
           "System.Net.Primitives": "4.0.10",
-          "System.Net.Security": "4.0.0-beta-23408",
-          "System.Net.Sockets": "4.0.10-beta-23408",
+          "System.Net.Security": "4.0.0-beta-23412",
+          "System.Net.Sockets": "4.0.10-beta-23412",
           "System.Net.WebHeaderCollection": "4.0.0",
-          "System.Net.WebSockets": "4.0.0-beta-23408",
-          "System.Net.WebSockets.Client": "4.0.0-beta-23408",
+          "System.Net.WebSockets": "4.0.0-beta-23412",
+          "System.Net.WebSockets.Client": "4.0.0-beta-23412",
           "System.ObjectModel": "4.0.10",
           "System.Reflection": "4.0.10",
           "System.Reflection.DispatchProxy": "4.0.0",
@@ -528,9 +526,9 @@
           "System.Runtime.Serialization.Primitives": "4.0.10",
           "System.Runtime.Serialization.Xml": "4.0.10",
           "System.Security.Claims": "4.0.0",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23408",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23412",
           "System.Security.Principal": "4.0.0",
-          "System.Security.Principal.Windows": "4.0.0-beta-23408",
+          "System.Security.Principal.Windows": "4.0.0-beta-23412",
           "System.Text.Encoding": "4.0.10",
           "System.Threading": "4.0.10",
           "System.Threading.Tasks": "4.0.10",
@@ -794,18 +792,18 @@
           "lib/dotnet/System.Security.Claims.dll": {}
         }
       },
-      "System.Security.Cryptography.Algorithms/4.0.0-beta-23408": {
+      "System.Security.Cryptography.Algorithms/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
           "System.Runtime": "4.0.0",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23408"
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23412"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.Algorithms.dll": {}
         }
       },
-      "System.Security.Cryptography.Encoding/4.0.0-beta-23408": {
+      "System.Security.Cryptography.Encoding/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -814,7 +812,7 @@
           "ref/dotnet/System.Security.Cryptography.Encoding.dll": {}
         }
       },
-      "System.Security.Cryptography.Primitives/4.0.0-beta-23408": {
+      "System.Security.Cryptography.Primitives/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.0",
@@ -832,13 +830,13 @@
           "lib/dotnet/System.Security.Cryptography.Primitives.dll": {}
         }
       },
-      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23408": {
+      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
           "System.Runtime.Handles": "4.0.0",
-          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23408",
-          "System.Security.Cryptography.Encoding": "4.0.0-beta-23408"
+          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23412",
+          "System.Security.Cryptography.Encoding": "4.0.0-beta-23412"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.X509Certificates.dll": {}
@@ -856,7 +854,7 @@
           "lib/dotnet/System.Security.Principal.dll": {}
         }
       },
-      "System.Security.Principal.Windows/4.0.0-beta-23408": {
+      "System.Security.Principal.Windows/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -879,10 +877,10 @@
           "lib/DNXCore50/System.Security.Principal.Windows.dll": {}
         }
       },
-      "System.ServiceModel.Duplex/4.0.1-beta-23408": {
+      "System.ServiceModel.Duplex/4.0.1-beta-23412": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-beta-23408"
+          "System.Private.ServiceModel": "4.1.0-beta-23412"
         },
         "compile": {
           "ref/dotnet/System.ServiceModel.Duplex.dll": {}
@@ -891,10 +889,10 @@
           "lib/DNXCore50/System.ServiceModel.Duplex.dll": {}
         }
       },
-      "System.ServiceModel.Http/4.0.11-beta-23408": {
+      "System.ServiceModel.Http/4.0.11-beta-23412": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-beta-23408",
+          "System.Private.ServiceModel": "4.1.0-beta-23412",
           "System.Runtime": "4.0.20"
         },
         "compile": {
@@ -904,10 +902,10 @@
           "lib/DNXCore50/System.ServiceModel.Http.dll": {}
         }
       },
-      "System.ServiceModel.NetTcp/4.0.1-beta-23408": {
+      "System.ServiceModel.NetTcp/4.0.1-beta-23412": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-beta-23408"
+          "System.Private.ServiceModel": "4.1.0-beta-23412"
         },
         "compile": {
           "ref/dotnet/System.ServiceModel.NetTcp.dll": {}
@@ -916,10 +914,10 @@
           "lib/DNXCore50/System.ServiceModel.NetTcp.dll": {}
         }
       },
-      "System.ServiceModel.Primitives/4.0.1-beta-23408": {
+      "System.ServiceModel.Primitives/4.0.1-beta-23412": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-beta-23408"
+          "System.Private.ServiceModel": "4.1.0-beta-23412"
         },
         "compile": {
           "ref/dotnet/System.ServiceModel.Primitives.dll": {}
@@ -1006,19 +1004,6 @@
         },
         "runtime": {
           "lib/DNXCore50/System.Threading.Tasks.dll": {}
-        }
-      },
-      "System.Threading.ThreadPool/4.0.10-beta-23408": {
-        "type": "package",
-        "dependencies": {
-          "System.Runtime": "4.0.0",
-          "System.Runtime.InteropServices": "4.0.0"
-        },
-        "compile": {
-          "ref/dotnet/System.Threading.ThreadPool.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Threading.ThreadPool.dll": {}
         }
       },
       "System.Threading.Timer/4.0.0": {
@@ -1201,7 +1186,7 @@
           "lib/dotnet/xunit.execution.dotnet.dll": {}
         }
       },
-      "xunit.netcore.extensions/1.0.0-prerelease-00104": {
+      "xunit.netcore.extensions/1.0.0-prerelease-00105": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.10",
@@ -1829,44 +1814,65 @@
         "System.Linq.Queryable.nuspec"
       ]
     },
-    "System.Net.Http/4.0.1-beta-23408": {
+    "System.Net.Http/4.0.1-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "n+tnV1VgCjbDKKnbgrvgUgxkPDwUFvSv9lTgH882rVzjbWyliVgbBflVzoAUjUSlga/Tr1XQIrfTLMRD5HfYGw==",
+      "sha512": "F7Yej+6QdRVzWg+qbkayRMcmf/7k7YfNFoVSA67wIsG9t5u7Wj4Go8FW72HL8qb9d7YjIsVB/5hA7g9MUT31Aw==",
       "files": [
         "lib/net45/_._",
         "lib/win8/_._",
         "lib/wpa81/_._",
+        "ref/dotnet/de/System.Net.Http.xml",
+        "ref/dotnet/es/System.Net.Http.xml",
+        "ref/dotnet/fr/System.Net.Http.xml",
+        "ref/dotnet/it/System.Net.Http.xml",
+        "ref/dotnet/ja/System.Net.Http.xml",
+        "ref/dotnet/ko/System.Net.Http.xml",
+        "ref/dotnet/ru/System.Net.Http.xml",
         "ref/dotnet/System.Net.Http.dll",
+        "ref/dotnet/System.Net.Http.xml",
+        "ref/dotnet/zh-hans/System.Net.Http.xml",
+        "ref/dotnet/zh-hant/System.Net.Http.xml",
         "ref/net45/_._",
         "ref/netcore50/System.Net.Http.dll",
+        "ref/netcore50/System.Net.Http.xml",
         "ref/win8/_._",
         "ref/wpa81/_._",
         "runtime.json",
-        "System.Net.Http.4.0.1-beta-23408.nupkg",
-        "System.Net.Http.4.0.1-beta-23408.nupkg.sha512",
+        "System.Net.Http.4.0.1-beta-23412.nupkg",
+        "System.Net.Http.4.0.1-beta-23412.nupkg.sha512",
         "System.Net.Http.nuspec"
       ]
     },
-    "System.Net.NameResolution/4.0.0-beta-23408": {
+    "System.Net.NameResolution/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "2A562VFL8GUL/jLCJ3mbQHhwwAIXzPyjxMpdtas1LVM8QLuP1OcHwV3z7ajWnYdGcPc7ZxPEGJQWicuaPD+0nA==",
+      "sha512": "HCF1zhFYBT+w/Ik+JuTzFJgj83Jfc+eA8VcgvIzdPiGMXfrZeXOogjgSCkCoJmFtKVz2DSfmISoEmiXB1oaLNQ==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.NameResolution.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Net.NameResolution.xml",
+        "ref/dotnet/es/System.Net.NameResolution.xml",
+        "ref/dotnet/fr/System.Net.NameResolution.xml",
+        "ref/dotnet/it/System.Net.NameResolution.xml",
+        "ref/dotnet/ja/System.Net.NameResolution.xml",
+        "ref/dotnet/ko/System.Net.NameResolution.xml",
+        "ref/dotnet/ru/System.Net.NameResolution.xml",
         "ref/dotnet/System.Net.NameResolution.dll",
+        "ref/dotnet/System.Net.NameResolution.xml",
+        "ref/dotnet/zh-hans/System.Net.NameResolution.xml",
+        "ref/dotnet/zh-hant/System.Net.NameResolution.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Net.NameResolution.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Net.NameResolution.4.0.0-beta-23408.nupkg",
-        "System.Net.NameResolution.4.0.0-beta-23408.nupkg.sha512",
+        "System.Net.NameResolution.4.0.0-beta-23412.nupkg",
+        "System.Net.NameResolution.4.0.0-beta-23412.nupkg.sha512",
         "System.Net.NameResolution.nuspec"
       ]
     },
@@ -1903,24 +1909,34 @@
         "System.Net.Primitives.nuspec"
       ]
     },
-    "System.Net.Security/4.0.0-beta-23408": {
+    "System.Net.Security/4.0.0-beta-23412": {
       "type": "package",
-      "sha512": "kEkunODO2t/VlBIsC80YFDG0KtY/FyIbtBApNyJQv+LYGEs5IFvEhpi9+p0/jHmhyRMKwbjajNedbXo+VMkt1A==",
+      "sha512": "Kcjne7jnvF5aTbRJsAT8kuP+1mxryUF2qYv8f3jnR19wtEjswSIOVU0XzuWc9YObEQcb+kEdzN71HTOm+ssv+w==",
       "files": [
-        "lib/DNXCore50/System.Net.Security.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.Security.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Net.Security.xml",
+        "ref/dotnet/es/System.Net.Security.xml",
+        "ref/dotnet/fr/System.Net.Security.xml",
+        "ref/dotnet/it/System.Net.Security.xml",
+        "ref/dotnet/ja/System.Net.Security.xml",
+        "ref/dotnet/ko/System.Net.Security.xml",
+        "ref/dotnet/ru/System.Net.Security.xml",
         "ref/dotnet/System.Net.Security.dll",
+        "ref/dotnet/System.Net.Security.xml",
+        "ref/dotnet/zh-hans/System.Net.Security.xml",
+        "ref/dotnet/zh-hant/System.Net.Security.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Net.Security.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.Security.4.0.0-beta-23408.nupkg",
-        "System.Net.Security.4.0.0-beta-23408.nupkg.sha512",
+        "runtime.json",
+        "System.Net.Security.4.0.0-beta-23412.nupkg",
+        "System.Net.Security.4.0.0-beta-23412.nupkg.sha512",
         "System.Net.Security.nuspec"
       ]
     },
@@ -1978,78 +1994,68 @@
         "System.Net.WebHeaderCollection.nuspec"
       ]
     },
-    "System.Net.WebSockets/4.0.0-beta-23408": {
+    "System.Net.WebSockets/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "BXy22/bNVtrXXsG76zXyhjcQnCjSYxQIFF37xWifqPRWmvzsCYSLQpNCTPQUCp7rjB7qWc5yLhC9bThaEx7MHQ==",
+      "sha512": "EvXAa0yd1RM8ROyLl1T0xC94F04Su8YMHnd4/w6j0Z/+4lKHZOU7bQPZ3odDN8WdPGKa/ZNJJGwiapydEWKzwQ==",
       "files": [
-        "lib/dotnet/de/System.Net.WebSockets.xml",
-        "lib/dotnet/es/System.Net.WebSockets.xml",
-        "lib/dotnet/fr/System.Net.WebSockets.xml",
-        "lib/dotnet/it/System.Net.WebSockets.xml",
-        "lib/dotnet/ja/System.Net.WebSockets.xml",
-        "lib/dotnet/ko/System.Net.WebSockets.xml",
-        "lib/dotnet/ru/System.Net.WebSockets.xml",
         "lib/dotnet/System.Net.WebSockets.dll",
-        "lib/dotnet/System.Net.WebSockets.xml",
-        "lib/dotnet/zh-hans/System.Net.WebSockets.xml",
-        "lib/dotnet/zh-hant/System.Net.WebSockets.xml",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.WebSockets.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Net.WebSockets.xml",
+        "ref/dotnet/es/System.Net.WebSockets.xml",
+        "ref/dotnet/fr/System.Net.WebSockets.xml",
+        "ref/dotnet/it/System.Net.WebSockets.xml",
+        "ref/dotnet/ja/System.Net.WebSockets.xml",
+        "ref/dotnet/ko/System.Net.WebSockets.xml",
+        "ref/dotnet/ru/System.Net.WebSockets.xml",
         "ref/dotnet/System.Net.WebSockets.dll",
+        "ref/dotnet/System.Net.WebSockets.xml",
+        "ref/dotnet/zh-hans/System.Net.WebSockets.xml",
+        "ref/dotnet/zh-hant/System.Net.WebSockets.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Net.WebSockets.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.WebSockets.4.0.0-beta-23408.nupkg",
-        "System.Net.WebSockets.4.0.0-beta-23408.nupkg.sha512",
+        "System.Net.WebSockets.4.0.0-beta-23412.nupkg",
+        "System.Net.WebSockets.4.0.0-beta-23412.nupkg.sha512",
         "System.Net.WebSockets.nuspec"
       ]
     },
-    "System.Net.WebSockets.Client/4.0.0-beta-23408": {
+    "System.Net.WebSockets.Client/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "smmvhCkcU0c4RNWc6NZwnN5EFktX58jf8+TJ6enfuXxWrpJ/2NRI5/2yT/okjFSngGK1g0MBrljZsfs2EJ7+Yw==",
+      "sha512": "uaO7c/81sK90605UtThSX9KVmzsJDA1vD4GMW7FsKKntymlkolJsprDekWblQ4A5YbhqxHv+ngXX2kIU0B3Fdw==",
       "files": [
-        "lib/DNXCore50/de/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/es/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/fr/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/it/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/ja/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/ko/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/ru/System.Net.WebSockets.Client.xml",
         "lib/DNXCore50/System.Net.WebSockets.Client.dll",
-        "lib/DNXCore50/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/zh-hans/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/zh-hant/System.Net.WebSockets.Client.xml",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.WebSockets.Client.dll",
-        "lib/netcore50/de/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/es/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/fr/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/it/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/ja/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/ko/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/ru/System.Net.WebSockets.Client.xml",
         "lib/netcore50/System.Net.WebSockets.Client.dll",
-        "lib/netcore50/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/zh-hans/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/zh-hant/System.Net.WebSockets.Client.xml",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/es/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/fr/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/it/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/ja/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/ko/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/ru/System.Net.WebSockets.Client.xml",
         "ref/dotnet/System.Net.WebSockets.Client.dll",
+        "ref/dotnet/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/zh-hans/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/zh-hant/System.Net.WebSockets.Client.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Net.WebSockets.Client.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.WebSockets.Client.4.0.0-beta-23408.nupkg",
-        "System.Net.WebSockets.Client.4.0.0-beta-23408.nupkg.sha512",
+        "System.Net.WebSockets.Client.4.0.0-beta-23412.nupkg",
+        "System.Net.WebSockets.Client.4.0.0-beta-23412.nupkg.sha512",
         "System.Net.WebSockets.Client.nuspec"
       ]
     },
@@ -2101,31 +2107,31 @@
         "System.Private.DataContractSerialization.nuspec"
       ]
     },
-    "System.Private.Networking/4.0.1-beta-23408": {
+    "System.Private.Networking/4.0.1-beta-23225": {
       "type": "package",
       "serviceable": true,
-      "sha512": "i2fRDRqM8Px3CP26C//deF/tCNR1AwqlPEr9+MYiXxNZtgGcSPBfqOJJ5CJdfmDb9Ap0hPG2MiPG7CinaSH7+Q==",
+      "sha512": "oVSynIrR3mIU0b/goscsaZDywr3RLxQijQnaFRKfl/VB3F9rKi5mdr0vHcGVWuq5ALSrG0OLwM8PRA4tM5e3rQ==",
       "files": [
         "lib/DNXCore50/System.Private.Networking.dll",
         "lib/netcore50/System.Private.Networking.dll",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "System.Private.Networking.4.0.1-beta-23408.nupkg",
-        "System.Private.Networking.4.0.1-beta-23408.nupkg.sha512",
+        "System.Private.Networking.4.0.1-beta-23225.nupkg",
+        "System.Private.Networking.4.0.1-beta-23225.nupkg.sha512",
         "System.Private.Networking.nuspec"
       ]
     },
-    "System.Private.ServiceModel/4.1.0-beta-23408": {
+    "System.Private.ServiceModel/4.1.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "l/2192yKa6uXhjKOWeukFJy3hoj9Zq1p55pTGe+Y28r8/5jlvgYxfunP9UyXJRo9W1u3UBtGfV/5R71ULzusGQ==",
+      "sha512": "Wm+8LcQ04YeAvYqu9faHsMZ/L8l/WvPPsqziBfifYB4jXIPXk1/kUxuAryjbLChghZDXvkDN0hv/IHSVPZGgBA==",
       "files": [
         "lib/DNXCore50/System.Private.ServiceModel.dll",
         "lib/netcore50/System.Private.ServiceModel.dll",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "System.Private.ServiceModel.4.1.0-beta-23408.nupkg",
-        "System.Private.ServiceModel.4.1.0-beta-23408.nupkg.sha512",
+        "System.Private.ServiceModel.4.1.0-beta-23412.nupkg",
+        "System.Private.ServiceModel.4.1.0-beta-23412.nupkg.sha512",
         "System.Private.ServiceModel.nuspec"
       ]
     },
@@ -2680,10 +2686,10 @@
         "System.Security.Claims.nuspec"
       ]
     },
-    "System.Security.Cryptography.Algorithms/4.0.0-beta-23408": {
+    "System.Security.Cryptography.Algorithms/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "G6eEqi8mZRrWftcwilcnllE4xJ/53JQlk3VVuJ+9qrX+DHvWz8itYJRUZX357JY4DgEEKQNOJzuRGrOBTUeoPg==",
+      "sha512": "nBjoiqJQiMD3cJgOVrqjIVDqEEPZeIqT+mrBIxjLE+YMQcjEyDuSyOG65Ntoopby5LH4onTLMM4zfXh8JRt9NQ==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2697,37 +2703,47 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.Algorithms.4.0.0-beta-23408.nupkg",
-        "System.Security.Cryptography.Algorithms.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Cryptography.Algorithms.4.0.0-beta-23412.nupkg",
+        "System.Security.Cryptography.Algorithms.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Cryptography.Algorithms.nuspec"
       ]
     },
-    "System.Security.Cryptography.Encoding/4.0.0-beta-23408": {
+    "System.Security.Cryptography.Encoding/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "fPsAK3vyMjnJ6nT4YchdS7KzfGca/6uVVAPCBO08ZpTRGhMGx30vq1MiIqAUrfsFMnot3Ub2jimnAFWkqY6g0Q==",
+      "sha512": "SR1zCARNdeyLoUKYH2SNMm1He7Lr3NR/l7yW3K135L44T6PS3YB8SfXpVoZdMpb22X2G07BZAHVz2x7e4AA1Cg==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Security.Cryptography.Encoding.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/es/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/fr/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/it/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/ja/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/ko/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/ru/System.Security.Cryptography.Encoding.xml",
         "ref/dotnet/System.Security.Cryptography.Encoding.dll",
+        "ref/dotnet/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/zh-hans/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/zh-hant/System.Security.Cryptography.Encoding.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Security.Cryptography.Encoding.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.Encoding.4.0.0-beta-23408.nupkg",
-        "System.Security.Cryptography.Encoding.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Cryptography.Encoding.4.0.0-beta-23412.nupkg",
+        "System.Security.Cryptography.Encoding.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Cryptography.Encoding.nuspec"
       ]
     },
-    "System.Security.Cryptography.Primitives/4.0.0-beta-23408": {
+    "System.Security.Cryptography.Primitives/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "A336dWYEIQxm1rEJCaE5ZZrUWHPUkBGTRH8uAj8qrTqg4/qRc2yN2wZxeGXaZauhI35QwDmOutK7oVb2Cd+4TA==",
+      "sha512": "H9EBNe0ahjAYjlVn0TnT18PSgZBrtROSQH1RRIKwAjzxQHt8zwDhO4yN0Q5QaaUIoSXgxVmgtWWk62wDvpy+QA==",
       "files": [
         "lib/dotnet/System.Security.Cryptography.Primitives.dll",
         "lib/MonoAndroid10/_._",
@@ -2741,30 +2757,40 @@
         "ref/net46/System.Security.Cryptography.Primitives.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Security.Cryptography.Primitives.4.0.0-beta-23408.nupkg",
-        "System.Security.Cryptography.Primitives.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Cryptography.Primitives.4.0.0-beta-23412.nupkg",
+        "System.Security.Cryptography.Primitives.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Cryptography.Primitives.nuspec"
       ]
     },
-    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23408": {
+    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "JSNf5d1V5Y47MIdf7QxZCuGnR5heM4UKbrsdXiWD5lfqu0mnNjebPIclMUXlTw/6IykuDsUpompV/DtsaLLHig==",
+      "sha512": "SfpMjvrfRaRjG42uynLugb3YgpXdpnU7X8vNAU7stIR5/4uW9m1SvWHvBjirjHRBtOpbKB86uD5ODQWX+tWDNA==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Security.Cryptography.X509Certificates.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/es/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/fr/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/it/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/ja/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/ko/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/ru/System.Security.Cryptography.X509Certificates.xml",
         "ref/dotnet/System.Security.Cryptography.X509Certificates.dll",
+        "ref/dotnet/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/zh-hans/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/zh-hant/System.Security.Cryptography.X509Certificates.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Security.Cryptography.X509Certificates.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23408.nupkg",
-        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23412.nupkg",
+        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Cryptography.X509Certificates.nuspec"
       ]
     },
@@ -2801,144 +2827,147 @@
         "System.Security.Principal.nuspec"
       ]
     },
-    "System.Security.Principal.Windows/4.0.0-beta-23408": {
+    "System.Security.Principal.Windows/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "xmjpZJvsT1AW23UkjqUkF/VrOh7DA1cagYY272UQmO8ei227TFD4C7j3ofatL/63hR3CXkLkoephuE4f2Z9fGA==",
+      "sha512": "Zvb/LzT+GjGNV1t8i5KVieilL+8P5LcQykIbJHw5aJxLPFEIQ4Y2hTJXdEkeKvZ4TCF5dlwY1jYyUrJkcqpxzw==",
       "files": [
-        "lib/DNXCore50/de/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/es/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/fr/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/it/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/ja/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/ko/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/ru/System.Security.Principal.Windows.xml",
         "lib/DNXCore50/System.Security.Principal.Windows.dll",
-        "lib/DNXCore50/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/zh-hans/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/zh-hant/System.Security.Principal.Windows.xml",
         "lib/net46/System.Security.Principal.Windows.dll",
+        "ref/dotnet/de/System.Security.Principal.Windows.xml",
+        "ref/dotnet/es/System.Security.Principal.Windows.xml",
+        "ref/dotnet/fr/System.Security.Principal.Windows.xml",
+        "ref/dotnet/it/System.Security.Principal.Windows.xml",
+        "ref/dotnet/ja/System.Security.Principal.Windows.xml",
+        "ref/dotnet/ko/System.Security.Principal.Windows.xml",
+        "ref/dotnet/ru/System.Security.Principal.Windows.xml",
         "ref/dotnet/System.Security.Principal.Windows.dll",
+        "ref/dotnet/System.Security.Principal.Windows.xml",
+        "ref/dotnet/zh-hans/System.Security.Principal.Windows.xml",
+        "ref/dotnet/zh-hant/System.Security.Principal.Windows.xml",
         "ref/net46/System.Security.Principal.Windows.dll",
-        "System.Security.Principal.Windows.4.0.0-beta-23408.nupkg",
-        "System.Security.Principal.Windows.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Principal.Windows.4.0.0-beta-23412.nupkg",
+        "System.Security.Principal.Windows.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Principal.Windows.nuspec"
       ]
     },
-    "System.ServiceModel.Duplex/4.0.1-beta-23408": {
+    "System.ServiceModel.Duplex/4.0.1-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "ZJ3aN/aEg801Rw+aVbBFZ+I9J51FyQVCoWOvSqTSh5i4qZuWuenCxmxahby43teIqNcCrCtHPoyRan2GfY8Vyg==",
+      "sha512": "o5w/amLOdG4NIfER18/TI69QL11pboppiBgH2fIwjzasKZ1OIlxE+KJPbvHJ5vt554reZYCcA+jY4CIx7/pkiw==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Duplex.dll",
         "lib/net45/_._",
-        "lib/netcore50/de/System.ServiceModel.Duplex.xml",
-        "lib/netcore50/es/System.ServiceModel.Duplex.xml",
-        "lib/netcore50/fr/System.ServiceModel.Duplex.xml",
-        "lib/netcore50/it/System.ServiceModel.Duplex.xml",
-        "lib/netcore50/ja/System.ServiceModel.Duplex.xml",
-        "lib/netcore50/ko/System.ServiceModel.Duplex.xml",
-        "lib/netcore50/ru/System.ServiceModel.Duplex.xml",
         "lib/netcore50/System.ServiceModel.Duplex.dll",
-        "lib/netcore50/System.ServiceModel.Duplex.xml",
-        "lib/netcore50/zh-hans/System.ServiceModel.Duplex.xml",
-        "lib/netcore50/zh-hant/System.ServiceModel.Duplex.xml",
         "lib/win8/_._",
+        "ref/dotnet/de/System.ServiceModel.Duplex.xml",
+        "ref/dotnet/es/System.ServiceModel.Duplex.xml",
+        "ref/dotnet/fr/System.ServiceModel.Duplex.xml",
+        "ref/dotnet/it/System.ServiceModel.Duplex.xml",
+        "ref/dotnet/ja/System.ServiceModel.Duplex.xml",
+        "ref/dotnet/ko/System.ServiceModel.Duplex.xml",
+        "ref/dotnet/ru/System.ServiceModel.Duplex.xml",
         "ref/dotnet/System.ServiceModel.Duplex.dll",
+        "ref/dotnet/System.ServiceModel.Duplex.xml",
+        "ref/dotnet/zh-hans/System.ServiceModel.Duplex.xml",
+        "ref/dotnet/zh-hant/System.ServiceModel.Duplex.xml",
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.Duplex.dll",
+        "ref/netcore50/System.ServiceModel.Duplex.xml",
         "ref/win8/_._",
-        "System.ServiceModel.Duplex.4.0.1-beta-23408.nupkg",
-        "System.ServiceModel.Duplex.4.0.1-beta-23408.nupkg.sha512",
+        "System.ServiceModel.Duplex.4.0.1-beta-23412.nupkg",
+        "System.ServiceModel.Duplex.4.0.1-beta-23412.nupkg.sha512",
         "System.ServiceModel.Duplex.nuspec"
       ]
     },
-    "System.ServiceModel.Http/4.0.11-beta-23408": {
+    "System.ServiceModel.Http/4.0.11-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "RScHZ1A3CfjumaP1Vh/xfOp/ga6T3nA8YLkjFOYcIcZm/LILL+yCh+PhIrJOEfz1Js8bLSQC6xbxwYlW6BNmYg==",
+      "sha512": "hKMGQbu/l2gv/PgPvm2ViLVElnVSwAPiv4cXKjinS+UHBf02uPF2m7lN13SCkJDNTBctwHav1rQnMYb1LUJHvw==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Http.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
-        "lib/netcore50/de/System.ServiceModel.Http.xml",
-        "lib/netcore50/es/System.ServiceModel.Http.xml",
-        "lib/netcore50/fr/System.ServiceModel.Http.xml",
-        "lib/netcore50/it/System.ServiceModel.Http.xml",
-        "lib/netcore50/ja/System.ServiceModel.Http.xml",
-        "lib/netcore50/ko/System.ServiceModel.Http.xml",
-        "lib/netcore50/ru/System.ServiceModel.Http.xml",
         "lib/netcore50/System.ServiceModel.Http.dll",
-        "lib/netcore50/System.ServiceModel.Http.xml",
-        "lib/netcore50/zh-hans/System.ServiceModel.Http.xml",
-        "lib/netcore50/zh-hant/System.ServiceModel.Http.xml",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.ServiceModel.Http.xml",
+        "ref/dotnet/es/System.ServiceModel.Http.xml",
+        "ref/dotnet/fr/System.ServiceModel.Http.xml",
+        "ref/dotnet/it/System.ServiceModel.Http.xml",
+        "ref/dotnet/ja/System.ServiceModel.Http.xml",
+        "ref/dotnet/ko/System.ServiceModel.Http.xml",
+        "ref/dotnet/ru/System.ServiceModel.Http.xml",
         "ref/dotnet/System.ServiceModel.Http.dll",
+        "ref/dotnet/System.ServiceModel.Http.xml",
+        "ref/dotnet/zh-hans/System.ServiceModel.Http.xml",
+        "ref/dotnet/zh-hant/System.ServiceModel.Http.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.ServiceModel.Http.4.0.11-beta-23408.nupkg",
-        "System.ServiceModel.Http.4.0.11-beta-23408.nupkg.sha512",
+        "System.ServiceModel.Http.4.0.11-beta-23412.nupkg",
+        "System.ServiceModel.Http.4.0.11-beta-23412.nupkg.sha512",
         "System.ServiceModel.Http.nuspec"
       ]
     },
-    "System.ServiceModel.NetTcp/4.0.1-beta-23408": {
+    "System.ServiceModel.NetTcp/4.0.1-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "ppruBpqoE6AngTs6fABV67r1ic6rKCgr6tw+4lMoRucrNWNfKgX5vWlONOqSd8bQXmQLZ/ftEhDGXYY5CLRUTQ==",
+      "sha512": "9I2iOpoYB8DtVy1Sw6BmOj6NGoxt9cKwOOds4q6G1JLzyyWErsv/FMeGAJT07bgLr8vnMx4s8GXxjCfkUwNtTw==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.NetTcp.dll",
         "lib/net45/_._",
-        "lib/netcore50/de/System.ServiceModel.NetTcp.xml",
-        "lib/netcore50/es/System.ServiceModel.NetTcp.xml",
-        "lib/netcore50/fr/System.ServiceModel.NetTcp.xml",
-        "lib/netcore50/it/System.ServiceModel.NetTcp.xml",
-        "lib/netcore50/ja/System.ServiceModel.NetTcp.xml",
-        "lib/netcore50/ko/System.ServiceModel.NetTcp.xml",
-        "lib/netcore50/ru/System.ServiceModel.NetTcp.xml",
         "lib/netcore50/System.ServiceModel.NetTcp.dll",
-        "lib/netcore50/System.ServiceModel.NetTcp.xml",
-        "lib/netcore50/zh-hans/System.ServiceModel.NetTcp.xml",
-        "lib/netcore50/zh-hant/System.ServiceModel.NetTcp.xml",
         "lib/win8/_._",
+        "ref/dotnet/de/System.ServiceModel.NetTcp.xml",
+        "ref/dotnet/es/System.ServiceModel.NetTcp.xml",
+        "ref/dotnet/fr/System.ServiceModel.NetTcp.xml",
+        "ref/dotnet/it/System.ServiceModel.NetTcp.xml",
+        "ref/dotnet/ja/System.ServiceModel.NetTcp.xml",
+        "ref/dotnet/ko/System.ServiceModel.NetTcp.xml",
+        "ref/dotnet/ru/System.ServiceModel.NetTcp.xml",
         "ref/dotnet/System.ServiceModel.NetTcp.dll",
+        "ref/dotnet/System.ServiceModel.NetTcp.xml",
+        "ref/dotnet/zh-hans/System.ServiceModel.NetTcp.xml",
+        "ref/dotnet/zh-hant/System.ServiceModel.NetTcp.xml",
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.NetTcp.dll",
+        "ref/netcore50/System.ServiceModel.NetTcp.xml",
         "ref/win8/_._",
-        "System.ServiceModel.NetTcp.4.0.1-beta-23408.nupkg",
-        "System.ServiceModel.NetTcp.4.0.1-beta-23408.nupkg.sha512",
+        "System.ServiceModel.NetTcp.4.0.1-beta-23412.nupkg",
+        "System.ServiceModel.NetTcp.4.0.1-beta-23412.nupkg.sha512",
         "System.ServiceModel.NetTcp.nuspec"
       ]
     },
-    "System.ServiceModel.Primitives/4.0.1-beta-23408": {
+    "System.ServiceModel.Primitives/4.0.1-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "bjXzg+V3Oq/tBXpMY5FwcERN2CQsFXoL4BMoURlwiBMkgwN2CPvBIaK45Moh7nc21jNTVukNayDtURetGzK6aA==",
+      "sha512": "dkCUkNtXb2m9Wf+DY7dc5B4J8DpaWtX4wpFfT3cYLpChxAnjQR85N+tJfMEHLfZNNerKgDRyGyaKa7uSHfvb5g==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Primitives.dll",
         "lib/net45/_._",
-        "lib/netcore50/de/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/es/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/fr/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/it/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/ja/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/ko/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/ru/System.ServiceModel.Primitives.xml",
         "lib/netcore50/System.ServiceModel.Primitives.dll",
-        "lib/netcore50/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/zh-hans/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/zh-hant/System.ServiceModel.Primitives.xml",
         "lib/win8/_._",
+        "ref/dotnet/de/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/es/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/fr/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/it/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/ja/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/ko/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/ru/System.ServiceModel.Primitives.xml",
         "ref/dotnet/System.ServiceModel.Primitives.dll",
+        "ref/dotnet/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/zh-hans/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/zh-hant/System.ServiceModel.Primitives.xml",
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.Primitives.dll",
+        "ref/netcore50/System.ServiceModel.Primitives.xml",
         "ref/win8/_._",
-        "System.ServiceModel.Primitives.4.0.1-beta-23408.nupkg",
-        "System.ServiceModel.Primitives.4.0.1-beta-23408.nupkg.sha512",
+        "System.ServiceModel.Primitives.4.0.1-beta-23412.nupkg",
+        "System.ServiceModel.Primitives.4.0.1-beta-23412.nupkg.sha512",
         "System.ServiceModel.Primitives.nuspec"
       ]
     },
@@ -3131,28 +3160,6 @@
         "System.Threading.Tasks.4.0.10.nupkg",
         "System.Threading.Tasks.4.0.10.nupkg.sha512",
         "System.Threading.Tasks.nuspec"
-      ]
-    },
-    "System.Threading.ThreadPool/4.0.10-beta-23408": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "ahdsVyj+WFj8/iSDwX/G7hkEU4jZmmvWzPS2ajZKdp0Crb0vZJOlM0LQYVASQgbimrUZHQ50o93JYEi8RFdh/Q==",
-      "files": [
-        "lib/DNXCore50/System.Threading.ThreadPool.dll",
-        "lib/MonoAndroid10/_._",
-        "lib/MonoTouch10/_._",
-        "lib/net46/System.Threading.ThreadPool.dll",
-        "lib/xamarinios10/_._",
-        "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Threading.ThreadPool.dll",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
-        "ref/net46/System.Threading.ThreadPool.dll",
-        "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.Threading.ThreadPool.4.0.10-beta-23408.nupkg",
-        "System.Threading.ThreadPool.4.0.10-beta-23408.nupkg.sha512",
-        "System.Threading.ThreadPool.nuspec"
       ]
     },
     "System.Threading.Timer/4.0.0": {
@@ -3402,14 +3409,14 @@
         "xunit.extensibility.execution.nuspec"
       ]
     },
-    "xunit.netcore.extensions/1.0.0-prerelease-00104": {
+    "xunit.netcore.extensions/1.0.0-prerelease-00105": {
       "type": "package",
       "serviceable": true,
-      "sha512": "ZMXxEBpGP7krXtvqbPMOWavd2u83w77ghtD254wfj5+d+7GmYYqP9pX1iRIxJK9CBa8Zc2cOrcYsmCLQgYriAQ==",
+      "sha512": "EnnGcy9rmSdQ8izHWvYSYVyjQGhbeFH7JeM/L35ZrrPGtYvq5XD3hc1cJPCs+43mXdF9cdqhkt5uTlXYzC+Z8g==",
       "files": [
         "lib/dotnet/Xunit.NetCore.Extensions.dll",
-        "xunit.netcore.extensions.1.0.0-prerelease-00104.nupkg",
-        "xunit.netcore.extensions.1.0.0-prerelease-00104.nupkg.sha512",
+        "xunit.netcore.extensions.1.0.0-prerelease-00105.nupkg",
+        "xunit.netcore.extensions.1.0.0-prerelease-00105.nupkg.sha512",
         "xunit.netcore.extensions.nuspec"
       ]
     }

--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/TypedClient/project.lock.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/TypedClient/project.lock.json
@@ -292,7 +292,7 @@
           "lib/dotnet/System.Linq.Queryable.dll": {}
         }
       },
-      "System.Net.Http/4.0.1-beta-23408": {
+      "System.Net.Http/4.0.1-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -305,7 +305,7 @@
           "ref/dotnet/System.Net.Http.dll": {}
         }
       },
-      "System.Net.NameResolution/4.0.0-beta-23408": {
+      "System.Net.NameResolution/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Net.Primitives": "4.0.10",
@@ -328,16 +328,17 @@
           "lib/DNXCore50/System.Net.Primitives.dll": {}
         }
       },
-      "System.Net.Security/4.0.0-beta-23408": {
+      "System.Net.Security/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
-          "System.Private.Networking": "4.0.1-beta-23408"
+          "System.IO": "4.0.0",
+          "System.Net.Primitives": "4.0.10",
+          "System.Runtime": "4.0.0",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23412",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Net.Security.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Net.Security.dll": {}
         }
       },
       "System.Net.Sockets/4.1.0-beta-23225": {
@@ -368,7 +369,7 @@
           "lib/dotnet/System.Net.WebHeaderCollection.dll": {}
         }
       },
-      "System.Net.WebSockets/4.0.0-beta-23408": {
+      "System.Net.WebSockets/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -383,7 +384,7 @@
           "lib/dotnet/System.Net.WebSockets.dll": {}
         }
       },
-      "System.Net.WebSockets.Client/4.0.0-beta-23408": {
+      "System.Net.WebSockets.Client/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -393,13 +394,13 @@
           "System.Globalization": "4.0.10",
           "System.Net.Primitives": "4.0.10",
           "System.Net.WebHeaderCollection": "4.0.0",
-          "System.Net.WebSockets": "4.0.0-beta-23408",
+          "System.Net.WebSockets": "4.0.0-beta-23412",
           "System.Resources.ResourceManager": "4.0.0",
           "System.Runtime": "4.0.20",
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23408",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23412",
           "System.Text.Encoding": "4.0.10",
           "System.Threading": "4.0.10",
           "System.Threading.Tasks": "4.0.10"
@@ -456,7 +457,7 @@
           "lib/DNXCore50/System.Private.DataContractSerialization.dll": {}
         }
       },
-      "System.Private.Networking/4.0.1-beta-23408": {
+      "System.Private.Networking/4.0.1-beta-23225": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -475,13 +476,10 @@
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23408",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23408",
-          "System.Security.Principal.Windows": "4.0.0-beta-23408",
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23225",
           "System.Threading": "4.0.10",
           "System.Threading.Overlapped": "4.0.0",
-          "System.Threading.Tasks": "4.0.10",
-          "System.Threading.ThreadPool": "4.0.10-beta-23408"
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dnxcore50/_._": {}
@@ -490,7 +488,7 @@
           "lib/DNXCore50/System.Private.Networking.dll": {}
         }
       },
-      "System.Private.ServiceModel/4.1.0-beta-23408": {
+      "System.Private.ServiceModel/4.1.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -507,14 +505,14 @@
           "System.Linq": "4.0.0",
           "System.Linq.Expressions": "4.0.10",
           "System.Linq.Queryable": "4.0.0",
-          "System.Net.Http": "4.0.1-beta-23408",
-          "System.Net.NameResolution": "4.0.0-beta-23408",
+          "System.Net.Http": "4.0.1-beta-23412",
+          "System.Net.NameResolution": "4.0.0-beta-23412",
           "System.Net.Primitives": "4.0.10",
-          "System.Net.Security": "4.0.0-beta-23408",
-          "System.Net.Sockets": "4.0.10-beta-23408",
+          "System.Net.Security": "4.0.0-beta-23412",
+          "System.Net.Sockets": "4.0.10-beta-23412",
           "System.Net.WebHeaderCollection": "4.0.0",
-          "System.Net.WebSockets": "4.0.0-beta-23408",
-          "System.Net.WebSockets.Client": "4.0.0-beta-23408",
+          "System.Net.WebSockets": "4.0.0-beta-23412",
+          "System.Net.WebSockets.Client": "4.0.0-beta-23412",
           "System.ObjectModel": "4.0.10",
           "System.Reflection": "4.0.10",
           "System.Reflection.DispatchProxy": "4.0.0",
@@ -528,9 +526,9 @@
           "System.Runtime.Serialization.Primitives": "4.0.10",
           "System.Runtime.Serialization.Xml": "4.0.10",
           "System.Security.Claims": "4.0.0",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23408",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23412",
           "System.Security.Principal": "4.0.0",
-          "System.Security.Principal.Windows": "4.0.0-beta-23408",
+          "System.Security.Principal.Windows": "4.0.0-beta-23412",
           "System.Text.Encoding": "4.0.10",
           "System.Threading": "4.0.10",
           "System.Threading.Tasks": "4.0.10",
@@ -779,18 +777,18 @@
           "lib/dotnet/System.Security.Claims.dll": {}
         }
       },
-      "System.Security.Cryptography.Algorithms/4.0.0-beta-23408": {
+      "System.Security.Cryptography.Algorithms/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
           "System.Runtime": "4.0.0",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23408"
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23412"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.Algorithms.dll": {}
         }
       },
-      "System.Security.Cryptography.Encoding/4.0.0-beta-23408": {
+      "System.Security.Cryptography.Encoding/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -799,7 +797,7 @@
           "ref/dotnet/System.Security.Cryptography.Encoding.dll": {}
         }
       },
-      "System.Security.Cryptography.Primitives/4.0.0-beta-23408": {
+      "System.Security.Cryptography.Primitives/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.0",
@@ -817,13 +815,13 @@
           "lib/dotnet/System.Security.Cryptography.Primitives.dll": {}
         }
       },
-      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23408": {
+      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
           "System.Runtime.Handles": "4.0.0",
-          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23408",
-          "System.Security.Cryptography.Encoding": "4.0.0-beta-23408"
+          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23412",
+          "System.Security.Cryptography.Encoding": "4.0.0-beta-23412"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.X509Certificates.dll": {}
@@ -841,7 +839,7 @@
           "lib/dotnet/System.Security.Principal.dll": {}
         }
       },
-      "System.Security.Principal.Windows/4.0.0-beta-23408": {
+      "System.Security.Principal.Windows/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -864,10 +862,10 @@
           "lib/DNXCore50/System.Security.Principal.Windows.dll": {}
         }
       },
-      "System.ServiceModel.Duplex/4.0.1-beta-23408": {
+      "System.ServiceModel.Duplex/4.0.1-beta-23412": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-beta-23408"
+          "System.Private.ServiceModel": "4.1.0-beta-23412"
         },
         "compile": {
           "ref/dotnet/System.ServiceModel.Duplex.dll": {}
@@ -876,10 +874,10 @@
           "lib/DNXCore50/System.ServiceModel.Duplex.dll": {}
         }
       },
-      "System.ServiceModel.Http/4.0.11-beta-23408": {
+      "System.ServiceModel.Http/4.0.11-beta-23412": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-beta-23408",
+          "System.Private.ServiceModel": "4.1.0-beta-23412",
           "System.Runtime": "4.0.20"
         },
         "compile": {
@@ -889,10 +887,10 @@
           "lib/DNXCore50/System.ServiceModel.Http.dll": {}
         }
       },
-      "System.ServiceModel.NetTcp/4.0.1-beta-23408": {
+      "System.ServiceModel.NetTcp/4.0.1-beta-23412": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-beta-23408"
+          "System.Private.ServiceModel": "4.1.0-beta-23412"
         },
         "compile": {
           "ref/dotnet/System.ServiceModel.NetTcp.dll": {}
@@ -901,10 +899,10 @@
           "lib/DNXCore50/System.ServiceModel.NetTcp.dll": {}
         }
       },
-      "System.ServiceModel.Primitives/4.0.1-beta-23408": {
+      "System.ServiceModel.Primitives/4.0.1-beta-23412": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-beta-23408"
+          "System.Private.ServiceModel": "4.1.0-beta-23412"
         },
         "compile": {
           "ref/dotnet/System.ServiceModel.Primitives.dll": {}
@@ -991,19 +989,6 @@
         },
         "runtime": {
           "lib/DNXCore50/System.Threading.Tasks.dll": {}
-        }
-      },
-      "System.Threading.ThreadPool/4.0.10-beta-23408": {
-        "type": "package",
-        "dependencies": {
-          "System.Runtime": "4.0.0",
-          "System.Runtime.InteropServices": "4.0.0"
-        },
-        "compile": {
-          "ref/dotnet/System.Threading.ThreadPool.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Threading.ThreadPool.dll": {}
         }
       },
       "System.Threading.Timer/4.0.0": {
@@ -1186,7 +1171,7 @@
           "lib/dotnet/xunit.execution.dotnet.dll": {}
         }
       },
-      "xunit.netcore.extensions/1.0.0-prerelease-00104": {
+      "xunit.netcore.extensions/1.0.0-prerelease-00105": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.10",
@@ -1814,44 +1799,65 @@
         "System.Linq.Queryable.nuspec"
       ]
     },
-    "System.Net.Http/4.0.1-beta-23408": {
+    "System.Net.Http/4.0.1-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "n+tnV1VgCjbDKKnbgrvgUgxkPDwUFvSv9lTgH882rVzjbWyliVgbBflVzoAUjUSlga/Tr1XQIrfTLMRD5HfYGw==",
+      "sha512": "F7Yej+6QdRVzWg+qbkayRMcmf/7k7YfNFoVSA67wIsG9t5u7Wj4Go8FW72HL8qb9d7YjIsVB/5hA7g9MUT31Aw==",
       "files": [
         "lib/net45/_._",
         "lib/win8/_._",
         "lib/wpa81/_._",
+        "ref/dotnet/de/System.Net.Http.xml",
+        "ref/dotnet/es/System.Net.Http.xml",
+        "ref/dotnet/fr/System.Net.Http.xml",
+        "ref/dotnet/it/System.Net.Http.xml",
+        "ref/dotnet/ja/System.Net.Http.xml",
+        "ref/dotnet/ko/System.Net.Http.xml",
+        "ref/dotnet/ru/System.Net.Http.xml",
         "ref/dotnet/System.Net.Http.dll",
+        "ref/dotnet/System.Net.Http.xml",
+        "ref/dotnet/zh-hans/System.Net.Http.xml",
+        "ref/dotnet/zh-hant/System.Net.Http.xml",
         "ref/net45/_._",
         "ref/netcore50/System.Net.Http.dll",
+        "ref/netcore50/System.Net.Http.xml",
         "ref/win8/_._",
         "ref/wpa81/_._",
         "runtime.json",
-        "System.Net.Http.4.0.1-beta-23408.nupkg",
-        "System.Net.Http.4.0.1-beta-23408.nupkg.sha512",
+        "System.Net.Http.4.0.1-beta-23412.nupkg",
+        "System.Net.Http.4.0.1-beta-23412.nupkg.sha512",
         "System.Net.Http.nuspec"
       ]
     },
-    "System.Net.NameResolution/4.0.0-beta-23408": {
+    "System.Net.NameResolution/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "2A562VFL8GUL/jLCJ3mbQHhwwAIXzPyjxMpdtas1LVM8QLuP1OcHwV3z7ajWnYdGcPc7ZxPEGJQWicuaPD+0nA==",
+      "sha512": "HCF1zhFYBT+w/Ik+JuTzFJgj83Jfc+eA8VcgvIzdPiGMXfrZeXOogjgSCkCoJmFtKVz2DSfmISoEmiXB1oaLNQ==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.NameResolution.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Net.NameResolution.xml",
+        "ref/dotnet/es/System.Net.NameResolution.xml",
+        "ref/dotnet/fr/System.Net.NameResolution.xml",
+        "ref/dotnet/it/System.Net.NameResolution.xml",
+        "ref/dotnet/ja/System.Net.NameResolution.xml",
+        "ref/dotnet/ko/System.Net.NameResolution.xml",
+        "ref/dotnet/ru/System.Net.NameResolution.xml",
         "ref/dotnet/System.Net.NameResolution.dll",
+        "ref/dotnet/System.Net.NameResolution.xml",
+        "ref/dotnet/zh-hans/System.Net.NameResolution.xml",
+        "ref/dotnet/zh-hant/System.Net.NameResolution.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Net.NameResolution.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Net.NameResolution.4.0.0-beta-23408.nupkg",
-        "System.Net.NameResolution.4.0.0-beta-23408.nupkg.sha512",
+        "System.Net.NameResolution.4.0.0-beta-23412.nupkg",
+        "System.Net.NameResolution.4.0.0-beta-23412.nupkg.sha512",
         "System.Net.NameResolution.nuspec"
       ]
     },
@@ -1888,24 +1894,34 @@
         "System.Net.Primitives.nuspec"
       ]
     },
-    "System.Net.Security/4.0.0-beta-23408": {
+    "System.Net.Security/4.0.0-beta-23412": {
       "type": "package",
-      "sha512": "kEkunODO2t/VlBIsC80YFDG0KtY/FyIbtBApNyJQv+LYGEs5IFvEhpi9+p0/jHmhyRMKwbjajNedbXo+VMkt1A==",
+      "sha512": "Kcjne7jnvF5aTbRJsAT8kuP+1mxryUF2qYv8f3jnR19wtEjswSIOVU0XzuWc9YObEQcb+kEdzN71HTOm+ssv+w==",
       "files": [
-        "lib/DNXCore50/System.Net.Security.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.Security.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Net.Security.xml",
+        "ref/dotnet/es/System.Net.Security.xml",
+        "ref/dotnet/fr/System.Net.Security.xml",
+        "ref/dotnet/it/System.Net.Security.xml",
+        "ref/dotnet/ja/System.Net.Security.xml",
+        "ref/dotnet/ko/System.Net.Security.xml",
+        "ref/dotnet/ru/System.Net.Security.xml",
         "ref/dotnet/System.Net.Security.dll",
+        "ref/dotnet/System.Net.Security.xml",
+        "ref/dotnet/zh-hans/System.Net.Security.xml",
+        "ref/dotnet/zh-hant/System.Net.Security.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Net.Security.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.Security.4.0.0-beta-23408.nupkg",
-        "System.Net.Security.4.0.0-beta-23408.nupkg.sha512",
+        "runtime.json",
+        "System.Net.Security.4.0.0-beta-23412.nupkg",
+        "System.Net.Security.4.0.0-beta-23412.nupkg.sha512",
         "System.Net.Security.nuspec"
       ]
     },
@@ -1963,78 +1979,68 @@
         "System.Net.WebHeaderCollection.nuspec"
       ]
     },
-    "System.Net.WebSockets/4.0.0-beta-23408": {
+    "System.Net.WebSockets/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "BXy22/bNVtrXXsG76zXyhjcQnCjSYxQIFF37xWifqPRWmvzsCYSLQpNCTPQUCp7rjB7qWc5yLhC9bThaEx7MHQ==",
+      "sha512": "EvXAa0yd1RM8ROyLl1T0xC94F04Su8YMHnd4/w6j0Z/+4lKHZOU7bQPZ3odDN8WdPGKa/ZNJJGwiapydEWKzwQ==",
       "files": [
-        "lib/dotnet/de/System.Net.WebSockets.xml",
-        "lib/dotnet/es/System.Net.WebSockets.xml",
-        "lib/dotnet/fr/System.Net.WebSockets.xml",
-        "lib/dotnet/it/System.Net.WebSockets.xml",
-        "lib/dotnet/ja/System.Net.WebSockets.xml",
-        "lib/dotnet/ko/System.Net.WebSockets.xml",
-        "lib/dotnet/ru/System.Net.WebSockets.xml",
         "lib/dotnet/System.Net.WebSockets.dll",
-        "lib/dotnet/System.Net.WebSockets.xml",
-        "lib/dotnet/zh-hans/System.Net.WebSockets.xml",
-        "lib/dotnet/zh-hant/System.Net.WebSockets.xml",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.WebSockets.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Net.WebSockets.xml",
+        "ref/dotnet/es/System.Net.WebSockets.xml",
+        "ref/dotnet/fr/System.Net.WebSockets.xml",
+        "ref/dotnet/it/System.Net.WebSockets.xml",
+        "ref/dotnet/ja/System.Net.WebSockets.xml",
+        "ref/dotnet/ko/System.Net.WebSockets.xml",
+        "ref/dotnet/ru/System.Net.WebSockets.xml",
         "ref/dotnet/System.Net.WebSockets.dll",
+        "ref/dotnet/System.Net.WebSockets.xml",
+        "ref/dotnet/zh-hans/System.Net.WebSockets.xml",
+        "ref/dotnet/zh-hant/System.Net.WebSockets.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Net.WebSockets.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.WebSockets.4.0.0-beta-23408.nupkg",
-        "System.Net.WebSockets.4.0.0-beta-23408.nupkg.sha512",
+        "System.Net.WebSockets.4.0.0-beta-23412.nupkg",
+        "System.Net.WebSockets.4.0.0-beta-23412.nupkg.sha512",
         "System.Net.WebSockets.nuspec"
       ]
     },
-    "System.Net.WebSockets.Client/4.0.0-beta-23408": {
+    "System.Net.WebSockets.Client/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "smmvhCkcU0c4RNWc6NZwnN5EFktX58jf8+TJ6enfuXxWrpJ/2NRI5/2yT/okjFSngGK1g0MBrljZsfs2EJ7+Yw==",
+      "sha512": "uaO7c/81sK90605UtThSX9KVmzsJDA1vD4GMW7FsKKntymlkolJsprDekWblQ4A5YbhqxHv+ngXX2kIU0B3Fdw==",
       "files": [
-        "lib/DNXCore50/de/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/es/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/fr/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/it/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/ja/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/ko/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/ru/System.Net.WebSockets.Client.xml",
         "lib/DNXCore50/System.Net.WebSockets.Client.dll",
-        "lib/DNXCore50/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/zh-hans/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/zh-hant/System.Net.WebSockets.Client.xml",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.WebSockets.Client.dll",
-        "lib/netcore50/de/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/es/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/fr/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/it/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/ja/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/ko/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/ru/System.Net.WebSockets.Client.xml",
         "lib/netcore50/System.Net.WebSockets.Client.dll",
-        "lib/netcore50/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/zh-hans/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/zh-hant/System.Net.WebSockets.Client.xml",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/es/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/fr/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/it/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/ja/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/ko/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/ru/System.Net.WebSockets.Client.xml",
         "ref/dotnet/System.Net.WebSockets.Client.dll",
+        "ref/dotnet/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/zh-hans/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/zh-hant/System.Net.WebSockets.Client.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Net.WebSockets.Client.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.WebSockets.Client.4.0.0-beta-23408.nupkg",
-        "System.Net.WebSockets.Client.4.0.0-beta-23408.nupkg.sha512",
+        "System.Net.WebSockets.Client.4.0.0-beta-23412.nupkg",
+        "System.Net.WebSockets.Client.4.0.0-beta-23412.nupkg.sha512",
         "System.Net.WebSockets.Client.nuspec"
       ]
     },
@@ -2086,31 +2092,31 @@
         "System.Private.DataContractSerialization.nuspec"
       ]
     },
-    "System.Private.Networking/4.0.1-beta-23408": {
+    "System.Private.Networking/4.0.1-beta-23225": {
       "type": "package",
       "serviceable": true,
-      "sha512": "i2fRDRqM8Px3CP26C//deF/tCNR1AwqlPEr9+MYiXxNZtgGcSPBfqOJJ5CJdfmDb9Ap0hPG2MiPG7CinaSH7+Q==",
+      "sha512": "oVSynIrR3mIU0b/goscsaZDywr3RLxQijQnaFRKfl/VB3F9rKi5mdr0vHcGVWuq5ALSrG0OLwM8PRA4tM5e3rQ==",
       "files": [
         "lib/DNXCore50/System.Private.Networking.dll",
         "lib/netcore50/System.Private.Networking.dll",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "System.Private.Networking.4.0.1-beta-23408.nupkg",
-        "System.Private.Networking.4.0.1-beta-23408.nupkg.sha512",
+        "System.Private.Networking.4.0.1-beta-23225.nupkg",
+        "System.Private.Networking.4.0.1-beta-23225.nupkg.sha512",
         "System.Private.Networking.nuspec"
       ]
     },
-    "System.Private.ServiceModel/4.1.0-beta-23408": {
+    "System.Private.ServiceModel/4.1.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "l/2192yKa6uXhjKOWeukFJy3hoj9Zq1p55pTGe+Y28r8/5jlvgYxfunP9UyXJRo9W1u3UBtGfV/5R71ULzusGQ==",
+      "sha512": "Wm+8LcQ04YeAvYqu9faHsMZ/L8l/WvPPsqziBfifYB4jXIPXk1/kUxuAryjbLChghZDXvkDN0hv/IHSVPZGgBA==",
       "files": [
         "lib/DNXCore50/System.Private.ServiceModel.dll",
         "lib/netcore50/System.Private.ServiceModel.dll",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "System.Private.ServiceModel.4.1.0-beta-23408.nupkg",
-        "System.Private.ServiceModel.4.1.0-beta-23408.nupkg.sha512",
+        "System.Private.ServiceModel.4.1.0-beta-23412.nupkg",
+        "System.Private.ServiceModel.4.1.0-beta-23412.nupkg.sha512",
         "System.Private.ServiceModel.nuspec"
       ]
     },
@@ -2639,10 +2645,10 @@
         "System.Security.Claims.nuspec"
       ]
     },
-    "System.Security.Cryptography.Algorithms/4.0.0-beta-23408": {
+    "System.Security.Cryptography.Algorithms/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "G6eEqi8mZRrWftcwilcnllE4xJ/53JQlk3VVuJ+9qrX+DHvWz8itYJRUZX357JY4DgEEKQNOJzuRGrOBTUeoPg==",
+      "sha512": "nBjoiqJQiMD3cJgOVrqjIVDqEEPZeIqT+mrBIxjLE+YMQcjEyDuSyOG65Ntoopby5LH4onTLMM4zfXh8JRt9NQ==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2656,37 +2662,47 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.Algorithms.4.0.0-beta-23408.nupkg",
-        "System.Security.Cryptography.Algorithms.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Cryptography.Algorithms.4.0.0-beta-23412.nupkg",
+        "System.Security.Cryptography.Algorithms.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Cryptography.Algorithms.nuspec"
       ]
     },
-    "System.Security.Cryptography.Encoding/4.0.0-beta-23408": {
+    "System.Security.Cryptography.Encoding/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "fPsAK3vyMjnJ6nT4YchdS7KzfGca/6uVVAPCBO08ZpTRGhMGx30vq1MiIqAUrfsFMnot3Ub2jimnAFWkqY6g0Q==",
+      "sha512": "SR1zCARNdeyLoUKYH2SNMm1He7Lr3NR/l7yW3K135L44T6PS3YB8SfXpVoZdMpb22X2G07BZAHVz2x7e4AA1Cg==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Security.Cryptography.Encoding.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/es/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/fr/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/it/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/ja/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/ko/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/ru/System.Security.Cryptography.Encoding.xml",
         "ref/dotnet/System.Security.Cryptography.Encoding.dll",
+        "ref/dotnet/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/zh-hans/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/zh-hant/System.Security.Cryptography.Encoding.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Security.Cryptography.Encoding.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.Encoding.4.0.0-beta-23408.nupkg",
-        "System.Security.Cryptography.Encoding.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Cryptography.Encoding.4.0.0-beta-23412.nupkg",
+        "System.Security.Cryptography.Encoding.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Cryptography.Encoding.nuspec"
       ]
     },
-    "System.Security.Cryptography.Primitives/4.0.0-beta-23408": {
+    "System.Security.Cryptography.Primitives/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "A336dWYEIQxm1rEJCaE5ZZrUWHPUkBGTRH8uAj8qrTqg4/qRc2yN2wZxeGXaZauhI35QwDmOutK7oVb2Cd+4TA==",
+      "sha512": "H9EBNe0ahjAYjlVn0TnT18PSgZBrtROSQH1RRIKwAjzxQHt8zwDhO4yN0Q5QaaUIoSXgxVmgtWWk62wDvpy+QA==",
       "files": [
         "lib/dotnet/System.Security.Cryptography.Primitives.dll",
         "lib/MonoAndroid10/_._",
@@ -2700,30 +2716,40 @@
         "ref/net46/System.Security.Cryptography.Primitives.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Security.Cryptography.Primitives.4.0.0-beta-23408.nupkg",
-        "System.Security.Cryptography.Primitives.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Cryptography.Primitives.4.0.0-beta-23412.nupkg",
+        "System.Security.Cryptography.Primitives.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Cryptography.Primitives.nuspec"
       ]
     },
-    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23408": {
+    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "JSNf5d1V5Y47MIdf7QxZCuGnR5heM4UKbrsdXiWD5lfqu0mnNjebPIclMUXlTw/6IykuDsUpompV/DtsaLLHig==",
+      "sha512": "SfpMjvrfRaRjG42uynLugb3YgpXdpnU7X8vNAU7stIR5/4uW9m1SvWHvBjirjHRBtOpbKB86uD5ODQWX+tWDNA==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Security.Cryptography.X509Certificates.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/es/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/fr/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/it/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/ja/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/ko/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/ru/System.Security.Cryptography.X509Certificates.xml",
         "ref/dotnet/System.Security.Cryptography.X509Certificates.dll",
+        "ref/dotnet/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/zh-hans/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/zh-hant/System.Security.Cryptography.X509Certificates.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Security.Cryptography.X509Certificates.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23408.nupkg",
-        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23412.nupkg",
+        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Cryptography.X509Certificates.nuspec"
       ]
     },
@@ -2760,144 +2786,147 @@
         "System.Security.Principal.nuspec"
       ]
     },
-    "System.Security.Principal.Windows/4.0.0-beta-23408": {
+    "System.Security.Principal.Windows/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "xmjpZJvsT1AW23UkjqUkF/VrOh7DA1cagYY272UQmO8ei227TFD4C7j3ofatL/63hR3CXkLkoephuE4f2Z9fGA==",
+      "sha512": "Zvb/LzT+GjGNV1t8i5KVieilL+8P5LcQykIbJHw5aJxLPFEIQ4Y2hTJXdEkeKvZ4TCF5dlwY1jYyUrJkcqpxzw==",
       "files": [
-        "lib/DNXCore50/de/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/es/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/fr/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/it/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/ja/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/ko/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/ru/System.Security.Principal.Windows.xml",
         "lib/DNXCore50/System.Security.Principal.Windows.dll",
-        "lib/DNXCore50/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/zh-hans/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/zh-hant/System.Security.Principal.Windows.xml",
         "lib/net46/System.Security.Principal.Windows.dll",
+        "ref/dotnet/de/System.Security.Principal.Windows.xml",
+        "ref/dotnet/es/System.Security.Principal.Windows.xml",
+        "ref/dotnet/fr/System.Security.Principal.Windows.xml",
+        "ref/dotnet/it/System.Security.Principal.Windows.xml",
+        "ref/dotnet/ja/System.Security.Principal.Windows.xml",
+        "ref/dotnet/ko/System.Security.Principal.Windows.xml",
+        "ref/dotnet/ru/System.Security.Principal.Windows.xml",
         "ref/dotnet/System.Security.Principal.Windows.dll",
+        "ref/dotnet/System.Security.Principal.Windows.xml",
+        "ref/dotnet/zh-hans/System.Security.Principal.Windows.xml",
+        "ref/dotnet/zh-hant/System.Security.Principal.Windows.xml",
         "ref/net46/System.Security.Principal.Windows.dll",
-        "System.Security.Principal.Windows.4.0.0-beta-23408.nupkg",
-        "System.Security.Principal.Windows.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Principal.Windows.4.0.0-beta-23412.nupkg",
+        "System.Security.Principal.Windows.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Principal.Windows.nuspec"
       ]
     },
-    "System.ServiceModel.Duplex/4.0.1-beta-23408": {
+    "System.ServiceModel.Duplex/4.0.1-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "ZJ3aN/aEg801Rw+aVbBFZ+I9J51FyQVCoWOvSqTSh5i4qZuWuenCxmxahby43teIqNcCrCtHPoyRan2GfY8Vyg==",
+      "sha512": "o5w/amLOdG4NIfER18/TI69QL11pboppiBgH2fIwjzasKZ1OIlxE+KJPbvHJ5vt554reZYCcA+jY4CIx7/pkiw==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Duplex.dll",
         "lib/net45/_._",
-        "lib/netcore50/de/System.ServiceModel.Duplex.xml",
-        "lib/netcore50/es/System.ServiceModel.Duplex.xml",
-        "lib/netcore50/fr/System.ServiceModel.Duplex.xml",
-        "lib/netcore50/it/System.ServiceModel.Duplex.xml",
-        "lib/netcore50/ja/System.ServiceModel.Duplex.xml",
-        "lib/netcore50/ko/System.ServiceModel.Duplex.xml",
-        "lib/netcore50/ru/System.ServiceModel.Duplex.xml",
         "lib/netcore50/System.ServiceModel.Duplex.dll",
-        "lib/netcore50/System.ServiceModel.Duplex.xml",
-        "lib/netcore50/zh-hans/System.ServiceModel.Duplex.xml",
-        "lib/netcore50/zh-hant/System.ServiceModel.Duplex.xml",
         "lib/win8/_._",
+        "ref/dotnet/de/System.ServiceModel.Duplex.xml",
+        "ref/dotnet/es/System.ServiceModel.Duplex.xml",
+        "ref/dotnet/fr/System.ServiceModel.Duplex.xml",
+        "ref/dotnet/it/System.ServiceModel.Duplex.xml",
+        "ref/dotnet/ja/System.ServiceModel.Duplex.xml",
+        "ref/dotnet/ko/System.ServiceModel.Duplex.xml",
+        "ref/dotnet/ru/System.ServiceModel.Duplex.xml",
         "ref/dotnet/System.ServiceModel.Duplex.dll",
+        "ref/dotnet/System.ServiceModel.Duplex.xml",
+        "ref/dotnet/zh-hans/System.ServiceModel.Duplex.xml",
+        "ref/dotnet/zh-hant/System.ServiceModel.Duplex.xml",
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.Duplex.dll",
+        "ref/netcore50/System.ServiceModel.Duplex.xml",
         "ref/win8/_._",
-        "System.ServiceModel.Duplex.4.0.1-beta-23408.nupkg",
-        "System.ServiceModel.Duplex.4.0.1-beta-23408.nupkg.sha512",
+        "System.ServiceModel.Duplex.4.0.1-beta-23412.nupkg",
+        "System.ServiceModel.Duplex.4.0.1-beta-23412.nupkg.sha512",
         "System.ServiceModel.Duplex.nuspec"
       ]
     },
-    "System.ServiceModel.Http/4.0.11-beta-23408": {
+    "System.ServiceModel.Http/4.0.11-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "RScHZ1A3CfjumaP1Vh/xfOp/ga6T3nA8YLkjFOYcIcZm/LILL+yCh+PhIrJOEfz1Js8bLSQC6xbxwYlW6BNmYg==",
+      "sha512": "hKMGQbu/l2gv/PgPvm2ViLVElnVSwAPiv4cXKjinS+UHBf02uPF2m7lN13SCkJDNTBctwHav1rQnMYb1LUJHvw==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Http.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
-        "lib/netcore50/de/System.ServiceModel.Http.xml",
-        "lib/netcore50/es/System.ServiceModel.Http.xml",
-        "lib/netcore50/fr/System.ServiceModel.Http.xml",
-        "lib/netcore50/it/System.ServiceModel.Http.xml",
-        "lib/netcore50/ja/System.ServiceModel.Http.xml",
-        "lib/netcore50/ko/System.ServiceModel.Http.xml",
-        "lib/netcore50/ru/System.ServiceModel.Http.xml",
         "lib/netcore50/System.ServiceModel.Http.dll",
-        "lib/netcore50/System.ServiceModel.Http.xml",
-        "lib/netcore50/zh-hans/System.ServiceModel.Http.xml",
-        "lib/netcore50/zh-hant/System.ServiceModel.Http.xml",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.ServiceModel.Http.xml",
+        "ref/dotnet/es/System.ServiceModel.Http.xml",
+        "ref/dotnet/fr/System.ServiceModel.Http.xml",
+        "ref/dotnet/it/System.ServiceModel.Http.xml",
+        "ref/dotnet/ja/System.ServiceModel.Http.xml",
+        "ref/dotnet/ko/System.ServiceModel.Http.xml",
+        "ref/dotnet/ru/System.ServiceModel.Http.xml",
         "ref/dotnet/System.ServiceModel.Http.dll",
+        "ref/dotnet/System.ServiceModel.Http.xml",
+        "ref/dotnet/zh-hans/System.ServiceModel.Http.xml",
+        "ref/dotnet/zh-hant/System.ServiceModel.Http.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.ServiceModel.Http.4.0.11-beta-23408.nupkg",
-        "System.ServiceModel.Http.4.0.11-beta-23408.nupkg.sha512",
+        "System.ServiceModel.Http.4.0.11-beta-23412.nupkg",
+        "System.ServiceModel.Http.4.0.11-beta-23412.nupkg.sha512",
         "System.ServiceModel.Http.nuspec"
       ]
     },
-    "System.ServiceModel.NetTcp/4.0.1-beta-23408": {
+    "System.ServiceModel.NetTcp/4.0.1-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "ppruBpqoE6AngTs6fABV67r1ic6rKCgr6tw+4lMoRucrNWNfKgX5vWlONOqSd8bQXmQLZ/ftEhDGXYY5CLRUTQ==",
+      "sha512": "9I2iOpoYB8DtVy1Sw6BmOj6NGoxt9cKwOOds4q6G1JLzyyWErsv/FMeGAJT07bgLr8vnMx4s8GXxjCfkUwNtTw==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.NetTcp.dll",
         "lib/net45/_._",
-        "lib/netcore50/de/System.ServiceModel.NetTcp.xml",
-        "lib/netcore50/es/System.ServiceModel.NetTcp.xml",
-        "lib/netcore50/fr/System.ServiceModel.NetTcp.xml",
-        "lib/netcore50/it/System.ServiceModel.NetTcp.xml",
-        "lib/netcore50/ja/System.ServiceModel.NetTcp.xml",
-        "lib/netcore50/ko/System.ServiceModel.NetTcp.xml",
-        "lib/netcore50/ru/System.ServiceModel.NetTcp.xml",
         "lib/netcore50/System.ServiceModel.NetTcp.dll",
-        "lib/netcore50/System.ServiceModel.NetTcp.xml",
-        "lib/netcore50/zh-hans/System.ServiceModel.NetTcp.xml",
-        "lib/netcore50/zh-hant/System.ServiceModel.NetTcp.xml",
         "lib/win8/_._",
+        "ref/dotnet/de/System.ServiceModel.NetTcp.xml",
+        "ref/dotnet/es/System.ServiceModel.NetTcp.xml",
+        "ref/dotnet/fr/System.ServiceModel.NetTcp.xml",
+        "ref/dotnet/it/System.ServiceModel.NetTcp.xml",
+        "ref/dotnet/ja/System.ServiceModel.NetTcp.xml",
+        "ref/dotnet/ko/System.ServiceModel.NetTcp.xml",
+        "ref/dotnet/ru/System.ServiceModel.NetTcp.xml",
         "ref/dotnet/System.ServiceModel.NetTcp.dll",
+        "ref/dotnet/System.ServiceModel.NetTcp.xml",
+        "ref/dotnet/zh-hans/System.ServiceModel.NetTcp.xml",
+        "ref/dotnet/zh-hant/System.ServiceModel.NetTcp.xml",
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.NetTcp.dll",
+        "ref/netcore50/System.ServiceModel.NetTcp.xml",
         "ref/win8/_._",
-        "System.ServiceModel.NetTcp.4.0.1-beta-23408.nupkg",
-        "System.ServiceModel.NetTcp.4.0.1-beta-23408.nupkg.sha512",
+        "System.ServiceModel.NetTcp.4.0.1-beta-23412.nupkg",
+        "System.ServiceModel.NetTcp.4.0.1-beta-23412.nupkg.sha512",
         "System.ServiceModel.NetTcp.nuspec"
       ]
     },
-    "System.ServiceModel.Primitives/4.0.1-beta-23408": {
+    "System.ServiceModel.Primitives/4.0.1-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "bjXzg+V3Oq/tBXpMY5FwcERN2CQsFXoL4BMoURlwiBMkgwN2CPvBIaK45Moh7nc21jNTVukNayDtURetGzK6aA==",
+      "sha512": "dkCUkNtXb2m9Wf+DY7dc5B4J8DpaWtX4wpFfT3cYLpChxAnjQR85N+tJfMEHLfZNNerKgDRyGyaKa7uSHfvb5g==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Primitives.dll",
         "lib/net45/_._",
-        "lib/netcore50/de/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/es/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/fr/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/it/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/ja/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/ko/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/ru/System.ServiceModel.Primitives.xml",
         "lib/netcore50/System.ServiceModel.Primitives.dll",
-        "lib/netcore50/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/zh-hans/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/zh-hant/System.ServiceModel.Primitives.xml",
         "lib/win8/_._",
+        "ref/dotnet/de/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/es/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/fr/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/it/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/ja/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/ko/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/ru/System.ServiceModel.Primitives.xml",
         "ref/dotnet/System.ServiceModel.Primitives.dll",
+        "ref/dotnet/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/zh-hans/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/zh-hant/System.ServiceModel.Primitives.xml",
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.Primitives.dll",
+        "ref/netcore50/System.ServiceModel.Primitives.xml",
         "ref/win8/_._",
-        "System.ServiceModel.Primitives.4.0.1-beta-23408.nupkg",
-        "System.ServiceModel.Primitives.4.0.1-beta-23408.nupkg.sha512",
+        "System.ServiceModel.Primitives.4.0.1-beta-23412.nupkg",
+        "System.ServiceModel.Primitives.4.0.1-beta-23412.nupkg.sha512",
         "System.ServiceModel.Primitives.nuspec"
       ]
     },
@@ -3090,28 +3119,6 @@
         "System.Threading.Tasks.4.0.10.nupkg",
         "System.Threading.Tasks.4.0.10.nupkg.sha512",
         "System.Threading.Tasks.nuspec"
-      ]
-    },
-    "System.Threading.ThreadPool/4.0.10-beta-23408": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "ahdsVyj+WFj8/iSDwX/G7hkEU4jZmmvWzPS2ajZKdp0Crb0vZJOlM0LQYVASQgbimrUZHQ50o93JYEi8RFdh/Q==",
-      "files": [
-        "lib/DNXCore50/System.Threading.ThreadPool.dll",
-        "lib/MonoAndroid10/_._",
-        "lib/MonoTouch10/_._",
-        "lib/net46/System.Threading.ThreadPool.dll",
-        "lib/xamarinios10/_._",
-        "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Threading.ThreadPool.dll",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
-        "ref/net46/System.Threading.ThreadPool.dll",
-        "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.Threading.ThreadPool.4.0.10-beta-23408.nupkg",
-        "System.Threading.ThreadPool.4.0.10-beta-23408.nupkg.sha512",
-        "System.Threading.ThreadPool.nuspec"
       ]
     },
     "System.Threading.Timer/4.0.0": {
@@ -3361,14 +3368,14 @@
         "xunit.extensibility.execution.nuspec"
       ]
     },
-    "xunit.netcore.extensions/1.0.0-prerelease-00104": {
+    "xunit.netcore.extensions/1.0.0-prerelease-00105": {
       "type": "package",
       "serviceable": true,
-      "sha512": "ZMXxEBpGP7krXtvqbPMOWavd2u83w77ghtD254wfj5+d+7GmYYqP9pX1iRIxJK9CBa8Zc2cOrcYsmCLQgYriAQ==",
+      "sha512": "EnnGcy9rmSdQ8izHWvYSYVyjQGhbeFH7JeM/L35ZrrPGtYvq5XD3hc1cJPCs+43mXdF9cdqhkt5uTlXYzC+Z8g==",
       "files": [
         "lib/dotnet/Xunit.NetCore.Extensions.dll",
-        "xunit.netcore.extensions.1.0.0-prerelease-00104.nupkg",
-        "xunit.netcore.extensions.1.0.0-prerelease-00104.nupkg.sha512",
+        "xunit.netcore.extensions.1.0.0-prerelease-00105.nupkg",
+        "xunit.netcore.extensions.1.0.0-prerelease-00105.nupkg.sha512",
         "xunit.netcore.extensions.nuspec"
       ]
     }

--- a/src/System.Private.ServiceModel/tests/Scenarios/Contract/Data/project.lock.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Contract/Data/project.lock.json
@@ -292,7 +292,7 @@
           "lib/dotnet/System.Linq.Queryable.dll": {}
         }
       },
-      "System.Net.Http/4.0.1-beta-23408": {
+      "System.Net.Http/4.0.1-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -305,7 +305,7 @@
           "ref/dotnet/System.Net.Http.dll": {}
         }
       },
-      "System.Net.NameResolution/4.0.0-beta-23408": {
+      "System.Net.NameResolution/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Net.Primitives": "4.0.10",
@@ -328,16 +328,17 @@
           "lib/DNXCore50/System.Net.Primitives.dll": {}
         }
       },
-      "System.Net.Security/4.0.0-beta-23408": {
+      "System.Net.Security/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
-          "System.Private.Networking": "4.0.1-beta-23408"
+          "System.IO": "4.0.0",
+          "System.Net.Primitives": "4.0.10",
+          "System.Runtime": "4.0.0",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23412",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Net.Security.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Net.Security.dll": {}
         }
       },
       "System.Net.Sockets/4.1.0-beta-23225": {
@@ -368,7 +369,7 @@
           "lib/dotnet/System.Net.WebHeaderCollection.dll": {}
         }
       },
-      "System.Net.WebSockets/4.0.0-beta-23408": {
+      "System.Net.WebSockets/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -383,7 +384,7 @@
           "lib/dotnet/System.Net.WebSockets.dll": {}
         }
       },
-      "System.Net.WebSockets.Client/4.0.0-beta-23408": {
+      "System.Net.WebSockets.Client/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -393,13 +394,13 @@
           "System.Globalization": "4.0.10",
           "System.Net.Primitives": "4.0.10",
           "System.Net.WebHeaderCollection": "4.0.0",
-          "System.Net.WebSockets": "4.0.0-beta-23408",
+          "System.Net.WebSockets": "4.0.0-beta-23412",
           "System.Resources.ResourceManager": "4.0.0",
           "System.Runtime": "4.0.20",
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23408",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23412",
           "System.Text.Encoding": "4.0.10",
           "System.Threading": "4.0.10",
           "System.Threading.Tasks": "4.0.10"
@@ -456,7 +457,7 @@
           "lib/DNXCore50/System.Private.DataContractSerialization.dll": {}
         }
       },
-      "System.Private.Networking/4.0.1-beta-23408": {
+      "System.Private.Networking/4.0.1-beta-23225": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -475,13 +476,10 @@
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23408",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23408",
-          "System.Security.Principal.Windows": "4.0.0-beta-23408",
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23225",
           "System.Threading": "4.0.10",
           "System.Threading.Overlapped": "4.0.0",
-          "System.Threading.Tasks": "4.0.10",
-          "System.Threading.ThreadPool": "4.0.10-beta-23408"
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dnxcore50/_._": {}
@@ -490,7 +488,7 @@
           "lib/DNXCore50/System.Private.Networking.dll": {}
         }
       },
-      "System.Private.ServiceModel/4.1.0-beta-23408": {
+      "System.Private.ServiceModel/4.1.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -507,14 +505,14 @@
           "System.Linq": "4.0.0",
           "System.Linq.Expressions": "4.0.10",
           "System.Linq.Queryable": "4.0.0",
-          "System.Net.Http": "4.0.1-beta-23408",
-          "System.Net.NameResolution": "4.0.0-beta-23408",
+          "System.Net.Http": "4.0.1-beta-23412",
+          "System.Net.NameResolution": "4.0.0-beta-23412",
           "System.Net.Primitives": "4.0.10",
-          "System.Net.Security": "4.0.0-beta-23408",
-          "System.Net.Sockets": "4.0.10-beta-23408",
+          "System.Net.Security": "4.0.0-beta-23412",
+          "System.Net.Sockets": "4.0.10-beta-23412",
           "System.Net.WebHeaderCollection": "4.0.0",
-          "System.Net.WebSockets": "4.0.0-beta-23408",
-          "System.Net.WebSockets.Client": "4.0.0-beta-23408",
+          "System.Net.WebSockets": "4.0.0-beta-23412",
+          "System.Net.WebSockets.Client": "4.0.0-beta-23412",
           "System.ObjectModel": "4.0.10",
           "System.Reflection": "4.0.10",
           "System.Reflection.DispatchProxy": "4.0.0",
@@ -528,9 +526,9 @@
           "System.Runtime.Serialization.Primitives": "4.0.10",
           "System.Runtime.Serialization.Xml": "4.0.10",
           "System.Security.Claims": "4.0.0",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23408",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23412",
           "System.Security.Principal": "4.0.0",
-          "System.Security.Principal.Windows": "4.0.0-beta-23408",
+          "System.Security.Principal.Windows": "4.0.0-beta-23412",
           "System.Text.Encoding": "4.0.10",
           "System.Threading": "4.0.10",
           "System.Threading.Tasks": "4.0.10",
@@ -794,18 +792,18 @@
           "lib/dotnet/System.Security.Claims.dll": {}
         }
       },
-      "System.Security.Cryptography.Algorithms/4.0.0-beta-23408": {
+      "System.Security.Cryptography.Algorithms/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
           "System.Runtime": "4.0.0",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23408"
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23412"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.Algorithms.dll": {}
         }
       },
-      "System.Security.Cryptography.Encoding/4.0.0-beta-23408": {
+      "System.Security.Cryptography.Encoding/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -814,7 +812,7 @@
           "ref/dotnet/System.Security.Cryptography.Encoding.dll": {}
         }
       },
-      "System.Security.Cryptography.Primitives/4.0.0-beta-23408": {
+      "System.Security.Cryptography.Primitives/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.0",
@@ -832,13 +830,13 @@
           "lib/dotnet/System.Security.Cryptography.Primitives.dll": {}
         }
       },
-      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23408": {
+      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
           "System.Runtime.Handles": "4.0.0",
-          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23408",
-          "System.Security.Cryptography.Encoding": "4.0.0-beta-23408"
+          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23412",
+          "System.Security.Cryptography.Encoding": "4.0.0-beta-23412"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.X509Certificates.dll": {}
@@ -856,7 +854,7 @@
           "lib/dotnet/System.Security.Principal.dll": {}
         }
       },
-      "System.Security.Principal.Windows/4.0.0-beta-23408": {
+      "System.Security.Principal.Windows/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -879,10 +877,10 @@
           "lib/DNXCore50/System.Security.Principal.Windows.dll": {}
         }
       },
-      "System.ServiceModel.Duplex/4.0.1-beta-23408": {
+      "System.ServiceModel.Duplex/4.0.1-beta-23412": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-beta-23408"
+          "System.Private.ServiceModel": "4.1.0-beta-23412"
         },
         "compile": {
           "ref/dotnet/System.ServiceModel.Duplex.dll": {}
@@ -891,10 +889,10 @@
           "lib/DNXCore50/System.ServiceModel.Duplex.dll": {}
         }
       },
-      "System.ServiceModel.Http/4.0.11-beta-23408": {
+      "System.ServiceModel.Http/4.0.11-beta-23412": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-beta-23408",
+          "System.Private.ServiceModel": "4.1.0-beta-23412",
           "System.Runtime": "4.0.20"
         },
         "compile": {
@@ -904,10 +902,10 @@
           "lib/DNXCore50/System.ServiceModel.Http.dll": {}
         }
       },
-      "System.ServiceModel.NetTcp/4.0.1-beta-23408": {
+      "System.ServiceModel.NetTcp/4.0.1-beta-23412": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-beta-23408"
+          "System.Private.ServiceModel": "4.1.0-beta-23412"
         },
         "compile": {
           "ref/dotnet/System.ServiceModel.NetTcp.dll": {}
@@ -916,10 +914,10 @@
           "lib/DNXCore50/System.ServiceModel.NetTcp.dll": {}
         }
       },
-      "System.ServiceModel.Primitives/4.0.1-beta-23408": {
+      "System.ServiceModel.Primitives/4.0.1-beta-23412": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-beta-23408"
+          "System.Private.ServiceModel": "4.1.0-beta-23412"
         },
         "compile": {
           "ref/dotnet/System.ServiceModel.Primitives.dll": {}
@@ -1006,19 +1004,6 @@
         },
         "runtime": {
           "lib/DNXCore50/System.Threading.Tasks.dll": {}
-        }
-      },
-      "System.Threading.ThreadPool/4.0.10-beta-23408": {
-        "type": "package",
-        "dependencies": {
-          "System.Runtime": "4.0.0",
-          "System.Runtime.InteropServices": "4.0.0"
-        },
-        "compile": {
-          "ref/dotnet/System.Threading.ThreadPool.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Threading.ThreadPool.dll": {}
         }
       },
       "System.Threading.Timer/4.0.0": {
@@ -1201,7 +1186,7 @@
           "lib/dotnet/xunit.execution.dotnet.dll": {}
         }
       },
-      "xunit.netcore.extensions/1.0.0-prerelease-00104": {
+      "xunit.netcore.extensions/1.0.0-prerelease-00105": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.10",
@@ -1829,44 +1814,65 @@
         "System.Linq.Queryable.nuspec"
       ]
     },
-    "System.Net.Http/4.0.1-beta-23408": {
+    "System.Net.Http/4.0.1-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "n+tnV1VgCjbDKKnbgrvgUgxkPDwUFvSv9lTgH882rVzjbWyliVgbBflVzoAUjUSlga/Tr1XQIrfTLMRD5HfYGw==",
+      "sha512": "F7Yej+6QdRVzWg+qbkayRMcmf/7k7YfNFoVSA67wIsG9t5u7Wj4Go8FW72HL8qb9d7YjIsVB/5hA7g9MUT31Aw==",
       "files": [
         "lib/net45/_._",
         "lib/win8/_._",
         "lib/wpa81/_._",
+        "ref/dotnet/de/System.Net.Http.xml",
+        "ref/dotnet/es/System.Net.Http.xml",
+        "ref/dotnet/fr/System.Net.Http.xml",
+        "ref/dotnet/it/System.Net.Http.xml",
+        "ref/dotnet/ja/System.Net.Http.xml",
+        "ref/dotnet/ko/System.Net.Http.xml",
+        "ref/dotnet/ru/System.Net.Http.xml",
         "ref/dotnet/System.Net.Http.dll",
+        "ref/dotnet/System.Net.Http.xml",
+        "ref/dotnet/zh-hans/System.Net.Http.xml",
+        "ref/dotnet/zh-hant/System.Net.Http.xml",
         "ref/net45/_._",
         "ref/netcore50/System.Net.Http.dll",
+        "ref/netcore50/System.Net.Http.xml",
         "ref/win8/_._",
         "ref/wpa81/_._",
         "runtime.json",
-        "System.Net.Http.4.0.1-beta-23408.nupkg",
-        "System.Net.Http.4.0.1-beta-23408.nupkg.sha512",
+        "System.Net.Http.4.0.1-beta-23412.nupkg",
+        "System.Net.Http.4.0.1-beta-23412.nupkg.sha512",
         "System.Net.Http.nuspec"
       ]
     },
-    "System.Net.NameResolution/4.0.0-beta-23408": {
+    "System.Net.NameResolution/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "2A562VFL8GUL/jLCJ3mbQHhwwAIXzPyjxMpdtas1LVM8QLuP1OcHwV3z7ajWnYdGcPc7ZxPEGJQWicuaPD+0nA==",
+      "sha512": "HCF1zhFYBT+w/Ik+JuTzFJgj83Jfc+eA8VcgvIzdPiGMXfrZeXOogjgSCkCoJmFtKVz2DSfmISoEmiXB1oaLNQ==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.NameResolution.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Net.NameResolution.xml",
+        "ref/dotnet/es/System.Net.NameResolution.xml",
+        "ref/dotnet/fr/System.Net.NameResolution.xml",
+        "ref/dotnet/it/System.Net.NameResolution.xml",
+        "ref/dotnet/ja/System.Net.NameResolution.xml",
+        "ref/dotnet/ko/System.Net.NameResolution.xml",
+        "ref/dotnet/ru/System.Net.NameResolution.xml",
         "ref/dotnet/System.Net.NameResolution.dll",
+        "ref/dotnet/System.Net.NameResolution.xml",
+        "ref/dotnet/zh-hans/System.Net.NameResolution.xml",
+        "ref/dotnet/zh-hant/System.Net.NameResolution.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Net.NameResolution.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Net.NameResolution.4.0.0-beta-23408.nupkg",
-        "System.Net.NameResolution.4.0.0-beta-23408.nupkg.sha512",
+        "System.Net.NameResolution.4.0.0-beta-23412.nupkg",
+        "System.Net.NameResolution.4.0.0-beta-23412.nupkg.sha512",
         "System.Net.NameResolution.nuspec"
       ]
     },
@@ -1903,24 +1909,34 @@
         "System.Net.Primitives.nuspec"
       ]
     },
-    "System.Net.Security/4.0.0-beta-23408": {
+    "System.Net.Security/4.0.0-beta-23412": {
       "type": "package",
-      "sha512": "kEkunODO2t/VlBIsC80YFDG0KtY/FyIbtBApNyJQv+LYGEs5IFvEhpi9+p0/jHmhyRMKwbjajNedbXo+VMkt1A==",
+      "sha512": "Kcjne7jnvF5aTbRJsAT8kuP+1mxryUF2qYv8f3jnR19wtEjswSIOVU0XzuWc9YObEQcb+kEdzN71HTOm+ssv+w==",
       "files": [
-        "lib/DNXCore50/System.Net.Security.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.Security.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Net.Security.xml",
+        "ref/dotnet/es/System.Net.Security.xml",
+        "ref/dotnet/fr/System.Net.Security.xml",
+        "ref/dotnet/it/System.Net.Security.xml",
+        "ref/dotnet/ja/System.Net.Security.xml",
+        "ref/dotnet/ko/System.Net.Security.xml",
+        "ref/dotnet/ru/System.Net.Security.xml",
         "ref/dotnet/System.Net.Security.dll",
+        "ref/dotnet/System.Net.Security.xml",
+        "ref/dotnet/zh-hans/System.Net.Security.xml",
+        "ref/dotnet/zh-hant/System.Net.Security.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Net.Security.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.Security.4.0.0-beta-23408.nupkg",
-        "System.Net.Security.4.0.0-beta-23408.nupkg.sha512",
+        "runtime.json",
+        "System.Net.Security.4.0.0-beta-23412.nupkg",
+        "System.Net.Security.4.0.0-beta-23412.nupkg.sha512",
         "System.Net.Security.nuspec"
       ]
     },
@@ -1978,78 +1994,68 @@
         "System.Net.WebHeaderCollection.nuspec"
       ]
     },
-    "System.Net.WebSockets/4.0.0-beta-23408": {
+    "System.Net.WebSockets/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "BXy22/bNVtrXXsG76zXyhjcQnCjSYxQIFF37xWifqPRWmvzsCYSLQpNCTPQUCp7rjB7qWc5yLhC9bThaEx7MHQ==",
+      "sha512": "EvXAa0yd1RM8ROyLl1T0xC94F04Su8YMHnd4/w6j0Z/+4lKHZOU7bQPZ3odDN8WdPGKa/ZNJJGwiapydEWKzwQ==",
       "files": [
-        "lib/dotnet/de/System.Net.WebSockets.xml",
-        "lib/dotnet/es/System.Net.WebSockets.xml",
-        "lib/dotnet/fr/System.Net.WebSockets.xml",
-        "lib/dotnet/it/System.Net.WebSockets.xml",
-        "lib/dotnet/ja/System.Net.WebSockets.xml",
-        "lib/dotnet/ko/System.Net.WebSockets.xml",
-        "lib/dotnet/ru/System.Net.WebSockets.xml",
         "lib/dotnet/System.Net.WebSockets.dll",
-        "lib/dotnet/System.Net.WebSockets.xml",
-        "lib/dotnet/zh-hans/System.Net.WebSockets.xml",
-        "lib/dotnet/zh-hant/System.Net.WebSockets.xml",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.WebSockets.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Net.WebSockets.xml",
+        "ref/dotnet/es/System.Net.WebSockets.xml",
+        "ref/dotnet/fr/System.Net.WebSockets.xml",
+        "ref/dotnet/it/System.Net.WebSockets.xml",
+        "ref/dotnet/ja/System.Net.WebSockets.xml",
+        "ref/dotnet/ko/System.Net.WebSockets.xml",
+        "ref/dotnet/ru/System.Net.WebSockets.xml",
         "ref/dotnet/System.Net.WebSockets.dll",
+        "ref/dotnet/System.Net.WebSockets.xml",
+        "ref/dotnet/zh-hans/System.Net.WebSockets.xml",
+        "ref/dotnet/zh-hant/System.Net.WebSockets.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Net.WebSockets.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.WebSockets.4.0.0-beta-23408.nupkg",
-        "System.Net.WebSockets.4.0.0-beta-23408.nupkg.sha512",
+        "System.Net.WebSockets.4.0.0-beta-23412.nupkg",
+        "System.Net.WebSockets.4.0.0-beta-23412.nupkg.sha512",
         "System.Net.WebSockets.nuspec"
       ]
     },
-    "System.Net.WebSockets.Client/4.0.0-beta-23408": {
+    "System.Net.WebSockets.Client/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "smmvhCkcU0c4RNWc6NZwnN5EFktX58jf8+TJ6enfuXxWrpJ/2NRI5/2yT/okjFSngGK1g0MBrljZsfs2EJ7+Yw==",
+      "sha512": "uaO7c/81sK90605UtThSX9KVmzsJDA1vD4GMW7FsKKntymlkolJsprDekWblQ4A5YbhqxHv+ngXX2kIU0B3Fdw==",
       "files": [
-        "lib/DNXCore50/de/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/es/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/fr/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/it/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/ja/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/ko/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/ru/System.Net.WebSockets.Client.xml",
         "lib/DNXCore50/System.Net.WebSockets.Client.dll",
-        "lib/DNXCore50/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/zh-hans/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/zh-hant/System.Net.WebSockets.Client.xml",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.WebSockets.Client.dll",
-        "lib/netcore50/de/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/es/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/fr/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/it/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/ja/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/ko/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/ru/System.Net.WebSockets.Client.xml",
         "lib/netcore50/System.Net.WebSockets.Client.dll",
-        "lib/netcore50/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/zh-hans/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/zh-hant/System.Net.WebSockets.Client.xml",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/es/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/fr/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/it/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/ja/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/ko/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/ru/System.Net.WebSockets.Client.xml",
         "ref/dotnet/System.Net.WebSockets.Client.dll",
+        "ref/dotnet/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/zh-hans/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/zh-hant/System.Net.WebSockets.Client.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Net.WebSockets.Client.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.WebSockets.Client.4.0.0-beta-23408.nupkg",
-        "System.Net.WebSockets.Client.4.0.0-beta-23408.nupkg.sha512",
+        "System.Net.WebSockets.Client.4.0.0-beta-23412.nupkg",
+        "System.Net.WebSockets.Client.4.0.0-beta-23412.nupkg.sha512",
         "System.Net.WebSockets.Client.nuspec"
       ]
     },
@@ -2101,31 +2107,31 @@
         "System.Private.DataContractSerialization.nuspec"
       ]
     },
-    "System.Private.Networking/4.0.1-beta-23408": {
+    "System.Private.Networking/4.0.1-beta-23225": {
       "type": "package",
       "serviceable": true,
-      "sha512": "i2fRDRqM8Px3CP26C//deF/tCNR1AwqlPEr9+MYiXxNZtgGcSPBfqOJJ5CJdfmDb9Ap0hPG2MiPG7CinaSH7+Q==",
+      "sha512": "oVSynIrR3mIU0b/goscsaZDywr3RLxQijQnaFRKfl/VB3F9rKi5mdr0vHcGVWuq5ALSrG0OLwM8PRA4tM5e3rQ==",
       "files": [
         "lib/DNXCore50/System.Private.Networking.dll",
         "lib/netcore50/System.Private.Networking.dll",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "System.Private.Networking.4.0.1-beta-23408.nupkg",
-        "System.Private.Networking.4.0.1-beta-23408.nupkg.sha512",
+        "System.Private.Networking.4.0.1-beta-23225.nupkg",
+        "System.Private.Networking.4.0.1-beta-23225.nupkg.sha512",
         "System.Private.Networking.nuspec"
       ]
     },
-    "System.Private.ServiceModel/4.1.0-beta-23408": {
+    "System.Private.ServiceModel/4.1.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "l/2192yKa6uXhjKOWeukFJy3hoj9Zq1p55pTGe+Y28r8/5jlvgYxfunP9UyXJRo9W1u3UBtGfV/5R71ULzusGQ==",
+      "sha512": "Wm+8LcQ04YeAvYqu9faHsMZ/L8l/WvPPsqziBfifYB4jXIPXk1/kUxuAryjbLChghZDXvkDN0hv/IHSVPZGgBA==",
       "files": [
         "lib/DNXCore50/System.Private.ServiceModel.dll",
         "lib/netcore50/System.Private.ServiceModel.dll",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "System.Private.ServiceModel.4.1.0-beta-23408.nupkg",
-        "System.Private.ServiceModel.4.1.0-beta-23408.nupkg.sha512",
+        "System.Private.ServiceModel.4.1.0-beta-23412.nupkg",
+        "System.Private.ServiceModel.4.1.0-beta-23412.nupkg.sha512",
         "System.Private.ServiceModel.nuspec"
       ]
     },
@@ -2680,10 +2686,10 @@
         "System.Security.Claims.nuspec"
       ]
     },
-    "System.Security.Cryptography.Algorithms/4.0.0-beta-23408": {
+    "System.Security.Cryptography.Algorithms/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "G6eEqi8mZRrWftcwilcnllE4xJ/53JQlk3VVuJ+9qrX+DHvWz8itYJRUZX357JY4DgEEKQNOJzuRGrOBTUeoPg==",
+      "sha512": "nBjoiqJQiMD3cJgOVrqjIVDqEEPZeIqT+mrBIxjLE+YMQcjEyDuSyOG65Ntoopby5LH4onTLMM4zfXh8JRt9NQ==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2697,37 +2703,47 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.Algorithms.4.0.0-beta-23408.nupkg",
-        "System.Security.Cryptography.Algorithms.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Cryptography.Algorithms.4.0.0-beta-23412.nupkg",
+        "System.Security.Cryptography.Algorithms.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Cryptography.Algorithms.nuspec"
       ]
     },
-    "System.Security.Cryptography.Encoding/4.0.0-beta-23408": {
+    "System.Security.Cryptography.Encoding/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "fPsAK3vyMjnJ6nT4YchdS7KzfGca/6uVVAPCBO08ZpTRGhMGx30vq1MiIqAUrfsFMnot3Ub2jimnAFWkqY6g0Q==",
+      "sha512": "SR1zCARNdeyLoUKYH2SNMm1He7Lr3NR/l7yW3K135L44T6PS3YB8SfXpVoZdMpb22X2G07BZAHVz2x7e4AA1Cg==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Security.Cryptography.Encoding.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/es/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/fr/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/it/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/ja/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/ko/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/ru/System.Security.Cryptography.Encoding.xml",
         "ref/dotnet/System.Security.Cryptography.Encoding.dll",
+        "ref/dotnet/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/zh-hans/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/zh-hant/System.Security.Cryptography.Encoding.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Security.Cryptography.Encoding.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.Encoding.4.0.0-beta-23408.nupkg",
-        "System.Security.Cryptography.Encoding.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Cryptography.Encoding.4.0.0-beta-23412.nupkg",
+        "System.Security.Cryptography.Encoding.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Cryptography.Encoding.nuspec"
       ]
     },
-    "System.Security.Cryptography.Primitives/4.0.0-beta-23408": {
+    "System.Security.Cryptography.Primitives/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "A336dWYEIQxm1rEJCaE5ZZrUWHPUkBGTRH8uAj8qrTqg4/qRc2yN2wZxeGXaZauhI35QwDmOutK7oVb2Cd+4TA==",
+      "sha512": "H9EBNe0ahjAYjlVn0TnT18PSgZBrtROSQH1RRIKwAjzxQHt8zwDhO4yN0Q5QaaUIoSXgxVmgtWWk62wDvpy+QA==",
       "files": [
         "lib/dotnet/System.Security.Cryptography.Primitives.dll",
         "lib/MonoAndroid10/_._",
@@ -2741,30 +2757,40 @@
         "ref/net46/System.Security.Cryptography.Primitives.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Security.Cryptography.Primitives.4.0.0-beta-23408.nupkg",
-        "System.Security.Cryptography.Primitives.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Cryptography.Primitives.4.0.0-beta-23412.nupkg",
+        "System.Security.Cryptography.Primitives.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Cryptography.Primitives.nuspec"
       ]
     },
-    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23408": {
+    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "JSNf5d1V5Y47MIdf7QxZCuGnR5heM4UKbrsdXiWD5lfqu0mnNjebPIclMUXlTw/6IykuDsUpompV/DtsaLLHig==",
+      "sha512": "SfpMjvrfRaRjG42uynLugb3YgpXdpnU7X8vNAU7stIR5/4uW9m1SvWHvBjirjHRBtOpbKB86uD5ODQWX+tWDNA==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Security.Cryptography.X509Certificates.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/es/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/fr/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/it/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/ja/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/ko/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/ru/System.Security.Cryptography.X509Certificates.xml",
         "ref/dotnet/System.Security.Cryptography.X509Certificates.dll",
+        "ref/dotnet/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/zh-hans/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/zh-hant/System.Security.Cryptography.X509Certificates.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Security.Cryptography.X509Certificates.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23408.nupkg",
-        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23412.nupkg",
+        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Cryptography.X509Certificates.nuspec"
       ]
     },
@@ -2801,144 +2827,147 @@
         "System.Security.Principal.nuspec"
       ]
     },
-    "System.Security.Principal.Windows/4.0.0-beta-23408": {
+    "System.Security.Principal.Windows/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "xmjpZJvsT1AW23UkjqUkF/VrOh7DA1cagYY272UQmO8ei227TFD4C7j3ofatL/63hR3CXkLkoephuE4f2Z9fGA==",
+      "sha512": "Zvb/LzT+GjGNV1t8i5KVieilL+8P5LcQykIbJHw5aJxLPFEIQ4Y2hTJXdEkeKvZ4TCF5dlwY1jYyUrJkcqpxzw==",
       "files": [
-        "lib/DNXCore50/de/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/es/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/fr/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/it/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/ja/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/ko/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/ru/System.Security.Principal.Windows.xml",
         "lib/DNXCore50/System.Security.Principal.Windows.dll",
-        "lib/DNXCore50/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/zh-hans/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/zh-hant/System.Security.Principal.Windows.xml",
         "lib/net46/System.Security.Principal.Windows.dll",
+        "ref/dotnet/de/System.Security.Principal.Windows.xml",
+        "ref/dotnet/es/System.Security.Principal.Windows.xml",
+        "ref/dotnet/fr/System.Security.Principal.Windows.xml",
+        "ref/dotnet/it/System.Security.Principal.Windows.xml",
+        "ref/dotnet/ja/System.Security.Principal.Windows.xml",
+        "ref/dotnet/ko/System.Security.Principal.Windows.xml",
+        "ref/dotnet/ru/System.Security.Principal.Windows.xml",
         "ref/dotnet/System.Security.Principal.Windows.dll",
+        "ref/dotnet/System.Security.Principal.Windows.xml",
+        "ref/dotnet/zh-hans/System.Security.Principal.Windows.xml",
+        "ref/dotnet/zh-hant/System.Security.Principal.Windows.xml",
         "ref/net46/System.Security.Principal.Windows.dll",
-        "System.Security.Principal.Windows.4.0.0-beta-23408.nupkg",
-        "System.Security.Principal.Windows.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Principal.Windows.4.0.0-beta-23412.nupkg",
+        "System.Security.Principal.Windows.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Principal.Windows.nuspec"
       ]
     },
-    "System.ServiceModel.Duplex/4.0.1-beta-23408": {
+    "System.ServiceModel.Duplex/4.0.1-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "ZJ3aN/aEg801Rw+aVbBFZ+I9J51FyQVCoWOvSqTSh5i4qZuWuenCxmxahby43teIqNcCrCtHPoyRan2GfY8Vyg==",
+      "sha512": "o5w/amLOdG4NIfER18/TI69QL11pboppiBgH2fIwjzasKZ1OIlxE+KJPbvHJ5vt554reZYCcA+jY4CIx7/pkiw==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Duplex.dll",
         "lib/net45/_._",
-        "lib/netcore50/de/System.ServiceModel.Duplex.xml",
-        "lib/netcore50/es/System.ServiceModel.Duplex.xml",
-        "lib/netcore50/fr/System.ServiceModel.Duplex.xml",
-        "lib/netcore50/it/System.ServiceModel.Duplex.xml",
-        "lib/netcore50/ja/System.ServiceModel.Duplex.xml",
-        "lib/netcore50/ko/System.ServiceModel.Duplex.xml",
-        "lib/netcore50/ru/System.ServiceModel.Duplex.xml",
         "lib/netcore50/System.ServiceModel.Duplex.dll",
-        "lib/netcore50/System.ServiceModel.Duplex.xml",
-        "lib/netcore50/zh-hans/System.ServiceModel.Duplex.xml",
-        "lib/netcore50/zh-hant/System.ServiceModel.Duplex.xml",
         "lib/win8/_._",
+        "ref/dotnet/de/System.ServiceModel.Duplex.xml",
+        "ref/dotnet/es/System.ServiceModel.Duplex.xml",
+        "ref/dotnet/fr/System.ServiceModel.Duplex.xml",
+        "ref/dotnet/it/System.ServiceModel.Duplex.xml",
+        "ref/dotnet/ja/System.ServiceModel.Duplex.xml",
+        "ref/dotnet/ko/System.ServiceModel.Duplex.xml",
+        "ref/dotnet/ru/System.ServiceModel.Duplex.xml",
         "ref/dotnet/System.ServiceModel.Duplex.dll",
+        "ref/dotnet/System.ServiceModel.Duplex.xml",
+        "ref/dotnet/zh-hans/System.ServiceModel.Duplex.xml",
+        "ref/dotnet/zh-hant/System.ServiceModel.Duplex.xml",
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.Duplex.dll",
+        "ref/netcore50/System.ServiceModel.Duplex.xml",
         "ref/win8/_._",
-        "System.ServiceModel.Duplex.4.0.1-beta-23408.nupkg",
-        "System.ServiceModel.Duplex.4.0.1-beta-23408.nupkg.sha512",
+        "System.ServiceModel.Duplex.4.0.1-beta-23412.nupkg",
+        "System.ServiceModel.Duplex.4.0.1-beta-23412.nupkg.sha512",
         "System.ServiceModel.Duplex.nuspec"
       ]
     },
-    "System.ServiceModel.Http/4.0.11-beta-23408": {
+    "System.ServiceModel.Http/4.0.11-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "RScHZ1A3CfjumaP1Vh/xfOp/ga6T3nA8YLkjFOYcIcZm/LILL+yCh+PhIrJOEfz1Js8bLSQC6xbxwYlW6BNmYg==",
+      "sha512": "hKMGQbu/l2gv/PgPvm2ViLVElnVSwAPiv4cXKjinS+UHBf02uPF2m7lN13SCkJDNTBctwHav1rQnMYb1LUJHvw==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Http.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
-        "lib/netcore50/de/System.ServiceModel.Http.xml",
-        "lib/netcore50/es/System.ServiceModel.Http.xml",
-        "lib/netcore50/fr/System.ServiceModel.Http.xml",
-        "lib/netcore50/it/System.ServiceModel.Http.xml",
-        "lib/netcore50/ja/System.ServiceModel.Http.xml",
-        "lib/netcore50/ko/System.ServiceModel.Http.xml",
-        "lib/netcore50/ru/System.ServiceModel.Http.xml",
         "lib/netcore50/System.ServiceModel.Http.dll",
-        "lib/netcore50/System.ServiceModel.Http.xml",
-        "lib/netcore50/zh-hans/System.ServiceModel.Http.xml",
-        "lib/netcore50/zh-hant/System.ServiceModel.Http.xml",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.ServiceModel.Http.xml",
+        "ref/dotnet/es/System.ServiceModel.Http.xml",
+        "ref/dotnet/fr/System.ServiceModel.Http.xml",
+        "ref/dotnet/it/System.ServiceModel.Http.xml",
+        "ref/dotnet/ja/System.ServiceModel.Http.xml",
+        "ref/dotnet/ko/System.ServiceModel.Http.xml",
+        "ref/dotnet/ru/System.ServiceModel.Http.xml",
         "ref/dotnet/System.ServiceModel.Http.dll",
+        "ref/dotnet/System.ServiceModel.Http.xml",
+        "ref/dotnet/zh-hans/System.ServiceModel.Http.xml",
+        "ref/dotnet/zh-hant/System.ServiceModel.Http.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.ServiceModel.Http.4.0.11-beta-23408.nupkg",
-        "System.ServiceModel.Http.4.0.11-beta-23408.nupkg.sha512",
+        "System.ServiceModel.Http.4.0.11-beta-23412.nupkg",
+        "System.ServiceModel.Http.4.0.11-beta-23412.nupkg.sha512",
         "System.ServiceModel.Http.nuspec"
       ]
     },
-    "System.ServiceModel.NetTcp/4.0.1-beta-23408": {
+    "System.ServiceModel.NetTcp/4.0.1-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "ppruBpqoE6AngTs6fABV67r1ic6rKCgr6tw+4lMoRucrNWNfKgX5vWlONOqSd8bQXmQLZ/ftEhDGXYY5CLRUTQ==",
+      "sha512": "9I2iOpoYB8DtVy1Sw6BmOj6NGoxt9cKwOOds4q6G1JLzyyWErsv/FMeGAJT07bgLr8vnMx4s8GXxjCfkUwNtTw==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.NetTcp.dll",
         "lib/net45/_._",
-        "lib/netcore50/de/System.ServiceModel.NetTcp.xml",
-        "lib/netcore50/es/System.ServiceModel.NetTcp.xml",
-        "lib/netcore50/fr/System.ServiceModel.NetTcp.xml",
-        "lib/netcore50/it/System.ServiceModel.NetTcp.xml",
-        "lib/netcore50/ja/System.ServiceModel.NetTcp.xml",
-        "lib/netcore50/ko/System.ServiceModel.NetTcp.xml",
-        "lib/netcore50/ru/System.ServiceModel.NetTcp.xml",
         "lib/netcore50/System.ServiceModel.NetTcp.dll",
-        "lib/netcore50/System.ServiceModel.NetTcp.xml",
-        "lib/netcore50/zh-hans/System.ServiceModel.NetTcp.xml",
-        "lib/netcore50/zh-hant/System.ServiceModel.NetTcp.xml",
         "lib/win8/_._",
+        "ref/dotnet/de/System.ServiceModel.NetTcp.xml",
+        "ref/dotnet/es/System.ServiceModel.NetTcp.xml",
+        "ref/dotnet/fr/System.ServiceModel.NetTcp.xml",
+        "ref/dotnet/it/System.ServiceModel.NetTcp.xml",
+        "ref/dotnet/ja/System.ServiceModel.NetTcp.xml",
+        "ref/dotnet/ko/System.ServiceModel.NetTcp.xml",
+        "ref/dotnet/ru/System.ServiceModel.NetTcp.xml",
         "ref/dotnet/System.ServiceModel.NetTcp.dll",
+        "ref/dotnet/System.ServiceModel.NetTcp.xml",
+        "ref/dotnet/zh-hans/System.ServiceModel.NetTcp.xml",
+        "ref/dotnet/zh-hant/System.ServiceModel.NetTcp.xml",
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.NetTcp.dll",
+        "ref/netcore50/System.ServiceModel.NetTcp.xml",
         "ref/win8/_._",
-        "System.ServiceModel.NetTcp.4.0.1-beta-23408.nupkg",
-        "System.ServiceModel.NetTcp.4.0.1-beta-23408.nupkg.sha512",
+        "System.ServiceModel.NetTcp.4.0.1-beta-23412.nupkg",
+        "System.ServiceModel.NetTcp.4.0.1-beta-23412.nupkg.sha512",
         "System.ServiceModel.NetTcp.nuspec"
       ]
     },
-    "System.ServiceModel.Primitives/4.0.1-beta-23408": {
+    "System.ServiceModel.Primitives/4.0.1-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "bjXzg+V3Oq/tBXpMY5FwcERN2CQsFXoL4BMoURlwiBMkgwN2CPvBIaK45Moh7nc21jNTVukNayDtURetGzK6aA==",
+      "sha512": "dkCUkNtXb2m9Wf+DY7dc5B4J8DpaWtX4wpFfT3cYLpChxAnjQR85N+tJfMEHLfZNNerKgDRyGyaKa7uSHfvb5g==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Primitives.dll",
         "lib/net45/_._",
-        "lib/netcore50/de/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/es/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/fr/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/it/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/ja/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/ko/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/ru/System.ServiceModel.Primitives.xml",
         "lib/netcore50/System.ServiceModel.Primitives.dll",
-        "lib/netcore50/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/zh-hans/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/zh-hant/System.ServiceModel.Primitives.xml",
         "lib/win8/_._",
+        "ref/dotnet/de/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/es/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/fr/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/it/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/ja/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/ko/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/ru/System.ServiceModel.Primitives.xml",
         "ref/dotnet/System.ServiceModel.Primitives.dll",
+        "ref/dotnet/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/zh-hans/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/zh-hant/System.ServiceModel.Primitives.xml",
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.Primitives.dll",
+        "ref/netcore50/System.ServiceModel.Primitives.xml",
         "ref/win8/_._",
-        "System.ServiceModel.Primitives.4.0.1-beta-23408.nupkg",
-        "System.ServiceModel.Primitives.4.0.1-beta-23408.nupkg.sha512",
+        "System.ServiceModel.Primitives.4.0.1-beta-23412.nupkg",
+        "System.ServiceModel.Primitives.4.0.1-beta-23412.nupkg.sha512",
         "System.ServiceModel.Primitives.nuspec"
       ]
     },
@@ -3131,28 +3160,6 @@
         "System.Threading.Tasks.4.0.10.nupkg",
         "System.Threading.Tasks.4.0.10.nupkg.sha512",
         "System.Threading.Tasks.nuspec"
-      ]
-    },
-    "System.Threading.ThreadPool/4.0.10-beta-23408": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "ahdsVyj+WFj8/iSDwX/G7hkEU4jZmmvWzPS2ajZKdp0Crb0vZJOlM0LQYVASQgbimrUZHQ50o93JYEi8RFdh/Q==",
-      "files": [
-        "lib/DNXCore50/System.Threading.ThreadPool.dll",
-        "lib/MonoAndroid10/_._",
-        "lib/MonoTouch10/_._",
-        "lib/net46/System.Threading.ThreadPool.dll",
-        "lib/xamarinios10/_._",
-        "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Threading.ThreadPool.dll",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
-        "ref/net46/System.Threading.ThreadPool.dll",
-        "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.Threading.ThreadPool.4.0.10-beta-23408.nupkg",
-        "System.Threading.ThreadPool.4.0.10-beta-23408.nupkg.sha512",
-        "System.Threading.ThreadPool.nuspec"
       ]
     },
     "System.Threading.Timer/4.0.0": {
@@ -3402,14 +3409,14 @@
         "xunit.extensibility.execution.nuspec"
       ]
     },
-    "xunit.netcore.extensions/1.0.0-prerelease-00104": {
+    "xunit.netcore.extensions/1.0.0-prerelease-00105": {
       "type": "package",
       "serviceable": true,
-      "sha512": "ZMXxEBpGP7krXtvqbPMOWavd2u83w77ghtD254wfj5+d+7GmYYqP9pX1iRIxJK9CBa8Zc2cOrcYsmCLQgYriAQ==",
+      "sha512": "EnnGcy9rmSdQ8izHWvYSYVyjQGhbeFH7JeM/L35ZrrPGtYvq5XD3hc1cJPCs+43mXdF9cdqhkt5uTlXYzC+Z8g==",
       "files": [
         "lib/dotnet/Xunit.NetCore.Extensions.dll",
-        "xunit.netcore.extensions.1.0.0-prerelease-00104.nupkg",
-        "xunit.netcore.extensions.1.0.0-prerelease-00104.nupkg.sha512",
+        "xunit.netcore.extensions.1.0.0-prerelease-00105.nupkg",
+        "xunit.netcore.extensions.1.0.0-prerelease-00105.nupkg.sha512",
         "xunit.netcore.extensions.nuspec"
       ]
     }

--- a/src/System.Private.ServiceModel/tests/Scenarios/Contract/Fault/project.lock.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Contract/Fault/project.lock.json
@@ -292,7 +292,7 @@
           "lib/dotnet/System.Linq.Queryable.dll": {}
         }
       },
-      "System.Net.Http/4.0.1-beta-23408": {
+      "System.Net.Http/4.0.1-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -305,7 +305,7 @@
           "ref/dotnet/System.Net.Http.dll": {}
         }
       },
-      "System.Net.NameResolution/4.0.0-beta-23408": {
+      "System.Net.NameResolution/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Net.Primitives": "4.0.10",
@@ -328,16 +328,17 @@
           "lib/DNXCore50/System.Net.Primitives.dll": {}
         }
       },
-      "System.Net.Security/4.0.0-beta-23408": {
+      "System.Net.Security/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
-          "System.Private.Networking": "4.0.1-beta-23408"
+          "System.IO": "4.0.0",
+          "System.Net.Primitives": "4.0.10",
+          "System.Runtime": "4.0.0",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23412",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Net.Security.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Net.Security.dll": {}
         }
       },
       "System.Net.Sockets/4.1.0-beta-23225": {
@@ -368,7 +369,7 @@
           "lib/dotnet/System.Net.WebHeaderCollection.dll": {}
         }
       },
-      "System.Net.WebSockets/4.0.0-beta-23408": {
+      "System.Net.WebSockets/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -383,7 +384,7 @@
           "lib/dotnet/System.Net.WebSockets.dll": {}
         }
       },
-      "System.Net.WebSockets.Client/4.0.0-beta-23408": {
+      "System.Net.WebSockets.Client/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -393,13 +394,13 @@
           "System.Globalization": "4.0.10",
           "System.Net.Primitives": "4.0.10",
           "System.Net.WebHeaderCollection": "4.0.0",
-          "System.Net.WebSockets": "4.0.0-beta-23408",
+          "System.Net.WebSockets": "4.0.0-beta-23412",
           "System.Resources.ResourceManager": "4.0.0",
           "System.Runtime": "4.0.20",
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23408",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23412",
           "System.Text.Encoding": "4.0.10",
           "System.Threading": "4.0.10",
           "System.Threading.Tasks": "4.0.10"
@@ -456,7 +457,7 @@
           "lib/DNXCore50/System.Private.DataContractSerialization.dll": {}
         }
       },
-      "System.Private.Networking/4.0.1-beta-23408": {
+      "System.Private.Networking/4.0.1-beta-23225": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -475,13 +476,10 @@
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23408",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23408",
-          "System.Security.Principal.Windows": "4.0.0-beta-23408",
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23225",
           "System.Threading": "4.0.10",
           "System.Threading.Overlapped": "4.0.0",
-          "System.Threading.Tasks": "4.0.10",
-          "System.Threading.ThreadPool": "4.0.10-beta-23408"
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dnxcore50/_._": {}
@@ -490,7 +488,7 @@
           "lib/DNXCore50/System.Private.Networking.dll": {}
         }
       },
-      "System.Private.ServiceModel/4.1.0-beta-23408": {
+      "System.Private.ServiceModel/4.1.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -507,14 +505,14 @@
           "System.Linq": "4.0.0",
           "System.Linq.Expressions": "4.0.10",
           "System.Linq.Queryable": "4.0.0",
-          "System.Net.Http": "4.0.1-beta-23408",
-          "System.Net.NameResolution": "4.0.0-beta-23408",
+          "System.Net.Http": "4.0.1-beta-23412",
+          "System.Net.NameResolution": "4.0.0-beta-23412",
           "System.Net.Primitives": "4.0.10",
-          "System.Net.Security": "4.0.0-beta-23408",
-          "System.Net.Sockets": "4.0.10-beta-23408",
+          "System.Net.Security": "4.0.0-beta-23412",
+          "System.Net.Sockets": "4.0.10-beta-23412",
           "System.Net.WebHeaderCollection": "4.0.0",
-          "System.Net.WebSockets": "4.0.0-beta-23408",
-          "System.Net.WebSockets.Client": "4.0.0-beta-23408",
+          "System.Net.WebSockets": "4.0.0-beta-23412",
+          "System.Net.WebSockets.Client": "4.0.0-beta-23412",
           "System.ObjectModel": "4.0.10",
           "System.Reflection": "4.0.10",
           "System.Reflection.DispatchProxy": "4.0.0",
@@ -528,9 +526,9 @@
           "System.Runtime.Serialization.Primitives": "4.0.10",
           "System.Runtime.Serialization.Xml": "4.0.10",
           "System.Security.Claims": "4.0.0",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23408",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23412",
           "System.Security.Principal": "4.0.0",
-          "System.Security.Principal.Windows": "4.0.0-beta-23408",
+          "System.Security.Principal.Windows": "4.0.0-beta-23412",
           "System.Text.Encoding": "4.0.10",
           "System.Threading": "4.0.10",
           "System.Threading.Tasks": "4.0.10",
@@ -794,18 +792,18 @@
           "lib/dotnet/System.Security.Claims.dll": {}
         }
       },
-      "System.Security.Cryptography.Algorithms/4.0.0-beta-23408": {
+      "System.Security.Cryptography.Algorithms/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
           "System.Runtime": "4.0.0",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23408"
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23412"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.Algorithms.dll": {}
         }
       },
-      "System.Security.Cryptography.Encoding/4.0.0-beta-23408": {
+      "System.Security.Cryptography.Encoding/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -814,7 +812,7 @@
           "ref/dotnet/System.Security.Cryptography.Encoding.dll": {}
         }
       },
-      "System.Security.Cryptography.Primitives/4.0.0-beta-23408": {
+      "System.Security.Cryptography.Primitives/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.0",
@@ -832,13 +830,13 @@
           "lib/dotnet/System.Security.Cryptography.Primitives.dll": {}
         }
       },
-      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23408": {
+      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
           "System.Runtime.Handles": "4.0.0",
-          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23408",
-          "System.Security.Cryptography.Encoding": "4.0.0-beta-23408"
+          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23412",
+          "System.Security.Cryptography.Encoding": "4.0.0-beta-23412"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.X509Certificates.dll": {}
@@ -856,7 +854,7 @@
           "lib/dotnet/System.Security.Principal.dll": {}
         }
       },
-      "System.Security.Principal.Windows/4.0.0-beta-23408": {
+      "System.Security.Principal.Windows/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -879,10 +877,10 @@
           "lib/DNXCore50/System.Security.Principal.Windows.dll": {}
         }
       },
-      "System.ServiceModel.Http/4.0.11-beta-23408": {
+      "System.ServiceModel.Http/4.0.11-beta-23412": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-beta-23408",
+          "System.Private.ServiceModel": "4.1.0-beta-23412",
           "System.Runtime": "4.0.20"
         },
         "compile": {
@@ -892,10 +890,10 @@
           "lib/DNXCore50/System.ServiceModel.Http.dll": {}
         }
       },
-      "System.ServiceModel.Primitives/4.0.1-beta-23408": {
+      "System.ServiceModel.Primitives/4.0.1-beta-23412": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-beta-23408"
+          "System.Private.ServiceModel": "4.1.0-beta-23412"
         },
         "compile": {
           "ref/dotnet/System.ServiceModel.Primitives.dll": {}
@@ -982,19 +980,6 @@
         },
         "runtime": {
           "lib/DNXCore50/System.Threading.Tasks.dll": {}
-        }
-      },
-      "System.Threading.ThreadPool/4.0.10-beta-23408": {
-        "type": "package",
-        "dependencies": {
-          "System.Runtime": "4.0.0",
-          "System.Runtime.InteropServices": "4.0.0"
-        },
-        "compile": {
-          "ref/dotnet/System.Threading.ThreadPool.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Threading.ThreadPool.dll": {}
         }
       },
       "System.Threading.Timer/4.0.0": {
@@ -1177,7 +1162,7 @@
           "lib/dotnet/xunit.execution.dotnet.dll": {}
         }
       },
-      "xunit.netcore.extensions/1.0.0-prerelease-00104": {
+      "xunit.netcore.extensions/1.0.0-prerelease-00105": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.10",
@@ -1805,44 +1790,65 @@
         "System.Linq.Queryable.nuspec"
       ]
     },
-    "System.Net.Http/4.0.1-beta-23408": {
+    "System.Net.Http/4.0.1-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "n+tnV1VgCjbDKKnbgrvgUgxkPDwUFvSv9lTgH882rVzjbWyliVgbBflVzoAUjUSlga/Tr1XQIrfTLMRD5HfYGw==",
+      "sha512": "F7Yej+6QdRVzWg+qbkayRMcmf/7k7YfNFoVSA67wIsG9t5u7Wj4Go8FW72HL8qb9d7YjIsVB/5hA7g9MUT31Aw==",
       "files": [
         "lib/net45/_._",
         "lib/win8/_._",
         "lib/wpa81/_._",
+        "ref/dotnet/de/System.Net.Http.xml",
+        "ref/dotnet/es/System.Net.Http.xml",
+        "ref/dotnet/fr/System.Net.Http.xml",
+        "ref/dotnet/it/System.Net.Http.xml",
+        "ref/dotnet/ja/System.Net.Http.xml",
+        "ref/dotnet/ko/System.Net.Http.xml",
+        "ref/dotnet/ru/System.Net.Http.xml",
         "ref/dotnet/System.Net.Http.dll",
+        "ref/dotnet/System.Net.Http.xml",
+        "ref/dotnet/zh-hans/System.Net.Http.xml",
+        "ref/dotnet/zh-hant/System.Net.Http.xml",
         "ref/net45/_._",
         "ref/netcore50/System.Net.Http.dll",
+        "ref/netcore50/System.Net.Http.xml",
         "ref/win8/_._",
         "ref/wpa81/_._",
         "runtime.json",
-        "System.Net.Http.4.0.1-beta-23408.nupkg",
-        "System.Net.Http.4.0.1-beta-23408.nupkg.sha512",
+        "System.Net.Http.4.0.1-beta-23412.nupkg",
+        "System.Net.Http.4.0.1-beta-23412.nupkg.sha512",
         "System.Net.Http.nuspec"
       ]
     },
-    "System.Net.NameResolution/4.0.0-beta-23408": {
+    "System.Net.NameResolution/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "2A562VFL8GUL/jLCJ3mbQHhwwAIXzPyjxMpdtas1LVM8QLuP1OcHwV3z7ajWnYdGcPc7ZxPEGJQWicuaPD+0nA==",
+      "sha512": "HCF1zhFYBT+w/Ik+JuTzFJgj83Jfc+eA8VcgvIzdPiGMXfrZeXOogjgSCkCoJmFtKVz2DSfmISoEmiXB1oaLNQ==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.NameResolution.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Net.NameResolution.xml",
+        "ref/dotnet/es/System.Net.NameResolution.xml",
+        "ref/dotnet/fr/System.Net.NameResolution.xml",
+        "ref/dotnet/it/System.Net.NameResolution.xml",
+        "ref/dotnet/ja/System.Net.NameResolution.xml",
+        "ref/dotnet/ko/System.Net.NameResolution.xml",
+        "ref/dotnet/ru/System.Net.NameResolution.xml",
         "ref/dotnet/System.Net.NameResolution.dll",
+        "ref/dotnet/System.Net.NameResolution.xml",
+        "ref/dotnet/zh-hans/System.Net.NameResolution.xml",
+        "ref/dotnet/zh-hant/System.Net.NameResolution.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Net.NameResolution.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Net.NameResolution.4.0.0-beta-23408.nupkg",
-        "System.Net.NameResolution.4.0.0-beta-23408.nupkg.sha512",
+        "System.Net.NameResolution.4.0.0-beta-23412.nupkg",
+        "System.Net.NameResolution.4.0.0-beta-23412.nupkg.sha512",
         "System.Net.NameResolution.nuspec"
       ]
     },
@@ -1879,24 +1885,34 @@
         "System.Net.Primitives.nuspec"
       ]
     },
-    "System.Net.Security/4.0.0-beta-23408": {
+    "System.Net.Security/4.0.0-beta-23412": {
       "type": "package",
-      "sha512": "kEkunODO2t/VlBIsC80YFDG0KtY/FyIbtBApNyJQv+LYGEs5IFvEhpi9+p0/jHmhyRMKwbjajNedbXo+VMkt1A==",
+      "sha512": "Kcjne7jnvF5aTbRJsAT8kuP+1mxryUF2qYv8f3jnR19wtEjswSIOVU0XzuWc9YObEQcb+kEdzN71HTOm+ssv+w==",
       "files": [
-        "lib/DNXCore50/System.Net.Security.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.Security.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Net.Security.xml",
+        "ref/dotnet/es/System.Net.Security.xml",
+        "ref/dotnet/fr/System.Net.Security.xml",
+        "ref/dotnet/it/System.Net.Security.xml",
+        "ref/dotnet/ja/System.Net.Security.xml",
+        "ref/dotnet/ko/System.Net.Security.xml",
+        "ref/dotnet/ru/System.Net.Security.xml",
         "ref/dotnet/System.Net.Security.dll",
+        "ref/dotnet/System.Net.Security.xml",
+        "ref/dotnet/zh-hans/System.Net.Security.xml",
+        "ref/dotnet/zh-hant/System.Net.Security.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Net.Security.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.Security.4.0.0-beta-23408.nupkg",
-        "System.Net.Security.4.0.0-beta-23408.nupkg.sha512",
+        "runtime.json",
+        "System.Net.Security.4.0.0-beta-23412.nupkg",
+        "System.Net.Security.4.0.0-beta-23412.nupkg.sha512",
         "System.Net.Security.nuspec"
       ]
     },
@@ -1954,78 +1970,68 @@
         "System.Net.WebHeaderCollection.nuspec"
       ]
     },
-    "System.Net.WebSockets/4.0.0-beta-23408": {
+    "System.Net.WebSockets/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "BXy22/bNVtrXXsG76zXyhjcQnCjSYxQIFF37xWifqPRWmvzsCYSLQpNCTPQUCp7rjB7qWc5yLhC9bThaEx7MHQ==",
+      "sha512": "EvXAa0yd1RM8ROyLl1T0xC94F04Su8YMHnd4/w6j0Z/+4lKHZOU7bQPZ3odDN8WdPGKa/ZNJJGwiapydEWKzwQ==",
       "files": [
-        "lib/dotnet/de/System.Net.WebSockets.xml",
-        "lib/dotnet/es/System.Net.WebSockets.xml",
-        "lib/dotnet/fr/System.Net.WebSockets.xml",
-        "lib/dotnet/it/System.Net.WebSockets.xml",
-        "lib/dotnet/ja/System.Net.WebSockets.xml",
-        "lib/dotnet/ko/System.Net.WebSockets.xml",
-        "lib/dotnet/ru/System.Net.WebSockets.xml",
         "lib/dotnet/System.Net.WebSockets.dll",
-        "lib/dotnet/System.Net.WebSockets.xml",
-        "lib/dotnet/zh-hans/System.Net.WebSockets.xml",
-        "lib/dotnet/zh-hant/System.Net.WebSockets.xml",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.WebSockets.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Net.WebSockets.xml",
+        "ref/dotnet/es/System.Net.WebSockets.xml",
+        "ref/dotnet/fr/System.Net.WebSockets.xml",
+        "ref/dotnet/it/System.Net.WebSockets.xml",
+        "ref/dotnet/ja/System.Net.WebSockets.xml",
+        "ref/dotnet/ko/System.Net.WebSockets.xml",
+        "ref/dotnet/ru/System.Net.WebSockets.xml",
         "ref/dotnet/System.Net.WebSockets.dll",
+        "ref/dotnet/System.Net.WebSockets.xml",
+        "ref/dotnet/zh-hans/System.Net.WebSockets.xml",
+        "ref/dotnet/zh-hant/System.Net.WebSockets.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Net.WebSockets.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.WebSockets.4.0.0-beta-23408.nupkg",
-        "System.Net.WebSockets.4.0.0-beta-23408.nupkg.sha512",
+        "System.Net.WebSockets.4.0.0-beta-23412.nupkg",
+        "System.Net.WebSockets.4.0.0-beta-23412.nupkg.sha512",
         "System.Net.WebSockets.nuspec"
       ]
     },
-    "System.Net.WebSockets.Client/4.0.0-beta-23408": {
+    "System.Net.WebSockets.Client/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "smmvhCkcU0c4RNWc6NZwnN5EFktX58jf8+TJ6enfuXxWrpJ/2NRI5/2yT/okjFSngGK1g0MBrljZsfs2EJ7+Yw==",
+      "sha512": "uaO7c/81sK90605UtThSX9KVmzsJDA1vD4GMW7FsKKntymlkolJsprDekWblQ4A5YbhqxHv+ngXX2kIU0B3Fdw==",
       "files": [
-        "lib/DNXCore50/de/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/es/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/fr/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/it/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/ja/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/ko/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/ru/System.Net.WebSockets.Client.xml",
         "lib/DNXCore50/System.Net.WebSockets.Client.dll",
-        "lib/DNXCore50/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/zh-hans/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/zh-hant/System.Net.WebSockets.Client.xml",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.WebSockets.Client.dll",
-        "lib/netcore50/de/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/es/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/fr/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/it/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/ja/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/ko/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/ru/System.Net.WebSockets.Client.xml",
         "lib/netcore50/System.Net.WebSockets.Client.dll",
-        "lib/netcore50/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/zh-hans/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/zh-hant/System.Net.WebSockets.Client.xml",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/es/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/fr/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/it/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/ja/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/ko/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/ru/System.Net.WebSockets.Client.xml",
         "ref/dotnet/System.Net.WebSockets.Client.dll",
+        "ref/dotnet/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/zh-hans/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/zh-hant/System.Net.WebSockets.Client.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Net.WebSockets.Client.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.WebSockets.Client.4.0.0-beta-23408.nupkg",
-        "System.Net.WebSockets.Client.4.0.0-beta-23408.nupkg.sha512",
+        "System.Net.WebSockets.Client.4.0.0-beta-23412.nupkg",
+        "System.Net.WebSockets.Client.4.0.0-beta-23412.nupkg.sha512",
         "System.Net.WebSockets.Client.nuspec"
       ]
     },
@@ -2077,31 +2083,31 @@
         "System.Private.DataContractSerialization.nuspec"
       ]
     },
-    "System.Private.Networking/4.0.1-beta-23408": {
+    "System.Private.Networking/4.0.1-beta-23225": {
       "type": "package",
       "serviceable": true,
-      "sha512": "i2fRDRqM8Px3CP26C//deF/tCNR1AwqlPEr9+MYiXxNZtgGcSPBfqOJJ5CJdfmDb9Ap0hPG2MiPG7CinaSH7+Q==",
+      "sha512": "oVSynIrR3mIU0b/goscsaZDywr3RLxQijQnaFRKfl/VB3F9rKi5mdr0vHcGVWuq5ALSrG0OLwM8PRA4tM5e3rQ==",
       "files": [
         "lib/DNXCore50/System.Private.Networking.dll",
         "lib/netcore50/System.Private.Networking.dll",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "System.Private.Networking.4.0.1-beta-23408.nupkg",
-        "System.Private.Networking.4.0.1-beta-23408.nupkg.sha512",
+        "System.Private.Networking.4.0.1-beta-23225.nupkg",
+        "System.Private.Networking.4.0.1-beta-23225.nupkg.sha512",
         "System.Private.Networking.nuspec"
       ]
     },
-    "System.Private.ServiceModel/4.1.0-beta-23408": {
+    "System.Private.ServiceModel/4.1.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "l/2192yKa6uXhjKOWeukFJy3hoj9Zq1p55pTGe+Y28r8/5jlvgYxfunP9UyXJRo9W1u3UBtGfV/5R71ULzusGQ==",
+      "sha512": "Wm+8LcQ04YeAvYqu9faHsMZ/L8l/WvPPsqziBfifYB4jXIPXk1/kUxuAryjbLChghZDXvkDN0hv/IHSVPZGgBA==",
       "files": [
         "lib/DNXCore50/System.Private.ServiceModel.dll",
         "lib/netcore50/System.Private.ServiceModel.dll",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "System.Private.ServiceModel.4.1.0-beta-23408.nupkg",
-        "System.Private.ServiceModel.4.1.0-beta-23408.nupkg.sha512",
+        "System.Private.ServiceModel.4.1.0-beta-23412.nupkg",
+        "System.Private.ServiceModel.4.1.0-beta-23412.nupkg.sha512",
         "System.Private.ServiceModel.nuspec"
       ]
     },
@@ -2656,10 +2662,10 @@
         "System.Security.Claims.nuspec"
       ]
     },
-    "System.Security.Cryptography.Algorithms/4.0.0-beta-23408": {
+    "System.Security.Cryptography.Algorithms/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "G6eEqi8mZRrWftcwilcnllE4xJ/53JQlk3VVuJ+9qrX+DHvWz8itYJRUZX357JY4DgEEKQNOJzuRGrOBTUeoPg==",
+      "sha512": "nBjoiqJQiMD3cJgOVrqjIVDqEEPZeIqT+mrBIxjLE+YMQcjEyDuSyOG65Ntoopby5LH4onTLMM4zfXh8JRt9NQ==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2673,37 +2679,47 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.Algorithms.4.0.0-beta-23408.nupkg",
-        "System.Security.Cryptography.Algorithms.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Cryptography.Algorithms.4.0.0-beta-23412.nupkg",
+        "System.Security.Cryptography.Algorithms.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Cryptography.Algorithms.nuspec"
       ]
     },
-    "System.Security.Cryptography.Encoding/4.0.0-beta-23408": {
+    "System.Security.Cryptography.Encoding/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "fPsAK3vyMjnJ6nT4YchdS7KzfGca/6uVVAPCBO08ZpTRGhMGx30vq1MiIqAUrfsFMnot3Ub2jimnAFWkqY6g0Q==",
+      "sha512": "SR1zCARNdeyLoUKYH2SNMm1He7Lr3NR/l7yW3K135L44T6PS3YB8SfXpVoZdMpb22X2G07BZAHVz2x7e4AA1Cg==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Security.Cryptography.Encoding.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/es/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/fr/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/it/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/ja/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/ko/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/ru/System.Security.Cryptography.Encoding.xml",
         "ref/dotnet/System.Security.Cryptography.Encoding.dll",
+        "ref/dotnet/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/zh-hans/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/zh-hant/System.Security.Cryptography.Encoding.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Security.Cryptography.Encoding.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.Encoding.4.0.0-beta-23408.nupkg",
-        "System.Security.Cryptography.Encoding.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Cryptography.Encoding.4.0.0-beta-23412.nupkg",
+        "System.Security.Cryptography.Encoding.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Cryptography.Encoding.nuspec"
       ]
     },
-    "System.Security.Cryptography.Primitives/4.0.0-beta-23408": {
+    "System.Security.Cryptography.Primitives/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "A336dWYEIQxm1rEJCaE5ZZrUWHPUkBGTRH8uAj8qrTqg4/qRc2yN2wZxeGXaZauhI35QwDmOutK7oVb2Cd+4TA==",
+      "sha512": "H9EBNe0ahjAYjlVn0TnT18PSgZBrtROSQH1RRIKwAjzxQHt8zwDhO4yN0Q5QaaUIoSXgxVmgtWWk62wDvpy+QA==",
       "files": [
         "lib/dotnet/System.Security.Cryptography.Primitives.dll",
         "lib/MonoAndroid10/_._",
@@ -2717,30 +2733,40 @@
         "ref/net46/System.Security.Cryptography.Primitives.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Security.Cryptography.Primitives.4.0.0-beta-23408.nupkg",
-        "System.Security.Cryptography.Primitives.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Cryptography.Primitives.4.0.0-beta-23412.nupkg",
+        "System.Security.Cryptography.Primitives.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Cryptography.Primitives.nuspec"
       ]
     },
-    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23408": {
+    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "JSNf5d1V5Y47MIdf7QxZCuGnR5heM4UKbrsdXiWD5lfqu0mnNjebPIclMUXlTw/6IykuDsUpompV/DtsaLLHig==",
+      "sha512": "SfpMjvrfRaRjG42uynLugb3YgpXdpnU7X8vNAU7stIR5/4uW9m1SvWHvBjirjHRBtOpbKB86uD5ODQWX+tWDNA==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Security.Cryptography.X509Certificates.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/es/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/fr/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/it/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/ja/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/ko/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/ru/System.Security.Cryptography.X509Certificates.xml",
         "ref/dotnet/System.Security.Cryptography.X509Certificates.dll",
+        "ref/dotnet/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/zh-hans/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/zh-hant/System.Security.Cryptography.X509Certificates.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Security.Cryptography.X509Certificates.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23408.nupkg",
-        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23412.nupkg",
+        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Cryptography.X509Certificates.nuspec"
       ]
     },
@@ -2777,88 +2803,89 @@
         "System.Security.Principal.nuspec"
       ]
     },
-    "System.Security.Principal.Windows/4.0.0-beta-23408": {
+    "System.Security.Principal.Windows/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "xmjpZJvsT1AW23UkjqUkF/VrOh7DA1cagYY272UQmO8ei227TFD4C7j3ofatL/63hR3CXkLkoephuE4f2Z9fGA==",
+      "sha512": "Zvb/LzT+GjGNV1t8i5KVieilL+8P5LcQykIbJHw5aJxLPFEIQ4Y2hTJXdEkeKvZ4TCF5dlwY1jYyUrJkcqpxzw==",
       "files": [
-        "lib/DNXCore50/de/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/es/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/fr/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/it/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/ja/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/ko/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/ru/System.Security.Principal.Windows.xml",
         "lib/DNXCore50/System.Security.Principal.Windows.dll",
-        "lib/DNXCore50/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/zh-hans/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/zh-hant/System.Security.Principal.Windows.xml",
         "lib/net46/System.Security.Principal.Windows.dll",
+        "ref/dotnet/de/System.Security.Principal.Windows.xml",
+        "ref/dotnet/es/System.Security.Principal.Windows.xml",
+        "ref/dotnet/fr/System.Security.Principal.Windows.xml",
+        "ref/dotnet/it/System.Security.Principal.Windows.xml",
+        "ref/dotnet/ja/System.Security.Principal.Windows.xml",
+        "ref/dotnet/ko/System.Security.Principal.Windows.xml",
+        "ref/dotnet/ru/System.Security.Principal.Windows.xml",
         "ref/dotnet/System.Security.Principal.Windows.dll",
+        "ref/dotnet/System.Security.Principal.Windows.xml",
+        "ref/dotnet/zh-hans/System.Security.Principal.Windows.xml",
+        "ref/dotnet/zh-hant/System.Security.Principal.Windows.xml",
         "ref/net46/System.Security.Principal.Windows.dll",
-        "System.Security.Principal.Windows.4.0.0-beta-23408.nupkg",
-        "System.Security.Principal.Windows.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Principal.Windows.4.0.0-beta-23412.nupkg",
+        "System.Security.Principal.Windows.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Principal.Windows.nuspec"
       ]
     },
-    "System.ServiceModel.Http/4.0.11-beta-23408": {
+    "System.ServiceModel.Http/4.0.11-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "RScHZ1A3CfjumaP1Vh/xfOp/ga6T3nA8YLkjFOYcIcZm/LILL+yCh+PhIrJOEfz1Js8bLSQC6xbxwYlW6BNmYg==",
+      "sha512": "hKMGQbu/l2gv/PgPvm2ViLVElnVSwAPiv4cXKjinS+UHBf02uPF2m7lN13SCkJDNTBctwHav1rQnMYb1LUJHvw==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Http.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
-        "lib/netcore50/de/System.ServiceModel.Http.xml",
-        "lib/netcore50/es/System.ServiceModel.Http.xml",
-        "lib/netcore50/fr/System.ServiceModel.Http.xml",
-        "lib/netcore50/it/System.ServiceModel.Http.xml",
-        "lib/netcore50/ja/System.ServiceModel.Http.xml",
-        "lib/netcore50/ko/System.ServiceModel.Http.xml",
-        "lib/netcore50/ru/System.ServiceModel.Http.xml",
         "lib/netcore50/System.ServiceModel.Http.dll",
-        "lib/netcore50/System.ServiceModel.Http.xml",
-        "lib/netcore50/zh-hans/System.ServiceModel.Http.xml",
-        "lib/netcore50/zh-hant/System.ServiceModel.Http.xml",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.ServiceModel.Http.xml",
+        "ref/dotnet/es/System.ServiceModel.Http.xml",
+        "ref/dotnet/fr/System.ServiceModel.Http.xml",
+        "ref/dotnet/it/System.ServiceModel.Http.xml",
+        "ref/dotnet/ja/System.ServiceModel.Http.xml",
+        "ref/dotnet/ko/System.ServiceModel.Http.xml",
+        "ref/dotnet/ru/System.ServiceModel.Http.xml",
         "ref/dotnet/System.ServiceModel.Http.dll",
+        "ref/dotnet/System.ServiceModel.Http.xml",
+        "ref/dotnet/zh-hans/System.ServiceModel.Http.xml",
+        "ref/dotnet/zh-hant/System.ServiceModel.Http.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.ServiceModel.Http.4.0.11-beta-23408.nupkg",
-        "System.ServiceModel.Http.4.0.11-beta-23408.nupkg.sha512",
+        "System.ServiceModel.Http.4.0.11-beta-23412.nupkg",
+        "System.ServiceModel.Http.4.0.11-beta-23412.nupkg.sha512",
         "System.ServiceModel.Http.nuspec"
       ]
     },
-    "System.ServiceModel.Primitives/4.0.1-beta-23408": {
+    "System.ServiceModel.Primitives/4.0.1-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "bjXzg+V3Oq/tBXpMY5FwcERN2CQsFXoL4BMoURlwiBMkgwN2CPvBIaK45Moh7nc21jNTVukNayDtURetGzK6aA==",
+      "sha512": "dkCUkNtXb2m9Wf+DY7dc5B4J8DpaWtX4wpFfT3cYLpChxAnjQR85N+tJfMEHLfZNNerKgDRyGyaKa7uSHfvb5g==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Primitives.dll",
         "lib/net45/_._",
-        "lib/netcore50/de/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/es/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/fr/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/it/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/ja/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/ko/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/ru/System.ServiceModel.Primitives.xml",
         "lib/netcore50/System.ServiceModel.Primitives.dll",
-        "lib/netcore50/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/zh-hans/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/zh-hant/System.ServiceModel.Primitives.xml",
         "lib/win8/_._",
+        "ref/dotnet/de/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/es/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/fr/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/it/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/ja/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/ko/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/ru/System.ServiceModel.Primitives.xml",
         "ref/dotnet/System.ServiceModel.Primitives.dll",
+        "ref/dotnet/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/zh-hans/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/zh-hant/System.ServiceModel.Primitives.xml",
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.Primitives.dll",
+        "ref/netcore50/System.ServiceModel.Primitives.xml",
         "ref/win8/_._",
-        "System.ServiceModel.Primitives.4.0.1-beta-23408.nupkg",
-        "System.ServiceModel.Primitives.4.0.1-beta-23408.nupkg.sha512",
+        "System.ServiceModel.Primitives.4.0.1-beta-23412.nupkg",
+        "System.ServiceModel.Primitives.4.0.1-beta-23412.nupkg.sha512",
         "System.ServiceModel.Primitives.nuspec"
       ]
     },
@@ -3051,28 +3078,6 @@
         "System.Threading.Tasks.4.0.10.nupkg",
         "System.Threading.Tasks.4.0.10.nupkg.sha512",
         "System.Threading.Tasks.nuspec"
-      ]
-    },
-    "System.Threading.ThreadPool/4.0.10-beta-23408": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "ahdsVyj+WFj8/iSDwX/G7hkEU4jZmmvWzPS2ajZKdp0Crb0vZJOlM0LQYVASQgbimrUZHQ50o93JYEi8RFdh/Q==",
-      "files": [
-        "lib/DNXCore50/System.Threading.ThreadPool.dll",
-        "lib/MonoAndroid10/_._",
-        "lib/MonoTouch10/_._",
-        "lib/net46/System.Threading.ThreadPool.dll",
-        "lib/xamarinios10/_._",
-        "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Threading.ThreadPool.dll",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
-        "ref/net46/System.Threading.ThreadPool.dll",
-        "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.Threading.ThreadPool.4.0.10-beta-23408.nupkg",
-        "System.Threading.ThreadPool.4.0.10-beta-23408.nupkg.sha512",
-        "System.Threading.ThreadPool.nuspec"
       ]
     },
     "System.Threading.Timer/4.0.0": {
@@ -3322,14 +3327,14 @@
         "xunit.extensibility.execution.nuspec"
       ]
     },
-    "xunit.netcore.extensions/1.0.0-prerelease-00104": {
+    "xunit.netcore.extensions/1.0.0-prerelease-00105": {
       "type": "package",
       "serviceable": true,
-      "sha512": "ZMXxEBpGP7krXtvqbPMOWavd2u83w77ghtD254wfj5+d+7GmYYqP9pX1iRIxJK9CBa8Zc2cOrcYsmCLQgYriAQ==",
+      "sha512": "EnnGcy9rmSdQ8izHWvYSYVyjQGhbeFH7JeM/L35ZrrPGtYvq5XD3hc1cJPCs+43mXdF9cdqhkt5uTlXYzC+Z8g==",
       "files": [
         "lib/dotnet/Xunit.NetCore.Extensions.dll",
-        "xunit.netcore.extensions.1.0.0-prerelease-00104.nupkg",
-        "xunit.netcore.extensions.1.0.0-prerelease-00104.nupkg.sha512",
+        "xunit.netcore.extensions.1.0.0-prerelease-00105.nupkg",
+        "xunit.netcore.extensions.1.0.0-prerelease-00105.nupkg.sha512",
         "xunit.netcore.extensions.nuspec"
       ]
     }

--- a/src/System.Private.ServiceModel/tests/Scenarios/Contract/Message/project.lock.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Contract/Message/project.lock.json
@@ -292,7 +292,7 @@
           "lib/dotnet/System.Linq.Queryable.dll": {}
         }
       },
-      "System.Net.Http/4.0.1-beta-23408": {
+      "System.Net.Http/4.0.1-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -305,7 +305,7 @@
           "ref/dotnet/System.Net.Http.dll": {}
         }
       },
-      "System.Net.NameResolution/4.0.0-beta-23408": {
+      "System.Net.NameResolution/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Net.Primitives": "4.0.10",
@@ -328,16 +328,17 @@
           "lib/DNXCore50/System.Net.Primitives.dll": {}
         }
       },
-      "System.Net.Security/4.0.0-beta-23408": {
+      "System.Net.Security/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
-          "System.Private.Networking": "4.0.1-beta-23408"
+          "System.IO": "4.0.0",
+          "System.Net.Primitives": "4.0.10",
+          "System.Runtime": "4.0.0",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23412",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Net.Security.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Net.Security.dll": {}
         }
       },
       "System.Net.Sockets/4.1.0-beta-23225": {
@@ -368,7 +369,7 @@
           "lib/dotnet/System.Net.WebHeaderCollection.dll": {}
         }
       },
-      "System.Net.WebSockets/4.0.0-beta-23408": {
+      "System.Net.WebSockets/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -383,7 +384,7 @@
           "lib/dotnet/System.Net.WebSockets.dll": {}
         }
       },
-      "System.Net.WebSockets.Client/4.0.0-beta-23408": {
+      "System.Net.WebSockets.Client/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -393,13 +394,13 @@
           "System.Globalization": "4.0.10",
           "System.Net.Primitives": "4.0.10",
           "System.Net.WebHeaderCollection": "4.0.0",
-          "System.Net.WebSockets": "4.0.0-beta-23408",
+          "System.Net.WebSockets": "4.0.0-beta-23412",
           "System.Resources.ResourceManager": "4.0.0",
           "System.Runtime": "4.0.20",
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23408",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23412",
           "System.Text.Encoding": "4.0.10",
           "System.Threading": "4.0.10",
           "System.Threading.Tasks": "4.0.10"
@@ -456,7 +457,7 @@
           "lib/DNXCore50/System.Private.DataContractSerialization.dll": {}
         }
       },
-      "System.Private.Networking/4.0.1-beta-23408": {
+      "System.Private.Networking/4.0.1-beta-23225": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -475,13 +476,10 @@
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23408",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23408",
-          "System.Security.Principal.Windows": "4.0.0-beta-23408",
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23225",
           "System.Threading": "4.0.10",
           "System.Threading.Overlapped": "4.0.0",
-          "System.Threading.Tasks": "4.0.10",
-          "System.Threading.ThreadPool": "4.0.10-beta-23408"
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dnxcore50/_._": {}
@@ -490,7 +488,7 @@
           "lib/DNXCore50/System.Private.Networking.dll": {}
         }
       },
-      "System.Private.ServiceModel/4.1.0-beta-23408": {
+      "System.Private.ServiceModel/4.1.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -507,14 +505,14 @@
           "System.Linq": "4.0.0",
           "System.Linq.Expressions": "4.0.10",
           "System.Linq.Queryable": "4.0.0",
-          "System.Net.Http": "4.0.1-beta-23408",
-          "System.Net.NameResolution": "4.0.0-beta-23408",
+          "System.Net.Http": "4.0.1-beta-23412",
+          "System.Net.NameResolution": "4.0.0-beta-23412",
           "System.Net.Primitives": "4.0.10",
-          "System.Net.Security": "4.0.0-beta-23408",
-          "System.Net.Sockets": "4.0.10-beta-23408",
+          "System.Net.Security": "4.0.0-beta-23412",
+          "System.Net.Sockets": "4.0.10-beta-23412",
           "System.Net.WebHeaderCollection": "4.0.0",
-          "System.Net.WebSockets": "4.0.0-beta-23408",
-          "System.Net.WebSockets.Client": "4.0.0-beta-23408",
+          "System.Net.WebSockets": "4.0.0-beta-23412",
+          "System.Net.WebSockets.Client": "4.0.0-beta-23412",
           "System.ObjectModel": "4.0.10",
           "System.Reflection": "4.0.10",
           "System.Reflection.DispatchProxy": "4.0.0",
@@ -528,9 +526,9 @@
           "System.Runtime.Serialization.Primitives": "4.0.10",
           "System.Runtime.Serialization.Xml": "4.0.10",
           "System.Security.Claims": "4.0.0",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23408",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23412",
           "System.Security.Principal": "4.0.0",
-          "System.Security.Principal.Windows": "4.0.0-beta-23408",
+          "System.Security.Principal.Windows": "4.0.0-beta-23412",
           "System.Text.Encoding": "4.0.10",
           "System.Threading": "4.0.10",
           "System.Threading.Tasks": "4.0.10",
@@ -779,18 +777,18 @@
           "lib/dotnet/System.Security.Claims.dll": {}
         }
       },
-      "System.Security.Cryptography.Algorithms/4.0.0-beta-23408": {
+      "System.Security.Cryptography.Algorithms/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
           "System.Runtime": "4.0.0",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23408"
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23412"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.Algorithms.dll": {}
         }
       },
-      "System.Security.Cryptography.Encoding/4.0.0-beta-23408": {
+      "System.Security.Cryptography.Encoding/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -799,7 +797,7 @@
           "ref/dotnet/System.Security.Cryptography.Encoding.dll": {}
         }
       },
-      "System.Security.Cryptography.Primitives/4.0.0-beta-23408": {
+      "System.Security.Cryptography.Primitives/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.0",
@@ -817,13 +815,13 @@
           "lib/dotnet/System.Security.Cryptography.Primitives.dll": {}
         }
       },
-      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23408": {
+      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
           "System.Runtime.Handles": "4.0.0",
-          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23408",
-          "System.Security.Cryptography.Encoding": "4.0.0-beta-23408"
+          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23412",
+          "System.Security.Cryptography.Encoding": "4.0.0-beta-23412"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.X509Certificates.dll": {}
@@ -841,7 +839,7 @@
           "lib/dotnet/System.Security.Principal.dll": {}
         }
       },
-      "System.Security.Principal.Windows/4.0.0-beta-23408": {
+      "System.Security.Principal.Windows/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -864,10 +862,10 @@
           "lib/DNXCore50/System.Security.Principal.Windows.dll": {}
         }
       },
-      "System.ServiceModel.Http/4.0.11-beta-23408": {
+      "System.ServiceModel.Http/4.0.11-beta-23412": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-beta-23408",
+          "System.Private.ServiceModel": "4.1.0-beta-23412",
           "System.Runtime": "4.0.20"
         },
         "compile": {
@@ -877,10 +875,10 @@
           "lib/DNXCore50/System.ServiceModel.Http.dll": {}
         }
       },
-      "System.ServiceModel.Primitives/4.0.1-beta-23408": {
+      "System.ServiceModel.Primitives/4.0.1-beta-23412": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-beta-23408"
+          "System.Private.ServiceModel": "4.1.0-beta-23412"
         },
         "compile": {
           "ref/dotnet/System.ServiceModel.Primitives.dll": {}
@@ -967,19 +965,6 @@
         },
         "runtime": {
           "lib/DNXCore50/System.Threading.Tasks.dll": {}
-        }
-      },
-      "System.Threading.ThreadPool/4.0.10-beta-23408": {
-        "type": "package",
-        "dependencies": {
-          "System.Runtime": "4.0.0",
-          "System.Runtime.InteropServices": "4.0.0"
-        },
-        "compile": {
-          "ref/dotnet/System.Threading.ThreadPool.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Threading.ThreadPool.dll": {}
         }
       },
       "System.Threading.Timer/4.0.0": {
@@ -1162,7 +1147,7 @@
           "lib/dotnet/xunit.execution.dotnet.dll": {}
         }
       },
-      "xunit.netcore.extensions/1.0.0-prerelease-00104": {
+      "xunit.netcore.extensions/1.0.0-prerelease-00105": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.10",
@@ -1790,44 +1775,65 @@
         "System.Linq.Queryable.nuspec"
       ]
     },
-    "System.Net.Http/4.0.1-beta-23408": {
+    "System.Net.Http/4.0.1-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "n+tnV1VgCjbDKKnbgrvgUgxkPDwUFvSv9lTgH882rVzjbWyliVgbBflVzoAUjUSlga/Tr1XQIrfTLMRD5HfYGw==",
+      "sha512": "F7Yej+6QdRVzWg+qbkayRMcmf/7k7YfNFoVSA67wIsG9t5u7Wj4Go8FW72HL8qb9d7YjIsVB/5hA7g9MUT31Aw==",
       "files": [
         "lib/net45/_._",
         "lib/win8/_._",
         "lib/wpa81/_._",
+        "ref/dotnet/de/System.Net.Http.xml",
+        "ref/dotnet/es/System.Net.Http.xml",
+        "ref/dotnet/fr/System.Net.Http.xml",
+        "ref/dotnet/it/System.Net.Http.xml",
+        "ref/dotnet/ja/System.Net.Http.xml",
+        "ref/dotnet/ko/System.Net.Http.xml",
+        "ref/dotnet/ru/System.Net.Http.xml",
         "ref/dotnet/System.Net.Http.dll",
+        "ref/dotnet/System.Net.Http.xml",
+        "ref/dotnet/zh-hans/System.Net.Http.xml",
+        "ref/dotnet/zh-hant/System.Net.Http.xml",
         "ref/net45/_._",
         "ref/netcore50/System.Net.Http.dll",
+        "ref/netcore50/System.Net.Http.xml",
         "ref/win8/_._",
         "ref/wpa81/_._",
         "runtime.json",
-        "System.Net.Http.4.0.1-beta-23408.nupkg",
-        "System.Net.Http.4.0.1-beta-23408.nupkg.sha512",
+        "System.Net.Http.4.0.1-beta-23412.nupkg",
+        "System.Net.Http.4.0.1-beta-23412.nupkg.sha512",
         "System.Net.Http.nuspec"
       ]
     },
-    "System.Net.NameResolution/4.0.0-beta-23408": {
+    "System.Net.NameResolution/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "2A562VFL8GUL/jLCJ3mbQHhwwAIXzPyjxMpdtas1LVM8QLuP1OcHwV3z7ajWnYdGcPc7ZxPEGJQWicuaPD+0nA==",
+      "sha512": "HCF1zhFYBT+w/Ik+JuTzFJgj83Jfc+eA8VcgvIzdPiGMXfrZeXOogjgSCkCoJmFtKVz2DSfmISoEmiXB1oaLNQ==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.NameResolution.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Net.NameResolution.xml",
+        "ref/dotnet/es/System.Net.NameResolution.xml",
+        "ref/dotnet/fr/System.Net.NameResolution.xml",
+        "ref/dotnet/it/System.Net.NameResolution.xml",
+        "ref/dotnet/ja/System.Net.NameResolution.xml",
+        "ref/dotnet/ko/System.Net.NameResolution.xml",
+        "ref/dotnet/ru/System.Net.NameResolution.xml",
         "ref/dotnet/System.Net.NameResolution.dll",
+        "ref/dotnet/System.Net.NameResolution.xml",
+        "ref/dotnet/zh-hans/System.Net.NameResolution.xml",
+        "ref/dotnet/zh-hant/System.Net.NameResolution.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Net.NameResolution.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Net.NameResolution.4.0.0-beta-23408.nupkg",
-        "System.Net.NameResolution.4.0.0-beta-23408.nupkg.sha512",
+        "System.Net.NameResolution.4.0.0-beta-23412.nupkg",
+        "System.Net.NameResolution.4.0.0-beta-23412.nupkg.sha512",
         "System.Net.NameResolution.nuspec"
       ]
     },
@@ -1864,24 +1870,34 @@
         "System.Net.Primitives.nuspec"
       ]
     },
-    "System.Net.Security/4.0.0-beta-23408": {
+    "System.Net.Security/4.0.0-beta-23412": {
       "type": "package",
-      "sha512": "kEkunODO2t/VlBIsC80YFDG0KtY/FyIbtBApNyJQv+LYGEs5IFvEhpi9+p0/jHmhyRMKwbjajNedbXo+VMkt1A==",
+      "sha512": "Kcjne7jnvF5aTbRJsAT8kuP+1mxryUF2qYv8f3jnR19wtEjswSIOVU0XzuWc9YObEQcb+kEdzN71HTOm+ssv+w==",
       "files": [
-        "lib/DNXCore50/System.Net.Security.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.Security.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Net.Security.xml",
+        "ref/dotnet/es/System.Net.Security.xml",
+        "ref/dotnet/fr/System.Net.Security.xml",
+        "ref/dotnet/it/System.Net.Security.xml",
+        "ref/dotnet/ja/System.Net.Security.xml",
+        "ref/dotnet/ko/System.Net.Security.xml",
+        "ref/dotnet/ru/System.Net.Security.xml",
         "ref/dotnet/System.Net.Security.dll",
+        "ref/dotnet/System.Net.Security.xml",
+        "ref/dotnet/zh-hans/System.Net.Security.xml",
+        "ref/dotnet/zh-hant/System.Net.Security.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Net.Security.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.Security.4.0.0-beta-23408.nupkg",
-        "System.Net.Security.4.0.0-beta-23408.nupkg.sha512",
+        "runtime.json",
+        "System.Net.Security.4.0.0-beta-23412.nupkg",
+        "System.Net.Security.4.0.0-beta-23412.nupkg.sha512",
         "System.Net.Security.nuspec"
       ]
     },
@@ -1939,78 +1955,68 @@
         "System.Net.WebHeaderCollection.nuspec"
       ]
     },
-    "System.Net.WebSockets/4.0.0-beta-23408": {
+    "System.Net.WebSockets/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "BXy22/bNVtrXXsG76zXyhjcQnCjSYxQIFF37xWifqPRWmvzsCYSLQpNCTPQUCp7rjB7qWc5yLhC9bThaEx7MHQ==",
+      "sha512": "EvXAa0yd1RM8ROyLl1T0xC94F04Su8YMHnd4/w6j0Z/+4lKHZOU7bQPZ3odDN8WdPGKa/ZNJJGwiapydEWKzwQ==",
       "files": [
-        "lib/dotnet/de/System.Net.WebSockets.xml",
-        "lib/dotnet/es/System.Net.WebSockets.xml",
-        "lib/dotnet/fr/System.Net.WebSockets.xml",
-        "lib/dotnet/it/System.Net.WebSockets.xml",
-        "lib/dotnet/ja/System.Net.WebSockets.xml",
-        "lib/dotnet/ko/System.Net.WebSockets.xml",
-        "lib/dotnet/ru/System.Net.WebSockets.xml",
         "lib/dotnet/System.Net.WebSockets.dll",
-        "lib/dotnet/System.Net.WebSockets.xml",
-        "lib/dotnet/zh-hans/System.Net.WebSockets.xml",
-        "lib/dotnet/zh-hant/System.Net.WebSockets.xml",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.WebSockets.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Net.WebSockets.xml",
+        "ref/dotnet/es/System.Net.WebSockets.xml",
+        "ref/dotnet/fr/System.Net.WebSockets.xml",
+        "ref/dotnet/it/System.Net.WebSockets.xml",
+        "ref/dotnet/ja/System.Net.WebSockets.xml",
+        "ref/dotnet/ko/System.Net.WebSockets.xml",
+        "ref/dotnet/ru/System.Net.WebSockets.xml",
         "ref/dotnet/System.Net.WebSockets.dll",
+        "ref/dotnet/System.Net.WebSockets.xml",
+        "ref/dotnet/zh-hans/System.Net.WebSockets.xml",
+        "ref/dotnet/zh-hant/System.Net.WebSockets.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Net.WebSockets.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.WebSockets.4.0.0-beta-23408.nupkg",
-        "System.Net.WebSockets.4.0.0-beta-23408.nupkg.sha512",
+        "System.Net.WebSockets.4.0.0-beta-23412.nupkg",
+        "System.Net.WebSockets.4.0.0-beta-23412.nupkg.sha512",
         "System.Net.WebSockets.nuspec"
       ]
     },
-    "System.Net.WebSockets.Client/4.0.0-beta-23408": {
+    "System.Net.WebSockets.Client/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "smmvhCkcU0c4RNWc6NZwnN5EFktX58jf8+TJ6enfuXxWrpJ/2NRI5/2yT/okjFSngGK1g0MBrljZsfs2EJ7+Yw==",
+      "sha512": "uaO7c/81sK90605UtThSX9KVmzsJDA1vD4GMW7FsKKntymlkolJsprDekWblQ4A5YbhqxHv+ngXX2kIU0B3Fdw==",
       "files": [
-        "lib/DNXCore50/de/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/es/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/fr/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/it/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/ja/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/ko/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/ru/System.Net.WebSockets.Client.xml",
         "lib/DNXCore50/System.Net.WebSockets.Client.dll",
-        "lib/DNXCore50/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/zh-hans/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/zh-hant/System.Net.WebSockets.Client.xml",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.WebSockets.Client.dll",
-        "lib/netcore50/de/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/es/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/fr/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/it/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/ja/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/ko/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/ru/System.Net.WebSockets.Client.xml",
         "lib/netcore50/System.Net.WebSockets.Client.dll",
-        "lib/netcore50/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/zh-hans/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/zh-hant/System.Net.WebSockets.Client.xml",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/es/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/fr/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/it/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/ja/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/ko/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/ru/System.Net.WebSockets.Client.xml",
         "ref/dotnet/System.Net.WebSockets.Client.dll",
+        "ref/dotnet/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/zh-hans/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/zh-hant/System.Net.WebSockets.Client.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Net.WebSockets.Client.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.WebSockets.Client.4.0.0-beta-23408.nupkg",
-        "System.Net.WebSockets.Client.4.0.0-beta-23408.nupkg.sha512",
+        "System.Net.WebSockets.Client.4.0.0-beta-23412.nupkg",
+        "System.Net.WebSockets.Client.4.0.0-beta-23412.nupkg.sha512",
         "System.Net.WebSockets.Client.nuspec"
       ]
     },
@@ -2062,31 +2068,31 @@
         "System.Private.DataContractSerialization.nuspec"
       ]
     },
-    "System.Private.Networking/4.0.1-beta-23408": {
+    "System.Private.Networking/4.0.1-beta-23225": {
       "type": "package",
       "serviceable": true,
-      "sha512": "i2fRDRqM8Px3CP26C//deF/tCNR1AwqlPEr9+MYiXxNZtgGcSPBfqOJJ5CJdfmDb9Ap0hPG2MiPG7CinaSH7+Q==",
+      "sha512": "oVSynIrR3mIU0b/goscsaZDywr3RLxQijQnaFRKfl/VB3F9rKi5mdr0vHcGVWuq5ALSrG0OLwM8PRA4tM5e3rQ==",
       "files": [
         "lib/DNXCore50/System.Private.Networking.dll",
         "lib/netcore50/System.Private.Networking.dll",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "System.Private.Networking.4.0.1-beta-23408.nupkg",
-        "System.Private.Networking.4.0.1-beta-23408.nupkg.sha512",
+        "System.Private.Networking.4.0.1-beta-23225.nupkg",
+        "System.Private.Networking.4.0.1-beta-23225.nupkg.sha512",
         "System.Private.Networking.nuspec"
       ]
     },
-    "System.Private.ServiceModel/4.1.0-beta-23408": {
+    "System.Private.ServiceModel/4.1.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "l/2192yKa6uXhjKOWeukFJy3hoj9Zq1p55pTGe+Y28r8/5jlvgYxfunP9UyXJRo9W1u3UBtGfV/5R71ULzusGQ==",
+      "sha512": "Wm+8LcQ04YeAvYqu9faHsMZ/L8l/WvPPsqziBfifYB4jXIPXk1/kUxuAryjbLChghZDXvkDN0hv/IHSVPZGgBA==",
       "files": [
         "lib/DNXCore50/System.Private.ServiceModel.dll",
         "lib/netcore50/System.Private.ServiceModel.dll",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "System.Private.ServiceModel.4.1.0-beta-23408.nupkg",
-        "System.Private.ServiceModel.4.1.0-beta-23408.nupkg.sha512",
+        "System.Private.ServiceModel.4.1.0-beta-23412.nupkg",
+        "System.Private.ServiceModel.4.1.0-beta-23412.nupkg.sha512",
         "System.Private.ServiceModel.nuspec"
       ]
     },
@@ -2615,10 +2621,10 @@
         "System.Security.Claims.nuspec"
       ]
     },
-    "System.Security.Cryptography.Algorithms/4.0.0-beta-23408": {
+    "System.Security.Cryptography.Algorithms/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "G6eEqi8mZRrWftcwilcnllE4xJ/53JQlk3VVuJ+9qrX+DHvWz8itYJRUZX357JY4DgEEKQNOJzuRGrOBTUeoPg==",
+      "sha512": "nBjoiqJQiMD3cJgOVrqjIVDqEEPZeIqT+mrBIxjLE+YMQcjEyDuSyOG65Ntoopby5LH4onTLMM4zfXh8JRt9NQ==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2632,37 +2638,47 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.Algorithms.4.0.0-beta-23408.nupkg",
-        "System.Security.Cryptography.Algorithms.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Cryptography.Algorithms.4.0.0-beta-23412.nupkg",
+        "System.Security.Cryptography.Algorithms.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Cryptography.Algorithms.nuspec"
       ]
     },
-    "System.Security.Cryptography.Encoding/4.0.0-beta-23408": {
+    "System.Security.Cryptography.Encoding/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "fPsAK3vyMjnJ6nT4YchdS7KzfGca/6uVVAPCBO08ZpTRGhMGx30vq1MiIqAUrfsFMnot3Ub2jimnAFWkqY6g0Q==",
+      "sha512": "SR1zCARNdeyLoUKYH2SNMm1He7Lr3NR/l7yW3K135L44T6PS3YB8SfXpVoZdMpb22X2G07BZAHVz2x7e4AA1Cg==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Security.Cryptography.Encoding.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/es/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/fr/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/it/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/ja/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/ko/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/ru/System.Security.Cryptography.Encoding.xml",
         "ref/dotnet/System.Security.Cryptography.Encoding.dll",
+        "ref/dotnet/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/zh-hans/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/zh-hant/System.Security.Cryptography.Encoding.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Security.Cryptography.Encoding.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.Encoding.4.0.0-beta-23408.nupkg",
-        "System.Security.Cryptography.Encoding.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Cryptography.Encoding.4.0.0-beta-23412.nupkg",
+        "System.Security.Cryptography.Encoding.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Cryptography.Encoding.nuspec"
       ]
     },
-    "System.Security.Cryptography.Primitives/4.0.0-beta-23408": {
+    "System.Security.Cryptography.Primitives/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "A336dWYEIQxm1rEJCaE5ZZrUWHPUkBGTRH8uAj8qrTqg4/qRc2yN2wZxeGXaZauhI35QwDmOutK7oVb2Cd+4TA==",
+      "sha512": "H9EBNe0ahjAYjlVn0TnT18PSgZBrtROSQH1RRIKwAjzxQHt8zwDhO4yN0Q5QaaUIoSXgxVmgtWWk62wDvpy+QA==",
       "files": [
         "lib/dotnet/System.Security.Cryptography.Primitives.dll",
         "lib/MonoAndroid10/_._",
@@ -2676,30 +2692,40 @@
         "ref/net46/System.Security.Cryptography.Primitives.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Security.Cryptography.Primitives.4.0.0-beta-23408.nupkg",
-        "System.Security.Cryptography.Primitives.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Cryptography.Primitives.4.0.0-beta-23412.nupkg",
+        "System.Security.Cryptography.Primitives.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Cryptography.Primitives.nuspec"
       ]
     },
-    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23408": {
+    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "JSNf5d1V5Y47MIdf7QxZCuGnR5heM4UKbrsdXiWD5lfqu0mnNjebPIclMUXlTw/6IykuDsUpompV/DtsaLLHig==",
+      "sha512": "SfpMjvrfRaRjG42uynLugb3YgpXdpnU7X8vNAU7stIR5/4uW9m1SvWHvBjirjHRBtOpbKB86uD5ODQWX+tWDNA==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Security.Cryptography.X509Certificates.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/es/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/fr/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/it/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/ja/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/ko/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/ru/System.Security.Cryptography.X509Certificates.xml",
         "ref/dotnet/System.Security.Cryptography.X509Certificates.dll",
+        "ref/dotnet/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/zh-hans/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/zh-hant/System.Security.Cryptography.X509Certificates.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Security.Cryptography.X509Certificates.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23408.nupkg",
-        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23412.nupkg",
+        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Cryptography.X509Certificates.nuspec"
       ]
     },
@@ -2736,88 +2762,89 @@
         "System.Security.Principal.nuspec"
       ]
     },
-    "System.Security.Principal.Windows/4.0.0-beta-23408": {
+    "System.Security.Principal.Windows/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "xmjpZJvsT1AW23UkjqUkF/VrOh7DA1cagYY272UQmO8ei227TFD4C7j3ofatL/63hR3CXkLkoephuE4f2Z9fGA==",
+      "sha512": "Zvb/LzT+GjGNV1t8i5KVieilL+8P5LcQykIbJHw5aJxLPFEIQ4Y2hTJXdEkeKvZ4TCF5dlwY1jYyUrJkcqpxzw==",
       "files": [
-        "lib/DNXCore50/de/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/es/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/fr/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/it/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/ja/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/ko/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/ru/System.Security.Principal.Windows.xml",
         "lib/DNXCore50/System.Security.Principal.Windows.dll",
-        "lib/DNXCore50/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/zh-hans/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/zh-hant/System.Security.Principal.Windows.xml",
         "lib/net46/System.Security.Principal.Windows.dll",
+        "ref/dotnet/de/System.Security.Principal.Windows.xml",
+        "ref/dotnet/es/System.Security.Principal.Windows.xml",
+        "ref/dotnet/fr/System.Security.Principal.Windows.xml",
+        "ref/dotnet/it/System.Security.Principal.Windows.xml",
+        "ref/dotnet/ja/System.Security.Principal.Windows.xml",
+        "ref/dotnet/ko/System.Security.Principal.Windows.xml",
+        "ref/dotnet/ru/System.Security.Principal.Windows.xml",
         "ref/dotnet/System.Security.Principal.Windows.dll",
+        "ref/dotnet/System.Security.Principal.Windows.xml",
+        "ref/dotnet/zh-hans/System.Security.Principal.Windows.xml",
+        "ref/dotnet/zh-hant/System.Security.Principal.Windows.xml",
         "ref/net46/System.Security.Principal.Windows.dll",
-        "System.Security.Principal.Windows.4.0.0-beta-23408.nupkg",
-        "System.Security.Principal.Windows.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Principal.Windows.4.0.0-beta-23412.nupkg",
+        "System.Security.Principal.Windows.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Principal.Windows.nuspec"
       ]
     },
-    "System.ServiceModel.Http/4.0.11-beta-23408": {
+    "System.ServiceModel.Http/4.0.11-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "RScHZ1A3CfjumaP1Vh/xfOp/ga6T3nA8YLkjFOYcIcZm/LILL+yCh+PhIrJOEfz1Js8bLSQC6xbxwYlW6BNmYg==",
+      "sha512": "hKMGQbu/l2gv/PgPvm2ViLVElnVSwAPiv4cXKjinS+UHBf02uPF2m7lN13SCkJDNTBctwHav1rQnMYb1LUJHvw==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Http.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
-        "lib/netcore50/de/System.ServiceModel.Http.xml",
-        "lib/netcore50/es/System.ServiceModel.Http.xml",
-        "lib/netcore50/fr/System.ServiceModel.Http.xml",
-        "lib/netcore50/it/System.ServiceModel.Http.xml",
-        "lib/netcore50/ja/System.ServiceModel.Http.xml",
-        "lib/netcore50/ko/System.ServiceModel.Http.xml",
-        "lib/netcore50/ru/System.ServiceModel.Http.xml",
         "lib/netcore50/System.ServiceModel.Http.dll",
-        "lib/netcore50/System.ServiceModel.Http.xml",
-        "lib/netcore50/zh-hans/System.ServiceModel.Http.xml",
-        "lib/netcore50/zh-hant/System.ServiceModel.Http.xml",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.ServiceModel.Http.xml",
+        "ref/dotnet/es/System.ServiceModel.Http.xml",
+        "ref/dotnet/fr/System.ServiceModel.Http.xml",
+        "ref/dotnet/it/System.ServiceModel.Http.xml",
+        "ref/dotnet/ja/System.ServiceModel.Http.xml",
+        "ref/dotnet/ko/System.ServiceModel.Http.xml",
+        "ref/dotnet/ru/System.ServiceModel.Http.xml",
         "ref/dotnet/System.ServiceModel.Http.dll",
+        "ref/dotnet/System.ServiceModel.Http.xml",
+        "ref/dotnet/zh-hans/System.ServiceModel.Http.xml",
+        "ref/dotnet/zh-hant/System.ServiceModel.Http.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.ServiceModel.Http.4.0.11-beta-23408.nupkg",
-        "System.ServiceModel.Http.4.0.11-beta-23408.nupkg.sha512",
+        "System.ServiceModel.Http.4.0.11-beta-23412.nupkg",
+        "System.ServiceModel.Http.4.0.11-beta-23412.nupkg.sha512",
         "System.ServiceModel.Http.nuspec"
       ]
     },
-    "System.ServiceModel.Primitives/4.0.1-beta-23408": {
+    "System.ServiceModel.Primitives/4.0.1-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "bjXzg+V3Oq/tBXpMY5FwcERN2CQsFXoL4BMoURlwiBMkgwN2CPvBIaK45Moh7nc21jNTVukNayDtURetGzK6aA==",
+      "sha512": "dkCUkNtXb2m9Wf+DY7dc5B4J8DpaWtX4wpFfT3cYLpChxAnjQR85N+tJfMEHLfZNNerKgDRyGyaKa7uSHfvb5g==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Primitives.dll",
         "lib/net45/_._",
-        "lib/netcore50/de/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/es/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/fr/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/it/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/ja/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/ko/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/ru/System.ServiceModel.Primitives.xml",
         "lib/netcore50/System.ServiceModel.Primitives.dll",
-        "lib/netcore50/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/zh-hans/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/zh-hant/System.ServiceModel.Primitives.xml",
         "lib/win8/_._",
+        "ref/dotnet/de/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/es/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/fr/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/it/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/ja/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/ko/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/ru/System.ServiceModel.Primitives.xml",
         "ref/dotnet/System.ServiceModel.Primitives.dll",
+        "ref/dotnet/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/zh-hans/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/zh-hant/System.ServiceModel.Primitives.xml",
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.Primitives.dll",
+        "ref/netcore50/System.ServiceModel.Primitives.xml",
         "ref/win8/_._",
-        "System.ServiceModel.Primitives.4.0.1-beta-23408.nupkg",
-        "System.ServiceModel.Primitives.4.0.1-beta-23408.nupkg.sha512",
+        "System.ServiceModel.Primitives.4.0.1-beta-23412.nupkg",
+        "System.ServiceModel.Primitives.4.0.1-beta-23412.nupkg.sha512",
         "System.ServiceModel.Primitives.nuspec"
       ]
     },
@@ -3010,28 +3037,6 @@
         "System.Threading.Tasks.4.0.10.nupkg",
         "System.Threading.Tasks.4.0.10.nupkg.sha512",
         "System.Threading.Tasks.nuspec"
-      ]
-    },
-    "System.Threading.ThreadPool/4.0.10-beta-23408": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "ahdsVyj+WFj8/iSDwX/G7hkEU4jZmmvWzPS2ajZKdp0Crb0vZJOlM0LQYVASQgbimrUZHQ50o93JYEi8RFdh/Q==",
-      "files": [
-        "lib/DNXCore50/System.Threading.ThreadPool.dll",
-        "lib/MonoAndroid10/_._",
-        "lib/MonoTouch10/_._",
-        "lib/net46/System.Threading.ThreadPool.dll",
-        "lib/xamarinios10/_._",
-        "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Threading.ThreadPool.dll",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
-        "ref/net46/System.Threading.ThreadPool.dll",
-        "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.Threading.ThreadPool.4.0.10-beta-23408.nupkg",
-        "System.Threading.ThreadPool.4.0.10-beta-23408.nupkg.sha512",
-        "System.Threading.ThreadPool.nuspec"
       ]
     },
     "System.Threading.Timer/4.0.0": {
@@ -3281,14 +3286,14 @@
         "xunit.extensibility.execution.nuspec"
       ]
     },
-    "xunit.netcore.extensions/1.0.0-prerelease-00104": {
+    "xunit.netcore.extensions/1.0.0-prerelease-00105": {
       "type": "package",
       "serviceable": true,
-      "sha512": "ZMXxEBpGP7krXtvqbPMOWavd2u83w77ghtD254wfj5+d+7GmYYqP9pX1iRIxJK9CBa8Zc2cOrcYsmCLQgYriAQ==",
+      "sha512": "EnnGcy9rmSdQ8izHWvYSYVyjQGhbeFH7JeM/L35ZrrPGtYvq5XD3hc1cJPCs+43mXdF9cdqhkt5uTlXYzC+Z8g==",
       "files": [
         "lib/dotnet/Xunit.NetCore.Extensions.dll",
-        "xunit.netcore.extensions.1.0.0-prerelease-00104.nupkg",
-        "xunit.netcore.extensions.1.0.0-prerelease-00104.nupkg.sha512",
+        "xunit.netcore.extensions.1.0.0-prerelease-00105.nupkg",
+        "xunit.netcore.extensions.1.0.0-prerelease-00105.nupkg.sha512",
         "xunit.netcore.extensions.nuspec"
       ]
     }

--- a/src/System.Private.ServiceModel/tests/Scenarios/Contract/Service/project.lock.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Contract/Service/project.lock.json
@@ -292,7 +292,7 @@
           "lib/dotnet/System.Linq.Queryable.dll": {}
         }
       },
-      "System.Net.Http/4.0.1-beta-23408": {
+      "System.Net.Http/4.0.1-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -305,7 +305,7 @@
           "ref/dotnet/System.Net.Http.dll": {}
         }
       },
-      "System.Net.NameResolution/4.0.0-beta-23408": {
+      "System.Net.NameResolution/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Net.Primitives": "4.0.10",
@@ -328,16 +328,17 @@
           "lib/DNXCore50/System.Net.Primitives.dll": {}
         }
       },
-      "System.Net.Security/4.0.0-beta-23408": {
+      "System.Net.Security/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
-          "System.Private.Networking": "4.0.1-beta-23408"
+          "System.IO": "4.0.0",
+          "System.Net.Primitives": "4.0.10",
+          "System.Runtime": "4.0.0",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23412",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Net.Security.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Net.Security.dll": {}
         }
       },
       "System.Net.Sockets/4.1.0-beta-23225": {
@@ -368,7 +369,7 @@
           "lib/dotnet/System.Net.WebHeaderCollection.dll": {}
         }
       },
-      "System.Net.WebSockets/4.0.0-beta-23408": {
+      "System.Net.WebSockets/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -383,7 +384,7 @@
           "lib/dotnet/System.Net.WebSockets.dll": {}
         }
       },
-      "System.Net.WebSockets.Client/4.0.0-beta-23408": {
+      "System.Net.WebSockets.Client/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -393,13 +394,13 @@
           "System.Globalization": "4.0.10",
           "System.Net.Primitives": "4.0.10",
           "System.Net.WebHeaderCollection": "4.0.0",
-          "System.Net.WebSockets": "4.0.0-beta-23408",
+          "System.Net.WebSockets": "4.0.0-beta-23412",
           "System.Resources.ResourceManager": "4.0.0",
           "System.Runtime": "4.0.20",
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23408",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23412",
           "System.Text.Encoding": "4.0.10",
           "System.Threading": "4.0.10",
           "System.Threading.Tasks": "4.0.10"
@@ -456,7 +457,7 @@
           "lib/DNXCore50/System.Private.DataContractSerialization.dll": {}
         }
       },
-      "System.Private.Networking/4.0.1-beta-23408": {
+      "System.Private.Networking/4.0.1-beta-23225": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -475,13 +476,10 @@
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23408",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23408",
-          "System.Security.Principal.Windows": "4.0.0-beta-23408",
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23225",
           "System.Threading": "4.0.10",
           "System.Threading.Overlapped": "4.0.0",
-          "System.Threading.Tasks": "4.0.10",
-          "System.Threading.ThreadPool": "4.0.10-beta-23408"
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dnxcore50/_._": {}
@@ -490,7 +488,7 @@
           "lib/DNXCore50/System.Private.Networking.dll": {}
         }
       },
-      "System.Private.ServiceModel/4.1.0-beta-23408": {
+      "System.Private.ServiceModel/4.1.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -507,14 +505,14 @@
           "System.Linq": "4.0.0",
           "System.Linq.Expressions": "4.0.10",
           "System.Linq.Queryable": "4.0.0",
-          "System.Net.Http": "4.0.1-beta-23408",
-          "System.Net.NameResolution": "4.0.0-beta-23408",
+          "System.Net.Http": "4.0.1-beta-23412",
+          "System.Net.NameResolution": "4.0.0-beta-23412",
           "System.Net.Primitives": "4.0.10",
-          "System.Net.Security": "4.0.0-beta-23408",
-          "System.Net.Sockets": "4.0.10-beta-23408",
+          "System.Net.Security": "4.0.0-beta-23412",
+          "System.Net.Sockets": "4.0.10-beta-23412",
           "System.Net.WebHeaderCollection": "4.0.0",
-          "System.Net.WebSockets": "4.0.0-beta-23408",
-          "System.Net.WebSockets.Client": "4.0.0-beta-23408",
+          "System.Net.WebSockets": "4.0.0-beta-23412",
+          "System.Net.WebSockets.Client": "4.0.0-beta-23412",
           "System.ObjectModel": "4.0.10",
           "System.Reflection": "4.0.10",
           "System.Reflection.DispatchProxy": "4.0.0",
@@ -528,9 +526,9 @@
           "System.Runtime.Serialization.Primitives": "4.0.10",
           "System.Runtime.Serialization.Xml": "4.0.10",
           "System.Security.Claims": "4.0.0",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23408",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23412",
           "System.Security.Principal": "4.0.0",
-          "System.Security.Principal.Windows": "4.0.0-beta-23408",
+          "System.Security.Principal.Windows": "4.0.0-beta-23412",
           "System.Text.Encoding": "4.0.10",
           "System.Threading": "4.0.10",
           "System.Threading.Tasks": "4.0.10",
@@ -779,18 +777,18 @@
           "lib/dotnet/System.Security.Claims.dll": {}
         }
       },
-      "System.Security.Cryptography.Algorithms/4.0.0-beta-23408": {
+      "System.Security.Cryptography.Algorithms/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
           "System.Runtime": "4.0.0",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23408"
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23412"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.Algorithms.dll": {}
         }
       },
-      "System.Security.Cryptography.Encoding/4.0.0-beta-23408": {
+      "System.Security.Cryptography.Encoding/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -799,7 +797,7 @@
           "ref/dotnet/System.Security.Cryptography.Encoding.dll": {}
         }
       },
-      "System.Security.Cryptography.Primitives/4.0.0-beta-23408": {
+      "System.Security.Cryptography.Primitives/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.0",
@@ -817,13 +815,13 @@
           "lib/dotnet/System.Security.Cryptography.Primitives.dll": {}
         }
       },
-      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23408": {
+      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
           "System.Runtime.Handles": "4.0.0",
-          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23408",
-          "System.Security.Cryptography.Encoding": "4.0.0-beta-23408"
+          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23412",
+          "System.Security.Cryptography.Encoding": "4.0.0-beta-23412"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.X509Certificates.dll": {}
@@ -841,7 +839,7 @@
           "lib/dotnet/System.Security.Principal.dll": {}
         }
       },
-      "System.Security.Principal.Windows/4.0.0-beta-23408": {
+      "System.Security.Principal.Windows/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -864,10 +862,10 @@
           "lib/DNXCore50/System.Security.Principal.Windows.dll": {}
         }
       },
-      "System.ServiceModel.Http/4.0.11-beta-23408": {
+      "System.ServiceModel.Http/4.0.11-beta-23412": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-beta-23408",
+          "System.Private.ServiceModel": "4.1.0-beta-23412",
           "System.Runtime": "4.0.20"
         },
         "compile": {
@@ -877,10 +875,10 @@
           "lib/DNXCore50/System.ServiceModel.Http.dll": {}
         }
       },
-      "System.ServiceModel.Primitives/4.0.1-beta-23408": {
+      "System.ServiceModel.Primitives/4.0.1-beta-23412": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-beta-23408"
+          "System.Private.ServiceModel": "4.1.0-beta-23412"
         },
         "compile": {
           "ref/dotnet/System.ServiceModel.Primitives.dll": {}
@@ -967,19 +965,6 @@
         },
         "runtime": {
           "lib/DNXCore50/System.Threading.Tasks.dll": {}
-        }
-      },
-      "System.Threading.ThreadPool/4.0.10-beta-23408": {
-        "type": "package",
-        "dependencies": {
-          "System.Runtime": "4.0.0",
-          "System.Runtime.InteropServices": "4.0.0"
-        },
-        "compile": {
-          "ref/dotnet/System.Threading.ThreadPool.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Threading.ThreadPool.dll": {}
         }
       },
       "System.Threading.Timer/4.0.0": {
@@ -1162,7 +1147,7 @@
           "lib/dotnet/xunit.execution.dotnet.dll": {}
         }
       },
-      "xunit.netcore.extensions/1.0.0-prerelease-00104": {
+      "xunit.netcore.extensions/1.0.0-prerelease-00105": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.10",
@@ -1790,44 +1775,65 @@
         "System.Linq.Queryable.nuspec"
       ]
     },
-    "System.Net.Http/4.0.1-beta-23408": {
+    "System.Net.Http/4.0.1-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "n+tnV1VgCjbDKKnbgrvgUgxkPDwUFvSv9lTgH882rVzjbWyliVgbBflVzoAUjUSlga/Tr1XQIrfTLMRD5HfYGw==",
+      "sha512": "F7Yej+6QdRVzWg+qbkayRMcmf/7k7YfNFoVSA67wIsG9t5u7Wj4Go8FW72HL8qb9d7YjIsVB/5hA7g9MUT31Aw==",
       "files": [
         "lib/net45/_._",
         "lib/win8/_._",
         "lib/wpa81/_._",
+        "ref/dotnet/de/System.Net.Http.xml",
+        "ref/dotnet/es/System.Net.Http.xml",
+        "ref/dotnet/fr/System.Net.Http.xml",
+        "ref/dotnet/it/System.Net.Http.xml",
+        "ref/dotnet/ja/System.Net.Http.xml",
+        "ref/dotnet/ko/System.Net.Http.xml",
+        "ref/dotnet/ru/System.Net.Http.xml",
         "ref/dotnet/System.Net.Http.dll",
+        "ref/dotnet/System.Net.Http.xml",
+        "ref/dotnet/zh-hans/System.Net.Http.xml",
+        "ref/dotnet/zh-hant/System.Net.Http.xml",
         "ref/net45/_._",
         "ref/netcore50/System.Net.Http.dll",
+        "ref/netcore50/System.Net.Http.xml",
         "ref/win8/_._",
         "ref/wpa81/_._",
         "runtime.json",
-        "System.Net.Http.4.0.1-beta-23408.nupkg",
-        "System.Net.Http.4.0.1-beta-23408.nupkg.sha512",
+        "System.Net.Http.4.0.1-beta-23412.nupkg",
+        "System.Net.Http.4.0.1-beta-23412.nupkg.sha512",
         "System.Net.Http.nuspec"
       ]
     },
-    "System.Net.NameResolution/4.0.0-beta-23408": {
+    "System.Net.NameResolution/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "2A562VFL8GUL/jLCJ3mbQHhwwAIXzPyjxMpdtas1LVM8QLuP1OcHwV3z7ajWnYdGcPc7ZxPEGJQWicuaPD+0nA==",
+      "sha512": "HCF1zhFYBT+w/Ik+JuTzFJgj83Jfc+eA8VcgvIzdPiGMXfrZeXOogjgSCkCoJmFtKVz2DSfmISoEmiXB1oaLNQ==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.NameResolution.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Net.NameResolution.xml",
+        "ref/dotnet/es/System.Net.NameResolution.xml",
+        "ref/dotnet/fr/System.Net.NameResolution.xml",
+        "ref/dotnet/it/System.Net.NameResolution.xml",
+        "ref/dotnet/ja/System.Net.NameResolution.xml",
+        "ref/dotnet/ko/System.Net.NameResolution.xml",
+        "ref/dotnet/ru/System.Net.NameResolution.xml",
         "ref/dotnet/System.Net.NameResolution.dll",
+        "ref/dotnet/System.Net.NameResolution.xml",
+        "ref/dotnet/zh-hans/System.Net.NameResolution.xml",
+        "ref/dotnet/zh-hant/System.Net.NameResolution.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Net.NameResolution.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Net.NameResolution.4.0.0-beta-23408.nupkg",
-        "System.Net.NameResolution.4.0.0-beta-23408.nupkg.sha512",
+        "System.Net.NameResolution.4.0.0-beta-23412.nupkg",
+        "System.Net.NameResolution.4.0.0-beta-23412.nupkg.sha512",
         "System.Net.NameResolution.nuspec"
       ]
     },
@@ -1864,24 +1870,34 @@
         "System.Net.Primitives.nuspec"
       ]
     },
-    "System.Net.Security/4.0.0-beta-23408": {
+    "System.Net.Security/4.0.0-beta-23412": {
       "type": "package",
-      "sha512": "kEkunODO2t/VlBIsC80YFDG0KtY/FyIbtBApNyJQv+LYGEs5IFvEhpi9+p0/jHmhyRMKwbjajNedbXo+VMkt1A==",
+      "sha512": "Kcjne7jnvF5aTbRJsAT8kuP+1mxryUF2qYv8f3jnR19wtEjswSIOVU0XzuWc9YObEQcb+kEdzN71HTOm+ssv+w==",
       "files": [
-        "lib/DNXCore50/System.Net.Security.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.Security.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Net.Security.xml",
+        "ref/dotnet/es/System.Net.Security.xml",
+        "ref/dotnet/fr/System.Net.Security.xml",
+        "ref/dotnet/it/System.Net.Security.xml",
+        "ref/dotnet/ja/System.Net.Security.xml",
+        "ref/dotnet/ko/System.Net.Security.xml",
+        "ref/dotnet/ru/System.Net.Security.xml",
         "ref/dotnet/System.Net.Security.dll",
+        "ref/dotnet/System.Net.Security.xml",
+        "ref/dotnet/zh-hans/System.Net.Security.xml",
+        "ref/dotnet/zh-hant/System.Net.Security.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Net.Security.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.Security.4.0.0-beta-23408.nupkg",
-        "System.Net.Security.4.0.0-beta-23408.nupkg.sha512",
+        "runtime.json",
+        "System.Net.Security.4.0.0-beta-23412.nupkg",
+        "System.Net.Security.4.0.0-beta-23412.nupkg.sha512",
         "System.Net.Security.nuspec"
       ]
     },
@@ -1939,78 +1955,68 @@
         "System.Net.WebHeaderCollection.nuspec"
       ]
     },
-    "System.Net.WebSockets/4.0.0-beta-23408": {
+    "System.Net.WebSockets/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "BXy22/bNVtrXXsG76zXyhjcQnCjSYxQIFF37xWifqPRWmvzsCYSLQpNCTPQUCp7rjB7qWc5yLhC9bThaEx7MHQ==",
+      "sha512": "EvXAa0yd1RM8ROyLl1T0xC94F04Su8YMHnd4/w6j0Z/+4lKHZOU7bQPZ3odDN8WdPGKa/ZNJJGwiapydEWKzwQ==",
       "files": [
-        "lib/dotnet/de/System.Net.WebSockets.xml",
-        "lib/dotnet/es/System.Net.WebSockets.xml",
-        "lib/dotnet/fr/System.Net.WebSockets.xml",
-        "lib/dotnet/it/System.Net.WebSockets.xml",
-        "lib/dotnet/ja/System.Net.WebSockets.xml",
-        "lib/dotnet/ko/System.Net.WebSockets.xml",
-        "lib/dotnet/ru/System.Net.WebSockets.xml",
         "lib/dotnet/System.Net.WebSockets.dll",
-        "lib/dotnet/System.Net.WebSockets.xml",
-        "lib/dotnet/zh-hans/System.Net.WebSockets.xml",
-        "lib/dotnet/zh-hant/System.Net.WebSockets.xml",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.WebSockets.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Net.WebSockets.xml",
+        "ref/dotnet/es/System.Net.WebSockets.xml",
+        "ref/dotnet/fr/System.Net.WebSockets.xml",
+        "ref/dotnet/it/System.Net.WebSockets.xml",
+        "ref/dotnet/ja/System.Net.WebSockets.xml",
+        "ref/dotnet/ko/System.Net.WebSockets.xml",
+        "ref/dotnet/ru/System.Net.WebSockets.xml",
         "ref/dotnet/System.Net.WebSockets.dll",
+        "ref/dotnet/System.Net.WebSockets.xml",
+        "ref/dotnet/zh-hans/System.Net.WebSockets.xml",
+        "ref/dotnet/zh-hant/System.Net.WebSockets.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Net.WebSockets.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.WebSockets.4.0.0-beta-23408.nupkg",
-        "System.Net.WebSockets.4.0.0-beta-23408.nupkg.sha512",
+        "System.Net.WebSockets.4.0.0-beta-23412.nupkg",
+        "System.Net.WebSockets.4.0.0-beta-23412.nupkg.sha512",
         "System.Net.WebSockets.nuspec"
       ]
     },
-    "System.Net.WebSockets.Client/4.0.0-beta-23408": {
+    "System.Net.WebSockets.Client/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "smmvhCkcU0c4RNWc6NZwnN5EFktX58jf8+TJ6enfuXxWrpJ/2NRI5/2yT/okjFSngGK1g0MBrljZsfs2EJ7+Yw==",
+      "sha512": "uaO7c/81sK90605UtThSX9KVmzsJDA1vD4GMW7FsKKntymlkolJsprDekWblQ4A5YbhqxHv+ngXX2kIU0B3Fdw==",
       "files": [
-        "lib/DNXCore50/de/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/es/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/fr/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/it/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/ja/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/ko/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/ru/System.Net.WebSockets.Client.xml",
         "lib/DNXCore50/System.Net.WebSockets.Client.dll",
-        "lib/DNXCore50/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/zh-hans/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/zh-hant/System.Net.WebSockets.Client.xml",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.WebSockets.Client.dll",
-        "lib/netcore50/de/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/es/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/fr/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/it/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/ja/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/ko/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/ru/System.Net.WebSockets.Client.xml",
         "lib/netcore50/System.Net.WebSockets.Client.dll",
-        "lib/netcore50/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/zh-hans/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/zh-hant/System.Net.WebSockets.Client.xml",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/es/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/fr/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/it/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/ja/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/ko/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/ru/System.Net.WebSockets.Client.xml",
         "ref/dotnet/System.Net.WebSockets.Client.dll",
+        "ref/dotnet/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/zh-hans/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/zh-hant/System.Net.WebSockets.Client.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Net.WebSockets.Client.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.WebSockets.Client.4.0.0-beta-23408.nupkg",
-        "System.Net.WebSockets.Client.4.0.0-beta-23408.nupkg.sha512",
+        "System.Net.WebSockets.Client.4.0.0-beta-23412.nupkg",
+        "System.Net.WebSockets.Client.4.0.0-beta-23412.nupkg.sha512",
         "System.Net.WebSockets.Client.nuspec"
       ]
     },
@@ -2062,31 +2068,31 @@
         "System.Private.DataContractSerialization.nuspec"
       ]
     },
-    "System.Private.Networking/4.0.1-beta-23408": {
+    "System.Private.Networking/4.0.1-beta-23225": {
       "type": "package",
       "serviceable": true,
-      "sha512": "i2fRDRqM8Px3CP26C//deF/tCNR1AwqlPEr9+MYiXxNZtgGcSPBfqOJJ5CJdfmDb9Ap0hPG2MiPG7CinaSH7+Q==",
+      "sha512": "oVSynIrR3mIU0b/goscsaZDywr3RLxQijQnaFRKfl/VB3F9rKi5mdr0vHcGVWuq5ALSrG0OLwM8PRA4tM5e3rQ==",
       "files": [
         "lib/DNXCore50/System.Private.Networking.dll",
         "lib/netcore50/System.Private.Networking.dll",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "System.Private.Networking.4.0.1-beta-23408.nupkg",
-        "System.Private.Networking.4.0.1-beta-23408.nupkg.sha512",
+        "System.Private.Networking.4.0.1-beta-23225.nupkg",
+        "System.Private.Networking.4.0.1-beta-23225.nupkg.sha512",
         "System.Private.Networking.nuspec"
       ]
     },
-    "System.Private.ServiceModel/4.1.0-beta-23408": {
+    "System.Private.ServiceModel/4.1.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "l/2192yKa6uXhjKOWeukFJy3hoj9Zq1p55pTGe+Y28r8/5jlvgYxfunP9UyXJRo9W1u3UBtGfV/5R71ULzusGQ==",
+      "sha512": "Wm+8LcQ04YeAvYqu9faHsMZ/L8l/WvPPsqziBfifYB4jXIPXk1/kUxuAryjbLChghZDXvkDN0hv/IHSVPZGgBA==",
       "files": [
         "lib/DNXCore50/System.Private.ServiceModel.dll",
         "lib/netcore50/System.Private.ServiceModel.dll",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "System.Private.ServiceModel.4.1.0-beta-23408.nupkg",
-        "System.Private.ServiceModel.4.1.0-beta-23408.nupkg.sha512",
+        "System.Private.ServiceModel.4.1.0-beta-23412.nupkg",
+        "System.Private.ServiceModel.4.1.0-beta-23412.nupkg.sha512",
         "System.Private.ServiceModel.nuspec"
       ]
     },
@@ -2615,10 +2621,10 @@
         "System.Security.Claims.nuspec"
       ]
     },
-    "System.Security.Cryptography.Algorithms/4.0.0-beta-23408": {
+    "System.Security.Cryptography.Algorithms/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "G6eEqi8mZRrWftcwilcnllE4xJ/53JQlk3VVuJ+9qrX+DHvWz8itYJRUZX357JY4DgEEKQNOJzuRGrOBTUeoPg==",
+      "sha512": "nBjoiqJQiMD3cJgOVrqjIVDqEEPZeIqT+mrBIxjLE+YMQcjEyDuSyOG65Ntoopby5LH4onTLMM4zfXh8JRt9NQ==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2632,37 +2638,47 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.Algorithms.4.0.0-beta-23408.nupkg",
-        "System.Security.Cryptography.Algorithms.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Cryptography.Algorithms.4.0.0-beta-23412.nupkg",
+        "System.Security.Cryptography.Algorithms.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Cryptography.Algorithms.nuspec"
       ]
     },
-    "System.Security.Cryptography.Encoding/4.0.0-beta-23408": {
+    "System.Security.Cryptography.Encoding/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "fPsAK3vyMjnJ6nT4YchdS7KzfGca/6uVVAPCBO08ZpTRGhMGx30vq1MiIqAUrfsFMnot3Ub2jimnAFWkqY6g0Q==",
+      "sha512": "SR1zCARNdeyLoUKYH2SNMm1He7Lr3NR/l7yW3K135L44T6PS3YB8SfXpVoZdMpb22X2G07BZAHVz2x7e4AA1Cg==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Security.Cryptography.Encoding.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/es/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/fr/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/it/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/ja/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/ko/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/ru/System.Security.Cryptography.Encoding.xml",
         "ref/dotnet/System.Security.Cryptography.Encoding.dll",
+        "ref/dotnet/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/zh-hans/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/zh-hant/System.Security.Cryptography.Encoding.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Security.Cryptography.Encoding.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.Encoding.4.0.0-beta-23408.nupkg",
-        "System.Security.Cryptography.Encoding.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Cryptography.Encoding.4.0.0-beta-23412.nupkg",
+        "System.Security.Cryptography.Encoding.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Cryptography.Encoding.nuspec"
       ]
     },
-    "System.Security.Cryptography.Primitives/4.0.0-beta-23408": {
+    "System.Security.Cryptography.Primitives/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "A336dWYEIQxm1rEJCaE5ZZrUWHPUkBGTRH8uAj8qrTqg4/qRc2yN2wZxeGXaZauhI35QwDmOutK7oVb2Cd+4TA==",
+      "sha512": "H9EBNe0ahjAYjlVn0TnT18PSgZBrtROSQH1RRIKwAjzxQHt8zwDhO4yN0Q5QaaUIoSXgxVmgtWWk62wDvpy+QA==",
       "files": [
         "lib/dotnet/System.Security.Cryptography.Primitives.dll",
         "lib/MonoAndroid10/_._",
@@ -2676,30 +2692,40 @@
         "ref/net46/System.Security.Cryptography.Primitives.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Security.Cryptography.Primitives.4.0.0-beta-23408.nupkg",
-        "System.Security.Cryptography.Primitives.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Cryptography.Primitives.4.0.0-beta-23412.nupkg",
+        "System.Security.Cryptography.Primitives.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Cryptography.Primitives.nuspec"
       ]
     },
-    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23408": {
+    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "JSNf5d1V5Y47MIdf7QxZCuGnR5heM4UKbrsdXiWD5lfqu0mnNjebPIclMUXlTw/6IykuDsUpompV/DtsaLLHig==",
+      "sha512": "SfpMjvrfRaRjG42uynLugb3YgpXdpnU7X8vNAU7stIR5/4uW9m1SvWHvBjirjHRBtOpbKB86uD5ODQWX+tWDNA==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Security.Cryptography.X509Certificates.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/es/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/fr/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/it/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/ja/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/ko/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/ru/System.Security.Cryptography.X509Certificates.xml",
         "ref/dotnet/System.Security.Cryptography.X509Certificates.dll",
+        "ref/dotnet/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/zh-hans/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/zh-hant/System.Security.Cryptography.X509Certificates.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Security.Cryptography.X509Certificates.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23408.nupkg",
-        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23412.nupkg",
+        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Cryptography.X509Certificates.nuspec"
       ]
     },
@@ -2736,88 +2762,89 @@
         "System.Security.Principal.nuspec"
       ]
     },
-    "System.Security.Principal.Windows/4.0.0-beta-23408": {
+    "System.Security.Principal.Windows/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "xmjpZJvsT1AW23UkjqUkF/VrOh7DA1cagYY272UQmO8ei227TFD4C7j3ofatL/63hR3CXkLkoephuE4f2Z9fGA==",
+      "sha512": "Zvb/LzT+GjGNV1t8i5KVieilL+8P5LcQykIbJHw5aJxLPFEIQ4Y2hTJXdEkeKvZ4TCF5dlwY1jYyUrJkcqpxzw==",
       "files": [
-        "lib/DNXCore50/de/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/es/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/fr/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/it/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/ja/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/ko/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/ru/System.Security.Principal.Windows.xml",
         "lib/DNXCore50/System.Security.Principal.Windows.dll",
-        "lib/DNXCore50/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/zh-hans/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/zh-hant/System.Security.Principal.Windows.xml",
         "lib/net46/System.Security.Principal.Windows.dll",
+        "ref/dotnet/de/System.Security.Principal.Windows.xml",
+        "ref/dotnet/es/System.Security.Principal.Windows.xml",
+        "ref/dotnet/fr/System.Security.Principal.Windows.xml",
+        "ref/dotnet/it/System.Security.Principal.Windows.xml",
+        "ref/dotnet/ja/System.Security.Principal.Windows.xml",
+        "ref/dotnet/ko/System.Security.Principal.Windows.xml",
+        "ref/dotnet/ru/System.Security.Principal.Windows.xml",
         "ref/dotnet/System.Security.Principal.Windows.dll",
+        "ref/dotnet/System.Security.Principal.Windows.xml",
+        "ref/dotnet/zh-hans/System.Security.Principal.Windows.xml",
+        "ref/dotnet/zh-hant/System.Security.Principal.Windows.xml",
         "ref/net46/System.Security.Principal.Windows.dll",
-        "System.Security.Principal.Windows.4.0.0-beta-23408.nupkg",
-        "System.Security.Principal.Windows.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Principal.Windows.4.0.0-beta-23412.nupkg",
+        "System.Security.Principal.Windows.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Principal.Windows.nuspec"
       ]
     },
-    "System.ServiceModel.Http/4.0.11-beta-23408": {
+    "System.ServiceModel.Http/4.0.11-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "RScHZ1A3CfjumaP1Vh/xfOp/ga6T3nA8YLkjFOYcIcZm/LILL+yCh+PhIrJOEfz1Js8bLSQC6xbxwYlW6BNmYg==",
+      "sha512": "hKMGQbu/l2gv/PgPvm2ViLVElnVSwAPiv4cXKjinS+UHBf02uPF2m7lN13SCkJDNTBctwHav1rQnMYb1LUJHvw==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Http.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
-        "lib/netcore50/de/System.ServiceModel.Http.xml",
-        "lib/netcore50/es/System.ServiceModel.Http.xml",
-        "lib/netcore50/fr/System.ServiceModel.Http.xml",
-        "lib/netcore50/it/System.ServiceModel.Http.xml",
-        "lib/netcore50/ja/System.ServiceModel.Http.xml",
-        "lib/netcore50/ko/System.ServiceModel.Http.xml",
-        "lib/netcore50/ru/System.ServiceModel.Http.xml",
         "lib/netcore50/System.ServiceModel.Http.dll",
-        "lib/netcore50/System.ServiceModel.Http.xml",
-        "lib/netcore50/zh-hans/System.ServiceModel.Http.xml",
-        "lib/netcore50/zh-hant/System.ServiceModel.Http.xml",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.ServiceModel.Http.xml",
+        "ref/dotnet/es/System.ServiceModel.Http.xml",
+        "ref/dotnet/fr/System.ServiceModel.Http.xml",
+        "ref/dotnet/it/System.ServiceModel.Http.xml",
+        "ref/dotnet/ja/System.ServiceModel.Http.xml",
+        "ref/dotnet/ko/System.ServiceModel.Http.xml",
+        "ref/dotnet/ru/System.ServiceModel.Http.xml",
         "ref/dotnet/System.ServiceModel.Http.dll",
+        "ref/dotnet/System.ServiceModel.Http.xml",
+        "ref/dotnet/zh-hans/System.ServiceModel.Http.xml",
+        "ref/dotnet/zh-hant/System.ServiceModel.Http.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.ServiceModel.Http.4.0.11-beta-23408.nupkg",
-        "System.ServiceModel.Http.4.0.11-beta-23408.nupkg.sha512",
+        "System.ServiceModel.Http.4.0.11-beta-23412.nupkg",
+        "System.ServiceModel.Http.4.0.11-beta-23412.nupkg.sha512",
         "System.ServiceModel.Http.nuspec"
       ]
     },
-    "System.ServiceModel.Primitives/4.0.1-beta-23408": {
+    "System.ServiceModel.Primitives/4.0.1-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "bjXzg+V3Oq/tBXpMY5FwcERN2CQsFXoL4BMoURlwiBMkgwN2CPvBIaK45Moh7nc21jNTVukNayDtURetGzK6aA==",
+      "sha512": "dkCUkNtXb2m9Wf+DY7dc5B4J8DpaWtX4wpFfT3cYLpChxAnjQR85N+tJfMEHLfZNNerKgDRyGyaKa7uSHfvb5g==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Primitives.dll",
         "lib/net45/_._",
-        "lib/netcore50/de/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/es/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/fr/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/it/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/ja/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/ko/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/ru/System.ServiceModel.Primitives.xml",
         "lib/netcore50/System.ServiceModel.Primitives.dll",
-        "lib/netcore50/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/zh-hans/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/zh-hant/System.ServiceModel.Primitives.xml",
         "lib/win8/_._",
+        "ref/dotnet/de/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/es/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/fr/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/it/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/ja/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/ko/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/ru/System.ServiceModel.Primitives.xml",
         "ref/dotnet/System.ServiceModel.Primitives.dll",
+        "ref/dotnet/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/zh-hans/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/zh-hant/System.ServiceModel.Primitives.xml",
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.Primitives.dll",
+        "ref/netcore50/System.ServiceModel.Primitives.xml",
         "ref/win8/_._",
-        "System.ServiceModel.Primitives.4.0.1-beta-23408.nupkg",
-        "System.ServiceModel.Primitives.4.0.1-beta-23408.nupkg.sha512",
+        "System.ServiceModel.Primitives.4.0.1-beta-23412.nupkg",
+        "System.ServiceModel.Primitives.4.0.1-beta-23412.nupkg.sha512",
         "System.ServiceModel.Primitives.nuspec"
       ]
     },
@@ -3010,28 +3037,6 @@
         "System.Threading.Tasks.4.0.10.nupkg",
         "System.Threading.Tasks.4.0.10.nupkg.sha512",
         "System.Threading.Tasks.nuspec"
-      ]
-    },
-    "System.Threading.ThreadPool/4.0.10-beta-23408": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "ahdsVyj+WFj8/iSDwX/G7hkEU4jZmmvWzPS2ajZKdp0Crb0vZJOlM0LQYVASQgbimrUZHQ50o93JYEi8RFdh/Q==",
-      "files": [
-        "lib/DNXCore50/System.Threading.ThreadPool.dll",
-        "lib/MonoAndroid10/_._",
-        "lib/MonoTouch10/_._",
-        "lib/net46/System.Threading.ThreadPool.dll",
-        "lib/xamarinios10/_._",
-        "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Threading.ThreadPool.dll",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
-        "ref/net46/System.Threading.ThreadPool.dll",
-        "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.Threading.ThreadPool.4.0.10-beta-23408.nupkg",
-        "System.Threading.ThreadPool.4.0.10-beta-23408.nupkg.sha512",
-        "System.Threading.ThreadPool.nuspec"
       ]
     },
     "System.Threading.Timer/4.0.0": {
@@ -3281,14 +3286,14 @@
         "xunit.extensibility.execution.nuspec"
       ]
     },
-    "xunit.netcore.extensions/1.0.0-prerelease-00104": {
+    "xunit.netcore.extensions/1.0.0-prerelease-00105": {
       "type": "package",
       "serviceable": true,
-      "sha512": "ZMXxEBpGP7krXtvqbPMOWavd2u83w77ghtD254wfj5+d+7GmYYqP9pX1iRIxJK9CBa8Zc2cOrcYsmCLQgYriAQ==",
+      "sha512": "EnnGcy9rmSdQ8izHWvYSYVyjQGhbeFH7JeM/L35ZrrPGtYvq5XD3hc1cJPCs+43mXdF9cdqhkt5uTlXYzC+Z8g==",
       "files": [
         "lib/dotnet/Xunit.NetCore.Extensions.dll",
-        "xunit.netcore.extensions.1.0.0-prerelease-00104.nupkg",
-        "xunit.netcore.extensions.1.0.0-prerelease-00104.nupkg.sha512",
+        "xunit.netcore.extensions.1.0.0-prerelease-00105.nupkg",
+        "xunit.netcore.extensions.1.0.0-prerelease-00105.nupkg.sha512",
         "xunit.netcore.extensions.nuspec"
       ]
     }

--- a/src/System.Private.ServiceModel/tests/Scenarios/Contract/XmlSerializer/project.lock.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Contract/XmlSerializer/project.lock.json
@@ -292,7 +292,7 @@
           "lib/dotnet/System.Linq.Queryable.dll": {}
         }
       },
-      "System.Net.Http/4.0.1-beta-23408": {
+      "System.Net.Http/4.0.1-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -305,7 +305,7 @@
           "ref/dotnet/System.Net.Http.dll": {}
         }
       },
-      "System.Net.NameResolution/4.0.0-beta-23408": {
+      "System.Net.NameResolution/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Net.Primitives": "4.0.10",
@@ -328,16 +328,17 @@
           "lib/DNXCore50/System.Net.Primitives.dll": {}
         }
       },
-      "System.Net.Security/4.0.0-beta-23408": {
+      "System.Net.Security/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
-          "System.Private.Networking": "4.0.1-beta-23408"
+          "System.IO": "4.0.0",
+          "System.Net.Primitives": "4.0.10",
+          "System.Runtime": "4.0.0",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23412",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Net.Security.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Net.Security.dll": {}
         }
       },
       "System.Net.Sockets/4.1.0-beta-23225": {
@@ -368,7 +369,7 @@
           "lib/dotnet/System.Net.WebHeaderCollection.dll": {}
         }
       },
-      "System.Net.WebSockets/4.0.0-beta-23408": {
+      "System.Net.WebSockets/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -383,7 +384,7 @@
           "lib/dotnet/System.Net.WebSockets.dll": {}
         }
       },
-      "System.Net.WebSockets.Client/4.0.0-beta-23408": {
+      "System.Net.WebSockets.Client/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -393,13 +394,13 @@
           "System.Globalization": "4.0.10",
           "System.Net.Primitives": "4.0.10",
           "System.Net.WebHeaderCollection": "4.0.0",
-          "System.Net.WebSockets": "4.0.0-beta-23408",
+          "System.Net.WebSockets": "4.0.0-beta-23412",
           "System.Resources.ResourceManager": "4.0.0",
           "System.Runtime": "4.0.20",
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23408",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23412",
           "System.Text.Encoding": "4.0.10",
           "System.Threading": "4.0.10",
           "System.Threading.Tasks": "4.0.10"
@@ -456,7 +457,7 @@
           "lib/DNXCore50/System.Private.DataContractSerialization.dll": {}
         }
       },
-      "System.Private.Networking/4.0.1-beta-23408": {
+      "System.Private.Networking/4.0.1-beta-23225": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -475,13 +476,10 @@
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23408",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23408",
-          "System.Security.Principal.Windows": "4.0.0-beta-23408",
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23225",
           "System.Threading": "4.0.10",
           "System.Threading.Overlapped": "4.0.0",
-          "System.Threading.Tasks": "4.0.10",
-          "System.Threading.ThreadPool": "4.0.10-beta-23408"
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dnxcore50/_._": {}
@@ -490,7 +488,7 @@
           "lib/DNXCore50/System.Private.Networking.dll": {}
         }
       },
-      "System.Private.ServiceModel/4.1.0-beta-23408": {
+      "System.Private.ServiceModel/4.1.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -507,14 +505,14 @@
           "System.Linq": "4.0.0",
           "System.Linq.Expressions": "4.0.10",
           "System.Linq.Queryable": "4.0.0",
-          "System.Net.Http": "4.0.1-beta-23408",
-          "System.Net.NameResolution": "4.0.0-beta-23408",
+          "System.Net.Http": "4.0.1-beta-23412",
+          "System.Net.NameResolution": "4.0.0-beta-23412",
           "System.Net.Primitives": "4.0.10",
-          "System.Net.Security": "4.0.0-beta-23408",
-          "System.Net.Sockets": "4.0.10-beta-23408",
+          "System.Net.Security": "4.0.0-beta-23412",
+          "System.Net.Sockets": "4.0.10-beta-23412",
           "System.Net.WebHeaderCollection": "4.0.0",
-          "System.Net.WebSockets": "4.0.0-beta-23408",
-          "System.Net.WebSockets.Client": "4.0.0-beta-23408",
+          "System.Net.WebSockets": "4.0.0-beta-23412",
+          "System.Net.WebSockets.Client": "4.0.0-beta-23412",
           "System.ObjectModel": "4.0.10",
           "System.Reflection": "4.0.10",
           "System.Reflection.DispatchProxy": "4.0.0",
@@ -528,9 +526,9 @@
           "System.Runtime.Serialization.Primitives": "4.0.10",
           "System.Runtime.Serialization.Xml": "4.0.10",
           "System.Security.Claims": "4.0.0",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23408",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23412",
           "System.Security.Principal": "4.0.0",
-          "System.Security.Principal.Windows": "4.0.0-beta-23408",
+          "System.Security.Principal.Windows": "4.0.0-beta-23412",
           "System.Text.Encoding": "4.0.10",
           "System.Threading": "4.0.10",
           "System.Threading.Tasks": "4.0.10",
@@ -794,18 +792,18 @@
           "lib/dotnet/System.Security.Claims.dll": {}
         }
       },
-      "System.Security.Cryptography.Algorithms/4.0.0-beta-23408": {
+      "System.Security.Cryptography.Algorithms/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
           "System.Runtime": "4.0.0",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23408"
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23412"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.Algorithms.dll": {}
         }
       },
-      "System.Security.Cryptography.Encoding/4.0.0-beta-23408": {
+      "System.Security.Cryptography.Encoding/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -814,7 +812,7 @@
           "ref/dotnet/System.Security.Cryptography.Encoding.dll": {}
         }
       },
-      "System.Security.Cryptography.Primitives/4.0.0-beta-23408": {
+      "System.Security.Cryptography.Primitives/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.0",
@@ -832,13 +830,13 @@
           "lib/dotnet/System.Security.Cryptography.Primitives.dll": {}
         }
       },
-      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23408": {
+      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
           "System.Runtime.Handles": "4.0.0",
-          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23408",
-          "System.Security.Cryptography.Encoding": "4.0.0-beta-23408"
+          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23412",
+          "System.Security.Cryptography.Encoding": "4.0.0-beta-23412"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.X509Certificates.dll": {}
@@ -856,7 +854,7 @@
           "lib/dotnet/System.Security.Principal.dll": {}
         }
       },
-      "System.Security.Principal.Windows/4.0.0-beta-23408": {
+      "System.Security.Principal.Windows/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -879,10 +877,10 @@
           "lib/DNXCore50/System.Security.Principal.Windows.dll": {}
         }
       },
-      "System.ServiceModel.Http/4.0.11-beta-23408": {
+      "System.ServiceModel.Http/4.0.11-beta-23412": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-beta-23408",
+          "System.Private.ServiceModel": "4.1.0-beta-23412",
           "System.Runtime": "4.0.20"
         },
         "compile": {
@@ -892,10 +890,10 @@
           "lib/DNXCore50/System.ServiceModel.Http.dll": {}
         }
       },
-      "System.ServiceModel.Primitives/4.0.1-beta-23408": {
+      "System.ServiceModel.Primitives/4.0.1-beta-23412": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-beta-23408"
+          "System.Private.ServiceModel": "4.1.0-beta-23412"
         },
         "compile": {
           "ref/dotnet/System.ServiceModel.Primitives.dll": {}
@@ -982,19 +980,6 @@
         },
         "runtime": {
           "lib/DNXCore50/System.Threading.Tasks.dll": {}
-        }
-      },
-      "System.Threading.ThreadPool/4.0.10-beta-23408": {
-        "type": "package",
-        "dependencies": {
-          "System.Runtime": "4.0.0",
-          "System.Runtime.InteropServices": "4.0.0"
-        },
-        "compile": {
-          "ref/dotnet/System.Threading.ThreadPool.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Threading.ThreadPool.dll": {}
         }
       },
       "System.Threading.Timer/4.0.0": {
@@ -1177,7 +1162,7 @@
           "lib/dotnet/xunit.execution.dotnet.dll": {}
         }
       },
-      "xunit.netcore.extensions/1.0.0-prerelease-00104": {
+      "xunit.netcore.extensions/1.0.0-prerelease-00105": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.10",
@@ -1805,44 +1790,65 @@
         "System.Linq.Queryable.nuspec"
       ]
     },
-    "System.Net.Http/4.0.1-beta-23408": {
+    "System.Net.Http/4.0.1-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "n+tnV1VgCjbDKKnbgrvgUgxkPDwUFvSv9lTgH882rVzjbWyliVgbBflVzoAUjUSlga/Tr1XQIrfTLMRD5HfYGw==",
+      "sha512": "F7Yej+6QdRVzWg+qbkayRMcmf/7k7YfNFoVSA67wIsG9t5u7Wj4Go8FW72HL8qb9d7YjIsVB/5hA7g9MUT31Aw==",
       "files": [
         "lib/net45/_._",
         "lib/win8/_._",
         "lib/wpa81/_._",
+        "ref/dotnet/de/System.Net.Http.xml",
+        "ref/dotnet/es/System.Net.Http.xml",
+        "ref/dotnet/fr/System.Net.Http.xml",
+        "ref/dotnet/it/System.Net.Http.xml",
+        "ref/dotnet/ja/System.Net.Http.xml",
+        "ref/dotnet/ko/System.Net.Http.xml",
+        "ref/dotnet/ru/System.Net.Http.xml",
         "ref/dotnet/System.Net.Http.dll",
+        "ref/dotnet/System.Net.Http.xml",
+        "ref/dotnet/zh-hans/System.Net.Http.xml",
+        "ref/dotnet/zh-hant/System.Net.Http.xml",
         "ref/net45/_._",
         "ref/netcore50/System.Net.Http.dll",
+        "ref/netcore50/System.Net.Http.xml",
         "ref/win8/_._",
         "ref/wpa81/_._",
         "runtime.json",
-        "System.Net.Http.4.0.1-beta-23408.nupkg",
-        "System.Net.Http.4.0.1-beta-23408.nupkg.sha512",
+        "System.Net.Http.4.0.1-beta-23412.nupkg",
+        "System.Net.Http.4.0.1-beta-23412.nupkg.sha512",
         "System.Net.Http.nuspec"
       ]
     },
-    "System.Net.NameResolution/4.0.0-beta-23408": {
+    "System.Net.NameResolution/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "2A562VFL8GUL/jLCJ3mbQHhwwAIXzPyjxMpdtas1LVM8QLuP1OcHwV3z7ajWnYdGcPc7ZxPEGJQWicuaPD+0nA==",
+      "sha512": "HCF1zhFYBT+w/Ik+JuTzFJgj83Jfc+eA8VcgvIzdPiGMXfrZeXOogjgSCkCoJmFtKVz2DSfmISoEmiXB1oaLNQ==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.NameResolution.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Net.NameResolution.xml",
+        "ref/dotnet/es/System.Net.NameResolution.xml",
+        "ref/dotnet/fr/System.Net.NameResolution.xml",
+        "ref/dotnet/it/System.Net.NameResolution.xml",
+        "ref/dotnet/ja/System.Net.NameResolution.xml",
+        "ref/dotnet/ko/System.Net.NameResolution.xml",
+        "ref/dotnet/ru/System.Net.NameResolution.xml",
         "ref/dotnet/System.Net.NameResolution.dll",
+        "ref/dotnet/System.Net.NameResolution.xml",
+        "ref/dotnet/zh-hans/System.Net.NameResolution.xml",
+        "ref/dotnet/zh-hant/System.Net.NameResolution.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Net.NameResolution.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Net.NameResolution.4.0.0-beta-23408.nupkg",
-        "System.Net.NameResolution.4.0.0-beta-23408.nupkg.sha512",
+        "System.Net.NameResolution.4.0.0-beta-23412.nupkg",
+        "System.Net.NameResolution.4.0.0-beta-23412.nupkg.sha512",
         "System.Net.NameResolution.nuspec"
       ]
     },
@@ -1879,24 +1885,34 @@
         "System.Net.Primitives.nuspec"
       ]
     },
-    "System.Net.Security/4.0.0-beta-23408": {
+    "System.Net.Security/4.0.0-beta-23412": {
       "type": "package",
-      "sha512": "kEkunODO2t/VlBIsC80YFDG0KtY/FyIbtBApNyJQv+LYGEs5IFvEhpi9+p0/jHmhyRMKwbjajNedbXo+VMkt1A==",
+      "sha512": "Kcjne7jnvF5aTbRJsAT8kuP+1mxryUF2qYv8f3jnR19wtEjswSIOVU0XzuWc9YObEQcb+kEdzN71HTOm+ssv+w==",
       "files": [
-        "lib/DNXCore50/System.Net.Security.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.Security.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Net.Security.xml",
+        "ref/dotnet/es/System.Net.Security.xml",
+        "ref/dotnet/fr/System.Net.Security.xml",
+        "ref/dotnet/it/System.Net.Security.xml",
+        "ref/dotnet/ja/System.Net.Security.xml",
+        "ref/dotnet/ko/System.Net.Security.xml",
+        "ref/dotnet/ru/System.Net.Security.xml",
         "ref/dotnet/System.Net.Security.dll",
+        "ref/dotnet/System.Net.Security.xml",
+        "ref/dotnet/zh-hans/System.Net.Security.xml",
+        "ref/dotnet/zh-hant/System.Net.Security.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Net.Security.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.Security.4.0.0-beta-23408.nupkg",
-        "System.Net.Security.4.0.0-beta-23408.nupkg.sha512",
+        "runtime.json",
+        "System.Net.Security.4.0.0-beta-23412.nupkg",
+        "System.Net.Security.4.0.0-beta-23412.nupkg.sha512",
         "System.Net.Security.nuspec"
       ]
     },
@@ -1954,78 +1970,68 @@
         "System.Net.WebHeaderCollection.nuspec"
       ]
     },
-    "System.Net.WebSockets/4.0.0-beta-23408": {
+    "System.Net.WebSockets/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "BXy22/bNVtrXXsG76zXyhjcQnCjSYxQIFF37xWifqPRWmvzsCYSLQpNCTPQUCp7rjB7qWc5yLhC9bThaEx7MHQ==",
+      "sha512": "EvXAa0yd1RM8ROyLl1T0xC94F04Su8YMHnd4/w6j0Z/+4lKHZOU7bQPZ3odDN8WdPGKa/ZNJJGwiapydEWKzwQ==",
       "files": [
-        "lib/dotnet/de/System.Net.WebSockets.xml",
-        "lib/dotnet/es/System.Net.WebSockets.xml",
-        "lib/dotnet/fr/System.Net.WebSockets.xml",
-        "lib/dotnet/it/System.Net.WebSockets.xml",
-        "lib/dotnet/ja/System.Net.WebSockets.xml",
-        "lib/dotnet/ko/System.Net.WebSockets.xml",
-        "lib/dotnet/ru/System.Net.WebSockets.xml",
         "lib/dotnet/System.Net.WebSockets.dll",
-        "lib/dotnet/System.Net.WebSockets.xml",
-        "lib/dotnet/zh-hans/System.Net.WebSockets.xml",
-        "lib/dotnet/zh-hant/System.Net.WebSockets.xml",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.WebSockets.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Net.WebSockets.xml",
+        "ref/dotnet/es/System.Net.WebSockets.xml",
+        "ref/dotnet/fr/System.Net.WebSockets.xml",
+        "ref/dotnet/it/System.Net.WebSockets.xml",
+        "ref/dotnet/ja/System.Net.WebSockets.xml",
+        "ref/dotnet/ko/System.Net.WebSockets.xml",
+        "ref/dotnet/ru/System.Net.WebSockets.xml",
         "ref/dotnet/System.Net.WebSockets.dll",
+        "ref/dotnet/System.Net.WebSockets.xml",
+        "ref/dotnet/zh-hans/System.Net.WebSockets.xml",
+        "ref/dotnet/zh-hant/System.Net.WebSockets.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Net.WebSockets.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.WebSockets.4.0.0-beta-23408.nupkg",
-        "System.Net.WebSockets.4.0.0-beta-23408.nupkg.sha512",
+        "System.Net.WebSockets.4.0.0-beta-23412.nupkg",
+        "System.Net.WebSockets.4.0.0-beta-23412.nupkg.sha512",
         "System.Net.WebSockets.nuspec"
       ]
     },
-    "System.Net.WebSockets.Client/4.0.0-beta-23408": {
+    "System.Net.WebSockets.Client/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "smmvhCkcU0c4RNWc6NZwnN5EFktX58jf8+TJ6enfuXxWrpJ/2NRI5/2yT/okjFSngGK1g0MBrljZsfs2EJ7+Yw==",
+      "sha512": "uaO7c/81sK90605UtThSX9KVmzsJDA1vD4GMW7FsKKntymlkolJsprDekWblQ4A5YbhqxHv+ngXX2kIU0B3Fdw==",
       "files": [
-        "lib/DNXCore50/de/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/es/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/fr/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/it/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/ja/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/ko/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/ru/System.Net.WebSockets.Client.xml",
         "lib/DNXCore50/System.Net.WebSockets.Client.dll",
-        "lib/DNXCore50/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/zh-hans/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/zh-hant/System.Net.WebSockets.Client.xml",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.WebSockets.Client.dll",
-        "lib/netcore50/de/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/es/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/fr/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/it/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/ja/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/ko/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/ru/System.Net.WebSockets.Client.xml",
         "lib/netcore50/System.Net.WebSockets.Client.dll",
-        "lib/netcore50/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/zh-hans/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/zh-hant/System.Net.WebSockets.Client.xml",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/es/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/fr/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/it/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/ja/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/ko/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/ru/System.Net.WebSockets.Client.xml",
         "ref/dotnet/System.Net.WebSockets.Client.dll",
+        "ref/dotnet/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/zh-hans/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/zh-hant/System.Net.WebSockets.Client.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Net.WebSockets.Client.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.WebSockets.Client.4.0.0-beta-23408.nupkg",
-        "System.Net.WebSockets.Client.4.0.0-beta-23408.nupkg.sha512",
+        "System.Net.WebSockets.Client.4.0.0-beta-23412.nupkg",
+        "System.Net.WebSockets.Client.4.0.0-beta-23412.nupkg.sha512",
         "System.Net.WebSockets.Client.nuspec"
       ]
     },
@@ -2077,31 +2083,31 @@
         "System.Private.DataContractSerialization.nuspec"
       ]
     },
-    "System.Private.Networking/4.0.1-beta-23408": {
+    "System.Private.Networking/4.0.1-beta-23225": {
       "type": "package",
       "serviceable": true,
-      "sha512": "i2fRDRqM8Px3CP26C//deF/tCNR1AwqlPEr9+MYiXxNZtgGcSPBfqOJJ5CJdfmDb9Ap0hPG2MiPG7CinaSH7+Q==",
+      "sha512": "oVSynIrR3mIU0b/goscsaZDywr3RLxQijQnaFRKfl/VB3F9rKi5mdr0vHcGVWuq5ALSrG0OLwM8PRA4tM5e3rQ==",
       "files": [
         "lib/DNXCore50/System.Private.Networking.dll",
         "lib/netcore50/System.Private.Networking.dll",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "System.Private.Networking.4.0.1-beta-23408.nupkg",
-        "System.Private.Networking.4.0.1-beta-23408.nupkg.sha512",
+        "System.Private.Networking.4.0.1-beta-23225.nupkg",
+        "System.Private.Networking.4.0.1-beta-23225.nupkg.sha512",
         "System.Private.Networking.nuspec"
       ]
     },
-    "System.Private.ServiceModel/4.1.0-beta-23408": {
+    "System.Private.ServiceModel/4.1.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "l/2192yKa6uXhjKOWeukFJy3hoj9Zq1p55pTGe+Y28r8/5jlvgYxfunP9UyXJRo9W1u3UBtGfV/5R71ULzusGQ==",
+      "sha512": "Wm+8LcQ04YeAvYqu9faHsMZ/L8l/WvPPsqziBfifYB4jXIPXk1/kUxuAryjbLChghZDXvkDN0hv/IHSVPZGgBA==",
       "files": [
         "lib/DNXCore50/System.Private.ServiceModel.dll",
         "lib/netcore50/System.Private.ServiceModel.dll",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "System.Private.ServiceModel.4.1.0-beta-23408.nupkg",
-        "System.Private.ServiceModel.4.1.0-beta-23408.nupkg.sha512",
+        "System.Private.ServiceModel.4.1.0-beta-23412.nupkg",
+        "System.Private.ServiceModel.4.1.0-beta-23412.nupkg.sha512",
         "System.Private.ServiceModel.nuspec"
       ]
     },
@@ -2656,10 +2662,10 @@
         "System.Security.Claims.nuspec"
       ]
     },
-    "System.Security.Cryptography.Algorithms/4.0.0-beta-23408": {
+    "System.Security.Cryptography.Algorithms/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "G6eEqi8mZRrWftcwilcnllE4xJ/53JQlk3VVuJ+9qrX+DHvWz8itYJRUZX357JY4DgEEKQNOJzuRGrOBTUeoPg==",
+      "sha512": "nBjoiqJQiMD3cJgOVrqjIVDqEEPZeIqT+mrBIxjLE+YMQcjEyDuSyOG65Ntoopby5LH4onTLMM4zfXh8JRt9NQ==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2673,37 +2679,47 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.Algorithms.4.0.0-beta-23408.nupkg",
-        "System.Security.Cryptography.Algorithms.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Cryptography.Algorithms.4.0.0-beta-23412.nupkg",
+        "System.Security.Cryptography.Algorithms.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Cryptography.Algorithms.nuspec"
       ]
     },
-    "System.Security.Cryptography.Encoding/4.0.0-beta-23408": {
+    "System.Security.Cryptography.Encoding/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "fPsAK3vyMjnJ6nT4YchdS7KzfGca/6uVVAPCBO08ZpTRGhMGx30vq1MiIqAUrfsFMnot3Ub2jimnAFWkqY6g0Q==",
+      "sha512": "SR1zCARNdeyLoUKYH2SNMm1He7Lr3NR/l7yW3K135L44T6PS3YB8SfXpVoZdMpb22X2G07BZAHVz2x7e4AA1Cg==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Security.Cryptography.Encoding.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/es/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/fr/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/it/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/ja/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/ko/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/ru/System.Security.Cryptography.Encoding.xml",
         "ref/dotnet/System.Security.Cryptography.Encoding.dll",
+        "ref/dotnet/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/zh-hans/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/zh-hant/System.Security.Cryptography.Encoding.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Security.Cryptography.Encoding.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.Encoding.4.0.0-beta-23408.nupkg",
-        "System.Security.Cryptography.Encoding.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Cryptography.Encoding.4.0.0-beta-23412.nupkg",
+        "System.Security.Cryptography.Encoding.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Cryptography.Encoding.nuspec"
       ]
     },
-    "System.Security.Cryptography.Primitives/4.0.0-beta-23408": {
+    "System.Security.Cryptography.Primitives/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "A336dWYEIQxm1rEJCaE5ZZrUWHPUkBGTRH8uAj8qrTqg4/qRc2yN2wZxeGXaZauhI35QwDmOutK7oVb2Cd+4TA==",
+      "sha512": "H9EBNe0ahjAYjlVn0TnT18PSgZBrtROSQH1RRIKwAjzxQHt8zwDhO4yN0Q5QaaUIoSXgxVmgtWWk62wDvpy+QA==",
       "files": [
         "lib/dotnet/System.Security.Cryptography.Primitives.dll",
         "lib/MonoAndroid10/_._",
@@ -2717,30 +2733,40 @@
         "ref/net46/System.Security.Cryptography.Primitives.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Security.Cryptography.Primitives.4.0.0-beta-23408.nupkg",
-        "System.Security.Cryptography.Primitives.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Cryptography.Primitives.4.0.0-beta-23412.nupkg",
+        "System.Security.Cryptography.Primitives.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Cryptography.Primitives.nuspec"
       ]
     },
-    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23408": {
+    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "JSNf5d1V5Y47MIdf7QxZCuGnR5heM4UKbrsdXiWD5lfqu0mnNjebPIclMUXlTw/6IykuDsUpompV/DtsaLLHig==",
+      "sha512": "SfpMjvrfRaRjG42uynLugb3YgpXdpnU7X8vNAU7stIR5/4uW9m1SvWHvBjirjHRBtOpbKB86uD5ODQWX+tWDNA==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Security.Cryptography.X509Certificates.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/es/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/fr/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/it/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/ja/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/ko/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/ru/System.Security.Cryptography.X509Certificates.xml",
         "ref/dotnet/System.Security.Cryptography.X509Certificates.dll",
+        "ref/dotnet/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/zh-hans/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/zh-hant/System.Security.Cryptography.X509Certificates.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Security.Cryptography.X509Certificates.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23408.nupkg",
-        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23412.nupkg",
+        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Cryptography.X509Certificates.nuspec"
       ]
     },
@@ -2777,88 +2803,89 @@
         "System.Security.Principal.nuspec"
       ]
     },
-    "System.Security.Principal.Windows/4.0.0-beta-23408": {
+    "System.Security.Principal.Windows/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "xmjpZJvsT1AW23UkjqUkF/VrOh7DA1cagYY272UQmO8ei227TFD4C7j3ofatL/63hR3CXkLkoephuE4f2Z9fGA==",
+      "sha512": "Zvb/LzT+GjGNV1t8i5KVieilL+8P5LcQykIbJHw5aJxLPFEIQ4Y2hTJXdEkeKvZ4TCF5dlwY1jYyUrJkcqpxzw==",
       "files": [
-        "lib/DNXCore50/de/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/es/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/fr/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/it/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/ja/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/ko/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/ru/System.Security.Principal.Windows.xml",
         "lib/DNXCore50/System.Security.Principal.Windows.dll",
-        "lib/DNXCore50/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/zh-hans/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/zh-hant/System.Security.Principal.Windows.xml",
         "lib/net46/System.Security.Principal.Windows.dll",
+        "ref/dotnet/de/System.Security.Principal.Windows.xml",
+        "ref/dotnet/es/System.Security.Principal.Windows.xml",
+        "ref/dotnet/fr/System.Security.Principal.Windows.xml",
+        "ref/dotnet/it/System.Security.Principal.Windows.xml",
+        "ref/dotnet/ja/System.Security.Principal.Windows.xml",
+        "ref/dotnet/ko/System.Security.Principal.Windows.xml",
+        "ref/dotnet/ru/System.Security.Principal.Windows.xml",
         "ref/dotnet/System.Security.Principal.Windows.dll",
+        "ref/dotnet/System.Security.Principal.Windows.xml",
+        "ref/dotnet/zh-hans/System.Security.Principal.Windows.xml",
+        "ref/dotnet/zh-hant/System.Security.Principal.Windows.xml",
         "ref/net46/System.Security.Principal.Windows.dll",
-        "System.Security.Principal.Windows.4.0.0-beta-23408.nupkg",
-        "System.Security.Principal.Windows.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Principal.Windows.4.0.0-beta-23412.nupkg",
+        "System.Security.Principal.Windows.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Principal.Windows.nuspec"
       ]
     },
-    "System.ServiceModel.Http/4.0.11-beta-23408": {
+    "System.ServiceModel.Http/4.0.11-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "RScHZ1A3CfjumaP1Vh/xfOp/ga6T3nA8YLkjFOYcIcZm/LILL+yCh+PhIrJOEfz1Js8bLSQC6xbxwYlW6BNmYg==",
+      "sha512": "hKMGQbu/l2gv/PgPvm2ViLVElnVSwAPiv4cXKjinS+UHBf02uPF2m7lN13SCkJDNTBctwHav1rQnMYb1LUJHvw==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Http.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
-        "lib/netcore50/de/System.ServiceModel.Http.xml",
-        "lib/netcore50/es/System.ServiceModel.Http.xml",
-        "lib/netcore50/fr/System.ServiceModel.Http.xml",
-        "lib/netcore50/it/System.ServiceModel.Http.xml",
-        "lib/netcore50/ja/System.ServiceModel.Http.xml",
-        "lib/netcore50/ko/System.ServiceModel.Http.xml",
-        "lib/netcore50/ru/System.ServiceModel.Http.xml",
         "lib/netcore50/System.ServiceModel.Http.dll",
-        "lib/netcore50/System.ServiceModel.Http.xml",
-        "lib/netcore50/zh-hans/System.ServiceModel.Http.xml",
-        "lib/netcore50/zh-hant/System.ServiceModel.Http.xml",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.ServiceModel.Http.xml",
+        "ref/dotnet/es/System.ServiceModel.Http.xml",
+        "ref/dotnet/fr/System.ServiceModel.Http.xml",
+        "ref/dotnet/it/System.ServiceModel.Http.xml",
+        "ref/dotnet/ja/System.ServiceModel.Http.xml",
+        "ref/dotnet/ko/System.ServiceModel.Http.xml",
+        "ref/dotnet/ru/System.ServiceModel.Http.xml",
         "ref/dotnet/System.ServiceModel.Http.dll",
+        "ref/dotnet/System.ServiceModel.Http.xml",
+        "ref/dotnet/zh-hans/System.ServiceModel.Http.xml",
+        "ref/dotnet/zh-hant/System.ServiceModel.Http.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.ServiceModel.Http.4.0.11-beta-23408.nupkg",
-        "System.ServiceModel.Http.4.0.11-beta-23408.nupkg.sha512",
+        "System.ServiceModel.Http.4.0.11-beta-23412.nupkg",
+        "System.ServiceModel.Http.4.0.11-beta-23412.nupkg.sha512",
         "System.ServiceModel.Http.nuspec"
       ]
     },
-    "System.ServiceModel.Primitives/4.0.1-beta-23408": {
+    "System.ServiceModel.Primitives/4.0.1-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "bjXzg+V3Oq/tBXpMY5FwcERN2CQsFXoL4BMoURlwiBMkgwN2CPvBIaK45Moh7nc21jNTVukNayDtURetGzK6aA==",
+      "sha512": "dkCUkNtXb2m9Wf+DY7dc5B4J8DpaWtX4wpFfT3cYLpChxAnjQR85N+tJfMEHLfZNNerKgDRyGyaKa7uSHfvb5g==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Primitives.dll",
         "lib/net45/_._",
-        "lib/netcore50/de/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/es/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/fr/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/it/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/ja/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/ko/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/ru/System.ServiceModel.Primitives.xml",
         "lib/netcore50/System.ServiceModel.Primitives.dll",
-        "lib/netcore50/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/zh-hans/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/zh-hant/System.ServiceModel.Primitives.xml",
         "lib/win8/_._",
+        "ref/dotnet/de/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/es/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/fr/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/it/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/ja/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/ko/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/ru/System.ServiceModel.Primitives.xml",
         "ref/dotnet/System.ServiceModel.Primitives.dll",
+        "ref/dotnet/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/zh-hans/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/zh-hant/System.ServiceModel.Primitives.xml",
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.Primitives.dll",
+        "ref/netcore50/System.ServiceModel.Primitives.xml",
         "ref/win8/_._",
-        "System.ServiceModel.Primitives.4.0.1-beta-23408.nupkg",
-        "System.ServiceModel.Primitives.4.0.1-beta-23408.nupkg.sha512",
+        "System.ServiceModel.Primitives.4.0.1-beta-23412.nupkg",
+        "System.ServiceModel.Primitives.4.0.1-beta-23412.nupkg.sha512",
         "System.ServiceModel.Primitives.nuspec"
       ]
     },
@@ -3051,28 +3078,6 @@
         "System.Threading.Tasks.4.0.10.nupkg",
         "System.Threading.Tasks.4.0.10.nupkg.sha512",
         "System.Threading.Tasks.nuspec"
-      ]
-    },
-    "System.Threading.ThreadPool/4.0.10-beta-23408": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "ahdsVyj+WFj8/iSDwX/G7hkEU4jZmmvWzPS2ajZKdp0Crb0vZJOlM0LQYVASQgbimrUZHQ50o93JYEi8RFdh/Q==",
-      "files": [
-        "lib/DNXCore50/System.Threading.ThreadPool.dll",
-        "lib/MonoAndroid10/_._",
-        "lib/MonoTouch10/_._",
-        "lib/net46/System.Threading.ThreadPool.dll",
-        "lib/xamarinios10/_._",
-        "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Threading.ThreadPool.dll",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
-        "ref/net46/System.Threading.ThreadPool.dll",
-        "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.Threading.ThreadPool.4.0.10-beta-23408.nupkg",
-        "System.Threading.ThreadPool.4.0.10-beta-23408.nupkg.sha512",
-        "System.Threading.ThreadPool.nuspec"
       ]
     },
     "System.Threading.Timer/4.0.0": {
@@ -3322,14 +3327,14 @@
         "xunit.extensibility.execution.nuspec"
       ]
     },
-    "xunit.netcore.extensions/1.0.0-prerelease-00104": {
+    "xunit.netcore.extensions/1.0.0-prerelease-00105": {
       "type": "package",
       "serviceable": true,
-      "sha512": "ZMXxEBpGP7krXtvqbPMOWavd2u83w77ghtD254wfj5+d+7GmYYqP9pX1iRIxJK9CBa8Zc2cOrcYsmCLQgYriAQ==",
+      "sha512": "EnnGcy9rmSdQ8izHWvYSYVyjQGhbeFH7JeM/L35ZrrPGtYvq5XD3hc1cJPCs+43mXdF9cdqhkt5uTlXYzC+Z8g==",
       "files": [
         "lib/dotnet/Xunit.NetCore.Extensions.dll",
-        "xunit.netcore.extensions.1.0.0-prerelease-00104.nupkg",
-        "xunit.netcore.extensions.1.0.0-prerelease-00104.nupkg.sha512",
+        "xunit.netcore.extensions.1.0.0-prerelease-00105.nupkg",
+        "xunit.netcore.extensions.1.0.0-prerelease-00105.nupkg.sha512",
         "xunit.netcore.extensions.nuspec"
       ]
     }

--- a/src/System.Private.ServiceModel/tests/Scenarios/Encoding/Encoders/project.lock.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Encoding/Encoders/project.lock.json
@@ -292,7 +292,7 @@
           "lib/dotnet/System.Linq.Queryable.dll": {}
         }
       },
-      "System.Net.Http/4.0.1-beta-23408": {
+      "System.Net.Http/4.0.1-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -305,7 +305,7 @@
           "ref/dotnet/System.Net.Http.dll": {}
         }
       },
-      "System.Net.NameResolution/4.0.0-beta-23408": {
+      "System.Net.NameResolution/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Net.Primitives": "4.0.10",
@@ -328,16 +328,17 @@
           "lib/DNXCore50/System.Net.Primitives.dll": {}
         }
       },
-      "System.Net.Security/4.0.0-beta-23408": {
+      "System.Net.Security/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
-          "System.Private.Networking": "4.0.1-beta-23408"
+          "System.IO": "4.0.0",
+          "System.Net.Primitives": "4.0.10",
+          "System.Runtime": "4.0.0",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23412",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Net.Security.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Net.Security.dll": {}
         }
       },
       "System.Net.Sockets/4.1.0-beta-23225": {
@@ -368,7 +369,7 @@
           "lib/dotnet/System.Net.WebHeaderCollection.dll": {}
         }
       },
-      "System.Net.WebSockets/4.0.0-beta-23408": {
+      "System.Net.WebSockets/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -383,7 +384,7 @@
           "lib/dotnet/System.Net.WebSockets.dll": {}
         }
       },
-      "System.Net.WebSockets.Client/4.0.0-beta-23408": {
+      "System.Net.WebSockets.Client/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -393,13 +394,13 @@
           "System.Globalization": "4.0.10",
           "System.Net.Primitives": "4.0.10",
           "System.Net.WebHeaderCollection": "4.0.0",
-          "System.Net.WebSockets": "4.0.0-beta-23408",
+          "System.Net.WebSockets": "4.0.0-beta-23412",
           "System.Resources.ResourceManager": "4.0.0",
           "System.Runtime": "4.0.20",
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23408",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23412",
           "System.Text.Encoding": "4.0.10",
           "System.Threading": "4.0.10",
           "System.Threading.Tasks": "4.0.10"
@@ -456,7 +457,7 @@
           "lib/DNXCore50/System.Private.DataContractSerialization.dll": {}
         }
       },
-      "System.Private.Networking/4.0.1-beta-23408": {
+      "System.Private.Networking/4.0.1-beta-23225": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -475,13 +476,10 @@
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23408",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23408",
-          "System.Security.Principal.Windows": "4.0.0-beta-23408",
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23225",
           "System.Threading": "4.0.10",
           "System.Threading.Overlapped": "4.0.0",
-          "System.Threading.Tasks": "4.0.10",
-          "System.Threading.ThreadPool": "4.0.10-beta-23408"
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dnxcore50/_._": {}
@@ -490,7 +488,7 @@
           "lib/DNXCore50/System.Private.Networking.dll": {}
         }
       },
-      "System.Private.ServiceModel/4.1.0-beta-23408": {
+      "System.Private.ServiceModel/4.1.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -507,14 +505,14 @@
           "System.Linq": "4.0.0",
           "System.Linq.Expressions": "4.0.10",
           "System.Linq.Queryable": "4.0.0",
-          "System.Net.Http": "4.0.1-beta-23408",
-          "System.Net.NameResolution": "4.0.0-beta-23408",
+          "System.Net.Http": "4.0.1-beta-23412",
+          "System.Net.NameResolution": "4.0.0-beta-23412",
           "System.Net.Primitives": "4.0.10",
-          "System.Net.Security": "4.0.0-beta-23408",
-          "System.Net.Sockets": "4.0.10-beta-23408",
+          "System.Net.Security": "4.0.0-beta-23412",
+          "System.Net.Sockets": "4.0.10-beta-23412",
           "System.Net.WebHeaderCollection": "4.0.0",
-          "System.Net.WebSockets": "4.0.0-beta-23408",
-          "System.Net.WebSockets.Client": "4.0.0-beta-23408",
+          "System.Net.WebSockets": "4.0.0-beta-23412",
+          "System.Net.WebSockets.Client": "4.0.0-beta-23412",
           "System.ObjectModel": "4.0.10",
           "System.Reflection": "4.0.10",
           "System.Reflection.DispatchProxy": "4.0.0",
@@ -528,9 +526,9 @@
           "System.Runtime.Serialization.Primitives": "4.0.10",
           "System.Runtime.Serialization.Xml": "4.0.10",
           "System.Security.Claims": "4.0.0",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23408",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23412",
           "System.Security.Principal": "4.0.0",
-          "System.Security.Principal.Windows": "4.0.0-beta-23408",
+          "System.Security.Principal.Windows": "4.0.0-beta-23412",
           "System.Text.Encoding": "4.0.10",
           "System.Threading": "4.0.10",
           "System.Threading.Tasks": "4.0.10",
@@ -794,18 +792,18 @@
           "lib/dotnet/System.Security.Claims.dll": {}
         }
       },
-      "System.Security.Cryptography.Algorithms/4.0.0-beta-23408": {
+      "System.Security.Cryptography.Algorithms/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
           "System.Runtime": "4.0.0",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23408"
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23412"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.Algorithms.dll": {}
         }
       },
-      "System.Security.Cryptography.Encoding/4.0.0-beta-23408": {
+      "System.Security.Cryptography.Encoding/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -814,7 +812,7 @@
           "ref/dotnet/System.Security.Cryptography.Encoding.dll": {}
         }
       },
-      "System.Security.Cryptography.Primitives/4.0.0-beta-23408": {
+      "System.Security.Cryptography.Primitives/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.0",
@@ -832,13 +830,13 @@
           "lib/dotnet/System.Security.Cryptography.Primitives.dll": {}
         }
       },
-      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23408": {
+      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
           "System.Runtime.Handles": "4.0.0",
-          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23408",
-          "System.Security.Cryptography.Encoding": "4.0.0-beta-23408"
+          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23412",
+          "System.Security.Cryptography.Encoding": "4.0.0-beta-23412"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.X509Certificates.dll": {}
@@ -856,7 +854,7 @@
           "lib/dotnet/System.Security.Principal.dll": {}
         }
       },
-      "System.Security.Principal.Windows/4.0.0-beta-23408": {
+      "System.Security.Principal.Windows/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -879,10 +877,10 @@
           "lib/DNXCore50/System.Security.Principal.Windows.dll": {}
         }
       },
-      "System.ServiceModel.Http/4.0.11-beta-23408": {
+      "System.ServiceModel.Http/4.0.11-beta-23412": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-beta-23408",
+          "System.Private.ServiceModel": "4.1.0-beta-23412",
           "System.Runtime": "4.0.20"
         },
         "compile": {
@@ -892,10 +890,10 @@
           "lib/DNXCore50/System.ServiceModel.Http.dll": {}
         }
       },
-      "System.ServiceModel.NetTcp/4.0.1-beta-23408": {
+      "System.ServiceModel.NetTcp/4.0.1-beta-23412": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-beta-23408"
+          "System.Private.ServiceModel": "4.1.0-beta-23412"
         },
         "compile": {
           "ref/dotnet/System.ServiceModel.NetTcp.dll": {}
@@ -904,10 +902,10 @@
           "lib/DNXCore50/System.ServiceModel.NetTcp.dll": {}
         }
       },
-      "System.ServiceModel.Primitives/4.0.1-beta-23408": {
+      "System.ServiceModel.Primitives/4.0.1-beta-23412": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-beta-23408"
+          "System.Private.ServiceModel": "4.1.0-beta-23412"
         },
         "compile": {
           "ref/dotnet/System.ServiceModel.Primitives.dll": {}
@@ -994,19 +992,6 @@
         },
         "runtime": {
           "lib/DNXCore50/System.Threading.Tasks.dll": {}
-        }
-      },
-      "System.Threading.ThreadPool/4.0.10-beta-23408": {
-        "type": "package",
-        "dependencies": {
-          "System.Runtime": "4.0.0",
-          "System.Runtime.InteropServices": "4.0.0"
-        },
-        "compile": {
-          "ref/dotnet/System.Threading.ThreadPool.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Threading.ThreadPool.dll": {}
         }
       },
       "System.Threading.Timer/4.0.0": {
@@ -1189,7 +1174,7 @@
           "lib/dotnet/xunit.execution.dotnet.dll": {}
         }
       },
-      "xunit.netcore.extensions/1.0.0-prerelease-00104": {
+      "xunit.netcore.extensions/1.0.0-prerelease-00105": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.10",
@@ -1817,44 +1802,65 @@
         "System.Linq.Queryable.nuspec"
       ]
     },
-    "System.Net.Http/4.0.1-beta-23408": {
+    "System.Net.Http/4.0.1-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "n+tnV1VgCjbDKKnbgrvgUgxkPDwUFvSv9lTgH882rVzjbWyliVgbBflVzoAUjUSlga/Tr1XQIrfTLMRD5HfYGw==",
+      "sha512": "F7Yej+6QdRVzWg+qbkayRMcmf/7k7YfNFoVSA67wIsG9t5u7Wj4Go8FW72HL8qb9d7YjIsVB/5hA7g9MUT31Aw==",
       "files": [
         "lib/net45/_._",
         "lib/win8/_._",
         "lib/wpa81/_._",
+        "ref/dotnet/de/System.Net.Http.xml",
+        "ref/dotnet/es/System.Net.Http.xml",
+        "ref/dotnet/fr/System.Net.Http.xml",
+        "ref/dotnet/it/System.Net.Http.xml",
+        "ref/dotnet/ja/System.Net.Http.xml",
+        "ref/dotnet/ko/System.Net.Http.xml",
+        "ref/dotnet/ru/System.Net.Http.xml",
         "ref/dotnet/System.Net.Http.dll",
+        "ref/dotnet/System.Net.Http.xml",
+        "ref/dotnet/zh-hans/System.Net.Http.xml",
+        "ref/dotnet/zh-hant/System.Net.Http.xml",
         "ref/net45/_._",
         "ref/netcore50/System.Net.Http.dll",
+        "ref/netcore50/System.Net.Http.xml",
         "ref/win8/_._",
         "ref/wpa81/_._",
         "runtime.json",
-        "System.Net.Http.4.0.1-beta-23408.nupkg",
-        "System.Net.Http.4.0.1-beta-23408.nupkg.sha512",
+        "System.Net.Http.4.0.1-beta-23412.nupkg",
+        "System.Net.Http.4.0.1-beta-23412.nupkg.sha512",
         "System.Net.Http.nuspec"
       ]
     },
-    "System.Net.NameResolution/4.0.0-beta-23408": {
+    "System.Net.NameResolution/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "2A562VFL8GUL/jLCJ3mbQHhwwAIXzPyjxMpdtas1LVM8QLuP1OcHwV3z7ajWnYdGcPc7ZxPEGJQWicuaPD+0nA==",
+      "sha512": "HCF1zhFYBT+w/Ik+JuTzFJgj83Jfc+eA8VcgvIzdPiGMXfrZeXOogjgSCkCoJmFtKVz2DSfmISoEmiXB1oaLNQ==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.NameResolution.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Net.NameResolution.xml",
+        "ref/dotnet/es/System.Net.NameResolution.xml",
+        "ref/dotnet/fr/System.Net.NameResolution.xml",
+        "ref/dotnet/it/System.Net.NameResolution.xml",
+        "ref/dotnet/ja/System.Net.NameResolution.xml",
+        "ref/dotnet/ko/System.Net.NameResolution.xml",
+        "ref/dotnet/ru/System.Net.NameResolution.xml",
         "ref/dotnet/System.Net.NameResolution.dll",
+        "ref/dotnet/System.Net.NameResolution.xml",
+        "ref/dotnet/zh-hans/System.Net.NameResolution.xml",
+        "ref/dotnet/zh-hant/System.Net.NameResolution.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Net.NameResolution.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Net.NameResolution.4.0.0-beta-23408.nupkg",
-        "System.Net.NameResolution.4.0.0-beta-23408.nupkg.sha512",
+        "System.Net.NameResolution.4.0.0-beta-23412.nupkg",
+        "System.Net.NameResolution.4.0.0-beta-23412.nupkg.sha512",
         "System.Net.NameResolution.nuspec"
       ]
     },
@@ -1891,24 +1897,34 @@
         "System.Net.Primitives.nuspec"
       ]
     },
-    "System.Net.Security/4.0.0-beta-23408": {
+    "System.Net.Security/4.0.0-beta-23412": {
       "type": "package",
-      "sha512": "kEkunODO2t/VlBIsC80YFDG0KtY/FyIbtBApNyJQv+LYGEs5IFvEhpi9+p0/jHmhyRMKwbjajNedbXo+VMkt1A==",
+      "sha512": "Kcjne7jnvF5aTbRJsAT8kuP+1mxryUF2qYv8f3jnR19wtEjswSIOVU0XzuWc9YObEQcb+kEdzN71HTOm+ssv+w==",
       "files": [
-        "lib/DNXCore50/System.Net.Security.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.Security.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Net.Security.xml",
+        "ref/dotnet/es/System.Net.Security.xml",
+        "ref/dotnet/fr/System.Net.Security.xml",
+        "ref/dotnet/it/System.Net.Security.xml",
+        "ref/dotnet/ja/System.Net.Security.xml",
+        "ref/dotnet/ko/System.Net.Security.xml",
+        "ref/dotnet/ru/System.Net.Security.xml",
         "ref/dotnet/System.Net.Security.dll",
+        "ref/dotnet/System.Net.Security.xml",
+        "ref/dotnet/zh-hans/System.Net.Security.xml",
+        "ref/dotnet/zh-hant/System.Net.Security.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Net.Security.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.Security.4.0.0-beta-23408.nupkg",
-        "System.Net.Security.4.0.0-beta-23408.nupkg.sha512",
+        "runtime.json",
+        "System.Net.Security.4.0.0-beta-23412.nupkg",
+        "System.Net.Security.4.0.0-beta-23412.nupkg.sha512",
         "System.Net.Security.nuspec"
       ]
     },
@@ -1966,78 +1982,68 @@
         "System.Net.WebHeaderCollection.nuspec"
       ]
     },
-    "System.Net.WebSockets/4.0.0-beta-23408": {
+    "System.Net.WebSockets/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "BXy22/bNVtrXXsG76zXyhjcQnCjSYxQIFF37xWifqPRWmvzsCYSLQpNCTPQUCp7rjB7qWc5yLhC9bThaEx7MHQ==",
+      "sha512": "EvXAa0yd1RM8ROyLl1T0xC94F04Su8YMHnd4/w6j0Z/+4lKHZOU7bQPZ3odDN8WdPGKa/ZNJJGwiapydEWKzwQ==",
       "files": [
-        "lib/dotnet/de/System.Net.WebSockets.xml",
-        "lib/dotnet/es/System.Net.WebSockets.xml",
-        "lib/dotnet/fr/System.Net.WebSockets.xml",
-        "lib/dotnet/it/System.Net.WebSockets.xml",
-        "lib/dotnet/ja/System.Net.WebSockets.xml",
-        "lib/dotnet/ko/System.Net.WebSockets.xml",
-        "lib/dotnet/ru/System.Net.WebSockets.xml",
         "lib/dotnet/System.Net.WebSockets.dll",
-        "lib/dotnet/System.Net.WebSockets.xml",
-        "lib/dotnet/zh-hans/System.Net.WebSockets.xml",
-        "lib/dotnet/zh-hant/System.Net.WebSockets.xml",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.WebSockets.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Net.WebSockets.xml",
+        "ref/dotnet/es/System.Net.WebSockets.xml",
+        "ref/dotnet/fr/System.Net.WebSockets.xml",
+        "ref/dotnet/it/System.Net.WebSockets.xml",
+        "ref/dotnet/ja/System.Net.WebSockets.xml",
+        "ref/dotnet/ko/System.Net.WebSockets.xml",
+        "ref/dotnet/ru/System.Net.WebSockets.xml",
         "ref/dotnet/System.Net.WebSockets.dll",
+        "ref/dotnet/System.Net.WebSockets.xml",
+        "ref/dotnet/zh-hans/System.Net.WebSockets.xml",
+        "ref/dotnet/zh-hant/System.Net.WebSockets.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Net.WebSockets.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.WebSockets.4.0.0-beta-23408.nupkg",
-        "System.Net.WebSockets.4.0.0-beta-23408.nupkg.sha512",
+        "System.Net.WebSockets.4.0.0-beta-23412.nupkg",
+        "System.Net.WebSockets.4.0.0-beta-23412.nupkg.sha512",
         "System.Net.WebSockets.nuspec"
       ]
     },
-    "System.Net.WebSockets.Client/4.0.0-beta-23408": {
+    "System.Net.WebSockets.Client/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "smmvhCkcU0c4RNWc6NZwnN5EFktX58jf8+TJ6enfuXxWrpJ/2NRI5/2yT/okjFSngGK1g0MBrljZsfs2EJ7+Yw==",
+      "sha512": "uaO7c/81sK90605UtThSX9KVmzsJDA1vD4GMW7FsKKntymlkolJsprDekWblQ4A5YbhqxHv+ngXX2kIU0B3Fdw==",
       "files": [
-        "lib/DNXCore50/de/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/es/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/fr/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/it/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/ja/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/ko/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/ru/System.Net.WebSockets.Client.xml",
         "lib/DNXCore50/System.Net.WebSockets.Client.dll",
-        "lib/DNXCore50/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/zh-hans/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/zh-hant/System.Net.WebSockets.Client.xml",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.WebSockets.Client.dll",
-        "lib/netcore50/de/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/es/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/fr/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/it/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/ja/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/ko/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/ru/System.Net.WebSockets.Client.xml",
         "lib/netcore50/System.Net.WebSockets.Client.dll",
-        "lib/netcore50/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/zh-hans/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/zh-hant/System.Net.WebSockets.Client.xml",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/es/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/fr/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/it/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/ja/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/ko/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/ru/System.Net.WebSockets.Client.xml",
         "ref/dotnet/System.Net.WebSockets.Client.dll",
+        "ref/dotnet/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/zh-hans/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/zh-hant/System.Net.WebSockets.Client.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Net.WebSockets.Client.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.WebSockets.Client.4.0.0-beta-23408.nupkg",
-        "System.Net.WebSockets.Client.4.0.0-beta-23408.nupkg.sha512",
+        "System.Net.WebSockets.Client.4.0.0-beta-23412.nupkg",
+        "System.Net.WebSockets.Client.4.0.0-beta-23412.nupkg.sha512",
         "System.Net.WebSockets.Client.nuspec"
       ]
     },
@@ -2089,31 +2095,31 @@
         "System.Private.DataContractSerialization.nuspec"
       ]
     },
-    "System.Private.Networking/4.0.1-beta-23408": {
+    "System.Private.Networking/4.0.1-beta-23225": {
       "type": "package",
       "serviceable": true,
-      "sha512": "i2fRDRqM8Px3CP26C//deF/tCNR1AwqlPEr9+MYiXxNZtgGcSPBfqOJJ5CJdfmDb9Ap0hPG2MiPG7CinaSH7+Q==",
+      "sha512": "oVSynIrR3mIU0b/goscsaZDywr3RLxQijQnaFRKfl/VB3F9rKi5mdr0vHcGVWuq5ALSrG0OLwM8PRA4tM5e3rQ==",
       "files": [
         "lib/DNXCore50/System.Private.Networking.dll",
         "lib/netcore50/System.Private.Networking.dll",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "System.Private.Networking.4.0.1-beta-23408.nupkg",
-        "System.Private.Networking.4.0.1-beta-23408.nupkg.sha512",
+        "System.Private.Networking.4.0.1-beta-23225.nupkg",
+        "System.Private.Networking.4.0.1-beta-23225.nupkg.sha512",
         "System.Private.Networking.nuspec"
       ]
     },
-    "System.Private.ServiceModel/4.1.0-beta-23408": {
+    "System.Private.ServiceModel/4.1.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "l/2192yKa6uXhjKOWeukFJy3hoj9Zq1p55pTGe+Y28r8/5jlvgYxfunP9UyXJRo9W1u3UBtGfV/5R71ULzusGQ==",
+      "sha512": "Wm+8LcQ04YeAvYqu9faHsMZ/L8l/WvPPsqziBfifYB4jXIPXk1/kUxuAryjbLChghZDXvkDN0hv/IHSVPZGgBA==",
       "files": [
         "lib/DNXCore50/System.Private.ServiceModel.dll",
         "lib/netcore50/System.Private.ServiceModel.dll",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "System.Private.ServiceModel.4.1.0-beta-23408.nupkg",
-        "System.Private.ServiceModel.4.1.0-beta-23408.nupkg.sha512",
+        "System.Private.ServiceModel.4.1.0-beta-23412.nupkg",
+        "System.Private.ServiceModel.4.1.0-beta-23412.nupkg.sha512",
         "System.Private.ServiceModel.nuspec"
       ]
     },
@@ -2668,10 +2674,10 @@
         "System.Security.Claims.nuspec"
       ]
     },
-    "System.Security.Cryptography.Algorithms/4.0.0-beta-23408": {
+    "System.Security.Cryptography.Algorithms/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "G6eEqi8mZRrWftcwilcnllE4xJ/53JQlk3VVuJ+9qrX+DHvWz8itYJRUZX357JY4DgEEKQNOJzuRGrOBTUeoPg==",
+      "sha512": "nBjoiqJQiMD3cJgOVrqjIVDqEEPZeIqT+mrBIxjLE+YMQcjEyDuSyOG65Ntoopby5LH4onTLMM4zfXh8JRt9NQ==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2685,37 +2691,47 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.Algorithms.4.0.0-beta-23408.nupkg",
-        "System.Security.Cryptography.Algorithms.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Cryptography.Algorithms.4.0.0-beta-23412.nupkg",
+        "System.Security.Cryptography.Algorithms.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Cryptography.Algorithms.nuspec"
       ]
     },
-    "System.Security.Cryptography.Encoding/4.0.0-beta-23408": {
+    "System.Security.Cryptography.Encoding/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "fPsAK3vyMjnJ6nT4YchdS7KzfGca/6uVVAPCBO08ZpTRGhMGx30vq1MiIqAUrfsFMnot3Ub2jimnAFWkqY6g0Q==",
+      "sha512": "SR1zCARNdeyLoUKYH2SNMm1He7Lr3NR/l7yW3K135L44T6PS3YB8SfXpVoZdMpb22X2G07BZAHVz2x7e4AA1Cg==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Security.Cryptography.Encoding.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/es/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/fr/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/it/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/ja/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/ko/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/ru/System.Security.Cryptography.Encoding.xml",
         "ref/dotnet/System.Security.Cryptography.Encoding.dll",
+        "ref/dotnet/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/zh-hans/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/zh-hant/System.Security.Cryptography.Encoding.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Security.Cryptography.Encoding.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.Encoding.4.0.0-beta-23408.nupkg",
-        "System.Security.Cryptography.Encoding.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Cryptography.Encoding.4.0.0-beta-23412.nupkg",
+        "System.Security.Cryptography.Encoding.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Cryptography.Encoding.nuspec"
       ]
     },
-    "System.Security.Cryptography.Primitives/4.0.0-beta-23408": {
+    "System.Security.Cryptography.Primitives/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "A336dWYEIQxm1rEJCaE5ZZrUWHPUkBGTRH8uAj8qrTqg4/qRc2yN2wZxeGXaZauhI35QwDmOutK7oVb2Cd+4TA==",
+      "sha512": "H9EBNe0ahjAYjlVn0TnT18PSgZBrtROSQH1RRIKwAjzxQHt8zwDhO4yN0Q5QaaUIoSXgxVmgtWWk62wDvpy+QA==",
       "files": [
         "lib/dotnet/System.Security.Cryptography.Primitives.dll",
         "lib/MonoAndroid10/_._",
@@ -2729,30 +2745,40 @@
         "ref/net46/System.Security.Cryptography.Primitives.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Security.Cryptography.Primitives.4.0.0-beta-23408.nupkg",
-        "System.Security.Cryptography.Primitives.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Cryptography.Primitives.4.0.0-beta-23412.nupkg",
+        "System.Security.Cryptography.Primitives.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Cryptography.Primitives.nuspec"
       ]
     },
-    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23408": {
+    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "JSNf5d1V5Y47MIdf7QxZCuGnR5heM4UKbrsdXiWD5lfqu0mnNjebPIclMUXlTw/6IykuDsUpompV/DtsaLLHig==",
+      "sha512": "SfpMjvrfRaRjG42uynLugb3YgpXdpnU7X8vNAU7stIR5/4uW9m1SvWHvBjirjHRBtOpbKB86uD5ODQWX+tWDNA==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Security.Cryptography.X509Certificates.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/es/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/fr/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/it/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/ja/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/ko/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/ru/System.Security.Cryptography.X509Certificates.xml",
         "ref/dotnet/System.Security.Cryptography.X509Certificates.dll",
+        "ref/dotnet/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/zh-hans/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/zh-hant/System.Security.Cryptography.X509Certificates.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Security.Cryptography.X509Certificates.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23408.nupkg",
-        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23412.nupkg",
+        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Cryptography.X509Certificates.nuspec"
       ]
     },
@@ -2789,116 +2815,118 @@
         "System.Security.Principal.nuspec"
       ]
     },
-    "System.Security.Principal.Windows/4.0.0-beta-23408": {
+    "System.Security.Principal.Windows/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "xmjpZJvsT1AW23UkjqUkF/VrOh7DA1cagYY272UQmO8ei227TFD4C7j3ofatL/63hR3CXkLkoephuE4f2Z9fGA==",
+      "sha512": "Zvb/LzT+GjGNV1t8i5KVieilL+8P5LcQykIbJHw5aJxLPFEIQ4Y2hTJXdEkeKvZ4TCF5dlwY1jYyUrJkcqpxzw==",
       "files": [
-        "lib/DNXCore50/de/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/es/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/fr/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/it/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/ja/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/ko/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/ru/System.Security.Principal.Windows.xml",
         "lib/DNXCore50/System.Security.Principal.Windows.dll",
-        "lib/DNXCore50/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/zh-hans/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/zh-hant/System.Security.Principal.Windows.xml",
         "lib/net46/System.Security.Principal.Windows.dll",
+        "ref/dotnet/de/System.Security.Principal.Windows.xml",
+        "ref/dotnet/es/System.Security.Principal.Windows.xml",
+        "ref/dotnet/fr/System.Security.Principal.Windows.xml",
+        "ref/dotnet/it/System.Security.Principal.Windows.xml",
+        "ref/dotnet/ja/System.Security.Principal.Windows.xml",
+        "ref/dotnet/ko/System.Security.Principal.Windows.xml",
+        "ref/dotnet/ru/System.Security.Principal.Windows.xml",
         "ref/dotnet/System.Security.Principal.Windows.dll",
+        "ref/dotnet/System.Security.Principal.Windows.xml",
+        "ref/dotnet/zh-hans/System.Security.Principal.Windows.xml",
+        "ref/dotnet/zh-hant/System.Security.Principal.Windows.xml",
         "ref/net46/System.Security.Principal.Windows.dll",
-        "System.Security.Principal.Windows.4.0.0-beta-23408.nupkg",
-        "System.Security.Principal.Windows.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Principal.Windows.4.0.0-beta-23412.nupkg",
+        "System.Security.Principal.Windows.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Principal.Windows.nuspec"
       ]
     },
-    "System.ServiceModel.Http/4.0.11-beta-23408": {
+    "System.ServiceModel.Http/4.0.11-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "RScHZ1A3CfjumaP1Vh/xfOp/ga6T3nA8YLkjFOYcIcZm/LILL+yCh+PhIrJOEfz1Js8bLSQC6xbxwYlW6BNmYg==",
+      "sha512": "hKMGQbu/l2gv/PgPvm2ViLVElnVSwAPiv4cXKjinS+UHBf02uPF2m7lN13SCkJDNTBctwHav1rQnMYb1LUJHvw==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Http.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
-        "lib/netcore50/de/System.ServiceModel.Http.xml",
-        "lib/netcore50/es/System.ServiceModel.Http.xml",
-        "lib/netcore50/fr/System.ServiceModel.Http.xml",
-        "lib/netcore50/it/System.ServiceModel.Http.xml",
-        "lib/netcore50/ja/System.ServiceModel.Http.xml",
-        "lib/netcore50/ko/System.ServiceModel.Http.xml",
-        "lib/netcore50/ru/System.ServiceModel.Http.xml",
         "lib/netcore50/System.ServiceModel.Http.dll",
-        "lib/netcore50/System.ServiceModel.Http.xml",
-        "lib/netcore50/zh-hans/System.ServiceModel.Http.xml",
-        "lib/netcore50/zh-hant/System.ServiceModel.Http.xml",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.ServiceModel.Http.xml",
+        "ref/dotnet/es/System.ServiceModel.Http.xml",
+        "ref/dotnet/fr/System.ServiceModel.Http.xml",
+        "ref/dotnet/it/System.ServiceModel.Http.xml",
+        "ref/dotnet/ja/System.ServiceModel.Http.xml",
+        "ref/dotnet/ko/System.ServiceModel.Http.xml",
+        "ref/dotnet/ru/System.ServiceModel.Http.xml",
         "ref/dotnet/System.ServiceModel.Http.dll",
+        "ref/dotnet/System.ServiceModel.Http.xml",
+        "ref/dotnet/zh-hans/System.ServiceModel.Http.xml",
+        "ref/dotnet/zh-hant/System.ServiceModel.Http.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.ServiceModel.Http.4.0.11-beta-23408.nupkg",
-        "System.ServiceModel.Http.4.0.11-beta-23408.nupkg.sha512",
+        "System.ServiceModel.Http.4.0.11-beta-23412.nupkg",
+        "System.ServiceModel.Http.4.0.11-beta-23412.nupkg.sha512",
         "System.ServiceModel.Http.nuspec"
       ]
     },
-    "System.ServiceModel.NetTcp/4.0.1-beta-23408": {
+    "System.ServiceModel.NetTcp/4.0.1-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "ppruBpqoE6AngTs6fABV67r1ic6rKCgr6tw+4lMoRucrNWNfKgX5vWlONOqSd8bQXmQLZ/ftEhDGXYY5CLRUTQ==",
+      "sha512": "9I2iOpoYB8DtVy1Sw6BmOj6NGoxt9cKwOOds4q6G1JLzyyWErsv/FMeGAJT07bgLr8vnMx4s8GXxjCfkUwNtTw==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.NetTcp.dll",
         "lib/net45/_._",
-        "lib/netcore50/de/System.ServiceModel.NetTcp.xml",
-        "lib/netcore50/es/System.ServiceModel.NetTcp.xml",
-        "lib/netcore50/fr/System.ServiceModel.NetTcp.xml",
-        "lib/netcore50/it/System.ServiceModel.NetTcp.xml",
-        "lib/netcore50/ja/System.ServiceModel.NetTcp.xml",
-        "lib/netcore50/ko/System.ServiceModel.NetTcp.xml",
-        "lib/netcore50/ru/System.ServiceModel.NetTcp.xml",
         "lib/netcore50/System.ServiceModel.NetTcp.dll",
-        "lib/netcore50/System.ServiceModel.NetTcp.xml",
-        "lib/netcore50/zh-hans/System.ServiceModel.NetTcp.xml",
-        "lib/netcore50/zh-hant/System.ServiceModel.NetTcp.xml",
         "lib/win8/_._",
+        "ref/dotnet/de/System.ServiceModel.NetTcp.xml",
+        "ref/dotnet/es/System.ServiceModel.NetTcp.xml",
+        "ref/dotnet/fr/System.ServiceModel.NetTcp.xml",
+        "ref/dotnet/it/System.ServiceModel.NetTcp.xml",
+        "ref/dotnet/ja/System.ServiceModel.NetTcp.xml",
+        "ref/dotnet/ko/System.ServiceModel.NetTcp.xml",
+        "ref/dotnet/ru/System.ServiceModel.NetTcp.xml",
         "ref/dotnet/System.ServiceModel.NetTcp.dll",
+        "ref/dotnet/System.ServiceModel.NetTcp.xml",
+        "ref/dotnet/zh-hans/System.ServiceModel.NetTcp.xml",
+        "ref/dotnet/zh-hant/System.ServiceModel.NetTcp.xml",
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.NetTcp.dll",
+        "ref/netcore50/System.ServiceModel.NetTcp.xml",
         "ref/win8/_._",
-        "System.ServiceModel.NetTcp.4.0.1-beta-23408.nupkg",
-        "System.ServiceModel.NetTcp.4.0.1-beta-23408.nupkg.sha512",
+        "System.ServiceModel.NetTcp.4.0.1-beta-23412.nupkg",
+        "System.ServiceModel.NetTcp.4.0.1-beta-23412.nupkg.sha512",
         "System.ServiceModel.NetTcp.nuspec"
       ]
     },
-    "System.ServiceModel.Primitives/4.0.1-beta-23408": {
+    "System.ServiceModel.Primitives/4.0.1-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "bjXzg+V3Oq/tBXpMY5FwcERN2CQsFXoL4BMoURlwiBMkgwN2CPvBIaK45Moh7nc21jNTVukNayDtURetGzK6aA==",
+      "sha512": "dkCUkNtXb2m9Wf+DY7dc5B4J8DpaWtX4wpFfT3cYLpChxAnjQR85N+tJfMEHLfZNNerKgDRyGyaKa7uSHfvb5g==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Primitives.dll",
         "lib/net45/_._",
-        "lib/netcore50/de/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/es/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/fr/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/it/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/ja/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/ko/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/ru/System.ServiceModel.Primitives.xml",
         "lib/netcore50/System.ServiceModel.Primitives.dll",
-        "lib/netcore50/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/zh-hans/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/zh-hant/System.ServiceModel.Primitives.xml",
         "lib/win8/_._",
+        "ref/dotnet/de/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/es/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/fr/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/it/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/ja/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/ko/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/ru/System.ServiceModel.Primitives.xml",
         "ref/dotnet/System.ServiceModel.Primitives.dll",
+        "ref/dotnet/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/zh-hans/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/zh-hant/System.ServiceModel.Primitives.xml",
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.Primitives.dll",
+        "ref/netcore50/System.ServiceModel.Primitives.xml",
         "ref/win8/_._",
-        "System.ServiceModel.Primitives.4.0.1-beta-23408.nupkg",
-        "System.ServiceModel.Primitives.4.0.1-beta-23408.nupkg.sha512",
+        "System.ServiceModel.Primitives.4.0.1-beta-23412.nupkg",
+        "System.ServiceModel.Primitives.4.0.1-beta-23412.nupkg.sha512",
         "System.ServiceModel.Primitives.nuspec"
       ]
     },
@@ -3091,28 +3119,6 @@
         "System.Threading.Tasks.4.0.10.nupkg",
         "System.Threading.Tasks.4.0.10.nupkg.sha512",
         "System.Threading.Tasks.nuspec"
-      ]
-    },
-    "System.Threading.ThreadPool/4.0.10-beta-23408": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "ahdsVyj+WFj8/iSDwX/G7hkEU4jZmmvWzPS2ajZKdp0Crb0vZJOlM0LQYVASQgbimrUZHQ50o93JYEi8RFdh/Q==",
-      "files": [
-        "lib/DNXCore50/System.Threading.ThreadPool.dll",
-        "lib/MonoAndroid10/_._",
-        "lib/MonoTouch10/_._",
-        "lib/net46/System.Threading.ThreadPool.dll",
-        "lib/xamarinios10/_._",
-        "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Threading.ThreadPool.dll",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
-        "ref/net46/System.Threading.ThreadPool.dll",
-        "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.Threading.ThreadPool.4.0.10-beta-23408.nupkg",
-        "System.Threading.ThreadPool.4.0.10-beta-23408.nupkg.sha512",
-        "System.Threading.ThreadPool.nuspec"
       ]
     },
     "System.Threading.Timer/4.0.0": {
@@ -3362,14 +3368,14 @@
         "xunit.extensibility.execution.nuspec"
       ]
     },
-    "xunit.netcore.extensions/1.0.0-prerelease-00104": {
+    "xunit.netcore.extensions/1.0.0-prerelease-00105": {
       "type": "package",
       "serviceable": true,
-      "sha512": "ZMXxEBpGP7krXtvqbPMOWavd2u83w77ghtD254wfj5+d+7GmYYqP9pX1iRIxJK9CBa8Zc2cOrcYsmCLQgYriAQ==",
+      "sha512": "EnnGcy9rmSdQ8izHWvYSYVyjQGhbeFH7JeM/L35ZrrPGtYvq5XD3hc1cJPCs+43mXdF9cdqhkt5uTlXYzC+Z8g==",
       "files": [
         "lib/dotnet/Xunit.NetCore.Extensions.dll",
-        "xunit.netcore.extensions.1.0.0-prerelease-00104.nupkg",
-        "xunit.netcore.extensions.1.0.0-prerelease-00104.nupkg.sha512",
+        "xunit.netcore.extensions.1.0.0-prerelease-00105.nupkg",
+        "xunit.netcore.extensions.1.0.0-prerelease-00105.nupkg.sha512",
         "xunit.netcore.extensions.nuspec"
       ]
     }

--- a/src/System.Private.ServiceModel/tests/Scenarios/Encoding/MessageVersion/project.lock.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Encoding/MessageVersion/project.lock.json
@@ -292,7 +292,7 @@
           "lib/dotnet/System.Linq.Queryable.dll": {}
         }
       },
-      "System.Net.Http/4.0.1-beta-23408": {
+      "System.Net.Http/4.0.1-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -305,7 +305,7 @@
           "ref/dotnet/System.Net.Http.dll": {}
         }
       },
-      "System.Net.NameResolution/4.0.0-beta-23408": {
+      "System.Net.NameResolution/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Net.Primitives": "4.0.10",
@@ -328,16 +328,17 @@
           "lib/DNXCore50/System.Net.Primitives.dll": {}
         }
       },
-      "System.Net.Security/4.0.0-beta-23408": {
+      "System.Net.Security/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
-          "System.Private.Networking": "4.0.1-beta-23408"
+          "System.IO": "4.0.0",
+          "System.Net.Primitives": "4.0.10",
+          "System.Runtime": "4.0.0",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23412",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Net.Security.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Net.Security.dll": {}
         }
       },
       "System.Net.Sockets/4.1.0-beta-23225": {
@@ -368,7 +369,7 @@
           "lib/dotnet/System.Net.WebHeaderCollection.dll": {}
         }
       },
-      "System.Net.WebSockets/4.0.0-beta-23408": {
+      "System.Net.WebSockets/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -383,7 +384,7 @@
           "lib/dotnet/System.Net.WebSockets.dll": {}
         }
       },
-      "System.Net.WebSockets.Client/4.0.0-beta-23408": {
+      "System.Net.WebSockets.Client/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -393,13 +394,13 @@
           "System.Globalization": "4.0.10",
           "System.Net.Primitives": "4.0.10",
           "System.Net.WebHeaderCollection": "4.0.0",
-          "System.Net.WebSockets": "4.0.0-beta-23408",
+          "System.Net.WebSockets": "4.0.0-beta-23412",
           "System.Resources.ResourceManager": "4.0.0",
           "System.Runtime": "4.0.20",
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23408",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23412",
           "System.Text.Encoding": "4.0.10",
           "System.Threading": "4.0.10",
           "System.Threading.Tasks": "4.0.10"
@@ -456,7 +457,7 @@
           "lib/DNXCore50/System.Private.DataContractSerialization.dll": {}
         }
       },
-      "System.Private.Networking/4.0.1-beta-23408": {
+      "System.Private.Networking/4.0.1-beta-23225": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -475,13 +476,10 @@
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23408",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23408",
-          "System.Security.Principal.Windows": "4.0.0-beta-23408",
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23225",
           "System.Threading": "4.0.10",
           "System.Threading.Overlapped": "4.0.0",
-          "System.Threading.Tasks": "4.0.10",
-          "System.Threading.ThreadPool": "4.0.10-beta-23408"
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dnxcore50/_._": {}
@@ -490,7 +488,7 @@
           "lib/DNXCore50/System.Private.Networking.dll": {}
         }
       },
-      "System.Private.ServiceModel/4.1.0-beta-23408": {
+      "System.Private.ServiceModel/4.1.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -507,14 +505,14 @@
           "System.Linq": "4.0.0",
           "System.Linq.Expressions": "4.0.10",
           "System.Linq.Queryable": "4.0.0",
-          "System.Net.Http": "4.0.1-beta-23408",
-          "System.Net.NameResolution": "4.0.0-beta-23408",
+          "System.Net.Http": "4.0.1-beta-23412",
+          "System.Net.NameResolution": "4.0.0-beta-23412",
           "System.Net.Primitives": "4.0.10",
-          "System.Net.Security": "4.0.0-beta-23408",
-          "System.Net.Sockets": "4.0.10-beta-23408",
+          "System.Net.Security": "4.0.0-beta-23412",
+          "System.Net.Sockets": "4.0.10-beta-23412",
           "System.Net.WebHeaderCollection": "4.0.0",
-          "System.Net.WebSockets": "4.0.0-beta-23408",
-          "System.Net.WebSockets.Client": "4.0.0-beta-23408",
+          "System.Net.WebSockets": "4.0.0-beta-23412",
+          "System.Net.WebSockets.Client": "4.0.0-beta-23412",
           "System.ObjectModel": "4.0.10",
           "System.Reflection": "4.0.10",
           "System.Reflection.DispatchProxy": "4.0.0",
@@ -528,9 +526,9 @@
           "System.Runtime.Serialization.Primitives": "4.0.10",
           "System.Runtime.Serialization.Xml": "4.0.10",
           "System.Security.Claims": "4.0.0",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23408",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23412",
           "System.Security.Principal": "4.0.0",
-          "System.Security.Principal.Windows": "4.0.0-beta-23408",
+          "System.Security.Principal.Windows": "4.0.0-beta-23412",
           "System.Text.Encoding": "4.0.10",
           "System.Threading": "4.0.10",
           "System.Threading.Tasks": "4.0.10",
@@ -779,18 +777,18 @@
           "lib/dotnet/System.Security.Claims.dll": {}
         }
       },
-      "System.Security.Cryptography.Algorithms/4.0.0-beta-23408": {
+      "System.Security.Cryptography.Algorithms/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
           "System.Runtime": "4.0.0",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23408"
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23412"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.Algorithms.dll": {}
         }
       },
-      "System.Security.Cryptography.Encoding/4.0.0-beta-23408": {
+      "System.Security.Cryptography.Encoding/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -799,7 +797,7 @@
           "ref/dotnet/System.Security.Cryptography.Encoding.dll": {}
         }
       },
-      "System.Security.Cryptography.Primitives/4.0.0-beta-23408": {
+      "System.Security.Cryptography.Primitives/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.0",
@@ -817,13 +815,13 @@
           "lib/dotnet/System.Security.Cryptography.Primitives.dll": {}
         }
       },
-      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23408": {
+      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
           "System.Runtime.Handles": "4.0.0",
-          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23408",
-          "System.Security.Cryptography.Encoding": "4.0.0-beta-23408"
+          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23412",
+          "System.Security.Cryptography.Encoding": "4.0.0-beta-23412"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.X509Certificates.dll": {}
@@ -841,7 +839,7 @@
           "lib/dotnet/System.Security.Principal.dll": {}
         }
       },
-      "System.Security.Principal.Windows/4.0.0-beta-23408": {
+      "System.Security.Principal.Windows/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -864,10 +862,10 @@
           "lib/DNXCore50/System.Security.Principal.Windows.dll": {}
         }
       },
-      "System.ServiceModel.Http/4.0.11-beta-23408": {
+      "System.ServiceModel.Http/4.0.11-beta-23412": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-beta-23408",
+          "System.Private.ServiceModel": "4.1.0-beta-23412",
           "System.Runtime": "4.0.20"
         },
         "compile": {
@@ -877,10 +875,10 @@
           "lib/DNXCore50/System.ServiceModel.Http.dll": {}
         }
       },
-      "System.ServiceModel.Primitives/4.0.1-beta-23408": {
+      "System.ServiceModel.Primitives/4.0.1-beta-23412": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-beta-23408"
+          "System.Private.ServiceModel": "4.1.0-beta-23412"
         },
         "compile": {
           "ref/dotnet/System.ServiceModel.Primitives.dll": {}
@@ -967,19 +965,6 @@
         },
         "runtime": {
           "lib/DNXCore50/System.Threading.Tasks.dll": {}
-        }
-      },
-      "System.Threading.ThreadPool/4.0.10-beta-23408": {
-        "type": "package",
-        "dependencies": {
-          "System.Runtime": "4.0.0",
-          "System.Runtime.InteropServices": "4.0.0"
-        },
-        "compile": {
-          "ref/dotnet/System.Threading.ThreadPool.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Threading.ThreadPool.dll": {}
         }
       },
       "System.Threading.Timer/4.0.0": {
@@ -1162,7 +1147,7 @@
           "lib/dotnet/xunit.execution.dotnet.dll": {}
         }
       },
-      "xunit.netcore.extensions/1.0.0-prerelease-00104": {
+      "xunit.netcore.extensions/1.0.0-prerelease-00105": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.10",
@@ -1790,44 +1775,65 @@
         "System.Linq.Queryable.nuspec"
       ]
     },
-    "System.Net.Http/4.0.1-beta-23408": {
+    "System.Net.Http/4.0.1-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "n+tnV1VgCjbDKKnbgrvgUgxkPDwUFvSv9lTgH882rVzjbWyliVgbBflVzoAUjUSlga/Tr1XQIrfTLMRD5HfYGw==",
+      "sha512": "F7Yej+6QdRVzWg+qbkayRMcmf/7k7YfNFoVSA67wIsG9t5u7Wj4Go8FW72HL8qb9d7YjIsVB/5hA7g9MUT31Aw==",
       "files": [
         "lib/net45/_._",
         "lib/win8/_._",
         "lib/wpa81/_._",
+        "ref/dotnet/de/System.Net.Http.xml",
+        "ref/dotnet/es/System.Net.Http.xml",
+        "ref/dotnet/fr/System.Net.Http.xml",
+        "ref/dotnet/it/System.Net.Http.xml",
+        "ref/dotnet/ja/System.Net.Http.xml",
+        "ref/dotnet/ko/System.Net.Http.xml",
+        "ref/dotnet/ru/System.Net.Http.xml",
         "ref/dotnet/System.Net.Http.dll",
+        "ref/dotnet/System.Net.Http.xml",
+        "ref/dotnet/zh-hans/System.Net.Http.xml",
+        "ref/dotnet/zh-hant/System.Net.Http.xml",
         "ref/net45/_._",
         "ref/netcore50/System.Net.Http.dll",
+        "ref/netcore50/System.Net.Http.xml",
         "ref/win8/_._",
         "ref/wpa81/_._",
         "runtime.json",
-        "System.Net.Http.4.0.1-beta-23408.nupkg",
-        "System.Net.Http.4.0.1-beta-23408.nupkg.sha512",
+        "System.Net.Http.4.0.1-beta-23412.nupkg",
+        "System.Net.Http.4.0.1-beta-23412.nupkg.sha512",
         "System.Net.Http.nuspec"
       ]
     },
-    "System.Net.NameResolution/4.0.0-beta-23408": {
+    "System.Net.NameResolution/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "2A562VFL8GUL/jLCJ3mbQHhwwAIXzPyjxMpdtas1LVM8QLuP1OcHwV3z7ajWnYdGcPc7ZxPEGJQWicuaPD+0nA==",
+      "sha512": "HCF1zhFYBT+w/Ik+JuTzFJgj83Jfc+eA8VcgvIzdPiGMXfrZeXOogjgSCkCoJmFtKVz2DSfmISoEmiXB1oaLNQ==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.NameResolution.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Net.NameResolution.xml",
+        "ref/dotnet/es/System.Net.NameResolution.xml",
+        "ref/dotnet/fr/System.Net.NameResolution.xml",
+        "ref/dotnet/it/System.Net.NameResolution.xml",
+        "ref/dotnet/ja/System.Net.NameResolution.xml",
+        "ref/dotnet/ko/System.Net.NameResolution.xml",
+        "ref/dotnet/ru/System.Net.NameResolution.xml",
         "ref/dotnet/System.Net.NameResolution.dll",
+        "ref/dotnet/System.Net.NameResolution.xml",
+        "ref/dotnet/zh-hans/System.Net.NameResolution.xml",
+        "ref/dotnet/zh-hant/System.Net.NameResolution.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Net.NameResolution.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Net.NameResolution.4.0.0-beta-23408.nupkg",
-        "System.Net.NameResolution.4.0.0-beta-23408.nupkg.sha512",
+        "System.Net.NameResolution.4.0.0-beta-23412.nupkg",
+        "System.Net.NameResolution.4.0.0-beta-23412.nupkg.sha512",
         "System.Net.NameResolution.nuspec"
       ]
     },
@@ -1864,24 +1870,34 @@
         "System.Net.Primitives.nuspec"
       ]
     },
-    "System.Net.Security/4.0.0-beta-23408": {
+    "System.Net.Security/4.0.0-beta-23412": {
       "type": "package",
-      "sha512": "kEkunODO2t/VlBIsC80YFDG0KtY/FyIbtBApNyJQv+LYGEs5IFvEhpi9+p0/jHmhyRMKwbjajNedbXo+VMkt1A==",
+      "sha512": "Kcjne7jnvF5aTbRJsAT8kuP+1mxryUF2qYv8f3jnR19wtEjswSIOVU0XzuWc9YObEQcb+kEdzN71HTOm+ssv+w==",
       "files": [
-        "lib/DNXCore50/System.Net.Security.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.Security.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Net.Security.xml",
+        "ref/dotnet/es/System.Net.Security.xml",
+        "ref/dotnet/fr/System.Net.Security.xml",
+        "ref/dotnet/it/System.Net.Security.xml",
+        "ref/dotnet/ja/System.Net.Security.xml",
+        "ref/dotnet/ko/System.Net.Security.xml",
+        "ref/dotnet/ru/System.Net.Security.xml",
         "ref/dotnet/System.Net.Security.dll",
+        "ref/dotnet/System.Net.Security.xml",
+        "ref/dotnet/zh-hans/System.Net.Security.xml",
+        "ref/dotnet/zh-hant/System.Net.Security.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Net.Security.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.Security.4.0.0-beta-23408.nupkg",
-        "System.Net.Security.4.0.0-beta-23408.nupkg.sha512",
+        "runtime.json",
+        "System.Net.Security.4.0.0-beta-23412.nupkg",
+        "System.Net.Security.4.0.0-beta-23412.nupkg.sha512",
         "System.Net.Security.nuspec"
       ]
     },
@@ -1939,78 +1955,68 @@
         "System.Net.WebHeaderCollection.nuspec"
       ]
     },
-    "System.Net.WebSockets/4.0.0-beta-23408": {
+    "System.Net.WebSockets/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "BXy22/bNVtrXXsG76zXyhjcQnCjSYxQIFF37xWifqPRWmvzsCYSLQpNCTPQUCp7rjB7qWc5yLhC9bThaEx7MHQ==",
+      "sha512": "EvXAa0yd1RM8ROyLl1T0xC94F04Su8YMHnd4/w6j0Z/+4lKHZOU7bQPZ3odDN8WdPGKa/ZNJJGwiapydEWKzwQ==",
       "files": [
-        "lib/dotnet/de/System.Net.WebSockets.xml",
-        "lib/dotnet/es/System.Net.WebSockets.xml",
-        "lib/dotnet/fr/System.Net.WebSockets.xml",
-        "lib/dotnet/it/System.Net.WebSockets.xml",
-        "lib/dotnet/ja/System.Net.WebSockets.xml",
-        "lib/dotnet/ko/System.Net.WebSockets.xml",
-        "lib/dotnet/ru/System.Net.WebSockets.xml",
         "lib/dotnet/System.Net.WebSockets.dll",
-        "lib/dotnet/System.Net.WebSockets.xml",
-        "lib/dotnet/zh-hans/System.Net.WebSockets.xml",
-        "lib/dotnet/zh-hant/System.Net.WebSockets.xml",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.WebSockets.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Net.WebSockets.xml",
+        "ref/dotnet/es/System.Net.WebSockets.xml",
+        "ref/dotnet/fr/System.Net.WebSockets.xml",
+        "ref/dotnet/it/System.Net.WebSockets.xml",
+        "ref/dotnet/ja/System.Net.WebSockets.xml",
+        "ref/dotnet/ko/System.Net.WebSockets.xml",
+        "ref/dotnet/ru/System.Net.WebSockets.xml",
         "ref/dotnet/System.Net.WebSockets.dll",
+        "ref/dotnet/System.Net.WebSockets.xml",
+        "ref/dotnet/zh-hans/System.Net.WebSockets.xml",
+        "ref/dotnet/zh-hant/System.Net.WebSockets.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Net.WebSockets.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.WebSockets.4.0.0-beta-23408.nupkg",
-        "System.Net.WebSockets.4.0.0-beta-23408.nupkg.sha512",
+        "System.Net.WebSockets.4.0.0-beta-23412.nupkg",
+        "System.Net.WebSockets.4.0.0-beta-23412.nupkg.sha512",
         "System.Net.WebSockets.nuspec"
       ]
     },
-    "System.Net.WebSockets.Client/4.0.0-beta-23408": {
+    "System.Net.WebSockets.Client/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "smmvhCkcU0c4RNWc6NZwnN5EFktX58jf8+TJ6enfuXxWrpJ/2NRI5/2yT/okjFSngGK1g0MBrljZsfs2EJ7+Yw==",
+      "sha512": "uaO7c/81sK90605UtThSX9KVmzsJDA1vD4GMW7FsKKntymlkolJsprDekWblQ4A5YbhqxHv+ngXX2kIU0B3Fdw==",
       "files": [
-        "lib/DNXCore50/de/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/es/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/fr/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/it/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/ja/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/ko/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/ru/System.Net.WebSockets.Client.xml",
         "lib/DNXCore50/System.Net.WebSockets.Client.dll",
-        "lib/DNXCore50/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/zh-hans/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/zh-hant/System.Net.WebSockets.Client.xml",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.WebSockets.Client.dll",
-        "lib/netcore50/de/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/es/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/fr/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/it/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/ja/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/ko/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/ru/System.Net.WebSockets.Client.xml",
         "lib/netcore50/System.Net.WebSockets.Client.dll",
-        "lib/netcore50/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/zh-hans/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/zh-hant/System.Net.WebSockets.Client.xml",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/es/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/fr/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/it/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/ja/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/ko/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/ru/System.Net.WebSockets.Client.xml",
         "ref/dotnet/System.Net.WebSockets.Client.dll",
+        "ref/dotnet/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/zh-hans/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/zh-hant/System.Net.WebSockets.Client.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Net.WebSockets.Client.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.WebSockets.Client.4.0.0-beta-23408.nupkg",
-        "System.Net.WebSockets.Client.4.0.0-beta-23408.nupkg.sha512",
+        "System.Net.WebSockets.Client.4.0.0-beta-23412.nupkg",
+        "System.Net.WebSockets.Client.4.0.0-beta-23412.nupkg.sha512",
         "System.Net.WebSockets.Client.nuspec"
       ]
     },
@@ -2062,31 +2068,31 @@
         "System.Private.DataContractSerialization.nuspec"
       ]
     },
-    "System.Private.Networking/4.0.1-beta-23408": {
+    "System.Private.Networking/4.0.1-beta-23225": {
       "type": "package",
       "serviceable": true,
-      "sha512": "i2fRDRqM8Px3CP26C//deF/tCNR1AwqlPEr9+MYiXxNZtgGcSPBfqOJJ5CJdfmDb9Ap0hPG2MiPG7CinaSH7+Q==",
+      "sha512": "oVSynIrR3mIU0b/goscsaZDywr3RLxQijQnaFRKfl/VB3F9rKi5mdr0vHcGVWuq5ALSrG0OLwM8PRA4tM5e3rQ==",
       "files": [
         "lib/DNXCore50/System.Private.Networking.dll",
         "lib/netcore50/System.Private.Networking.dll",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "System.Private.Networking.4.0.1-beta-23408.nupkg",
-        "System.Private.Networking.4.0.1-beta-23408.nupkg.sha512",
+        "System.Private.Networking.4.0.1-beta-23225.nupkg",
+        "System.Private.Networking.4.0.1-beta-23225.nupkg.sha512",
         "System.Private.Networking.nuspec"
       ]
     },
-    "System.Private.ServiceModel/4.1.0-beta-23408": {
+    "System.Private.ServiceModel/4.1.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "l/2192yKa6uXhjKOWeukFJy3hoj9Zq1p55pTGe+Y28r8/5jlvgYxfunP9UyXJRo9W1u3UBtGfV/5R71ULzusGQ==",
+      "sha512": "Wm+8LcQ04YeAvYqu9faHsMZ/L8l/WvPPsqziBfifYB4jXIPXk1/kUxuAryjbLChghZDXvkDN0hv/IHSVPZGgBA==",
       "files": [
         "lib/DNXCore50/System.Private.ServiceModel.dll",
         "lib/netcore50/System.Private.ServiceModel.dll",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "System.Private.ServiceModel.4.1.0-beta-23408.nupkg",
-        "System.Private.ServiceModel.4.1.0-beta-23408.nupkg.sha512",
+        "System.Private.ServiceModel.4.1.0-beta-23412.nupkg",
+        "System.Private.ServiceModel.4.1.0-beta-23412.nupkg.sha512",
         "System.Private.ServiceModel.nuspec"
       ]
     },
@@ -2615,10 +2621,10 @@
         "System.Security.Claims.nuspec"
       ]
     },
-    "System.Security.Cryptography.Algorithms/4.0.0-beta-23408": {
+    "System.Security.Cryptography.Algorithms/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "G6eEqi8mZRrWftcwilcnllE4xJ/53JQlk3VVuJ+9qrX+DHvWz8itYJRUZX357JY4DgEEKQNOJzuRGrOBTUeoPg==",
+      "sha512": "nBjoiqJQiMD3cJgOVrqjIVDqEEPZeIqT+mrBIxjLE+YMQcjEyDuSyOG65Ntoopby5LH4onTLMM4zfXh8JRt9NQ==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2632,37 +2638,47 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.Algorithms.4.0.0-beta-23408.nupkg",
-        "System.Security.Cryptography.Algorithms.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Cryptography.Algorithms.4.0.0-beta-23412.nupkg",
+        "System.Security.Cryptography.Algorithms.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Cryptography.Algorithms.nuspec"
       ]
     },
-    "System.Security.Cryptography.Encoding/4.0.0-beta-23408": {
+    "System.Security.Cryptography.Encoding/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "fPsAK3vyMjnJ6nT4YchdS7KzfGca/6uVVAPCBO08ZpTRGhMGx30vq1MiIqAUrfsFMnot3Ub2jimnAFWkqY6g0Q==",
+      "sha512": "SR1zCARNdeyLoUKYH2SNMm1He7Lr3NR/l7yW3K135L44T6PS3YB8SfXpVoZdMpb22X2G07BZAHVz2x7e4AA1Cg==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Security.Cryptography.Encoding.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/es/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/fr/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/it/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/ja/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/ko/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/ru/System.Security.Cryptography.Encoding.xml",
         "ref/dotnet/System.Security.Cryptography.Encoding.dll",
+        "ref/dotnet/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/zh-hans/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/zh-hant/System.Security.Cryptography.Encoding.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Security.Cryptography.Encoding.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.Encoding.4.0.0-beta-23408.nupkg",
-        "System.Security.Cryptography.Encoding.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Cryptography.Encoding.4.0.0-beta-23412.nupkg",
+        "System.Security.Cryptography.Encoding.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Cryptography.Encoding.nuspec"
       ]
     },
-    "System.Security.Cryptography.Primitives/4.0.0-beta-23408": {
+    "System.Security.Cryptography.Primitives/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "A336dWYEIQxm1rEJCaE5ZZrUWHPUkBGTRH8uAj8qrTqg4/qRc2yN2wZxeGXaZauhI35QwDmOutK7oVb2Cd+4TA==",
+      "sha512": "H9EBNe0ahjAYjlVn0TnT18PSgZBrtROSQH1RRIKwAjzxQHt8zwDhO4yN0Q5QaaUIoSXgxVmgtWWk62wDvpy+QA==",
       "files": [
         "lib/dotnet/System.Security.Cryptography.Primitives.dll",
         "lib/MonoAndroid10/_._",
@@ -2676,30 +2692,40 @@
         "ref/net46/System.Security.Cryptography.Primitives.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Security.Cryptography.Primitives.4.0.0-beta-23408.nupkg",
-        "System.Security.Cryptography.Primitives.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Cryptography.Primitives.4.0.0-beta-23412.nupkg",
+        "System.Security.Cryptography.Primitives.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Cryptography.Primitives.nuspec"
       ]
     },
-    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23408": {
+    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "JSNf5d1V5Y47MIdf7QxZCuGnR5heM4UKbrsdXiWD5lfqu0mnNjebPIclMUXlTw/6IykuDsUpompV/DtsaLLHig==",
+      "sha512": "SfpMjvrfRaRjG42uynLugb3YgpXdpnU7X8vNAU7stIR5/4uW9m1SvWHvBjirjHRBtOpbKB86uD5ODQWX+tWDNA==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Security.Cryptography.X509Certificates.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/es/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/fr/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/it/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/ja/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/ko/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/ru/System.Security.Cryptography.X509Certificates.xml",
         "ref/dotnet/System.Security.Cryptography.X509Certificates.dll",
+        "ref/dotnet/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/zh-hans/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/zh-hant/System.Security.Cryptography.X509Certificates.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Security.Cryptography.X509Certificates.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23408.nupkg",
-        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23412.nupkg",
+        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Cryptography.X509Certificates.nuspec"
       ]
     },
@@ -2736,88 +2762,89 @@
         "System.Security.Principal.nuspec"
       ]
     },
-    "System.Security.Principal.Windows/4.0.0-beta-23408": {
+    "System.Security.Principal.Windows/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "xmjpZJvsT1AW23UkjqUkF/VrOh7DA1cagYY272UQmO8ei227TFD4C7j3ofatL/63hR3CXkLkoephuE4f2Z9fGA==",
+      "sha512": "Zvb/LzT+GjGNV1t8i5KVieilL+8P5LcQykIbJHw5aJxLPFEIQ4Y2hTJXdEkeKvZ4TCF5dlwY1jYyUrJkcqpxzw==",
       "files": [
-        "lib/DNXCore50/de/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/es/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/fr/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/it/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/ja/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/ko/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/ru/System.Security.Principal.Windows.xml",
         "lib/DNXCore50/System.Security.Principal.Windows.dll",
-        "lib/DNXCore50/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/zh-hans/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/zh-hant/System.Security.Principal.Windows.xml",
         "lib/net46/System.Security.Principal.Windows.dll",
+        "ref/dotnet/de/System.Security.Principal.Windows.xml",
+        "ref/dotnet/es/System.Security.Principal.Windows.xml",
+        "ref/dotnet/fr/System.Security.Principal.Windows.xml",
+        "ref/dotnet/it/System.Security.Principal.Windows.xml",
+        "ref/dotnet/ja/System.Security.Principal.Windows.xml",
+        "ref/dotnet/ko/System.Security.Principal.Windows.xml",
+        "ref/dotnet/ru/System.Security.Principal.Windows.xml",
         "ref/dotnet/System.Security.Principal.Windows.dll",
+        "ref/dotnet/System.Security.Principal.Windows.xml",
+        "ref/dotnet/zh-hans/System.Security.Principal.Windows.xml",
+        "ref/dotnet/zh-hant/System.Security.Principal.Windows.xml",
         "ref/net46/System.Security.Principal.Windows.dll",
-        "System.Security.Principal.Windows.4.0.0-beta-23408.nupkg",
-        "System.Security.Principal.Windows.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Principal.Windows.4.0.0-beta-23412.nupkg",
+        "System.Security.Principal.Windows.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Principal.Windows.nuspec"
       ]
     },
-    "System.ServiceModel.Http/4.0.11-beta-23408": {
+    "System.ServiceModel.Http/4.0.11-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "RScHZ1A3CfjumaP1Vh/xfOp/ga6T3nA8YLkjFOYcIcZm/LILL+yCh+PhIrJOEfz1Js8bLSQC6xbxwYlW6BNmYg==",
+      "sha512": "hKMGQbu/l2gv/PgPvm2ViLVElnVSwAPiv4cXKjinS+UHBf02uPF2m7lN13SCkJDNTBctwHav1rQnMYb1LUJHvw==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Http.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
-        "lib/netcore50/de/System.ServiceModel.Http.xml",
-        "lib/netcore50/es/System.ServiceModel.Http.xml",
-        "lib/netcore50/fr/System.ServiceModel.Http.xml",
-        "lib/netcore50/it/System.ServiceModel.Http.xml",
-        "lib/netcore50/ja/System.ServiceModel.Http.xml",
-        "lib/netcore50/ko/System.ServiceModel.Http.xml",
-        "lib/netcore50/ru/System.ServiceModel.Http.xml",
         "lib/netcore50/System.ServiceModel.Http.dll",
-        "lib/netcore50/System.ServiceModel.Http.xml",
-        "lib/netcore50/zh-hans/System.ServiceModel.Http.xml",
-        "lib/netcore50/zh-hant/System.ServiceModel.Http.xml",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.ServiceModel.Http.xml",
+        "ref/dotnet/es/System.ServiceModel.Http.xml",
+        "ref/dotnet/fr/System.ServiceModel.Http.xml",
+        "ref/dotnet/it/System.ServiceModel.Http.xml",
+        "ref/dotnet/ja/System.ServiceModel.Http.xml",
+        "ref/dotnet/ko/System.ServiceModel.Http.xml",
+        "ref/dotnet/ru/System.ServiceModel.Http.xml",
         "ref/dotnet/System.ServiceModel.Http.dll",
+        "ref/dotnet/System.ServiceModel.Http.xml",
+        "ref/dotnet/zh-hans/System.ServiceModel.Http.xml",
+        "ref/dotnet/zh-hant/System.ServiceModel.Http.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.ServiceModel.Http.4.0.11-beta-23408.nupkg",
-        "System.ServiceModel.Http.4.0.11-beta-23408.nupkg.sha512",
+        "System.ServiceModel.Http.4.0.11-beta-23412.nupkg",
+        "System.ServiceModel.Http.4.0.11-beta-23412.nupkg.sha512",
         "System.ServiceModel.Http.nuspec"
       ]
     },
-    "System.ServiceModel.Primitives/4.0.1-beta-23408": {
+    "System.ServiceModel.Primitives/4.0.1-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "bjXzg+V3Oq/tBXpMY5FwcERN2CQsFXoL4BMoURlwiBMkgwN2CPvBIaK45Moh7nc21jNTVukNayDtURetGzK6aA==",
+      "sha512": "dkCUkNtXb2m9Wf+DY7dc5B4J8DpaWtX4wpFfT3cYLpChxAnjQR85N+tJfMEHLfZNNerKgDRyGyaKa7uSHfvb5g==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Primitives.dll",
         "lib/net45/_._",
-        "lib/netcore50/de/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/es/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/fr/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/it/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/ja/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/ko/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/ru/System.ServiceModel.Primitives.xml",
         "lib/netcore50/System.ServiceModel.Primitives.dll",
-        "lib/netcore50/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/zh-hans/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/zh-hant/System.ServiceModel.Primitives.xml",
         "lib/win8/_._",
+        "ref/dotnet/de/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/es/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/fr/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/it/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/ja/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/ko/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/ru/System.ServiceModel.Primitives.xml",
         "ref/dotnet/System.ServiceModel.Primitives.dll",
+        "ref/dotnet/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/zh-hans/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/zh-hant/System.ServiceModel.Primitives.xml",
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.Primitives.dll",
+        "ref/netcore50/System.ServiceModel.Primitives.xml",
         "ref/win8/_._",
-        "System.ServiceModel.Primitives.4.0.1-beta-23408.nupkg",
-        "System.ServiceModel.Primitives.4.0.1-beta-23408.nupkg.sha512",
+        "System.ServiceModel.Primitives.4.0.1-beta-23412.nupkg",
+        "System.ServiceModel.Primitives.4.0.1-beta-23412.nupkg.sha512",
         "System.ServiceModel.Primitives.nuspec"
       ]
     },
@@ -3010,28 +3037,6 @@
         "System.Threading.Tasks.4.0.10.nupkg",
         "System.Threading.Tasks.4.0.10.nupkg.sha512",
         "System.Threading.Tasks.nuspec"
-      ]
-    },
-    "System.Threading.ThreadPool/4.0.10-beta-23408": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "ahdsVyj+WFj8/iSDwX/G7hkEU4jZmmvWzPS2ajZKdp0Crb0vZJOlM0LQYVASQgbimrUZHQ50o93JYEi8RFdh/Q==",
-      "files": [
-        "lib/DNXCore50/System.Threading.ThreadPool.dll",
-        "lib/MonoAndroid10/_._",
-        "lib/MonoTouch10/_._",
-        "lib/net46/System.Threading.ThreadPool.dll",
-        "lib/xamarinios10/_._",
-        "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Threading.ThreadPool.dll",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
-        "ref/net46/System.Threading.ThreadPool.dll",
-        "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.Threading.ThreadPool.4.0.10-beta-23408.nupkg",
-        "System.Threading.ThreadPool.4.0.10-beta-23408.nupkg.sha512",
-        "System.Threading.ThreadPool.nuspec"
       ]
     },
     "System.Threading.Timer/4.0.0": {
@@ -3281,14 +3286,14 @@
         "xunit.extensibility.execution.nuspec"
       ]
     },
-    "xunit.netcore.extensions/1.0.0-prerelease-00104": {
+    "xunit.netcore.extensions/1.0.0-prerelease-00105": {
       "type": "package",
       "serviceable": true,
-      "sha512": "ZMXxEBpGP7krXtvqbPMOWavd2u83w77ghtD254wfj5+d+7GmYYqP9pX1iRIxJK9CBa8Zc2cOrcYsmCLQgYriAQ==",
+      "sha512": "EnnGcy9rmSdQ8izHWvYSYVyjQGhbeFH7JeM/L35ZrrPGtYvq5XD3hc1cJPCs+43mXdF9cdqhkt5uTlXYzC+Z8g==",
       "files": [
         "lib/dotnet/Xunit.NetCore.Extensions.dll",
-        "xunit.netcore.extensions.1.0.0-prerelease-00104.nupkg",
-        "xunit.netcore.extensions.1.0.0-prerelease-00104.nupkg.sha512",
+        "xunit.netcore.extensions.1.0.0-prerelease-00105.nupkg",
+        "xunit.netcore.extensions.1.0.0-prerelease-00105.nupkg.sha512",
         "xunit.netcore.extensions.nuspec"
       ]
     }

--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/project.lock.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/project.lock.json
@@ -292,7 +292,7 @@
           "lib/dotnet/System.Linq.Queryable.dll": {}
         }
       },
-      "System.Net.Http/4.0.1-beta-23408": {
+      "System.Net.Http/4.0.1-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -305,7 +305,7 @@
           "ref/dotnet/System.Net.Http.dll": {}
         }
       },
-      "System.Net.NameResolution/4.0.0-beta-23408": {
+      "System.Net.NameResolution/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Net.Primitives": "4.0.10",
@@ -328,16 +328,17 @@
           "lib/DNXCore50/System.Net.Primitives.dll": {}
         }
       },
-      "System.Net.Security/4.0.0-beta-23408": {
+      "System.Net.Security/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
-          "System.Private.Networking": "4.0.1-beta-23408"
+          "System.IO": "4.0.0",
+          "System.Net.Primitives": "4.0.10",
+          "System.Runtime": "4.0.0",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23412",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Net.Security.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Net.Security.dll": {}
         }
       },
       "System.Net.Sockets/4.1.0-beta-23225": {
@@ -368,7 +369,7 @@
           "lib/dotnet/System.Net.WebHeaderCollection.dll": {}
         }
       },
-      "System.Net.WebSockets/4.0.0-beta-23408": {
+      "System.Net.WebSockets/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -383,7 +384,7 @@
           "lib/dotnet/System.Net.WebSockets.dll": {}
         }
       },
-      "System.Net.WebSockets.Client/4.0.0-beta-23408": {
+      "System.Net.WebSockets.Client/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -393,13 +394,13 @@
           "System.Globalization": "4.0.10",
           "System.Net.Primitives": "4.0.10",
           "System.Net.WebHeaderCollection": "4.0.0",
-          "System.Net.WebSockets": "4.0.0-beta-23408",
+          "System.Net.WebSockets": "4.0.0-beta-23412",
           "System.Resources.ResourceManager": "4.0.0",
           "System.Runtime": "4.0.20",
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23408",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23412",
           "System.Text.Encoding": "4.0.10",
           "System.Threading": "4.0.10",
           "System.Threading.Tasks": "4.0.10"
@@ -456,7 +457,7 @@
           "lib/DNXCore50/System.Private.DataContractSerialization.dll": {}
         }
       },
-      "System.Private.Networking/4.0.1-beta-23408": {
+      "System.Private.Networking/4.0.1-beta-23225": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -475,13 +476,10 @@
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23408",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23408",
-          "System.Security.Principal.Windows": "4.0.0-beta-23408",
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23225",
           "System.Threading": "4.0.10",
           "System.Threading.Overlapped": "4.0.0",
-          "System.Threading.Tasks": "4.0.10",
-          "System.Threading.ThreadPool": "4.0.10-beta-23408"
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dnxcore50/_._": {}
@@ -490,7 +488,7 @@
           "lib/DNXCore50/System.Private.Networking.dll": {}
         }
       },
-      "System.Private.ServiceModel/4.1.0-beta-23408": {
+      "System.Private.ServiceModel/4.1.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -507,14 +505,14 @@
           "System.Linq": "4.0.0",
           "System.Linq.Expressions": "4.0.10",
           "System.Linq.Queryable": "4.0.0",
-          "System.Net.Http": "4.0.1-beta-23408",
-          "System.Net.NameResolution": "4.0.0-beta-23408",
+          "System.Net.Http": "4.0.1-beta-23412",
+          "System.Net.NameResolution": "4.0.0-beta-23412",
           "System.Net.Primitives": "4.0.10",
-          "System.Net.Security": "4.0.0-beta-23408",
-          "System.Net.Sockets": "4.0.10-beta-23408",
+          "System.Net.Security": "4.0.0-beta-23412",
+          "System.Net.Sockets": "4.0.10-beta-23412",
           "System.Net.WebHeaderCollection": "4.0.0",
-          "System.Net.WebSockets": "4.0.0-beta-23408",
-          "System.Net.WebSockets.Client": "4.0.0-beta-23408",
+          "System.Net.WebSockets": "4.0.0-beta-23412",
+          "System.Net.WebSockets.Client": "4.0.0-beta-23412",
           "System.ObjectModel": "4.0.10",
           "System.Reflection": "4.0.10",
           "System.Reflection.DispatchProxy": "4.0.0",
@@ -528,9 +526,9 @@
           "System.Runtime.Serialization.Primitives": "4.0.10",
           "System.Runtime.Serialization.Xml": "4.0.10",
           "System.Security.Claims": "4.0.0",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23408",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23412",
           "System.Security.Principal": "4.0.0",
-          "System.Security.Principal.Windows": "4.0.0-beta-23408",
+          "System.Security.Principal.Windows": "4.0.0-beta-23412",
           "System.Text.Encoding": "4.0.10",
           "System.Threading": "4.0.10",
           "System.Threading.Tasks": "4.0.10",
@@ -779,18 +777,18 @@
           "lib/dotnet/System.Security.Claims.dll": {}
         }
       },
-      "System.Security.Cryptography.Algorithms/4.0.0-beta-23408": {
+      "System.Security.Cryptography.Algorithms/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
           "System.Runtime": "4.0.0",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23408"
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23412"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.Algorithms.dll": {}
         }
       },
-      "System.Security.Cryptography.Encoding/4.0.0-beta-23408": {
+      "System.Security.Cryptography.Encoding/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -799,7 +797,7 @@
           "ref/dotnet/System.Security.Cryptography.Encoding.dll": {}
         }
       },
-      "System.Security.Cryptography.Primitives/4.0.0-beta-23408": {
+      "System.Security.Cryptography.Primitives/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.0",
@@ -817,13 +815,13 @@
           "lib/dotnet/System.Security.Cryptography.Primitives.dll": {}
         }
       },
-      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23408": {
+      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
           "System.Runtime.Handles": "4.0.0",
-          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23408",
-          "System.Security.Cryptography.Encoding": "4.0.0-beta-23408"
+          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23412",
+          "System.Security.Cryptography.Encoding": "4.0.0-beta-23412"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.X509Certificates.dll": {}
@@ -841,7 +839,7 @@
           "lib/dotnet/System.Security.Principal.dll": {}
         }
       },
-      "System.Security.Principal.Windows/4.0.0-beta-23408": {
+      "System.Security.Principal.Windows/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -864,10 +862,10 @@
           "lib/DNXCore50/System.Security.Principal.Windows.dll": {}
         }
       },
-      "System.ServiceModel.Http/4.0.11-beta-23408": {
+      "System.ServiceModel.Http/4.0.11-beta-23412": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-beta-23408",
+          "System.Private.ServiceModel": "4.1.0-beta-23412",
           "System.Runtime": "4.0.20"
         },
         "compile": {
@@ -877,10 +875,10 @@
           "lib/DNXCore50/System.ServiceModel.Http.dll": {}
         }
       },
-      "System.ServiceModel.NetTcp/4.0.1-beta-23408": {
+      "System.ServiceModel.NetTcp/4.0.1-beta-23412": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-beta-23408"
+          "System.Private.ServiceModel": "4.1.0-beta-23412"
         },
         "compile": {
           "ref/dotnet/System.ServiceModel.NetTcp.dll": {}
@@ -889,10 +887,10 @@
           "lib/DNXCore50/System.ServiceModel.NetTcp.dll": {}
         }
       },
-      "System.ServiceModel.Primitives/4.0.1-beta-23408": {
+      "System.ServiceModel.Primitives/4.0.1-beta-23412": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-beta-23408"
+          "System.Private.ServiceModel": "4.1.0-beta-23412"
         },
         "compile": {
           "ref/dotnet/System.ServiceModel.Primitives.dll": {}
@@ -901,10 +899,10 @@
           "lib/DNXCore50/System.ServiceModel.Primitives.dll": {}
         }
       },
-      "System.ServiceModel.Security/4.0.1-beta-23408": {
+      "System.ServiceModel.Security/4.0.1-beta-23412": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-beta-23408"
+          "System.Private.ServiceModel": "4.1.0-beta-23412"
         },
         "compile": {
           "ref/dotnet/System.ServiceModel.Security.dll": {}
@@ -991,19 +989,6 @@
         },
         "runtime": {
           "lib/DNXCore50/System.Threading.Tasks.dll": {}
-        }
-      },
-      "System.Threading.ThreadPool/4.0.10-beta-23408": {
-        "type": "package",
-        "dependencies": {
-          "System.Runtime": "4.0.0",
-          "System.Runtime.InteropServices": "4.0.0"
-        },
-        "compile": {
-          "ref/dotnet/System.Threading.ThreadPool.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Threading.ThreadPool.dll": {}
         }
       },
       "System.Threading.Timer/4.0.0": {
@@ -1186,7 +1171,7 @@
           "lib/dotnet/xunit.execution.dotnet.dll": {}
         }
       },
-      "xunit.netcore.extensions/1.0.0-prerelease-00104": {
+      "xunit.netcore.extensions/1.0.0-prerelease-00105": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.10",
@@ -1814,44 +1799,65 @@
         "System.Linq.Queryable.nuspec"
       ]
     },
-    "System.Net.Http/4.0.1-beta-23408": {
+    "System.Net.Http/4.0.1-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "n+tnV1VgCjbDKKnbgrvgUgxkPDwUFvSv9lTgH882rVzjbWyliVgbBflVzoAUjUSlga/Tr1XQIrfTLMRD5HfYGw==",
+      "sha512": "F7Yej+6QdRVzWg+qbkayRMcmf/7k7YfNFoVSA67wIsG9t5u7Wj4Go8FW72HL8qb9d7YjIsVB/5hA7g9MUT31Aw==",
       "files": [
         "lib/net45/_._",
         "lib/win8/_._",
         "lib/wpa81/_._",
+        "ref/dotnet/de/System.Net.Http.xml",
+        "ref/dotnet/es/System.Net.Http.xml",
+        "ref/dotnet/fr/System.Net.Http.xml",
+        "ref/dotnet/it/System.Net.Http.xml",
+        "ref/dotnet/ja/System.Net.Http.xml",
+        "ref/dotnet/ko/System.Net.Http.xml",
+        "ref/dotnet/ru/System.Net.Http.xml",
         "ref/dotnet/System.Net.Http.dll",
+        "ref/dotnet/System.Net.Http.xml",
+        "ref/dotnet/zh-hans/System.Net.Http.xml",
+        "ref/dotnet/zh-hant/System.Net.Http.xml",
         "ref/net45/_._",
         "ref/netcore50/System.Net.Http.dll",
+        "ref/netcore50/System.Net.Http.xml",
         "ref/win8/_._",
         "ref/wpa81/_._",
         "runtime.json",
-        "System.Net.Http.4.0.1-beta-23408.nupkg",
-        "System.Net.Http.4.0.1-beta-23408.nupkg.sha512",
+        "System.Net.Http.4.0.1-beta-23412.nupkg",
+        "System.Net.Http.4.0.1-beta-23412.nupkg.sha512",
         "System.Net.Http.nuspec"
       ]
     },
-    "System.Net.NameResolution/4.0.0-beta-23408": {
+    "System.Net.NameResolution/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "2A562VFL8GUL/jLCJ3mbQHhwwAIXzPyjxMpdtas1LVM8QLuP1OcHwV3z7ajWnYdGcPc7ZxPEGJQWicuaPD+0nA==",
+      "sha512": "HCF1zhFYBT+w/Ik+JuTzFJgj83Jfc+eA8VcgvIzdPiGMXfrZeXOogjgSCkCoJmFtKVz2DSfmISoEmiXB1oaLNQ==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.NameResolution.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Net.NameResolution.xml",
+        "ref/dotnet/es/System.Net.NameResolution.xml",
+        "ref/dotnet/fr/System.Net.NameResolution.xml",
+        "ref/dotnet/it/System.Net.NameResolution.xml",
+        "ref/dotnet/ja/System.Net.NameResolution.xml",
+        "ref/dotnet/ko/System.Net.NameResolution.xml",
+        "ref/dotnet/ru/System.Net.NameResolution.xml",
         "ref/dotnet/System.Net.NameResolution.dll",
+        "ref/dotnet/System.Net.NameResolution.xml",
+        "ref/dotnet/zh-hans/System.Net.NameResolution.xml",
+        "ref/dotnet/zh-hant/System.Net.NameResolution.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Net.NameResolution.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Net.NameResolution.4.0.0-beta-23408.nupkg",
-        "System.Net.NameResolution.4.0.0-beta-23408.nupkg.sha512",
+        "System.Net.NameResolution.4.0.0-beta-23412.nupkg",
+        "System.Net.NameResolution.4.0.0-beta-23412.nupkg.sha512",
         "System.Net.NameResolution.nuspec"
       ]
     },
@@ -1888,24 +1894,34 @@
         "System.Net.Primitives.nuspec"
       ]
     },
-    "System.Net.Security/4.0.0-beta-23408": {
+    "System.Net.Security/4.0.0-beta-23412": {
       "type": "package",
-      "sha512": "kEkunODO2t/VlBIsC80YFDG0KtY/FyIbtBApNyJQv+LYGEs5IFvEhpi9+p0/jHmhyRMKwbjajNedbXo+VMkt1A==",
+      "sha512": "Kcjne7jnvF5aTbRJsAT8kuP+1mxryUF2qYv8f3jnR19wtEjswSIOVU0XzuWc9YObEQcb+kEdzN71HTOm+ssv+w==",
       "files": [
-        "lib/DNXCore50/System.Net.Security.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.Security.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Net.Security.xml",
+        "ref/dotnet/es/System.Net.Security.xml",
+        "ref/dotnet/fr/System.Net.Security.xml",
+        "ref/dotnet/it/System.Net.Security.xml",
+        "ref/dotnet/ja/System.Net.Security.xml",
+        "ref/dotnet/ko/System.Net.Security.xml",
+        "ref/dotnet/ru/System.Net.Security.xml",
         "ref/dotnet/System.Net.Security.dll",
+        "ref/dotnet/System.Net.Security.xml",
+        "ref/dotnet/zh-hans/System.Net.Security.xml",
+        "ref/dotnet/zh-hant/System.Net.Security.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Net.Security.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.Security.4.0.0-beta-23408.nupkg",
-        "System.Net.Security.4.0.0-beta-23408.nupkg.sha512",
+        "runtime.json",
+        "System.Net.Security.4.0.0-beta-23412.nupkg",
+        "System.Net.Security.4.0.0-beta-23412.nupkg.sha512",
         "System.Net.Security.nuspec"
       ]
     },
@@ -1963,78 +1979,68 @@
         "System.Net.WebHeaderCollection.nuspec"
       ]
     },
-    "System.Net.WebSockets/4.0.0-beta-23408": {
+    "System.Net.WebSockets/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "BXy22/bNVtrXXsG76zXyhjcQnCjSYxQIFF37xWifqPRWmvzsCYSLQpNCTPQUCp7rjB7qWc5yLhC9bThaEx7MHQ==",
+      "sha512": "EvXAa0yd1RM8ROyLl1T0xC94F04Su8YMHnd4/w6j0Z/+4lKHZOU7bQPZ3odDN8WdPGKa/ZNJJGwiapydEWKzwQ==",
       "files": [
-        "lib/dotnet/de/System.Net.WebSockets.xml",
-        "lib/dotnet/es/System.Net.WebSockets.xml",
-        "lib/dotnet/fr/System.Net.WebSockets.xml",
-        "lib/dotnet/it/System.Net.WebSockets.xml",
-        "lib/dotnet/ja/System.Net.WebSockets.xml",
-        "lib/dotnet/ko/System.Net.WebSockets.xml",
-        "lib/dotnet/ru/System.Net.WebSockets.xml",
         "lib/dotnet/System.Net.WebSockets.dll",
-        "lib/dotnet/System.Net.WebSockets.xml",
-        "lib/dotnet/zh-hans/System.Net.WebSockets.xml",
-        "lib/dotnet/zh-hant/System.Net.WebSockets.xml",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.WebSockets.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Net.WebSockets.xml",
+        "ref/dotnet/es/System.Net.WebSockets.xml",
+        "ref/dotnet/fr/System.Net.WebSockets.xml",
+        "ref/dotnet/it/System.Net.WebSockets.xml",
+        "ref/dotnet/ja/System.Net.WebSockets.xml",
+        "ref/dotnet/ko/System.Net.WebSockets.xml",
+        "ref/dotnet/ru/System.Net.WebSockets.xml",
         "ref/dotnet/System.Net.WebSockets.dll",
+        "ref/dotnet/System.Net.WebSockets.xml",
+        "ref/dotnet/zh-hans/System.Net.WebSockets.xml",
+        "ref/dotnet/zh-hant/System.Net.WebSockets.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Net.WebSockets.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.WebSockets.4.0.0-beta-23408.nupkg",
-        "System.Net.WebSockets.4.0.0-beta-23408.nupkg.sha512",
+        "System.Net.WebSockets.4.0.0-beta-23412.nupkg",
+        "System.Net.WebSockets.4.0.0-beta-23412.nupkg.sha512",
         "System.Net.WebSockets.nuspec"
       ]
     },
-    "System.Net.WebSockets.Client/4.0.0-beta-23408": {
+    "System.Net.WebSockets.Client/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "smmvhCkcU0c4RNWc6NZwnN5EFktX58jf8+TJ6enfuXxWrpJ/2NRI5/2yT/okjFSngGK1g0MBrljZsfs2EJ7+Yw==",
+      "sha512": "uaO7c/81sK90605UtThSX9KVmzsJDA1vD4GMW7FsKKntymlkolJsprDekWblQ4A5YbhqxHv+ngXX2kIU0B3Fdw==",
       "files": [
-        "lib/DNXCore50/de/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/es/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/fr/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/it/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/ja/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/ko/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/ru/System.Net.WebSockets.Client.xml",
         "lib/DNXCore50/System.Net.WebSockets.Client.dll",
-        "lib/DNXCore50/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/zh-hans/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/zh-hant/System.Net.WebSockets.Client.xml",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.WebSockets.Client.dll",
-        "lib/netcore50/de/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/es/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/fr/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/it/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/ja/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/ko/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/ru/System.Net.WebSockets.Client.xml",
         "lib/netcore50/System.Net.WebSockets.Client.dll",
-        "lib/netcore50/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/zh-hans/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/zh-hant/System.Net.WebSockets.Client.xml",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/es/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/fr/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/it/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/ja/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/ko/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/ru/System.Net.WebSockets.Client.xml",
         "ref/dotnet/System.Net.WebSockets.Client.dll",
+        "ref/dotnet/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/zh-hans/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/zh-hant/System.Net.WebSockets.Client.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Net.WebSockets.Client.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.WebSockets.Client.4.0.0-beta-23408.nupkg",
-        "System.Net.WebSockets.Client.4.0.0-beta-23408.nupkg.sha512",
+        "System.Net.WebSockets.Client.4.0.0-beta-23412.nupkg",
+        "System.Net.WebSockets.Client.4.0.0-beta-23412.nupkg.sha512",
         "System.Net.WebSockets.Client.nuspec"
       ]
     },
@@ -2086,31 +2092,31 @@
         "System.Private.DataContractSerialization.nuspec"
       ]
     },
-    "System.Private.Networking/4.0.1-beta-23408": {
+    "System.Private.Networking/4.0.1-beta-23225": {
       "type": "package",
       "serviceable": true,
-      "sha512": "i2fRDRqM8Px3CP26C//deF/tCNR1AwqlPEr9+MYiXxNZtgGcSPBfqOJJ5CJdfmDb9Ap0hPG2MiPG7CinaSH7+Q==",
+      "sha512": "oVSynIrR3mIU0b/goscsaZDywr3RLxQijQnaFRKfl/VB3F9rKi5mdr0vHcGVWuq5ALSrG0OLwM8PRA4tM5e3rQ==",
       "files": [
         "lib/DNXCore50/System.Private.Networking.dll",
         "lib/netcore50/System.Private.Networking.dll",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "System.Private.Networking.4.0.1-beta-23408.nupkg",
-        "System.Private.Networking.4.0.1-beta-23408.nupkg.sha512",
+        "System.Private.Networking.4.0.1-beta-23225.nupkg",
+        "System.Private.Networking.4.0.1-beta-23225.nupkg.sha512",
         "System.Private.Networking.nuspec"
       ]
     },
-    "System.Private.ServiceModel/4.1.0-beta-23408": {
+    "System.Private.ServiceModel/4.1.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "l/2192yKa6uXhjKOWeukFJy3hoj9Zq1p55pTGe+Y28r8/5jlvgYxfunP9UyXJRo9W1u3UBtGfV/5R71ULzusGQ==",
+      "sha512": "Wm+8LcQ04YeAvYqu9faHsMZ/L8l/WvPPsqziBfifYB4jXIPXk1/kUxuAryjbLChghZDXvkDN0hv/IHSVPZGgBA==",
       "files": [
         "lib/DNXCore50/System.Private.ServiceModel.dll",
         "lib/netcore50/System.Private.ServiceModel.dll",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "System.Private.ServiceModel.4.1.0-beta-23408.nupkg",
-        "System.Private.ServiceModel.4.1.0-beta-23408.nupkg.sha512",
+        "System.Private.ServiceModel.4.1.0-beta-23412.nupkg",
+        "System.Private.ServiceModel.4.1.0-beta-23412.nupkg.sha512",
         "System.Private.ServiceModel.nuspec"
       ]
     },
@@ -2639,10 +2645,10 @@
         "System.Security.Claims.nuspec"
       ]
     },
-    "System.Security.Cryptography.Algorithms/4.0.0-beta-23408": {
+    "System.Security.Cryptography.Algorithms/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "G6eEqi8mZRrWftcwilcnllE4xJ/53JQlk3VVuJ+9qrX+DHvWz8itYJRUZX357JY4DgEEKQNOJzuRGrOBTUeoPg==",
+      "sha512": "nBjoiqJQiMD3cJgOVrqjIVDqEEPZeIqT+mrBIxjLE+YMQcjEyDuSyOG65Ntoopby5LH4onTLMM4zfXh8JRt9NQ==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2656,37 +2662,47 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.Algorithms.4.0.0-beta-23408.nupkg",
-        "System.Security.Cryptography.Algorithms.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Cryptography.Algorithms.4.0.0-beta-23412.nupkg",
+        "System.Security.Cryptography.Algorithms.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Cryptography.Algorithms.nuspec"
       ]
     },
-    "System.Security.Cryptography.Encoding/4.0.0-beta-23408": {
+    "System.Security.Cryptography.Encoding/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "fPsAK3vyMjnJ6nT4YchdS7KzfGca/6uVVAPCBO08ZpTRGhMGx30vq1MiIqAUrfsFMnot3Ub2jimnAFWkqY6g0Q==",
+      "sha512": "SR1zCARNdeyLoUKYH2SNMm1He7Lr3NR/l7yW3K135L44T6PS3YB8SfXpVoZdMpb22X2G07BZAHVz2x7e4AA1Cg==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Security.Cryptography.Encoding.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/es/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/fr/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/it/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/ja/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/ko/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/ru/System.Security.Cryptography.Encoding.xml",
         "ref/dotnet/System.Security.Cryptography.Encoding.dll",
+        "ref/dotnet/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/zh-hans/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/zh-hant/System.Security.Cryptography.Encoding.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Security.Cryptography.Encoding.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.Encoding.4.0.0-beta-23408.nupkg",
-        "System.Security.Cryptography.Encoding.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Cryptography.Encoding.4.0.0-beta-23412.nupkg",
+        "System.Security.Cryptography.Encoding.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Cryptography.Encoding.nuspec"
       ]
     },
-    "System.Security.Cryptography.Primitives/4.0.0-beta-23408": {
+    "System.Security.Cryptography.Primitives/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "A336dWYEIQxm1rEJCaE5ZZrUWHPUkBGTRH8uAj8qrTqg4/qRc2yN2wZxeGXaZauhI35QwDmOutK7oVb2Cd+4TA==",
+      "sha512": "H9EBNe0ahjAYjlVn0TnT18PSgZBrtROSQH1RRIKwAjzxQHt8zwDhO4yN0Q5QaaUIoSXgxVmgtWWk62wDvpy+QA==",
       "files": [
         "lib/dotnet/System.Security.Cryptography.Primitives.dll",
         "lib/MonoAndroid10/_._",
@@ -2700,30 +2716,40 @@
         "ref/net46/System.Security.Cryptography.Primitives.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Security.Cryptography.Primitives.4.0.0-beta-23408.nupkg",
-        "System.Security.Cryptography.Primitives.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Cryptography.Primitives.4.0.0-beta-23412.nupkg",
+        "System.Security.Cryptography.Primitives.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Cryptography.Primitives.nuspec"
       ]
     },
-    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23408": {
+    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "JSNf5d1V5Y47MIdf7QxZCuGnR5heM4UKbrsdXiWD5lfqu0mnNjebPIclMUXlTw/6IykuDsUpompV/DtsaLLHig==",
+      "sha512": "SfpMjvrfRaRjG42uynLugb3YgpXdpnU7X8vNAU7stIR5/4uW9m1SvWHvBjirjHRBtOpbKB86uD5ODQWX+tWDNA==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Security.Cryptography.X509Certificates.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/es/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/fr/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/it/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/ja/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/ko/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/ru/System.Security.Cryptography.X509Certificates.xml",
         "ref/dotnet/System.Security.Cryptography.X509Certificates.dll",
+        "ref/dotnet/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/zh-hans/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/zh-hant/System.Security.Cryptography.X509Certificates.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Security.Cryptography.X509Certificates.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23408.nupkg",
-        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23412.nupkg",
+        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Cryptography.X509Certificates.nuspec"
       ]
     },
@@ -2760,144 +2786,147 @@
         "System.Security.Principal.nuspec"
       ]
     },
-    "System.Security.Principal.Windows/4.0.0-beta-23408": {
+    "System.Security.Principal.Windows/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "xmjpZJvsT1AW23UkjqUkF/VrOh7DA1cagYY272UQmO8ei227TFD4C7j3ofatL/63hR3CXkLkoephuE4f2Z9fGA==",
+      "sha512": "Zvb/LzT+GjGNV1t8i5KVieilL+8P5LcQykIbJHw5aJxLPFEIQ4Y2hTJXdEkeKvZ4TCF5dlwY1jYyUrJkcqpxzw==",
       "files": [
-        "lib/DNXCore50/de/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/es/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/fr/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/it/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/ja/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/ko/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/ru/System.Security.Principal.Windows.xml",
         "lib/DNXCore50/System.Security.Principal.Windows.dll",
-        "lib/DNXCore50/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/zh-hans/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/zh-hant/System.Security.Principal.Windows.xml",
         "lib/net46/System.Security.Principal.Windows.dll",
+        "ref/dotnet/de/System.Security.Principal.Windows.xml",
+        "ref/dotnet/es/System.Security.Principal.Windows.xml",
+        "ref/dotnet/fr/System.Security.Principal.Windows.xml",
+        "ref/dotnet/it/System.Security.Principal.Windows.xml",
+        "ref/dotnet/ja/System.Security.Principal.Windows.xml",
+        "ref/dotnet/ko/System.Security.Principal.Windows.xml",
+        "ref/dotnet/ru/System.Security.Principal.Windows.xml",
         "ref/dotnet/System.Security.Principal.Windows.dll",
+        "ref/dotnet/System.Security.Principal.Windows.xml",
+        "ref/dotnet/zh-hans/System.Security.Principal.Windows.xml",
+        "ref/dotnet/zh-hant/System.Security.Principal.Windows.xml",
         "ref/net46/System.Security.Principal.Windows.dll",
-        "System.Security.Principal.Windows.4.0.0-beta-23408.nupkg",
-        "System.Security.Principal.Windows.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Principal.Windows.4.0.0-beta-23412.nupkg",
+        "System.Security.Principal.Windows.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Principal.Windows.nuspec"
       ]
     },
-    "System.ServiceModel.Http/4.0.11-beta-23408": {
+    "System.ServiceModel.Http/4.0.11-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "RScHZ1A3CfjumaP1Vh/xfOp/ga6T3nA8YLkjFOYcIcZm/LILL+yCh+PhIrJOEfz1Js8bLSQC6xbxwYlW6BNmYg==",
+      "sha512": "hKMGQbu/l2gv/PgPvm2ViLVElnVSwAPiv4cXKjinS+UHBf02uPF2m7lN13SCkJDNTBctwHav1rQnMYb1LUJHvw==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Http.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
-        "lib/netcore50/de/System.ServiceModel.Http.xml",
-        "lib/netcore50/es/System.ServiceModel.Http.xml",
-        "lib/netcore50/fr/System.ServiceModel.Http.xml",
-        "lib/netcore50/it/System.ServiceModel.Http.xml",
-        "lib/netcore50/ja/System.ServiceModel.Http.xml",
-        "lib/netcore50/ko/System.ServiceModel.Http.xml",
-        "lib/netcore50/ru/System.ServiceModel.Http.xml",
         "lib/netcore50/System.ServiceModel.Http.dll",
-        "lib/netcore50/System.ServiceModel.Http.xml",
-        "lib/netcore50/zh-hans/System.ServiceModel.Http.xml",
-        "lib/netcore50/zh-hant/System.ServiceModel.Http.xml",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.ServiceModel.Http.xml",
+        "ref/dotnet/es/System.ServiceModel.Http.xml",
+        "ref/dotnet/fr/System.ServiceModel.Http.xml",
+        "ref/dotnet/it/System.ServiceModel.Http.xml",
+        "ref/dotnet/ja/System.ServiceModel.Http.xml",
+        "ref/dotnet/ko/System.ServiceModel.Http.xml",
+        "ref/dotnet/ru/System.ServiceModel.Http.xml",
         "ref/dotnet/System.ServiceModel.Http.dll",
+        "ref/dotnet/System.ServiceModel.Http.xml",
+        "ref/dotnet/zh-hans/System.ServiceModel.Http.xml",
+        "ref/dotnet/zh-hant/System.ServiceModel.Http.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.ServiceModel.Http.4.0.11-beta-23408.nupkg",
-        "System.ServiceModel.Http.4.0.11-beta-23408.nupkg.sha512",
+        "System.ServiceModel.Http.4.0.11-beta-23412.nupkg",
+        "System.ServiceModel.Http.4.0.11-beta-23412.nupkg.sha512",
         "System.ServiceModel.Http.nuspec"
       ]
     },
-    "System.ServiceModel.NetTcp/4.0.1-beta-23408": {
+    "System.ServiceModel.NetTcp/4.0.1-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "ppruBpqoE6AngTs6fABV67r1ic6rKCgr6tw+4lMoRucrNWNfKgX5vWlONOqSd8bQXmQLZ/ftEhDGXYY5CLRUTQ==",
+      "sha512": "9I2iOpoYB8DtVy1Sw6BmOj6NGoxt9cKwOOds4q6G1JLzyyWErsv/FMeGAJT07bgLr8vnMx4s8GXxjCfkUwNtTw==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.NetTcp.dll",
         "lib/net45/_._",
-        "lib/netcore50/de/System.ServiceModel.NetTcp.xml",
-        "lib/netcore50/es/System.ServiceModel.NetTcp.xml",
-        "lib/netcore50/fr/System.ServiceModel.NetTcp.xml",
-        "lib/netcore50/it/System.ServiceModel.NetTcp.xml",
-        "lib/netcore50/ja/System.ServiceModel.NetTcp.xml",
-        "lib/netcore50/ko/System.ServiceModel.NetTcp.xml",
-        "lib/netcore50/ru/System.ServiceModel.NetTcp.xml",
         "lib/netcore50/System.ServiceModel.NetTcp.dll",
-        "lib/netcore50/System.ServiceModel.NetTcp.xml",
-        "lib/netcore50/zh-hans/System.ServiceModel.NetTcp.xml",
-        "lib/netcore50/zh-hant/System.ServiceModel.NetTcp.xml",
         "lib/win8/_._",
+        "ref/dotnet/de/System.ServiceModel.NetTcp.xml",
+        "ref/dotnet/es/System.ServiceModel.NetTcp.xml",
+        "ref/dotnet/fr/System.ServiceModel.NetTcp.xml",
+        "ref/dotnet/it/System.ServiceModel.NetTcp.xml",
+        "ref/dotnet/ja/System.ServiceModel.NetTcp.xml",
+        "ref/dotnet/ko/System.ServiceModel.NetTcp.xml",
+        "ref/dotnet/ru/System.ServiceModel.NetTcp.xml",
         "ref/dotnet/System.ServiceModel.NetTcp.dll",
+        "ref/dotnet/System.ServiceModel.NetTcp.xml",
+        "ref/dotnet/zh-hans/System.ServiceModel.NetTcp.xml",
+        "ref/dotnet/zh-hant/System.ServiceModel.NetTcp.xml",
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.NetTcp.dll",
+        "ref/netcore50/System.ServiceModel.NetTcp.xml",
         "ref/win8/_._",
-        "System.ServiceModel.NetTcp.4.0.1-beta-23408.nupkg",
-        "System.ServiceModel.NetTcp.4.0.1-beta-23408.nupkg.sha512",
+        "System.ServiceModel.NetTcp.4.0.1-beta-23412.nupkg",
+        "System.ServiceModel.NetTcp.4.0.1-beta-23412.nupkg.sha512",
         "System.ServiceModel.NetTcp.nuspec"
       ]
     },
-    "System.ServiceModel.Primitives/4.0.1-beta-23408": {
+    "System.ServiceModel.Primitives/4.0.1-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "bjXzg+V3Oq/tBXpMY5FwcERN2CQsFXoL4BMoURlwiBMkgwN2CPvBIaK45Moh7nc21jNTVukNayDtURetGzK6aA==",
+      "sha512": "dkCUkNtXb2m9Wf+DY7dc5B4J8DpaWtX4wpFfT3cYLpChxAnjQR85N+tJfMEHLfZNNerKgDRyGyaKa7uSHfvb5g==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Primitives.dll",
         "lib/net45/_._",
-        "lib/netcore50/de/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/es/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/fr/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/it/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/ja/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/ko/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/ru/System.ServiceModel.Primitives.xml",
         "lib/netcore50/System.ServiceModel.Primitives.dll",
-        "lib/netcore50/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/zh-hans/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/zh-hant/System.ServiceModel.Primitives.xml",
         "lib/win8/_._",
+        "ref/dotnet/de/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/es/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/fr/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/it/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/ja/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/ko/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/ru/System.ServiceModel.Primitives.xml",
         "ref/dotnet/System.ServiceModel.Primitives.dll",
+        "ref/dotnet/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/zh-hans/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/zh-hant/System.ServiceModel.Primitives.xml",
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.Primitives.dll",
+        "ref/netcore50/System.ServiceModel.Primitives.xml",
         "ref/win8/_._",
-        "System.ServiceModel.Primitives.4.0.1-beta-23408.nupkg",
-        "System.ServiceModel.Primitives.4.0.1-beta-23408.nupkg.sha512",
+        "System.ServiceModel.Primitives.4.0.1-beta-23412.nupkg",
+        "System.ServiceModel.Primitives.4.0.1-beta-23412.nupkg.sha512",
         "System.ServiceModel.Primitives.nuspec"
       ]
     },
-    "System.ServiceModel.Security/4.0.1-beta-23408": {
+    "System.ServiceModel.Security/4.0.1-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "rWTUEu+P30ytvkAGX051GEj9Rqj0Zk2ildyC748zdJE5qO89ZXOdC2WnMVrnQJlFcTASFOmT9BFcym4U2EzLGg==",
+      "sha512": "X+TJPs0+TVaHtDcrgw+QYtRUea0OHyy8VRzWKLL0nls52THNfeZZeTecd3eQnb6lQKpDIU42gl6tP0uePUpvMA==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Security.dll",
         "lib/net45/_._",
-        "lib/netcore50/de/System.ServiceModel.Security.xml",
-        "lib/netcore50/es/System.ServiceModel.Security.xml",
-        "lib/netcore50/fr/System.ServiceModel.Security.xml",
-        "lib/netcore50/it/System.ServiceModel.Security.xml",
-        "lib/netcore50/ja/System.ServiceModel.Security.xml",
-        "lib/netcore50/ko/System.ServiceModel.Security.xml",
-        "lib/netcore50/ru/System.ServiceModel.Security.xml",
         "lib/netcore50/System.ServiceModel.Security.dll",
-        "lib/netcore50/System.ServiceModel.Security.xml",
-        "lib/netcore50/zh-hans/System.ServiceModel.Security.xml",
-        "lib/netcore50/zh-hant/System.ServiceModel.Security.xml",
         "lib/win8/_._",
+        "ref/dotnet/de/System.ServiceModel.Security.xml",
+        "ref/dotnet/es/System.ServiceModel.Security.xml",
+        "ref/dotnet/fr/System.ServiceModel.Security.xml",
+        "ref/dotnet/it/System.ServiceModel.Security.xml",
+        "ref/dotnet/ja/System.ServiceModel.Security.xml",
+        "ref/dotnet/ko/System.ServiceModel.Security.xml",
+        "ref/dotnet/ru/System.ServiceModel.Security.xml",
         "ref/dotnet/System.ServiceModel.Security.dll",
+        "ref/dotnet/System.ServiceModel.Security.xml",
+        "ref/dotnet/zh-hans/System.ServiceModel.Security.xml",
+        "ref/dotnet/zh-hant/System.ServiceModel.Security.xml",
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.Security.dll",
+        "ref/netcore50/System.ServiceModel.Security.xml",
         "ref/win8/_._",
-        "System.ServiceModel.Security.4.0.1-beta-23408.nupkg",
-        "System.ServiceModel.Security.4.0.1-beta-23408.nupkg.sha512",
+        "System.ServiceModel.Security.4.0.1-beta-23412.nupkg",
+        "System.ServiceModel.Security.4.0.1-beta-23412.nupkg.sha512",
         "System.ServiceModel.Security.nuspec"
       ]
     },
@@ -3090,28 +3119,6 @@
         "System.Threading.Tasks.4.0.10.nupkg",
         "System.Threading.Tasks.4.0.10.nupkg.sha512",
         "System.Threading.Tasks.nuspec"
-      ]
-    },
-    "System.Threading.ThreadPool/4.0.10-beta-23408": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "ahdsVyj+WFj8/iSDwX/G7hkEU4jZmmvWzPS2ajZKdp0Crb0vZJOlM0LQYVASQgbimrUZHQ50o93JYEi8RFdh/Q==",
-      "files": [
-        "lib/DNXCore50/System.Threading.ThreadPool.dll",
-        "lib/MonoAndroid10/_._",
-        "lib/MonoTouch10/_._",
-        "lib/net46/System.Threading.ThreadPool.dll",
-        "lib/xamarinios10/_._",
-        "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Threading.ThreadPool.dll",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
-        "ref/net46/System.Threading.ThreadPool.dll",
-        "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.Threading.ThreadPool.4.0.10-beta-23408.nupkg",
-        "System.Threading.ThreadPool.4.0.10-beta-23408.nupkg.sha512",
-        "System.Threading.ThreadPool.nuspec"
       ]
     },
     "System.Threading.Timer/4.0.0": {
@@ -3361,14 +3368,14 @@
         "xunit.extensibility.execution.nuspec"
       ]
     },
-    "xunit.netcore.extensions/1.0.0-prerelease-00104": {
+    "xunit.netcore.extensions/1.0.0-prerelease-00105": {
       "type": "package",
       "serviceable": true,
-      "sha512": "ZMXxEBpGP7krXtvqbPMOWavd2u83w77ghtD254wfj5+d+7GmYYqP9pX1iRIxJK9CBa8Zc2cOrcYsmCLQgYriAQ==",
+      "sha512": "EnnGcy9rmSdQ8izHWvYSYVyjQGhbeFH7JeM/L35ZrrPGtYvq5XD3hc1cJPCs+43mXdF9cdqhkt5uTlXYzC+Z8g==",
       "files": [
         "lib/dotnet/Xunit.NetCore.Extensions.dll",
-        "xunit.netcore.extensions.1.0.0-prerelease-00104.nupkg",
-        "xunit.netcore.extensions.1.0.0-prerelease-00104.nupkg.sha512",
+        "xunit.netcore.extensions.1.0.0-prerelease-00105.nupkg",
+        "xunit.netcore.extensions.1.0.0-prerelease-00105.nupkg.sha512",
         "xunit.netcore.extensions.nuspec"
       ]
     }

--- a/src/System.Private.ServiceModel/tests/Stress/SharedPoolsOfWCFObjects/project.lock.json
+++ b/src/System.Private.ServiceModel/tests/Stress/SharedPoolsOfWCFObjects/project.lock.json
@@ -16,10 +16,10 @@
           "lib/dotnet/Microsoft.Win32.Primitives.dll": {}
         }
       },
-      "System.Collections/4.0.11-beta-23408": {
+      "System.Collections/4.0.11-beta-23412": {
         "type": "package",
         "dependencies": {
-          "System.Runtime": "4.0.21-beta-23408"
+          "System.Runtime": "4.0.21-beta-23412"
         },
         "compile": {
           "ref/dotnet/System.Collections.dll": {}
@@ -65,7 +65,7 @@
           "lib/dotnet/System.Collections.NonGeneric.dll": {}
         }
       },
-      "System.Collections.Specialized/4.0.1-beta-23408": {
+      "System.Collections.Specialized/4.0.1-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Collections.NonGeneric": "4.0.0",
@@ -98,7 +98,7 @@
           "lib/dotnet/System.ComponentModel.EventBasedAsync.dll": {}
         }
       },
-      "System.Console/4.0.0-beta-23408": {
+      "System.Console/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -120,7 +120,7 @@
           "lib/DNXCore50/System.Diagnostics.Contracts.dll": {}
         }
       },
-      "System.Diagnostics.Debug/4.0.11-beta-23408": {
+      "System.Diagnostics.Debug/4.0.11-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -129,7 +129,7 @@
           "ref/dotnet/System.Diagnostics.Debug.dll": {}
         }
       },
-      "System.Diagnostics.Tools/4.0.1-beta-23408": {
+      "System.Diagnostics.Tools/4.0.1-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -251,7 +251,7 @@
           "lib/dotnet/System.IO.FileSystem.Primitives.dll": {}
         }
       },
-      "System.Linq/4.0.1-beta-23408": {
+      "System.Linq/4.0.1-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -311,7 +311,7 @@
           "lib/dotnet/System.Linq.Queryable.dll": {}
         }
       },
-      "System.Net.Http/4.0.1-beta-23408": {
+      "System.Net.Http/4.0.1-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -565,7 +565,7 @@
           "lib/DNXCore50/System.Private.ServiceModel.dll": {}
         }
       },
-      "System.Private.Uri/4.0.1-beta-23408": {
+      "System.Private.Uri/4.0.1-beta-23412": {
         "type": "package",
         "compile": {
           "ref/dnxcore50/_._": {}
@@ -686,10 +686,10 @@
           "lib/DNXCore50/System.Resources.ResourceManager.dll": {}
         }
       },
-      "System.Runtime/4.0.21-beta-23408": {
+      "System.Runtime/4.0.21-beta-23412": {
         "type": "package",
         "dependencies": {
-          "System.Private.Uri": "4.0.1-beta-23408"
+          "System.Private.Uri": "4.0.1-beta-23412"
         },
         "compile": {
           "ref/dotnet/System.Runtime.dll": {}
@@ -867,10 +867,10 @@
           "lib/DNXCore50/System.Security.Principal.Windows.dll": {}
         }
       },
-      "System.ServiceModel.Duplex/4.0.1-beta-23408": {
+      "System.ServiceModel.Duplex/4.0.1-beta-23412": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-beta-23408"
+          "System.Private.ServiceModel": "4.1.0-beta-23412"
         },
         "compile": {
           "ref/dotnet/System.ServiceModel.Duplex.dll": {}
@@ -879,10 +879,10 @@
           "lib/DNXCore50/System.ServiceModel.Duplex.dll": {}
         }
       },
-      "System.ServiceModel.Http/4.0.11-beta-23408": {
+      "System.ServiceModel.Http/4.0.11-beta-23412": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-beta-23408",
+          "System.Private.ServiceModel": "4.1.0-beta-23412",
           "System.Runtime": "4.0.20"
         },
         "compile": {
@@ -892,10 +892,10 @@
           "lib/DNXCore50/System.ServiceModel.Http.dll": {}
         }
       },
-      "System.ServiceModel.NetTcp/4.0.1-beta-23408": {
+      "System.ServiceModel.NetTcp/4.0.1-beta-23412": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-beta-23408"
+          "System.Private.ServiceModel": "4.1.0-beta-23412"
         },
         "compile": {
           "ref/dotnet/System.ServiceModel.NetTcp.dll": {}
@@ -904,10 +904,10 @@
           "lib/DNXCore50/System.ServiceModel.NetTcp.dll": {}
         }
       },
-      "System.ServiceModel.Primitives/4.0.1-beta-23408": {
+      "System.ServiceModel.Primitives/4.0.1-beta-23412": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-beta-23408"
+          "System.Private.ServiceModel": "4.1.0-beta-23412"
         },
         "compile": {
           "ref/dotnet/System.ServiceModel.Primitives.dll": {}
@@ -916,10 +916,10 @@
           "lib/DNXCore50/System.ServiceModel.Primitives.dll": {}
         }
       },
-      "System.ServiceModel.Security/4.0.1-beta-23408": {
+      "System.ServiceModel.Security/4.0.1-beta-23412": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-beta-23408"
+          "System.Private.ServiceModel": "4.1.0-beta-23412"
         },
         "compile": {
           "ref/dotnet/System.ServiceModel.Security.dll": {}
@@ -970,7 +970,7 @@
           "lib/dotnet/System.Text.RegularExpressions.dll": {}
         }
       },
-      "System.Threading/4.0.11-beta-23408": {
+      "System.Threading/4.0.11-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
@@ -1138,57 +1138,37 @@
         "ref/xamarinmac20/_._"
       ]
     },
-    "System.Collections/4.0.11-beta-23408": {
+    "System.Collections/4.0.11-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "JSpo4NZg1VkpwQpJnw97Hq8elwMKaqssZUbHMbz00p6VBP1eq+0TiOLL4KwdjefosZ5/Au6sMk5ma7PWwFo/Fw==",
+      "sha512": "KHXBqhA0tFkXudcRzcwXQuH5g3/WI/08Sh2pzrJsnZZcX27Wuf2aHVB/49pDjdHjQQT85ASx8XiNHnhDpyNndA==",
       "files": [
-        "lib/DNXCore50/de/System.Collections.xml",
-        "lib/DNXCore50/es/System.Collections.xml",
-        "lib/DNXCore50/fr/System.Collections.xml",
-        "lib/DNXCore50/it/System.Collections.xml",
-        "lib/DNXCore50/ja/System.Collections.xml",
-        "lib/DNXCore50/ko/System.Collections.xml",
-        "lib/DNXCore50/ru/System.Collections.xml",
         "lib/DNXCore50/System.Collections.dll",
-        "lib/DNXCore50/System.Collections.xml",
-        "lib/DNXCore50/zh-hans/System.Collections.xml",
-        "lib/DNXCore50/zh-hant/System.Collections.xml",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
-        "lib/netcore50/de/System.Collections.xml",
-        "lib/netcore50/es/System.Collections.xml",
-        "lib/netcore50/fr/System.Collections.xml",
-        "lib/netcore50/it/System.Collections.xml",
-        "lib/netcore50/ja/System.Collections.xml",
-        "lib/netcore50/ko/System.Collections.xml",
-        "lib/netcore50/ru/System.Collections.xml",
         "lib/netcore50/System.Collections.dll",
-        "lib/netcore50/System.Collections.xml",
-        "lib/netcore50/zh-hans/System.Collections.xml",
-        "lib/netcore50/zh-hant/System.Collections.xml",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Collections.xml",
+        "ref/dotnet/es/System.Collections.xml",
+        "ref/dotnet/fr/System.Collections.xml",
+        "ref/dotnet/it/System.Collections.xml",
+        "ref/dotnet/ja/System.Collections.xml",
+        "ref/dotnet/ko/System.Collections.xml",
+        "ref/dotnet/ru/System.Collections.xml",
         "ref/dotnet/System.Collections.dll",
+        "ref/dotnet/System.Collections.xml",
+        "ref/dotnet/zh-hans/System.Collections.xml",
+        "ref/dotnet/zh-hant/System.Collections.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/de/System.Collections.xml",
-        "runtimes/win8-aot/lib/netcore50/es/System.Collections.xml",
-        "runtimes/win8-aot/lib/netcore50/fr/System.Collections.xml",
-        "runtimes/win8-aot/lib/netcore50/it/System.Collections.xml",
-        "runtimes/win8-aot/lib/netcore50/ja/System.Collections.xml",
-        "runtimes/win8-aot/lib/netcore50/ko/System.Collections.xml",
-        "runtimes/win8-aot/lib/netcore50/ru/System.Collections.xml",
         "runtimes/win8-aot/lib/netcore50/System.Collections.dll",
-        "runtimes/win8-aot/lib/netcore50/System.Collections.xml",
-        "runtimes/win8-aot/lib/netcore50/zh-hans/System.Collections.xml",
-        "runtimes/win8-aot/lib/netcore50/zh-hant/System.Collections.xml",
-        "System.Collections.4.0.11-beta-23408.nupkg",
-        "System.Collections.4.0.11-beta-23408.nupkg.sha512",
+        "System.Collections.4.0.11-beta-23412.nupkg",
+        "System.Collections.4.0.11-beta-23412.nupkg.sha512",
         "System.Collections.nuspec"
       ]
     },
@@ -1256,35 +1236,35 @@
         "System.Collections.NonGeneric.nuspec"
       ]
     },
-    "System.Collections.Specialized/4.0.1-beta-23408": {
+    "System.Collections.Specialized/4.0.1-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "BSuF9dV6vr0+rU3HEeOen/5KjblFC5P0lJOtyGOCToc66QAe2YjxOdEjd/LI7wsu9utx1SfJk9c0yrfkFS4giA==",
+      "sha512": "kGEKO5DCZlxEFqqzeOvif/tmYI5UURg1p7YEf9qLkMkS/lxniBK1pTttyf43EHljM3t/AO1nyXVlfh3fIeF2TQ==",
       "files": [
-        "lib/dotnet/de/System.Collections.Specialized.xml",
-        "lib/dotnet/es/System.Collections.Specialized.xml",
-        "lib/dotnet/fr/System.Collections.Specialized.xml",
-        "lib/dotnet/it/System.Collections.Specialized.xml",
-        "lib/dotnet/ja/System.Collections.Specialized.xml",
-        "lib/dotnet/ko/System.Collections.Specialized.xml",
-        "lib/dotnet/ru/System.Collections.Specialized.xml",
         "lib/dotnet/System.Collections.Specialized.dll",
-        "lib/dotnet/System.Collections.Specialized.xml",
-        "lib/dotnet/zh-hans/System.Collections.Specialized.xml",
-        "lib/dotnet/zh-hant/System.Collections.Specialized.xml",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Collections.Specialized.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Collections.Specialized.xml",
+        "ref/dotnet/es/System.Collections.Specialized.xml",
+        "ref/dotnet/fr/System.Collections.Specialized.xml",
+        "ref/dotnet/it/System.Collections.Specialized.xml",
+        "ref/dotnet/ja/System.Collections.Specialized.xml",
+        "ref/dotnet/ko/System.Collections.Specialized.xml",
+        "ref/dotnet/ru/System.Collections.Specialized.xml",
         "ref/dotnet/System.Collections.Specialized.dll",
+        "ref/dotnet/System.Collections.Specialized.xml",
+        "ref/dotnet/zh-hans/System.Collections.Specialized.xml",
+        "ref/dotnet/zh-hant/System.Collections.Specialized.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Collections.Specialized.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Collections.Specialized.4.0.1-beta-23408.nupkg",
-        "System.Collections.Specialized.4.0.1-beta-23408.nupkg.sha512",
+        "System.Collections.Specialized.4.0.1-beta-23412.nupkg",
+        "System.Collections.Specialized.4.0.1-beta-23412.nupkg.sha512",
         "System.Collections.Specialized.nuspec"
       ]
     },
@@ -1320,25 +1300,35 @@
         "System.ComponentModel.EventBasedAsync.nuspec"
       ]
     },
-    "System.Console/4.0.0-beta-23408": {
+    "System.Console/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "iCGS/bP/CurTicT3HAhRn0CoxkxWjRsnG2ck+/S7j+dJFZVsbzPUzKIVrXpL3VkPMJMXxjR5UNumKTrAVXoQDQ==",
+      "sha512": "D/Pk2kfWvaleX6Fj/YOelUieW1uOD+oS0gesfvjqA6cIolxJJZ1fBRBdXsI7LeTIEc4tGRle08/gKJNkZcDPtA==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Console.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Console.xml",
+        "ref/dotnet/es/System.Console.xml",
+        "ref/dotnet/fr/System.Console.xml",
+        "ref/dotnet/it/System.Console.xml",
+        "ref/dotnet/ja/System.Console.xml",
+        "ref/dotnet/ko/System.Console.xml",
+        "ref/dotnet/ru/System.Console.xml",
         "ref/dotnet/System.Console.dll",
+        "ref/dotnet/System.Console.xml",
+        "ref/dotnet/zh-hans/System.Console.xml",
+        "ref/dotnet/zh-hant/System.Console.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Console.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Console.4.0.0-beta-23408.nupkg",
-        "System.Console.4.0.0-beta-23408.nupkg.sha512",
+        "System.Console.4.0.0-beta-23412.nupkg",
+        "System.Console.4.0.0-beta-23412.nupkg.sha512",
         "System.Console.nuspec"
       ]
     },
@@ -1375,78 +1365,69 @@
         "System.Diagnostics.Contracts.nuspec"
       ]
     },
-    "System.Diagnostics.Debug/4.0.11-beta-23408": {
+    "System.Diagnostics.Debug/4.0.11-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "1lHlhWqBuwpEhvsv6NORuYW0pej4ORdYvsnQYaJhjtR7FPvNo7vdkW0Cj9JCnXT5zDgSsCCT7dZYrdUTKaq32w==",
+      "sha512": "R8VssRvEFtTiH5jvALt70x3F++7Qqwl2wns+IeC6MwYT1qsjL50y59DHTNAWs+LPfXfgq/TYzcE9yljX6ymcQg==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Diagnostics.Debug.xml",
+        "ref/dotnet/es/System.Diagnostics.Debug.xml",
+        "ref/dotnet/fr/System.Diagnostics.Debug.xml",
+        "ref/dotnet/it/System.Diagnostics.Debug.xml",
+        "ref/dotnet/ja/System.Diagnostics.Debug.xml",
+        "ref/dotnet/ko/System.Diagnostics.Debug.xml",
+        "ref/dotnet/ru/System.Diagnostics.Debug.xml",
         "ref/dotnet/System.Diagnostics.Debug.dll",
+        "ref/dotnet/System.Diagnostics.Debug.xml",
+        "ref/dotnet/zh-hans/System.Diagnostics.Debug.xml",
+        "ref/dotnet/zh-hant/System.Diagnostics.Debug.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Diagnostics.Debug.4.0.11-beta-23408.nupkg",
-        "System.Diagnostics.Debug.4.0.11-beta-23408.nupkg.sha512",
+        "System.Diagnostics.Debug.4.0.11-beta-23412.nupkg",
+        "System.Diagnostics.Debug.4.0.11-beta-23412.nupkg.sha512",
         "System.Diagnostics.Debug.nuspec"
       ]
     },
-    "System.Diagnostics.Tools/4.0.1-beta-23408": {
+    "System.Diagnostics.Tools/4.0.1-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "mM69+d5dqcsSkAe4a6bpsvJzc8xfMXq9I4KCBweaqNi3GdlSdmAmx9pgA9RdyvuQV1mfwnl0s8fIvYkjS6h0Ug==",
+      "sha512": "ec1Qnf5fFFQlxQIh5LrIREozAdYZiy2CeK25UEBMzF068tN5jY/zbL+ahSgpmB4cBd2jsBV6974WWSvPwQ0uYg==",
       "files": [
-        "lib/DNXCore50/de/System.Diagnostics.Tools.xml",
-        "lib/DNXCore50/es/System.Diagnostics.Tools.xml",
-        "lib/DNXCore50/fr/System.Diagnostics.Tools.xml",
-        "lib/DNXCore50/it/System.Diagnostics.Tools.xml",
-        "lib/DNXCore50/ja/System.Diagnostics.Tools.xml",
-        "lib/DNXCore50/ko/System.Diagnostics.Tools.xml",
-        "lib/DNXCore50/ru/System.Diagnostics.Tools.xml",
         "lib/DNXCore50/System.Diagnostics.Tools.dll",
-        "lib/DNXCore50/System.Diagnostics.Tools.xml",
-        "lib/DNXCore50/zh-hans/System.Diagnostics.Tools.xml",
-        "lib/DNXCore50/zh-hant/System.Diagnostics.Tools.xml",
         "lib/net45/_._",
-        "lib/netcore50/de/System.Diagnostics.Tools.xml",
-        "lib/netcore50/es/System.Diagnostics.Tools.xml",
-        "lib/netcore50/fr/System.Diagnostics.Tools.xml",
-        "lib/netcore50/it/System.Diagnostics.Tools.xml",
-        "lib/netcore50/ja/System.Diagnostics.Tools.xml",
-        "lib/netcore50/ko/System.Diagnostics.Tools.xml",
-        "lib/netcore50/ru/System.Diagnostics.Tools.xml",
         "lib/netcore50/System.Diagnostics.Tools.dll",
-        "lib/netcore50/System.Diagnostics.Tools.xml",
-        "lib/netcore50/zh-hans/System.Diagnostics.Tools.xml",
-        "lib/netcore50/zh-hant/System.Diagnostics.Tools.xml",
         "lib/win8/_._",
         "lib/wp80/_._",
         "lib/wpa81/_._",
+        "ref/dotnet/de/System.Diagnostics.Tools.xml",
+        "ref/dotnet/es/System.Diagnostics.Tools.xml",
+        "ref/dotnet/fr/System.Diagnostics.Tools.xml",
+        "ref/dotnet/it/System.Diagnostics.Tools.xml",
+        "ref/dotnet/ja/System.Diagnostics.Tools.xml",
+        "ref/dotnet/ko/System.Diagnostics.Tools.xml",
+        "ref/dotnet/ru/System.Diagnostics.Tools.xml",
         "ref/dotnet/System.Diagnostics.Tools.dll",
+        "ref/dotnet/System.Diagnostics.Tools.xml",
+        "ref/dotnet/zh-hans/System.Diagnostics.Tools.xml",
+        "ref/dotnet/zh-hant/System.Diagnostics.Tools.xml",
         "ref/net45/_._",
         "ref/netcore50/System.Diagnostics.Tools.dll",
+        "ref/netcore50/System.Diagnostics.Tools.xml",
         "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "runtimes/win8-aot/lib/netcore50/de/System.Diagnostics.Tools.xml",
-        "runtimes/win8-aot/lib/netcore50/es/System.Diagnostics.Tools.xml",
-        "runtimes/win8-aot/lib/netcore50/fr/System.Diagnostics.Tools.xml",
-        "runtimes/win8-aot/lib/netcore50/it/System.Diagnostics.Tools.xml",
-        "runtimes/win8-aot/lib/netcore50/ja/System.Diagnostics.Tools.xml",
-        "runtimes/win8-aot/lib/netcore50/ko/System.Diagnostics.Tools.xml",
-        "runtimes/win8-aot/lib/netcore50/ru/System.Diagnostics.Tools.xml",
         "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Tools.dll",
-        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Tools.xml",
-        "runtimes/win8-aot/lib/netcore50/zh-hans/System.Diagnostics.Tools.xml",
-        "runtimes/win8-aot/lib/netcore50/zh-hant/System.Diagnostics.Tools.xml",
-        "System.Diagnostics.Tools.4.0.1-beta-23408.nupkg",
-        "System.Diagnostics.Tools.4.0.1-beta-23408.nupkg.sha512",
+        "System.Diagnostics.Tools.4.0.1-beta-23412.nupkg",
+        "System.Diagnostics.Tools.4.0.1-beta-23412.nupkg.sha512",
         "System.Diagnostics.Tools.nuspec"
       ]
     },
@@ -1688,36 +1669,36 @@
         "System.IO.FileSystem.Primitives.nuspec"
       ]
     },
-    "System.Linq/4.0.1-beta-23408": {
+    "System.Linq/4.0.1-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "x5Dk5u0eto3Y+zwpMITsxoHQLjqX8vXlDFRQHK89zyOgk9BhwYejQtY540xNDEu8+lMFTdWuop93YAoQIlPmGg==",
+      "sha512": "U+HwH5hneDpZjKVytmSCHeUxK6sTpyXnCVnjynubW51miaNF+Z2JZIzwwgBpU8um+piuPxflFgiDXpFjUr/Sdw==",
       "files": [
-        "lib/dotnet/de/System.Linq.xml",
-        "lib/dotnet/es/System.Linq.xml",
-        "lib/dotnet/fr/System.Linq.xml",
-        "lib/dotnet/it/System.Linq.xml",
-        "lib/dotnet/ja/System.Linq.xml",
-        "lib/dotnet/ko/System.Linq.xml",
-        "lib/dotnet/ru/System.Linq.xml",
         "lib/dotnet/System.Linq.dll",
-        "lib/dotnet/System.Linq.xml",
-        "lib/dotnet/zh-hans/System.Linq.xml",
-        "lib/dotnet/zh-hant/System.Linq.xml",
         "lib/net45/_._",
         "lib/netcore50/System.Linq.dll",
-        "lib/netcore50/System.Linq.xml",
         "lib/win8/_._",
         "lib/wp80/_._",
         "lib/wpa81/_._",
+        "ref/dotnet/de/System.Linq.xml",
+        "ref/dotnet/es/System.Linq.xml",
+        "ref/dotnet/fr/System.Linq.xml",
+        "ref/dotnet/it/System.Linq.xml",
+        "ref/dotnet/ja/System.Linq.xml",
+        "ref/dotnet/ko/System.Linq.xml",
+        "ref/dotnet/ru/System.Linq.xml",
         "ref/dotnet/System.Linq.dll",
+        "ref/dotnet/System.Linq.xml",
+        "ref/dotnet/zh-hans/System.Linq.xml",
+        "ref/dotnet/zh-hant/System.Linq.xml",
         "ref/net45/_._",
         "ref/netcore50/System.Linq.dll",
+        "ref/netcore50/System.Linq.xml",
         "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "System.Linq.4.0.1-beta-23408.nupkg",
-        "System.Linq.4.0.1-beta-23408.nupkg.sha512",
+        "System.Linq.4.0.1-beta-23412.nupkg",
+        "System.Linq.4.0.1-beta-23412.nupkg.sha512",
         "System.Linq.nuspec"
       ]
     },
@@ -1789,22 +1770,33 @@
         "System.Linq.Queryable.nuspec"
       ]
     },
-    "System.Net.Http/4.0.1-beta-23408": {
+    "System.Net.Http/4.0.1-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "n+tnV1VgCjbDKKnbgrvgUgxkPDwUFvSv9lTgH882rVzjbWyliVgbBflVzoAUjUSlga/Tr1XQIrfTLMRD5HfYGw==",
+      "sha512": "F7Yej+6QdRVzWg+qbkayRMcmf/7k7YfNFoVSA67wIsG9t5u7Wj4Go8FW72HL8qb9d7YjIsVB/5hA7g9MUT31Aw==",
       "files": [
         "lib/net45/_._",
         "lib/win8/_._",
         "lib/wpa81/_._",
+        "ref/dotnet/de/System.Net.Http.xml",
+        "ref/dotnet/es/System.Net.Http.xml",
+        "ref/dotnet/fr/System.Net.Http.xml",
+        "ref/dotnet/it/System.Net.Http.xml",
+        "ref/dotnet/ja/System.Net.Http.xml",
+        "ref/dotnet/ko/System.Net.Http.xml",
+        "ref/dotnet/ru/System.Net.Http.xml",
         "ref/dotnet/System.Net.Http.dll",
+        "ref/dotnet/System.Net.Http.xml",
+        "ref/dotnet/zh-hans/System.Net.Http.xml",
+        "ref/dotnet/zh-hant/System.Net.Http.xml",
         "ref/net45/_._",
         "ref/netcore50/System.Net.Http.dll",
+        "ref/netcore50/System.Net.Http.xml",
         "ref/win8/_._",
         "ref/wpa81/_._",
         "runtime.json",
-        "System.Net.Http.4.0.1-beta-23408.nupkg",
-        "System.Net.Http.4.0.1-beta-23408.nupkg.sha512",
+        "System.Net.Http.4.0.1-beta-23412.nupkg",
+        "System.Net.Http.4.0.1-beta-23412.nupkg.sha512",
         "System.Net.Http.nuspec"
       ]
     },
@@ -2089,15 +2081,15 @@
         "System.Private.ServiceModel.nuspec"
       ]
     },
-    "System.Private.Uri/4.0.1-beta-23408": {
+    "System.Private.Uri/4.0.1-beta-23412": {
       "type": "package",
-      "sha512": "r9CW7qEIX6/DFQXncpc4nuT5fxE+9GfKT8yKPPmTuLXMhhihIuaE0dvDjFtiHrjyzPVp2fRXpK/9jCpmzu9i8A==",
+      "sha512": "Jg+U6g22+NYx0SzVzmovdsV9j9grqP9EH1iQ+XqXrOTTcEEQ797barUz2N1WZeGOR8wOX4zT7Bv01HZsOPRrxw==",
       "files": [
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
         "runtime.json",
-        "System.Private.Uri.4.0.1-beta-23408.nupkg",
-        "System.Private.Uri.4.0.1-beta-23408.nupkg.sha512",
+        "System.Private.Uri.4.0.1-beta-23412.nupkg",
+        "System.Private.Uri.4.0.1-beta-23412.nupkg.sha512",
         "System.Private.Uri.nuspec"
       ]
     },
@@ -2358,57 +2350,37 @@
         "System.Resources.ResourceManager.nuspec"
       ]
     },
-    "System.Runtime/4.0.21-beta-23408": {
+    "System.Runtime/4.0.21-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "EFB/GvPtLZQ7zQGQ/SAVFTTx3ub47VIyPLrHl/og5T/LIOrJEGy9rux1x8A3T9Dohg3S/KMEaLw5CSpQfi8o5A==",
+      "sha512": "FMMQtZbnUqsY6+8Y77P7vowIXDbAhCSuLhKvIxXvwHa0Gc7vJ0mQM+p0qd1OwnrZSXYpOGkbXPXqFS/dKYB7+g==",
       "files": [
-        "lib/DNXCore50/de/System.Runtime.xml",
-        "lib/DNXCore50/es/System.Runtime.xml",
-        "lib/DNXCore50/fr/System.Runtime.xml",
-        "lib/DNXCore50/it/System.Runtime.xml",
-        "lib/DNXCore50/ja/System.Runtime.xml",
-        "lib/DNXCore50/ko/System.Runtime.xml",
-        "lib/DNXCore50/ru/System.Runtime.xml",
         "lib/DNXCore50/System.Runtime.dll",
-        "lib/DNXCore50/System.Runtime.xml",
-        "lib/DNXCore50/zh-hans/System.Runtime.xml",
-        "lib/DNXCore50/zh-hant/System.Runtime.xml",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
-        "lib/netcore50/de/System.Runtime.xml",
-        "lib/netcore50/es/System.Runtime.xml",
-        "lib/netcore50/fr/System.Runtime.xml",
-        "lib/netcore50/it/System.Runtime.xml",
-        "lib/netcore50/ja/System.Runtime.xml",
-        "lib/netcore50/ko/System.Runtime.xml",
-        "lib/netcore50/ru/System.Runtime.xml",
         "lib/netcore50/System.Runtime.dll",
-        "lib/netcore50/System.Runtime.xml",
-        "lib/netcore50/zh-hans/System.Runtime.xml",
-        "lib/netcore50/zh-hant/System.Runtime.xml",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Runtime.xml",
+        "ref/dotnet/es/System.Runtime.xml",
+        "ref/dotnet/fr/System.Runtime.xml",
+        "ref/dotnet/it/System.Runtime.xml",
+        "ref/dotnet/ja/System.Runtime.xml",
+        "ref/dotnet/ko/System.Runtime.xml",
+        "ref/dotnet/ru/System.Runtime.xml",
         "ref/dotnet/System.Runtime.dll",
+        "ref/dotnet/System.Runtime.xml",
+        "ref/dotnet/zh-hans/System.Runtime.xml",
+        "ref/dotnet/zh-hant/System.Runtime.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/de/System.Runtime.xml",
-        "runtimes/win8-aot/lib/netcore50/es/System.Runtime.xml",
-        "runtimes/win8-aot/lib/netcore50/fr/System.Runtime.xml",
-        "runtimes/win8-aot/lib/netcore50/it/System.Runtime.xml",
-        "runtimes/win8-aot/lib/netcore50/ja/System.Runtime.xml",
-        "runtimes/win8-aot/lib/netcore50/ko/System.Runtime.xml",
-        "runtimes/win8-aot/lib/netcore50/ru/System.Runtime.xml",
         "runtimes/win8-aot/lib/netcore50/System.Runtime.dll",
-        "runtimes/win8-aot/lib/netcore50/System.Runtime.xml",
-        "runtimes/win8-aot/lib/netcore50/zh-hans/System.Runtime.xml",
-        "runtimes/win8-aot/lib/netcore50/zh-hant/System.Runtime.xml",
-        "System.Runtime.4.0.21-beta-23408.nupkg",
-        "System.Runtime.4.0.21-beta-23408.nupkg.sha512",
+        "System.Runtime.4.0.21-beta-23412.nupkg",
+        "System.Runtime.4.0.21-beta-23412.nupkg.sha512",
         "System.Runtime.nuspec"
       ]
     },
@@ -2756,148 +2728,152 @@
         "System.Security.Principal.Windows.nuspec"
       ]
     },
-    "System.ServiceModel.Duplex/4.0.1-beta-23408": {
+    "System.ServiceModel.Duplex/4.0.1-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "ZJ3aN/aEg801Rw+aVbBFZ+I9J51FyQVCoWOvSqTSh5i4qZuWuenCxmxahby43teIqNcCrCtHPoyRan2GfY8Vyg==",
+      "sha512": "o5w/amLOdG4NIfER18/TI69QL11pboppiBgH2fIwjzasKZ1OIlxE+KJPbvHJ5vt554reZYCcA+jY4CIx7/pkiw==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Duplex.dll",
         "lib/net45/_._",
-        "lib/netcore50/de/System.ServiceModel.Duplex.xml",
-        "lib/netcore50/es/System.ServiceModel.Duplex.xml",
-        "lib/netcore50/fr/System.ServiceModel.Duplex.xml",
-        "lib/netcore50/it/System.ServiceModel.Duplex.xml",
-        "lib/netcore50/ja/System.ServiceModel.Duplex.xml",
-        "lib/netcore50/ko/System.ServiceModel.Duplex.xml",
-        "lib/netcore50/ru/System.ServiceModel.Duplex.xml",
         "lib/netcore50/System.ServiceModel.Duplex.dll",
-        "lib/netcore50/System.ServiceModel.Duplex.xml",
-        "lib/netcore50/zh-hans/System.ServiceModel.Duplex.xml",
-        "lib/netcore50/zh-hant/System.ServiceModel.Duplex.xml",
         "lib/win8/_._",
+        "ref/dotnet/de/System.ServiceModel.Duplex.xml",
+        "ref/dotnet/es/System.ServiceModel.Duplex.xml",
+        "ref/dotnet/fr/System.ServiceModel.Duplex.xml",
+        "ref/dotnet/it/System.ServiceModel.Duplex.xml",
+        "ref/dotnet/ja/System.ServiceModel.Duplex.xml",
+        "ref/dotnet/ko/System.ServiceModel.Duplex.xml",
+        "ref/dotnet/ru/System.ServiceModel.Duplex.xml",
         "ref/dotnet/System.ServiceModel.Duplex.dll",
+        "ref/dotnet/System.ServiceModel.Duplex.xml",
+        "ref/dotnet/zh-hans/System.ServiceModel.Duplex.xml",
+        "ref/dotnet/zh-hant/System.ServiceModel.Duplex.xml",
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.Duplex.dll",
+        "ref/netcore50/System.ServiceModel.Duplex.xml",
         "ref/win8/_._",
-        "System.ServiceModel.Duplex.4.0.1-beta-23408.nupkg",
-        "System.ServiceModel.Duplex.4.0.1-beta-23408.nupkg.sha512",
+        "System.ServiceModel.Duplex.4.0.1-beta-23412.nupkg",
+        "System.ServiceModel.Duplex.4.0.1-beta-23412.nupkg.sha512",
         "System.ServiceModel.Duplex.nuspec"
       ]
     },
-    "System.ServiceModel.Http/4.0.11-beta-23408": {
+    "System.ServiceModel.Http/4.0.11-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "RScHZ1A3CfjumaP1Vh/xfOp/ga6T3nA8YLkjFOYcIcZm/LILL+yCh+PhIrJOEfz1Js8bLSQC6xbxwYlW6BNmYg==",
+      "sha512": "hKMGQbu/l2gv/PgPvm2ViLVElnVSwAPiv4cXKjinS+UHBf02uPF2m7lN13SCkJDNTBctwHav1rQnMYb1LUJHvw==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Http.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
-        "lib/netcore50/de/System.ServiceModel.Http.xml",
-        "lib/netcore50/es/System.ServiceModel.Http.xml",
-        "lib/netcore50/fr/System.ServiceModel.Http.xml",
-        "lib/netcore50/it/System.ServiceModel.Http.xml",
-        "lib/netcore50/ja/System.ServiceModel.Http.xml",
-        "lib/netcore50/ko/System.ServiceModel.Http.xml",
-        "lib/netcore50/ru/System.ServiceModel.Http.xml",
         "lib/netcore50/System.ServiceModel.Http.dll",
-        "lib/netcore50/System.ServiceModel.Http.xml",
-        "lib/netcore50/zh-hans/System.ServiceModel.Http.xml",
-        "lib/netcore50/zh-hant/System.ServiceModel.Http.xml",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.ServiceModel.Http.xml",
+        "ref/dotnet/es/System.ServiceModel.Http.xml",
+        "ref/dotnet/fr/System.ServiceModel.Http.xml",
+        "ref/dotnet/it/System.ServiceModel.Http.xml",
+        "ref/dotnet/ja/System.ServiceModel.Http.xml",
+        "ref/dotnet/ko/System.ServiceModel.Http.xml",
+        "ref/dotnet/ru/System.ServiceModel.Http.xml",
         "ref/dotnet/System.ServiceModel.Http.dll",
+        "ref/dotnet/System.ServiceModel.Http.xml",
+        "ref/dotnet/zh-hans/System.ServiceModel.Http.xml",
+        "ref/dotnet/zh-hant/System.ServiceModel.Http.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.ServiceModel.Http.4.0.11-beta-23408.nupkg",
-        "System.ServiceModel.Http.4.0.11-beta-23408.nupkg.sha512",
+        "System.ServiceModel.Http.4.0.11-beta-23412.nupkg",
+        "System.ServiceModel.Http.4.0.11-beta-23412.nupkg.sha512",
         "System.ServiceModel.Http.nuspec"
       ]
     },
-    "System.ServiceModel.NetTcp/4.0.1-beta-23408": {
+    "System.ServiceModel.NetTcp/4.0.1-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "ppruBpqoE6AngTs6fABV67r1ic6rKCgr6tw+4lMoRucrNWNfKgX5vWlONOqSd8bQXmQLZ/ftEhDGXYY5CLRUTQ==",
+      "sha512": "9I2iOpoYB8DtVy1Sw6BmOj6NGoxt9cKwOOds4q6G1JLzyyWErsv/FMeGAJT07bgLr8vnMx4s8GXxjCfkUwNtTw==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.NetTcp.dll",
         "lib/net45/_._",
-        "lib/netcore50/de/System.ServiceModel.NetTcp.xml",
-        "lib/netcore50/es/System.ServiceModel.NetTcp.xml",
-        "lib/netcore50/fr/System.ServiceModel.NetTcp.xml",
-        "lib/netcore50/it/System.ServiceModel.NetTcp.xml",
-        "lib/netcore50/ja/System.ServiceModel.NetTcp.xml",
-        "lib/netcore50/ko/System.ServiceModel.NetTcp.xml",
-        "lib/netcore50/ru/System.ServiceModel.NetTcp.xml",
         "lib/netcore50/System.ServiceModel.NetTcp.dll",
-        "lib/netcore50/System.ServiceModel.NetTcp.xml",
-        "lib/netcore50/zh-hans/System.ServiceModel.NetTcp.xml",
-        "lib/netcore50/zh-hant/System.ServiceModel.NetTcp.xml",
         "lib/win8/_._",
+        "ref/dotnet/de/System.ServiceModel.NetTcp.xml",
+        "ref/dotnet/es/System.ServiceModel.NetTcp.xml",
+        "ref/dotnet/fr/System.ServiceModel.NetTcp.xml",
+        "ref/dotnet/it/System.ServiceModel.NetTcp.xml",
+        "ref/dotnet/ja/System.ServiceModel.NetTcp.xml",
+        "ref/dotnet/ko/System.ServiceModel.NetTcp.xml",
+        "ref/dotnet/ru/System.ServiceModel.NetTcp.xml",
         "ref/dotnet/System.ServiceModel.NetTcp.dll",
+        "ref/dotnet/System.ServiceModel.NetTcp.xml",
+        "ref/dotnet/zh-hans/System.ServiceModel.NetTcp.xml",
+        "ref/dotnet/zh-hant/System.ServiceModel.NetTcp.xml",
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.NetTcp.dll",
+        "ref/netcore50/System.ServiceModel.NetTcp.xml",
         "ref/win8/_._",
-        "System.ServiceModel.NetTcp.4.0.1-beta-23408.nupkg",
-        "System.ServiceModel.NetTcp.4.0.1-beta-23408.nupkg.sha512",
+        "System.ServiceModel.NetTcp.4.0.1-beta-23412.nupkg",
+        "System.ServiceModel.NetTcp.4.0.1-beta-23412.nupkg.sha512",
         "System.ServiceModel.NetTcp.nuspec"
       ]
     },
-    "System.ServiceModel.Primitives/4.0.1-beta-23408": {
+    "System.ServiceModel.Primitives/4.0.1-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "bjXzg+V3Oq/tBXpMY5FwcERN2CQsFXoL4BMoURlwiBMkgwN2CPvBIaK45Moh7nc21jNTVukNayDtURetGzK6aA==",
+      "sha512": "dkCUkNtXb2m9Wf+DY7dc5B4J8DpaWtX4wpFfT3cYLpChxAnjQR85N+tJfMEHLfZNNerKgDRyGyaKa7uSHfvb5g==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Primitives.dll",
         "lib/net45/_._",
-        "lib/netcore50/de/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/es/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/fr/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/it/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/ja/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/ko/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/ru/System.ServiceModel.Primitives.xml",
         "lib/netcore50/System.ServiceModel.Primitives.dll",
-        "lib/netcore50/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/zh-hans/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/zh-hant/System.ServiceModel.Primitives.xml",
         "lib/win8/_._",
+        "ref/dotnet/de/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/es/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/fr/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/it/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/ja/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/ko/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/ru/System.ServiceModel.Primitives.xml",
         "ref/dotnet/System.ServiceModel.Primitives.dll",
+        "ref/dotnet/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/zh-hans/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/zh-hant/System.ServiceModel.Primitives.xml",
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.Primitives.dll",
+        "ref/netcore50/System.ServiceModel.Primitives.xml",
         "ref/win8/_._",
-        "System.ServiceModel.Primitives.4.0.1-beta-23408.nupkg",
-        "System.ServiceModel.Primitives.4.0.1-beta-23408.nupkg.sha512",
+        "System.ServiceModel.Primitives.4.0.1-beta-23412.nupkg",
+        "System.ServiceModel.Primitives.4.0.1-beta-23412.nupkg.sha512",
         "System.ServiceModel.Primitives.nuspec"
       ]
     },
-    "System.ServiceModel.Security/4.0.1-beta-23408": {
+    "System.ServiceModel.Security/4.0.1-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "rWTUEu+P30ytvkAGX051GEj9Rqj0Zk2ildyC748zdJE5qO89ZXOdC2WnMVrnQJlFcTASFOmT9BFcym4U2EzLGg==",
+      "sha512": "X+TJPs0+TVaHtDcrgw+QYtRUea0OHyy8VRzWKLL0nls52THNfeZZeTecd3eQnb6lQKpDIU42gl6tP0uePUpvMA==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Security.dll",
         "lib/net45/_._",
-        "lib/netcore50/de/System.ServiceModel.Security.xml",
-        "lib/netcore50/es/System.ServiceModel.Security.xml",
-        "lib/netcore50/fr/System.ServiceModel.Security.xml",
-        "lib/netcore50/it/System.ServiceModel.Security.xml",
-        "lib/netcore50/ja/System.ServiceModel.Security.xml",
-        "lib/netcore50/ko/System.ServiceModel.Security.xml",
-        "lib/netcore50/ru/System.ServiceModel.Security.xml",
         "lib/netcore50/System.ServiceModel.Security.dll",
-        "lib/netcore50/System.ServiceModel.Security.xml",
-        "lib/netcore50/zh-hans/System.ServiceModel.Security.xml",
-        "lib/netcore50/zh-hant/System.ServiceModel.Security.xml",
         "lib/win8/_._",
+        "ref/dotnet/de/System.ServiceModel.Security.xml",
+        "ref/dotnet/es/System.ServiceModel.Security.xml",
+        "ref/dotnet/fr/System.ServiceModel.Security.xml",
+        "ref/dotnet/it/System.ServiceModel.Security.xml",
+        "ref/dotnet/ja/System.ServiceModel.Security.xml",
+        "ref/dotnet/ko/System.ServiceModel.Security.xml",
+        "ref/dotnet/ru/System.ServiceModel.Security.xml",
         "ref/dotnet/System.ServiceModel.Security.dll",
+        "ref/dotnet/System.ServiceModel.Security.xml",
+        "ref/dotnet/zh-hans/System.ServiceModel.Security.xml",
+        "ref/dotnet/zh-hant/System.ServiceModel.Security.xml",
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.Security.dll",
+        "ref/netcore50/System.ServiceModel.Security.xml",
         "ref/win8/_._",
-        "System.ServiceModel.Security.4.0.1-beta-23408.nupkg",
-        "System.ServiceModel.Security.4.0.1-beta-23408.nupkg.sha512",
+        "System.ServiceModel.Security.4.0.1-beta-23412.nupkg",
+        "System.ServiceModel.Security.4.0.1-beta-23412.nupkg.sha512",
         "System.ServiceModel.Security.nuspec"
       ]
     },
@@ -2999,25 +2975,35 @@
         "System.Text.RegularExpressions.nuspec"
       ]
     },
-    "System.Threading/4.0.11-beta-23408": {
+    "System.Threading/4.0.11-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "/jzCiSsUl+pwQjUMe4NXXmnCLXv6I40G2g+B9ypHaftZ/UNOXp98mabT9QtZV5hzpIz3U6pC0j9ECCzYQmEB/g==",
+      "sha512": "yLgYPp6J5CLhWDXF/CJzCZ1YSy+8ACgrz/S9LFq66WzeoX6iagzWMTY8uosk3IOjBEJVst3Bqvs2abfShjy5bQ==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Threading.xml",
+        "ref/dotnet/es/System.Threading.xml",
+        "ref/dotnet/fr/System.Threading.xml",
+        "ref/dotnet/it/System.Threading.xml",
+        "ref/dotnet/ja/System.Threading.xml",
+        "ref/dotnet/ko/System.Threading.xml",
+        "ref/dotnet/ru/System.Threading.xml",
         "ref/dotnet/System.Threading.dll",
+        "ref/dotnet/System.Threading.xml",
+        "ref/dotnet/zh-hans/System.Threading.xml",
+        "ref/dotnet/zh-hant/System.Threading.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Threading.4.0.11-beta-23408.nupkg",
-        "System.Threading.4.0.11-beta-23408.nupkg.sha512",
+        "System.Threading.4.0.11-beta-23412.nupkg",
+        "System.Threading.4.0.11-beta-23412.nupkg.sha512",
         "System.Threading.nuspec"
       ]
     },

--- a/src/System.Private.ServiceModel/tests/Unit/project.json
+++ b/src/System.Private.ServiceModel/tests/Unit/project.json
@@ -31,7 +31,7 @@
     "System.Runtime.Handles": "4.0.0",
     "System.Runtime.InteropServices": "4.0.20-beta-*",
     "System.Runtime.Serialization.Xml": "4.0.10",
-    "System.Security.Claims": "4.0.0",
+    "System.Security.Claims": "4.0.1-beta-*",
     "System.Security.Principal": "4.0.0",
     "System.Text.Encoding": "4.0.10",
     "System.Threading": "4.0.10",

--- a/src/System.Private.ServiceModel/tests/Unit/project.lock.json
+++ b/src/System.Private.ServiceModel/tests/Unit/project.lock.json
@@ -316,7 +316,7 @@
           "lib/dotnet/System.Linq.Queryable.dll": {}
         }
       },
-      "System.Net.Http/4.0.1-beta-23408": {
+      "System.Net.Http/4.0.1-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -329,7 +329,7 @@
           "ref/dotnet/System.Net.Http.dll": {}
         }
       },
-      "System.Net.NameResolution/4.0.0-beta-23408": {
+      "System.Net.NameResolution/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Net.Primitives": "4.0.10",
@@ -352,16 +352,17 @@
           "lib/DNXCore50/System.Net.Primitives.dll": {}
         }
       },
-      "System.Net.Security/4.0.0-beta-23408": {
+      "System.Net.Security/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
-          "System.Private.Networking": "4.0.1-beta-23408"
+          "System.IO": "4.0.0",
+          "System.Net.Primitives": "4.0.10",
+          "System.Runtime": "4.0.0",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23412",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Net.Security.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Net.Security.dll": {}
         }
       },
       "System.Net.Sockets/4.0.10-beta-23213": {
@@ -391,7 +392,7 @@
           "lib/dotnet/System.Net.WebHeaderCollection.dll": {}
         }
       },
-      "System.Net.WebSockets/4.0.0-beta-23408": {
+      "System.Net.WebSockets/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -406,7 +407,7 @@
           "lib/dotnet/System.Net.WebSockets.dll": {}
         }
       },
-      "System.Net.WebSockets.Client/4.0.0-beta-23408": {
+      "System.Net.WebSockets.Client/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -416,13 +417,13 @@
           "System.Globalization": "4.0.10",
           "System.Net.Primitives": "4.0.10",
           "System.Net.WebHeaderCollection": "4.0.0",
-          "System.Net.WebSockets": "4.0.0-beta-23408",
+          "System.Net.WebSockets": "4.0.0-beta-23412",
           "System.Resources.ResourceManager": "4.0.0",
           "System.Runtime": "4.0.20",
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23408",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23412",
           "System.Text.Encoding": "4.0.10",
           "System.Threading": "4.0.10",
           "System.Threading.Tasks": "4.0.10"
@@ -479,7 +480,7 @@
           "lib/DNXCore50/System.Private.DataContractSerialization.dll": {}
         }
       },
-      "System.Private.Networking/4.0.1-beta-23408": {
+      "System.Private.Networking/4.0.1-beta-23213": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -498,13 +499,14 @@
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23408",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23408",
-          "System.Security.Principal.Windows": "4.0.0-beta-23408",
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23213",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23213",
+          "System.Security.Principal.Windows": "4.0.0-beta-23213",
+          "System.Security.SecureString": "4.0.0-beta-23213",
           "System.Threading": "4.0.10",
           "System.Threading.Overlapped": "4.0.0",
           "System.Threading.Tasks": "4.0.10",
-          "System.Threading.ThreadPool": "4.0.10-beta-23408"
+          "System.Threading.ThreadPool": "4.0.10-beta-23213"
         },
         "compile": {
           "ref/dnxcore50/_._": {}
@@ -727,7 +729,7 @@
           "lib/DNXCore50/System.Runtime.Serialization.Xml.dll": {}
         }
       },
-      "System.Security.Claims/4.0.1-beta-23408": {
+      "System.Security.Claims/4.0.1-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -746,18 +748,18 @@
           "lib/dotnet/System.Security.Claims.dll": {}
         }
       },
-      "System.Security.Cryptography.Algorithms/4.0.0-beta-23408": {
+      "System.Security.Cryptography.Algorithms/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
           "System.Runtime": "4.0.0",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23408"
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23412"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.Algorithms.dll": {}
         }
       },
-      "System.Security.Cryptography.Encoding/4.0.0-beta-23408": {
+      "System.Security.Cryptography.Encoding/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -766,7 +768,7 @@
           "ref/dotnet/System.Security.Cryptography.Encoding.dll": {}
         }
       },
-      "System.Security.Cryptography.Primitives/4.0.0-beta-23408": {
+      "System.Security.Cryptography.Primitives/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.0",
@@ -784,13 +786,13 @@
           "lib/dotnet/System.Security.Cryptography.Primitives.dll": {}
         }
       },
-      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23408": {
+      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
           "System.Runtime.Handles": "4.0.0",
-          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23408",
-          "System.Security.Cryptography.Encoding": "4.0.0-beta-23408"
+          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23412",
+          "System.Security.Cryptography.Encoding": "4.0.0-beta-23412"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.X509Certificates.dll": {}
@@ -808,7 +810,7 @@
           "lib/dotnet/System.Security.Principal.dll": {}
         }
       },
-      "System.Security.Principal.Windows/4.0.0-beta-23408": {
+      "System.Security.Principal.Windows/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -829,6 +831,23 @@
         },
         "runtime": {
           "lib/DNXCore50/System.Security.Principal.Windows.dll": {}
+        }
+      },
+      "System.Security.SecureString/4.0.0-beta-23213": {
+        "type": "package",
+        "dependencies": {
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23213",
+          "System.Threading": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Security.SecureString.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Security.SecureString.dll": {}
         }
       },
       "System.Text.Encoding/4.0.10": {
@@ -911,7 +930,7 @@
           "lib/DNXCore50/System.Threading.Tasks.dll": {}
         }
       },
-      "System.Threading.ThreadPool/4.0.10-beta-23408": {
+      "System.Threading.ThreadPool/4.0.10-beta-23213": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
@@ -1126,7 +1145,7 @@
           "lib/dotnet/xunit.execution.dotnet.dll": {}
         }
       },
-      "xunit.netcore.extensions/1.0.0-prerelease-00104": {
+      "xunit.netcore.extensions/1.0.0-prerelease-00105": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.10",
@@ -1821,44 +1840,65 @@
         "System.Linq.Queryable.nuspec"
       ]
     },
-    "System.Net.Http/4.0.1-beta-23408": {
+    "System.Net.Http/4.0.1-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "n+tnV1VgCjbDKKnbgrvgUgxkPDwUFvSv9lTgH882rVzjbWyliVgbBflVzoAUjUSlga/Tr1XQIrfTLMRD5HfYGw==",
+      "sha512": "F7Yej+6QdRVzWg+qbkayRMcmf/7k7YfNFoVSA67wIsG9t5u7Wj4Go8FW72HL8qb9d7YjIsVB/5hA7g9MUT31Aw==",
       "files": [
         "lib/net45/_._",
         "lib/win8/_._",
         "lib/wpa81/_._",
+        "ref/dotnet/de/System.Net.Http.xml",
+        "ref/dotnet/es/System.Net.Http.xml",
+        "ref/dotnet/fr/System.Net.Http.xml",
+        "ref/dotnet/it/System.Net.Http.xml",
+        "ref/dotnet/ja/System.Net.Http.xml",
+        "ref/dotnet/ko/System.Net.Http.xml",
+        "ref/dotnet/ru/System.Net.Http.xml",
         "ref/dotnet/System.Net.Http.dll",
+        "ref/dotnet/System.Net.Http.xml",
+        "ref/dotnet/zh-hans/System.Net.Http.xml",
+        "ref/dotnet/zh-hant/System.Net.Http.xml",
         "ref/net45/_._",
         "ref/netcore50/System.Net.Http.dll",
+        "ref/netcore50/System.Net.Http.xml",
         "ref/win8/_._",
         "ref/wpa81/_._",
         "runtime.json",
-        "System.Net.Http.4.0.1-beta-23408.nupkg",
-        "System.Net.Http.4.0.1-beta-23408.nupkg.sha512",
+        "System.Net.Http.4.0.1-beta-23412.nupkg",
+        "System.Net.Http.4.0.1-beta-23412.nupkg.sha512",
         "System.Net.Http.nuspec"
       ]
     },
-    "System.Net.NameResolution/4.0.0-beta-23408": {
+    "System.Net.NameResolution/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "2A562VFL8GUL/jLCJ3mbQHhwwAIXzPyjxMpdtas1LVM8QLuP1OcHwV3z7ajWnYdGcPc7ZxPEGJQWicuaPD+0nA==",
+      "sha512": "HCF1zhFYBT+w/Ik+JuTzFJgj83Jfc+eA8VcgvIzdPiGMXfrZeXOogjgSCkCoJmFtKVz2DSfmISoEmiXB1oaLNQ==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.NameResolution.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Net.NameResolution.xml",
+        "ref/dotnet/es/System.Net.NameResolution.xml",
+        "ref/dotnet/fr/System.Net.NameResolution.xml",
+        "ref/dotnet/it/System.Net.NameResolution.xml",
+        "ref/dotnet/ja/System.Net.NameResolution.xml",
+        "ref/dotnet/ko/System.Net.NameResolution.xml",
+        "ref/dotnet/ru/System.Net.NameResolution.xml",
         "ref/dotnet/System.Net.NameResolution.dll",
+        "ref/dotnet/System.Net.NameResolution.xml",
+        "ref/dotnet/zh-hans/System.Net.NameResolution.xml",
+        "ref/dotnet/zh-hant/System.Net.NameResolution.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Net.NameResolution.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Net.NameResolution.4.0.0-beta-23408.nupkg",
-        "System.Net.NameResolution.4.0.0-beta-23408.nupkg.sha512",
+        "System.Net.NameResolution.4.0.0-beta-23412.nupkg",
+        "System.Net.NameResolution.4.0.0-beta-23412.nupkg.sha512",
         "System.Net.NameResolution.nuspec"
       ]
     },
@@ -1895,24 +1935,34 @@
         "System.Net.Primitives.nuspec"
       ]
     },
-    "System.Net.Security/4.0.0-beta-23408": {
+    "System.Net.Security/4.0.0-beta-23412": {
       "type": "package",
-      "sha512": "kEkunODO2t/VlBIsC80YFDG0KtY/FyIbtBApNyJQv+LYGEs5IFvEhpi9+p0/jHmhyRMKwbjajNedbXo+VMkt1A==",
+      "sha512": "Kcjne7jnvF5aTbRJsAT8kuP+1mxryUF2qYv8f3jnR19wtEjswSIOVU0XzuWc9YObEQcb+kEdzN71HTOm+ssv+w==",
       "files": [
-        "lib/DNXCore50/System.Net.Security.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.Security.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Net.Security.xml",
+        "ref/dotnet/es/System.Net.Security.xml",
+        "ref/dotnet/fr/System.Net.Security.xml",
+        "ref/dotnet/it/System.Net.Security.xml",
+        "ref/dotnet/ja/System.Net.Security.xml",
+        "ref/dotnet/ko/System.Net.Security.xml",
+        "ref/dotnet/ru/System.Net.Security.xml",
         "ref/dotnet/System.Net.Security.dll",
+        "ref/dotnet/System.Net.Security.xml",
+        "ref/dotnet/zh-hans/System.Net.Security.xml",
+        "ref/dotnet/zh-hant/System.Net.Security.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Net.Security.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.Security.4.0.0-beta-23408.nupkg",
-        "System.Net.Security.4.0.0-beta-23408.nupkg.sha512",
+        "runtime.json",
+        "System.Net.Security.4.0.0-beta-23412.nupkg",
+        "System.Net.Security.4.0.0-beta-23412.nupkg.sha512",
         "System.Net.Security.nuspec"
       ]
     },
@@ -1977,78 +2027,68 @@
         "System.Net.WebHeaderCollection.nuspec"
       ]
     },
-    "System.Net.WebSockets/4.0.0-beta-23408": {
+    "System.Net.WebSockets/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "BXy22/bNVtrXXsG76zXyhjcQnCjSYxQIFF37xWifqPRWmvzsCYSLQpNCTPQUCp7rjB7qWc5yLhC9bThaEx7MHQ==",
+      "sha512": "EvXAa0yd1RM8ROyLl1T0xC94F04Su8YMHnd4/w6j0Z/+4lKHZOU7bQPZ3odDN8WdPGKa/ZNJJGwiapydEWKzwQ==",
       "files": [
-        "lib/dotnet/de/System.Net.WebSockets.xml",
-        "lib/dotnet/es/System.Net.WebSockets.xml",
-        "lib/dotnet/fr/System.Net.WebSockets.xml",
-        "lib/dotnet/it/System.Net.WebSockets.xml",
-        "lib/dotnet/ja/System.Net.WebSockets.xml",
-        "lib/dotnet/ko/System.Net.WebSockets.xml",
-        "lib/dotnet/ru/System.Net.WebSockets.xml",
         "lib/dotnet/System.Net.WebSockets.dll",
-        "lib/dotnet/System.Net.WebSockets.xml",
-        "lib/dotnet/zh-hans/System.Net.WebSockets.xml",
-        "lib/dotnet/zh-hant/System.Net.WebSockets.xml",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.WebSockets.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Net.WebSockets.xml",
+        "ref/dotnet/es/System.Net.WebSockets.xml",
+        "ref/dotnet/fr/System.Net.WebSockets.xml",
+        "ref/dotnet/it/System.Net.WebSockets.xml",
+        "ref/dotnet/ja/System.Net.WebSockets.xml",
+        "ref/dotnet/ko/System.Net.WebSockets.xml",
+        "ref/dotnet/ru/System.Net.WebSockets.xml",
         "ref/dotnet/System.Net.WebSockets.dll",
+        "ref/dotnet/System.Net.WebSockets.xml",
+        "ref/dotnet/zh-hans/System.Net.WebSockets.xml",
+        "ref/dotnet/zh-hant/System.Net.WebSockets.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Net.WebSockets.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.WebSockets.4.0.0-beta-23408.nupkg",
-        "System.Net.WebSockets.4.0.0-beta-23408.nupkg.sha512",
+        "System.Net.WebSockets.4.0.0-beta-23412.nupkg",
+        "System.Net.WebSockets.4.0.0-beta-23412.nupkg.sha512",
         "System.Net.WebSockets.nuspec"
       ]
     },
-    "System.Net.WebSockets.Client/4.0.0-beta-23408": {
+    "System.Net.WebSockets.Client/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "smmvhCkcU0c4RNWc6NZwnN5EFktX58jf8+TJ6enfuXxWrpJ/2NRI5/2yT/okjFSngGK1g0MBrljZsfs2EJ7+Yw==",
+      "sha512": "uaO7c/81sK90605UtThSX9KVmzsJDA1vD4GMW7FsKKntymlkolJsprDekWblQ4A5YbhqxHv+ngXX2kIU0B3Fdw==",
       "files": [
-        "lib/DNXCore50/de/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/es/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/fr/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/it/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/ja/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/ko/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/ru/System.Net.WebSockets.Client.xml",
         "lib/DNXCore50/System.Net.WebSockets.Client.dll",
-        "lib/DNXCore50/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/zh-hans/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/zh-hant/System.Net.WebSockets.Client.xml",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.WebSockets.Client.dll",
-        "lib/netcore50/de/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/es/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/fr/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/it/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/ja/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/ko/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/ru/System.Net.WebSockets.Client.xml",
         "lib/netcore50/System.Net.WebSockets.Client.dll",
-        "lib/netcore50/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/zh-hans/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/zh-hant/System.Net.WebSockets.Client.xml",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/es/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/fr/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/it/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/ja/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/ko/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/ru/System.Net.WebSockets.Client.xml",
         "ref/dotnet/System.Net.WebSockets.Client.dll",
+        "ref/dotnet/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/zh-hans/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/zh-hant/System.Net.WebSockets.Client.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Net.WebSockets.Client.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.WebSockets.Client.4.0.0-beta-23408.nupkg",
-        "System.Net.WebSockets.Client.4.0.0-beta-23408.nupkg.sha512",
+        "System.Net.WebSockets.Client.4.0.0-beta-23412.nupkg",
+        "System.Net.WebSockets.Client.4.0.0-beta-23412.nupkg.sha512",
         "System.Net.WebSockets.Client.nuspec"
       ]
     },
@@ -2100,17 +2140,17 @@
         "System.Private.DataContractSerialization.nuspec"
       ]
     },
-    "System.Private.Networking/4.0.1-beta-23408": {
+    "System.Private.Networking/4.0.1-beta-23213": {
       "type": "package",
       "serviceable": true,
-      "sha512": "i2fRDRqM8Px3CP26C//deF/tCNR1AwqlPEr9+MYiXxNZtgGcSPBfqOJJ5CJdfmDb9Ap0hPG2MiPG7CinaSH7+Q==",
+      "sha512": "/TG5go+oetTk5uhN0/3qgjmjYQf05YWJnZTHOiMw5VCUGTOUtlwUs8+wpgcpTsKQ82P+Juny9pVq7AxZIYUtVQ==",
       "files": [
         "lib/DNXCore50/System.Private.Networking.dll",
         "lib/netcore50/System.Private.Networking.dll",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "System.Private.Networking.4.0.1-beta-23408.nupkg",
-        "System.Private.Networking.4.0.1-beta-23408.nupkg.sha512",
+        "System.Private.Networking.4.0.1-beta-23213.nupkg",
+        "System.Private.Networking.4.0.1-beta-23213.nupkg.sha512",
         "System.Private.Networking.nuspec"
       ]
     },
@@ -2607,42 +2647,42 @@
         "System.Runtime.Serialization.Xml.nuspec"
       ]
     },
-    "System.Security.Claims/4.0.1-beta-23408": {
+    "System.Security.Claims/4.0.1-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "9rsYgMq/0OqUX9xKlNUkOvaBaZETICCGd7SPcFPv+/bMYte2+PMD/tZpxFrbiXpB2211mHYk/wBVwejEyZuGcQ==",
+      "sha512": "Uu9h4cMBVr8DvFgRGxnTjd2fJkMmL3JApUxL82Bf333NHH5S0F85TGizF2kZkX0TOsySJ8TJUSJSQT+yq3m5Kg==",
       "files": [
-        "lib/dotnet/de/System.Security.Claims.xml",
-        "lib/dotnet/es/System.Security.Claims.xml",
-        "lib/dotnet/fr/System.Security.Claims.xml",
-        "lib/dotnet/it/System.Security.Claims.xml",
-        "lib/dotnet/ja/System.Security.Claims.xml",
-        "lib/dotnet/ko/System.Security.Claims.xml",
-        "lib/dotnet/ru/System.Security.Claims.xml",
         "lib/dotnet/System.Security.Claims.dll",
-        "lib/dotnet/System.Security.Claims.xml",
-        "lib/dotnet/zh-hans/System.Security.Claims.xml",
-        "lib/dotnet/zh-hant/System.Security.Claims.xml",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Security.Claims.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Security.Claims.xml",
+        "ref/dotnet/es/System.Security.Claims.xml",
+        "ref/dotnet/fr/System.Security.Claims.xml",
+        "ref/dotnet/it/System.Security.Claims.xml",
+        "ref/dotnet/ja/System.Security.Claims.xml",
+        "ref/dotnet/ko/System.Security.Claims.xml",
+        "ref/dotnet/ru/System.Security.Claims.xml",
         "ref/dotnet/System.Security.Claims.dll",
+        "ref/dotnet/System.Security.Claims.xml",
+        "ref/dotnet/zh-hans/System.Security.Claims.xml",
+        "ref/dotnet/zh-hant/System.Security.Claims.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Security.Claims.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Security.Claims.4.0.1-beta-23408.nupkg",
-        "System.Security.Claims.4.0.1-beta-23408.nupkg.sha512",
+        "System.Security.Claims.4.0.1-beta-23412.nupkg",
+        "System.Security.Claims.4.0.1-beta-23412.nupkg.sha512",
         "System.Security.Claims.nuspec"
       ]
     },
-    "System.Security.Cryptography.Algorithms/4.0.0-beta-23408": {
+    "System.Security.Cryptography.Algorithms/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "G6eEqi8mZRrWftcwilcnllE4xJ/53JQlk3VVuJ+9qrX+DHvWz8itYJRUZX357JY4DgEEKQNOJzuRGrOBTUeoPg==",
+      "sha512": "nBjoiqJQiMD3cJgOVrqjIVDqEEPZeIqT+mrBIxjLE+YMQcjEyDuSyOG65Ntoopby5LH4onTLMM4zfXh8JRt9NQ==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2656,37 +2696,47 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.Algorithms.4.0.0-beta-23408.nupkg",
-        "System.Security.Cryptography.Algorithms.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Cryptography.Algorithms.4.0.0-beta-23412.nupkg",
+        "System.Security.Cryptography.Algorithms.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Cryptography.Algorithms.nuspec"
       ]
     },
-    "System.Security.Cryptography.Encoding/4.0.0-beta-23408": {
+    "System.Security.Cryptography.Encoding/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "fPsAK3vyMjnJ6nT4YchdS7KzfGca/6uVVAPCBO08ZpTRGhMGx30vq1MiIqAUrfsFMnot3Ub2jimnAFWkqY6g0Q==",
+      "sha512": "SR1zCARNdeyLoUKYH2SNMm1He7Lr3NR/l7yW3K135L44T6PS3YB8SfXpVoZdMpb22X2G07BZAHVz2x7e4AA1Cg==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Security.Cryptography.Encoding.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/es/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/fr/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/it/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/ja/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/ko/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/ru/System.Security.Cryptography.Encoding.xml",
         "ref/dotnet/System.Security.Cryptography.Encoding.dll",
+        "ref/dotnet/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/zh-hans/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/zh-hant/System.Security.Cryptography.Encoding.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Security.Cryptography.Encoding.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.Encoding.4.0.0-beta-23408.nupkg",
-        "System.Security.Cryptography.Encoding.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Cryptography.Encoding.4.0.0-beta-23412.nupkg",
+        "System.Security.Cryptography.Encoding.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Cryptography.Encoding.nuspec"
       ]
     },
-    "System.Security.Cryptography.Primitives/4.0.0-beta-23408": {
+    "System.Security.Cryptography.Primitives/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "A336dWYEIQxm1rEJCaE5ZZrUWHPUkBGTRH8uAj8qrTqg4/qRc2yN2wZxeGXaZauhI35QwDmOutK7oVb2Cd+4TA==",
+      "sha512": "H9EBNe0ahjAYjlVn0TnT18PSgZBrtROSQH1RRIKwAjzxQHt8zwDhO4yN0Q5QaaUIoSXgxVmgtWWk62wDvpy+QA==",
       "files": [
         "lib/dotnet/System.Security.Cryptography.Primitives.dll",
         "lib/MonoAndroid10/_._",
@@ -2700,30 +2750,40 @@
         "ref/net46/System.Security.Cryptography.Primitives.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Security.Cryptography.Primitives.4.0.0-beta-23408.nupkg",
-        "System.Security.Cryptography.Primitives.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Cryptography.Primitives.4.0.0-beta-23412.nupkg",
+        "System.Security.Cryptography.Primitives.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Cryptography.Primitives.nuspec"
       ]
     },
-    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23408": {
+    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "JSNf5d1V5Y47MIdf7QxZCuGnR5heM4UKbrsdXiWD5lfqu0mnNjebPIclMUXlTw/6IykuDsUpompV/DtsaLLHig==",
+      "sha512": "SfpMjvrfRaRjG42uynLugb3YgpXdpnU7X8vNAU7stIR5/4uW9m1SvWHvBjirjHRBtOpbKB86uD5ODQWX+tWDNA==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Security.Cryptography.X509Certificates.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/es/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/fr/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/it/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/ja/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/ko/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/ru/System.Security.Cryptography.X509Certificates.xml",
         "ref/dotnet/System.Security.Cryptography.X509Certificates.dll",
+        "ref/dotnet/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/zh-hans/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/zh-hant/System.Security.Cryptography.X509Certificates.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Security.Cryptography.X509Certificates.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23408.nupkg",
-        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23412.nupkg",
+        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Cryptography.X509Certificates.nuspec"
       ]
     },
@@ -2760,28 +2820,60 @@
         "System.Security.Principal.nuspec"
       ]
     },
-    "System.Security.Principal.Windows/4.0.0-beta-23408": {
+    "System.Security.Principal.Windows/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "xmjpZJvsT1AW23UkjqUkF/VrOh7DA1cagYY272UQmO8ei227TFD4C7j3ofatL/63hR3CXkLkoephuE4f2Z9fGA==",
+      "sha512": "Zvb/LzT+GjGNV1t8i5KVieilL+8P5LcQykIbJHw5aJxLPFEIQ4Y2hTJXdEkeKvZ4TCF5dlwY1jYyUrJkcqpxzw==",
       "files": [
-        "lib/DNXCore50/de/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/es/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/fr/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/it/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/ja/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/ko/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/ru/System.Security.Principal.Windows.xml",
         "lib/DNXCore50/System.Security.Principal.Windows.dll",
-        "lib/DNXCore50/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/zh-hans/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/zh-hant/System.Security.Principal.Windows.xml",
         "lib/net46/System.Security.Principal.Windows.dll",
+        "ref/dotnet/de/System.Security.Principal.Windows.xml",
+        "ref/dotnet/es/System.Security.Principal.Windows.xml",
+        "ref/dotnet/fr/System.Security.Principal.Windows.xml",
+        "ref/dotnet/it/System.Security.Principal.Windows.xml",
+        "ref/dotnet/ja/System.Security.Principal.Windows.xml",
+        "ref/dotnet/ko/System.Security.Principal.Windows.xml",
+        "ref/dotnet/ru/System.Security.Principal.Windows.xml",
         "ref/dotnet/System.Security.Principal.Windows.dll",
+        "ref/dotnet/System.Security.Principal.Windows.xml",
+        "ref/dotnet/zh-hans/System.Security.Principal.Windows.xml",
+        "ref/dotnet/zh-hant/System.Security.Principal.Windows.xml",
         "ref/net46/System.Security.Principal.Windows.dll",
-        "System.Security.Principal.Windows.4.0.0-beta-23408.nupkg",
-        "System.Security.Principal.Windows.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Principal.Windows.4.0.0-beta-23412.nupkg",
+        "System.Security.Principal.Windows.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Principal.Windows.nuspec"
+      ]
+    },
+    "System.Security.SecureString/4.0.0-beta-23213": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "CFqRzPegvjf6SLmU+/7iay8+NZ0PrKuuHiZNCTDKW2z7UIFVG8PnU6mks8+GyQoEuK4ANZg9efboMKwTDM93sw==",
+      "files": [
+        "lib/DNXCore50/System.Security.SecureString.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Security.SecureString.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Security.SecureString.xml",
+        "ref/dotnet/es/System.Security.SecureString.xml",
+        "ref/dotnet/fr/System.Security.SecureString.xml",
+        "ref/dotnet/it/System.Security.SecureString.xml",
+        "ref/dotnet/ja/System.Security.SecureString.xml",
+        "ref/dotnet/ko/System.Security.SecureString.xml",
+        "ref/dotnet/ru/System.Security.SecureString.xml",
+        "ref/dotnet/System.Security.SecureString.dll",
+        "ref/dotnet/System.Security.SecureString.xml",
+        "ref/dotnet/zh-hans/System.Security.SecureString.xml",
+        "ref/dotnet/zh-hant/System.Security.SecureString.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Security.SecureString.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Security.SecureString.4.0.0-beta-23213.nupkg",
+        "System.Security.SecureString.4.0.0-beta-23213.nupkg.sha512",
+        "System.Security.SecureString.nuspec"
       ]
     },
     "System.Text.Encoding/4.0.10": {
@@ -2975,10 +3067,9 @@
         "System.Threading.Tasks.nuspec"
       ]
     },
-    "System.Threading.ThreadPool/4.0.10-beta-23408": {
+    "System.Threading.ThreadPool/4.0.10-beta-23213": {
       "type": "package",
-      "serviceable": true,
-      "sha512": "ahdsVyj+WFj8/iSDwX/G7hkEU4jZmmvWzPS2ajZKdp0Crb0vZJOlM0LQYVASQgbimrUZHQ50o93JYEi8RFdh/Q==",
+      "sha512": "N3LOO3EFTwqchQsmZiKc/PdIvH47ByA7KbhhJK/OM3CnPfogsCKkBBgO3T4KNSw1zT1GTg43p047L2jv/hguLQ==",
       "files": [
         "lib/DNXCore50/System.Threading.ThreadPool.dll",
         "lib/MonoAndroid10/_._",
@@ -2986,14 +3077,24 @@
         "lib/net46/System.Threading.ThreadPool.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Threading.ThreadPool.xml",
+        "ref/dotnet/es/System.Threading.ThreadPool.xml",
+        "ref/dotnet/fr/System.Threading.ThreadPool.xml",
+        "ref/dotnet/it/System.Threading.ThreadPool.xml",
+        "ref/dotnet/ja/System.Threading.ThreadPool.xml",
+        "ref/dotnet/ko/System.Threading.ThreadPool.xml",
+        "ref/dotnet/ru/System.Threading.ThreadPool.xml",
         "ref/dotnet/System.Threading.ThreadPool.dll",
+        "ref/dotnet/System.Threading.ThreadPool.xml",
+        "ref/dotnet/zh-hans/System.Threading.ThreadPool.xml",
+        "ref/dotnet/zh-hant/System.Threading.ThreadPool.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Threading.ThreadPool.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Threading.ThreadPool.4.0.10-beta-23408.nupkg",
-        "System.Threading.ThreadPool.4.0.10-beta-23408.nupkg.sha512",
+        "System.Threading.ThreadPool.4.0.10-beta-23213.nupkg",
+        "System.Threading.ThreadPool.4.0.10-beta-23213.nupkg.sha512",
         "System.Threading.ThreadPool.nuspec"
       ]
     },
@@ -3276,14 +3377,14 @@
         "xunit.extensibility.execution.nuspec"
       ]
     },
-    "xunit.netcore.extensions/1.0.0-prerelease-00104": {
+    "xunit.netcore.extensions/1.0.0-prerelease-00105": {
       "type": "package",
       "serviceable": true,
-      "sha512": "ZMXxEBpGP7krXtvqbPMOWavd2u83w77ghtD254wfj5+d+7GmYYqP9pX1iRIxJK9CBa8Zc2cOrcYsmCLQgYriAQ==",
+      "sha512": "EnnGcy9rmSdQ8izHWvYSYVyjQGhbeFH7JeM/L35ZrrPGtYvq5XD3hc1cJPCs+43mXdF9cdqhkt5uTlXYzC+Z8g==",
       "files": [
         "lib/dotnet/Xunit.NetCore.Extensions.dll",
-        "xunit.netcore.extensions.1.0.0-prerelease-00104.nupkg",
-        "xunit.netcore.extensions.1.0.0-prerelease-00104.nupkg.sha512",
+        "xunit.netcore.extensions.1.0.0-prerelease-00105.nupkg",
+        "xunit.netcore.extensions.1.0.0-prerelease-00105.nupkg.sha512",
         "xunit.netcore.extensions.nuspec"
       ]
     }

--- a/src/System.Private.ServiceModel/tests/Unit/project.lock.json
+++ b/src/System.Private.ServiceModel/tests/Unit/project.lock.json
@@ -727,7 +727,7 @@
           "lib/DNXCore50/System.Runtime.Serialization.Xml.dll": {}
         }
       },
-      "System.Security.Claims/4.0.0": {
+      "System.Security.Claims/4.0.1-beta-23408": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -2607,35 +2607,35 @@
         "System.Runtime.Serialization.Xml.nuspec"
       ]
     },
-    "System.Security.Claims/4.0.0": {
+    "System.Security.Claims/4.0.1-beta-23408": {
       "type": "package",
       "serviceable": true,
-      "sha512": "94NFR/7JN3YdyTH7hl2iSvYmdA8aqShriTHectcK+EbizT71YczMaG6LuqJBQP/HWo66AQyikYYM9aw+4EzGXg==",
+      "sha512": "9rsYgMq/0OqUX9xKlNUkOvaBaZETICCGd7SPcFPv+/bMYte2+PMD/tZpxFrbiXpB2211mHYk/wBVwejEyZuGcQ==",
       "files": [
+        "lib/dotnet/de/System.Security.Claims.xml",
+        "lib/dotnet/es/System.Security.Claims.xml",
+        "lib/dotnet/fr/System.Security.Claims.xml",
+        "lib/dotnet/it/System.Security.Claims.xml",
+        "lib/dotnet/ja/System.Security.Claims.xml",
+        "lib/dotnet/ko/System.Security.Claims.xml",
+        "lib/dotnet/ru/System.Security.Claims.xml",
         "lib/dotnet/System.Security.Claims.dll",
+        "lib/dotnet/System.Security.Claims.xml",
+        "lib/dotnet/zh-hans/System.Security.Claims.xml",
+        "lib/dotnet/zh-hant/System.Security.Claims.xml",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Security.Claims.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/de/System.Security.Claims.xml",
-        "ref/dotnet/es/System.Security.Claims.xml",
-        "ref/dotnet/fr/System.Security.Claims.xml",
-        "ref/dotnet/it/System.Security.Claims.xml",
-        "ref/dotnet/ja/System.Security.Claims.xml",
-        "ref/dotnet/ko/System.Security.Claims.xml",
-        "ref/dotnet/ru/System.Security.Claims.xml",
         "ref/dotnet/System.Security.Claims.dll",
-        "ref/dotnet/System.Security.Claims.xml",
-        "ref/dotnet/zh-hans/System.Security.Claims.xml",
-        "ref/dotnet/zh-hant/System.Security.Claims.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Security.Claims.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Security.Claims.4.0.0.nupkg",
-        "System.Security.Claims.4.0.0.nupkg.sha512",
+        "System.Security.Claims.4.0.1-beta-23408.nupkg",
+        "System.Security.Claims.4.0.1-beta-23408.nupkg.sha512",
         "System.Security.Claims.nuspec"
       ]
     },
@@ -3321,7 +3321,7 @@
       "System.Runtime.Handles >= 4.0.0",
       "System.Runtime.InteropServices >= 4.0.20-beta-*",
       "System.Runtime.Serialization.Xml >= 4.0.10",
-      "System.Security.Claims >= 4.0.0",
+      "System.Security.Claims >= 4.0.1-beta-*",
       "System.Security.Principal >= 4.0.0",
       "System.Text.Encoding >= 4.0.10",
       "System.Threading >= 4.0.10",

--- a/src/System.ServiceModel.Duplex/tests/project.lock.json
+++ b/src/System.ServiceModel.Duplex/tests/project.lock.json
@@ -1045,7 +1045,7 @@
           "lib/dotnet/xunit.execution.dotnet.dll": {}
         }
       },
-      "xunit.netcore.extensions/1.0.0-prerelease-00104": {
+      "xunit.netcore.extensions/1.0.0-prerelease-00105": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.10",
@@ -3022,14 +3022,14 @@
         "xunit.extensibility.execution.nuspec"
       ]
     },
-    "xunit.netcore.extensions/1.0.0-prerelease-00104": {
+    "xunit.netcore.extensions/1.0.0-prerelease-00105": {
       "type": "package",
       "serviceable": true,
-      "sha512": "ZMXxEBpGP7krXtvqbPMOWavd2u83w77ghtD254wfj5+d+7GmYYqP9pX1iRIxJK9CBa8Zc2cOrcYsmCLQgYriAQ==",
+      "sha512": "EnnGcy9rmSdQ8izHWvYSYVyjQGhbeFH7JeM/L35ZrrPGtYvq5XD3hc1cJPCs+43mXdF9cdqhkt5uTlXYzC+Z8g==",
       "files": [
         "lib/dotnet/Xunit.NetCore.Extensions.dll",
-        "xunit.netcore.extensions.1.0.0-prerelease-00104.nupkg",
-        "xunit.netcore.extensions.1.0.0-prerelease-00104.nupkg.sha512",
+        "xunit.netcore.extensions.1.0.0-prerelease-00105.nupkg",
+        "xunit.netcore.extensions.1.0.0-prerelease-00105.nupkg.sha512",
         "xunit.netcore.extensions.nuspec"
       ]
     }

--- a/src/System.ServiceModel.Http/tests/project.lock.json
+++ b/src/System.ServiceModel.Http/tests/project.lock.json
@@ -292,7 +292,7 @@
           "lib/dotnet/System.Linq.Queryable.dll": {}
         }
       },
-      "System.Net.Http/4.0.1-beta-23408": {
+      "System.Net.Http/4.0.1-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -305,7 +305,7 @@
           "ref/dotnet/System.Net.Http.dll": {}
         }
       },
-      "System.Net.NameResolution/4.0.0-beta-23408": {
+      "System.Net.NameResolution/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Net.Primitives": "4.0.10",
@@ -328,16 +328,17 @@
           "lib/DNXCore50/System.Net.Primitives.dll": {}
         }
       },
-      "System.Net.Security/4.0.0-beta-23408": {
+      "System.Net.Security/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
-          "System.Private.Networking": "4.0.1-beta-23408"
+          "System.IO": "4.0.0",
+          "System.Net.Primitives": "4.0.10",
+          "System.Runtime": "4.0.0",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23412",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Net.Security.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Net.Security.dll": {}
         }
       },
       "System.Net.Sockets/4.1.0-beta-23225": {
@@ -368,7 +369,7 @@
           "lib/dotnet/System.Net.WebHeaderCollection.dll": {}
         }
       },
-      "System.Net.WebSockets/4.0.0-beta-23408": {
+      "System.Net.WebSockets/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -383,7 +384,7 @@
           "lib/dotnet/System.Net.WebSockets.dll": {}
         }
       },
-      "System.Net.WebSockets.Client/4.0.0-beta-23408": {
+      "System.Net.WebSockets.Client/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -393,13 +394,13 @@
           "System.Globalization": "4.0.10",
           "System.Net.Primitives": "4.0.10",
           "System.Net.WebHeaderCollection": "4.0.0",
-          "System.Net.WebSockets": "4.0.0-beta-23408",
+          "System.Net.WebSockets": "4.0.0-beta-23412",
           "System.Resources.ResourceManager": "4.0.0",
           "System.Runtime": "4.0.20",
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23408",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23412",
           "System.Text.Encoding": "4.0.10",
           "System.Threading": "4.0.10",
           "System.Threading.Tasks": "4.0.10"
@@ -456,7 +457,7 @@
           "lib/DNXCore50/System.Private.DataContractSerialization.dll": {}
         }
       },
-      "System.Private.Networking/4.0.1-beta-23408": {
+      "System.Private.Networking/4.0.1-beta-23225": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -475,13 +476,10 @@
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23408",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23408",
-          "System.Security.Principal.Windows": "4.0.0-beta-23408",
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23225",
           "System.Threading": "4.0.10",
           "System.Threading.Overlapped": "4.0.0",
-          "System.Threading.Tasks": "4.0.10",
-          "System.Threading.ThreadPool": "4.0.10-beta-23408"
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dnxcore50/_._": {}
@@ -490,7 +488,7 @@
           "lib/DNXCore50/System.Private.Networking.dll": {}
         }
       },
-      "System.Private.ServiceModel/4.1.0-beta-23408": {
+      "System.Private.ServiceModel/4.1.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -507,14 +505,14 @@
           "System.Linq": "4.0.0",
           "System.Linq.Expressions": "4.0.10",
           "System.Linq.Queryable": "4.0.0",
-          "System.Net.Http": "4.0.1-beta-23408",
-          "System.Net.NameResolution": "4.0.0-beta-23408",
+          "System.Net.Http": "4.0.1-beta-23412",
+          "System.Net.NameResolution": "4.0.0-beta-23412",
           "System.Net.Primitives": "4.0.10",
-          "System.Net.Security": "4.0.0-beta-23408",
-          "System.Net.Sockets": "4.0.10-beta-23408",
+          "System.Net.Security": "4.0.0-beta-23412",
+          "System.Net.Sockets": "4.0.10-beta-23412",
           "System.Net.WebHeaderCollection": "4.0.0",
-          "System.Net.WebSockets": "4.0.0-beta-23408",
-          "System.Net.WebSockets.Client": "4.0.0-beta-23408",
+          "System.Net.WebSockets": "4.0.0-beta-23412",
+          "System.Net.WebSockets.Client": "4.0.0-beta-23412",
           "System.ObjectModel": "4.0.10",
           "System.Reflection": "4.0.10",
           "System.Reflection.DispatchProxy": "4.0.0",
@@ -528,9 +526,9 @@
           "System.Runtime.Serialization.Primitives": "4.0.10",
           "System.Runtime.Serialization.Xml": "4.0.10",
           "System.Security.Claims": "4.0.0",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23408",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23412",
           "System.Security.Principal": "4.0.0",
-          "System.Security.Principal.Windows": "4.0.0-beta-23408",
+          "System.Security.Principal.Windows": "4.0.0-beta-23412",
           "System.Text.Encoding": "4.0.10",
           "System.Threading": "4.0.10",
           "System.Threading.Tasks": "4.0.10",
@@ -779,18 +777,18 @@
           "lib/dotnet/System.Security.Claims.dll": {}
         }
       },
-      "System.Security.Cryptography.Algorithms/4.0.0-beta-23408": {
+      "System.Security.Cryptography.Algorithms/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
           "System.Runtime": "4.0.0",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23408"
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23412"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.Algorithms.dll": {}
         }
       },
-      "System.Security.Cryptography.Encoding/4.0.0-beta-23408": {
+      "System.Security.Cryptography.Encoding/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -799,7 +797,7 @@
           "ref/dotnet/System.Security.Cryptography.Encoding.dll": {}
         }
       },
-      "System.Security.Cryptography.Primitives/4.0.0-beta-23408": {
+      "System.Security.Cryptography.Primitives/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.0",
@@ -817,13 +815,13 @@
           "lib/dotnet/System.Security.Cryptography.Primitives.dll": {}
         }
       },
-      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23408": {
+      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
           "System.Runtime.Handles": "4.0.0",
-          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23408",
-          "System.Security.Cryptography.Encoding": "4.0.0-beta-23408"
+          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23412",
+          "System.Security.Cryptography.Encoding": "4.0.0-beta-23412"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.X509Certificates.dll": {}
@@ -841,7 +839,7 @@
           "lib/dotnet/System.Security.Principal.dll": {}
         }
       },
-      "System.Security.Principal.Windows/4.0.0-beta-23408": {
+      "System.Security.Principal.Windows/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -864,10 +862,10 @@
           "lib/DNXCore50/System.Security.Principal.Windows.dll": {}
         }
       },
-      "System.ServiceModel.Http/4.0.11-beta-23408": {
+      "System.ServiceModel.Http/4.0.11-beta-23412": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-beta-23408",
+          "System.Private.ServiceModel": "4.1.0-beta-23412",
           "System.Runtime": "4.0.20"
         },
         "compile": {
@@ -877,10 +875,10 @@
           "lib/DNXCore50/System.ServiceModel.Http.dll": {}
         }
       },
-      "System.ServiceModel.Primitives/4.0.1-beta-23408": {
+      "System.ServiceModel.Primitives/4.0.1-beta-23412": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-beta-23408"
+          "System.Private.ServiceModel": "4.1.0-beta-23412"
         },
         "compile": {
           "ref/dotnet/System.ServiceModel.Primitives.dll": {}
@@ -967,19 +965,6 @@
         },
         "runtime": {
           "lib/DNXCore50/System.Threading.Tasks.dll": {}
-        }
-      },
-      "System.Threading.ThreadPool/4.0.10-beta-23408": {
-        "type": "package",
-        "dependencies": {
-          "System.Runtime": "4.0.0",
-          "System.Runtime.InteropServices": "4.0.0"
-        },
-        "compile": {
-          "ref/dotnet/System.Threading.ThreadPool.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Threading.ThreadPool.dll": {}
         }
       },
       "System.Threading.Timer/4.0.0": {
@@ -1162,7 +1147,7 @@
           "lib/dotnet/xunit.execution.dotnet.dll": {}
         }
       },
-      "xunit.netcore.extensions/1.0.0-prerelease-00104": {
+      "xunit.netcore.extensions/1.0.0-prerelease-00105": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.10",
@@ -1790,44 +1775,65 @@
         "System.Linq.Queryable.nuspec"
       ]
     },
-    "System.Net.Http/4.0.1-beta-23408": {
+    "System.Net.Http/4.0.1-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "n+tnV1VgCjbDKKnbgrvgUgxkPDwUFvSv9lTgH882rVzjbWyliVgbBflVzoAUjUSlga/Tr1XQIrfTLMRD5HfYGw==",
+      "sha512": "F7Yej+6QdRVzWg+qbkayRMcmf/7k7YfNFoVSA67wIsG9t5u7Wj4Go8FW72HL8qb9d7YjIsVB/5hA7g9MUT31Aw==",
       "files": [
         "lib/net45/_._",
         "lib/win8/_._",
         "lib/wpa81/_._",
+        "ref/dotnet/de/System.Net.Http.xml",
+        "ref/dotnet/es/System.Net.Http.xml",
+        "ref/dotnet/fr/System.Net.Http.xml",
+        "ref/dotnet/it/System.Net.Http.xml",
+        "ref/dotnet/ja/System.Net.Http.xml",
+        "ref/dotnet/ko/System.Net.Http.xml",
+        "ref/dotnet/ru/System.Net.Http.xml",
         "ref/dotnet/System.Net.Http.dll",
+        "ref/dotnet/System.Net.Http.xml",
+        "ref/dotnet/zh-hans/System.Net.Http.xml",
+        "ref/dotnet/zh-hant/System.Net.Http.xml",
         "ref/net45/_._",
         "ref/netcore50/System.Net.Http.dll",
+        "ref/netcore50/System.Net.Http.xml",
         "ref/win8/_._",
         "ref/wpa81/_._",
         "runtime.json",
-        "System.Net.Http.4.0.1-beta-23408.nupkg",
-        "System.Net.Http.4.0.1-beta-23408.nupkg.sha512",
+        "System.Net.Http.4.0.1-beta-23412.nupkg",
+        "System.Net.Http.4.0.1-beta-23412.nupkg.sha512",
         "System.Net.Http.nuspec"
       ]
     },
-    "System.Net.NameResolution/4.0.0-beta-23408": {
+    "System.Net.NameResolution/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "2A562VFL8GUL/jLCJ3mbQHhwwAIXzPyjxMpdtas1LVM8QLuP1OcHwV3z7ajWnYdGcPc7ZxPEGJQWicuaPD+0nA==",
+      "sha512": "HCF1zhFYBT+w/Ik+JuTzFJgj83Jfc+eA8VcgvIzdPiGMXfrZeXOogjgSCkCoJmFtKVz2DSfmISoEmiXB1oaLNQ==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.NameResolution.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Net.NameResolution.xml",
+        "ref/dotnet/es/System.Net.NameResolution.xml",
+        "ref/dotnet/fr/System.Net.NameResolution.xml",
+        "ref/dotnet/it/System.Net.NameResolution.xml",
+        "ref/dotnet/ja/System.Net.NameResolution.xml",
+        "ref/dotnet/ko/System.Net.NameResolution.xml",
+        "ref/dotnet/ru/System.Net.NameResolution.xml",
         "ref/dotnet/System.Net.NameResolution.dll",
+        "ref/dotnet/System.Net.NameResolution.xml",
+        "ref/dotnet/zh-hans/System.Net.NameResolution.xml",
+        "ref/dotnet/zh-hant/System.Net.NameResolution.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Net.NameResolution.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Net.NameResolution.4.0.0-beta-23408.nupkg",
-        "System.Net.NameResolution.4.0.0-beta-23408.nupkg.sha512",
+        "System.Net.NameResolution.4.0.0-beta-23412.nupkg",
+        "System.Net.NameResolution.4.0.0-beta-23412.nupkg.sha512",
         "System.Net.NameResolution.nuspec"
       ]
     },
@@ -1864,24 +1870,34 @@
         "System.Net.Primitives.nuspec"
       ]
     },
-    "System.Net.Security/4.0.0-beta-23408": {
+    "System.Net.Security/4.0.0-beta-23412": {
       "type": "package",
-      "sha512": "kEkunODO2t/VlBIsC80YFDG0KtY/FyIbtBApNyJQv+LYGEs5IFvEhpi9+p0/jHmhyRMKwbjajNedbXo+VMkt1A==",
+      "sha512": "Kcjne7jnvF5aTbRJsAT8kuP+1mxryUF2qYv8f3jnR19wtEjswSIOVU0XzuWc9YObEQcb+kEdzN71HTOm+ssv+w==",
       "files": [
-        "lib/DNXCore50/System.Net.Security.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.Security.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Net.Security.xml",
+        "ref/dotnet/es/System.Net.Security.xml",
+        "ref/dotnet/fr/System.Net.Security.xml",
+        "ref/dotnet/it/System.Net.Security.xml",
+        "ref/dotnet/ja/System.Net.Security.xml",
+        "ref/dotnet/ko/System.Net.Security.xml",
+        "ref/dotnet/ru/System.Net.Security.xml",
         "ref/dotnet/System.Net.Security.dll",
+        "ref/dotnet/System.Net.Security.xml",
+        "ref/dotnet/zh-hans/System.Net.Security.xml",
+        "ref/dotnet/zh-hant/System.Net.Security.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Net.Security.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.Security.4.0.0-beta-23408.nupkg",
-        "System.Net.Security.4.0.0-beta-23408.nupkg.sha512",
+        "runtime.json",
+        "System.Net.Security.4.0.0-beta-23412.nupkg",
+        "System.Net.Security.4.0.0-beta-23412.nupkg.sha512",
         "System.Net.Security.nuspec"
       ]
     },
@@ -1939,78 +1955,68 @@
         "System.Net.WebHeaderCollection.nuspec"
       ]
     },
-    "System.Net.WebSockets/4.0.0-beta-23408": {
+    "System.Net.WebSockets/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "BXy22/bNVtrXXsG76zXyhjcQnCjSYxQIFF37xWifqPRWmvzsCYSLQpNCTPQUCp7rjB7qWc5yLhC9bThaEx7MHQ==",
+      "sha512": "EvXAa0yd1RM8ROyLl1T0xC94F04Su8YMHnd4/w6j0Z/+4lKHZOU7bQPZ3odDN8WdPGKa/ZNJJGwiapydEWKzwQ==",
       "files": [
-        "lib/dotnet/de/System.Net.WebSockets.xml",
-        "lib/dotnet/es/System.Net.WebSockets.xml",
-        "lib/dotnet/fr/System.Net.WebSockets.xml",
-        "lib/dotnet/it/System.Net.WebSockets.xml",
-        "lib/dotnet/ja/System.Net.WebSockets.xml",
-        "lib/dotnet/ko/System.Net.WebSockets.xml",
-        "lib/dotnet/ru/System.Net.WebSockets.xml",
         "lib/dotnet/System.Net.WebSockets.dll",
-        "lib/dotnet/System.Net.WebSockets.xml",
-        "lib/dotnet/zh-hans/System.Net.WebSockets.xml",
-        "lib/dotnet/zh-hant/System.Net.WebSockets.xml",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.WebSockets.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Net.WebSockets.xml",
+        "ref/dotnet/es/System.Net.WebSockets.xml",
+        "ref/dotnet/fr/System.Net.WebSockets.xml",
+        "ref/dotnet/it/System.Net.WebSockets.xml",
+        "ref/dotnet/ja/System.Net.WebSockets.xml",
+        "ref/dotnet/ko/System.Net.WebSockets.xml",
+        "ref/dotnet/ru/System.Net.WebSockets.xml",
         "ref/dotnet/System.Net.WebSockets.dll",
+        "ref/dotnet/System.Net.WebSockets.xml",
+        "ref/dotnet/zh-hans/System.Net.WebSockets.xml",
+        "ref/dotnet/zh-hant/System.Net.WebSockets.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Net.WebSockets.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.WebSockets.4.0.0-beta-23408.nupkg",
-        "System.Net.WebSockets.4.0.0-beta-23408.nupkg.sha512",
+        "System.Net.WebSockets.4.0.0-beta-23412.nupkg",
+        "System.Net.WebSockets.4.0.0-beta-23412.nupkg.sha512",
         "System.Net.WebSockets.nuspec"
       ]
     },
-    "System.Net.WebSockets.Client/4.0.0-beta-23408": {
+    "System.Net.WebSockets.Client/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "smmvhCkcU0c4RNWc6NZwnN5EFktX58jf8+TJ6enfuXxWrpJ/2NRI5/2yT/okjFSngGK1g0MBrljZsfs2EJ7+Yw==",
+      "sha512": "uaO7c/81sK90605UtThSX9KVmzsJDA1vD4GMW7FsKKntymlkolJsprDekWblQ4A5YbhqxHv+ngXX2kIU0B3Fdw==",
       "files": [
-        "lib/DNXCore50/de/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/es/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/fr/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/it/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/ja/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/ko/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/ru/System.Net.WebSockets.Client.xml",
         "lib/DNXCore50/System.Net.WebSockets.Client.dll",
-        "lib/DNXCore50/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/zh-hans/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/zh-hant/System.Net.WebSockets.Client.xml",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.WebSockets.Client.dll",
-        "lib/netcore50/de/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/es/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/fr/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/it/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/ja/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/ko/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/ru/System.Net.WebSockets.Client.xml",
         "lib/netcore50/System.Net.WebSockets.Client.dll",
-        "lib/netcore50/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/zh-hans/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/zh-hant/System.Net.WebSockets.Client.xml",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/es/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/fr/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/it/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/ja/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/ko/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/ru/System.Net.WebSockets.Client.xml",
         "ref/dotnet/System.Net.WebSockets.Client.dll",
+        "ref/dotnet/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/zh-hans/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/zh-hant/System.Net.WebSockets.Client.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Net.WebSockets.Client.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.WebSockets.Client.4.0.0-beta-23408.nupkg",
-        "System.Net.WebSockets.Client.4.0.0-beta-23408.nupkg.sha512",
+        "System.Net.WebSockets.Client.4.0.0-beta-23412.nupkg",
+        "System.Net.WebSockets.Client.4.0.0-beta-23412.nupkg.sha512",
         "System.Net.WebSockets.Client.nuspec"
       ]
     },
@@ -2062,31 +2068,31 @@
         "System.Private.DataContractSerialization.nuspec"
       ]
     },
-    "System.Private.Networking/4.0.1-beta-23408": {
+    "System.Private.Networking/4.0.1-beta-23225": {
       "type": "package",
       "serviceable": true,
-      "sha512": "i2fRDRqM8Px3CP26C//deF/tCNR1AwqlPEr9+MYiXxNZtgGcSPBfqOJJ5CJdfmDb9Ap0hPG2MiPG7CinaSH7+Q==",
+      "sha512": "oVSynIrR3mIU0b/goscsaZDywr3RLxQijQnaFRKfl/VB3F9rKi5mdr0vHcGVWuq5ALSrG0OLwM8PRA4tM5e3rQ==",
       "files": [
         "lib/DNXCore50/System.Private.Networking.dll",
         "lib/netcore50/System.Private.Networking.dll",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "System.Private.Networking.4.0.1-beta-23408.nupkg",
-        "System.Private.Networking.4.0.1-beta-23408.nupkg.sha512",
+        "System.Private.Networking.4.0.1-beta-23225.nupkg",
+        "System.Private.Networking.4.0.1-beta-23225.nupkg.sha512",
         "System.Private.Networking.nuspec"
       ]
     },
-    "System.Private.ServiceModel/4.1.0-beta-23408": {
+    "System.Private.ServiceModel/4.1.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "l/2192yKa6uXhjKOWeukFJy3hoj9Zq1p55pTGe+Y28r8/5jlvgYxfunP9UyXJRo9W1u3UBtGfV/5R71ULzusGQ==",
+      "sha512": "Wm+8LcQ04YeAvYqu9faHsMZ/L8l/WvPPsqziBfifYB4jXIPXk1/kUxuAryjbLChghZDXvkDN0hv/IHSVPZGgBA==",
       "files": [
         "lib/DNXCore50/System.Private.ServiceModel.dll",
         "lib/netcore50/System.Private.ServiceModel.dll",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "System.Private.ServiceModel.4.1.0-beta-23408.nupkg",
-        "System.Private.ServiceModel.4.1.0-beta-23408.nupkg.sha512",
+        "System.Private.ServiceModel.4.1.0-beta-23412.nupkg",
+        "System.Private.ServiceModel.4.1.0-beta-23412.nupkg.sha512",
         "System.Private.ServiceModel.nuspec"
       ]
     },
@@ -2615,10 +2621,10 @@
         "System.Security.Claims.nuspec"
       ]
     },
-    "System.Security.Cryptography.Algorithms/4.0.0-beta-23408": {
+    "System.Security.Cryptography.Algorithms/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "G6eEqi8mZRrWftcwilcnllE4xJ/53JQlk3VVuJ+9qrX+DHvWz8itYJRUZX357JY4DgEEKQNOJzuRGrOBTUeoPg==",
+      "sha512": "nBjoiqJQiMD3cJgOVrqjIVDqEEPZeIqT+mrBIxjLE+YMQcjEyDuSyOG65Ntoopby5LH4onTLMM4zfXh8JRt9NQ==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2632,37 +2638,47 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.Algorithms.4.0.0-beta-23408.nupkg",
-        "System.Security.Cryptography.Algorithms.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Cryptography.Algorithms.4.0.0-beta-23412.nupkg",
+        "System.Security.Cryptography.Algorithms.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Cryptography.Algorithms.nuspec"
       ]
     },
-    "System.Security.Cryptography.Encoding/4.0.0-beta-23408": {
+    "System.Security.Cryptography.Encoding/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "fPsAK3vyMjnJ6nT4YchdS7KzfGca/6uVVAPCBO08ZpTRGhMGx30vq1MiIqAUrfsFMnot3Ub2jimnAFWkqY6g0Q==",
+      "sha512": "SR1zCARNdeyLoUKYH2SNMm1He7Lr3NR/l7yW3K135L44T6PS3YB8SfXpVoZdMpb22X2G07BZAHVz2x7e4AA1Cg==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Security.Cryptography.Encoding.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/es/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/fr/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/it/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/ja/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/ko/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/ru/System.Security.Cryptography.Encoding.xml",
         "ref/dotnet/System.Security.Cryptography.Encoding.dll",
+        "ref/dotnet/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/zh-hans/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/zh-hant/System.Security.Cryptography.Encoding.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Security.Cryptography.Encoding.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.Encoding.4.0.0-beta-23408.nupkg",
-        "System.Security.Cryptography.Encoding.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Cryptography.Encoding.4.0.0-beta-23412.nupkg",
+        "System.Security.Cryptography.Encoding.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Cryptography.Encoding.nuspec"
       ]
     },
-    "System.Security.Cryptography.Primitives/4.0.0-beta-23408": {
+    "System.Security.Cryptography.Primitives/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "A336dWYEIQxm1rEJCaE5ZZrUWHPUkBGTRH8uAj8qrTqg4/qRc2yN2wZxeGXaZauhI35QwDmOutK7oVb2Cd+4TA==",
+      "sha512": "H9EBNe0ahjAYjlVn0TnT18PSgZBrtROSQH1RRIKwAjzxQHt8zwDhO4yN0Q5QaaUIoSXgxVmgtWWk62wDvpy+QA==",
       "files": [
         "lib/dotnet/System.Security.Cryptography.Primitives.dll",
         "lib/MonoAndroid10/_._",
@@ -2676,30 +2692,40 @@
         "ref/net46/System.Security.Cryptography.Primitives.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Security.Cryptography.Primitives.4.0.0-beta-23408.nupkg",
-        "System.Security.Cryptography.Primitives.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Cryptography.Primitives.4.0.0-beta-23412.nupkg",
+        "System.Security.Cryptography.Primitives.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Cryptography.Primitives.nuspec"
       ]
     },
-    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23408": {
+    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "JSNf5d1V5Y47MIdf7QxZCuGnR5heM4UKbrsdXiWD5lfqu0mnNjebPIclMUXlTw/6IykuDsUpompV/DtsaLLHig==",
+      "sha512": "SfpMjvrfRaRjG42uynLugb3YgpXdpnU7X8vNAU7stIR5/4uW9m1SvWHvBjirjHRBtOpbKB86uD5ODQWX+tWDNA==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Security.Cryptography.X509Certificates.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/es/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/fr/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/it/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/ja/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/ko/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/ru/System.Security.Cryptography.X509Certificates.xml",
         "ref/dotnet/System.Security.Cryptography.X509Certificates.dll",
+        "ref/dotnet/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/zh-hans/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/zh-hant/System.Security.Cryptography.X509Certificates.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Security.Cryptography.X509Certificates.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23408.nupkg",
-        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23412.nupkg",
+        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Cryptography.X509Certificates.nuspec"
       ]
     },
@@ -2736,88 +2762,89 @@
         "System.Security.Principal.nuspec"
       ]
     },
-    "System.Security.Principal.Windows/4.0.0-beta-23408": {
+    "System.Security.Principal.Windows/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "xmjpZJvsT1AW23UkjqUkF/VrOh7DA1cagYY272UQmO8ei227TFD4C7j3ofatL/63hR3CXkLkoephuE4f2Z9fGA==",
+      "sha512": "Zvb/LzT+GjGNV1t8i5KVieilL+8P5LcQykIbJHw5aJxLPFEIQ4Y2hTJXdEkeKvZ4TCF5dlwY1jYyUrJkcqpxzw==",
       "files": [
-        "lib/DNXCore50/de/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/es/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/fr/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/it/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/ja/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/ko/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/ru/System.Security.Principal.Windows.xml",
         "lib/DNXCore50/System.Security.Principal.Windows.dll",
-        "lib/DNXCore50/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/zh-hans/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/zh-hant/System.Security.Principal.Windows.xml",
         "lib/net46/System.Security.Principal.Windows.dll",
+        "ref/dotnet/de/System.Security.Principal.Windows.xml",
+        "ref/dotnet/es/System.Security.Principal.Windows.xml",
+        "ref/dotnet/fr/System.Security.Principal.Windows.xml",
+        "ref/dotnet/it/System.Security.Principal.Windows.xml",
+        "ref/dotnet/ja/System.Security.Principal.Windows.xml",
+        "ref/dotnet/ko/System.Security.Principal.Windows.xml",
+        "ref/dotnet/ru/System.Security.Principal.Windows.xml",
         "ref/dotnet/System.Security.Principal.Windows.dll",
+        "ref/dotnet/System.Security.Principal.Windows.xml",
+        "ref/dotnet/zh-hans/System.Security.Principal.Windows.xml",
+        "ref/dotnet/zh-hant/System.Security.Principal.Windows.xml",
         "ref/net46/System.Security.Principal.Windows.dll",
-        "System.Security.Principal.Windows.4.0.0-beta-23408.nupkg",
-        "System.Security.Principal.Windows.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Principal.Windows.4.0.0-beta-23412.nupkg",
+        "System.Security.Principal.Windows.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Principal.Windows.nuspec"
       ]
     },
-    "System.ServiceModel.Http/4.0.11-beta-23408": {
+    "System.ServiceModel.Http/4.0.11-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "RScHZ1A3CfjumaP1Vh/xfOp/ga6T3nA8YLkjFOYcIcZm/LILL+yCh+PhIrJOEfz1Js8bLSQC6xbxwYlW6BNmYg==",
+      "sha512": "hKMGQbu/l2gv/PgPvm2ViLVElnVSwAPiv4cXKjinS+UHBf02uPF2m7lN13SCkJDNTBctwHav1rQnMYb1LUJHvw==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Http.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
-        "lib/netcore50/de/System.ServiceModel.Http.xml",
-        "lib/netcore50/es/System.ServiceModel.Http.xml",
-        "lib/netcore50/fr/System.ServiceModel.Http.xml",
-        "lib/netcore50/it/System.ServiceModel.Http.xml",
-        "lib/netcore50/ja/System.ServiceModel.Http.xml",
-        "lib/netcore50/ko/System.ServiceModel.Http.xml",
-        "lib/netcore50/ru/System.ServiceModel.Http.xml",
         "lib/netcore50/System.ServiceModel.Http.dll",
-        "lib/netcore50/System.ServiceModel.Http.xml",
-        "lib/netcore50/zh-hans/System.ServiceModel.Http.xml",
-        "lib/netcore50/zh-hant/System.ServiceModel.Http.xml",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.ServiceModel.Http.xml",
+        "ref/dotnet/es/System.ServiceModel.Http.xml",
+        "ref/dotnet/fr/System.ServiceModel.Http.xml",
+        "ref/dotnet/it/System.ServiceModel.Http.xml",
+        "ref/dotnet/ja/System.ServiceModel.Http.xml",
+        "ref/dotnet/ko/System.ServiceModel.Http.xml",
+        "ref/dotnet/ru/System.ServiceModel.Http.xml",
         "ref/dotnet/System.ServiceModel.Http.dll",
+        "ref/dotnet/System.ServiceModel.Http.xml",
+        "ref/dotnet/zh-hans/System.ServiceModel.Http.xml",
+        "ref/dotnet/zh-hant/System.ServiceModel.Http.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.ServiceModel.Http.4.0.11-beta-23408.nupkg",
-        "System.ServiceModel.Http.4.0.11-beta-23408.nupkg.sha512",
+        "System.ServiceModel.Http.4.0.11-beta-23412.nupkg",
+        "System.ServiceModel.Http.4.0.11-beta-23412.nupkg.sha512",
         "System.ServiceModel.Http.nuspec"
       ]
     },
-    "System.ServiceModel.Primitives/4.0.1-beta-23408": {
+    "System.ServiceModel.Primitives/4.0.1-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "bjXzg+V3Oq/tBXpMY5FwcERN2CQsFXoL4BMoURlwiBMkgwN2CPvBIaK45Moh7nc21jNTVukNayDtURetGzK6aA==",
+      "sha512": "dkCUkNtXb2m9Wf+DY7dc5B4J8DpaWtX4wpFfT3cYLpChxAnjQR85N+tJfMEHLfZNNerKgDRyGyaKa7uSHfvb5g==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Primitives.dll",
         "lib/net45/_._",
-        "lib/netcore50/de/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/es/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/fr/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/it/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/ja/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/ko/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/ru/System.ServiceModel.Primitives.xml",
         "lib/netcore50/System.ServiceModel.Primitives.dll",
-        "lib/netcore50/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/zh-hans/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/zh-hant/System.ServiceModel.Primitives.xml",
         "lib/win8/_._",
+        "ref/dotnet/de/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/es/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/fr/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/it/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/ja/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/ko/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/ru/System.ServiceModel.Primitives.xml",
         "ref/dotnet/System.ServiceModel.Primitives.dll",
+        "ref/dotnet/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/zh-hans/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/zh-hant/System.ServiceModel.Primitives.xml",
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.Primitives.dll",
+        "ref/netcore50/System.ServiceModel.Primitives.xml",
         "ref/win8/_._",
-        "System.ServiceModel.Primitives.4.0.1-beta-23408.nupkg",
-        "System.ServiceModel.Primitives.4.0.1-beta-23408.nupkg.sha512",
+        "System.ServiceModel.Primitives.4.0.1-beta-23412.nupkg",
+        "System.ServiceModel.Primitives.4.0.1-beta-23412.nupkg.sha512",
         "System.ServiceModel.Primitives.nuspec"
       ]
     },
@@ -3010,28 +3037,6 @@
         "System.Threading.Tasks.4.0.10.nupkg",
         "System.Threading.Tasks.4.0.10.nupkg.sha512",
         "System.Threading.Tasks.nuspec"
-      ]
-    },
-    "System.Threading.ThreadPool/4.0.10-beta-23408": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "ahdsVyj+WFj8/iSDwX/G7hkEU4jZmmvWzPS2ajZKdp0Crb0vZJOlM0LQYVASQgbimrUZHQ50o93JYEi8RFdh/Q==",
-      "files": [
-        "lib/DNXCore50/System.Threading.ThreadPool.dll",
-        "lib/MonoAndroid10/_._",
-        "lib/MonoTouch10/_._",
-        "lib/net46/System.Threading.ThreadPool.dll",
-        "lib/xamarinios10/_._",
-        "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Threading.ThreadPool.dll",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
-        "ref/net46/System.Threading.ThreadPool.dll",
-        "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.Threading.ThreadPool.4.0.10-beta-23408.nupkg",
-        "System.Threading.ThreadPool.4.0.10-beta-23408.nupkg.sha512",
-        "System.Threading.ThreadPool.nuspec"
       ]
     },
     "System.Threading.Timer/4.0.0": {
@@ -3281,14 +3286,14 @@
         "xunit.extensibility.execution.nuspec"
       ]
     },
-    "xunit.netcore.extensions/1.0.0-prerelease-00104": {
+    "xunit.netcore.extensions/1.0.0-prerelease-00105": {
       "type": "package",
       "serviceable": true,
-      "sha512": "ZMXxEBpGP7krXtvqbPMOWavd2u83w77ghtD254wfj5+d+7GmYYqP9pX1iRIxJK9CBa8Zc2cOrcYsmCLQgYriAQ==",
+      "sha512": "EnnGcy9rmSdQ8izHWvYSYVyjQGhbeFH7JeM/L35ZrrPGtYvq5XD3hc1cJPCs+43mXdF9cdqhkt5uTlXYzC+Z8g==",
       "files": [
         "lib/dotnet/Xunit.NetCore.Extensions.dll",
-        "xunit.netcore.extensions.1.0.0-prerelease-00104.nupkg",
-        "xunit.netcore.extensions.1.0.0-prerelease-00104.nupkg.sha512",
+        "xunit.netcore.extensions.1.0.0-prerelease-00105.nupkg",
+        "xunit.netcore.extensions.1.0.0-prerelease-00105.nupkg.sha512",
         "xunit.netcore.extensions.nuspec"
       ]
     }

--- a/src/System.ServiceModel.NetTcp/tests/project.lock.json
+++ b/src/System.ServiceModel.NetTcp/tests/project.lock.json
@@ -292,7 +292,7 @@
           "lib/dotnet/System.Linq.Queryable.dll": {}
         }
       },
-      "System.Net.Http/4.0.1-beta-23408": {
+      "System.Net.Http/4.0.1-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -305,7 +305,7 @@
           "ref/dotnet/System.Net.Http.dll": {}
         }
       },
-      "System.Net.NameResolution/4.0.0-beta-23408": {
+      "System.Net.NameResolution/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Net.Primitives": "4.0.10",
@@ -328,16 +328,17 @@
           "lib/DNXCore50/System.Net.Primitives.dll": {}
         }
       },
-      "System.Net.Security/4.0.0-beta-23408": {
+      "System.Net.Security/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
-          "System.Private.Networking": "4.0.1-beta-23408"
+          "System.IO": "4.0.0",
+          "System.Net.Primitives": "4.0.10",
+          "System.Runtime": "4.0.0",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23412",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Net.Security.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Net.Security.dll": {}
         }
       },
       "System.Net.Sockets/4.1.0-beta-23225": {
@@ -368,7 +369,7 @@
           "lib/dotnet/System.Net.WebHeaderCollection.dll": {}
         }
       },
-      "System.Net.WebSockets/4.0.0-beta-23408": {
+      "System.Net.WebSockets/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -383,7 +384,7 @@
           "lib/dotnet/System.Net.WebSockets.dll": {}
         }
       },
-      "System.Net.WebSockets.Client/4.0.0-beta-23408": {
+      "System.Net.WebSockets.Client/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -393,13 +394,13 @@
           "System.Globalization": "4.0.10",
           "System.Net.Primitives": "4.0.10",
           "System.Net.WebHeaderCollection": "4.0.0",
-          "System.Net.WebSockets": "4.0.0-beta-23408",
+          "System.Net.WebSockets": "4.0.0-beta-23412",
           "System.Resources.ResourceManager": "4.0.0",
           "System.Runtime": "4.0.20",
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23408",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23412",
           "System.Text.Encoding": "4.0.10",
           "System.Threading": "4.0.10",
           "System.Threading.Tasks": "4.0.10"
@@ -456,7 +457,7 @@
           "lib/DNXCore50/System.Private.DataContractSerialization.dll": {}
         }
       },
-      "System.Private.Networking/4.0.1-beta-23408": {
+      "System.Private.Networking/4.0.1-beta-23225": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -475,13 +476,10 @@
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23408",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23408",
-          "System.Security.Principal.Windows": "4.0.0-beta-23408",
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23225",
           "System.Threading": "4.0.10",
           "System.Threading.Overlapped": "4.0.0",
-          "System.Threading.Tasks": "4.0.10",
-          "System.Threading.ThreadPool": "4.0.10-beta-23408"
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dnxcore50/_._": {}
@@ -490,7 +488,7 @@
           "lib/DNXCore50/System.Private.Networking.dll": {}
         }
       },
-      "System.Private.ServiceModel/4.1.0-beta-23408": {
+      "System.Private.ServiceModel/4.1.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -507,14 +505,14 @@
           "System.Linq": "4.0.0",
           "System.Linq.Expressions": "4.0.10",
           "System.Linq.Queryable": "4.0.0",
-          "System.Net.Http": "4.0.1-beta-23408",
-          "System.Net.NameResolution": "4.0.0-beta-23408",
+          "System.Net.Http": "4.0.1-beta-23412",
+          "System.Net.NameResolution": "4.0.0-beta-23412",
           "System.Net.Primitives": "4.0.10",
-          "System.Net.Security": "4.0.0-beta-23408",
-          "System.Net.Sockets": "4.0.10-beta-23408",
+          "System.Net.Security": "4.0.0-beta-23412",
+          "System.Net.Sockets": "4.0.10-beta-23412",
           "System.Net.WebHeaderCollection": "4.0.0",
-          "System.Net.WebSockets": "4.0.0-beta-23408",
-          "System.Net.WebSockets.Client": "4.0.0-beta-23408",
+          "System.Net.WebSockets": "4.0.0-beta-23412",
+          "System.Net.WebSockets.Client": "4.0.0-beta-23412",
           "System.ObjectModel": "4.0.10",
           "System.Reflection": "4.0.10",
           "System.Reflection.DispatchProxy": "4.0.0",
@@ -528,9 +526,9 @@
           "System.Runtime.Serialization.Primitives": "4.0.10",
           "System.Runtime.Serialization.Xml": "4.0.10",
           "System.Security.Claims": "4.0.0",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23408",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23412",
           "System.Security.Principal": "4.0.0",
-          "System.Security.Principal.Windows": "4.0.0-beta-23408",
+          "System.Security.Principal.Windows": "4.0.0-beta-23412",
           "System.Text.Encoding": "4.0.10",
           "System.Threading": "4.0.10",
           "System.Threading.Tasks": "4.0.10",
@@ -779,18 +777,18 @@
           "lib/dotnet/System.Security.Claims.dll": {}
         }
       },
-      "System.Security.Cryptography.Algorithms/4.0.0-beta-23408": {
+      "System.Security.Cryptography.Algorithms/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
           "System.Runtime": "4.0.0",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23408"
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23412"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.Algorithms.dll": {}
         }
       },
-      "System.Security.Cryptography.Encoding/4.0.0-beta-23408": {
+      "System.Security.Cryptography.Encoding/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -799,7 +797,7 @@
           "ref/dotnet/System.Security.Cryptography.Encoding.dll": {}
         }
       },
-      "System.Security.Cryptography.Primitives/4.0.0-beta-23408": {
+      "System.Security.Cryptography.Primitives/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.0",
@@ -817,13 +815,13 @@
           "lib/dotnet/System.Security.Cryptography.Primitives.dll": {}
         }
       },
-      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23408": {
+      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
           "System.Runtime.Handles": "4.0.0",
-          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23408",
-          "System.Security.Cryptography.Encoding": "4.0.0-beta-23408"
+          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23412",
+          "System.Security.Cryptography.Encoding": "4.0.0-beta-23412"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.X509Certificates.dll": {}
@@ -841,7 +839,7 @@
           "lib/dotnet/System.Security.Principal.dll": {}
         }
       },
-      "System.Security.Principal.Windows/4.0.0-beta-23408": {
+      "System.Security.Principal.Windows/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -864,10 +862,10 @@
           "lib/DNXCore50/System.Security.Principal.Windows.dll": {}
         }
       },
-      "System.ServiceModel.NetTcp/4.0.1-beta-23408": {
+      "System.ServiceModel.NetTcp/4.0.1-beta-23412": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-beta-23408"
+          "System.Private.ServiceModel": "4.1.0-beta-23412"
         },
         "compile": {
           "ref/dotnet/System.ServiceModel.NetTcp.dll": {}
@@ -876,10 +874,10 @@
           "lib/DNXCore50/System.ServiceModel.NetTcp.dll": {}
         }
       },
-      "System.ServiceModel.Primitives/4.0.1-beta-23408": {
+      "System.ServiceModel.Primitives/4.0.1-beta-23412": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-beta-23408"
+          "System.Private.ServiceModel": "4.1.0-beta-23412"
         },
         "compile": {
           "ref/dotnet/System.ServiceModel.Primitives.dll": {}
@@ -966,19 +964,6 @@
         },
         "runtime": {
           "lib/DNXCore50/System.Threading.Tasks.dll": {}
-        }
-      },
-      "System.Threading.ThreadPool/4.0.10-beta-23408": {
-        "type": "package",
-        "dependencies": {
-          "System.Runtime": "4.0.0",
-          "System.Runtime.InteropServices": "4.0.0"
-        },
-        "compile": {
-          "ref/dotnet/System.Threading.ThreadPool.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Threading.ThreadPool.dll": {}
         }
       },
       "System.Threading.Timer/4.0.0": {
@@ -1161,7 +1146,7 @@
           "lib/dotnet/xunit.execution.dotnet.dll": {}
         }
       },
-      "xunit.netcore.extensions/1.0.0-prerelease-00104": {
+      "xunit.netcore.extensions/1.0.0-prerelease-00105": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.10",
@@ -1789,44 +1774,65 @@
         "System.Linq.Queryable.nuspec"
       ]
     },
-    "System.Net.Http/4.0.1-beta-23408": {
+    "System.Net.Http/4.0.1-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "n+tnV1VgCjbDKKnbgrvgUgxkPDwUFvSv9lTgH882rVzjbWyliVgbBflVzoAUjUSlga/Tr1XQIrfTLMRD5HfYGw==",
+      "sha512": "F7Yej+6QdRVzWg+qbkayRMcmf/7k7YfNFoVSA67wIsG9t5u7Wj4Go8FW72HL8qb9d7YjIsVB/5hA7g9MUT31Aw==",
       "files": [
         "lib/net45/_._",
         "lib/win8/_._",
         "lib/wpa81/_._",
+        "ref/dotnet/de/System.Net.Http.xml",
+        "ref/dotnet/es/System.Net.Http.xml",
+        "ref/dotnet/fr/System.Net.Http.xml",
+        "ref/dotnet/it/System.Net.Http.xml",
+        "ref/dotnet/ja/System.Net.Http.xml",
+        "ref/dotnet/ko/System.Net.Http.xml",
+        "ref/dotnet/ru/System.Net.Http.xml",
         "ref/dotnet/System.Net.Http.dll",
+        "ref/dotnet/System.Net.Http.xml",
+        "ref/dotnet/zh-hans/System.Net.Http.xml",
+        "ref/dotnet/zh-hant/System.Net.Http.xml",
         "ref/net45/_._",
         "ref/netcore50/System.Net.Http.dll",
+        "ref/netcore50/System.Net.Http.xml",
         "ref/win8/_._",
         "ref/wpa81/_._",
         "runtime.json",
-        "System.Net.Http.4.0.1-beta-23408.nupkg",
-        "System.Net.Http.4.0.1-beta-23408.nupkg.sha512",
+        "System.Net.Http.4.0.1-beta-23412.nupkg",
+        "System.Net.Http.4.0.1-beta-23412.nupkg.sha512",
         "System.Net.Http.nuspec"
       ]
     },
-    "System.Net.NameResolution/4.0.0-beta-23408": {
+    "System.Net.NameResolution/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "2A562VFL8GUL/jLCJ3mbQHhwwAIXzPyjxMpdtas1LVM8QLuP1OcHwV3z7ajWnYdGcPc7ZxPEGJQWicuaPD+0nA==",
+      "sha512": "HCF1zhFYBT+w/Ik+JuTzFJgj83Jfc+eA8VcgvIzdPiGMXfrZeXOogjgSCkCoJmFtKVz2DSfmISoEmiXB1oaLNQ==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.NameResolution.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Net.NameResolution.xml",
+        "ref/dotnet/es/System.Net.NameResolution.xml",
+        "ref/dotnet/fr/System.Net.NameResolution.xml",
+        "ref/dotnet/it/System.Net.NameResolution.xml",
+        "ref/dotnet/ja/System.Net.NameResolution.xml",
+        "ref/dotnet/ko/System.Net.NameResolution.xml",
+        "ref/dotnet/ru/System.Net.NameResolution.xml",
         "ref/dotnet/System.Net.NameResolution.dll",
+        "ref/dotnet/System.Net.NameResolution.xml",
+        "ref/dotnet/zh-hans/System.Net.NameResolution.xml",
+        "ref/dotnet/zh-hant/System.Net.NameResolution.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Net.NameResolution.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Net.NameResolution.4.0.0-beta-23408.nupkg",
-        "System.Net.NameResolution.4.0.0-beta-23408.nupkg.sha512",
+        "System.Net.NameResolution.4.0.0-beta-23412.nupkg",
+        "System.Net.NameResolution.4.0.0-beta-23412.nupkg.sha512",
         "System.Net.NameResolution.nuspec"
       ]
     },
@@ -1863,24 +1869,34 @@
         "System.Net.Primitives.nuspec"
       ]
     },
-    "System.Net.Security/4.0.0-beta-23408": {
+    "System.Net.Security/4.0.0-beta-23412": {
       "type": "package",
-      "sha512": "kEkunODO2t/VlBIsC80YFDG0KtY/FyIbtBApNyJQv+LYGEs5IFvEhpi9+p0/jHmhyRMKwbjajNedbXo+VMkt1A==",
+      "sha512": "Kcjne7jnvF5aTbRJsAT8kuP+1mxryUF2qYv8f3jnR19wtEjswSIOVU0XzuWc9YObEQcb+kEdzN71HTOm+ssv+w==",
       "files": [
-        "lib/DNXCore50/System.Net.Security.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.Security.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Net.Security.xml",
+        "ref/dotnet/es/System.Net.Security.xml",
+        "ref/dotnet/fr/System.Net.Security.xml",
+        "ref/dotnet/it/System.Net.Security.xml",
+        "ref/dotnet/ja/System.Net.Security.xml",
+        "ref/dotnet/ko/System.Net.Security.xml",
+        "ref/dotnet/ru/System.Net.Security.xml",
         "ref/dotnet/System.Net.Security.dll",
+        "ref/dotnet/System.Net.Security.xml",
+        "ref/dotnet/zh-hans/System.Net.Security.xml",
+        "ref/dotnet/zh-hant/System.Net.Security.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Net.Security.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.Security.4.0.0-beta-23408.nupkg",
-        "System.Net.Security.4.0.0-beta-23408.nupkg.sha512",
+        "runtime.json",
+        "System.Net.Security.4.0.0-beta-23412.nupkg",
+        "System.Net.Security.4.0.0-beta-23412.nupkg.sha512",
         "System.Net.Security.nuspec"
       ]
     },
@@ -1938,78 +1954,68 @@
         "System.Net.WebHeaderCollection.nuspec"
       ]
     },
-    "System.Net.WebSockets/4.0.0-beta-23408": {
+    "System.Net.WebSockets/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "BXy22/bNVtrXXsG76zXyhjcQnCjSYxQIFF37xWifqPRWmvzsCYSLQpNCTPQUCp7rjB7qWc5yLhC9bThaEx7MHQ==",
+      "sha512": "EvXAa0yd1RM8ROyLl1T0xC94F04Su8YMHnd4/w6j0Z/+4lKHZOU7bQPZ3odDN8WdPGKa/ZNJJGwiapydEWKzwQ==",
       "files": [
-        "lib/dotnet/de/System.Net.WebSockets.xml",
-        "lib/dotnet/es/System.Net.WebSockets.xml",
-        "lib/dotnet/fr/System.Net.WebSockets.xml",
-        "lib/dotnet/it/System.Net.WebSockets.xml",
-        "lib/dotnet/ja/System.Net.WebSockets.xml",
-        "lib/dotnet/ko/System.Net.WebSockets.xml",
-        "lib/dotnet/ru/System.Net.WebSockets.xml",
         "lib/dotnet/System.Net.WebSockets.dll",
-        "lib/dotnet/System.Net.WebSockets.xml",
-        "lib/dotnet/zh-hans/System.Net.WebSockets.xml",
-        "lib/dotnet/zh-hant/System.Net.WebSockets.xml",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.WebSockets.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Net.WebSockets.xml",
+        "ref/dotnet/es/System.Net.WebSockets.xml",
+        "ref/dotnet/fr/System.Net.WebSockets.xml",
+        "ref/dotnet/it/System.Net.WebSockets.xml",
+        "ref/dotnet/ja/System.Net.WebSockets.xml",
+        "ref/dotnet/ko/System.Net.WebSockets.xml",
+        "ref/dotnet/ru/System.Net.WebSockets.xml",
         "ref/dotnet/System.Net.WebSockets.dll",
+        "ref/dotnet/System.Net.WebSockets.xml",
+        "ref/dotnet/zh-hans/System.Net.WebSockets.xml",
+        "ref/dotnet/zh-hant/System.Net.WebSockets.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Net.WebSockets.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.WebSockets.4.0.0-beta-23408.nupkg",
-        "System.Net.WebSockets.4.0.0-beta-23408.nupkg.sha512",
+        "System.Net.WebSockets.4.0.0-beta-23412.nupkg",
+        "System.Net.WebSockets.4.0.0-beta-23412.nupkg.sha512",
         "System.Net.WebSockets.nuspec"
       ]
     },
-    "System.Net.WebSockets.Client/4.0.0-beta-23408": {
+    "System.Net.WebSockets.Client/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "smmvhCkcU0c4RNWc6NZwnN5EFktX58jf8+TJ6enfuXxWrpJ/2NRI5/2yT/okjFSngGK1g0MBrljZsfs2EJ7+Yw==",
+      "sha512": "uaO7c/81sK90605UtThSX9KVmzsJDA1vD4GMW7FsKKntymlkolJsprDekWblQ4A5YbhqxHv+ngXX2kIU0B3Fdw==",
       "files": [
-        "lib/DNXCore50/de/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/es/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/fr/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/it/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/ja/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/ko/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/ru/System.Net.WebSockets.Client.xml",
         "lib/DNXCore50/System.Net.WebSockets.Client.dll",
-        "lib/DNXCore50/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/zh-hans/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/zh-hant/System.Net.WebSockets.Client.xml",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.WebSockets.Client.dll",
-        "lib/netcore50/de/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/es/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/fr/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/it/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/ja/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/ko/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/ru/System.Net.WebSockets.Client.xml",
         "lib/netcore50/System.Net.WebSockets.Client.dll",
-        "lib/netcore50/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/zh-hans/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/zh-hant/System.Net.WebSockets.Client.xml",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/es/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/fr/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/it/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/ja/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/ko/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/ru/System.Net.WebSockets.Client.xml",
         "ref/dotnet/System.Net.WebSockets.Client.dll",
+        "ref/dotnet/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/zh-hans/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/zh-hant/System.Net.WebSockets.Client.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Net.WebSockets.Client.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.WebSockets.Client.4.0.0-beta-23408.nupkg",
-        "System.Net.WebSockets.Client.4.0.0-beta-23408.nupkg.sha512",
+        "System.Net.WebSockets.Client.4.0.0-beta-23412.nupkg",
+        "System.Net.WebSockets.Client.4.0.0-beta-23412.nupkg.sha512",
         "System.Net.WebSockets.Client.nuspec"
       ]
     },
@@ -2061,31 +2067,31 @@
         "System.Private.DataContractSerialization.nuspec"
       ]
     },
-    "System.Private.Networking/4.0.1-beta-23408": {
+    "System.Private.Networking/4.0.1-beta-23225": {
       "type": "package",
       "serviceable": true,
-      "sha512": "i2fRDRqM8Px3CP26C//deF/tCNR1AwqlPEr9+MYiXxNZtgGcSPBfqOJJ5CJdfmDb9Ap0hPG2MiPG7CinaSH7+Q==",
+      "sha512": "oVSynIrR3mIU0b/goscsaZDywr3RLxQijQnaFRKfl/VB3F9rKi5mdr0vHcGVWuq5ALSrG0OLwM8PRA4tM5e3rQ==",
       "files": [
         "lib/DNXCore50/System.Private.Networking.dll",
         "lib/netcore50/System.Private.Networking.dll",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "System.Private.Networking.4.0.1-beta-23408.nupkg",
-        "System.Private.Networking.4.0.1-beta-23408.nupkg.sha512",
+        "System.Private.Networking.4.0.1-beta-23225.nupkg",
+        "System.Private.Networking.4.0.1-beta-23225.nupkg.sha512",
         "System.Private.Networking.nuspec"
       ]
     },
-    "System.Private.ServiceModel/4.1.0-beta-23408": {
+    "System.Private.ServiceModel/4.1.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "l/2192yKa6uXhjKOWeukFJy3hoj9Zq1p55pTGe+Y28r8/5jlvgYxfunP9UyXJRo9W1u3UBtGfV/5R71ULzusGQ==",
+      "sha512": "Wm+8LcQ04YeAvYqu9faHsMZ/L8l/WvPPsqziBfifYB4jXIPXk1/kUxuAryjbLChghZDXvkDN0hv/IHSVPZGgBA==",
       "files": [
         "lib/DNXCore50/System.Private.ServiceModel.dll",
         "lib/netcore50/System.Private.ServiceModel.dll",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "System.Private.ServiceModel.4.1.0-beta-23408.nupkg",
-        "System.Private.ServiceModel.4.1.0-beta-23408.nupkg.sha512",
+        "System.Private.ServiceModel.4.1.0-beta-23412.nupkg",
+        "System.Private.ServiceModel.4.1.0-beta-23412.nupkg.sha512",
         "System.Private.ServiceModel.nuspec"
       ]
     },
@@ -2614,10 +2620,10 @@
         "System.Security.Claims.nuspec"
       ]
     },
-    "System.Security.Cryptography.Algorithms/4.0.0-beta-23408": {
+    "System.Security.Cryptography.Algorithms/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "G6eEqi8mZRrWftcwilcnllE4xJ/53JQlk3VVuJ+9qrX+DHvWz8itYJRUZX357JY4DgEEKQNOJzuRGrOBTUeoPg==",
+      "sha512": "nBjoiqJQiMD3cJgOVrqjIVDqEEPZeIqT+mrBIxjLE+YMQcjEyDuSyOG65Ntoopby5LH4onTLMM4zfXh8JRt9NQ==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2631,37 +2637,47 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.Algorithms.4.0.0-beta-23408.nupkg",
-        "System.Security.Cryptography.Algorithms.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Cryptography.Algorithms.4.0.0-beta-23412.nupkg",
+        "System.Security.Cryptography.Algorithms.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Cryptography.Algorithms.nuspec"
       ]
     },
-    "System.Security.Cryptography.Encoding/4.0.0-beta-23408": {
+    "System.Security.Cryptography.Encoding/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "fPsAK3vyMjnJ6nT4YchdS7KzfGca/6uVVAPCBO08ZpTRGhMGx30vq1MiIqAUrfsFMnot3Ub2jimnAFWkqY6g0Q==",
+      "sha512": "SR1zCARNdeyLoUKYH2SNMm1He7Lr3NR/l7yW3K135L44T6PS3YB8SfXpVoZdMpb22X2G07BZAHVz2x7e4AA1Cg==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Security.Cryptography.Encoding.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/es/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/fr/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/it/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/ja/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/ko/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/ru/System.Security.Cryptography.Encoding.xml",
         "ref/dotnet/System.Security.Cryptography.Encoding.dll",
+        "ref/dotnet/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/zh-hans/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/zh-hant/System.Security.Cryptography.Encoding.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Security.Cryptography.Encoding.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.Encoding.4.0.0-beta-23408.nupkg",
-        "System.Security.Cryptography.Encoding.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Cryptography.Encoding.4.0.0-beta-23412.nupkg",
+        "System.Security.Cryptography.Encoding.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Cryptography.Encoding.nuspec"
       ]
     },
-    "System.Security.Cryptography.Primitives/4.0.0-beta-23408": {
+    "System.Security.Cryptography.Primitives/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "A336dWYEIQxm1rEJCaE5ZZrUWHPUkBGTRH8uAj8qrTqg4/qRc2yN2wZxeGXaZauhI35QwDmOutK7oVb2Cd+4TA==",
+      "sha512": "H9EBNe0ahjAYjlVn0TnT18PSgZBrtROSQH1RRIKwAjzxQHt8zwDhO4yN0Q5QaaUIoSXgxVmgtWWk62wDvpy+QA==",
       "files": [
         "lib/dotnet/System.Security.Cryptography.Primitives.dll",
         "lib/MonoAndroid10/_._",
@@ -2675,30 +2691,40 @@
         "ref/net46/System.Security.Cryptography.Primitives.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Security.Cryptography.Primitives.4.0.0-beta-23408.nupkg",
-        "System.Security.Cryptography.Primitives.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Cryptography.Primitives.4.0.0-beta-23412.nupkg",
+        "System.Security.Cryptography.Primitives.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Cryptography.Primitives.nuspec"
       ]
     },
-    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23408": {
+    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "JSNf5d1V5Y47MIdf7QxZCuGnR5heM4UKbrsdXiWD5lfqu0mnNjebPIclMUXlTw/6IykuDsUpompV/DtsaLLHig==",
+      "sha512": "SfpMjvrfRaRjG42uynLugb3YgpXdpnU7X8vNAU7stIR5/4uW9m1SvWHvBjirjHRBtOpbKB86uD5ODQWX+tWDNA==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Security.Cryptography.X509Certificates.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/es/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/fr/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/it/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/ja/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/ko/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/ru/System.Security.Cryptography.X509Certificates.xml",
         "ref/dotnet/System.Security.Cryptography.X509Certificates.dll",
+        "ref/dotnet/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/zh-hans/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/zh-hant/System.Security.Cryptography.X509Certificates.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Security.Cryptography.X509Certificates.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23408.nupkg",
-        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23412.nupkg",
+        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Cryptography.X509Certificates.nuspec"
       ]
     },
@@ -2735,83 +2761,85 @@
         "System.Security.Principal.nuspec"
       ]
     },
-    "System.Security.Principal.Windows/4.0.0-beta-23408": {
+    "System.Security.Principal.Windows/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "xmjpZJvsT1AW23UkjqUkF/VrOh7DA1cagYY272UQmO8ei227TFD4C7j3ofatL/63hR3CXkLkoephuE4f2Z9fGA==",
+      "sha512": "Zvb/LzT+GjGNV1t8i5KVieilL+8P5LcQykIbJHw5aJxLPFEIQ4Y2hTJXdEkeKvZ4TCF5dlwY1jYyUrJkcqpxzw==",
       "files": [
-        "lib/DNXCore50/de/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/es/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/fr/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/it/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/ja/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/ko/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/ru/System.Security.Principal.Windows.xml",
         "lib/DNXCore50/System.Security.Principal.Windows.dll",
-        "lib/DNXCore50/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/zh-hans/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/zh-hant/System.Security.Principal.Windows.xml",
         "lib/net46/System.Security.Principal.Windows.dll",
+        "ref/dotnet/de/System.Security.Principal.Windows.xml",
+        "ref/dotnet/es/System.Security.Principal.Windows.xml",
+        "ref/dotnet/fr/System.Security.Principal.Windows.xml",
+        "ref/dotnet/it/System.Security.Principal.Windows.xml",
+        "ref/dotnet/ja/System.Security.Principal.Windows.xml",
+        "ref/dotnet/ko/System.Security.Principal.Windows.xml",
+        "ref/dotnet/ru/System.Security.Principal.Windows.xml",
         "ref/dotnet/System.Security.Principal.Windows.dll",
+        "ref/dotnet/System.Security.Principal.Windows.xml",
+        "ref/dotnet/zh-hans/System.Security.Principal.Windows.xml",
+        "ref/dotnet/zh-hant/System.Security.Principal.Windows.xml",
         "ref/net46/System.Security.Principal.Windows.dll",
-        "System.Security.Principal.Windows.4.0.0-beta-23408.nupkg",
-        "System.Security.Principal.Windows.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Principal.Windows.4.0.0-beta-23412.nupkg",
+        "System.Security.Principal.Windows.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Principal.Windows.nuspec"
       ]
     },
-    "System.ServiceModel.NetTcp/4.0.1-beta-23408": {
+    "System.ServiceModel.NetTcp/4.0.1-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "ppruBpqoE6AngTs6fABV67r1ic6rKCgr6tw+4lMoRucrNWNfKgX5vWlONOqSd8bQXmQLZ/ftEhDGXYY5CLRUTQ==",
+      "sha512": "9I2iOpoYB8DtVy1Sw6BmOj6NGoxt9cKwOOds4q6G1JLzyyWErsv/FMeGAJT07bgLr8vnMx4s8GXxjCfkUwNtTw==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.NetTcp.dll",
         "lib/net45/_._",
-        "lib/netcore50/de/System.ServiceModel.NetTcp.xml",
-        "lib/netcore50/es/System.ServiceModel.NetTcp.xml",
-        "lib/netcore50/fr/System.ServiceModel.NetTcp.xml",
-        "lib/netcore50/it/System.ServiceModel.NetTcp.xml",
-        "lib/netcore50/ja/System.ServiceModel.NetTcp.xml",
-        "lib/netcore50/ko/System.ServiceModel.NetTcp.xml",
-        "lib/netcore50/ru/System.ServiceModel.NetTcp.xml",
         "lib/netcore50/System.ServiceModel.NetTcp.dll",
-        "lib/netcore50/System.ServiceModel.NetTcp.xml",
-        "lib/netcore50/zh-hans/System.ServiceModel.NetTcp.xml",
-        "lib/netcore50/zh-hant/System.ServiceModel.NetTcp.xml",
         "lib/win8/_._",
+        "ref/dotnet/de/System.ServiceModel.NetTcp.xml",
+        "ref/dotnet/es/System.ServiceModel.NetTcp.xml",
+        "ref/dotnet/fr/System.ServiceModel.NetTcp.xml",
+        "ref/dotnet/it/System.ServiceModel.NetTcp.xml",
+        "ref/dotnet/ja/System.ServiceModel.NetTcp.xml",
+        "ref/dotnet/ko/System.ServiceModel.NetTcp.xml",
+        "ref/dotnet/ru/System.ServiceModel.NetTcp.xml",
         "ref/dotnet/System.ServiceModel.NetTcp.dll",
+        "ref/dotnet/System.ServiceModel.NetTcp.xml",
+        "ref/dotnet/zh-hans/System.ServiceModel.NetTcp.xml",
+        "ref/dotnet/zh-hant/System.ServiceModel.NetTcp.xml",
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.NetTcp.dll",
+        "ref/netcore50/System.ServiceModel.NetTcp.xml",
         "ref/win8/_._",
-        "System.ServiceModel.NetTcp.4.0.1-beta-23408.nupkg",
-        "System.ServiceModel.NetTcp.4.0.1-beta-23408.nupkg.sha512",
+        "System.ServiceModel.NetTcp.4.0.1-beta-23412.nupkg",
+        "System.ServiceModel.NetTcp.4.0.1-beta-23412.nupkg.sha512",
         "System.ServiceModel.NetTcp.nuspec"
       ]
     },
-    "System.ServiceModel.Primitives/4.0.1-beta-23408": {
+    "System.ServiceModel.Primitives/4.0.1-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "bjXzg+V3Oq/tBXpMY5FwcERN2CQsFXoL4BMoURlwiBMkgwN2CPvBIaK45Moh7nc21jNTVukNayDtURetGzK6aA==",
+      "sha512": "dkCUkNtXb2m9Wf+DY7dc5B4J8DpaWtX4wpFfT3cYLpChxAnjQR85N+tJfMEHLfZNNerKgDRyGyaKa7uSHfvb5g==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Primitives.dll",
         "lib/net45/_._",
-        "lib/netcore50/de/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/es/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/fr/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/it/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/ja/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/ko/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/ru/System.ServiceModel.Primitives.xml",
         "lib/netcore50/System.ServiceModel.Primitives.dll",
-        "lib/netcore50/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/zh-hans/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/zh-hant/System.ServiceModel.Primitives.xml",
         "lib/win8/_._",
+        "ref/dotnet/de/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/es/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/fr/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/it/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/ja/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/ko/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/ru/System.ServiceModel.Primitives.xml",
         "ref/dotnet/System.ServiceModel.Primitives.dll",
+        "ref/dotnet/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/zh-hans/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/zh-hant/System.ServiceModel.Primitives.xml",
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.Primitives.dll",
+        "ref/netcore50/System.ServiceModel.Primitives.xml",
         "ref/win8/_._",
-        "System.ServiceModel.Primitives.4.0.1-beta-23408.nupkg",
-        "System.ServiceModel.Primitives.4.0.1-beta-23408.nupkg.sha512",
+        "System.ServiceModel.Primitives.4.0.1-beta-23412.nupkg",
+        "System.ServiceModel.Primitives.4.0.1-beta-23412.nupkg.sha512",
         "System.ServiceModel.Primitives.nuspec"
       ]
     },
@@ -3004,28 +3032,6 @@
         "System.Threading.Tasks.4.0.10.nupkg",
         "System.Threading.Tasks.4.0.10.nupkg.sha512",
         "System.Threading.Tasks.nuspec"
-      ]
-    },
-    "System.Threading.ThreadPool/4.0.10-beta-23408": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "ahdsVyj+WFj8/iSDwX/G7hkEU4jZmmvWzPS2ajZKdp0Crb0vZJOlM0LQYVASQgbimrUZHQ50o93JYEi8RFdh/Q==",
-      "files": [
-        "lib/DNXCore50/System.Threading.ThreadPool.dll",
-        "lib/MonoAndroid10/_._",
-        "lib/MonoTouch10/_._",
-        "lib/net46/System.Threading.ThreadPool.dll",
-        "lib/xamarinios10/_._",
-        "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Threading.ThreadPool.dll",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
-        "ref/net46/System.Threading.ThreadPool.dll",
-        "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.Threading.ThreadPool.4.0.10-beta-23408.nupkg",
-        "System.Threading.ThreadPool.4.0.10-beta-23408.nupkg.sha512",
-        "System.Threading.ThreadPool.nuspec"
       ]
     },
     "System.Threading.Timer/4.0.0": {
@@ -3275,14 +3281,14 @@
         "xunit.extensibility.execution.nuspec"
       ]
     },
-    "xunit.netcore.extensions/1.0.0-prerelease-00104": {
+    "xunit.netcore.extensions/1.0.0-prerelease-00105": {
       "type": "package",
       "serviceable": true,
-      "sha512": "ZMXxEBpGP7krXtvqbPMOWavd2u83w77ghtD254wfj5+d+7GmYYqP9pX1iRIxJK9CBa8Zc2cOrcYsmCLQgYriAQ==",
+      "sha512": "EnnGcy9rmSdQ8izHWvYSYVyjQGhbeFH7JeM/L35ZrrPGtYvq5XD3hc1cJPCs+43mXdF9cdqhkt5uTlXYzC+Z8g==",
       "files": [
         "lib/dotnet/Xunit.NetCore.Extensions.dll",
-        "xunit.netcore.extensions.1.0.0-prerelease-00104.nupkg",
-        "xunit.netcore.extensions.1.0.0-prerelease-00104.nupkg.sha512",
+        "xunit.netcore.extensions.1.0.0-prerelease-00105.nupkg",
+        "xunit.netcore.extensions.1.0.0-prerelease-00105.nupkg.sha512",
         "xunit.netcore.extensions.nuspec"
       ]
     }

--- a/src/System.ServiceModel.Primitives/tests/project.lock.json
+++ b/src/System.ServiceModel.Primitives/tests/project.lock.json
@@ -383,7 +383,7 @@
           "lib/dotnet/System.Net.WebHeaderCollection.dll": {}
         }
       },
-      "System.Net.WebSockets/4.0.0-beta-23408": {
+      "System.Net.WebSockets/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -398,7 +398,7 @@
           "lib/dotnet/System.Net.WebSockets.dll": {}
         }
       },
-      "System.Net.WebSockets.Client/4.0.0-beta-23408": {
+      "System.Net.WebSockets.Client/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -408,13 +408,13 @@
           "System.Globalization": "4.0.10",
           "System.Net.Primitives": "4.0.10",
           "System.Net.WebHeaderCollection": "4.0.0",
-          "System.Net.WebSockets": "4.0.0-beta-23408",
+          "System.Net.WebSockets": "4.0.0-beta-23412",
           "System.Resources.ResourceManager": "4.0.0",
           "System.Runtime": "4.0.20",
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23408",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23412",
           "System.Text.Encoding": "4.0.10",
           "System.Threading": "4.0.10",
           "System.Threading.Tasks": "4.0.10"
@@ -786,18 +786,18 @@
           "lib/dotnet/System.Security.Claims.dll": {}
         }
       },
-      "System.Security.Cryptography.Algorithms/4.0.0-beta-23408": {
+      "System.Security.Cryptography.Algorithms/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
           "System.Runtime": "4.0.0",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23408"
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23412"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.Algorithms.dll": {}
         }
       },
-      "System.Security.Cryptography.Encoding/4.0.0-beta-23408": {
+      "System.Security.Cryptography.Encoding/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -806,7 +806,7 @@
           "ref/dotnet/System.Security.Cryptography.Encoding.dll": {}
         }
       },
-      "System.Security.Cryptography.Primitives/4.0.0-beta-23408": {
+      "System.Security.Cryptography.Primitives/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.0",
@@ -824,13 +824,13 @@
           "lib/dotnet/System.Security.Cryptography.Primitives.dll": {}
         }
       },
-      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23408": {
+      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
           "System.Runtime.Handles": "4.0.0",
-          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23408",
-          "System.Security.Cryptography.Encoding": "4.0.0-beta-23408"
+          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23412",
+          "System.Security.Cryptography.Encoding": "4.0.0-beta-23412"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.X509Certificates.dll": {}
@@ -1190,7 +1190,7 @@
           "lib/dotnet/xunit.execution.dotnet.dll": {}
         }
       },
-      "xunit.netcore.extensions/1.0.0-prerelease-00104": {
+      "xunit.netcore.extensions/1.0.0-prerelease-00105": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.10",
@@ -2005,78 +2005,68 @@
         "System.Net.WebHeaderCollection.nuspec"
       ]
     },
-    "System.Net.WebSockets/4.0.0-beta-23408": {
+    "System.Net.WebSockets/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "BXy22/bNVtrXXsG76zXyhjcQnCjSYxQIFF37xWifqPRWmvzsCYSLQpNCTPQUCp7rjB7qWc5yLhC9bThaEx7MHQ==",
+      "sha512": "EvXAa0yd1RM8ROyLl1T0xC94F04Su8YMHnd4/w6j0Z/+4lKHZOU7bQPZ3odDN8WdPGKa/ZNJJGwiapydEWKzwQ==",
       "files": [
-        "lib/dotnet/de/System.Net.WebSockets.xml",
-        "lib/dotnet/es/System.Net.WebSockets.xml",
-        "lib/dotnet/fr/System.Net.WebSockets.xml",
-        "lib/dotnet/it/System.Net.WebSockets.xml",
-        "lib/dotnet/ja/System.Net.WebSockets.xml",
-        "lib/dotnet/ko/System.Net.WebSockets.xml",
-        "lib/dotnet/ru/System.Net.WebSockets.xml",
         "lib/dotnet/System.Net.WebSockets.dll",
-        "lib/dotnet/System.Net.WebSockets.xml",
-        "lib/dotnet/zh-hans/System.Net.WebSockets.xml",
-        "lib/dotnet/zh-hant/System.Net.WebSockets.xml",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.WebSockets.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Net.WebSockets.xml",
+        "ref/dotnet/es/System.Net.WebSockets.xml",
+        "ref/dotnet/fr/System.Net.WebSockets.xml",
+        "ref/dotnet/it/System.Net.WebSockets.xml",
+        "ref/dotnet/ja/System.Net.WebSockets.xml",
+        "ref/dotnet/ko/System.Net.WebSockets.xml",
+        "ref/dotnet/ru/System.Net.WebSockets.xml",
         "ref/dotnet/System.Net.WebSockets.dll",
+        "ref/dotnet/System.Net.WebSockets.xml",
+        "ref/dotnet/zh-hans/System.Net.WebSockets.xml",
+        "ref/dotnet/zh-hant/System.Net.WebSockets.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Net.WebSockets.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.WebSockets.4.0.0-beta-23408.nupkg",
-        "System.Net.WebSockets.4.0.0-beta-23408.nupkg.sha512",
+        "System.Net.WebSockets.4.0.0-beta-23412.nupkg",
+        "System.Net.WebSockets.4.0.0-beta-23412.nupkg.sha512",
         "System.Net.WebSockets.nuspec"
       ]
     },
-    "System.Net.WebSockets.Client/4.0.0-beta-23408": {
+    "System.Net.WebSockets.Client/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "smmvhCkcU0c4RNWc6NZwnN5EFktX58jf8+TJ6enfuXxWrpJ/2NRI5/2yT/okjFSngGK1g0MBrljZsfs2EJ7+Yw==",
+      "sha512": "uaO7c/81sK90605UtThSX9KVmzsJDA1vD4GMW7FsKKntymlkolJsprDekWblQ4A5YbhqxHv+ngXX2kIU0B3Fdw==",
       "files": [
-        "lib/DNXCore50/de/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/es/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/fr/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/it/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/ja/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/ko/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/ru/System.Net.WebSockets.Client.xml",
         "lib/DNXCore50/System.Net.WebSockets.Client.dll",
-        "lib/DNXCore50/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/zh-hans/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/zh-hant/System.Net.WebSockets.Client.xml",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.WebSockets.Client.dll",
-        "lib/netcore50/de/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/es/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/fr/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/it/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/ja/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/ko/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/ru/System.Net.WebSockets.Client.xml",
         "lib/netcore50/System.Net.WebSockets.Client.dll",
-        "lib/netcore50/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/zh-hans/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/zh-hant/System.Net.WebSockets.Client.xml",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/es/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/fr/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/it/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/ja/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/ko/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/ru/System.Net.WebSockets.Client.xml",
         "ref/dotnet/System.Net.WebSockets.Client.dll",
+        "ref/dotnet/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/zh-hans/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/zh-hant/System.Net.WebSockets.Client.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Net.WebSockets.Client.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.WebSockets.Client.4.0.0-beta-23408.nupkg",
-        "System.Net.WebSockets.Client.4.0.0-beta-23408.nupkg.sha512",
+        "System.Net.WebSockets.Client.4.0.0-beta-23412.nupkg",
+        "System.Net.WebSockets.Client.4.0.0-beta-23412.nupkg.sha512",
         "System.Net.WebSockets.Client.nuspec"
       ]
     },
@@ -2681,10 +2671,10 @@
         "System.Security.Claims.nuspec"
       ]
     },
-    "System.Security.Cryptography.Algorithms/4.0.0-beta-23408": {
+    "System.Security.Cryptography.Algorithms/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "G6eEqi8mZRrWftcwilcnllE4xJ/53JQlk3VVuJ+9qrX+DHvWz8itYJRUZX357JY4DgEEKQNOJzuRGrOBTUeoPg==",
+      "sha512": "nBjoiqJQiMD3cJgOVrqjIVDqEEPZeIqT+mrBIxjLE+YMQcjEyDuSyOG65Ntoopby5LH4onTLMM4zfXh8JRt9NQ==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2698,37 +2688,47 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.Algorithms.4.0.0-beta-23408.nupkg",
-        "System.Security.Cryptography.Algorithms.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Cryptography.Algorithms.4.0.0-beta-23412.nupkg",
+        "System.Security.Cryptography.Algorithms.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Cryptography.Algorithms.nuspec"
       ]
     },
-    "System.Security.Cryptography.Encoding/4.0.0-beta-23408": {
+    "System.Security.Cryptography.Encoding/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "fPsAK3vyMjnJ6nT4YchdS7KzfGca/6uVVAPCBO08ZpTRGhMGx30vq1MiIqAUrfsFMnot3Ub2jimnAFWkqY6g0Q==",
+      "sha512": "SR1zCARNdeyLoUKYH2SNMm1He7Lr3NR/l7yW3K135L44T6PS3YB8SfXpVoZdMpb22X2G07BZAHVz2x7e4AA1Cg==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Security.Cryptography.Encoding.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/es/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/fr/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/it/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/ja/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/ko/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/ru/System.Security.Cryptography.Encoding.xml",
         "ref/dotnet/System.Security.Cryptography.Encoding.dll",
+        "ref/dotnet/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/zh-hans/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/zh-hant/System.Security.Cryptography.Encoding.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Security.Cryptography.Encoding.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.Encoding.4.0.0-beta-23408.nupkg",
-        "System.Security.Cryptography.Encoding.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Cryptography.Encoding.4.0.0-beta-23412.nupkg",
+        "System.Security.Cryptography.Encoding.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Cryptography.Encoding.nuspec"
       ]
     },
-    "System.Security.Cryptography.Primitives/4.0.0-beta-23408": {
+    "System.Security.Cryptography.Primitives/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "A336dWYEIQxm1rEJCaE5ZZrUWHPUkBGTRH8uAj8qrTqg4/qRc2yN2wZxeGXaZauhI35QwDmOutK7oVb2Cd+4TA==",
+      "sha512": "H9EBNe0ahjAYjlVn0TnT18PSgZBrtROSQH1RRIKwAjzxQHt8zwDhO4yN0Q5QaaUIoSXgxVmgtWWk62wDvpy+QA==",
       "files": [
         "lib/dotnet/System.Security.Cryptography.Primitives.dll",
         "lib/MonoAndroid10/_._",
@@ -2742,30 +2742,40 @@
         "ref/net46/System.Security.Cryptography.Primitives.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Security.Cryptography.Primitives.4.0.0-beta-23408.nupkg",
-        "System.Security.Cryptography.Primitives.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Cryptography.Primitives.4.0.0-beta-23412.nupkg",
+        "System.Security.Cryptography.Primitives.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Cryptography.Primitives.nuspec"
       ]
     },
-    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23408": {
+    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "JSNf5d1V5Y47MIdf7QxZCuGnR5heM4UKbrsdXiWD5lfqu0mnNjebPIclMUXlTw/6IykuDsUpompV/DtsaLLHig==",
+      "sha512": "SfpMjvrfRaRjG42uynLugb3YgpXdpnU7X8vNAU7stIR5/4uW9m1SvWHvBjirjHRBtOpbKB86uD5ODQWX+tWDNA==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Security.Cryptography.X509Certificates.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/es/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/fr/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/it/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/ja/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/ko/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/ru/System.Security.Cryptography.X509Certificates.xml",
         "ref/dotnet/System.Security.Cryptography.X509Certificates.dll",
+        "ref/dotnet/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/zh-hans/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/zh-hant/System.Security.Cryptography.X509Certificates.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Security.Cryptography.X509Certificates.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23408.nupkg",
-        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23412.nupkg",
+        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Cryptography.X509Certificates.nuspec"
       ]
     },
@@ -3413,14 +3423,14 @@
         "xunit.extensibility.execution.nuspec"
       ]
     },
-    "xunit.netcore.extensions/1.0.0-prerelease-00104": {
+    "xunit.netcore.extensions/1.0.0-prerelease-00105": {
       "type": "package",
       "serviceable": true,
-      "sha512": "ZMXxEBpGP7krXtvqbPMOWavd2u83w77ghtD254wfj5+d+7GmYYqP9pX1iRIxJK9CBa8Zc2cOrcYsmCLQgYriAQ==",
+      "sha512": "EnnGcy9rmSdQ8izHWvYSYVyjQGhbeFH7JeM/L35ZrrPGtYvq5XD3hc1cJPCs+43mXdF9cdqhkt5uTlXYzC+Z8g==",
       "files": [
         "lib/dotnet/Xunit.NetCore.Extensions.dll",
-        "xunit.netcore.extensions.1.0.0-prerelease-00104.nupkg",
-        "xunit.netcore.extensions.1.0.0-prerelease-00104.nupkg.sha512",
+        "xunit.netcore.extensions.1.0.0-prerelease-00105.nupkg",
+        "xunit.netcore.extensions.1.0.0-prerelease-00105.nupkg.sha512",
         "xunit.netcore.extensions.nuspec"
       ]
     }

--- a/src/System.ServiceModel.Security/tests/project.lock.json
+++ b/src/System.ServiceModel.Security/tests/project.lock.json
@@ -292,7 +292,7 @@
           "lib/dotnet/System.Linq.Queryable.dll": {}
         }
       },
-      "System.Net.Http/4.0.1-beta-23408": {
+      "System.Net.Http/4.0.1-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -305,7 +305,7 @@
           "ref/dotnet/System.Net.Http.dll": {}
         }
       },
-      "System.Net.NameResolution/4.0.0-beta-23408": {
+      "System.Net.NameResolution/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Net.Primitives": "4.0.10",
@@ -328,16 +328,17 @@
           "lib/DNXCore50/System.Net.Primitives.dll": {}
         }
       },
-      "System.Net.Security/4.0.0-beta-23408": {
+      "System.Net.Security/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
-          "System.Private.Networking": "4.0.1-beta-23408"
+          "System.IO": "4.0.0",
+          "System.Net.Primitives": "4.0.10",
+          "System.Runtime": "4.0.0",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23412",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Net.Security.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Net.Security.dll": {}
         }
       },
       "System.Net.Sockets/4.1.0-beta-23225": {
@@ -368,7 +369,7 @@
           "lib/dotnet/System.Net.WebHeaderCollection.dll": {}
         }
       },
-      "System.Net.WebSockets/4.0.0-beta-23408": {
+      "System.Net.WebSockets/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -383,7 +384,7 @@
           "lib/dotnet/System.Net.WebSockets.dll": {}
         }
       },
-      "System.Net.WebSockets.Client/4.0.0-beta-23408": {
+      "System.Net.WebSockets.Client/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -393,13 +394,13 @@
           "System.Globalization": "4.0.10",
           "System.Net.Primitives": "4.0.10",
           "System.Net.WebHeaderCollection": "4.0.0",
-          "System.Net.WebSockets": "4.0.0-beta-23408",
+          "System.Net.WebSockets": "4.0.0-beta-23412",
           "System.Resources.ResourceManager": "4.0.0",
           "System.Runtime": "4.0.20",
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23408",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23412",
           "System.Text.Encoding": "4.0.10",
           "System.Threading": "4.0.10",
           "System.Threading.Tasks": "4.0.10"
@@ -456,7 +457,7 @@
           "lib/DNXCore50/System.Private.DataContractSerialization.dll": {}
         }
       },
-      "System.Private.Networking/4.0.1-beta-23408": {
+      "System.Private.Networking/4.0.1-beta-23225": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -475,13 +476,10 @@
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23408",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23408",
-          "System.Security.Principal.Windows": "4.0.0-beta-23408",
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23225",
           "System.Threading": "4.0.10",
           "System.Threading.Overlapped": "4.0.0",
-          "System.Threading.Tasks": "4.0.10",
-          "System.Threading.ThreadPool": "4.0.10-beta-23408"
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dnxcore50/_._": {}
@@ -490,7 +488,7 @@
           "lib/DNXCore50/System.Private.Networking.dll": {}
         }
       },
-      "System.Private.ServiceModel/4.1.0-beta-23408": {
+      "System.Private.ServiceModel/4.1.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -507,14 +505,14 @@
           "System.Linq": "4.0.0",
           "System.Linq.Expressions": "4.0.10",
           "System.Linq.Queryable": "4.0.0",
-          "System.Net.Http": "4.0.1-beta-23408",
-          "System.Net.NameResolution": "4.0.0-beta-23408",
+          "System.Net.Http": "4.0.1-beta-23412",
+          "System.Net.NameResolution": "4.0.0-beta-23412",
           "System.Net.Primitives": "4.0.10",
-          "System.Net.Security": "4.0.0-beta-23408",
-          "System.Net.Sockets": "4.0.10-beta-23408",
+          "System.Net.Security": "4.0.0-beta-23412",
+          "System.Net.Sockets": "4.0.10-beta-23412",
           "System.Net.WebHeaderCollection": "4.0.0",
-          "System.Net.WebSockets": "4.0.0-beta-23408",
-          "System.Net.WebSockets.Client": "4.0.0-beta-23408",
+          "System.Net.WebSockets": "4.0.0-beta-23412",
+          "System.Net.WebSockets.Client": "4.0.0-beta-23412",
           "System.ObjectModel": "4.0.10",
           "System.Reflection": "4.0.10",
           "System.Reflection.DispatchProxy": "4.0.0",
@@ -528,9 +526,9 @@
           "System.Runtime.Serialization.Primitives": "4.0.10",
           "System.Runtime.Serialization.Xml": "4.0.10",
           "System.Security.Claims": "4.0.0",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23408",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23412",
           "System.Security.Principal": "4.0.0",
-          "System.Security.Principal.Windows": "4.0.0-beta-23408",
+          "System.Security.Principal.Windows": "4.0.0-beta-23412",
           "System.Text.Encoding": "4.0.10",
           "System.Threading": "4.0.10",
           "System.Threading.Tasks": "4.0.10",
@@ -779,18 +777,18 @@
           "lib/dotnet/System.Security.Claims.dll": {}
         }
       },
-      "System.Security.Cryptography.Algorithms/4.0.0-beta-23408": {
+      "System.Security.Cryptography.Algorithms/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
           "System.Runtime": "4.0.0",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23408"
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23412"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.Algorithms.dll": {}
         }
       },
-      "System.Security.Cryptography.Encoding/4.0.0-beta-23408": {
+      "System.Security.Cryptography.Encoding/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -799,7 +797,7 @@
           "ref/dotnet/System.Security.Cryptography.Encoding.dll": {}
         }
       },
-      "System.Security.Cryptography.Primitives/4.0.0-beta-23408": {
+      "System.Security.Cryptography.Primitives/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.0",
@@ -817,13 +815,13 @@
           "lib/dotnet/System.Security.Cryptography.Primitives.dll": {}
         }
       },
-      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23408": {
+      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
           "System.Runtime.Handles": "4.0.0",
-          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23408",
-          "System.Security.Cryptography.Encoding": "4.0.0-beta-23408"
+          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23412",
+          "System.Security.Cryptography.Encoding": "4.0.0-beta-23412"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.X509Certificates.dll": {}
@@ -841,7 +839,7 @@
           "lib/dotnet/System.Security.Principal.dll": {}
         }
       },
-      "System.Security.Principal.Windows/4.0.0-beta-23408": {
+      "System.Security.Principal.Windows/4.0.0-beta-23412": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -864,10 +862,10 @@
           "lib/DNXCore50/System.Security.Principal.Windows.dll": {}
         }
       },
-      "System.ServiceModel.Http/4.0.11-beta-23408": {
+      "System.ServiceModel.Http/4.0.11-beta-23412": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-beta-23408",
+          "System.Private.ServiceModel": "4.1.0-beta-23412",
           "System.Runtime": "4.0.20"
         },
         "compile": {
@@ -877,10 +875,10 @@
           "lib/DNXCore50/System.ServiceModel.Http.dll": {}
         }
       },
-      "System.ServiceModel.Primitives/4.0.1-beta-23408": {
+      "System.ServiceModel.Primitives/4.0.1-beta-23412": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-beta-23408"
+          "System.Private.ServiceModel": "4.1.0-beta-23412"
         },
         "compile": {
           "ref/dotnet/System.ServiceModel.Primitives.dll": {}
@@ -889,10 +887,10 @@
           "lib/DNXCore50/System.ServiceModel.Primitives.dll": {}
         }
       },
-      "System.ServiceModel.Security/4.0.1-beta-23408": {
+      "System.ServiceModel.Security/4.0.1-beta-23412": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-beta-23408"
+          "System.Private.ServiceModel": "4.1.0-beta-23412"
         },
         "compile": {
           "ref/dotnet/System.ServiceModel.Security.dll": {}
@@ -979,19 +977,6 @@
         },
         "runtime": {
           "lib/DNXCore50/System.Threading.Tasks.dll": {}
-        }
-      },
-      "System.Threading.ThreadPool/4.0.10-beta-23408": {
-        "type": "package",
-        "dependencies": {
-          "System.Runtime": "4.0.0",
-          "System.Runtime.InteropServices": "4.0.0"
-        },
-        "compile": {
-          "ref/dotnet/System.Threading.ThreadPool.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Threading.ThreadPool.dll": {}
         }
       },
       "System.Threading.Timer/4.0.0": {
@@ -1174,7 +1159,7 @@
           "lib/dotnet/xunit.execution.dotnet.dll": {}
         }
       },
-      "xunit.netcore.extensions/1.0.0-prerelease-00104": {
+      "xunit.netcore.extensions/1.0.0-prerelease-00105": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.10",
@@ -1802,44 +1787,65 @@
         "System.Linq.Queryable.nuspec"
       ]
     },
-    "System.Net.Http/4.0.1-beta-23408": {
+    "System.Net.Http/4.0.1-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "n+tnV1VgCjbDKKnbgrvgUgxkPDwUFvSv9lTgH882rVzjbWyliVgbBflVzoAUjUSlga/Tr1XQIrfTLMRD5HfYGw==",
+      "sha512": "F7Yej+6QdRVzWg+qbkayRMcmf/7k7YfNFoVSA67wIsG9t5u7Wj4Go8FW72HL8qb9d7YjIsVB/5hA7g9MUT31Aw==",
       "files": [
         "lib/net45/_._",
         "lib/win8/_._",
         "lib/wpa81/_._",
+        "ref/dotnet/de/System.Net.Http.xml",
+        "ref/dotnet/es/System.Net.Http.xml",
+        "ref/dotnet/fr/System.Net.Http.xml",
+        "ref/dotnet/it/System.Net.Http.xml",
+        "ref/dotnet/ja/System.Net.Http.xml",
+        "ref/dotnet/ko/System.Net.Http.xml",
+        "ref/dotnet/ru/System.Net.Http.xml",
         "ref/dotnet/System.Net.Http.dll",
+        "ref/dotnet/System.Net.Http.xml",
+        "ref/dotnet/zh-hans/System.Net.Http.xml",
+        "ref/dotnet/zh-hant/System.Net.Http.xml",
         "ref/net45/_._",
         "ref/netcore50/System.Net.Http.dll",
+        "ref/netcore50/System.Net.Http.xml",
         "ref/win8/_._",
         "ref/wpa81/_._",
         "runtime.json",
-        "System.Net.Http.4.0.1-beta-23408.nupkg",
-        "System.Net.Http.4.0.1-beta-23408.nupkg.sha512",
+        "System.Net.Http.4.0.1-beta-23412.nupkg",
+        "System.Net.Http.4.0.1-beta-23412.nupkg.sha512",
         "System.Net.Http.nuspec"
       ]
     },
-    "System.Net.NameResolution/4.0.0-beta-23408": {
+    "System.Net.NameResolution/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "2A562VFL8GUL/jLCJ3mbQHhwwAIXzPyjxMpdtas1LVM8QLuP1OcHwV3z7ajWnYdGcPc7ZxPEGJQWicuaPD+0nA==",
+      "sha512": "HCF1zhFYBT+w/Ik+JuTzFJgj83Jfc+eA8VcgvIzdPiGMXfrZeXOogjgSCkCoJmFtKVz2DSfmISoEmiXB1oaLNQ==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.NameResolution.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Net.NameResolution.xml",
+        "ref/dotnet/es/System.Net.NameResolution.xml",
+        "ref/dotnet/fr/System.Net.NameResolution.xml",
+        "ref/dotnet/it/System.Net.NameResolution.xml",
+        "ref/dotnet/ja/System.Net.NameResolution.xml",
+        "ref/dotnet/ko/System.Net.NameResolution.xml",
+        "ref/dotnet/ru/System.Net.NameResolution.xml",
         "ref/dotnet/System.Net.NameResolution.dll",
+        "ref/dotnet/System.Net.NameResolution.xml",
+        "ref/dotnet/zh-hans/System.Net.NameResolution.xml",
+        "ref/dotnet/zh-hant/System.Net.NameResolution.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Net.NameResolution.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Net.NameResolution.4.0.0-beta-23408.nupkg",
-        "System.Net.NameResolution.4.0.0-beta-23408.nupkg.sha512",
+        "System.Net.NameResolution.4.0.0-beta-23412.nupkg",
+        "System.Net.NameResolution.4.0.0-beta-23412.nupkg.sha512",
         "System.Net.NameResolution.nuspec"
       ]
     },
@@ -1876,24 +1882,34 @@
         "System.Net.Primitives.nuspec"
       ]
     },
-    "System.Net.Security/4.0.0-beta-23408": {
+    "System.Net.Security/4.0.0-beta-23412": {
       "type": "package",
-      "sha512": "kEkunODO2t/VlBIsC80YFDG0KtY/FyIbtBApNyJQv+LYGEs5IFvEhpi9+p0/jHmhyRMKwbjajNedbXo+VMkt1A==",
+      "sha512": "Kcjne7jnvF5aTbRJsAT8kuP+1mxryUF2qYv8f3jnR19wtEjswSIOVU0XzuWc9YObEQcb+kEdzN71HTOm+ssv+w==",
       "files": [
-        "lib/DNXCore50/System.Net.Security.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.Security.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Net.Security.xml",
+        "ref/dotnet/es/System.Net.Security.xml",
+        "ref/dotnet/fr/System.Net.Security.xml",
+        "ref/dotnet/it/System.Net.Security.xml",
+        "ref/dotnet/ja/System.Net.Security.xml",
+        "ref/dotnet/ko/System.Net.Security.xml",
+        "ref/dotnet/ru/System.Net.Security.xml",
         "ref/dotnet/System.Net.Security.dll",
+        "ref/dotnet/System.Net.Security.xml",
+        "ref/dotnet/zh-hans/System.Net.Security.xml",
+        "ref/dotnet/zh-hant/System.Net.Security.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Net.Security.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.Security.4.0.0-beta-23408.nupkg",
-        "System.Net.Security.4.0.0-beta-23408.nupkg.sha512",
+        "runtime.json",
+        "System.Net.Security.4.0.0-beta-23412.nupkg",
+        "System.Net.Security.4.0.0-beta-23412.nupkg.sha512",
         "System.Net.Security.nuspec"
       ]
     },
@@ -1951,78 +1967,68 @@
         "System.Net.WebHeaderCollection.nuspec"
       ]
     },
-    "System.Net.WebSockets/4.0.0-beta-23408": {
+    "System.Net.WebSockets/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "BXy22/bNVtrXXsG76zXyhjcQnCjSYxQIFF37xWifqPRWmvzsCYSLQpNCTPQUCp7rjB7qWc5yLhC9bThaEx7MHQ==",
+      "sha512": "EvXAa0yd1RM8ROyLl1T0xC94F04Su8YMHnd4/w6j0Z/+4lKHZOU7bQPZ3odDN8WdPGKa/ZNJJGwiapydEWKzwQ==",
       "files": [
-        "lib/dotnet/de/System.Net.WebSockets.xml",
-        "lib/dotnet/es/System.Net.WebSockets.xml",
-        "lib/dotnet/fr/System.Net.WebSockets.xml",
-        "lib/dotnet/it/System.Net.WebSockets.xml",
-        "lib/dotnet/ja/System.Net.WebSockets.xml",
-        "lib/dotnet/ko/System.Net.WebSockets.xml",
-        "lib/dotnet/ru/System.Net.WebSockets.xml",
         "lib/dotnet/System.Net.WebSockets.dll",
-        "lib/dotnet/System.Net.WebSockets.xml",
-        "lib/dotnet/zh-hans/System.Net.WebSockets.xml",
-        "lib/dotnet/zh-hant/System.Net.WebSockets.xml",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.WebSockets.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Net.WebSockets.xml",
+        "ref/dotnet/es/System.Net.WebSockets.xml",
+        "ref/dotnet/fr/System.Net.WebSockets.xml",
+        "ref/dotnet/it/System.Net.WebSockets.xml",
+        "ref/dotnet/ja/System.Net.WebSockets.xml",
+        "ref/dotnet/ko/System.Net.WebSockets.xml",
+        "ref/dotnet/ru/System.Net.WebSockets.xml",
         "ref/dotnet/System.Net.WebSockets.dll",
+        "ref/dotnet/System.Net.WebSockets.xml",
+        "ref/dotnet/zh-hans/System.Net.WebSockets.xml",
+        "ref/dotnet/zh-hant/System.Net.WebSockets.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Net.WebSockets.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.WebSockets.4.0.0-beta-23408.nupkg",
-        "System.Net.WebSockets.4.0.0-beta-23408.nupkg.sha512",
+        "System.Net.WebSockets.4.0.0-beta-23412.nupkg",
+        "System.Net.WebSockets.4.0.0-beta-23412.nupkg.sha512",
         "System.Net.WebSockets.nuspec"
       ]
     },
-    "System.Net.WebSockets.Client/4.0.0-beta-23408": {
+    "System.Net.WebSockets.Client/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "smmvhCkcU0c4RNWc6NZwnN5EFktX58jf8+TJ6enfuXxWrpJ/2NRI5/2yT/okjFSngGK1g0MBrljZsfs2EJ7+Yw==",
+      "sha512": "uaO7c/81sK90605UtThSX9KVmzsJDA1vD4GMW7FsKKntymlkolJsprDekWblQ4A5YbhqxHv+ngXX2kIU0B3Fdw==",
       "files": [
-        "lib/DNXCore50/de/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/es/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/fr/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/it/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/ja/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/ko/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/ru/System.Net.WebSockets.Client.xml",
         "lib/DNXCore50/System.Net.WebSockets.Client.dll",
-        "lib/DNXCore50/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/zh-hans/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/zh-hant/System.Net.WebSockets.Client.xml",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.WebSockets.Client.dll",
-        "lib/netcore50/de/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/es/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/fr/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/it/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/ja/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/ko/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/ru/System.Net.WebSockets.Client.xml",
         "lib/netcore50/System.Net.WebSockets.Client.dll",
-        "lib/netcore50/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/zh-hans/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/zh-hant/System.Net.WebSockets.Client.xml",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/es/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/fr/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/it/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/ja/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/ko/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/ru/System.Net.WebSockets.Client.xml",
         "ref/dotnet/System.Net.WebSockets.Client.dll",
+        "ref/dotnet/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/zh-hans/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/zh-hant/System.Net.WebSockets.Client.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Net.WebSockets.Client.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.WebSockets.Client.4.0.0-beta-23408.nupkg",
-        "System.Net.WebSockets.Client.4.0.0-beta-23408.nupkg.sha512",
+        "System.Net.WebSockets.Client.4.0.0-beta-23412.nupkg",
+        "System.Net.WebSockets.Client.4.0.0-beta-23412.nupkg.sha512",
         "System.Net.WebSockets.Client.nuspec"
       ]
     },
@@ -2074,31 +2080,31 @@
         "System.Private.DataContractSerialization.nuspec"
       ]
     },
-    "System.Private.Networking/4.0.1-beta-23408": {
+    "System.Private.Networking/4.0.1-beta-23225": {
       "type": "package",
       "serviceable": true,
-      "sha512": "i2fRDRqM8Px3CP26C//deF/tCNR1AwqlPEr9+MYiXxNZtgGcSPBfqOJJ5CJdfmDb9Ap0hPG2MiPG7CinaSH7+Q==",
+      "sha512": "oVSynIrR3mIU0b/goscsaZDywr3RLxQijQnaFRKfl/VB3F9rKi5mdr0vHcGVWuq5ALSrG0OLwM8PRA4tM5e3rQ==",
       "files": [
         "lib/DNXCore50/System.Private.Networking.dll",
         "lib/netcore50/System.Private.Networking.dll",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "System.Private.Networking.4.0.1-beta-23408.nupkg",
-        "System.Private.Networking.4.0.1-beta-23408.nupkg.sha512",
+        "System.Private.Networking.4.0.1-beta-23225.nupkg",
+        "System.Private.Networking.4.0.1-beta-23225.nupkg.sha512",
         "System.Private.Networking.nuspec"
       ]
     },
-    "System.Private.ServiceModel/4.1.0-beta-23408": {
+    "System.Private.ServiceModel/4.1.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "l/2192yKa6uXhjKOWeukFJy3hoj9Zq1p55pTGe+Y28r8/5jlvgYxfunP9UyXJRo9W1u3UBtGfV/5R71ULzusGQ==",
+      "sha512": "Wm+8LcQ04YeAvYqu9faHsMZ/L8l/WvPPsqziBfifYB4jXIPXk1/kUxuAryjbLChghZDXvkDN0hv/IHSVPZGgBA==",
       "files": [
         "lib/DNXCore50/System.Private.ServiceModel.dll",
         "lib/netcore50/System.Private.ServiceModel.dll",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "System.Private.ServiceModel.4.1.0-beta-23408.nupkg",
-        "System.Private.ServiceModel.4.1.0-beta-23408.nupkg.sha512",
+        "System.Private.ServiceModel.4.1.0-beta-23412.nupkg",
+        "System.Private.ServiceModel.4.1.0-beta-23412.nupkg.sha512",
         "System.Private.ServiceModel.nuspec"
       ]
     },
@@ -2627,10 +2633,10 @@
         "System.Security.Claims.nuspec"
       ]
     },
-    "System.Security.Cryptography.Algorithms/4.0.0-beta-23408": {
+    "System.Security.Cryptography.Algorithms/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "G6eEqi8mZRrWftcwilcnllE4xJ/53JQlk3VVuJ+9qrX+DHvWz8itYJRUZX357JY4DgEEKQNOJzuRGrOBTUeoPg==",
+      "sha512": "nBjoiqJQiMD3cJgOVrqjIVDqEEPZeIqT+mrBIxjLE+YMQcjEyDuSyOG65Ntoopby5LH4onTLMM4zfXh8JRt9NQ==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2644,37 +2650,47 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.Algorithms.4.0.0-beta-23408.nupkg",
-        "System.Security.Cryptography.Algorithms.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Cryptography.Algorithms.4.0.0-beta-23412.nupkg",
+        "System.Security.Cryptography.Algorithms.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Cryptography.Algorithms.nuspec"
       ]
     },
-    "System.Security.Cryptography.Encoding/4.0.0-beta-23408": {
+    "System.Security.Cryptography.Encoding/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "fPsAK3vyMjnJ6nT4YchdS7KzfGca/6uVVAPCBO08ZpTRGhMGx30vq1MiIqAUrfsFMnot3Ub2jimnAFWkqY6g0Q==",
+      "sha512": "SR1zCARNdeyLoUKYH2SNMm1He7Lr3NR/l7yW3K135L44T6PS3YB8SfXpVoZdMpb22X2G07BZAHVz2x7e4AA1Cg==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Security.Cryptography.Encoding.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/es/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/fr/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/it/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/ja/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/ko/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/ru/System.Security.Cryptography.Encoding.xml",
         "ref/dotnet/System.Security.Cryptography.Encoding.dll",
+        "ref/dotnet/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/zh-hans/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/zh-hant/System.Security.Cryptography.Encoding.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Security.Cryptography.Encoding.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.Encoding.4.0.0-beta-23408.nupkg",
-        "System.Security.Cryptography.Encoding.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Cryptography.Encoding.4.0.0-beta-23412.nupkg",
+        "System.Security.Cryptography.Encoding.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Cryptography.Encoding.nuspec"
       ]
     },
-    "System.Security.Cryptography.Primitives/4.0.0-beta-23408": {
+    "System.Security.Cryptography.Primitives/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "A336dWYEIQxm1rEJCaE5ZZrUWHPUkBGTRH8uAj8qrTqg4/qRc2yN2wZxeGXaZauhI35QwDmOutK7oVb2Cd+4TA==",
+      "sha512": "H9EBNe0ahjAYjlVn0TnT18PSgZBrtROSQH1RRIKwAjzxQHt8zwDhO4yN0Q5QaaUIoSXgxVmgtWWk62wDvpy+QA==",
       "files": [
         "lib/dotnet/System.Security.Cryptography.Primitives.dll",
         "lib/MonoAndroid10/_._",
@@ -2688,30 +2704,40 @@
         "ref/net46/System.Security.Cryptography.Primitives.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Security.Cryptography.Primitives.4.0.0-beta-23408.nupkg",
-        "System.Security.Cryptography.Primitives.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Cryptography.Primitives.4.0.0-beta-23412.nupkg",
+        "System.Security.Cryptography.Primitives.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Cryptography.Primitives.nuspec"
       ]
     },
-    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23408": {
+    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "JSNf5d1V5Y47MIdf7QxZCuGnR5heM4UKbrsdXiWD5lfqu0mnNjebPIclMUXlTw/6IykuDsUpompV/DtsaLLHig==",
+      "sha512": "SfpMjvrfRaRjG42uynLugb3YgpXdpnU7X8vNAU7stIR5/4uW9m1SvWHvBjirjHRBtOpbKB86uD5ODQWX+tWDNA==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Security.Cryptography.X509Certificates.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/es/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/fr/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/it/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/ja/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/ko/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/ru/System.Security.Cryptography.X509Certificates.xml",
         "ref/dotnet/System.Security.Cryptography.X509Certificates.dll",
+        "ref/dotnet/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/zh-hans/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/zh-hant/System.Security.Cryptography.X509Certificates.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Security.Cryptography.X509Certificates.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23408.nupkg",
-        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23412.nupkg",
+        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Cryptography.X509Certificates.nuspec"
       ]
     },
@@ -2748,116 +2774,118 @@
         "System.Security.Principal.nuspec"
       ]
     },
-    "System.Security.Principal.Windows/4.0.0-beta-23408": {
+    "System.Security.Principal.Windows/4.0.0-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "xmjpZJvsT1AW23UkjqUkF/VrOh7DA1cagYY272UQmO8ei227TFD4C7j3ofatL/63hR3CXkLkoephuE4f2Z9fGA==",
+      "sha512": "Zvb/LzT+GjGNV1t8i5KVieilL+8P5LcQykIbJHw5aJxLPFEIQ4Y2hTJXdEkeKvZ4TCF5dlwY1jYyUrJkcqpxzw==",
       "files": [
-        "lib/DNXCore50/de/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/es/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/fr/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/it/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/ja/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/ko/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/ru/System.Security.Principal.Windows.xml",
         "lib/DNXCore50/System.Security.Principal.Windows.dll",
-        "lib/DNXCore50/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/zh-hans/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/zh-hant/System.Security.Principal.Windows.xml",
         "lib/net46/System.Security.Principal.Windows.dll",
+        "ref/dotnet/de/System.Security.Principal.Windows.xml",
+        "ref/dotnet/es/System.Security.Principal.Windows.xml",
+        "ref/dotnet/fr/System.Security.Principal.Windows.xml",
+        "ref/dotnet/it/System.Security.Principal.Windows.xml",
+        "ref/dotnet/ja/System.Security.Principal.Windows.xml",
+        "ref/dotnet/ko/System.Security.Principal.Windows.xml",
+        "ref/dotnet/ru/System.Security.Principal.Windows.xml",
         "ref/dotnet/System.Security.Principal.Windows.dll",
+        "ref/dotnet/System.Security.Principal.Windows.xml",
+        "ref/dotnet/zh-hans/System.Security.Principal.Windows.xml",
+        "ref/dotnet/zh-hant/System.Security.Principal.Windows.xml",
         "ref/net46/System.Security.Principal.Windows.dll",
-        "System.Security.Principal.Windows.4.0.0-beta-23408.nupkg",
-        "System.Security.Principal.Windows.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Principal.Windows.4.0.0-beta-23412.nupkg",
+        "System.Security.Principal.Windows.4.0.0-beta-23412.nupkg.sha512",
         "System.Security.Principal.Windows.nuspec"
       ]
     },
-    "System.ServiceModel.Http/4.0.11-beta-23408": {
+    "System.ServiceModel.Http/4.0.11-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "RScHZ1A3CfjumaP1Vh/xfOp/ga6T3nA8YLkjFOYcIcZm/LILL+yCh+PhIrJOEfz1Js8bLSQC6xbxwYlW6BNmYg==",
+      "sha512": "hKMGQbu/l2gv/PgPvm2ViLVElnVSwAPiv4cXKjinS+UHBf02uPF2m7lN13SCkJDNTBctwHav1rQnMYb1LUJHvw==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Http.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
-        "lib/netcore50/de/System.ServiceModel.Http.xml",
-        "lib/netcore50/es/System.ServiceModel.Http.xml",
-        "lib/netcore50/fr/System.ServiceModel.Http.xml",
-        "lib/netcore50/it/System.ServiceModel.Http.xml",
-        "lib/netcore50/ja/System.ServiceModel.Http.xml",
-        "lib/netcore50/ko/System.ServiceModel.Http.xml",
-        "lib/netcore50/ru/System.ServiceModel.Http.xml",
         "lib/netcore50/System.ServiceModel.Http.dll",
-        "lib/netcore50/System.ServiceModel.Http.xml",
-        "lib/netcore50/zh-hans/System.ServiceModel.Http.xml",
-        "lib/netcore50/zh-hant/System.ServiceModel.Http.xml",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.ServiceModel.Http.xml",
+        "ref/dotnet/es/System.ServiceModel.Http.xml",
+        "ref/dotnet/fr/System.ServiceModel.Http.xml",
+        "ref/dotnet/it/System.ServiceModel.Http.xml",
+        "ref/dotnet/ja/System.ServiceModel.Http.xml",
+        "ref/dotnet/ko/System.ServiceModel.Http.xml",
+        "ref/dotnet/ru/System.ServiceModel.Http.xml",
         "ref/dotnet/System.ServiceModel.Http.dll",
+        "ref/dotnet/System.ServiceModel.Http.xml",
+        "ref/dotnet/zh-hans/System.ServiceModel.Http.xml",
+        "ref/dotnet/zh-hant/System.ServiceModel.Http.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.ServiceModel.Http.4.0.11-beta-23408.nupkg",
-        "System.ServiceModel.Http.4.0.11-beta-23408.nupkg.sha512",
+        "System.ServiceModel.Http.4.0.11-beta-23412.nupkg",
+        "System.ServiceModel.Http.4.0.11-beta-23412.nupkg.sha512",
         "System.ServiceModel.Http.nuspec"
       ]
     },
-    "System.ServiceModel.Primitives/4.0.1-beta-23408": {
+    "System.ServiceModel.Primitives/4.0.1-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "bjXzg+V3Oq/tBXpMY5FwcERN2CQsFXoL4BMoURlwiBMkgwN2CPvBIaK45Moh7nc21jNTVukNayDtURetGzK6aA==",
+      "sha512": "dkCUkNtXb2m9Wf+DY7dc5B4J8DpaWtX4wpFfT3cYLpChxAnjQR85N+tJfMEHLfZNNerKgDRyGyaKa7uSHfvb5g==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Primitives.dll",
         "lib/net45/_._",
-        "lib/netcore50/de/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/es/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/fr/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/it/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/ja/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/ko/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/ru/System.ServiceModel.Primitives.xml",
         "lib/netcore50/System.ServiceModel.Primitives.dll",
-        "lib/netcore50/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/zh-hans/System.ServiceModel.Primitives.xml",
-        "lib/netcore50/zh-hant/System.ServiceModel.Primitives.xml",
         "lib/win8/_._",
+        "ref/dotnet/de/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/es/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/fr/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/it/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/ja/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/ko/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/ru/System.ServiceModel.Primitives.xml",
         "ref/dotnet/System.ServiceModel.Primitives.dll",
+        "ref/dotnet/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/zh-hans/System.ServiceModel.Primitives.xml",
+        "ref/dotnet/zh-hant/System.ServiceModel.Primitives.xml",
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.Primitives.dll",
+        "ref/netcore50/System.ServiceModel.Primitives.xml",
         "ref/win8/_._",
-        "System.ServiceModel.Primitives.4.0.1-beta-23408.nupkg",
-        "System.ServiceModel.Primitives.4.0.1-beta-23408.nupkg.sha512",
+        "System.ServiceModel.Primitives.4.0.1-beta-23412.nupkg",
+        "System.ServiceModel.Primitives.4.0.1-beta-23412.nupkg.sha512",
         "System.ServiceModel.Primitives.nuspec"
       ]
     },
-    "System.ServiceModel.Security/4.0.1-beta-23408": {
+    "System.ServiceModel.Security/4.0.1-beta-23412": {
       "type": "package",
       "serviceable": true,
-      "sha512": "rWTUEu+P30ytvkAGX051GEj9Rqj0Zk2ildyC748zdJE5qO89ZXOdC2WnMVrnQJlFcTASFOmT9BFcym4U2EzLGg==",
+      "sha512": "X+TJPs0+TVaHtDcrgw+QYtRUea0OHyy8VRzWKLL0nls52THNfeZZeTecd3eQnb6lQKpDIU42gl6tP0uePUpvMA==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Security.dll",
         "lib/net45/_._",
-        "lib/netcore50/de/System.ServiceModel.Security.xml",
-        "lib/netcore50/es/System.ServiceModel.Security.xml",
-        "lib/netcore50/fr/System.ServiceModel.Security.xml",
-        "lib/netcore50/it/System.ServiceModel.Security.xml",
-        "lib/netcore50/ja/System.ServiceModel.Security.xml",
-        "lib/netcore50/ko/System.ServiceModel.Security.xml",
-        "lib/netcore50/ru/System.ServiceModel.Security.xml",
         "lib/netcore50/System.ServiceModel.Security.dll",
-        "lib/netcore50/System.ServiceModel.Security.xml",
-        "lib/netcore50/zh-hans/System.ServiceModel.Security.xml",
-        "lib/netcore50/zh-hant/System.ServiceModel.Security.xml",
         "lib/win8/_._",
+        "ref/dotnet/de/System.ServiceModel.Security.xml",
+        "ref/dotnet/es/System.ServiceModel.Security.xml",
+        "ref/dotnet/fr/System.ServiceModel.Security.xml",
+        "ref/dotnet/it/System.ServiceModel.Security.xml",
+        "ref/dotnet/ja/System.ServiceModel.Security.xml",
+        "ref/dotnet/ko/System.ServiceModel.Security.xml",
+        "ref/dotnet/ru/System.ServiceModel.Security.xml",
         "ref/dotnet/System.ServiceModel.Security.dll",
+        "ref/dotnet/System.ServiceModel.Security.xml",
+        "ref/dotnet/zh-hans/System.ServiceModel.Security.xml",
+        "ref/dotnet/zh-hant/System.ServiceModel.Security.xml",
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.Security.dll",
+        "ref/netcore50/System.ServiceModel.Security.xml",
         "ref/win8/_._",
-        "System.ServiceModel.Security.4.0.1-beta-23408.nupkg",
-        "System.ServiceModel.Security.4.0.1-beta-23408.nupkg.sha512",
+        "System.ServiceModel.Security.4.0.1-beta-23412.nupkg",
+        "System.ServiceModel.Security.4.0.1-beta-23412.nupkg.sha512",
         "System.ServiceModel.Security.nuspec"
       ]
     },
@@ -3050,28 +3078,6 @@
         "System.Threading.Tasks.4.0.10.nupkg",
         "System.Threading.Tasks.4.0.10.nupkg.sha512",
         "System.Threading.Tasks.nuspec"
-      ]
-    },
-    "System.Threading.ThreadPool/4.0.10-beta-23408": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "ahdsVyj+WFj8/iSDwX/G7hkEU4jZmmvWzPS2ajZKdp0Crb0vZJOlM0LQYVASQgbimrUZHQ50o93JYEi8RFdh/Q==",
-      "files": [
-        "lib/DNXCore50/System.Threading.ThreadPool.dll",
-        "lib/MonoAndroid10/_._",
-        "lib/MonoTouch10/_._",
-        "lib/net46/System.Threading.ThreadPool.dll",
-        "lib/xamarinios10/_._",
-        "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Threading.ThreadPool.dll",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
-        "ref/net46/System.Threading.ThreadPool.dll",
-        "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.Threading.ThreadPool.4.0.10-beta-23408.nupkg",
-        "System.Threading.ThreadPool.4.0.10-beta-23408.nupkg.sha512",
-        "System.Threading.ThreadPool.nuspec"
       ]
     },
     "System.Threading.Timer/4.0.0": {
@@ -3321,14 +3327,14 @@
         "xunit.extensibility.execution.nuspec"
       ]
     },
-    "xunit.netcore.extensions/1.0.0-prerelease-00104": {
+    "xunit.netcore.extensions/1.0.0-prerelease-00105": {
       "type": "package",
       "serviceable": true,
-      "sha512": "ZMXxEBpGP7krXtvqbPMOWavd2u83w77ghtD254wfj5+d+7GmYYqP9pX1iRIxJK9CBa8Zc2cOrcYsmCLQgYriAQ==",
+      "sha512": "EnnGcy9rmSdQ8izHWvYSYVyjQGhbeFH7JeM/L35ZrrPGtYvq5XD3hc1cJPCs+43mXdF9cdqhkt5uTlXYzC+Z8g==",
       "files": [
         "lib/dotnet/Xunit.NetCore.Extensions.dll",
-        "xunit.netcore.extensions.1.0.0-prerelease-00104.nupkg",
-        "xunit.netcore.extensions.1.0.0-prerelease-00104.nupkg.sha512",
+        "xunit.netcore.extensions.1.0.0-prerelease-00105.nupkg",
+        "xunit.netcore.extensions.1.0.0-prerelease-00105.nupkg.sha512",
         "xunit.netcore.extensions.nuspec"
       ]
     }


### PR DESCRIPTION
There was a bug in System.Security.Claims that prevented our Ssl stream scenarios
from working. Moving the dependency for S.Security.Claims to depend on the -beta
versions so we can consume this change

Resolves #387