### PR TITLE
Fix NullReferenceException in SendRequestAsync during async streaming

### DIFF
--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/HttpChannelFactory.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/HttpChannelFactory.cs
@@ -904,6 +904,9 @@ namespace System.ServiceModel.Channels
                     _httpClient = await _channel.GetHttpClientAsync(_to, _via, _timeoutHelper);
                     _httpRequestMessage = _channel.GetHttpRequestMessage(_via);
 
+                    // The _httpRequestMessage field will be set to null by Cleanup() due to faulting
+                    // or aborting, so use a local copy for exception handling within this method.
+                    HttpRequestMessage httpRequestMessage = _httpRequestMessage;
                     Message request = message;
 
                     try
@@ -949,7 +952,7 @@ namespace System.ServiceModel.Channels
                         }
                         catch (HttpRequestException requestException)
                         {
-                            HttpChannelUtilities.ProcessGetResponseWebException(requestException, _httpRequestMessage,
+                            HttpChannelUtilities.ProcessGetResponseWebException(requestException, httpRequestMessage,
                                 _abortReason);
                         }
                         catch (OperationCanceledException)
@@ -957,7 +960,7 @@ namespace System.ServiceModel.Channels
                             if (cancelTokenTask.Result.IsCancellationRequested)
                             {
                                 throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new TimeoutException(SR.Format(
-                                    SR.HttpRequestTimedOut, _httpRequestMessage.RequestUri, _timeoutHelper.OriginalTimeout)));
+                                    SR.HttpRequestTimedOut, httpRequestMessage.RequestUri, _timeoutHelper.OriginalTimeout)));
                             }
                             else
                             {


### PR DESCRIPTION
Problem: HttpChannelFactory.SendRequestAsync keeps the HttpRequestMessage
in a member field and uses it during async processing.  But a Fault or Abort
will null the HttpRequestMessage field.  If this happens while the
SendRequestAsync method is executing, it leads to NullReferenceException
during error handling.

Solution: keep a local variable copy of the HttpRequestMessage for use in
error handling.  Even if the original is disposed or the field set to null,
error handling only requires access to the RequestUri property.

Fixes #931