### PR TITLE
Reenable streaming tests after CoreFx fix

### DIFF
--- a/src/System.Private.ServiceModel/tests/Scenarios/Contract/Service/ServiceContractTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Contract/Service/ServiceContractTests.cs
@@ -41,7 +41,6 @@ public static class ServiceContractTests
 
     [Fact]
     [OuterLoop]
-    [ActiveIssue(4077)]//CoreFX
     public static void DefaultSettings_Echo_RoundTrips_String_StreamedRequest()
     {
         string testString = "Hello";
@@ -94,7 +93,6 @@ public static class ServiceContractTests
 
     [Fact]
     [OuterLoop]
-    [ActiveIssue(4077)]//CoreFX
     public static void DefaultSettings_Echo_RoundTrips_String_Streamed()
     {
         string testString = "Hello";
@@ -130,7 +128,6 @@ public static class ServiceContractTests
 
     [Fact]
     [OuterLoop]
-    [ActiveIssue(4077)]//CoreFX
     public static void DefaultSettings_Echo_RoundTrips_String_Streamed_Async()
     {
         string testString = "Hello";
@@ -166,7 +163,6 @@ public static class ServiceContractTests
 
     [Fact]
     [OuterLoop]
-    [ActiveIssue(4077)]//CoreFX
     public static void DefaultSettings_Echo_RoundTrips_String_Streamed_WithSingleThreadedSyncContext()
     {
         bool success = Task.Run(() =>
@@ -181,7 +177,6 @@ public static class ServiceContractTests
 
     [Fact]
     [OuterLoop]
-    [ActiveIssue(4077)]//CoreFX
     public static void DefaultSettings_Echo_RoundTrips_String_Streamed_Async_WithSingleThreadedSyncContext()
     {
         bool success = Task.Run(() =>


### PR DESCRIPTION
The streaming tests were disabled due to issue
https://github.com/dotnet/corefx/issues/4077.

But now that the issue is fixed, these tests pass again,
so this PR re-enables them. Verified in Linux too.