### PR TITLE
Add BouncyCastle package dependency

### DIFF
--- a/src/System.Private.ServiceModel/tools/CertificateGenerator/CertificateGenerator.csproj
+++ b/src/System.Private.ServiceModel/tools/CertificateGenerator/CertificateGenerator.csproj
@@ -36,8 +36,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="BouncyCastle.Crypto, Version=1.7.4137.9688, Culture=neutral, PublicKeyToken=a4292a325f69b123, processorArchitecture=MSIL">
-      <HintPath>$(PackageOutputDir)\BouncyCastle.1.7.0\lib\Net40-Client\BouncyCastle.Crypto.dll</HintPath>
+    <Reference Include="BouncyCastle.Crypto, Version=1.8.1.0, Culture=neutral, PublicKeyToken=0e99375e54769942">
+      <HintPath>$(PackageOutputDir)\BouncyCastle.Crypto.dll.1.8.1\lib\BouncyCastle.Crypto.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -58,6 +58,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />
+    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Properties\" />

--- a/src/System.Private.ServiceModel/tools/CertificateGenerator/packages.config
+++ b/src/System.Private.ServiceModel/tools/CertificateGenerator/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="BouncyCastle.Crypto.dll" version="1.8.1" targetFramework="net45" />
+</packages>


### PR DESCRIPTION
* Build certificate generator will fail on a new machine because the dependency is not defined.