### PR TITLE
Adding primary scenario test for Issue #366

### DIFF
--- a/src/System.Private.ServiceModel/tests/Common/Infrastructure/src/BridgeClientCertificateManager.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Infrastructure/src/BridgeClientCertificateManager.cs
@@ -29,6 +29,8 @@ namespace Infrastructure.Common
         private const string ClientCertificateSubject = "WCF Client Certificate";
         private const string ClientCertificatePassword = "test"; // this needs to be kept in sync with the Bridge configuration 
 
+        public static string LocalCertThumbprint { get; private set; }
+
         // Dictionary of certificates installed by CertificateManager
         // Keyed by the Thumbprint of the certificate
         private static Dictionary<string, CertificateCacheEntry> s_myCertificates = new Dictionary<string, CertificateCacheEntry>(StringComparer.OrdinalIgnoreCase);
@@ -127,6 +129,9 @@ namespace Infrastructure.Common
             {
                 if (response.TryGetValue(ThumbprintKeyName, out thumbprint))
                 {
+                    // Set property with the thumbprint so a test case can use it.
+                    LocalCertThumbprint = thumbprint;
+
                     foundUserCertificate = s_myCertificates.ContainsKey(thumbprint);
 
                     // The Bridge tells us if the request has been made for a local certificate local to the bridge. 

--- a/src/System.Private.ServiceModel/tests/Common/Scenarios/Endpoints.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Scenarios/Endpoints.cs
@@ -218,4 +218,13 @@ public static partial class Endpoints
             return BridgeClient.GetResourceHostName("WcfService.TestResources.TcpTransportSecurityWithSslResource");
         }
     }
+
+    public static string Tcp_ClientCredentialType_Certificate_Address
+    {
+        get
+        {
+            BridgeClientCertificateManager.InstallLocalCertificateFromBridge();
+            return BridgeClient.GetResourceAddress("WcfService.TestResources.TcpTransportSecuritySslClientCredentialTypeCertificate");
+        }
+    }
 }

--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Security.TransportSecurity.Tests.csproj
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Security.TransportSecurity.Tests.csproj
@@ -46,3 +46,4 @@
     </ItemGroup>
     <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>
+

--- a/src/System.Private.ServiceModel/tools/test/SelfHostWcfService/TestResources/TcpTransportSecuritySslClientCredentialTypeCertificate.cs
+++ b/src/System.Private.ServiceModel/tools/test/SelfHostWcfService/TestResources/TcpTransportSecuritySslClientCredentialTypeCertificate.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics;
+using System.Security.Cryptography.X509Certificates;
+using System.ServiceModel;
+using System.ServiceModel.Channels;
+using System.ServiceModel.Security;
+using WcfService.CertificateResources;
+using WcfTestBridgeCommon;
+
+namespace WcfService.TestResources
+{
+    internal class TcpTransportSecuritySslClientCredentialTypeCertificate : TcpResource
+    {
+        protected override string Address { get { return "tcp-server-ssl-security-clientcredentialtype-certificate"; } }
+
+        protected override Binding GetBinding()
+        {
+            NetTcpBinding binding = new NetTcpBinding(SecurityMode.Transport);
+            binding.Security.Transport.ClientCredentialType = TcpClientCredentialType.Certificate;
+            return binding;
+        }
+
+        protected override void ModifyHost(ServiceHost serviceHost, ResourceRequestContext context)
+        {
+            // Ensure the https certificate is installed before this endpoint resource is used
+            string thumbprint = CertificateResourceHelpers.EnsureSslPortCertificateInstalled(context.BridgeConfiguration);
+
+            serviceHost.Credentials.ClientCertificate.Authentication.CertificateValidationMode = X509CertificateValidationMode.None;
+            serviceHost.Credentials.ServiceCertificate.SetCertificate(StoreLocation.LocalMachine,
+                                                      StoreName.My,
+                                                      X509FindType.FindByThumbprint,
+                                                      thumbprint);
+        }
+    }
+}

--- a/src/System.Private.ServiceModel/tools/test/SelfHostWcfService/WcfService.csproj
+++ b/src/System.Private.ServiceModel/tools/test/SelfHostWcfService/WcfService.csproj
@@ -87,6 +87,7 @@
     <Compile Include="TestResources\TcpNoSecurityResource.cs" />
     <Compile Include="TestResources\TcpNoSecurityTextResource.cs" />
     <Compile Include="TestResources\TcpResource.cs" />
+    <Compile Include="TestResources\TcpTransportSecuritySslClientCredentialTypeCertificate.cs" />
     <Compile Include="TestResources\TcpTransportSecurityWithSslResource.cs" />
     <Compile Include="TestResources\TcpVerifyDNSResource.cs" />
     <Compile Include="TestResources\HttpsSoap12Resource.cs" />


### PR DESCRIPTION
* Added a property in BridgeClientCertificateManager to hold the thumbprint of the ClientCertificate so that a test case can get it.
* Test sets the DnsEndpointIdentity to "localhost" which means this will only work when the Bridge and the test run on the same machine.
* Hong has a PR that adds a resource to the Bridge that will return the server Identity. I will update this PR to use that Resource
   once her PR is merged, before I merge this one.
* Test currently fails due to Issue #458, added ActiveIssue