### PR TITLE
Fixed a bug with MessageHeader.CreateHeader().

### DIFF
--- a/src/System.Private.ServiceModel/src/Resources/System.Private.ServiceModel.rd.xml
+++ b/src/System.Private.ServiceModel/src/Resources/System.Private.ServiceModel.rd.xml
@@ -51,6 +51,11 @@
         </Type>
         <Type Name="CustomBinding" Dynamic="Required All" />
         <Type Name="IRequestChannel" Dynamic="Required All" />
+        <Type Name="MessageHeader" Dynamic="Required All">
+          <Method Name="CreateHeader">
+            <Parameter Name="value" Dynamic="Required All" DataContractSerializer="Public" />
+          </Method>
+        </Type>
       </Namespace>
     </Assembly>
   </Library>

--- a/src/System.Private.ServiceModel/tests/Common/Scenarios/ScenarioTestTypes.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Scenarios/ScenarioTestTypes.cs
@@ -14,6 +14,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Xml;
+using System.Xml.Serialization;
 
 namespace TestTypes
 {
@@ -1229,4 +1230,24 @@ public class NonInstantiatedType
 public class UniqueType
 {
     public string stringValue;
+}
+
+// This type should be exclusively used by test OperationContextScope_HttpRequestCustomMessageHeader_RoundTrip_Verify.
+[XmlType(Namespace = "urn:TestWebServices/MyWebService/")]
+public class MesssageHeaderCreateHeaderWithXmlSerializerTestType
+{
+    private string message;
+
+    [XmlElement(Order = 0)]
+    public string Message
+    {
+        get
+        {
+            return message;
+        }
+        set
+        {
+            message = value;
+        }
+    }
 }

--- a/src/System.Private.ServiceModel/tests/Common/Scenarios/ServiceInterfaces.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Scenarios/ServiceInterfaces.cs
@@ -102,8 +102,12 @@ public interface IWcfServiceXmlGenerated
     [OperationContract(Action = "http://tempuri.org/IWcfService/EchoXmlVeryComplexType"),
     XmlSerializerFormat]
     XmlVeryComplexType EchoXmlVeryComplexType(XmlVeryComplexType complex);
-}
 
+    [XmlSerializerFormat]
+    [ServiceKnownType(typeof(MesssageHeaderCreateHeaderWithXmlSerializerTestType))]
+    [OperationContract(Action = "http://tempuri.org/IWcfService/GetIncomingMessageHeadersMessage", ReplyAction = "*")]
+    string GetIncomingMessageHeadersMessage(string customHeaderName, string customHeaderNS);
+}
 
 [System.ServiceModel.ServiceContractAttribute(ConfigurationName = "IWcfService")]
 public interface IWcfServiceGenerated

--- a/src/System.Private.ServiceModel/tools/test/SelfHostWcfService/CompositeType.cs
+++ b/src/System.Private.ServiceModel/tools/test/SelfHostWcfService/CompositeType.cs
@@ -3,6 +3,7 @@
 
 using System.Runtime.Serialization;
 using System.ServiceModel;
+using System.Xml.Serialization;
 
 namespace WcfService
 {
@@ -177,3 +178,24 @@ public class NonInstantiatedType
 {
 
 }
+
+[XmlType(Namespace = "urn:TestWebServices/MyWebService/")]
+public partial class MesssageHeaderCreateHeaderWithXmlSerializerTestType
+{
+    private string message;
+
+    /// <remarks/>
+    [XmlElement(Order = 0)]
+    public string Message
+    {
+        get
+        {
+            return message;
+        }
+        set
+        {
+            message = value;
+        }
+    }
+}
+

--- a/src/System.Private.ServiceModel/tools/test/SelfHostWcfService/IWcfService.cs
+++ b/src/System.Private.ServiceModel/tools/test/SelfHostWcfService/IWcfService.cs
@@ -84,6 +84,11 @@ namespace WcfService
         [XmlSerializerFormat]
         LoginResponse Login(LoginRequest request);
 
+        [XmlSerializerFormat]
+        [ServiceKnownType(typeof(MesssageHeaderCreateHeaderWithXmlSerializerTestType))]
+        [OperationContract(Action = "http://tempuri.org/IWcfService/GetIncomingMessageHeadersMessage", ReplyAction = "http://tempuri.org/IWcfService/GetIncomingMessageHeadersMessageResponse")]
+        string GetIncomingMessageHeadersMessage(string customHeaderName, string customHeaderNS);
+
         [OperationContract]
         Stream GetStreamFromString(string data);
 

--- a/src/System.Private.ServiceModel/tools/test/SelfHostWcfService/WcfService.cs
+++ b/src/System.Private.ServiceModel/tools/test/SelfHostWcfService/WcfService.cs
@@ -251,6 +251,18 @@ namespace WcfService
             return infos;
         }
 
+        public string GetIncomingMessageHeadersMessage(string customHeaderName, string customHeaderNS)
+        {
+            MessageHeaders headers = OperationContext.Current.IncomingMessageHeaders;
+            MesssageHeaderCreateHeaderWithXmlSerializerTestType header = headers.GetHeader<MesssageHeaderCreateHeaderWithXmlSerializerTestType>(customHeaderName, customHeaderNS);
+            if (header != null)
+            {
+                return header.Message;
+            }
+
+            return string.Empty;
+        }
+
         public string EchoXmlSerializerFormat(string message)
         {
             return message;


### PR DESCRIPTION
When XmlSerializerFormatAttribute is marked on a OperationContract, .Net Native tool assums that the operation wants to serialize objects using XmlSerializer and so pre-generates XmlSerializer for all relevant types. However, MessageHeader.CreateHeader() internally used DataContractSerializer to serialize the header object, even if the operation is marked with XmlSerializerFormatAttribute.

The fix is adding directives in the rd.xml to tell .Net Native tool to generate DataContractSerializer for the 'value' parameter of the MessageHeader.CreateHeader() method.

I also added tests covering the case of using MessageHeader.CreateHeader together with XmlSerializerFormatAttribute.

Fix #740