### PR TITLE
Add ConditionalFact to WebSockets tests that need it

### DIFF
--- a/src/System.Private.ServiceModel/tests/Scenarios/Extensibility/WebSockets/Extensibility.WebSockets.Tests.csproj
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Extensibility/WebSockets/Extensibility.WebSockets.Tests.csproj
@@ -36,6 +36,10 @@
       <Project>{9098B41C-9C2E-4FC6-B7D8-FC3411736A22}</Project>
       <Name>ScenarioTests.Common</Name>
     </ProjectReference>
+    <ProjectReference Include="$(WcfInfrastructureCommonProj)">
+      <Project>{AFD69665-89A3-42AE-A32E-AB2CBBE6EE7E}</Project>
+      <Name>Infrastructure.Common</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Private.ServiceModel/tests/Scenarios/Extensibility/WebSockets/WebSocketTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Extensibility/WebSockets/WebSocketTests.cs
@@ -8,8 +8,9 @@ using System.ServiceModel.Channels;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
+using Infrastructure.Common;
 
-public static class WebSocketTests
+public class WebSocketTests : ConditionalWcfTest
 {
     [Fact]
     [OuterLoop]
@@ -169,7 +170,7 @@ public static class WebSocketTests
         }
     }
 
-    [Fact]
+    [ConditionalFact(nameof(Root_Certificate_Installed))]
     [OuterLoop]
 #if !FEATURE_NETNATIVE
     [ActiveIssue(420, PlatformID.AnyUnix)]
@@ -653,7 +654,7 @@ public static class WebSocketTests
         }
     }
 
-    [Fact]
+    [ConditionalFact(nameof(Root_Certificate_Installed))]
     [OuterLoop]
     [ActiveIssue(625, PlatformID.AnyUnix)]
     public static void WebSocket_Https_RequestReply_BinaryBuffered()
@@ -704,7 +705,7 @@ public static class WebSocketTests
         }
     }
 
-    [Fact]
+    [ConditionalFact(nameof(Root_Certificate_Installed))]
     [OuterLoop]
     [ActiveIssue(625, PlatformID.AnyUnix)]
     public static void WebSocket_Https_RequestReply_TextBuffered_KeepAlive()
@@ -757,7 +758,7 @@ public static class WebSocketTests
         }
     }
 
-    [Fact]
+    [ConditionalFact(nameof(Root_Certificate_Installed))]
     [OuterLoop]
     [ActiveIssue(625, PlatformID.AnyUnix)]
     public static void WebSocket_Https_Duplex_BinaryBuffered()
@@ -824,7 +825,7 @@ public static class WebSocketTests
         }
     }
 
-    [Fact]
+    [ConditionalFact(nameof(Root_Certificate_Installed))]
     [OuterLoop]
     [ActiveIssue(625, PlatformID.AnyUnix)]
     public static void WebSocket_Https_Duplex_TextBuffered_KeepAlive()


### PR DESCRIPTION
Some WebSockets tests started failing under ToF because
they really depended on there being a root certificate but
didn't say so.  They passed in GitHub because other tests
had caused them to be installed.

This change adds ConditionalFact to those WebSockets tests
that failed in ToF.