### PR TITLE
Update rd.xml to allow instantiation of open generic FaultException

### DIFF
--- a/src/System.Private.ServiceModel/src/Resources/System.Private.ServiceModel.rd.xml
+++ b/src/System.Private.ServiceModel/src/Resources/System.Private.ServiceModel.rd.xml
@@ -44,6 +44,8 @@
         <Type Name="ExceptionDetail" Dynamic="Required All" DataContractJsonSerializer="Public" DataContractSerializer="Public" />
         <!-- Allowing Reflection on FaultException{Object} permits type instantiation of FaultException{TDetail} -->
         <Type Name="FaultException{System.Object}" Dynamic="Required All" />
+        <!-- Allow instantiation of generic FaultException for both classes and value types -->
+        <Type Name="FaultException`1" Dynamic="Required All" />
       </Namespace>
       <Namespace Name="System.ServiceModel.Channels">
         <Type Name="Binding" Dynamic="Required All" >


### PR DESCRIPTION
The NET Native toolchain has been improved to allow the instantiation
of open generics via a new entry in the rd.xml file.  This PR adds that
new line.

The rd.xml already had a similar line that permitted this
for generic types where the T was a class. That line has been left
unmodified to mitigate risk if a new WCF package is used with an
older toolchain.

An app was built containing this new syntax and compiled against the
older toolchain to demonstrate the new syntax would not break it.

Fixes #664