### PR TITLE
Fix channel factory async close path to not run synchronously

### DIFF
--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/HttpChannelFactory.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/HttpChannelFactory.cs
@@ -520,8 +520,7 @@ namespace System.ServiceModel.Channels
 
         protected internal override Task OnCloseAsync(TimeSpan timeout)
         {
-            OnClose(timeout);
-            return TaskHelpers.CompletedTask();
+            return base.OnCloseAsync(timeout);
         }
 
         protected override void OnClosed()

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/TransportChannelFactory.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/TransportChannelFactory.cs
@@ -4,6 +4,7 @@
 
 
 using System.Collections.ObjectModel;
+using System.Threading.Tasks;
 
 namespace System.ServiceModel.Channels
 {
@@ -142,6 +143,12 @@ namespace System.ServiceModel.Channels
         {
             OnCloseOrAbort();
             base.OnClose(timeout);
+        }
+
+        internal protected override Task OnCloseAsync(TimeSpan timeout)
+        {
+            OnCloseOrAbort();
+            return base.OnCloseAsync(timeout);
         }
 
         private void OnCloseOrAbort()


### PR DESCRIPTION
HttpChannelFactory was handling OnCloseAsync but triggered
a synchronous close path in the layers below it.  With this
change, the underlying layers implement the async close path
and HttpChannelFactory uses it.

Fixes #1154