### PR TITLE
run-test.sh no longer copies binaries from WCF bin folder

### DIFF
--- a/run-test.sh
+++ b/run-test.sh
@@ -102,7 +102,11 @@ create_test_overlay()
 	echo "WCF binaries not found at $WcfBins"
 	exit 1
   fi
-  find $WcfBins -name '*.dll' -and -not -name "*Test*" -exec cp '{}' "$OverlayDir" ";"
+  # We no longer copy binaries from the WCF bin folder because they can contain
+  # assemblies built from other than the test folders.  The test folders already
+  # contain any WCF-built assemblies they require.  We leave this legacy copy here
+  # in case we need to bring it back.
+#  find $WcfBins -name '*.dll' -and -not -name "*Test*" -exec cp '{}' "$OverlayDir" ";"
 
   if [ ! -d $packageLibDir ]
   then


### PR DESCRIPTION
Prior to this change the run-test.sh script used to run the tests
in Linux copied all the assemblies from the WCF bin folder into the
WCF test folders.  This was harmless when the assemblies were the
same but caused issues when the bin folder contains other versions
of the assemblies.

With this change, the script no longer copies assemblies from the
WCF bin folder but relies on the test folders containing all they need.