### PR TITLE
Fixing rule to ignore /Tools folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@ syntax: glob
 ### VisualStudio ###
 
 # Tool Runtime Dir
-[Tt]ools/
+/[Tt]ools/
 
 # User-specific files
 *.suo


### PR DESCRIPTION
The rule was also matching src/System.Private.ServiceModel/tools/* which meant new files in that folder were ignored