### PR TITLE
Change test to use X509ServiceCertificateAuthentication constructor

### DIFF
--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Https/HttpsTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Https/HttpsTests.cs
@@ -187,8 +187,7 @@ public class HttpsTests : ConditionalWcfTest
             clientCertThumb = ServiceUtilHelper.LocalCertThumbprint;
 
             factory = new ChannelFactory<IWcfService>(binding, endpointAddress);
-            factory.Credentials.ServiceCertificate.SslCertificateAuthentication = factory.Credentials.ServiceCertificate.Authentication;
-            //factory.Credentials.ServiceCertificate.SslCertificateAuthentication = new X509ServiceCertificateAuthentication();
+            factory.Credentials.ServiceCertificate.SslCertificateAuthentication = new X509ServiceCertificateAuthentication();
             factory.Credentials.ServiceCertificate.SslCertificateAuthentication.CertificateValidationMode = X509CertificateValidationMode.Custom;
             MyX509CertificateValidator myX509CertificateValidator = new MyX509CertificateValidator(ScenarioTestHelpers.CertificateIssuerName);
             factory.Credentials.ServiceCertificate.SslCertificateAuthentication.CustomCertificateValidator = myX509CertificateValidator;


### PR DESCRIPTION
Now that the constructor for X509ServiceCertificateAuthentication is public in the contract, the workaround is no longer needed in the test to be able to set this.