### PR TITLE
Prevent spin-waiting by using WaitHandle from Task

### DIFF
--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/RequestChannel.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/RequestChannel.cs
@@ -246,7 +246,7 @@ namespace System.ServiceModel.Channels
 
         public Message Request(Message message, TimeSpan timeout)
         {
-            return RequestAsyncInternal(message, timeout).WaitForCompletion();
+            return RequestAsyncInternal(message, timeout).WaitForCompletionNoSpin();
         }
 
         public Task<Message> RequestAsync(Message message)

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/TextMessageEncoder.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/TextMessageEncoder.cs
@@ -464,12 +464,12 @@ namespace System.ServiceModel.Channels
 
             public override ArraySegment<byte> WriteMessage(Message message, int maxMessageSize, BufferManager bufferManager, int messageOffset)
             {
-                return WriteMessageAsync(message, maxMessageSize, bufferManager, messageOffset).WaitForCompletion();
+                return WriteMessageAsync(message, maxMessageSize, bufferManager, messageOffset).WaitForCompletionNoSpin();
             }
 
             public override void WriteMessage(Message message, Stream stream)
             {
-                WriteMessageAsyncInternal(message, stream).WaitForCompletion();
+                WriteMessageAsyncInternal(message, stream).WaitForCompletionNoSpin();
             }
 
             public override Task<ArraySegment<byte>> WriteMessageAsync(Message message, int maxMessageSize, BufferManager bufferManager, int messageOffset)

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/WebSocketTransportDuplexSessionChannel.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/WebSocketTransportDuplexSessionChannel.cs
@@ -536,27 +536,9 @@ namespace System.ServiceModel.Channels
                 return message;
             }
 
-            // TODO: As we're waiting blocking on a task anyway, should just call ReceiveAsync and block on that task.
             public Message Receive(TimeSpan timeout)
             {
-                bool waitingResult = _receiveTask.Task.WaitWithTimeSpan(timeout);
-                ThrowOnPendingException(ref _pendingException);
-
-                if (!waitingResult)
-                {
-                    throw FxTrace.Exception.AsError(new TimeoutException(
-                               SR.Format(SR.WaitForMessageTimedOut, timeout),
-                               TimeoutHelper.CreateEnterTimedOutException(timeout)));
-                }
-
-                Message message = GetPendingMessage();
-
-                if (message != null)
-                {
-                    StartNextReceiveAsync();
-                }
-
-                return message;
+                return ReceiveAsync(timeout).WaitForCompletionNoSpin();
             }
 
             private async Task ReadBufferedMessageAsync()


### PR DESCRIPTION
Created NoSpin variations of WaitForCompletion which immediately uses a WaitHandle. The original variations are still there as they will be more performant when a Task is expected to complete immediately. Switching to NoSpin variations should only be done when it's known an operation will take more than a fraction of a second to complete or when a profile shows it would be advantageous.