### PR TITLE
Implement SecurityBindingElement.IsSetKeyDerivation

### DIFF
--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/SecurityBindingElement.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/SecurityBindingElement.cs
@@ -271,12 +271,12 @@ namespace System.ServiceModel.Channels
 
         public virtual void SetKeyDerivation(bool requireDerivedKeys)
         {
-            throw ExceptionHelper.PlatformNotSupported("SecurityBindingElement.SetKeyDerivation is not supported.");
+            EndpointSupportingTokenParameters.SetKeyDerivation(requireDerivedKeys);
         }
 
         internal virtual bool IsSetKeyDerivation(bool requireDerivedKeys)
         {
-            if (!this.EndpointSupportingTokenParameters.IsSetKeyDerivation(requireDerivedKeys))
+            if (!EndpointSupportingTokenParameters.IsSetKeyDerivation(requireDerivedKeys))
                 return false;
 
             return true;


### PR DESCRIPTION
Now that we have started implementing the tokens/token parameters, we can now start implementing SecurityBindingElement.IsSetKeyDerivation instead of throwing `PlatformNotSupportedException`.

Fixes #540