### PR TITLE
Prevent spin-waiting for async Task to complete by using Task.RunSynchronously

### DIFF
--- a/src/System.Private.ServiceModel/src/Internals/System/Runtime/TaskHelpers.cs
+++ b/src/System.Private.ServiceModel/src/Internals/System/Runtime/TaskHelpers.cs
@@ -179,16 +179,121 @@ namespace System.Runtime
             }
         }
 
-        // Task.GetAwaiter().GetResult() calls an internal variant of Wait() which doesn't wrap exceptions in
-        // an AggregateException.
-        public static void WaitForCompletion(this Task task)
+        public static void RunSyncWithParams<T1>(this Func<T1, Task> function, T1 param1)
         {
-            task.GetAwaiter().GetResult();
+            var state = Tuple.Create(function, param1);
+            var syncTask = new Task<Task>(obj => {
+                var tuple = obj as Tuple<Func<T1, Task>, T1>;
+                var func = tuple.Item1;
+                var p1 = tuple.Item2;
+                return func(p1);
+            }, state, CancellationToken.None);
+            syncTask.RunSynchronously(TaskScheduler.Default);
+            syncTask.GetAwaiter().GetResult().GetAwaiter().GetResult();
         }
 
-        public static TResult WaitForCompletion<TResult>(this Task<TResult> task)
+        public static void RunSyncWithParams<T1, T2>(this Func<T1, T2, Task> function, T1 param1, T2 param2)
         {
-            return task.GetAwaiter().GetResult();
+            var state = Tuple.Create(function, param1, param2);
+            var syncTask = new Task<Task>(obj => {
+                var tuple = obj as Tuple<Func<T1, T2, Task>, T1, T2>;
+                var func = tuple.Item1;
+                var p1 = tuple.Item2;
+                var p2 = tuple.Item3;
+                return func(p1, p2);
+            }, state, CancellationToken.None);
+            syncTask.RunSynchronously(TaskScheduler.Default);
+            syncTask.GetAwaiter().GetResult().GetAwaiter().GetResult();
+        }
+
+        public static void RunSyncWithParams<T1, T2, T3>(this Func<T1, T2, T3, Task> function, T1 param1, T2 param2, T3 param3)
+        {
+            var state = Tuple.Create(function, param1, param2, param3);
+            var syncTask = new Task<Task>(obj => {
+                var tuple = obj as Tuple<Func<T1, T2, T3, Task>, T1, T2, T3>;
+                var func = tuple.Item1;
+                var p1 = tuple.Item2;
+                var p2 = tuple.Item3;
+                var p3 = tuple.Item4;
+                return func(p1, p2, p3);
+            }, state, CancellationToken.None);
+            syncTask.RunSynchronously(TaskScheduler.Default);
+            syncTask.GetAwaiter().GetResult().GetAwaiter().GetResult();
+        }
+
+        public static void RunSyncWithParams<T1, T2, T3, T4>(this Func<T1, T2, T3, T4, Task> function, T1 param1, T2 param2, T3 param3, T4 param4)
+        {
+            var state = Tuple.Create(function, param1, param2, param3, param4);
+            var syncTask = new Task<Task>(obj => {
+                var tuple = obj as Tuple<Func<T1, T2, T3, T4, Task>, T1, T2, T3, T4>;
+                var func = tuple.Item1;
+                var p1 = tuple.Item2;
+                var p2 = tuple.Item3;
+                var p3 = tuple.Item4;
+                var p4 = tuple.Item5;
+                return func(p1, p2, p3, p4);
+            }, state, CancellationToken.None);
+            syncTask.RunSynchronously(TaskScheduler.Default);
+            syncTask.GetAwaiter().GetResult().GetAwaiter().GetResult();
+        }
+
+        public static TResult RunSyncWithParams<T1, TResult>(this Func<T1, Task<TResult>> function, T1 param1)
+        {
+            var state = Tuple.Create(function, param1);
+            var syncTask = new Task<Task<TResult>>(obj =>
+            {
+                var tuple = obj as Tuple<Func<T1, Task<TResult>>, T1>;
+                var func = tuple.Item1;
+                var p1 = tuple.Item2;
+                return func(p1);
+            }, state, CancellationToken.None);
+            syncTask.RunSynchronously(TaskScheduler.Default);
+            return syncTask.GetAwaiter().GetResult().GetAwaiter().GetResult();
+        }
+
+        public static TResult RunSyncWithParams<T1, T2, TResult>(this Func<T1, T2, Task<TResult>> function, T1 param1, T2 param2)
+        {
+            var state = Tuple.Create(function, param1, param2);
+            var syncTask = new Task<Task<TResult>>(obj => {
+                var tuple = obj as Tuple<Func<T1, T2, Task<TResult>>, T1, T2>;
+                var func = tuple.Item1;
+                var p1 = tuple.Item2;
+                var p2 = tuple.Item3;
+                return func(p1, p2);
+            }, state, CancellationToken.None);
+            syncTask.RunSynchronously(TaskScheduler.Default);
+            return syncTask.GetAwaiter().GetResult().GetAwaiter().GetResult();
+        }
+
+        public static TResult RunSyncWithParams<T1, T2, T3, TResult>(this Func<T1, T2, T3, Task<TResult>> function, T1 param1, T2 param2, T3 param3)
+        {
+            var state = Tuple.Create(function, param1, param2, param3);
+            var syncTask = new Task<Task<TResult>>(obj => {
+                var tuple = obj as Tuple<Func<T1, T2, T3, Task<TResult>>, T1, T2, T3>;
+                var func = tuple.Item1;
+                var p1 = tuple.Item2;
+                var p2 = tuple.Item3;
+                var p3 = tuple.Item4;
+                return func(p1, p2, p3);
+            }, state, CancellationToken.None);
+            syncTask.RunSynchronously(TaskScheduler.Default);
+            return syncTask.GetAwaiter().GetResult().GetAwaiter().GetResult();
+        }
+
+        public static TResult RunSyncWithParams<T1, T2, T3, T4, TResult>(this Func<T1, T2, T3, T4, Task<TResult>> function, T1 param1, T2 param2, T3 param3, T4 param4)
+        {
+            var state = Tuple.Create(function, param1, param2, param3, param4);
+            var syncTask = new Task<Task<TResult>>(obj => {
+                var tuple = obj as Tuple<Func<T1, T2, T3, T4, Task<TResult>>, T1, T2, T3, T4>;
+                var func = tuple.Item1;
+                var p1 = tuple.Item2;
+                var p2 = tuple.Item3;
+                var p3 = tuple.Item4;
+                var p4 = tuple.Item5;
+                return func(p1, p2, p3, p4);
+            }, state, CancellationToken.None);
+            syncTask.RunSynchronously(TaskScheduler.Default);
+            return syncTask.GetAwaiter().GetResult().GetAwaiter().GetResult();
         }
 
         public static bool WaitWithTimeSpan(this Task task, TimeSpan timeout)

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/CommunicationObject.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/CommunicationObject.cs
@@ -141,7 +141,7 @@ namespace System.ServiceModel.Channels
 
         public void Close(TimeSpan timeout)
         {
-            CloseAsyncInternal(timeout).WaitForCompletion();
+            TaskHelpers.RunSyncWithParams(CloseAsyncInternal, timeout);
         }
 
         private async Task CloseAsyncInternal(TimeSpan timeout)
@@ -316,7 +316,7 @@ namespace System.ServiceModel.Channels
 
         public void Open(TimeSpan timeout)
         {
-            OpenAsyncInternal(timeout).WaitForCompletion();
+            TaskHelpers.RunSyncWithParams(OpenAsyncInternal, timeout);
         }
 
         private async Task OpenAsyncInternal(TimeSpan timeout)
@@ -803,7 +803,7 @@ namespace System.ServiceModel.Channels
 
         public static void OnClose(CommunicationObject communicationObject, TimeSpan timeout)
         {
-            OnCloseAsyncInternal(communicationObject, timeout).WaitForCompletion();
+            TaskHelpers.RunSyncWithParams(OnCloseAsyncInternal, communicationObject, timeout);
         }
 
         public static IAsyncResult OnBeginClose(CommunicationObject communicationObject, TimeSpan timeout, AsyncCallback callback, object state)
@@ -818,7 +818,7 @@ namespace System.ServiceModel.Channels
 
         public static void OnOpen(CommunicationObject communicationObject, TimeSpan timeout)
         {
-            OnOpenAsyncInternal(communicationObject, timeout).WaitForCompletion();
+            TaskHelpers.RunSyncWithParams(OnOpenAsyncInternal, communicationObject, timeout);
         }
 
         public static IAsyncResult OnBeginOpen(CommunicationObject communicationObject, TimeSpan timeout, AsyncCallback callback, object state)

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/RequestChannel.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/RequestChannel.cs
@@ -246,7 +246,7 @@ namespace System.ServiceModel.Channels
 
         public Message Request(Message message, TimeSpan timeout)
         {
-            return RequestAsyncInternal(message, timeout).WaitForCompletion();
+            return TaskHelpers.RunSyncWithParams(RequestAsyncInternal, message, timeout);
         }
 
         public Task<Message> RequestAsync(Message message)

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/TextMessageEncoder.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/TextMessageEncoder.cs
@@ -464,12 +464,12 @@ namespace System.ServiceModel.Channels
 
             public override ArraySegment<byte> WriteMessage(Message message, int maxMessageSize, BufferManager bufferManager, int messageOffset)
             {
-                return WriteMessageAsync(message, maxMessageSize, bufferManager, messageOffset).WaitForCompletion();
+                return TaskHelpers.RunSyncWithParams(WriteMessageAsync, message, maxMessageSize, bufferManager, messageOffset);
             }
 
             public override void WriteMessage(Message message, Stream stream)
             {
-                WriteMessageAsyncInternal(message, stream).WaitForCompletion();
+                TaskHelpers.RunSyncWithParams(WriteMessageAsyncInternal, message, stream);
             }
 
             public override Task<ArraySegment<byte>> WriteMessageAsync(Message message, int maxMessageSize, BufferManager bufferManager, int messageOffset)

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/TimeoutStream.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/TimeoutStream.cs
@@ -33,7 +33,7 @@ namespace System.ServiceModel.Channels
 
         public override int Read(byte[] buffer, int offset, int count)
         {
-            return ReadAsyncInternal(buffer, offset, count, CancellationToken.None).WaitForCompletion();
+            return TaskHelpers.RunSyncWithParams(ReadAsyncInternal, buffer, offset, count, CancellationToken.None);
         }
 
         public override int ReadByte()
@@ -62,7 +62,7 @@ namespace System.ServiceModel.Channels
 
         public override void Write(byte[] buffer, int offset, int count)
         {
-            WriteAsyncInternal(buffer, offset, count, CancellationToken.None).WaitForCompletion();
+            TaskHelpers.RunSyncWithParams(WriteAsyncInternal, buffer, offset, count, CancellationToken.None);
         }
 
         public override void WriteByte(byte value)


### PR DESCRIPTION
When calling Task.GetAwaiter().GetResult(), the wait which results when the task goes async is a SpinWait. This change causes the Task to be started synchronously on the current thread and avoid the spinwait. To avoid the spinwait, there needs to be no timeout on the wait, the cancellation token for the task needs to be not cancellable and there needs to be an ambient task scheduler present in the task. This third item isn't the case as when the wait was being started, no continuations have been asynchronously called so there wasn't an ambient task schedule. On a 24 core machine, we were spin waiting for 25% of total CPU time. 