### PR TITLE
Make Bridge honor max idle timeout set from command line

### DIFF
--- a/src/System.Private.ServiceModel/tools/setupfiles/EnsureBridgeRunning.cmd
+++ b/src/System.Private.ServiceModel/tools/setupfiles/EnsureBridgeRunning.cmd
@@ -1,0 +1,28 @@
+echo off
+setlocal
+
+tasklist /FI "IMAGENAME eq Bridge.exe" 2>NUL | find /I /N "Bridge.exe">NUL
+if "%ERRORLEVEL%"=="0" (
+  echo The Bridge is already running.
+  goto running
+)
+
+pushd %~dp0
+echo Building the Bridge...
+call BuildWCFTestService.cmd
+popd
+
+if '%BridgeResourceFolder%' == '' (
+   set _bridgeResourceFolder=..\..\Bridge\Resources
+) else (
+   set _bridgeResourceFolder=%BridgeResourceFolder%
+)
+
+pushd %~dp0..\..\..\..\bin\wcf\tools\Bridge
+echo Invoking Bridge.exe with arguments: /BridgeResourceFolder:%_bridgeResourceFolder% %*
+start /MIN Bridge.exe /BridgeResourceFolder:%_bridgeResourceFolder% %*
+popd
+
+:running
+exit /b
+

--- a/src/System.Private.ServiceModel/tools/test/Bridge/Bridge/Program.cs
+++ b/src/System.Private.ServiceModel/tools/test/Bridge/Bridge/Program.cs
@@ -347,6 +347,9 @@ namespace Bridge
                 {
                     Console.Clear(); 
                 }
+
+                // Key presses to the Bridge restart the idle timeout
+                IdleTimeoutHandler.RestartTimer();
             }
 
             BridgeController.StopBridgeProcess(0);


### PR DESCRIPTION
Prior to this change, the Bridge initialized its max idle
timeout to a fixed value and did not adjust for a value being
passed on the commandline at startup.

It was necessary to fix this issue so that a Bridge launched
on a lab machine can be given a maximum idle timeout.  This
permits the Bridge to close gracefully regardless how a test
run completes.