### PR TITLE
Fix DisablePayloadMasking_Property_Get_PNSE_Throws.

### DIFF
--- a/src/System.ServiceModel.Http/tests/Channels/WebSocketTransportSettingsTest.cs
+++ b/src/System.ServiceModel.Http/tests/Channels/WebSocketTransportSettingsTest.cs
@@ -18,6 +18,8 @@ public static class WebSocketTransportSettingsTest
     public static void DisablePayloadMasking_Property_Get_PNSE_Throws()
     {
         var setting = new WebSocketTransportSettings();
-        Assert.Throws<PlatformNotSupportedException>(() => setting.DisablePayloadMasking);
+        bool disablePayloadMasking = false;
+        Assert.Throws<PlatformNotSupportedException>(() => disablePayloadMasking = setting.DisablePayloadMasking);
+        Assert.False(disablePayloadMasking);
     }
 }


### PR DESCRIPTION
The above test didn't build in TOF (because the Assert types in ToF do not support Func.) Changed the func to an action.

Fix #551