### PR TITLE
Update NuGet.Config to keep in sync with dir.props sources

### DIFF
--- a/src/NuGet.config
+++ b/src/NuGet.config
@@ -3,10 +3,9 @@
   <!-- NOTE: Leave this file here and keep it in sync with list in dir.props. -->
   <!-- The command-line doesn't need it, but the IDE does.                    -->
   <packageSources>
-    <add key="myget.org dotnet-core" value="https://www.myget.org/F/dotnet-core/" />
-    <add key="myget.org dotnet-coreclr" value="https://www.myget.org/F/dotnet-coreclr/" />
-    <add key="myget.org dotnet-corefxtestdata" value="https://www.myget.org/F/dotnet-corefxtestdata/" />
-    <add key="myget.org dotnet-buildtools" value="https://www.myget.org/F/dotnet-buildtools/" />
+    <add key="myget.org dotnet-core" value="https://dotnet.myget.org/F/dotnet-core/" />
+    <add key="myget.org dotnet-corefxtestdata" value="https://dotnet.myget.org/F/dotnet-corefxtestdata/" />
+    <add key="myget.org dotnet-buildtools" value="https://dotnet.myget.org/F/dotnet-buildtools/" />
     <add key="nuget.org" value="https://www.nuget.org/api/v2/" />
   </packageSources>
   <config>


### PR DESCRIPTION
Removes old dotnet-coreclr feed and changes other feeds from www.myget.org to dotnet.myget.org.

Context: https://github.com/dotnet-bot/wcf/commit/ca0619a91853351a7fa012ac587dad992e531ac5#commitcomment-15996325

cc @iamjasonp 