### PR TITLE
Disabling test due to incorrect behavior on the Bridge

### DIFF
--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/ExpectedExceptions/ExpectedExceptionTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/ExpectedExceptions/ExpectedExceptionTests.cs
@@ -35,6 +35,7 @@ public static class ExpectedExceptionTests
 
     [Fact]
     [OuterLoop]
+    [ActiveIssue(398)]
     public static void ServiceRestart_Throws_CommunicationException()
     {
         StringBuilder errorBuilder = new StringBuilder();


### PR DESCRIPTION
* Prior to moving to the Bridge this test worked as expected, since the move it looks like the
wrong ServiceHost is getting killed which can cause other tests to randomly fail.
* Due to other higher priority tasks just disabling this test for the short term.