### PR TITLE
Adding OS X ActiveIssue for tests failing due to Issue #951

### DIFF
--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/ChannelLayer/DuplexChannelShapeTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/ChannelLayer/DuplexChannelShapeTests.cs
@@ -21,6 +21,7 @@ public static class DuplexChannelShapeTests
 
     [Fact]
     [OuterLoop]
+    [ActiveIssue(951, PlatformID.OSX)]
     public static void IDuplexSessionChannel_Tcp_NetTcpBinding()
     {
         StringBuilder errorBuilder = new StringBuilder();

--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/ClientBase/DuplexClientBaseTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/ClientBase/DuplexClientBaseTests.cs
@@ -51,6 +51,7 @@ public static class DuplexClientBaseTests
 
     [Fact]
     [OuterLoop]
+    [ActiveIssue(951, PlatformID.OSX)]
     public static void DuplexClientBaseOfT_OverNetTcp_Synchronous_Call()
     {
         DuplexClientBase<IWcfDuplexService> duplexService = null;

--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/TypedClient/TypedProxyDuplexTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/TypedClient/TypedProxyDuplexTests.cs
@@ -17,6 +17,7 @@ public static class TypedProxyDuplexTests
 
     [Fact]
     [OuterLoop]
+    [ActiveIssue(951, PlatformID.OSX)]
     public static void ServiceContract_TypedProxy_AsyncTask_CallbackReturn()
     {
         DuplexChannelFactory<IWcfDuplexTaskReturnService> factory = null;

--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/TypedClient/TypedProxyTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/TypedClient/TypedProxyTests.cs
@@ -35,6 +35,7 @@ public static class TypedProxyTests
 
     [Fact]
     [OuterLoop]
+    [ActiveIssue(951, PlatformID.OSX)]
     public static void ServiceContract_TypedProxy_NetTcpBinding_AsyncBeginEnd_Call()
     {
         NetTcpBinding netTcpBinding = new NetTcpBinding(SecurityMode.None);
@@ -54,6 +55,7 @@ public static class TypedProxyTests
 
     [Fact]
     [OuterLoop]
+    [ActiveIssue(951, PlatformID.OSX)]
     public static void ServiceContract_TypedProxy_NetTcpBinding_AsyncBeginEnd_Call_WithNoCallback()
     {
         NetTcpBinding netTcpBinding = new NetTcpBinding(SecurityMode.None);
@@ -76,6 +78,7 @@ public static class TypedProxyTests
 
     [Fact]
     [OuterLoop]
+    [ActiveIssue(951, PlatformID.OSX)]
     public static void ServiceContract_TypedProxy_NetTcpBinding_AsyncBeginEnd_Call_WithSingleThreadedSyncContext()
     {
         bool success = Task.Run(() =>
@@ -101,6 +104,7 @@ public static class TypedProxyTests
 
     [Fact]
     [OuterLoop]
+    [ActiveIssue(951, PlatformID.OSX)]
     public static void ServiceContract_TypedProxy_NetTcpBinding_AsyncTask_Call()
     {
         NetTcpBinding netTcpBinding = new NetTcpBinding();
@@ -125,6 +129,7 @@ public static class TypedProxyTests
 
     [Fact]
     [OuterLoop]
+    [ActiveIssue(951, PlatformID.OSX)]
     public static void ServiceContract_TypedProxy__NetTcpBinding_AsyncTask_Call_WithSingleThreadedSyncContext()
     {
         bool success = Task.Run(() =>
@@ -414,6 +419,7 @@ public static class TypedProxyTests
 
     [Fact]
     [OuterLoop]
+    [ActiveIssue(951, PlatformID.OSX)]
     public static void ServiceContract_TypedProxy_DuplexCallback()
     {
         DuplexChannelFactory<IDuplexChannelService> factory = null;

--- a/src/System.Private.ServiceModel/tests/Scenarios/Contract/Data/DataContractTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Contract/Data/DataContractTests.cs
@@ -56,6 +56,7 @@ public static class DataContractTests
     // Verify that a callback contract correctly returns a complex type when this type is not part of the contract with the ServiceContract attribute.
     [Fact]
     [OuterLoop]
+    [ActiveIssue(951, PlatformID.OSX)]
     public static void NetTcpBinding_DuplexCallback_ReturnsDataContractComplexType()
     {
         DuplexChannelFactory<IWcfDuplexService_DataContract> factory = null;
@@ -94,6 +95,7 @@ public static class DataContractTests
     // Verify that a callback contract correctly returns a complex type using Xml instead of DataContract when this type is not part of the contract with the ServiceContract attribute.
     [Fact]
     [OuterLoop]
+    [ActiveIssue(951, PlatformID.OSX)]
     public static void NetTcpBinding_DuplexCallback_ReturnsXmlComplexType()
     {
         DuplexChannelFactory<IWcfDuplexService_Xml> factory = null;

--- a/src/System.Private.ServiceModel/tests/Scenarios/Contract/Service/ServiceContractTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Contract/Service/ServiceContractTests.cs
@@ -349,6 +349,7 @@ public static class ServiceContractTests
 
     [Fact]
     [OuterLoop]
+    [ActiveIssue(951, PlatformID.OSX)]
     public static void NetTcp_NoSecurity_Buffered_RoundTrips_String()
     {
         string testString = "Hello";

--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Tcp/ClientCredentialTypeTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Tcp/ClientCredentialTypeTests.cs
@@ -55,6 +55,7 @@ public static class Tcp_ClientCredentialTypeTests
     // Simple echo of a string using NetTcpBinding on both client and server with SecurityMode=None
     [Fact]
     [OuterLoop]
+    [ActiveIssue(951, PlatformID.OSX)]
     public static void SameBinding_SecurityModeNone_EchoString()
     {
         string testString = "Hello";
@@ -169,6 +170,8 @@ public static class Tcp_ClientCredentialTypeTests
     [Fact]
 #if FEATURE_NETNATIVE
     [ActiveIssue(834)] // Not supported in NET Native
+#else
+    [ActiveIssue(951, PlatformID.OSX)]
 #endif
     [OuterLoop]
     public static void TcpClientCredentialType_Certificate_EchoString()
@@ -219,6 +222,8 @@ public static class Tcp_ClientCredentialTypeTests
     [Fact]
 #if FEATURE_NETNATIVE
     [ActiveIssue(834)] // Not supported in NET Native
+#else
+    [ActiveIssue(951, PlatformID.OSX)]
 #endif
     [OuterLoop]
     public static void TcpClientCredentialType_Certificate_CustomValidator_EchoString()


### PR DESCRIPTION
* Issue #951 is blocked by dotnet/corefx#7403 skipping the affected tests for OS X platform.