### PR TITLE
Adds new /require option to Bridge.exe to allow optional start

### DIFF
--- a/src/System.Private.ServiceModel/tools/setupfiles/EnsureBridgeRunning.cmd
+++ b/src/System.Private.ServiceModel/tools/setupfiles/EnsureBridgeRunning.cmd
@@ -1,17 +1,27 @@
 echo off
 setlocal
 
+REM Ensure that the Bridge is running.
+REM If the Bridge is already running, this script simply exits.
+REM If the Bridge is not running, it will be started in a new process,
+REM and this script will block until it is started (or the wait times out).
+
 tasklist /FI "IMAGENAME eq Bridge.exe" 2>NUL | find /I /N "Bridge.exe">NUL
 if "%ERRORLEVEL%"=="0" (
-  echo The Bridge is already running.
-  goto running
+  goto built
 )
 
+REM The Bridge process is not running, so ensure it is built
 pushd %~dp0
 echo Building the Bridge...
 call BuildWCFTestService.cmd
 popd
 
+REM The Bridge is either running or has just been built.
+REM Invoke it either to start it or ping it is alive.
+REM In either case, this script will return as soon as the Bridge
+REM is known running or fails to start.
+:built
 if '%BridgeResourceFolder%' == '' (
    set _bridgeResourceFolder=..\..\Bridge\Resources
 ) else (
@@ -19,10 +29,10 @@ if '%BridgeResourceFolder%' == '' (
 )
 
 pushd %~dp0..\..\..\..\bin\wcf\tools\Bridge
-echo Invoking Bridge.exe with arguments: /BridgeResourceFolder:%_bridgeResourceFolder% %*
-start /MIN Bridge.exe /BridgeResourceFolder:%_bridgeResourceFolder% %*
+echo Invoking Bridge.exe -require -BridgeResourceFolder:%_bridgeResourceFolder% %*
+call Bridge.exe -require -BridgeResourceFolder:%_bridgeResourceFolder% %*
 popd
 
-:running
+
 exit /b
 


### PR DESCRIPTION
The new /require option will ensure the Bridge is running.
If it is already running, it just returns.  But if it is not
running it starts the Bridge.exe in a new process and waits for
it to respond to pings.

This new option is not yet used but will be in automated runs
on Windows machines that require the Bridge is running before
a test can execute.