### PR TITLE
Add Test for the Scenario where Two Contracts use same Namespace.

### DIFF
--- a/src/System.Private.ServiceModel/tests/Common/Scenarios/ServiceInterfaces.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Scenarios/ServiceInterfaces.cs
@@ -109,6 +109,16 @@ public interface IWcfServiceXmlGenerated
     string GetIncomingMessageHeadersMessage(string customHeaderName, string customHeaderNS);
 }
 
+// This type share the same name space with IWcfServiceXmlGenerated.
+// And this type contains a method which is also defined in IWcfServiceXmlGenerated.
+[ServiceContract(ConfigurationName = "IWcfService")]
+public interface ISameNamespaceWithIWcfServiceXmlGenerated
+{
+    [OperationContractAttribute(Action = "http://tempuri.org/IWcfService/EchoXmlSerializerFormat", ReplyAction = "http://tempuri.org/IWcfService/EchoXmlSerializerFormatResponse"),
+    XmlSerializerFormat]
+    string EchoXmlSerializerFormat(string message);
+}
+
 [System.ServiceModel.ServiceContractAttribute(ConfigurationName = "IWcfService")]
 public interface IWcfServiceGenerated
 {

--- a/src/System.Private.ServiceModel/tests/Scenarios/Contract/XmlSerializer/XmlSerializerFormatTest.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Contract/XmlSerializer/XmlSerializerFormatTest.cs
@@ -277,4 +277,33 @@ public static class XmlSerializerFormatTests
             ScenarioTestHelpers.CloseCommunicationObjects((ICommunicationObject)serviceProxy, factory);
         }
     }
+
+    [Fact]
+    [OuterLoop]
+    public static void XmlSerializerFormat_SameNamespace_SameOperation() {
+        // This test covers the scenariow where two service contracts share
+        // the same namespace and have the same method.
+
+        // *** SETUP *** \\
+        BasicHttpBinding binding = new BasicHttpBinding();
+        EndpointAddress endpointAddress = new EndpointAddress(s_basicEndpointAddress);
+        ChannelFactory<ISameNamespaceWithIWcfServiceXmlGenerated> factory = new ChannelFactory<ISameNamespaceWithIWcfServiceXmlGenerated>(binding, endpointAddress);
+        ISameNamespaceWithIWcfServiceXmlGenerated serviceProxy = factory.CreateChannel();
+
+        try {
+            // *** EXECUTE *** \\
+            string response = serviceProxy.EchoXmlSerializerFormat("message");
+
+            // *** VALIDATE *** \\
+            Assert.Equal("message", response);
+
+            // *** CLEANUP *** \\
+            ((ICommunicationObject)serviceProxy).Close();
+        }
+        finally
+        {
+            // *** ENSURE CLEANUP *** \\
+            ScenarioTestHelpers.CloseCommunicationObjects((ICommunicationObject)serviceProxy, factory);
+        }
+    }
 }


### PR DESCRIPTION
This test covers the scenario where two service contracts use the same namespace and contains the same operation. 

Fix #823 