### PR TITLE
Adding text encoder variations to WebSocket scenario tests.

### DIFF
--- a/src/System.Private.ServiceModel/tests/Common/Scenarios/Endpoints.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Scenarios/Endpoints.cs
@@ -61,6 +61,16 @@ public static partial class Endpoints
         get { return BridgeClient.GetResourceAddress("WcfService.TestResources.WebSocketHttpRequestReplyBinaryStreamedResource"); }
     }
 
+    public static string WebSocketHttpRequestReplyTextStreamed_Address
+    {
+        get { return BridgeClient.GetResourceAddress("WcfService.TestResources.WebSocketHttpRequestReplyTextStreamedResource"); }
+    }
+
+    public static string WebSocketHttpDuplexTextStreamed_Address
+    {
+        get { return BridgeClient.GetResourceAddress("WcfService.TestResources.WebSocketHttpDuplexTextStreamedResource"); }
+    }
+
     // HTTPS Addresses
     public static string Https_BasicAuth_Address
     {
@@ -140,6 +150,15 @@ public static partial class Endpoints
         {
             BridgeClientCertificateManager.InstallRootCertificateFromBridge();
             return BridgeClient.GetResourceAddress("WcfService.TestResources.WebSocketHttpsDuplexBinaryStreamedResource");
+        }
+    }
+
+    public static string WebSocketHttpsDuplexTextStreamed_Address
+    {
+        get
+        {
+            BridgeClientCertificateManager.InstallRootCertificateFromBridge();
+            return BridgeClient.GetResourceAddress("WcfService.TestResources.WebSocketHttpsDuplexTextStreamedResource");
         }
     }
 

--- a/src/System.Private.ServiceModel/tools/test/SelfHostWcfService/TestResources/WebSocketResources.cs
+++ b/src/System.Private.ServiceModel/tools/test/SelfHostWcfService/TestResources/WebSocketResources.cs
@@ -3,6 +3,7 @@
 
 using System.ServiceModel;
 using System.ServiceModel.Channels;
+using WcfService.CertificateResources;
 using WcfTestBridgeCommon;
 
 namespace WcfService.TestResources
@@ -99,7 +100,7 @@ namespace WcfService.TestResources
 
         protected override int GetPort(ResourceRequestContext context)
         {
-            return context.BridgeConfiguration.BridgeWebSocketPort + 1;
+            return context.BridgeConfiguration.BridgeWebSocketPort;
         }
 
         protected override string Address { get { return "WebSocketHttpsDuplexBinaryStreamedResource"; } }
@@ -115,6 +116,90 @@ namespace WcfService.TestResources
             httpsTransportBindingElement.MaxBufferSize = DefaultMaxReceivedMessageSize;
             httpsTransportBindingElement.TransferMode = TransferMode.Streamed;
             CustomBinding binding = new CustomBinding(binaryMessageEncodingBindingElement, httpsTransportBindingElement);
+            return binding;
+        }
+    }
+
+    internal class WebSocketHttpsDuplexTextStreamedResource : EndpointResource<WSDuplexService, IWSDuplexService>
+    {
+        protected override string Protocol { get { return BaseAddressResource.Https; } }
+
+        protected override int GetPort(ResourceRequestContext context)
+        {
+            return context.BridgeConfiguration.BridgeHttpsPort;
+        }
+
+        protected override string Address { get { return "WebSocketHttpsDuplexTextStreamedResource"; } }
+
+        protected override Binding GetBinding()
+        {
+            int DefaultMaxReceivedMessageSize = 64 * 1024 * 1024;
+
+            TextMessageEncodingBindingElement textMessageEncodingBindingElement = new TextMessageEncodingBindingElement();
+            HttpsTransportBindingElement httpsTransportBindingElement = new HttpsTransportBindingElement();
+            httpsTransportBindingElement.WebSocketSettings.TransportUsage = WebSocketTransportUsage.Always;
+            httpsTransportBindingElement.MaxReceivedMessageSize = DefaultMaxReceivedMessageSize;
+            httpsTransportBindingElement.MaxBufferSize = DefaultMaxReceivedMessageSize;
+            httpsTransportBindingElement.TransferMode = TransferMode.Streamed;
+            CustomBinding binding = new CustomBinding(textMessageEncodingBindingElement, httpsTransportBindingElement);
+            return binding;
+        }
+
+        protected override void ModifyHost(ServiceHost serviceHost, ResourceRequestContext context)
+        {
+            // Ensure the https certificate is installed before this endpoint resource is used
+            CertificateResourceHelpers.EnsureSslPortCertificateInstalled(context.BridgeConfiguration);
+
+            base.ModifyHost(serviceHost, context);
+        }
+    }
+
+    internal class WebSocketHttpRequestReplyTextStreamedResource : EndpointResource<WSRequestReplyService, IWSRequestReplyService>
+    {
+        protected override string Protocol { get { return BaseAddressResource.Http; } }
+
+        protected override int GetPort(ResourceRequestContext context)
+        {
+            return context.BridgeConfiguration.BridgeWebSocketPort;
+        }
+
+        protected override string Address { get { return "WebSocketHttpRequestReplyTextStreamedResource"; } }
+
+        protected override Binding GetBinding()
+        {
+            int DefaultMaxReceivedMessageSize = 64 * 1024 * 1024;
+
+            NetHttpBinding binding = new NetHttpBinding();
+            binding.WebSocketSettings.TransportUsage = WebSocketTransportUsage.Always;
+            binding.MaxReceivedMessageSize = DefaultMaxReceivedMessageSize;
+            binding.MaxBufferSize = DefaultMaxReceivedMessageSize;
+            binding.TransferMode = TransferMode.Streamed;
+            binding.MessageEncoding = NetHttpMessageEncoding.Text;
+            return binding;
+        }
+    }
+
+    internal class WebSocketHttpDuplexTextStreamedResource : EndpointResource<WSDuplexService, IWSDuplexService>
+    {
+        protected override string Protocol { get { return BaseAddressResource.Http; } }
+
+        protected override int GetPort(ResourceRequestContext context)
+        {
+            return context.BridgeConfiguration.BridgeWebSocketPort;
+        }
+
+        protected override string Address { get { return "WebSocketHttpDuplexTextStreamedResource"; } }
+
+        protected override Binding GetBinding()
+        {
+            int DefaultMaxReceivedMessageSize = 64 * 1024 * 1024;
+
+            NetHttpBinding binding = new NetHttpBinding();
+            binding.WebSocketSettings.TransportUsage = WebSocketTransportUsage.Always;
+            binding.MaxReceivedMessageSize = DefaultMaxReceivedMessageSize;
+            binding.MaxBufferSize = DefaultMaxReceivedMessageSize;
+            binding.TransferMode = TransferMode.Streamed;
+            binding.MessageEncoding = NetHttpMessageEncoding.Text;
             return binding;
         }
     }


### PR DESCRIPTION
* Fixes #484
* Fixed an error getting the port number for the WebSocketHttpsDuplexBinaryStreamedResource, not caught earlier since all these tests are failing for other reasons.
* These new tests fail for the same high level reasons as their binary counterparts, but @mconnew in fixing the high level issues has reached a lower level issue where the type of encoding matters, so these tests may help him with his debugging efforts.