### PR TITLE
Remove one of the duplicated commandline args

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -112,7 +112,7 @@ goto :AfterBuild
 
 :build
 :: *** start WCF Content <WCF uses additional msbuild args> ***
-%_buildprefix% msbuild "%_buildproj%" %_defaultBuildConfig% /nologo /maxcpucount /v:minimal /clp:Summary /nodeReuse:false /flp:v=diag;LogFile="%_buildlog%";Append %* "/l:BinClashLogger,%_binclashLoggerDll%;LogFile=%_binclashlog%" %__args% %_buildpostfix%
+%_buildprefix% msbuild "%_buildproj%" %_defaultBuildConfig% /nologo /maxcpucount /v:minimal /clp:Summary /nodeReuse:false /flp:v=diag;LogFile="%_buildlog%";Append "/l:BinClashLogger,%_binclashLoggerDll%;LogFile=%_binclashlog%" %__args% %_buildpostfix%
 set BUILDERRORLEVEL=!ERRORLEVEL!
 :: *** end WCF Content ***
 goto :eof


### PR DESCRIPTION
* commit e284227f820e2d0eb34d2b640e13acf71a7997e3 add
set "__args=%*", make __args the same as %*. thus we
pass commandline args twice to msbuild. This breaks
Helix, as Helix target does not allow two responses files
specified, even thougth they are the same
* The fix is to remove the redundancy.