### PR TITLE
Change MessageContent to internal class to fix CLS compliance

### DIFF
--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/MessageContent.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/MessageContent.cs
@@ -13,13 +13,11 @@ using System.Linq;
 
 namespace System.ServiceModel.Channels
 {
-    public abstract class MessageContent : HttpContent
+    internal abstract class MessageContent : HttpContent
     {
-#pragma warning disable 3008	// not CLS-compliant
         protected Message _message;
         protected MessageEncoder _messageEncoder;
         protected Stream _stream = null;
-#pragma warning restore 3008	// not CLS-compliant
         private bool _disposed;
 
         public MessageContent(Message message, MessageEncoder messageEncoder)
@@ -165,7 +163,7 @@ namespace System.ServiceModel.Channels
         }
     }
 
-    public class StreamedMessageContent : MessageContent
+    internal class StreamedMessageContent : MessageContent
     {
         // Using the BufferedWriteStream default buffer size which is 4K. HttpWebRequest uses a 4K buffer internally,
         // so using the same size to have the same performance characteristics.

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/ProducerConsumerStream.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/ProducerConsumerStream.cs
@@ -192,9 +192,9 @@ namespace System.ServiceModel.Channels
             }
         }
 
-#pragma warning disable 659,660,661  // Hashcode not needed, Equals overriden for fast path comparison of EmptyContainer
+#pragma warning disable 659,661  // Hashcode not needed, Equals overriden for fast path comparison of EmptyContainer
         private struct WriteBufferWrapper : IEquatable<WriteBufferWrapper>
-#pragma warning restore 659,660,661
+#pragma warning restore 659,661
         {
             public static readonly WriteBufferWrapper EmptyContainer = new WriteBufferWrapper(null, -1, -1, true);
 
@@ -227,9 +227,7 @@ namespace System.ServiceModel.Channels
                 get { return _count; }
             }
 
-#pragma warning disable 659 // Hashcode not needed, Equals overriden for fast path comparison of EmptyContainer
             public override bool Equals(object obj)
-#pragma warning restore 659
             {
                 if (obj is WriteBufferWrapper)
                     return this.Equals((WriteBufferWrapper)obj);


### PR DESCRIPTION
#116 disabled some compiler warnings after importing MessageContent.cs. We want to make sure that the class (and therefore the assembly) remains CLS compliant. 

@mconnew said in #116: 
> The compliance issue is that protected fields can't start with an underscore. What's the naming standard for protected fields? I would rather change the field names rather then disable the warning.

> If they are left as not CLS compliant, this simply means that those fields can't be accessed by code written in some other languages which only support CLS compliant assemblies. As this is only public to enable writing unit tests and isn't exposed on the contract, in practice this non-CLS compliance doesn't negatively affect any scenario.

The class was made public to enable unit tests... but our tests can only test against public contracts. Hence there's no point in making the class public. If we move this to be an internal class, the CLS compliance issues go away. 

Part of #117 