### PR TITLE
Remove SR.Format calls and replace with string.Format

### DIFF
--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/AddressingVersion.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/AddressingVersion.cs
@@ -140,7 +140,7 @@ namespace System.ServiceModel.Channels
 
         public override string ToString()
         {
-            return SR.Format(_toStringFormat, Namespace);
+            return string.Format(_toStringFormat, Namespace);
         }
     }
 }

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/EnvelopeVersion.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/EnvelopeVersion.cs
@@ -163,7 +163,7 @@ namespace System.ServiceModel
 
         public override string ToString()
         {
-            return SR.Format(_toStringFormat, Namespace);
+            return string.Format(_toStringFormat, Namespace);
         }
     }
 }


### PR DESCRIPTION
* Const strings had already been included with the expected ToString formatting but the two ToString methods had not been updated and were still using SR.Format
* Fixes #323