### PR TITLE
Fix TFMs for System.Private.ServiceModel deps

### DIFF
--- a/src/System.ServiceModel.Duplex/pkg/System.ServiceModel.Duplex.pkgproj
+++ b/src/System.ServiceModel.Duplex/pkg/System.ServiceModel.Duplex.pkgproj
@@ -11,10 +11,8 @@
     <InboxOnTargetFramework Include="win8" />
 
     <ProjectReference Include="..\..\System.Private.ServiceModel\pkg\System.Private.ServiceModel.pkgproj">
-      <PackageTargetFramework>netstandardapp1.5</PackageTargetFramework>
-    </ProjectReference>
-    <ProjectReference Include="..\..\System.Private.ServiceModel\pkg\System.Private.ServiceModel.pkgproj">
-      <PackageTargetFramework>netcore50</PackageTargetFramework>
+      <!-- this needs to match the PackageTargetFramework of the facade -->
+      <PackageTargetFramework>netstandard1.3</PackageTargetFramework>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/System.ServiceModel.Http/pkg/System.ServiceModel.Http.pkgproj
+++ b/src/System.ServiceModel.Http/pkg/System.ServiceModel.Http.pkgproj
@@ -24,10 +24,8 @@
     <InboxOnTargetFramework Include="xamarinwatchos10" />
 
     <ProjectReference Include="..\..\System.Private.ServiceModel\pkg\System.Private.ServiceModel.pkgproj">
-      <PackageTargetFramework>netstandardapp1.5</PackageTargetFramework>
-    </ProjectReference>
-    <ProjectReference Include="..\..\System.Private.ServiceModel\pkg\System.Private.ServiceModel.pkgproj">
-      <PackageTargetFramework>netcore50</PackageTargetFramework>
+      <!-- this needs to match the PackageTargetFramework of the facade -->
+      <PackageTargetFramework>netstandard1.3</PackageTargetFramework>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/System.ServiceModel.NetTcp/pkg/System.ServiceModel.NetTcp.pkgproj
+++ b/src/System.ServiceModel.NetTcp/pkg/System.ServiceModel.NetTcp.pkgproj
@@ -15,10 +15,8 @@
     <InboxOnTargetFramework Include="win8" />
 
     <ProjectReference Include="..\..\System.Private.ServiceModel\pkg\System.Private.ServiceModel.pkgproj">
-      <PackageTargetFramework>netstandardapp1.5</PackageTargetFramework>
-    </ProjectReference>
-    <ProjectReference Include="..\..\System.Private.ServiceModel\pkg\System.Private.ServiceModel.pkgproj">
-      <PackageTargetFramework>netcore50</PackageTargetFramework>
+      <!-- this needs to match the PackageTargetFramework of the facade -->
+      <PackageTargetFramework>netstandard1.3</PackageTargetFramework>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/System.ServiceModel.Primitives/pkg/System.ServiceModel.Primitives.pkgproj
+++ b/src/System.ServiceModel.Primitives/pkg/System.ServiceModel.Primitives.pkgproj
@@ -25,10 +25,8 @@
     <InboxOnTargetFramework Include="xamarinwatchos10" />
 
     <ProjectReference Include="..\..\System.Private.ServiceModel\pkg\System.Private.ServiceModel.pkgproj">
-      <PackageTargetFramework>netstandardapp1.5</PackageTargetFramework>
-    </ProjectReference>
-    <ProjectReference Include="..\..\System.Private.ServiceModel\pkg\System.Private.ServiceModel.pkgproj">
-      <PackageTargetFramework>netcore50</PackageTargetFramework>
+      <!-- this needs to match the PackageTargetFramework of the facade -->
+      <PackageTargetFramework>netstandard1.3</PackageTargetFramework>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/System.ServiceModel.Security/pkg/System.ServiceModel.Security.pkgproj
+++ b/src/System.ServiceModel.Security/pkg/System.ServiceModel.Security.pkgproj
@@ -16,10 +16,8 @@
     <InboxOnTargetFramework Include="wp80" />
 
     <ProjectReference Include="..\..\System.Private.ServiceModel\pkg\System.Private.ServiceModel.pkgproj">
-      <PackageTargetFramework>netstandardapp1.5</PackageTargetFramework>
-    </ProjectReference>
-    <ProjectReference Include="..\..\System.Private.ServiceModel\pkg\System.Private.ServiceModel.pkgproj">
-      <PackageTargetFramework>netcore50</PackageTargetFramework>
+      <!-- this needs to match the PackageTargetFramework of the facade -->
+      <PackageTargetFramework>netstandard1.3</PackageTargetFramework>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />


### PR DESCRIPTION
The TFM for these dependencies is incorrect, causing the S.P.SM to be
missed when not targeting netstandardapp1.5 (eg for a portable app).

Fix this TFM to match the implementation TFM.

I've filed a buildtools issue https://github.com/dotnet/buildtools/issues/617
to help eliminate the need for this completely.

/cc @StephenBonikowsky