### PR TITLE
Add support for building rc2 branch in CI

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -161,7 +161,7 @@ branchList.each { branchName ->
 // Define outerloop testing for OSes that can build and run.  Run locally on each machine.
 // **************************
 
-def supportedFullCycleOuterloopPlatforms = ['Windows_NT', 'Ubuntu14.04', 'CentOS7.1', 'OSX']
+def supportedFullCycleOuterloopPlatforms = ['Windows_NT', 'Ubuntu14.04', 'OSX']
 branchList.each { branchName ->
     configurationGroupList.each { configurationGroup ->
         supportedFullCycleOuterloopPlatforms.each { os ->

--- a/src/System.Private.ServiceModel/tools/PRService/pr.ashx
+++ b/src/System.Private.ServiceModel/tools/PRService/pr.ashx
@@ -99,10 +99,11 @@ public class PullRequestHandler : IHttpHandler
             {
                 case "master":
                 case "origin/master":
+                case "origin/infrastructure":
                     success = SyncToBranch(branchString, result);
                     break;
                 default:
-                    context.Response.Write(string.Format("Branch name specified, '{0}' is not supported by this script<br/>", HttpUtility.HtmlEncode(branchString)));
+                    context.Response.Write(string.Format("Branch name specified, '{0}' is not supported by this service<br/>", HttpUtility.HtmlEncode(branchString)));
                     break;
             }
         }


### PR DESCRIPTION
* Add support for building rc2 and infrastructure branch in CI
* ~~Add PR Number guard to prevent PRService from breaks. When syncing to PR numbers lower than 987, the PRService will be wiped from the PRService endpoint and be put into an unrecoverable state.~~

~~Add a guard here to prevent syncing to a PR number < 987 and return HTTP/200 so that CI can succeed.~~

~~This should not happen during the normal course of events. In any case, PRs prior to 987 will not hit the hosted WcfService, so this no-op will not affect the outcome of any tests before that~~

(this will not prevent all breaks, but at least prevents one class of them)