### PR TITLE
Add support for [ConditionalFact] based on TestProperties

### DIFF
--- a/src/System.Private.ServiceModel/tests/Common/Infrastructure/src/ConditionalWcfTest.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Infrastructure/src/ConditionalWcfTest.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+namespace Infrastructure.Common
+{
+    // ConditionalWcfTest is expected to be the base class of any test
+    // class that includes [ConditionalFact] or [ConditionalTheory]. This
+    // is necessary because the conditional attributes are expected to
+    // refer to members within their test class or its base classes.
+    public class ConditionalWcfTest
+    {
+        private static bool IsConditionalTestEnabled(string testCategoryName)
+        {
+            string propertyValue = TestProperties.GetProperty(testCategoryName);
+            bool isEnabled;
+            if (!String.IsNullOrEmpty(propertyValue) && bool.TryParse(propertyValue, out isEnabled))
+            {
+                return isEnabled;
+            }
+
+            return false;
+        }
+
+        public static bool Domain_Joined()
+        {
+            return IsConditionalTestEnabled(TestProperties.Domain_Joined_PropertyName);
+        }
+
+        public static bool Root_Certificate_Installed()
+        {
+            return IsConditionalTestEnabled(TestProperties.Root_Certificate_Installed_PropertyName);
+        }
+
+        public static bool Client_Certificate_Installed()
+        {
+            return IsConditionalTestEnabled(TestProperties.Client_Certificate_Installed_PropertyName);
+        }
+
+        public static bool SPN_Available()
+        {
+            return IsConditionalTestEnabled(TestProperties.SPN_Available_PropertyName);
+        }
+
+        public static bool Kerberos_Available()
+        {
+            return IsConditionalTestEnabled(TestProperties.Kerberos_Available_PropertyName);
+        }
+
+    }
+}

--- a/src/System.Private.ServiceModel/tests/Common/Infrastructure/src/TestProperties.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Infrastructure/src/TestProperties.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System;
 using System.Collections.Generic;
 

--- a/src/System.Private.ServiceModel/tests/Common/Infrastructure/src/testproperties.props
+++ b/src/System.Private.ServiceModel/tests/Common/Infrastructure/src/testproperties.props
@@ -86,6 +86,26 @@
       <NegotiateTestUpn>testuser@DOMAIN.CONTOSO.COM</NegotiateTestUpn>
     </PropertyGroup>
 
+    <PropertyGroup Condition="'$(Domain_Joined)' == ''">
+      <Domain_Joined>false</Domain_Joined>
+    </PropertyGroup>
+  
+    <PropertyGroup Condition="'$(Root_Certificate_Installed)' == ''">
+      <Root_Certificate_Installed>false</Root_Certificate_Installed>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(Client_Certificate_Installed)' == ''">
+      <Client_Certificate_Installed>false</Client_Certificate_Installed>
+    </PropertyGroup>
+  
+    <PropertyGroup Condition="'$(SPN_Available)' == ''">
+      <SPN_Available>false</SPN_Available>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(Kerberos_Available)' == ''">
+      <Kerberos_Available>false</Kerberos_Available>
+    </PropertyGroup>
+  
   <!--
      GeneratedTestPropertiesFileName:
      The full path of the C# file that will be generated at build time to

--- a/src/System.Private.ServiceModel/tests/Common/Infrastructure/src/testproperties.targets
+++ b/src/System.Private.ServiceModel/tests/Common/Infrastructure/src/testproperties.targets
@@ -38,7 +38,12 @@ namespace Infrastructure.Common
         public static readonly string NegotiateTestPassword_PropertyName = "NegotiateTestPassword"%3B
         public static readonly string NegotiateTestSpn_PropertyName = "NegotiateTestSpn"%3B
         public static readonly string NegotiateTestUpn_PropertyName = "NegotiateTestUpn"%3B
-        
+        public static readonly string Domain_Joined_PropertyName = "Domain_Joined"%3B
+        public static readonly string Root_Certificate_Installed_PropertyName = "Root_Certificate_Installed"%3B
+        public static readonly string Client_Certificate_Installed_PropertyName = "Client_Certificate_Installed"%3B
+        public static readonly string SPN_Available_PropertyName = "SPN_Available"%3B
+        public static readonly string Kerberos_Available_PropertyName = "Kerberos_Available"%3B
+                
         static partial void Initialize(Dictionary<string, string> properties)
         {
             properties["BridgeResourceFolder"] = @"$(BridgeResourceFolder)"%3B
@@ -61,6 +66,11 @@ namespace Infrastructure.Common
             properties["NegotiateTestPassword"] = "$(NegotiateTestPassword)"%3B
             properties["NegotiateTestSpn"] = "$(NegotiateTestSpn)"%3B
             properties["NegotiateTestUpn"] = "$(NegotiateTestUpn)"%3B
+            properties["Domain_Joined"] = "$(Domain_Joined)"%3B
+            properties["Root_Certificate_Installed"] = "$(Root_Certificate_Installed)"%3B
+            properties["Client_Certificate_Installed"] = "$(Client_Certificate_Installed)"%3B
+            properties["SPN_Available"] = "$(SPN_Available)"%3B
+            properties["Kerberos_Available"] = "$(Kerberos_Available)"%3B
         }
     }
 }

--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Https/ClientCredentialTypeTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Https/ClientCredentialTypeTests.cs
@@ -6,8 +6,9 @@ using System.ServiceModel;
 using System.ServiceModel.Security;
 using System.Text;
 using Xunit;
+using Infrastructure.Common;
 
-public static class Https_ClientCredentialTypeTests
+public class Https_ClientCredentialTypeTests : ConditionalWcfTest
 {
     private static string s_username;
     private static string s_password;
@@ -108,8 +109,7 @@ public static class Https_ClientCredentialTypeTests
         Assert.True(exception.Message.ToLower().Contains(paraMessage), string.Format("Expected exception message to contain: '{0}', actual: '{1}'", paraMessage, exception.Message));
     }
 
-    [Fact]
-    [ActiveIssue(270)]
+    [ConditionalFact(nameof(Domain_Joined))]
     [OuterLoop]
     public static void DigestAuthentication_RoundTrips_Echo()
     {


### PR DESCRIPTION
We need a way to optionally run tests that are not normally
run by default.  This includes tests that have special requirements
for setup or environment.

We also need such tests to show as "skipped" rather than being
silently stripped from the test results, as happens with the
xunit -notrait option.