### PR TITLE
Implement NetTcpBinding Certification authority revokes a certificate

### DIFF
--- a/src/System.Private.ServiceModel/tests/Common/Scenarios/Endpoints.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Scenarios/Endpoints.cs
@@ -179,6 +179,22 @@ public static partial class Endpoints
         }
     }
 
+    public static string Tcp_RevocatedServerCertResource_HostName
+    {
+        get
+        {
+            return BridgeClient.GetResourceHostName("WcfService.TestResources.TcpRevocatedServerCertResource");
+        }
+    }
+
+    public static string Tcp_RevocatedServerCertResource_Address
+    {
+        get
+        {
+            return BridgeClient.GetResourceAddress("WcfService.TestResources.TcpRevocatedServerCertResource");
+        }
+    }
+
     public static string Tcp_ExpiredServerCertResource_HostName
     {
         get
@@ -186,6 +202,7 @@ public static partial class Endpoints
             return BridgeClient.GetResourceHostName("WcfService.TestResources.TcpExpiredServerCertResource");
         }
     }
+
 
     public static string Tcp_NoSecurity_Callback_Address
     {

--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/ExpectedExceptions/ExpectedExceptionTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/ExpectedExceptions/ExpectedExceptionTests.cs
@@ -511,6 +511,42 @@ public static class ExpectedExceptionTests
             ScenarioTestHelpers.CloseCommunicationObjects(factory);
         }
     }
+
+    [Fact]
+    [OuterLoop]
+    // Verify product throws MessageSecurityException when the service cert is revocated
+    public static void TCP_ServiceCertRevoked_Throw_MessageSecurityException()
+    {
+        string testString = "Hello";
+
+        NetTcpBinding binding = new NetTcpBinding();
+        binding.Security.Mode = SecurityMode.Transport;
+        binding.Security.Transport.ClientCredentialType = TcpClientCredentialType.None;
+
+        EndpointAddress endpointAddress = new EndpointAddress(new Uri(Endpoints.Tcp_RevocatedServerCertResource_Address), new DnsEndpointIdentity(Endpoints.Tcp_RevocatedServerCertResource_HostName));
+        ChannelFactory<IWcfService> factory = new ChannelFactory<IWcfService>(binding, endpointAddress);
+        IWcfService serviceProxy = factory.CreateChannel();
+
+        try
+        {
+            var result = serviceProxy.Echo(testString);
+            Assert.True(false, "Expected: SecurityNegotiationException, Actual: no exception");
+        }
+        catch (CommunicationException exception)
+        {
+            string exceptionType = exception.GetType().Name;
+            if (exceptionType != "SecurityNegotiationException")
+            {
+                Assert.True(false, string.Format("Expected type SecurityNegotiationException, Actual: {0}", exceptionType));
+            }
+            string exceptionMessage = exception.Message;
+            Assert.True(exceptionMessage.Contains(Endpoints.Tcp_ExpiredServerCertResource_HostName), string.Format("Expected message contains {0}, actual message: {1}", Endpoints.Tcp_ExpiredServerCertResource_HostName, exceptionMessage));
+        }
+        finally
+        {
+            ScenarioTestHelpers.CloseCommunicationObjects(factory);
+        }
+    }
 }
 
 public class MyCertificateValidator : X509CertificateValidator

--- a/src/System.Private.ServiceModel/tools/test/Bridge/WcfTestBridgeCommon/CertificateGenerator.cs
+++ b/src/System.Private.ServiceModel/tools/test/Bridge/WcfTestBridgeCommon/CertificateGenerator.cs
@@ -424,8 +424,12 @@ namespace WcfTestBridgeCommon
             
             _crlGenerator.Reset();
 
-            _crlGenerator.SetThisUpdate(_initializationDateTime);
-            _crlGenerator.SetNextUpdate(DateTime.UtcNow.Add(_crlValidityPeriod));
+            // Use UtcNow does not work. current local time works.
+            // Could be a BouncyCastle issue.
+            // We need to assume two test machines are in the same time zone.
+            DateTime now = DateTime.Now;
+            _crlGenerator.SetThisUpdate(now);
+            _crlGenerator.SetNextUpdate(now.Add(_crlValidityPeriod));
             _crlGenerator.SetIssuerDN(PrincipalUtilities.GetSubjectX509Principal(signingCertificate));
             _crlGenerator.SetSignatureAlgorithm(_signatureAlthorithm);
 

--- a/src/System.Private.ServiceModel/tools/test/Bridge/WcfTestBridgeCommon/CertificateManager.cs
+++ b/src/System.Private.ServiceModel/tools/test/Bridge/WcfTestBridgeCommon/CertificateManager.cs
@@ -237,6 +237,19 @@ namespace WcfTestBridgeCommon
             }
         }
 
+        public static void RevocatingACert(CertificateGenerator certificateGenerator, string serialNum)
+        {
+            if (certificateGenerator == null)
+            {
+                throw new ArgumentNullException("certificateGenerator");
+            }
+
+            lock (s_certificateLock)
+            {
+                certificateGenerator.RevokeCertificateBySerialNumber(serialNum);
+            }
+        }
+
         public static void UninstallAllRootCertificates(bool force)
         {
             UninstallCertificates(StoreName.Root, StoreLocation.LocalMachine, s_rootCertificates, force);

--- a/src/System.Private.ServiceModel/tools/test/SelfHostWcfService/TestResources/TcpRevocatedServerCertResource.cs
+++ b/src/System.Private.ServiceModel/tools/test/SelfHostWcfService/TestResources/TcpRevocatedServerCertResource.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using System;
+using System.Net;
+using System.ServiceModel;
+using System.ServiceModel.Channels;
+using System.Security.Cryptography.X509Certificates;
+using WcfTestBridgeCommon;
+using WcfService.CertificateResources;
+
+namespace WcfService.TestResources
+{
+    internal class TcpRevocatedServerCertResource : TcpResource
+    {
+        protected override string Address { get { return "tcp-RevocatedServerCert"; } }
+
+        protected override Binding GetBinding()
+        {
+            NetTcpBinding binding = new NetTcpBinding() { PortSharingEnabled = false };
+            binding.Security.Mode = SecurityMode.Transport;
+            binding.Security.Transport.ClientCredentialType = TcpClientCredentialType.None;
+
+            return binding;
+        }
+
+        protected override void ModifyHost(ServiceHost serviceHost, ResourceRequestContext context)
+        {
+            // Ensure the service certificate is installed before this endpoint resource is used
+            //Create a certificate and add to the revocation list
+            CertificateCreationSettings certificateCreationSettings = new CertificateCreationSettings()
+            {
+                IsValidCert = false,
+                Subjects = new string[] { s_fqdn, s_hostname, "localhost" }
+            };
+
+            string thumbprint = CertificateResourceHelpers.EnsureNonDefaultCertificateInstalled(context.BridgeConfiguration, certificateCreationSettings, Address);
+            CertificateManager.RevocatingACert(CertificateResourceHelpers.GetCertificateGeneratorInstance(context.BridgeConfiguration), thumbprint);
+
+            serviceHost.Credentials.ServiceCertificate.SetCertificate(StoreLocation.LocalMachine,
+                                                        StoreName.My,
+                                                        X509FindType.FindByThumbprint,
+                                                        thumbprint);
+        }
+    }
+}

--- a/src/System.Private.ServiceModel/tools/test/SelfHostWcfService/WcfService.csproj
+++ b/src/System.Private.ServiceModel/tools/test/SelfHostWcfService/WcfService.csproj
@@ -85,6 +85,7 @@
     <Compile Include="TestResources\HttpsNtlmResource.cs" />
     <Compile Include="TestResources\HttpsDigestResource.cs" />
     <Compile Include="TestResources\TcpDefaultResource.cs" />
+    <Compile Include="TestResources\TcpRevocatedServerCertResource.cs" />
     <Compile Include="TestResources\TcpNoSecurityResource.cs" />
     <Compile Include="TestResources\TcpNoSecurityTextResource.cs" />
     <Compile Include="TestResources\TcpResource.cs" />


### PR DESCRIPTION
* Add a test to check client call will fail if the service cert is revocated.

Fixes #369