### PR TITLE
Lock CoreCLR version

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -31,7 +31,7 @@ def project = 'dotnet/wcf'
                 copyArtifacts('dotnet_coreclr/release_ubuntu') {
                     excludePatterns('**/testResults.xml', '**/*.ni.dll')
                     buildSelector {
-                        latestSuccessful(true)
+                        buildNumber('146')
                     }
                     targetDirectory('coreclr')
                 }


### PR DESCRIPTION
There are some incompatibilites between CoreFX and CoreCLR, we need to
lock to a specific build of CoreCLR for testing for a bit of time.