### PR TITLE
Use latest networking fixes

### DIFF
--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/CoreClrSocketConnection.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/CoreClrSocketConnection.cs
@@ -892,15 +892,15 @@ namespace System.ServiceModel.Channels
             }
         }
 
-        protected override Task<IConnection> CreateConnectionAsync(IPAddress address, int port)
+        protected override async Task<IConnection> CreateConnectionAsync(IPAddress address, int port)
         {
             Socket socket = null;
             try
             {
                 AddressFamily addressFamily = address.AddressFamily;
                 socket = new Socket(addressFamily, SocketType.Stream, ProtocolType.Tcp);
-                socket.Connect(new IPEndPoint(address, port));
-                return Task.FromResult<IConnection>(new CoreClrSocketConnection(socket, _connectionBufferPool));
+                await socket.ConnectAsync(new IPEndPoint(address, port));
+                return new CoreClrSocketConnection(socket, _connectionBufferPool);
             }
             catch
             {


### PR DESCRIPTION
Two issues addressed here.
1. Switch to socket.ConnectAsync now that it's available
2. Enable HTTP streaming tests now that dotnet/corefx#4077 has been fixed
This required updating dependant versions to get the fixed networking builds