### PR TITLE
NegotiateStream tests

### DIFF
--- a/src/System.Private.ServiceModel/src/System/ServiceModel/SpnEndpointIdentity.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/SpnEndpointIdentity.cs
@@ -44,8 +44,7 @@ namespace System.ServiceModel
                         new ArgumentOutOfRangeException("value", value.Ticks, SR.Format(SR.ValueMustBeNonNegative)));
                 }
                 _spnLookupTime = value;
-            }
+            }            
         }
-
     }
 }

--- a/src/System.Private.ServiceModel/tests/Common/Infrastructure/src/testproperties.props
+++ b/src/System.Private.ServiceModel/tests/Common/Infrastructure/src/testproperties.props
@@ -61,7 +61,31 @@
     <PropertyGroup Condition="'$(MaxTestTimeSpan)' == ''">
       <MaxTestTimeSpan>00:01:00</MaxTestTimeSpan>
     </PropertyGroup>
-  
+
+    <PropertyGroup Condition="'$(NegotiateTestRealm)' == ''">
+      <NegotiateTestRealm>DOMAIN.CONTOSO.COM</NegotiateTestRealm>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(NegotiateTestDomain)' == ''">
+      <NegotiateTestDomain>DOMAIN</NegotiateTestDomain>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(NegotiateTestUserName)' == ''">
+      <NegotiateTestUserName>testuser</NegotiateTestUserName>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(NegotiateTestPassword)' == ''">
+      <NegotiateTestPassword>hunter2</NegotiateTestPassword>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(NegotiateTestSpn)' == ''">
+      <NegotiateTestSpn>testhost.domain.contoso.com</NegotiateTestSpn>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(NegotiateTestUpn)' == ''">
+      <NegotiateTestUpn>testuser@DOMAIN.CONTOSO.COM</NegotiateTestUpn>
+    </PropertyGroup>
+
   <!--
      GeneratedTestPropertiesFileName:
      The full path of the C# file that will be generated at build time to

--- a/src/System.Private.ServiceModel/tests/Common/Infrastructure/src/testproperties.targets
+++ b/src/System.Private.ServiceModel/tests/Common/Infrastructure/src/testproperties.targets
@@ -32,6 +32,13 @@ namespace Infrastructure.Common
         public static readonly string UseFiddlerUrl_PropertyName = "UseFiddlerUrl"%3B
         public static readonly string BridgeMaxIdleTimeSpan_PropertyName = "BridgeMaxIdleTimeSpan"%3B
         public static readonly string MaxTestTimeSpan_PropertyName = "MaxTestTimeSpan"%3B
+        public static readonly string NegotiateTestRealm_PropertyName = "NegotiateTestRealm"%3B
+        public static readonly string NegotiateTestDomain_PropertyName = "NegotiateTestDomain"%3B
+        public static readonly string NegotiateTestUserName_PropertyName = "NegotiateTestUserName"%3B
+        public static readonly string NegotiateTestPassword_PropertyName = "NegotiateTestPassword"%3B
+        public static readonly string NegotiateTestSpn_PropertyName = "NegotiateTestSpn"%3B
+        public static readonly string NegotiateTestUpn_PropertyName = "NegotiateTestUpn"%3B
+        
         static partial void Initialize(Dictionary<string, string> properties)
         {
             properties["BridgeResourceFolder"] = @"$(BridgeResourceFolder)"%3B
@@ -48,6 +55,12 @@ namespace Infrastructure.Common
             properties["UseFiddlerUrl"] = "$(UseFiddlerUrl)"%3B
             properties["BridgeMaxIdleTimeSpan"] = "$(BridgeMaxIdleTimeSpan)"%3B
             properties["MaxTestTimeSpan"] = "$(MaxTestTimeSpan)"%3B
+            properties["NegotiateTestRealm"] = "$(NegotiateTestRealm)"%3B
+            properties["NegotiateTestDomain"] = "$(NegotiateTestDomain)"%3B
+            properties["NegotiateTestUserName"] = "$(NegotiateTestUserName)"%3B
+            properties["NegotiateTestPassword"] = "$(NegotiateTestPassword)"%3B
+            properties["NegotiateTestSpn"] = "$(NegotiateTestSpn)"%3B
+            properties["NegotiateTestUpn"] = "$(NegotiateTestUpn)"%3B
         }
     }
 }

--- a/src/System.Private.ServiceModel/tests/Common/Infrastructure/tests/TestPropertiesTest.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Infrastructure/tests/TestPropertiesTest.cs
@@ -20,6 +20,9 @@ public static class TestPropertiesTest
         Assert.NotNull(TestProperties.BridgeHost_PropertyName);
         Assert.NotNull(TestProperties.BridgePort_PropertyName);
         Assert.NotNull(TestProperties.UseFiddlerUrl_PropertyName);
+        Assert.NotNull(TestProperties.NegotiateTestDomain_PropertyName);
+        Assert.NotNull(TestProperties.NegotiateTestUserName_PropertyName);
+        Assert.NotNull(TestProperties.NegotiateTestPassword_PropertyName);
     }
 
     [Fact]

--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Negotiate/NegotiateStreamTestConfiguration.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Negotiate/NegotiateStreamTestConfiguration.cs
@@ -1,0 +1,122 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+public static class NegotiateStreamTestConfiguration
+{
+    private static readonly string Default_NegotiateTestRealm = "DOMAIN.CONTOSO.COM";
+    private static readonly string Default_NegotiateTestDomain = "DOMAIN";
+    private static readonly string Default_NegotiateTestUserName = "testuser";
+    private static readonly string Default_NegotiateTestPassword = "hunter2";
+    private static readonly string Default_NegotiateTestSpn = "testhost.domain.contoso.com";
+    private static readonly string Default_NegotiateTestUpn = "testuser@DOMAIN.CONTOSO.COM";
+
+    // These property names must match the names used in TestProperties because
+    // that is the set of name/value pairs from which this type is created.
+    private const string NegotiateTestRealm_PropertyName = "NegotiateTestRealm";
+    private const string NegotiateTestDomain_PropertyName = "NegotiateTestDomain";
+    private const string NegotiateTestUserName_PropertyName = "NegotiateTestUserName";
+    private const string NegotiateTestPassword_PropertyName = "NegotiateTestPassword";
+    private const string NegotiateTestSpn_PropertyName = "NegotiateTestSpn";
+    private const string NegotiateTestUpn_PropertyName = "NegotiateTestUpn";
+
+    public static string NegotiateTestRealm { get; set; }
+    public static string NegotiateTestDomain { get; set; }
+    public static string NegotiateTestUserName { get; set; }
+    public static string NegotiateTestPassword { get; set; }
+    public static string NegotiateTestSpn { get; set; }
+    public static string NegotiateTestUpn { get; set; }
+
+    static NegotiateStreamTestConfiguration()
+    {
+        NegotiateTestRealm = Default_NegotiateTestRealm;
+        NegotiateTestDomain = Default_NegotiateTestDomain;
+        NegotiateTestUserName = Default_NegotiateTestUserName;
+        NegotiateTestPassword = Default_NegotiateTestPassword;
+        NegotiateTestSpn = Default_NegotiateTestSpn;
+        NegotiateTestUpn = Default_NegotiateTestUpn;
+    }
+
+    //public NegotiateStreamTestConfiguration(Dictionary<string, string> properties) 
+    //    : this(new NegotiateStreamTestConfiguration(), properties)
+    //{
+    //}
+
+    // This ctor accepts an existing BridgeConfiguration and a set of name/value pairs.
+    // It will create a new BridgeConfiguration instance that is a clone of the existing
+    // one and will overwrite any properties with corresponding entries found in the name/value pairs.
+    //public NegotiateStreamTestConfiguration(NegotiateStreamTestConfiguration configuration, Dictionary<string, string> properties)
+    //{
+    //    NegotiateTestRealm = configuration.NegotiateTestRealm;
+    //    NegotiateTestDomain = configuration.NegotiateTestDomain;
+    //    NegotiateTestUsername = configuration.NegotiateTestUsername;
+    //    NegotiateTestPassword = configuration.NegotiateTestPassword;
+    //    NegotiateTestSpn = configuration.NegotiateTestSpn;
+    //    NegotiateTestUpn = configuration.NegotiateTestUpn;
+
+    //    if (properties != null)
+    //    {
+    //        string propertyValue = null;
+
+    //        if (properties.TryGetValue(NegotiateTestRealm_PropertyName, out propertyValue))
+    //        {
+    //            NegotiateTestRealm = propertyValue;
+    //        }
+
+    //        if (properties.TryGetValue(NegotiateTestDomain_PropertyName, out propertyValue))
+    //        {
+    //            NegotiateTestDomain = propertyValue;
+    //        }
+
+    //        if (properties.TryGetValue(NegotiateTestUsername_PropertyName, out propertyValue))
+    //        {
+    //            NegotiateTestUsername = propertyValue;
+    //        }
+
+    //        if (properties.TryGetValue(NegotiateTestPassword_PropertyName, out propertyValue))
+    //        {
+    //            NegotiateTestPassword = propertyValue;
+    //        }
+
+    //        if (properties.TryGetValue(NegotiateTestSpn_PropertyName, out propertyValue))
+    //        {
+    //            NegotiateTestSpn = propertyValue;
+    //        }
+
+    //        if (properties.TryGetValue(NegotiateTestUpn_PropertyName, out propertyValue))
+    //        {
+    //            NegotiateTestUpn = propertyValue;
+    //        }
+    //    }
+    //}
+
+    public static Dictionary<string, string> ToDictionary()
+    {
+        Dictionary<string, string> result = new Dictionary<string, string>();
+        result[NegotiateTestRealm_PropertyName] = NegotiateTestRealm;
+        result[NegotiateTestDomain_PropertyName] = NegotiateTestDomain;
+        result[NegotiateTestUserName_PropertyName] = NegotiateTestUserName;
+        result[NegotiateTestPassword_PropertyName] = NegotiateTestPassword;
+        result[NegotiateTestSpn_PropertyName] = NegotiateTestSpn;
+        result[NegotiateTestUpn_PropertyName] = NegotiateTestUpn;
+        
+        return result;
+    }
+
+    public static new string ToString()
+    {
+        StringBuilder sb = new StringBuilder();
+        sb.AppendFormat("  {0} : '{1}'{2}", NegotiateTestRealm_PropertyName, NegotiateTestRealm, Environment.NewLine)
+          .AppendFormat("  {0} : '{1}'{2}", NegotiateTestDomain_PropertyName, NegotiateTestDomain, Environment.NewLine)
+          .AppendFormat("  {0} : '{1}'{2}", NegotiateTestUserName_PropertyName, NegotiateTestUserName, Environment.NewLine)
+          .AppendFormat("  {0} : '{1}'{2}", NegotiateTestPassword_PropertyName, NegotiateTestPassword, Environment.NewLine)
+          .AppendFormat("  {0} : '{1}'{2}", NegotiateTestSpn_PropertyName, NegotiateTestSpn, Environment.NewLine)
+          .AppendFormat("  {0} : '{1}'{2}", NegotiateTestUpn_PropertyName, NegotiateTestUpn, Environment.NewLine);
+        return sb.ToString();
+    }
+}

--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Negotiate/NegotiateStreamTestConfiguration.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Negotiate/NegotiateStreamTestConfiguration.cs
@@ -6,15 +6,16 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using Infrastructure.Common;
 
-public static class NegotiateStreamTestConfiguration
+public class NegotiateStreamTestConfiguration
 {
-    private static readonly string Default_NegotiateTestRealm = "DOMAIN.CONTOSO.COM";
-    private static readonly string Default_NegotiateTestDomain = "DOMAIN";
-    private static readonly string Default_NegotiateTestUserName = "testuser";
-    private static readonly string Default_NegotiateTestPassword = "hunter2";
-    private static readonly string Default_NegotiateTestSpn = "testhost.domain.contoso.com";
-    private static readonly string Default_NegotiateTestUpn = "testuser@DOMAIN.CONTOSO.COM";
+    //private static readonly string Default_NegotiateTestRealm = "DOMAIN.CONTOSO.COM";
+    //private static readonly string Default_NegotiateTestDomain = "DOMAIN";
+    //private static readonly string Default_NegotiateTestUserName = "testuser";
+    //private static readonly string Default_NegotiateTestPassword = "hunter2";
+    //private static readonly string Default_NegotiateTestSpn = "testhost.domain.contoso.com";
+    //private static readonly string Default_NegotiateTestUpn = "testuser@DOMAIN.CONTOSO.COM";
 
     // These property names must match the names used in TestProperties because
     // that is the set of name/value pairs from which this type is created.
@@ -25,77 +26,91 @@ public static class NegotiateStreamTestConfiguration
     private const string NegotiateTestSpn_PropertyName = "NegotiateTestSpn";
     private const string NegotiateTestUpn_PropertyName = "NegotiateTestUpn";
 
-    public static string NegotiateTestRealm { get; set; }
-    public static string NegotiateTestDomain { get; set; }
-    public static string NegotiateTestUserName { get; set; }
-    public static string NegotiateTestPassword { get; set; }
-    public static string NegotiateTestSpn { get; set; }
-    public static string NegotiateTestUpn { get; set; }
+    public string NegotiateTestRealm { get; set; }
+    public string NegotiateTestDomain { get; set; }
+    public string NegotiateTestUserName { get; set; }
+    public string NegotiateTestPassword { get; set; }
+    public string NegotiateTestSpn { get; set; }
+    public string NegotiateTestUpn { get; set; }
 
-    static NegotiateStreamTestConfiguration()
+    private static NegotiateStreamTestConfiguration s_instance; 
+
+    private NegotiateStreamTestConfiguration()
     {
-        NegotiateTestRealm = Default_NegotiateTestRealm;
-        NegotiateTestDomain = Default_NegotiateTestDomain;
-        NegotiateTestUserName = Default_NegotiateTestUserName;
-        NegotiateTestPassword = Default_NegotiateTestPassword;
-        NegotiateTestSpn = Default_NegotiateTestSpn;
-        NegotiateTestUpn = Default_NegotiateTestUpn;
+        NegotiateTestRealm = TestProperties.GetProperty(NegotiateTestRealm_PropertyName); 
+        NegotiateTestDomain = TestProperties.GetProperty(NegotiateTestDomain_PropertyName);
+        NegotiateTestUserName = TestProperties.GetProperty(NegotiateTestUserName_PropertyName);
+        NegotiateTestPassword = TestProperties.GetProperty(NegotiateTestPassword_PropertyName);
+        NegotiateTestSpn = TestProperties.GetProperty(NegotiateTestSpn_PropertyName);
+        NegotiateTestUpn = TestProperties.GetProperty(NegotiateTestUpn_PropertyName);
     }
 
-    //public NegotiateStreamTestConfiguration(Dictionary<string, string> properties) 
-    //    : this(new NegotiateStreamTestConfiguration(), properties)
-    //{
-    //}
+    public static NegotiateStreamTestConfiguration Instance
+    {
+        get
+        {
+            if (s_instance == null)
+            {
+                s_instance = new NegotiateStreamTestConfiguration(); 
+            }
+            return s_instance;
+        }
+    }
 
-    // This ctor accepts an existing BridgeConfiguration and a set of name/value pairs.
-    // It will create a new BridgeConfiguration instance that is a clone of the existing
+    public NegotiateStreamTestConfiguration(Dictionary<string, string> properties)
+        : this(new NegotiateStreamTestConfiguration(), properties)
+    {
+    }
+
+    // This ctor accepts an existing Configuration and a set of name/value pairs.
+    // It will create a new Configuration instance that is a clone of the existing
     // one and will overwrite any properties with corresponding entries found in the name/value pairs.
-    //public NegotiateStreamTestConfiguration(NegotiateStreamTestConfiguration configuration, Dictionary<string, string> properties)
-    //{
-    //    NegotiateTestRealm = configuration.NegotiateTestRealm;
-    //    NegotiateTestDomain = configuration.NegotiateTestDomain;
-    //    NegotiateTestUsername = configuration.NegotiateTestUsername;
-    //    NegotiateTestPassword = configuration.NegotiateTestPassword;
-    //    NegotiateTestSpn = configuration.NegotiateTestSpn;
-    //    NegotiateTestUpn = configuration.NegotiateTestUpn;
+    public NegotiateStreamTestConfiguration(NegotiateStreamTestConfiguration configuration, Dictionary<string, string> properties)
+    {
+        NegotiateTestRealm = configuration.NegotiateTestRealm;
+        NegotiateTestDomain = configuration.NegotiateTestDomain;
+        NegotiateTestUserName = configuration.NegotiateTestUserName;
+        NegotiateTestPassword = configuration.NegotiateTestPassword;
+        NegotiateTestSpn = configuration.NegotiateTestSpn;
+        NegotiateTestUpn = configuration.NegotiateTestUpn;
 
-    //    if (properties != null)
-    //    {
-    //        string propertyValue = null;
+        if (properties != null)
+        {
+            string propertyValue = null;
 
-    //        if (properties.TryGetValue(NegotiateTestRealm_PropertyName, out propertyValue))
-    //        {
-    //            NegotiateTestRealm = propertyValue;
-    //        }
+            if (properties.TryGetValue(NegotiateTestRealm_PropertyName, out propertyValue))
+            {
+                NegotiateTestRealm = propertyValue;
+            }
 
-    //        if (properties.TryGetValue(NegotiateTestDomain_PropertyName, out propertyValue))
-    //        {
-    //            NegotiateTestDomain = propertyValue;
-    //        }
+            if (properties.TryGetValue(NegotiateTestDomain_PropertyName, out propertyValue))
+            {
+                NegotiateTestDomain = propertyValue;
+            }
 
-    //        if (properties.TryGetValue(NegotiateTestUsername_PropertyName, out propertyValue))
-    //        {
-    //            NegotiateTestUsername = propertyValue;
-    //        }
+            if (properties.TryGetValue(NegotiateTestUserName_PropertyName, out propertyValue))
+            {
+                NegotiateTestUserName = propertyValue;
+            }
 
-    //        if (properties.TryGetValue(NegotiateTestPassword_PropertyName, out propertyValue))
-    //        {
-    //            NegotiateTestPassword = propertyValue;
-    //        }
+            if (properties.TryGetValue(NegotiateTestPassword_PropertyName, out propertyValue))
+            {
+                NegotiateTestPassword = propertyValue;
+            }
 
-    //        if (properties.TryGetValue(NegotiateTestSpn_PropertyName, out propertyValue))
-    //        {
-    //            NegotiateTestSpn = propertyValue;
-    //        }
+            if (properties.TryGetValue(NegotiateTestSpn_PropertyName, out propertyValue))
+            {
+                NegotiateTestSpn = propertyValue;
+            }
 
-    //        if (properties.TryGetValue(NegotiateTestUpn_PropertyName, out propertyValue))
-    //        {
-    //            NegotiateTestUpn = propertyValue;
-    //        }
-    //    }
-    //}
+            if (properties.TryGetValue(NegotiateTestUpn_PropertyName, out propertyValue))
+            {
+                NegotiateTestUpn = propertyValue;
+            }
+        }
+    }
 
-    public static Dictionary<string, string> ToDictionary()
+    public Dictionary<string, string> ToDictionary()
     {
         Dictionary<string, string> result = new Dictionary<string, string>();
         result[NegotiateTestRealm_PropertyName] = NegotiateTestRealm;
@@ -108,7 +123,7 @@ public static class NegotiateStreamTestConfiguration
         return result;
     }
 
-    public static new string ToString()
+    public override string ToString()
     {
         StringBuilder sb = new StringBuilder();
         sb.AppendFormat("  {0} : '{1}'{2}", NegotiateTestRealm_PropertyName, NegotiateTestRealm, Environment.NewLine)

--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Negotiate/NegotiateStream_Http_Tests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Negotiate/NegotiateStream_Http_Tests.cs
@@ -1,0 +1,301 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Infrastructure.Common;
+using System;
+using System.Security.Cryptography.X509Certificates;
+using System.ServiceModel;
+using System.ServiceModel.Channels;
+using System.ServiceModel.Security;
+using Xunit;
+
+public static class NegotiateStream_Http_Tests
+{
+    // The tests are as follows:
+    //
+    // NegotiateStream_*_AmbientCredentials
+    //     Windows: This should pass by default without any code changes
+    //       Linux: This should not pass by default 
+    //              Run 'kinit user@DC.DOMAIN.COM' before running this test to use ambient credentials
+    //              ('DC.DOMAIN.COM' must be in capital letters) 
+    //              If previous tests were run, it may be necessary to run 'kdestroy -A' to remove all
+    //              prior Kerberos tickets
+    // 
+    // NegotiateStream_*_With_ExplicitUserNameAndPassword
+    //     Windows: Edit the s_UserName and s_Password variables to a user valid on your Kerberos realm
+    //       Linux: Edit the s_UserName and s_Password variables to a user valid on your Kerberos realm
+    //              If previous tests were run, it may be necessary to run 'kdestroy -A' to remove all
+    //              prior Kerberos tickets
+    // 
+    // NegotiateStream_*_With_ExplicitSpn
+    //     Windows: Edit the s_Spn variable to match a valid SPN for the server 
+    //       Linux: Edit the s_Spn variable to match a valid SPN for the server 
+    //   
+    //     By default, the SPN is the same as the host's fully qualified domain name, for example, 
+    //     'host.domain.com'
+    //     On a Windows host, one has to register the SPN using 'setspn', or run the process as LOCAL SYSTEM
+    //     by using a tool like psexec and running 'psexec -s -h <WcfBridge.exe>' 
+    // 
+    // NegotiateStream_*_With_Upn
+    //     Windows: Edit the s_Upn field to match a valid UPN for the server in the form of 
+    //              'user@DOMAIN.COM'
+    //       Linux: This scenario is not yet supported - dotnet/corefx#6606
+    //
+    // NegotiateStream_*_With_ExplicitUserNameAndPassword_With_Spn
+    //     Windows: Edit the s_Spn variable to match a valid SPN for the server
+    //              Edit the s_UserName and s_Password variables to a user valid on your Kerberos realm
+    //       Linux: Edit the s_Spn variable to match a valid SPN for the server
+    //              Edit the s_UserName and s_Password variables to a user valid on your Kerberos realm
+    // 
+    // NegotiateStream_*_With_ExplicitUserNameAndPassword_With_Upn
+    //     Windows: Edit the s_Upn variable to match a valid UPN for the server
+    //              Edit the s_UserName and s_Password variables to a user valid on your Kerberos realm
+    //       Linux: This scenario is not yet supported - dotnet/corefx#6606
+
+    private const string s_Domain = "domain";
+    private const string s_Username = "azureuser";
+    private const string s_Password = "hunter2";
+    private const string s_Spn = "host";
+    private const string s_Upn = "azureuser@DOMAIN.COM";
+
+    // These tests are used for testing NegotiateStream (SecurityMode.Transport) 
+
+    [Fact]
+    [ActiveIssue(851, PlatformID.AnyUnix)]
+    [OuterLoop]
+    public static void NegotiateStream_Http_AmbientCredentials()
+    {
+        string testString = "Hello";
+        ChannelFactory<IWcfService> factory = null;
+        IWcfService serviceProxy = null;
+
+        try
+        {
+            // *** SETUP *** \\
+            BasicHttpBinding binding = new BasicHttpBinding(BasicHttpSecurityMode.Transport);
+            factory = new ChannelFactory<IWcfService>(
+                binding, 
+                new EndpointAddress(Endpoints.Https_WindowsAuth_Address));
+            serviceProxy = factory.CreateChannel();
+
+            // *** EXECUTE *** \\
+            string result = serviceProxy.Echo(testString);
+
+            // *** VALIDATE *** \\
+            Assert.Equal(testString, result);
+
+            // *** CLEANUP *** \\
+            ((ICommunicationObject)serviceProxy).Close();
+            factory.Close();
+        }
+        finally
+        {
+            // *** ENSURE CLEANUP *** \\
+            ScenarioTestHelpers.CloseCommunicationObjects((ICommunicationObject)serviceProxy, factory);
+        }
+    }
+
+    [Fact]
+    [ActiveIssue(851)]
+    [OuterLoop]
+    public static void NegotiateStream_Http_With_ExplicitUserNameAndPassword()
+    {
+        string testString = "Hello";
+        ChannelFactory<IWcfService> factory = null;
+        IWcfService serviceProxy = null;
+
+        try
+        {
+            // *** SETUP *** \\
+            BasicHttpBinding binding = new BasicHttpBinding(BasicHttpSecurityMode.Transport);
+            factory = new ChannelFactory<IWcfService>(
+                binding, 
+                new EndpointAddress(Endpoints.Https_WindowsAuth_Address));
+
+            factory.Credentials.Windows.ClientCredential.Domain = s_Domain;
+            factory.Credentials.Windows.ClientCredential.UserName = s_Username;
+            factory.Credentials.Windows.ClientCredential.Password = s_Password;
+
+            serviceProxy = factory.CreateChannel();
+
+            // *** EXECUTE *** \\
+            string result = serviceProxy.Echo(testString);
+
+            // *** VALIDATE *** \\
+            Assert.Equal(testString, result);
+
+            // *** CLEANUP *** \\
+            ((ICommunicationObject)serviceProxy).Close();
+            factory.Close();
+        }
+        finally
+        {
+            // *** ENSURE CLEANUP *** \\
+            ScenarioTestHelpers.CloseCommunicationObjects((ICommunicationObject)serviceProxy, factory);
+        }
+    }
+
+    [Fact]
+    [ActiveIssue(851)]
+    [OuterLoop]
+    public static void NegotiateStream_Http_With_ExplicitSpn()
+    {
+        string testString = "Hello";
+        ChannelFactory<IWcfService> factory = null;
+        IWcfService serviceProxy = null;
+
+        try
+        {
+            // *** SETUP *** \\
+            BasicHttpBinding binding = new BasicHttpBinding(BasicHttpSecurityMode.Transport);
+            factory = new ChannelFactory<IWcfService>(
+                binding,
+                new EndpointAddress(
+                    new Uri(Endpoints.Https_WindowsAuth_Address),
+                    new SpnEndpointIdentity(s_Spn)
+            ));
+
+            serviceProxy = factory.CreateChannel();
+
+            // *** EXECUTE *** \\
+            string result = serviceProxy.Echo(testString);
+
+            // *** VALIDATE *** \\
+            Assert.Equal(testString, result);
+
+            // *** CLEANUP *** \\
+            ((ICommunicationObject)serviceProxy).Close();
+            factory.Close();
+        }
+        finally
+        {
+            // *** ENSURE CLEANUP *** \\
+            ScenarioTestHelpers.CloseCommunicationObjects((ICommunicationObject)serviceProxy, factory);
+        }
+    }
+
+    [Fact]
+    [ActiveIssue(851)]
+    [OuterLoop]
+    public static void NegotiateStream_Http_With_Upn()
+    {
+        string testString = "Hello";
+        ChannelFactory<IWcfService> factory = null;
+        IWcfService serviceProxy = null;
+
+        try
+        {
+            // *** SETUP *** \\
+            BasicHttpBinding binding = new BasicHttpBinding(BasicHttpSecurityMode.Transport);
+            factory = new ChannelFactory<IWcfService>(
+                binding,
+                new EndpointAddress(
+                    new Uri(Endpoints.Https_WindowsAuth_Address),
+                    new UpnEndpointIdentity(s_Upn)
+            ));
+
+            serviceProxy = factory.CreateChannel();
+
+            // *** EXECUTE *** \\
+            string result = serviceProxy.Echo(testString);
+
+            // *** VALIDATE *** \\
+            Assert.Equal(testString, result);
+
+            // *** CLEANUP *** \\
+            ((ICommunicationObject)serviceProxy).Close();
+            factory.Close();
+        }
+        finally
+        {
+            // *** ENSURE CLEANUP *** \\
+            ScenarioTestHelpers.CloseCommunicationObjects((ICommunicationObject)serviceProxy, factory);
+        }
+    }
+
+    [Fact]
+    [ActiveIssue(851)]
+    [OuterLoop]
+    public static void NegotiateStream_Http_With_ExplicitUserNameAndPassword_With_Spn()
+    {
+        string testString = "Hello";
+        ChannelFactory<IWcfService> factory = null;
+        IWcfService serviceProxy = null;
+
+        try
+        {
+            // *** SETUP *** \\
+            BasicHttpBinding binding = new BasicHttpBinding(BasicHttpSecurityMode.Transport);
+            factory = new ChannelFactory<IWcfService>(
+                binding,
+                new EndpointAddress(
+                    new Uri(Endpoints.Https_WindowsAuth_Address),
+                    new SpnEndpointIdentity(s_Spn)
+            ));
+
+            factory.Credentials.Windows.ClientCredential.Domain = s_Domain;
+            factory.Credentials.Windows.ClientCredential.UserName = s_Username;
+            factory.Credentials.Windows.ClientCredential.Password = s_Password;
+
+            serviceProxy = factory.CreateChannel();
+
+            // *** EXECUTE *** \\
+            string result = serviceProxy.Echo(testString);
+
+            // *** VALIDATE *** \\
+            Assert.Equal(testString, result);
+
+            // *** CLEANUP *** \\
+            ((ICommunicationObject)serviceProxy).Close();
+            factory.Close();
+        }
+        finally
+        {
+            // *** ENSURE CLEANUP *** \\
+            ScenarioTestHelpers.CloseCommunicationObjects((ICommunicationObject)serviceProxy, factory);
+        }
+    }
+
+    [Fact]
+    [ActiveIssue(851)]
+    [OuterLoop]
+    public static void NegotiateStream_Http_With_ExplicitUserNameAndPassword_With_Upn()
+    {
+        string testString = "Hello";
+        ChannelFactory<IWcfService> factory = null;
+        IWcfService serviceProxy = null;
+
+        try
+        {
+            // *** SETUP *** \\
+            BasicHttpBinding binding = new BasicHttpBinding(BasicHttpSecurityMode.Transport);
+            factory = new ChannelFactory<IWcfService>(
+                binding,
+                new EndpointAddress(
+                    new Uri(Endpoints.Https_WindowsAuth_Address),
+                    new UpnEndpointIdentity(s_Upn)
+            ));
+
+            factory.Credentials.Windows.ClientCredential.Domain = s_Domain;
+            factory.Credentials.Windows.ClientCredential.UserName = s_Username;
+            factory.Credentials.Windows.ClientCredential.Password = s_Password;
+
+            serviceProxy = factory.CreateChannel();
+
+            // *** EXECUTE *** \\
+            string result = serviceProxy.Echo(testString);
+
+            // *** VALIDATE *** \\
+            Assert.Equal(testString, result);
+
+            // *** CLEANUP *** \\
+            ((ICommunicationObject)serviceProxy).Close();
+            factory.Close();
+        }
+        finally
+        {
+            // *** ENSURE CLEANUP *** \\
+            ScenarioTestHelpers.CloseCommunicationObjects((ICommunicationObject)serviceProxy, factory);
+        }
+    }
+}

--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Negotiate/NegotiateStream_Http_Tests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Negotiate/NegotiateStream_Http_Tests.cs
@@ -22,14 +22,14 @@ public static class NegotiateStream_Http_Tests
     //              prior Kerberos tickets
     // 
     // NegotiateStream_*_With_ExplicitUserNameAndPassword
-    //     Windows: Edit the s_UserName and s_Password variables to a user valid on your Kerberos realm
-    //       Linux: Edit the s_UserName and s_Password variables to a user valid on your Kerberos realm
+    //     Windows: Edit the NegotiateStreamTestConfiguration.UserName and .Password variables to a user valid on your Kerberos realm
+    //       Linux: Edit the NegotiateStreamTestConfiguration.UserName and .Password variables to a user valid on your Kerberos realm
     //              If previous tests were run, it may be necessary to run 'kdestroy -A' to remove all
     //              prior Kerberos tickets
     // 
     // NegotiateStream_*_With_ExplicitSpn
-    //     Windows: Edit the s_Spn variable to match a valid SPN for the server 
-    //       Linux: Edit the s_Spn variable to match a valid SPN for the server 
+    //     Windows: Edit the NegotiateStreamTestConfiguration.Spn variable to match a valid SPN for the server 
+    //       Linux: Edit the NegotiateStreamTestConfiguration.Spn variable to match a valid SPN for the server 
     //   
     //     By default, the SPN is the same as the host's fully qualified domain name, for example, 
     //     'host.domain.com'
@@ -37,26 +37,20 @@ public static class NegotiateStream_Http_Tests
     //     by using a tool like psexec and running 'psexec -s -h <WcfBridge.exe>' 
     // 
     // NegotiateStream_*_With_Upn
-    //     Windows: Edit the s_Upn field to match a valid UPN for the server in the form of 
+    //     Windows: Edit the NegotiateStreamTestConfiguration.Upn field to match a valid UPN for the server in the form of 
     //              'user@DOMAIN.COM'
     //       Linux: This scenario is not yet supported - dotnet/corefx#6606
     //
     // NegotiateStream_*_With_ExplicitUserNameAndPassword_With_Spn
-    //     Windows: Edit the s_Spn variable to match a valid SPN for the server
-    //              Edit the s_UserName and s_Password variables to a user valid on your Kerberos realm
-    //       Linux: Edit the s_Spn variable to match a valid SPN for the server
-    //              Edit the s_UserName and s_Password variables to a user valid on your Kerberos realm
+    //     Windows: Edit the NegotiateStreamTestConfiguration.Spn variable to match a valid SPN for the server
+    //              Edit the NegotiateStreamTestConfiguration.UserName and .Password variables to a user valid on your Kerberos realm
+    //       Linux: Edit the NegotiateStreamTestConfiguration.Spn variable to match a valid SPN for the server
+    //              Edit the NegotiateStreamTestConfiguration.UserName and .Password variables to a user valid on your Kerberos realm
     // 
     // NegotiateStream_*_With_ExplicitUserNameAndPassword_With_Upn
-    //     Windows: Edit the s_Upn variable to match a valid UPN for the server
-    //              Edit the s_UserName and s_Password variables to a user valid on your Kerberos realm
+    //     Windows: Edit the NegotiateStreamTestConfiguration.Upn variable to match a valid UPN for the server
+    //              Edit the NegotiateStreamTestConfiguration.UserName and .Password variables to a user valid on your Kerberos realm
     //       Linux: This scenario is not yet supported - dotnet/corefx#6606
-
-    private const string s_Domain = "domain";
-    private const string s_Username = "azureuser";
-    private const string s_Password = "hunter2";
-    private const string s_Spn = "host";
-    private const string s_Upn = "azureuser@DOMAIN.COM";
 
     // These tests are used for testing NegotiateStream (SecurityMode.Transport) 
 
@@ -112,9 +106,9 @@ public static class NegotiateStream_Http_Tests
                 binding, 
                 new EndpointAddress(Endpoints.Https_WindowsAuth_Address));
 
-            factory.Credentials.Windows.ClientCredential.Domain = s_Domain;
-            factory.Credentials.Windows.ClientCredential.UserName = s_Username;
-            factory.Credentials.Windows.ClientCredential.Password = s_Password;
+            factory.Credentials.Windows.ClientCredential.Domain = NegotiateStreamTestConfiguration.NegotiateTestDomain;
+            factory.Credentials.Windows.ClientCredential.UserName = NegotiateStreamTestConfiguration.NegotiateTestUserName;
+            factory.Credentials.Windows.ClientCredential.Password = NegotiateStreamTestConfiguration.NegotiateTestPassword;
 
             serviceProxy = factory.CreateChannel();
 
@@ -152,7 +146,7 @@ public static class NegotiateStream_Http_Tests
                 binding,
                 new EndpointAddress(
                     new Uri(Endpoints.Https_WindowsAuth_Address),
-                    new SpnEndpointIdentity(s_Spn)
+                    new SpnEndpointIdentity(NegotiateStreamTestConfiguration.NegotiateTestSpn)
             ));
 
             serviceProxy = factory.CreateChannel();
@@ -191,7 +185,7 @@ public static class NegotiateStream_Http_Tests
                 binding,
                 new EndpointAddress(
                     new Uri(Endpoints.Https_WindowsAuth_Address),
-                    new UpnEndpointIdentity(s_Upn)
+                    new UpnEndpointIdentity(NegotiateStreamTestConfiguration.NegotiateTestUpn)
             ));
 
             serviceProxy = factory.CreateChannel();
@@ -230,12 +224,12 @@ public static class NegotiateStream_Http_Tests
                 binding,
                 new EndpointAddress(
                     new Uri(Endpoints.Https_WindowsAuth_Address),
-                    new SpnEndpointIdentity(s_Spn)
+                    new SpnEndpointIdentity(NegotiateStreamTestConfiguration.NegotiateTestSpn)
             ));
 
-            factory.Credentials.Windows.ClientCredential.Domain = s_Domain;
-            factory.Credentials.Windows.ClientCredential.UserName = s_Username;
-            factory.Credentials.Windows.ClientCredential.Password = s_Password;
+            factory.Credentials.Windows.ClientCredential.Domain = NegotiateStreamTestConfiguration.NegotiateTestDomain;
+            factory.Credentials.Windows.ClientCredential.UserName = NegotiateStreamTestConfiguration.NegotiateTestUserName;
+            factory.Credentials.Windows.ClientCredential.Password = NegotiateStreamTestConfiguration.NegotiateTestPassword;
 
             serviceProxy = factory.CreateChannel();
 
@@ -273,12 +267,12 @@ public static class NegotiateStream_Http_Tests
                 binding,
                 new EndpointAddress(
                     new Uri(Endpoints.Https_WindowsAuth_Address),
-                    new UpnEndpointIdentity(s_Upn)
+                    new UpnEndpointIdentity(NegotiateStreamTestConfiguration.NegotiateTestUpn)
             ));
 
-            factory.Credentials.Windows.ClientCredential.Domain = s_Domain;
-            factory.Credentials.Windows.ClientCredential.UserName = s_Username;
-            factory.Credentials.Windows.ClientCredential.Password = s_Password;
+            factory.Credentials.Windows.ClientCredential.Domain = NegotiateStreamTestConfiguration.NegotiateTestDomain;
+            factory.Credentials.Windows.ClientCredential.UserName = NegotiateStreamTestConfiguration.NegotiateTestUserName;
+            factory.Credentials.Windows.ClientCredential.Password = NegotiateStreamTestConfiguration.NegotiateTestPassword;
 
             serviceProxy = factory.CreateChannel();
 

--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Negotiate/NegotiateStream_Http_Tests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Negotiate/NegotiateStream_Http_Tests.cs
@@ -22,14 +22,14 @@ public static class NegotiateStream_Http_Tests
     //              prior Kerberos tickets
     // 
     // NegotiateStream_*_With_ExplicitUserNameAndPassword
-    //     Windows: Edit the NegotiateStreamTestConfiguration.UserName and .Password variables to a user valid on your Kerberos realm
-    //       Linux: Edit the NegotiateStreamTestConfiguration.UserName and .Password variables to a user valid on your Kerberos realm
+    //     Windows: Edit the NegotiateStreamTestConfiguration.Instance.UserName and .Password variables to a user valid on your Kerberos realm
+    //       Linux: Edit the NegotiateStreamTestConfiguration.Instance.UserName and .Password variables to a user valid on your Kerberos realm
     //              If previous tests were run, it may be necessary to run 'kdestroy -A' to remove all
     //              prior Kerberos tickets
     // 
     // NegotiateStream_*_With_ExplicitSpn
-    //     Windows: Edit the NegotiateStreamTestConfiguration.Spn variable to match a valid SPN for the server 
-    //       Linux: Edit the NegotiateStreamTestConfiguration.Spn variable to match a valid SPN for the server 
+    //     Windows: Edit the NegotiateStreamTestConfiguration.Instance.Spn variable to match a valid SPN for the server 
+    //       Linux: Edit the NegotiateStreamTestConfiguration.Instance.Spn variable to match a valid SPN for the server 
     //   
     //     By default, the SPN is the same as the host's fully qualified domain name, for example, 
     //     'host.domain.com'
@@ -37,19 +37,19 @@ public static class NegotiateStream_Http_Tests
     //     by using a tool like psexec and running 'psexec -s -h <WcfBridge.exe>' 
     // 
     // NegotiateStream_*_With_Upn
-    //     Windows: Edit the NegotiateStreamTestConfiguration.Upn field to match a valid UPN for the server in the form of 
+    //     Windows: Edit the NegotiateStreamTestConfiguration.Instance.Upn field to match a valid UPN for the server in the form of 
     //              'user@DOMAIN.COM'
     //       Linux: This scenario is not yet supported - dotnet/corefx#6606
     //
     // NegotiateStream_*_With_ExplicitUserNameAndPassword_With_Spn
-    //     Windows: Edit the NegotiateStreamTestConfiguration.Spn variable to match a valid SPN for the server
-    //              Edit the NegotiateStreamTestConfiguration.UserName and .Password variables to a user valid on your Kerberos realm
-    //       Linux: Edit the NegotiateStreamTestConfiguration.Spn variable to match a valid SPN for the server
-    //              Edit the NegotiateStreamTestConfiguration.UserName and .Password variables to a user valid on your Kerberos realm
+    //     Windows: Edit the NegotiateStreamTestConfiguration.Instance.Spn variable to match a valid SPN for the server
+    //              Edit the NegotiateStreamTestConfiguration.Instance.UserName and .Password variables to a user valid on your Kerberos realm
+    //       Linux: Edit the NegotiateStreamTestConfiguration.Instance.Spn variable to match a valid SPN for the server
+    //              Edit the NegotiateStreamTestConfiguration.Instance.UserName and .Password variables to a user valid on your Kerberos realm
     // 
     // NegotiateStream_*_With_ExplicitUserNameAndPassword_With_Upn
-    //     Windows: Edit the NegotiateStreamTestConfiguration.Upn variable to match a valid UPN for the server
-    //              Edit the NegotiateStreamTestConfiguration.UserName and .Password variables to a user valid on your Kerberos realm
+    //     Windows: Edit the NegotiateStreamTestConfiguration.Instance.Upn variable to match a valid UPN for the server
+    //              Edit the NegotiateStreamTestConfiguration.Instance.UserName and .Password variables to a user valid on your Kerberos realm
     //       Linux: This scenario is not yet supported - dotnet/corefx#6606
 
     // These tests are used for testing NegotiateStream (SecurityMode.Transport) 
@@ -62,6 +62,7 @@ public static class NegotiateStream_Http_Tests
         string testString = "Hello";
         ChannelFactory<IWcfService> factory = null;
         IWcfService serviceProxy = null;
+        bool success = false;
 
         try
         {
@@ -81,11 +82,17 @@ public static class NegotiateStream_Http_Tests
             // *** CLEANUP *** \\
             ((ICommunicationObject)serviceProxy).Close();
             factory.Close();
+            success = true; 
         }
         finally
         {
             // *** ENSURE CLEANUP *** \\
             ScenarioTestHelpers.CloseCommunicationObjects((ICommunicationObject)serviceProxy, factory);
+
+            if (!success)
+            {
+                Assert.True(false, string.Format("Credentials passed:{0}{1}", Environment.NewLine, NegotiateStreamTestConfiguration.Instance.ToString()));
+            }
         }
     }
 
@@ -106,9 +113,9 @@ public static class NegotiateStream_Http_Tests
                 binding, 
                 new EndpointAddress(Endpoints.Https_WindowsAuth_Address));
 
-            factory.Credentials.Windows.ClientCredential.Domain = NegotiateStreamTestConfiguration.NegotiateTestDomain;
-            factory.Credentials.Windows.ClientCredential.UserName = NegotiateStreamTestConfiguration.NegotiateTestUserName;
-            factory.Credentials.Windows.ClientCredential.Password = NegotiateStreamTestConfiguration.NegotiateTestPassword;
+            factory.Credentials.Windows.ClientCredential.Domain = NegotiateStreamTestConfiguration.Instance.NegotiateTestDomain;
+            factory.Credentials.Windows.ClientCredential.UserName = NegotiateStreamTestConfiguration.Instance.NegotiateTestUserName;
+            factory.Credentials.Windows.ClientCredential.Password = NegotiateStreamTestConfiguration.Instance.NegotiateTestPassword;
 
             serviceProxy = factory.CreateChannel();
 
@@ -146,7 +153,7 @@ public static class NegotiateStream_Http_Tests
                 binding,
                 new EndpointAddress(
                     new Uri(Endpoints.Https_WindowsAuth_Address),
-                    new SpnEndpointIdentity(NegotiateStreamTestConfiguration.NegotiateTestSpn)
+                    new SpnEndpointIdentity(NegotiateStreamTestConfiguration.Instance.NegotiateTestSpn)
             ));
 
             serviceProxy = factory.CreateChannel();
@@ -185,7 +192,7 @@ public static class NegotiateStream_Http_Tests
                 binding,
                 new EndpointAddress(
                     new Uri(Endpoints.Https_WindowsAuth_Address),
-                    new UpnEndpointIdentity(NegotiateStreamTestConfiguration.NegotiateTestUpn)
+                    new UpnEndpointIdentity(NegotiateStreamTestConfiguration.Instance.NegotiateTestUpn)
             ));
 
             serviceProxy = factory.CreateChannel();
@@ -224,12 +231,12 @@ public static class NegotiateStream_Http_Tests
                 binding,
                 new EndpointAddress(
                     new Uri(Endpoints.Https_WindowsAuth_Address),
-                    new SpnEndpointIdentity(NegotiateStreamTestConfiguration.NegotiateTestSpn)
+                    new SpnEndpointIdentity(NegotiateStreamTestConfiguration.Instance.NegotiateTestSpn)
             ));
 
-            factory.Credentials.Windows.ClientCredential.Domain = NegotiateStreamTestConfiguration.NegotiateTestDomain;
-            factory.Credentials.Windows.ClientCredential.UserName = NegotiateStreamTestConfiguration.NegotiateTestUserName;
-            factory.Credentials.Windows.ClientCredential.Password = NegotiateStreamTestConfiguration.NegotiateTestPassword;
+            factory.Credentials.Windows.ClientCredential.Domain = NegotiateStreamTestConfiguration.Instance.NegotiateTestDomain;
+            factory.Credentials.Windows.ClientCredential.UserName = NegotiateStreamTestConfiguration.Instance.NegotiateTestUserName;
+            factory.Credentials.Windows.ClientCredential.Password = NegotiateStreamTestConfiguration.Instance.NegotiateTestPassword;
 
             serviceProxy = factory.CreateChannel();
 
@@ -267,12 +274,12 @@ public static class NegotiateStream_Http_Tests
                 binding,
                 new EndpointAddress(
                     new Uri(Endpoints.Https_WindowsAuth_Address),
-                    new UpnEndpointIdentity(NegotiateStreamTestConfiguration.NegotiateTestUpn)
+                    new UpnEndpointIdentity(NegotiateStreamTestConfiguration.Instance.NegotiateTestUpn)
             ));
 
-            factory.Credentials.Windows.ClientCredential.Domain = NegotiateStreamTestConfiguration.NegotiateTestDomain;
-            factory.Credentials.Windows.ClientCredential.UserName = NegotiateStreamTestConfiguration.NegotiateTestUserName;
-            factory.Credentials.Windows.ClientCredential.Password = NegotiateStreamTestConfiguration.NegotiateTestPassword;
+            factory.Credentials.Windows.ClientCredential.Domain = NegotiateStreamTestConfiguration.Instance.NegotiateTestDomain;
+            factory.Credentials.Windows.ClientCredential.UserName = NegotiateStreamTestConfiguration.Instance.NegotiateTestUserName;
+            factory.Credentials.Windows.ClientCredential.Password = NegotiateStreamTestConfiguration.Instance.NegotiateTestPassword;
 
             serviceProxy = factory.CreateChannel();
 

--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Negotiate/NegotiateStream_Tcp_Tests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Negotiate/NegotiateStream_Tcp_Tests.cs
@@ -1,0 +1,297 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Infrastructure.Common;
+using System;
+using System.Security.Cryptography.X509Certificates;
+using System.ServiceModel;
+using System.ServiceModel.Channels;
+using System.ServiceModel.Security;
+using Xunit;
+
+public static class NegotiateStream_Tcp_Tests
+{
+    // The tests are as follows:
+    //
+    // NegotiateStream_*_AmbientCredentials
+    //     Windows: This should pass by default without any code changes
+    //       Linux: This should not pass by default 
+    //              Run 'kinit user@DC.DOMAIN.COM' before running this test to use ambient credentials
+    //              ('DC.DOMAIN.COM' must be in capital letters) 
+    //              If previous tests were run, it may be necessary to run 'kdestroy -A' to remove all
+    //              prior Kerberos tickets
+    // 
+    // NegotiateStream_*_With_ExplicitUserNameAndPassword
+    //     Windows: Edit the s_UserName and s_Password variables to a user valid on your Kerberos realm
+    //       Linux: Edit the s_UserName and s_Password variables to a user valid on your Kerberos realm
+    //              If previous tests were run, it may be necessary to run 'kdestroy -A' to remove all
+    //              prior Kerberos tickets
+    // 
+    // NegotiateStream_*_With_ExplicitSpn
+    //     Windows: Edit the s_Spn variable to match a valid SPN for the server 
+    //       Linux: Edit the s_Spn variable to match a valid SPN for the server 
+    //   
+    //     By default, the SPN is the same as the host's fully qualified domain name, for example, 
+    //     'host.domain.com'
+    //     On a Windows host, one has to register the SPN using 'setspn', or run the process as LOCAL SYSTEM
+    //     by using a tool like psexec and running 'psexec -s -h <WcfBridge.exe>' 
+    // 
+    // NegotiateStream_*_With_Upn
+    //     Windows: Edit the s_Upn field to match a valid UPN for the server in the form of 
+    //              'user@DOMAIN.COM'
+    //       Linux: This scenario is not yet supported - dotnet/corefx#6606
+    //
+    // NegotiateStream_*_With_ExplicitUserNameAndPassword_With_Spn
+    //     Windows: Edit the s_Spn variable to match a valid SPN for the server
+    //              Edit the s_UserName and s_Password variables to a user valid on your Kerberos realm
+    //       Linux: Edit the s_Spn variable to match a valid SPN for the server
+    //              Edit the s_UserName and s_Password variables to a user valid on your Kerberos realm
+    // 
+    // NegotiateStream_*_With_ExplicitUserNameAndPassword_With_Upn
+    //     Windows: Edit the s_Upn variable to match a valid UPN for the server
+    //              Edit the s_UserName and s_Password variables to a user valid on your Kerberos realm
+    //       Linux: This scenario is not yet supported - dotnet/corefx#6606
+
+    private const string s_Domain = "domain";
+    private const string s_Username = "azureuser";
+    private const string s_Password = "hunter2";
+    private const string s_Spn = "host";
+    private const string s_Upn = "azureuser@DOMAIN.COM";
+
+    // These tests are used for testing NegotiateStream (SecurityMode.Transport) 
+
+    [Fact]
+    [ActiveIssue(851, PlatformID.AnyUnix)]
+    [OuterLoop]
+    public static void NegotiateStream_Tcp_AmbientCredentials()
+    {
+        string testString = "Hello";
+        ChannelFactory<IWcfService> factory = null;
+        IWcfService serviceProxy = null;
+
+        try
+        {
+            // *** SETUP *** \\
+            NetTcpBinding binding = new NetTcpBinding(SecurityMode.Transport);
+            factory = new ChannelFactory<IWcfService>(binding, new EndpointAddress(Endpoints.Tcp_DefaultBinding_Address));
+            serviceProxy = factory.CreateChannel();
+
+            // *** EXECUTE *** \\
+            string result = serviceProxy.Echo(testString);
+
+            // *** VALIDATE *** \\
+            Assert.Equal(testString, result);
+
+            // *** CLEANUP *** \\
+            ((ICommunicationObject)serviceProxy).Close();
+            factory.Close();
+        }
+        finally
+        {
+            // *** ENSURE CLEANUP *** \\
+            ScenarioTestHelpers.CloseCommunicationObjects((ICommunicationObject)serviceProxy, factory);
+        }
+    }
+
+    [Fact]
+    [ActiveIssue(851)]
+    [OuterLoop]
+    public static void NegotiateStream_Tcp_With_ExplicitUserNameAndPassword()
+    {
+        string testString = "Hello";
+        ChannelFactory<IWcfService> factory = null;
+        IWcfService serviceProxy = null;
+
+        try
+        {
+            // *** SETUP *** \\
+            NetTcpBinding binding = new NetTcpBinding();
+            factory = new ChannelFactory<IWcfService>(binding, 
+                new EndpointAddress(Endpoints.Tcp_DefaultBinding_Address));
+
+            factory.Credentials.Windows.ClientCredential.Domain = s_Domain;
+            factory.Credentials.Windows.ClientCredential.UserName = s_Username;
+            factory.Credentials.Windows.ClientCredential.Password = s_Password;
+
+            serviceProxy = factory.CreateChannel();
+
+            // *** EXECUTE *** \\
+            string result = serviceProxy.Echo(testString);
+
+            // *** VALIDATE *** \\
+            Assert.Equal(testString, result);
+
+            // *** CLEANUP *** \\
+            ((ICommunicationObject)serviceProxy).Close();
+            factory.Close();
+        }
+        finally
+        {
+            // *** ENSURE CLEANUP *** \\
+            ScenarioTestHelpers.CloseCommunicationObjects((ICommunicationObject)serviceProxy, factory);
+        }
+    }
+
+    [Fact]
+    [ActiveIssue(851)]
+    [OuterLoop]
+    public static void NegotiateStream_Tcp_With_ExplicitSpn()
+    {
+        string testString = "Hello";
+        ChannelFactory<IWcfService> factory = null;
+        IWcfService serviceProxy = null;
+
+        try
+        {
+            // *** SETUP *** \\
+            NetTcpBinding binding = new NetTcpBinding();
+            factory = new ChannelFactory<IWcfService>(binding,
+                new EndpointAddress(
+                    new Uri(Endpoints.Tcp_DefaultBinding_Address),
+                    new SpnEndpointIdentity(s_Spn)
+            ));
+
+            serviceProxy = factory.CreateChannel();
+
+            // *** EXECUTE *** \\
+            string result = serviceProxy.Echo(testString);
+
+            // *** VALIDATE *** \\
+            Assert.Equal(testString, result);
+
+            // *** CLEANUP *** \\
+            ((ICommunicationObject)serviceProxy).Close();
+            factory.Close();
+        }
+        finally
+        {
+            // *** ENSURE CLEANUP *** \\
+            ScenarioTestHelpers.CloseCommunicationObjects((ICommunicationObject)serviceProxy, factory);
+        }
+    }
+
+    [Fact]
+    [ActiveIssue(851)]
+    [OuterLoop]
+    public static void NegotiateStream_Tcp_With_Upn()
+    {
+        string testString = "Hello";
+        ChannelFactory<IWcfService> factory = null;
+        IWcfService serviceProxy = null;
+
+        try
+        {
+            // *** SETUP *** \\
+            NetTcpBinding binding = new NetTcpBinding();
+            factory = new ChannelFactory<IWcfService>(
+                binding,
+                new EndpointAddress(
+                    new Uri(Endpoints.Tcp_DefaultBinding_Address),
+                    new SpnEndpointIdentity(s_Spn)
+            ));
+
+            serviceProxy = factory.CreateChannel();
+
+            // *** EXECUTE *** \\
+            string result = serviceProxy.Echo(testString);
+
+            // *** VALIDATE *** \\
+            Assert.Equal(testString, result);
+
+            // *** CLEANUP *** \\
+            ((ICommunicationObject)serviceProxy).Close();
+            factory.Close();
+        }
+        finally
+        {
+            // *** ENSURE CLEANUP *** \\
+            ScenarioTestHelpers.CloseCommunicationObjects((ICommunicationObject)serviceProxy, factory);
+        }
+    }
+
+    [Fact]
+    [ActiveIssue(851)]
+    [OuterLoop]
+    public static void NegotiateStream_Tcp_With_ExplicitUserNameAndPassword_With_Spn()
+    {
+        string testString = "Hello";
+        ChannelFactory<IWcfService> factory = null;
+        IWcfService serviceProxy = null;
+
+        try
+        {
+            // *** SETUP *** \\
+            NetTcpBinding binding = new NetTcpBinding();
+            factory = new ChannelFactory<IWcfService>(
+                binding,
+                new EndpointAddress(
+                    new Uri(Endpoints.Tcp_DefaultBinding_Address),
+                    new SpnEndpointIdentity(s_Spn)
+            ));
+
+            factory.Credentials.Windows.ClientCredential.Domain = s_Domain;
+            factory.Credentials.Windows.ClientCredential.UserName = s_Username;
+            factory.Credentials.Windows.ClientCredential.Password = s_Password;
+
+            serviceProxy = factory.CreateChannel();
+
+            // *** EXECUTE *** \\
+            string result = serviceProxy.Echo(testString);
+
+            // *** VALIDATE *** \\
+            Assert.Equal(testString, result);
+
+            // *** CLEANUP *** \\
+            ((ICommunicationObject)serviceProxy).Close();
+            factory.Close();
+        }
+        finally
+        {
+            // *** ENSURE CLEANUP *** \\
+            ScenarioTestHelpers.CloseCommunicationObjects((ICommunicationObject)serviceProxy, factory);
+        }
+    }
+
+    [Fact]
+    [ActiveIssue(851)]
+    [OuterLoop]
+    public static void NegotiateStream_Tcp_With_ExplicitUserNameAndPassword_With_Upn()
+    {
+        string testString = "Hello";
+        ChannelFactory<IWcfService> factory = null;
+        IWcfService serviceProxy = null;
+
+        try
+        {
+            // *** SETUP *** \\
+            NetTcpBinding binding = new NetTcpBinding();
+            factory = new ChannelFactory<IWcfService>(
+                binding,
+                new EndpointAddress(
+                    new Uri(Endpoints.Tcp_DefaultBinding_Address),
+                    new UpnEndpointIdentity(s_Upn)
+            ));
+
+            factory.Credentials.Windows.ClientCredential.Domain = s_Domain;
+            factory.Credentials.Windows.ClientCredential.UserName = s_Username;
+            factory.Credentials.Windows.ClientCredential.Password = s_Password;
+
+            serviceProxy = factory.CreateChannel();
+
+            // *** EXECUTE *** \\
+            string result = serviceProxy.Echo(testString);
+
+            // *** VALIDATE *** \\
+            Assert.Equal(testString, result);
+
+            // *** CLEANUP *** \\
+            ((ICommunicationObject)serviceProxy).Close();
+            factory.Close();
+        }
+        finally
+        {
+            // *** ENSURE CLEANUP *** \\
+            ScenarioTestHelpers.CloseCommunicationObjects((ICommunicationObject)serviceProxy, factory);
+        }
+    }
+}

--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Negotiate/NegotiateStream_Tcp_Tests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Negotiate/NegotiateStream_Tcp_Tests.cs
@@ -52,12 +52,6 @@ public static class NegotiateStream_Tcp_Tests
     //              Edit the s_UserName and s_Password variables to a user valid on your Kerberos realm
     //       Linux: This scenario is not yet supported - dotnet/corefx#6606
 
-    private const string s_Domain = "domain";
-    private const string s_Username = "azureuser";
-    private const string s_Password = "hunter2";
-    private const string s_Spn = "host";
-    private const string s_Upn = "azureuser@DOMAIN.COM";
-
     // These tests are used for testing NegotiateStream (SecurityMode.Transport) 
 
     [Fact]
@@ -71,8 +65,8 @@ public static class NegotiateStream_Tcp_Tests
 
         try
         {
-            // *** SETUP *** \\
-            NetTcpBinding binding = new NetTcpBinding(SecurityMode.Transport);
+               // *** SETUP *** \\
+               NetTcpBinding binding = new NetTcpBinding(SecurityMode.Transport);
             factory = new ChannelFactory<IWcfService>(binding, new EndpointAddress(Endpoints.Tcp_DefaultBinding_Address));
             serviceProxy = factory.CreateChannel();
 
@@ -109,9 +103,9 @@ public static class NegotiateStream_Tcp_Tests
             factory = new ChannelFactory<IWcfService>(binding, 
                 new EndpointAddress(Endpoints.Tcp_DefaultBinding_Address));
 
-            factory.Credentials.Windows.ClientCredential.Domain = s_Domain;
-            factory.Credentials.Windows.ClientCredential.UserName = s_Username;
-            factory.Credentials.Windows.ClientCredential.Password = s_Password;
+            factory.Credentials.Windows.ClientCredential.Domain = NegotiateStreamTestConfiguration.NegotiateTestDomain;
+            factory.Credentials.Windows.ClientCredential.UserName = NegotiateStreamTestConfiguration.NegotiateTestUserName;
+            factory.Credentials.Windows.ClientCredential.Password = NegotiateStreamTestConfiguration.NegotiateTestPassword;
 
             serviceProxy = factory.CreateChannel();
 
@@ -148,7 +142,7 @@ public static class NegotiateStream_Tcp_Tests
             factory = new ChannelFactory<IWcfService>(binding,
                 new EndpointAddress(
                     new Uri(Endpoints.Tcp_DefaultBinding_Address),
-                    new SpnEndpointIdentity(s_Spn)
+                    new SpnEndpointIdentity(NegotiateStreamTestConfiguration.NegotiateTestSpn)
             ));
 
             serviceProxy = factory.CreateChannel();
@@ -187,7 +181,7 @@ public static class NegotiateStream_Tcp_Tests
                 binding,
                 new EndpointAddress(
                     new Uri(Endpoints.Tcp_DefaultBinding_Address),
-                    new SpnEndpointIdentity(s_Spn)
+                    new SpnEndpointIdentity(NegotiateStreamTestConfiguration.NegotiateTestSpn)
             ));
 
             serviceProxy = factory.CreateChannel();
@@ -226,12 +220,12 @@ public static class NegotiateStream_Tcp_Tests
                 binding,
                 new EndpointAddress(
                     new Uri(Endpoints.Tcp_DefaultBinding_Address),
-                    new SpnEndpointIdentity(s_Spn)
+                    new SpnEndpointIdentity(NegotiateStreamTestConfiguration.NegotiateTestSpn)
             ));
 
-            factory.Credentials.Windows.ClientCredential.Domain = s_Domain;
-            factory.Credentials.Windows.ClientCredential.UserName = s_Username;
-            factory.Credentials.Windows.ClientCredential.Password = s_Password;
+            factory.Credentials.Windows.ClientCredential.Domain = NegotiateStreamTestConfiguration.NegotiateTestDomain;
+            factory.Credentials.Windows.ClientCredential.UserName = NegotiateStreamTestConfiguration.NegotiateTestUserName;
+            factory.Credentials.Windows.ClientCredential.Password = NegotiateStreamTestConfiguration.NegotiateTestPassword;
 
             serviceProxy = factory.CreateChannel();
 
@@ -269,12 +263,12 @@ public static class NegotiateStream_Tcp_Tests
                 binding,
                 new EndpointAddress(
                     new Uri(Endpoints.Tcp_DefaultBinding_Address),
-                    new UpnEndpointIdentity(s_Upn)
+                    new UpnEndpointIdentity(NegotiateStreamTestConfiguration.NegotiateTestUpn)
             ));
 
-            factory.Credentials.Windows.ClientCredential.Domain = s_Domain;
-            factory.Credentials.Windows.ClientCredential.UserName = s_Username;
-            factory.Credentials.Windows.ClientCredential.Password = s_Password;
+            factory.Credentials.Windows.ClientCredential.Domain = NegotiateStreamTestConfiguration.NegotiateTestDomain;
+            factory.Credentials.Windows.ClientCredential.UserName = NegotiateStreamTestConfiguration.NegotiateTestUserName;
+            factory.Credentials.Windows.ClientCredential.Password = NegotiateStreamTestConfiguration.NegotiateTestPassword;
 
             serviceProxy = factory.CreateChannel();
 

--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Negotiate/NegotiateStream_Tcp_Tests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Negotiate/NegotiateStream_Tcp_Tests.cs
@@ -62,11 +62,12 @@ public static class NegotiateStream_Tcp_Tests
         string testString = "Hello";
         ChannelFactory<IWcfService> factory = null;
         IWcfService serviceProxy = null;
+        bool success = false; 
 
         try
         {
-               // *** SETUP *** \\
-               NetTcpBinding binding = new NetTcpBinding(SecurityMode.Transport);
+            // *** SETUP *** \\
+            NetTcpBinding binding = new NetTcpBinding(SecurityMode.Transport);
             factory = new ChannelFactory<IWcfService>(binding, new EndpointAddress(Endpoints.Tcp_DefaultBinding_Address));
             serviceProxy = factory.CreateChannel();
 
@@ -79,11 +80,17 @@ public static class NegotiateStream_Tcp_Tests
             // *** CLEANUP *** \\
             ((ICommunicationObject)serviceProxy).Close();
             factory.Close();
+            success = true; 
         }
         finally
         {
             // *** ENSURE CLEANUP *** \\
             ScenarioTestHelpers.CloseCommunicationObjects((ICommunicationObject)serviceProxy, factory);
+
+            if (!success)
+            {
+                Assert.True(false, string.Format("Credentials passed:{0}{1}", Environment.NewLine, NegotiateStreamTestConfiguration.Instance.ToString()));
+            }
         }
     }
 
@@ -103,9 +110,9 @@ public static class NegotiateStream_Tcp_Tests
             factory = new ChannelFactory<IWcfService>(binding, 
                 new EndpointAddress(Endpoints.Tcp_DefaultBinding_Address));
 
-            factory.Credentials.Windows.ClientCredential.Domain = NegotiateStreamTestConfiguration.NegotiateTestDomain;
-            factory.Credentials.Windows.ClientCredential.UserName = NegotiateStreamTestConfiguration.NegotiateTestUserName;
-            factory.Credentials.Windows.ClientCredential.Password = NegotiateStreamTestConfiguration.NegotiateTestPassword;
+            factory.Credentials.Windows.ClientCredential.Domain = NegotiateStreamTestConfiguration.Instance.NegotiateTestDomain;
+            factory.Credentials.Windows.ClientCredential.UserName = NegotiateStreamTestConfiguration.Instance.NegotiateTestUserName;
+            factory.Credentials.Windows.ClientCredential.Password = NegotiateStreamTestConfiguration.Instance.NegotiateTestPassword;
 
             serviceProxy = factory.CreateChannel();
 
@@ -142,7 +149,7 @@ public static class NegotiateStream_Tcp_Tests
             factory = new ChannelFactory<IWcfService>(binding,
                 new EndpointAddress(
                     new Uri(Endpoints.Tcp_DefaultBinding_Address),
-                    new SpnEndpointIdentity(NegotiateStreamTestConfiguration.NegotiateTestSpn)
+                    new SpnEndpointIdentity(NegotiateStreamTestConfiguration.Instance.NegotiateTestSpn)
             ));
 
             serviceProxy = factory.CreateChannel();
@@ -181,7 +188,7 @@ public static class NegotiateStream_Tcp_Tests
                 binding,
                 new EndpointAddress(
                     new Uri(Endpoints.Tcp_DefaultBinding_Address),
-                    new SpnEndpointIdentity(NegotiateStreamTestConfiguration.NegotiateTestSpn)
+                    new SpnEndpointIdentity(NegotiateStreamTestConfiguration.Instance.NegotiateTestSpn)
             ));
 
             serviceProxy = factory.CreateChannel();
@@ -220,12 +227,12 @@ public static class NegotiateStream_Tcp_Tests
                 binding,
                 new EndpointAddress(
                     new Uri(Endpoints.Tcp_DefaultBinding_Address),
-                    new SpnEndpointIdentity(NegotiateStreamTestConfiguration.NegotiateTestSpn)
+                    new SpnEndpointIdentity(NegotiateStreamTestConfiguration.Instance.NegotiateTestSpn)
             ));
 
-            factory.Credentials.Windows.ClientCredential.Domain = NegotiateStreamTestConfiguration.NegotiateTestDomain;
-            factory.Credentials.Windows.ClientCredential.UserName = NegotiateStreamTestConfiguration.NegotiateTestUserName;
-            factory.Credentials.Windows.ClientCredential.Password = NegotiateStreamTestConfiguration.NegotiateTestPassword;
+            factory.Credentials.Windows.ClientCredential.Domain = NegotiateStreamTestConfiguration.Instance.NegotiateTestDomain;
+            factory.Credentials.Windows.ClientCredential.UserName = NegotiateStreamTestConfiguration.Instance.NegotiateTestUserName;
+            factory.Credentials.Windows.ClientCredential.Password = NegotiateStreamTestConfiguration.Instance.NegotiateTestPassword;
 
             serviceProxy = factory.CreateChannel();
 
@@ -263,12 +270,12 @@ public static class NegotiateStream_Tcp_Tests
                 binding,
                 new EndpointAddress(
                     new Uri(Endpoints.Tcp_DefaultBinding_Address),
-                    new UpnEndpointIdentity(NegotiateStreamTestConfiguration.NegotiateTestUpn)
+                    new UpnEndpointIdentity(NegotiateStreamTestConfiguration.Instance.NegotiateTestUpn)
             ));
 
-            factory.Credentials.Windows.ClientCredential.Domain = NegotiateStreamTestConfiguration.NegotiateTestDomain;
-            factory.Credentials.Windows.ClientCredential.UserName = NegotiateStreamTestConfiguration.NegotiateTestUserName;
-            factory.Credentials.Windows.ClientCredential.Password = NegotiateStreamTestConfiguration.NegotiateTestPassword;
+            factory.Credentials.Windows.ClientCredential.Domain = NegotiateStreamTestConfiguration.Instance.NegotiateTestDomain;
+            factory.Credentials.Windows.ClientCredential.UserName = NegotiateStreamTestConfiguration.Instance.NegotiateTestUserName;
+            factory.Credentials.Windows.ClientCredential.Password = NegotiateStreamTestConfiguration.Instance.NegotiateTestPassword;
 
             serviceProxy = factory.CreateChannel();
 

--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Security.TransportSecurity.Tests.csproj
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Security.TransportSecurity.Tests.csproj
@@ -20,6 +20,7 @@
     <Compile Include="Https\ClientCredentialTypeTests.cs" />
     <Compile Include="Https\HttpsTests.cs" />
     <Compile Include="Http\ClientCredentialTypeTests.cs" />
+    <Compile Include="Negotiate\NegotiateStreamTestConfiguration.cs" />
     <Compile Include="Negotiate\NegotiateStream_Tcp_Tests.cs" />
     <Compile Include="Negotiate\NegotiateStream_Http_Tests.cs" />
     <Compile Include="Tcp\ClientCredentialTypeTests.cs" />

--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Security.TransportSecurity.Tests.csproj
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Security.TransportSecurity.Tests.csproj
@@ -20,6 +20,8 @@
     <Compile Include="Https\ClientCredentialTypeTests.cs" />
     <Compile Include="Https\HttpsTests.cs" />
     <Compile Include="Http\ClientCredentialTypeTests.cs" />
+    <Compile Include="Negotiate\NegotiateStream_Tcp_Tests.cs" />
+    <Compile Include="Negotiate\NegotiateStream_Http_Tests.cs" />
     <Compile Include="Tcp\ClientCredentialTypeTests.cs" />
     <Compile Include="Tcp\ClientCredentialTypeCertificateCanonicalNameTests.cs" />
     <Compile Include="Tcp\IdentityTests.cs" />


### PR DESCRIPTION
Looking for some early feedback and discussion. Only review the NegotiateStream_*_Tests.cs files, please. 

I'm waiting for #893 to go in before rebasing this one. For some strange reason the rebasing is being weird, so you'll see a bunch of additional files. 

**Discussion:** 

* We need to figure out our story for how to specify usernames/passwords reasonably dynamically - this will probably involve using TestProperties so that they can be specified on the command line. 
* Furthermore, I would like to remove the [ActiveIssues] - rather, I would like to use some mechanism (like TestProperties or a ConditionalFact) to specify whether or not these tests should be run and should pass
* For example, one set of tests requires that the Bridge be run as LOCAL SYSTEM. This may require the Bridge to report on the context it's running as. 

This is the set of tests I am trying to do: 

|Host running as|targetidentity passed|Network credential|Expected Result|Actual|
|---|---|---|---|---|
|testuser|UPN -> realuser@DC.DOMAIN.COM|DC\realuser|Expected fail|Blocked (UPN missing)|
|testuser|UPN -> testuser@DC.DOMAIN.COM|DC\testuser|Expected pass | Blocked (UPN missing)|
|testuser|SPN -> mymachine|DC\testuser|Expected fail | Blocked (Assert) |
|LOCAL SYSTEM|UPN -> testuser@DC.DOMAIN.COM|DC\testuser|Expected fail | Fail|
|LOCAL SYSTEM|SPN -> mymachine|DC\testuser|Expected pass | Pass|
|LOCAL SYSTEM|SPN -> mymachine|DC\realuser|Expected pass | Pass |
|LOCAL SYSTEM|SPN -> mymachine|(none) |Expected pass | Pass|
|User (Server needs SPN reg'n)|SPN -> bridge/mymachine |(none / any valid) |Expected Pass | (Not passing - under investigation) |
|LOCAL SYSTEM (Server needs SPN reg'n)|SPN -> bridge/mymachine|(none / any valid) |Expected Pass | (Under investigation -> next ) |

Note too that there will need to be additional pivots on the server - that is: 

* Server supports Kerberos auth, falling back to NTLM auth if necessary
* Server supports only Kerberos auth
* Server supports only NTLM auth
* Server supports neither

However, I posit that the server pivots are going to be pri 2 while client pivots are going to be pri 1