### PR TITLE
Allow MsBuild properties at build time to flow to the Bridge.

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -63,7 +63,7 @@ set _buildpostfix=^> "%_buildlog%"
 
 if "%outloop%" equ "true"  (
     pushd %setupFilesFolder%
-    call EnsureBridgeRunning.cmd
+    call EnsureBridgeRunning.cmd %*
     set _bridgeReturnCode=!ERRORLEVEL!
     echo EnsureBridgeRunning returned !_bridgeReturnCode!
     popd

--- a/src/System.Private.ServiceModel/tools/test/Bridge/Bridge/Program.cs
+++ b/src/System.Private.ServiceModel/tools/test/Bridge/Bridge/Program.cs
@@ -610,6 +610,21 @@ namespace Bridge
                         return false;
                     }
 
+                    // Accept MsBuild /p:x=y style properties to allow this program to be
+                    // invoked from a script using MsBuild.
+                    // This allows /BridgeHost:xyz and /p:BridgeHost=xyz to be equivalent.
+                    if (String.Equals(argName, "p", StringComparison.OrdinalIgnoreCase) ||
+                        String.Equals(argName, "property", StringComparison.OrdinalIgnoreCase))
+                    {
+                        index = argValue.IndexOf("=");
+                        if (index < 1)
+                        {
+                            continue;
+                        }
+                        argName = argValue.Substring(0, index);
+                        argValue = argValue.Substring(index + 1);
+                    }
+
                     argumentDictionary[argName] = argValue;
                 }
 
@@ -755,6 +770,8 @@ namespace Bridge
                     helpBuilder.AppendLine(String.Format("   -{0}:value", propertyName));
                 }
                 Console.WriteLine(helpBuilder.ToString());
+                Console.WriteLine();
+                Console.WriteLine("It is also acceptable to use MsBuild syntax for arguments, such as /p:BridgeHost=xyz");
                 Console.WriteLine();
                 Console.WriteLine("If no other option is specified, and the Bridge is not already running, it will be started.");
                 Console.WriteLine("Whenever the Bridge is started, it will block the current process until it is stopped.");


### PR DESCRIPTION
This PR makes it possible for Bridge configuration properties
expressed at build time to be built into the test binaries.
And it also allows Build.exe to accept the MSBuild style of
property arguments.

This enables 2 important scenarios for our multi-machine effort.

1. Doing "build /p:BridgeHost=xyz" will generate the appropriate
TestProperties at compile time so that the generated test binaries
carry this information. Then if they are uploaded to Helix to
execute, they already carry the information necessary to communicate
with a Bridge on a different machine.  There is no need to set
environment variables on the execution machine for this.

2. By allowing Bridge.exe to parse the MSBuild style property
arguments, it allows our build scripts to flow Bridge configuration
information to the Bridge startup/ping scripts so they agree with
what the tests expect.

Prior to this PR, it would have been necessary to set environment
variables on both the client and execution machines to have a
shared Bridge configuration.