### PR TITLE
Add platform-dependent logic to BridgeClientCertificateManager

### DIFF
--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Tcp/ClientCredentialTypeTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Tcp/ClientCredentialTypeTests.cs
@@ -156,7 +156,7 @@ public static class Tcp_ClientCredentialTypeTests
             factory = new ChannelFactory<IWcfService>(binding, endpointAddress);
             factory.Credentials.ServiceCertificate.Authentication.CertificateValidationMode = X509CertificateValidationMode.None;
             factory.Credentials.ClientCertificate.SetCertificate(
-                StoreLocation.LocalMachine,
+                StoreLocation.CurrentUser,
                 StoreName.My,
                 X509FindType.FindByThumbprint,
                 clientCertThumb);


### PR DESCRIPTION
In Windows, we read/write our certificates from/to the LocalMachine store.
On *nix, however, we only have access to the User store. The BridgeClient needs
to be aware of where it's running and switch the cert store used as necessary

Fixes #434