### PR TITLE
Remove --infer-runtimes restore argument

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -146,7 +146,6 @@
     <DnuRestoreCommand>$(DnuRestoreCommand) --packages "$(PackagesDir.TrimEnd('/\'.ToCharArray()))" $(DnuRestoreSource)</DnuRestoreCommand>
     <DnuRestoreCommand Condition="'$(LockDependencies)' == 'true'">$(DnuRestoreCommand) --lock</DnuRestoreCommand>
     <DnuRestoreCommand Condition="'$(NuGetConfigPath)'!=''">$(DnuRestoreCommand) --configfile $(NuGetConfigPath)</DnuRestoreCommand>
-    <DnuRestoreCommand Condition="'$(InferRuntimes)'!='false'">$(DnuRestoreCommand) --infer-runtimes</DnuRestoreCommand>
   </PropertyGroup>
 
   <!-- Create a collection of all project.json files for dependency updates. -->


### PR DESCRIPTION
Just like https://github.com/dotnet/corefx/pull/8107: runtimes are in the project.json files now thanks to https://github.com/dotnet/wcf/pull/996, so we can remove this temporary restore arg.

/cc @weshaggard @ericstj @roncain 