### PR TITLE
Disable the debug mode compilation of WCF service

### DIFF
--- a/src/System.Private.ServiceModel/tools/IISHostedWcfService/Web.config
+++ b/src/System.Private.ServiceModel/tools/IISHostedWcfService/Web.config
@@ -11,9 +11,7 @@
     </sources>
   </system.diagnostics>
   <system.web>
-    <compilation debug="true">
-</compilation>
-
+    <compilation debug="false" />
     <httpRuntime targetFramework="4.5" />
   </system.web>
   <system.serviceModel>


### PR DESCRIPTION
Debug mode could take way too long and slow down our start up unnecessarily.