### PR TITLE
Enable ETW when throwing exceptions

### DIFF
--- a/src/System.Private.ServiceModel/src/Internals/FxTrace.cs
+++ b/src/System.Private.ServiceModel/src/Internals/FxTrace.cs
@@ -11,7 +11,7 @@ namespace System
 {
     internal static partial class FxTrace
     {
-        private const string baseEventSourceName = "TRACESOURCE_NAME";
+        private const string baseEventSourceName = "System.ServiceModel";
         private const string EventSourceVersion = "4.0.0.0";
 
         private static Guid s_etwProviderId;

--- a/src/System.Private.ServiceModel/src/SMDiagnostics/System/ServiceModel/Diagnostics/ExceptionUtility.cs
+++ b/src/System.Private.ServiceModel/src/SMDiagnostics/System/ServiceModel/Diagnostics/ExceptionUtility.cs
@@ -1,7 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections;
 using System.Diagnostics;
+using System.Diagnostics.Tracing;
 using System.Runtime;
 using System.Runtime.Diagnostics;
 using System.Xml;
@@ -85,16 +87,23 @@ namespace System.ServiceModel.Diagnostics
 
         public Exception ThrowHelperCritical(Exception exception)
         {
-            return exception;
+            return ThrowHelper(exception, EventLevel.Critical);
         }
 
         public Exception ThrowHelperError(Exception exception)
         {
-            return exception;
+            return ThrowHelper(exception, EventLevel.Error);
         }
 
         public Exception ThrowHelperWarning(Exception exception)
         {
+            return ThrowHelper(exception, EventLevel.Warning);
+        }
+
+        internal Exception ThrowHelper(Exception exception, EventLevel eventLevel)
+        {
+            FxTrace.Exception.TraceEtwException(exception, eventLevel);
+
             return exception;
         }
 


### PR DESCRIPTION
* Change the base Event source name to System.ServiceModel as it
becomes internal to us now.
* The code logic for handling different Event level is the same as Desktop.

Fixes #690