### PR TITLE
Port custom text encoder scenario tests to new new infrastructure

### DIFF
--- a/src/System.Private.ServiceModel/tests/Common/Scenarios/Endpoints.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Scenarios/Endpoints.cs
@@ -290,14 +290,12 @@ public static partial class Endpoints
 
     public static string CustomTextEncoderBuffered_Address
     {
-        get { return GetEndpointAdddress("CustomTextEncoderBuffered.svc//CustomTextEncoderBuffered"); }
-        //get { return BridgeClient.GetResourceAddress("WcfService.TestResources.CustomTextEncoderBufferedResource"); }
+        get { return GetEndpointAdddress("CustomTextEncoderBuffered.svc//http-customtextencoder"); }
     }
 
     public static string CustomTextEncoderStreamed_Address
     {
-        get { return GetEndpointAdddress("CustomTextEncoderStreamed.svc//CustomTextEncoderStreamed"); }
-        //get { return BridgeClient.GetResourceAddress("WcfService.TestResources.CustomTextEncoderStreamedResource"); }
+        get { return GetEndpointAdddress("CustomTextEncoderStreamed.svc//http-customtextencoder-streamed"); }
     }
     #endregion Custom Message Encoder Addresses
     #endregion HTTP Addresses

--- a/src/System.Private.ServiceModel/tests/Scenarios/Extensibility/MessageEncoder/TextTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Extensibility/MessageEncoder/TextTests.cs
@@ -17,7 +17,6 @@ public static class TextTests
 {
     [Fact]
     [OuterLoop]
-    [ActiveIssue(1042)]
     public static void CustomTextMessageEncoder_Http_RequestReply_Buffered()
     {
         ChannelFactory<IWcfService> channelFactory = null;
@@ -56,7 +55,6 @@ public static class TextTests
 
     [Fact]
     [OuterLoop]
-    [ActiveIssue(1042)]
     public static void CustomTextMessageEncoder_Http_RequestReply_Streamed()
     {
         // 84K, larger than any buffers, but won't allocate in LOH
@@ -109,7 +107,11 @@ public static class TextTests
             // *** VALIDATE *** \\
             MemoryStream ms = new MemoryStream(streamLength);
             returnStream.CopyTo(ms);
-            Assert.Equal(ms.Length, streamLength);
+
+            Assert.True(streamLength == ms.Length, 
+                        String.Format("Expected returned stream length = {0}, actual = {1}", 
+                                        streamLength, ms.Length));
+
             ArraySegment<byte> returnedByteArraySegment;
             ms.TryGetBuffer(out returnedByteArraySegment);
             Assert.True(requestBytes.SequenceEqual(returnedByteArraySegment.Array), "Returned bytes are different than sent bytes");

--- a/src/System.Private.ServiceModel/tools/IISHostedWcfService/App_code/WcfService.cs
+++ b/src/System.Private.ServiceModel/tools/IISHostedWcfService/App_code/WcfService.cs
@@ -394,7 +394,7 @@ namespace WcfService
         private static Stream StringToStream(string str)
         {
             var ms = new MemoryStream();
-            var sw = new StreamWriter(ms, Encoding.UTF8);
+            var sw = new StreamWriter(ms, new UTF8Encoding(false));
 
             sw.Write(str);
             sw.Flush();

--- a/src/System.Private.ServiceModel/tools/IISHostedWcfService/App_code/testhosts/CustomTextEncoderBufferedServiceHost.cs
+++ b/src/System.Private.ServiceModel/tools/IISHostedWcfService/App_code/testhosts/CustomTextEncoderBufferedServiceHost.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.ServiceModel;
+using System.ServiceModel.Activation;
+using System.ServiceModel.Channels;
+
+namespace WcfService
+{
+    public class CustomTextEncoderBufferedTestServiceFactory : ServiceHostFactory
+    {
+        protected override ServiceHost CreateServiceHost(Type serviceType, Uri[] baseAddresses)
+        {
+            CustomTextEncoderBufferedTestServiceHost serviceHost = new CustomTextEncoderBufferedTestServiceHost(serviceType, baseAddresses);
+            return serviceHost;
+        }
+    }
+
+    public class CustomTextEncoderBufferedTestServiceHost : TestServiceHostBase<IWcfService>
+    {
+        protected override string Address { get { return "http-customtextencoder"; } }
+
+        protected override Binding GetBinding()
+        {
+            return new CustomBinding(new CustomTextMessageBindingElement("ISO-8859-1"), new HttpTransportBindingElement
+            {
+                MaxReceivedMessageSize = SixtyFourMB,
+                MaxBufferSize = SixtyFourMB
+            });
+        }
+
+        public CustomTextEncoderBufferedTestServiceHost(Type serviceType, params Uri[] baseAddresses)
+            : base(serviceType, baseAddresses)
+        {
+        }
+    }
+}

--- a/src/System.Private.ServiceModel/tools/IISHostedWcfService/App_code/testhosts/CustomTextEncoderStreamedServiceHost.cs
+++ b/src/System.Private.ServiceModel/tools/IISHostedWcfService/App_code/testhosts/CustomTextEncoderStreamedServiceHost.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.ServiceModel;
+using System.ServiceModel.Activation;
+using System.ServiceModel.Channels;
+
+namespace WcfService
+{
+    public class CustomTextEncoderStreamedTestServiceFactory : ServiceHostFactory
+    {
+        protected override ServiceHost CreateServiceHost(Type serviceType, Uri[] baseAddresses)
+        {
+            CustomTextEncoderStreamedTestServiceHost serviceHost = new CustomTextEncoderStreamedTestServiceHost(serviceType, baseAddresses);
+            return serviceHost;
+        }
+    }
+
+    public class CustomTextEncoderStreamedTestServiceHost : TestServiceHostBase<IWcfService>
+    {
+        protected override string Address { get { return "http-customtextencoder-streamed"; } }
+
+        protected override Binding GetBinding()
+        {
+            return new CustomBinding(new CustomTextMessageBindingElement("ISO-8859-1"),
+                new HttpTransportBindingElement
+                {
+                    MaxReceivedMessageSize = SixtyFourMB,
+                    MaxBufferSize = SixtyFourMB,
+                    TransferMode = TransferMode.Streamed
+                });
+        }
+
+        public CustomTextEncoderStreamedTestServiceHost(Type serviceType, params Uri[] baseAddresses)
+            : base(serviceType, baseAddresses)
+        {
+        }
+    }
+}

--- a/src/System.Private.ServiceModel/tools/IISHostedWcfService/App_code/testhosts/CustomTextMessageBindingElement.cs
+++ b/src/System.Private.ServiceModel/tools/IISHostedWcfService/App_code/testhosts/CustomTextMessageBindingElement.cs
@@ -1,0 +1,165 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.ServiceModel.Channels;
+using System.Xml;
+
+namespace WcfService
+{
+    public class CustomTextMessageBindingElement : MessageEncodingBindingElement
+    {
+        private MessageVersion _msgVersion;
+        private string _mediaType;
+        private string _encoding;
+        private XmlDictionaryReaderQuotas _readerQuotas;
+
+        CustomTextMessageBindingElement(CustomTextMessageBindingElement binding)
+            : this(binding.Encoding, binding.MediaType, binding.MessageVersion)
+        {
+            _readerQuotas = new XmlDictionaryReaderQuotas();
+            binding.ReaderQuotas.CopyTo(_readerQuotas);
+        }
+
+        public CustomTextMessageBindingElement(string encoding, string mediaType, MessageVersion msgVersion)
+        {
+            if (encoding == null)
+                throw new ArgumentNullException("encoding");
+
+            if (mediaType == null)
+                throw new ArgumentNullException("mediaType");
+
+            if (msgVersion == null)
+                throw new ArgumentNullException("msgVersion");
+
+            _msgVersion = msgVersion;
+            _mediaType = mediaType;
+            _encoding = encoding;
+            _readerQuotas = new XmlDictionaryReaderQuotas();
+        }
+
+        public CustomTextMessageBindingElement(string encoding, string mediaType)
+    : this(encoding, mediaType, System.ServiceModel.Channels.MessageVersion.Soap12WSAddressing10)
+        {
+        }
+
+        public CustomTextMessageBindingElement(string encoding)
+            : this(encoding, "text/xml")
+        {
+
+        }
+
+        public override MessageVersion MessageVersion
+        {
+            get
+            {
+                return _msgVersion;
+            }
+
+            set
+            {
+                if (value == null)
+                    throw new ArgumentNullException("value");
+                _msgVersion = value;
+            }
+        }
+
+        public string MediaType
+        {
+            get
+            {
+                return _mediaType;
+            }
+
+            set
+            {
+                if (value == null)
+                    throw new ArgumentNullException("value");
+                _mediaType = value;
+            }
+        }
+
+        public string Encoding
+        {
+            get
+            {
+                return _encoding;
+            }
+
+            set
+            {
+                if (value == null)
+                    throw new ArgumentNullException("value");
+                _encoding = value;
+            }
+        }
+
+        // This encoder does not enforces any quotas for the unsecure messages. The 
+        // quotas are enforced for the secure portions of messages when this encoder
+        // is used in a binding that is configured with security. 
+        public XmlDictionaryReaderQuotas ReaderQuotas
+        {
+            get
+            {
+                return _readerQuotas;
+            }
+        }
+
+        public override MessageEncoderFactory CreateMessageEncoderFactory()
+        {
+            return new CustomTextMessageEncoderFactory(MediaType,
+                Encoding, MessageVersion);
+        }
+
+        public override BindingElement Clone()
+        {
+            return new CustomTextMessageBindingElement(this);
+        }
+
+        public override IChannelFactory<TChannel> BuildChannelFactory<TChannel>(BindingContext context)
+        {
+            if (context == null)
+                throw new ArgumentNullException("context");
+
+            context.BindingParameters.Add(this);
+            return context.BuildInnerChannelFactory<TChannel>();
+        }
+
+        public override bool CanBuildChannelFactory<TChannel>(BindingContext context)
+        {
+            if (context == null)
+                throw new ArgumentNullException("context");
+
+            return context.CanBuildInnerChannelFactory<TChannel>();
+        }
+
+        public override IChannelListener<TChannel> BuildChannelListener<TChannel>(BindingContext context)
+        {
+            if (context == null)
+                throw new ArgumentNullException("context");
+
+            context.BindingParameters.Add(this);
+            return context.BuildInnerChannelListener<TChannel>();
+        }
+
+        public override bool CanBuildChannelListener<TChannel>(BindingContext context)
+        {
+            if (context == null)
+                throw new ArgumentNullException("context");
+
+            context.BindingParameters.Add(this);
+            return context.CanBuildInnerChannelListener<TChannel>();
+        }
+
+        public override T GetProperty<T>(BindingContext context)
+        {
+            if (typeof(T) == typeof(XmlDictionaryReaderQuotas))
+            {
+                return (T)(object)_readerQuotas;
+            }
+
+            return base.GetProperty<T>(context);
+        }
+    }
+
+}

--- a/src/System.Private.ServiceModel/tools/IISHostedWcfService/App_code/testhosts/CustomTextMessageEncoder.cs
+++ b/src/System.Private.ServiceModel/tools/IISHostedWcfService/App_code/testhosts/CustomTextMessageEncoder.cs
@@ -1,0 +1,106 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using System.ServiceModel.Channels;
+using System.Text;
+using System.Xml;
+
+namespace WcfService
+{
+    class CustomTextMessageEncoder : System.ServiceModel.Channels.MessageEncoder
+    {
+        private CustomTextMessageEncoderFactory _factory;
+        private XmlWriterSettings _writerSettings;
+        private string _contentType;
+
+        public CustomTextMessageEncoder(CustomTextMessageEncoderFactory factory)
+        {
+            _factory = factory;
+
+            _writerSettings = new XmlWriterSettings();
+            _writerSettings.Encoding = Encoding.GetEncoding(factory.CharSet);
+            _contentType = string.Format("{0}; charset={1}",
+                _factory.MediaType, _writerSettings.Encoding.WebName);
+        }
+
+        public override string ContentType
+        {
+            get
+            {
+                return _contentType;
+            }
+        }
+
+        public override string MediaType
+        {
+            get
+            {
+                return _factory.MediaType;
+            }
+        }
+
+        public override MessageVersion MessageVersion
+        {
+            get
+            {
+                return _factory.MessageVersion;
+            }
+        }
+
+        public override Message ReadMessage(Stream stream, int maxSizeOfHeaders, string contentType)
+        {
+            XmlReader reader = XmlReader.Create(stream);
+            return Message.CreateMessage(reader, maxSizeOfHeaders, MessageVersion);
+        }
+
+        public override Message ReadMessage(ArraySegment<byte> buffer, BufferManager bufferManager, string contentType)
+        {
+            byte[] msgContents = new byte[buffer.Count];
+            Array.Copy(buffer.Array, buffer.Offset, msgContents, 0, msgContents.Length);
+            bufferManager.ReturnBuffer(buffer.Array);
+
+            MemoryStream stream = new MemoryStream(msgContents);
+            return ReadMessage(stream, int.MaxValue);
+        }
+
+        public override void WriteMessage(Message message, Stream stream)
+        {
+            using (XmlWriter writer = XmlWriter.Create(stream, _writerSettings))
+            {
+                message.WriteMessage(writer);
+            }
+        }
+
+        public override ArraySegment<byte> WriteMessage(Message message, int maxMessageSize, BufferManager bufferManager, int messageOffset)
+        {
+            ArraySegment<byte> messageBuffer;
+            byte[] writeBuffer = null;
+
+            int messageLength;
+            using (MemoryStream stream = new MemoryStream())
+            {
+                using (XmlWriter writer = XmlWriter.Create(stream, _writerSettings))
+                {
+                    message.WriteMessage(writer);
+                }
+
+                // TryGetBuffer is the preferred path but requires 4.6
+                //stream.TryGetBuffer(out messageBuffer);
+                writeBuffer = stream.ToArray();
+                messageBuffer = new ArraySegment<byte>(writeBuffer);
+
+                messageLength = (int)stream.Position;
+            }
+
+            int totalLength = messageLength + messageOffset;
+            byte[] totalBytes = bufferManager.TakeBuffer(totalLength);
+            Array.Copy(messageBuffer.Array, 0, totalBytes, messageOffset, messageLength);
+
+            ArraySegment<byte> byteArray = new ArraySegment<byte>(totalBytes, messageOffset, messageLength);
+            return byteArray;
+        }
+    }
+
+}

--- a/src/System.Private.ServiceModel/tools/IISHostedWcfService/App_code/testhosts/CustomTextMessageEncoderFactory.cs
+++ b/src/System.Private.ServiceModel/tools/IISHostedWcfService/App_code/testhosts/CustomTextMessageEncoderFactory.cs
@@ -1,0 +1,55 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.ServiceModel.Channels;
+
+namespace WcfService
+{
+    class CustomTextMessageEncoderFactory : MessageEncoderFactory
+    {
+        private System.ServiceModel.Channels.MessageEncoder _encoder;
+        private MessageVersion _version;
+        private string _mediaType;
+        private string _charSet;
+
+        internal CustomTextMessageEncoderFactory(string mediaType, string charSet, MessageVersion version)
+        {
+            _version = version;
+            _mediaType = mediaType;
+            _charSet = charSet;
+            _encoder = new CustomTextMessageEncoder(this);
+        }
+
+        public override System.ServiceModel.Channels.MessageEncoder Encoder
+        {
+            get
+            {
+                return _encoder;
+            }
+        }
+
+        public override MessageVersion MessageVersion
+        {
+            get
+            {
+                return _version;
+            }
+        }
+
+        internal string MediaType
+        {
+            get
+            {
+                return _mediaType;
+            }
+        }
+
+        internal string CharSet
+        {
+            get
+            {
+                return _charSet;
+            }
+        }
+    }
+}

--- a/src/System.Private.ServiceModel/tools/IISHostedWcfService/Web.config
+++ b/src/System.Private.ServiceModel/tools/IISHostedWcfService/Web.config
@@ -26,6 +26,8 @@
         <add factory="WcfService.BasicAuthTestServiceHostFactory" service="WcfService.WcfUserNameService" relativeAddress="~\BasicAuth.svc" />
         <add factory="WcfService.BasicHttpsTestServiceHostFactory" service="WcfService.WcfService" relativeAddress="~\BasicHttps.svc" />
         <add factory="WcfService.BasicHttpTestServiceHostFactory" service="WcfService.WcfService" relativeAddress="~\BasicHttp.svc" />
+        <add factory="WcfService.CustomTextEncoderBufferedTestServiceFactory" service="WcfService.WcfService" relativeAddress="~\CustomTextEncoderBuffered.svc" />
+        <add factory="WcfService.CustomTextEncoderStreamedTestServiceFactory" service="WcfService.WcfService" relativeAddress="~\CustomTextEncoderStreamed.svc" />
         <add factory="WcfService.DefaultCustomHttpTestServiceHostFactory" service="WcfService.WcfService" relativeAddress="~\DefaultCustomHttp.svc" />
         <add factory="WcfService.DuplexTestServiceHostFactory" service="WcfService.WcfDuplexService" relativeAddress="~\Duplex.svc" />
         <add factory="WcfService.DuplexCallbackTestServiceHostFactory" service="WcfService.DuplexCallbackService" relativeAddress="~\DuplexCallback.svc" />

--- a/src/System.Private.ServiceModel/tools/SelfHostedWcfService/Program.cs
+++ b/src/System.Private.ServiceModel/tools/SelfHostedWcfService/Program.cs
@@ -58,6 +58,14 @@ namespace SelfHostedWCFService
             BasicHttpTestServiceHost basicHttpTestServiceHostServiceHost = new BasicHttpTestServiceHost(typeof(WcfService.WcfService), basicHttpTestServiceHostbaseAddress);
             basicHttpTestServiceHostServiceHost.Open();
 
+            Uri[] CustomTextEncoderBufferedTestServiceHostbaseAddress = new Uri[] { new Uri(string.Format("{0}/CustomTextEncoderBuffered.svc", httpBaseAddress)) };
+            CustomTextEncoderBufferedTestServiceHost customTextMessageEncoderBufferedTestServiceHost = new CustomTextEncoderBufferedTestServiceHost(typeof(WcfService.WcfService), CustomTextEncoderBufferedTestServiceHostbaseAddress);
+            customTextMessageEncoderBufferedTestServiceHost.Open();
+
+            Uri[] CustomTextEncoderStreamedTestServiceHostbaseAddress = new Uri[] { new Uri(string.Format("{0}/CustomTextEncoderStreamed.svc", httpBaseAddress)) };
+            CustomTextEncoderStreamedTestServiceHost customTextMessageEncoderStreamedTestServiceHost = new CustomTextEncoderStreamedTestServiceHost(typeof(WcfService.WcfService), CustomTextEncoderStreamedTestServiceHostbaseAddress);
+            customTextMessageEncoderStreamedTestServiceHost.Open();
+
             Uri[] defaultCustomHttpTestServiceHostbaseAddress = new Uri[]  { new Uri(string.Format("{0}/DefaultCustomHttp.svc", httpBaseAddress))};
             DefaultCustomHttpTestServiceHost defaultCustomHttpTestServiceHostServiceHost = new DefaultCustomHttpTestServiceHost(typeof(WcfService.WcfService), defaultCustomHttpTestServiceHostbaseAddress);
             defaultCustomHttpTestServiceHostServiceHost.Open();


### PR DESCRIPTION
This PR just ports the custom text encoder scenario tests and converts
their Bridge endpoint resources to the new test infrastructure's
ServiceHosts.

Fixes #1042