### PR TITLE
Update netci.groovy for code coverage runs

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -120,7 +120,7 @@ branchList.each { branchName ->
     
     newJob.with {
         steps {
-            batchFile("build.cmd /p:ShouldCreatePackage=false /p:ShouldGenerateNuSpec=false /p:OSGroup=${osGroupMap[os]} /p:ConfigurationGroup=${configurationGroup} /p:Coverage=true /p:WithCategories=\"InnerLoop;OuterLoop\"")
+            batchFile("build.cmd /p:ShouldCreatePackage=false /p:ShouldGenerateNuSpec=false /p:OSGroup=${osGroupMap[os]} /p:ConfigurationGroup=${configurationGroup} /p:Coverage=true /p:WithCategories=\"InnerLoop;OuterLoop\" /p:ServiceUri=%WcfServiceUri%")
         }
     }
 


### PR DESCRIPTION
The code coverage CI jobs were not passing in the ServiceUri parameter when running; this is needed for outerloop tests, which code coverage requires