### PR TITLE
Consolidate various PRServices into one endpoint

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -62,7 +62,7 @@ def branch = GithubBranchName
 // **************************
 class WcfUtilities
 {
-    def wcfRepoSyncServiceCount = 0 
+    def wcfPRServiceCount = 0 
     
     // Outerloop jobs for WCF Core require an external server reference
     // This should be run 
@@ -73,27 +73,28 @@ class WcfUtilities
             return 
         }
 
-        wcfRepoSyncServiceCount++
+        wcfPRServiceCount++
 
         def operation = isPR ? "pr" : "branch"
 
         job.with { 
             parameters {
-                stringParam('WcfServiceUri', "wcfcoresrv2.cloudapp.net/WcfService${wcfRepoSyncServiceCount}", 'Wcf OuterLoop Test Service Uri')
-                stringParam('WcfRepoSyncServiceUri', "http://wcfcoresrv2.cloudapp.net/PRService${wcfRepoSyncServiceCount}/pr.ashx", 'Wcf OuterLoop Test PR Service Uri')
+                stringParam('WcfServiceUri', "wcfcoresrv2.cloudapp.net/WcfService${wcfPRServiceCount}", 'Wcf OuterLoop Test Service Uri')
+                stringParam('WcfPRServiceUri', "http://wcfcoresrv2.cloudapp.net/PRServiceMaster/pr.ashx", 'Wcf OuterLoop Test PR Service Uri')
+                stringParam('WcfPRServiceId', "${wcfPRServiceCount}", 'Wcf OuterLoop Test PR Service Id')
             }
         }
         if (os.toLowerCase().contains("windows")) {
             job.with { 
                 steps {
-                    batchFile(".\\src\\System.Private.ServiceModel\\tools\\scripts\\sync-pr.cmd ${operation} %WcfRepoSyncServiceUri%")
+                    batchFile(".\\src\\System.Private.ServiceModel\\tools\\scripts\\sync-pr.cmd %WcfPRServiceId% ${operation} %WcfPRServiceUri%")
                 }           
             }
         } 
         else {
             job.with { 
                 steps {
-                   shell("HOME=\$WORKSPACE/tempHome ./src/System.Private.ServiceModel/tools/scripts/sync-pr.sh ${operation} \$WcfRepoSyncServiceUri")
+                   shell("HOME=\$WORKSPACE/tempHome ./src/System.Private.ServiceModel/tools/scripts/sync-pr.sh \$WcfPRServiceId ${operation} \$WcfPRServiceUri")
                 }
             }
         }

--- a/src/System.Private.ServiceModel/tools/PRService/web.config
+++ b/src/System.Private.ServiceModel/tools/PRService/web.config
@@ -8,7 +8,21 @@
 <configuration>
   <system.web>
     <compilation debug="false" />
-    <httpRuntime/>
+    <!-- some git syncs may take a long time, so upping the executionTimeout to help with this -->
+    <httpRuntime executionTimeout="300" />
   </system.web>
+  <appSettings>
+    <!--
+      These appSettings provide the default environment under which we execute
+      These should be changed to reflect what is correct on the local system, or 
+      specified as a system-wide environment variable. 
+      
+      Environment variables take precedence over what is specified here
+    -->
+    <add key="GitExecutablePath" value="C:\Program Files\Git\cmd\git.exe"/>
+    <add key="GitRepositoriesBasePath" value="C:\git"/>
+    <add key="GitExecutionTimeout" value="00:01:00"/>
+    
+  </appSettings>
 </configuration>
 

--- a/src/System.Private.ServiceModel/tools/scripts/sync-pr.cmd
+++ b/src/System.Private.ServiceModel/tools/scripts/sync-pr.cmd
@@ -15,31 +15,37 @@ echo.
 
 if "%__args%"=="" (
     echo   [%~n0] A URL must be specified for the pull request synchronization URL
-    echo     Usage:  %~n0 [branch/pr] [sync-url] [optional branch-name / pr-number]
+    echo     Usage:  %~n0 [repo] [branch/pr] [sync-url] [optional branch-name / pr-number]
     echo   
+    echo   repo        - ID of the repo on the PR Service
     echo   branch/pr   - Sync to branch or PR [choose one]
     echo   sync-url    - URL on remote server for PR synchronization
     echo   branch-name - branch name to sync to
     echo   pr-number   - PR number to sync to
     echo.
-    echo   Example:  %~n0 branch http://wcfci-sync-server/PRService1/pr.ashx 
-    echo   Example:  %~n0 branch http://wcfci-sync-server/PRService1/pr.ashx master
-    echo   Example:  %~n0 pr http://wcfci-sync-server/PRService1/pr.ashx 
-    echo   Example:  %~n0 pr http://wcfci-sync-server/PRService1/pr.ashx 404
+    echo   If the branch-name or pr-number are left blank, then the script will use 
+    echo   the GIT_BRANCH or ghprbPullId environment variable depending on the operation mode
+    echo.
+    echo   Example:  %~n0 1 branch http://wcfci-sync-server/PRService/pr.ashx
+    echo   Example:  %~n0 2 branch http://wcfci-sync-server/PRService/pr.ashx master
+    echo   Example:  %~n0 3 pr http://wcfci-sync-server/PRService/pr.ashx
+    echo   Example:  %~n0 4 pr http://wcfci-sync-server/PRService/pr.ashx 404
     set __EXITCODE=1
     goto done
 )
 
-set __OPERATION_MODE=%1
+set __REPO_ID=%1
+
+set __OPERATION_MODE=%2
 
 if not "%__OPERATION_MODE%"=="branch" if not "%__OPERATION_MODE%"=="pr" (
     echo   Invalid operation mode specified 
     goto done
 )
 
-set __SYNC_HOST_URL=%2
+set __SYNC_HOST_URL=%3
 
-if "%3"=="" (
+if "%4"=="" (
     if '%__OPERATION_MODE%'=='branch' (
         if '%GIT_BRANCH%'=='' (
             echo   [%~n0] This script should only be called only from the context of a GitHub Pull Request
@@ -60,15 +66,17 @@ if "%3"=="" (
         )
     )
 ) else (
-    set __BRANCH_OR_PR_ID=%3
+    set __BRANCH_OR_PR_ID=%4
     echo   [%~n0] WARNING: This script should usually only be called only from the context of a GitHub Pull Request
-    echo   [%~n0] Branch or PR ID overridden: '%3'
+    echo   [%~n0] Branch or PR ID overridden: '%4'
 ) 
 
-set __REQUEST_URL=%__SYNC_HOST_URL%?%__OPERATION_MODE%=%__BRANCH_OR_PR_ID%
+REM Disregard the chevrons and quotataions in the next line - it's to output the correct ampersand character to PowerShell
+REM We have to duplicate the request URL below for output and for PowerShell because of Powershell's crazy escape sequences interacting 
+REM badly with cmd's crazy and conflicting escape sequences
 
-echo   [%~n0] Making call to '%__REQUEST_URL%'
-powershell -NoProfile -ExecutionPolicy unrestricted -Command "(New-Object Net.WebClient).DownloadString('%__REQUEST_URL%'); 
+echo   [%~n0] Making call to %__SYNC_HOST_URL%?repo=%__REPO_ID%^&%__OPERATION_MODE%=%__BRANCH_OR_PR_ID%
+powershell -NoProfile -ExecutionPolicy unrestricted -Command "(New-Object Net.WebClient).DownloadString('%__SYNC_HOST_URL%?repo=%__REPO_ID%&%__OPERATION_MODE%=%__BRANCH_OR_PR_ID%');"
 
 set __EXITCODE=%ERRORLEVEL% 
 


### PR DESCRIPTION
Rather than have multiple PRServices (one for each repo) on the PR service machine, centralize them into one endpoint, and instead pass the repo id. This has the benefit of allowing only one copy of the service to be maintained, having fewer points of entry, having one consistent service across all repos, and finally, preventing accidental syncs from killing the service and requiring manual intervention