### PR TITLE
Disable svclog tracing in IIS-hosted test services

### DIFF
--- a/src/System.Private.ServiceModel/tools/IISHostedWcfService/Web.config
+++ b/src/System.Private.ServiceModel/tools/IISHostedWcfService/Web.config
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
  <!--Copyright (c) Microsoft Corporation.  All Rights Reserved.-->
 <configuration>
+
+<!-- Uncomment this section to enable tracing
   <system.diagnostics>
     <sources>
       <source name="System.ServiceModel" switchValue="Information, ActivityTracing" propagateActivity="true">
@@ -10,6 +12,8 @@
       </source>
     </sources>
   </system.diagnostics>
+-->
+
   <system.web>
     <compilation debug="false" />
     <httpRuntime targetFramework="4.5" />


### PR DESCRIPTION
This changes the default behavior of IIS-hosted test services
so that they do not trace to svclog files.  The web.config section
is preserved as a comment to allow it to be re-enabled to debug.