### PR TITLE
Add comment to the dir.props file diffs from corefx

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -222,6 +222,11 @@
     <OSGroup Condition="'$(OSGroup)'=='' and $(Configuration.StartsWith('Linux'))">Linux</OSGroup>
     <OSGroup Condition="'$(OSGroup)'=='' and $(Configuration.StartsWith('OSX'))">OSX</OSGroup>
     <OSGroup Condition="'$(OSGroup)'=='' and $(Configuration.StartsWith('FreeBSD'))">FreeBSD</OSGroup>
+
+    <!-- 
+    This logic differs from corefx's dir.props. Most things we build are not "AnyOS", so unless explicilty specified, we want to 
+    inherit the OS environment that we are building under 
+    --> 
     <OSGroup Condition="'$(OSGroup)'==''">$(OSEnvironment)</OSGroup>
 
     <TargetGroup Condition="'$(TargetGroup)'=='' and $(Configuration.Contains('netcore50aot'))">netcore50aot</TargetGroup>

--- a/src/System.Private.ServiceModel/src/System.Private.ServiceModel.csproj
+++ b/src/System.Private.ServiceModel/src/System.Private.ServiceModel.csproj
@@ -1,8 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
-  <PropertyGroup>
-    <Configuration Condition="'$(Configuration)'==''">Windows_Debug</Configuration>
-  </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Private.ServiceModel</AssemblyName>


### PR DESCRIPTION
* Add comment to the dir.props file where it differs from corefx
* Remove the workaround we had used in System.Private.ServiceModel.csproj when the fix to $(OSGroup) wasn't in place. 

See https://github.com/dotnet/wcf/pull/694#commitcomment-15440494 for discussion:

> @mconnew and I had a chat about this.

> I'm reasonably convinced now that we can leave this here. and revert the default configuration change in System.Private.ServiceModel.csproj. This way all of our projects will automatically get the benefit of the $(TargetsWindows) being set correctly, rather than solving this on a per-project basis.

> We should, however, comment clearly that we've diverged from CoreFx here so that we're not surprised down the line.

cc @mconnew 