### PR TITLE
Fix custom message encoder test to use supported code page

### DIFF
--- a/src/System.Private.ServiceModel/tests/Scenarios/Extensibility/MessageEncoder/TextTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Extensibility/MessageEncoder/TextTests.cs
@@ -28,7 +28,7 @@ public static class TextTests
         try
         {
             // *** SETUP *** \\
-            CustomBinding binding = new CustomBinding(new CustomTextMessageBindingElement("ISO-8859-1"),
+            CustomBinding binding = new CustomBinding(new CustomTextMessageBindingElement(Encoding.UTF8.WebName),
                 new HttpTransportBindingElement
                 {
                     MaxReceivedMessageSize = ScenarioTestHelpers.SixtyFourMB,
@@ -71,7 +71,7 @@ public static class TextTests
         try
         {
             // *** SETUP *** \\
-            CustomBinding binding = new CustomBinding(new CustomTextMessageBindingElement("ISO-8859-1"),
+            CustomBinding binding = new CustomBinding(new CustomTextMessageBindingElement(Encoding.UTF8.WebName),
                 new HttpTransportBindingElement
                 {
                     MaxReceivedMessageSize = ScenarioTestHelpers.SixtyFourMB,

--- a/src/System.Private.ServiceModel/tools/IISHostedWcfService/App_code/testhosts/CustomTextEncoderBufferedServiceHost.cs
+++ b/src/System.Private.ServiceModel/tools/IISHostedWcfService/App_code/testhosts/CustomTextEncoderBufferedServiceHost.cs
@@ -7,6 +7,7 @@ using System;
 using System.ServiceModel;
 using System.ServiceModel.Activation;
 using System.ServiceModel.Channels;
+using System.Text;
 
 namespace WcfService
 {
@@ -25,7 +26,7 @@ namespace WcfService
 
         protected override Binding GetBinding()
         {
-            return new CustomBinding(new CustomTextMessageBindingElement("ISO-8859-1"), new HttpTransportBindingElement
+            return new CustomBinding(new CustomTextMessageBindingElement(Encoding.UTF8.WebName), new HttpTransportBindingElement
             {
                 MaxReceivedMessageSize = SixtyFourMB,
                 MaxBufferSize = SixtyFourMB

--- a/src/System.Private.ServiceModel/tools/IISHostedWcfService/App_code/testhosts/CustomTextEncoderStreamedServiceHost.cs
+++ b/src/System.Private.ServiceModel/tools/IISHostedWcfService/App_code/testhosts/CustomTextEncoderStreamedServiceHost.cs
@@ -7,6 +7,7 @@ using System;
 using System.ServiceModel;
 using System.ServiceModel.Activation;
 using System.ServiceModel.Channels;
+using System.Text;
 
 namespace WcfService
 {
@@ -25,7 +26,7 @@ namespace WcfService
 
         protected override Binding GetBinding()
         {
-            return new CustomBinding(new CustomTextMessageBindingElement("ISO-8859-1"),
+            return new CustomBinding(new CustomTextMessageBindingElement(Encoding.UTF8.WebName),
                 new HttpTransportBindingElement
                 {
                     MaxReceivedMessageSize = SixtyFourMB,


### PR DESCRIPTION
The custom message encoder tests caused periodic hangs running
on Linux.  Suspicion was use of an unsupported code page.  This
PR changes to a supported code page, and the hangs have not
been observed again.

Fixes #1148