### PR TITLE
Add "test all outerloop" phrase to CI

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -177,7 +177,7 @@ branchList.each { branchName ->
                         shell("HOME=\$WORKSPACE/tempHome ./build.sh /p:ConfigurationGroup=${configurationGroup} /p:OSGroup=${osGroupMap[os]} /p:WithCategories=OuterLoop /p:TestWithLocalLibraries=true /p:ServiceUri=\$WcfServiceUri")
                     }
                 }
-            }                
+            }
 
             // Set the affinity.  OS name matches the machine affinity.
             if (os == 'Windows_NT') {
@@ -212,7 +212,7 @@ branchList.each { branchName ->
             // Set up appropriate triggers. PR on demand, otherwise daily
             if (isPR) {
                 // Set PR trigger.
-                Utilities.addGithubPRTrigger(newJob, "OuterLoop ${os} ${configurationGroup}", "(?i).*test\\W+outerloop\\W+${os}.*")
+                Utilities.addGithubPRTrigger(newJob, "OuterLoop ${os} ${configurationGroup}", "(?i).*test\\W+(all\\W+outerloop|outerloop\\W+${os}).*")
             } 
             else {
                 // Set a periodic trigger


### PR DESCRIPTION
We used to have the phrase "test outerloop please" for testing, but it eventually got removed in the process of merging the groovy files from corefx. Change the triggers so that we allow using "test all outerloop" as a phrase to trigger CI builds