### PR TITLE
Implement SpnEndpointIdentity.SpnLookupTime

### DIFF
--- a/src/System.Private.ServiceModel/src/System/ServiceModel/SpnEndpointIdentity.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/SpnEndpointIdentity.cs
@@ -8,7 +8,9 @@ using System.Security.Principal;
 namespace System.ServiceModel
 {
     public class SpnEndpointIdentity : EndpointIdentity
-    { 
+    {
+        private static TimeSpan _spnLookupTime = TimeSpan.FromMinutes(1);
+
         public SpnEndpointIdentity(string spnName)
         {
             if (spnName == null)
@@ -27,8 +29,23 @@ namespace System.ServiceModel
 
             base.Initialize(identity);
         }
-        
-        public static TimeSpan SpnLookupTime {get;set;}
-        
+
+        public static TimeSpan SpnLookupTime
+        {
+            get
+            {
+                return _spnLookupTime;
+            }
+            set
+            {
+                if (value.Ticks < 0)
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(
+                        new ArgumentOutOfRangeException("value", value.Ticks, SR.Format(SR.ValueMustBeNonNegative)));
+                }
+                _spnLookupTime = value;
+            }
+        }
+
     }
 }

--- a/src/System.ServiceModel.Security/tests/ServiceModel/SpnEndpointIdentityTest.cs
+++ b/src/System.ServiceModel.Security/tests/ServiceModel/SpnEndpointIdentityTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
 using System.ServiceModel;
 using Xunit;
 
@@ -25,5 +26,43 @@ public static class SpnEndpointIdentityTest
         {
             SpnEndpointIdentity spnEndpointEntity = new SpnEndpointIdentity(spnName);
         });
+    }
+
+    [Theory]
+    [MemberData("ValidTimeSpans", MemberType = typeof(TestData))]
+    public static void Set_SpnLookupTime_ValidTimes(TimeSpan timeSpan)
+    {
+        SpnEndpointIdentity.SpnLookupTime = timeSpan; 
+    }
+
+    [Theory]
+    [MemberData("InvalidTimeSpans", MemberType = typeof(TestData))]
+    public static void Set_SpnLookupTime_InvalidTimes_Throws(TimeSpan timeSpan)
+    {
+        Assert.Throws<ArgumentOutOfRangeException>("value", () =>
+        {
+            SpnEndpointIdentity.SpnLookupTime = timeSpan;
+        });
+    }
+
+    private class TestData
+    {
+        public static IEnumerable<object> ValidTimeSpans()
+        {
+            TimeSpan[] validTimeSpans = new TimeSpan[] { TimeSpan.Zero, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(60), TimeSpan.MaxValue };
+            foreach (var ts in validTimeSpans)
+            {
+                yield return new object[] { ts };
+            }
+        }
+
+        public static IEnumerable<object> InvalidTimeSpans()
+        {
+            TimeSpan[] validTimeSpans = new TimeSpan[] { TimeSpan.FromSeconds(-1), TimeSpan.MinValue };
+            foreach (var ts in validTimeSpans)
+            {
+                yield return new object[] { ts };
+            }
+        }
     }
 }


### PR DESCRIPTION
SpnEndpointIdentity.SpnLookupTime was not used previously as it wasn't used; it ended up causing a TFS build break, so an AutoProperty was implemented to unbreak the build. 

In #902, we have a discussion about what the real CoreFx implementation should look like. This PR shows what it looks like if we just took the desktop implementation (my preferred option) 

Note that the SpnLookupTime API is still unused, but this is essentially a harmless addition. 