### PR TITLE
Update [Theory] to [ConditionalTheory] for failing test.

### DIFF
--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Tcp/ClientCredentialTypeCertificateCanonicalNameTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Tcp/ClientCredentialTypeCertificateCanonicalNameTests.cs
@@ -25,7 +25,6 @@ public class Tcp_ClientCredentialTypeCertificateCanonicalNameTests : Conditional
     [ConditionalTheory(nameof(Root_Certificate_Installed))]
     [OuterLoop]
     [MemberData("TcpClientCredentialType_Certificate_With_Only_CanonicalName_MemberData")]
-    [ActiveIssue(1047)]
     public static void TcpClientCredentialType_Certificate_With_Only_CanonicalName_EchoString(Uri endpointUri, bool shouldCallSucceed)
     {
         var endpointAddress = new EndpointAddress(endpointUri);

--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Tcp/ClientCredentialTypeCertificateCanonicalNameTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Tcp/ClientCredentialTypeCertificateCanonicalNameTests.cs
@@ -11,7 +11,7 @@ using Xunit;
 using System.Collections.Generic;
 using System.Text;
 
-public static class Tcp_ClientCredentialTypeCertificateCanonicalNameTests
+public class Tcp_ClientCredentialTypeCertificateCanonicalNameTests : ConditionalWcfTest
 {
     // We set up three endpoints on the Bridge (server) side, each with a different certificate: 
     // Tcp_ClientCredentialType_Certificate_With_CanonicalName_Localhost_Address - is bound to a cert where CN=localhost
@@ -22,7 +22,7 @@ public static class Tcp_ClientCredentialTypeCertificateCanonicalNameTests
     // Hence, we are only able to determine at runtime whether a particular endpoint presented by the Bridge is going 
     // to pass a variation or fail a variation. 
 
-    [Theory]
+    [ConditionalTheory(nameof(Root_Certificate_Installed))]
     [OuterLoop]
     [MemberData("TcpClientCredentialType_Certificate_With_Only_CanonicalName_MemberData")]
     [ActiveIssue(1047)]


### PR DESCRIPTION
Updates a single [Theory] to use [ConditionalTheory] so that a test
requiring certificates does not fail when the setup steps are skipped.

PR #1026 should have included this change, but I didn't see it until
I ran the tests under Linux and deliberately skipped the cert setup steps.  It also failed under CI or any other scenario that did not initialize certificates.

Fixes #1047