### PR TITLE
Change BuildCertificateInstaller.sh to chmod downloaded cert

### DIFF
--- a/src/System.Private.ServiceModel/tools/setupfiles/BridgeCertificateInstaller.sh
+++ b/src/System.Private.ServiceModel/tools/setupfiles/BridgeCertificateInstaller.sh
@@ -32,6 +32,7 @@ install_root_cert()
 {
     __cafile=$1
 
+    chmod a+r "$__cafile"
     cp -f "$__cafile" /usr/local/share/ca-certificates
 
     if [ $? -ne 0 ]; then 


### PR DESCRIPTION
The downloaded cert was in some circumstances not chmodded to world writable, which meant that cURL would have trouble accessing the certificates when trying to establish an HTTPS connection

Not sure why this wasn't happening on my main dev box, but this problem exists on another box I spun up. 

@roncain, this should fix the problem you've been seeing when running outerloops on Linux and seeing the HTTP Security.TransportSecurity.Tests tests fail. 

You may need to remove all certs inside `/usr/local/share/ca-certificates/*` and re-run the BridgeCertificateInstaller in order to have this take. Also, please check the directory permissions on `/usr/local/share/ca-certificates` to ensure it's world-readable

skip ci please