### PR TITLE
Return certificates with private key from Bridge

### DIFF
--- a/src/System.Private.ServiceModel/tools/test/Bridge/WcfTestBridgeCommon/CertificateGenerator.cs
+++ b/src/System.Private.ServiceModel/tools/test/Bridge/WcfTestBridgeCommon/CertificateGenerator.cs
@@ -5,9 +5,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Diagnostics.Contracts;
 using System.IO;
-using System.Net;
 using Org.BouncyCastle.Asn1;
 using Org.BouncyCastle.Asn1.X509;
 using Org.BouncyCastle.Crypto;
@@ -50,8 +48,8 @@ namespace WcfTestBridgeCommon
         private static readonly X509V3CertificateGenerator _certGenerator = new X509V3CertificateGenerator();
         private static readonly X509V2CrlGenerator _crlGenerator = new X509V2CrlGenerator();
 
-        // key: thumbprint, value: revocation time
-        private static Dictionary<string, DateTime> _revokedCertificates = new Dictionary<string,DateTime>(); 
+        // key: serial number, value: revocation time
+        private static Dictionary<string, DateTime> _revokedCertificates = new Dictionary<string, DateTime>(); 
         
         private RsaKeyPairGenerator _keyPairGenerator;
         private SecureRandom _random;
@@ -370,6 +368,8 @@ namespace WcfTestBridgeCommon
             } 
             else
             {
+                // Otherwise, allow encode with the private key. note that X509Certificate2.RawData will not provide the private key
+                // you will have to re-export this cert if needed
                 outputCert = new X509Certificate2(container.Pfx, _password, X509KeyStorageFlags.MachineKeySet | X509KeyStorageFlags.Exportable | X509KeyStorageFlags.PersistKeySet);
             }
 

--- a/src/System.Private.ServiceModel/tools/test/Bridge/WcfTestBridgeCommon/CertificateManager.cs
+++ b/src/System.Private.ServiceModel/tools/test/Bridge/WcfTestBridgeCommon/CertificateManager.cs
@@ -70,6 +70,8 @@ namespace WcfTestBridgeCommon
             try
             {
                 store = new X509Store(storeName, storeLocation);
+
+                // We assume Bridge is running elevated
                 store.Open(OpenFlags.ReadWrite);
                 existingCert = CertificateFromThumbprint(store, certificate.Thumbprint);
                 if (existingCert == null)
@@ -116,18 +118,14 @@ namespace WcfTestBridgeCommon
                 };
 
                 return certificate.Thumbprint;
-
             }
         }
 
         // Install the certificate into the My store.
         // It will not install the certificate if it is already present in the store.
         // It returns the thumbprint of the certificate, regardless whether it was added or found.
-        public static string InstallCertificateToMyStore(X509Certificate2 certificate, X509Certificate2 rootCertificate)
+        public static string InstallCertificateToMyStore(X509Certificate2 certificate)
         {
-            // Installing any MY certificate guarantees the certificate authority is loaded first
-            InstallCertificateToRootStore(rootCertificate);
-
             lock (s_certificateLock)
             {
                 CertificateCacheEntry entry = null;
@@ -179,7 +177,8 @@ namespace WcfTestBridgeCommon
 
                 // Since s_myCertificates keys by subject name, we won't install a cert for the same subject twice
                 // only the first-created cert will win
-                InstallCertificateToMyStore(hostCert, rootCertificate);
+                InstallCertificateToRootStore(rootCertificate);
+                InstallCertificateToMyStore(hostCert);
                 s_localCertificate = hostCert;
             }
 
@@ -220,6 +219,7 @@ namespace WcfTestBridgeCommon
                 X509Store store = null;
                 try
                 {
+                    // We assume Bridge is running elevated
                     store = new X509Store(storeName, storeLocation);
                     store.Open(OpenFlags.ReadWrite);
                     foreach (var pair in cache)
@@ -264,6 +264,7 @@ namespace WcfTestBridgeCommon
 
                 try
                 {
+                    // We assume Bridge is running elevated
                     store = new X509Store(storeName, storeLocation);
                     store.Open(OpenFlags.ReadWrite);
 

--- a/src/System.Private.ServiceModel/tools/test/SelfHostWcfService/CertificateResources/CertificateResource.cs
+++ b/src/System.Private.ServiceModel/tools/test/SelfHostWcfService/CertificateResources/CertificateResource.cs
@@ -26,6 +26,7 @@ namespace WcfService.CertificateResources
 
         protected static string s_localHostname; 
         
+        // Cache for certs created via CertificateResources
         // key: subject CN, value: X509Certificate2
         protected static Dictionary<string, X509Certificate2> s_createdCertsBySubject = new Dictionary<string, X509Certificate2>();
         // key: cert thumbprint, value: X509Certificate2

--- a/src/System.Private.ServiceModel/tools/test/SelfHostWcfService/CertificateResources/EndCertificateResource.cs
+++ b/src/System.Private.ServiceModel/tools/test/SelfHostWcfService/CertificateResources/EndCertificateResource.cs
@@ -46,6 +46,8 @@ namespace WcfService.CertificateResources
                     }
                 }
 
+                // this isn't ideal, as semantically in JSON they aren't grouped together. Our current Json serializer implementation 
+                // doesn't support serializing nested key-val pairs
                 response.Properties.Add(subjectsKeyName, string.Join(",", subjects));
                 response.Properties.Add(thumbprintsKeyName, string.Join(",", thumbprints));
                 return response;
@@ -72,8 +74,10 @@ namespace WcfService.CertificateResources
 
                 if (certHasBeenCreated)
                 {
+                    var certGenerator = CertificateResourceHelpers.GetCertificateGeneratorInstance(context.BridgeConfiguration); 
+
                     response.Properties.Add(thumbprintKeyName, certificate.Thumbprint);
-                    response.Properties.Add(certificateKeyName, Convert.ToBase64String(certificate.RawData));
+                    response.Properties.Add(certificateKeyName, Convert.ToBase64String(certificate.Export(X509ContentType.Pfx, certGenerator.CertificatePassword)));
                 }
                 else
                 {

--- a/src/System.Private.ServiceModel/tools/test/SelfHostWcfService/CertificateResources/MachineCertificateResource.cs
+++ b/src/System.Private.ServiceModel/tools/test/SelfHostWcfService/CertificateResources/MachineCertificateResource.cs
@@ -59,9 +59,15 @@ namespace WcfService.CertificateResources
                     {
                         certificate = generator.CreateMachineCertificate(subjects).Certificate;
                     }
-                    // Cache the certificates
-                    s_createdCertsBySubject.Add(subjects[0], certificate);
-                    s_createdCertsByThumbprint.Add(certificate.Thumbprint, certificate);
+
+                    X509Certificate2 dummy;
+                    if (!isLocal || !s_createdCertsByThumbprint.TryGetValue(certificate.Thumbprint, out dummy))
+                    {
+                        // when isLocal, it's possible for there to be > 1 subject sharing the same thumbprint
+                        // in this case, we only cache the first isLocal subject, the rest we don't cache
+                        s_createdCertsBySubject.Add(subjects[0], certificate);
+                        s_createdCertsByThumbprint.Add(certificate.Thumbprint, certificate);
+                    }
                 }
             }
 

--- a/src/System.Private.ServiceModel/tools/test/SelfHostWcfService/CertificateResources/UserCertificateResource.cs
+++ b/src/System.Private.ServiceModel/tools/test/SelfHostWcfService/CertificateResources/UserCertificateResource.cs
@@ -41,6 +41,11 @@ namespace WcfService.CertificateResources
                     // Cache the certificates
                     s_createdCertsBySubject.Add(subjects[0], certificate);
                     s_createdCertsByThumbprint.Add(certificate.Thumbprint, certificate);
+
+                    // Created certs get put onto the local machine
+                    // We ideally don't want this to happen, but until we find a way to have BridgeClient not need elevation for cert installs
+                    // we need this to happen so that running locally doesn't require elevation as it messes up our CI and developer builds
+                    CertificateManager.InstallCertificateToMyStore(certificate);
                 }
             }
 


### PR DESCRIPTION
* Machine and user certs returned from the Bridge previously did not contain a private key, making some scenarios fail.
* BridgeClientCertificateManager will request User rather than Machine certificates
* BridgeClientCertificateManager will now check whether or not certificates were previously installed by opening the X509Store ReadOnly before attempting to install them
* BridgeClientCertificateManager error message for when an CryptographicException "Access Denied" is thrown improved
* Change the Bridge to install all "user" certs generated (not machine)
   We need this so that localhost tests don't require elevation