### PR TITLE
Adding digest tests without domain controller

### DIFF
--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/HttpChannelHelpers.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/HttpChannelHelpers.cs
@@ -71,7 +71,7 @@ namespace System.ServiceModel.Channels
             impersonationLevelWrapper.Value = TokenImpersonationLevel.None;
             authenticationLevelWrapper.Value = AuthenticationLevel.None;
 
-            NetworkCredential result = null;
+            NetworkCredential result;
 
             switch (authenticationScheme)
             {
@@ -83,7 +83,6 @@ namespace System.ServiceModel.Channels
                 case AuthenticationSchemes.Digest:
                     result = await TransportSecurityHelpers.GetSspiCredentialAsync(credentialProvider,
                         impersonationLevelWrapper, authenticationLevelWrapper, cancellationToken);
-                    ValidateDigestCredential(result, impersonationLevelWrapper.Value);
                     break;
 
                 case AuthenticationSchemes.Negotiate:
@@ -107,21 +106,6 @@ namespace System.ServiceModel.Channels
             }
 
             return result;
-        }
-
-        public static void ValidateDigestCredential(NetworkCredential credential, TokenImpersonationLevel impersonationLevel)
-        {
-            if (!SecurityUtils.NetworkCredentialHelper.IsDefault(credential))
-            {
-                // With a non-default credential, Digest will not honor a client impersonation constraint of 
-                // TokenImpersonationLevel.Identification.
-                if (!TokenImpersonationLevelHelper.IsGreaterOrEqual(impersonationLevel,
-                    TokenImpersonationLevel.Impersonation))
-                {
-                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(
-                        SR.DigestExplicitCredsImpersonationLevel, impersonationLevel)));
-                }
-            }
         }
 
         public static HttpResponseMessage ProcessGetResponseWebException(HttpRequestException requestException, HttpRequestMessage request, HttpAbortReason abortReason)

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Description/ClientCredentials.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Description/ClientCredentials.cs
@@ -114,7 +114,7 @@ namespace System.ServiceModel.Description
 
         public override SecurityTokenManager CreateSecurityTokenManager()
         {
-            return new ClientCredentialsSecurityTokenManager(this.Clone());
+            return new ClientCredentialsSecurityTokenManager(Clone());
         }
 
         protected virtual ClientCredentials CloneCore()
@@ -125,9 +125,9 @@ namespace System.ServiceModel.Description
         public ClientCredentials Clone()
         {
             ClientCredentials result = CloneCore();
-            if (result == null || result.GetType() != this.GetType())
+            if (result == null || result.GetType() != GetType())
             {
-                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(NotImplemented.ByDesignWithMessage(SR.Format(SR.CloneNotImplementedCorrectly, this.GetType(), (result != null) ? result.ToString() : "null")));
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(NotImplemented.ByDesignWithMessage(SR.Format(SR.CloneNotImplementedCorrectly, GetType(), (result != null) ? result.ToString() : "null")));
             }
             return result;
         }

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/ClientCredentialsSecurityTokenManager.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/ClientCredentialsSecurityTokenManager.cs
@@ -5,6 +5,7 @@ using System.IdentityModel.Selectors;
 using System.IdentityModel.Tokens;
 using System.Net;
 using System.Security.Authentication.ExtendedProtection;
+using System.Security.Principal;
 using System.ServiceModel.Channels;
 using System.ServiceModel.Description;
 using System.ServiceModel.Security;
@@ -149,7 +150,7 @@ namespace System.ServiceModel
                 {
                     if (IsDigestAuthenticationScheme(initiatorRequirement))
                     {
-                        result = new SspiSecurityTokenProvider(SecurityUtils.GetNetworkCredentialOrDefault(_parent.HttpDigest.ClientCredential), true, _parent.HttpDigest.AllowedImpersonationLevel);
+                        result = new SspiSecurityTokenProvider(SecurityUtils.GetNetworkCredentialOrDefault(_parent.HttpDigest.ClientCredential), true, TokenImpersonationLevel.Delegation);
                     }
                     else
                     {

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/HttpDigestClientCredential.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/HttpDigestClientCredential.cs
@@ -8,7 +8,6 @@ namespace System.ServiceModel.Security
 {
     public sealed class HttpDigestClientCredential
     {
-        private TokenImpersonationLevel _allowedImpersonationLevel = WindowsClientCredential.DefaultImpersonationLevel;
         private NetworkCredential _digestCredentials;
         private bool _isReadOnly;
 
@@ -19,22 +18,8 @@ namespace System.ServiceModel.Security
 
         internal HttpDigestClientCredential(HttpDigestClientCredential other)
         {
-            _allowedImpersonationLevel = other._allowedImpersonationLevel;
             _digestCredentials = SecurityUtils.GetNetworkCredentialsCopy(other._digestCredentials);
             _isReadOnly = other._isReadOnly;
-        }
-
-        public TokenImpersonationLevel AllowedImpersonationLevel
-        {
-            get
-            {
-                return _allowedImpersonationLevel;
-            }
-            set
-            {
-                ThrowIfImmutable();
-                _allowedImpersonationLevel = value;
-            }
         }
 
         public NetworkCredential ClientCredential

--- a/src/System.Private.ServiceModel/tests/Common/Infrastructure/src/BridgeClient.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Infrastructure/src/BridgeClient.cs
@@ -80,33 +80,19 @@ namespace Infrastructure.Common
 
         public static string GetResourceAddress(string resourceName)
         {
-            EnsureBridgeIsRunning();
-
-            string resourceAddress = null;
-            lock (s_thisLock)
-            {
-                Dictionary<string, string> resources = null;
-                if (s_BridgeStatus == BridgeState.Started)
-                {
-                    if (!_Resources.TryGetValue(resourceName, out resources))
-                    {
-                        resources = MakeEndpointResourcePutRequest(resourceName);
-                      
-                        _Resources.Add(resourceName, resources);
-                    }
-                  
-                    resources.TryGetValue(EndpointResourceResponseUriKeyName, out resourceAddress);
-                }
-            }
-
-            return resourceAddress;
+            return GetResourceProperty(resourceName, EndpointResourceResponseUriKeyName);
         }
 
         public static string GetResourceHostName(string resourceName)
         {
+            return GetResourceProperty(resourceName, EndpointResourceResponseFQHNKeyName);
+        }
+
+        public static string GetResourceProperty(string resourceName, string propertyName)
+        {
             EnsureBridgeIsRunning();
 
-            string hostName = null;
+            string property = null;
             lock (s_thisLock)
             {
                 Dictionary<string, string> resources = null;
@@ -118,12 +104,12 @@ namespace Infrastructure.Common
                         _Resources.Add(resourceName, resources);
                     }
 
-                    resources.TryGetValue(EndpointResourceResponseFQHNKeyName, out hostName);
-                    
+                    resources.TryGetValue(propertyName, out property);
+
                 }
             }
 
-            return hostName;
+            return property;
         }
 
         // Ensure the given response was successful. If it was not, generate

--- a/src/System.Private.ServiceModel/tests/Common/Infrastructure/src/BridgeClientAuthenticationManager.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Infrastructure/src/BridgeClientAuthenticationManager.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// 
+
+using System;
+using System.Net;
+
+namespace Infrastructure.Common
+{
+    public static class BridgeClientAuthenticationManager
+    {
+        private const string AuthenticationResourceName = "WcfService.TestResources.AuthenticationResource";
+        private const string UsernameKeyName = "authUsername";
+        private const string PasswordKeyName = "authPassword";
+        private static readonly object s_authLock = new object();
+        private static NetworkCredential s_networkCredential;
+
+        public static NetworkCredential NetworkCredential
+        {
+            get
+            {
+                if (s_networkCredential == null)
+                {
+                    lock (s_authLock)
+                    {
+                        if (s_networkCredential == null)
+                        {
+                            var response = BridgeClient.MakeResourceGetRequest(AuthenticationResourceName, null);
+                            var credential = new NetworkCredential();
+                            credential.UserName = response[UsernameKeyName];
+                            credential.Password = response[PasswordKeyName];
+                            if (string.IsNullOrEmpty(credential.UserName))
+                            {
+                                throw new NullReferenceException(UsernameKeyName);
+                            }
+
+                            if (string.IsNullOrEmpty(credential.Password))
+                            {
+                                throw new NullReferenceException(PasswordKeyName);
+                            }
+
+                            s_networkCredential = credential;
+                        }
+                    }
+                }
+
+                return s_networkCredential;
+            }
+        }
+    }
+}

--- a/src/System.Private.ServiceModel/tests/Common/Scenarios/Endpoints.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Scenarios/Endpoints.cs
@@ -110,6 +110,14 @@ public static partial class Endpoints
         }
     }
 
+    public static string Http_DigestAuth_NoDomain_Address
+    {
+        get
+        {
+            return BridgeClient.GetResourceAddress("WcfService.TestResources.HttpDigestNoDomainResource");
+        }
+    }
+
     public static string Https_NtlmAuth_Address
     {
         get

--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Http/ClientCredentialTypeTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Http/ClientCredentialTypeTests.cs
@@ -1,0 +1,47 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// 
+
+using System.ServiceModel;
+
+using Infrastructure.Common;
+
+using Xunit;
+
+public static class Http_ClientCredentialTypeTests
+{
+    [Fact]
+    [OuterLoop]
+    public static void DigestAuthentication_Echo_RoundTrips_String_No_Domain()
+    {
+        ChannelFactory<IWcfService> factory = null;
+        IWcfService serviceProxy = null;
+        string testString = "Hello";
+        BasicHttpBinding binding;
+
+        try
+        {
+            // *** SETUP *** \\
+            binding = new BasicHttpBinding(BasicHttpSecurityMode.TransportCredentialOnly);
+            binding.Security.Transport.ClientCredentialType = HttpClientCredentialType.Digest;
+            factory = new ChannelFactory<IWcfService>(binding, new EndpointAddress(Endpoints.Http_DigestAuth_NoDomain_Address));
+            factory.Credentials.HttpDigest.ClientCredential = BridgeClientAuthenticationManager.NetworkCredential;
+            serviceProxy = factory.CreateChannel();
+
+            // *** EXECUTE *** \\
+            string result = serviceProxy.Echo(testString);
+
+            // *** VALIDATE *** \\
+            Assert.True(result == testString, string.Format("Error: expected response from service: '{0}' Actual was: '{1}'", testString, result));
+
+            // *** CLEANUP *** \\
+            factory.Close();
+            ((ICommunicationObject)serviceProxy).Close();
+        }
+        finally
+        {
+            // *** ENSURE CLEANUP *** \\
+            ScenarioTestHelpers.CloseCommunicationObjects((ICommunicationObject)serviceProxy, factory);
+        }
+    }
+}

--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Security.TransportSecurity.Tests.csproj
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Security.TransportSecurity.Tests.csproj
@@ -19,6 +19,7 @@
   <ItemGroup>
     <Compile Include="Https\ClientCredentialTypeTests.cs" />
     <Compile Include="Https\HttpsTests.cs" />
+    <Compile Include="Http\ClientCredentialTypeTests.cs" />
     <Compile Include="Tcp\ClientCredentialTypeTests.cs" />
     <Compile Include="Tcp\IdentityTests.cs" />
   </ItemGroup>

--- a/src/System.Private.ServiceModel/tools/test/SelfHostWcfService/TestResources/AuthenticationResource.cs
+++ b/src/System.Private.ServiceModel/tools/test/SelfHostWcfService/TestResources/AuthenticationResource.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+using WcfTestBridgeCommon;
+
+namespace WcfService.TestResources
+{
+    public class AuthenticationResource : IResource
+    {
+        public ResourceResponse Put(ResourceRequestContext context)
+        {
+            throw new NotImplementedException("Cannot PUT on this resource");
+        }
+
+        public ResourceResponse Get(ResourceRequestContext context)
+        {
+            ResourceResponse response = new ResourceResponse();
+            AuthenticationResourceHelper.AddCredentialsToResponse(response);
+            return response;
+        }
+    }
+}

--- a/src/System.Private.ServiceModel/tools/test/SelfHostWcfService/TestResources/AuthenticationResourceHelper.cs
+++ b/src/System.Private.ServiceModel/tools/test/SelfHostWcfService/TestResources/AuthenticationResourceHelper.cs
@@ -1,0 +1,69 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.ServiceModel;
+using WcfTestBridgeCommon;
+
+namespace WcfService.TestResources
+{
+    public static class AuthenticationResourceHelper
+    {
+        private static string s_username;
+        private static string s_password;
+        private static string s_digestrealm;
+        public const string usernameKeyName = "authUsername";
+        public const string passwordKeyName = "authPassword";
+        public const string digestRealmKeyName = "authDigestRealm";
+
+        static AuthenticationResourceHelper()
+        {
+            s_username = RandomString(10);
+            s_password = RandomString(20);
+            s_digestrealm = RandomString(5);
+        }
+
+        public static string RandomString(int length)
+        {
+            const string chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+            var random = new Random();
+            return new string(Enumerable.Repeat(chars, length)
+              .Select(s => s[random.Next(s.Length)]).ToArray());
+        }
+
+        public static string Username { get { return s_username; } }
+        public static string Password { get { return s_password; } }
+        public static string DigestRealm { get { return s_digestrealm; } }
+
+        public static void ConfigureServiceHostUseDigestAuth(ServiceHost serviceHost)
+        {
+            var authManager = new ResourceDigestServiceAuthorizationManager(s_digestrealm);
+            serviceHost.Description.Behaviors.Add(authManager);
+        }
+
+        private class ResourceDigestServiceAuthorizationManager : DigestServiceAuthorizationManager
+        {
+            public ResourceDigestServiceAuthorizationManager(string realm) : base(realm) { }
+            public override bool GetPassword(string username, out string password)
+            {
+                if (username.Equals(s_username))
+                {
+                    password = s_password;
+                    return true;
+                }
+
+                password = null;
+                return false;
+            }
+        }
+
+        public static void AddCredentialsToResponse(ResourceResponse response)
+        {
+            response.Properties.Add(usernameKeyName, s_username);
+            response.Properties.Add(passwordKeyName, s_password);
+            response.Properties.Add(digestRealmKeyName, s_digestrealm);
+        }
+    }
+}

--- a/src/System.Private.ServiceModel/tools/test/SelfHostWcfService/TestResources/DigestServiceAuthorizationManager.cs
+++ b/src/System.Private.ServiceModel/tools/test/SelfHostWcfService/TestResources/DigestServiceAuthorizationManager.cs
@@ -1,0 +1,315 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Net;
+using System.Security.Cryptography;
+using System.Security.Principal;
+using System.ServiceModel;
+using System.ServiceModel.Channels;
+using System.ServiceModel.Description;
+using System.ServiceModel.Dispatcher;
+using System.Text;
+
+namespace WcfService.TestResources
+{
+    public abstract class DigestServiceAuthorizationManager : ServiceAuthorizationManager, IServiceBehavior
+    {
+        private readonly string _realm;
+        private readonly TimeSpan _nonceValidityTime = TimeSpan.FromMinutes(1);
+
+        public DigestServiceAuthorizationManager(string realm)
+        {
+            if (string.IsNullOrEmpty(realm))
+            {
+                throw new ArgumentNullException("realm");
+            }
+
+            _realm = realm;
+        }
+
+        private bool Authorized(DigestAuthenticationState digestState, OperationContext operationContext, ref Message message)
+        {
+            object identitiesListObject;
+            if (!operationContext.ServiceSecurityContext.AuthorizationContext.Properties.TryGetValue("Identities",
+                out identitiesListObject))
+            {
+                identitiesListObject = new List<IIdentity>(1);
+                operationContext.ServiceSecurityContext.AuthorizationContext.Properties.Add("Identities", identitiesListObject);
+            }
+
+            var identities = identitiesListObject as IList<IIdentity>;
+            identities.Add(new GenericIdentity(digestState.Username, "GenericPrincipal"));
+
+            return true;
+        }
+
+        public override bool CheckAccess(OperationContext operationContext, ref Message message)
+        {
+            var digestState = new DigestAuthenticationState(operationContext, _realm);
+            if (!digestState.IsRequestDigestAuth)
+            {
+                return UnauthorizedResponse(digestState);
+            }
+
+            string password;
+            if (!GetPassword(digestState.Username, out password))
+            {
+                return UnauthorizedResponse(digestState);
+            }
+
+            digestState.Password = password;
+            if (!digestState.Authorized || digestState.IsNonceStale)
+            {
+                return UnauthorizedResponse(digestState);
+            }
+
+            return Authorized(digestState, operationContext, ref message);
+        }
+
+        protected virtual DateTime GetNonceExpiryTime()
+        {
+            return DateTime.Now + _nonceValidityTime;
+        }
+
+        public abstract bool GetPassword(string username, out string password);
+
+        private bool UnauthorizedResponse(DigestAuthenticationState digestState)
+        {
+            digestState.NonceExpiryTime = GetNonceExpiryTime();
+            digestState.SetChallengeResponse(HttpStatusCode.Unauthorized, "Access Denied");
+            return false;
+        }
+
+        #region IServiceBehavior
+        public void Validate(ServiceDescription serviceDescription, ServiceHostBase serviceHostBase) { }
+
+        public void AddBindingParameters(ServiceDescription serviceDescription, ServiceHostBase serviceHostBase, Collection<ServiceEndpoint> endpoints,
+            BindingParameterCollection bindingParameters) { }
+
+        public void ApplyDispatchBehavior(ServiceDescription serviceDescription, ServiceHostBase serviceHostBase)
+        {
+            serviceHostBase.Authorization.ServiceAuthorizationManager = this;
+            foreach (ChannelDispatcherBase t in serviceHostBase.ChannelDispatchers)
+            {
+                ChannelDispatcher channelDispatcher = t as ChannelDispatcher;
+                foreach (EndpointDispatcher endpointDispatcher in channelDispatcher.Endpoints)
+                {
+                    endpointDispatcher.DispatchRuntime.ServiceAuthorizationManager = this;
+                }
+            }
+        }
+        #endregion
+
+        private struct DigestAuthenticationState
+        {
+            private const string DigestAuthenticationMechanism = "Digest ";
+            private const int DigestAuthenticationMechanismLength = 7; // DigestAuthenticationMechanism.Length;
+            private const string UriAuthenticationParameter = "uri";
+            private const string UsernameAuthenticationParameter = "username";
+            private const string NonceAuthenticationParameter = "nonce";
+            private const string RealmAuthenticationParameter = "realm";
+            private const string ResponseAuthenticationParameter = "response";
+            private const string AuthenticationChallengeHeaderName = "WWW-Authenticate";
+            private const string AuthorizationHeaderName = "Authorization";
+            private readonly string _authorizationHeader;
+            private readonly OperationContext _operationContext;
+            private readonly Dictionary<string, string> _authorizationParameters;
+            private readonly string _method;
+            private readonly string _realm;
+            private string _nonceString;
+            private string _password;
+            private bool? _authorized;
+
+            public DigestAuthenticationState(OperationContext operationContext, string realm)
+            {
+                _operationContext = operationContext;
+                _realm = realm;
+                _password = null;
+                _authorized = new bool?();
+                _authorizationHeader = GetAuthorizationHeader(operationContext, out _method);
+                if (_authorizationHeader.Length < DigestAuthenticationMechanismLength)
+                {
+                    _authorized = false;
+                    _nonceString = string.Empty;
+                    _authorizationParameters = new Dictionary<string, string>();
+                    return;
+                }
+
+                string[] digestElements = _authorizationHeader.Substring(DigestAuthenticationMechanismLength).Split(',');
+                _authorizationParameters = new Dictionary<string, string>(digestElements.Length);
+                foreach (string element in digestElements)
+                {
+                    string[] keyValue = element.Split(new[] { '=' }, 2);
+                    string key = keyValue[0].Trim(' ', '\"');
+                    string value = keyValue[1].Trim(' ', '\"');
+                    _authorizationParameters.Add(key, value);
+                }
+
+                _nonceString = _authorizationParameters[NonceAuthenticationParameter];
+            }
+
+            public bool Authorized
+            {
+                get
+                {
+                    if (!_authorized.HasValue)
+                    {
+                        VerifyAuthorization();
+                    }
+
+                    return _authorized.Value;
+                }
+            }
+
+            public bool IsRequestDigestAuth { get { return _authorizationHeader.StartsWith(DigestAuthenticationMechanism); } }
+
+            public string Nonce { get { return _nonceString; } }
+
+            public DateTime NonceExpiryTime
+            {
+                get
+                {
+                    DateTime expiry;
+
+                    // Make sure the base64 value is padded right as nonce's can't
+                    // have the character = at the end.
+                    var nonce = Nonce;
+                    int remainder = nonce.Length % 4;
+                    if (remainder > 0)
+                    {
+                        int padCount = 4 - remainder;
+                        nonce = nonce + new string('=', padCount);
+                    }
+
+                    try
+                    {
+                        byte[] nonceBytes = Convert.FromBase64String(nonce);
+                        string expiryString = Encoding.ASCII.GetString(nonceBytes);
+                        expiry = DateTime.Parse(expiryString);
+                    }
+                    catch (FormatException)
+                    {
+                        return DateTime.MinValue;
+                    }
+
+                    return expiry;
+                }
+                set
+                {
+                    string nonceExpiryString = value.ToString("G");
+                    byte[] nonceExpiryBytes = Encoding.ASCII.GetBytes(nonceExpiryString);
+                    string nonceString = Convert.ToBase64String(nonceExpiryBytes);
+                    _nonceString = nonceString.TrimEnd('=');
+                }
+            }
+
+            public Dictionary<string, string> Parameters { get { return _authorizationParameters; } }
+
+            public string Password { set { _password = value; } }
+
+            public bool IsNonceStale { get { return NonceExpiryTime < DateTime.Now; } }
+
+            public string Uri { get { return Parameters[UriAuthenticationParameter]; } }
+
+            public string Username { get { return Parameters[UsernameAuthenticationParameter]; } }
+
+            private string CalculateHash(string plaintext)
+            {
+                Encoding enc = Encoding.ASCII;
+                MD5 md5 = MD5.Create();
+                byte[] hashbytes = md5.ComputeHash(enc.GetBytes(plaintext));
+                var hashStringBuilder = new StringBuilder();
+                for (int i = 0; i < 16; i++)
+                {
+                    hashStringBuilder.AppendFormat("{0:x02}", hashbytes[i]);
+                }
+
+                return hashStringBuilder.ToString();
+            }
+
+            public void SetChallengeResponse(HttpStatusCode statusCode, string statusDescription)
+            {
+                StringBuilder authChallenge = new StringBuilder(DigestAuthenticationMechanism);
+                authChallenge.AppendFormat(RealmAuthenticationParameter + "=\"{0}\", ", _realm);
+                authChallenge.AppendFormat(NonceAuthenticationParameter + "=\"{0}\", ", Nonce);
+                authChallenge.Append("opaque=\"0000000000000000\", ");
+                authChallenge.AppendFormat("stale={0}, ", IsNonceStale ? "true" : "false");
+                authChallenge.Append("algorithm=MD5, qop=\"auth\"");
+
+                object responsePropertyObject;
+                if (!_operationContext.OutgoingMessageProperties.TryGetValue(HttpResponseMessageProperty.Name, out responsePropertyObject))
+                {
+                    responsePropertyObject = new HttpResponseMessageProperty();
+                    _operationContext.OutgoingMessageProperties[HttpResponseMessageProperty.Name] = responsePropertyObject;
+                }
+
+                var responseMessageProperty = (HttpResponseMessageProperty)responsePropertyObject;
+                responseMessageProperty.Headers[AuthenticationChallengeHeaderName] = authChallenge.ToString();
+                responseMessageProperty.StatusCode = statusCode;
+                responseMessageProperty.StatusDescription = statusDescription;
+            }
+
+            private void VerifyAuthorization()
+            {
+                if (_authorized.HasValue)
+                {
+                    return;
+                }
+
+                if (_realm == null || Username == null || _password == null || _method == null)
+                {
+                    throw new InvalidOperationException("Insufficient information to determine authorization");
+                }
+
+                string SA1 = string.Concat(Username, ":", _realm, ":", _password);
+                string HA1 = CalculateHash(SA1);
+                string SA2 = string.Concat(_method, ":", Uri);
+                string HA2 = CalculateHash(SA2);
+
+                string responseString;
+                if (Parameters["qop"] != null)
+                {
+                    responseString = string.Concat(
+                        HA1, ":",
+                        Nonce, ":",
+                        Parameters["nc"], ":",
+                        Parameters["cnonce"], ":",
+                        Parameters["qop"], ":",
+                        HA2);
+                }
+                else
+                {
+                    responseString = string.Concat(HA1, ":", Nonce, ":", HA2);
+                }
+
+                string responseDigest = CalculateHash(responseString);
+                _authorized = (Parameters[ResponseAuthenticationParameter] == responseDigest);
+            }
+
+            private static string GetAuthorizationHeader(OperationContext operationContext, out string method)
+            {
+                object requestMessagePropertyObject;
+                if (!operationContext.IncomingMessageProperties.TryGetValue(HttpRequestMessageProperty.Name,
+                        out requestMessagePropertyObject))
+                {
+                    throw new InvalidOperationException("Not an HTTP request");
+                }
+
+                HttpRequestMessageProperty requestMessageProperties = (HttpRequestMessageProperty)requestMessagePropertyObject;
+                method = requestMessageProperties.Method;
+                var requestHeaders = requestMessageProperties.Headers;
+
+                var authorizationHeader = requestHeaders[AuthorizationHeaderName];
+                if (authorizationHeader == null)
+                {
+                    authorizationHeader = string.Empty;
+                }
+
+                return authorizationHeader.Trim();
+            }
+        }
+    }
+}

--- a/src/System.Private.ServiceModel/tools/test/SelfHostWcfService/TestResources/HttpDigestResource.cs
+++ b/src/System.Private.ServiceModel/tools/test/SelfHostWcfService/TestResources/HttpDigestResource.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.ServiceModel;
+using System.ServiceModel.Channels;
+using WcfTestBridgeCommon;
+
+namespace WcfService.TestResources
+{
+    internal class HttpDigestNoDomainResource : HttpResource
+    {
+        protected override string Address { get { return "http-digest-nodomain"; } }
+
+        protected override Binding GetBinding()
+        {
+            var binding = new BasicHttpBinding(BasicHttpSecurityMode.None);
+            binding.Security.Transport.ClientCredentialType = HttpClientCredentialType.None;
+            return binding;
+        }
+
+        protected override void ModifyHost(ServiceHost serviceHost, ResourceRequestContext context)
+        {
+            AuthenticationResourceHelper.ConfigureServiceHostUseDigestAuth(serviceHost);
+            base.ModifyHost(serviceHost, context);
+        }
+    }
+}

--- a/src/System.Private.ServiceModel/tools/test/SelfHostWcfService/WcfService.csproj
+++ b/src/System.Private.ServiceModel/tools/test/SelfHostWcfService/WcfService.csproj
@@ -73,11 +73,15 @@
     <Compile Include="ReplyBankingData.cs" />
     <Compile Include="ReplyBankingDataNotWrapped.cs" />
     <Compile Include="RequestBankingData.cs" />
+    <Compile Include="TestResources\AuthenticationResource.cs" />
+    <Compile Include="TestResources\AuthenticationResourceHelper.cs" />
     <Compile Include="TestResources\BaseAddressResource.cs" />
     <Compile Include="TestResources\BasicAuthResource.cs" />
     <Compile Include="TestResources\BasicHttpsResource.cs" />
     <Compile Include="TestResources\DefaultCustomHttpResource.cs" />
+    <Compile Include="TestResources\DigestServiceAuthorizationManager.cs" />
     <Compile Include="TestResources\DuplexResources.cs" />
+    <Compile Include="TestResources\HttpDigestResource.cs" />
     <Compile Include="TestResources\HttpResource.cs" />
     <Compile Include="TestResources\HttpsClientCertificateResource.cs" />
     <Compile Include="TestResources\HttpsResource.cs" />


### PR DESCRIPTION
Also fixing digest authentication to allow explicit credentials. There is currently an impersonation constraint which only makes sense with message security and we don't expose the property to modify it. I'm removing that constraint so that explicit credentials can be used.