### PR TITLE
Undefine PackagingTargetFramework property to avoid different global properties

### DIFF
--- a/src/System.Private.ServiceModel/pkg/System.Private.ServiceModel.pkgproj
+++ b/src/System.Private.ServiceModel/pkg/System.Private.ServiceModel.pkgproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
-  
+
   <PropertyGroup>
     <PreventImplementationReference>true</PreventImplementationReference>
   </PropertyGroup>
@@ -9,8 +9,9 @@
   <ItemGroup>
     <ProjectReference Include="..\src\System.Private.ServiceModel.builds">
       <AdditionalProperties>FilterToOSGroup=Windows_NT</AdditionalProperties>
+      <UndefineProperties>%(ProjectReference.UndefinedProperties);PackageTargetFramework</UndefineProperties>
     </ProjectReference>
   </ItemGroup>
-  
+
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>


### PR DESCRIPTION
By default the PackageTargetFramework flows down to ProjectReferences for pkgprojs,
that is indended when referencing another pkgproj but not when you reference
a .builds or .csproj file as that will mess with the global properties for those
projects and cause race conditions.

cc @roncain @mconnew this should fix the race condition we have been seeing in TFS.

@ericstj we should probably fix this in packaging.targets directly. I know you had some other changes in the promoting of metadata to AdditionalProperties. As part of that can you please Undefine or not pass these properties for csproj/builds ProjectReferences.