### PR TITLE
Enable TCP client credential test

### DIFF
--- a/src/System.Private.ServiceModel/tests/Common/Scenarios/Endpoints.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Scenarios/Endpoints.cs
@@ -174,13 +174,22 @@ public static partial class Endpoints
     {
         get { return BridgeClient.GetResourceAddress("WcfService.TestResources.DuplexCallbackXmlComplexTypeResource"); }
     }
-            
+
+
     public static string Tcp_CustomBinding_SslStreamSecurity_Address
     {
         get
         {
             BridgeClientCertificateManager.InstallLocalCertificateFromBridge();
             return BridgeClient.GetResourceAddress("WcfService.TestResources.TcpTransportSecurityWithSslResource");
+        }
+    }
+
+    public static string Tcp_CustomBinding_SslStreamSecurity_HostName
+    {
+        get
+        {
+            return BridgeClient.GetResourceHostName("WcfService.TestResources.TcpTransportSecurityWithSslResource");
         }
     }
 }

--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Tcp/ClientCredentialTypeTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Tcp/ClientCredentialTypeTests.cs
@@ -94,7 +94,6 @@ public static class Tcp_ClientCredentialTypeTests
     // Simple echo of a string using a CustomBinding to mimic a NetTcpBinding with Security.Mode = TransportWithMessageCredentials
     // This does not exactly match the binding elements in a NetTcpBinding which also includes a TransportSecurityBindingElement
     [Fact]
-    [ActiveIssue(310)]
     [OuterLoop]
     public static void SameBinding_SecurityModeTransport_ClientCredentialTypeCertificate_EchoString()
     {
@@ -108,7 +107,8 @@ public static class Tcp_ClientCredentialTypeTests
                 new BinaryMessageEncodingBindingElement(),
                 new TcpTransportBindingElement());
             
-            factory = new ChannelFactory<IWcfService>(binding, new EndpointAddress(Endpoints.Tcp_CustomBinding_SslStreamSecurity_Address));
+            var endpointIdentity = new DnsEndpointIdentity(Endpoints.Tcp_CustomBinding_SslStreamSecurity_HostName);
+            factory = new ChannelFactory<IWcfService>(binding, new EndpointAddress(new Uri(Endpoints.Tcp_CustomBinding_SslStreamSecurity_Address), endpointIdentity));
             
             IWcfService serviceProxy = factory.CreateChannel();
 


### PR DESCRIPTION
Test was disabled due to System.Security.Claims..ctor issue where the test-runtime
package was not up to date. Enable this test as test runtime package has now been
updated

Also change the endpoint so that we correctly obtain the DnsEndpointIdentity when
testing when the Bridge is located at an address other than the FQDN (e.g., when
testing against localhost or hostname)

Needs #457 to be merged first. 