### PR TITLE
Map ERROR_INVALID_HANDLE to EndpointNotFoundException

### DIFF
--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/HttpChannelHelpers.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/HttpChannelHelpers.cs
@@ -134,6 +134,8 @@ namespace System.ServiceModel.Channels
                     goto case WININET_E_CONNECTION_RESET;
                 case WININET_E_CONNECTION_RESET:
                     return new CommunicationException(SR.Format(SR.HttpReceiveFailure, request.RequestUri), exception);
+                // Linux HttpClient returns ERROR_INVALID_HANDLE in the endpoint-not-found case, so map to EndpointNotFoundException
+                case UnsafeNativeMethods.ERROR_INVALID_HANDLE:
                 case WININET_E_NAME_NOT_RESOLVED:
                     return new EndpointNotFoundException(SR.Format(SR.EndpointNotFound, request.RequestUri.AbsoluteUri), exception);
                 case ERROR_WINHTTP_SECURE_FAILURE:


### PR DESCRIPTION
On Linux, HttpClient returns an HResult with ERROR_INVALID_HANDLE
attempting to access an endpoint it cannot find. As a result, we
throw CommunicationException rather than EndpointNotFoundException.

This is inconsistent with Windows behavior and breaks a scenario
test for this case.

Until CoreFx provides a common way to map HResults to a predictable
set of values across platforms, we must map this specific HResult
manually in our exception conversion helpers.

Fixes #419