### PR TITLE
Fix test projects to not build AnyOS flavor of S.P.SM

### DIFF
--- a/src/System.Private.ServiceModel/src/System.Private.ServiceModel.csproj
+++ b/src/System.Private.ServiceModel/src/System.Private.ServiceModel.csproj
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
+  <PropertyGroup>
+    <Configuration Condition="'$(Configuration)'==''">$(OS)_Debug</Configuration>
+  </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Private.ServiceModel</AssemblyName>

--- a/src/System.Private.ServiceModel/tests/Common/Infrastructure/src/Infrastructure.Common.csproj
+++ b/src/System.Private.ServiceModel/tests/Common/Infrastructure/src/Infrastructure.Common.csproj
@@ -1,9 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition="'$(Configuration)'==''">$(OS)_Debug</Configuration>
+  </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>

--- a/src/System.Private.ServiceModel/tests/Common/Infrastructure/tests/Infrastructure.Common.Tests.csproj
+++ b/src/System.Private.ServiceModel/tests/Common/Infrastructure/tests/Infrastructure.Common.Tests.csproj
@@ -1,9 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition="'$(Configuration)'==''">$(OS)_Debug</Configuration>
+  </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>

--- a/src/System.Private.ServiceModel/tests/Common/Scenarios/ScenarioTests.Common.csproj
+++ b/src/System.Private.ServiceModel/tests/Common/Scenarios/ScenarioTests.Common.csproj
@@ -1,9 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition="'$(Configuration)'==''">$(OS)_Debug</Configuration>
+  </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>

--- a/src/System.Private.ServiceModel/tests/Common/Unit/UnitTests.Common.csproj
+++ b/src/System.Private.ServiceModel/tests/Common/Unit/UnitTests.Common.csproj
@@ -1,35 +1,37 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-    <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
-    <PropertyGroup>
-        <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
-        <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-        <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-        <OutputType>Library</OutputType>
-        <AppDesignerFolder>Properties</AppDesignerFolder>
-        <RootNamespace>UnitTests.Common</RootNamespace>
-        <AssemblyName>UnitTests.Common</AssemblyName>
-        <SignAssembly>false</SignAssembly>
-        <CLSCompliant>false</CLSCompliant>
-        <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-        <ProjectGuid>{E896294A-AB4A-4AF5-A01C-A19E3972EFF9}</ProjectGuid>
-    </PropertyGroup>
-    <ItemGroup>
-        <Compile Include="**\*.cs" />
-    </ItemGroup>
-    <ItemGroup>
-        <None Include="project.json" />
-    </ItemGroup>
-    <ItemGroup>
-        <!-- Compile tests against the contract, but copy our local-built implementation for testing -->
-        <ProjectReference Include='$(WcfSourceProj)'>
-            <Project>{9e50e7bf-cd6e-4269-a6dd-59fd0bd6c0fd}</Project>
-            <Name>System.Private.ServiceModel</Name>
-            <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-            <OutputItemType>Content</OutputItemType>
-            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-            <Targets>Build;DebugSymbolsProjectOutputGroup</Targets>
-        </ProjectReference>
-    </ItemGroup>
-    <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup>
+    <Configuration Condition="'$(Configuration)'==''">$(OS)_Debug</Configuration>
+  </PropertyGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>UnitTests.Common</RootNamespace>
+    <AssemblyName>UnitTests.Common</AssemblyName>
+    <SignAssembly>false</SignAssembly>
+    <CLSCompliant>false</CLSCompliant>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <ProjectGuid>{E896294A-AB4A-4AF5-A01C-A19E3972EFF9}</ProjectGuid>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="**\*.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <ItemGroup>
+    <!-- Compile tests against the contract, but copy our local-built implementation for testing -->
+    <ProjectReference Include='$(WcfSourceProj)'>
+      <Project>{9e50e7bf-cd6e-4269-a6dd-59fd0bd6c0fd}</Project>
+      <Name>System.Private.ServiceModel</Name>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+      <OutputItemType>Content</OutputItemType>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Targets>Build;DebugSymbolsProjectOutputGroup</Targets>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Private.ServiceModel/tests/Scenarios/Binding/Custom/Binding.Custom.Tests.csproj
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Binding/Custom/Binding.Custom.Tests.csproj
@@ -1,41 +1,41 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-    <PropertyGroup>
-        <TestCategories>OuterLoop</TestCategories>
-    </PropertyGroup>
-    <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
-    <PropertyGroup>
-        <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
-        <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-        <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-        <OutputType>Library</OutputType>
-        <AppDesignerFolder>Properties</AppDesignerFolder>
-        <RootNamespace>Binding.Custom.Tests</RootNamespace>
-        <AssemblyName>Binding.Custom.Tests</AssemblyName>
-        <SignAssembly>false</SignAssembly>
-        <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-        <ProjectGuid>{EDC88742-E7BF-4B7A-9DE2-55055B81B8F2}</ProjectGuid>
-    </PropertyGroup>
-    <ItemGroup>
-        <Compile Include="CustomBindingTests.cs" />
-    </ItemGroup>
-    <ItemGroup>
-        <None Include="project.json" />
-    </ItemGroup>
-    <ItemGroup>
-        <!-- Compile tests against the contract, but copy our local-built implementation for testing -->
-        <ProjectReference Include="$(WcfSourceProj)">
-            <Project>{9e50e7bf-cd6e-4269-a6dd-59fd0bd6c0fd}</Project>
-            <Name>System.Private.ServiceModel</Name>
-            <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-            <OutputItemType>Content</OutputItemType>
-            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-            <Targets>Build;DebugSymbolsProjectOutputGroup</Targets>
-        </ProjectReference>
-        <ProjectReference Include='$(WcfScenarioTestCommonProj)'>
-            <Project>{9098B41C-9C2E-4FC6-B7D8-FC3411736A22}</Project>
-            <Name>ScenarioTests.Common</Name>
-        </ProjectReference>
-    </ItemGroup>
-    <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup>
+    <TestCategories>OuterLoop</TestCategories>
+    <Configuration Condition="'$(Configuration)'==''">$(OS)_Debug</Configuration>
+  </PropertyGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Binding.Custom.Tests</RootNamespace>
+    <AssemblyName>Binding.Custom.Tests</AssemblyName>
+    <SignAssembly>false</SignAssembly>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <ProjectGuid>{EDC88742-E7BF-4B7A-9DE2-55055B81B8F2}</ProjectGuid>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="CustomBindingTests.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <ItemGroup>
+    <!-- Compile tests against the contract, but copy our local-built implementation for testing -->
+    <ProjectReference Include="$(WcfSourceProj)">
+      <Project>{9e50e7bf-cd6e-4269-a6dd-59fd0bd6c0fd}</Project>
+      <Name>System.Private.ServiceModel</Name>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+      <OutputItemType>Content</OutputItemType>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Targets>Build;DebugSymbolsProjectOutputGroup</Targets>
+    </ProjectReference>
+    <ProjectReference Include='$(WcfScenarioTestCommonProj)'>
+      <Project>{9098B41C-9C2E-4FC6-B7D8-FC3411736A22}</Project>
+      <Name>ScenarioTests.Common</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Private.ServiceModel/tests/Scenarios/Binding/Http/Binding.Http.Tests.csproj
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Binding/Http/Binding.Http.Tests.csproj
@@ -1,42 +1,42 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-    <PropertyGroup>
-        <TestCategories>OuterLoop</TestCategories>
-    </PropertyGroup>
-    <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
-    <PropertyGroup>
-        <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
-        <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-        <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-        <OutputType>Library</OutputType>
-        <AppDesignerFolder>Properties</AppDesignerFolder>
-        <RootNamespace>Binding.Http.Tests</RootNamespace>
-        <AssemblyName>Binding.Http.Tests</AssemblyName>
-        <SignAssembly>false</SignAssembly>
-        <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-        <ProjectGuid>{15636BB6-CD0B-4EC7-B7A8-9AB59A17B625}</ProjectGuid>
-    </PropertyGroup>
-    <ItemGroup>
-        <Compile Include="BasicHttpBindingTests.cs" />
-        <Compile Include="NetHttpBindingTests.cs" />
-    </ItemGroup>
-    <ItemGroup>
-        <None Include="project.json" />
-    </ItemGroup>
-    <ItemGroup>
-        <!-- Compile tests against the contract, but copy our local-built implementation for testing -->
-        <ProjectReference Include="$(WcfSourceProj)">
-            <Project>{9e50e7bf-cd6e-4269-a6dd-59fd0bd6c0fd}</Project>
-            <Name>System.Private.ServiceModel</Name>
-            <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-            <OutputItemType>Content</OutputItemType>
-            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-            <Targets>Build;DebugSymbolsProjectOutputGroup</Targets>
-        </ProjectReference>
-        <ProjectReference Include='$(WcfScenarioTestCommonProj)'>
-            <Project>{9098B41C-9C2E-4FC6-B7D8-FC3411736A22}</Project>
-            <Name>ScenarioTests.Common</Name>
-        </ProjectReference>
-    </ItemGroup>
-    <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup>
+    <TestCategories>OuterLoop</TestCategories>
+    <Configuration Condition="'$(Configuration)'==''">$(OS)_Debug</Configuration>
+  </PropertyGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Binding.Http.Tests</RootNamespace>
+    <AssemblyName>Binding.Http.Tests</AssemblyName>
+    <SignAssembly>false</SignAssembly>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <ProjectGuid>{15636BB6-CD0B-4EC7-B7A8-9AB59A17B625}</ProjectGuid>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="BasicHttpBindingTests.cs" />
+    <Compile Include="NetHttpBindingTests.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <ItemGroup>
+    <!-- Compile tests against the contract, but copy our local-built implementation for testing -->
+    <ProjectReference Include="$(WcfSourceProj)">
+      <Project>{9e50e7bf-cd6e-4269-a6dd-59fd0bd6c0fd}</Project>
+      <Name>System.Private.ServiceModel</Name>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+      <OutputItemType>Content</OutputItemType>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Targets>Build;DebugSymbolsProjectOutputGroup</Targets>
+    </ProjectReference>
+    <ProjectReference Include='$(WcfScenarioTestCommonProj)'>
+      <Project>{9098B41C-9C2E-4FC6-B7D8-FC3411736A22}</Project>
+      <Name>ScenarioTests.Common</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/ChannelLayer/Client.ChannelLayer.Tests.csproj
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/ChannelLayer/Client.ChannelLayer.Tests.csproj
@@ -1,42 +1,42 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-    <PropertyGroup>
-        <TestCategories>OuterLoop</TestCategories>
-    </PropertyGroup>
-    <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
-    <PropertyGroup>
-        <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
-        <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-        <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-        <OutputType>Library</OutputType>
-        <AppDesignerFolder>Properties</AppDesignerFolder>
-        <RootNamespace>Client.ChannelLayer.Tests</RootNamespace>
-        <AssemblyName>Client.ChannelLayer.Tests</AssemblyName>
-        <SignAssembly>false</SignAssembly>
-        <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-        <ProjectGuid>{1DFF7AF1-5873-4984-B871-73F2F9A84239}</ProjectGuid>
-    </PropertyGroup>
-    <ItemGroup>
-        <Compile Include="DuplexChannelShapeTests.cs" />
-        <Compile Include="RequestReplyChannelShapeTests.cs" />
-    </ItemGroup>
-    <ItemGroup>
-        <None Include="project.json" />
-    </ItemGroup>
-    <ItemGroup>
-        <!-- Compile tests against the contract, but copy our local-built implementation for testing -->
-        <ProjectReference Include="$(WcfSourceProj)">
-            <Project>{9e50e7bf-cd6e-4269-a6dd-59fd0bd6c0fd}</Project>
-            <Name>System.Private.ServiceModel</Name>
-            <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-            <OutputItemType>Content</OutputItemType>
-            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-            <Targets>Build;DebugSymbolsProjectOutputGroup</Targets>
-        </ProjectReference>
-        <ProjectReference Include='$(WcfScenarioTestCommonProj)'>
-            <Project>{9098B41C-9C2E-4FC6-B7D8-FC3411736A22}</Project>
-            <Name>ScenarioTests.Common</Name>
-        </ProjectReference>
-    </ItemGroup>
-    <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup>
+    <TestCategories>OuterLoop</TestCategories>
+    <Configuration Condition="'$(Configuration)'==''">$(OS)_Debug</Configuration>
+  </PropertyGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Client.ChannelLayer.Tests</RootNamespace>
+    <AssemblyName>Client.ChannelLayer.Tests</AssemblyName>
+    <SignAssembly>false</SignAssembly>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <ProjectGuid>{1DFF7AF1-5873-4984-B871-73F2F9A84239}</ProjectGuid>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="DuplexChannelShapeTests.cs" />
+    <Compile Include="RequestReplyChannelShapeTests.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <ItemGroup>
+    <!-- Compile tests against the contract, but copy our local-built implementation for testing -->
+    <ProjectReference Include="$(WcfSourceProj)">
+      <Project>{9e50e7bf-cd6e-4269-a6dd-59fd0bd6c0fd}</Project>
+      <Name>System.Private.ServiceModel</Name>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+      <OutputItemType>Content</OutputItemType>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Targets>Build;DebugSymbolsProjectOutputGroup</Targets>
+    </ProjectReference>
+    <ProjectReference Include='$(WcfScenarioTestCommonProj)'>
+      <Project>{9098B41C-9C2E-4FC6-B7D8-FC3411736A22}</Project>
+      <Name>ScenarioTests.Common</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/ClientBase/Client.ClientBase.Tests.csproj
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/ClientBase/Client.ClientBase.Tests.csproj
@@ -1,42 +1,42 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-    <PropertyGroup>
-        <TestCategories>OuterLoop</TestCategories>
-    </PropertyGroup>
-    <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
-    <PropertyGroup>
-        <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
-        <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-        <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-        <OutputType>Library</OutputType>
-        <AppDesignerFolder>Properties</AppDesignerFolder>
-        <RootNamespace>Client.ClientBase.Tests</RootNamespace>
-        <AssemblyName>Client.ClientBase.Tests</AssemblyName>
-        <SignAssembly>false</SignAssembly>
-        <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-        <ProjectGuid>{E0142AC1-DA3D-4143-BFF1-7A70EE0981D4}</ProjectGuid>
-    </PropertyGroup>
-    <ItemGroup>
-        <None Include="project.json" />
-    </ItemGroup>
-    <ItemGroup>
-        <!-- Compile tests against the contract, but copy our local-built implementation for testing -->
-        <ProjectReference Include="$(WcfSourceProj)">
-            <Project>{9e50e7bf-cd6e-4269-a6dd-59fd0bd6c0fd}</Project>
-            <Name>System.Private.ServiceModel</Name>
-            <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-            <OutputItemType>Content</OutputItemType>
-            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-            <Targets>Build;DebugSymbolsProjectOutputGroup</Targets>
-        </ProjectReference>
-        <ProjectReference Include='$(WcfScenarioTestCommonProj)'>
-            <Project>{9098B41C-9C2E-4FC6-B7D8-FC3411736A22}</Project>
-            <Name>ScenarioTests.Common</Name>
-        </ProjectReference>
-    </ItemGroup>
-    <ItemGroup>
-        <Compile Include="ClientBaseTests.cs" />
-        <Compile Include="DuplexClientBaseTests.cs" />
-    </ItemGroup>
-    <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup>
+    <TestCategories>OuterLoop</TestCategories>
+    <Configuration Condition="'$(Configuration)'==''">$(OS)_Debug</Configuration>
+  </PropertyGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Client.ClientBase.Tests</RootNamespace>
+    <AssemblyName>Client.ClientBase.Tests</AssemblyName>
+    <SignAssembly>false</SignAssembly>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <ProjectGuid>{E0142AC1-DA3D-4143-BFF1-7A70EE0981D4}</ProjectGuid>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <ItemGroup>
+    <!-- Compile tests against the contract, but copy our local-built implementation for testing -->
+    <ProjectReference Include="$(WcfSourceProj)">
+      <Project>{9e50e7bf-cd6e-4269-a6dd-59fd0bd6c0fd}</Project>
+      <Name>System.Private.ServiceModel</Name>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+      <OutputItemType>Content</OutputItemType>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Targets>Build;DebugSymbolsProjectOutputGroup</Targets>
+    </ProjectReference>
+    <ProjectReference Include='$(WcfScenarioTestCommonProj)'>
+      <Project>{9098B41C-9C2E-4FC6-B7D8-FC3411736A22}</Project>
+      <Name>ScenarioTests.Common</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="ClientBaseTests.cs" />
+    <Compile Include="DuplexClientBaseTests.cs" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/ExpectedExceptions/Client.ExpectedExceptions.Tests.csproj
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/ExpectedExceptions/Client.ExpectedExceptions.Tests.csproj
@@ -1,41 +1,41 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-    <PropertyGroup>
-        <TestCategories>OuterLoop</TestCategories>
-    </PropertyGroup>
-    <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
-    <PropertyGroup>
-        <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
-        <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-        <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-        <OutputType>Library</OutputType>
-        <AppDesignerFolder>Properties</AppDesignerFolder>
-        <RootNamespace>Client.ExpectedExceptions.Tests</RootNamespace>
-        <AssemblyName>Client.ExpectedExceptions.Tests</AssemblyName>
-        <SignAssembly>false</SignAssembly>
-        <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-        <ProjectGuid>{C9DBD082-1903-4367-894F-DDF3CEC28A64}</ProjectGuid>
-    </PropertyGroup>
-    <ItemGroup>
-        <Compile Include="ExpectedExceptionTests.cs" />
-    </ItemGroup>
-    <ItemGroup>
-        <None Include="project.json" />
-    </ItemGroup>
-    <ItemGroup>
-        <!-- Compile tests against the contract, but copy our local-built implementation for testing -->
-        <ProjectReference Include="$(WcfSourceProj)">
-            <Project>{9e50e7bf-cd6e-4269-a6dd-59fd0bd6c0fd}</Project>
-            <Name>System.Private.ServiceModel</Name>
-            <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-            <OutputItemType>Content</OutputItemType>
-            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-            <Targets>Build;DebugSymbolsProjectOutputGroup</Targets>
-        </ProjectReference>
-        <ProjectReference Include='$(WcfScenarioTestCommonProj)'>
-            <Project>{9098B41C-9C2E-4FC6-B7D8-FC3411736A22}</Project>
-            <Name>ScenarioTests.Common</Name>
-        </ProjectReference>
-    </ItemGroup>
-    <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup>
+    <TestCategories>OuterLoop</TestCategories>
+    <Configuration Condition="'$(Configuration)'==''">$(OS)_Debug</Configuration>
+  </PropertyGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Client.ExpectedExceptions.Tests</RootNamespace>
+    <AssemblyName>Client.ExpectedExceptions.Tests</AssemblyName>
+    <SignAssembly>false</SignAssembly>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <ProjectGuid>{C9DBD082-1903-4367-894F-DDF3CEC28A64}</ProjectGuid>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="ExpectedExceptionTests.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <ItemGroup>
+    <!-- Compile tests against the contract, but copy our local-built implementation for testing -->
+    <ProjectReference Include="$(WcfSourceProj)">
+      <Project>{9e50e7bf-cd6e-4269-a6dd-59fd0bd6c0fd}</Project>
+      <Name>System.Private.ServiceModel</Name>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+      <OutputItemType>Content</OutputItemType>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Targets>Build;DebugSymbolsProjectOutputGroup</Targets>
+    </ProjectReference>
+    <ProjectReference Include='$(WcfScenarioTestCommonProj)'>
+      <Project>{9098B41C-9C2E-4FC6-B7D8-FC3411736A22}</Project>
+      <Name>ScenarioTests.Common</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/TypedClient/Client.TypedClient.Tests.csproj
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/TypedClient/Client.TypedClient.Tests.csproj
@@ -1,42 +1,42 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-    <PropertyGroup>
-        <TestCategories>OuterLoop</TestCategories>
-    </PropertyGroup>
-    <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
-    <PropertyGroup>
-        <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
-        <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-        <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-        <OutputType>Library</OutputType>
-        <AppDesignerFolder>Properties</AppDesignerFolder>
-        <RootNamespace>Client.TypedClient.Tests</RootNamespace>
-        <AssemblyName>Client.TypedClient.Tests</AssemblyName>
-        <SignAssembly>false</SignAssembly>
-        <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-        <ProjectGuid>{09EB5A34-9F50-4349-B8D9-D8E82A3FAE8E}</ProjectGuid>
-    </PropertyGroup>
-    <ItemGroup>
-        <Compile Include="TypedProxyDuplexTests.cs" />
-        <Compile Include="TypedProxyTests.cs" />
-    </ItemGroup>
-    <ItemGroup>
-        <None Include="project.json" />
-    </ItemGroup>
-    <ItemGroup>
-        <!-- Compile tests against the contract, but copy our local-built implementation for testing -->
-        <ProjectReference Include="$(WcfSourceProj)">
-            <Project>{9e50e7bf-cd6e-4269-a6dd-59fd0bd6c0fd}</Project>
-            <Name>System.Private.ServiceModel</Name>
-            <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-            <OutputItemType>Content</OutputItemType>
-            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-            <Targets>Build;DebugSymbolsProjectOutputGroup</Targets>
-        </ProjectReference>
-        <ProjectReference Include='$(WcfScenarioTestCommonProj)'>
-            <Project>{9098B41C-9C2E-4FC6-B7D8-FC3411736A22}</Project>
-            <Name>ScenarioTests.Common</Name>
-        </ProjectReference>
-    </ItemGroup>
-    <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup>
+    <TestCategories>OuterLoop</TestCategories>
+    <Configuration Condition="'$(Configuration)'==''">$(OS)_Debug</Configuration>
+  </PropertyGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Client.TypedClient.Tests</RootNamespace>
+    <AssemblyName>Client.TypedClient.Tests</AssemblyName>
+    <SignAssembly>false</SignAssembly>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <ProjectGuid>{09EB5A34-9F50-4349-B8D9-D8E82A3FAE8E}</ProjectGuid>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="TypedProxyDuplexTests.cs" />
+    <Compile Include="TypedProxyTests.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <ItemGroup>
+    <!-- Compile tests against the contract, but copy our local-built implementation for testing -->
+    <ProjectReference Include="$(WcfSourceProj)">
+      <Project>{9e50e7bf-cd6e-4269-a6dd-59fd0bd6c0fd}</Project>
+      <Name>System.Private.ServiceModel</Name>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+      <OutputItemType>Content</OutputItemType>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Targets>Build;DebugSymbolsProjectOutputGroup</Targets>
+    </ProjectReference>
+    <ProjectReference Include='$(WcfScenarioTestCommonProj)'>
+      <Project>{9098B41C-9C2E-4FC6-B7D8-FC3411736A22}</Project>
+      <Name>ScenarioTests.Common</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Private.ServiceModel/tests/Scenarios/Contract/Data/Contract.Data.Tests.csproj
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Contract/Data/Contract.Data.Tests.csproj
@@ -1,41 +1,41 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-    <PropertyGroup>
-        <TestCategories>OuterLoop</TestCategories>
-    </PropertyGroup>
-    <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
-    <PropertyGroup>
-        <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
-        <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-        <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-        <OutputType>Library</OutputType>
-        <AppDesignerFolder>Properties</AppDesignerFolder>
-        <RootNamespace>Contract.Data.Tests</RootNamespace>
-        <AssemblyName>Contract.Data.Tests</AssemblyName>
-        <SignAssembly>false</SignAssembly>
-        <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-        <ProjectGuid>{4361D851-B56C-44CD-B7BD-D9EFD32F94AD}</ProjectGuid>
-    </PropertyGroup>
-    <ItemGroup>
-        <Compile Include="DataContractTests.cs" />
-    </ItemGroup>
-    <ItemGroup>
-        <None Include="project.json" />
-    </ItemGroup>
-    <ItemGroup>
-        <!-- Compile tests against the contract, but copy our local-built implementation for testing -->
-        <ProjectReference Include="$(WcfSourceProj)">
-            <Project>{9e50e7bf-cd6e-4269-a6dd-59fd0bd6c0fd}</Project>
-            <Name>System.Private.ServiceModel</Name>
-            <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-            <OutputItemType>Content</OutputItemType>
-            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-            <Targets>Build;DebugSymbolsProjectOutputGroup</Targets>
-        </ProjectReference>
-        <ProjectReference Include='$(WcfScenarioTestCommonProj)'>
-            <Project>{9098B41C-9C2E-4FC6-B7D8-FC3411736A22}</Project>
-            <Name>ScenarioTests.Common</Name>
-        </ProjectReference>
-    </ItemGroup>
-    <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup>
+    <TestCategories>OuterLoop</TestCategories>
+    <Configuration Condition="'$(Configuration)'==''">$(OS)_Debug</Configuration>
+  </PropertyGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Contract.Data.Tests</RootNamespace>
+    <AssemblyName>Contract.Data.Tests</AssemblyName>
+    <SignAssembly>false</SignAssembly>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <ProjectGuid>{4361D851-B56C-44CD-B7BD-D9EFD32F94AD}</ProjectGuid>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="DataContractTests.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <ItemGroup>
+    <!-- Compile tests against the contract, but copy our local-built implementation for testing -->
+    <ProjectReference Include="$(WcfSourceProj)">
+      <Project>{9e50e7bf-cd6e-4269-a6dd-59fd0bd6c0fd}</Project>
+      <Name>System.Private.ServiceModel</Name>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+      <OutputItemType>Content</OutputItemType>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Targets>Build;DebugSymbolsProjectOutputGroup</Targets>
+    </ProjectReference>
+    <ProjectReference Include='$(WcfScenarioTestCommonProj)'>
+      <Project>{9098B41C-9C2E-4FC6-B7D8-FC3411736A22}</Project>
+      <Name>ScenarioTests.Common</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Private.ServiceModel/tests/Scenarios/Contract/Fault/Contract.Fault.Tests.csproj
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Contract/Fault/Contract.Fault.Tests.csproj
@@ -1,41 +1,41 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-    <PropertyGroup>
-        <TestCategories>OuterLoop</TestCategories>
-    </PropertyGroup>
-    <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
-    <PropertyGroup>
-        <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
-        <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-        <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-        <OutputType>Library</OutputType>
-        <AppDesignerFolder>Properties</AppDesignerFolder>
-        <RootNamespace>Contract.Fault.Tests</RootNamespace>
-        <AssemblyName>Contract.Fault.Tests</AssemblyName>
-        <SignAssembly>false</SignAssembly>
-        <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-        <ProjectGuid>{0324E738-B6EF-43FB-8321-DC49640D2615}</ProjectGuid>
-    </PropertyGroup>
-    <ItemGroup>
-        <Compile Include="FaultExceptionTests.cs" />
-    </ItemGroup>
-    <ItemGroup>
-        <None Include="project.json" />
-    </ItemGroup>
-    <ItemGroup>
-        <!-- Compile tests against the contract, but copy our local-built implementation for testing -->
-        <ProjectReference Include="$(WcfSourceProj)">
-            <Project>{9e50e7bf-cd6e-4269-a6dd-59fd0bd6c0fd}</Project>
-            <Name>System.Private.ServiceModel</Name>
-            <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-            <OutputItemType>Content</OutputItemType>
-            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-            <Targets>Build;DebugSymbolsProjectOutputGroup</Targets>
-        </ProjectReference>
-        <ProjectReference Include='$(WcfScenarioTestCommonProj)'>
-            <Project>{9098B41C-9C2E-4FC6-B7D8-FC3411736A22}</Project>
-            <Name>ScenarioTests.Common</Name>
-        </ProjectReference>
-    </ItemGroup>
-    <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup>
+    <TestCategories>OuterLoop</TestCategories>
+    <Configuration Condition="'$(Configuration)'==''">$(OS)_Debug</Configuration>
+  </PropertyGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Contract.Fault.Tests</RootNamespace>
+    <AssemblyName>Contract.Fault.Tests</AssemblyName>
+    <SignAssembly>false</SignAssembly>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <ProjectGuid>{0324E738-B6EF-43FB-8321-DC49640D2615}</ProjectGuid>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="FaultExceptionTests.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <ItemGroup>
+    <!-- Compile tests against the contract, but copy our local-built implementation for testing -->
+    <ProjectReference Include="$(WcfSourceProj)">
+      <Project>{9e50e7bf-cd6e-4269-a6dd-59fd0bd6c0fd}</Project>
+      <Name>System.Private.ServiceModel</Name>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+      <OutputItemType>Content</OutputItemType>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Targets>Build;DebugSymbolsProjectOutputGroup</Targets>
+    </ProjectReference>
+    <ProjectReference Include='$(WcfScenarioTestCommonProj)'>
+      <Project>{9098B41C-9C2E-4FC6-B7D8-FC3411736A22}</Project>
+      <Name>ScenarioTests.Common</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Private.ServiceModel/tests/Scenarios/Contract/Message/Contract.Message.Tests.csproj
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Contract/Message/Contract.Message.Tests.csproj
@@ -1,43 +1,43 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-    <PropertyGroup>
-        <TestCategories>OuterLoop</TestCategories>
-    </PropertyGroup>
-    <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
-    <PropertyGroup>
-        <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
-        <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-        <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-        <OutputType>Library</OutputType>
-        <AppDesignerFolder>Properties</AppDesignerFolder>
-        <RootNamespace>Contract.Message.Tests</RootNamespace>
-        <AssemblyName>Contract.Message.Tests</AssemblyName>
-        <SignAssembly>false</SignAssembly>
-        <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-        <ProjectGuid>{A835C2BC-DFD0-4ED6-A240-59FBEE7F0157}</ProjectGuid>
-    </PropertyGroup>
-    <ItemGroup>
-        <Compile Include="MessageContractCommon.cs" />
-        <Compile Include="MessageContractTests.cs" />
-        <Compile Include="MessageTests.cs" />
-    </ItemGroup>
-    <ItemGroup>
-        <None Include="project.json" />
-    </ItemGroup>
-    <ItemGroup>
-        <!-- Compile tests against the contract, but copy our local-built implementation for testing -->
-        <ProjectReference Include="$(WcfSourceProj)">
-            <Project>{9e50e7bf-cd6e-4269-a6dd-59fd0bd6c0fd}</Project>
-            <Name>System.Private.ServiceModel</Name>
-            <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-            <OutputItemType>Content</OutputItemType>
-            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-            <Targets>Build;DebugSymbolsProjectOutputGroup</Targets>
-        </ProjectReference>
-        <ProjectReference Include='$(WcfScenarioTestCommonProj)'>
-            <Project>{9098B41C-9C2E-4FC6-B7D8-FC3411736A22}</Project>
-            <Name>ScenarioTests.Common</Name>
-        </ProjectReference>
-    </ItemGroup>
-    <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup>
+    <TestCategories>OuterLoop</TestCategories>
+    <Configuration Condition="'$(Configuration)'==''">$(OS)_Debug</Configuration>
+  </PropertyGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Contract.Message.Tests</RootNamespace>
+    <AssemblyName>Contract.Message.Tests</AssemblyName>
+    <SignAssembly>false</SignAssembly>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <ProjectGuid>{A835C2BC-DFD0-4ED6-A240-59FBEE7F0157}</ProjectGuid>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="MessageContractCommon.cs" />
+    <Compile Include="MessageContractTests.cs" />
+    <Compile Include="MessageTests.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <ItemGroup>
+    <!-- Compile tests against the contract, but copy our local-built implementation for testing -->
+    <ProjectReference Include="$(WcfSourceProj)">
+      <Project>{9e50e7bf-cd6e-4269-a6dd-59fd0bd6c0fd}</Project>
+      <Name>System.Private.ServiceModel</Name>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+      <OutputItemType>Content</OutputItemType>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Targets>Build;DebugSymbolsProjectOutputGroup</Targets>
+    </ProjectReference>
+    <ProjectReference Include='$(WcfScenarioTestCommonProj)'>
+      <Project>{9098B41C-9C2E-4FC6-B7D8-FC3411736A22}</Project>
+      <Name>ScenarioTests.Common</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Private.ServiceModel/tests/Scenarios/Contract/Service/Contract.Service.Tests.csproj
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Contract/Service/Contract.Service.Tests.csproj
@@ -1,42 +1,42 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-    <PropertyGroup>
-        <TestCategories>OuterLoop</TestCategories>
-    </PropertyGroup>
-    <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
-    <PropertyGroup>
-        <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
-        <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-        <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-        <OutputType>Library</OutputType>
-        <AppDesignerFolder>Properties</AppDesignerFolder>
-        <RootNamespace>Contract.Service.Tests</RootNamespace>
-        <AssemblyName>Contract.Service.Tests</AssemblyName>
-        <SignAssembly>false</SignAssembly>
-        <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-        <ProjectGuid>{8773AC5C-5B4D-4745-BECF-01415CB10F1C}</ProjectGuid>
-    </PropertyGroup>
-    <ItemGroup>
-        <Compile Include="ServiceContractTests.cs" />
-        <Compile Include="ServiceKnownTypeTests.cs" />
-    </ItemGroup>
-    <ItemGroup>
-        <None Include="project.json" />
-    </ItemGroup>
-    <ItemGroup>
-        <!-- Compile tests against the contract, but copy our local-built implementation for testing -->
-        <ProjectReference Include="$(WcfSourceProj)">
-            <Project>{9e50e7bf-cd6e-4269-a6dd-59fd0bd6c0fd}</Project>
-            <Name>System.Private.ServiceModel</Name>
-            <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-            <OutputItemType>Content</OutputItemType>
-            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-            <Targets>Build;DebugSymbolsProjectOutputGroup</Targets>
-        </ProjectReference>
-        <ProjectReference Include='$(WcfScenarioTestCommonProj)'>
-            <Project>{9098B41C-9C2E-4FC6-B7D8-FC3411736A22}</Project>
-            <Name>ScenarioTests.Common</Name>
-        </ProjectReference>
-    </ItemGroup>
-    <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup>
+    <TestCategories>OuterLoop</TestCategories>
+    <Configuration Condition="'$(Configuration)'==''">$(OS)_Debug</Configuration>
+  </PropertyGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Contract.Service.Tests</RootNamespace>
+    <AssemblyName>Contract.Service.Tests</AssemblyName>
+    <SignAssembly>false</SignAssembly>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <ProjectGuid>{8773AC5C-5B4D-4745-BECF-01415CB10F1C}</ProjectGuid>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="ServiceContractTests.cs" />
+    <Compile Include="ServiceKnownTypeTests.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <ItemGroup>
+    <!-- Compile tests against the contract, but copy our local-built implementation for testing -->
+    <ProjectReference Include="$(WcfSourceProj)">
+      <Project>{9e50e7bf-cd6e-4269-a6dd-59fd0bd6c0fd}</Project>
+      <Name>System.Private.ServiceModel</Name>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+      <OutputItemType>Content</OutputItemType>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Targets>Build;DebugSymbolsProjectOutputGroup</Targets>
+    </ProjectReference>
+    <ProjectReference Include='$(WcfScenarioTestCommonProj)'>
+      <Project>{9098B41C-9C2E-4FC6-B7D8-FC3411736A22}</Project>
+      <Name>ScenarioTests.Common</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Private.ServiceModel/tests/Scenarios/Contract/XmlSerializer/Contract.XmlSerializer.Tests.csproj
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Contract/XmlSerializer/Contract.XmlSerializer.Tests.csproj
@@ -2,11 +2,11 @@
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <TestCategories>OuterLoop</TestCategories>
+    <Configuration Condition="'$(Configuration)'==''">$(OS)_Debug</Configuration>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
@@ -32,10 +32,10 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Targets>Build;DebugSymbolsProjectOutputGroup</Targets>
     </ProjectReference>
-      <ProjectReference Include='$(WcfScenarioTestCommonProj)'>
-          <Project>{9098B41C-9C2E-4FC6-B7D8-FC3411736A22}</Project>
-          <Name>ScenarioTests.Common</Name>
-      </ProjectReference>
+    <ProjectReference Include='$(WcfScenarioTestCommonProj)'>
+      <Project>{9098B41C-9C2E-4FC6-B7D8-FC3411736A22}</Project>
+      <Name>ScenarioTests.Common</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Private.ServiceModel/tests/Scenarios/Encoding/Encoders/Encoding.Encoders.Tests.csproj
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Encoding/Encoders/Encoding.Encoders.Tests.csproj
@@ -1,42 +1,42 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-    <PropertyGroup>
-        <TestCategories>OuterLoop</TestCategories>
-    </PropertyGroup>
-    <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
-    <PropertyGroup>
-        <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
-        <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-        <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-        <OutputType>Library</OutputType>
-        <AppDesignerFolder>Properties</AppDesignerFolder>
-        <RootNamespace>Encoding.Encoders.Tests</RootNamespace>
-        <AssemblyName>Encoding.Encoders.Tests</AssemblyName>
-        <SignAssembly>false</SignAssembly>
-        <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-        <ProjectGuid>{F7193054-CE9B-4BC7-8CA9-4FA722CF8CEF}</ProjectGuid>
-    </PropertyGroup>
-    <ItemGroup>
-        <Compile Include="BinaryEncodingTests.cs" />
-        <Compile Include="TextEncodingTests.cs" />
-    </ItemGroup>
-    <ItemGroup>
-        <None Include="project.json" />
-    </ItemGroup>
-    <ItemGroup>
-        <!-- Compile tests against the contract, but copy our local-built implementation for testing -->
-        <ProjectReference Include="$(WcfSourceProj)">
-            <Project>{9e50e7bf-cd6e-4269-a6dd-59fd0bd6c0fd}</Project>
-            <Name>System.Private.ServiceModel</Name>
-            <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-            <OutputItemType>Content</OutputItemType>
-            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-            <Targets>Build;DebugSymbolsProjectOutputGroup</Targets>
-        </ProjectReference>
-        <ProjectReference Include='$(WcfScenarioTestCommonProj)'>
-            <Project>{9098B41C-9C2E-4FC6-B7D8-FC3411736A22}</Project>
-            <Name>ScenarioTests.Common</Name>
-        </ProjectReference>
-    </ItemGroup>
-    <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup>
+    <TestCategories>OuterLoop</TestCategories>
+    <Configuration Condition="'$(Configuration)'==''">$(OS)_Debug</Configuration>
+  </PropertyGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Encoding.Encoders.Tests</RootNamespace>
+    <AssemblyName>Encoding.Encoders.Tests</AssemblyName>
+    <SignAssembly>false</SignAssembly>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <ProjectGuid>{F7193054-CE9B-4BC7-8CA9-4FA722CF8CEF}</ProjectGuid>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="BinaryEncodingTests.cs" />
+    <Compile Include="TextEncodingTests.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <ItemGroup>
+    <!-- Compile tests against the contract, but copy our local-built implementation for testing -->
+    <ProjectReference Include="$(WcfSourceProj)">
+      <Project>{9e50e7bf-cd6e-4269-a6dd-59fd0bd6c0fd}</Project>
+      <Name>System.Private.ServiceModel</Name>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+      <OutputItemType>Content</OutputItemType>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Targets>Build;DebugSymbolsProjectOutputGroup</Targets>
+    </ProjectReference>
+    <ProjectReference Include='$(WcfScenarioTestCommonProj)'>
+      <Project>{9098B41C-9C2E-4FC6-B7D8-FC3411736A22}</Project>
+      <Name>ScenarioTests.Common</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Private.ServiceModel/tests/Scenarios/Encoding/MessageVersion/Encoding.MessageVersion.Tests.csproj
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Encoding/MessageVersion/Encoding.MessageVersion.Tests.csproj
@@ -1,41 +1,41 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-    <PropertyGroup>
-        <TestCategories>OuterLoop</TestCategories>
-    </PropertyGroup>
-    <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
-    <PropertyGroup>
-        <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
-        <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-        <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-        <OutputType>Library</OutputType>
-        <AppDesignerFolder>Properties</AppDesignerFolder>
-        <RootNamespace>Encoding.MessageVersion.Tests</RootNamespace>
-        <AssemblyName>Encoding.MessageVersion.Tests</AssemblyName>
-        <SignAssembly>false</SignAssembly>
-        <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-        <ProjectGuid>{604EBABB-0160-48EF-AE10-FEAE8DE39F19}</ProjectGuid>
-    </PropertyGroup>
-    <ItemGroup>
-        <Compile Include="MessageVersionTests.cs" />
-    </ItemGroup>
-    <ItemGroup>
-        <None Include="project.json" />
-    </ItemGroup>
-    <ItemGroup>
-        <!-- Compile tests against the contract, but copy our local-built implementation for testing -->
-        <ProjectReference Include="$(WcfSourceProj)">
-            <Project>{9e50e7bf-cd6e-4269-a6dd-59fd0bd6c0fd}</Project>
-            <Name>System.Private.ServiceModel</Name>
-            <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-            <OutputItemType>Content</OutputItemType>
-            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-            <Targets>Build;DebugSymbolsProjectOutputGroup</Targets>
-        </ProjectReference>
-        <ProjectReference Include='$(WcfScenarioTestCommonProj)'>
-            <Project>{9098B41C-9C2E-4FC6-B7D8-FC3411736A22}</Project>
-            <Name>ScenarioTests.Common</Name>
-        </ProjectReference>
-    </ItemGroup>
-    <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup>
+    <TestCategories>OuterLoop</TestCategories>
+    <Configuration Condition="'$(Configuration)'==''">$(OS)_Debug</Configuration>
+  </PropertyGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Encoding.MessageVersion.Tests</RootNamespace>
+    <AssemblyName>Encoding.MessageVersion.Tests</AssemblyName>
+    <SignAssembly>false</SignAssembly>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <ProjectGuid>{604EBABB-0160-48EF-AE10-FEAE8DE39F19}</ProjectGuid>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="MessageVersionTests.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <ItemGroup>
+    <!-- Compile tests against the contract, but copy our local-built implementation for testing -->
+    <ProjectReference Include="$(WcfSourceProj)">
+      <Project>{9e50e7bf-cd6e-4269-a6dd-59fd0bd6c0fd}</Project>
+      <Name>System.Private.ServiceModel</Name>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+      <OutputItemType>Content</OutputItemType>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Targets>Build;DebugSymbolsProjectOutputGroup</Targets>
+    </ProjectReference>
+    <ProjectReference Include='$(WcfScenarioTestCommonProj)'>
+      <Project>{9098B41C-9C2E-4FC6-B7D8-FC3411736A22}</Project>
+      <Name>ScenarioTests.Common</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Private.ServiceModel/tests/Scenarios/Extensibility/WebSockets/Extensibility.WebSockets.Tests.csproj
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Extensibility/WebSockets/Extensibility.WebSockets.Tests.csproj
@@ -1,41 +1,41 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-    <PropertyGroup>
-        <TestCategories>OuterLoop</TestCategories>
-    </PropertyGroup>
-    <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
-    <PropertyGroup>
-        <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
-        <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-        <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-        <OutputType>Library</OutputType>
-        <AppDesignerFolder>Properties</AppDesignerFolder>
-        <RootNamespace>Extensibility.WebSockets.Tests</RootNamespace>
-        <AssemblyName>Extensibility.WebSockets.Tests</AssemblyName>
-        <SignAssembly>false</SignAssembly>
-        <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-		<ProjectGuid>{BAF18A70-9EDA-46E9-80A1-7B5F62215C02}</ProjectGuid>
-    </PropertyGroup>
-    <ItemGroup>
-        <Compile Include="WebSocketTests.cs" />
-    </ItemGroup>
-    <ItemGroup>
-        <None Include="project.json" />
-    </ItemGroup>
-    <ItemGroup>
-        <!-- Compile tests against the contract, but copy our local-built implementation for testing -->
-        <ProjectReference Include="$(WcfSourceProj)">
-            <Project>{9e50e7bf-cd6e-4269-a6dd-59fd0bd6c0fd}</Project>
-            <Name>System.Private.ServiceModel</Name>
-            <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-            <OutputItemType>Content</OutputItemType>
-            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-            <Targets>Build;DebugSymbolsProjectOutputGroup</Targets>
-        </ProjectReference>
-        <ProjectReference Include='$(WcfScenarioTestCommonProj)'>
-            <Project>{9098B41C-9C2E-4FC6-B7D8-FC3411736A22}</Project>
-            <Name>ScenarioTests.Common</Name>
-        </ProjectReference>
-    </ItemGroup>
-    <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup>
+    <TestCategories>OuterLoop</TestCategories>
+    <Configuration Condition="'$(Configuration)'==''">$(OS)_Debug</Configuration>
+  </PropertyGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Extensibility.WebSockets.Tests</RootNamespace>
+    <AssemblyName>Extensibility.WebSockets.Tests</AssemblyName>
+    <SignAssembly>false</SignAssembly>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <ProjectGuid>{BAF18A70-9EDA-46E9-80A1-7B5F62215C02}</ProjectGuid>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="WebSocketTests.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <ItemGroup>
+    <!-- Compile tests against the contract, but copy our local-built implementation for testing -->
+    <ProjectReference Include="$(WcfSourceProj)">
+      <Project>{9e50e7bf-cd6e-4269-a6dd-59fd0bd6c0fd}</Project>
+      <Name>System.Private.ServiceModel</Name>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+      <OutputItemType>Content</OutputItemType>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Targets>Build;DebugSymbolsProjectOutputGroup</Targets>
+    </ProjectReference>
+    <ProjectReference Include='$(WcfScenarioTestCommonProj)'>
+      <Project>{9098B41C-9C2E-4FC6-B7D8-FC3411736A22}</Project>
+      <Name>ScenarioTests.Common</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Security.TransportSecurity.Tests.csproj
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Security.TransportSecurity.Tests.csproj
@@ -2,11 +2,11 @@
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <TestCategories>OuterLoop</TestCategories>
+    <Configuration Condition="'$(Configuration)'==''">$(OS)_Debug</Configuration>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>

--- a/src/System.Private.ServiceModel/tests/Unit/System.Private.ServiceModel.Tests.csproj
+++ b/src/System.Private.ServiceModel/tests/Unit/System.Private.ServiceModel.Tests.csproj
@@ -1,33 +1,35 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-    <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
-    <PropertyGroup>
-        <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
-        <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-        <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-        <OutputType>Library</OutputType>
-        <AppDesignerFolder>Properties</AppDesignerFolder>
-        <RootNamespace>System.Private.ServiceModel.Tests</RootNamespace>
-        <AssemblyName>System.Private.ServiceModel.Tests</AssemblyName>
-        <SignAssembly>false</SignAssembly>
-        <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-        <ProjectGuid>{BB3B114D-68D7-4E36-9EBE-127E694E6EC9}</ProjectGuid>
-    </PropertyGroup>
-    <ItemGroup>
-        <Compile Include="**\*.cs" />
-    </ItemGroup>
-    <ItemGroup>
-        <None Include="project.json" />
-    </ItemGroup>
-    <ItemGroup>
-        <ProjectReference Include="$(WcfSourceProj)">
-            <Project>{9e50e7bf-cd6e-4269-a6dd-59fd0bd6c0fd}</Project>
-            <Name>System.Private.ServiceModel</Name>
-        </ProjectReference>
-        <ProjectReference Include='$(WcfUnitTestCommonProj)'>
-            <Project>{E896294A-AB4A-4AF5-A01C-A19E3972EFF9}</Project>
-            <Name>UnitTests.Common</Name>
-        </ProjectReference>
-    </ItemGroup>
-    <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup>
+    <Configuration Condition="'$(Configuration)'==''">Windows_Debug</Configuration>
+  </PropertyGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>System.Private.ServiceModel.Tests</RootNamespace>
+    <AssemblyName>System.Private.ServiceModel.Tests</AssemblyName>
+    <SignAssembly>false</SignAssembly>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <ProjectGuid>{BB3B114D-68D7-4E36-9EBE-127E694E6EC9}</ProjectGuid>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="**\*.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(WcfSourceProj)">
+      <Project>{9e50e7bf-cd6e-4269-a6dd-59fd0bd6c0fd}</Project>
+      <Name>System.Private.ServiceModel</Name>
+    </ProjectReference>
+    <ProjectReference Include='$(WcfUnitTestCommonProj)'>
+      <Project>{E896294A-AB4A-4AF5-A01C-A19E3972EFF9}</Project>
+      <Name>UnitTests.Common</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Private.ServiceModel/tools/test/CertificateCleanup/CertificateCleanup.csproj
+++ b/src/System.Private.ServiceModel/tools/test/CertificateCleanup/CertificateCleanup.csproj
@@ -1,9 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition="'$(Configuration)'==''">$(OS)_Debug</Configuration>
+  </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>

--- a/src/System.ServiceModel.Duplex/src/System.ServiceModel.Duplex.csproj
+++ b/src/System.ServiceModel.Duplex/src/System.ServiceModel.Duplex.csproj
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition="'$(Configuration)'==''">$(OS)_Debug</Configuration>
+  </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.ServiceModel.Duplex</AssemblyName>

--- a/src/System.ServiceModel.Duplex/tests/System.ServiceModel.Duplex.Tests.csproj
+++ b/src/System.ServiceModel.Duplex/tests/System.ServiceModel.Duplex.Tests.csproj
@@ -1,9 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition="'$(Configuration)'==''">$(OS)_Debug</Configuration>
+  </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>

--- a/src/System.ServiceModel.Http/src/System.ServiceModel.Http.csproj
+++ b/src/System.ServiceModel.Http/src/System.ServiceModel.Http.csproj
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition="'$(Configuration)'==''">$(OS)_Debug</Configuration>
+  </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.ServiceModel.Http</AssemblyName>

--- a/src/System.ServiceModel.Http/tests/System.ServiceModel.Http.Tests.csproj
+++ b/src/System.ServiceModel.Http/tests/System.ServiceModel.Http.Tests.csproj
@@ -1,39 +1,41 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-    <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
-    <PropertyGroup>
-        <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
-        <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-        <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-        <OutputType>Library</OutputType>
-        <AppDesignerFolder>Properties</AppDesignerFolder>
-        <RootNamespace>System.ServiceModel.Http.Tests</RootNamespace>
-        <AssemblyName>System.ServiceModel.Http.Tests</AssemblyName>
-        <TestCategories>InnerLoop</TestCategories>
-        <SignAssembly>false</SignAssembly>
-        <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-        <ProjectGuid>{0DE9D9C2-10FB-4DF0-9668-7BD5290EC936}</ProjectGuid>
-    </PropertyGroup>
-    <ItemGroup>
-        <Compile Include="**\*.cs" />
-    </ItemGroup>
-    <ItemGroup>
-        <None Include="project.json" />
-    </ItemGroup>
-    <ItemGroup>
-        <!-- Compile tests against the contract, but copy our local-built implementation for testing -->
-        <ProjectReference Include="$(WcfSourceProj)">
-            <Project>{9e50e7bf-cd6e-4269-a6dd-59fd0bd6c0fd}</Project>
-            <Name>System.Private.ServiceModel</Name>
-            <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-            <OutputItemType>Content</OutputItemType>
-            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-            <Targets>Build;DebugSymbolsProjectOutputGroup</Targets>
-        </ProjectReference>
-        <ProjectReference Include='$(WcfUnitTestCommonProj)'>
-            <Project>{E896294A-AB4A-4AF5-A01C-A19E3972EFF9}</Project>
-            <Name>UnitTests.Common</Name>
-        </ProjectReference>
-    </ItemGroup>
-    <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup>
+    <Configuration Condition="'$(Configuration)'==''">$(OS)_Debug</Configuration>
+  </PropertyGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>System.ServiceModel.Http.Tests</RootNamespace>
+    <AssemblyName>System.ServiceModel.Http.Tests</AssemblyName>
+    <TestCategories>InnerLoop</TestCategories>
+    <SignAssembly>false</SignAssembly>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <ProjectGuid>{0DE9D9C2-10FB-4DF0-9668-7BD5290EC936}</ProjectGuid>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="**\*.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <ItemGroup>
+    <!-- Compile tests against the contract, but copy our local-built implementation for testing -->
+    <ProjectReference Include="$(WcfSourceProj)">
+      <Project>{9e50e7bf-cd6e-4269-a6dd-59fd0bd6c0fd}</Project>
+      <Name>System.Private.ServiceModel</Name>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+      <OutputItemType>Content</OutputItemType>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Targets>Build;DebugSymbolsProjectOutputGroup</Targets>
+    </ProjectReference>
+    <ProjectReference Include='$(WcfUnitTestCommonProj)'>
+      <Project>{E896294A-AB4A-4AF5-A01C-A19E3972EFF9}</Project>
+      <Name>UnitTests.Common</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.ServiceModel.NetTcp/src/System.ServiceModel.NetTcp.csproj
+++ b/src/System.ServiceModel.NetTcp/src/System.ServiceModel.NetTcp.csproj
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition="'$(Configuration)'==''">$(OS)_Debug</Configuration>
+  </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.ServiceModel.NetTcp</AssemblyName>

--- a/src/System.ServiceModel.NetTcp/tests/System.ServiceModel.NetTcp.Tests.csproj
+++ b/src/System.ServiceModel.NetTcp/tests/System.ServiceModel.NetTcp.Tests.csproj
@@ -1,39 +1,41 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-    <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
-    <PropertyGroup>
-        <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
-        <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-        <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-        <OutputType>Library</OutputType>
-        <AppDesignerFolder>Properties</AppDesignerFolder>
-        <RootNamespace>System.ServiceModel.NetTcp.Tests</RootNamespace>
-        <AssemblyName>System.ServiceModel.NetTcp.Tests</AssemblyName>
-        <TestCategories>InnerLoop</TestCategories>
-        <SignAssembly>false</SignAssembly>
-        <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-        <ProjectGuid>{135C7EE5-6E44-4619-ADD5-589034443AE7}</ProjectGuid>
-    </PropertyGroup>
-    <ItemGroup>
-        <Compile Include="**\*.cs" />
-    </ItemGroup>
-    <ItemGroup>
-        <None Include="project.json" />
-    </ItemGroup>
-    <ItemGroup>
-        <!-- Compile tests against the contract, but copy our local-built implementation for testing -->
-        <ProjectReference Include="$(WcfSourceProj)">
-            <Project>{9e50e7bf-cd6e-4269-a6dd-59fd0bd6c0fd}</Project>
-            <Name>System.Private.ServiceModel</Name>
-            <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-            <OutputItemType>Content</OutputItemType>
-            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-            <Targets>Build;DebugSymbolsProjectOutputGroup</Targets>
-        </ProjectReference>
-        <ProjectReference Include='$(WcfUnitTestCommonProj)'>
-            <Project>{E896294A-AB4A-4AF5-A01C-A19E3972EFF9}</Project>
-            <Name>UnitTests.Common</Name>
-        </ProjectReference>
-    </ItemGroup>
-    <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup>
+    <Configuration Condition="'$(Configuration)'==''">$(OS)_Debug</Configuration>
+  </PropertyGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>System.ServiceModel.NetTcp.Tests</RootNamespace>
+    <AssemblyName>System.ServiceModel.NetTcp.Tests</AssemblyName>
+    <TestCategories>InnerLoop</TestCategories>
+    <SignAssembly>false</SignAssembly>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <ProjectGuid>{135C7EE5-6E44-4619-ADD5-589034443AE7}</ProjectGuid>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="**\*.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <ItemGroup>
+    <!-- Compile tests against the contract, but copy our local-built implementation for testing -->
+    <ProjectReference Include="$(WcfSourceProj)">
+      <Project>{9e50e7bf-cd6e-4269-a6dd-59fd0bd6c0fd}</Project>
+      <Name>System.Private.ServiceModel</Name>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+      <OutputItemType>Content</OutputItemType>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Targets>Build;DebugSymbolsProjectOutputGroup</Targets>
+    </ProjectReference>
+    <ProjectReference Include='$(WcfUnitTestCommonProj)'>
+      <Project>{E896294A-AB4A-4AF5-A01C-A19E3972EFF9}</Project>
+      <Name>UnitTests.Common</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.ServiceModel.Primitives/src/System.ServiceModel.Primitives.csproj
+++ b/src/System.ServiceModel.Primitives/src/System.ServiceModel.Primitives.csproj
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition="'$(Configuration)'==''">$(OS)_Debug</Configuration>
+  </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.ServiceModel.Primitives</AssemblyName>

--- a/src/System.ServiceModel.Primitives/tests/System.ServiceModel.Primitives.Tests.csproj
+++ b/src/System.ServiceModel.Primitives/tests/System.ServiceModel.Primitives.Tests.csproj
@@ -1,39 +1,41 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-    <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
-    <PropertyGroup>
-        <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
-        <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-        <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-        <OutputType>Library</OutputType>
-        <AppDesignerFolder>Properties</AppDesignerFolder>
-        <RootNamespace>System.ServiceModel.Primitives.Tests</RootNamespace>
-        <AssemblyName>System.ServiceModel.Primitives.Tests</AssemblyName>
-        <TestCategories>InnerLoop</TestCategories>
-        <SignAssembly>false</SignAssembly>
-        <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-        <ProjectGuid>{856A232C-4292-4AC7-87FE-41AE0C22C4E4}</ProjectGuid>
-    </PropertyGroup>
-    <ItemGroup>
-        <Compile Include="**\*.cs" />
-    </ItemGroup>
-    <ItemGroup>
-        <None Include="project.json" />
-    </ItemGroup>
-    <ItemGroup>
-        <!-- Compile tests against the contract, but copy our local-built implementation for testing -->
-        <ProjectReference Include="$(WcfSourceProj)">
-            <Project>{9e50e7bf-cd6e-4269-a6dd-59fd0bd6c0fd}</Project>
-            <Name>System.Private.ServiceModel</Name>
-            <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-            <OutputItemType>Content</OutputItemType>
-            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-            <Targets>Build;DebugSymbolsProjectOutputGroup</Targets>
-        </ProjectReference>
-        <ProjectReference Include='$(WcfUnitTestCommonProj)'>
-            <Project>{E896294A-AB4A-4AF5-A01C-A19E3972EFF9}</Project>
-            <Name>UnitTests.Common</Name>
-        </ProjectReference>
-    </ItemGroup>
-    <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup>
+    <Configuration Condition="'$(Configuration)'==''">$(OS)_Debug</Configuration>
+  </PropertyGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>System.ServiceModel.Primitives.Tests</RootNamespace>
+    <AssemblyName>System.ServiceModel.Primitives.Tests</AssemblyName>
+    <TestCategories>InnerLoop</TestCategories>
+    <SignAssembly>false</SignAssembly>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <ProjectGuid>{856A232C-4292-4AC7-87FE-41AE0C22C4E4}</ProjectGuid>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="**\*.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <ItemGroup>
+    <!-- Compile tests against the contract, but copy our local-built implementation for testing -->
+    <ProjectReference Include="$(WcfSourceProj)">
+      <Project>{9e50e7bf-cd6e-4269-a6dd-59fd0bd6c0fd}</Project>
+      <Name>System.Private.ServiceModel</Name>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+      <OutputItemType>Content</OutputItemType>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Targets>Build;DebugSymbolsProjectOutputGroup</Targets>
+    </ProjectReference>
+    <ProjectReference Include='$(WcfUnitTestCommonProj)'>
+      <Project>{E896294A-AB4A-4AF5-A01C-A19E3972EFF9}</Project>
+      <Name>UnitTests.Common</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.ServiceModel.Security/src/System.ServiceModel.Security.csproj
+++ b/src/System.ServiceModel.Security/src/System.ServiceModel.Security.csproj
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition="'$(Configuration)'==''">$(OS)_Debug</Configuration>
+  </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.ServiceModel.Security</AssemblyName>

--- a/src/System.ServiceModel.Security/tests/System.ServiceModel.Security.Tests.csproj
+++ b/src/System.ServiceModel.Security/tests/System.ServiceModel.Security.Tests.csproj
@@ -1,9 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition="'$(Configuration)'==''">$(OS)_Debug</Configuration>
+  </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>


### PR DESCRIPTION
* Test projects were causing S.P.SM to be built as AnyOS.
* S.P.SM forks based on whether it is a Windows build or not, so this was producing a non-windows build of S.P.SM being used with tests that expect a Windows build of S.P.SM.
* Fixes #750
* Fixes #838