### PR TITLE
Add scenario test for FaultException using primitive type.

### DIFF
--- a/src/System.Private.ServiceModel/tests/Common/Scenarios/ServiceInterfaces.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Scenarios/ServiceInterfaces.cs
@@ -32,6 +32,10 @@ public interface IWcfService
     void TestFault(string faultMsg);
 
     [OperationContract]
+    [FaultContract(typeof(int), Action = "http://tempuri.org/IWcfService/TestFaultIntFault", Name = "IntFault", Namespace = "http://www.contoso.com/wcfnamespace")]
+    void TestFaultInt(int faultCode);
+
+    [OperationContract]
     void ThrowInvalidOperationException(string message);
 
     [OperationContract]

--- a/src/System.Private.ServiceModel/tests/Common/Unit/ServiceInterfaces.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Unit/ServiceInterfaces.cs
@@ -31,6 +31,10 @@ public interface IWcfService
     void TestFault(string faultMsg);
 
     [OperationContract]
+    [FaultContract(typeof(int), Action = "http://tempuri.org/IWcfService/TestFaultIntFault", Name = "IntFault", Namespace = "http://www.contoso.com/wcfnamespace")]
+    void TestFaultInt(int faultCode);
+
+    [OperationContract]
     void ThrowInvalidOperationException(string message);
 
     [OperationContract]

--- a/src/System.Private.ServiceModel/tests/Scenarios/Contract/Fault/FaultExceptionTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Contract/Fault/FaultExceptionTests.cs
@@ -89,4 +89,42 @@ public static class FaultExceptionTests
 
         Assert.True(false, "Expected FaultException<FaultDetail> exception, but no exception thrown.");
     }
+
+    [Fact]
+    [OuterLoop]
+    public static void FaultException_Throws_With_Int()
+    {
+        ChannelFactory<IWcfService> factory = null;
+        IWcfService serviceProxy = null;
+        BasicHttpBinding binding = null;
+
+        int expectedFaultCode = 5;  // arbitrary integer choice
+        FaultException<int> thrownException = null;
+
+        try
+        {
+            // *** SETUP *** \\
+            binding = new BasicHttpBinding();
+            factory = new ChannelFactory<IWcfService>(binding, new EndpointAddress(Endpoints.HttpBaseAddress_Basic));
+            serviceProxy = factory.CreateChannel();
+
+            // *** EXECUTE *** \\
+            thrownException = Assert.Throws <FaultException<int>>(() =>
+            {
+                serviceProxy.TestFaultInt(expectedFaultCode);
+            });
+
+            // *** VALIDATE *** \\
+            Assert.Equal(expectedFaultCode, thrownException.Detail);
+
+            // *** CLEANUP *** \\
+            factory.Close();
+            ((ICommunicationObject)serviceProxy).Close();
+        }
+        finally
+        {
+            // *** ENSURE CLEANUP *** \\
+            ScenarioTestHelpers.CloseCommunicationObjects((ICommunicationObject)serviceProxy, factory);
+        }
+    }
 }

--- a/src/System.Private.ServiceModel/tools/test/SelfHostWcfService/IWcfService.cs
+++ b/src/System.Private.ServiceModel/tools/test/SelfHostWcfService/IWcfService.cs
@@ -29,6 +29,10 @@ namespace WcfService
         void TestFault(String faultMsg);
 
         [OperationContract]
+        [FaultContract(typeof(int), Action = "http://tempuri.org/IWcfService/TestFaultIntFault", Name = "IntFault", Namespace = "http://www.contoso.com/wcfnamespace")]
+        void TestFaultInt(int faultCode);
+
+        [OperationContract]
         void ThrowInvalidOperationException(string message);
 
         [OperationContract(Action = "http://tempuri.org/IWcfService/GetDataUsingDataContract")]

--- a/src/System.Private.ServiceModel/tools/test/SelfHostWcfService/WcfService.cs
+++ b/src/System.Private.ServiceModel/tools/test/SelfHostWcfService/WcfService.cs
@@ -117,6 +117,10 @@ namespace WcfService
         {
             throw new FaultException<FaultDetail>(new FaultDetail(faultMsg));
         }
+        public void TestFaultInt(int faultCode)
+        {
+            throw new FaultException<int>(faultCode);
+        }
 
         public void ThrowInvalidOperationException(string message)
         {


### PR DESCRIPTION
This PR adds a new scenario test that demonstrates primitive types
can be used in FaultContracts.  It is known to succeed in CoreCLR
but expected to fail in NET Native.

Making this test succeed in NET Native will occur in a different PR.