### PR TITLE
Escape *'s in validation regex

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -80,11 +80,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ValidationPattern Include="^((System\..*)|(Microsoft\.CSharp)|(Microsoft\.NETCore.*)|(Microsoft\.Win32\..*)|(Microsoft\.VisualBasic))(?&lt;!TestData)$">
+    <ValidationPattern Include="^((System\..%2A)|(Microsoft\.CSharp)|(Microsoft\.NETCore.%2A)|(Microsoft\.Win32\..%2A)|(Microsoft\.VisualBasic))(?&lt;!TestData)$">
       <ExpectedPrerelease>rc2-23712</ExpectedPrerelease>
-    </ValidationPattern>
-    <ValidationPattern Include="^(System\..*TestData)$">
-      <ExpectedVersion>1.0.0-prerelease</ExpectedVersion>
     </ValidationPattern>
     <ValidationPattern Include="^xunit$">
       <ExpectedVersion>2.1.0</ExpectedVersion>


### PR DESCRIPTION
Same changes as https://github.com/dotnet/corefx/pull/5665.

MSBuild uses `*` as a special character in `Include`, so I [escaped](https://msdn.microsoft.com/en-us/library/bb383819.aspx) the regexes. I also removed the TestData rule because it doesn't seem to be validateable: some packages are 1.0.0-prerelease and others are 1.0.1-prerelease, but TestData packages aren't produced in lockstep versions so this is normal.

cc @roncain @weshaggard