### PR TITLE
Add initial [ConditionalFact] detectors

### DIFF
--- a/src/System.Private.ServiceModel/tests/Common/Infrastructure/src/BridgeClient.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Infrastructure/src/BridgeClient.cs
@@ -10,7 +10,7 @@ using System.Text;
 
 namespace Infrastructure.Common
 {
-    public static class BridgeClient 
+    internal static class BridgeClient 
     {
         private const string EndpointResourceResponseUriKeyName = "uri";
         private const string EndpointResourceResponseFQHNKeyName = "hostname";

--- a/src/System.Private.ServiceModel/tests/Common/Infrastructure/src/BridgeClientAuthenticationManager.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Infrastructure/src/BridgeClientAuthenticationManager.cs
@@ -7,7 +7,7 @@ using System.Net;
 
 namespace Infrastructure.Common
 {
-    public static class BridgeClientAuthenticationManager
+    internal static class BridgeClientAuthenticationManager
     {
         private const string AuthenticationResourceName = "WcfService.TestResources.AuthenticationResource";
         private const string UsernameKeyName = "authUsername";

--- a/src/System.Private.ServiceModel/tests/Common/Infrastructure/src/BridgeClientCertificateManager.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Infrastructure/src/BridgeClientCertificateManager.cs
@@ -11,7 +11,7 @@ namespace Infrastructure.Common
 {
     // This class manages the adding and removal of certificates.
     // It also handles informing http.sys of which certificate to associate with SSL ports.
-    public static class BridgeClientCertificateManager
+    internal static class BridgeClientCertificateManager
     {
         private static object s_certificateLock = new object();
 

--- a/src/System.Private.ServiceModel/tests/Common/Infrastructure/src/ConditionalTestDetectors.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Infrastructure/src/ConditionalTestDetectors.cs
@@ -1,0 +1,94 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace Infrastructure.Common
+{
+    // This class contains helper "detector" methods to detect specific
+    // conditions about the environment in which the tests are run.
+    // They are used for [ConditionalFact] and [ConditionalTheory]
+    // tests.  They are called at most once, and the return value cached.
+    internal static class ConditionalTestDetectors
+    {
+        public static bool IsRootCertificateInstalled()
+        {
+            try
+            {
+                ServiceUtilHelper.EnsureRootCertificateInstalled();
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        public static bool IsClientCertificateInstalled()
+        {
+            try
+            {
+                ServiceUtilHelper.EnsureLocalClientCertificateInstalled();
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        public static bool IsClientDomainJoined()
+        {
+            // Currently non-Windows clients always return false until we have
+            // a cross-platform way to detect this.
+            if (!IsWindows())
+            {
+                return false;
+            }
+
+            // To determine whether the client is running on a domain joined machine,
+            // we use this heuristic based on well known environment variables.
+            string computerName = Environment.GetEnvironmentVariable("COMPUTERNAME");
+            string logonServer = Environment.GetEnvironmentVariable("LOGONSERVER");
+            string userDomain = Environment.GetEnvironmentVariable("USERDOMAIN");
+
+            return !String.Equals(computerName, logonServer, StringComparison.OrdinalIgnoreCase) &&
+                   !String.Equals(computerName, userDomain, StringComparison.OrdinalIgnoreCase);
+        }
+
+        public static bool IsServerDomainJoined()
+        {
+            // Requires solution to https://github.com/dotnet/wcf/issues/1095
+            // Till then, heuristic is that running localhost == domain joined if client is domain joined
+            return IsServerLocalHost() && IsClientDomainJoined();
+        }
+
+        public static bool IsWindows()
+        {
+            return RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+        }
+
+        // This test is meant to be used only to detect that our service URI
+        // indicates localhost.  It is not intended to be used to detect that
+        // the services are running locally but using an explicit host name.
+        public static bool IsServerLocalHost()
+        {
+            string host = TestProperties.GetProperty(TestProperties.ServiceUri_PropertyName);
+
+            if (String.IsNullOrWhiteSpace(host))
+            {
+                return false;
+            }
+
+            int index = host.IndexOf("localhost", 0, StringComparison.OrdinalIgnoreCase);
+            return index == 0;
+        }
+
+        public static bool AreUserNameAndPasswordAvailable()
+        {
+            return !String.IsNullOrWhiteSpace(TestProperties.GetProperty(TestProperties.TestUserName_PropertyName)) &&
+                   !String.IsNullOrWhiteSpace(TestProperties.GetProperty(TestProperties.TestPassword_PropertyName));
+        }
+    }
+}

--- a/src/System.Private.ServiceModel/tests/Common/Infrastructure/src/ConditionalWcfTest.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Infrastructure/src/ConditionalWcfTest.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.InteropServices;
 
 namespace Infrastructure.Common
 {
@@ -76,58 +75,41 @@ namespace Infrastructure.Common
             }
         }
 
-        private static bool Is_Server_Local()
+        private static bool Server_Is_LocalHost()
         {
-            // Temporary workaround to detect whether this test is using localhost
-            // for either new or old test infrastructure.
-            // Refactor this after integration to address https://github.com/dotnet/wcf/issues/1024 
-            // to use centralized helper method.
-            string host = null;
-            if (TestProperties.PropertyNames.Contains("ServiceUri"))
-            {
-                host = TestProperties.GetProperty("ServiceUri");
-            }
-            else if (TestProperties.PropertyNames.Contains("BridgeHost"))
-            {
-                host = TestProperties.GetProperty("BridgeHost");
-            }
-
-            if (String.IsNullOrWhiteSpace(host))
-            {
-                return false;
-            }
-
-            int index = host.IndexOf("localhost", 0, StringComparison.OrdinalIgnoreCase);
-            return index >= 0;
+            return GetConditionValue(nameof(Server_Is_LocalHost),
+                                     ConditionalTestDetectors.IsServerLocalHost);
         }
         
         private static bool Is_Windows()
         {
-            return RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+            return GetConditionValue(nameof(Is_Windows),
+                                     ConditionalTestDetectors.IsWindows);
         }
 
         public static bool Domain_Joined()
         {
-            // Temporarily use the simple heuristic that if we are running the services locally, it is.
-            // Refactor this after integration to address https://github.com/dotnet/wcf/issues/1024 
             return GetConditionValue(nameof(Domain_Joined),
-                                     Is_Server_Local);
+                                     () => ConditionalTestDetectors.IsClientDomainJoined() && 
+                                           ConditionalTestDetectors.IsServerDomainJoined());
         }
 
         public static bool Root_Certificate_Installed()
         {
-            // Temporarily use the simple heuristic that if we are running the services locally, it is.
-            // Refactor this to test only when solving https://github.com/dotnet/wcf/issues/1024 
             return GetConditionValue(nameof(Root_Certificate_Installed),
-                                     Is_Server_Local);
+                                     ConditionalTestDetectors.IsRootCertificateInstalled);
         }
 
         public static bool Client_Certificate_Installed()
         {
-            // Temporarily use the simple heuristic that if we are running the services locally, it is.
-            // Refactor this to test only when solving https://github.com/dotnet/wcf/issues/1024 
             return GetConditionValue(nameof(Client_Certificate_Installed),
-                                     Is_Server_Local);
+                                     ConditionalTestDetectors.IsClientCertificateInstalled);
+        }
+
+        public static bool UserName_And_Password_Available()
+        {
+            return GetConditionValue(nameof(UserName_And_Password_Available),
+                                     ConditionalTestDetectors.AreUserNameAndPasswordAvailable);
         }
 
         public static bool SPN_Available()
@@ -135,7 +117,7 @@ namespace Infrastructure.Common
             // Temporarily use the simple heuristic that if we are running the services locally, it is.
             // Refactor this after integration to address https://github.com/dotnet/wcf/issues/1024 
             return GetConditionValue(nameof(SPN_Available),
-                                     Is_Server_Local);
+                                     Server_Is_LocalHost);
         }
 
         public static bool Kerberos_Available()
@@ -143,7 +125,31 @@ namespace Infrastructure.Common
             // Temporarily use the simple heuristic that if we are running the services locally, it is.
             // Refactor this after integration to address https://github.com/dotnet/wcf/issues/1024 
             return GetConditionValue(nameof(Kerberos_Available),
-                                     Is_Server_Local);
+                                     Server_Is_LocalHost);
+        }
+
+        public static bool Server_Accepts_Certificates()
+        {
+            // Temporarily use the simple heuristic that if we are running the services locally, it does.
+            // Refactor this after integration to address https://github.com/dotnet/wcf/issues/1024 
+            return GetConditionValue(nameof(Server_Accepts_Certificates),
+                                     Server_Is_LocalHost);
+        }
+
+        public static bool Basic_Authentication_Available()
+        {
+            // Temporarily use the simple heuristic that if we are running the services locally, it is.
+            // Refactor this after integration to address https://github.com/dotnet/wcf/issues/1024 
+            return GetConditionValue(nameof(Basic_Authentication_Available),
+                                     Server_Is_LocalHost);
+        }
+
+        public static bool Digest_Authentication_Available()
+        {
+            // Temporarily use the simple heuristic that if we are running the services locally, it is.
+            // Refactor this after integration to address https://github.com/dotnet/wcf/issues/1024 
+            return GetConditionValue(nameof(Digest_Authentication_Available),
+                                     Server_Is_LocalHost);
         }
 
         public static bool Windows_Authentication_Available()
@@ -151,7 +157,7 @@ namespace Infrastructure.Common
             // Temporarily use the simple heuristic that if we are running the services locally, it is.
             // Refactor this after integration to address https://github.com/dotnet/wcf/issues/1024 
             return GetConditionValue(nameof(Windows_Authentication_Available),
-                                     Is_Server_Local);
+                                     Server_Is_LocalHost);
         }
 
         public static bool NTLM_Available()
@@ -159,7 +165,7 @@ namespace Infrastructure.Common
             // Temporarily use the simple heuristic that if we are running the services locally, it is.
             // Refactor this after integration to address https://github.com/dotnet/wcf/issues/1024 
             return GetConditionValue(nameof(NTLM_Available),
-                                     Is_Server_Local);
+                                     Server_Is_LocalHost);
         }
     }
 }

--- a/src/System.Private.ServiceModel/tests/Common/Infrastructure/src/IUtil.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Infrastructure/src/IUtil.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.ServiceModel;
+
+[ServiceContract]
+public interface IUtil
+{
+    [OperationContract]
+    byte[] GetClientCert(bool exportAsPem);
+
+    [OperationContract]
+    byte[] GetRootCert(bool exportAsPem);
+
+    [OperationContract]
+    string GetFQDN();
+}

--- a/src/System.Private.ServiceModel/tests/Common/Infrastructure/src/ServiceUtilHelper.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Infrastructure/src/ServiceUtilHelper.cs
@@ -1,0 +1,202 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.ServiceModel;
+using System.Security.Cryptography.X509Certificates;
+
+using Infrastructure.Common;
+
+public static class ServiceUtilHelper
+{
+    private static X509Certificate2 rootCert;
+    private static X509Certificate2 clientCert;
+    private static object rootCertLock = new object();
+    private static object clientCertLock = new object();
+    private static string serviceHostName = string.Empty;
+
+    public static string LocalCertThumbprint { get; set; }
+
+    //Install Root certificate, this is required for all https test
+    public static void EnsureRootCertificateInstalled()
+    {
+        lock (rootCertLock)
+        {
+            if (rootCert == null)
+            {
+                BasicHttpBinding basicHttpBinding = new BasicHttpBinding();
+                ChannelFactory<IUtil> factory = null;
+                IUtil serviceProxy = null;
+                try
+                {
+                    factory = new ChannelFactory<IUtil>(basicHttpBinding, new EndpointAddress(ServiceUtil_Address));
+                    serviceProxy = factory.CreateChannel();
+                    rootCert = new X509Certificate2(serviceProxy.GetRootCert(false));
+
+                    if (rootCert == null)
+                    {
+                        //throw
+                        throw new Exception("Failed to obtain root cert from the server");
+                    }
+
+                    BridgeClientCertificateManager.InstallCertificateToRootStore(rootCert);
+                }
+                finally
+                {
+                    CloseCommunicationObjects((ICommunicationObject)serviceProxy, factory);
+                }
+            }
+        }
+    }
+
+    //Install client certificate
+    public static void EnsureLocalClientCertificateInstalled()
+    {
+        EnsureRootCertificateInstalled();
+        lock (clientCertLock)
+        {
+            if (clientCert == null)
+            {
+                BasicHttpBinding basicHttpBinding = new BasicHttpBinding();
+                ChannelFactory<IUtil> factory = null;
+                IUtil serviceProxy = null;
+                try
+                {
+                    factory = new ChannelFactory<IUtil>(basicHttpBinding, new EndpointAddress(ServiceUtil_Address));
+                    serviceProxy = factory.CreateChannel();
+                    clientCert = new X509Certificate2(serviceProxy.GetClientCert(false), "test", X509KeyStorageFlags.PersistKeySet);
+                    if (clientCert == null)
+                    {
+                        //throw
+                        throw new Exception("Failed to obtain client cert from the server");
+                    }
+
+                    BridgeClientCertificateManager.AddToStoreIfNeeded(StoreName.My, StoreLocation.CurrentUser, clientCert);
+                    LocalCertThumbprint = clientCert.Thumbprint;
+                }
+                finally
+                {
+                    CloseCommunicationObjects((ICommunicationObject)serviceProxy, factory);
+                }
+            }
+        }
+    }
+
+    private static void CloseCommunicationObjects(params ICommunicationObject[] objects)
+    {
+        foreach (ICommunicationObject comObj in objects)
+        {
+            try
+            {
+                if (comObj == null)
+                {
+                    continue;
+                }
+                // Only want to call Close if it is in the Opened state
+                if (comObj.State == CommunicationState.Opened)
+                {
+                    comObj.Close();
+                }
+                // Anything not closed by this point should be aborted
+                if (comObj.State != CommunicationState.Closed)
+                {
+                    comObj.Abort();
+                }
+            }
+            catch (TimeoutException)
+            {
+                comObj.Abort();
+            }
+            catch (CommunicationException)
+            {
+                comObj.Abort();
+            }
+        }
+    }
+
+    public static string ServiceHostName
+    {
+        get
+        {
+            //Get the host name from server
+            if (string.IsNullOrEmpty(serviceHostName))
+            {
+                BasicHttpBinding basicHttpBinding = new BasicHttpBinding();
+                ChannelFactory<IUtil> factory = null;
+                IUtil serviceProxy = null;
+                try
+                {
+                    factory = new ChannelFactory<IUtil>(basicHttpBinding, new EndpointAddress(ServiceUtil_Address));
+                    serviceProxy = factory.CreateChannel();
+                    serviceHostName = serviceProxy.GetFQDN();
+                }
+                finally
+                {
+                    CloseCommunicationObjects((ICommunicationObject)serviceProxy, factory);
+                }
+            }
+
+            return serviceHostName;
+        }
+    }
+
+    private static bool IISHosted
+    {
+        get
+        {
+            // We assume the self hosted service does not have test service base addess, only the host name passed
+            // This will satisfy all current requirements
+            if (TestProperties.GetProperty(TestProperties.ServiceUri_PropertyName).Contains("/"))
+            {
+                return true;
+            };
+
+            return false;
+        }
+    }
+
+    private static Uri BuildBaseUri(string protocol)
+    {
+        var builder = new UriBuilder();
+        builder.Host = TestProperties.GetProperty(TestProperties.ServiceUri_PropertyName);
+        builder.Scheme = protocol;
+
+        if (!IISHosted)
+        {
+            switch (protocol)
+            {
+                case "http":
+                    builder.Port = int.Parse(TestProperties.GetProperty(TestProperties.BridgeHttpPort_PropertyName));
+                    break;
+                case "ws":
+                    builder.Port = int.Parse(TestProperties.GetProperty(TestProperties.BridgeWebSocketPort_PropertyName));
+                    builder.Scheme = "http";
+                    break;
+                case "https":
+                     builder.Port = int.Parse(TestProperties.GetProperty(TestProperties.BridgeHttpsPort_PropertyName));
+                    break;
+                case "wss":
+                    builder.Port = int.Parse(TestProperties.GetProperty(TestProperties.BridgeSecureWebSocketPort_PropertyName));
+                    builder.Scheme = "https";
+                    break;
+                case "net.tcp":
+                    builder.Port = int.Parse(TestProperties.GetProperty(TestProperties.BridgeTcpPort_PropertyName));
+                    break;
+                default:
+                    break;
+            }
+        }
+
+        return builder.Uri;
+    }
+    public static string GetEndpointAddress(string endpoint, string protocol = "http")
+    {
+        return string.Format(@"{0}/{1}", BuildBaseUri(protocol), endpoint);
+    }
+
+    public static string ServiceUtil_Address
+    {
+        get { return GetEndpointAddress("Util.svc//Util"); }
+    }
+}
+

--- a/src/System.Private.ServiceModel/tests/Common/Infrastructure/src/testproperties.props
+++ b/src/System.Private.ServiceModel/tests/Common/Infrastructure/src/testproperties.props
@@ -115,6 +115,18 @@
       <NTLM_Available></NTLM_Available>
     </PropertyGroup>
 
+    <PropertyGroup Condition="'$(Server_Accepts_Certificates)' == ''">
+      <Server_Accepts_Certificates></Server_Accepts_Certificates>
+    </PropertyGroup>
+  
+    <PropertyGroup Condition="'$(Basic_Authentication_Available)' == ''">
+      <Basic_Authentication_Available></Basic_Authentication_Available>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(Digest_Authentication_Available)' == ''">
+      <Digest_Authentication_Available></Digest_Authentication_Available>
+    </PropertyGroup>
+  
     <PropertyGroup Condition="'$(Windows_Authentication_Available)' == ''">
       <Windows_Authentication_Available></Windows_Authentication_Available>
     </PropertyGroup>
@@ -123,6 +135,14 @@
       <ServiceUri >localhost</ServiceUri >
     </PropertyGroup>
 
+  <PropertyGroup Condition="'$(TestUserName)' == ''">
+    <TestUserName ></TestUserName >
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TestPassword)' == ''">
+    <TestPassword ></TestPassword >
+  </PropertyGroup>
+  
   <!--
      GeneratedTestPropertiesFileName:
      The full path of the C# file that will be generated at build time to

--- a/src/System.Private.ServiceModel/tests/Common/Infrastructure/src/testproperties.targets
+++ b/src/System.Private.ServiceModel/tests/Common/Infrastructure/src/testproperties.targets
@@ -43,9 +43,14 @@ namespace Infrastructure.Common
         public static readonly string Client_Certificate_Installed_PropertyName = "Client_Certificate_Installed"%3B
         public static readonly string SPN_Available_PropertyName = "SPN_Available"%3B
         public static readonly string Kerberos_Available_PropertyName = "Kerberos_Available"%3B
+        public static readonly string Server_Accepts_Certificates_PropertyName = "Server_Accepts_Certificates"%3B
+        public static readonly string Basic_Authentication_Available_PropertyName = "Basic_Authentication_Available"%3B
+        public static readonly string Digest_Authentication_Available_PropertyName = "Digest_Authentication_Available"%3B
         public static readonly string Windows_Authentication_Available_PropertyName = "Windows_Authentication_Available"%3B
         public static readonly string NTLM_Available_PropertyName = "NTLM_Available"%3B
         public static readonly string ServiceUri_PropertyName = "ServiceUri"%3B
+        public static readonly string TestUserName_PropertyName = "TestUserName"%3B
+        public static readonly string TestPassword_PropertyName = "TestPassword"%3B
                 
         static partial void Initialize(Dictionary<string, string> properties)
         {
@@ -74,9 +79,14 @@ namespace Infrastructure.Common
             properties["Client_Certificate_Installed"] = "$(Client_Certificate_Installed)"%3B
             properties["SPN_Available"] = "$(SPN_Available)"%3B
             properties["Kerberos_Available"] = "$(Kerberos_Available)"%3B
+            properties["Server_Accepts_Certificates"] = "$(Server_Accepts_Certificates)"%3B
+            properties["Basic_Authentication_Available"] = "$(Basic_Authentication_Available)"%3B
+            properties["Digest_Authentication_Available"] = "$(Digest_Authentication_Available)"%3B
             properties["Windows_Authentication_Available"] = "$(Windows_Authentication_Available)"%3B
             properties["NTLM_Available"] = "$(NTLM_Available)"%3B
             properties["ServiceUri"] = "$(ServiceUri)"%3B
+            properties["TestUserName"] = "$(TestUserName)"%3B
+            properties["TestPassword"] = "$(TestPassword)"%3B
         }
     }
 }

--- a/src/System.Private.ServiceModel/tests/Common/Scenarios/ServiceInterfaces.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Scenarios/ServiceInterfaces.cs
@@ -506,15 +506,3 @@ public interface IWcfAspNetCompatibleService
     string EchoTimeAndSetCookie(string name);
 }
 
-[ServiceContract]
-public interface IUtil
-{
-    [OperationContract]
-    byte[] GetClientCert(bool exportAsPem);
-
-    [OperationContract]
-    byte[] GetRootCert(bool exportAsPem);
-
-    [OperationContract]
-    string GetFQDN();
-}

--- a/src/System.Private.ServiceModel/tests/Scenarios/Binding/Custom/CustomBindingTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Binding/Custom/CustomBindingTests.cs
@@ -51,6 +51,7 @@ public class CustomBindingTests : ConditionalWcfTest
     // Https: Client and Server bindings setup exactly the same using default settings.
     [ConditionalFact(nameof(Root_Certificate_Installed))]
     [OuterLoop]
+    [ActiveIssue(1123, PlatformID.AnyUnix)]
     public static void DefaultSettings_Https_Text_Echo_RoundTrips_String()
     {
         string testString = "Hello";

--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Http/ClientCredentialTypeTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Http/ClientCredentialTypeTests.cs
@@ -26,7 +26,10 @@ public static class Http_ClientCredentialTypeTests
             binding = new BasicHttpBinding(BasicHttpSecurityMode.TransportCredentialOnly);
             binding.Security.Transport.ClientCredentialType = HttpClientCredentialType.Digest;
             factory = new ChannelFactory<IWcfService>(binding, new EndpointAddress(Endpoints.Http_DigestAuth_NoDomain_Address));
-            factory.Credentials.HttpDigest.ClientCredential = BridgeClientAuthenticationManager.NetworkCredential;
+
+            // https://github.com/dotnet/wcf/issues/1045 needs to supply a replacement for NetworkCredential below
+            //factory.Credentials.HttpDigest.ClientCredential = BridgeClientAuthenticationManager.NetworkCredential;
+
             serviceProxy = factory.CreateChannel();
 
             // *** EXECUTE *** \\

--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Https/ClientCredentialTypeTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Https/ClientCredentialTypeTests.cs
@@ -19,7 +19,7 @@ public class Https_ClientCredentialTypeTests : ConditionalWcfTest
         s_password = "wcfSaysHell0World!";
     }
 
-    [ConditionalFact(nameof(Root_Certificate_Installed))]
+    [ConditionalFact(nameof(Root_Certificate_Installed), nameof(Basic_Authentication_Available))]
     [OuterLoop]
     public static void BasicAuthentication_RoundTrips_Echo()
     {
@@ -55,7 +55,7 @@ public class Https_ClientCredentialTypeTests : ConditionalWcfTest
         Assert.True(errorBuilder.Length == 0, String.Format("Test Case: BasicAuthentication FAILED with the following errors: {0}", errorBuilder));
     }
 
-    [ConditionalFact(nameof(Root_Certificate_Installed))]
+    [ConditionalFact(nameof(Root_Certificate_Installed), nameof(Basic_Authentication_Available))]
     [OuterLoop]
     public static void BasicAuthenticationInvalidPwd_throw_MessageSecurityException()
     {

--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Https/HttpsTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Https/HttpsTests.cs
@@ -19,6 +19,7 @@ public class HttpsTests : ConditionalWcfTest
     // Server: BasicHttpsBinding default value is Soap11
     [ConditionalFact(nameof(Root_Certificate_Installed))]
     [OuterLoop]
+    [ActiveIssue(1123, PlatformID.AnyUnix)]
     public static void CrossBinding_Soap11_EchoString()
     {
         string variationDetails = "Client:: CustomBinding/MessageVersion=Soap11\nServer:: BasicHttpsBinding/DefaultValues";
@@ -53,7 +54,7 @@ public class HttpsTests : ConditionalWcfTest
     }
 
     // Client and Server bindings setup exactly the same using default settings.
-    [ConditionalFact(nameof(Root_Certificate_Installed))]
+    [ConditionalFact(nameof(Root_Certificate_Installed), nameof(Server_Accepts_Certificates))]
     [OuterLoop]
     public static void SameBinding_DefaultSettings_EchoString()
     {
@@ -91,6 +92,7 @@ public class HttpsTests : ConditionalWcfTest
     // Client and Server bindings setup exactly the same using Soap11
     [ConditionalFact(nameof(Root_Certificate_Installed))]
     [OuterLoop]
+    [ActiveIssue(1123, PlatformID.AnyUnix)]
     public static void SameBinding_Soap11_EchoString()
     {
         string variationDetails = "Client:: CustomBinding/MessageVersion=Soap11\nServer:: CustomBinding/MessageVersion=Soap11";
@@ -127,6 +129,7 @@ public class HttpsTests : ConditionalWcfTest
     // Client and Server bindings setup exactly the same using Soap12
     [ConditionalFact(nameof(Root_Certificate_Installed))]
     [OuterLoop]
+    [ActiveIssue(1123, PlatformID.AnyUnix)]
     public static void SameBinding_Soap12_EchoString()
     {
         string variationDetails = "Client:: CustomBinding/MessageVersion=Soap12\nServer:: CustomBinding/MessageVersion=Soap12";
@@ -181,7 +184,7 @@ public class HttpsTests : ConditionalWcfTest
             CustomBinding binding = new CustomBinding(new TextMessageEncodingBindingElement(MessageVersion.Soap11, Encoding.UTF8), new HttpsTransportBindingElement());
 
             endpointAddress = new EndpointAddress(new Uri(Endpoints.Https_DefaultBinding_Address));
-            clientCertThumb = BridgeClientCertificateManager.LocalCertThumbprint; // ClientCert as given by the Bridge
+            clientCertThumb = ServiceUtilHelper.LocalCertThumbprint;
 
             factory = new ChannelFactory<IWcfService>(binding, endpointAddress);
             factory.Credentials.ServiceCertificate.SslCertificateAuthentication = factory.Credentials.ServiceCertificate.Authentication;
@@ -210,7 +213,7 @@ public class HttpsTests : ConditionalWcfTest
         }
     }
 
-    [ConditionalFact(nameof(Root_Certificate_Installed), nameof(Client_Certificate_Installed))]
+    [ConditionalFact(nameof(Root_Certificate_Installed), nameof(Client_Certificate_Installed), nameof(Server_Accepts_Certificates))]
     [ActiveIssue(960, PlatformID.AnyUnix)]
     [OuterLoop]
     public static void ClientCertificate_EchoString()
@@ -228,7 +231,7 @@ public class HttpsTests : ConditionalWcfTest
             basicHttpsBinding.Security.Transport.ClientCredentialType = HttpClientCredentialType.Certificate;
 
             endpointAddress = new EndpointAddress(new Uri(Endpoints.Https_ClientCertificateAuth_Address));
-            clientCertThumb = BridgeClientCertificateManager.LocalCertThumbprint; // ClientCert as given by the Bridge
+            clientCertThumb = ServiceUtilHelper.LocalCertThumbprint;
 
             factory = new ChannelFactory<IWcfService>(basicHttpsBinding, endpointAddress);
             factory.Credentials.ClientCertificate.SetCertificate(

--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Tcp/ClientCredentialTypeTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Tcp/ClientCredentialTypeTests.cs
@@ -15,7 +15,7 @@ public class Tcp_ClientCredentialTypeTests : ConditionalWcfTest
     // Default settings are:
     //                         - SecurityMode = Transport
     //                         - ClientCredentialType = Windows
-    [ConditionalFact(nameof(Root_Certificate_Installed))]
+    [ConditionalFact(nameof(Root_Certificate_Installed), nameof(Server_Accepts_Certificates))]
 #if !FEATURE_NETNATIVE
     [ActiveIssue(592, PlatformID.AnyUnix)] // NegotiateStream works on Windows but is not yet supported on Unix
 #else
@@ -87,7 +87,7 @@ public class Tcp_ClientCredentialTypeTests : ConditionalWcfTest
 
     // Simple echo of a string using NetTcpBinding on both client and server with SecurityMode=Transport
     // By default ClientCredentialType will be 'Windows'
-    [ConditionalFact(nameof(Root_Certificate_Installed))]
+    [ConditionalFact(nameof(Root_Certificate_Installed), nameof(Server_Accepts_Certificates))]
 #if !FEATURE_NETNATIVE
     [ActiveIssue(592, PlatformID.AnyUnix)] // NegotiateStream works on Windows but is not yet supported on Unix
 #else
@@ -184,7 +184,7 @@ public class Tcp_ClientCredentialTypeTests : ConditionalWcfTest
 
             endpointAddress = new EndpointAddress(new Uri(Endpoints.Tcp_ClientCredentialType_Certificate_Address),
                 new DnsEndpointIdentity(Endpoints.Tcp_VerifyDNS_HostName));
-            clientCertThumb = BridgeClientCertificateManager.LocalCertThumbprint; // ClientCert as given by the Bridge
+            clientCertThumb = ServiceUtilHelper.LocalCertThumbprint;
 
             factory = new ChannelFactory<IWcfService>(binding, endpointAddress);
             factory.Credentials.ServiceCertificate.Authentication.CertificateValidationMode = X509CertificateValidationMode.None;
@@ -231,7 +231,7 @@ public class Tcp_ClientCredentialTypeTests : ConditionalWcfTest
 
             endpointAddress = new EndpointAddress(new Uri(Endpoints.Tcp_ClientCredentialType_Certificate_CustomValidation_Address),
                 new DnsEndpointIdentity(Endpoints.Tcp_VerifyDNS_HostName));
-            clientCertThumb = BridgeClientCertificateManager.LocalCertThumbprint; // ClientCert as given by the Bridge
+            clientCertThumb = ServiceUtilHelper.LocalCertThumbprint;
 
             factory = new ChannelFactory<IWcfService>(binding, endpointAddress);
             factory.Credentials.ServiceCertificate.Authentication.CertificateValidationMode = X509CertificateValidationMode.Custom;

--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Tcp/StreamingTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Tcp/StreamingTests.cs
@@ -15,7 +15,7 @@ using Xunit;
 
 public class StreamingTests : ConditionalWcfTest
 {
-    [ConditionalFact(nameof(Root_Certificate_Installed), nameof(Client_Certificate_Installed))]
+    [ConditionalFact(nameof(Root_Certificate_Installed), nameof(Client_Certificate_Installed), nameof(Server_Accepts_Certificates))]
     [OuterLoop]
 #if !FEATURE_NETNATIVE
     [ActiveIssue(851, PlatformID.AnyUnix)] // NegotiateStream works on Windows but limitations related to credentials means automated tests can't work on Unix at this point.
@@ -56,7 +56,7 @@ public class StreamingTests : ConditionalWcfTest
         }
     }
 
-    [ConditionalFact(nameof(Root_Certificate_Installed), nameof(Client_Certificate_Installed))]
+    [ConditionalFact(nameof(Root_Certificate_Installed), nameof(Client_Certificate_Installed), nameof(Server_Accepts_Certificates))]
     [OuterLoop]
 #if !FEATURE_NETNATIVE
     [ActiveIssue(851, PlatformID.AnyUnix)] // NegotiateStream works on Windows but limitations related to credentials means automated tests can't work on Unix at this point.
@@ -96,7 +96,7 @@ public class StreamingTests : ConditionalWcfTest
         }
     }
 
-    [ConditionalFact(nameof(Root_Certificate_Installed), nameof(Client_Certificate_Installed))]
+    [ConditionalFact(nameof(Root_Certificate_Installed), nameof(Client_Certificate_Installed), nameof(Server_Accepts_Certificates))]
     [OuterLoop]
 #if !FEATURE_NETNATIVE
     [ActiveIssue(851, PlatformID.AnyUnix)] // NegotiateStream works on Windows but limitations related to credentials means automated tests can't work on Unix at this point.
@@ -138,7 +138,7 @@ public class StreamingTests : ConditionalWcfTest
         }
     }
 
-    [ConditionalFact(nameof(Root_Certificate_Installed), nameof(Client_Certificate_Installed))]
+    [ConditionalFact(nameof(Root_Certificate_Installed), nameof(Client_Certificate_Installed), nameof(Server_Accepts_Certificates))]
     [OuterLoop]
 #if !FEATURE_NETNATIVE
     [ActiveIssue(851, PlatformID.AnyUnix)] // NegotiateStream works on Windows but limitations related to credentials means automated tests can't work on Unix at this point.
@@ -196,7 +196,7 @@ public class StreamingTests : ConditionalWcfTest
         }
     }
 
-    [ConditionalFact(nameof(Root_Certificate_Installed), nameof(Client_Certificate_Installed))]
+    [ConditionalFact(nameof(Root_Certificate_Installed), nameof(Client_Certificate_Installed), nameof(Server_Accepts_Certificates))]
     [OuterLoop]
 #if !FEATURE_NETNATIVE
     [ActiveIssue(851, PlatformID.AnyUnix)] // NegotiateStream works on Windows but limitations related to credentials means automated tests can't work on Unix at this point.
@@ -239,7 +239,7 @@ public class StreamingTests : ConditionalWcfTest
         }
     }
 
-    [ConditionalFact(nameof(Root_Certificate_Installed), nameof(Client_Certificate_Installed))]
+    [ConditionalFact(nameof(Root_Certificate_Installed), nameof(Client_Certificate_Installed), nameof(Server_Accepts_Certificates))]
     [OuterLoop]
 #if !FEATURE_NETNATIVE
     [ActiveIssue(851, PlatformID.AnyUnix)] // NegotiateStream works on Windows but limitations related to credentials means automated tests can't work on Unix at this point.
@@ -282,7 +282,7 @@ public class StreamingTests : ConditionalWcfTest
         }
     }
 
-    [ConditionalFact(nameof(Root_Certificate_Installed), nameof(Client_Certificate_Installed))]
+    [ConditionalFact(nameof(Root_Certificate_Installed), nameof(Client_Certificate_Installed), nameof(Server_Accepts_Certificates))]
     [OuterLoop]
 #if !FEATURE_NETNATIVE
     [ActiveIssue(851, PlatformID.AnyUnix)] // NegotiateStream works on Windows but limitations related to credentials means automated tests can't work on Unix at this point.
@@ -325,7 +325,7 @@ public class StreamingTests : ConditionalWcfTest
         }
     }
 
-    [ConditionalFact(nameof(Root_Certificate_Installed), nameof(Client_Certificate_Installed))]
+    [ConditionalFact(nameof(Root_Certificate_Installed), nameof(Client_Certificate_Installed), nameof(Server_Accepts_Certificates))]
     [OuterLoop]
 #if !FEATURE_NETNATIVE
     [ActiveIssue(851, PlatformID.AnyUnix)] // NegotiateStream works on Windows but limitations related to credentials means automated tests can't work on Unix at this point.
@@ -344,7 +344,7 @@ public class StreamingTests : ConditionalWcfTest
         Assert.True(success, "Test Scenario: NetTcp_TransportSecurity_String_Streamed_RoundTrips_WithSingleThreadedSyncContext timed-out.");
     }
 
-    [ConditionalFact(nameof(Root_Certificate_Installed), nameof(Client_Certificate_Installed))]
+    [ConditionalFact(nameof(Root_Certificate_Installed), nameof(Client_Certificate_Installed), nameof(Server_Accepts_Certificates))]
     [OuterLoop]
 #if !FEATURE_NETNATIVE
     [ActiveIssue(851, PlatformID.AnyUnix)] // NegotiateStream works on Windows but limitations related to credentials means automated tests can't work on Unix at this point.


### PR DESCRIPTION
Prior to this, the [ConditionalFact] condition tests were
simple heuristics.  This PR introduces runtime detectors that
to detect root and client certificates are installed as well as
whether the client is domain joined.