### PR TITLE
Move build.sh back to v2 myget feeds to work around CI issue

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -85,7 +85,7 @@ prepare_managed_build()
     # Grab the MSBuild package if we don't have it already
     if [ ! -e "$__msbuildpath" ]; then
         echo "Restoring MSBuild..."
-        mono "$__nugetpath" install $__msbuildpackageid -Version $__msbuildpackageversion -source "https://dotnet.myget.org/F/dotnet-buildtools/api/v3/index.json" -OutputDirectory "$__packageroot"
+        mono "$__nugetpath" install $__msbuildpackageid -Version $__msbuildpackageversion -source "https://dotnet.myget.org/F/dotnet-buildtools/" -OutputDirectory "$__packageroot"
         if [ $? -ne 0 ]; then
             echo "Failed to restore MSBuild."
             exit 1


### PR DESCRIPTION
The CI machines don't seem to like using the v3 myget feeds right now, so move back to v2 feeds to unblock Linux testing in CI