### PR TITLE
Adding ServiceContract tests for keyword 'out' and 'ref' variations.

### DIFF
--- a/src/System.Private.ServiceModel/tests/Common/Scenarios/Endpoints.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Scenarios/Endpoints.cs
@@ -91,6 +91,26 @@ public static partial class Endpoints
         get { return BridgeClient.GetResourceAddress("WcfService.TestResources.WebSocketHttpDuplexBinaryBufferedResource"); }
     }
 
+    public static string ServiceContractAsyncIntOut_Address
+    {
+        get { return BridgeClient.GetResourceAddress("WcfService.TestResources.ServiceContractAsyncIntOutResource"); }
+    }
+
+    public static string ServiceContractAsyncComplexOut_Address
+    {
+        get { return BridgeClient.GetResourceAddress("WcfService.TestResources.ServiceContractAsyncComplexOutResource"); }
+    }
+
+    public static string ServiceContractAsyncIntRef_Address
+    {
+        get { return BridgeClient.GetResourceAddress("WcfService.TestResources.ServiceContractAsyncIntRefResource"); }
+    }
+
+    public static string ServiceContractAsyncComplexRef_Address
+    {
+        get { return BridgeClient.GetResourceAddress("WcfService.TestResources.ServiceContractAsyncComplexRefResource"); }
+    }
+
     // HTTPS Addresses
     public static string Https_BasicAuth_Address
     {

--- a/src/System.Private.ServiceModel/tests/Common/Scenarios/ServiceInterfaces.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Scenarios/ServiceInterfaces.cs
@@ -111,8 +111,6 @@ public interface IWcfServiceGenerated
     string EchoMessageParameter(string name);
 }
 
-// 
-
 [System.ServiceModel.ServiceContractAttribute(ConfigurationName = "IWcfService")]
 public interface IWcfServiceBeginEndGenerated
 {
@@ -261,7 +259,7 @@ public interface IWcfDuplexTaskReturnService
     Task<Guid> Ping(Guid guid);
 
     [OperationContract]
-    [FaultContract(typeof (FaultDetail), Name = "FaultDetail",
+    [FaultContract(typeof(FaultDetail), Name = "FaultDetail",
         Action = "http://tempuri.org/IWcfDuplexTaskReturnService/FaultPingFaultDetailFault")]
     Task<Guid> FaultPing(Guid guid);
 }
@@ -272,7 +270,7 @@ public interface IWcfDuplexTaskReturnCallback
     Task<Guid> ServicePingCallback(Guid guid);
 
     [OperationContract]
-    [FaultContract(typeof (FaultDetail), Name = "FaultDetail",
+    [FaultContract(typeof(FaultDetail), Name = "FaultDetail",
         Action = "http://tempuri.org/IWcfDuplexTaskReturnCallback/ServicePingFaultCallbackFaultDetailFault")]
     Task<Guid> ServicePingFaultCallback(Guid guid);
 }
@@ -388,4 +386,42 @@ public interface IPushCallback
 
     [OperationContract(IsOneWay = true)]
     void ReceiveLog(List<string> log);
+}
+
+// ********************************************************************************
+
+[ServiceContract]
+public interface IServiceContractIntOutService
+{
+    [OperationContract(AsyncPattern = true)]
+    IAsyncResult BeginRequest(string stringRequest, AsyncCallback callback, object asyncState);
+
+    void EndRequest(out int intResponse, IAsyncResult result);
+}
+
+[ServiceContract]
+public interface IServiceContractComplexOutService
+{
+    [OperationContract(AsyncPattern = true)]
+    IAsyncResult BeginRequest(string stringRequest, AsyncCallback callback, object asyncState);
+
+    void EndRequest(out ComplexCompositeType complexResponse, IAsyncResult result);
+}
+
+[ServiceContract]
+public interface IServiceContractIntRefService
+{
+    [OperationContract(AsyncPattern = true)]
+    IAsyncResult BeginRequest(string stringRequest, ref int referencedInteger, AsyncCallback callback, object asyncState);
+
+    void EndRequest(ref int referencedInteger, IAsyncResult result);
+}
+
+[ServiceContract]
+public interface IServiceContractComplexRefService
+{
+    [OperationContract(AsyncPattern = true)]
+    IAsyncResult BeginRequest(string stringRequest, ref ComplexCompositeType complexResponse, AsyncCallback callback, object asyncState);
+
+    void EndRequest(ref ComplexCompositeType complexResponse, IAsyncResult result);
 }

--- a/src/System.Private.ServiceModel/tests/Scenarios/Contract/Service/ServiceContractTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Contract/Service/ServiceContractTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.IO;
+using System.Linq;
 using System.Net.Http;
 using System.ServiceModel;
 using System.ServiceModel.Channels;
@@ -231,6 +232,191 @@ public static class ServiceContractTests
         }
 
         Assert.True(errorBuilder.Length == 0, string.Format("Test Scenario: ServiceContract_Call_Operation_With_MessageParameterAttribute FAILED with the following errors: {0}", errorBuilder));
+    }
+
+    // End operation includes keyword "out" on an Int as an arg.
+    [Fact]
+    [OuterLoop]
+    public static void ServiceContract_TypedProxy_AsyncEndOperation_IntOutArg()
+    {
+        string message = "Hello";
+        BasicHttpBinding binding = null;
+        ChannelFactory<IServiceContractIntOutService> factory = null;
+        IServiceContractIntOutService serviceProxy = null;
+        int number = 0;
+
+        try
+        {
+            // *** SETUP *** \\
+            binding = new BasicHttpBinding();
+            factory = new ChannelFactory<IServiceContractIntOutService>(binding, new EndpointAddress(Endpoints.ServiceContractAsyncIntOut_Address));
+            serviceProxy = factory.CreateChannel();
+
+            ManualResetEvent waitEvent = new ManualResetEvent(false);
+
+            // *** EXECUTE *** \\
+            // This delegate will execute when the call has completed, which is how we get the result of the call.
+            AsyncCallback callback = (iar) =>
+            {
+                serviceProxy.EndRequest(out number, iar);
+                waitEvent.Set();
+            };
+
+            IAsyncResult ar = serviceProxy.BeginRequest(message, callback, null);
+
+            // *** VALIDATE *** \\
+            Assert.True(waitEvent.WaitOne(ScenarioTestHelpers.TestTimeout), "AsyncCallback was not called.");
+            Assert.True((number == message.Count<char>()), String.Format("The local int variable was not correctly set, expected {0} but got {1}", message.Count<char>(), number));
+
+            // *** CLEANUP *** \\
+            ((ICommunicationObject)serviceProxy).Close();
+            factory.Close();
+        }
+        finally
+        {
+            // *** ENSURE CLEANUP *** \\
+            ScenarioTestHelpers.CloseCommunicationObjects((ICommunicationObject)serviceProxy, factory);
+        }
+    }
+
+    // End operation includes keyword "out" on a Complex Type as an arg.
+    // The complex type used must not appear anywhere else in any contracts.
+    [Fact]
+    [OuterLoop]
+    public static void ServiceContract_TypedProxy_AsyncEndOperation_ComplexOutArg()
+    {
+        string message = "Hello";
+        BasicHttpBinding binding = null;
+        ChannelFactory<IServiceContractComplexOutService> factory = null;
+        IServiceContractComplexOutService serviceProxy = null;
+        ComplexCompositeType complexType = null;
+
+        try
+        {
+            // *** SETUP *** \\
+            binding = new BasicHttpBinding();
+            factory = new ChannelFactory<IServiceContractComplexOutService>(binding, new EndpointAddress(Endpoints.ServiceContractAsyncComplexOut_Address));
+            serviceProxy = factory.CreateChannel();
+
+            ManualResetEvent waitEvent = new ManualResetEvent(false);
+
+            // *** EXECUTE *** \\
+            // This delegate will execute when the call has completed, which is how we get the result of the call.
+            AsyncCallback callback = (iar) =>
+            {
+                serviceProxy.EndRequest(out complexType, iar);
+                waitEvent.Set();
+            };
+
+            IAsyncResult ar = serviceProxy.BeginRequest(message, callback, null);
+
+            // *** VALIDATE *** \\
+            Assert.True(waitEvent.WaitOne(ScenarioTestHelpers.TestTimeout), "AsyncCallback was not called.");
+            Assert.True((complexType.StringValue == message),
+                String.Format("The value of the 'StringValue' field in the complex type was not as expected. expected {0} but got {1}", message, complexType.StringValue));
+
+            // *** CLEANUP *** \\
+            ((ICommunicationObject)serviceProxy).Close();
+            factory.Close();
+        }
+        finally
+        {
+            // *** ENSURE CLEANUP *** \\
+            ScenarioTestHelpers.CloseCommunicationObjects((ICommunicationObject)serviceProxy, factory);
+        }
+    }
+
+    // End & Begin operations include keyword "ref" on an Int as an arg.
+    [Fact]
+    [OuterLoop]
+    public static void ServiceContract_TypedProxy_AsyncEndOperation_IntRefArg()
+    {
+        string message = "Hello";
+        BasicHttpBinding binding = null;
+        ChannelFactory<IServiceContractIntRefService> factory = null;
+        IServiceContractIntRefService serviceProxy = null;
+        int number = 0;
+
+        try
+        {
+            // *** SETUP *** \\
+            binding = new BasicHttpBinding();
+            factory = new ChannelFactory<IServiceContractIntRefService>(binding, new EndpointAddress(Endpoints.ServiceContractAsyncIntRef_Address));
+            serviceProxy = factory.CreateChannel();
+
+            ManualResetEvent waitEvent = new ManualResetEvent(false);
+
+            // *** EXECUTE *** \\
+            // This delegate will execute when the call has completed, which is how we get the result of the call.
+            AsyncCallback callback = (iar) =>
+            {
+                serviceProxy.EndRequest(ref number, iar);
+                waitEvent.Set();
+            };
+
+            IAsyncResult ar = serviceProxy.BeginRequest(message, ref number, callback, null);
+
+            // *** VALIDATE *** \\
+            Assert.True(waitEvent.WaitOne(ScenarioTestHelpers.TestTimeout), "AsyncCallback was not called.");
+            Assert.True((number == message.Count<char>()),
+                String.Format("The value of the integer sent by reference was not the expected value. expected {0} but got {1}", message.Count<char>(), number));
+
+            // *** CLEANUP *** \\
+            ((ICommunicationObject)serviceProxy).Close();
+            factory.Close();
+        }
+        finally
+        {
+            // *** ENSURE CLEANUP *** \\
+            ScenarioTestHelpers.CloseCommunicationObjects((ICommunicationObject)serviceProxy, factory);
+        }
+    }
+
+    // End & Begin operations include keyword "ref" on a Complex Type as an arg.
+    // The complex type used must not appear anywhere else in any contracts.
+    [Fact]
+    [OuterLoop]
+    public static void ServiceContract_TypedProxy_AsyncEndOperation_ComplexRefArg()
+    {
+        string message = "Hello";
+        BasicHttpBinding binding = null;
+        ChannelFactory<IServiceContractComplexRefService> factory = null;
+        IServiceContractComplexRefService serviceProxy = null;
+        ComplexCompositeType complexType = null;
+
+        try
+        {
+            // *** SETUP *** \\
+            binding = new BasicHttpBinding();
+            factory = new ChannelFactory<IServiceContractComplexRefService>(binding, new EndpointAddress(Endpoints.ServiceContractAsyncComplexRef_Address));
+            serviceProxy = factory.CreateChannel();
+
+            ManualResetEvent waitEvent = new ManualResetEvent(false);
+
+            // *** EXECUTE *** \\
+            // This delegate will execute when the call has completed, which is how we get the result of the call.
+            AsyncCallback callback = (iar) =>
+            {
+                serviceProxy.EndRequest(ref complexType, iar);
+                waitEvent.Set();
+            };
+
+            IAsyncResult ar = serviceProxy.BeginRequest(message, ref complexType, callback, null);
+
+            // *** VALIDATE *** \\
+            Assert.True(waitEvent.WaitOne(ScenarioTestHelpers.TestTimeout), "AsyncCallback was not called.");
+            Assert.True((complexType.StringValue == message),
+                String.Format("The value of the 'StringValue' field in the complex type was not as expected. expected {0} but got {1}", message, complexType.StringValue));
+
+            // *** CLEANUP *** \\
+            ((ICommunicationObject)serviceProxy).Close();
+            factory.Close();
+        }
+        finally
+        {
+            // *** ENSURE CLEANUP *** \\
+            ScenarioTestHelpers.CloseCommunicationObjects((ICommunicationObject)serviceProxy, factory);
+        }
     }
 
     private static void PrintInnerExceptionsHresult(Exception e, StringBuilder errorBuilder)

--- a/src/System.Private.ServiceModel/tools/test/SelfHostWcfService/ScenarioTestHelpers.cs
+++ b/src/System.Private.ServiceModel/tools/test/SelfHostWcfService/ScenarioTestHelpers.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Text;
+
+namespace WcfService
+{
+    public static class ScenarioTestHelpers
+    {
+        public static ComplexCompositeType GetInitializedComplexCompositeType()
+        {
+            ComplexCompositeType compositeObject = new ComplexCompositeType()
+            {
+                BoolValue = true,
+                ByteArrayValue = new byte[] { 0x60, 0x61, 0x62 },
+                CharArrayValue = new char[] { 'a', 'b', 'c' },
+                CharValue = 'a',
+                DateTimeValue = new DateTime(2000, 1, 1),
+                DayOfWeekValue = DayOfWeek.Sunday,
+                DoubleValue = 3.14159265,
+                FloatValue = 2.71828183f,
+                GuidValue = new Guid("EFEA21A0-F59A-4F43-B5D3-B2C667CA6FB6"),
+                IntValue = int.MinValue,
+                LongerStringValue = GenerateStringValue(2048),
+                LongValue = long.MaxValue,
+                SbyteValue = (sbyte)'a',
+                ShortValue = short.MaxValue,
+                StringValue = "the quick brown fox jumps over the lazy dog",
+                TimeSpanValue = TimeSpan.MinValue,
+                UintValue = uint.MaxValue,
+                UlongValue = ulong.MaxValue,
+                UshortValue = ushort.MaxValue
+            };
+
+            return compositeObject;
+        }
+
+        public static string GenerateStringValue(int length)
+        {
+            // There's no great reason why we use this set of characters - we just want to be able to generate a longish string
+            uint firstCharacter = 0x41; // A
+
+            StringBuilder builder = new StringBuilder(length);
+            for (int i = 0; i < length; i++)
+            {
+                builder.Append((char)(firstCharacter + i % 25));
+            }
+
+            return builder.ToString();
+        }
+    }
+}

--- a/src/System.Private.ServiceModel/tools/test/SelfHostWcfService/ServiceContractAsyncInterfaces.cs
+++ b/src/System.Private.ServiceModel/tools/test/SelfHostWcfService/ServiceContractAsyncInterfaces.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.ServiceModel;
+
+namespace WcfService
+{
+    [ServiceContract]
+    public interface IServiceContractIntOutService
+    {
+        [OperationContract]
+        void Request(string stringRequest, out int intResponse);
+    }
+
+    [ServiceContract]
+    public interface IServiceContractComplexOutService
+    {
+        [OperationContract]
+        void Request(string stringRequest, out ComplexCompositeType complexResponse);
+    }
+
+    [ServiceContract]
+    public interface IServiceContractIntRefService
+    {
+        [OperationContract]
+        void Request(string stringRequest, ref int referencedInteger);
+    }
+
+    [ServiceContract]
+    public interface IServiceContractComplexRefService
+    {
+        [OperationContract]
+        void Request(string stringRequest, ref ComplexCompositeType complexResponse);
+    }
+}

--- a/src/System.Private.ServiceModel/tools/test/SelfHostWcfService/ServiceContractAsyncServices.cs
+++ b/src/System.Private.ServiceModel/tools/test/SelfHostWcfService/ServiceContractAsyncServices.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Linq;
+
+namespace WcfService
+{
+    public class ServiceContractIntOutService : IServiceContractIntOutService
+    {
+        public void Request(string request, out int response)
+        {
+            int number = request.Count<char>();
+            response = number;
+        }
+    }
+
+    public class ServiceContractComplexOutService : IServiceContractComplexOutService
+    {
+        public void Request(string stringRequest, out ComplexCompositeType complexResponse)
+        {
+            complexResponse = ScenarioTestHelpers.GetInitializedComplexCompositeType();
+            complexResponse.StringValue = stringRequest;
+        }
+    }
+
+    public class ServiceContractIntRefService : IServiceContractIntRefService
+    {
+        public void Request(string stringRequest, ref int referencedInteger)
+        {
+            referencedInteger = stringRequest.Count<char>();
+        }
+    }
+
+    class ServiceContractComplexRefService : IServiceContractComplexRefService
+    {
+        public void Request(string stringRequest, ref ComplexCompositeType complexResponse)
+        {
+            complexResponse = ScenarioTestHelpers.GetInitializedComplexCompositeType();
+            complexResponse.StringValue = stringRequest;
+        }
+    }
+}

--- a/src/System.Private.ServiceModel/tools/test/SelfHostWcfService/TestResources/ServiceContractAsyncResources.cs
+++ b/src/System.Private.ServiceModel/tools/test/SelfHostWcfService/TestResources/ServiceContractAsyncResources.cs
@@ -1,0 +1,73 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.ServiceModel;
+using System.ServiceModel.Channels;
+using WcfTestBridgeCommon;
+
+namespace WcfService.TestResources
+{
+    internal class ServiceContractAsyncIntOutResource : EndpointResource<ServiceContractIntOutService, IServiceContractIntOutService>
+    {
+        protected override string Protocol { get { return BaseAddressResource.Http; } }
+
+        protected override int GetPort(ResourceRequestContext context)
+        {
+            return context.BridgeConfiguration.BridgeHttpPort;
+        }
+        protected override string Address { get { return "ServiceContractIntOut"; } }
+
+        protected override Binding GetBinding()
+        {
+            return new BasicHttpBinding();
+        }
+    }
+
+    internal class ServiceContractAsyncComplexOutResource : EndpointResource<ServiceContractComplexOutService, IServiceContractComplexOutService>
+    {
+        protected override string Protocol { get { return BaseAddressResource.Http; } }
+
+        protected override int GetPort(ResourceRequestContext context)
+        {
+            return context.BridgeConfiguration.BridgeHttpPort;
+        }
+        protected override string Address { get { return "ServiceContractComplexOut"; } }
+
+        protected override Binding GetBinding()
+        {
+            return new BasicHttpBinding();
+        }
+    }
+
+    internal class ServiceContractAsyncIntRefResource : EndpointResource<ServiceContractIntRefService, IServiceContractIntRefService>
+    {
+        protected override string Protocol { get { return BaseAddressResource.Http; } }
+
+        protected override int GetPort(ResourceRequestContext context)
+        {
+            return context.BridgeConfiguration.BridgeHttpPort;
+        }
+        protected override string Address { get { return "ServiceContractIntRef"; } }
+
+        protected override Binding GetBinding()
+        {
+            return new BasicHttpBinding();
+        }
+    }
+
+    internal class ServiceContractAsyncComplexRefResource : EndpointResource<ServiceContractComplexRefService, IServiceContractComplexRefService>
+    {
+        protected override string Protocol { get { return BaseAddressResource.Http; } }
+
+        protected override int GetPort(ResourceRequestContext context)
+        {
+            return context.BridgeConfiguration.BridgeHttpPort;
+        }
+        protected override string Address { get { return "ServiceContractComplexRef"; } }
+
+        protected override Binding GetBinding()
+        {
+            return new BasicHttpBinding();
+        }
+    }
+}

--- a/src/System.Private.ServiceModel/tools/test/SelfHostWcfService/WcfService.csproj
+++ b/src/System.Private.ServiceModel/tools/test/SelfHostWcfService/WcfService.csproj
@@ -73,6 +73,9 @@
     <Compile Include="ReplyBankingData.cs" />
     <Compile Include="ReplyBankingDataNotWrapped.cs" />
     <Compile Include="RequestBankingData.cs" />
+    <Compile Include="ScenarioTestHelpers.cs" />
+    <Compile Include="ServiceContractAsyncInterfaces.cs" />
+    <Compile Include="ServiceContractAsyncServices.cs" />
     <Compile Include="TestResources\AuthenticationResource.cs" />
     <Compile Include="TestResources\AuthenticationResourceHelper.cs" />
     <Compile Include="TestResources\BaseAddressResource.cs" />
@@ -89,6 +92,7 @@
     <Compile Include="TestResources\HttpsWindowsResource.cs" />
     <Compile Include="TestResources\HttpsNtlmResource.cs" />
     <Compile Include="TestResources\HttpsDigestResource.cs" />
+    <Compile Include="TestResources\ServiceContractAsyncResources.cs" />
     <Compile Include="TestResources\TcpDefaultResource.cs" />
     <Compile Include="TestResources\TcpRevokedServerCertResource.cs" />
     <Compile Include="TestResources\TcpNoSecurityResource.cs" />


### PR DESCRIPTION
Fixes #467