### PR TITLE
Update System.Runtime.Serialization.Xml dependency to stable version

### DIFF
--- a/src/Common/test-runtime/project.json
+++ b/src/Common/test-runtime/project.json
@@ -41,7 +41,7 @@
     "System.Runtime.Handles": "4.0.0",
     "System.Runtime.InteropServices": "4.0.0",
     "System.Runtime.InteropServices.RuntimeInformation": "4.0.0-rc3-23809",
-    "System.Runtime.Serialization.Xml": "4.1.0-rc3-23809",
+    "System.Runtime.Serialization.Xml": "4.1.0",
     "System.Security.Claims": "4.0.0",
     "System.Security.Cryptography.X509Certificates": "4.0.0-rc3-23809",
     "System.Security.Principal": "4.0.0",

--- a/src/System.Private.ServiceModel/src/project.json
+++ b/src/System.Private.ServiceModel/src/project.json
@@ -34,7 +34,7 @@
     "System.Runtime.Handles": "4.0.0",
     "System.Runtime.InteropServices": "4.0.0",
     "System.Runtime.InteropServices.RuntimeInformation": "4.0.0-rc3-23809",
-    "System.Runtime.Serialization.Xml": "4.1.0-rc3-23809",
+    "System.Runtime.Serialization.Xml": "4.1.0",
     "System.Security.Claims": "4.0.0",
     "System.Security.Cryptography.X509Certificates": "4.0.0-rc3-23809",
     "System.Security.Principal": "4.0.0",

--- a/src/System.Private.ServiceModel/src/windows/project.json
+++ b/src/System.Private.ServiceModel/src/windows/project.json
@@ -34,7 +34,7 @@
     "System.Runtime.Handles": "4.0.0",
     "System.Runtime.InteropServices": "4.0.0",
     "System.Runtime.InteropServices.RuntimeInformation": "4.0.0-rc3-23809",
-    "System.Runtime.Serialization.Xml": "4.1.0-rc3-23809",
+    "System.Runtime.Serialization.Xml": "4.1.0",
     "System.Security.Claims": "4.0.0",
     "System.Security.Cryptography.X509Certificates": "4.0.0-rc3-23809",
     "System.Security.Principal": "4.0.0",

--- a/src/System.Private.ServiceModel/tests/Common/Scenarios/project.json
+++ b/src/System.Private.ServiceModel/tests/Common/Scenarios/project.json
@@ -6,7 +6,7 @@
 	"System.Net.Http": "4.0.0",
 	"System.Net.Primitives": "4.0.10",
 	"System.Net.WebHeaderCollection": "4.0.0",
-    "System.Runtime.Serialization.Xml": "4.1.0-rc3-23809",
+    "System.Runtime.Serialization.Xml": "4.1.0",
 	"System.Security.Cryptography.X509Certificates": "4.0.0-rc3-23809",
 	"System.Security.Principal": "4.0.0",
     "System.ServiceModel.Duplex": "4.0.1-rc3-23809",

--- a/src/System.Private.ServiceModel/tests/Common/Unit/project.json
+++ b/src/System.Private.ServiceModel/tests/Common/Unit/project.json
@@ -5,7 +5,7 @@
     "System.Linq": "4.0.0",
     "System.Net.Primitives": "4.0.10",
     "System.ObjectModel": "4.0.0",
-    "System.Runtime.Serialization.Xml": "4.1.0-rc3-23809",
+    "System.Runtime.Serialization.Xml": "4.1.0",
     "System.ServiceModel.Duplex": "4.0.1-rc3-23809",
     "System.ServiceModel.Http": "4.0.11-rc3-23809",
     "System.ServiceModel.Primitives": "4.1.0-rc3-23809",

--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/ChannelLayer/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/ChannelLayer/project.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "Microsoft.NETCore.Platforms": "1.0.1-rc3-23809",
-    "System.Runtime.Serialization.Xml": "4.1.0-rc3-23809",
+    "System.Runtime.Serialization.Xml": "4.1.0",
     "System.ServiceModel.Http": "4.0.11-rc3-23809",
     "System.ServiceModel.NetTcp": "4.0.1-rc3-23809",
     "System.ServiceModel.Primitives": "4.1.0-rc3-23809",

--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/ExpectedExceptions/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/ExpectedExceptions/project.json
@@ -8,7 +8,7 @@
 		"System.Net.WebHeaderCollection": "4.0.0",
 		"System.Reflection.Emit.Lightweight": "4.0.0",
 		"System.Runtime.Serialization.Primitives": "4.1.0-rc3-23809",
-		"System.Runtime.Serialization.Xml": "4.1.0-rc3-23809",
+		"System.Runtime.Serialization.Xml": "4.1.0",
 		"System.Security.Cryptography.X509Certificates": "4.0.0-rc3-23809",
 		"System.Security.Principal": "4.0.0",
 		"System.ServiceModel.Duplex": "4.0.1-rc3-23809",

--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/TypedClient/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/TypedClient/project.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "Microsoft.NETCore.Platforms": "1.0.1-rc3-23809",
-    "System.Runtime.Serialization.Xml": "4.1.0-rc3-23809",
+    "System.Runtime.Serialization.Xml": "4.1.0",
     "System.ServiceModel.Duplex": "4.0.1-rc3-23809",
     "System.ServiceModel.Http": "4.0.11-rc3-23809",
     "System.ServiceModel.NetTcp": "4.0.1-rc3-23809",

--- a/src/System.Private.ServiceModel/tests/Scenarios/Contract/Message/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Contract/Message/project.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "Microsoft.NETCore.Platforms": "1.0.1-rc3-23809",
-    "System.Runtime.Serialization.Xml": "4.1.0-rc3-23809",
+    "System.Runtime.Serialization.Xml": "4.1.0",
     "System.ServiceModel.Http": "4.0.11-rc3-23809",
     "System.ServiceModel.Primitives": "4.1.0-rc3-23809",
     "System.Xml.ReaderWriter": "4.0.0",

--- a/src/System.Private.ServiceModel/tests/Scenarios/Contract/Service/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Contract/Service/project.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "Microsoft.NETCore.Platforms": "1.0.1-rc3-23809",
     "System.IO": "4.0.10",
-    "System.Runtime.Serialization.Xml": "4.1.0-rc3-23809",
+    "System.Runtime.Serialization.Xml": "4.1.0",
     "System.ServiceModel.Http": "4.0.11-rc3-23809",
     "System.ServiceModel.NetTcp": "4.0.1-rc3-23809",
     "System.ServiceModel.Primitives": "4.1.0-rc3-23809",

--- a/src/System.ServiceModel.Http/tests/project.json
+++ b/src/System.ServiceModel.Http/tests/project.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "Microsoft.NETCore.Platforms": "1.0.1-rc3-23809",
     "System.Net.WebHeaderCollection": "4.0.0",
-    "System.Runtime.Serialization.Xml": "4.1.0-rc3-23809",
+    "System.Runtime.Serialization.Xml": "4.1.0",
     "System.ServiceModel.Http": "4.0.11-rc3-23809",
     "System.ServiceModel.Primitives": "4.1.0-rc3-23809",
     "System.ServiceModel.Security": "4.0.1-rc3-23809",

--- a/src/System.ServiceModel.NetTcp/tests/project.json
+++ b/src/System.ServiceModel.NetTcp/tests/project.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "Microsoft.NETCore.Platforms": "1.0.1-rc3-23809",
-    "System.Runtime.Serialization.Xml": "4.1.0-rc3-23809",
+    "System.Runtime.Serialization.Xml": "4.1.0",
     "System.ServiceModel.NetTcp": "4.1.0-rc3-23809",
     "System.ServiceModel.Primitives": "4.1.0-rc3-23809",
 

--- a/src/System.ServiceModel.Primitives/tests/project.json
+++ b/src/System.ServiceModel.Primitives/tests/project.json
@@ -3,7 +3,7 @@
     "Microsoft.NETCore.Platforms": "1.0.1-rc3-23809",
     "System.Net.WebSockets": "4.0.0-rc3-23809",
     "System.Net.WebSockets.Client": "4.0.0-rc3-23809",
-    "System.Runtime.Serialization.Xml": "4.1.0-rc3-23809",
+    "System.Runtime.Serialization.Xml": "4.1.0",
     "System.ServiceModel.Duplex": "4.0.1-rc3-23809",
     "System.ServiceModel.Http": "4.1.0-rc3-23809",
     "System.ServiceModel.NetTcp": "4.1.0-rc3-23809",


### PR DESCRIPTION
System.Runtime.Serialization.Xml 4.1.0 is now a stable package,
and the RC versions will become deprecated. This change updates
the previous dependencies from the RC to the stable version.