### PR TITLE
Reactivate negative encoding tests disabled for Linux

### DIFF
--- a/src/System.ServiceModel.Http/tests/ServiceModel/BasicHttpBindingTest.cs
+++ b/src/System.ServiceModel.Http/tests/ServiceModel/BasicHttpBindingTest.cs
@@ -349,7 +349,6 @@ public static class BasicHttpBindingTest
 
     [Theory]
     [MemberData("InvalidEncodings", MemberType = typeof(TestData))]
-    [ActiveIssue(333, PlatformID.AnyUnix)]
     public static void TextEncoding_Property_Set_Invalid_Value_Throws(Encoding encoding)
     {
         var binding = new BasicHttpBinding();

--- a/src/System.ServiceModel.Primitives/tests/Channels/TextMessageEncodingBindingElementTest.cs
+++ b/src/System.ServiceModel.Primitives/tests/Channels/TextMessageEncodingBindingElementTest.cs
@@ -28,7 +28,6 @@ public static class TextMessageEncodingBindingElementTest
 
     [Theory]
     [MemberData("InvalidEncodings", MemberType = typeof(TestData))]
-    [ActiveIssue(333, PlatformID.AnyUnix)]
     public static void WriteEncoding_Property_Set_Throws_For_Invalid_Encodings(Encoding encoding)
     {
         TextMessageEncodingBindingElement element = new TextMessageEncodingBindingElement();


### PR DESCRIPTION
These tests were deactivated on Linux because Encoding had
not yet been implemented.  But this was fixed in CoreFx via
issue https://github.com/dotnet/corefx/issues/2774.