### PR TITLE
Adds scenario test for AV during Http async stream read

### DIFF
--- a/src/System.Private.ServiceModel/tests/Common/Scenarios/TestMockStream.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Scenarios/TestMockStream.cs
@@ -1,0 +1,87 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace ScenarioTests.Common
+{
+    // This class provides a mock for a Stream that allows tests
+    // to override its methods to inject different test behaviors.
+    public class TestMockStream : Stream
+    {
+        public TestMockStream() : this(new MemoryStream())
+        {
+        }
+
+        public TestMockStream(Stream innerStream)
+        {
+            InnerStream = innerStream;
+        }
+
+        private Stream InnerStream { get; set; }
+
+        // Func to call for CopyToAsync (default is inner stream's CopyToAsync)
+        public Func<Stream, int, CancellationToken, Task> CopyToAsyncFunc { get; set; }
+
+        // Func to call instead for Read() (default is inner stream's Read)
+        public Func<byte[], int, int, int> ReadFunc { get; set; }
+
+        public override bool CanRead { get { return InnerStream.CanRead; } }
+
+        public override bool CanSeek { get { return InnerStream.CanSeek; } }
+
+        public override bool CanWrite { get { return InnerStream.CanWrite; } }
+
+        public override long Length { get { return InnerStream.Length; } }
+
+        public override long Position
+        {
+            get { return InnerStream.Position; }
+            set { InnerStream.Position = value; }
+        }
+
+        public override Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken)
+        {
+            Task t = null;
+
+            // Call out to mock user's func.  If the returned Task is non-null,
+            // return it, else fall into default logic
+            if (CopyToAsyncFunc != null)
+            {
+                t = CopyToAsyncFunc(destination, bufferSize, cancellationToken);
+            }
+
+            return t ?? InnerStream.CopyToAsync(destination, bufferSize, cancellationToken);
+        }
+
+        public override void Flush()
+        {
+            InnerStream.Flush();
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            return ReadFunc != null
+                ? ReadFunc(buffer, offset, count)
+                : InnerStream.Read(buffer, offset, count);
+        }
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            return InnerStream.Seek(offset, origin);
+        }
+
+        public override void SetLength(long value)
+        {
+            InnerStream.SetLength(value);
+        }
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            InnerStream.Write(buffer, offset, count);
+        }
+    }
+}

--- a/src/System.Private.ServiceModel/tests/Scenarios/Contract/Service/ServiceContractTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Contract/Service/ServiceContractTests.cs
@@ -9,7 +9,9 @@ using System.ServiceModel.Channels;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using ScenarioTests.Common;
 using Xunit;
+
 
 public static class ServiceContractTests
 {
@@ -222,6 +224,68 @@ public static class ServiceContractTests
             });
         }).Wait(ScenarioTestHelpers.TestTimeout);
         Assert.True(success, "Test Scenario: BasicHttp_DefaultSettings_Echo_RoundTrips_String_Streamed_Async_WithSingleThreadedSyncContext timed-out.");
+    }
+
+    [Fact]
+    [OuterLoop]
+    public static void BasicHttp_Echo_Streamed_Async_Delayed_Throws_TimeoutException()
+    {
+        BasicHttpBinding binding = null;
+        ChannelFactory<IWcfService> factory = null;
+        IWcfService serviceProxy = null;
+        Stream stream = null;
+        int sendTimeoutMs = 3000;
+
+        try
+        {
+            // *** SETUP *** \\
+            binding = new BasicHttpBinding(BasicHttpSecurityMode.None);
+            binding.TransferMode = TransferMode.Streamed;
+            binding.SendTimeout = TimeSpan.FromMilliseconds(sendTimeoutMs);
+            factory = new ChannelFactory<IWcfService>(binding, new EndpointAddress(Endpoints.HttpBaseAddress_Basic));
+            serviceProxy = factory.CreateChannel();
+
+            // Create a read stream that will abort the proxy channel when the async read is called.
+            // We also intercept the synchronous read because that path can also be executed during
+            // an async read.
+            stream = new TestMockStream()
+            {
+                CopyToAsyncFunc = (Stream destination, int bufferSize, CancellationToken ct) =>
+                {
+                    // Abort to force the internal HttpClientChannelAsyncRequest.Cleanup()
+                    // to clear its data structures before it cancels its timeout task.
+                    ((ICommunicationObject)serviceProxy).Abort();
+                    Task.Delay(sendTimeoutMs * 2).Wait();
+                    return null;
+                },
+
+                ReadFunc = (byte[] buffer, int offset, int count) =>
+                {
+                    // Abort to force the internal HttpClientChannelAsyncRequest.Cleanup()
+                    // to clear its data structures before it cancels its timeout task.
+                    ((ICommunicationObject)serviceProxy).Abort();
+                    Task.Delay(sendTimeoutMs * 2).Wait();
+                    return -1;
+                }
+            };
+
+            // *** EXECUTE *** \\
+            Assert.Throws<TimeoutException>(() =>
+            {
+                var unused = serviceProxy.EchoStreamAsync(stream).GetAwaiter().GetResult();
+            });
+
+            // *** VALIDATE *** \\
+
+            // *** CLEANUP *** \\
+            ((ICommunicationObject)serviceProxy).Close();
+            factory.Close();
+        }
+        finally
+        {
+            // *** ENSURE CLEANUP *** \\
+            ScenarioTestHelpers.CloseCommunicationObjects((ICommunicationObject)serviceProxy, factory);
+        }
     }
 
     [Fact]


### PR DESCRIPTION
Issue #931 was discovered by stress tests, where an aborted
Http request doing an asynchronous read would throw a
NullReferenceException.

The cause is not a race condition but instead incorrect use of
member fields in exception handling.  This PR adds a scenario test
that exactly duplicates the stress test and causes NullRefException.

This test will be merged only after #935 that contains the fix to
issue #931.  The changes are being kept separate to allow selective
cherry-picking into the RC2 branch.