### PR TITLE
Update version of xunit.netcore.extensions to 187

### DIFF
--- a/BuildToolsVersion.txt
+++ b/BuildToolsVersion.txt
@@ -1,1 +1,1 @@
-1.0.25-prerelease-00206
+1.0.25-prerelease-00220

--- a/src/System.Private.ServiceModel/tests/Common/Infrastructure/tests/project.json
+++ b/src/System.Private.ServiceModel/tests/Common/Infrastructure/tests/project.json
@@ -5,7 +5,7 @@
     "System.ServiceModel.Primitives": "4.1.0-rc3-23921",
     "System.ServiceModel.Security": "4.0.1-rc3-23921",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00187"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Private.ServiceModel/tests/Common/Scenarios/project.json
+++ b/src/System.Private.ServiceModel/tests/Common/Scenarios/project.json
@@ -19,7 +19,7 @@
     "System.Threading.Tasks": "4.0.11-rc3-23921",
     "System.Xml.XmlSerializer": "4.0.11-rc3-23921",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00187"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Private.ServiceModel/tests/Scenarios/Binding/Custom/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Binding/Custom/project.json
@@ -5,7 +5,7 @@
     "System.ServiceModel.Http": "4.1.0-rc3-23921",
     "System.ServiceModel.Primitives": "4.1.0-rc3-23921",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00187"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Private.ServiceModel/tests/Scenarios/Binding/Http/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Binding/Http/project.json
@@ -5,7 +5,7 @@
     "System.ServiceModel.Http": "4.1.0-rc3-23921",
     "System.ServiceModel.Primitives": "4.1.0-rc3-23921",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00187"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/ChannelLayer/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/ChannelLayer/project.json
@@ -7,7 +7,7 @@
     "System.ServiceModel.NetTcp": "4.1.0-rc3-23921",
     "System.ServiceModel.Primitives": "4.1.0-rc3-23921",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00187"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/ClientBase/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/ClientBase/project.json
@@ -10,7 +10,7 @@
     "System.ServiceModel.NetTcp": "4.1.0-rc3-23921",
     "System.ServiceModel.Primitives": "4.1.0-rc3-23921",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00187"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/ExpectedExceptions/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/ExpectedExceptions/project.json
@@ -20,7 +20,7 @@
     "System.Xml.ReaderWriter": "4.0.11-rc3-23921",
     "System.Xml.XmlSerializer": "4.0.11-rc3-23921",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00187"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/TypedClient/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/TypedClient/project.json
@@ -8,7 +8,7 @@
     "System.ServiceModel.NetTcp": "4.1.0-rc3-23921",
     "System.ServiceModel.Primitives": "4.1.0-rc3-23921",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00187"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Private.ServiceModel/tests/Scenarios/Contract/Data/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Contract/Data/project.json
@@ -8,7 +8,7 @@
     "System.ServiceModel.NetTcp": "4.1.0-rc3-23921",
     "System.ServiceModel.Primitives": "4.1.0-rc3-23921",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00187"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Private.ServiceModel/tests/Scenarios/Contract/Fault/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Contract/Fault/project.json
@@ -6,7 +6,7 @@
     "System.ServiceModel.Http": "4.1.0-rc3-23921",
     "System.ServiceModel.Primitives": "4.1.0-rc3-23921",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00187"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Private.ServiceModel/tests/Scenarios/Contract/Message/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Contract/Message/project.json
@@ -6,7 +6,7 @@
     "System.ServiceModel.Http": "4.1.0-rc3-23921",
     "System.ServiceModel.Primitives": "4.1.0-rc3-23921",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00187"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Private.ServiceModel/tests/Scenarios/Contract/Service/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Contract/Service/project.json
@@ -9,7 +9,7 @@
     "System.ServiceModel.Primitives": "4.1.0-rc3-23921",
     "System.Text.Encoding": "4.0.11-rc3-23921",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00187"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Private.ServiceModel/tests/Scenarios/Contract/XmlSerializer/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Contract/XmlSerializer/project.json
@@ -6,7 +6,7 @@
     "System.ServiceModel.Http": "4.1.0-rc3-23921",
     "System.ServiceModel.Primitives": "4.1.0-rc3-23921",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00187"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Private.ServiceModel/tests/Scenarios/Encoding/Encoders/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Encoding/Encoders/project.json
@@ -7,7 +7,7 @@
     "System.ServiceModel.NetTcp": "4.1.0-rc3-23921",
     "System.ServiceModel.Primitives": "4.1.0-rc3-23921",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00187"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Private.ServiceModel/tests/Scenarios/Encoding/MessageVersion/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Encoding/MessageVersion/project.json
@@ -5,7 +5,7 @@
     "System.ServiceModel.Http": "4.1.0-rc3-23921",
     "System.ServiceModel.Primitives": "4.1.0-rc3-23921",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00187"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Private.ServiceModel/tests/Scenarios/Extensibility/WebSockets/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Extensibility/WebSockets/project.json
@@ -9,7 +9,7 @@
     "System.ServiceModel.NetTcp": "4.1.0-rc3-23921",
     "System.ServiceModel.Primitives": "4.1.0-rc3-23921",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00187"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/project.json
@@ -9,7 +9,7 @@
     "System.ServiceModel.Primitives": "4.1.0-rc3-23921",
     "System.ServiceModel.Security": "4.0.1-rc3-23921",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00187"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.ServiceModel.Duplex/tests/project.json
+++ b/src/System.ServiceModel.Duplex/tests/project.json
@@ -8,7 +8,7 @@
     "System.ServiceModel.Primitives": "4.1.0-rc3-23921",
     "System.ServiceModel.Security": "4.0.1-rc3-23921",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00187"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.ServiceModel.Http/tests/project.json
+++ b/src/System.ServiceModel.Http/tests/project.json
@@ -8,7 +8,7 @@
     "System.ServiceModel.Primitives": "4.1.0-rc3-23921",
     "System.ServiceModel.Security": "4.0.1-rc3-23921",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00187"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.ServiceModel.NetTcp/tests/project.json
+++ b/src/System.ServiceModel.NetTcp/tests/project.json
@@ -6,7 +6,7 @@
     "System.ServiceModel.NetTcp": "4.1.0-rc3-23921",
     "System.ServiceModel.Primitives": "4.1.0-rc3-23921",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00187"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.ServiceModel.Primitives/tests/project.json
+++ b/src/System.ServiceModel.Primitives/tests/project.json
@@ -11,7 +11,7 @@
     "System.ServiceModel.Primitives": "4.1.0-rc3-23921",
     "System.ServiceModel.Security": "4.0.1-rc3-23921",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00187"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.ServiceModel.Security/tests/project.json
+++ b/src/System.ServiceModel.Security/tests/project.json
@@ -6,7 +6,7 @@
     "System.ServiceModel.Primitives": "4.1.0-rc3-23921",
     "System.ServiceModel.Security": "4.0.1-rc3-23921",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00187"
   },
   "frameworks": {
     "dnxcore50": {


### PR DESCRIPTION
Updates the version of xunit.netcore.extensions to 187.
This is to stay in sync with CoreFx and take some of the
fixes and enhancements in the test case discoverers.