### PR TITLE
Fixing command line used by Jenkins to build and run CI tests.

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -130,7 +130,7 @@ def project = 'dotnet/wcf'
             label('windows')
             steps {
                 // Use inline replacement
-                batchFile("build.cmd /p:Configuration=${configuration} /p:OSGroup=${os}")
+                batchFile("build.cmd /p:Configuration=${os}_${configuration} /p:OSGroup=${os}")
                 // Pack up the results for max efficiency
                 batchFile("C:\\Packer\\Packer.exe .\\bin\\build.pack .\\bin")
             }
@@ -152,7 +152,7 @@ def project = 'dotnet/wcf'
             label('windows')
             steps {
                 // Use inline replacement
-                batchFile("build.cmd /p:Configuration=${configuration} /p:OSGroup=${os}")
+                batchFile("build.cmd /p:Configuration=${os}_${configuration} /p:OSGroup=${os}")
                 // Pack up the results for max efficiency
                 batchFile("C:\\Packer\\Packer.exe .\\bin\\build.pack .\\bin")
             }
@@ -274,7 +274,7 @@ Utilities.addGithubPRTrigger(prCCJob, 'Code Coverage Windows Debug', '@dotnet-bo
     def newRollingJob = job(Utilities.getFullJobName(project, jobName, false)) {
         label('windows-elevated')
         steps {
-            batchFile("build.cmd /p:Configuration=${configuration} /p:WithCategories=OuterLoop")
+            batchFile("build.cmd /p:Configuration=${os}_${configuration} /p:WithCategories=OuterLoop")
         }
     }
 
@@ -289,7 +289,7 @@ Utilities.addGithubPRTrigger(prCCJob, 'Code Coverage Windows Debug', '@dotnet-bo
     def newPRJob = job(Utilities.getFullJobName(project, jobName, true)) {
         label('windows-elevated')
         steps {
-            batchFile("build.cmd /p:Configuration=${configuration} /p:WithCategories=OuterLoop")
+            batchFile("build.cmd /p:Configuration=${os}_${configuration} /p:WithCategories=OuterLoop")
         }
     }
     


### PR DESCRIPTION
* The value used for the parameter "/p:Configuration" will now be the OS name plus either Debug or Release.
* Like this: Windows_NT_Debug
* When the configuration is just "Debug" or "Release" WCF OuterLoop test projects are running against the wrong build of the product, there is broken logic in the build process around this which has not yet been figured out, this is a short term solution.
* Fixes Issue #731