### PR TITLE
Integrate dev experience to build

### DIFF
--- a/build.override.targets
+++ b/build.override.targets
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0"  xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <PropertyGroup>
+    <TraversalBuildDependsOn>
+      WcfSetup;
+      $(TraversalBuildDependsOn);
+      WcfCleanup;
+    </TraversalBuildDependsOn>
+  </PropertyGroup>
+  <!--if ServiceUri is set, the service has been already started on another machine-->
+  <Target Name="WcfSetup" Condition="($(WithCategories.Contains('OuterLoop')) or '$(OuterLoop)' == 'true') and ('$(ServiceUri)' == '') and $(OSEnvironment) == 'Windows_NT'" >
+    <Exec Command="$(MSBuildThisFileDirectory)\src\System.Private.ServiceModel\tools\scripts\StartWCFSelfHostedSvc.cmd" ContinueOnError="true">
+      <Output TaskParameter="ExitCode" PropertyName="WcfSetupErrorCode"/>
+    </Exec>
+    <Message Text="WcfSetupErrorCode: $(WcfSetupErrorCode)" />
+  </Target>
+
+  <Target Name="WcfCleanUp" Condition="$(WcfSetupErrorCode)!='-1' and $(WcfSetupErrorCode)!=''" >
+    <Exec Command="$(MSBuildThisFileDirectory)\src\System.Private.ServiceModel\tools\scripts\CleanUpWCFSelfHostedSvc.cmd" ContinueOnError="true">
+    </Exec>
+  </Target>
+</Project>

--- a/src/System.Private.ServiceModel/tools/CertificateGenerator/Program.cs
+++ b/src/System.Private.ServiceModel/tools/CertificateGenerator/Program.cs
@@ -51,11 +51,37 @@ namespace CertUtil
 
             RemoveCertificatesFromStore(StoreName.Root, StoreLocation.LocalMachine);
             RemoveCertificatesFromStore(StoreName.Root, StoreLocation.CurrentUser);
+
+            RemoveCertificatesFromStore(StoreName.TrustedPeople, StoreLocation.LocalMachine);
         }
 
-        static void Main(string[] args)
+        static void Usage()
+        {
+            Console.WriteLine("Supported argument is -Uninstall");
+            Console.WriteLine("                      -help");
+        }
+        static int Main(string[] args)
         {
             ApplyAppSettings();
+
+            if (args.Length > 0)
+            {
+                if (string.Compare(args[0], "-Uninstall", true) == 0)
+                {
+                    UninstallAllCerts();
+                    return 0;
+                }
+                else if (string.Compare(args[0], "-help", true) == 0)
+                {
+                    Usage();
+                    return 0;
+                }
+                else
+                {
+                    Usage();
+                    return 1;
+                }
+            }
 
             UninstallAllCerts();
 
@@ -153,6 +179,8 @@ namespace CertUtil
 
             //Create CRL and save it
             File.WriteAllBytes(s_CrlFileLocation, certificateGenerate.CrlEncoded);
+
+            return 0;
 
         }
 

--- a/src/System.Private.ServiceModel/tools/SelfHostedWcfService/Program.cs
+++ b/src/System.Private.ServiceModel/tools/SelfHostedWcfService/Program.cs
@@ -34,14 +34,6 @@ namespace SelfHostedWCFService
             string websocketsBaseAddress = string.Format(@"https://localhost:{0}", websocketsPort);
 
             //Do not need to catch exceptions and dispose service hosts as the process will terminate
-            Uri crlUrl = new Uri(string.Format("http://localhost/CrlService.svc", httpPort));
-            WebServiceHost host = new WebServiceHost(typeof(CrlService), crlUrl);
-            WebHttpBinding binding = new WebHttpBinding();
-            host.AddServiceEndpoint(typeof(ICrlService), binding, "");
-            ServiceDebugBehavior stp = host.Description.Behaviors.Find<ServiceDebugBehavior>();
-            stp.HttpHelpPageEnabled = false;
-            host.Open();
-
             Uri[] utilTestServiceHostbaseAddress = new Uri[]  { new Uri(string.Format("{0}/Util.svc", httpBaseAddress))};
             UtilTestServiceHost utilTestServiceHostServiceHost = new UtilTestServiceHost(typeof(WcfService.Util), utilTestServiceHostbaseAddress);
             utilTestServiceHostServiceHost.Open();
@@ -286,9 +278,26 @@ namespace SelfHostedWCFService
             WebSocketHttpsDuplexTextBufferedTestServiceHost webSocketHttpsDuplexTextBufferedTestServiceHostServiceHost = new WebSocketHttpsDuplexTextBufferedTestServiceHost(typeof(WcfService.WSDuplexService), webSocketHttpsDuplexTextBufferedTestServiceHostbaseAddress);
             webSocketHttpsDuplexTextBufferedTestServiceHostServiceHost.Open();
 
+            //Start the crlUrl service last as the client use it to ensure all services have been started
+            Uri crlUrl = new Uri(string.Format("http://localhost/CrlService.svc", httpPort));
+            WebServiceHost host = new WebServiceHost(typeof(CrlService), crlUrl);
+            WebHttpBinding binding = new WebHttpBinding();
+            host.AddServiceEndpoint(typeof(ICrlService), binding, "");
+            ServiceDebugBehavior serviceDebugBehavior = host.Description.Behaviors.Find<ServiceDebugBehavior>();
+            serviceDebugBehavior.HttpHelpPageEnabled = false;
+            host.Open();
+
             Console.WriteLine("All service hosts have started.");
-            Console.WriteLine("Press <ENTER> to terminate the self service Host.");
-            Console.ReadLine();
+            do
+            {
+                Console.WriteLine("Type <Exit> to terminate the self service Host.");
+                string input = Console.ReadLine();
+                if (string.Compare(input, "exit", true) == 0)
+                {
+                    return;
+                }
+            } while (true);
+
         }
     }
 }

--- a/src/System.Private.ServiceModel/tools/scripts/BuildCertUtil.cmd
+++ b/src/System.Private.ServiceModel/tools/scripts/BuildCertUtil.cmd
@@ -37,5 +37,4 @@ echo.
 findstr /ir /c:".*Warning(s)" /c:".*Error(s)" /c:"Time Elapsed.*" "%_buildlog%"
 echo Build Exit Code = %BUILDERRORLEVEL%
 
-endlocal
 exit /b %BUILDERRORLEVEL%

--- a/src/System.Private.ServiceModel/tools/scripts/CleanUpHttpsPort.cmd
+++ b/src/System.Private.ServiceModel/tools/scripts/CleanUpHttpsPort.cmd
@@ -1,0 +1,33 @@
+@if "%_echo%" neq "on" echo off
+setlocal
+
+echo Remove Https configuration
+
+net session >nul 2>&1
+set __EXITCODE=%ERRORLEVEL%
+if NOT [%__EXITCODE%]==[0] (
+    echo Error: this script must be called in an elevated window
+	goto :done
+)
+
+call :RemoveHttps 0.0.0.0:8084
+
+call :RemoveHttps 0.0.0.0:44285
+
+call :RemoveHttps 0.0.0.0:443
+
+goto :done
+
+:RemoveHttps
+netsh http delete sslcert ipport=%1
+REM If the rules are not there, we get a errorleve 1, thus errorlevel 1 should be ignored
+set _ErrorLevel=%ERRORLEVEL%
+if NOT [%_ErrorLevel%]==[0] if NOT [%_ErrorLevel%]==[1] (
+    set __EXITCODE=%_ErrorLevel%
+    echo WARNING: An error occurred while deleting sslcert from port %1
+  )
+goto :eof
+
+:done
+
+exit /b %__EXITCODE%

--- a/src/System.Private.ServiceModel/tools/scripts/CleanUpWCFSelfHostedSvc.cmd
+++ b/src/System.Private.ServiceModel/tools/scripts/CleanUpWCFSelfHostedSvc.cmd
@@ -1,0 +1,46 @@
+@if "%_echo%" neq "on" echo off
+setlocal
+
+REM
+echo Cleanup test services
+REM  Note that we always return successful code in clean up routine because clean up errors are not fatal
+
+TASKKILL /F /IM SelfHostedWCFService.exe
+REM error 128 will be returned if The process not found
+if NOT [%ERRORLEVEL%]==[0]  if NOT [%ERRORLEVEL%]==[128] (
+	echo Warning: An error occurred while killing the SelfHostedWCFService.exe.
+	)
+
+If NOT exist %~dp0..\..\..\..\bin\Wcf\tools\CertificateGenerator\CertificateGenerator.exe (
+	call %~dp0BuildCertUtil.cmd
+	set __EXITCODE=%ERRORLEVEL%
+	if NOT [%__EXITCODE%]==[0] (
+		echo Warning: An error occurred while building the Certificate generator.
+	 )
+)
+
+REM We will open a separate elevated window to do clean up only if the current window is not elevated
+REM This is to improve the debugging experience
+net session >nul 2>&1
+if NOT [%ERRORLEVEL%]==[0] (
+    set runelvated=%~dp0RunElevated.vbs
+)
+
+call %runelvated% %~dp0CleanUpHttpsPort.cmd
+if NOT [%ERRORLEVEL%]==[0] (
+	echo Warning: An error occurred while removing https port.
+	)
+
+call %runelvated% %~dp0RemoveFirewallPorts.cmd
+if NOT [%ERRORLEVEL%]==[0] (
+	echo Warning: An error occurred while removing Firewall ports.
+	)
+
+call %runelvated% %~dp0..\..\..\..\bin\Wcf\tools\CertificateGenerator\CertificateGenerator.exe -Uninstall
+if NOT [%ERRORLEVEL%]==[0] (
+	echo Warning: An error occurred while removing test certificates.
+	)
+
+:done
+
+exit /b 0

--- a/src/System.Private.ServiceModel/tools/scripts/OpenFirewallPorts.cmd
+++ b/src/System.Private.ServiceModel/tools/scripts/OpenFirewallPorts.cmd
@@ -1,20 +1,51 @@
 @echo off 
 setlocal
 
-REM 
 echo Start Open all ports WCF test services use
-REM
 
-netsh advfirewall firewall add rule name="_WCF Test Server PortHttp" dir=in action=allow profile=any localport=8081 protocol=tcp
-netsh advfirewall firewall add rule name="_WCF Test Server PortHttps" dir=in action=allow profile=any localport=44285 protocol=tcp
-netsh advfirewall firewall add rule name="_WCF Test Server PortTcp" dir=in action=allow profile=any localport=809 protocol=tcp
-netsh advfirewall firewall add rule name="_WCF Test Server PortWebSocket" dir=in action=allow profile=any localport=8083 protocol=tcp
-netsh advfirewall firewall add rule name="_WCF Test Server PortWebSockets" dir=in action=allow profile=any localport=8084 protocol=tcp
+SET __EXITCODE=0
 
-REM we do not currently check the error level for the netsh advfirewall command. Will need to investigate the expected error
-REM code in all successful cases and add the check. Will also need to add remove the firewall rules script for clean up
+net session >nul 2>&1
 set __EXITCODE=%ERRORLEVEL%
+if NOT [%__EXITCODE%]==[0] (
+    echo Error: this script must be called in an elevated window
+	goto :done
+)
 
-endlocal
-exit /b %__EXITCODE% 
+netsh advfirewall firewall add rule name="_WCF Test Server PortHttp"  dir=in action=allow profile=any localport=8081 protocol=tcp
+set __EXITCODE=%ERRORLEVEL%
+if NOT [%__EXITCODE%]==[0] (
+  echo Error: error adding rule name _WCF Test Server PortHttp
+  goto :done
+  )
 
+netsh advfirewall firewall add rule name="_WCF Test Server PortHttps"  dir=in action=allow profile=any localport=44285 protocol=tcp
+set __EXITCODE=%ERRORLEVEL%
+if NOT [%__EXITCODE%]==[0] (
+  echo Error: error adding rule name _WCF Test Server PortHttps
+  goto :done
+  )
+
+netsh advfirewall firewall add rule name="_WCF Test Server PortTcp"  dir=in action=allow profile=any localport=809 protocol=tcp
+set __EXITCODE=%ERRORLEVEL%
+if NOT [%__EXITCODE%]==[0] (
+  echo Error: error adding rule name _WCF Test Server PortTcp
+  goto :done
+  )
+
+netsh advfirewall firewall add rule name="_WCF Test Server PortWebSocket"  dir=in action=allow profile=any localport=8083 protocol=tcp
+set __EXITCODE=%ERRORLEVEL%
+if NOT [%__EXITCODE%]==[0] (
+  echo Error: error adding rule name _WCF Test Server PortWebSocket
+  goto :done
+  )
+
+netsh advfirewall firewall add rule name="_WCF Test Server PortWebSockets"  dir=in action=allow profile=any localport=8084 protocol=tcp
+set __EXITCODE=%ERRORLEVEL%
+if NOT [%__EXITCODE%]==[0] (
+  echo Error: error adding rule name _WCF Test Server PortWebSockets
+  goto :done
+  )
+
+:done
+exit /b %__EXITCODE%

--- a/src/System.Private.ServiceModel/tools/scripts/PingWCFService.ps1
+++ b/src/System.Private.ServiceModel/tools/scripts/PingWCFService.ps1
@@ -1,0 +1,19 @@
+﻿param (
+    [Parameter(Mandatory=$true)]
+    [string] $Url
+)
+$request = New-Object System.Net.WebClient
+For ($i=0; $i -le 10; $i++)
+{
+    try
+    {
+        $request.DownloadFile($Url, "temp.crl")
+    }
+    catch
+    {
+        Start-Sleep -s 5
+        continue;
+    }
+    exit 0;
+}
+exit 1;

--- a/src/System.Private.ServiceModel/tools/scripts/RemoveFirewallPorts.cmd
+++ b/src/System.Private.ServiceModel/tools/scripts/RemoveFirewallPorts.cmd
@@ -1,0 +1,41 @@
+@if "%_echo%" neq "on" echo off
+setlocal
+
+echo Start Remove all ports WCF test services use
+
+SET __EXITCODE=0
+
+net session >nul 2>&1
+set __EXITCODE=%ERRORLEVEL%
+if NOT [%__EXITCODE%]==[0] (
+    echo Error: this script must be called in an elevated window
+	goto :done
+)
+
+call :DeleteRule "_WCF Test Server PortHttp"
+
+call :DeleteRule "_WCF Test Server PortHttps"
+
+call :DeleteRule "_WCF Test Server PortTcp"
+
+call :DeleteRule "_WCF Test Server PortWebSocket"
+
+call :DeleteRule "_WCF Test Server PortWebSockets"
+
+goto :done
+
+:DeleteRule
+netsh advfirewall firewall delete rule name=%1
+set _ErrorLevel=%ERRORLEVEL%
+REM errorlevel 1 means the rule is not found, thus we should ignore it.
+if NOT [%_ErrorLevel%]==[0] if NOT [%_ErrorLevel%]==[1] (
+    echo WARNING: An error occurred while removing firewall rule %1.
+    set __EXITCODE=%_ErrorLevel%
+  )
+
+goto:eof
+
+:done
+
+exit /b %__EXITCODE%
+

--- a/src/System.Private.ServiceModel/tools/scripts/RunElevated.vbs
+++ b/src/System.Private.ServiceModel/tools/scripts/RunElevated.vbs
@@ -1,0 +1,5 @@
+Set objShell = CreateObject("Shell.Application")
+dim fso,currentDirectory
+Set fso = CreateObject("Scripting.FileSystemObject")
+currentDirectory = fso.GetAbsolutePathName(".")
+objShell.ShellExecute WScript.Arguments(0), currentDirectory,"", "runas", 1

--- a/src/System.Private.ServiceModel/tools/scripts/StartWCFSelfHostedSvc.cmd
+++ b/src/System.Private.ServiceModel/tools/scripts/StartWCFSelfHostedSvc.cmd
@@ -1,0 +1,33 @@
+@if "%_echo%" neq "on" echo off
+setlocal
+
+REM Script return code
+REM -1: Already running
+REM 0: Started the test service
+
+Echo Set Up test services
+set __EXITCODE=0
+
+REM If it's already running, we will not set up/clean up service
+tasklist /FI "imagename eq SelfHostedWCFService.exe" | findstr /i /C:"SelfHostedWCFService.exe" 1>nul
+if [%ERRORLEVEL%]==[0] (
+    set __EXITCODE=-1
+    goto :PingService
+)
+
+REM run the start wcf service elevated
+start /D %~dp0 RunElevated.vbs StartWCFSelfHostedSvcDoWork.cmd
+
+:PingService
+REM the serial number is not used in the service side. Thus it can be any number
+call powershell -NoProfile -ExecutionPolicy unrestricted %~dp0pingWcfService.ps1 "http://localhost/CrlService.svc/GetCrl?serialNum=b52"
+SET _ERRORLEVEL=%ERRORLEVEL%
+if [%_ERRORLEVEL%] NEQ [0] (
+    echo Error: failed to ping WCF Test Service.
+	set __EXITCODE=%_ERRORLEVEL%
+    goto :done
+)
+
+:done
+
+exit /b %__EXITCODE%

--- a/src/System.Private.ServiceModel/tools/scripts/StartWCFSelfHostedSvcDoWork.cmd
+++ b/src/System.Private.ServiceModel/tools/scripts/StartWCFSelfHostedSvcDoWork.cmd
@@ -1,50 +1,50 @@
-@echo off 
+@if "%_echo%" neq "on" echo off
 setlocal
 
-REM 
-echo Start WCF Self Hosted Service on local machine
-REM
+REM This script should always be called from StartWCFSelfHostedSvc.cmd
+
+echo Do the actual work to start WCF self hosted service
 
 REM Build tools
 call %~dp0BuildWCFSelfHostedService.cmd
-if NOT [%ERRORLEVEL%]==[0] (
+SET __EXITCODE=%ERRORLEVEL%
+if NOT [%__EXITCODE%]==[0] (
     echo ERROR: An error occurred while building WCF Self hosted Service.
-    set __EXITCODE=%ERRORLEVEL% 
     goto :done
   )
 call %~dp0BuildCertUtil.cmd
-if NOT [%ERRORLEVEL%]==[0] (
+set __EXITCODE=%ERRORLEVEL%
+if NOT [%__EXITCODE%]==[0] (
     echo ERROR: An error occurred while building the Certificate generator.
-    set __EXITCODE=%ERRORLEVEL%
     goto :done
   )
 
-
 REM Config Certs
 REM we need the direcotry to save the test.crl file. We are investigate a way to get rid of it
-REM
 md c:\wcftest
-call %~dp0..\..\..\..\bin\Wcf\tools\CertificateGenerator\CertificateGenerator.exe %*
-set __EXITCODE=%ERRORLEVEL%
-
-if NOT [%__EXITCODE%]==[0] (
+REM Certificate configuration errors are all non fatal currently because we non cert tests will still pass
+%~dp0..\..\..\..\bin\Wcf\tools\CertificateGenerator\CertificateGenerator.exe
+if NOT [%ERRORLEVEL%]==[0] (
     echo Warning: An error occurred while running certificate generator.
   )
 
-REM skip the checking of error code as OpenFirewallPorts can return different error code even it's successful
 call %~dp0OpenFirewallPorts.cmd
+if NOT [%ERRORLEVEL%]==[0] (
+    echo Warning: An error occurred while running certificate generator.
+  )
 
 powershell -NoProfile -ExecutionPolicy unrestricted %~dp0ConfigHttpsPort.ps1
 if NOT [%ERRORLEVEL%]==[0] (
     echo Warning: An error occurred while configuration https port.
   )
 
+REM
 REM Start the self hosted WCF Test Service
-call %~dp0..\..\..\..\bin\Wcf\tools\SelfHostedWcfService\SelfHostedWcfService.exe %*
+call %~dp0..\..\..\..\bin\Wcf\tools\SelfHostedWcfService\SelfHostedWcfService.exe
 set __EXITCODE=%ERRORLEVEL%
 
+:Cleanup
+call %~dp0CleanUpWCFSelfHostedSvc.cmd
 :done
 
-endlocal
-exit /b %__EXITCODE% 
-
+exit /b %__EXITCODE%


### PR DESCRIPTION
* Hook Start and clean up service into build
* If the build starts the service, it will clean up the service as well.
* If the service already started, the build will not restart and clean up.
* The start service will be elevated.
* Need feedback on whether "BuildAllProjects" target is the best target to ensure
set up get run before tests start.
* I have removed all ENDLOCAL as it's not needed.
* Each script is designed to handle a particular set up and clean up so that the scripts can share between Lab and Dev experiences.
* We ping the service in the set up to ensure the service is fully started.
* All clean up errors are treated as non fatal. Need feedback on it.