### PR TITLE
Fix Default TCP endpoint in client

### DIFF
--- a/src/System.Private.ServiceModel/tests/Common/Scenarios/Endpoints.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Scenarios/Endpoints.cs
@@ -402,7 +402,7 @@ public static partial class Endpoints
     // net.tcp Addresses
     public static string Tcp_DefaultBinding_Address
     {
-        get { return GetEndpointAdddress("TcpDefault.svc//tcp-nosecurity", protocol: "net.tcp"); }
+        get { return GetEndpointAdddress("TcpDefault.svc//tcp-default", protocol: "net.tcp"); }
     }
 
     public static string Tcp_NoSecurity_Address


### PR DESCRIPTION
* It should be tcp-default, not the no security one.
* A one line of code change that will fixes several security tests.