### PR TITLE
Fix FQDNs if the server hosted on a Cloud machine

### DIFF
--- a/src/System.Private.ServiceModel/tools/test/Bridge/WcfTestBridgeCommon/CertificateManager.cs
+++ b/src/System.Private.ServiceModel/tools/test/Bridge/WcfTestBridgeCommon/CertificateManager.cs
@@ -36,6 +36,8 @@ namespace WcfTestBridgeCommon
 
         public static EventHandler BridgeConfigurationChanged;
 
+        private const string CloudServerDomain = "cloudapp.net";
+
         // Any change to the Bridge resource folder uninstalls all the certificates
         // installed by those resources.
         public static void OnResourceFolderChanged(string oldFolder, string newFolder)
@@ -202,6 +204,10 @@ namespace WcfTestBridgeCommon
 
                 var fqdn = Dns.GetHostEntry("127.0.0.1").HostName;
                 var hostname = fqdn.Split('.')[0];
+                if (fqdn == hostname)
+                {
+                    fqdn = string.Format("{0}.{1}", fqdn, CloudServerDomain);
+                }
 
                 // always create a certificate locally for the current machine's fully qualified domain name, 
                 // hostname, and "localhost". 

--- a/src/System.Private.ServiceModel/tools/test/SelfHostWcfService/TestResources/EndpointResource.cs
+++ b/src/System.Private.ServiceModel/tools/test/SelfHostWcfService/TestResources/EndpointResource.cs
@@ -15,11 +15,12 @@ namespace WcfService.TestResources
     {
         private const string ResourceResponseUriKeyName = "uri";
         private const string ResourceResponseFQHNKeyName = "hostname";
+        private const string CloudServerDomain = "cloudapp.net";
 
         protected static int SixtyFourMB = 64 * 1024 * 1024;
         private static Dictionary<string, ServiceHost> s_currentHosts = new Dictionary<string, ServiceHost>();
         private static object s_currentHostLock = new object();
-        protected static string s_fqdn = Dns.GetHostEntry("127.0.0.1").HostName;
+        protected static string s_fqdn = Getfqdn();
         protected static string s_hostname = Dns.GetHostEntry("127.0.0.1").HostName.Split('.')[0];
 
         #region Host Listen Uri components
@@ -109,6 +110,18 @@ namespace WcfService.TestResources
             builder.Path = AppDomain.CurrentDomain.FriendlyName + "/" + Address;
             builder.Scheme = Protocol;
             return builder.Uri;
+        }
+
+        private static string Getfqdn()
+        {
+            IPHostEntry hostEntry = Dns.GetHostEntry("127.0.0.1");
+            string fqdn = hostEntry.HostName;
+            if (fqdn == fqdn.Split('.')[0])
+            {
+                fqdn = string.Format("{0}.{1}", fqdn, CloudServerDomain);
+            }
+
+            return fqdn;
         }
     }
 }


### PR DESCRIPTION
* On cloud machines, the current logic to get FQDN does not work.
We need to append domain name cloudapp.net.

Fix #855