### PR TITLE
Add the BinClasher logger to our normal WCF build process.

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -58,6 +58,8 @@ set Platform=
 :: Log build command line
 set _buildproj=%~dp0build.proj
 set _buildlog=%~dp0msbuild.log
+set _binclashLoggerDll=%~dp0Tools\net45\Microsoft.DotNet.Build.Tasks.dll  
+set _binclashlog=%~dp0binclash.log  
 set _buildprefix=echo
 set _buildpostfix=^> "%_buildlog%"
 
@@ -80,7 +82,7 @@ call :build %*
 goto :AfterBuild
 
 :build
-%_buildprefix% msbuild "%_buildproj%" %_defaultBuildConfig% /nologo /maxcpucount /verbosity:minimal /nodeReuse:false /fileloggerparameters:Verbosity=diag;LogFile="%_buildlog%";Append %* %_buildpostfix%
+%_buildprefix% msbuild "%_buildproj%" %_defaultBuildConfig% /nologo /maxcpucount /v:minimal /clp:Summary /nodeReuse:false /flp:v=diag;LogFile="%_buildlog%";Append "/l:BinClashLogger,%_binclashLoggerDll%;LogFile=%_binclashlog%" %__args% %_buildpostfix%
 set BUILDERRORLEVEL=!ERRORLEVEL!
 goto :eof
 

--- a/src/dirs.proj
+++ b/src/dirs.proj
@@ -1,9 +1,6 @@
 <Project ToolsVersion="12.0" DefaultTargets="BuildAndTest" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="dir.props" />
- <PropertyGroup>
-    <ExcludeProjects>System.Private.ServiceModel\tests\Scenarios\SelfHostWcfService\WcfService.csproj</ExcludeProjects>
-  </PropertyGroup>
-  
+
   <ItemGroup>
     <Project Include="ref.builds" />
     <Project Include="src.builds" />
@@ -14,17 +11,8 @@
   <ItemGroup>
     <Project Include="$(MSBuildProjectDirectory)\System.Private.ServiceModel\tools\test\CertificateCleanup\CertificateCleanup.csproj" />
   </ItemGroup>
-  
-  <ItemGroup>
-    <Project Include="*\ref\**\*.*proj" Exclude="@(ExcludeProjects)" />
-    <Project Include="*\src\*.csproj" Exclude="$(ExcludeProjects)" />
-    <Project Include="*\src\*.vbproj" Exclude="$(ExcludeProjects)" />
-    <Project Include="*\tests\**\*.csproj" Exclude="$(ExcludeProjects)" />
-    <Project Include="*\tests\**\*.vbproj" Exclude="$(ExcludeProjects)" />
-  </ItemGroup>
 
   <Import Project="..\dir.targets" />
-
   <Import Project="..\dir.traversal.targets" />
 
   <Import Project="$(ToolsDir)packages.targets" Condition="Exists('$(ToolsDir)packages.targets') and '$(ImportGetNuGetPackageVersions)' != 'false'" />

--- a/src/ref.builds
+++ b/src/ref.builds
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
     <Project Include="*\ref\**\*.*proj">
-      <OSGroup>AnyOS</OSGroup>
+      <UndefineProperties>OSGroup;TargetGroup</UndefineProperties>
     </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />

--- a/src/tests.builds
+++ b/src/tests.builds
@@ -2,7 +2,8 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
-    <Project Include="*\test*\**\*.csproj">
+    <ExcludeProjects Include="System.Private.ServiceModel\tests\Scenarios\SelfHostWcfService\WcfService.csproj" />
+    <Project Include="*\test*\**\*.csproj" Exclude="@(ExcludeProjects)">
       <OSGroup Condition="'$(FilterToOSGroup)'!=''">$(FilterToOSGroup)</OSGroup>
     </Project>
     <Project Include="*\test*\**\*.vbproj" Condition="'$(IncludeVbProjects)'!='false'">


### PR DESCRIPTION
* Fix the clashes the tool found.
* Sync related files to the originals in corefx repo.
* Fixes #859