### PR TITLE
Add a unix package of System.Private.ServiceModel

### DIFF
--- a/src/System.Private.ServiceModel/pkg/System.Private.ServiceModel.builds
+++ b/src/System.Private.ServiceModel/pkg/System.Private.ServiceModel.builds
@@ -3,6 +3,12 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
     <Project Include="System.Private.ServiceModel.pkgproj"/>
+    <Project Include="win\System.Private.ServiceModel.pkgproj">
+      <OSGroup>Windows_NT</OSGroup>
+    </Project>
+    <Project Include="unix\System.Private.ServiceModel.pkgproj">
+      <OSGroup>Linux</OSGroup>
+    </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.Private.ServiceModel/pkg/unix/System.Private.ServiceModel.pkgproj
+++ b/src/System.Private.ServiceModel/pkg/unix/System.Private.ServiceModel.pkgproj
@@ -3,14 +3,14 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
 
   <PropertyGroup>
-    <!-- Ideally we'd harvest this from the runtime dependencies -->
-    <Version>4.0.1</Version>
+    <PackageTargetRuntime>unix</PackageTargetRuntime>
     <PreventImplementationReference>true</PreventImplementationReference>
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="win\System.Private.ServiceModel.pkgproj" />
-    <ProjectReference Include="unix\System.Private.ServiceModel.pkgproj" />
+    <ProjectReference Include="..\..\src\System.Private.ServiceModel.builds">
+      <AdditionalProperties>FilterToOSGroup=Linux</AdditionalProperties>
+    </ProjectReference>
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/System.Private.ServiceModel/pkg/win/System.Private.ServiceModel.pkgproj
+++ b/src/System.Private.ServiceModel/pkg/win/System.Private.ServiceModel.pkgproj
@@ -3,14 +3,14 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
 
   <PropertyGroup>
-    <!-- Ideally we'd harvest this from the runtime dependencies -->
-    <Version>4.0.1</Version>
+    <PackageTargetRuntime>win7</PackageTargetRuntime>
     <PreventImplementationReference>true</PreventImplementationReference>
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="win\System.Private.ServiceModel.pkgproj" />
-    <ProjectReference Include="unix\System.Private.ServiceModel.pkgproj" />
+    <ProjectReference Include="..\..\src\System.Private.ServiceModel.builds">
+      <AdditionalProperties>FilterToOSGroup=Windows_NT</AdditionalProperties>
+    </ProjectReference>
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />


### PR DESCRIPTION
* WCF Core has a Windows and a Unix implementation both implementations need to be available in the package.
* Fixes Issue #749