### PR TITLE
Enable AllowCookies=true.

### DIFF
--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/HttpChannelFactory.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/HttpChannelFactory.cs
@@ -273,6 +273,7 @@ namespace System.ServiceModel.Channels
                     var clientHandler = GetHttpMessageHandler(to, clientCertificateToken);
                     clientHandler.AutomaticDecompression = DecompressionMethods.Deflate | DecompressionMethods.GZip;
                     clientHandler.UseCookies = _allowCookies;
+                    clientHandler.CookieContainer = _allowCookies ? _httpCookieContainerManager.CookieContainer : null;
                     clientHandler.PreAuthenticate = true;
                     if (clientHandler.SupportsProxy)
                     {

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/ServiceModelHttpMessageHandler.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/ServiceModelHttpMessageHandler.cs
@@ -19,5 +19,11 @@ namespace System.ServiceModel.Channels
             get { return _innerHandler.PreAuthenticate; }
             set { _innerHandler.PreAuthenticate = value; }
         }
+
+        public CookieContainer CookieContainer
+        {
+            get { return _innerHandler.CookieContainer; }
+            set { _innerHandler.CookieContainer = value; }
+        }
     }
 }

--- a/src/System.Private.ServiceModel/tests/Common/Scenarios/ServiceInterfaces.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Scenarios/ServiceInterfaces.cs
@@ -492,3 +492,13 @@ public interface IXmlMessageContarctTestService
     [XmlSerializerFormat(SupportFaults = true)]
     XmlMessageContractTestResponse EchoMessageResquestWithMessageHeader(XmlMessageContractTestRequestWithMessageHeader request);
 }
+
+[ServiceContract]
+public interface IWcfAspNetCompatibleService
+{
+    [OperationContract(Action = "http://tempuri.org/IWcfService/EchoCookie", ReplyAction = "http://tempuri.org/IWcfService/EchoCookieResponse")]
+    string EchoCookie();
+
+    [OperationContract(Action = "http://tempuri.org/IWcfService/EchoTimeAndSetCookie", ReplyAction = "http://tempuri.org/IIWcfService/EchoTimeAndSetCookieResponse")]
+    string EchoTimeAndSetCookie(string name);
+}

--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/ClientBase/ClientBaseTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/ClientBase/ClientBaseTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Net;
 using System.ServiceModel;
 using System.ServiceModel.Channels;
 using System.ServiceModel.Description;
@@ -216,6 +217,101 @@ public static class ClientBaseTests
             {
                 client.Abort();
             }
+        }
+    }
+
+    [Fact]
+    [OuterLoop]
+    public static void DefaultSettings_Echo_Cookie()
+    {
+        // *** SETUP *** \\
+        var factory = new ChannelFactory<IWcfAspNetCompatibleService>(
+                 new BasicHttpBinding()
+                 {
+                     AllowCookies = true
+                 },
+                 new EndpointAddress(Endpoints.HttpBaseAddress_Basic));
+
+        IWcfAspNetCompatibleService serviceProxy = factory.CreateChannel();
+
+        IHttpCookieContainerManager cookieManager = ((IChannel)serviceProxy).GetProperty<IHttpCookieContainerManager>();
+        Assert.True(cookieManager != null, "cookieManager was null.");
+        Assert.True(cookieManager.CookieContainer != null, "cookieManager.CookieContainer was null.");
+        string cookieName = "cookieName";
+        string cookieValue = "cookieValue";
+        string cookieSentOut = string.Format("{0}={1}", cookieName, cookieValue);
+        cookieManager.CookieContainer.Add(new Uri(Endpoints.HttpBaseAddress_Basic), new System.Net.Cookie(cookieName, cookieValue));
+
+        try
+        {
+            // *** EXECUTE *** \\
+            string cookieSentBack = serviceProxy.EchoCookie();
+
+            // *** VALIDATE *** \\
+            Assert.True(cookieSentOut == cookieSentBack,
+                string.Format("The expected cookie sent back from the server was '{0}', but the actual cookie was '{1}'", cookieSentOut, cookieSentBack));
+
+            // *** CLEANUP *** \\
+            factory.Close();
+            ((ICommunicationObject)serviceProxy).Close();
+        }
+        finally
+        {
+            // *** ENSURE CLEANUP *** \\
+            ScenarioTestHelpers.CloseCommunicationObjects((ICommunicationObject)serviceProxy, factory);
+        }
+    }
+
+    [Fact]
+    [OuterLoop]
+    public static void DefaultSettings_SetCookieOnServerSide()
+    {
+        // *** SETUP *** \\
+        Uri uri = new Uri(Endpoints.HttpBaseAddress_Basic);
+        var factory = new ChannelFactory<IWcfAspNetCompatibleService>(
+                 new BasicHttpBinding()
+                 {
+                     AllowCookies = true
+                 },
+                 new EndpointAddress(uri));
+
+        IWcfAspNetCompatibleService serviceProxy = factory.CreateChannel();
+
+        IHttpCookieContainerManager cookieManager = ((IChannel)serviceProxy).GetProperty<IHttpCookieContainerManager>();
+        Assert.True(cookieManager != null, "cookieManager was null.");
+        Assert.True(cookieManager.CookieContainer != null, "cookieManager.CookieContainer was null.");
+
+        try
+        {
+            string cookieName = "cookie_time";
+            
+
+            // *** EXECUTE *** \\
+            // EchoTimeAndSetCookie returns the current time and also sets the cookie named 'cookieName' to be the same time returned.
+            string timeReturned = serviceProxy.EchoTimeAndSetCookie(cookieName);
+
+            CookieCollection cookies = cookieManager.CookieContainer.GetCookies(uri);
+            Assert.True(cookies != null, "cookies was null.");
+
+            Cookie cookie = cookies[cookieName];
+            Assert.True(cookie != null, "cookie was null.");
+
+            string timeSetInCookie = cookie.Value;
+
+            // *** VALIDATE *** \\
+            Assert.True(timeReturned != null, "timeReturned != null");
+            Assert.True(timeSetInCookie != null, "timeSetInCookie != null");
+            Assert.True(timeReturned == timeSetInCookie,
+                string.Format("Expected cookie named '{0}' to be set to '{1}', but the actual value was '{2}'", cookieName, timeReturned, timeSetInCookie));
+
+            // *** CLEANUP *** \\
+            factory.Close();
+            ((ICommunicationObject)serviceProxy).Close();
+        }
+        finally
+        {
+            // *** ENSURE CLEANUP *** \\
+            ScenarioTestHelpers.CloseCommunicationObjects((ICommunicationObject)serviceProxy, factory);
         }
     }
 

--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/ClientBase/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/ClientBase/project.json
@@ -1,6 +1,7 @@
 {
   "dependencies": {
     "Microsoft.NETCore.Platforms": "1.0.1-rc3-23809",
+    "System.Net.Primitives": "4.0.10",
     "System.Net.WebHeaderCollection": "4.0.0",
     "System.Reflection.Emit.Lightweight": "4.0.0",
     "System.ServiceModel.Duplex": "4.0.1-rc3-23809",

--- a/src/System.Private.ServiceModel/tools/test/SelfHostWcfService/IWcfService.cs
+++ b/src/System.Private.ServiceModel/tools/test/SelfHostWcfService/IWcfService.cs
@@ -68,6 +68,12 @@ namespace WcfService
         [OperationContract(Action = "http://tempuri.org/IWcfService/GetIncomingMessageHeaders", ReplyAction = "*")]
         Dictionary<string, string> GetIncomingMessageHeaders();
 
+        [OperationContract(Action = "http://tempuri.org/IWcfService/EchoCookie", ReplyAction = "*")]
+        string EchoCookie();
+
+        [OperationContract(Action = "http://tempuri.org/IWcfService/EchoTimeAndSetCookie", ReplyAction = "*")]
+        string EchoTimeAndSetCookie(string name);
+
         [OperationContract(Action = "http://tempuri.org/IWcfService/EchoXmlSerializerFormat"), XmlSerializerFormat]
         string EchoXmlSerializerFormat(string message);
 

--- a/src/System.Private.ServiceModel/tools/test/SelfHostWcfService/WcfService.cs
+++ b/src/System.Private.ServiceModel/tools/test/SelfHostWcfService/WcfService.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Net;
 using System.ServiceModel;
 using System.ServiceModel.Channels;
+using System.ServiceModel.Web;
 using System.Text;
 
 namespace WcfService
@@ -365,6 +366,22 @@ namespace WcfService
 
             var httpRespononseMessageProperty = (HttpResponseMessageProperty)httpResponseMessagePropertyObj;
             httpRespononseMessageProperty.Headers[HttpResponseHeader.ContentType] = contentType;
+        }
+
+        public string EchoCookie()
+        {
+            string cookie = WebOperationContext.Current.IncomingRequest.Headers[HttpRequestHeader.Cookie];
+            return cookie;
+        }
+
+        // Returns the current time and also sets the cookie named 'name' to be the same time returned.
+        public string EchoTimeAndSetCookie(string name)
+        {
+            string cookie = WebOperationContext.Current.IncomingRequest.Headers[HttpRequestHeader.Cookie];
+            string value = DateTime.Now.ToString();
+            cookie = string.Format("{0}={1}", name, value);
+            WebOperationContext.Current.OutgoingResponse.Headers.Add(string.Format("Set-Cookie: {0};", cookie));
+            return value;
         }
 
         private static string StreamToString(Stream stream)

--- a/src/System.Private.ServiceModel/tools/test/SelfHostWcfService/WcfService.csproj
+++ b/src/System.Private.ServiceModel/tools/test/SelfHostWcfService/WcfService.csproj
@@ -42,6 +42,7 @@
     <Reference Include="System.ServiceModel" />
     <Reference Include="System.ServiceModel.Activation" />
     <Reference Include="System.ServiceModel.Channels" />
+    <Reference Include="System.ServiceModel.Web" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/src/System.ServiceModel.Primitives/tests/ServiceModel/ChannelFactoryTest.cs
+++ b/src/System.ServiceModel.Primitives/tests/ServiceModel/ChannelFactoryTest.cs
@@ -231,4 +231,41 @@ public class ChannelFactoryTest
             }
         }
     }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public static void ChannelFactory_AllowCookies(bool allowCookies)
+    {
+        ChannelFactory<IWcfService> factory = null;
+
+        try
+        {
+            factory = new ChannelFactory<IWcfService>(
+                     new BasicHttpBinding()
+                     {
+                         AllowCookies = allowCookies
+                     },
+                     new EndpointAddress(FakeAddress.HttpAddress));
+
+            IWcfService serviceProxy = factory.CreateChannel();
+
+            IHttpCookieContainerManager cookieManager = ((IChannel)serviceProxy).GetProperty<IHttpCookieContainerManager>();
+            Assert.True(allowCookies == (cookieManager != null),
+                string.Format($"AllowCookies was '{0}', 'cookieManager != null' was expected to be '{0}', but it was '{1}'.", allowCookies, cookieManager != null));
+
+            if (allowCookies)
+            {
+                Assert.True(allowCookies == (cookieManager.CookieContainer != null),
+                    string.Format($"AllowCookies was '{0}', 'cookieManager.CookieContainer != null' was expected to be '{0}', but it was '{1}'.", allowCookies, cookieManager != null));
+            }
+        }
+        finally
+        {
+            if (factory != null)
+            {
+                factory.Close();
+            }
+        }
+    }
 }


### PR DESCRIPTION
Invoking operations on a channel that has AllowCookies = true currently fails with:

> Unhandled Exception: System.InvalidOperationException: When using CookieUsePolicy.UseSpecifiedCookieContainer, the CookieContainer property must not be null.

The root cause is that we didn't assign a CookieContainer to the winhttp handler.

Fix #853.