### PR TITLE
Fixing mistake in PR #739

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -274,7 +274,7 @@ Utilities.addGithubPRTrigger(prCCJob, 'Code Coverage Windows Debug', '@dotnet-bo
     def newRollingJob = job(Utilities.getFullJobName(project, jobName, false)) {
         label('windows-elevated')
         steps {
-            batchFile("build.cmd /p:Configuration=${os}_${configuration} /p:WithCategories=OuterLoop")
+            batchFile("build.cmd /p:Configuration=Windows_NT_${configuration} /p:WithCategories=OuterLoop")
         }
     }
 


### PR DESCRIPTION
* Line 277 the variable 'os' is not known, hardcoding it since calls to build.cmd and running OuterLoops can only be on Windows.