### PR TITLE
Update S.IO.Compression to pre-release version.

### DIFF
--- a/src/Common/test-runtime/project.json
+++ b/src/Common/test-runtime/project.json
@@ -20,7 +20,7 @@
     "System.Diagnostics.Tracing": "4.0.20",
     "System.Globalization": "4.0.0",
     "System.IO": "4.0.10",
-    "System.IO.Compression": "4.0.0",
+    "System.IO.Compression": "4.1.0-rc3-23915",
     "System.Linq": "4.0.0",
     "System.Linq.Expressions": "4.0.0",
     "System.Linq.Queryable": "4.0.0",

--- a/src/System.Private.ServiceModel/src/project.json
+++ b/src/System.Private.ServiceModel/src/project.json
@@ -13,7 +13,7 @@
     "System.Diagnostics.Tracing": "4.0.20",
     "System.Globalization": "4.0.0",
     "System.IO": "4.0.10",
-    "System.IO.Compression": "4.0.0",
+    "System.IO.Compression": "4.1.0-rc3-23915",
     "System.Linq": "4.0.0",
     "System.Linq.Expressions": "4.0.0",
     "System.Linq.Queryable": "4.0.0",

--- a/src/System.Private.ServiceModel/src/windows/project.json
+++ b/src/System.Private.ServiceModel/src/windows/project.json
@@ -13,7 +13,7 @@
     "System.Diagnostics.Tracing": "4.0.20",
     "System.Globalization": "4.0.0",
     "System.IO": "4.0.10",
-    "System.IO.Compression": "4.0.0",
+    "System.IO.Compression": "4.1.0-rc3-23915",
     "System.Linq": "4.0.0",
     "System.Linq.Expressions": "4.0.0",
     "System.Linq.Queryable": "4.0.0",


### PR DESCRIPTION
* Latest version of System.Net.Http.WinHttpHandler requires a move to the pre-release version of S.IO.Compression