### PR TITLE
Update Identity positive test and add a negative test

### DIFF
--- a/src/System.Private.ServiceModel/tests/Common/Infrastructure/src/BridgeClientCertificateManager.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Infrastructure/src/BridgeClientCertificateManager.cs
@@ -176,10 +176,13 @@ namespace Infrastructure.Common
                 }
             }
 
-            InstallCertificateToMyStore(certificateToInstall);
-
-            // We also need to install the root cert if we install a local cert
-            InstallRootCertificateFromBridge();
+            // certificateToInstall could be null in the case the user certification exists
+            if (certificateToInstall != null)
+            {
+                InstallCertificateToMyStore(certificateToInstall);
+                // We also need to install the root cert if we install a local cert
+                InstallRootCertificateFromBridge();
+            }
         }
 
         // Returns the certificate matching the given thumbprint from the given store.

--- a/src/System.Private.ServiceModel/tests/Common/Scenarios/Endpoints.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Scenarios/Endpoints.cs
@@ -145,6 +145,14 @@ public static partial class Endpoints
         }
     }
 
+    public static string Tcp_VerifyDNS_HostName
+    {
+        get
+        {
+            return BridgeClient.GetResourceHostName("WcfService.TestResources.TcpVerifyDNSResource");
+        }
+    }
+
     public static string Tcp_NoSecurity_Callback_Address
     {
         get { return BridgeClient.GetResourceAddress("WcfService.TestResources.DuplexResource"); }

--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Security.TransportSecurity.Tests.csproj
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Security.TransportSecurity.Tests.csproj
@@ -39,6 +39,10 @@
             <Project>{9098B41C-9C2E-4FC6-B7D8-FC3411736A22}</Project>
             <Name>ScenarioTests.Common</Name>
         </ProjectReference>
+    	<ProjectReference Include="$(WcfInfrastructureCommonProj)">
+      	    <Project>{AFD69665-89A3-42AE-A32E-AB2CBBE6EE7E}</Project>
+            <Name>Infrastructure.Common</Name>
+        </ProjectReference>
     </ItemGroup>
     <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Private.ServiceModel/tools/test/SelfHostWcfService/TestResources/EndpointResource.cs
+++ b/src/System.Private.ServiceModel/tools/test/SelfHostWcfService/TestResources/EndpointResource.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Net;
 using System.ServiceModel;
 using System.ServiceModel.Channels;
 using System.ServiceModel.Description;
@@ -13,6 +14,7 @@ namespace WcfService.TestResources
     internal abstract class EndpointResource<ServiceType, ContractType> : IResource where ServiceType : class, ContractType
     {
         private const string ResourceResponseUriKeyName = "uri";
+        private const string ResourceResponseFQHNKeyName = "hostname";
 
         private static Dictionary<string, ServiceHost> s_currentHosts = new Dictionary<string, ServiceHost>();
         private static object s_currentHostLock = new object();
@@ -58,6 +60,7 @@ namespace WcfService.TestResources
             if (host.Description.Endpoints.Count == 1)
             {
                 response.Properties.Add(ResourceResponseUriKeyName, host.Description.Endpoints[0].ListenUri.ToString());
+                response.Properties.Add(ResourceResponseFQHNKeyName, Dns.GetHostEntry("127.0.0.1").HostName);
             }
 
             return response;
@@ -70,6 +73,7 @@ namespace WcfService.TestResources
             if (s_currentHosts.TryGetValue(Address, out host) && (host.Description.Endpoints.Count == 1))
             {
                 response.Properties.Add(ResourceResponseUriKeyName, host.Description.Endpoints[0].ListenUri.ToString());
+                response.Properties.Add(ResourceResponseFQHNKeyName, Dns.GetHostEntry("127.0.0.1").HostName);
             }
 
             return response;


### PR DESCRIPTION
* Update identity positve test per cert generation changes in bridge.
* Enable the positve test because it's now pass as both product and cert
functionalities are in place.
* Add a negative test.

Fixes issue #368