### PR TITLE
Add a test to cover OperationContextScope major scenario

### DIFF
--- a/src/System.Private.ServiceModel/tests/Common/Scenarios/ServiceInterfaces.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Scenarios/ServiceInterfaces.cs
@@ -50,6 +50,9 @@ public interface IWcfService
     [OperationContract(Action = "http://tempuri.org/IWcfService/GetRequestCustomHeader", ReplyAction = "*")]
     string GetRequestCustomHeader(string customHeaderName, string customHeaderNamespace);
 
+    [OperationContract(Action = "http://tempuri.org/IWcfService/GetIncomingMessageHeaders", ReplyAction = "*")]
+    Dictionary<string, string> GetIncomingMessageHeaders();
+
     [OperationContract]
     Stream GetStreamFromString(string data);
 

--- a/src/System.Private.ServiceModel/tests/Common/Unit/ServiceInterfaces.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Unit/ServiceInterfaces.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.ServiceModel;
 using System.ServiceModel.Channels;
@@ -60,6 +61,9 @@ public interface IWcfService
 
     [OperationContractAttribute(Action = "http://tempuri.org/IWcfService/EchoStream", ReplyAction = "http://tempuri.org/IWcfService/EchoStreamResponse")]
     Task<Stream> EchoStreamAsync(Stream stream);
+
+    [OperationContract(Action = "http://tempuri.org/IWcfService/GetIncomingMessageHeaders", ReplyAction = "*")]
+    Dictionary<MessageHeaderInfo, string> GetIncomingMessageHeaders();
 }
 
 [System.ServiceModel.ServiceContractAttribute(ConfigurationName = "IWcfService")]

--- a/src/System.Private.ServiceModel/tools/test/SelfHostWcfService/IWcfService.cs
+++ b/src/System.Private.ServiceModel/tools/test/SelfHostWcfService/IWcfService.cs
@@ -65,6 +65,9 @@ namespace WcfService
         [OperationContract(Action = "http://tempuri.org/IWcfService/GetRequestCustomHeader", ReplyAction = "*")]
         string GetRequestCustomHeader(string customHeaderName, string customHeaderNamespace);
 
+        [OperationContract(Action = "http://tempuri.org/IWcfService/GetIncomingMessageHeaders", ReplyAction = "*")]
+        Dictionary<string, string> GetIncomingMessageHeaders();
+
         [OperationContract(Action = "http://tempuri.org/IWcfService/EchoXmlSerializerFormat"), XmlSerializerFormat]
         string EchoXmlSerializerFormat(string message);
 

--- a/src/System.Private.ServiceModel/tools/test/SelfHostWcfService/WcfService.cs
+++ b/src/System.Private.ServiceModel/tools/test/SelfHostWcfService/WcfService.cs
@@ -235,6 +235,22 @@ namespace WcfService
             return value;
         }
 
+        public Dictionary<string, string> GetIncomingMessageHeaders()
+        {
+            Dictionary<string, string> infos = new Dictionary<string, string>();
+            MessageHeaders headers = OperationContext.Current.IncomingMessageHeaders;
+            // look at headers on incoming message
+            for (int i = 0; i < headers.Count; ++i)
+            {
+                MessageHeaderInfo h = headers[i];
+                System.Xml.XmlReader xr = headers.GetReaderAtHeader(i);
+                string value = xr.ReadElementContentAsString();
+                infos.Add(string.Format("{0}//{1}", h.Namespace, h.Name), value);
+            }
+
+            return infos;
+        }
+
         public string EchoXmlSerializerFormat(string message)
         {
             return message;


### PR DESCRIPTION
* we currently does not have OperationContextScope coverage. This is to
ensure we cover the major usage.

Fixes #655