### PR TITLE
Fix ClientCredential.Clone method which missed Windows credentials

### DIFF
--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Description/ClientCredentials.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Description/ClientCredentials.cs
@@ -31,8 +31,11 @@ namespace System.ServiceModel.Description
                 _clientCertificate = new X509CertificateInitiatorClientCredential(other._clientCertificate);
             if (other._serviceCertificate != null)
                 _serviceCertificate = new X509CertificateRecipientClientCredential(other._serviceCertificate);
+            if (other._windows != null)
+                _windows = new WindowsClientCredential(other._windows);
             if (other._httpDigest != null)
                 _httpDigest = new HttpDigestClientCredential(other._httpDigest);
+
             _isReadOnly = other._isReadOnly;
         }
 


### PR DESCRIPTION
The initial porting work meant that some methods had functionality stripped to allow for compile. In this case, we stripped out the clone capability for the WindowsClientCredential and neglected to add it back when we were turning this capability back on

This is required for WindowsStreamSecurityUpgradePRovider to to successfully pass our creds along to the underlying NegotiateStream

(a big omission... a simple change... but boy this took forever to hunt down...) 