### PR TITLE
Add PR sync scripts to repo for CI

### DIFF
--- a/src/System.Private.ServiceModel/tools/setupfiles/sync-pr.cmd
+++ b/src/System.Private.ServiceModel/tools/setupfiles/sync-pr.cmd
@@ -2,23 +2,24 @@
 setlocal
 
 REM 
-REM This calls a web service, specified on the command line, which syncs a 
-REM remote server's repo to the correct PR. 
+REM This notifies a the test web service, specified on the command line,
+REM that a test is about to start
 REM This script is meant to be called from a GitHub Pull Request. 
 REM 
 
 set __args=%*
 
 echo.
-echo  WCF Remote Github Repo sync script
+echo  WCF Test Service Pull Request sync script
 echo. 
 
-if '%__args%'=='' (
+if "__args%"=="" (
     echo   [%~n0] A URL must be specified for the pull request synchronization URL
-    echo     Usage:  %~n0 [sync url] [pr-number (optional)]
+    echo     Usage:  %~n0 [sync url] [optional pr-number]
     echo   sync-url  - URL on remote server for PR synchronization
     echo   pr-number - PR number to sync to
     echo.
+    echo   Example:  %~n0 http://wcfci-sync-server/repo/sync.ashx 
     echo   Example:  %~n0 http://wcfci-sync-server/repo/sync.ashx 404
     set __EXITCODE=1
     goto done
@@ -26,7 +27,7 @@ if '%__args%'=='' (
 
 set __SYNC_HOST_URL=%1
 
-if '%2'=='' (
+if "%2"=="" (
     if '%ghprbPullId%'=='' (
         echo   [%~n0] This script should only be called only from the context of a GitHub Pull Request
         echo   [%~n0] 'ghprbPullId' environment variable not set
@@ -38,7 +39,7 @@ if '%2'=='' (
 ) else (
     set __PR_ID=%2
     echo   [%~n0] WARNING: This script should usually only be called only from the context of a GitHub Pull Request
-    echo   [%~n0] PR ID overridden: '%__PR_ID%'
+    echo   [%~n0] PR ID overridden: '%2'
 ) 
 
 set __REQUEST_URL=%__SYNC_HOST_URL%?pr=%__PR_ID%

--- a/src/System.Private.ServiceModel/tools/setupfiles/sync-pr.cmd
+++ b/src/System.Private.ServiceModel/tools/setupfiles/sync-pr.cmd
@@ -1,0 +1,53 @@
+@echo off 
+setlocal
+
+REM 
+REM This calls a web service, specified on the command line, which syncs a 
+REM remote server's repo to the correct PR. 
+REM This script is meant to be called from a GitHub Pull Request. 
+REM 
+
+set __args=%*
+
+echo.
+echo  WCF Remote Github Repo sync script
+echo. 
+
+if '%__args%'=='' (
+    echo   [%~n0] A URL must be specified for the pull request synchronization URL
+    echo     Usage:  %~n0 [sync url] [pr-number (optional)]
+    echo   sync-url  - URL on remote server for PR synchronization
+    echo   pr-number - PR number to sync to
+    echo.
+    echo   Example:  %~n0 http://wcfci-sync-server/repo/sync.ashx 404
+    set __EXITCODE=1
+    goto done
+)
+
+set __SYNC_HOST_URL=%1
+
+if '%2'=='' (
+    if '%ghprbPullId%'=='' (
+        echo   [%~n0] This script should only be called only from the context of a GitHub Pull Request
+        echo   [%~n0] 'ghprbPullId' environment variable not set
+        set __EXITCODE=1
+        goto done
+    ) else ( 
+        set __PR_ID=%ghprbPullId%
+    )
+) else (
+    set __PR_ID=%2
+    echo   [%~n0] WARNING: This script should usually only be called only from the context of a GitHub Pull Request
+    echo   [%~n0] PR ID overridden: '%__PR_ID%'
+) 
+
+set __REQUEST_URL=%__SYNC_HOST_URL%?pr=%__PR_ID%
+echo   [%~n0] Making call to '%__REQUEST_URL%'
+powershell -NoProfile -ExecutionPolicy unrestricted -Command "(New-Object Net.WebClient).DownloadString('%__REQUEST_URL%'); 
+
+set __EXITCODE=%ERRORLEVEL% 
+
+:done
+endlocal
+exit /b %__EXITCODE% 
+

--- a/src/System.Private.ServiceModel/tools/setupfiles/sync-pr.sh
+++ b/src/System.Private.ServiceModel/tools/setupfiles/sync-pr.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+
+show_banner()
+{
+    echo ""
+    echo "WCF Remote Github Repo sync script"
+    echo ""
+}
+
+show_usage() 
+{
+    echo "    A URL must be specified for the pull request synchronization URL"
+    echo "    Usage: $0 [sync-url] [pr-number (optional)]"
+    echo "    sync-url  - URL on remote server for PR synchronization"
+    echo "    pr-number - PR to sync to"
+    echo ""
+    echo "    Example:  $0 http://wcfci-sync-server/repo/sync.ashx 404"
+    echo ""
+}
+
+run_request() 
+{
+    __sync_url=$1
+    __ghprbPullId=$2
+
+    __request_uri=${__sync_url}?pr=${__ghprbPullId}
+
+    echo "    Making a call to '${__request_uri}'" 
+
+    which curl wget > /dev/null 2> /dev/null
+    if [ $? -ne 0 -a $? -ne 1 ]; then
+        echo "    cURL or wget is required to make this request. Please see https://github.com/dotnet/wcf/blob/master/Documentation/building/unix-instructions.md for more details."
+        exit 1
+    fi
+
+    # curl has HTTPS CA trust-issues less often than wget, so lets try that first.
+    which curl > /dev/null 2> /dev/null
+    if [ $? -ne 0 ]; then
+       wget -q -O- ${__request_uri}
+    else
+       output=`curl -sw "\n%{http_code}" ${__request_uri}`
+       echo $output
+       retCode=`echo ${output} | grep "200\$"`
+    fi
+
+    return $?
+}
+
+# Main execution
+
+show_banner
+
+# Check parameters
+
+if [ -z "$1" ]; then 
+    show_usage
+    exit 1
+fi 
+
+__sync_url=$1
+
+if [ -z "$2" ]; then 
+    if [ -z "$ghprbPullId" ]; then 
+        show_usage
+        echo "    This script should only be called only from the context of a GitHub Pull Request"
+        echo "    'ghprbPullId' environment variable not set"
+    
+        exit 1
+    else 
+        __pr_id=$ghprbPullId
+    fi  
+else  
+    __pr_id=$2
+    show_usage 
+    echo "    WARNING: This script should usually only be called only from the context of a GitHub Pull Request"
+    echo "    PR ID overridden '${__pr_id}'"
+fi
+
+# Run 
+run_request $__sync_url $__pr_id
+
+__exit_code=$?
+
+if [ $__exit_code -ne 0 ]; then
+    echo "Server error when syncing to Pull Request"
+fi 
+
+exit $__exit_code 

--- a/src/System.Private.ServiceModel/tools/setupfiles/sync-pr.sh
+++ b/src/System.Private.ServiceModel/tools/setupfiles/sync-pr.sh
@@ -1,9 +1,13 @@
 #!/usr/bin/env bash
 
+# This notifies a the test web service, specified on the command line,
+# that a test is about to start
+# This script is meant to be called from a GitHub Pull Request.
+
 show_banner()
 {
     echo ""
-    echo "WCF Remote Github Repo sync script"
+    echo "WCF Test Service Pull Request sync script"
     echo ""
 }
 
@@ -14,6 +18,7 @@ show_usage()
     echo "    sync-url  - URL on remote server for PR synchronization"
     echo "    pr-number - PR to sync to"
     echo ""
+    echo "    Example:  $0 http://wcfci-sync-server/repo/sync.ashx"
     echo "    Example:  $0 http://wcfci-sync-server/repo/sync.ashx 404"
     echo ""
 }


### PR DESCRIPTION
These scripts are for allowing the CI system to call out to a WCF sync service for outerloop tests. This is not incorporated into the CI system yet, as the relevant pieces on the test server/client are not yet done. 

skip ci please