### PR TITLE
Dispose websocket object after Close

### DIFF
--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/WebSocketTransportDuplexSessionChannel.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/WebSocketTransportDuplexSessionChannel.cs
@@ -202,6 +202,18 @@ namespace System.ServiceModel.Channels
             }
         }
 
+        protected internal override async Task OnCloseAsync(TimeSpan timeout)
+        {
+            try
+            {
+                await base.OnCloseAsync(timeout);
+            }
+            finally
+            {
+                Cleanup();
+            }
+        }
+
         protected override void ReturnConnectionIfNecessary(bool abort, TimeSpan timeout)
         {
         }


### PR DESCRIPTION
* We use WebSocket.CloseAsync to close the WebSocket object. We do not dispose it
in normal Close case. We need to aggressively dispose it as WebSocket
is a disposable object and hold unmanaged resources.

Fixes #431