### PR TITLE
Remove SSL3 from default protocols supported

### DIFF
--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/TransportDefaults.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/TransportDefaults.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Net;
@@ -152,7 +152,8 @@ namespace System.ServiceModel.Channels
         public const bool RequireClientCertificate = false;
         public const int MaxFaultSize = MaxBufferSize;
         public const int MaxSecurityFaultSize = 16384;
-        public const SslProtocols SslProtocols = System.Security.Authentication.SslProtocols.Ssl3 |
+        public const SslProtocols SslProtocols = 
+                                           // SSL3 is not supported in CoreFx.
                                            System.Security.Authentication.SslProtocols.Tls |
                                            System.Security.Authentication.SslProtocols.Tls11 |
                                            System.Security.Authentication.SslProtocols.Tls12;


### PR DESCRIPTION
Starting with PR https://github.com/dotnet/corefx/pull/4483
System.Net.Security does not support SSL3 in CoreFx.

Therefore we remove it from WCF's list of transport defaults.

Fixes #578, #579, #580, #581, #582, #583, #584, #585