### PR TITLE
Add X509Certificate-related APIs to System.ServiceModel.Primitives

### DIFF
--- a/src/System.ServiceModel.Primitives/ref/System.ServiceModel.Primitives.cs
+++ b/src/System.ServiceModel.Primitives/ref/System.ServiceModel.Primitives.cs
@@ -4,7 +4,12 @@
 // Changes to this file must follow the http://aka.ms/api-review process.
 // ------------------------------------------------------------------------------
 
-
+namespace System.IdentityModel.Selectors {
+  public abstract partial class X509CertificateValidator {
+    protected X509CertificateValidator() { }
+    public abstract void Validate(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate);
+  }
+}
 namespace System.ServiceModel
 {
     public partial class ActionNotSupportedException : System.ServiceModel.CommunicationException
@@ -1160,7 +1165,9 @@ namespace System.ServiceModel.Description
     {
         public ClientCredentials() { }
         protected ClientCredentials(System.ServiceModel.Description.ClientCredentials other) { }
+        public System.ServiceModel.Security.X509CertificateInitiatorClientCredential ClientCertificate { get { return default(System.ServiceModel.Security.X509CertificateInitiatorClientCredential); } }
         public System.ServiceModel.Security.HttpDigestClientCredential HttpDigest { get { return default(System.ServiceModel.Security.HttpDigestClientCredential); } }
+        public System.ServiceModel.Security.X509CertificateRecipientClientCredential ServiceCertificate { get { return default(System.ServiceModel.Security.X509CertificateRecipientClientCredential); } }
         public System.ServiceModel.Security.UserNamePasswordClientCredential UserName { get { return default(System.ServiceModel.Security.UserNamePasswordClientCredential); } }
         public System.ServiceModel.Security.WindowsClientCredential Windows { get { return default(System.ServiceModel.Security.WindowsClientCredential); } }
         public virtual void ApplyClientBehavior(System.ServiceModel.Description.ServiceEndpoint serviceEndpoint, System.ServiceModel.Dispatcher.ClientRuntime behavior) { }
@@ -1436,5 +1443,36 @@ namespace System.ServiceModel.Security
         internal WindowsClientCredential() { }
         public System.Security.Principal.TokenImpersonationLevel AllowedImpersonationLevel { get { return default(System.Security.Principal.TokenImpersonationLevel); } set { } }
         public System.Net.NetworkCredential ClientCredential { get { return default(System.Net.NetworkCredential); } set { } }
+    }
+    public sealed partial class X509ServiceCertificateAuthentication {
+        internal X509ServiceCertificateAuthentication() { }
+        public System.ServiceModel.Security.X509CertificateValidationMode CertificateValidationMode { get { return default(System.ServiceModel.Security.X509CertificateValidationMode); } set { } }
+        public System.IdentityModel.Selectors.X509CertificateValidator CustomCertificateValidator { get { return default(System.IdentityModel.Selectors.X509CertificateValidator); } set { } }
+        public System.Security.Cryptography.X509Certificates.X509RevocationMode RevocationMode { get { return default(System.Security.Cryptography.X509Certificates.X509RevocationMode); } set { } }
+        public System.Security.Cryptography.X509Certificates.StoreLocation TrustedStoreLocation { get { return default(System.Security.Cryptography.X509Certificates.StoreLocation); } set { } }
+    }
+    public sealed partial class X509CertificateInitiatorClientCredential {
+        internal X509CertificateInitiatorClientCredential() { }
+        public System.Security.Cryptography.X509Certificates.X509Certificate2 Certificate { get { return default(System.Security.Cryptography.X509Certificates.X509Certificate2); } set { } }
+        public void SetCertificate(System.Security.Cryptography.X509Certificates.StoreLocation storeLocation, System.Security.Cryptography.X509Certificates.StoreName storeName, System.Security.Cryptography.X509Certificates.X509FindType findType, object findValue) { }
+        public void SetCertificate(string subjectName, System.Security.Cryptography.X509Certificates.StoreLocation storeLocation, System.Security.Cryptography.X509Certificates.StoreName storeName) { }
+    }
+    public sealed partial class X509CertificateRecipientClientCredential {
+        internal X509CertificateRecipientClientCredential() { }
+        public System.ServiceModel.Security.X509ServiceCertificateAuthentication Authentication { get { return default(System.ServiceModel.Security.X509ServiceCertificateAuthentication); } }
+        public System.Security.Cryptography.X509Certificates.X509Certificate2 DefaultCertificate { get { return default(System.Security.Cryptography.X509Certificates.X509Certificate2); } set { } }
+        public System.Collections.Generic.Dictionary<System.Uri, System.Security.Cryptography.X509Certificates.X509Certificate2> ScopedCertificates { get { return default(System.Collections.Generic.Dictionary<System.Uri, System.Security.Cryptography.X509Certificates.X509Certificate2>); } }
+        public System.ServiceModel.Security.X509ServiceCertificateAuthentication SslCertificateAuthentication { get { return default(System.ServiceModel.Security.X509ServiceCertificateAuthentication); } set { } }
+        public void SetDefaultCertificate(System.Security.Cryptography.X509Certificates.StoreLocation storeLocation, System.Security.Cryptography.X509Certificates.StoreName storeName, System.Security.Cryptography.X509Certificates.X509FindType findType, object findValue) { }
+        public void SetDefaultCertificate(string subjectName, System.Security.Cryptography.X509Certificates.StoreLocation storeLocation, System.Security.Cryptography.X509Certificates.StoreName storeName) { }
+        public void SetScopedCertificate(System.Security.Cryptography.X509Certificates.StoreLocation storeLocation, System.Security.Cryptography.X509Certificates.StoreName storeName, System.Security.Cryptography.X509Certificates.X509FindType findType, object findValue, System.Uri targetService) { }
+        public void SetScopedCertificate(string subjectName, System.Security.Cryptography.X509Certificates.StoreLocation storeLocation, System.Security.Cryptography.X509Certificates.StoreName storeName, System.Uri targetService) { }
+    }
+    public enum X509CertificateValidationMode {
+        ChainTrust = 2,
+        Custom = 4,
+        None = 0,
+        PeerOrChainTrust = 3,
+        PeerTrust = 1,
     }
 }

--- a/src/System.ServiceModel.Primitives/ref/System.ServiceModel.Primitives.csproj
+++ b/src/System.ServiceModel.Primitives/ref/System.ServiceModel.Primitives.csproj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <OutputType>Library</OutputType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/System.ServiceModel.Primitives/ref/project.json
+++ b/src/System.ServiceModel.Primitives/ref/project.json
@@ -13,6 +13,8 @@
     "System.Reflection": "4.0.0",
     "System.Net.Primitives": "4.0.0",
     "System.Security.Principal": "4.0.0",
+    "System.Security.Cryptography.X509Certificates" : "4.0.0-beta-*",
+    "System.Collections" : "4.0.0", 
     "System.Runtime.Serialization.Primitives": "4.0.0"
   },
   "frameworks": {


### PR DESCRIPTION
Dependent on #386, where we bumped the version of System.Private.ServiceModel

Full API addition discussion is at #385 