### PR TITLE
Stability improvments to WSDuplexService and Bridge

### DIFF
--- a/src/System.Private.ServiceModel/tools/test/Bridge/Bridge/Program.cs
+++ b/src/System.Private.ServiceModel/tools/test/Bridge/Bridge/Program.cs
@@ -21,6 +21,8 @@ namespace Bridge
 
         private static void Main(string[] args)
         {
+            AppDomain.CurrentDomain.UnhandledException +=
+                new UnhandledExceptionEventHandler(BridgeUnhandledExceptionHandler);
             CommandLineArguments commandLineArgs = new CommandLineArguments(args);
 
             Console.WriteLine("Bridge.exe was launched with:{0}{1}", 
@@ -365,6 +367,18 @@ namespace Bridge
             }
 
             return false;
+        }
+
+        private static void BridgeUnhandledExceptionHandler(object sender, UnhandledExceptionEventArgs args)
+        {
+            Exception e = (Exception) args.ExceptionObject;
+            Console.WriteLine("*** Unhandled exception ***" + Environment.NewLine);
+            Console.WriteLine(e + Environment.NewLine);
+            Console.WriteLine("***                     ***" + Environment.NewLine);
+            if (Debugger.IsAttached)
+            {
+                Debugger.Break();
+            }
         }
 
         class CommandLineArguments

--- a/src/System.Private.ServiceModel/tools/test/SelfHostWcfService/WSDuplexService.cs
+++ b/src/System.Private.ServiceModel/tools/test/SelfHostWcfService/WSDuplexService.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.ServiceModel;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace WcfService
 {
@@ -77,7 +78,7 @@ namespace WcfService
             log.Add("StartPushingData");
             continuePushingData = true;
             IPushCallback pushCallbackChannel = OperationContext.Current.GetCallbackChannel<IPushCallback>();
-            ThreadPool.QueueUserWorkItem(new WaitCallback(PushData), pushCallbackChannel);
+            Task.Factory.StartNew(PushData, pushCallbackChannel, CancellationToken.None, TaskCreationOptions.DenyChildAttach, TaskScheduler.Default);
         }
 
         public void StopPushingData()
@@ -90,14 +91,14 @@ namespace WcfService
         {
             log.Add("StartPushingStream");
             IPushCallback pushCallbackChannel = OperationContext.Current.GetCallbackChannel<IPushCallback>();
-            ThreadPool.QueueUserWorkItem(new WaitCallback(PushStream), pushCallbackChannel);
+            Task.Factory.StartNew(PushStream, pushCallbackChannel, CancellationToken.None, TaskCreationOptions.DenyChildAttach, TaskScheduler.Default);
         }
 
         public void StartPushingStreamLongWait()
         {
             log.Add("StartPushingStream");
             IPushCallback pushCallbackChannel = OperationContext.Current.GetCallbackChannel<IPushCallback>();
-            ThreadPool.QueueUserWorkItem(new WaitCallback(PushStreamLongwait), pushCallbackChannel);
+            Task.Factory.StartNew(PushStreamLongwait, pushCallbackChannel, CancellationToken.None, TaskCreationOptions.DenyChildAttach, TaskScheduler.Default);
         }
 
         public void StopPushingStream()


### PR DESCRIPTION
Fixed WSDuplexService so it shouldn't throw unhandled exceptions any more
Added global exception handler to bridge default app domain (which will handle unhandled exceptions in all other app domains) so that we won't crash the process if something similar happens in the future.
Fixes #513 