### PR TITLE
Enable NegotiateStream tests for non-Unix platforms

### DIFF
--- a/src/System.Private.ServiceModel/src/System.Private.ServiceModel.csproj
+++ b/src/System.Private.ServiceModel/src/System.Private.ServiceModel.csproj
@@ -1,9 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
+  <PropertyGroup>
+    <Configuration Condition="'$(Configuration)'==''">Windows_Debug</Configuration>
+  </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
-    <Platform Condition="'$(Platform)' == ''">AnyCPU</Platform>
     <AssemblyName>System.Private.ServiceModel</AssemblyName>
     <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <RootNamespace>System.ServiceModel</RootNamespace>
@@ -19,8 +20,6 @@
   </PropertyGroup>
 
   <!-- Default configurations to help VS understand the options -->
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Linux_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Linux_Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_Debug|AnyCPU'"/>

--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Tcp/ClientCredentialTypeTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Tcp/ClientCredentialTypeTests.cs
@@ -16,7 +16,7 @@ public static class Tcp_ClientCredentialTypeTests
     //                         - SecurityMode = Transport
     //                         - ClientCredentialType = Windows
     [Fact]
-    [ActiveIssue(592)]
+    [ActiveIssue(592, PlatformID.AnyUnix)]
     [OuterLoop]
     public static void SameBinding_DefaultSettings_EchoString()
     {
@@ -84,7 +84,7 @@ public static class Tcp_ClientCredentialTypeTests
     // Simple echo of a string using NetTcpBinding on both client and server with SecurityMode=Transport
     // By default ClientCredentialType will be 'Windows'
     [Fact]
-    [ActiveIssue(592)]
+    [ActiveIssue(592, PlatformID.AnyUnix)]
     [OuterLoop]
     public static void SameBinding_SecurityModeTransport_EchoString()
     {


### PR DESCRIPTION
Includes two changes: 

* Modifies System.Private.ServiceModel.csproj to allow TargetsWindows condition to be set - this is consistent with https://github.com/dotnet/corefx/commit/9e1da13cf6d5ff4b37b1867beb3411a2fe61da6a
* Enables the NegotiateStream tests