### PR TITLE
Fix AllowCookies logic to not set cookie container to null

### DIFF
--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/HttpChannelFactory.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/HttpChannelFactory.cs
@@ -273,7 +273,11 @@ namespace System.ServiceModel.Channels
                     var clientHandler = GetHttpMessageHandler(to, clientCertificateToken);
                     clientHandler.AutomaticDecompression = DecompressionMethods.Deflate | DecompressionMethods.GZip;
                     clientHandler.UseCookies = _allowCookies;
-                    clientHandler.CookieContainer = _allowCookies ? _httpCookieContainerManager.CookieContainer : null;
+                    if (_allowCookies)
+                    {
+                        clientHandler.CookieContainer = _httpCookieContainerManager.CookieContainer;
+                    }
+
                     clientHandler.PreAuthenticate = true;
                     if (clientHandler.SupportsProxy)
                     {


### PR DESCRIPTION
The recent PR #883 for AllowCookies added code to assign the
cookie container to null when AllowCookies was false.  But on
NET Native, this causes an ArgumentNullException.  This caused
all Http OuterLoop tests to fail.

The fix is to set the cookie container only when AllowCookies is true.