### PR TITLE
April 14 Script Sync

### DIFF
--- a/Packaging.props
+++ b/Packaging.props
@@ -29,13 +29,13 @@
 
   <!-- Add required legal files to packages -->
   <ItemGroup Condition="'$(MSBuildProjectExtension)' == '.pkgproj'">
-    <File Condition="Exists('$(PackageLicenseFile)')"
+    <File Condition="Exists('$(PackageLicenseFile)')" 
 	  	    Include="$(PackageLicenseFile)" >
-      <SkipPackageFileCheck>true</SkipPackageFileCheck>
-    </File>
+        <SkipPackageFileCheck>true</SkipPackageFileCheck>
+    </File>        
     <File Condition="Exists('$(PackageThirdPartyNoticesFile)')"
 	        Include="$(PackageThirdPartyNoticesFile)" >
-      <SkipPackageFileCheck>true</SkipPackageFileCheck>
-    </File>
+        <SkipPackageFileCheck>true</SkipPackageFileCheck>
+    </File>        
   </ItemGroup>
 </Project>

--- a/build-packages.sh
+++ b/build-packages.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+
+usage()
+{
+    echo "Builds the NuGet packages from the binaries that were built in the Build product binaries step."
+    echo "No option parameters."
+    exit 1
+}
+
+working_tree_root="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+build_packages_log=$working_tree_root/build-packages.log
+binclashlog=$working_tree_root/binclash.log
+binclashloggerdll=$working_tree_root/Tools/Microsoft.DotNet.Build.Tasks.dll
+RuntimeOS=ubuntu.$VERSION_ID
+
+# Use uname to determine what the OS is.
+OSName=$(uname -s)
+case $OSName in
+    Darwin)
+        # Darwin version can be three sets of digits (e.g. 10.10.3), we want just the first two
+        DarwinVersion=$(sw_vers -productVersion | awk 'match($0, /[0-9]+\.[0-9]+/) { print substr($0, RSTART, RLENGTH) }')
+        RuntimeOS=osx.$DarwinVersion
+        ;;
+
+    FreeBSD|NetBSD)
+        # TODO this doesn't seem correct
+        RuntimeOS=osx.10.10
+        ;;
+
+    Linux)
+        source /etc/os-release
+        VersionMajor=$(echo $VERSION_ID | awk 'match($0, /[0-9]+/) { print substr($0, RSTART, RLENGTH) }')
+        if [ "$ID" == "rhel" ]; then
+            RuntimeOS=rhel.$VersionMajor
+        elif [ "$ID" == "debian" ]; then
+            RuntimeOS=debian.$VersionMajor
+        elif [ "$ID" == "ubuntu" ]; then
+            RuntimeOS=ubuntu.$VERSION_ID
+        else
+            echo "Unsupported Linux distribution '$ID' detected. Configuring as if for Ubuntu."
+        fi
+        ;;
+
+    *)
+        echo "Unsupported OS '$OSName' detected. Configuring as if for Ubuntu."
+        ;;
+esac
+
+options="/m /nologo /v:minimal /clp:Summary /flp:v=diagnostic;Append;LogFile=$build_packages_log /l:BinClashLogger,$binclashloggerdll;LogFile=$binclashlog /p:FilterToOSGroup=$RuntimeOS"
+allargs="$@"
+
+echo -e "Running build-packages.sh $allargs" > $build_packages_log
+
+if [ "$allargs" == "-h" ] || [ "$allargs" == "--help" ]; then
+    usage
+fi
+
+# Ensure that MSBuild is available
+echo "Running init-tools.sh"
+$working_tree_root/init-tools.sh
+
+echo -e "\n$working_tree_root/Tools/corerun $working_tree_root/Tools/MSBuild.exe $working_tree_root/src/packages.builds $options $allargs" >> $build_packages_log
+$working_tree_root/Tools/corerun $working_tree_root/Tools/MSBuild.exe $working_tree_root/src/packages.builds $options $allargs
+
+
+if [ $? -ne 0 ]; then
+    echo -e "\nAn error occurred. Aborting build-packages.sh ." >> $build_packages_log
+    echo "ERROR: An error occurred while building packages, see $build_packages_log for more details."
+    exit 1
+fi
+
+echo "Done building packages."
+echo -e "\nDone building packages." >> $build_packages_log
+exit 0

--- a/build-tests.cmd
+++ b/build-tests.cmd
@@ -1,0 +1,33 @@
+@if "%_echo%" neq "on" echo off
+setlocal EnableDelayedExpansion
+
+set buildTests=build-tests.log
+set binclashLoggerDll=%~dp0Tools\net45\Microsoft.DotNet.Build.Tasks.dll
+set binclashlog=%~dp0binclash.log
+echo Running build-tests.cmd %* > %buildTests%
+
+set options=/nologo /maxcpucount /v:minimal /clp:Summary /nodeReuse:false /flp:v=detailed;Append;LogFile=%buildTests% /l:BinClashLogger,%binclashLoggerDll%;LogFile=%binclashlog%
+set allargs=%*
+
+if /I [%1] == [/?] goto Usage
+if /I [%1] == [/help] goto Usage
+
+REM ensure that msbuild is available
+echo Running init-tools.cmd
+call %~dp0init-tools.cmd
+
+echo msbuild.exe %~dp0src\tests.builds !options! !allargs! >> %buildTests%
+call msbuild.exe %~dp0src\tests.builds !options! !allargs!
+if NOT [%ERRORLEVEL%]==[0] (
+  echo ERROR: An error occurred while building the tests, see %buildTests% for more details.
+  exit /b
+)
+
+echo Done Building tests.
+exit /b
+
+:Usage
+echo.
+echo Builds the tests that are in the repository.
+echo No option parameters.
+exit /b

--- a/build-tests.sh
+++ b/build-tests.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+usage()
+{
+    echo "Builds the tests that are in the repository."
+    echo "No option parameters."
+    exit 1
+}
+
+working_tree_root="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+build_tests_log=$working_tree_root/build-tests.log
+binclashlog=$working_tree_root/binclash.log
+binclashloggerdll=$working_tree_root/Tools/Microsoft.DotNet.Build.Tasks.dll
+
+options="/m /nologo /v:minimal /clp:Summary /flp:v=detailed;Append;LogFile=$build_tests_log /l:BinClashLogger,$binclashloggerdll;LogFile=$binclashlog"
+allargs="$@"
+
+echo -e "Running build-tests.sh $allargs" > $build_tests_log
+
+if [ "$allargs" == "-h" ] || [ "$allargs" == "--help" ]; then
+    usage
+fi
+
+# Ensure that MSBuild is available
+echo "Running init-tools.sh"
+$working_tree_root/init-tools.sh
+
+echo -e "\n$working_tree_root/Tools/corerun $working_tree_root/Tools/MSBuild.exe $working_tree_root/src/tests.builds $options $allargs" >> $build_tests_log
+$working_tree_root/Tools/corerun $working_tree_root/Tools/MSBuild.exe $working_tree_root/src/tests.builds $options $allargs
+
+
+if [ $? -ne 0 ]; then
+    echo -e "\nAn error occurred. Aborting build-tests.sh ." >> $build_tests_log
+    echo "ERROR: An error occurred while building tests, see $build_tests_log for more details."
+    exit 1
+fi
+
+echo "Done building tests."
+echo -e "\nDone building tests." >> $build_tests_log
+exit 0

--- a/build.proj
+++ b/build.proj
@@ -4,6 +4,10 @@
     <!-- Capture OSGroup passed to command line for setting default FilterToOSGroup value below -->
     <_OriginalOSGroup>$(OSGroup)</_OriginalOSGroup>
   </PropertyGroup>
+  <PropertyGroup>
+    <InputOSGroup>$(OSGroup)</InputOSGroup>
+    <InputOSGroup Condition="'$(InputOSGroup)'==''">$(FilterToOSGroup)</InputOSGroup>
+  </PropertyGroup>
   <Import Project="dir.props" />
 
   <!-- required to build the projects in their specified order -->
@@ -31,8 +35,11 @@
     <Project Include="src\dirs.proj">
       <!-- For the root traversal default filter the OSGroup to the OSEnvironment which is the OS we are running on -->
       <FilterToOSGroup Condition="'$(_OriginalOSGroup)' == ''">$(OSEnvironment)</FilterToOSGroup>
+      <InputOSGroup>$(InputOSGroup)</InputOSGroup>
     </Project>
-    <Project Include="src\tests.builds" Condition="$(BuildTests)=='true'"/>
+    <Project Include="src\tests.builds" Condition="$(BuildTests)=='true'">
+      <InputOSGroup>$(InputOSGroup)</InputOSGroup>
+    </Project>
     <!-- signing must happen before packaging -->
     <!-- <Project Include="src\sign.builds" /> This does not currently work in WCF repo -->
     <Project Include="src\packages.builds" Condition="'$(BuildPackages)'=='true'"/>

--- a/build.proj
+++ b/build.proj
@@ -17,6 +17,8 @@
     <RestoreDuringBuild Condition="'$(RestoreDuringBuild)'==''">true</RestoreDuringBuild>
     <!-- To disable building packages, set BuildPackages=false or pass /p:BuildPackages=false.-->
     <BuildPackages Condition="'$(BuildPackages)'==''">true</BuildPackages>
+    <!-- To disable building tests, set BuildTests=false or pass /p:BuildTests=false.-->
+    <BuildTests Condition="'$(BuildTests)'==''">true</BuildTests>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -30,6 +32,7 @@
       <!-- For the root traversal default filter the OSGroup to the OSEnvironment which is the OS we are running on -->
       <FilterToOSGroup Condition="'$(_OriginalOSGroup)' == ''">$(OSEnvironment)</FilterToOSGroup>
     </Project>
+    <Project Include="src\tests.builds" Condition="$(BuildTests)=='true'"/>
     <!-- signing must happen before packaging -->
     <!-- <Project Include="src\sign.builds" /> This does not currently work in WCF repo -->
     <Project Include="src\packages.builds" Condition="'$(BuildPackages)'=='true'"/>

--- a/clean.sh
+++ b/clean.sh
@@ -28,13 +28,15 @@ check_exit_status()
 
 WorkingTreeRoot="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 CleanLog=$WorkingTreeRoot/clean.log
+
+options="/nologo /v:minimal /clp:Summary /flp:v=detailed;Append;LogFile=$CleanLog"
+unprocessedBuildArgs=
 CleanSuccessful=true
 CleanTargets=
 
-# Parse arguments
-
 echo "Running clean.sh $*" > $CleanLog
 
+# Parse arguments
 if [ $# == 0 ]
 then
     CleanTargets="Clean;"
@@ -67,10 +69,7 @@ do
         CleanTargets="Clean;CleanPackages;CleanPackagesCache;"
         ;;
         *)
-        echo "Unrecognized argument '$opt'"
-        echo "Use 'clean -h' for help."
-        exit 1
-        ;;
+        unprocessedBuildArgs="$unprocessedBuildArgs $1"
     esac
     shift
 done
@@ -85,8 +84,8 @@ then
     CleanTargetsTrimmed=${CleanTargets:0:${#CleanTargets}-1}
 
     echo "Running MSBuild target(s): $CleanTargetsTrimmed"
-    echo -e "\n$WorkingTreeRoot/Tools/corerun $WorkingTreeRoot/Tools/MSBuild.exe $WorkingTreeRoot/build.proj /t:$CleanTargetsTrimmed /nologo /verbosity:minimal /flp:v=detailed;Append;LogFile=$CleanLog" >> $CleanLog
-    $WorkingTreeRoot/Tools/corerun $WorkingTreeRoot/Tools/MSBuild.exe $WorkingTreeRoot/build.proj /t:$CleanTargetsTrimmed /nologo /verbosity:minimal "/flp:v=detailed;Append;LogFile=$CleanLog"
+    echo -e "\n$WorkingTreeRoot/Tools/corerun $WorkingTreeRoot/Tools/MSBuild.exe $WorkingTreeRoot/build.proj /t:$CleanTargetsTrimmed $options $unprocessedBuildArgs" >> $CleanLog
+    $WorkingTreeRoot/Tools/corerun $WorkingTreeRoot/Tools/MSBuild.exe $WorkingTreeRoot/build.proj /t:$CleanTargetsTrimmed $options $unprocessedBuildArgs
     check_exit_status
 fi
 

--- a/dir.props
+++ b/dir.props
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Condition="Exists('..\dir.props')" Project="..\dir.props" />
 
@@ -110,16 +111,23 @@
 
   <!-- list of nuget package sources passed to dnu -->
   <ItemGroup Condition="'$(ExcludeInternetFeeds)' != 'true'">
+    <!-- PackagesDrops is passed in via the commandline "/p:PackagesDrops=[drop location]" -->
+    <DnuSourceList Condition="'$(BuildTestsAgainstPackages)' == 'true'" Include="$(PackagesDrops)" />
     <!-- Need to escape double forward slash (%2F) or MSBuild will normalize to one slash on Unix. -->
-
     <DnuSourceList Include="https:%2F%2Fdotnet.myget.org/F/dotnet-core/api/v3/index.json" />
     <DnuSourceList Include="https:%2F%2Fwww.nuget.org/api/v2/" />
   </ItemGroup>
+
+  <!-- This is the directory where we dynamically generate project.json's for our test build package dependencies -->
+  <PropertyGroup Condition="'$(BuildTestsAgainstPackages)' == 'true'">
+      <GeneratedProjectJsonDir>$(ObjDir)generated</GeneratedProjectJsonDir>
+  </PropertyGroup>
 
   <!-- list of directories to perform batch restore -->
   <ItemGroup>
     <DnuRestoreDir Include="$(MSBuildThisFileDirectory)/src" />
     <DnuRestoreDir Include="$(MSBuildThisFileDirectory)/pkg" />
+    <DnuRestoreDir Condition="'$(BuildTestsAgainstPackages)' == 'true'" Include="$(GeneratedProjectJsonDir)" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/dir.props
+++ b/dir.props
@@ -10,6 +10,10 @@
     <OsEnvironment Condition="'$(OsEnvironment)'==''">$(OS)</OsEnvironment>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <InputOSGroup Condition="'$(InputOSGroup)'==''">$(OSEnvironment)</InputOSGroup>
+  </PropertyGroup>
+
   <!-- Build Tools Versions -->
   <PropertyGroup>
     <RoslynVersion>1.0.0-rc3-20150510-01</RoslynVersion>

--- a/dir.targets
+++ b/dir.targets
@@ -13,6 +13,10 @@
   <Target Name="RebuildAndTest" DependsOnTargets="Rebuild;Test" />
   <Target Name="Test" />
 
+  <!-- Targets will be overridden if buildagainstpackages.targets is imported. -->
+  <Target Name="GenerateTestProjectJson" />
+  <Target Name="GenerateAllTestProjectJsons" />
+
   <Import Project="$(ToolsDir)/Build.Common.targets" />
 
   <!-- permit a wrapping build system to contribute targets to this build -->

--- a/dir.traversal.targets
+++ b/dir.traversal.targets
@@ -178,6 +178,36 @@
     <Error Condition="'$(MSBuildLastTaskResult)'=='false'" />
   </Target>
 
+  <Target Name="GenerateAllTestProjectJsons">
+    <PropertyGroup>
+      <DefaultGenerateAllTestProjectJsonsTarget Condition="'$(DefaultGenerateAllTestProjectJsonsTarget)' == ''">GenerateAllTestProjectJsons</DefaultGenerateAllTestProjectJsonsTarget>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <GeneratedProject Include="@(Project)">
+        <AdditionalProperties>GeneratedTargetGroup=%(Project.TargetGroup);GeneratedOSGroup=%(Project.OSGroup);%(Project.AdditionalProperties)</AdditionalProperties>
+      </GeneratedProject>
+    </ItemGroup>
+
+    <!-- To Serialize we use msbuild's batching functionality '%' to force it to batch all similar projects with the same identity
+         however since the project names are unique it will essentially force each to run in its own batch -->
+    <MSBuild Targets="$(DefaultGenerateAllTestProjectJsonsTarget)"
+             Projects="@(GeneratedProject)"
+             Condition="'$(SerializeProjects)' != 'true'"
+             Properties="GenerateAllTestProjectJsons=$(DefaultGenerateAllTestProjectJsonsTarget)"
+             BuildInParallel="true"
+             ContinueOnError="ErrorAndContinue" />
+
+    <MSBuild Targets="$(DefaultGenerateAllTestProjectJsonsTarget)"
+             Projects="@(GeneratedProject)"
+             Condition="'$(SerializeProjects)' == 'true' AND '%(Identity)' != ''"
+             Properties="GenerateAllTestProjectJsons=$(DefaultGenerateAllTestProjectJsonsTarget)"
+             ContinueOnError="ErrorAndContinue" />
+
+    <!-- Given we ErrorAndContinue we need to propagate the error if the overall task failed -->
+    <Error Condition="'$(MSBuildLastTaskResult)'=='false'" />
+  </Target> 
+
   <PropertyGroup>
     <TraversalBuildDependsOn>
       BuildAllProjects;
@@ -189,8 +219,18 @@
       $(TraversalCleanDependsOn);
     </TraversalCleanDependsOn>
 
+    <TraversalGenerateTestProjectJsonsDependsOn>
+      GenerateAllTestProjectJsons;
+      $(TraversalGenerateTestProjectJsonsDependsOn)
+    </TraversalGenerateTestProjectJsonsDependsOn>
+
     <TraversalRestorePackagesDependsOn>
       RestoreAllProjectPackages;
+      $(TraversalRestorePackagesDependsOn)
+    </TraversalRestorePackagesDependsOn>
+
+    <TraversalRestorePackagesDependsOn Condition="'$(_BuildAgainstPackages)' == 'true'">
+      $(TraversalGenerateTestProjectJsonsDependsOn);
       $(TraversalRestorePackagesDependsOn)
     </TraversalRestorePackagesDependsOn>
   </PropertyGroup>
@@ -206,4 +246,7 @@
   <Target Name="RebuildAndTest" DependsOnTargets="Rebuild;Test" />
   <Target Name="Test" />
 
+  <!-- Target will be overridden if buildagainstpackages.targets is imported. -->
+  <Target Name="GenerateTestProjectJson" />
+  <Import Condition="'$(_BuildAgainstPackages)' == 'true'" Project="$(ToolsDir)/buildagainstpackages.targets" />
 </Project>

--- a/dir.traversal.targets
+++ b/dir.traversal.targets
@@ -11,6 +11,9 @@
         <AdditionalProperties Condition="'%(Project.TargetGroup)'!=''">TargetGroup=%(Project.TargetGroup);%(Project.AdditionalProperties)</AdditionalProperties>
       </Project>
       <Project>
+        <FilterToTargetGroup Condition="'$(FilterToTargetGroup)'!=''">$(FilterToTargetGroup)</FilterToTargetGroup>
+      </Project>
+      <Project>
         <FilterToOSGroup Condition="'$(FilterToOSGroup)'!=''">$(FilterToOSGroup)</FilterToOSGroup>
       </Project>
       <Project>
@@ -21,6 +24,12 @@
       </Project>
       <Project>
         <AdditionalProperties Condition="'%(Project.FilterToOSGroup)'!=''">FilterToOSGroup=%(Project.FilterToOSGroup);%(Project.AdditionalProperties)</AdditionalProperties>
+      </Project>
+      <Project>
+        <AdditionalProperties Condition="'%(Project.FilterToTargetGroup)'!=''">FilterToTargetGroup=%(Project.FilterToTargetGroup);%(Project.AdditionalProperties)</AdditionalProperties>
+      </Project>
+      <Project>
+        <AdditionalProperties Condition="'%(Project.InputOSGroup)' != ''">InputOSGroup=%(Project.InputOSGroup);%(Project.AdditionalProperties)</AdditionalProperties>
       </Project>
       <Project>
         <AdditionalProperties Condition="'%(Project.BuildAllOSGroups)' != ''">BuildAllOSGroups=%(Project.BuildAllOSGroups);%(Project.AdditionalProperties)</AdditionalProperties>
@@ -41,11 +50,32 @@
       </Project>
     </ItemGroup>
 
-    <ItemGroup Condition="'$(FilterToOSGroup)'!='' and '$(BuildAllOSGroups)' != 'true'">
-      <ProjectsToBuild Include="@(Project)" Condition="'%(Project.OSGroup)'=='$(FilterToOSGroup)' or '%(Project.OSGroup)'=='AnyOS' or '%(Project.OSGroup)'==''" />
+    <PropertyGroup>
+      <OSGroupList>AnyOS;$(FilterToOSGroup);</OSGroupList>
+      <OSGroupList Condition="'$(FilterToOSGroup)'=='OSX'">$(OSGroupList);Unix;</OSGroupList>
+      <OSGroupList Condition="'$(FilterToOSGroup)'=='Linux'">$(OSGroupList);Unix;</OSGroupList>
+      <OSGroupList Condition="'$(FilterToOSGroup)'=='FreeBSD'">$(OSGroupList);Unix;</OSGroupList>
+      <OSGroupList Condition="'$(FilterToOSGroup)'=='NetBSD'">$(OSGroupList);Unix;</OSGroupList>
+    </PropertyGroup>
 
+    <ItemGroup Condition="'$(FilterToOSGroup)'!='' and '$(BuildAllOSGroups)' != 'true'">
+      <ProjectsToBuild Include="@(Project)" Condition="$(OSGroupList.Contains('%(Project.OSGroup);'))" />
+ 
       <Project Remove="@(Project)" />
       <Project Include="@(ProjectsToBuild)" />
+    </ItemGroup>
+
+    <PropertyGroup>
+      <TargetGroupList>;$(FilterToTargetGroup);</TargetGroupList>
+      <TargetGroupList Condition="'$(FilterToTargetGroup)'=='net46'">$(TargetGroupList)net461;net462;</TargetGroupList>
+      <TargetGroupList Condition="'$(FilterToTargetGroup)'=='net461'">$(TargetGroupList)net462;</TargetGroupList>
+    </PropertyGroup>
+
+    <ItemGroup Condition="'$(FilterToTargetGroup)'!=''">
+      <FilteredProjectsToBuild Include="@(Project)" Condition="$(TargetGroupList.Contains(';%(Project.TargetGroup);')) Or '%(Project.Extension)' == '.proj' Or '%(Project.Extension)' == '.builds'" />
+
+      <Project Remove="@(Project)" />
+      <Project Include="@(FilteredProjectsToBuild)" />
     </ItemGroup>
   </Target>
 

--- a/global.json
+++ b/global.json
@@ -1,0 +1,3 @@
+{
+  "projects": [ "./src", "./src/Common" ]
+}

--- a/init-tools.sh
+++ b/init-tools.sh
@@ -19,6 +19,7 @@ case $OSName in
     Darwin)
         OS=OSX
         __DOTNET_PKG=dotnet-dev-osx-x64
+        ulimit -n 2048
         ;;
 
     Linux)

--- a/publish-packages.cmd
+++ b/publish-packages.cmd
@@ -1,0 +1,33 @@
+@if "%_echo%" neq "on" echo off
+setlocal EnableDelayedExpansion
+
+set packagesLog=publish-packages.log
+echo Running publish-packages.cmd %* > %packagesLog%
+
+set options=/nologo /v:minimal /flp:v=detailed;Append;LogFile=%packagesLog%
+set allargs=%*
+
+if /I [%1] == [/?] goto Usage
+if /I [%1] == [/help] goto Usage
+
+REM ensure that msbuild is available
+echo Running init-tools.cmd
+call %~dp0init-tools.cmd
+
+echo msbuild.exe %~dp0src\publish.builds !options! !allargs! >> %packagesLog%
+call msbuild.exe %~dp0src\publish.builds !options! !allargs!
+if NOT [%ERRORLEVEL%]==[0] (
+  echo ERROR: An error occurred while publishing packages, see %packagesLog% for more details.
+  exit /b
+)
+
+echo Done publishing packages.
+exit /b
+
+:Usage
+echo.
+echo Publishes the NuGet packages to the specified location.
+echo For publishing to Azure the following properties are required.
+echo   /p:CloudDropAccountName="account name"
+echo   /p:CloudDropAccessToken="access token"
+exit /b

--- a/publish-packages.sh
+++ b/publish-packages.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+usage()
+{
+    echo "Publishes the NuGet packages to the specified location."
+    echo "For publishing to Azure the following properties are required."
+    echo "  /p:CloudDropAccountName='account name'"
+    echo "  /p:CloudDropAccessToken='access token'"
+    exit 1
+}
+
+working_tree_root="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+publish_packages_log=$working_tree_root/publish-packages.log
+options="/nologo /flp:v=detailed;Append;LogFile=$publish_packages_log"
+allargs="$@"
+
+echo -e "Running publish-packages.sh $allargs" > $publish_packages_log
+
+# Parse arguments
+if [ "$allargs" == "-h" ] || [ "$allargs" == "--help" ]; then
+    usage
+fi
+
+# Ensure that MSBuild is available
+echo "Running init-tools.sh"
+$working_tree_root/init-tools.sh
+
+echo -e "\n$working_tree_root/Tools/corerun $working_tree_root/Tools/MSBuild.exe $working_tree_root/src/publish.builds $options $allargs" >> $publish_packages_log
+$working_tree_root/Tools/corerun $working_tree_root/Tools/MSBuild.exe $working_tree_root/src/publish.builds $options $allargs
+
+if [ $? -ne 0 ]; then
+    echo -e "\nAn error occurred. Aborting publish-packages.sh ." >> $publish_packages_log
+    echo "ERROR: An error occurred while building packages, see $publish_packages_log for more details."
+    exit 1
+fi
+
+echo "Done building packages."
+echo -e "\nDone building packages." >> $publish_packages_log
+exit 0

--- a/run-test.cmd
+++ b/run-test.cmd
@@ -1,0 +1,17 @@
+@if "%_echo%" neq "on" echo off
+
+:: To run tests outside of MSBuild.exe
+:: %1 is the path to the tests\<OSConfig> folder
+
+pushd %1
+
+FOR /D %%F IN (*.Tests) DO (
+	IF EXIST %%F\dnxcore50 (
+		pushd %%F\dnxcore50
+		@echo "corerun.exe xunit.console.netcore.exe %%F.dll -xml testResults.xml -notrait category=outerloop -notrait category=failing -notrait category=nonwindowstests -notrait Benchmark=true"
+		corerun.exe xunit.console.netcore.exe %%F.dll -xml testResults.xml -notrait category=outerloop -notrait category=failing -notrait category=nonwindowstests -notrait Benchmark=true
+		popd
+	)
+)
+
+popd

--- a/src/System.Private.ServiceModel/tests/Common/Infrastructure/tests/Infrastructure.Common.Tests.builds
+++ b/src/System.Private.ServiceModel/tests/Common/Infrastructure/tests/Infrastructure.Common.Tests.builds
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="Infrastructure.Common.Tests.csproj" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>

--- a/src/System.Private.ServiceModel/tests/Scenarios/ServiceModel.Scenario.Tests.builds
+++ b/src/System.Private.ServiceModel/tests/Scenarios/ServiceModel.Scenario.Tests.builds
@@ -2,21 +2,7 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
-    <Project Include="Binding\Custom\Binding.Custom.Tests.csproj" />
-    <Project Include="Binding\Http\Binding.Http.Tests.csproj" />
-    <Project Include="Client\ChannelLayer\Client.ChannelLayer.Tests.csproj" />
-    <Project Include="Client\ClientBase\Client.ClientBase.Tests.csproj" />
-    <Project Include="Client\ExpectedExceptions\Client.ExpectedExceptions.Tests.csproj" />
-    <Project Include="Client\TypedClient\Client.TypedClient.Tests.csproj" />
-    <Project Include="Contract\Data\Contract.Data.Tests.csproj" />
-    <Project Include="Contract\Fault\Contract.Fault.Tests.csproj" />
-    <Project Include="Contract\Message\Contract.Message.Tests.csproj" />
-    <Project Include="Contract\Service\Contract.Service.Tests.csproj" />
-    <Project Include="Contract\XmlSerializer\Contract.XmlSerializer.Tests.csproj" />
-    <Project Include="Encoding\Encoders\Encoding.Encoders.Tests.csproj" />
-    <Project Include="Encoding\MessageVersion\Encoding.MessageVersion.Tests.csproj" />
-    <Project Include="Extensibility\WebSockets\Extensibility.WebSockets.Tests.csproj" />
-    <Project Include="Security\TransportSecurity\Security.TransportSecurity.Tests.csproj" />
+    <Project Include="**\*.csproj" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.Private.ServiceModel/tests/Scenarios/ServiceModel.Scenario.Tests.builds
+++ b/src/System.Private.ServiceModel/tests/Scenarios/ServiceModel.Scenario.Tests.builds
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="Binding\Custom\Binding.Custom.Tests.csproj" />
+    <Project Include="Binding\Http\Binding.Http.Tests.csproj" />
+    <Project Include="Client\ChannelLayer\Client.ChannelLayer.Tests.csproj" />
+    <Project Include="Client\ClientBase\Client.ClientBase.Tests.csproj" />
+    <Project Include="Client\ExpectedExceptions\Client.ExpectedExceptions.Tests.csproj" />
+    <Project Include="Client\TypedClient\Client.TypedClient.Tests.csproj" />
+    <Project Include="Contract\Data\Contract.Data.Tests.csproj" />
+    <Project Include="Contract\Fault\Contract.Fault.Tests.csproj" />
+    <Project Include="Contract\Message\Contract.Message.Tests.csproj" />
+    <Project Include="Contract\Service\Contract.Service.Tests.csproj" />
+    <Project Include="Contract\XmlSerializer\Contract.XmlSerializer.Tests.csproj" />
+    <Project Include="Encoding\Encoders\Encoding.Encoders.Tests.csproj" />
+    <Project Include="Encoding\MessageVersion\Encoding.MessageVersion.Tests.csproj" />
+    <Project Include="Extensibility\WebSockets\Extensibility.WebSockets.Tests.csproj" />
+    <Project Include="Security\TransportSecurity\Security.TransportSecurity.Tests.csproj" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>

--- a/src/System.ServiceModel.Duplex/tests/System.ServiceModel.Duplex.Tests.builds
+++ b/src/System.ServiceModel.Duplex/tests/System.ServiceModel.Duplex.Tests.builds
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="System.ServiceModel.Duplex.Tests.csproj" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>

--- a/src/System.ServiceModel.Http/tests/System.ServiceModel.Http.Tests.builds
+++ b/src/System.ServiceModel.Http/tests/System.ServiceModel.Http.Tests.builds
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="System.ServiceModel.Http.Tests.csproj" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>

--- a/src/System.ServiceModel.NetTcp/tests/System.ServiceModel.NetTcp.Tests.builds
+++ b/src/System.ServiceModel.NetTcp/tests/System.ServiceModel.NetTcp.Tests.builds
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="System.ServiceModel.NetTcp.Tests.csproj" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>

--- a/src/System.ServiceModel.Primitives/tests/System.ServiceModel.Primitives.Tests.builds
+++ b/src/System.ServiceModel.Primitives/tests/System.ServiceModel.Primitives.Tests.builds
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="System.ServiceModel.Primitives.Tests.csproj" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>

--- a/src/System.ServiceModel.Security/tests/System.ServiceModel.Security.Tests.builds
+++ b/src/System.ServiceModel.Security/tests/System.ServiceModel.Security.Tests.builds
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="System.ServiceModel.Security.Tests.csproj" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>

--- a/src/dirs.proj
+++ b/src/dirs.proj
@@ -4,7 +4,6 @@
   <ItemGroup>
     <Project Include="ref.builds" />
     <Project Include="src.builds" />
-    <Project Include="tests.builds" />
   </ItemGroup>
 
   <!-- *** start WCF Content *** -->

--- a/src/global.json
+++ b/src/global.json
@@ -1,3 +1,0 @@
-{
-  "projects": [ "./", "./Common" ]
-}

--- a/src/tests.builds
+++ b/src/tests.builds
@@ -4,22 +4,12 @@
     <!-- Capture OSGroup passed to command line for setting default FilterToOSGroup value below -->
     <_OriginalOSGroup>$(OSGroup)</_OriginalOSGroup>
   </PropertyGroup>
-  
+
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
-
-  <PropertyGroup>
-    <FilterToOSGroup Condition="'$(_OriginalOSGroup)' == ''">$(OSEnvironment)</FilterToOSGroup>
-  </PropertyGroup>
-
   <ItemGroup>
-    <!-- *** start WCF Content *** -->
-    <ExcludeProjects Include="System.Private.ServiceModel\tests\Scenarios\SelfHostWcfService\WcfService.csproj" />
-    <!-- *** end WCF Content *** -->
-    <Project Include="*\test*\**\*.csproj" Exclude="@(ExcludeProjects)">
-      <OSGroup Condition="'$(FilterToOSGroup)'!=''">$(FilterToOSGroup)</OSGroup>
-    </Project>
-    <Project Include="*\test*\**\*.vbproj" Condition="'$(IncludeVbProjects)'!='false'">
-      <OSGroup Condition="'$(FilterToOSGroup)'!=''">$(FilterToOSGroup)</OSGroup>
+    <Project Include="*\tests\**\*.builds">
+      <BuildAllOSGroups Condition="'$(OSGroup)' != '' OR '$(FilterToOSGroup)' != ''">false</BuildAllOSGroups>
+      <FilterToOSGroup Condition="'$(_OriginalOSGroup)' == ''">$(OSEnvironment)</FilterToOSGroup>
     </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />

--- a/src/tests.builds
+++ b/src/tests.builds
@@ -1,6 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <!-- Capture OSGroup passed to command line for setting default FilterToOSGroup value below -->
+    <_OriginalOSGroup>$(OSGroup)</_OriginalOSGroup>
+  </PropertyGroup>
+  
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+
+  <PropertyGroup>
+    <FilterToOSGroup Condition="'$(_OriginalOSGroup)' == ''">$(OSEnvironment)</FilterToOSGroup>
+  </PropertyGroup>
+
   <ItemGroup>
     <!-- *** start WCF Content *** -->
     <ExcludeProjects Include="System.Private.ServiceModel\tests\Scenarios\SelfHostWcfService\WcfService.csproj" />

--- a/src/tests.builds
+++ b/src/tests.builds
@@ -6,8 +6,13 @@
   </PropertyGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  
   <ItemGroup>
-    <Project Include="*\tests\**\*.builds">
+    <!-- *** start WCF Content *** -->
+    <ExcludeProjects Include="System.Private.ServiceModel\tests\Scenarios\SelfHostWcfService\WcfService.csproj" />
+    
+    <Project Include="*\tests\**\*.builds" Exclude="@(ExcludeProjects)">
+    <!-- *** end WCF Content *** -->
       <BuildAllOSGroups Condition="'$(OSGroup)' != '' OR '$(FilterToOSGroup)' != ''">false</BuildAllOSGroups>
       <FilterToOSGroup Condition="'$(_OriginalOSGroup)' == ''">$(OSEnvironment)</FilterToOSGroup>
     </Project>

--- a/sync.sh
+++ b/sync.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+
+usage()
+{
+    echo "Usage: sync [-p] [-s]"
+    echo "Repository syncing script."
+    echo "  -s         Fetch source history from all configured remotes"
+    echo "             (git fetch --all -p -v)"
+    echo "  -p         Restore all NuGet packages for the repository"
+    echo
+    echo "If no option is specified, then \"sync.sh -p -s\" is implied."
+    exit 1
+}
+
+working_tree_root="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+sync_log=$working_tree_root/sync.log
+
+options="/nologo /v:minimal /clp:Summary /flp:v=detailed;Append;LogFile=$sync_log"
+unprocessedBuildArgs=
+
+echo "Running sync.sh $*" > $sync_log
+
+# Parse arguments
+if [ $# == 0 ]; then
+    sync_packages=true
+    sync_src=true
+fi
+
+while [[ $# > 0 ]]
+do
+    opt="$1"
+    case $opt in
+        -h|--help)
+        usage
+        ;;
+        -p)
+        sync_packages=true
+        ;;
+        -s)
+        sync_src=true
+        ;;
+        *)
+        unprocessedBuildArgs="$unprocessedBuildArgs $1"
+    esac
+    shift
+done
+
+echo "Running init-tools.sh"
+$working_tree_root/init-tools.sh
+
+if [ "$sync_src" == true ]; then
+    echo "Fetching git database from remote repos..."
+    git fetch --all -p -v >> $sync_log 2>&1
+    if [ $? -ne 0 ]; then
+        echo -e "\ngit fetch failed. Aborting sync." >> $sync_log
+        echo "ERROR: An error occurred while fetching remote source code; see $sync_log for more details."
+        exit 1
+    fi
+fi
+
+if [ "$sync_packages" == true ]; then
+    options="$options /t:BatchRestorePackages /p:RestoreDuringBuild=true"
+    echo "Restoring all packages..."
+    echo -e "\n$working_tree_root/Tools/corerun $working_tree_root/Tools/MSBuild.exe $working_tree_root/build.proj $options $unprocessedBuildArgs" >> $sync_log
+    $working_tree_root/Tools/corerun $working_tree_root/Tools/MSBuild.exe $working_tree_root/build.proj $options $unprocessedBuildArgs
+    if [ $? -ne 0 ]
+    then
+        echo -e "\nPackage restored failed. Aborting sync." >> $sync_log
+        echo "ERROR: An error occurred while syncing packages; see $sync_log for more details. There may have been networking problems, so please try again in a few minutes."
+        exit 1
+    fi
+fi
+
+echo "Sync completed successfully."
+echo -e "\nSync completed successfully." >> $sync_log
+exit 0


### PR DESCRIPTION
First commit syncs build-tests.cmd and related changes.
Second commit adopts the new test .builds files for building and running test projects.
Third commit takes updates to changes to shared files from last 24 hours and updates all the .sh files.
   - The .sh files have not been tested on Linux.
   - Even though we do not use run-test.sh I synced it, we may have to at some point.