### PR TITLE
Validate X509CertificateClaims by SAN instead of by CN

### DIFF
--- a/src/System.Private.ServiceModel/tests/Common/Scenarios/Endpoints.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Scenarios/Endpoints.cs
@@ -362,4 +362,13 @@ public static partial class Endpoints
             return BridgeClient.GetResourceAddress("WcfService.TestResources.TcpTransportSecuritySslCustomCertValidationResource");
         }
     }
+
+    public static string Tcp_ClientCredentialType_Certificate_With_ServerAltName_Address
+    {
+        get
+        {
+            BridgeClientCertificateManager.InstallLocalCertificateFromBridge();
+            return BridgeClient.GetResourceAddress("WcfService.TestResources.TcpCertificateWithServerAltNameResource");
+        }
+    }
 }

--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/ExpectedExceptions/ExpectedExceptionTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/ExpectedExceptions/ExpectedExceptionTests.cs
@@ -514,7 +514,6 @@ public static class ExpectedExceptionTests
 
     [Fact]
     [OuterLoop]
-    [ActiveIssue(533)]
     // Verify product throws MessageSecurityException when the service cert is revoked
     public static void TCP_ServiceCertRevoked_Throw_MessageSecurityException()
     {

--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Tcp/ClientCredentialTypeTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Tcp/ClientCredentialTypeTests.cs
@@ -252,4 +252,43 @@ public static class Tcp_ClientCredentialTypeTests
             ScenarioTestHelpers.CloseCommunicationObjects((ICommunicationObject)serviceProxy, factory);
         }
     }
+
+    [Fact]
+    [OuterLoop]
+    public static void TcpClientCredentialType_Certificate_With_ServerAltName_EchoString()
+    {
+        EndpointAddress endpointAddress = null;
+        string testString = "Hello";
+        ChannelFactory<IWcfService> factory = null;
+        IWcfService serviceProxy = null;
+
+        try
+        {
+            // *** SETUP *** \\
+            NetTcpBinding binding = new NetTcpBinding(SecurityMode.Transport);
+            binding.Security.Transport.ClientCredentialType = TcpClientCredentialType.None;
+
+            endpointAddress = new EndpointAddress(new Uri(Endpoints.Tcp_ClientCredentialType_Certificate_With_ServerAltName_Address));
+
+            factory = new ChannelFactory<IWcfService>(binding, endpointAddress);
+            factory.Credentials.ServiceCertificate.Authentication.CertificateValidationMode = X509CertificateValidationMode.ChainTrust;
+            
+            serviceProxy = factory.CreateChannel();
+
+            // *** EXECUTE *** \\
+            string result = serviceProxy.Echo(testString);
+
+            // *** VALIDATE *** \\
+            Assert.Equal(testString, result);
+
+            // *** CLEANUP *** \\
+            ((ICommunicationObject)serviceProxy).Close();
+            factory.Close();
+        }
+        finally
+        {
+            // *** ENSURE CLEANUP *** \\
+            ScenarioTestHelpers.CloseCommunicationObjects((ICommunicationObject)serviceProxy, factory);
+        }
+    }
 }

--- a/src/System.Private.ServiceModel/tools/test/Bridge/WcfTestBridgeCommon/CertificateCreationSettings.cs
+++ b/src/System.Private.ServiceModel/tools/test/Bridge/WcfTestBridgeCommon/CertificateCreationSettings.cs
@@ -14,11 +14,19 @@ namespace WcfTestBridgeCommon
         public CertificateCreationSettings()
         {
             Subjects = new string[] { string.Empty };
-            IsValidCert = true;
+            ValidityType = CertificateValidityType.Valid;
         }
         public string [] Subjects { get; set; }
         public DateTime ValidityNotBefore { get; set; }
         public DateTime ValidityNotAfter { get; set; }
-        public bool IsValidCert { get; set; }
+        public CertificateValidityType ValidityType { get; set; }
+    }
+    
+    [Serializable]
+    public enum CertificateValidityType
+    {
+        Valid = 0, 
+        Expired = 1, 
+        Revoked = 2
     }
 }

--- a/src/System.Private.ServiceModel/tools/test/Bridge/WcfTestBridgeCommon/CertificateManager.cs
+++ b/src/System.Private.ServiceModel/tools/test/Bridge/WcfTestBridgeCommon/CertificateManager.cs
@@ -15,10 +15,16 @@ namespace WcfTestBridgeCommon
         private static object s_certificateLock = new object();
 
         // Dictionary of certificates installed by CertificateManager
-        // Keyed by the Subject of the certificate
+        
+        // Keyed by the Subject of the certificate - there should be only one valid cert per endpoint
+        // Valid certs are shareable across endpoints 
         private static Dictionary<string, CertificateCacheEntry> s_myCertificates = new Dictionary<string, CertificateCacheEntry>(StringComparer.OrdinalIgnoreCase);
-        //Keyed by endpoint address as each endpoint can only configure one invalid service certificate
+
+        // Keyed by endpoint address - each endpoint can only configure one invalid service certificate,
+        // Each endpoint address can have a unique cert
         private static Dictionary<string, CertificateCacheEntry> s_myInvalidCertificates = new Dictionary<string, CertificateCacheEntry>(StringComparer.OrdinalIgnoreCase);
+
+        // Keyed by CA subject
         private static Dictionary<string, CertificateCacheEntry> s_rootCertificates = new Dictionary<string, CertificateCacheEntry>(StringComparer.OrdinalIgnoreCase);
 
         // Keyed by port, value is cert thumbprint
@@ -205,7 +211,7 @@ namespace WcfTestBridgeCommon
                 // Since s_myCertificates keys by subject name, we won't install a cert for the same subject twice
                 // only the first-created cert will win
                 InstallCertificateToRootStore(rootCertificate);
-                InstallCertificateToMyStore(hostCert, certificateCreationSettings.IsValidCert);
+                InstallCertificateToMyStore(hostCert, certificateCreationSettings.ValidityType == CertificateValidityType.Valid);
                 s_localCertificate = hostCert;
             }
 
@@ -232,7 +238,7 @@ namespace WcfTestBridgeCommon
                 var rootCertificate = certificateGenerator.AuthorityCertificate.Certificate;
                 var hostCert = certificateGenerator.CreateMachineCertificate(certificateCreationSettings).Certificate;
                 InstallCertificateToRootStore(rootCertificate);
-                InstallCertificateToMyStore(hostCert, certificateCreationSettings.IsValidCert, resourceAddress);
+                InstallCertificateToMyStore(hostCert, certificateCreationSettings.ValidityType == CertificateValidityType.Valid, resourceAddress);
                 return hostCert;
             }
         }

--- a/src/System.Private.ServiceModel/tools/test/SelfHostWcfService/CertificateResources/CertificateResourceHelpers.cs
+++ b/src/System.Private.ServiceModel/tools/test/SelfHostWcfService/CertificateResources/CertificateResourceHelpers.cs
@@ -93,14 +93,7 @@ namespace WcfService.CertificateResources
             return cert.Thumbprint;
         }
 
-        internal static string EnsureNonDefaultCertificateInstalled(BridgeConfiguration configuration, CertificateCreationSettings certificateCreationSettings, string resourceAddress)
-        {
-            X509Certificate2 cert = CertificateManager.CreateAndInstallNonDefaultMachineCertificates(GetCertificateGeneratorInstance(configuration), certificateCreationSettings, resourceAddress);
-
-            return cert.Thumbprint;
-        }
-
-        internal static X509Certificate2 EnsureRevokedCertificateInstalled(BridgeConfiguration configuration, CertificateCreationSettings certificateCreationSettings, string resourceAddress)
+        internal static X509Certificate2 EnsureCustomCertificateInstalled(BridgeConfiguration configuration, CertificateCreationSettings certificateCreationSettings, string resourceAddress)
         {
             return CertificateManager.CreateAndInstallNonDefaultMachineCertificates(GetCertificateGeneratorInstance(configuration), certificateCreationSettings, resourceAddress);
         }

--- a/src/System.Private.ServiceModel/tools/test/SelfHostWcfService/TestResources/TcpRevokedServerCertResource.cs
+++ b/src/System.Private.ServiceModel/tools/test/SelfHostWcfService/TestResources/TcpRevokedServerCertResource.cs
@@ -30,12 +30,11 @@ namespace WcfService.TestResources
             //Create a certificate and add to the revocation list
             CertificateCreationSettings certificateCreationSettings = new CertificateCreationSettings()
             {
-                IsValidCert = false,
+                ValidityType = CertificateValidityType.Revoked,
                 Subjects = new string[] { s_fqdn, s_hostname, "localhost" }
             };
 
-            X509Certificate2 cert = CertificateResourceHelpers.EnsureRevokedCertificateInstalled(context.BridgeConfiguration, certificateCreationSettings, Address);
-            CertificateManager.RevokeCertificate(CertificateResourceHelpers.GetCertificateGeneratorInstance(context.BridgeConfiguration), cert.SerialNumber);
+            X509Certificate2 cert = CertificateResourceHelpers.EnsureCustomCertificateInstalled(context.BridgeConfiguration, certificateCreationSettings, Address);
 
             serviceHost.Credentials.ServiceCertificate.SetCertificate(StoreLocation.LocalMachine,
                                                         StoreName.My,

--- a/src/System.Private.ServiceModel/tools/test/SelfHostWcfService/WcfService.csproj
+++ b/src/System.Private.ServiceModel/tools/test/SelfHostWcfService/WcfService.csproj
@@ -98,6 +98,7 @@
     <Compile Include="TestResources\TcpTransportSecuritySslCustomCertValidationResource.cs" />
     <Compile Include="TestResources\TcpTransportSecurityWithSslResource.cs" />
     <Compile Include="TestResources\TcpExpiredServerCertResource.cs" />
+    <Compile Include="TestResources\TcpCertificateWithServerAltNameResource.cs" />
     <Compile Include="TestResources\TcpVerifyDNSResource.cs" />
     <Compile Include="TestResources\HttpsSoap12Resource.cs" />
     <Compile Include="TestResources\HttpSoap12Resource.cs" />


### PR DESCRIPTION
X509CertificateClaimSet should validate based on Subject Alternative Name instead of the Canonical Name to be consistent with Desktop .NET >= 4.6

Today, We are checking against the Subject (e.g. CN=host) on the certificate, to determine whether or not the cert was issued for a particular server, as this was the behaviour in <= 4.5. However, this is inflexible as the host could be serving the same cert but bound to multiple endpoints.

In the old case, for example, foo-bar.test.com != foo-bar, and a generated cert can only be valid for exactly one of these. In the new case, a certificate can have a Subject with a particular CN, but  multiple Subject Alt Names for which the cert is also valid.

In the wild, most certs issued already contain SANs for the names that the server can be, so we should be consistent with current behaviour and ditch the legacy way of checking certs against servers.

Fixes #321