### PR TITLE
Fix broken NTLM functional test when self-hosted

### DIFF
--- a/src/System.Private.ServiceModel/tests/Common/Scenarios/Endpoints.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Scenarios/Endpoints.cs
@@ -335,7 +335,7 @@ public static partial class Endpoints
         get
         {
             EnsureLocalClientCertifciateInstalled();
-            return GetEndpointAdddress("HttpsNtlm.svc//https-ntlm.svc//");
+            return GetEndpointAdddress("HttpsNtlm.svc//https-ntlm", protocol: "https");
         }
     }
 


### PR DESCRIPTION
The new self-hosted WCF service was creating the NTLM test
service host with incorrect parameters.

Fixes #1056