### PR TITLE
Fix PortManager addresses for resource domain

### DIFF
--- a/src/System.Private.ServiceModel/tools/test/Bridge/Bridge/AppDomainManager.cs
+++ b/src/System.Private.ServiceModel/tools/test/Bridge/Bridge/AppDomainManager.cs
@@ -58,6 +58,7 @@ namespace Bridge
                     Path.Combine(path, "WcfTestBridgeCommon.dll"),
                     loaderType.FullName);
             loader.LoadAssemblies();
+            loader.SetPortManagerRemoteAddresses(PortManager.RemoteAddresses);
 
             TypeCache.AppDomains.Add(friendlyName, newAppDomain);
             TypeCache.Cache.Add(friendlyName, loader.GetTypes());

--- a/src/System.Private.ServiceModel/tools/test/Bridge/WcfTestBridgeCommon/AssemblyLoader.cs
+++ b/src/System.Private.ServiceModel/tools/test/Bridge/WcfTestBridgeCommon/AssemblyLoader.cs
@@ -72,5 +72,10 @@ namespace WcfTestBridgeCommon
         {
             return t.FullName == "WcfTestBridgeCommon.IResource";
         }
+
+        public void SetPortManagerRemoteAddresses(string remoteAddresses)
+        {
+            PortManager.RemoteAddresses = remoteAddresses;
+        }
     }
 }


### PR DESCRIPTION
The remote addresses property wasn't being set in the test resource app domain. This fix sets the PortManager.RemoteAddresses value in the new app domain to match what's in the default app domain.