### PR TITLE
Server setup script fix

### DIFF
--- a/src/System.Private.ServiceModel/tools/scripts/SetupWcfIISHostedService.cmd
+++ b/src/System.Private.ServiceModel/tools/scripts/SetupWcfIISHostedService.cmd
@@ -24,6 +24,7 @@ if '%1'=='/help' goto :Usage
 if '%1'=='-help' goto :Usage
 
 :: Make sure this script is running in elevated
+if EXIST %_logFile% del %_logFile% /f /q
 net session>nul 2>&1
 if ERRORLEVEL 1 (
     echo. & echo ERROR: Please run this script with elevated permission.
@@ -46,7 +47,6 @@ echo Deleting WCF repo at %_currentRepo% if exists and associated application po
 %_appcmd% delete apppool %_wcfServiceName% >nul
 if EXIST %_currentRepo% rmdir /s /q %_currentRepo%
 if EXIST %_wcfTestDir% if /I '%_masterRepo%'=='%_currentRepo%' rmdir /s /q %_wcfTestDir%
-if EXIST %_logFile% del %_logFile% /f /q
 echo Clean up done.
 if /I '%2'=='/c' goto :Done
 

--- a/src/System.Private.ServiceModel/tools/scripts/WcfTestServerSetup.cmd
+++ b/src/System.Private.ServiceModel/tools/scripts/WcfTestServerSetup.cmd
@@ -24,9 +24,9 @@ if '%1'=='/help' goto :Usage
 if '%1'=='-help' goto :Usage
 
 :: Make sure this script is running in elevated
-net session>nul
+net session>nul 2>&1
 if ERRORLEVEL 1 (
-    echo Exiting... Please run this script with elevated permission.
+    echo. & echo ERROR: Please run this script with elevated permission.
     goto :Failure
 )
 
@@ -44,8 +44,9 @@ echo Deleting WCF repo at %_currentRepo% if exists and associated application po
 %_appcmd% delete apppool %_prServiceName% >nul
 %_appcmd% delete app "Default Web Site/%_wcfServiceName%" >nul
 %_appcmd% delete apppool %_wcfServiceName% >nul
-if exist %_currentRepo% rmdir /s /q %_currentRepo%
-if exist %_wcfTestDir% if /I '%_masterRepo%'=='%_currentRepo%' rmdir /s /q %_wcfTestDir%
+if EXIST %_currentRepo% rmdir /s /q %_currentRepo%
+if EXIST %_wcfTestDir% if /I '%_masterRepo%'=='%_currentRepo%' rmdir /s /q %_wcfTestDir%
+if EXIST %_logFile% del %_logFile% /f /q
 echo Clean up done.
 if /I '%2'=='/c' goto :Done
 
@@ -180,16 +181,12 @@ goto :Done
 :Run
 set _cmd=%*
 if EXIST %_logFile% del %_logFile% /f /q
-call %_cmd%>%_logFile%
+call %_cmd% >%_logFile% 2>&1
 exit /b
 
 :Failure
 set _exitCode=1
-if NOT '%_cmd%'=='' (
-    echo.
-    echo Failed to run:
-    echo %_cmd%
-)
+if DEFINED _cmd echo. & echo Failed to run: & echo %_cmd%
 if EXIST %_logFile% type %_logFile%
 
 :Done


### PR DESCRIPTION
Fix error handling in server setup script
- Fixed `:Failure` that is completely messed up when `%_cmd%` contains quotes or parenthesis
- Redirect both standard output and standard error to log so error information can be displayed properly in failure case

Rename WcfTestServerSetup.cmd to SetupWcfIISHostedService.cmd so it follows the same "DoWhat" naming convention as the rest of scripts.