### PR TITLE
Remove OpenExistingOnly flag

### DIFF
--- a/src/System.Private.ServiceModel/tests/Common/Infrastructure/src/BridgeClientCertificateManager.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Infrastructure/src/BridgeClientCertificateManager.cs
@@ -267,7 +267,7 @@ namespace Infrastructure.Common
                     {
                         try
                         {
-                            store.Open(OpenFlags.ReadWrite | OpenFlags.OpenExistingOnly);
+                            store.Open(OpenFlags.ReadWrite);
                         }
                         catch (CryptographicException inner)
                         {


### PR DESCRIPTION
* This flag is no longer needed according to Jason. 
Removing it because it requires we pre-create cert folders on Linux.