### PR TITLE
Modify NegotiateStream ambient credential tests

### DIFF
--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Negotiate/NegotiateStream_Http_Tests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Negotiate/NegotiateStream_Http_Tests.cs
@@ -62,7 +62,6 @@ public static class NegotiateStream_Http_Tests
         string testString = "Hello";
         ChannelFactory<IWcfService> factory = null;
         IWcfService serviceProxy = null;
-        bool success = false;
 
         try
         {
@@ -82,17 +81,11 @@ public static class NegotiateStream_Http_Tests
             // *** CLEANUP *** \\
             ((ICommunicationObject)serviceProxy).Close();
             factory.Close();
-            success = true; 
         }
         finally
         {
             // *** ENSURE CLEANUP *** \\
             ScenarioTestHelpers.CloseCommunicationObjects((ICommunicationObject)serviceProxy, factory);
-
-            if (!success)
-            {
-                Assert.True(false, string.Format("Credentials passed:{0}{1}", Environment.NewLine, NegotiateStreamTestConfiguration.Instance.ToString()));
-            }
         }
     }
 

--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Negotiate/NegotiateStream_Tcp_Tests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Negotiate/NegotiateStream_Tcp_Tests.cs
@@ -62,7 +62,6 @@ public static class NegotiateStream_Tcp_Tests
         string testString = "Hello";
         ChannelFactory<IWcfService> factory = null;
         IWcfService serviceProxy = null;
-        bool success = false; 
 
         try
         {
@@ -80,17 +79,11 @@ public static class NegotiateStream_Tcp_Tests
             // *** CLEANUP *** \\
             ((ICommunicationObject)serviceProxy).Close();
             factory.Close();
-            success = true; 
         }
         finally
         {
             // *** ENSURE CLEANUP *** \\
             ScenarioTestHelpers.CloseCommunicationObjects((ICommunicationObject)serviceProxy, factory);
-
-            if (!success)
-            {
-                Assert.True(false, string.Format("Credentials passed:{0}{1}", Environment.NewLine, NegotiateStreamTestConfiguration.Instance.ToString()));
-            }
         }
     }
 


### PR DESCRIPTION
In Helix, the runs do not spew out as much information as they do when running locally. We need to remove the Assert.True() at the end (used for showing the credentials used) so that the call stacks are shown.