### PR TITLE
Revert temporary fix to lock CoreCLR version

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -31,7 +31,7 @@ def project = 'dotnet/wcf'
                 copyArtifacts('dotnet_coreclr/release_ubuntu') {
                     excludePatterns('**/testResults.xml', '**/*.ni.dll')
                     buildSelector {
-                        buildNumber('146')
+                        latestSuccessful(true)
                     }
                     targetDirectory('coreclr')
                 }


### PR DESCRIPTION
This reverts the temporary fix in 367c3c8218d5571e94dbb531e28e584f4b835e07.
This was necessary to unblock Linux testing.

Now that the WCF repo carries the correct runtime-tools, it is
appropriate to use the latest successful builds, not a specific version.