### PR TITLE
Enable running against latest dependencies

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -19,6 +19,16 @@ if %errorlevel% equ 0 (
   set outloop=true
 )
 
+echo %* | findstr /i /C:"FloatingTestRuntimeDependencies=true"  1>nul
+set _FloatingDependencies=!ERRORLEVEL!
+if '!_FloatingDependencies!'=='0' (
+  set TestFixedRuntimeProjectJson=%~dp0src\Common\test-runtime\LatestDependencies\project.json
+  echo %* | findstr /i /C:"/p:Configuration="  1>nul
+  if !ERRORLEVEL! neq 0 (
+  set _defaultBuildConfig=/p:Configuration=Windows_NT_Debug
+  )
+)
+
 if not defined VisualStudioVersion (
     if defined VS140COMNTOOLS (
         call "%VS140COMNTOOLS%\VsDevCmd.bat"
@@ -70,7 +80,7 @@ call :build %*
 goto :AfterBuild
 
 :build
-%_buildprefix% msbuild "%_buildproj%" /nologo /maxcpucount /verbosity:minimal /nodeReuse:false /fileloggerparameters:Verbosity=diag;LogFile="%_buildlog%";Append %* %_buildpostfix%
+%_buildprefix% msbuild "%_buildproj%" %_defaultBuildConfig% /nologo /maxcpucount /verbosity:minimal /nodeReuse:false /fileloggerparameters:Verbosity=diag;LogFile="%_buildlog%";Append %* %_buildpostfix%
 set BUILDERRORLEVEL=!ERRORLEVEL!
 goto :eof
 

--- a/dir.props
+++ b/dir.props
@@ -425,8 +425,8 @@
   <PropertyGroup>
     <TestRuntimePath>$(SourceDir)Common/test-runtime/</TestRuntimePath>
 
-    <TestFixedRuntimeProjectJson>$(TestRuntimePath)project.json</TestFixedRuntimeProjectJson>
-    <TestFixedRuntimeProjectLockJson>$(TestRuntimePath)project.lock.json</TestFixedRuntimeProjectLockJson>
+    <TestFixedRuntimeProjectJson Condition="'$(TestFixedRuntimeProjectJson)' == ''">$(TestRuntimePath)project.json</TestFixedRuntimeProjectJson>
+    <TestFixedRuntimeProjectLockJson  Condition="'$(TestFixedRuntimeProjectJson)' == ''">$(TestRuntimePath)project.lock.json</TestFixedRuntimeProjectLockJson>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Common/test-runtime/LatestDependencies/project.json
+++ b/src/Common/test-runtime/LatestDependencies/project.json
@@ -1,0 +1,75 @@
+{
+  "dependencies": {
+    "Microsoft.NETCore.Platforms": "1.0.1-rc3-23729",
+    "Microsoft.NETCore.TestHost": "1.0.0-rc3-23729",
+    "Microsoft.NETCore.Console": "1.0.0-rc3-23729",
+    "coveralls.io": "1.4",
+    "OpenCover": "4.6.166",
+    "ReportGenerator": "2.3.4",
+    "Microsoft.DotNet.xunit.performance.analysis": "1.0.0-alpha-build0025",
+    "Microsoft.DotNet.xunit.performance.runner.Windows": "1.0.0-alpha-build0025",
+    "System.Collections": "4.0.11-rc3-23729",
+    "System.Collections.Concurrent": "4.0.11-rc3-23729",
+    "System.Collections.NonGeneric": "4.0.1-rc3-23729",
+    "System.Collections.Specialized": "4.0.1-rc3-23729",
+    "System.ComponentModel": "4.0.1-rc3-23729",
+    "System.ComponentModel.EventBasedAsync": "4.0.11-rc3-23729",
+    "System.Diagnostics.Contracts": "4.0.1-rc3-23729",
+    "System.Diagnostics.Debug": "4.0.11-rc3-23729",
+    "System.Diagnostics.Tools": "4.0.1-rc3-23729",
+    "System.Diagnostics.Tracing": "4.0.21-rc3-23729",
+    "System.Globalization": "4.0.11-rc3-23729",
+    "System.IO": "4.0.11-rc3-23729",
+    "System.IO.Compression": "4.1.0-rc3-23729",
+    "System.Linq": "4.0.1-rc3-23729",
+    "System.Linq.Expressions": "4.0.11-rc3-23729",
+    "System.Linq.Queryable": "4.0.1-rc3-23729",
+    "System.Net.Http": "4.0.1-rc3-23729",
+    "System.Net.Primitives": "4.0.11-rc3-23729",
+    "System.Net.WebHeaderCollection": "4.0.1-rc3-23729",
+    "System.Net.WebSockets": "4.0.0-rc3-23729",
+    "System.Net.WebSockets.Client": "4.0.0-rc3-23729",
+    "System.ObjectModel": "4.0.11-rc3-23729",
+    "System.Reflection": "4.0.11",
+    "System.Reflection.DispatchProxy": "4.0.1-rc3-23729",
+    "System.Reflection.Extensions": "4.0.1-rc3-23729",
+    "System.Reflection.Primitives": "4.0.1-rc3-23729",
+    "System.Reflection.TypeExtensions": "4.0.1-rc3-23729",
+    "System.Resources.ResourceManager": "4.0.1-rc3-23729",
+    "System.Runtime": "4.0.21-rc3-23729",
+    "System.Runtime.Extensions": "4.0.11-rc3-23729",
+    "System.Runtime.Handles": "4.0.1-rc3-23729",
+    "System.Runtime.InteropServices": "4.0.21-rc3-23729",
+    "System.Runtime.Serialization.Xml": "4.1.0-rc3-23729",
+    "System.Security.Claims": "4.0.1-rc3-23729",
+    "System.Security.Cryptography.X509Certificates": "4.0.0-rc3-23729",
+    "System.Security.Principal": "4.0.1-rc3-23729",
+    "System.Text.Encoding": "4.0.11-rc3-23729",
+    "System.Threading": "4.0.11-rc3-23729",
+    "System.Threading.Tasks": "4.0.11-rc3-23729",
+    "System.Threading.Timer": "4.0.1-rc3-23729",
+    "System.Xml.ReaderWriter": "4.0.11-rc3-23729",
+    "System.Xml.XDocument": "4.0.11-rc3-23729",
+    "System.Xml.XmlDocument": "4.0.1-rc3-23729",
+    "System.Xml.XmlSerializer": "4.0.11-rc3-23729",
+    "xunit": "2.1.0",
+    "xunit.console.netcore": "1.0.2-prerelease-00120",
+    "xunit.runner.utility": "2.1.0"
+  },
+  "frameworks": {
+    "dnxcore50": {
+      "imports": "portable-net45+win8", 
+      "dependencies": {
+        "System.Net.Http.WinHttpHandler": "4.0.0-rc3-23729",
+        "System.Net.Security": "4.0.0-rc3-23729"
+      }
+    }
+  },
+  "runtimes": {
+    "win7-x64": {},
+    "win7-x86": {},
+    "ubuntu.14.04-x64": {},
+    "osx.10.10-x64": {}
+  }
+}
+


### PR DESCRIPTION
* Use FloatingTestRuntimeDependencies=true to run against latest dependencies
* Fix the build script to allow config TestFixedRuntimeProjectJson
* Note that versions "4.0.11-rc3-23725" will be changed to "4.0.11-*" in
the build process and copy to a location used by the tests.
* Add default configration explcitly to work around the issue it will fail
if no build configration is specified