### PR TITLE
Re-enable temporarily disabled WebSockets tests

### DIFF
--- a/src/System.Private.ServiceModel/tests/Common/Scenarios/ScenarioTestHelpers.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Scenarios/ScenarioTestHelpers.cs
@@ -31,10 +31,13 @@ public static class ScenarioTestHelpers
         }
     }
 
-    public static bool BridgeIsLocalHost()
+    // Returns true only if the test services are accessed via "localhost".
+    // This test is not intended to be used to determine whether test services 
+    // are running on the same machine as the tests.
+    public static bool IsLocalHost()
     {
-        string bridgeHost = TestProperties.GetProperty(TestProperties.BridgeHost_PropertyName);
-        return String.Equals("localhost", bridgeHost, StringComparison.OrdinalIgnoreCase);
+        string serviceUri = TestProperties.GetProperty(TestProperties.ServiceUri_PropertyName);
+        return String.Equals("localhost", serviceUri, StringComparison.OrdinalIgnoreCase);
     }
 
     public static string GenerateStringValue(int length)

--- a/src/System.Private.ServiceModel/tests/Scenarios/Extensibility/WebSockets/WebSocketTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Extensibility/WebSockets/WebSocketTests.cs
@@ -13,7 +13,6 @@ public static class WebSocketTests
 {
     [Fact]
     [OuterLoop]
-    [ActiveIssue(1043)]
     [ActiveIssue(420, PlatformID.AnyUnix)]
     public static void WebSocket_Http_RequestReply_BinaryStreamed()
     {
@@ -60,7 +59,7 @@ public static class WebSocketTests
             foreach (string serverLogItem in client.GetLog())
             {
                 //Assert.True(serverLogItem != ScenarioTestHelpers.RemoteEndpointMessagePropertyFailure, ScenarioTestHelpers.RemoteEndpointMessagePropertyFailure);
-                Assert.True(!ScenarioTestHelpers.BridgeIsLocalHost() || !serverLogItem.Contains(ScenarioTestHelpers.RemoteEndpointMessagePropertyFailure), serverLogItem);
+                Assert.True(!ScenarioTestHelpers.IsLocalHost() || !serverLogItem.Contains(ScenarioTestHelpers.RemoteEndpointMessagePropertyFailure), serverLogItem);
             }
 
             // *** CLEANUP *** \\
@@ -470,7 +469,6 @@ public static class WebSocketTests
 
     [Fact]
     [OuterLoop]
-    [ActiveIssue(1043)]
     [ActiveIssue(420, PlatformID.AnyUnix)]
     public static void WebSocket_Http_RequestReply_TextStreamed()
     {
@@ -517,7 +515,7 @@ public static class WebSocketTests
             foreach (string serverLogItem in client.GetLog())
             {
                 //Assert.True(serverLogItem != ScenarioTestHelpers.RemoteEndpointMessagePropertyFailure, ScenarioTestHelpers.RemoteEndpointMessagePropertyFailure);
-                Assert.True(!ScenarioTestHelpers.BridgeIsLocalHost() || !serverLogItem.Contains(ScenarioTestHelpers.RemoteEndpointMessagePropertyFailure), serverLogItem);
+                Assert.True(!ScenarioTestHelpers.IsLocalHost() || !serverLogItem.Contains(ScenarioTestHelpers.RemoteEndpointMessagePropertyFailure), serverLogItem);
             }
 
             // *** CLEANUP *** \\
@@ -657,7 +655,6 @@ public static class WebSocketTests
 
     [Fact]
     [OuterLoop]
-    [ActiveIssue(1043)]
     [ActiveIssue(625, PlatformID.AnyUnix)]
     public static void WebSocket_Https_RequestReply_BinaryBuffered()
     {
@@ -693,7 +690,7 @@ public static class WebSocketTests
             foreach (string serverLogItem in client.GetLog())
             {
                 //Assert.True(serverLogItem != ScenarioTestHelpers.RemoteEndpointMessagePropertyFailure, ScenarioTestHelpers.RemoteEndpointMessagePropertyFailure);
-                Assert.True(!ScenarioTestHelpers.BridgeIsLocalHost() || !serverLogItem.Contains(ScenarioTestHelpers.RemoteEndpointMessagePropertyFailure), serverLogItem);
+                Assert.True(!ScenarioTestHelpers.IsLocalHost() || !serverLogItem.Contains(ScenarioTestHelpers.RemoteEndpointMessagePropertyFailure), serverLogItem);
             }
 
             // *** CLEANUP *** \\
@@ -709,7 +706,6 @@ public static class WebSocketTests
 
     [Fact]
     [OuterLoop]
-    [ActiveIssue(1043)]
     [ActiveIssue(625, PlatformID.AnyUnix)]
     public static void WebSocket_Https_RequestReply_TextBuffered_KeepAlive()
     {
@@ -747,7 +743,7 @@ public static class WebSocketTests
             foreach (string serverLogItem in client.GetLog())
             {
                 //Assert.True(serverLogItem != ScenarioTestHelpers.RemoteEndpointMessagePropertyFailure, ScenarioTestHelpers.RemoteEndpointMessagePropertyFailure);
-                Assert.True(!ScenarioTestHelpers.BridgeIsLocalHost() || !serverLogItem.Contains(ScenarioTestHelpers.RemoteEndpointMessagePropertyFailure), serverLogItem);
+                Assert.True(!ScenarioTestHelpers.IsLocalHost() || !serverLogItem.Contains(ScenarioTestHelpers.RemoteEndpointMessagePropertyFailure), serverLogItem);
             }
 
             // *** CLEANUP *** \\
@@ -897,7 +893,6 @@ public static class WebSocketTests
 
     [Fact]
     [OuterLoop]
-    [ActiveIssue(1043)]
     [ActiveIssue(625, PlatformID.AnyUnix)]
     public static void WebSocket_Http_RequestReply_TextBuffered()
     {
@@ -931,7 +926,7 @@ public static class WebSocketTests
             foreach (string serverLogItem in client.GetLog())
             {
                 //Assert.True(serverLogItem != ScenarioTestHelpers.RemoteEndpointMessagePropertyFailure, ScenarioTestHelpers.RemoteEndpointMessagePropertyFailure);
-                Assert.True(!ScenarioTestHelpers.BridgeIsLocalHost() || !serverLogItem.Contains(ScenarioTestHelpers.RemoteEndpointMessagePropertyFailure), serverLogItem);
+                Assert.True(!ScenarioTestHelpers.IsLocalHost() || !serverLogItem.Contains(ScenarioTestHelpers.RemoteEndpointMessagePropertyFailure), serverLogItem);
             }
 
             // *** CLEANUP *** \\
@@ -947,7 +942,6 @@ public static class WebSocketTests
 
     [Fact]
     [OuterLoop]
-    [ActiveIssue(1043)]
     [ActiveIssue(625, PlatformID.AnyUnix)]
     public static void WebSocket_Http_RequestReply_BinaryBuffered_KeepAlive()
     {
@@ -982,7 +976,7 @@ public static class WebSocketTests
             foreach (string serverLogItem in client.GetLog())
             {
                 //Assert.True(serverLogItem != ScenarioTestHelpers.RemoteEndpointMessagePropertyFailure, ScenarioTestHelpers.RemoteEndpointMessagePropertyFailure);
-                Assert.True(!ScenarioTestHelpers.BridgeIsLocalHost() || !serverLogItem.Contains(ScenarioTestHelpers.RemoteEndpointMessagePropertyFailure), serverLogItem);
+                Assert.True(!ScenarioTestHelpers.IsLocalHost() || !serverLogItem.Contains(ScenarioTestHelpers.RemoteEndpointMessagePropertyFailure), serverLogItem);
             }
 
             // *** CLEANUP *** \\


### PR DESCRIPTION
Moving to the new test infrastructure made these tests
fail due to using the BridgeHost property to determine
if they were running as localhost. We disabled them
temporarily during infrastructure integration.

The fix is to use the ServiceUri instead of BridgeHost.

Fixes #1043