### PR TITLE
Init checkin of client changes

### DIFF
--- a/src/System.Private.ServiceModel/tests/Common/Infrastructure/src/BridgeClientCertificateManager.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Infrastructure/src/BridgeClientCertificateManager.cs
@@ -29,7 +29,7 @@ namespace Infrastructure.Common
         private const string ClientCertificateSubject = "WCF Client Certificate";
         private const string ClientCertificatePassword = "test"; // this needs to be kept in sync with the Bridge configuration 
 
-        public static string LocalCertThumbprint { get; private set; }
+        public static string LocalCertThumbprint { get; set; }
 
         // Dictionary of certificates installed by CertificateManager
         // Keyed by the Thumbprint of the certificate
@@ -246,7 +246,7 @@ namespace Infrastructure.Common
 
         // Adds the given certificate to the given store unless it is
         // already present.  Returns 'true' if the certificate was added.
-        private static bool AddToStoreIfNeeded(StoreName storeName,
+        public static bool AddToStoreIfNeeded(StoreName storeName,
                                                StoreLocation storeLocation,
                                                X509Certificate2 certificate)
         {

--- a/src/System.Private.ServiceModel/tests/Common/Infrastructure/src/testproperties.props
+++ b/src/System.Private.ServiceModel/tests/Common/Infrastructure/src/testproperties.props
@@ -105,7 +105,11 @@
     <PropertyGroup Condition="'$(Kerberos_Available)' == ''">
       <Kerberos_Available>false</Kerberos_Available>
     </PropertyGroup>
-  
+
+    <PropertyGroup Condition="'$(ServiceUri)' == ''">
+      <ServiceUri >localhost</ServiceUri >
+    </PropertyGroup>
+
   <!--
      GeneratedTestPropertiesFileName:
      The full path of the C# file that will be generated at build time to

--- a/src/System.Private.ServiceModel/tests/Common/Infrastructure/src/testproperties.targets
+++ b/src/System.Private.ServiceModel/tests/Common/Infrastructure/src/testproperties.targets
@@ -43,6 +43,7 @@ namespace Infrastructure.Common
         public static readonly string Client_Certificate_Installed_PropertyName = "Client_Certificate_Installed"%3B
         public static readonly string SPN_Available_PropertyName = "SPN_Available"%3B
         public static readonly string Kerberos_Available_PropertyName = "Kerberos_Available"%3B
+        public static readonly string ServiceUri_PropertyName = "ServiceUri"%3B
                 
         static partial void Initialize(Dictionary<string, string> properties)
         {
@@ -71,6 +72,7 @@ namespace Infrastructure.Common
             properties["Client_Certificate_Installed"] = "$(Client_Certificate_Installed)"%3B
             properties["SPN_Available"] = "$(SPN_Available)"%3B
             properties["Kerberos_Available"] = "$(Kerberos_Available)"%3B
+            properties["ServiceUri"] = "$(ServiceUri)"%3B
         }
     }
 }

--- a/src/System.Private.ServiceModel/tests/Common/Scenarios/ServiceInterfaces.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Scenarios/ServiceInterfaces.cs
@@ -502,3 +502,13 @@ public interface IWcfAspNetCompatibleService
     [OperationContract(Action = "http://tempuri.org/IWcfService/EchoTimeAndSetCookie", ReplyAction = "http://tempuri.org/IIWcfService/EchoTimeAndSetCookieResponse")]
     string EchoTimeAndSetCookie(string name);
 }
+
+[ServiceContract]
+public interface IUtil
+{
+    [OperationContract]
+    byte[] GetClientCert(bool exportAsPem);
+
+    [OperationContract]
+    byte[] GetRootCert(bool exportAsPem);
+}

--- a/src/System.Private.ServiceModel/tests/Common/Unit/ServiceInterfaces.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Unit/ServiceInterfaces.cs
@@ -172,3 +172,13 @@ public interface IWcfDuplexTaskReturnCallback
     [FaultContract(typeof(FaultDetail), Name = "FaultDetail")]
     Task<Guid> ServicePingFaultCallback(Guid guid);
 }
+
+[ServiceContract]
+public interface IUtil
+{
+    [OperationContract]
+    byte[] GetClientCert(bool exportAsPem);
+
+    [OperationContract]
+    byte[] GetRootCert(bool exportAsPem);
+}


### PR DESCRIPTION
* Allow Test property ServiceUri.
* Note that we in the self hosted case, we only allow localhost, not multiple
service instances(localhost/wcfservice1).
* Change all endpoints point to the new services.