### PR TITLE
Fixes CallOnceManager to signal its blocked waiters when channel is unusable

### DIFF
--- a/src/System.Private.ServiceModel/tests/Common/Scenarios/ServiceInterfaces.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Scenarios/ServiceInterfaces.cs
@@ -24,6 +24,9 @@ public interface IWcfService
     [OperationContract(Action = "http://tempuri.org/IWcfService/EchoWithTimeout")]
     String EchoWithTimeout(String message, TimeSpan serviceOperationTimeout);
 
+    [OperationContract(Action = "http://tempuri.org/IWcfService/EchoWithTimeout")]
+    Task<String> EchoWithTimeoutAsync(String message, TimeSpan serviceOperationTimeout);
+
     [OperationContract(Action = "http://tempuri.org/IWcfService/GetDataUsingDataContract")]
     CompositeType GetDataUsingDataContract(CompositeType composite);
 

--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/ExpectedExceptions/ExpectedExceptionTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/ExpectedExceptions/ExpectedExceptionTests.cs
@@ -11,6 +11,8 @@ using System.ServiceModel.Security;
 using System.Text;
 using System.Threading.Tasks;
 using Xunit;
+using System.Threading;
+using System.IO;
 
 public static class ExpectedExceptionTests
 {
@@ -573,6 +575,363 @@ public static class ExpectedExceptionTests
             ScenarioTestHelpers.CloseCommunicationObjects(factory);
         }
     }
+
+    [Fact]
+    [OuterLoop]
+    public static void Abort_During_Implicit_Open_Closes_Sync_Waiters()
+    {
+        // This test is a regression test of an issue with CallOnceManager.
+        // When a single proxy is used to make several service calls without
+        // explicitly opening it, the CallOnceManager queues up all the requests
+        // that happen while it is opening the channel (or handling previously
+        // queued service calls.  If the channel was closed or faulted during
+        // the handling of any queued requests, it caused a pathological worst
+        // case where every queued request waited for its complete SendTimeout
+        // before failing.
+        //
+        // This test operates by making multiple concurrent synchronous service
+        // calls, but stalls the Opening event to allow them to be queued before
+        // any of them are allowed to proceed.  It then aborts the channel when
+        // the first service operation is allowed to proceed.  This causes the
+        // CallOnce manager to deal with all its queued operations and cause
+        // them to complete other than by timing out.
+
+        BasicHttpBinding binding = null;
+        ChannelFactory<IWcfService> factory = null;
+        IWcfService serviceProxy = null;
+        int timeoutMs = 20000;
+        long operationsQueued = 0;
+        int operationCount = 5;
+        Task<string>[] tasks = new Task<string>[operationCount];
+        Exception[] exceptions = new Exception[operationCount];
+        string[] results = new string[operationCount];
+        bool isClosed = false;
+        DateTime endOfOpeningStall = DateTime.Now;
+        int serverDelayMs = 100;
+        TimeSpan serverDelayTimeSpan = TimeSpan.FromMilliseconds(serverDelayMs);
+        string testMessage = "testMessage";
+
+        try
+        {
+            // *** SETUP *** \\
+            binding = new BasicHttpBinding(BasicHttpSecurityMode.None);
+            binding.TransferMode = TransferMode.Streamed;
+            // SendTimeout is the timeout used for implicit opens
+            binding.SendTimeout = TimeSpan.FromMilliseconds(timeoutMs);
+            factory = new ChannelFactory<IWcfService>(binding, new EndpointAddress(Endpoints.HttpBaseAddress_Basic));
+            serviceProxy = factory.CreateChannel();
+
+            // Force the implicit open to stall until we have multiple concurrent calls pending.
+            // This forces the CallOnceManager to have a queue of waiters it will need to notify.
+            ((ICommunicationObject)serviceProxy).Opening += (s, e) =>
+            {
+                // Wait until we see sync calls have been queued
+                DateTime startOfOpeningStall = DateTime.Now;
+                while (true)
+                {
+                    endOfOpeningStall = DateTime.Now;
+
+                    // Don't wait forever -- if we stall longer than the SendTimeout, it means something
+                    // is wrong other than what we are testing, so just fail early.
+                    if ((endOfOpeningStall - startOfOpeningStall).TotalMilliseconds > timeoutMs)
+                    {
+                        Assert.True(false, "The Opening event timed out waiting for operations to queue, which was not expected for this test.");
+                    }
+
+                    // As soon as we have all our Tasks at least running, wait a little
+                    // longer to allow them finish queuing up their waiters, then stop stalling the Opening
+                    if (Interlocked.Read(ref operationsQueued) >= operationCount)
+                    {
+                        Task.Delay(500).Wait();
+                        endOfOpeningStall = DateTime.Now;
+                        return;
+                    }
+
+                    Task.Delay(100).Wait();
+                }
+            };
+
+            // Each task will make a synchronous service call, which will cause all but the
+            // first to be queued for the implicit open.  The first call to complete then closes
+            // the channel so that it is forced to deal with queued waiters.
+            Func<string> callFunc = () =>
+            {
+                // We increment the # ops queued before making the actual sync call, which is
+                // technically a short race condition in the test.  But reversing the order would
+                // timeout the implicit open and fault the channel. 
+                Interlocked.Increment(ref operationsQueued);
+
+                // The call of the operation is what creates the entry in the CallOnceManager queue.
+                // So as each Task below starts, it increments the count and adds a waiter to the
+                // queue.  We ask for a small delay on the server side just to introduce a small
+                // stall after the sync request has been made before it can complete.  Otherwise
+                // fast machines can finish all the requests before the first one finishes the Close().
+                string result = serviceProxy.EchoWithTimeout("test", serverDelayTimeSpan);
+                lock (tasks)
+                {
+                    if (!isClosed)
+                    {
+                        try
+                        {
+                            isClosed = true;
+                            ((ICommunicationObject)serviceProxy).Abort();
+                        }
+                        catch { }
+                    }
+                }
+                return result;
+            };
+
+            // *** EXECUTE *** \\
+
+            DateTime startTime = DateTime.Now;
+            for (int i = 0; i < operationCount; ++i)
+            {
+                tasks[i] = Task.Run(callFunc);
+            }
+
+            for (int i = 0; i < operationCount; ++i)
+            {
+                try
+                {
+                    results[i] = tasks[i].GetAwaiter().GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exceptions[i] = ex;
+                }
+            }
+
+            // *** VALIDATE *** \\
+            double elapsedMs = (DateTime.Now - endOfOpeningStall).TotalMilliseconds;
+
+            // Before validating that the issue was fixed, first validate that we received the exceptions or the
+            // results we expected. This is to verify the fix did not introduce a behavioral change other than the
+            // elimination of the long unnecessary timeouts after the channel was closed.
+            int nFailures = 0;
+            for (int i = 0; i < operationCount; ++i)
+            {
+                if (exceptions[i] == null)
+                {
+                    Assert.True((String.Equals("test", results[i])),
+                                    String.Format("Expected operation #{0} to return '{1}' but actual was '{2}'",
+                                                    i, testMessage, results[i]));
+                }
+                else
+                {
+                    ++nFailures;
+
+                    TimeoutException toe = exceptions[i] as TimeoutException;
+                    Assert.True(toe == null, String.Format("Task [{0}] should not have failed with TimeoutException", i));
+                }
+            }
+
+            Assert.True(nFailures > 0, 
+                String.Format("Expected at least one operation to throw an exception, but none did. Elapsed time = {0} ms.", 
+                    elapsedMs));
+
+            Assert.True(nFailures < operationCount,
+                String.Format("Expected at least one operation to succeed but none did. Elapsed time = {0} ms.",
+                    elapsedMs));
+
+            // The original issue was that sync waiters in the CallOnceManager were not notified when
+            // the channel became unusable and therefore continued to time out for the full amount.
+            // Additionally, because they were executed sequentially, it was also possible for each one
+            // to time out for the full amount.  Given that we closed the channel, we expect all the queued
+            // waiters to have been immediately waked up and detected failure.
+            int expectedElapsedMs = (operationCount * serverDelayMs) + timeoutMs / 2;
+            Assert.True(elapsedMs < expectedElapsedMs,
+                        String.Format("The {0} operations took {1} ms to complete which exceeds the expected {2} ms",
+                                      operationCount, elapsedMs, expectedElapsedMs));
+
+            // *** CLEANUP *** \\
+            ((ICommunicationObject)serviceProxy).Close();
+            factory.Close();
+        }
+        finally
+        {
+            // *** ENSURE CLEANUP *** \\
+            ScenarioTestHelpers.CloseCommunicationObjects((ICommunicationObject)serviceProxy, factory);
+        }
+    }
+
+    [Fact]
+    [OuterLoop]
+    public static void Abort_During_Implicit_Open_Closes_Async_Waiters()
+    {
+        // This test is a regression test of an issue with CallOnceManager.
+        // When a single proxy is used to make several service calls without
+        // explicitly opening it, the CallOnceManager queues up all the requests
+        // that happen while it is opening the channel (or handling previously
+        // queued service calls.  If the channel was closed or faulted during
+        // the handling of any queued requests, it caused a pathological worst
+        // case where every queued request waited for its complete SendTimeout
+        // before failing.
+        //
+        // This test operates by making multiple concurrent asynchronous service
+        // calls, but stalls the Opening event to allow them to be queued before
+        // any of them are allowed to proceed.  It then closes the channel when
+        // the first service operation is allowed to proceed.  This causes the
+        // CallOnce manager to deal with all its queued operations and cause
+        // them to complete other than by timing out.
+
+        BasicHttpBinding binding = null;
+        ChannelFactory<IWcfService> factory = null;
+        IWcfService serviceProxy = null;
+        int timeoutMs = 20000;
+        long operationsQueued = 0;
+        int operationCount = 5;
+        Task<string>[] tasks = new Task<string>[operationCount];
+        Exception[] exceptions = new Exception[operationCount];
+        string[] results = new string[operationCount];
+        bool isClosed = false;
+        DateTime endOfOpeningStall = DateTime.Now;
+        int serverDelayMs = 100;
+        TimeSpan serverDelayTimeSpan = TimeSpan.FromMilliseconds(serverDelayMs);
+        string testMessage = "testMessage";
+
+        try
+        {
+            // *** SETUP *** \\
+            binding = new BasicHttpBinding(BasicHttpSecurityMode.None);
+            binding.TransferMode = TransferMode.Streamed;
+            // SendTimeout is the timeout used for implicit opens
+            binding.SendTimeout = TimeSpan.FromMilliseconds(timeoutMs);
+            factory = new ChannelFactory<IWcfService>(binding, new EndpointAddress(Endpoints.HttpBaseAddress_Basic));
+            serviceProxy = factory.CreateChannel();
+
+            // Force the implicit open to stall until we have multiple concurrent calls pending.
+            // This forces the CallOnceManager to have a queue of waiters it will need to notify.
+            ((ICommunicationObject)serviceProxy).Opening += (s, e) =>
+            {
+                // Wait until we see sync calls have been queued
+                DateTime startOfOpeningStall = DateTime.Now;
+                while (true)
+                {
+                    endOfOpeningStall = DateTime.Now;
+
+                    // Don't wait forever -- if we stall longer than the SendTimeout, it means something
+                    // is wrong other than what we are testing, so just fail early.
+                    if ((endOfOpeningStall - startOfOpeningStall).TotalMilliseconds > timeoutMs)
+                    {
+                        Assert.True(false, "The Opening event timed out waiting for operations to queue, which was not expected for this test.");
+                    }
+
+                    // As soon as we have all our Tasks at least running, wait a little
+                    // longer to allow them finish queuing up their waiters, then stop stalling the Opening
+                    if (Interlocked.Read(ref operationsQueued) >= operationCount)
+                    {
+                        Task.Delay(500).Wait();
+                        endOfOpeningStall = DateTime.Now;
+                        return;
+                    }
+
+                    Task.Delay(100).Wait();
+                }
+            };
+
+            // Each task will make a synchronous service call, which will cause all but the
+            // first to be queued for the implicit open.  The first call to complete then closes
+            // the channel so that it is forced to deal with queued waiters.
+            Func<string> callFunc = () =>
+            {
+                // We increment the # ops queued before making the actual sync call, which is
+                // technically a short race condition in the test.  But reversing the order would
+                // timeout the implicit open and fault the channel. 
+                Interlocked.Increment(ref operationsQueued);
+
+                // The call of the operation is what creates the entry in the CallOnceManager queue.
+                // So as each Task below starts, it increments the count and adds a waiter to the
+                // queue.  We ask for a small delay on the server side just to introduce a small
+                // stall after the sync request has been made before it can complete.  Otherwise
+                // fast machines can finish all the requests before the first one finishes the Close().
+                Task<string> t = serviceProxy.EchoWithTimeoutAsync(testMessage, serverDelayTimeSpan);
+                lock (tasks)
+                {
+                    if (!isClosed)
+                    {
+                        try
+                        {
+                            isClosed = true;
+                            ((ICommunicationObject)serviceProxy).Abort();
+                        }
+                        catch { }
+                    }
+                }
+                return t.GetAwaiter().GetResult();
+            };
+
+            // *** EXECUTE *** \\
+
+            DateTime startTime = DateTime.Now;
+            for (int i = 0; i < operationCount; ++i)
+            {
+                tasks[i] = Task.Run(callFunc);
+            }
+
+            for (int i = 0; i < operationCount; ++i)
+            {
+                try
+                {
+                    results[i] = tasks[i].GetAwaiter().GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exceptions[i] = ex;
+                }
+            }
+
+            // *** VALIDATE *** \\
+            double elapsedMs = (DateTime.Now - endOfOpeningStall).TotalMilliseconds;
+
+            // Before validating that the issue was fixed, first validate that we received the exceptions or the
+            // results we expected. This is to verify the fix did not introduce a behavioral change other than the
+            // elimination of the long unnecessary timeouts after the channel was closed.
+            int nFailures = 0;
+            for (int i = 0; i < operationCount; ++i)
+            {
+                if (exceptions[i] == null)
+                {
+                    Assert.True((String.Equals("test", results[i])),
+                                    String.Format("Expected operation #{0} to return '{1}' but actual was '{2}'",
+                                                    i, testMessage, results[i]));
+                }
+                else
+                {
+                    ++nFailures;
+
+                    TimeoutException toe = exceptions[i] as TimeoutException;
+                    Assert.True(toe == null, String.Format("Task [{0}] should not have failed with TimeoutException", i));
+                }
+            }
+
+            Assert.True(nFailures > 0,
+                String.Format("Expected at least one operation to throw an exception, but none did. Elapsed time = {0} ms.",
+                    elapsedMs));
+
+
+            // --- Here is the test of the actual bug fix ---
+            // The original issue was that sync waiters in the CallOnceManager were not notified when
+            // the channel became unusable and therefore continued to time out for the full amount.
+            // Additionally, because they were executed sequentially, it was also possible for each one
+            // to time out for the full amount.  Given that we closed the channel, we expect all the queued
+            // waiters to have been immediately waked up and detected failure.
+            int expectedElapsedMs = (operationCount * serverDelayMs) + timeoutMs / 2;
+            Assert.True(elapsedMs < expectedElapsedMs,
+                        String.Format("The {0} operations took {1} ms to complete which exceeds the expected {2} ms",
+                                      operationCount, elapsedMs, expectedElapsedMs));
+
+            // *** CLEANUP *** \\
+            ((ICommunicationObject)serviceProxy).Close();
+            factory.Close();
+        }
+        finally
+        {
+            // *** ENSURE CLEANUP *** \\
+            ScenarioTestHelpers.CloseCommunicationObjects((ICommunicationObject)serviceProxy, factory);
+        }
+    }
+
 
 }
 


### PR DESCRIPTION
Background: When a proxy is not opened explicitly before use, the
CallOnceManager class does the open on the first service call.
Any other calls made during the open are queued, and when the
open completes are called in FIFO order.

Problem: the queued calls block on a WaitHandle that is set
only by the previous operation succeeding or by timeout. But
if the channel faults, there is no logic to set the WaitHandle,
so it will be set only after the timeout expires.  And then the
next queued operation begins its own timed wait and so on.  Code
in this state can easily lead to large numbers of blocked threads

Solution: detect when the channel faults or is closed and signal
the waiter's WaitHandles to wake up and complete their operation
(typically a failure because the channel is not usable by then).

Fixes #108