### PR TITLE
Verify that SecurityBindingElement.IsSetKeyDerivation no longer throws

### DIFF
--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/SecurityBindingElement.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/SecurityBindingElement.cs
@@ -242,7 +242,19 @@ namespace System.ServiceModel.Channels
             if (context == null)
                 throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("context");
 
-            throw ExceptionHelper.PlatformNotSupported("SecurityBindingElement.CanBuildChannelFactory is not supported.");
+            if (this.SessionMode)
+            {
+                return this.CanBuildSessionChannelFactory<TChannel>(context);
+            }
+
+            if (!context.CanBuildInnerChannelFactory<TChannel>())
+            {
+                return false;
+            }
+
+            return typeof(TChannel) == typeof(IOutputChannel) || typeof(TChannel) == typeof(IOutputSessionChannel) ||
+                (this.SupportsDuplex && (typeof(TChannel) == typeof(IDuplexChannel) || typeof(TChannel) == typeof(IDuplexSessionChannel))) ||
+                (this.SupportsRequestReply && (typeof(TChannel) == typeof(IRequestChannel) || typeof(TChannel) == typeof(IRequestSessionChannel)));
         }
 
         private bool CanBuildSessionChannelFactory<TChannel>(BindingContext context)

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/TransportSecurityBindingElement.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/TransportSecurityBindingElement.cs
@@ -3,6 +3,7 @@
 
 
 using System.Net.Security;
+using System.ServiceModel.Security;
 
 namespace System.ServiceModel.Channels
 {
@@ -56,8 +57,15 @@ namespace System.ServiceModel.Channels
         {
             if (context == null)
                 throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("context");
-
-            throw ExceptionHelper.PlatformNotSupported("TransportSecurityBindingElement.GetProperty is not supported.");
+            
+            if (typeof(T) == typeof(ChannelProtectionRequirements))
+            {
+                throw ExceptionHelper.PlatformNotSupported("TransportSecurityBindingElement doesn't support ChannelProtectionRequirements yet.");
+            }
+            else
+            {
+                return base.GetProperty<T>(context);
+            }
         }
 
         public override BindingElement Clone()

--- a/src/System.ServiceModel.Http/tests/ServiceModel/BasicHttpBindingTest.cs
+++ b/src/System.ServiceModel.Http/tests/ServiceModel/BasicHttpBindingTest.cs
@@ -84,7 +84,7 @@ public static class BasicHttpBindingTest
         Assert.True(TestHelpers.XmlDictionaryReaderQuotasAreEqual(binding.ReaderQuotas, new XmlDictionaryReaderQuotas()), "XmlDictionaryReaderQuotas");
     }
 
-    [Fact(Skip = "SecurityBindingElement Not Supported Yet")]
+    [Fact]
     public static void Ctor_With_BasicHttpSecurityMode_TransportWithMessageCredential_Initializes_Properties()
     {
         var binding = new BasicHttpBinding(BasicHttpSecurityMode.TransportWithMessageCredential);

--- a/src/System.ServiceModel.Http/tests/ServiceModel/SecurityBindingElementTest.cs
+++ b/src/System.ServiceModel.Http/tests/ServiceModel/SecurityBindingElementTest.cs
@@ -1,0 +1,47 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Linq;
+using System.ServiceModel;
+using System.ServiceModel.Channels;
+using Xunit;
+
+public static class SecurityBindingElementTest
+{
+    [Fact]
+    public static void Create_HttpBinding_SecurityMode_TransportWithMessageCredential()
+    {
+        BasicHttpBinding binding = new BasicHttpBinding(BasicHttpSecurityMode.TransportWithMessageCredential);
+        var bindingElements = binding.CreateBindingElements();
+
+        var securityBindingElement = bindingElements.FirstOrDefault(x => x is SecurityBindingElement) as SecurityBindingElement;
+        Assert.True(securityBindingElement != null, "securityBindingElement should not be null when BasicHttpSecurityMode.TransportWithMessageCredential is specified");
+    }
+
+    [Theory]
+    [InlineData(BasicHttpSecurityMode.TransportCredentialOnly)]
+    [InlineData(BasicHttpSecurityMode.Transport)]
+    [InlineData(BasicHttpSecurityMode.None)]
+    public static void Create_HttpBinding_SecurityMode_Without_SecurityBindingElement(BasicHttpSecurityMode securityMode)
+    {
+        BasicHttpBinding binding = new BasicHttpBinding(securityMode);
+        var bindingElements = binding.CreateBindingElements();
+
+        var securityBindingElement = bindingElements.FirstOrDefault(x => x is SecurityBindingElement) as SecurityBindingElement;
+        Assert.True(securityBindingElement == null, "securityBindingElement should be null when BasicHttpSecurityMode.TransportCredentialOnly is specified");
+    }
+
+    [Theory]
+    [InlineData(BasicHttpSecurityMode.Message)]
+    // BasicHttpSecurityMode.Message is not supported
+    public static void Create_HttpBinding_SecurityMode_Message_Throws_NotSupported(BasicHttpSecurityMode securityMode)
+    {
+        BasicHttpBinding binding = new BasicHttpBinding(securityMode);
+
+        Assert.Throws<NotSupportedException>(() => {
+            var bindingElements = binding.CreateBindingElements();
+        });
+    }
+
+}

--- a/src/System.ServiceModel.Http/tests/project.json
+++ b/src/System.ServiceModel.Http/tests/project.json
@@ -2,6 +2,7 @@
   "dependencies": {
     "System.ServiceModel.Http": "4.0.11-rc2-23602",
     "System.ServiceModel.Primitives": "4.1.0-rc2-23602",
+    "System.ServiceModel.Security": "4.0.1-rc2-23602",
     "xunit": "2.1.0",
     "xunit.netcore.extensions": "1.0.0-prerelease-*"
   },

--- a/src/System.ServiceModel.Http/tests/project.lock.json
+++ b/src/System.ServiceModel.Http/tests/project.lock.json
@@ -787,6 +787,18 @@
           "lib/DNXCore50/System.ServiceModel.Primitives.dll": {}
         }
       },
+      "System.ServiceModel.Security/4.0.1-rc2-23602": {
+        "type": "package",
+        "dependencies": {
+          "System.Private.ServiceModel": "4.1.0-rc2-23602"
+        },
+        "compile": {
+          "ref/dotnet5.2/System.ServiceModel.Security.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.ServiceModel.Security.dll": {}
+        }
+      },
       "System.Text.Encoding/4.0.11-rc2-23602": {
         "type": "package",
         "dependencies": {
@@ -1028,7 +1040,7 @@
           "lib/dotnet/xunit.execution.dotnet.dll": {}
         }
       },
-      "xunit.netcore.extensions/1.0.0-prerelease-00123": {
+      "xunit.netcore.extensions/1.0.0-prerelease-00129": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.10",
@@ -2305,6 +2317,18 @@
           "lib/DNXCore50/System.ServiceModel.Primitives.dll": {}
         }
       },
+      "System.ServiceModel.Security/4.0.1-rc2-23602": {
+        "type": "package",
+        "dependencies": {
+          "System.Private.ServiceModel": "4.1.0-rc2-23602"
+        },
+        "compile": {
+          "ref/dotnet5.2/System.ServiceModel.Security.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.ServiceModel.Security.dll": {}
+        }
+      },
       "System.Text.Encoding/4.0.11-rc2-23602": {
         "type": "package",
         "dependencies": {
@@ -2559,7 +2583,7 @@
           "lib/dotnet/xunit.execution.dotnet.dll": {}
         }
       },
-      "xunit.netcore.extensions/1.0.0-prerelease-00123": {
+      "xunit.netcore.extensions/1.0.0-prerelease-00129": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.10",
@@ -3836,6 +3860,18 @@
           "lib/DNXCore50/System.ServiceModel.Primitives.dll": {}
         }
       },
+      "System.ServiceModel.Security/4.0.1-rc2-23602": {
+        "type": "package",
+        "dependencies": {
+          "System.Private.ServiceModel": "4.1.0-rc2-23602"
+        },
+        "compile": {
+          "ref/dotnet5.2/System.ServiceModel.Security.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.ServiceModel.Security.dll": {}
+        }
+      },
       "System.Text.Encoding/4.0.11-rc2-23602": {
         "type": "package",
         "dependencies": {
@@ -4090,7 +4126,7 @@
           "lib/dotnet/xunit.execution.dotnet.dll": {}
         }
       },
-      "xunit.netcore.extensions/1.0.0-prerelease-00123": {
+      "xunit.netcore.extensions/1.0.0-prerelease-00129": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.10",
@@ -6826,6 +6862,57 @@
         "System.ServiceModel.Primitives.nuspec"
       ]
     },
+    "System.ServiceModel.Security/4.0.1-rc2-23602": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "tmlmOXUiaJgg5lBLxvgTObowOBtMCnU8zICUSDOgtGOUFmQk1ceXTZcUGBkjcW/HBfaityiUBpZLmF4UOvEYdQ==",
+      "files": [
+        "lib/DNXCore50/System.ServiceModel.Security.dll",
+        "lib/net45/_._",
+        "lib/netcore50/System.ServiceModel.Security.dll",
+        "lib/win8/_._",
+        "lib/wp80/_._",
+        "ref/dotnet5.1/de/System.ServiceModel.Security.xml",
+        "ref/dotnet5.1/es/System.ServiceModel.Security.xml",
+        "ref/dotnet5.1/fr/System.ServiceModel.Security.xml",
+        "ref/dotnet5.1/it/System.ServiceModel.Security.xml",
+        "ref/dotnet5.1/ja/System.ServiceModel.Security.xml",
+        "ref/dotnet5.1/ko/System.ServiceModel.Security.xml",
+        "ref/dotnet5.1/ru/System.ServiceModel.Security.xml",
+        "ref/dotnet5.1/System.ServiceModel.Security.dll",
+        "ref/dotnet5.1/System.ServiceModel.Security.xml",
+        "ref/dotnet5.1/zh-hans/System.ServiceModel.Security.xml",
+        "ref/dotnet5.1/zh-hant/System.ServiceModel.Security.xml",
+        "ref/dotnet5.2/de/System.ServiceModel.Security.xml",
+        "ref/dotnet5.2/es/System.ServiceModel.Security.xml",
+        "ref/dotnet5.2/fr/System.ServiceModel.Security.xml",
+        "ref/dotnet5.2/it/System.ServiceModel.Security.xml",
+        "ref/dotnet5.2/ja/System.ServiceModel.Security.xml",
+        "ref/dotnet5.2/ko/System.ServiceModel.Security.xml",
+        "ref/dotnet5.2/ru/System.ServiceModel.Security.xml",
+        "ref/dotnet5.2/System.ServiceModel.Security.dll",
+        "ref/dotnet5.2/System.ServiceModel.Security.xml",
+        "ref/dotnet5.2/zh-hans/System.ServiceModel.Security.xml",
+        "ref/dotnet5.2/zh-hant/System.ServiceModel.Security.xml",
+        "ref/net45/_._",
+        "ref/netcore50/de/System.ServiceModel.Security.xml",
+        "ref/netcore50/es/System.ServiceModel.Security.xml",
+        "ref/netcore50/fr/System.ServiceModel.Security.xml",
+        "ref/netcore50/it/System.ServiceModel.Security.xml",
+        "ref/netcore50/ja/System.ServiceModel.Security.xml",
+        "ref/netcore50/ko/System.ServiceModel.Security.xml",
+        "ref/netcore50/ru/System.ServiceModel.Security.xml",
+        "ref/netcore50/System.ServiceModel.Security.dll",
+        "ref/netcore50/System.ServiceModel.Security.xml",
+        "ref/netcore50/zh-hans/System.ServiceModel.Security.xml",
+        "ref/netcore50/zh-hant/System.ServiceModel.Security.xml",
+        "ref/win8/_._",
+        "ref/wp80/_._",
+        "System.ServiceModel.Security.4.0.1-rc2-23602.nupkg",
+        "System.ServiceModel.Security.4.0.1-rc2-23602.nupkg.sha512",
+        "System.ServiceModel.Security.nuspec"
+      ]
+    },
     "System.Text.Encoding/4.0.11-rc2-23602": {
       "type": "package",
       "serviceable": true,
@@ -7451,14 +7538,14 @@
         "xunit.extensibility.execution.nuspec"
       ]
     },
-    "xunit.netcore.extensions/1.0.0-prerelease-00123": {
+    "xunit.netcore.extensions/1.0.0-prerelease-00129": {
       "type": "package",
       "serviceable": true,
-      "sha512": "Vu2OW/0+lKZKXiX21o2AnxOr+mrqEZqg6TL+mbhkaQjGN2sZsuCba5ZrVSRDtzg+wR72FvswusWAcCsAJ1Lo+g==",
+      "sha512": "z1Oe1+uCKdsDkI2R7jzVfVuunXSSHgs23Y+oK0KP+zcHxdx2wMTRt6wRQ5cpJ4IN1VpCIOrgkqILkbYG1LOJsQ==",
       "files": [
         "lib/dotnet/Xunit.NetCore.Extensions.dll",
-        "xunit.netcore.extensions.1.0.0-prerelease-00123.nupkg",
-        "xunit.netcore.extensions.1.0.0-prerelease-00123.nupkg.sha512",
+        "xunit.netcore.extensions.1.0.0-prerelease-00129.nupkg",
+        "xunit.netcore.extensions.1.0.0-prerelease-00129.nupkg.sha512",
         "xunit.netcore.extensions.nuspec"
       ]
     }
@@ -7467,6 +7554,7 @@
     "": [
       "System.ServiceModel.Http >= 4.0.11-rc2-23602",
       "System.ServiceModel.Primitives >= 4.1.0-rc2-23602",
+      "System.ServiceModel.Security >= 4.0.1-rc2-23602",
       "xunit >= 2.1.0",
       "xunit.netcore.extensions >= 1.0.0-prerelease-*"
     ],


### PR DESCRIPTION
Follow up for #540, "Calling BasicHttpMessageSecurity.CreateMessageSecurity results in PNSE, "

Implement a test that exercises the codepath and check that the eventual call to SecurityBindingElement.IsSetKeyDerivation no longer throws