### PR TITLE
Enable ChannelFactory to use async close of inner channel factory

### DIFF
--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/ChannelFactoryBase.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/ChannelFactoryBase.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace System.ServiceModel.Channels
 {
-    public abstract class ChannelFactoryBase : ChannelManagerBase, IChannelFactory
+    public abstract class ChannelFactoryBase : ChannelManagerBase, IChannelFactory, IAsyncChannelFactory
     {
         private TimeSpan _closeTimeout = ServiceDefaults.CloseTimeout;
         private TimeSpan _openTimeout = ServiceDefaults.OpenTimeout;


### PR DESCRIPTION
Problem: ChannelFactory's async close was invoking its inner channelfactory's
async close only if it implemented IAsyncChannelFactory, otherwise it used
the synchronous close.  This led to stress issues where asynchonous closes
blocked threads.

Solution: make all channel factories declare they implement IAsyncChannelFactory.
IAsyncChannelFactory is only a tagging interface that wraps IChannelFactory and
IAsyncCommunicationObject.  And in practice, all channel factories were already
implementing both IChannelFactory as well as IAsyncCommunicationObject (because
their base class is CommunicationObject).  So the fix was only to add
IAsyncChannelFactory to their list of implemented interfaces.  This allowed
ChannelFactory to be able to call through to the async close on the base class
CommunicationObject.

Fixes #819