### PR TITLE
Change X509 to not use handles in *nix

### DIFF
--- a/src/System.Private.ServiceModel/src/System/IdentityModel/Claims/X509CertificateClaimSet.cs
+++ b/src/System.Private.ServiceModel/src/System/IdentityModel/Claims/X509CertificateClaimSet.cs
@@ -3,6 +3,8 @@
 
 using System.Collections.Generic;
 using System.IdentityModel.Policy;
+using System.Runtime;
+using System.Runtime.InteropServices;
 using System.Security.Claims;
 using System.Security.Cryptography.X509Certificates;
 using System.Security.Principal;
@@ -28,6 +30,11 @@ namespace System.IdentityModel.Claims
 
         internal X509CertificateClaimSet(X509Certificate2 certificate, bool clone)
         {
+            Fx.Assert(
+                !clone || RuntimeInformation.IsOSPlatform(OSPlatform.Windows),
+                "Certificates MUST NOT be cloned on non-Windows platforms"
+            );
+
             if (certificate == null)
                 throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("certificate");
             _certificate = clone ? new X509Certificate2(certificate.Handle) : certificate;
@@ -509,6 +516,11 @@ namespace System.IdentityModel.Claims
         internal X509Identity(X509Certificate2 certificate, bool clone, bool disposable)
             : base(X509, X509)
         {
+            Fx.Assert(
+                !clone || RuntimeInformation.IsOSPlatform(OSPlatform.Windows),
+                "Certificates MUST NOT be cloned on non-Windows platforms"
+            );
+
             _certificate = clone ? new X509Certificate2(certificate.Handle) : certificate;
             _disposable = clone || disposable;
         }

--- a/src/System.Private.ServiceModel/src/System/IdentityModel/Selectors/X509SecurityTokenAuthenticator.cs
+++ b/src/System.Private.ServiceModel/src/System/IdentityModel/Selectors/X509SecurityTokenAuthenticator.cs
@@ -5,6 +5,7 @@ using System.Collections.ObjectModel;
 using System.IdentityModel.Claims;
 using System.IdentityModel.Policy;
 using System.IdentityModel.Tokens;
+using System.Runtime.InteropServices;
 using System.ServiceModel;
 
 namespace System.IdentityModel.Selectors
@@ -32,7 +33,7 @@ namespace System.IdentityModel.Selectors
         }
 
         public X509SecurityTokenAuthenticator(X509CertificateValidator validator, bool mapToWindows, bool includeWindowsGroups)
-            : this(validator, mapToWindows, includeWindowsGroups, true)
+            : this(validator, mapToWindows, includeWindowsGroups, cloneHandle: RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
         }
 

--- a/src/System.Private.ServiceModel/src/System/IdentityModel/Selectors/X509SecurityTokenProvider.cs
+++ b/src/System.Private.ServiceModel/src/System/IdentityModel/Selectors/X509SecurityTokenProvider.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.IdentityModel.Tokens;
+using System.Runtime;
+using System.Runtime.InteropServices;
 using System.Security.Cryptography.X509Certificates;
 using System.ServiceModel;
 using System.Threading;
@@ -18,20 +20,18 @@ namespace System.IdentityModel.Selectors
 
         internal X509SecurityTokenProvider(X509Certificate2 certificate, bool clone)
         {
+            Fx.Assert(
+                !clone || RuntimeInformation.IsOSPlatform(OSPlatform.Windows),
+                "Certificates MUST NOT be cloned on non-Windows platforms"
+            );
+
             if (certificate == null)
             {
                 throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("certificate");
             }
 
             _clone = clone;
-            if (_clone)
-            {
-                _certificate = new X509Certificate2(certificate.Handle);
-            }
-            else
-            {
-                _certificate = certificate;
-            }
+            _certificate = _clone ? new X509Certificate2(certificate.Handle) : _certificate = certificate;
         }
 
         protected override async Task<SecurityToken> GetTokenCoreAsync(CancellationToken cancellationToken)

--- a/src/System.Private.ServiceModel/src/System/IdentityModel/Tokens/X509SecurityToken.cs
+++ b/src/System.Private.ServiceModel/src/System/IdentityModel/Tokens/X509SecurityToken.cs
@@ -3,6 +3,8 @@
 
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Runtime;
+using System.Runtime.InteropServices;
 using System.Security.Cryptography.X509Certificates;
 using System.ServiceModel;
 
@@ -45,6 +47,11 @@ namespace System.IdentityModel.Tokens
 
         internal X509SecurityToken(X509Certificate2 certificate, string id, bool clone, bool disposable)
         {
+            Fx.Assert(
+                !clone || RuntimeInformation.IsOSPlatform(OSPlatform.Windows),
+                "Certificates MUST NOT be cloned on non-Windows platforms"
+            );
+
             if (certificate == null)
                 throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("certificate");
             if (id == null)
@@ -68,13 +75,6 @@ namespace System.IdentityModel.Tokens
             {
                 ThrowIfDisposed();
                 throw ExceptionHelper.PlatformNotSupported("X509SecurityToken.SecurityKeys");
-                //if (_securityKeys == null)
-                //{
-                //    List<SecurityKey> temp = new List<SecurityKey>(1);
-                //    temp.Add(new X509AsymmetricSecurityKey(_certificate));
-                //    _securityKeys = temp.AsReadOnly();
-                //}
-                //return _securityKeys;
             }
         }
 

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SecurityUtils.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SecurityUtils.cs
@@ -12,6 +12,7 @@ using System.IdentityModel.Tokens;
 using System.Net;
 using System.Net.Security;
 using System.Runtime;
+using System.Runtime.InteropServices;
 using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
 using System.Security.Principal;
@@ -861,7 +862,14 @@ namespace System.ServiceModel.Security
                 certs = store.Certificates.Find(findType, findValue, false);
                 if (certs.Count == 1)
                 {
-                    return new X509Certificate2(certs[0].Handle);
+                    if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                    {
+                        return new X509Certificate2(certs[0].Handle);
+                    }
+                    else
+                    {
+                        return certs[0];
+                    }
                 }
                 if (throwIfMultipleOrNoMatch)
                 {


### PR DESCRIPTION
Please wait to review; there are still some issues that still aren't resolved yet

--- 

In Linux, we use OpenSSL as a backing for our certificate-based operations.
However, when retrieving a handle to the certificate via X509Certificate2.Handle,
OpenSSL does not pass along the PrivateKey to us

Pass along the certificate without trying to re-create the certificate in Linux
so we can obtain the private key
