### PR TITLE
Disable Linux tests using System.Security.Principal.Windows

### DIFF
--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Https/ClientCredentialTypeTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Https/ClientCredentialTypeTests.cs
@@ -137,6 +137,7 @@ public static class Https_ClientCredentialTypeTests
 
     [Fact]
     [OuterLoop]
+    [ActiveIssue(604, PlatformID.AnyUnix)]
     public static void NtlmAuthentication_RoundTrips_Echo()
     {
         StringBuilder errorBuilder = new StringBuilder();
@@ -158,6 +159,7 @@ public static class Https_ClientCredentialTypeTests
 
     [Fact]
     [OuterLoop]
+    [ActiveIssue(604, PlatformID.AnyUnix)]
     public static void WindowsAuthentication_RoundTrips_Echo()
     {
         StringBuilder errorBuilder = new StringBuilder();


### PR DESCRIPTION
These tests invoke code that causes failures in OuterLoop due to
the fact System.Security.Principal.Windows is not supported on Linux
but we still depend on it.  This causes the Windows assembly to be
used instead.

When #604 is resolved to remove this dependency we will need to
fix these tests or make them conditional on OS.