### PR TITLE
Add default Configuration to BridgeCertificateInstaller.csproj

### DIFF
--- a/src/System.Private.ServiceModel/tools/test/BridgeCertificateInstaller/BridgeCertificateInstaller.csproj
+++ b/src/System.Private.ServiceModel/tools/test/BridgeCertificateInstaller/BridgeCertificateInstaller.csproj
@@ -1,6 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
+    <Configuration Condition="'$(Configuration)'==''">$(OS)_Debug</Configuration>
+  </PropertyGroup>
+  <PropertyGroup>
     <TestCategories>OuterLoop</TestCategories>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />


### PR DESCRIPTION
* If not specificed it will trigger an AnyOS build of referenced assemblies in the project which triggers BinClasher errors.