### PR TITLE
Add unpack step to netci.groovy for corefx binaries

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -76,6 +76,7 @@ def project = 'dotnet/wcf'
                 }
             
                 // Unpack
+                shell("unpacker ./corefx/bin/build.pack ./corefx/bin")
                 shell("unpacker ./bin/build.pack ./bin")
                 shell("""
 ./run-test.sh --coreclr-bins \${WORKSPACE}/coreclr/bin/Product/Linux.x64.Release \\


### PR DESCRIPTION
Our Linux tests were not being run as corefx binaries were not being unpacked from the corefx build.pack. Unpack the artifacts from build.pack so that ./run-tests.sh can run in CI and produce us with test results