### PR TITLE
Increase Bridge CA cert expiry to 7 days

### DIFF
--- a/src/System.Private.ServiceModel/tests/Common/Infrastructure/src/testproperties.props
+++ b/src/System.Private.ServiceModel/tests/Common/Infrastructure/src/testproperties.props
@@ -53,7 +53,7 @@
       </TestProperty>
       <TestProperty Include="BridgeCertificateValidityPeriod">
         <Value>$(BridgeCertificateValidityPeriod)</Value>
-        <DefaultValue>1.00:00:00</DefaultValue>
+        <DefaultValue>7.00:00:00</DefaultValue>
       </TestProperty>
       <TestProperty Include="UseFiddlerUrl">
         <Value>$(UseFiddlerUrl)</Value>


### PR DESCRIPTION
Currently, the expiration time for certificates is only 1 day, which means that keeping the Bridge open over multiple days will result in certs expiring, making debugging more difficult. Change this expiry time to 7 days so that a Bridge can be kept up for a longer period of time.