### PR TITLE
Reduce the number of times the Timer is modified

### DIFF
--- a/src/System.Private.ServiceModel/src/Internals/System/Runtime/IOTimer.cs
+++ b/src/System.Private.ServiceModel/src/Internals/System/Runtime/IOTimer.cs
@@ -1,0 +1,67 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Threading;
+
+namespace System.Runtime
+{
+    public class IOTimer<TState> : IDisposable
+    {
+        private readonly Action<TState> _callback;
+        private readonly TState _state;
+        private Timer _timer;
+        private bool _enabled;
+        private DateTime _dueDateTime;
+        private readonly double MaxSkew = 100.0; // Milliseconds
+
+        public IOTimer(Action<TState> callback, TState state)
+        {
+            _callback = callback;
+            _state = state;
+            _enabled = false;
+            _dueDateTime = DateTime.MinValue;
+            // Creating a closure of the instance method OnTimer. This is to avoid a cast which
+            // includes checking if the cast is compatible when the timer fires.
+            _timer = new Timer(OnTimer, null, Timeout.Infinite, Timeout.Infinite);
+        }
+
+        public void Cancel()
+        {
+            // As this is an IOTimer, it is likely that the timer will either be reused or rescheduled
+            // before the timer would actually fire. By disabling the callback from running, the timer
+            // is effectively cancelled without the cost of changing the timer schedule in the timer manager.
+            _enabled = false;
+        }
+
+        public void ScheduleAfter(TimeSpan delay)
+        {
+            // In high request rate scenarios, the requested timer scheduled time will be very close in time
+            // to the previous requested expiration. In those cases, the high cost of changing the timer 
+            // scheduled time can be avoided.
+            DateTime now = DateTime.UtcNow;
+            DateTime requestedDueDateTime = now.Add(delay);
+            TimeSpan diff = requestedDueDateTime.Subtract(_dueDateTime);
+            double millisecondsDiff = diff.TotalMilliseconds;
+            if (millisecondsDiff < 0)
+                millisecondsDiff = 0 - millisecondsDiff;
+            if (millisecondsDiff > MaxSkew)
+            {
+                _timer.Change(delay, TimeSpan.FromMilliseconds(-1));
+                _dueDateTime = requestedDueDateTime;
+            }
+
+            _enabled = true;
+        }
+
+        private void OnTimer(object state)
+        {
+            if(_enabled)
+                _callback(_state);
+        }
+
+        public void Dispose()
+        {
+            _timer.Dispose();
+        }
+    }
+}

--- a/src/System.Private.ServiceModel/src/Internals/System/Runtime/IOTimer.cs
+++ b/src/System.Private.ServiceModel/src/Internals/System/Runtime/IOTimer.cs
@@ -5,14 +5,14 @@ using System.Threading;
 
 namespace System.Runtime
 {
-    public class IOTimer<TState> : IDisposable
+    internal class IOTimer<TState> : IDisposable
     {
         private readonly Action<TState> _callback;
         private readonly TState _state;
         private Timer _timer;
         private bool _enabled;
         private DateTime _dueDateTime;
-        private readonly double MaxSkew = 100.0; // Milliseconds
+        private const double MaxSkew = 100.0; // Milliseconds
 
         public IOTimer(Action<TState> callback, TState state)
         {

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/SocketConnection.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/SocketConnection.cs
@@ -87,19 +87,15 @@ namespace System.ServiceModel.Channels
             }
         }
 
-
-
-    protected static void OnReceiveTimeout(object state)
+        protected static void OnReceiveTimeout(SocketConnection socketConnection)
         {
-            SocketConnection thisPtr = (SocketConnection)state;
-            thisPtr.Abort(SR.Format(SR.SocketAbortedReceiveTimedOut, thisPtr._receiveTimeout), TransferOperation.Read);
+            socketConnection.Abort(SR.Format(SR.SocketAbortedReceiveTimedOut, socketConnection._receiveTimeout), TransferOperation.Read);
         }
 
-        protected static void OnSendTimeout(object state)
+        protected static void OnSendTimeout(SocketConnection socketConnection)
         {
-            SocketConnection thisPtr = (SocketConnection)state;
-            thisPtr.Abort(4,	// TraceEventType.Warning
-                SR.Format(SR.SocketAbortedSendTimedOut, thisPtr._sendTimeout), TransferOperation.Write);
+            socketConnection.Abort(4,	// TraceEventType.Warning
+                SR.Format(SR.SocketAbortedSendTimedOut, socketConnection._sendTimeout), TransferOperation.Write);
         }
 
         public void Abort()

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Dispatcher/DuplexChannelBinder.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Dispatcher/DuplexChannelBinder.cs
@@ -881,7 +881,8 @@ namespace System.ServiceModel.Dispatcher
                 {
                     if (_timer != null)
                     {
-                        _timer.Change(TimeSpan.FromMilliseconds(-1), TimeSpan.FromMilliseconds(-1));
+                        _timer.Dispose();
+                        _timer = null;
                     }
 
                     lock (_parent.ThisLock)


### PR DESCRIPTION
We are seeing high contention on the call to Timer.Change which takes a lock to modify a global priority queue of timers. By reducing the number of calls to Timer.Change, we increase throughput and won't interfere with other code running in the process which also uses Timers.
Also explicitly dispose Timer to remove from finalization queue.
Fixes #1074