### PR TITLE
Syncing build scripts to corefx.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,10 @@ syntax: glob
 ### VisualStudio ###
 
 # Tool Runtime Dir
+# *** start WCF Content ***
+# The syntax used in the corefx version would also ignore WCF changes under "wcf\src\System.Private.ServiceModel\tools"
 /[Tt]ools/
+# *** end WCF Content ***
 
 # User-specific files
 *.suo
@@ -23,6 +26,9 @@ bld/
 [Bb]in/
 [Oo]bj/
 msbuild.log
+
+# Cross building rootfs
+cross/rootfs/
 
 # Visual Studio 2015
 .vs/

--- a/BuildToolsVersion.txt
+++ b/BuildToolsVersion.txt
@@ -1,1 +1,1 @@
-1.0.25-prerelease-00183
+1.0.25-prerelease-00184

--- a/Packaging.props
+++ b/Packaging.props
@@ -1,11 +1,15 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <!-- Packaging configuration -->
-    <PreReleaseLabel>rc3</PreReleaseLabel> 
+    <PreReleaseLabel>rc3</PreReleaseLabel>
     <PackageDescriptionFile>$(ProjectDir)pkg/descriptions.json</PackageDescriptionFile>
     <PackageLicenseFile>$(ProjectDir)pkg/dotnet_library_license.txt</PackageLicenseFile>
     <PackageThirdPartyNoticesFile>$(ProjectDir)pkg/ThirdPartyNotices.txt</PackageThirdPartyNoticesFile>
+    
+    <!-- *** start WCF Content *** -->
+    <!-- *** this file is located differently in corefx *** -->
     <RuntimeIdGraphDefinitionFile>$(PackagesDir)Microsoft.NETCore.Platforms/1.0.1-rc3-23809/runtime.json</RuntimeIdGraphDefinitionFile>
+    <!-- *** end WCF Content *** -->
+
     <!-- Add a condition for this when we are able to run on .NET Core -->
     <PackagingTaskDir>$(ToolsDir)net45/</PackagingTaskDir>
     <BuildNumberMajor Condition="'$(BuildNumberMajor)' == ''">$(RevisionNumber)</BuildNumberMajor>
@@ -25,14 +29,14 @@
   </PropertyGroup>
 
   <!-- Add required legal files to packages -->
-  <ItemGroup  Condition="'$(MSBuildProjectExtension)' == '.pkgproj'">
-    <File Condition="Exists('$(PackageLicenseFile)')" 
-          Include="$(PackageLicenseFile)" >
-        <SkipPackageFileCheck>true</SkipPackageFileCheck>
-    </File>        
+  <ItemGroup Condition="'$(MSBuildProjectExtension)' == '.pkgproj'">
+    <File Condition="Exists('$(PackageLicenseFile)')"
+	  	    Include="$(PackageLicenseFile)" >
+      <SkipPackageFileCheck>true</SkipPackageFileCheck>
+    </File>
     <File Condition="Exists('$(PackageThirdPartyNoticesFile)')"
-          Include="$(PackageThirdPartyNoticesFile)" >
-        <SkipPackageFileCheck>true</SkipPackageFileCheck>
-    </File>        
+	        Include="$(PackageThirdPartyNoticesFile)" >
+      <SkipPackageFileCheck>true</SkipPackageFileCheck>
+    </File>
   </ItemGroup>
 </Project>

--- a/build.proj
+++ b/build.proj
@@ -18,12 +18,17 @@
       <!-- For the root traversal default filter the OSGroup to the OSEnvironment which is the OS we are running on -->
       <FilterToOSGroup Condition="'$(BuildAllOSGroups)' != 'true'">$(OSEnvironment)</FilterToOSGroup>
     </Project>
-    <Project Include="src\post.msbuild" />
+    <Project Include="src\post.builds">
+      <!-- For the root traversal default filter the OSGroup to the OSEnvironment which is the OS we are running on -->
+      <FilterToOSGroup Condition="'$(BuildAllOSGroups)' != 'true'">$(OSEnvironment)</FilterToOSGroup>
+    </Project>
   </ItemGroup>
 
   <Import Project="dir.targets" />
 
   <Import Project="dir.traversal.targets" />
+
+  <Import Project="$(ToolsDir)clean.targets" />
 
   <PropertyGroup>
     <!--
@@ -40,6 +45,8 @@
       $(TraversalBuildDependsOn);
     </TraversalBuildDependsOn>
   </PropertyGroup>
+
+  <UsingTask TaskName="GatherDirectoriesToRestore" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll" />
 
   <Target Name="BatchRestorePackages">
     <Message Importance="High" Text="[$([System.DateTime]::Now.ToString('HH:mm:ss.ff'))] Restoring all packages..." />
@@ -85,19 +92,6 @@
   <!-- Override clean from dir.traversal.targets and just remove the full BinDir -->
   <Target Name="Clean">
     <RemoveDir Directories="$(BinDir)" />
-  </Target>
-
-  <PropertyGroup>
-    <UserLocalFolder Condition="'$(OsEnvironment)'!='Unix'">$(LocalAppData)/</UserLocalFolder>
-    <UserLocalFolder Condition="'$(OsEnvironment)'=='Unix'">$(HOME)/.local/share/</UserLocalFolder>
-  </PropertyGroup>
-
-  <Target Name="CleanPackages">
-    <RemoveDir Directories="$(PackagesDir)" />
-  </Target>
-
-  <Target Name="CleanPackagesCache">
-    <RemoveDir Directories="$(UserLocalFolder)NuGet/Cache/;$(UserLocalFolder)NuGet/v3-cache/;$(UserLocalFolder)dnu/cache/" />
   </Target>
 
 </Project>

--- a/clean.cmd
+++ b/clean.cmd
@@ -5,7 +5,7 @@ set cleanlog=%~dp0clean.log
 echo Running Clean.cmd %* > %cleanlog%
 
 if [%1] == [] (
-  set clean_targets=Clean
+  set clean_targets=Clean;
   goto Begin
 )
 
@@ -13,6 +13,7 @@ set clean_targets=
 set clean_src=
 set clean_tools=
 set clean_all=
+set clean_successful=true
 
 :Loop
 if [%1] == [] goto Begin
@@ -61,35 +62,47 @@ goto Loop
 
 :Begin
 
+echo Running init-tools.cmd
 call %~dp0init-tools.cmd
 
 if /I [%clean_src%] == [true] (
   echo Cleaning src directory ...
-  call git clean %~dp0src -xdf >> %cleanlog%
+  echo. >> %cleanlog% && echo git clean -xdf %~dp0src >> %cleanlog%
+  call git clean -xdf %~dp0src >> %cleanlog%
+  call :CheckErrorLevel
 )
 
 if NOT "%clean_targets%" == "" (
   echo Running msbuild clean targets "%clean_targets:~0,-1%" ...
-  echo msbuild.exe %~dp0build.proj /t:%clean_targets:~0,-1% /nologo /v:minimal /flp:v=diag;Append;LogFile=%cleanlog% >> %cleanlog%
-  call msbuild.exe %~dp0build.proj /t:%clean_targets:~0,-1% /nologo /v:minimal /flp:v=diag;Append;LogFile=%cleanlog%
-  if NOT [%ERRORLEVEL%]==[0] (
-    echo ERROR: An error occurred while cleaning, see %cleanlog% for more details.
-    exit /b
-  )
+  echo. >> %cleanlog% && echo msbuild.exe %~dp0build.proj /t:%clean_targets:~0,-1% /nologo /v:minimal /flp:v=detailed;Append;LogFile=%cleanlog% >> %cleanlog%
+  call msbuild.exe %~dp0build.proj /t:%clean_targets:~0,-1% /nologo /v:minimal /flp:v=detailed;Append;LogFile=%cleanlog%
+  call :CheckErrorLevel
 )
 
 if /I [%clean_tools%] == [true] (
   echo Cleaning tools directory ...
-  rmdir /s /q %~dp0tools >> %cleanlog%dir
+  echo. >> %cleanlog% && echo rmdir /s /q %~dp0tools >> %cleanlog%
+  rmdir /s /q %~dp0tools >> %cleanlog%
+  REM Don't call CheckErrorLevel because if the Tools directory didn't exist when this script was
+  REM invoked, then it sometimes exits with error level 3 despite successfully deleting the directory.
 )
 
 if /I [%clean_all%] == [true] (
   echo Cleaning entire working directory ...
-  call git clean %~dp0 -xdf >> %cleanlog%
+  echo. >> %cleanlog% && echo git clean -xdf -e clean.log %~dp0 >> %cleanlog%
+  call git clean -xdf -e clean.log %~dp0 >> %cleanlog%
+  call :CheckErrorLevel
 )
 
-echo Done Cleaning.
-exit /b 0
+if /I [%clean_successful%] == [true] (
+  echo Clean completed successfully.
+  echo. >> %cleanlog% && echo Clean completed successfully. >> %cleanlog%
+  exit /b 0
+) else (
+  echo An error occured while cleaning; see %cleanlog% for more details.
+  echo. >> %cleanlog% && echo Clean completed with errors. >> %cleanlog%
+  exit /b 1
+)
 
 :Usage
 echo.
@@ -98,9 +111,18 @@ echo.
 echo Options:
 echo     /b     - Deletes the binary output directory.
 echo     /p     - Deletes the repo-local nuget package directory.
-echo     /c     - Deleted the user-local nuget package cache.
+echo     /c     - Deletes the user-local nuget package cache.
 echo     /t     - Deletes the tools directory.
 echo     /s     - Deletes the untracked files under src directory (git clean src -xdf).
 echo     /all   - Combines all of the above.
 echo.
 echo If no option is specified then clean.cmd /b is implied.
+
+exit /b 1
+
+:CheckErrorLevel
+if NOT [%ERRORLEVEL%]==[0] (
+  echo Command exited with ERRORLEVEL %ERRORLEVEL% >> %cleanlog%
+  set clean_successful=false
+)
+exit /b

--- a/dir.props
+++ b/dir.props
@@ -1,11 +1,13 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Condition="Exists('..\dir.props')" Project="..\dir.props" />
   <Import Project="src\BuildValues.props" />
-  
+
   <!--
     $(OS) is set to Unix/Windows_NT. This comes from an environment variable on Windows and MSBuild on Unix.
   -->
   <PropertyGroup>
+    <!-- Temp change to make OS X build behave as a Linux build -->
+    <OsEnvironment Condition="'$(OsEnvironment)'=='' AND '$(OS)'=='OSX'">Unix</OsEnvironment>
     <OsEnvironment Condition="'$(OsEnvironment)'==''">$(OS)</OsEnvironment>
   </PropertyGroup>
 
@@ -23,7 +25,7 @@
       <Value>True</Value>
     </AssemblyMetadata>
   </ItemGroup>
-  
+
   <!-- 
     Switching to the .NET Core version of the BuildTools tasks seems to break numerous scenarios, such as VS intellisense and resource designer 
     as well as runnning the build on mono. Until we can get these sorted out we will continue using the .NET 4.5 version of the tasks. 
@@ -35,7 +37,7 @@
   <!-- Common repo directories -->
   <PropertyGroup>
     <ProjectDir>$(MSBuildThisFileDirectory)</ProjectDir>
-    <SourceDir>$(ProjectDir)src\</SourceDir>
+    <SourceDir>$(ProjectDir)src/</SourceDir>
 
     <!-- Output directories -->
     <BinDir Condition="'$(BinDir)'==''">$(ProjectDir)bin/</BinDir>
@@ -50,7 +52,14 @@
     <ToolsDir Condition="'$(ToolsDir)'==''">$(ProjectDir)Tools/</ToolsDir>
     <DotnetCliPath Condition="'$(DotnetCliPath)'==''">$(ToolRuntimePath)dotnetcli/bin/</DotnetCliPath>
     <BuildToolsTaskDir Condition="'$(BuildToolsTargets45)' == 'true'">$(ToolsDir)net45/</BuildToolsTaskDir>
+    <UseRoslynCompilers Condition="'$(UseRoslynCompilers)'=='' and '$(OSEnvironment)'!='Windows_NT'">false</UseRoslynCompilers>
   </PropertyGroup>
+
+  <!-- Use Roslyn Compilers to build -->
+  <PropertyGroup Condition="'$(UseRoslynCompilers)'!='false'">
+    <UseSharedCompilation>true</UseSharedCompilation>
+  </PropertyGroup>
+  <Import Project="$(ToolRuntimePath)/net45/roslyn/build/Microsoft.Net.Compilers.props" Condition="'$(UseRoslynCompilers)'!='false'" />
 
   <!-- Import packaging props -->
   <Import Project="$(MSBuildThisFileDirectory)Packaging.props" />
@@ -71,7 +80,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ValidationPattern Include="^(?i)((System\..%2A)|(Microsoft\.CSharp)|(Microsoft\.NETCore.%2A)|(Microsoft\.TargetingPack\.Private\.(CoreCLR|NETNative))|(Microsoft\.Win32\..%2A)|(Microsoft\.VisualBasic))(?&lt;!TestData)$">
+    <ValidationPattern Include="^(?i)((System\..%2A)|(NETStandard\.Library)|(Microsoft\.CSharp)|(Microsoft\.NETCore.%2A)|(Microsoft\.TargetingPack\.Private\.(CoreCLR|NETNative))|(Microsoft\.Win32\..%2A)|(Microsoft\.VisualBasic))(?&lt;!TestData)$">
       <ExpectedPrerelease>rc3-23809</ExpectedPrerelease>
     </ValidationPattern>
     <ValidationPattern Include="^(?i)Microsoft\.TargetingPack\.(NetFramework.%2A|Private\.WinRT)$">
@@ -90,19 +99,18 @@
     <!-- Need to escape double forward slash (%2F) or MSBuild will normalize to one slash on Unix. -->
 
     <DnuSourceList Include="https:%2F%2Fdotnet.myget.org/F/dotnet-core/api/v3/index.json" />
-    <DnuSourceList Include="https:%2F%2Fdotnet.myget.org/F/dotnet-corefxtestdata/api/v3/index.json" />
-    <DnuSourceList Include="https:%2F%2Fdotnet.myget.org/F/dotnet-buildtools/api/v3/index.json" />
     <DnuSourceList Include="https:%2F%2Fwww.nuget.org/api/v2/" />
   </ItemGroup>
 
   <!-- list of directories to perform batch restore -->
   <ItemGroup>
-    <DnuRestoreDir Include="$(MSBuildThisFileDirectory)\src" />
+    <DnuRestoreDir Include="$(MSBuildThisFileDirectory)/src" />
+    <DnuRestoreDir Include="$(MSBuildThisFileDirectory)/pkg" />
   </ItemGroup>
 
   <PropertyGroup>
     <DnxPackageDir Condition="'$(DnxPackageDir)'==''">$(PackagesDir)/$(DnxPackageName)/</DnxPackageDir>
-    <DnuToolPath Condition="'$(DnuToolPath)'=='' and '$(OsEnvironment)'!='Unix'">$(DnxPackageDir)\bin\dnu.cmd</DnuToolPath>
+    <DnuToolPath Condition="'$(DnuToolPath)'=='' and '$(OsEnvironment)'!='Unix'">$(DnxPackageDir)/bin/dnu.cmd</DnuToolPath>
     <DnuToolPath Condition="'$(DnuToolPath)'=='' and '$(OsEnvironment)'=='Unix'">$(DnxPackageDir)/bin/dnu</DnuToolPath>
     <DotnetToolCommand Condition="'$(DotnetToolCommand)' == '' and '$(OsEnvironment)'!='Unix'">$(DotnetCliPath)dotnet.exe</DotnetToolCommand>
     <DotnetToolCommand Condition="'$(DotnetToolCommand)' == '' and '$(OsEnvironment)'=='Unix'">$(DotnetCliPath)dotnet</DotnetToolCommand>
@@ -120,12 +128,13 @@
 
   <!-- Create a collection of all project.json files for dependency updates. -->
   <ItemGroup>
-    <ProjectJsonFiles Include="$(SourceDir)**\project.json" />
+    <ProjectJsonFiles Include="$(SourceDir)**/project.json" />
+    <ProjectJsonFiles Include="$(MSBuildThisFileDirectory)/pkg/**/project.json" />
   </ItemGroup>
 
-  <PropertyGroup Condition="'$(BuildAllProjects)'=='true'">  
-    <!-- When we do a traversal build we get all packages up front, don't restore them again -->  
-    <RestorePackages>false</RestorePackages>  
+  <PropertyGroup Condition="'$(BuildAllProjects)'=='true'">
+    <!-- When we do a traversal build we get all packages up front, don't restore them again -->
+    <RestorePackages>false</RestorePackages>
   </PropertyGroup>
 
   <!--
@@ -136,11 +145,9 @@
     <RoslynPropsFile>$(RoslynPackageDir)build/Microsoft.Net.ToolsetCompilers.props</RoslynPropsFile>
 
     <!--
-      PDB support isn't implemented yet. https://github.com/dotnet/roslyn/issues/2449
-      Note that both DebugSymbols and DebugType need set or project references will assume they need to copy pdbs and fail.
+      Portable PDBs are now supported in Linux and OSX with .Net Core MSBuild.
     -->
-    <DebugSymbols>false</DebugSymbols>
-    <DebugType>none</DebugType>
+    <DebugType>Portable</DebugType>
 
     <!--
       Delay signing with the ECMA key currently doesn't work.
@@ -149,12 +156,18 @@
     <UseECMAKey>false</UseECMAKey>
 
     <!--
+      Full signing with Open key doesn't work with Portable Csc.
+      https://github.com/dotnet/roslyn/issues/8210
+    -->
+    <UseOpenKey>false</UseOpenKey>
+
+    <!--
       Mono currently doesn't include VB targets for portable, notably /lib/mono/xbuild/Microsoft/Portable/v4.5/Microsoft.Portable.VisualBasic.targets.
       Fixed in https://github.com/mono/mono/pull/1726.
     -->
     <IncludeVbProjects>false</IncludeVbProjects>
   </PropertyGroup>
-  
+
   <PropertyGroup>
     <!-- By default make all libraries to be AnyCPU but individual projects can override it if they need to -->
     <Platform>AnyCPU</Platform>
@@ -344,17 +357,6 @@
     <ProjectLockJson Condition="Exists('$(MSBuildProjectDirectory)/$(TargetGroup)/project.json') AND Exists('$(MSBuildProjectDirectory)/$(TargetGroup)/project.lock.json')">$(MSBuildProjectDirectory)/$(TargetGroup)/project.lock.json</ProjectLockJson>
   </PropertyGroup>
 
-  <!-- Provide defaults for ToolNugetRuntimeId -->
-  <PropertyGroup Condition="'$(ToolNugetRuntimeId)'== ''">
-    <ToolNugetRuntimeId Condition="'$(OsEnvironment)'=='Windows_NT'">win7-x64</ToolNugetRuntimeId>
-
-    <!-- This is a bit of a hack because inside MSBuild we have no real concept of the host distro, so we'll assume
-         that if you are building on not windows, your host OS is the same as your target.  If that's not
-         the case, you'll have to provide your own ToolNugetRuntimeId, which is not the end of the world (build.sh will
-         do this for you, for example). -->
-    <ToolNugetRuntimeId Condition="'$(OsEnvironment)'=='Unix'">$(TestNugetRuntimeId)</ToolNugetRuntimeId>
-  </PropertyGroup>
-
   <!-- Disable some standard properties for building our projects -->
   <PropertyGroup>
     <NoStdLib>true</NoStdLib>
@@ -367,11 +369,6 @@
   <PropertyGroup>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-  </PropertyGroup>
-
-  <!-- Temporary until build/CI system is upgraded to C# 6: disable C# 6 features -->
-  <PropertyGroup Condition="'$(MSBuildProjectExtension)' == '.csproj' OR '$(Language)' == 'C#'">
-    <LangVersion>5</LangVersion>
   </PropertyGroup>
 
   <!-- Set up some common paths -->
@@ -402,6 +399,7 @@
     <SkipTests Condition="'$(SkipTests)'=='' and ('$(OsEnvironment)'=='Windows_NT' and '$(TargetsWindows)'!='true' and '$(OSGroup)'!='AnyOS')">true</SkipTests>
   </PropertyGroup>
 
+  <!-- *** start WCF Content *** -->
   <!-- Test runtime -->
   <PropertyGroup>
     <TestRuntimePath>$(SourceDir)Common/test-runtime/</TestRuntimePath>
@@ -425,6 +423,7 @@
   <ItemGroup Condition="'$(FloatingTestRuntimeDependencies)'=='true'">
     <DnuRestoreDir Include="$(TestRuntimeProjectJson)" />
   </ItemGroup>
+  <!-- *** end WCF Content *** -->
 
   <Import Project="$(RoslynPropsFile)" Condition="'$(OsEnvironment)'=='Unix' and Exists('$(RoslynPropsFile)')" />
 

--- a/dir.targets
+++ b/dir.targets
@@ -14,7 +14,11 @@
   <Target Name="Test" />
 
   <Import Project="$(ToolsDir)/Build.Common.targets" />
-  
+
+  <!-- permit a wrapping build system to contribute targets to this build -->
+  <Import Condition="Exists('$(MSBuildThisFileDirectory)..\open.targets')" Project="$(MSBuildThisFileDirectory)..\open.targets" />
+
+  <!-- *** start WCF Content *** -->
   <!-- Copy the test-runtime project.json and change it to use floating (*) CoreFX dependencies for testing against the latest packages. -->
   <Target Name="GenerateFloatingTestRuntimeProjectJson"
           Inputs="$(TestFixedRuntimeProjectJson)"
@@ -35,5 +39,6 @@
                                        ValidationPatterns="@(FixedToFloatingValidationPattern)"
                                        UpdateInvalidDependencies="true" />
   </Target>
+  <!-- *** end WCF Content *** -->
 
 </Project>

--- a/dir.traversal.targets
+++ b/dir.traversal.targets
@@ -66,6 +66,7 @@
              Properties="DefaultBuildAllTarget=$(DefaultBuildAllTarget);BuildAllProjects=true"
              ContinueOnError="ErrorAndContinue" />
 
+    <!-- *** start WCF Content *** -->
     <!-- WCF differs from CoreFx for BuildInParallel because there is a race condition in CoreResGen updating the same file -->
     <MSBuild Targets="$(DefaultBuildAllTarget)"
              Projects="@(Project)"
@@ -73,6 +74,7 @@
              Properties="DefaultBuildAllTarget=$(DefaultBuildAllTarget);BuildAllProjects=true"
              BuildInParallel="false"
              ContinueOnError="ErrorAndContinue" />
+    <!-- *** end WCF Content *** -->
 
     <!-- Given we ErrorAndContinue we need to propagate the error if the overall task failed -->
     <Error Condition="'$(MSBuildLastTaskResult)'=='false'" />

--- a/src/NuGet.config
+++ b/src/NuGet.config
@@ -5,8 +5,6 @@
   <packageSources>
     <clear/>
     <add key="myget.org dotnet-core" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
-    <add key="myget.org dotnet-corefxtestdata" value="https://dotnet.myget.org/F/dotnet-corefxtestdata/api/v3/index.json" />
-    <add key="myget.org dotnet-buildtools" value="https://dotnet.myget.org/F/dotnet-buildtools/api/v3/index.json" />
     <add key="nuget.org" value="https://www.nuget.org/api/v2/" />
   </packageSources>
   <config>

--- a/src/dir.props
+++ b/src/dir.props
@@ -1,4 +1,6 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\dir.props" />
+  <!-- *** start WCF Content *** -->
   <Import Project=".\test.props" />
+  <!-- *** end WCF Content *** -->
 </Project>

--- a/src/dir.targets
+++ b/src/dir.targets
@@ -15,11 +15,13 @@
   <Target Name="GetDocumentationFile"
           Returns="$(DocumentationFile)"/>
 
+  <!-- *** start WCF Content *** -->
   <Import Project="..\override.targets" Condition="Exists('..\override.targets')"/>
   <Import Project="..\wcf.targets" Condition="Exists('..\wcf.targets')"/>
+  <!-- *** end WCF Content *** -->
 
-  <Target Name="DumpTargets">
-    <Message Text="$(MSBuildProjectName), OS=$(OSGroup), Target=$(TargetGroup)" Importance="High"/>
+  <Target Name="DumpTargets" BeforeTargets="ResolveProjectReferences">
+    <Message Text="DumpTargets> $(OutputPath), C=[$(Configuration)], CG=[$(ConfigurationGroup)], OG=[$(OSGroup)], TG=[$(TargetGroup)]" Importance="Low" />
   </Target>
   
 </Project>

--- a/src/dirs.proj
+++ b/src/dirs.proj
@@ -7,11 +7,13 @@
     <Project Include="tests.builds" />
   </ItemGroup>
 
+  <!-- *** start WCF Content *** -->
   <!-- Additional WCF tool projects -->
   <ItemGroup>
     <Project Include="$(MSBuildProjectDirectory)\System.Private.ServiceModel\tools\test\CertificateCleanup\CertificateCleanup.csproj" />
     <Project Include="$(MSBuildProjectDirectory)\System.Private.ServiceModel\tools\test\BridgeCertificateInstaller\BridgeCertificateInstaller.csproj" />
   </ItemGroup>
+  <!-- *** end WCF Content *** -->
 
   <Import Project="..\dir.targets" />
   <Import Project="..\dir.traversal.targets" />

--- a/src/post.builds
+++ b/src/post.builds
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
+  <PropertyGroup>
+    <OSGroup Condition="'$(FilterToOSGroup)'!=''">$(FilterToOSGroup)</OSGroup>
+  </PropertyGroup>
+
   <Import Project="dir.props" />
   <Import Project="..\dir.targets" />
   <Import Project="$(ToolsDir)Build.Post.targets" Condition="Exists('$(ToolsDir)Build.Post.targets')" />

--- a/src/tests.builds
+++ b/src/tests.builds
@@ -2,7 +2,9 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
+    <!-- *** start WCF Content *** -->
     <ExcludeProjects Include="System.Private.ServiceModel\tests\Scenarios\SelfHostWcfService\WcfService.csproj" />
+    <!-- *** end WCF Content *** -->
     <Project Include="*\test*\**\*.csproj" Exclude="@(ExcludeProjects)">
       <OSGroup Condition="'$(FilterToOSGroup)'!=''">$(FilterToOSGroup)</OSGroup>
     </Project>

--- a/sync.cmd
+++ b/sync.cmd
@@ -37,11 +37,12 @@ goto Loop
 
 :Begin
 
+echo Running init-tools.cmd
 call %~dp0init-tools.cmd
 
 if [%src%] == [true] (
   echo Fetching git database from remote repos ...
-  call git fetch --all -p >> %synclog%
+  call git fetch --all -p -v >> %synclog% 2>&1
   if NOT [%ERRORLEVEL%]==[0] (
     echo ERROR: An error occurred while fetching remote source code, see %synclog% for more details.
     exit /b
@@ -50,8 +51,8 @@ if [%src%] == [true] (
 
 if [%packages%] == [true] (
   echo Restoring all packages ...
-  echo msbuild.exe %~dp0build.proj /t:BatchRestorePackages /nologo /v:minimal /p:RestoreDuringBuild=true /flp:v=diag;Append;LogFile=%synclog% >> %synclog%
-  call msbuild.exe %~dp0build.proj /t:BatchRestorePackages /nologo /v:minimal /p:RestoreDuringBuild=true /flp:v=diag;Append;LogFile=%synclog%
+  echo msbuild.exe %~dp0build.proj /t:BatchRestorePackages /nologo /v:minimal /p:RestoreDuringBuild=true /flp:v=detailed;Append;LogFile=%synclog% >> %synclog%
+  call msbuild.exe %~dp0build.proj /t:BatchRestorePackages /nologo /v:minimal /p:RestoreDuringBuild=true /flp:v=detailed;Append;LogFile=%synclog%
   if NOT [%ERRORLEVEL%]==[0] (
     echo ERROR: An error occurred while syncing packages, see %synclog% for more details. There may have been networking problems so please try again in a few minutes.
     exit /b
@@ -68,7 +69,8 @@ echo.
 echo Repository syncing script.
 echo.
 echo Options:
-echo     /s     - Fetches source history from all configured remotes (git fetch --all)
+echo     /s     - Fetches source history from all configured remotes
+echo              (git fetch --all -p -v)
 echo     /p     - Restores all nuget packages for repository
 echo.
 echo If no option is specified then sync.cmd /s /p is implied.


### PR DESCRIPTION
* Changes to dir.props and dir.targets made in corefx cause failures in WCF repo.
* Use of Roslyn compiler keeps around the task "VBCSCompiler.exe" which must be manually killed after each local build before running "git clean -xdf"
* There are a few files that either exist in corefx but not in Wcf or vice versa, am not using this PR to investigate those discrepancies.
* For sections where we have WCF specific changes I have added the comments "*** start WCF Content ***" and "*** end WCF Content ***", this should make it easier in the future to identify sections that can safely be ignored when diffing the files. 