### PR TITLE
 Light up async paths needed for Ssl StreamSecurity (I)

### DIFF
--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/StreamUpgradeInitiator.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/StreamUpgradeInitiator.cs
@@ -3,6 +3,7 @@
 
 using System.IO;
 using System.Runtime;
+using System.Threading.Tasks;
 
 namespace System.ServiceModel.Channels
 {
@@ -15,35 +16,15 @@ namespace System.ServiceModel.Channels
         public abstract string GetNextUpgrade();
 
         public abstract Stream InitiateUpgrade(Stream stream);
-        public abstract IAsyncResult BeginInitiateUpgrade(Stream stream, AsyncCallback callback, object state);
-        public abstract Stream EndInitiateUpgrade(IAsyncResult result);
 
-        internal virtual IAsyncResult BeginOpen(TimeSpan timeout, AsyncCallback callback, object state)
-        {
-            return new CompletedAsyncResult(callback, state);
-        }
+        internal abstract Task<Stream> InitiateUpgradeAsync(Stream stream);
 
-        internal virtual void EndOpen(IAsyncResult result)
-        {
-            CompletedAsyncResult.End(result);
-        }
+        internal abstract void Open(TimeSpan timeout);
 
-        internal virtual IAsyncResult BeginClose(TimeSpan timeout, AsyncCallback callback, object state)
-        {
-            return new CompletedAsyncResult(callback, state);
-        }
+        internal abstract Task OpenAsync(TimeSpan timeout);
 
-        internal virtual void EndClose(IAsyncResult result)
-        {
-            CompletedAsyncResult.End(result);
-        }
+        internal abstract void Close(TimeSpan timeout);
 
-        internal virtual void Open(TimeSpan timeout)
-        {
-        }
-
-        internal virtual void Close(TimeSpan timeout)
-        {
-        }
+        internal abstract Task CloseAsync(TimeSpan timeout);
     }
 }


### PR DESCRIPTION
Made ClientFramingDuplexSessionChannel.SendPreambleAsync use async methods.

Part of the fix for #303 .