### PR TITLE
Fix some WebSocket issues

### DIFF
--- a/src/System.Private.ServiceModel/src/Internals/System/Runtime/TaskHelpers.cs
+++ b/src/System.Private.ServiceModel/src/Internals/System/Runtime/TaskHelpers.cs
@@ -189,6 +189,17 @@ namespace System.Runtime
             return task.GetAwaiter().GetResult();
         }
 
+        public static bool WaitWithTimeSpan(this Task task, TimeSpan timeout)
+        {
+            if (timeout >= TimeoutHelper.MaxWait)
+            {
+                task.Wait();
+                return true;
+            }
+
+            return task.Wait(timeout);
+        }
+
         // Used by WebSocketTransportDuplexSessionChannel on the sync code path.
         // TODO: Try and switch as many code paths as possible which use this to async
         public static void Wait(this Task task, TimeSpan timeout, Action<Exception, TimeSpan, string> exceptionConverter, string operationType)

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/CoreClrClientWebSocketFactory.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/CoreClrClientWebSocketFactory.cs
@@ -16,7 +16,11 @@ namespace System.ServiceModel.Channels
         {
             ClientWebSocket webSocket = new ClientWebSocket();
             webSocket.Options.Credentials = credentials;
-            webSocket.Options.AddSubProtocol(settings.SubProtocol);
+            if(!string.IsNullOrEmpty(settings.SubProtocol))
+            {
+                webSocket.Options.AddSubProtocol(settings.SubProtocol);
+            }
+            
             webSocket.Options.KeepAliveInterval = settings.KeepAliveInterval;
             foreach (var headerObj in headers)
             {

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/HttpChannelFactory.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/HttpChannelFactory.cs
@@ -23,7 +23,7 @@ namespace System.ServiceModel.Channels
     {
         private static CacheControlHeaderValue s_requestCacheHeader = new CacheControlHeaderValue { NoCache = true, MaxAge = new TimeSpan(0) };
 
-        readonly ClientWebSocketFactory _clientWebSocketFactory;
+        protected readonly ClientWebSocketFactory _clientWebSocketFactory;
 
         private bool _allowCookies;
         private AuthenticationSchemes _authenticationScheme;

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/HttpsChannelFactory.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/HttpsChannelFactory.cs
@@ -70,6 +70,7 @@ namespace System.ServiceModel.Channels
         protected override TChannel OnCreateChannelCore(EndpointAddress address, Uri via)
         {
             ValidateCreateChannelParameters(address, via);
+            ValidateWebSocketTransportUsage();
 
             if (typeof(TChannel) == typeof(IRequestChannel))
             {
@@ -77,7 +78,7 @@ namespace System.ServiceModel.Channels
             }
             else
             {
-                throw ExceptionHelper.PlatformNotSupported("Channel shape not supported");
+                return (TChannel)(object)new ClientWebSocketTransportDuplexSessionChannel((HttpChannelFactory<IDuplexSessionChannel>)(object)this, _clientWebSocketFactory, address, via, this.WebSocketBufferPool);
             }
         }
 

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/TimeoutStream.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/TimeoutStream.cs
@@ -14,6 +14,7 @@ namespace System.ServiceModel.Channels
     {
         private TimeoutHelper _timeoutHelper;
         private bool _disposed;
+        private byte[] _oneByteArray = new byte[1];
 
         public TimeoutStream(Stream stream, TimeSpan timeout)
             : base(stream)
@@ -31,6 +32,14 @@ namespace System.ServiceModel.Channels
         public override int Read(byte[] buffer, int offset, int count)
         {
             return ReadAsyncInternal(buffer, offset, count, CancellationToken.None).WaitForCompletion();
+        }
+
+        public override int ReadByte()
+        {
+            int r = Read(_oneByteArray, 0, 1);
+            if (r == 0)
+                return -1;
+            return _oneByteArray[0];
         }
 
         public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
@@ -51,6 +60,12 @@ namespace System.ServiceModel.Channels
         public override void Write(byte[] buffer, int offset, int count)
         {
             WriteAsyncInternal(buffer, offset, count, CancellationToken.None).WaitForCompletion();
+        }
+
+        public override void WriteByte(byte value)
+        {
+            _oneByteArray[0] = value;
+            Write(_oneByteArray, 0, 1);
         }
 
         public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)

--- a/src/System.Private.ServiceModel/tests/Common/Infrastructure/src/testproperties.props
+++ b/src/System.Private.ServiceModel/tests/Common/Infrastructure/src/testproperties.props
@@ -39,6 +39,10 @@
         <Value>$(BridgeWebSocketPort)</Value>
         <DefaultValue>8083</DefaultValue>
       </TestProperty>
+      <TestProperty Include="BridgeSecureWebSocketPort">
+        <Value>$(BridgeSecureWebSocketPort)</Value>
+        <DefaultValue>8084</DefaultValue>
+      </TestProperty>
       <TestProperty Include="BridgeRemoteEnabled">
         <Value>$(BridgeRemoteEnabled)</Value>
         <DefaultValue>false</DefaultValue>

--- a/src/System.Private.ServiceModel/tests/Scenarios/Extensibility/WebSockets/WebSocketTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Extensibility/WebSockets/WebSocketTests.cs
@@ -12,7 +12,7 @@ public static class WebSocketTests
 {
     [Fact]
     [OuterLoop]
-    [ActiveIssue(468)]
+    [ActiveIssue(420, PlatformID.AnyUnix)]
     public static void WebSocket_Http_RequestReply_BinaryStreamed()
     {
         NetHttpBinding binding = null;
@@ -71,7 +71,7 @@ public static class WebSocketTests
 
     [Fact]
     [OuterLoop]
-    [ActiveIssue(468)]
+    [ActiveIssue(420, PlatformID.AnyUnix)]
     public static void WebSocket_Http_Duplex_BinaryStreamed()
     {
         NetHttpBinding binding = null;
@@ -153,7 +153,7 @@ public static class WebSocketTests
 
     [Fact]
     [OuterLoop]
-    [ActiveIssue(470)]
+    [ActiveIssue(420, PlatformID.AnyUnix)]
     public static void WebSocket_Https_Duplex_BinaryStreamed()
     {
         BinaryMessageEncodingBindingElement binaryMessageEncodingBindingElement = null;

--- a/src/System.Private.ServiceModel/tests/Scenarios/Extensibility/WebSockets/WebSocketTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Extensibility/WebSockets/WebSocketTests.cs
@@ -153,6 +153,7 @@ public static class WebSocketTests
 
     [Fact]
     [OuterLoop]
+    [ActiveIssue(470)]
     [ActiveIssue(420, PlatformID.AnyUnix)]
     public static void WebSocket_Https_Duplex_BinaryStreamed()
     {

--- a/src/System.Private.ServiceModel/tests/Scenarios/Extensibility/WebSockets/WebSocketTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Extensibility/WebSockets/WebSocketTests.cs
@@ -244,6 +244,7 @@ public static class WebSocketTests
     [Fact]
     [OuterLoop]
     [ActiveIssue(470)]
+    [ActiveIssue(420, PlatformID.AnyUnix)]
     public static void WebSocket_Https_Duplex_TextStreamed()
     {
         TextMessageEncodingBindingElement textMessageEncodingBindingElement = null;
@@ -332,7 +333,7 @@ public static class WebSocketTests
 
     [Fact]
     [OuterLoop]
-    [ActiveIssue(468)]
+    [ActiveIssue(420, PlatformID.AnyUnix)]
     public static void WebSocket_Http_Duplex_TextStreamed()
     {
         NetHttpBinding binding = null;
@@ -416,7 +417,7 @@ public static class WebSocketTests
 
     [Fact]
     [OuterLoop]
-    [ActiveIssue(468)]
+    [ActiveIssue(420, PlatformID.AnyUnix)]
     public static void WebSocket_Http_RequestReply_TextStreamed()
     {
         NetHttpBinding binding = null;

--- a/src/System.Private.ServiceModel/tools/test/Bridge/WcfTestBridgeCommon/BridgeConfiguration.cs
+++ b/src/System.Private.ServiceModel/tools/test/Bridge/WcfTestBridgeCommon/BridgeConfiguration.cs
@@ -18,6 +18,7 @@ namespace WcfTestBridgeCommon
         private static readonly int Default_BridgeHttpsPort = 44285;
         private static readonly int Default_BridgeTcpPort = 809;
         private static readonly int Default_BridgeWebSocketPort = 8083;
+        private static readonly int Default_BridgeSecureWebSocketPort = 8084;
         private static readonly TimeSpan Default_BridgeMaxIdleTimeSpan = TimeSpan.FromHours(24);
         
         // These property names must match the names used in TestProperties because
@@ -29,6 +30,7 @@ namespace WcfTestBridgeCommon
         private const string BridgeHttpsPort_PropertyName = "BridgeHttpsPort";
         private const string BridgeTcpPort_PropertyName = "BridgeTcpPort";
         private const string BridgeWebSocketPort_PropertyName = "BridgeWebSocketPort";
+        private const string BridgeSecureWebSocketPort_PropertyName = "BridgeSecureWebSocketPort";
         private const string BridgeCertificatePassword_PropertyName = "BridgeCertificatePassword";
         private const string BridgeCertificateValidityPeriod_PropertyName = "BridgeCertificateValidityPeriod";
         private const string BridgeMaxIdleTimeSpan_PropertyName = "BridgeMaxIdleTimeSpan";
@@ -41,6 +43,7 @@ namespace WcfTestBridgeCommon
         public int BridgeHttpsPort { get; set; }
         public int BridgeTcpPort { get; set; }
         public int BridgeWebSocketPort { get; set; }
+        public int BridgeSecureWebSocketPort { get; set; }
         public string BridgeCertificatePassword { get; set; }
         public TimeSpan BridgeCertificateValidityPeriod { get; set; }
         public TimeSpan BridgeMaxIdleTimeSpan { get; set; }
@@ -54,6 +57,7 @@ namespace WcfTestBridgeCommon
             BridgeHttpsPort = Default_BridgeHttpsPort;
             BridgeTcpPort = Default_BridgeTcpPort;
             BridgeWebSocketPort = Default_BridgeWebSocketPort;
+            BridgeSecureWebSocketPort = Default_BridgeSecureWebSocketPort;
             BridgeMaxIdleTimeSpan = Default_BridgeMaxIdleTimeSpan;
         }
 
@@ -69,6 +73,7 @@ namespace WcfTestBridgeCommon
             BridgeHttpsPort = configuration.BridgeHttpsPort;
             BridgeTcpPort = configuration.BridgeTcpPort;
             BridgeWebSocketPort = configuration.BridgeWebSocketPort;
+            BridgeSecureWebSocketPort = configuration.BridgeSecureWebSocketPort;
             BridgeCertificatePassword = configuration.BridgeCertificatePassword;
             BridgeCertificateValidityPeriod = configuration.BridgeCertificateValidityPeriod;
             BridgeMaxIdleTimeSpan = configuration.BridgeMaxIdleTimeSpan;
@@ -128,6 +133,11 @@ namespace WcfTestBridgeCommon
             if (TryParseIntegerProperty(BridgeWebSocketPort_PropertyName, properties, out port))
             {
                 BridgeWebSocketPort = port;
+            }
+
+            if (TryParseIntegerProperty(BridgeSecureWebSocketPort_PropertyName, properties, out port))
+            {
+                BridgeSecureWebSocketPort = port;
             }
 
             if (properties.TryGetValue(BridgeMaxIdleTimeSpan_PropertyName, out propertyValue))
@@ -201,6 +211,7 @@ namespace WcfTestBridgeCommon
             result[BridgeHttpsPort_PropertyName] = BridgeHttpsPort.ToString();
             result[BridgeTcpPort_PropertyName] = BridgeTcpPort.ToString();
             result[BridgeWebSocketPort_PropertyName] = BridgeWebSocketPort.ToString();
+            result[BridgeSecureWebSocketPort_PropertyName] = BridgeSecureWebSocketPort.ToString();
             result[BridgeCertificatePassword_PropertyName] = BridgeCertificatePassword;
             result[BridgeCertificateValidityPeriod_PropertyName] = BridgeCertificateValidityPeriod.ToString();
             result[BridgeMaxIdleTimeSpan_PropertyName] = BridgeMaxIdleTimeSpan.ToString();
@@ -219,6 +230,7 @@ namespace WcfTestBridgeCommon
               .AppendFormat("  {0} : '{1}'{2}", BridgeHttpsPort_PropertyName, BridgeHttpsPort, Environment.NewLine)
               .AppendFormat("  {0} : '{1}'{2}", BridgeTcpPort_PropertyName, BridgeTcpPort, Environment.NewLine)
               .AppendFormat("  {0} : '{1}'{2}", BridgeWebSocketPort_PropertyName, BridgeWebSocketPort, Environment.NewLine)
+              .AppendFormat("  {0} : '{1}'{2}", BridgeSecureWebSocketPort_PropertyName, BridgeSecureWebSocketPort, Environment.NewLine)
               .AppendFormat("  {0} : '{1}'{2}", BridgeCertificatePassword_PropertyName, BridgeCertificatePassword, Environment.NewLine)
               .AppendFormat("  {0} : '{1}'{2}", BridgeCertificateValidityPeriod_PropertyName, BridgeCertificateValidityPeriod, Environment.NewLine)
               .AppendFormat("  {0} : '{1}'{2}", BridgeMaxIdleTimeSpan_PropertyName, BridgeMaxIdleTimeSpan, Environment.NewLine)

--- a/src/System.Private.ServiceModel/tools/test/SelfHostWcfService/TestResources/WebSocketResources.cs
+++ b/src/System.Private.ServiceModel/tools/test/SelfHostWcfService/TestResources/WebSocketResources.cs
@@ -100,7 +100,7 @@ namespace WcfService.TestResources
 
         protected override int GetPort(ResourceRequestContext context)
         {
-            return context.BridgeConfiguration.BridgeWebSocketPort;
+            return context.BridgeConfiguration.BridgeSecureWebSocketPort;
         }
 
         protected override string Address { get { return "WebSocketHttpsDuplexBinaryStreamedResource"; } }


### PR DESCRIPTION
1. HttpsChannelFactory was hard coded to throw on duplex contracts
2. TimeoutStream didn't override ReadByte and WriteByte which cause WebSocketStream.Read/Write to be called  

Fixes #468