### PR TITLE
Remove uses of async/await where not needed

### DIFF
--- a/src/System.Private.ServiceModel/src/System/IdentityModel/Selectors/X509SecurityTokenProvider.cs
+++ b/src/System.Private.ServiceModel/src/System/IdentityModel/Selectors/X509SecurityTokenProvider.cs
@@ -34,9 +34,9 @@ namespace System.IdentityModel.Selectors
             }
         }
 
-        protected override async Task<SecurityToken> GetTokenCoreAsync(CancellationToken cancellationToken)
+        protected override Task<SecurityToken> GetTokenCoreAsync(CancellationToken cancellationToken)
         {
-            return await Task.FromResult<SecurityToken>(new X509SecurityToken(certificate: _certificate, clone: _clone, disposable:_clone));
+            return Task.FromResult<SecurityToken>(new X509SecurityToken(certificate: _certificate, clone: _clone, disposable:_clone));
         }
 
         public void Dispose()

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/MessageContent.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/MessageContent.cs
@@ -180,7 +180,7 @@ namespace System.ServiceModel.Channels
             // to run on a different thread to prevent a deadlock.
             _stream = new ProducerConsumerStream();
             var bufferedStream = new BufferedWriteStream(_stream, WriteBufferSize);
-            Task.Run(async () => await _messageEncoder.WriteMessageAsync(_message, bufferedStream));
+            Task.Run(() => _messageEncoder.WriteMessageAsync(_message, bufferedStream));
             return Task.FromResult(_stream);
         }
 

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/TransportSecurityHelpers.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/TransportSecurityHelpers.cs
@@ -34,11 +34,11 @@ namespace System.ServiceModel.Channels
         }
 
         // used by client WindowsStream security (from InitiateUpgrade)
-        public static async Task<NetworkCredential> GetSspiCredentialAsync(SspiSecurityTokenProvider tokenProvider,
+        public static Task<NetworkCredential> GetSspiCredentialAsync(SspiSecurityTokenProvider tokenProvider,
             OutWrapper<TokenImpersonationLevel> impersonationLevel, OutWrapper<bool> allowNtlm, CancellationToken cancellationToken)
         {
             OutWrapper<bool> dummyExtractWindowsGroupClaimsWrapper = new OutWrapper<bool>();
-            return await GetSspiCredentialAsync(tokenProvider,
+            return GetSspiCredentialAsync(tokenProvider,
                 dummyExtractWindowsGroupClaimsWrapper, impersonationLevel, allowNtlm, cancellationToken);
         }
 


### PR DESCRIPTION
Hi! This is my first time contributing to WCF 😄 This is just a minor pull request to remove uses of async/await where they're not needed. e.g.

```cs
async Task<int> Foo()
{
    return await Bar();
}
```

could simply be replaced with

```cs
Task<int> Foo()
{
    return Bar();
}
```