### PR TITLE
Update to latest xunit.netcore.extensions

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -100,7 +100,7 @@
     </ValidationPattern>
     <ValidationPattern Include="xUnitExtensionsVersions">
       <IdentityRegex>^(?i)xunit\.netcore\.extensions$</IdentityRegex>
-      <ExpectedVersion>1.0.0-prerelease-00231-07</ExpectedVersion>
+      <ExpectedVersion>1.0.0-prerelease-00312-04</ExpectedVersion>
     </ValidationPattern>
   </ItemGroup>
 

--- a/src/System.Private.ServiceModel/tests/Common/Infrastructure/tests/project.json
+++ b/src/System.Private.ServiceModel/tests/Common/Infrastructure/tests/project.json
@@ -5,7 +5,7 @@
     "System.ServiceModel.Primitives": "4.1.0-rc3-23931-00",
     "System.ServiceModel.Security": "4.0.1-rc3-23931-00",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00231-07",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Private.ServiceModel/tests/Common/Scenarios/project.json
+++ b/src/System.Private.ServiceModel/tests/Common/Scenarios/project.json
@@ -19,7 +19,7 @@
     "System.Threading.Tasks": "4.0.11-rc3-23931-00",
     "System.Xml.XmlSerializer": "4.0.11-rc3-23931-00",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00231-07",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Private.ServiceModel/tests/Scenarios/Binding/Custom/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Binding/Custom/project.json
@@ -5,7 +5,7 @@
     "System.ServiceModel.Http": "4.1.0-rc3-23931-00",
     "System.ServiceModel.Primitives": "4.1.0-rc3-23931-00",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00231-07",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Private.ServiceModel/tests/Scenarios/Binding/Http/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Binding/Http/project.json
@@ -5,7 +5,7 @@
     "System.ServiceModel.Http": "4.1.0-rc3-23931-00",
     "System.ServiceModel.Primitives": "4.1.0-rc3-23931-00",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00231-07",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/ChannelLayer/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/ChannelLayer/project.json
@@ -7,7 +7,7 @@
     "System.ServiceModel.NetTcp": "4.1.0-rc3-23931-00",
     "System.ServiceModel.Primitives": "4.1.0-rc3-23931-00",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00231-07",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/ClientBase/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/ClientBase/project.json
@@ -10,7 +10,7 @@
     "System.ServiceModel.NetTcp": "4.1.0-rc3-23931-00",
     "System.ServiceModel.Primitives": "4.1.0-rc3-23931-00",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00231-07",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/ExpectedExceptions/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/ExpectedExceptions/project.json
@@ -20,7 +20,7 @@
     "System.Xml.ReaderWriter": "4.0.11-rc3-23931-00",
     "System.Xml.XmlSerializer": "4.0.11-rc3-23931-00",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00231-07",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/TypedClient/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/TypedClient/project.json
@@ -8,7 +8,7 @@
     "System.ServiceModel.NetTcp": "4.1.0-rc3-23931-00",
     "System.ServiceModel.Primitives": "4.1.0-rc3-23931-00",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00231-07",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Private.ServiceModel/tests/Scenarios/Contract/Data/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Contract/Data/project.json
@@ -8,7 +8,7 @@
     "System.ServiceModel.NetTcp": "4.1.0-rc3-23931-00",
     "System.ServiceModel.Primitives": "4.1.0-rc3-23931-00",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00231-07",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Private.ServiceModel/tests/Scenarios/Contract/Fault/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Contract/Fault/project.json
@@ -6,7 +6,7 @@
     "System.ServiceModel.Http": "4.1.0-rc3-23931-00",
     "System.ServiceModel.Primitives": "4.1.0-rc3-23931-00",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00231-07",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Private.ServiceModel/tests/Scenarios/Contract/Message/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Contract/Message/project.json
@@ -6,7 +6,7 @@
     "System.ServiceModel.Http": "4.1.0-rc3-23931-00",
     "System.ServiceModel.Primitives": "4.1.0-rc3-23931-00",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00231-07",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Private.ServiceModel/tests/Scenarios/Contract/Service/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Contract/Service/project.json
@@ -9,7 +9,7 @@
     "System.ServiceModel.Primitives": "4.1.0-rc3-23931-00",
     "System.Text.Encoding": "4.0.11-rc3-23931-00",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00231-07",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Private.ServiceModel/tests/Scenarios/Contract/XmlSerializer/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Contract/XmlSerializer/project.json
@@ -6,7 +6,7 @@
     "System.ServiceModel.Http": "4.1.0-rc3-23931-00",
     "System.ServiceModel.Primitives": "4.1.0-rc3-23931-00",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00231-07",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Private.ServiceModel/tests/Scenarios/Encoding/Encoders/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Encoding/Encoders/project.json
@@ -7,7 +7,7 @@
     "System.ServiceModel.NetTcp": "4.1.0-rc3-23931-00",
     "System.ServiceModel.Primitives": "4.1.0-rc3-23931-00",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00231-07",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Private.ServiceModel/tests/Scenarios/Encoding/MessageVersion/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Encoding/MessageVersion/project.json
@@ -5,7 +5,7 @@
     "System.ServiceModel.Http": "4.1.0-rc3-23931-00",
     "System.ServiceModel.Primitives": "4.1.0-rc3-23931-00",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00231-07",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Private.ServiceModel/tests/Scenarios/Extensibility/WebSockets/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Extensibility/WebSockets/project.json
@@ -9,7 +9,7 @@
     "System.ServiceModel.NetTcp": "4.1.0-rc3-23931-00",
     "System.ServiceModel.Primitives": "4.1.0-rc3-23931-00",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00231-07",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/project.json
@@ -9,7 +9,7 @@
     "System.ServiceModel.Primitives": "4.1.0-rc3-23931-00",
     "System.ServiceModel.Security": "4.0.1-rc3-23931-00",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00231-07",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.ServiceModel.Duplex/tests/project.json
+++ b/src/System.ServiceModel.Duplex/tests/project.json
@@ -8,7 +8,7 @@
     "System.ServiceModel.Primitives": "4.1.0-rc3-23931-00",
     "System.ServiceModel.Security": "4.0.1-rc3-23931-00",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00231-07",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.ServiceModel.Http/tests/project.json
+++ b/src/System.ServiceModel.Http/tests/project.json
@@ -8,7 +8,7 @@
     "System.ServiceModel.Primitives": "4.1.0-rc3-23931-00",
     "System.ServiceModel.Security": "4.0.1-rc3-23931-00",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00231-07",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.ServiceModel.NetTcp/tests/project.json
+++ b/src/System.ServiceModel.NetTcp/tests/project.json
@@ -6,7 +6,7 @@
     "System.ServiceModel.NetTcp": "4.1.0-rc3-23931-00",
     "System.ServiceModel.Primitives": "4.1.0-rc3-23931-00",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00231-07",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.ServiceModel.Primitives/tests/project.json
+++ b/src/System.ServiceModel.Primitives/tests/project.json
@@ -11,7 +11,7 @@
     "System.ServiceModel.Primitives": "4.1.0-rc3-23931-00",
     "System.ServiceModel.Security": "4.0.1-rc3-23931-00",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00231-07",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.ServiceModel.Security/tests/project.json
+++ b/src/System.ServiceModel.Security/tests/project.json
@@ -6,7 +6,7 @@
     "System.ServiceModel.Primitives": "4.1.0-rc3-23931-00",
     "System.ServiceModel.Security": "4.0.1-rc3-23931-00",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00231-07",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"


### PR DESCRIPTION
This update allows us to use multiple conditions in
[ConditionalFact] tests.

This feature was added to xunit.netcore.extensions with
PR https://github.com/dotnet/buildtools/pull/619, and now
that the latest package is available, we can use it.