### PR TITLE
Use new Implemented Async Methods in System.Runtime.Serialization.Xml

### DIFF
--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/TextMessageEncoder.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/TextMessageEncoder.cs
@@ -547,8 +547,7 @@ namespace System.ServiceModel.Channels
                     xmlWriter.WriteEndDocument();
                 }
 
-                // The underlying type of xmlWriter, XmlUTF8TextWriter, has not implemented FlushAsync() yet.
-                xmlWriter.Flush();
+                await xmlWriter.FlushAsync();
                 ReturnStreamedWriter(xmlWriter);
 
                 if (TD.StreamedMessageWrittenByEncoderIsEnabled())

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Dispatcher/OperationFormatter.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Dispatcher/OperationFormatter.cs
@@ -46,6 +46,12 @@ namespace System.ServiceModel.Dispatcher
 
         protected abstract void AddHeadersToMessage(Message message, MessageDescription messageDescription, object[] parameters, bool isRequest);
         protected abstract void SerializeBody(XmlDictionaryWriter writer, MessageVersion version, string action, MessageDescription messageDescription, object returnValue, object[] parameters, bool isRequest);
+        protected virtual Task SerializeBodyAsync(XmlDictionaryWriter writer, MessageVersion version, string action, MessageDescription messageDescription, object returnValue, object[] parameters, bool isRequest)
+        {
+            SerializeBody(writer, version, action, messageDescription, returnValue, parameters, isRequest);
+            return Task.CompletedTask;
+        }
+
         protected abstract void GetHeadersFromMessage(Message message, MessageDescription messageDescription, object[] parameters, bool isRequest);
         protected abstract object DeserializeBody(XmlDictionaryReader reader, MessageVersion version, string action, MessageDescription messageDescription, object[] parameters, bool isRequest);
 
@@ -356,7 +362,7 @@ namespace System.ServiceModel.Dispatcher
                 return;
             }
 
-            SerializeBody(writer, version, RequestAction, messageDescription, returnValue, parameters, isRequest);
+            await SerializeBodyAsync(writer, version, RequestAction, messageDescription, returnValue, parameters, isRequest);
         }
 
         private IAsyncResult BeginSerializeBodyContents(XmlDictionaryWriter writer, MessageVersion version, object[] parameters, object returnValue, bool isRequest,

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Dispatcher/StreamFormatter.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Dispatcher/StreamFormatter.cs
@@ -73,15 +73,15 @@ namespace System.ServiceModel.Dispatcher
             return streamValue;
         }
 
-        private Task<Stream> GetStreamAndWriteStartWrapperIfNecessaryAsync(XmlDictionaryWriter writer, object[] parameters, object returnValue)
+        private async Task<Stream> GetStreamAndWriteStartWrapperIfNecessaryAsync(XmlDictionaryWriter writer, object[] parameters, object returnValue)
         {
             Stream streamValue = GetStreamValue(parameters, returnValue);
             if (streamValue == null)
                 throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull(_partName);
             if (WrapperName != null)
-                writer.WriteStartElement(null, WrapperName, WrapperNamespace);
-            writer.WriteStartElement(null, PartName, PartNamespace);
-            return Task.FromResult(streamValue);
+                await writer.WriteStartElementAsync(null, WrapperName, WrapperNamespace);
+            await writer.WriteStartElementAsync(null, PartName, PartNamespace);
+            return streamValue;
         }
 
         private void WriteEndWrapperIfNecessary(XmlDictionaryWriter writer)


### PR DESCRIPTION
System.Runtime.Serialization.Xml implemented some async methods per our request (see https://github.com/dotnet/corefx/issues/2502). The fix is to use those methods in our code.

Fixes #218, #221, and #222.