### PR TITLE
Revert "Simplify CI triggers" for innerloop tests

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -269,7 +269,7 @@ branchList.each { branchName ->
             // Set up triggers
             if (isPR) {
                 // Set PR trigger.
-                Utilities.addGithubPRTrigger(newJob, "Innerloop ${os} ${configurationGroup}","(?i).*test\\W+innerloop\\W+${os}.*")
+                Utilities.addGithubPRTrigger(newJob, "Innerloop ${os} ${configurationGroup} Build and Test")
             } 
             else {
                 // Set a push trigger


### PR DESCRIPTION
This reverts part of commit 0ab55905c26be86a96d4c66266a5da37a232bdd6.
Triggers simplified in this way for innerloop seems to cause problems due to the
way the utilities groovy class handles the optional parameter - basically
specifying that parameter prevents innerloops from auto-triggering.
For now, revert the simplification for innerloop tests