### PR TITLE
PRService: update sync-pr scripts for new PRService

### DIFF
--- a/src/System.Private.ServiceModel/tools/scripts/sync-pr.cmd
+++ b/src/System.Private.ServiceModel/tools/scripts/sync-pr.cmd
@@ -15,9 +15,9 @@ echo.
 
 if "%__args%"=="" (
     echo   [%~n0] A URL must be specified for the pull request synchronization URL
-    echo     Usage:  %~n0 [repo] [branch/pr] [sync-url] [optional branch-name / pr-number]
+    echo     Usage:  %~n0 [id] [branch/pr] [sync-url] [optional branch-name / pr-number]
     echo   
-    echo   repo        - ID of the repo on the PR Service
+    echo   id          - ID of the repo on the PR Service
     echo   branch/pr   - Sync to branch or PR [choose one]
     echo   sync-url    - URL on remote server for PR synchronization
     echo   branch-name - branch name to sync to
@@ -75,8 +75,8 @@ REM Disregard the chevrons and quotataions in the next line - it's to output the
 REM We have to duplicate the request URL below for output and for PowerShell because of Powershell's crazy escape sequences interacting 
 REM badly with cmd's crazy and conflicting escape sequences
 
-echo   [%~n0] Making call to %__SYNC_HOST_URL%?repo=%__REPO_ID%^&%__OPERATION_MODE%=%__BRANCH_OR_PR_ID%
-powershell -NoProfile -ExecutionPolicy unrestricted -Command "(New-Object Net.WebClient).DownloadString('%__SYNC_HOST_URL%?repo=%__REPO_ID%&%__OPERATION_MODE%=%__BRANCH_OR_PR_ID%');"
+echo   [%~n0] Making call to %__SYNC_HOST_URL%?id=%__REPO_ID%^&%__OPERATION_MODE%=%__BRANCH_OR_PR_ID%
+powershell -NoProfile -ExecutionPolicy unrestricted -Command "(New-Object Net.WebClient).DownloadString('%__SYNC_HOST_URL%?id=%__REPO_ID%&%__OPERATION_MODE%=%__BRANCH_OR_PR_ID%');"
 
 set __EXITCODE=%ERRORLEVEL% 
 

--- a/src/System.Private.ServiceModel/tools/scripts/sync-pr.sh
+++ b/src/System.Private.ServiceModel/tools/scripts/sync-pr.sh
@@ -14,8 +14,8 @@ show_banner()
 show_usage() 
 {
     echo "    A URL must be specified for the pull request synchronization URL"
-    echo "    Usage: $0 [repo] [branch|pr] [sync-url] [branch-name | pr-number (optional)]"
-    echo "    repo        - ID of the repo on the PR service"
+    echo "    Usage: $0 [id] [branch|pr] [sync-url] [branch-name | pr-number (optional)]"
+    echo "    id          - ID of the repo on the PR service"
     echo "    branch|pr   - Sync to branch or PR (choose one)"
     echo "    sync-url    - URL on remote server for PR synchronization"
     echo "    branch-name - branch name to sync to"
@@ -38,7 +38,7 @@ run_request()
     __sync_url=$3
     __branch_or_pullid=$4
 
-    __request_uri=${__sync_url}?repo=${__repo_id}\&${__operation_mode}=${__branch_or_pullid}
+    __request_uri=${__sync_url}?id=${__repo_id}\&${__operation_mode}=${__branch_or_pullid}
 
     echo "    Making a call to '${__request_uri}'" 
 


### PR DESCRIPTION
The earlier iteration of PRService relied on the URI query string passing repo=repo_id, however
we pushed a change that changed the repo ID identifier be 'id' on the query string

Modify the two scripts so they call the PR service correctly