### PR TITLE
Remove Digest test that requires a domain

### DIFF
--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Https/ClientCredentialTypeTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Https/ClientCredentialTypeTests.cs
@@ -109,7 +109,7 @@ public static class Https_ClientCredentialTypeTests
     }
 
     [Fact]
-    [ActiveIssue(69)]
+    [ActiveIssue(270)]
     [OuterLoop]
     public static void DigestAuthentication_RoundTrips_Echo()
     {


### PR DESCRIPTION
* this test is no longer needed as Matt has added a digest test without
the need of a domain.

Fixes #69