### PR TITLE
Add SpnLookupTime property back to SpnEndpointIdentity

### DIFF
--- a/src/System.Private.ServiceModel/src/System/ServiceModel/SpnEndpointIdentity.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/SpnEndpointIdentity.cs
@@ -27,5 +27,8 @@ namespace System.ServiceModel
 
             base.Initialize(identity);
         }
+        
+        public static TimeSpan SpnLookupTime {get;set;}
+        
     }
 }


### PR DESCRIPTION
This property exists in the public contract and needed to
be added back to fix a build break in TFS.