### PR TITLE
Add OperationFault to rd.xml

### DIFF
--- a/src/System.Private.ServiceModel/src/Resources/System.Private.ServiceModel.rd.xml
+++ b/src/System.Private.ServiceModel/src/Resources/System.Private.ServiceModel.rd.xml
@@ -59,6 +59,11 @@
           </Method>
         </Type>
       </Namespace>
+      <Namespace Name="System.ServiceModel.Dispatcher">
+          <Type Name="FaultFormatter">
+            <Type Name="OperationFault{T}" Dynamic="Required All" />
+          </Type>
+      </Namespace>
     </Assembly>
   </Library>
 </Directives>


### PR DESCRIPTION
* This is needed to fix issue #769 from our side.
* Toolchain does not know we need this type and remove it during reduce
dependencies. Adding to rd.xml to explictly tell the toolchain we need it.
* I have verified the rd.xml fix worked by working around the toolchain bug 
189994: Reflection blocking applying to namespaces in unblocked assemblies. 