### PR TITLE
MessageParameterAttribute for return response not working

### DIFF
--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Description/CustomAttributeProvider.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Description/CustomAttributeProvider.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Generic;
 using System.Diagnostics.Contracts;
 using System.Linq;
 using System.Reflection;
@@ -83,7 +84,10 @@ namespace System.ServiceModel.Description
                 case AttributeProviderType.MemberInfo:
                     return this.MemberInfo.GetCustomAttributes(attributeType, inherit).ToArray();
                 case AttributeProviderType.ParameterInfo:
-                    return this.ParameterInfo.GetCustomAttributes(attributeType, inherit).ToArray();
+                    //GetCustomAttributes could return null instead of empty collection for a known System.Relection issue, workaround the issue by explicitly checking the null
+                    IEnumerable<Attribute> customAttributes = null;
+                    customAttributes = this.ParameterInfo.GetCustomAttributes(attributeType, inherit);
+                    return customAttributes == null ? null: customAttributes.ToArray();
             }
             Contract.Assert(false, "This should never execute.");
             throw ExceptionHelper.PlatformNotSupported();

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Description/ServiceReflector.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Description/ServiceReflector.cs
@@ -527,7 +527,7 @@ namespace System.ServiceModel.Description
         {
             Type attrType = typeof(T);
             object[] attrs = GetCustomAttributes(attrProvider, attrType);
-            if (attrs.Length == 0)
+            if (attrs == null || attrs.Length == 0)
             {
                 return null;
             }

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Description/TypeLoader.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Description/TypeLoader.cs
@@ -1150,7 +1150,7 @@ namespace System.ServiceModel.Description
                 if (responseType.IsDefined(typeof(MessageContractAttribute), false) && parameters.Length == 0)
                 {
                     messageDescription = CreateTypedMessageDescription(responseType,
-                                                         methodInfo.ReturnType,
+                                                         methodInfo.ReturnParameter,
                                                          returnValueName,
                                                          defaultNS,
                                                          action,
@@ -1160,7 +1160,7 @@ namespace System.ServiceModel.Description
                 {
                     messageDescription = CreateParameterMessageDescription(parameters,
                                                          responseType,
-                                                         methodInfo.ReturnType,
+                                                         methodInfo.ReturnParameter,
                                                          returnValueName,
                                                          methodName,
                                                          defaultNS,
@@ -1244,8 +1244,9 @@ namespace System.ServiceModel.Description
         private static MessagePartDescription CreateParameterPartDescription(XmlName defaultName, string defaultNS, int index, CustomAttributeProvider attrProvider, Type type)
         {
             MessagePartDescription parameterPart;
+            MessageParameterAttribute paramAttr = ServiceReflector.GetSingleAttribute<MessageParameterAttribute>(attrProvider);
 
-            XmlName name = defaultName;
+            XmlName name = paramAttr == null || !paramAttr.IsNameSetExplicit ? defaultName : new XmlName(paramAttr.Name);
             parameterPart = new MessagePartDescription(name.EncodedName, defaultNS);
             parameterPart.Type = type;
             parameterPart.Index = index;

--- a/src/System.Private.ServiceModel/tests/Common/Scenarios/ServiceInterfaces.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Scenarios/ServiceInterfaces.cs
@@ -105,6 +105,10 @@ public interface IWcfServiceGenerated
 
     [System.ServiceModel.OperationContractAttribute(Action = "http://tempuri.org/IWcfService/Echo", ReplyAction = "http://tempuri.org/IWcfService/EchoResponse")]
     System.Threading.Tasks.Task<string> EchoAsync(string message);
+
+    [System.ServiceModel.OperationContractAttribute(Action = "http://tempuri.org/IWcfService/EchoMessageParameter", ReplyAction = "http://tempuri.org/IWcfService/EchoMessageParameterResponse")]
+    [return: System.ServiceModel.MessageParameterAttribute(Name = "result")]
+    string EchoMessageParameter(string name);
 }
 
 // 

--- a/src/System.Private.ServiceModel/tests/Common/Unit/ServiceInterfaces.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Unit/ServiceInterfaces.cs
@@ -72,6 +72,10 @@ public interface IWcfServiceGenerated
 
     [System.ServiceModel.OperationContractAttribute(Action = "http://tempuri.org/IWcfService/Echo", ReplyAction = "http://tempuri.org/IWcfService/EchoResponse")]
     System.Threading.Tasks.Task<string> EchoAsync(string message);
+
+    [System.ServiceModel.OperationContractAttribute(Action = "http://tempuri.org/IWcfService/EchoMessageParameter", ReplyAction = "http://tempuri.org/IWcfService/EchoMessageParameterResponse")]
+    [return: System.ServiceModel.MessageParameterAttribute(Name = "result")]
+    string EchoMessageParameter(string name);
 }
 
 // Dummy interface used for ContractDescriptionTests

--- a/src/System.Private.ServiceModel/tools/test/SelfHostWcfService/IWcfService.cs
+++ b/src/System.Private.ServiceModel/tools/test/SelfHostWcfService/IWcfService.cs
@@ -75,5 +75,9 @@ namespace WcfService
 
         [OperationContractAttribute(Action = "http://tempuri.org/IWcfService/EchoStream", ReplyAction = "http://tempuri.org/IWcfService/EchoStreamResponse")]
         Stream EchoStream(Stream stream);
+
+        [OperationContract(Action = "http://tempuri.org/IWcfService/EchoMessageParameter")]
+        [return: System.ServiceModel.MessageParameterAttribute(Name = "result")]
+        string EchoMessageParameter(string name);
     }
 }

--- a/src/System.Private.ServiceModel/tools/test/SelfHostWcfService/WcfService.cs
+++ b/src/System.Private.ServiceModel/tools/test/SelfHostWcfService/WcfService.cs
@@ -255,6 +255,11 @@ namespace WcfService
             return StringToStream(data);            
         }
 
+        public string EchoMessageParameter(string name)
+        {
+            return string.Format("Hello {0}", name);
+        }
+
         private static string StreamToString(Stream stream)
         {
             var reader = new StreamReader(stream, Encoding.UTF8);


### PR DESCRIPTION
To enable it
* add back MessageParameterAttribute in CreateParameterPartDescription
* use methodInfo.ReturnParameter instead of methodInfo.ReturnType.
In the full framework, we use ReturnTypeCustomAttributes, it's essentially
ReturnParameter.
* Add a scenario test.

Fixes #527