### PR TITLE
Move setup and cleanup steps to msbuild.

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -104,7 +104,6 @@ set _binclashLoggerDll=%~dp0Tools\net45\Microsoft.DotNet.Build.Tasks.dll
 set _binclashlog=%~dp0binclash.log
 set _buildprefix=echo
 set _buildpostfix=^> "%_buildlog%"
-
 call :build %__args%
 
 :: Build

--- a/build.proj
+++ b/build.proj
@@ -114,4 +114,7 @@
     <RemoveDir Directories="$(BinDir)" />
   </Target>
 
+  <!-- Hook that can be used to insert custom build tasks to the build process such as setup and/or cleanup tasks -->
+  <Import Project="build.override.targets" Condition="Exists('build.override.targets')" />
+
 </Project>


### PR DESCRIPTION
* Where before we did setup and cleanup steps directly in build.cmd now adding a generic "build.override.targets" hook to build.proj from which we can call any custom scripts to do whatever we want.
* Including example code to show how to create a setup and cleanup Target.
* Minor change to build.cmd for corefx diff reason.