### PR TITLE
Message encoder content type fix

### DIFF
--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/MessageEncoder.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/MessageEncoder.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.IO;
+using System.Net.Http.Headers;
 using System.ServiceModel.Diagnostics;
 using System.Runtime;
 using System.Threading;
@@ -194,8 +195,23 @@ namespace System.ServiceModel.Channels
 
             // sometimes we get a contentType that has parameters, but our encoders
             // merely expose the base content-type, so we will check a stripped version
+            try
+            {
+                MediaTypeHeaderValue parsedContentType = MediaTypeHeaderValue.Parse(contentType);
 
-            throw ExceptionHelper.PlatformNotSupported("MessageEncoder content type parsing is not supported.");
+                if (supportedMediaType.Length > 0 && !supportedMediaType.Equals(parsedContentType.MediaType, StringComparison.OrdinalIgnoreCase))
+                    return false;
+
+                if (!IsCharSetSupported(parsedContentType.CharSet))
+                    return false;
+            }
+            catch (FormatException)
+            {
+                // bad content type, so we definitely don't support it!
+                return false;
+            }
+
+            return true;
         }
 
         internal virtual bool IsCharSetSupported(string charset)

--- a/src/System.Private.ServiceModel/tests/Common/Scenarios/ServiceInterfaces.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Scenarios/ServiceInterfaces.cs
@@ -64,6 +64,9 @@ public interface IWcfService
 
     [OperationContractAttribute(Action = "http://tempuri.org/IWcfService/EchoStream", ReplyAction = "http://tempuri.org/IWcfService/EchoStreamResponse")]
     Task<Stream> EchoStreamAsync(Stream stream);
+    
+    [OperationContract]
+    void ReturnContentType(string contentType);
 }
 
 [ServiceContract]

--- a/src/System.Private.ServiceModel/tests/Scenarios/Encoding/Encoders/TextEncodingTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Encoding/Encoders/TextEncodingTests.cs
@@ -48,4 +48,36 @@ public static class TextEncodingTests
 
         Assert.True(errorBuilder.Length == 0, "Test case FAILED with errors: " + errorBuilder.ToString());
     }
+
+    [Fact]
+    [OuterLoop]
+    public static void TextMessageEncoder_WrongContentTypeResponse_Throws_ProtocolException()
+    {
+        ChannelFactory<IWcfService> factory = null;
+        IWcfService serviceProxy = null;
+        string testContentType = "text/blah";
+        Binding binding = null;
+
+        try
+        {
+            // *** SETUP *** \\
+            binding = new BasicHttpBinding(BasicHttpSecurityMode.None);
+            factory = new ChannelFactory<IWcfService>(binding, new EndpointAddress(Endpoints.HttpBaseAddress_Basic));
+            serviceProxy = factory.CreateChannel();
+
+            // *** EXECUTE *** \\
+            Assert.Throws<ProtocolException>(() => { serviceProxy.ReturnContentType(testContentType); });
+
+            // *** VALIDATE *** \\
+
+            // *** CLEANUP *** \\
+            factory.Close();
+            ((ICommunicationObject)serviceProxy).Close();
+        }
+        finally
+        {
+            // *** ENSURE CLEANUP *** \\
+            ScenarioTestHelpers.CloseCommunicationObjects((ICommunicationObject)serviceProxy, factory);
+        }
+    }
 }

--- a/src/System.Private.ServiceModel/tools/test/SelfHostWcfService/IWcfService.cs
+++ b/src/System.Private.ServiceModel/tools/test/SelfHostWcfService/IWcfService.cs
@@ -110,5 +110,8 @@ namespace WcfService
 
         [OperationContract(Action = "http://tempuri.org/IWcfService/EchoXmlVeryComplexType"), XmlSerializerFormat]
         XmlVeryComplexType EchoXmlVeryComplexType(XmlVeryComplexType complex);
+
+        [OperationContract]
+        void ReturnContentType(string contentType);
     }
 }

--- a/src/System.Private.ServiceModel/tools/test/SelfHostWcfService/WcfService.cs
+++ b/src/System.Private.ServiceModel/tools/test/SelfHostWcfService/WcfService.cs
@@ -324,6 +324,20 @@ namespace WcfService
             return string.Format("Hello {0}", name);
         }
 
+        public void ReturnContentType(string contentType)
+        {
+            var outgoingMessageProperties = OperationContext.Current.OutgoingMessageProperties;
+            object httpResponseMessagePropertyObj;
+            if (!outgoingMessageProperties.TryGetValue(HttpResponseMessageProperty.Name, out httpResponseMessagePropertyObj))
+            {
+                httpResponseMessagePropertyObj = new HttpResponseMessageProperty();
+                outgoingMessageProperties.Add(HttpResponseMessageProperty.Name, httpResponseMessagePropertyObj);
+            }
+
+            var httpRespononseMessageProperty = (HttpResponseMessageProperty)httpResponseMessagePropertyObj;
+            httpRespononseMessageProperty.Headers[HttpResponseHeader.ContentType] = contentType;
+        }
+
         private static string StreamToString(Stream stream)
         {
             var reader = new StreamReader(stream, Encoding.UTF8);


### PR DESCRIPTION
Because we no longer have the ContentType class, we had previously added a PNSE exception in MessageEncoder.IsContentTypeSupported. This change restores the desktop framework implementation replacing ContentType with MediaTypeHeaderValue for parsing.