### PR TITLE
Fix default test timeout

### DIFF
--- a/src/System.Private.ServiceModel/tests/Common/Infrastructure/src/testproperties.props
+++ b/src/System.Private.ServiceModel/tests/Common/Infrastructure/src/testproperties.props
@@ -65,7 +65,7 @@
       </TestProperty>
       <TestProperty Include="MaxTestTimeSpan">
         <Value>$(MaxTestTimeSpan)</Value>
-        <DefaultValue>00:20</DefaultValue>
+        <DefaultValue>00:01:00</DefaultValue>
       </TestProperty>
     </ItemGroup>
 


### PR DESCRIPTION
* Currenty test timeout default value is 20 minutes. A test
could hang for 20 minutes before it times out. A typical test
should not run more than 1 minute.