### PR TITLE
Disable WebSockets functional tests on Unix

### DIFF
--- a/src/System.Private.ServiceModel/tests/Scenarios/Binding/NetHttp/WebSocketTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Binding/NetHttp/WebSocketTests.cs
@@ -12,6 +12,7 @@ public static class Binding_NetHttp_WebSocketTests
     // Duplex over WebSocket occurs automatically when the service contract is declared with a callback contract.
     [Fact]
     [OuterLoop]
+    [ActiveIssue(420, PlatformID.AnyUnix)]
     public static void DuplexOverWebSocket_Echo_RoundTrips_Guid()
     {
         DuplexChannelFactory<IWcfDuplexService> factory = null;
@@ -50,6 +51,7 @@ public static class Binding_NetHttp_WebSocketTests
     // Force the binding to use WebSocket by setting the WebSocket transport usage to Always.
     [Fact]
     [OuterLoop]
+    [ActiveIssue(420, PlatformID.AnyUnix)]
     public static void RequestResponseOverWebSocketManually_Echo_RoundTrips_Guid()
     {
         DuplexChannelFactory<IWcfDuplexService> factory = null;
@@ -88,6 +90,7 @@ public static class Binding_NetHttp_WebSocketTests
 
     [Fact]
     [OuterLoop]
+    [ActiveIssue(420, PlatformID.AnyUnix)]
     public static void TransportUsageAlways_WebSockets_Synchronous_Call()
     {
         DuplexChannelFactory<IWcfDuplexService> factory = null;


### PR DESCRIPTION
The WebSockets tests currently hang for long periods
on Linux.  This PR just disables those tests on Linux.

Issue #420 tracks fixing the issue and re-enabling the tests.