### PR TITLE
Remove accidental addition of S.N.WebSockets namespace

### DIFF
--- a/src/System.Private.ServiceModel/tests/Scenarios/Extensibility/WebSockets/WebSocketTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Extensibility/WebSockets/WebSocketTests.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.IO;
-using System.Net.WebSockets;
 using System.ServiceModel;
 using System.ServiceModel.Channels;
 using System.Threading;


### PR DESCRIPTION
This was accidentally added when debugging the failing WebSockets tests previously.