### PR TITLE
Mark client certs installed by BridgeClient as PersistKeySet

### DIFF
--- a/src/System.Private.ServiceModel/tests/Common/Infrastructure/src/BridgeClientCertificateManager.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Infrastructure/src/BridgeClientCertificateManager.cs
@@ -206,7 +206,7 @@ namespace Infrastructure.Common
                     string certificateAsBase64;
                     if (response.TryGetValue(CertificateKeyName, out certificateAsBase64))
                     {
-                        certificateToInstall = new X509Certificate2(Convert.FromBase64String(certificateAsBase64), ClientCertificatePassword);
+                        certificateToInstall = new X509Certificate2(Convert.FromBase64String(certificateAsBase64), ClientCertificatePassword, X509KeyStorageFlags.PersistKeySet);
                     }
                     else
                     {
@@ -267,7 +267,7 @@ namespace Infrastructure.Common
                     {
                         try
                         {
-                            store.Open(OpenFlags.ReadWrite);
+                            store.Open(OpenFlags.ReadWrite | OpenFlags.OpenExistingOnly);
                         }
                         catch (CryptographicException inner)
                         {

--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Tcp/ClientCredentialTypeTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Tcp/ClientCredentialTypeTests.cs
@@ -228,7 +228,7 @@ public static class Tcp_ClientCredentialTypeTests
             MyX509CertificateValidator myX509CertificateValidator = new MyX509CertificateValidator(ScenarioTestHelpers.CertificateIssuerName);
             factory.Credentials.ServiceCertificate.Authentication.CustomCertificateValidator = myX509CertificateValidator;
             factory.Credentials.ClientCertificate.SetCertificate(
-                StoreLocation.LocalMachine,
+                StoreLocation.CurrentUser,
                 StoreName.My,
                 X509FindType.FindByThumbprint,
                 clientCertThumb);


### PR DESCRIPTION
Mark all installed certificates as PersistKeySet; this seems to be a difference when
importing to the CurrentUser certificate store vs. the LocalMachine store in
Windows. This caused issues when attemtping to use the certificates in tests and
sems to avert the issue of the tcp tests running into the following excception:

```
System.ComponentModel.Win32Exception :
The credentials supplied to the package were not recognized
```

Fixes #495 (hopefully) 