### PR TITLE
Adding ActiveIssues for tests failing only on NET Native

### DIFF
--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/ExpectedExceptions/ExpectedExceptionTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/ExpectedExceptions/ExpectedExceptionTests.cs
@@ -355,6 +355,9 @@ public static class ExpectedExceptionTests
     }
 
     [Fact]
+#if FEATURE_NETNATIVE
+    [ActiveIssue(769)] // Blocked from working in NET Native due to a toolchain issue.
+#endif
     [OuterLoop]
     public static void DuplexCallback_Throws_FaultException_DirectThrow()
     {
@@ -400,6 +403,9 @@ public static class ExpectedExceptionTests
     }
 
     [Fact]
+#if FEATURE_NETNATIVE
+    [ActiveIssue(769)] // Blocked from working in NET Native due to a toolchain issue.
+#endif
     [OuterLoop]
     public static void DuplexCallback_Throws_FaultException_ReturnsFaultedTask()
     {
@@ -445,6 +451,9 @@ public static class ExpectedExceptionTests
     }
 
     [Fact]
+#if FEATURE_NETNATIVE
+    [ActiveIssue(833)] // Not supported in NET Native
+#endif
     [OuterLoop]
     // Verify product throws MessageSecurityException when the Dns identity from the server does not match the expectation
     public static void TCP_ServiceCertExpired_Throw_MessageSecurityException()
@@ -512,6 +521,9 @@ public static class ExpectedExceptionTests
     }
 
     [Fact]
+#if FEATURE_NETNATIVE
+    [ActiveIssue(833)] // Not supported in NET Native
+#endif
     [OuterLoop]
     // Verify product throws MessageSecurityException when the service cert is revoked
     public static void TCP_ServiceCertRevoked_Throw_MessageSecurityException()

--- a/src/System.Private.ServiceModel/tests/Scenarios/Extensibility/WebSockets/WebSocketTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Extensibility/WebSockets/WebSocketTests.cs
@@ -75,7 +75,11 @@ public static class WebSocketTests
 
     [Fact]
     [OuterLoop]
+#if !FEATURE_NETNATIVE
     [ActiveIssue(420, PlatformID.AnyUnix)]
+#else
+    [ActiveIssue(526)]
+#endif
     public static void WebSocket_Http_Duplex_BinaryStreamed()
     {
         NetHttpBinding binding = null;
@@ -167,7 +171,11 @@ public static class WebSocketTests
 
     [Fact]
     [OuterLoop]
+#if !FEATURE_NETNATIVE
     [ActiveIssue(420, PlatformID.AnyUnix)]
+#else
+    [ActiveIssue(526)]
+#endif
     public static void WebSocket_Https_Duplex_BinaryStreamed()
     {
         BinaryMessageEncodingBindingElement binaryMessageEncodingBindingElement = null;
@@ -262,9 +270,13 @@ public static class WebSocketTests
 
     [Fact]
     [OuterLoop]
+#if !FEATURE_NETNATIVE
     [ActiveIssue(4429)] // In #CoreFX
     [ActiveIssue(470)]
     [ActiveIssue(420, PlatformID.AnyUnix)]
+#else
+    [ActiveIssue(526)]
+#endif
     public static void WebSocket_Https_Duplex_TextStreamed()
     {
         TextMessageEncodingBindingElement textMessageEncodingBindingElement = null;
@@ -359,7 +371,13 @@ public static class WebSocketTests
 
     [Fact]
     [OuterLoop]
+#if !FEATURE_NETNATIVE
+    [ActiveIssue(4429)] // In #CoreFX
+    [ActiveIssue(470)]
     [ActiveIssue(420, PlatformID.AnyUnix)]
+#else
+    [ActiveIssue(526)]
+#endif
     public static void WebSocket_Http_Duplex_TextStreamed()
     {
         NetHttpBinding binding = null;

--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Https/HttpsTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Https/HttpsTests.cs
@@ -161,7 +161,9 @@ public static class HttpsTests
     }
 
     [Fact]
-    [ActiveIssue(544, PlatformID.AnyUnix)]
+#if FEATURE_NETNATIVE
+    [ActiveIssue(544)] // Server certificate validation not supported in NET Native
+#endif
     [OuterLoop]
     public static void ServerCertificateValidation_EchoString()
     {
@@ -222,7 +224,7 @@ public static class HttpsTests
             // *** SETUP *** \\
             BasicHttpsBinding basicHttpsBinding = new BasicHttpsBinding(BasicHttpsSecurityMode.Transport);
             basicHttpsBinding.Security.Transport.ClientCredentialType = HttpClientCredentialType.Certificate;
-            
+
             endpointAddress = new EndpointAddress(new Uri(Endpoints.Https_ClientCertificateAuth_Address));
             clientCertThumb = BridgeClientCertificateManager.LocalCertThumbprint; // ClientCert as given by the Bridge
 

--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Tcp/ClientCredentialTypeTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Tcp/ClientCredentialTypeTests.cs
@@ -16,7 +16,11 @@ public static class Tcp_ClientCredentialTypeTests
     //                         - SecurityMode = Transport
     //                         - ClientCredentialType = Windows
     [Fact]
-    [ActiveIssue(592, PlatformID.AnyUnix)]
+#if !FEATURE_NETNATIVE
+    [ActiveIssue(592, PlatformID.AnyUnix)] // NegotiateStream works on Windows but is not yet supported on Unix
+#else
+    [ActiveIssue(832)] // Windows Stream Security is not supported in NET Native
+#endif
     [OuterLoop]
     public static void SameBinding_DefaultSettings_EchoString()
     {
@@ -84,7 +88,11 @@ public static class Tcp_ClientCredentialTypeTests
     // Simple echo of a string using NetTcpBinding on both client and server with SecurityMode=Transport
     // By default ClientCredentialType will be 'Windows'
     [Fact]
-    [ActiveIssue(592, PlatformID.AnyUnix)]
+#if !FEATURE_NETNATIVE
+    [ActiveIssue(592, PlatformID.AnyUnix)] // NegotiateStream works on Windows but is not yet supported on Unix
+#else
+    [ActiveIssue(832)] // Windows Stream Security is not supported in NET Native
+#endif
     [OuterLoop]
     public static void SameBinding_SecurityModeTransport_EchoString()
     {
@@ -119,6 +127,9 @@ public static class Tcp_ClientCredentialTypeTests
     // Simple echo of a string using a CustomBinding to mimic a NetTcpBinding with Security.Mode = TransportWithMessageCredentials
     // This does not exactly match the binding elements in a NetTcpBinding which also includes a TransportSecurityBindingElement
     [Fact]
+#if FEATURE_NETNATIVE
+    [ActiveIssue(833)] // Not supported in NET Native
+#endif
     [OuterLoop]
     public static void SameBinding_SecurityModeTransport_ClientCredentialTypeCertificate_EchoString()
     {
@@ -133,7 +144,7 @@ public static class Tcp_ClientCredentialTypeTests
                 new SslStreamSecurityBindingElement(), // This is the binding element used when Security.Mode  = TransportWithMessageCredentials
                 new BinaryMessageEncodingBindingElement(),
                 new TcpTransportBindingElement());
-            
+
             var endpointIdentity = new DnsEndpointIdentity(Endpoints.Tcp_CustomBinding_SslStreamSecurity_HostName);
             factory = new ChannelFactory<IWcfService>(binding, new EndpointAddress(new Uri(Endpoints.Tcp_CustomBinding_SslStreamSecurity_Address), endpointIdentity));
             serviceProxy = factory.CreateChannel();
@@ -156,6 +167,9 @@ public static class Tcp_ClientCredentialTypeTests
     }
 
     [Fact]
+#if FEATURE_NETNATIVE
+    [ActiveIssue(834)] // Not supported in NET Native
+#endif
     [OuterLoop]
     public static void TcpClientCredentialType_Certificate_EchoString()
     {
@@ -203,6 +217,9 @@ public static class Tcp_ClientCredentialTypeTests
     }
 
     [Fact]
+#if FEATURE_NETNATIVE
+    [ActiveIssue(834)] // Not supported in NET Native
+#endif
     [OuterLoop]
     public static void TcpClientCredentialType_Certificate_CustomValidator_EchoString()
     {
@@ -254,6 +271,9 @@ public static class Tcp_ClientCredentialTypeTests
     }
 
     [Fact]
+#if FEATURE_NETNATIVE
+    [ActiveIssue(833)] // Not supported in NET Native
+#endif
     [OuterLoop]
     public static void TcpClientCredentialType_Certificate_With_ServerAltName_EchoString()
     {
@@ -272,7 +292,7 @@ public static class Tcp_ClientCredentialTypeTests
 
             factory = new ChannelFactory<IWcfService>(binding, endpointAddress);
             factory.Credentials.ServiceCertificate.Authentication.CertificateValidationMode = X509CertificateValidationMode.ChainTrust;
-            
+
             serviceProxy = factory.CreateChannel();
 
             // *** EXECUTE *** \\

--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Tcp/IdentityTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Tcp/IdentityTests.cs
@@ -9,6 +9,9 @@ using Infrastructure.Common;
 public static class IdentityTests
 {
     [Fact]
+#if FEATURE_NETNATIVE
+    [ActiveIssue(833)] // Not supported in NET Native
+#endif
     [OuterLoop]
     // The product code will check the Dns identity from the server and throw if it does not match what is specified in DnsEndpointIdentity
     public static void VerifyServiceIdentityMatchDnsEndpointIdentity()
@@ -37,6 +40,9 @@ public static class IdentityTests
     }
 
     [Fact]
+#if FEATURE_NETNATIVE
+    [ActiveIssue(833)] // Not supported in NET Native
+#endif
     [OuterLoop]
     // Verify product throws MessageSecurityException when the Dns identity from the server does not match the expectation
     public static void ServiceIdentityNotMatch_Throw_MessageSecurityException()

--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Tcp/StreamingTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Tcp/StreamingTests.cs
@@ -16,7 +16,11 @@ public static class StreamingTests
 {
     [Fact]
     [OuterLoop]
-    [ActiveIssue(851, PlatformID.AnyUnix)] 
+#if !FEATURE_NETNATIVE
+    [ActiveIssue(851, PlatformID.AnyUnix)] // NegotiateStream works on Windows but limitations related to credentials means automated tests can't work on Unix at this point.
+#else
+    [ActiveIssue(832)] // Windows Stream Security is not supported in NET Native
+#endif
     public static void NetTcp_TransportSecurity_StreamedRequest_RoundTrips_String()
     {
         string testString = "Hello";
@@ -53,7 +57,11 @@ public static class StreamingTests
 
     [Fact]
     [OuterLoop]
-    [ActiveIssue(851, PlatformID.AnyUnix)] 
+#if !FEATURE_NETNATIVE
+    [ActiveIssue(851, PlatformID.AnyUnix)] // NegotiateStream works on Windows but limitations related to credentials means automated tests can't work on Unix at this point.
+#else
+    [ActiveIssue(832)] // Windows Stream Security is not supported in NET Native
+#endif
     public static void NetTcp_TransportSecurity_StreamedResponse_RoundTrips_String()
     {
         string testString = "Hello";
@@ -89,7 +97,11 @@ public static class StreamingTests
 
     [Fact]
     [OuterLoop]
-    [ActiveIssue(851, PlatformID.AnyUnix)] 
+#if !FEATURE_NETNATIVE
+    [ActiveIssue(851, PlatformID.AnyUnix)] // NegotiateStream works on Windows but limitations related to credentials means automated tests can't work on Unix at this point.
+#else
+    [ActiveIssue(832)] // Windows Stream Security is not supported in NET Native
+#endif
     public static void NetTcp_TransportSecurity_Streamed_RoundTrips_String()
     {
         string testString = "Hello";
@@ -127,7 +139,11 @@ public static class StreamingTests
 
     [Fact]
     [OuterLoop]
-    [ActiveIssue(851, PlatformID.AnyUnix)] 
+#if !FEATURE_NETNATIVE
+    [ActiveIssue(851, PlatformID.AnyUnix)] // NegotiateStream works on Windows but limitations related to credentials means automated tests can't work on Unix at this point.
+#else
+    [ActiveIssue(832)] // Windows Stream Security is not supported in NET Native
+#endif
     public static void NetTcp_TransportSecurity_Streamed_TimeOut_Long_Running_Operation()
     {
         string testString = "Hello";
@@ -181,7 +197,11 @@ public static class StreamingTests
 
     [Fact]
     [OuterLoop]
-    [ActiveIssue(851, PlatformID.AnyUnix)] 
+#if !FEATURE_NETNATIVE
+    [ActiveIssue(851, PlatformID.AnyUnix)] // NegotiateStream works on Windows but limitations related to credentials means automated tests can't work on Unix at this point.
+#else
+    [ActiveIssue(832)] // Windows Stream Security is not supported in NET Native
+#endif
     public static void NetTcp_TransportSecurity_Streamed_Async_RoundTrips_String()
     {
         string testString = "Hello";
@@ -220,7 +240,11 @@ public static class StreamingTests
 
     [Fact]
     [OuterLoop]
-    [ActiveIssue(851, PlatformID.AnyUnix)] 
+#if !FEATURE_NETNATIVE
+    [ActiveIssue(851, PlatformID.AnyUnix)] // NegotiateStream works on Windows but limitations related to credentials means automated tests can't work on Unix at this point.
+#else
+    [ActiveIssue(832)] // Windows Stream Security is not supported in NET Native
+#endif
     public static void NetTcp_TransportSecurity_StreamedRequest_Async_RoundTrips_String()
     {
         string testString = "Hello";
@@ -259,7 +283,11 @@ public static class StreamingTests
 
     [Fact]
     [OuterLoop]
-    [ActiveIssue(851, PlatformID.AnyUnix)] 
+#if !FEATURE_NETNATIVE
+    [ActiveIssue(851, PlatformID.AnyUnix)] // NegotiateStream works on Windows but limitations related to credentials means automated tests can't work on Unix at this point.
+#else
+    [ActiveIssue(832)] // Windows Stream Security is not supported in NET Native
+#endif
     public static void NetTcp_TransportSecurity_StreamedResponse_Async_RoundTrips_String()
     {
         string testString = "Hello";
@@ -298,7 +326,11 @@ public static class StreamingTests
 
     [Fact]
     [OuterLoop]
-    [ActiveIssue(851, PlatformID.AnyUnix)] 
+#if !FEATURE_NETNATIVE
+    [ActiveIssue(851, PlatformID.AnyUnix)] // NegotiateStream works on Windows but limitations related to credentials means automated tests can't work on Unix at this point.
+#else
+    [ActiveIssue(832)] // Windows Stream Security is not supported in NET Native
+#endif
     public static void NetTcp_TransportSecurity_Streamed_RoundTrips_String_WithSingleThreadedSyncContext()
     {
         bool success = Task.Run(() =>
@@ -313,7 +345,11 @@ public static class StreamingTests
 
     [Fact]
     [OuterLoop]
-    [ActiveIssue(851, PlatformID.AnyUnix)] 
+#if !FEATURE_NETNATIVE
+    [ActiveIssue(851, PlatformID.AnyUnix)] // NegotiateStream works on Windows but limitations related to credentials means automated tests can't work on Unix at this point.
+#else
+    [ActiveIssue(832)] // Windows Stream Security is not supported in NET Native
+#endif
     public static void NetTcp_TransportSecurity_Streamed_Async_RoundTrips_String_WithSingleThreadedSyncContext()
     {
         bool success = Task.Run(() =>
@@ -325,7 +361,7 @@ public static class StreamingTests
         }).Wait(ScenarioTestHelpers.TestTimeout);
         Assert.True(success, "Test Scenario: NetTcp_TransportSecurity_Streamed_Async_RoundTrips_String_WithSingleThreadedSyncContext timed-out.");
     }
-    
+
     private static void PrintInnerExceptionsHresult(Exception e, StringBuilder errorBuilder)
     {
         if (e.InnerException != null)


### PR DESCRIPTION
* By wrapping the ActiveIssue in an #if #endif based on FEATURE_NETNATIVE we should be able to only skip these test on NET Native and not on NET Core.