### PR TITLE
Remove code dependencies on System.Net.Security for NET Native

### DIFF
--- a/src/System.Private.ServiceModel/src/Mockups/ExtendedProtectionPolicy.cs
+++ b/src/System.Private.ServiceModel/src/Mockups/ExtendedProtectionPolicy.cs
@@ -1,0 +1,55 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information
+
+#if FEATURE_NETNATIVE
+using System.Collections;
+using System.ServiceModel;
+using System.Text;
+
+namespace System.Security.Authentication.ExtendedProtection
+{
+    /// <summary>
+    /// This class contains the necessary settings for specifying how Extended Protection 
+    /// should behave. Use one of the Build* methods to create an instance of this type.
+    /// </summary>
+    public class ExtendedProtectionPolicy
+    {
+        public ExtendedProtectionPolicy(PolicyEnforcement policyEnforcement)
+        {
+            PolicyEnforcement = policyEnforcement;
+        }
+
+        public PolicyEnforcement PolicyEnforcement { get; private set; }
+
+        public ProtectionScenario ProtectionScenario
+        {
+            get { return ProtectionScenario.TransportSelected; }
+        }
+
+        public ChannelBinding CustomChannelBinding
+        {
+            get { return null; }
+        }
+        public static bool OSSupportsExtendedProtection
+        {
+            get
+            {
+                return false;
+            }
+        }
+    }
+
+    public enum PolicyEnforcement
+    {
+        Never,
+        WhenSupported,
+        Always
+    }
+
+    public enum ProtectionScenario
+    {
+        TransportSelected,
+        TrustedProxy
+    }
+}
+#endif // FEATURE_NETNATIVE

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/ChannelBindingUtility.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/ChannelBindingUtility.cs
@@ -10,34 +10,12 @@ namespace System.ServiceModel.Channels
 {
     internal static class ChannelBindingUtility
     {
-        private static ExtendedProtectionPolicy s_disabledPolicy = new ExtendedProtectionPolicy(PolicyEnforcement.Never);
-        private static ExtendedProtectionPolicy s_defaultPolicy = s_disabledPolicy;
-
-        public static ExtendedProtectionPolicy DisabledPolicy
-        {
-            get
-            {
-                return s_disabledPolicy;
-            }
-        }
-
-        public static ExtendedProtectionPolicy DefaultPolicy
-        {
-            get
-            {
-                return s_defaultPolicy;
-            }
-        }
-
-        public static bool IsDefaultPolicy(ExtendedProtectionPolicy policy)
-        {
-            return Object.ReferenceEquals(policy, s_defaultPolicy);
-        }
-
+#if !FEATURE_NETNATIVE
         public static ChannelBinding GetToken(SslStream stream)
         {
             return GetToken(stream.TransportContext);
         }
+#endif // !FEATURE_NETNATIVE
 
         public static ChannelBinding GetToken(TransportContext context)
         {
@@ -57,57 +35,6 @@ namespace System.ServiceModel.Channels
                 property.AddTo(message);
                 property.Dispose(); //message.Properties.Add() creates a copy...
             }
-        }
-
-        //does not validate the ExtendedProtectionPolicy.CustomServiceNames collections on the policies
-        public static bool AreEqual(ExtendedProtectionPolicy policy1, ExtendedProtectionPolicy policy2)
-        {
-            Fx.Assert(policy1 != null, "policy1 param cannot be null");
-            Fx.Assert(policy2 != null, "policy2 param cannot be null");
-
-            if (policy1.PolicyEnforcement == PolicyEnforcement.Never && policy2.PolicyEnforcement == PolicyEnforcement.Never)
-            {
-                return true;
-            }
-
-            if (policy1.PolicyEnforcement != policy2.PolicyEnforcement)
-            {
-                return false;
-            }
-
-            if (policy1.ProtectionScenario != policy2.ProtectionScenario)
-            {
-                return false;
-            }
-
-            if (policy1.CustomChannelBinding != policy2.CustomChannelBinding)
-            {
-                return false;
-            }
-
-            return true;
-        }
-
-        public static bool IsSubset(ServiceNameCollection primaryList, ServiceNameCollection subset)
-        {
-            bool result = false;
-            if (subset == null || subset.Count == 0)
-            {
-                result = true;
-            }
-            else if (primaryList == null || primaryList.Count < subset.Count)
-            {
-                result = false;
-            }
-            else
-            {
-                ServiceNameCollection merged = primaryList.Merge(subset);
-
-                //The merge routine only adds an entry if it is unique.
-                result = (merged.Count == primaryList.Count);
-            }
-
-            return result;
         }
 
         public static void Dispose(ref ChannelBinding channelBinding)

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/HttpTransportBindingElement.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/HttpTransportBindingElement.cs
@@ -28,7 +28,9 @@ namespace System.ServiceModel.Channels
         private bool _unsafeConnectionNtlmAuthentication;
         private bool _useDefaultWebProxy;
         private WebSocketTransportSettings _webSocketSettings;
+#if !FEATURE_NETNATIVE
         private ExtendedProtectionPolicy _extendedProtectionPolicy;
+#endif // !FEATURE_NETNATIVE
         private HttpMessageHandlerFactory _httpMessageHandlerFactory;
         private int _maxPendingAccepts;
 
@@ -70,7 +72,9 @@ namespace System.ServiceModel.Channels
             _unsafeConnectionNtlmAuthentication = elementToBeCloned._unsafeConnectionNtlmAuthentication;
             _useDefaultWebProxy = elementToBeCloned._useDefaultWebProxy;
             _webSocketSettings = elementToBeCloned._webSocketSettings.Clone();
+#if !FEATURE_NETNATIVE
             _extendedProtectionPolicy = elementToBeCloned.ExtendedProtectionPolicy;
+#endif // !FEATURE_NETNATIVE
             this.MessageHandlerFactory = elementToBeCloned.MessageHandlerFactory;
         }
 
@@ -140,6 +144,7 @@ namespace System.ServiceModel.Channels
             }
         }
 
+#if !FEATURE_NETNATIVE
         public ExtendedProtectionPolicy ExtendedProtectionPolicy
         {
             get
@@ -162,6 +167,7 @@ namespace System.ServiceModel.Channels
                 _extendedProtectionPolicy = value;
             }
         }
+#endif // !FEATURE_NETNATIVE
 
         // MB#26970: used by MEX to ensure that we don't conflict on base-address scoped settings
         internal bool InheritBaseAddressSettings
@@ -411,10 +417,12 @@ namespace System.ServiceModel.Channels
             {
                 return (T)(object)this.TransferMode;
             }
+#if !FEATURE_NETNATIVE
             else if (typeof(T) == typeof(ExtendedProtectionPolicy))
             {
                 return (T)(object)this.ExtendedProtectionPolicy;
             }
+#endif //!FEATURE_NETNATIVE
             else if (typeof(T) == typeof(ITransportCompressionSupport))
             {
                 return (T)(object)new TransportCompressionSupportHelper();

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/SslStreamSecurityUpgradeProvider.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/SslStreamSecurityUpgradeProvider.cs
@@ -338,6 +338,10 @@ namespace System.ServiceModel.Channels
 
         protected override Stream OnAcceptUpgrade(Stream stream, out SecurityMessageProperty remoteSecurity)
         {
+#if FEATURE_NETNATIVE
+            throw ExceptionHelper.PlatformNotSupported("SslStreamSecurityUpgradeAcceptor.OnAcceptUpgrade");
+#else // !FEATURE_NETNATIVE
+
             if (TD.SslOnAcceptUpgradeIsEnabled())
             {
                 TD.SslOnAcceptUpgrade(this.EventTraceActivity);
@@ -370,6 +374,7 @@ namespace System.ServiceModel.Channels
             }
 
             return sslStream;
+#endif // !FEATURE_NETNATIVE
         }
 
         protected override IAsyncResult OnBeginAcceptUpgrade(Stream stream, AsyncCallback callback, object state)
@@ -390,7 +395,7 @@ namespace System.ServiceModel.Channels
             {
                 if (certificate == null)
                 {
-                    Contract.Assert(certificate != null, "certificate MUST NOT be null"); 
+                    Contract.Assert(certificate != null, "certificate MUST NOT be null");
                     return false;
                 }
                 // Note: add ref to handle since the caller will reset the cert after the callback return.
@@ -439,7 +444,9 @@ namespace System.ServiceModel.Channels
         private X509SecurityToken _clientToken;
         private SecurityTokenAuthenticator _serverCertificateAuthenticator;
         private ChannelBinding _channelBindingToken;
+#if !FEATURE_NETNATIVE
         private static LocalCertificateSelectionCallback s_clientCertificateSelectionCallback;
+#endif // !FEATURE_NETNATIVE
 
         public SslStreamSecurityUpgradeInitiator(SslStreamSecurityUpgradeProvider parent,
             EndpointAddress remoteAddress, Uri via)
@@ -476,6 +483,7 @@ namespace System.ServiceModel.Channels
             }
         }
 
+#if !FEATURE_NETNATIVE
         private static LocalCertificateSelectionCallback ClientCertificateSelectionCallback
         {
             get
@@ -488,6 +496,7 @@ namespace System.ServiceModel.Channels
                 return s_clientCertificateSelectionCallback;
             }
         }
+#endif //!FEATURE_NETNATIVE
 
         internal ChannelBinding ChannelBinding
         {
@@ -583,6 +592,10 @@ namespace System.ServiceModel.Channels
 
         protected override Stream OnInitiateUpgrade(Stream stream, out SecurityMessageProperty remoteSecurity)
         {
+#if FEATURE_NETNATIVE
+            throw ExceptionHelper.PlatformNotSupported("SslStreamSecurityUpgradeInitiator.InInitiateUpgrade");
+#else // !FEATURE_NETNATIVE
+
             if (TD.SslOnInitiateUpgradeIsEnabled())
             {
                 TD.SslOnInitiateUpgrade();
@@ -628,6 +641,7 @@ namespace System.ServiceModel.Channels
             }
 
             return sslStream;
+#endif //!FEATURE_NETNATIVE
         }
 
         private static X509Certificate SelectClientCertificate(object sender, string targetHost,

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SecurityProtocolFactory.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SecurityProtocolFactory.cs
@@ -194,12 +194,6 @@ namespace System.ServiceModel.Security
             }
         }
 
-        public ExtendedProtectionPolicy ExtendedProtectionPolicy
-        {
-            get { return _extendedProtectionPolicy; }
-            set { _extendedProtectionPolicy = value; }
-        }
-
         internal bool IsDuplexReply
         {
             get

--- a/src/System.Private.ServiceModel/src/project.json
+++ b/src/System.Private.ServiceModel/src/project.json
@@ -18,7 +18,6 @@
     "System.Linq.Queryable": "4.0.0",
     "System.Net.Http": "4.0.1-beta-*",
     "System.Net.Primitives": "4.0.10",
-    "System.Net.Security": "4.0.0-beta-*",
     "System.Net.WebHeaderCollection": "4.0.0",
     "System.Net.WebSockets": "4.0.0-beta-*",
     "System.Net.WebSockets.Client": "4.0.0-beta-*",
@@ -51,6 +50,7 @@
     "dnxcore50": {
       "dependencies": {
         "System.Net.NameResolution": "4.0.0-beta-*",
+        "System.Net.Security": "4.0.0-beta-*",
         "System.Net.Sockets": "4.0.10-beta-*"
       }
     },

--- a/src/System.Private.ServiceModel/src/project.lock.json
+++ b/src/System.Private.ServiceModel/src/project.lock.json
@@ -316,7 +316,7 @@
           "lib/dotnet/System.Linq.Queryable.dll": {}
         }
       },
-      "System.Net.Http/4.0.1-beta-23408": {
+      "System.Net.Http/4.0.1-beta-23409": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -329,7 +329,7 @@
           "ref/dotnet/System.Net.Http.dll": {}
         }
       },
-      "System.Net.NameResolution/4.0.0-beta-23408": {
+      "System.Net.NameResolution/4.0.0-beta-23409": {
         "type": "package",
         "dependencies": {
           "System.Net.Primitives": "4.0.10",
@@ -352,16 +352,17 @@
           "lib/DNXCore50/System.Net.Primitives.dll": {}
         }
       },
-      "System.Net.Security/4.0.0-beta-23408": {
+      "System.Net.Security/4.0.0-beta-23409": {
         "type": "package",
         "dependencies": {
-          "System.Private.Networking": "4.0.1-beta-23408"
+          "System.IO": "4.0.0",
+          "System.Net.Primitives": "4.0.10",
+          "System.Runtime": "4.0.0",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23409",
+          "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Net.Security.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Net.Security.dll": {}
         }
       },
       "System.Net.Sockets/4.0.10-beta-23213": {
@@ -391,7 +392,7 @@
           "lib/dotnet/System.Net.WebHeaderCollection.dll": {}
         }
       },
-      "System.Net.WebSockets/4.0.0-beta-23408": {
+      "System.Net.WebSockets/4.0.0-beta-23409": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -406,7 +407,7 @@
           "lib/dotnet/System.Net.WebSockets.dll": {}
         }
       },
-      "System.Net.WebSockets.Client/4.0.0-beta-23408": {
+      "System.Net.WebSockets.Client/4.0.0-beta-23409": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -416,13 +417,13 @@
           "System.Globalization": "4.0.10",
           "System.Net.Primitives": "4.0.10",
           "System.Net.WebHeaderCollection": "4.0.0",
-          "System.Net.WebSockets": "4.0.0-beta-23408",
+          "System.Net.WebSockets": "4.0.0-beta-23409",
           "System.Resources.ResourceManager": "4.0.0",
           "System.Runtime": "4.0.20",
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23408",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23409",
           "System.Text.Encoding": "4.0.10",
           "System.Threading": "4.0.10",
           "System.Threading.Tasks": "4.0.10"
@@ -479,7 +480,7 @@
           "lib/DNXCore50/System.Private.DataContractSerialization.dll": {}
         }
       },
-      "System.Private.Networking/4.0.1-beta-23408": {
+      "System.Private.Networking/4.0.1-beta-23213": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -498,13 +499,14 @@
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23408",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23408",
-          "System.Security.Principal.Windows": "4.0.0-beta-23408",
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23213",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23213",
+          "System.Security.Principal.Windows": "4.0.0-beta-23213",
+          "System.Security.SecureString": "4.0.0-beta-23213",
           "System.Threading": "4.0.10",
           "System.Threading.Overlapped": "4.0.0",
           "System.Threading.Tasks": "4.0.10",
-          "System.Threading.ThreadPool": "4.0.10-beta-23408"
+          "System.Threading.ThreadPool": "4.0.10-beta-23213"
         },
         "compile": {
           "ref/dnxcore50/_._": {}
@@ -733,18 +735,18 @@
           "lib/dotnet/System.Security.Claims.dll": {}
         }
       },
-      "System.Security.Cryptography.Algorithms/4.0.0-beta-23408": {
+      "System.Security.Cryptography.Algorithms/4.0.0-beta-23409": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
           "System.Runtime": "4.0.0",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23408"
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23409"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.Algorithms.dll": {}
         }
       },
-      "System.Security.Cryptography.Encoding/4.0.0-beta-23408": {
+      "System.Security.Cryptography.Encoding/4.0.0-beta-23409": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -753,7 +755,7 @@
           "ref/dotnet/System.Security.Cryptography.Encoding.dll": {}
         }
       },
-      "System.Security.Cryptography.Primitives/4.0.0-beta-23408": {
+      "System.Security.Cryptography.Primitives/4.0.0-beta-23409": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.0",
@@ -771,13 +773,13 @@
           "lib/dotnet/System.Security.Cryptography.Primitives.dll": {}
         }
       },
-      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23408": {
+      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23409": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
           "System.Runtime.Handles": "4.0.0",
-          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23408",
-          "System.Security.Cryptography.Encoding": "4.0.0-beta-23408"
+          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23409",
+          "System.Security.Cryptography.Encoding": "4.0.0-beta-23409"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.X509Certificates.dll": {}
@@ -795,7 +797,7 @@
           "lib/dotnet/System.Security.Principal.dll": {}
         }
       },
-      "System.Security.Principal.Windows/4.0.0-beta-23408": {
+      "System.Security.Principal.Windows/4.0.0-beta-23409": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -816,6 +818,23 @@
         },
         "runtime": {
           "lib/DNXCore50/System.Security.Principal.Windows.dll": {}
+        }
+      },
+      "System.Security.SecureString/4.0.0-beta-23213": {
+        "type": "package",
+        "dependencies": {
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23213",
+          "System.Threading": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Security.SecureString.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Security.SecureString.dll": {}
         }
       },
       "System.Text.Encoding/4.0.10": {
@@ -898,7 +917,7 @@
           "lib/DNXCore50/System.Threading.Tasks.dll": {}
         }
       },
-      "System.Threading.ThreadPool/4.0.10-beta-23408": {
+      "System.Threading.ThreadPool/4.0.10-beta-23213": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
@@ -1349,7 +1368,7 @@
           "lib/netcore50/System.Linq.Queryable.dll": {}
         }
       },
-      "System.Net.Http/4.0.1-beta-23408": {
+      "System.Net.Http/4.0.1-beta-23409": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -1378,19 +1397,6 @@
           "lib/netcore50/System.Net.Primitives.dll": {}
         }
       },
-      "System.Net.Security/4.0.0-beta-23408": {
-        "type": "package",
-        "dependencies": {
-          "System.IO": "4.0.0",
-          "System.Net.Primitives": "4.0.10",
-          "System.Runtime": "4.0.0",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23408",
-          "System.Threading.Tasks": "4.0.0"
-        },
-        "compile": {
-          "ref/dotnet/System.Net.Security.dll": {}
-        }
-      },
       "System.Net.WebHeaderCollection/4.0.0": {
         "type": "package",
         "dependencies": {
@@ -1406,7 +1412,7 @@
           "lib/dotnet/System.Net.WebHeaderCollection.dll": {}
         }
       },
-      "System.Net.WebSockets/4.0.0-beta-23408": {
+      "System.Net.WebSockets/4.0.0-beta-23409": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -1421,7 +1427,7 @@
           "lib/dotnet/System.Net.WebSockets.dll": {}
         }
       },
-      "System.Net.WebSockets.Client/4.0.0-beta-23408": {
+      "System.Net.WebSockets.Client/4.0.0-beta-23409": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -1430,14 +1436,14 @@
           "System.Globalization": "4.0.10",
           "System.Net.Primitives": "4.0.10",
           "System.Net.WebHeaderCollection": "4.0.0",
-          "System.Net.WebSockets": "4.0.0-beta-23408",
+          "System.Net.WebSockets": "4.0.0-beta-23409",
           "System.Resources.ResourceManager": "4.0.0",
           "System.Runtime": "4.0.20",
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.InteropServices": "4.0.20",
           "System.Runtime.InteropServices.WindowsRuntime": "4.0.0",
           "System.Runtime.WindowsRuntime": "4.0.0",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23408",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23409",
           "System.Text.Encoding": "4.0.10",
           "System.Threading": "4.0.10",
           "System.Threading.Tasks": "4.0.10"
@@ -1757,18 +1763,18 @@
           "lib/dotnet/System.Security.Claims.dll": {}
         }
       },
-      "System.Security.Cryptography.Algorithms/4.0.0-beta-23408": {
+      "System.Security.Cryptography.Algorithms/4.0.0-beta-23409": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
           "System.Runtime": "4.0.0",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23408"
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23409"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.Algorithms.dll": {}
         }
       },
-      "System.Security.Cryptography.Encoding/4.0.0-beta-23408": {
+      "System.Security.Cryptography.Encoding/4.0.0-beta-23409": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -1777,7 +1783,7 @@
           "ref/dotnet/System.Security.Cryptography.Encoding.dll": {}
         }
       },
-      "System.Security.Cryptography.Primitives/4.0.0-beta-23408": {
+      "System.Security.Cryptography.Primitives/4.0.0-beta-23409": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.0",
@@ -1795,13 +1801,13 @@
           "lib/dotnet/System.Security.Cryptography.Primitives.dll": {}
         }
       },
-      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23408": {
+      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23409": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
           "System.Runtime.Handles": "4.0.0",
-          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23408",
-          "System.Security.Cryptography.Encoding": "4.0.0-beta-23408"
+          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23409",
+          "System.Security.Cryptography.Encoding": "4.0.0-beta-23409"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.X509Certificates.dll": {}
@@ -1819,7 +1825,7 @@
           "lib/netcore50/System.Security.Principal.dll": {}
         }
       },
-      "System.Security.Principal.Windows/4.0.0-beta-23408": {
+      "System.Security.Principal.Windows/4.0.0-beta-23409": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
@@ -2692,44 +2698,65 @@
         "System.Linq.Queryable.nuspec"
       ]
     },
-    "System.Net.Http/4.0.1-beta-23408": {
+    "System.Net.Http/4.0.1-beta-23409": {
       "type": "package",
       "serviceable": true,
-      "sha512": "n+tnV1VgCjbDKKnbgrvgUgxkPDwUFvSv9lTgH882rVzjbWyliVgbBflVzoAUjUSlga/Tr1XQIrfTLMRD5HfYGw==",
+      "sha512": "O3kwJt8OEdR6c0NLHBemp0OMQFSQLNHtNMC7Hm7daoHp9aju/+SGsj+xQRIErb9be7lWnVjBLKwf71OcAfvsUg==",
       "files": [
         "lib/net45/_._",
         "lib/win8/_._",
         "lib/wpa81/_._",
+        "ref/dotnet/de/System.Net.Http.xml",
+        "ref/dotnet/es/System.Net.Http.xml",
+        "ref/dotnet/fr/System.Net.Http.xml",
+        "ref/dotnet/it/System.Net.Http.xml",
+        "ref/dotnet/ja/System.Net.Http.xml",
+        "ref/dotnet/ko/System.Net.Http.xml",
+        "ref/dotnet/ru/System.Net.Http.xml",
         "ref/dotnet/System.Net.Http.dll",
+        "ref/dotnet/System.Net.Http.xml",
+        "ref/dotnet/zh-hans/System.Net.Http.xml",
+        "ref/dotnet/zh-hant/System.Net.Http.xml",
         "ref/net45/_._",
         "ref/netcore50/System.Net.Http.dll",
+        "ref/netcore50/System.Net.Http.xml",
         "ref/win8/_._",
         "ref/wpa81/_._",
         "runtime.json",
-        "System.Net.Http.4.0.1-beta-23408.nupkg",
-        "System.Net.Http.4.0.1-beta-23408.nupkg.sha512",
+        "System.Net.Http.4.0.1-beta-23409.nupkg",
+        "System.Net.Http.4.0.1-beta-23409.nupkg.sha512",
         "System.Net.Http.nuspec"
       ]
     },
-    "System.Net.NameResolution/4.0.0-beta-23408": {
+    "System.Net.NameResolution/4.0.0-beta-23409": {
       "type": "package",
       "serviceable": true,
-      "sha512": "2A562VFL8GUL/jLCJ3mbQHhwwAIXzPyjxMpdtas1LVM8QLuP1OcHwV3z7ajWnYdGcPc7ZxPEGJQWicuaPD+0nA==",
+      "sha512": "g2ErHzffXH9MefxX2eaG58g6gFCZyXavpAmQiOu5CpDjAmDbBt6ixMgOfHN17Km88EE10iTaFA9B/0gBuFiMng==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.NameResolution.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Net.NameResolution.xml",
+        "ref/dotnet/es/System.Net.NameResolution.xml",
+        "ref/dotnet/fr/System.Net.NameResolution.xml",
+        "ref/dotnet/it/System.Net.NameResolution.xml",
+        "ref/dotnet/ja/System.Net.NameResolution.xml",
+        "ref/dotnet/ko/System.Net.NameResolution.xml",
+        "ref/dotnet/ru/System.Net.NameResolution.xml",
         "ref/dotnet/System.Net.NameResolution.dll",
+        "ref/dotnet/System.Net.NameResolution.xml",
+        "ref/dotnet/zh-hans/System.Net.NameResolution.xml",
+        "ref/dotnet/zh-hant/System.Net.NameResolution.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Net.NameResolution.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Net.NameResolution.4.0.0-beta-23408.nupkg",
-        "System.Net.NameResolution.4.0.0-beta-23408.nupkg.sha512",
+        "System.Net.NameResolution.4.0.0-beta-23409.nupkg",
+        "System.Net.NameResolution.4.0.0-beta-23409.nupkg.sha512",
         "System.Net.NameResolution.nuspec"
       ]
     },
@@ -2766,24 +2793,34 @@
         "System.Net.Primitives.nuspec"
       ]
     },
-    "System.Net.Security/4.0.0-beta-23408": {
+    "System.Net.Security/4.0.0-beta-23409": {
       "type": "package",
-      "sha512": "kEkunODO2t/VlBIsC80YFDG0KtY/FyIbtBApNyJQv+LYGEs5IFvEhpi9+p0/jHmhyRMKwbjajNedbXo+VMkt1A==",
+      "sha512": "cGfAjgloAeG5XSPJFPw3R1VOhwZDmwUGu/evyssEwXiCsf9tfD0uo5EO95nGlTsSThHpfRDpH4qzzBAfSve/Vg==",
       "files": [
-        "lib/DNXCore50/System.Net.Security.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.Security.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Net.Security.xml",
+        "ref/dotnet/es/System.Net.Security.xml",
+        "ref/dotnet/fr/System.Net.Security.xml",
+        "ref/dotnet/it/System.Net.Security.xml",
+        "ref/dotnet/ja/System.Net.Security.xml",
+        "ref/dotnet/ko/System.Net.Security.xml",
+        "ref/dotnet/ru/System.Net.Security.xml",
         "ref/dotnet/System.Net.Security.dll",
+        "ref/dotnet/System.Net.Security.xml",
+        "ref/dotnet/zh-hans/System.Net.Security.xml",
+        "ref/dotnet/zh-hant/System.Net.Security.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Net.Security.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.Security.4.0.0-beta-23408.nupkg",
-        "System.Net.Security.4.0.0-beta-23408.nupkg.sha512",
+        "runtime.json",
+        "System.Net.Security.4.0.0-beta-23409.nupkg",
+        "System.Net.Security.4.0.0-beta-23409.nupkg.sha512",
         "System.Net.Security.nuspec"
       ]
     },
@@ -2848,78 +2885,68 @@
         "System.Net.WebHeaderCollection.nuspec"
       ]
     },
-    "System.Net.WebSockets/4.0.0-beta-23408": {
+    "System.Net.WebSockets/4.0.0-beta-23409": {
       "type": "package",
       "serviceable": true,
-      "sha512": "BXy22/bNVtrXXsG76zXyhjcQnCjSYxQIFF37xWifqPRWmvzsCYSLQpNCTPQUCp7rjB7qWc5yLhC9bThaEx7MHQ==",
+      "sha512": "iVYL/Ok4yVDukkBI+Juk4GIa70G8DKGqm4xGbbSEDm3n7h2cqaLUpGm3Kj+GUEGOX4aXzP1ixyJQ7PCz0lNGeg==",
       "files": [
-        "lib/dotnet/de/System.Net.WebSockets.xml",
-        "lib/dotnet/es/System.Net.WebSockets.xml",
-        "lib/dotnet/fr/System.Net.WebSockets.xml",
-        "lib/dotnet/it/System.Net.WebSockets.xml",
-        "lib/dotnet/ja/System.Net.WebSockets.xml",
-        "lib/dotnet/ko/System.Net.WebSockets.xml",
-        "lib/dotnet/ru/System.Net.WebSockets.xml",
         "lib/dotnet/System.Net.WebSockets.dll",
-        "lib/dotnet/System.Net.WebSockets.xml",
-        "lib/dotnet/zh-hans/System.Net.WebSockets.xml",
-        "lib/dotnet/zh-hant/System.Net.WebSockets.xml",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.WebSockets.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Net.WebSockets.xml",
+        "ref/dotnet/es/System.Net.WebSockets.xml",
+        "ref/dotnet/fr/System.Net.WebSockets.xml",
+        "ref/dotnet/it/System.Net.WebSockets.xml",
+        "ref/dotnet/ja/System.Net.WebSockets.xml",
+        "ref/dotnet/ko/System.Net.WebSockets.xml",
+        "ref/dotnet/ru/System.Net.WebSockets.xml",
         "ref/dotnet/System.Net.WebSockets.dll",
+        "ref/dotnet/System.Net.WebSockets.xml",
+        "ref/dotnet/zh-hans/System.Net.WebSockets.xml",
+        "ref/dotnet/zh-hant/System.Net.WebSockets.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Net.WebSockets.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.WebSockets.4.0.0-beta-23408.nupkg",
-        "System.Net.WebSockets.4.0.0-beta-23408.nupkg.sha512",
+        "System.Net.WebSockets.4.0.0-beta-23409.nupkg",
+        "System.Net.WebSockets.4.0.0-beta-23409.nupkg.sha512",
         "System.Net.WebSockets.nuspec"
       ]
     },
-    "System.Net.WebSockets.Client/4.0.0-beta-23408": {
+    "System.Net.WebSockets.Client/4.0.0-beta-23409": {
       "type": "package",
       "serviceable": true,
-      "sha512": "smmvhCkcU0c4RNWc6NZwnN5EFktX58jf8+TJ6enfuXxWrpJ/2NRI5/2yT/okjFSngGK1g0MBrljZsfs2EJ7+Yw==",
+      "sha512": "h4cDjk/jlU3V+WEP3fABIYQN70iF/UftFMx/2d2hsIsaxt/o9FCUcNenhQiCeNVMC+pAxUkwUxb1742vfXDoXw==",
       "files": [
-        "lib/DNXCore50/de/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/es/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/fr/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/it/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/ja/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/ko/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/ru/System.Net.WebSockets.Client.xml",
         "lib/DNXCore50/System.Net.WebSockets.Client.dll",
-        "lib/DNXCore50/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/zh-hans/System.Net.WebSockets.Client.xml",
-        "lib/DNXCore50/zh-hant/System.Net.WebSockets.Client.xml",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.WebSockets.Client.dll",
-        "lib/netcore50/de/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/es/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/fr/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/it/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/ja/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/ko/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/ru/System.Net.WebSockets.Client.xml",
         "lib/netcore50/System.Net.WebSockets.Client.dll",
-        "lib/netcore50/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/zh-hans/System.Net.WebSockets.Client.xml",
-        "lib/netcore50/zh-hant/System.Net.WebSockets.Client.xml",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/es/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/fr/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/it/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/ja/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/ko/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/ru/System.Net.WebSockets.Client.xml",
         "ref/dotnet/System.Net.WebSockets.Client.dll",
+        "ref/dotnet/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/zh-hans/System.Net.WebSockets.Client.xml",
+        "ref/dotnet/zh-hant/System.Net.WebSockets.Client.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Net.WebSockets.Client.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.WebSockets.Client.4.0.0-beta-23408.nupkg",
-        "System.Net.WebSockets.Client.4.0.0-beta-23408.nupkg.sha512",
+        "System.Net.WebSockets.Client.4.0.0-beta-23409.nupkg",
+        "System.Net.WebSockets.Client.4.0.0-beta-23409.nupkg.sha512",
         "System.Net.WebSockets.Client.nuspec"
       ]
     },
@@ -2985,17 +3012,17 @@
         "System.Private.Networking.nuspec"
       ]
     },
-    "System.Private.Networking/4.0.1-beta-23408": {
+    "System.Private.Networking/4.0.1-beta-23213": {
       "type": "package",
       "serviceable": true,
-      "sha512": "i2fRDRqM8Px3CP26C//deF/tCNR1AwqlPEr9+MYiXxNZtgGcSPBfqOJJ5CJdfmDb9Ap0hPG2MiPG7CinaSH7+Q==",
+      "sha512": "/TG5go+oetTk5uhN0/3qgjmjYQf05YWJnZTHOiMw5VCUGTOUtlwUs8+wpgcpTsKQ82P+Juny9pVq7AxZIYUtVQ==",
       "files": [
         "lib/DNXCore50/System.Private.Networking.dll",
         "lib/netcore50/System.Private.Networking.dll",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "System.Private.Networking.4.0.1-beta-23408.nupkg",
-        "System.Private.Networking.4.0.1-beta-23408.nupkg.sha512",
+        "System.Private.Networking.4.0.1-beta-23213.nupkg",
+        "System.Private.Networking.4.0.1-beta-23213.nupkg.sha512",
         "System.Private.Networking.nuspec"
       ]
     },
@@ -3566,10 +3593,10 @@
         "System.Security.Claims.nuspec"
       ]
     },
-    "System.Security.Cryptography.Algorithms/4.0.0-beta-23408": {
+    "System.Security.Cryptography.Algorithms/4.0.0-beta-23409": {
       "type": "package",
       "serviceable": true,
-      "sha512": "G6eEqi8mZRrWftcwilcnllE4xJ/53JQlk3VVuJ+9qrX+DHvWz8itYJRUZX357JY4DgEEKQNOJzuRGrOBTUeoPg==",
+      "sha512": "+fTP36jzRYPFFG6j3iLDhCp1t7uOg6q7urwe1XAh1JNhqoRPKassTV2FABKzwx1L8LIQXEYIlbK2tb/SOeLcug==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -3583,37 +3610,47 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.Algorithms.4.0.0-beta-23408.nupkg",
-        "System.Security.Cryptography.Algorithms.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Cryptography.Algorithms.4.0.0-beta-23409.nupkg",
+        "System.Security.Cryptography.Algorithms.4.0.0-beta-23409.nupkg.sha512",
         "System.Security.Cryptography.Algorithms.nuspec"
       ]
     },
-    "System.Security.Cryptography.Encoding/4.0.0-beta-23408": {
+    "System.Security.Cryptography.Encoding/4.0.0-beta-23409": {
       "type": "package",
       "serviceable": true,
-      "sha512": "fPsAK3vyMjnJ6nT4YchdS7KzfGca/6uVVAPCBO08ZpTRGhMGx30vq1MiIqAUrfsFMnot3Ub2jimnAFWkqY6g0Q==",
+      "sha512": "Nw4bCWshkW6UTpKag/IJj3/IDkT5x42fRAyGoKjhBXykI6izLz3IocOSHVkBgI8KlMaezhV4+2QCFCD7s+cbGw==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Security.Cryptography.Encoding.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/es/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/fr/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/it/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/ja/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/ko/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/ru/System.Security.Cryptography.Encoding.xml",
         "ref/dotnet/System.Security.Cryptography.Encoding.dll",
+        "ref/dotnet/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/zh-hans/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/zh-hant/System.Security.Cryptography.Encoding.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Security.Cryptography.Encoding.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.Encoding.4.0.0-beta-23408.nupkg",
-        "System.Security.Cryptography.Encoding.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Cryptography.Encoding.4.0.0-beta-23409.nupkg",
+        "System.Security.Cryptography.Encoding.4.0.0-beta-23409.nupkg.sha512",
         "System.Security.Cryptography.Encoding.nuspec"
       ]
     },
-    "System.Security.Cryptography.Primitives/4.0.0-beta-23408": {
+    "System.Security.Cryptography.Primitives/4.0.0-beta-23409": {
       "type": "package",
       "serviceable": true,
-      "sha512": "A336dWYEIQxm1rEJCaE5ZZrUWHPUkBGTRH8uAj8qrTqg4/qRc2yN2wZxeGXaZauhI35QwDmOutK7oVb2Cd+4TA==",
+      "sha512": "A9uRLcec2cnppupdLyiU3AJCCphk2MQe37Kfm3rA6Oi00mFTfy/fD6SsBjKzJsE6rtx1IjpJUqrNe0dp+r32cg==",
       "files": [
         "lib/dotnet/System.Security.Cryptography.Primitives.dll",
         "lib/MonoAndroid10/_._",
@@ -3627,30 +3664,40 @@
         "ref/net46/System.Security.Cryptography.Primitives.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Security.Cryptography.Primitives.4.0.0-beta-23408.nupkg",
-        "System.Security.Cryptography.Primitives.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Cryptography.Primitives.4.0.0-beta-23409.nupkg",
+        "System.Security.Cryptography.Primitives.4.0.0-beta-23409.nupkg.sha512",
         "System.Security.Cryptography.Primitives.nuspec"
       ]
     },
-    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23408": {
+    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23409": {
       "type": "package",
       "serviceable": true,
-      "sha512": "JSNf5d1V5Y47MIdf7QxZCuGnR5heM4UKbrsdXiWD5lfqu0mnNjebPIclMUXlTw/6IykuDsUpompV/DtsaLLHig==",
+      "sha512": "rKzrKqyWNTP8EYgmlkzOb9Qdi8LrBQ6dJ2k4Uka900ax+iSoiQ2b9osfnBgk1XFPnRUUf1Z4PF4txeOndZOpew==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Security.Cryptography.X509Certificates.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/es/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/fr/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/it/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/ja/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/ko/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/ru/System.Security.Cryptography.X509Certificates.xml",
         "ref/dotnet/System.Security.Cryptography.X509Certificates.dll",
+        "ref/dotnet/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/zh-hans/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/zh-hant/System.Security.Cryptography.X509Certificates.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Security.Cryptography.X509Certificates.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23408.nupkg",
-        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23409.nupkg",
+        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23409.nupkg.sha512",
         "System.Security.Cryptography.X509Certificates.nuspec"
       ]
     },
@@ -3687,28 +3734,60 @@
         "System.Security.Principal.nuspec"
       ]
     },
-    "System.Security.Principal.Windows/4.0.0-beta-23408": {
+    "System.Security.Principal.Windows/4.0.0-beta-23409": {
       "type": "package",
       "serviceable": true,
-      "sha512": "xmjpZJvsT1AW23UkjqUkF/VrOh7DA1cagYY272UQmO8ei227TFD4C7j3ofatL/63hR3CXkLkoephuE4f2Z9fGA==",
+      "sha512": "l24CzvkR0FUSmojdk/cXkvPKRqZ2jIJ8h2d440kFwG6yyyJwvOcZkzYDR/XV2npEmls13HcA+KvMsXxmprLn6A==",
       "files": [
-        "lib/DNXCore50/de/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/es/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/fr/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/it/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/ja/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/ko/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/ru/System.Security.Principal.Windows.xml",
         "lib/DNXCore50/System.Security.Principal.Windows.dll",
-        "lib/DNXCore50/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/zh-hans/System.Security.Principal.Windows.xml",
-        "lib/DNXCore50/zh-hant/System.Security.Principal.Windows.xml",
         "lib/net46/System.Security.Principal.Windows.dll",
+        "ref/dotnet/de/System.Security.Principal.Windows.xml",
+        "ref/dotnet/es/System.Security.Principal.Windows.xml",
+        "ref/dotnet/fr/System.Security.Principal.Windows.xml",
+        "ref/dotnet/it/System.Security.Principal.Windows.xml",
+        "ref/dotnet/ja/System.Security.Principal.Windows.xml",
+        "ref/dotnet/ko/System.Security.Principal.Windows.xml",
+        "ref/dotnet/ru/System.Security.Principal.Windows.xml",
         "ref/dotnet/System.Security.Principal.Windows.dll",
+        "ref/dotnet/System.Security.Principal.Windows.xml",
+        "ref/dotnet/zh-hans/System.Security.Principal.Windows.xml",
+        "ref/dotnet/zh-hant/System.Security.Principal.Windows.xml",
         "ref/net46/System.Security.Principal.Windows.dll",
-        "System.Security.Principal.Windows.4.0.0-beta-23408.nupkg",
-        "System.Security.Principal.Windows.4.0.0-beta-23408.nupkg.sha512",
+        "System.Security.Principal.Windows.4.0.0-beta-23409.nupkg",
+        "System.Security.Principal.Windows.4.0.0-beta-23409.nupkg.sha512",
         "System.Security.Principal.Windows.nuspec"
+      ]
+    },
+    "System.Security.SecureString/4.0.0-beta-23213": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "CFqRzPegvjf6SLmU+/7iay8+NZ0PrKuuHiZNCTDKW2z7UIFVG8PnU6mks8+GyQoEuK4ANZg9efboMKwTDM93sw==",
+      "files": [
+        "lib/DNXCore50/System.Security.SecureString.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Security.SecureString.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Security.SecureString.xml",
+        "ref/dotnet/es/System.Security.SecureString.xml",
+        "ref/dotnet/fr/System.Security.SecureString.xml",
+        "ref/dotnet/it/System.Security.SecureString.xml",
+        "ref/dotnet/ja/System.Security.SecureString.xml",
+        "ref/dotnet/ko/System.Security.SecureString.xml",
+        "ref/dotnet/ru/System.Security.SecureString.xml",
+        "ref/dotnet/System.Security.SecureString.dll",
+        "ref/dotnet/System.Security.SecureString.xml",
+        "ref/dotnet/zh-hans/System.Security.SecureString.xml",
+        "ref/dotnet/zh-hant/System.Security.SecureString.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Security.SecureString.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Security.SecureString.4.0.0-beta-23213.nupkg",
+        "System.Security.SecureString.4.0.0-beta-23213.nupkg.sha512",
+        "System.Security.SecureString.nuspec"
       ]
     },
     "System.Text.Encoding/4.0.10": {
@@ -3902,10 +3981,9 @@
         "System.Threading.Tasks.nuspec"
       ]
     },
-    "System.Threading.ThreadPool/4.0.10-beta-23408": {
+    "System.Threading.ThreadPool/4.0.10-beta-23213": {
       "type": "package",
-      "serviceable": true,
-      "sha512": "ahdsVyj+WFj8/iSDwX/G7hkEU4jZmmvWzPS2ajZKdp0Crb0vZJOlM0LQYVASQgbimrUZHQ50o93JYEi8RFdh/Q==",
+      "sha512": "N3LOO3EFTwqchQsmZiKc/PdIvH47ByA7KbhhJK/OM3CnPfogsCKkBBgO3T4KNSw1zT1GTg43p047L2jv/hguLQ==",
       "files": [
         "lib/DNXCore50/System.Threading.ThreadPool.dll",
         "lib/MonoAndroid10/_._",
@@ -3913,14 +3991,24 @@
         "lib/net46/System.Threading.ThreadPool.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Threading.ThreadPool.xml",
+        "ref/dotnet/es/System.Threading.ThreadPool.xml",
+        "ref/dotnet/fr/System.Threading.ThreadPool.xml",
+        "ref/dotnet/it/System.Threading.ThreadPool.xml",
+        "ref/dotnet/ja/System.Threading.ThreadPool.xml",
+        "ref/dotnet/ko/System.Threading.ThreadPool.xml",
+        "ref/dotnet/ru/System.Threading.ThreadPool.xml",
         "ref/dotnet/System.Threading.ThreadPool.dll",
+        "ref/dotnet/System.Threading.ThreadPool.xml",
+        "ref/dotnet/zh-hans/System.Threading.ThreadPool.xml",
+        "ref/dotnet/zh-hant/System.Threading.ThreadPool.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Threading.ThreadPool.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Threading.ThreadPool.4.0.10-beta-23408.nupkg",
-        "System.Threading.ThreadPool.4.0.10-beta-23408.nupkg.sha512",
+        "System.Threading.ThreadPool.4.0.10-beta-23213.nupkg",
+        "System.Threading.ThreadPool.4.0.10-beta-23213.nupkg.sha512",
         "System.Threading.ThreadPool.nuspec"
       ]
     },
@@ -4107,7 +4195,6 @@
       "System.Linq.Queryable >= 4.0.0",
       "System.Net.Http >= 4.0.1-beta-*",
       "System.Net.Primitives >= 4.0.10",
-      "System.Net.Security >= 4.0.0-beta-*",
       "System.Net.WebHeaderCollection >= 4.0.0",
       "System.Net.WebSockets >= 4.0.0-beta-*",
       "System.Net.WebSockets.Client >= 4.0.0-beta-*",
@@ -4138,6 +4225,7 @@
     ],
     "DNXCore,Version=v5.0": [
       "System.Net.NameResolution >= 4.0.0-beta-*",
+      "System.Net.Security >= 4.0.0-beta-*",
       "System.Net.Sockets >= 4.0.10-beta-*"
     ],
     ".NETCore,Version=v5.0": [


### PR DESCRIPTION
The System.Net.Security package is not available for UWP apps,
but WCF currently lists it as a dependency and uses it,
regardless of platform.  This causes UWP apps to fail in beta8.

The fix is to remove use of it when building for Net Native.

This PR is the first of 2.  The first adds conditional compilation
directives around code using System.Net.Security to exclude usage
when building for NET Native.

The 2nd PR will modify the project.json and project.lock.json files
to remove the dependency.

It is being done in 2 stages like this so that the code changes
can be integrated into the release branch for beta8 independently.

The change to the project*.json files will require careful planning
so that when integrated to the release branch it does not carry with
it the new (post-beta8) dependencies currently in WCF.