### PR TITLE
Disable concurrent builds in code coverage

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -133,6 +133,13 @@ branchList.each { branchName ->
     // Archive results
     Utilities.addArchival(newJob, '**/coverage/*,msbuild.log')
     
+    // Our outerloops rely on us calling WcfPRServiceUri to sync server code, after which the client 
+    // will test against WcfServiceUri.
+    // The current design limitation means that if we allow concurrent builds, it becomes possible to pave over 
+    // the server endpoint with mismatched code while another test is running.
+    // Due to this design limitation, we have to disable concurrent builds for outerloops 
+    newJob.concurrentBuild(false)
+
     // Set triggers
     if (isPR)
     {


### PR DESCRIPTION
Copies a change for outerloops (see Line 215) to prevent ~~current~~ concurrent builds from happening in code coverage, at it also relies on outerloops with the WcfService

@dotnet-bot test ci please

EDIT: current -> concurrent