### PR TITLE
Add new custom binding test to eliminate lab test failure reports

### DIFF
--- a/src/System.Private.ServiceModel/tests/Scenarios/Binding/Custom/CustomBindingTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Binding/Custom/CustomBindingTests.cs
@@ -12,7 +12,44 @@ using Infrastructure.Common;
 
 public class CustomBindingTests : ConditionalWcfTest
 {
-    // Client and Server bindings setup exactly the same using default settings.
+    // Http: Client and Server bindings setup exactly the same using default settings.
+    [Fact]
+    [OuterLoop]
+    public static void DefaultSettings_Http_Text_Echo_RoundTrips_String()
+    {
+        string variationDetails = "Client:: CustomBinding/DefaultValues\nServer:: CustomBinding/DefaultValues";
+        string testString = "Hello";
+        StringBuilder errorBuilder = new StringBuilder();
+        bool success = false;
+        
+        try
+        {
+            CustomBinding binding = new CustomBinding(new TextMessageEncodingBindingElement(), new HttpTransportBindingElement());
+            ChannelFactory<IWcfService> factory = new ChannelFactory<IWcfService>(binding, new EndpointAddress(Endpoints.DefaultCustomHttp_Address));
+
+            IWcfService serviceProxy = factory.CreateChannel();
+
+            string result = serviceProxy.Echo(testString);
+            success = string.Equals(result, testString);
+
+            if (!success)
+            {
+                errorBuilder.AppendLine(String.Format("    Error: expected response from service: '{0}' Actual was: '{1}'", testString, result));
+            }
+        }
+        catch (Exception ex)
+        {
+            errorBuilder.AppendLine(String.Format("    Error: Unexpected exception was caught while doing the basic echo test for variation...\n'{0}'\nException: {1}", variationDetails, ex.ToString()));
+            for (Exception innerException = ex.InnerException; innerException != null; innerException = innerException.InnerException)
+            {
+                errorBuilder.AppendLine(String.Format("Inner exception: {0}", innerException.ToString()));
+            }
+        }
+
+        Assert.True(errorBuilder.Length == 0, "Test case FAILED with errors: " + errorBuilder.ToString());
+    }
+
+    // Https: Client and Server bindings setup exactly the same using default settings.
     [ConditionalFact(nameof(Root_Certificate_Installed))]
     [OuterLoop]
     public static void DefaultSettings_Https_Text_Echo_RoundTrips_String()
@@ -21,7 +58,7 @@ public class CustomBindingTests : ConditionalWcfTest
         string testString = "Hello";
         StringBuilder errorBuilder = new StringBuilder();
         bool success = false;
-        
+
         try
         {
             CustomBinding binding = new CustomBinding(new TextMessageEncodingBindingElement(), new HttpsTransportBindingElement());
@@ -48,4 +85,5 @@ public class CustomBindingTests : ConditionalWcfTest
 
         Assert.True(errorBuilder.Length == 0, "Test case FAILED with errors: " + errorBuilder.ToString());
     }
+
 }


### PR DESCRIPTION
Adds a single new CustomBinding test that uses Http rather than
the existing Https test. Done for 2 reasons:
  1. Slightly better coverage
  2. The existing Https test has [ConditionalFact] and is the only test in
     this project.  When a lab run in Helix or ToF chooses not to run
     this test, they both report failure due to having no tests to run
     in the project.  Having a 2nd test eliminates these spurious error
     reports.