### PR TITLE
Enable the packaging targets to build

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -12,7 +12,7 @@
       <!-- For the root traversal default filter the OSGroup to the OSEnvironment which is the OS we are running on -->
       <FilterToOSGroup Condition="'$(BuildAllOSGroups)' != 'true'">$(OSEnvironment)</FilterToOSGroup>
     </Project>
-    <Project Include="src\packages.builds" Condition="'$(BuildPackages)' == 'true'">
+    <Project Include="src\packages.builds">
       <!-- When we do a traversal build we build all libraries prior to building packages -->
       <AdditionalProperties>BuildPackageLibraryReferences=false</AdditionalProperties>
       <!-- For the root traversal default filter the OSGroup to the OSEnvironment which is the OS we are running on -->

--- a/dir.props
+++ b/dir.props
@@ -238,11 +238,13 @@
     <OSGroup Condition="'$(OSGroup)'=='' and $(Configuration.StartsWith('Linux'))">Linux</OSGroup>
     <OSGroup Condition="'$(OSGroup)'=='' and $(Configuration.StartsWith('OSX'))">OSX</OSGroup>
     <OSGroup Condition="'$(OSGroup)'=='' and $(Configuration.StartsWith('FreeBSD'))">FreeBSD</OSGroup>
-    <OSGroup Condition="'$(OSGroup)'==''">$(OSEnvironment)</OSGroup>
+    <OSGroup Condition="'$(OSGroup)'==''">AnyOS</OSGroup>
 
     <TargetGroup Condition="'$(TargetGroup)'=='' and $(Configuration.Contains('netcore50aot'))">netcore50aot</TargetGroup>
     <TargetGroup Condition="'$(TargetGroup)'=='' and $(Configuration.Contains('netcore50'))">netcore50</TargetGroup>
     <TargetGroup Condition="'$(TargetGroup)'=='' and $(Configuration.Contains('dnxcore50'))">dnxcore50</TargetGroup>
+    <TargetGroup Condition="'$(TargetGroup)'=='' and $(Configuration.Contains('net462'))">net462</TargetGroup>
+    <TargetGroup Condition="'$(TargetGroup)'=='' and $(Configuration.Contains('net461'))">net461</TargetGroup>
     <TargetGroup Condition="'$(TargetGroup)'=='' and $(Configuration.Contains('net46'))">net46</TargetGroup>
     <TargetGroup Condition="'$(TargetGroup)'=='' and $(Configuration.Contains('net45'))">net45</TargetGroup>
   </PropertyGroup>
@@ -342,6 +344,20 @@
         <PackageTargetFramework>dnxcore50</PackageTargetFramework>
         <TargetingPackNugetPackageId>Microsoft.TargetingPack.Private.CoreCLR</TargetingPackNugetPackageId>
         <NuGetTargetMoniker>DNXCore,Version=v5.0</NuGetTargetMoniker>
+      </PropertyGroup>
+    </When>
+    <When Condition="'$(TargetGroup)'=='net462'">
+      <PropertyGroup>
+        <PackageTargetFramework>net462</PackageTargetFramework>
+        <TargetingPackNugetPackageId>Microsoft.TargetingPack.NETFramework.v4.6.2</TargetingPackNugetPackageId>
+        <NuGetTargetMoniker>.NETFramework,Version=v4.6.2</NuGetTargetMoniker>
+      </PropertyGroup>
+    </When>
+    <When Condition="'$(TargetGroup)'=='net461'">
+      <PropertyGroup>
+        <PackageTargetFramework>net461</PackageTargetFramework>
+        <TargetingPackNugetPackageId>Microsoft.TargetingPack.NETFramework.v4.6.1</TargetingPackNugetPackageId>
+        <NuGetTargetMoniker>.NETFramework,Version=v4.6.1</NuGetTargetMoniker>
       </PropertyGroup>
     </When>
     <When Condition="'$(TargetGroup)'=='net46'">

--- a/src/NuGet.config
+++ b/src/NuGet.config
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <!-- NOTE: Leave this file here and keep it in sync with list in dir.props. -->
+  <!-- The command-line doesn't need it, but the IDE does.                    -->
+  <packageSources>
+    <clear/>
+    <add key="myget.org dotnet-core" value="https://www.myget.org/F/dotnet-core/" />
+    <add key="myget.org dotnet-coreclr" value="https://www.myget.org/F/dotnet-coreclr/" />
+    <add key="myget.org dotnet-corefxtestdata" value="https://www.myget.org/F/dotnet-corefxtestdata/" />
+    <add key="myget.org dotnet-buildtools" value="https://www.myget.org/F/dotnet-buildtools/" />
+    <add key="nuget.org" value="https://www.nuget.org/api/v2/" />
+  </packageSources>
+  <config>
+    <add key="repositoryPath" value="..\packages" />
+  </config>
+</configuration>

--- a/src/dirs.proj
+++ b/src/dirs.proj
@@ -1,11 +1,16 @@
 <Project ToolsVersion="12.0" DefaultTargets="BuildAndTest" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="dir.props" />
-  <Import Project="BuildValues.props" />
  <PropertyGroup>
     <ExcludeProjects>System.Private.ServiceModel\tests\Scenarios\SelfHostWcfService\WcfService.csproj</ExcludeProjects>
   </PropertyGroup>
   
-    <!-- Additional WCF tool projects -->
+  <ItemGroup>
+    <Project Include="ref.builds" />
+    <Project Include="src.builds" />
+    <Project Include="tests.builds" />
+  </ItemGroup>
+
+  <!-- Additional WCF tool projects -->
   <ItemGroup>
     <Project Include="$(MSBuildProjectDirectory)\System.Private.ServiceModel\tools\test\CertificateCleanup\CertificateCleanup.csproj" />
   </ItemGroup>
@@ -37,5 +42,12 @@
   </PropertyGroup>
   <Import Project="$(ToolsDir)CodeCoverage.targets" Condition="Exists('$(ToolsDir)CodeCoverage.targets')" />
   <Import Project="$(ToolsDir)PerfTesting.targets" Condition="Exists('$(ToolsDir)PerfTesting.targets')" />
+
+  <PropertyGroup Condition="Exists('$(ToolsDir)toolruntime.targets')">
+    <TraversalBuildDependsOn>
+      EnsureBuildToolsRuntime;
+      $(TraversalBuildDependsOn)
+    </TraversalBuildDependsOn>
+  </PropertyGroup>
 
 </Project>

--- a/src/packages.builds
+++ b/src/packages.builds
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="BuildAndTest" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="Native\pkg\**\*.builds">
+      <AdditionalProperties>SkipCreatePackageOnMissingFiles=true</AdditionalProperties>
+    </Project>
+    <Project Include="*\pkg\*.builds" />
+  </ItemGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>

--- a/src/ref.builds
+++ b/src/ref.builds
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="*\ref\**\*.*proj">
+      <OSGroup>AnyOS</OSGroup>
+    </Project>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>

--- a/src/src.builds
+++ b/src/src.builds
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="*\src\*.builds" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>

--- a/src/tests.builds
+++ b/src/tests.builds
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="*\test*\**\*.csproj">
+      <OSGroup Condition="'$(FilterToOSGroup)'!=''">$(FilterToOSGroup)</OSGroup>
+    </Project>
+    <Project Include="*\test*\**\*.vbproj" Condition="'$(IncludeVbProjects)'!='false'">
+      <OSGroup Condition="'$(FilterToOSGroup)'!=''">$(FilterToOSGroup)</OSGroup>
+    </Project>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>


### PR DESCRIPTION
This PR copies files and.or edits from CoreFx to enable the packaging targets to build.  It does not yet build successfully, pending the merge of some open PR's to update some pkgproj files. I will rebase and update when those PR's are merged.