### PR TITLE
Fix test failure when BasicAuth tests were first to run

### DIFF
--- a/src/System.Private.ServiceModel/tools/test/SelfHostWcfService/TestResources/BasicAuthResource.cs
+++ b/src/System.Private.ServiceModel/tools/test/SelfHostWcfService/TestResources/BasicAuthResource.cs
@@ -7,6 +7,7 @@ using System.ServiceModel;
 using System.ServiceModel.Channels;
 using System.ServiceModel.Description;
 using System.ServiceModel.Security;
+using WcfService.CertificateResources;
 using WcfTestBridgeCommon;
 
 namespace WcfService.TestResources
@@ -43,6 +44,14 @@ namespace WcfService.TestResources
 
             desc.Behaviors.Remove<ServiceCredentials>();
             desc.Behaviors.Add(GetServiceCredentials());
+        }
+        
+        protected override void ModifyHost(ServiceHost serviceHost, ResourceRequestContext context)
+        {
+            // Ensure the https certificate is installed before this endpoint resource is used
+            CertificateResourceHelpers.EnsureSslPortCertificateInstalled(context.BridgeConfiguration);
+
+            base.ModifyHost(serviceHost, context);
         }
     }
 }


### PR DESCRIPTION
The Https BasicAuthentication tests failed were they were the first
scenario tests run after a fresh start of the Bridge.  But they succeeded
when other scenario tests ran first.

Root cause was that the BasicAuthResource was not explicitly ensuring
the SSL port certificate was installed.  It passed if another scenario
test did that first.

The fix was to duplicate what the other Https test resources do and
explicitly ensure the SSL port certificate is installed.

Fixes #788