### PR TITLE
Made a performance improvement in XmlSerializerOperationBehavior.

### DIFF
--- a/src/System.Private.ServiceModel/tests/Scenarios/Contract/Service/ServiceKnownTypeTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Contract/Service/ServiceKnownTypeTests.cs
@@ -69,6 +69,11 @@ public static class ServiceKnownTypeTests
     [OuterLoop]
     public static void ServiceKnownType_XmlSerializerFormat_TwoOperationsShareKnownTypes_Test()
     {
+        // In XmlSerializerOperationBehavior.cs we made a performance improvement change for the scenario
+        // where multiple operations of one service contract share the same ServiceKnownTypeAttribute(s).
+        // The fix was to skip parsing duplicate ServiceKnownTypeAttribute(s). This test was to verify that
+        // scenario still works after the fix.
+
         // *** SETUP *** \\
         ChannelFactory<IServiceKnownTypeTest_AttrOnType_Xml> factory = GetChannelFactory<IServiceKnownTypeTest_AttrOnType_Xml>();
         IServiceKnownTypeTest_AttrOnType_Xml serviceProxy = factory.CreateChannel();

--- a/src/System.Private.ServiceModel/tests/Scenarios/Contract/Service/ServiceKnownTypeTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Contract/Service/ServiceKnownTypeTests.cs
@@ -65,6 +65,20 @@ public static class ServiceKnownTypeTests
         RunTestMethodAndCleanup(factory, serviceProxy, serviceProxy.EchoItems_Xml, new Widget3());
     }
 
+    [Fact]
+    [OuterLoop]
+    public static void ServiceKnownType_XmlSerializerFormat_TwoOperationsShareKnownTypes_Test()
+    {
+        // *** SETUP *** \\
+        ChannelFactory<IServiceKnownTypeTest_AttrOnType_Xml> factory = GetChannelFactory<IServiceKnownTypeTest_AttrOnType_Xml>();
+        IServiceKnownTypeTest_AttrOnType_Xml serviceProxy = factory.CreateChannel();
+
+        // *** EXECUTE *** \\
+        // *** VALIDATE *** \\
+        // *** CLEANUP *** \\
+        RunTestMethodAndCleanup(factory, serviceProxy, serviceProxy.EchoItems_Xml1, new Widget3());
+    }
+
     private static ChannelFactory<ServiceContractType> GetChannelFactory<ServiceContractType>()
     {
         var binding = new BasicHttpBinding();
@@ -141,6 +155,10 @@ public interface IServiceKnownTypeTest_AttrOnType_Xml
     [OperationContract(Action = "http://tempuri.org/IWcfService/EchoItemsXml", ReplyAction = "http://tempuri.org/IWcfService/EchoItemsXmlResponse")]
     [XmlSerializerFormat]
     object[] EchoItems_Xml(object[] objects);
+
+    [OperationContract(Action = "http://tempuri.org/IWcfService/EchoItemsXml1", ReplyAction = "http://tempuri.org/IWcfService/EchoItemsXml1Response")]
+    [XmlSerializerFormat]
+    object[] EchoItems_Xml1(object[] objects);
 }
 
 [DataContract()]

--- a/src/System.Private.ServiceModel/tools/test/SelfHostWcfService/IWcfService.cs
+++ b/src/System.Private.ServiceModel/tools/test/SelfHostWcfService/IWcfService.cs
@@ -113,6 +113,12 @@ namespace WcfService
         [XmlSerializerFormat]
         object[] EchoItems_Xml(object[] objects);
 
+        [OperationContract(Action = "http://tempuri.org/IWcfService/EchoItemsXml1")]
+        [ServiceKnownType(typeof(Widget2))]
+        [ServiceKnownType(typeof(Widget3))]
+        [XmlSerializerFormat]
+        object[] EchoItems_Xml1(object[] objects);
+
         [OperationContract(Action = "http://tempuri.org/IWcfService/EchoXmlVeryComplexType"), XmlSerializerFormat]
         XmlVeryComplexType EchoXmlVeryComplexType(XmlVeryComplexType complex);
 

--- a/src/System.Private.ServiceModel/tools/test/SelfHostWcfService/WcfService.cs
+++ b/src/System.Private.ServiceModel/tools/test/SelfHostWcfService/WcfService.cs
@@ -320,6 +320,11 @@ namespace WcfService
             return objects;
         }
 
+        public object[] EchoItems_Xml1(object[] objects)
+        {
+            return objects;
+        }
+
         public XmlVeryComplexType EchoXmlVeryComplexType(XmlVeryComplexType complex)
         {
             return complex;


### PR DESCRIPTION
If a ServiceContract is marked with XmlSerializerFormatAttribute, WCF would parse each operation of the service, generate a special XmlMapping object for the operation, and then generate a customized XmlSerializer instance for the operation based on the XmlMapping object. If the ServiceContract has a lot of ServiceKnownTypeAttribute, WCF might take a long time to generate the XmlMapping objects for the operations of the service. When generating an XmlMaping object for an operation WCF needs to call XmlReflectionImporter.IncludeType(Type) on every ServiceKnownType of the operation. This call is expensive. The ServiceContract defined in the [WcfPerfTest.zip](https://github.com/dotnet/wcf/files/132539/WcfPerfTest.zip), which was provided by @atanasa, contains 720 operations and each operation has 1,193 ServiceKnownTypeAttributes (858,960 in total). XmlReflectionImporter.IncludeType(Type) is called 858,960 times. It took about **40** seconds to generate all XmlMappings on my machine.

As all the operations of one service share the same XmlReflectionImporter instance, the improvement we can do for this scenario is to let the XmlReflectionImporter instance include a type only once. In the above example, instead of being called 858,960 times, the IncludeType would be called 1,193 times after the fix. It took about **11** seconds to generate all the XmlMappings on my machine.

Fix #775.