### PR TITLE
Don't need ERRORLEVEL to be set/used by setup/cleanup scripts.

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -116,7 +116,7 @@ goto :AfterBuild
 
 :build
 %_buildprefix% msbuild "%_buildproj%" /nologo /maxcpucount /v:minimal /clp:Summary /nodeReuse:false /flp:v=normal;LogFile="%_buildlog%";Append "/l:BinClashLogger,%_binclashLoggerDll%;LogFile=%_binclashlog%" !unprocessedBuildArgs! %_buildpostfix% %OfficialBuildIdArg%
-set BUILDERRORLEVEL=!ERRORLEVEL!
+set BUILDERRORLEVEL=%ERRORLEVEL%
 goto :eof
 
 :AfterBuild


### PR DESCRIPTION
* Since we no longer execute setup and cleanup scripts from build.cmd we no longer need !ERRORLEVEL! after the call to msbuild, doesn't hurt to keep it but its out of sync with corefx and I think it makes more sense to change it in WCF since we don't technically need it anymore.