### PR TITLE
Add more tests for FaultContract and ServiceKnownType

### DIFF
--- a/src/System.Private.ServiceModel/tests/Common/Scenarios/ScenarioTestTypes.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Scenarios/ScenarioTestTypes.cs
@@ -402,6 +402,25 @@ public class FaultDetail
     }
 }
 
+
+[DataContract(Name = "FaultDetail2", Namespace = "http://www.contoso.com/wcfnamespace")]
+public class FaultDetail2
+{
+    private string _report;
+
+    public FaultDetail2(string message)
+    {
+        _report = message;
+    }
+
+    [DataMember]
+    public string Message
+    {
+        get { return _report; }
+        set { _report = value; }
+    }
+}
+
 [DataContract(Namespace = "http://www.contoso.com/wcfnamespace")]
 public class ComplexCompositeType : IEquatable<ComplexCompositeType>
 {
@@ -1316,5 +1335,27 @@ public partial class XmlMessageContractTestResponse
         {
             _message = value;
         }
+    }
+}
+
+[DataContract(Name = "KnownTypeA", Namespace = "http://www.contoso.com/wcfnamespace")]
+public class KnownTypeA
+{
+    private string _content;
+
+    public KnownTypeA()
+    {
+    }
+
+    public KnownTypeA(string content)
+    {
+        _content = content;
+    }
+
+    [DataMember]
+    public string Content
+    {
+        get { return _content; }
+        set { _content = value; }
     }
 }

--- a/src/System.Private.ServiceModel/tests/Common/Scenarios/ServiceInterfaces.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Scenarios/ServiceInterfaces.cs
@@ -41,6 +41,17 @@ public interface IWcfService
     void TestFaultInt(int faultCode);
 
     [OperationContract]
+    [FaultContract(typeof(FaultDetail), Action = "http://tempuri.org/IWcfService/TestFaultFaultDetailFault", Name = "FaultDetail", Namespace = "http://www.contoso.com/wcfnamespace")]
+    [FaultContract(typeof(FaultDetail2), Action = "http://tempuri.org/IWcfService/TestFaultFaultDetailFault2", Name = "FaultDetail2", Namespace = "http://www.contoso.com/wcfnamespace")]
+    void TestFaults(string faultMsg, bool throwFaultDetail);
+
+    [OperationContract]
+    [FaultContract(typeof(FaultDetail), Action = "http://tempuri.org/IWcfService/TestFaultFaultDetailFault", Name = "FaultDetail", Namespace = "http://www.contoso.com/wcfnamespace")]
+    [ServiceKnownType(typeof(KnownTypeA))]
+    [ServiceKnownType(typeof(FaultDetail))]
+    object[] TestFaultWithKnownType(string faultMsg, object[] objects);
+
+    [OperationContract]
     void ThrowInvalidOperationException(string message);
 
     [OperationContract]

--- a/src/System.Private.ServiceModel/tests/Scenarios/Contract/Fault/FaultExceptionTests.4.0.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Contract/Fault/FaultExceptionTests.4.0.0.cs
@@ -129,4 +129,152 @@ public static class FaultExceptionTests
             ScenarioTestHelpers.CloseCommunicationObjects((ICommunicationObject)serviceProxy, factory);
         }
     }
+
+    [Fact]
+    [OuterLoop]
+    public static void FaultException_MultipleFaultContracts_Throws_WithFaultDetail()
+    {
+        string faultMsg = "Test Fault Exception";
+        BasicHttpBinding binding;
+        ChannelFactory<IWcfService> factory;
+        IWcfService serviceProxy;
+
+        // *** VALIDATE *** \\
+        var exception = Assert.Throws<FaultException<FaultDetail>>(() =>
+        {
+            // *** SETUP *** \\
+            binding = new BasicHttpBinding();
+            factory = new ChannelFactory<IWcfService>(binding, new EndpointAddress(Endpoints.HttpBaseAddress_Basic));
+            serviceProxy = factory.CreateChannel();
+
+            // *** EXECUTE *** \\
+            try
+            {
+                serviceProxy.TestFaults(faultMsg, true);
+
+                // *** CLEANUP *** \\
+                ((ICommunicationObject)serviceProxy).Close();
+                factory.Close();
+            }
+            finally
+            {
+                // *** ENSURE CLEANUP *** \\
+                ScenarioTestHelpers.CloseCommunicationObjects((ICommunicationObject)serviceProxy, factory);
+            }
+        });
+
+        // *** ADDITIONAL VALIDATION *** \\
+        Assert.Equal(faultMsg, exception.Detail.Message);
+    }
+
+    [Fact]
+    [OuterLoop]
+    public static void FaultException_MultipleFaultContracts_Throws_WithFaultDetail2()
+    {
+        string faultMsg = "Test Fault Exception";
+        BasicHttpBinding binding;
+        ChannelFactory<IWcfService> factory;
+        IWcfService serviceProxy;
+
+        // *** VALIDATE *** \\
+        var exception = Assert.Throws<FaultException<FaultDetail2>>(() =>
+        {
+            // *** SETUP *** \\
+            binding = new BasicHttpBinding();
+            factory = new ChannelFactory<IWcfService>(binding, new EndpointAddress(Endpoints.HttpBaseAddress_Basic));
+            serviceProxy = factory.CreateChannel();
+
+            // *** EXECUTE *** \\
+            try
+            {
+                serviceProxy.TestFaults(faultMsg, false);
+
+                // *** CLEANUP *** \\
+                ((ICommunicationObject)serviceProxy).Close();
+                factory.Close();
+            }
+            finally
+            {
+                // *** ENSURE CLEANUP *** \\
+                ScenarioTestHelpers.CloseCommunicationObjects((ICommunicationObject)serviceProxy, factory);
+            }
+        });
+
+        // *** ADDITIONAL VALIDATION *** \\
+        Assert.Equal(faultMsg, exception.Detail.Message);
+    }
+
+    [Fact]
+    [OuterLoop]
+    public static void FaultException_FaultContractAndKnownType_Throws_WithFaultDetail()
+    {
+        string faultMsg = "Test Fault Exception";
+        BasicHttpBinding binding;
+        ChannelFactory<IWcfService> factory;
+        IWcfService serviceProxy;
+
+        // *** VALIDATE *** \\
+        var exception = Assert.Throws<FaultException<FaultDetail>>(() =>
+        {
+            // *** SETUP *** \\
+            binding = new BasicHttpBinding();
+            factory = new ChannelFactory<IWcfService>(binding, new EndpointAddress(Endpoints.HttpBaseAddress_Basic));
+            serviceProxy = factory.CreateChannel();
+
+            // *** EXECUTE *** \\
+            try
+            {
+                serviceProxy.TestFaultWithKnownType(faultMsg, null);
+
+                // *** CLEANUP *** \\
+                ((ICommunicationObject)serviceProxy).Close();
+                factory.Close();
+            }
+            finally
+            {
+                // *** ENSURE CLEANUP *** \\
+                ScenarioTestHelpers.CloseCommunicationObjects((ICommunicationObject)serviceProxy, factory);
+            }
+        });
+
+        // *** ADDITIONAL VALIDATION *** \\
+        Assert.Equal(faultMsg, exception.Detail.Message);
+    }
+
+    [Fact]
+    [OuterLoop]
+    public static void FaultException_FaultContractAndKnownType_Echo()
+    {
+        BasicHttpBinding binding;
+        ChannelFactory<IWcfService> factory;
+        IWcfService serviceProxy;
+
+        // *** SETUP *** \\
+        binding = new BasicHttpBinding();
+        factory = new ChannelFactory<IWcfService>(binding, new EndpointAddress(Endpoints.HttpBaseAddress_Basic));
+        serviceProxy = factory.CreateChannel();
+
+        // *** EXECUTE *** \\
+        try
+        {
+            var input = new object[] { new FaultDetail(), new KnownTypeA() };
+            var response = serviceProxy.TestFaultWithKnownType(null, input);
+
+            // *** VALIDATE *** \\
+            Assert.True(input.Length == response.Length, String.Format("Expected {0} response items but actual was {1}", input.Length, response.Length));
+            Assert.True(response[0] != null, "Expected response item to be FaultDetail, but actual was null");
+            Assert.True(response[0].GetType() == typeof(FaultDetail), String.Format("Expected response item to be FaultDetail but actual was {0}", response[0].GetType()));
+            Assert.True(response[1] != null, "Expected response item to be KnownTypeA, but actual was null");
+            Assert.True(response[1].GetType() == typeof(KnownTypeA), String.Format("Expected response item to be FaultDetail2 but actual was {0}", response[1].GetType()));
+
+            // *** CLEANUP *** \\
+            ((ICommunicationObject)serviceProxy).Close();
+            factory.Close();
+        }
+        finally
+        {
+            // *** ENSURE CLEANUP *** \\
+            ScenarioTestHelpers.CloseCommunicationObjects((ICommunicationObject)serviceProxy, factory);
+        }
+    }
 }

--- a/src/System.Private.ServiceModel/tools/IISHostedWcfService/App_code/FaultDetail2.cs
+++ b/src/System.Private.ServiceModel/tools/IISHostedWcfService/App_code/FaultDetail2.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Runtime.Serialization;
+
+namespace WcfService
+{
+    [DataContract(Name = "FaultDetail", Namespace = "http://www.contoso.com/wcfnamespace")]
+    public class FaultDetail2
+    {
+        private string _report;
+
+        public FaultDetail2(string message)
+        {
+            _report = message;
+        }
+
+        [DataMember]
+        public string Message
+        {
+            get { return _report; }
+            set { _report = value; }
+        }
+    }
+}

--- a/src/System.Private.ServiceModel/tools/IISHostedWcfService/App_code/IWcfService.cs
+++ b/src/System.Private.ServiceModel/tools/IISHostedWcfService/App_code/IWcfService.cs
@@ -35,6 +35,17 @@ namespace WcfService
         void TestFaultInt(int faultCode);
 
         [OperationContract]
+        [FaultContract(typeof(FaultDetail), Action = "http://tempuri.org/IWcfService/TestFaultFaultDetailFault", Name = "FaultDetail", Namespace = "http://www.contoso.com/wcfnamespace")]
+        [FaultContract(typeof(FaultDetail2), Action = "http://tempuri.org/IWcfService/TestFaultFaultDetailFault2", Name = "FaultDetail2", Namespace = "http://www.contoso.com/wcfnamespace")]
+        void TestFaults(string faultMsg, bool throwFaultDetail);
+
+        [OperationContract]
+        [FaultContract(typeof(FaultDetail), Action = "http://tempuri.org/IWcfService/TestFaultFaultDetailFault", Name = "FaultDetail", Namespace = "http://www.contoso.com/wcfnamespace")]
+        [ServiceKnownType(typeof(KnownTypeA))]
+        [ServiceKnownType(typeof(FaultDetail))]
+        object[] TestFaultWithKnownType(string faultMsg, object[] objects);
+
+        [OperationContract]
         void ThrowInvalidOperationException(string message);
 
         [OperationContract(Action = "http://tempuri.org/IWcfService/GetDataUsingDataContract")]

--- a/src/System.Private.ServiceModel/tools/IISHostedWcfService/App_code/KnownTypeA.cs
+++ b/src/System.Private.ServiceModel/tools/IISHostedWcfService/App_code/KnownTypeA.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Runtime.Serialization;
+
+namespace WcfService
+{
+    [DataContract(Name = "KnownTypeA", Namespace = "http://www.contoso.com/wcfnamespace")]
+    public class KnownTypeA
+    {
+        private string _content;
+
+        public KnownTypeA()
+        {
+        }
+
+        public KnownTypeA(string content)
+        {
+            _content = content;
+        }
+
+        [DataMember]
+        public string Content
+        {
+            get { return _content; }
+            set { _content = value; }
+        }
+    }
+}

--- a/src/System.Private.ServiceModel/tools/IISHostedWcfService/App_code/WcfService.cs
+++ b/src/System.Private.ServiceModel/tools/IISHostedWcfService/App_code/WcfService.cs
@@ -125,6 +125,25 @@ namespace WcfService
         {
             throw new FaultException<int>(faultCode);
         }
+        public void TestFaults(string faultMsg, bool throwFaultDetail)
+        {
+            if (throwFaultDetail)
+            {
+                throw new FaultException<FaultDetail>(new FaultDetail(faultMsg));
+            }
+            else
+            {
+                throw new FaultException<FaultDetail2>(new FaultDetail2(faultMsg));
+            }
+        }
+        public object[] TestFaultWithKnownType(string faultMsg, object[] objects)
+        {
+            if (objects == null)
+            {
+                throw new FaultException<FaultDetail>(new FaultDetail(faultMsg));
+            }
+            return objects;
+        }
 
         public void ThrowInvalidOperationException(string message)
         {


### PR DESCRIPTION
Fix #710
Add tests for: 
1) More than one ServiceKnowTypeAttribute. - already covered
2) More than one FaultContractAttribute
3) Mix of FaultContractAttribute and ServiceKnowTypeAttribute.

cc: @hongdai 