### PR TITLE
Add port80 to firewall because crl service need it

### DIFF
--- a/src/System.Private.ServiceModel/tools/scripts/OpenFirewallPorts.cmd
+++ b/src/System.Private.ServiceModel/tools/scripts/OpenFirewallPorts.cmd
@@ -12,6 +12,13 @@ if NOT [%__EXITCODE%]==[0] (
 	goto :done
 )
 
+netsh advfirewall firewall add rule name="_WCF Test Server PortHttp80"  dir=in action=allow profile=any localport=80 protocol=tcp
+set __EXITCODE=%ERRORLEVEL%
+if NOT [%__EXITCODE%]==[0] (
+  echo Error: error adding rule name _WCF Test Server PortHttp80
+  goto :done
+  )
+
 netsh advfirewall firewall add rule name="_WCF Test Server PortHttp"  dir=in action=allow profile=any localport=8081 protocol=tcp
 set __EXITCODE=%ERRORLEVEL%
 if NOT [%__EXITCODE%]==[0] (

--- a/src/System.Private.ServiceModel/tools/scripts/RemoveFirewallPorts.cmd
+++ b/src/System.Private.ServiceModel/tools/scripts/RemoveFirewallPorts.cmd
@@ -12,6 +12,8 @@ if NOT [%__EXITCODE%]==[0] (
 	goto :done
 )
 
+call :DeleteRule "_WCF Test Server PortHttp80"
+
 call :DeleteRule "_WCF Test Server PortHttp"
 
 call :DeleteRule "_WCF Test Server PortHttps"


### PR DESCRIPTION
* This is because there is only one server certificate created per machine.
To run both selfhost and IIS hosted server on the same machine, we need to
use the same port.