### PR TITLE
Code generation of TestProperties no longer uses CodeTaskFactory

### DIFF
--- a/src/System.Private.ServiceModel/tests/Common/Infrastructure/src/testproperties.props
+++ b/src/System.Private.ServiceModel/tests/Common/Infrastructure/src/testproperties.props
@@ -1,74 +1,67 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-    <!-- 
-      TestProperty:
-        This item collection gives the name and value for each property to generate
-        into TestProperties.Properties. The included ItemSpec for each item will
-        become the property's key.  The value for the property will be taken from
-        the "Value" metadata, or if it is blank, from the "DefaultValue" metadata.
-        This pattern permits properties to specify their defaults here but to be
-        overridden from the command line.
-        Example: 'msbuild /p:UseFiddlerUrl=true' will override the default false.
-    -->
-    <ItemGroup>
-      <TestProperty Include="BridgeResourceFolder">
-        <Value>$(BridgeResourceFolder)</Value>
-        <DefaultValue>$(OutputPath)</DefaultValue>
-      </TestProperty>
-      <TestProperty Include="BridgeHost">
-        <Value>$(BridgeHost)</Value>
-        <DefaultValue>localhost</DefaultValue>
-      </TestProperty>
-      <TestProperty Include="BridgePort">
-        <Value>$(BridgePort)</Value>
-        <DefaultValue>44283</DefaultValue>
-      </TestProperty>
-      <TestProperty Include="BridgeHttpPort">
-        <Value>$(BridgeHttpPort)</Value>
-        <DefaultValue>8081</DefaultValue>
-      </TestProperty>
-      <TestProperty Include="BridgeHttpsPort">
-        <Value>$(BridgeHttpsPort)</Value>
-        <DefaultValue>44285</DefaultValue>
-      </TestProperty>
-      <TestProperty Include="BridgeTcpPort">
-        <Value>$(BridgeTcpPort)</Value>
-        <DefaultValue>809</DefaultValue>
-      </TestProperty>
-      <TestProperty Include="BridgeWebSocketPort">
-        <Value>$(BridgeWebSocketPort)</Value>
-        <DefaultValue>8083</DefaultValue>
-      </TestProperty>
-      <TestProperty Include="BridgeSecureWebSocketPort">
-        <Value>$(BridgeSecureWebSocketPort)</Value>
-        <DefaultValue>8084</DefaultValue>
-      </TestProperty>
-      <TestProperty Include="BridgeRemoteEnabled">
-        <Value>$(BridgeRemoteEnabled)</Value>
-        <DefaultValue>false</DefaultValue>
-      </TestProperty>
-      <TestProperty Include="BridgeCertificatePassword">
-        <Value>$(BridgeCertificatePassword)</Value>
-        <DefaultValue>test</DefaultValue>
-      </TestProperty>
-      <TestProperty Include="BridgeCertificateValidityPeriod">
-        <Value>$(BridgeCertificateValidityPeriod)</Value>
-        <DefaultValue>7.00:00:00</DefaultValue>
-      </TestProperty>
-      <TestProperty Include="UseFiddlerUrl">
-        <Value>$(UseFiddlerUrl)</Value>
-        <DefaultValue>false</DefaultValue>
-      </TestProperty>
-      <TestProperty Include="BridgeMaxIdleTimeSpan">
-        <Value>$(BridgeMaxIdleTimeSpan)</Value>
-        <DefaultValue>24:00:00</DefaultValue>
-      </TestProperty>
-      <TestProperty Include="MaxTestTimeSpan">
-        <Value>$(MaxTestTimeSpan)</Value>
-        <DefaultValue>00:01:00</DefaultValue>
-      </TestProperty>
-    </ItemGroup>
 
+
+    <!-- Set default values for any TestProperties not already specified.
+           When adding or removing TestProperties, update testproperties.targets
+           to generate code at build time.
+    -->
+    <PropertyGroup Condition="'$(BridgeResourceFolder)' == ''">
+      <BridgeResourceFolder>$(OutputPath)</BridgeResourceFolder>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(BridgeHost)' == ''">
+      <BridgeHost>localhost</BridgeHost>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(BridgePort)' == ''">
+      <BridgePort>44283</BridgePort>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(BridgeHttpPort)' == ''">
+      <BridgeHttpPort>8081</BridgeHttpPort>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(BridgeHttpsPort)' == ''">
+      <BridgeHttpsPort>44285</BridgeHttpsPort>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(BridgeTcpPort)' == ''">
+      <BridgeTcpPort>809</BridgeTcpPort>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(BridgeWebSocketPort)' == ''">
+      <BridgeWebSocketPort>8083</BridgeWebSocketPort>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(BridgeSecureWebSocketPort)' == ''">
+      <BridgeSecureWebSocketPort>8084</BridgeSecureWebSocketPort>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(BridgeRemoteEnabled)' == ''">
+      <BridgeRemoteEnabled>false</BridgeRemoteEnabled>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(BridgeCertificatePassword)' == ''">
+      <BridgeCertificatePassword>test</BridgeCertificatePassword>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(BridgeCertificateValidityPeriod)' == ''">
+      <BridgeCertificateValidityPeriod>7.00:00:00</BridgeCertificateValidityPeriod>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(UseFiddlerUrl)' == ''">
+      <UseFiddlerUrl>false</UseFiddlerUrl>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(BridgeMaxIdleTimeSpan)' == ''">
+      <BridgeMaxIdleTimeSpan>24:00:00</BridgeMaxIdleTimeSpan>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(MaxTestTimeSpan)' == ''">
+      <MaxTestTimeSpan>00:01:00</MaxTestTimeSpan>
+    </PropertyGroup>
+  
   <!--
      GeneratedTestPropertiesFileName:
      The full path of the C# file that will be generated at build time to

--- a/src/System.Private.ServiceModel/tests/Common/Infrastructure/src/testproperties.targets
+++ b/src/System.Private.ServiceModel/tests/Common/Infrastructure/src/testproperties.targets
@@ -1,115 +1,85 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-
-  <!-- 
-    CreateTestPropertiesFile:
-      This task generates a C# file to initialize the TestProperties.Properties
-      dictionary with the provided name/value pairs.
-      FileName :          the full name of the file to generate
-      TestPropertyItems : item collection of name/value pairs to generate
-                          name = item.ItemSpec
-                          value = item's metadata for "Value" or "DefaultValue" if "Value" is blank
+  <!--
+    $(_TestPropertyCode):
+      Contains the code that will be created at build time
+      and added to the @(Compile) collection to be compiled.  It exists so that
+      any of these special MSBuild properties or environment variables are captured
+      at build time into the test binaries.  This allows those binaries to execute
+      on other machines and use the variable properties specified at build time.
+      If any items are added to testproperties.props, please update this file as well 
+      to generate a property name and dictionary entry for it.
   -->
-  <UsingTask TaskName="CreateTestPropertiesFile" TaskFactory="CodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.v12.0.dll">
-    <ParameterGroup>
-      <FileName ParameterType="System.String" Required="true" />
-      <TestPropertyItems ParameterType="Microsoft.Build.Framework.ITaskItem[]" Required="true" />
-    </ParameterGroup>
-    <Task>
-      <Reference Include="System" />
-      <Reference Include="System.IO" />
-      <Code Type="Fragment" Language="cs">
-        <![CDATA[
-        
-        // In some build environments, paths such as $(OutputPath) are
-        // not created prior to starting the build.  So we may find
-        // we need to create the folder for the generated file.
-        string outputFolder = Path.GetDirectoryName(FileName);
-        if (!Directory.Exists(outputFolder))
-        {
-            Log.LogMessage("Creating output folder {0}", outputFolder);
-            Directory.CreateDirectory(outputFolder);
-        }
-
-        StringBuilder sb = new StringBuilder();
-	      sb.AppendLine(
- @"using System.Collections.Generic;
+  <PropertyGroup>
+    <_TestPropertyCode>
+      <![CDATA[
+using System.Collections.Generic%3B
 namespace Infrastructure.Common
 {
     public static partial class TestProperties
-    {");
-        
-        // Generate a string for each property name.
-        // Code accessing the properties should use these generated names.
-        foreach (var item in TestPropertyItems)
+    {
+        public static readonly string BridgeResourceFolder_PropertyName = "BridgeResourceFolder"%3B
+        public static readonly string BridgeHost_PropertyName = "BridgeHost"%3B
+        public static readonly string BridgePort_PropertyName = "BridgePort"%3B
+        public static readonly string BridgeHttpPort_PropertyName = "BridgeHttpPort"%3B
+        public static readonly string BridgeHttpsPort_PropertyName = "BridgeHttpsPort"%3B
+        public static readonly string BridgeTcpPort_PropertyName = "BridgeTcpPort"%3B
+        public static readonly string BridgeWebSocketPort_PropertyName = "BridgeWebSocketPort"%3B
+        public static readonly string BridgeSecureWebSocketPort_PropertyName = "BridgeSecureWebSocketPort"%3B
+        public static readonly string BridgeRemoteEnabled_PropertyName = "BridgeRemoteEnabled"%3B
+        public static readonly string BridgeCertificatePassword_PropertyName = "BridgeCertificatePassword"%3B
+        public static readonly string BridgeCertificateValidityPeriod_PropertyName = "BridgeCertificateValidityPeriod"%3B
+        public static readonly string UseFiddlerUrl_PropertyName = "UseFiddlerUrl"%3B
+        public static readonly string BridgeMaxIdleTimeSpan_PropertyName = "BridgeMaxIdleTimeSpan"%3B
+        public static readonly string MaxTestTimeSpan_PropertyName = "MaxTestTimeSpan"%3B
+        static partial void Initialize(Dictionary<string, string> properties)
         {
-            sb.AppendLine(String.Format("        public static readonly string {0}_PropertyName = \"{0}\";", item.ItemSpec));
+            properties["BridgeResourceFolder"] = @"$(BridgeResourceFolder)"%3B
+            properties["BridgeHost"] = "$(BridgeHost)"%3B
+            properties["BridgePort"] = "$(BridgePort)"%3B
+            properties["BridgeHttpPort"] = "$(BridgeHttpPort)"%3B
+            properties["BridgeHttpsPort"] = "$(BridgeHttpsPort)"%3B
+            properties["BridgeTcpPort"] = "$(BridgeTcpPort)"%3B
+            properties["BridgeWebSocketPort"] = "$(BridgeWebSocketPort)"%3B
+            properties["BridgeSecureWebSocketPort"] = "$(BridgeSecureWebSocketPort)"%3B
+            properties["BridgeRemoteEnabled"] = "$(BridgeRemoteEnabled)"%3B
+            properties["BridgeCertificatePassword"] = "$(BridgeCertificatePassword)"%3B
+            properties["BridgeCertificateValidityPeriod"] = "$(BridgeCertificateValidityPeriod)"%3B
+            properties["UseFiddlerUrl"] = "$(UseFiddlerUrl)"%3B
+            properties["BridgeMaxIdleTimeSpan"] = "$(BridgeMaxIdleTimeSpan)"%3B
+            properties["MaxTestTimeSpan"] = "$(MaxTestTimeSpan)"%3B
         }
-        
-        // Generate the Initialize partial method to populate the dictionary
-        sb.AppendLine(
-@"        static partial void Initialize(Dictionary<string, string> properties)
-        {");
-                
-        foreach (var item in TestPropertyItems)
-        {
-            string propertyName = item.ItemSpec;
-            string propertyValue = item.GetMetadata("Value");
-            if (String.IsNullOrEmpty(propertyValue))
-            {
-                propertyValue = item.GetMetadata("DefaultValue");
-            }
-         
-            // Convert the property value into a legal string literal.     
-            StringBuilder literal = new StringBuilder();       
-            foreach (var c in propertyValue)
-            {
-                switch (c)
-                {
-                    case '\'': literal.Append(@"\'"); break;
-                    case '\"': literal.Append("\\\""); break;
-                    case '\\': literal.Append(@"\\"); break;
-                    default:
-                        if (c >= 0x20 && c <= 0x7e)
-                        {
-                            // ASCII printable character
-                            literal.Append(c);
-                        }
-                        else
-                        {
-                            // As UTF16 escaped character
-                            literal.AppendFormat(@"\u{0:x4}", (int)c);
-                        }
-                        break;
-                }
-            }
-            
-            string setStatement = String.Format("            properties[\"{0}\"] = \"{1}\";", propertyName, literal.ToString());
-            Log.LogMessage(setStatement);
-            sb.AppendLine(setStatement);
-        }
-            
-	      sb.AppendLine(
- @"        }
     }
-}");
-        
-        // Do not rewrite file if there are no changes.  This permits incremental builds.
-        string contentsToWrite = sb.ToString();
-        string priorContents = File.Exists(FileName) ? File.ReadAllText(FileName) : String.Empty;
-        if (!String.Equals(contentsToWrite, priorContents))
-        {
-            Log.LogMessage("Test properties were generated to {0}.", FileName);
-            File.WriteAllText(FileName, sb.ToString());
-        }
-        else
-        {
-             Log.LogMessage("No changes were made to the existing file {0}", FileName);
-        }
-        ]]>
-      </Code>
-    </Task>
-  </UsingTask>
+}
+                ]]>
+    </_TestPropertyCode>
+  </PropertyGroup>
+
+  <!-- 
+    SanitizeTestProperties:
+      This target ensures the test property values are sanitized for proper
+      evaluation at runtime.
+  -->
+  <Target Name="SanitizeTestProperties">
+    <!-- BridgeResourceFolder needs to convert forward slashes to backward
+         slashes to be usable on Windows, where the Bridge runs.
+    -->
+    <PropertyGroup Condition="$(BridgeResourceFolder.Contains('/'))">
+      <BridgeResourceFolder>$(BridgeResourceFolder.Replace('/', '\'))</BridgeResourceFolder>
+    </PropertyGroup>
+  </Target>
+  
+  <!-- 
+    CreateTestPropertiesFile:
+      This target writes the test properties to the file specified by
+      $(GeneratedTestPropertiesFileName) if it does not already exist.
+  -->
+  <Target Name="CreateTestPropertiesFile" Condition="!Exists('$(GeneratedTestPropertiesFileName)')">
+    <WriteLinesToFile
+        File="$(GeneratedTestPropertiesFileName)"
+        Lines="$(_TestPropertyCode)"
+        Overwrite="true"/>
+  </Target>
 
   <!--
     CreateTestProperties:
@@ -119,17 +89,16 @@ namespace Infrastructure.Common
       properties in TestProperties.Properties should use these generated
       names rather than separate string literals.
   -->
-  <Target Name="CreateTestProperties">
-
-    <!-- Generate the file (will be a NOP if file exists and doesn't need to change) -->
-    <CreateTestPropertiesFile FileName ="$(GeneratedTestPropertiesFileName)" TestPropertyItems="@(TestProperty)"/>
-
+  <Target Name="CreateTestProperties" DependsOnTargets="SanitizeTestProperties;CreateTestPropertiesFile">
+    
+    <Message Text="CreateTestProperties is using the generated test property file at $(GeneratedTestPropertiesFileName)" />
+    
     <!-- Add the generated file to the @(Compile) collection so it gets built. -->
     <ItemGroup>
       <Compile Include="$(GeneratedTestPropertiesFileName)" />
     </ItemGroup>
-
   </Target>
+
 </Project>
 
 


### PR DESCRIPTION
The CodeTaskFactory feature is not supported in the CoreCLR
version of MsBuild.  This resulted in build failure on Linux
when we attempted to code-gen TestProperties building
tests/Common/Infrastructure.

This PR eliminates the use of CodeTaskFactory and massively
simplifies code generation to a single CDATA section.