### PR TITLE
Update System.ServiceModel.Http.csproj to build v4.1.0.0

### DIFF
--- a/src/System.ServiceModel.Http/src/System.ServiceModel.Http.csproj
+++ b/src/System.ServiceModel.Http/src/System.ServiceModel.Http.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.ServiceModel.Http</AssemblyName>
-    <AssemblyVersion>4.0.11.0</AssemblyVersion>
+    <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
   </PropertyGroup>
 


### PR DESCRIPTION
The last update to System.ServiceModel.Http (#634) didn't update the src/System.ServiceModel.Http.csproj version number. It looks like after #629 got merged, this issue surfaced where GenFacades complains about a version mismatch between the contract (ref/ directory) and the implementation (src/ directory) version.

Update System.ServiceModel.Http.csproj to assembly v4.1.0.0 to bring the csproj in line with the ref/csproj. 