### PR TITLE
Revert "Package S.P.SM as dotnet5.4 and consolidate facade builds."

### DIFF
--- a/src/System.Private.ServiceModel/src/System.Private.ServiceModel.csproj
+++ b/src/System.Private.ServiceModel/src/System.Private.ServiceModel.csproj
@@ -1,5 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
+  <PropertyGroup>
+    <Configuration Condition="'$(Configuration)'==''">Windows_Debug</Configuration>
+  </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Private.ServiceModel</AssemblyName>
@@ -12,7 +15,7 @@
     <DebugSymbols>true</DebugSymbols>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <ProjectGuid>{9E50E7BF-CD6E-4269-A6DD-59FD0BD6C0FD}</ProjectGuid>
-    <PackageTargetFramework Condition="'$(PackageTargetFramework)'==''">dotnet5.4</PackageTargetFramework>
+    <PackageTargetFramework Condition="'$(TargetGroup)' == ''">DNXCore50</PackageTargetFramework>
     <CommonPath Condition="'$(CommonPath)' == ''">..\..\Common\src</CommonPath>
   </PropertyGroup>
 

--- a/src/System.ServiceModel.Duplex/src/System.ServiceModel.Duplex.builds
+++ b/src/System.ServiceModel.Duplex/src/System.ServiceModel.Duplex.builds
@@ -7,8 +7,13 @@
       <TargetGroup>net46</TargetGroup>
     </Project>
     -->
-    <Project Include="System.ServiceModel.Duplex.csproj" />
-
+    <Project Include="System.ServiceModel.Duplex.csproj" >
+      <OSGroup>Windows_NT</OSGroup>
+    </Project>
+    <Project Include="System.ServiceModel.Duplex.csproj" >
+      <OSGroup>Windows_NT</OSGroup>
+      <TargetGroup>netcore50</TargetGroup>
+    </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.ServiceModel.Duplex/src/System.ServiceModel.Duplex.csproj
+++ b/src/System.ServiceModel.Duplex/src/System.ServiceModel.Duplex.csproj
@@ -5,7 +5,7 @@
     <AssemblyName>System.ServiceModel.Duplex</AssemblyName>
     <AssemblyVersion>4.0.1.0</AssemblyVersion>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
-    <PackageTargetFramework Condition="'$(PackageTargetFramework)'==''">dotnet5.4</PackageTargetFramework>
+    <PackageTargetFramework Condition="'$(TargetGroup)' == ''">dnxcore50</PackageTargetFramework>
   </PropertyGroup>
 
   <!-- Help VS understand available configurations -->
@@ -19,7 +19,9 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
 
   <ItemGroup>
-    <ProjectReference Include="$(SourceDir)System.Private.ServiceModel\src\System.Private.ServiceModel.csproj" >
+    <TargetingPackReference Include="mscorlib" Condition="'$(TargetGroup)' != 'netcore50aot'" />
+    <TargetingPackReference Include="System.ServiceModel" Condition="'$(TargetGroup)' == 'net46'" />
+    <ProjectReference Include="$(SourceDir)System.Private.ServiceModel\src\System.Private.ServiceModel.csproj" Condition="'$(TargetGroup)' != 'net46'" >
       <AdditionalProperties>OSGroup=Windows_NT</AdditionalProperties>
     </ProjectReference>
   </ItemGroup>

--- a/src/System.ServiceModel.Duplex/src/project.json
+++ b/src/System.ServiceModel.Duplex/src/project.json
@@ -3,15 +3,13 @@
     "dnxcore50": {
       "dependencies": {
         "Microsoft.NETCore.Platforms": "1.0.1-rc3-23809",
-		"Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc3-23809",
-		"System.Private.ServiceModel": "4.1.0-rc3-23809"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc3-23809"
       }
     },
     "netcore50": {
       "dependencies": {
         "Microsoft.NETCore.Platforms": "1.0.1-rc3-23809",
-		"Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc3-23809",
-		"System.Private.ServiceModel": "4.1.0-rc3-23809"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc3-23809"
       }
     },
     "net46": {

--- a/src/System.ServiceModel.Http/src/System.ServiceModel.Http.builds
+++ b/src/System.ServiceModel.Http/src/System.ServiceModel.Http.builds
@@ -5,7 +5,13 @@
     <Project Include="System.ServiceModel.Http.csproj" >
       <TargetGroup>net46</TargetGroup>
     </Project>
-    <Project Include="System.ServiceModel.Http.csproj" />
+    <Project Include="System.ServiceModel.Http.csproj" >
+      <OSGroup>Windows_NT</OSGroup>
+    </Project>
+    <Project Include="System.ServiceModel.Http.csproj" >
+      <OSGroup>Windows_NT</OSGroup>
+      <TargetGroup>netcore50</TargetGroup>
+    </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.ServiceModel.Http/src/System.ServiceModel.Http.csproj
+++ b/src/System.ServiceModel.Http/src/System.ServiceModel.Http.csproj
@@ -5,7 +5,7 @@
     <AssemblyName>System.ServiceModel.Http</AssemblyName>
     <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
-    <PackageTargetFramework Condition="'$(PackageTargetFramework)'==''">dotnet5.4</PackageTargetFramework>
+    <PackageTargetFramework Condition="'$(TargetGroup)' == ''">dnxcore50</PackageTargetFramework>
   </PropertyGroup>
 
   <!-- Help VS understand available configurations -->
@@ -19,7 +19,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
 
   <ItemGroup>
-    <TargetingPackReference Include="mscorlib" Condition="'$(TargetGroup)' == 'net46'" />
+    <TargetingPackReference Include="mscorlib" Condition="'$(TargetGroup)' != 'netcore50aot'" />
     <TargetingPackReference Include="System.ServiceModel" Condition="'$(TargetGroup)' == 'net46'" />
     <ProjectReference Include="$(SourceDir)System.Private.ServiceModel\src\System.Private.ServiceModel.csproj" Condition="'$(TargetGroup)' != 'net46'" >
       <AdditionalProperties>OSGroup=Windows_NT</AdditionalProperties>

--- a/src/System.ServiceModel.Http/src/project.json
+++ b/src/System.ServiceModel.Http/src/project.json
@@ -3,15 +3,13 @@
     "dnxcore50": {
       "dependencies": {
         "Microsoft.NETCore.Platforms": "1.0.1-rc3-23809",
-		"Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc3-23809",
-		"System.Private.ServiceModel": "4.1.0-rc3-23809"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc3-23809"
       }
     },
     "netcore50": {
       "dependencies": {
         "Microsoft.NETCore.Platforms": "1.0.1-rc3-23809",
-		"Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc3-23809",
-		"System.Private.ServiceModel": "4.1.0-rc3-23809"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc3-23809"
       }
     },
     "net46": {

--- a/src/System.ServiceModel.NetTcp/src/System.ServiceModel.NetTcp.builds
+++ b/src/System.ServiceModel.NetTcp/src/System.ServiceModel.NetTcp.builds
@@ -6,6 +6,11 @@
       <TargetGroup>net46</TargetGroup>
     </Project>
     <Project Include="System.ServiceModel.NetTcp.csproj">
+      <OSGroup>Windows_NT</OSGroup>
+    </Project>
+    <Project Include="System.ServiceModel.NetTcp.csproj" >
+      <OSGroup>Windows_NT</OSGroup>
+      <TargetGroup>netcore50</TargetGroup>
     </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />

--- a/src/System.ServiceModel.NetTcp/src/System.ServiceModel.NetTcp.csproj
+++ b/src/System.ServiceModel.NetTcp/src/System.ServiceModel.NetTcp.csproj
@@ -5,7 +5,7 @@
     <AssemblyName>System.ServiceModel.NetTcp</AssemblyName>
     <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
-    <PackageTargetFramework Condition="'$(PackageTargetFramework)'==''">dotnet5.4</PackageTargetFramework>
+    <PackageTargetFramework Condition="'$(TargetGroup)' == ''">dnxcore50</PackageTargetFramework>
   </PropertyGroup>
 
   <!-- Help VS understand available configurations -->
@@ -19,7 +19,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
 
   <ItemGroup>
-    <TargetingPackReference Include="mscorlib" Condition="'$(TargetGroup)' == 'net46'" />
+    <TargetingPackReference Include="mscorlib" Condition="'$(TargetGroup)' != 'netcore50aot'" />
     <TargetingPackReference Include="System.ServiceModel" Condition="'$(TargetGroup)' == 'net46'" />
     <ProjectReference Include="$(SourceDir)System.Private.ServiceModel\src\System.Private.ServiceModel.csproj" Condition="'$(TargetGroup)' != 'net46'" >
       <AdditionalProperties>OSGroup=Windows_NT</AdditionalProperties>

--- a/src/System.ServiceModel.NetTcp/src/project.json
+++ b/src/System.ServiceModel.NetTcp/src/project.json
@@ -3,15 +3,13 @@
     "dnxcore50": {
       "dependencies": {
         "Microsoft.NETCore.Platforms": "1.0.1-rc3-23809",
-		"Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc3-23809",
-		"System.Private.ServiceModel": "4.1.0-rc3-23809"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc3-23809"
       }
     },
     "netcore50": {
       "dependencies": {
         "Microsoft.NETCore.Platforms": "1.0.1-rc3-23809",
-		"Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc3-23809",
-		"System.Private.ServiceModel": "4.1.0-rc3-23809"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc3-23809"
       }
     },
     "net46": {

--- a/src/System.ServiceModel.Primitives/src/System.ServiceModel.Primitives.builds
+++ b/src/System.ServiceModel.Primitives/src/System.ServiceModel.Primitives.builds
@@ -6,6 +6,11 @@
       <TargetGroup>net46</TargetGroup>
     </Project>
     <Project Include="System.ServiceModel.Primitives.csproj" >
+      <OSGroup>Windows_NT</OSGroup>
+    </Project>
+    <Project Include="System.ServiceModel.Primitives.csproj" >
+      <OSGroup>Windows_NT</OSGroup>
+      <TargetGroup>netcore50</TargetGroup>
     </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />

--- a/src/System.ServiceModel.Primitives/src/System.ServiceModel.Primitives.csproj
+++ b/src/System.ServiceModel.Primitives/src/System.ServiceModel.Primitives.csproj
@@ -5,7 +5,7 @@
     <AssemblyName>System.ServiceModel.Primitives</AssemblyName>
     <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
-    <PackageTargetFramework Condition="'$(PackageTargetFramework)'==''">dotnet5.4</PackageTargetFramework>
+    <PackageTargetFramework Condition="'$(TargetGroup)' == ''">dnxcore50</PackageTargetFramework>
   </PropertyGroup>
 
   <!-- Help VS understand available configurations -->
@@ -19,7 +19,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
 
   <ItemGroup>
-    <TargetingPackReference Include="mscorlib" Condition="'$(TargetGroup)' == 'net46'" />
+    <TargetingPackReference Include="mscorlib" Condition="'$(TargetGroup)' != 'netcore50aot'" />
     <TargetingPackReference Include="System.IdentityModel" Condition="'$(TargetGroup)' == 'net46'" />
     <TargetingPackReference Include="System.ServiceModel" Condition="'$(TargetGroup)' == 'net46'" />
     <ProjectReference Include="$(SourceDir)System.Private.ServiceModel\src\System.Private.ServiceModel.csproj" Condition="'$(TargetGroup)' != 'net46'" >

--- a/src/System.ServiceModel.Primitives/src/project.json
+++ b/src/System.ServiceModel.Primitives/src/project.json
@@ -3,15 +3,13 @@
     "dnxcore50": {
       "dependencies": {
         "Microsoft.NETCore.Platforms": "1.0.1-rc3-23809",
-		"Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc3-23809",
-		"System.Private.ServiceModel": "4.1.0-rc3-23809"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc3-23809"
       }
     },
     "netcore50": {
       "dependencies": {
         "Microsoft.NETCore.Platforms": "1.0.1-rc3-23809",
-		"Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc3-23809",
-		"System.Private.ServiceModel": "4.1.0-rc3-23809"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc3-23809"
       }
     },
     "net46": {

--- a/src/System.ServiceModel.Security/src/System.ServiceModel.Security.builds
+++ b/src/System.ServiceModel.Security/src/System.ServiceModel.Security.builds
@@ -2,7 +2,18 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
-    <Project Include="System.ServiceModel.Security.csproj" />
+    <!-- facade is inbox on Net 4.6
+    <Project Include="System.ServiceModel.Security.csproj" >
+      <TargetGroup>net46</TargetGroup>
+    </Project> 
+    -->
+    <Project Include="System.ServiceModel.Security.csproj" >
+      <OSGroup>Windows_NT</OSGroup>
+    </Project>
+    <Project Include="System.ServiceModel.Security.csproj" >
+      <OSGroup>Windows_NT</OSGroup>
+      <TargetGroup>netcore50</TargetGroup>
+    </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.ServiceModel.Security/src/System.ServiceModel.Security.csproj
+++ b/src/System.ServiceModel.Security/src/System.ServiceModel.Security.csproj
@@ -5,7 +5,7 @@
     <AssemblyName>System.ServiceModel.Security</AssemblyName>
     <AssemblyVersion>4.0.1.0</AssemblyVersion>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
-    <PackageTargetFramework Condition="'$(PackageTargetFramework)'==''">dotnet5.4</PackageTargetFramework>
+    <PackageTargetFramework Condition="'$(TargetGroup)' == ''">dnxcore50</PackageTargetFramework>
   </PropertyGroup>
 
   <!-- Help VS understand available configurations -->
@@ -19,7 +19,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
 
   <ItemGroup>
-    <TargetingPackReference Include="mscorlib" Condition="'$(TargetGroup)' == 'net46'" />
+    <TargetingPackReference Include="mscorlib" Condition="'$(TargetGroup)' != 'netcore50aot'" />
     <TargetingPackReference Include="System.ServiceModel" Condition="'$(TargetGroup)' == 'net46'" />
     <ProjectReference Include="$(SourceDir)System.Private.ServiceModel\src\System.Private.ServiceModel.csproj" Condition="'$(TargetGroup)' != 'net46'" >
       <AdditionalProperties>OSGroup=Windows_NT</AdditionalProperties>

--- a/src/System.ServiceModel.Security/src/project.json
+++ b/src/System.ServiceModel.Security/src/project.json
@@ -3,15 +3,13 @@
     "dnxcore50": {
       "dependencies": {
         "Microsoft.NETCore.Platforms": "1.0.1-rc3-23809",
-		"Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc3-23809",
-		"System.Private.ServiceModel": "4.1.0-rc3-23809"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc3-23809"
       }
     },
     "netcore50": {
       "dependencies": {
         "Microsoft.NETCore.Platforms": "1.0.1-rc3-23809",
-		"Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc3-23809",
-		"System.Private.ServiceModel": "4.1.0-rc3-23809"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc3-23809"
       }
     },
     "net46": {

--- a/wcf.targets
+++ b/wcf.targets
@@ -47,9 +47,4 @@
      <WcfToolsOutputPath>$(WcfRootFolder)bin\Wcf\tools\</WcfToolsOutputPath>
   </PropertyGroup>
 
-  <!-- Override ValidateIgnoreReference from Target 'ValidatePackageTargetFramework' in PackageLibs.targets -->
-  <ItemGroup>
-    <ValidateIgnoreReference Include="System.Private.ServiceModel" />
-  </ItemGroup>
-
 </Project>


### PR DESCRIPTION
Reverts dotnet/wcf#793
Seems to be a conflict with changes by Davis Goodin in TFS, reverting until we understand the changes he made and how they affect this PR.