### PR TITLE
Fix .NET Native build of S.P.SM due to mscorlib reference.

### DIFF
--- a/src/System.Private.ServiceModel/src/windows/project.json
+++ b/src/System.Private.ServiceModel/src/windows/project.json
@@ -62,6 +62,7 @@
       "dependencies": {
         "System.Runtime.WindowsRuntime": "4.0.0",
         "Microsoft.TargetingPack.Private.NetNative": "1.0.0-rc3-23809",
+        "Microsoft.NETCore.Portable.Compatibility": "1.0.1-rc3-23809",
         "Microsoft.TargetingPack.Private.WinRT": "1.0.1"
       }
     }


### PR DESCRIPTION
* The NET Native assembly for System.private.ServiceModel can't resolve the references in Windows.winmd, because they refer to mscorlib.
* Adding a reference to Microsoft.NETCore.Portable.Compatibility, which has an mscorlib façade in it fixes the problem.