### PR TITLE
Re-enable scenario tests disabled in OS X due to SetLingerOption issue.

### DIFF
--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/ChannelLayer/DuplexChannelShapeTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/ChannelLayer/DuplexChannelShapeTests.cs
@@ -21,7 +21,6 @@ public static class DuplexChannelShapeTests
 
     [Fact]
     [OuterLoop]
-    [ActiveIssue(951, PlatformID.OSX)]
     public static void IDuplexSessionChannel_Tcp_NetTcpBinding()
     {
         StringBuilder errorBuilder = new StringBuilder();

--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/ClientBase/DuplexClientBaseTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/ClientBase/DuplexClientBaseTests.cs
@@ -52,7 +52,6 @@ public class DuplexClientBaseTests : ConditionalWcfTest
 
     [Fact]
     [OuterLoop]
-    [ActiveIssue(951, PlatformID.OSX)]
     public static void DuplexClientBaseOfT_OverNetTcp_Synchronous_Call()
     {
         DuplexClientBase<IWcfDuplexService> duplexService = null;

--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/TypedClient/TypedProxyDuplexTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/TypedClient/TypedProxyDuplexTests.cs
@@ -17,7 +17,6 @@ public static class TypedProxyDuplexTests
 
     [Fact]
     [OuterLoop]
-    [ActiveIssue(951, PlatformID.OSX)]
     public static void ServiceContract_TypedProxy_AsyncTask_CallbackReturn()
     {
         DuplexChannelFactory<IWcfDuplexTaskReturnService> factory = null;

--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/TypedClient/TypedProxyTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/TypedClient/TypedProxyTests.cs
@@ -35,7 +35,6 @@ public static class TypedProxyTests
 
     [Fact]
     [OuterLoop]
-    [ActiveIssue(951, PlatformID.OSX)]
     public static void ServiceContract_TypedProxy_NetTcpBinding_AsyncBeginEnd_Call()
     {
         NetTcpBinding netTcpBinding = new NetTcpBinding(SecurityMode.None);
@@ -55,7 +54,6 @@ public static class TypedProxyTests
 
     [Fact]
     [OuterLoop]
-    [ActiveIssue(951, PlatformID.OSX)]
     public static void ServiceContract_TypedProxy_NetTcpBinding_AsyncBeginEnd_Call_WithNoCallback()
     {
         NetTcpBinding netTcpBinding = new NetTcpBinding(SecurityMode.None);
@@ -78,7 +76,6 @@ public static class TypedProxyTests
 
     [Fact]
     [OuterLoop]
-    [ActiveIssue(951, PlatformID.OSX)]
     public static void ServiceContract_TypedProxy_NetTcpBinding_AsyncBeginEnd_Call_WithSingleThreadedSyncContext()
     {
         bool success = Task.Run(() =>
@@ -104,7 +101,6 @@ public static class TypedProxyTests
 
     [Fact]
     [OuterLoop]
-    [ActiveIssue(951, PlatformID.OSX)]
     public static void ServiceContract_TypedProxy_NetTcpBinding_AsyncTask_Call()
     {
         NetTcpBinding netTcpBinding = new NetTcpBinding();
@@ -129,7 +125,6 @@ public static class TypedProxyTests
 
     [Fact]
     [OuterLoop]
-    [ActiveIssue(951, PlatformID.OSX)]
     public static void ServiceContract_TypedProxy__NetTcpBinding_AsyncTask_Call_WithSingleThreadedSyncContext()
     {
         bool success = Task.Run(() =>
@@ -419,7 +414,6 @@ public static class TypedProxyTests
 
     [Fact]
     [OuterLoop]
-    [ActiveIssue(951, PlatformID.OSX)]
     public static void ServiceContract_TypedProxy_DuplexCallback()
     {
         DuplexChannelFactory<IDuplexChannelService> factory = null;

--- a/src/System.Private.ServiceModel/tests/Scenarios/Contract/Data/DataContractTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Contract/Data/DataContractTests.cs
@@ -56,7 +56,6 @@ public static class DataContractTests
     // Verify that a callback contract correctly returns a complex type when this type is not part of the contract with the ServiceContract attribute.
     [Fact]
     [OuterLoop]
-    [ActiveIssue(951, PlatformID.OSX)]
     public static void NetTcpBinding_DuplexCallback_ReturnsDataContractComplexType()
     {
         DuplexChannelFactory<IWcfDuplexService_DataContract> factory = null;
@@ -95,7 +94,6 @@ public static class DataContractTests
     // Verify that a callback contract correctly returns a complex type using Xml instead of DataContract when this type is not part of the contract with the ServiceContract attribute.
     [Fact]
     [OuterLoop]
-    [ActiveIssue(951, PlatformID.OSX)]
     public static void NetTcpBinding_DuplexCallback_ReturnsXmlComplexType()
     {
         DuplexChannelFactory<IWcfDuplexService_Xml> factory = null;

--- a/src/System.Private.ServiceModel/tests/Scenarios/Contract/Service/ServiceContractTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Contract/Service/ServiceContractTests.cs
@@ -349,7 +349,6 @@ public static class ServiceContractTests
 
     [Fact]
     [OuterLoop]
-    [ActiveIssue(951, PlatformID.OSX)]
     public static void NetTcp_NoSecurity_Buffered_RoundTrips_String()
     {
         string testString = "Hello";

--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Tcp/ClientCredentialTypeTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Tcp/ClientCredentialTypeTests.cs
@@ -55,7 +55,6 @@ public class Tcp_ClientCredentialTypeTests : ConditionalWcfTest
     // Simple echo of a string using NetTcpBinding on both client and server with SecurityMode=None
     [Fact]
     [OuterLoop]
-    [ActiveIssue(951, PlatformID.OSX)]
     public static void SameBinding_SecurityModeNone_EchoString()
     {
         string testString = "Hello";
@@ -170,8 +169,6 @@ public class Tcp_ClientCredentialTypeTests : ConditionalWcfTest
     [ConditionalFact(nameof(Root_Certificate_Installed), nameof(Client_Certificate_Installed))]
 #if FEATURE_NETNATIVE
     [ActiveIssue(833)] // Not supported in NET Native
-#else
-    [ActiveIssue(951, PlatformID.OSX)]
 #endif
     [OuterLoop]
     public static void TcpClientCredentialType_Certificate_EchoString()
@@ -222,8 +219,6 @@ public class Tcp_ClientCredentialTypeTests : ConditionalWcfTest
     [ConditionalFact(nameof(Root_Certificate_Installed), nameof(Client_Certificate_Installed))]
 #if FEATURE_NETNATIVE
     [ActiveIssue(833)] // Not supported in NET Native
-#else
-    [ActiveIssue(951, PlatformID.OSX)]
 #endif
     [OuterLoop]
     public static void TcpClientCredentialType_Certificate_CustomValidator_EchoString()


### PR DESCRIPTION
Issue https://github.com/dotnet/corefx/issues/7403 caused multiple tests
to fail in OS X, so we disabled them with [ActiveIssue].

Now that 7403 is fixed, these tests can be re-enabled. Testing these
in the labs will require updating to latest CoreFx packages.