### PR TITLE
Remove setting timer to null as it may be accessed in race condition of read/write callback and Abort

### DIFF
--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/CoreClrSocketConnection.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/CoreClrSocketConnection.cs
@@ -497,7 +497,6 @@ namespace System.ServiceModel.Channels
             if (_sendTimer != null)
             {
                 _sendTimer.Dispose();
-                _sendTimer = null;
             }
         }
 
@@ -768,7 +767,6 @@ namespace System.ServiceModel.Channels
             if (_receiveTimer != null)
             {
                 _receiveTimer.Dispose();
-                _receiveTimer = null;
             }
         }
 


### PR DESCRIPTION
Fixes #1153 
