### PR TITLE
Allow caller to await on TimeoutHelper.CancelationToken

### DIFF
--- a/src/System.Private.ServiceModel/src/Internals/System/Runtime/TimeoutHelper.cs
+++ b/src/System.Private.ServiceModel/src/Internals/System/Runtime/TimeoutHelper.cs
@@ -8,69 +8,54 @@ using System.Threading.Tasks;
 
 namespace System.Runtime
 {
-    public struct TimeoutHelper : IDisposable
+    public struct TimeoutHelper
     {
+        public static readonly TimeSpan MaxWait = TimeSpan.FromMilliseconds(Int32.MaxValue);
+        private static readonly CancellationToken s_precancelledToken = new CancellationToken(true);
+
         private bool _cancellationTokenInitialized;
         private bool _deadlineSet;
 
         private CancellationToken _cancellationToken;
-        private CancellationTokenSource _cts;
         private DateTime _deadline;
         private TimeSpan _originalTimeout;
-        public static readonly TimeSpan MaxWait = TimeSpan.FromMilliseconds(Int32.MaxValue);
-        private static Action<object> s_cancelOnTimeout = state => ((TimeoutHelper)state)._cts.Cancel();
 
         public TimeoutHelper(TimeSpan timeout)
         {
             Contract.Assert(timeout >= TimeSpan.Zero, "timeout must be non-negative");
 
             _cancellationTokenInitialized = false;
-            _cts = null;
             _originalTimeout = timeout;
             _deadline = DateTime.MaxValue;
             _deadlineSet = (timeout == TimeSpan.MaxValue);
         }
 
-        // No locks as we expect this class to be used linearly. 
-        // If another CancellationTokenSource is created, we might have a CancellationToken outstanding
-        // that isn't cancelled if _cts.Cancel() is called. This happens only on the Abort paths, so it's not an issue. 
-        private void InitializeCancellationToken(TimeSpan timeout)
+        public CancellationToken GetCancellationToken()
         {
-            if (timeout == TimeSpan.MaxValue || timeout == Timeout.InfiniteTimeSpan)
-            {
-                _cancellationToken = CancellationToken.None;
-            }
-            else if (timeout > TimeSpan.Zero)
-            {
-                _cts = new CancellationTokenSource();
-                _cancellationToken = _cts.Token;
-                TimeoutTokenSource.FromTimeout((int)timeout.TotalMilliseconds).Register(s_cancelOnTimeout, this);
-            }
-            else
-            {
-                _cancellationToken = new CancellationToken(true);
-            }
-            _cancellationTokenInitialized = true;
+            return GetCancellationTokenAsync().Result;
         }
 
-        public CancellationToken CancellationToken
+        public async Task<CancellationToken> GetCancellationTokenAsync()
         {
-            get
+            if (!_cancellationTokenInitialized)
             {
-                if (!_cancellationTokenInitialized)
+                var timeout = RemainingTime();
+                if (timeout >= MaxWait || timeout == Timeout.InfiniteTimeSpan)
                 {
-                    InitializeCancellationToken(this.RemainingTime());
+                    _cancellationToken = CancellationToken.None;
                 }
-                return _cancellationToken;
+                else if (timeout > TimeSpan.Zero)
+                {
+                    _cancellationToken = await TimeoutTokenSource.FromTimeoutAsync((int)timeout.TotalMilliseconds);
+                }
+                else
+                {
+                    _cancellationToken = s_precancelledToken;
+                }
+                _cancellationTokenInitialized = true;
             }
-        }
 
-        public void CancelCancellationToken(bool throwOnFirstException = false)
-        {
-            if (_cts != null)
-            {
-                _cts.Cancel(throwOnFirstException);
-            }
+            return _cancellationToken;
         }
 
         public TimeSpan OriginalTimeout
@@ -194,16 +179,6 @@ namespace System.Runtime
             _deadlineSet = true;
         }
 
-        public void Dispose()
-        {
-            if (_cancellationTokenInitialized && _cts !=null)
-            {
-                _cts.Dispose();
-                _cancellationTokenInitialized = false;
-                _cancellationToken = default(CancellationToken);
-            }
-        }
-
         public static void ThrowIfNegativeArgument(TimeSpan timeout)
         {
             ThrowIfNegativeArgument(timeout, "timeout");
@@ -260,9 +235,29 @@ namespace System.Runtime
     /// </summary>
     internal static class TimeoutTokenSource
     {
-        private const int COALESCING_SPAN_MS = 15;
+        /// <summary>
+        /// These are constants use to calculate timeout coalescing, for more description see method FromTimeoutAsync
+        /// </summary>
+        private const int CoalescingFactor = 15;
+        private const int GranularityFactor = 2000;
+        private const int SegmentationFactor = CoalescingFactor * GranularityFactor;
+
         private static readonly ConcurrentDictionary<long, Task<CancellationToken>> s_tokenCache =
             new ConcurrentDictionary<long, Task<CancellationToken>>();
+        private static readonly Action<object> s_deregisterToken = (object state) =>
+        {
+            var args = (Tuple<long, CancellationTokenSource>)state;
+
+            Task<CancellationToken> ignored;
+            try
+            {
+                s_tokenCache.TryRemove(args.Item1, out ignored);
+            }
+            finally
+            {
+                args.Item2.Dispose();
+            }
+        };
 
         public static CancellationToken FromTimeout(int millisecondsTimeout)
         {
@@ -278,10 +273,25 @@ namespace System.Runtime
                 throw new ArgumentOutOfRangeException("Invalid millisecondsTimeout value " + millisecondsTimeout);
             }
 
+
+            // To prevent s_tokenCache growing too large, we have to adjust the granularity of the our coalesce depending
+            // on the value of millisecondsTimeout. The coalescing span scales proportionally with millisecondsTimeout which
+            // would garentee constant s_tokenCache size in the case where similar millisecondsTimeout values are accepted.
+            // If the method is given a wildly different millisecondsTimeout values all the time, the dictionary would still
+            // only grow logarithmically with respect to the range of the input values
             uint currentTime = (uint)Environment.TickCount;
             long targetTime = millisecondsTimeout + currentTime;
-            // round the targetTime up to the next closest 15ms
-            targetTime = ((targetTime + (COALESCING_SPAN_MS - 1)) / COALESCING_SPAN_MS) * COALESCING_SPAN_MS;
+
+            // Formula for our coalescing span:
+            // Divide millisecondsTimeout by SegmentationFactor and take the highest bit and then multiply CoalescingFactor back
+            var segmentValue = millisecondsTimeout / SegmentationFactor;
+            var coalescingSpanMs = CoalescingFactor;
+            while (segmentValue > 0)
+            {
+                segmentValue >>= 1;
+                coalescingSpanMs <<= 1;
+            }
+            targetTime = ((targetTime + (coalescingSpanMs - 1)) / coalescingSpanMs) * coalescingSpanMs;
 
             Task<CancellationToken> tokenTask;
 
@@ -294,13 +304,11 @@ namespace System.Runtime
                 {
                     // Since this thread was successful reserving a spot in the cache, it would be the only thread
                     // that construct the CancellationTokenSource
-                    var token = new CancellationTokenSource((int)(targetTime - currentTime)).Token;
+                    var tokenSource = new CancellationTokenSource((int)(targetTime - currentTime));
+                    var token = tokenSource.Token;
 
                     // Clean up cache when Token is canceled
-                    token.Register(t => {
-                        Task<CancellationToken> ignored;
-                        s_tokenCache.TryRemove((long)t, out ignored);
-                    }, targetTime);
+                    token.Register(s_deregisterToken, Tuple.Create(targetTime, tokenSource));
 
                     // set the result so other thread may observe the token, and return
                     tcs.TrySetResult(token);

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/CoreClrClientWebSocketFactory.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/CoreClrClientWebSocketFactory.cs
@@ -24,7 +24,8 @@ namespace System.ServiceModel.Channels
                 webSocket.Options.SetRequestHeader(header, headers[header]);
             }
 
-            await webSocket.ConnectAsync(address, timeoutHelper.CancellationToken);
+            var cancelToken = await timeoutHelper.GetCancellationTokenAsync();
+            await webSocket.ConnectAsync(address, cancelToken);
             return webSocket;
         }
     }

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/WebSocketTransportDuplexSessionChannel.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/WebSocketTransportDuplexSessionChannel.cs
@@ -234,7 +234,7 @@ namespace System.ServiceModel.Channels
                     RemoteAddress != null ? RemoteAddress.ToString() : string.Empty);
             }
 
-            Task task = WebSocket.SendAsync(messageData, outgoingMessageType, true, helper.CancellationToken);
+            Task task = WebSocket.SendAsync(messageData, outgoingMessageType, true, helper.GetCancellationToken());
             Contract.Assert(_pendingWritingMessageException == null, "'pendingWritingMessageException' MUST be NULL at this point.");
 
             if (task.IsCompleted)
@@ -285,7 +285,7 @@ namespace System.ServiceModel.Channels
             Fx.Assert(callback != null, "callback should not be null.");
 
             var helper = new TimeoutHelper(timeout);
-            Task task = CloseOutputAsync(helper.CancellationToken);
+            Task task = CloseOutputAsync(helper.GetCancellationToken());
             Fx.Assert(_pendingWritingMessageException == null, "'pendingWritingMessageException' MUST be NULL at this point.");
 
             if (task.IsCompleted)
@@ -326,7 +326,7 @@ namespace System.ServiceModel.Channels
                             RemoteAddress != null ? RemoteAddress.ToString() : string.Empty);
                     }
 
-                    Task task = WebSocket.SendAsync(messageData, outgoingMessageType, true, helper.CancellationToken);
+                    Task task = WebSocket.SendAsync(messageData, outgoingMessageType, true, helper.GetCancellationToken());
                     task.Wait(helper.RemainingTime(), WebSocketHelper.ThrowCorrectException, WebSocketHelper.SendOperation);
 
                     if (TD.WebSocketAsyncWriteStopIsEnabled())
@@ -1067,7 +1067,8 @@ namespace System.ServiceModel.Channels
             {
                 Contract.Assert(_messageSource != null, "messageSource should not be null in read case.");
 
-                if (_readTimeoutHelper.CancellationToken.IsCancellationRequested)
+                var cancelToken = _readTimeoutHelper.GetCancellationToken();
+                if (cancelToken.IsCancellationRequested)
                 {
                     throw FxTrace.Exception.AsError(WebSocketHelper.GetTimeoutException(null,
                         _readTimeoutHelper.OriginalTimeout, WebSocketHelper.ReceiveOperation));
@@ -1233,7 +1234,7 @@ namespace System.ServiceModel.Channels
 
                 if (Interlocked.CompareExchange(ref _endOfMessageWritten, WebSocketHelper.OperationFinished, WebSocketHelper.OperationNotStarted) == WebSocketHelper.OperationNotStarted)
                 {
-                    Task task = _webSocket.SendAsync(new ArraySegment<byte>(Array.Empty<byte>(), 0, 0), _outgoingMessageType, true, timeoutHelper.CancellationToken);
+                    Task task = _webSocket.SendAsync(new ArraySegment<byte>(Array.Empty<byte>(), 0, 0), _outgoingMessageType, true, timeoutHelper.GetCancellationToken());
                     task.Wait(timeoutHelper.RemainingTime(), WebSocketHelper.ThrowCorrectException, WebSocketHelper.SendOperation);
                 }
 
@@ -1254,40 +1255,38 @@ namespace System.ServiceModel.Channels
                         string.Empty);
                 }
 
-                using (var timeoutHelper = new TimeoutHelper(_closeTimeout))
+                var timeoutHelper = new TimeoutHelper(_closeTimeout);
+                var cancelTokenTask = timeoutHelper.GetCancellationTokenAsync();
+                try
                 {
-                    try
+                    var cancelToken = await cancelTokenTask;
+                    await _webSocket.SendAsync(new ArraySegment<byte>(Array.Empty<byte>(), 0, 0), _outgoingMessageType, true, cancelToken);
+
+                    if (TD.WebSocketAsyncWriteStopIsEnabled())
                     {
-                        await
-                            _webSocket.SendAsync(new ArraySegment<byte>(Array.Empty<byte>(), 0, 0), _outgoingMessageType,
-                                true, timeoutHelper.CancellationToken);
-
-                        if (TD.WebSocketAsyncWriteStopIsEnabled())
-                        {
-                            TD.WebSocketAsyncWriteStop(_webSocket.GetHashCode());
-                        }
+                        TD.WebSocketAsyncWriteStop(_webSocket.GetHashCode());
                     }
-                    catch (Exception ex)
+                }
+                catch (Exception ex)
+                {
+                    if (Fx.IsFatal(ex))
                     {
-                        if (Fx.IsFatal(ex))
-                        {
-                            throw;
-                        }
-
-                        if (timeoutHelper.CancellationToken.IsCancellationRequested)
-                        {
-                            throw Fx.Exception.AsError(
-                                new TimeoutException(InternalSR.TaskTimedOutError(timeoutHelper.OriginalTimeout)));
-                        }
-
-                        throw WebSocketHelper.ConvertAndTraceException(ex, timeoutHelper.OriginalTimeout,
-                            WebSocketHelper.SendOperation);
-
+                        throw;
                     }
-                    finally
+
+                    if (cancelTokenTask.Result.IsCancellationRequested)
                     {
-                        callback.Invoke(state);
+                        throw Fx.Exception.AsError(
+                            new TimeoutException(InternalSR.TaskTimedOutError(timeoutHelper.OriginalTimeout)));
                     }
+
+                    throw WebSocketHelper.ConvertAndTraceException(ex, timeoutHelper.OriginalTimeout,
+                        WebSocketHelper.SendOperation);
+
+                }
+                finally
+                {
+                    callback.Invoke(state);
                 }
             }
 
@@ -1320,20 +1319,18 @@ namespace System.ServiceModel.Channels
                             if (!_endofMessageReceived && (_webSocket.State == WebSocketState.Open || _webSocket.State == WebSocketState.CloseSent))
                             {
                                 // Drain the reading stream
-                                using (var closeTimeoutHelper = new TimeoutHelper(_closeTimeout))
+                                var closeTimeoutHelper = new TimeoutHelper(_closeTimeout);
+                                do
                                 {
-                                    do
-                                    {
-                                        Task<WebSocketReceiveResult> receiveTask =
-                                            _webSocket.ReceiveAsync(new ArraySegment<byte>(_initialReadBuffer.Array),
-                                                closeTimeoutHelper.CancellationToken);
-                                        receiveTask.Wait(closeTimeoutHelper.RemainingTime(),
-                                            WebSocketHelper.ThrowCorrectException, WebSocketHelper.ReceiveOperation);
-                                        _endofMessageReceived = receiveTask.GetAwaiter().GetResult().EndOfMessage;
-                                    } while (!_endofMessageReceived &&
-                                             (_webSocket.State == WebSocketState.Open ||
-                                              _webSocket.State == WebSocketState.CloseSent));
-                                }
+                                    Task<WebSocketReceiveResult> receiveTask =
+                                        _webSocket.ReceiveAsync(new ArraySegment<byte>(_initialReadBuffer.Array),
+                                            closeTimeoutHelper.GetCancellationToken());
+                                    receiveTask.Wait(closeTimeoutHelper.RemainingTime(),
+                                        WebSocketHelper.ThrowCorrectException, WebSocketHelper.ReceiveOperation);
+                                    _endofMessageReceived = receiveTask.GetAwaiter().GetResult().EndOfMessage;
+                                } while (!_endofMessageReceived &&
+                                         (_webSocket.State == WebSocketState.Open ||
+                                          _webSocket.State == WebSocketState.CloseSent));
                             }
                         }
                         catch (Exception ex)


### PR DESCRIPTION
This is the first of 2 code improvement requests from the previous PR https://github.com/dotnet/wcf/pull/410. Since TimeoutHelper now create cancellation token asynchronously it make sense to allow caller to await on the creation of Cancellation token.

(Performance progression at about 1% in the Http scenario)