### PR TITLE
Modify WebSocket test asserts to be correct cross-machine

### DIFF
--- a/src/System.Private.ServiceModel/tests/Common/Scenarios/ScenarioTestHelpers.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Scenarios/ScenarioTestHelpers.cs
@@ -31,6 +31,12 @@ public static class ScenarioTestHelpers
         }
     }
 
+    public static bool BridgeIsLocalHost()
+    {
+        string bridgeHost = TestProperties.GetProperty(TestProperties.BridgeHost_PropertyName);
+        return String.Equals("localhost", bridgeHost, StringComparison.OrdinalIgnoreCase);
+    }
+
     public static string GenerateStringValue(int length)
     {
         // There's no great reason why we use this set of characters - we just want to be able to generate a longish string

--- a/src/System.Private.ServiceModel/tests/Scenarios/Extensibility/WebSockets/WebSocketTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Extensibility/WebSockets/WebSocketTests.cs
@@ -59,7 +59,7 @@ public static class WebSocketTests
             foreach (string serverLogItem in client.GetLog())
             {
                 //Assert.True(serverLogItem != ScenarioTestHelpers.RemoteEndpointMessagePropertyFailure, ScenarioTestHelpers.RemoteEndpointMessagePropertyFailure);
-                Assert.True(!serverLogItem.Contains(ScenarioTestHelpers.RemoteEndpointMessagePropertyFailure), serverLogItem);
+                Assert.True(!ScenarioTestHelpers.BridgeIsLocalHost() || !serverLogItem.Contains(ScenarioTestHelpers.RemoteEndpointMessagePropertyFailure), serverLogItem);
             }
 
             // *** CLEANUP *** \\
@@ -497,7 +497,7 @@ public static class WebSocketTests
             foreach (string serverLogItem in client.GetLog())
             {
                 //Assert.True(serverLogItem != ScenarioTestHelpers.RemoteEndpointMessagePropertyFailure, ScenarioTestHelpers.RemoteEndpointMessagePropertyFailure);
-                Assert.True(!serverLogItem.Contains(ScenarioTestHelpers.RemoteEndpointMessagePropertyFailure), serverLogItem);
+                Assert.True(!ScenarioTestHelpers.BridgeIsLocalHost() || !serverLogItem.Contains(ScenarioTestHelpers.RemoteEndpointMessagePropertyFailure), serverLogItem);
             }
 
             // *** CLEANUP *** \\
@@ -672,7 +672,7 @@ public static class WebSocketTests
             foreach (string serverLogItem in client.GetLog())
             {
                 //Assert.True(serverLogItem != ScenarioTestHelpers.RemoteEndpointMessagePropertyFailure, ScenarioTestHelpers.RemoteEndpointMessagePropertyFailure);
-                Assert.True(!serverLogItem.Contains(ScenarioTestHelpers.RemoteEndpointMessagePropertyFailure), serverLogItem);
+                Assert.True(!ScenarioTestHelpers.BridgeIsLocalHost() || !serverLogItem.Contains(ScenarioTestHelpers.RemoteEndpointMessagePropertyFailure), serverLogItem);
             }
 
             // *** CLEANUP *** \\
@@ -725,7 +725,7 @@ public static class WebSocketTests
             foreach (string serverLogItem in client.GetLog())
             {
                 //Assert.True(serverLogItem != ScenarioTestHelpers.RemoteEndpointMessagePropertyFailure, ScenarioTestHelpers.RemoteEndpointMessagePropertyFailure);
-                Assert.True(!serverLogItem.Contains(ScenarioTestHelpers.RemoteEndpointMessagePropertyFailure), serverLogItem);
+                Assert.True(!ScenarioTestHelpers.BridgeIsLocalHost() || !serverLogItem.Contains(ScenarioTestHelpers.RemoteEndpointMessagePropertyFailure), serverLogItem);
             }
 
             // *** CLEANUP *** \\
@@ -908,7 +908,7 @@ public static class WebSocketTests
             foreach (string serverLogItem in client.GetLog())
             {
                 //Assert.True(serverLogItem != ScenarioTestHelpers.RemoteEndpointMessagePropertyFailure, ScenarioTestHelpers.RemoteEndpointMessagePropertyFailure);
-                Assert.True(!serverLogItem.Contains(ScenarioTestHelpers.RemoteEndpointMessagePropertyFailure), serverLogItem);
+                Assert.True(!ScenarioTestHelpers.BridgeIsLocalHost() || !serverLogItem.Contains(ScenarioTestHelpers.RemoteEndpointMessagePropertyFailure), serverLogItem);
             }
 
             // *** CLEANUP *** \\
@@ -958,7 +958,7 @@ public static class WebSocketTests
             foreach (string serverLogItem in client.GetLog())
             {
                 //Assert.True(serverLogItem != ScenarioTestHelpers.RemoteEndpointMessagePropertyFailure, ScenarioTestHelpers.RemoteEndpointMessagePropertyFailure);
-                Assert.True(!serverLogItem.Contains(ScenarioTestHelpers.RemoteEndpointMessagePropertyFailure), serverLogItem);
+                Assert.True(!ScenarioTestHelpers.BridgeIsLocalHost() || !serverLogItem.Contains(ScenarioTestHelpers.RemoteEndpointMessagePropertyFailure), serverLogItem);
             }
 
             // *** CLEANUP *** \\


### PR DESCRIPTION
Some asserts in WebSockets tests were valid only when the
Bridge was running as localhost, but failed when running on
a different machine.

The change only modifies the assert to be tested if the Bridge
is running as localhost.

Fixes #677