### PR TITLE
Add additional runtimes

### DIFF
--- a/src/Common/test-runtime/project.json
+++ b/src/Common/test-runtime/project.json
@@ -17,7 +17,10 @@
   },
   "frameworks": {
     "dnxcore50": {
-      "imports": [ "netstandard1.6", "portable-net45+win8" ],
+      "imports": [
+        "netstandard1.6",
+        "portable-net45+win8"
+      ],
       "dependencies": {
         "System.Net.Http.WinHttpHandler": "4.0.0-rc3-24109-00",
         "System.Net.Security": "4.0.0-rc3-24109-00"
@@ -25,9 +28,13 @@
     }
   },
   "runtimes": {
-    "win7-x64": {},
-    "win7-x86": {},
+    "centos.7-x64": {},
+    "debian.8-x64": {},
+    "linux-x64": {},
+    "osx.10.10-x64": {},
+    "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
-    "osx.10.10-x64": {}
+    "win7-x64": {},
+    "win7-x86": {}
   }
 }

--- a/src/System.Private.ServiceModel/tests/Common/Infrastructure/tests/project.json
+++ b/src/System.Private.ServiceModel/tests/Common/Infrastructure/tests/project.json
@@ -13,16 +13,20 @@
   },
   "frameworks": {
     "dnxcore50": {
-      "imports": [ "netstandard1.6", "portable-net45+win8" ]
+      "imports": [
+        "netstandard1.6",
+        "portable-net45+win8"
+      ]
     }
   },
   "runtimes": {
-    "win7-x64": {},
-    "win7-x86": {},
-    "ubuntu.14.04-x64": {},
-    "osx.10.10-x64": {},
     "centos.7-x64": {},
+    "debian.8-x64": {},
+    "linux-x64": {},
+    "osx.10.10-x64": {},
     "rhel.7-x64": {},
-    "debian.8.2-x64": {}
+    "ubuntu.14.04-x64": {},
+    "win7-x64": {},
+    "win7-x86": {}
   }
 }

--- a/src/System.Private.ServiceModel/tests/Common/Scenarios/project.json
+++ b/src/System.Private.ServiceModel/tests/Common/Scenarios/project.json
@@ -27,16 +27,20 @@
   },
   "frameworks": {
     "dnxcore50": {
-      "imports": [ "netstandard1.6", "portable-net45+win8" ]
+      "imports": [
+        "netstandard1.6",
+        "portable-net45+win8"
+      ]
     }
   },
   "runtimes": {
-    "win7-x64": {},
-    "win7-x86": {},
-    "ubuntu.14.04-x64": {},
-    "osx.10.10-x64": {},
     "centos.7-x64": {},
+    "debian.8-x64": {},
+    "linux-x64": {},
+    "osx.10.10-x64": {},
     "rhel.7-x64": {},
-    "debian.8.2-x64": {}
+    "ubuntu.14.04-x64": {},
+    "win7-x64": {},
+    "win7-x86": {}
   }
 }

--- a/src/System.Private.ServiceModel/tests/Common/Unit/project.json
+++ b/src/System.Private.ServiceModel/tests/Common/Unit/project.json
@@ -18,7 +18,10 @@
   },
   "frameworks": {
     "dnxcore50": {
-      "imports": [ "netstandard1.6", "portable-net45+win8" ],
+      "imports": [
+        "netstandard1.6",
+        "portable-net45+win8"
+      ],
       "dependencies": {
         "System.Net.WebSockets": "4.0.0-rc3-24109-00",
         "System.Net.WebSockets.Client": "4.0.0-rc3-24109-00"
@@ -26,12 +29,13 @@
     }
   },
   "runtimes": {
-    "win7-x64": {},
-    "win7-x86": {},
-    "ubuntu.14.04-x64": {},
-    "osx.10.10-x64": {},
     "centos.7-x64": {},
+    "debian.8-x64": {},
+    "linux-x64": {},
+    "osx.10.10-x64": {},
     "rhel.7-x64": {},
-    "debian.8.2-x64": {}
+    "ubuntu.14.04-x64": {},
+    "win7-x64": {},
+    "win7-x86": {}
   }
 }

--- a/src/System.Private.ServiceModel/tests/Scenarios/Binding/Custom/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Binding/Custom/project.json
@@ -14,16 +14,20 @@
   },
   "frameworks": {
     "dnxcore50": {
-      "imports": [ "netstandard1.6", "portable-net45+win8" ]
+      "imports": [
+        "netstandard1.6",
+        "portable-net45+win8"
+      ]
     }
   },
   "runtimes": {
-    "win7-x64": { },
-    "win7-x86": { },
-    "ubuntu.14.04-x64": { },
-    "osx.10.10-x64": { },
-    "centos.7-x64": { },
-    "rhel.7-x64": { },
-    "debian.8.2-x64": { }
+    "centos.7-x64": {},
+    "debian.8-x64": {},
+    "linux-x64": {},
+    "osx.10.10-x64": {},
+    "rhel.7-x64": {},
+    "ubuntu.14.04-x64": {},
+    "win7-x64": {},
+    "win7-x86": {}
   }
 }

--- a/src/System.Private.ServiceModel/tests/Scenarios/Binding/Http/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Binding/Http/project.json
@@ -13,16 +13,20 @@
   },
   "frameworks": {
     "dnxcore50": {
-      "imports": [ "netstandard1.6", "portable-net45+win8" ]
+      "imports": [
+        "netstandard1.6",
+        "portable-net45+win8"
+      ]
     }
   },
   "runtimes": {
-    "win7-x64": {},
-    "win7-x86": {},
-    "ubuntu.14.04-x64": {},
-    "osx.10.10-x64": {},
     "centos.7-x64": {},
+    "debian.8-x64": {},
+    "linux-x64": {},
+    "osx.10.10-x64": {},
     "rhel.7-x64": {},
-    "debian.8.2-x64": {}
+    "ubuntu.14.04-x64": {},
+    "win7-x64": {},
+    "win7-x86": {}
   }
 }

--- a/src/System.Private.ServiceModel/tests/Scenarios/Binding/Tcp/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Binding/Tcp/project.json
@@ -14,16 +14,20 @@
   },
   "frameworks": {
     "dnxcore50": {
-      "imports": [ "netstandard1.6", "portable-net45+win8" ]
+      "imports": [
+        "netstandard1.6",
+        "portable-net45+win8"
+      ]
     }
   },
   "runtimes": {
-    "win7-x64": { },
-    "win7-x86": { },
-    "ubuntu.14.04-x64": { },
-    "osx.10.10-x64": { },
-    "centos.7-x64": { },
-    "rhel.7-x64": { },
-    "debian.8.2-x64": { }
+    "centos.7-x64": {},
+    "debian.8-x64": {},
+    "linux-x64": {},
+    "osx.10.10-x64": {},
+    "rhel.7-x64": {},
+    "ubuntu.14.04-x64": {},
+    "win7-x64": {},
+    "win7-x86": {}
   }
 }

--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/ChannelLayer/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/ChannelLayer/project.json
@@ -15,16 +15,20 @@
   },
   "frameworks": {
     "dnxcore50": {
-      "imports": [ "netstandard1.6", "portable-net45+win8" ]
+      "imports": [
+        "netstandard1.6",
+        "portable-net45+win8"
+      ]
     }
   },
   "runtimes": {
-    "win7-x64": {},
-    "win7-x86": {},
-    "ubuntu.14.04-x64": {},
-    "osx.10.10-x64": {},
     "centos.7-x64": {},
+    "debian.8-x64": {},
+    "linux-x64": {},
+    "osx.10.10-x64": {},
     "rhel.7-x64": {},
-    "debian.8.2-x64": {}
+    "ubuntu.14.04-x64": {},
+    "win7-x64": {},
+    "win7-x86": {}
   }
 }

--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/ClientBase/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/ClientBase/project.json
@@ -18,16 +18,20 @@
   },
   "frameworks": {
     "dnxcore50": {
-      "imports": [ "netstandard1.6", "portable-net45+win8" ]
+      "imports": [
+        "netstandard1.6",
+        "portable-net45+win8"
+      ]
     }
   },
   "runtimes": {
-    "win7-x64": {},
-    "win7-x86": {},
-    "ubuntu.14.04-x64": {},
-    "osx.10.10-x64": {},
     "centos.7-x64": {},
+    "debian.8-x64": {},
+    "linux-x64": {},
+    "osx.10.10-x64": {},
     "rhel.7-x64": {},
-    "debian.8.2-x64": {}
+    "ubuntu.14.04-x64": {},
+    "win7-x64": {},
+    "win7-x86": {}
   }
 }

--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/ExpectedExceptions/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/ExpectedExceptions/project.json
@@ -28,16 +28,20 @@
   },
   "frameworks": {
     "dnxcore50": {
-      "imports": [ "netstandard1.6", "portable-net45+win8" ]
+      "imports": [
+        "netstandard1.6",
+        "portable-net45+win8"
+      ]
     }
   },
   "runtimes": {
-    "win7-x64": {},
-    "win7-x86": {},
-    "ubuntu.14.04-x64": {},
-    "osx.10.10-x64": {},
     "centos.7-x64": {},
+    "debian.8-x64": {},
+    "linux-x64": {},
+    "osx.10.10-x64": {},
     "rhel.7-x64": {},
-    "debian.8.2-x64": {}
+    "ubuntu.14.04-x64": {},
+    "win7-x64": {},
+    "win7-x86": {}
   }
 }

--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/TypedClient/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/TypedClient/project.json
@@ -16,16 +16,20 @@
   },
   "frameworks": {
     "dnxcore50": {
-      "imports": [ "netstandard1.6", "portable-net45+win8" ]
+      "imports": [
+        "netstandard1.6",
+        "portable-net45+win8"
+      ]
     }
   },
   "runtimes": {
-    "win7-x64": {},
-    "win7-x86": {},
-    "ubuntu.14.04-x64": {},
-    "osx.10.10-x64": {},
     "centos.7-x64": {},
+    "debian.8-x64": {},
+    "linux-x64": {},
+    "osx.10.10-x64": {},
     "rhel.7-x64": {},
-    "debian.8.2-x64": {}
+    "ubuntu.14.04-x64": {},
+    "win7-x64": {},
+    "win7-x86": {}
   }
 }

--- a/src/System.Private.ServiceModel/tests/Scenarios/Contract/Data/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Contract/Data/project.json
@@ -16,16 +16,20 @@
   },
   "frameworks": {
     "dnxcore50": {
-      "imports": [ "netstandard1.6", "portable-net45+win8" ]
+      "imports": [
+        "netstandard1.6",
+        "portable-net45+win8"
+      ]
     }
   },
   "runtimes": {
-    "win7-x64": {},
-    "win7-x86": {},
-    "ubuntu.14.04-x64": {},
-    "osx.10.10-x64": {},
     "centos.7-x64": {},
+    "debian.8-x64": {},
+    "linux-x64": {},
+    "osx.10.10-x64": {},
     "rhel.7-x64": {},
-    "debian.8.2-x64": {}
+    "ubuntu.14.04-x64": {},
+    "win7-x64": {},
+    "win7-x86": {}
   }
 }

--- a/src/System.Private.ServiceModel/tests/Scenarios/Contract/Fault/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Contract/Fault/project.json
@@ -14,16 +14,20 @@
   },
   "frameworks": {
     "dnxcore50": {
-      "imports": [ "netstandard1.6", "portable-net45+win8" ]
+      "imports": [
+        "netstandard1.6",
+        "portable-net45+win8"
+      ]
     }
   },
   "runtimes": {
-    "win7-x64": {},
-    "win7-x86": {},
-    "ubuntu.14.04-x64": {},
-    "osx.10.10-x64": {},
     "centos.7-x64": {},
+    "debian.8-x64": {},
+    "linux-x64": {},
+    "osx.10.10-x64": {},
     "rhel.7-x64": {},
-    "debian.8.2-x64": {}
+    "ubuntu.14.04-x64": {},
+    "win7-x64": {},
+    "win7-x86": {}
   }
 }

--- a/src/System.Private.ServiceModel/tests/Scenarios/Contract/Message/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Contract/Message/project.json
@@ -14,16 +14,20 @@
   },
   "frameworks": {
     "dnxcore50": {
-      "imports": [ "netstandard1.6", "portable-net45+win8" ]
+      "imports": [
+        "netstandard1.6",
+        "portable-net45+win8"
+      ]
     }
   },
   "runtimes": {
-    "win7-x64": {},
-    "win7-x86": {},
-    "ubuntu.14.04-x64": {},
-    "osx.10.10-x64": {},
     "centos.7-x64": {},
+    "debian.8-x64": {},
+    "linux-x64": {},
+    "osx.10.10-x64": {},
     "rhel.7-x64": {},
-    "debian.8.2-x64": {}
+    "ubuntu.14.04-x64": {},
+    "win7-x64": {},
+    "win7-x86": {}
   }
 }

--- a/src/System.Private.ServiceModel/tests/Scenarios/Contract/Service/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Contract/Service/project.json
@@ -17,16 +17,20 @@
   },
   "frameworks": {
     "dnxcore50": {
-      "imports": [ "netstandard1.6", "portable-net45+win8" ]
+      "imports": [
+        "netstandard1.6",
+        "portable-net45+win8"
+      ]
     }
   },
   "runtimes": {
-    "win7-x64": {},
-    "win7-x86": {},
-    "ubuntu.14.04-x64": {},
-    "osx.10.10-x64": {},
     "centos.7-x64": {},
+    "debian.8-x64": {},
+    "linux-x64": {},
+    "osx.10.10-x64": {},
     "rhel.7-x64": {},
-    "debian.8.2-x64": {}
+    "ubuntu.14.04-x64": {},
+    "win7-x64": {},
+    "win7-x86": {}
   }
 }

--- a/src/System.Private.ServiceModel/tests/Scenarios/Contract/XmlSerializer/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Contract/XmlSerializer/project.json
@@ -14,16 +14,20 @@
   },
   "frameworks": {
     "dnxcore50": {
-      "imports": [ "netstandard1.6", "portable-net45+win8" ]
+      "imports": [
+        "netstandard1.6",
+        "portable-net45+win8"
+      ]
     }
   },
   "runtimes": {
-    "win7-x64": {},
-    "win7-x86": {},
-    "ubuntu.14.04-x64": {},
-    "osx.10.10-x64": {},
     "centos.7-x64": {},
+    "debian.8-x64": {},
+    "linux-x64": {},
+    "osx.10.10-x64": {},
     "rhel.7-x64": {},
-    "debian.8.2-x64": {}
+    "ubuntu.14.04-x64": {},
+    "win7-x64": {},
+    "win7-x86": {}
   }
 }

--- a/src/System.Private.ServiceModel/tests/Scenarios/Encoding/Encoders/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Encoding/Encoders/project.json
@@ -15,16 +15,20 @@
   },
   "frameworks": {
     "dnxcore50": {
-      "imports": [ "netstandard1.6", "portable-net45+win8" ]
+      "imports": [
+        "netstandard1.6",
+        "portable-net45+win8"
+      ]
     }
   },
   "runtimes": {
-    "win7-x64": {},
-    "win7-x86": {},
-    "ubuntu.14.04-x64": {},
-    "osx.10.10-x64": {},
     "centos.7-x64": {},
+    "debian.8-x64": {},
+    "linux-x64": {},
+    "osx.10.10-x64": {},
     "rhel.7-x64": {},
-    "debian.8.2-x64": {}
+    "ubuntu.14.04-x64": {},
+    "win7-x64": {},
+    "win7-x86": {}
   }
 }

--- a/src/System.Private.ServiceModel/tests/Scenarios/Encoding/MessageVersion/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Encoding/MessageVersion/project.json
@@ -13,16 +13,20 @@
   },
   "frameworks": {
     "dnxcore50": {
-      "imports": [ "netstandard1.6", "portable-net45+win8" ]
+      "imports": [
+        "netstandard1.6",
+        "portable-net45+win8"
+      ]
     }
   },
   "runtimes": {
-    "win7-x64": {},
-    "win7-x86": {},
-    "ubuntu.14.04-x64": {},
-    "osx.10.10-x64": {},
     "centos.7-x64": {},
+    "debian.8-x64": {},
+    "linux-x64": {},
+    "osx.10.10-x64": {},
     "rhel.7-x64": {},
-    "debian.8.2-x64": {}
+    "ubuntu.14.04-x64": {},
+    "win7-x64": {},
+    "win7-x86": {}
   }
 }

--- a/src/System.Private.ServiceModel/tests/Scenarios/Extensibility/MessageEncoder/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Extensibility/MessageEncoder/project.json
@@ -17,16 +17,20 @@
   },
   "frameworks": {
     "dnxcore50": {
-      "imports": [ "netstandard1.6", "portable-net45+win8" ]
+      "imports": [
+        "netstandard1.6",
+        "portable-net45+win8"
+      ]
     }
   },
   "runtimes": {
-    "win7-x64": {},
-    "win7-x86": {},
-    "ubuntu.14.04-x64": {},
-    "osx.10.10-x64": {},
     "centos.7-x64": {},
+    "debian.8-x64": {},
+    "linux-x64": {},
+    "osx.10.10-x64": {},
     "rhel.7-x64": {},
-    "debian.8.2-x64": {}
+    "ubuntu.14.04-x64": {},
+    "win7-x64": {},
+    "win7-x86": {}
   }
 }

--- a/src/System.Private.ServiceModel/tests/Scenarios/Extensibility/WebSockets/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Extensibility/WebSockets/project.json
@@ -17,16 +17,20 @@
   },
   "frameworks": {
     "dnxcore50": {
-      "imports": [ "netstandard1.6", "portable-net45+win8" ]
+      "imports": [
+        "netstandard1.6",
+        "portable-net45+win8"
+      ]
     }
   },
   "runtimes": {
-    "win7-x64": {},
-    "win7-x86": {},
-    "ubuntu.14.04-x64": {},
-    "osx.10.10-x64": {},
     "centos.7-x64": {},
+    "debian.8-x64": {},
+    "linux-x64": {},
+    "osx.10.10-x64": {},
     "rhel.7-x64": {},
-    "debian.8.2-x64": {}
+    "ubuntu.14.04-x64": {},
+    "win7-x64": {},
+    "win7-x86": {}
   }
 }

--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/project.json
@@ -17,16 +17,20 @@
   },
   "frameworks": {
     "dnxcore50": {
-      "imports": [ "netstandard1.6", "portable-net45+win8" ]
+      "imports": [
+        "netstandard1.6",
+        "portable-net45+win8"
+      ]
     }
   },
   "runtimes": {
-    "win7-x64": {},
-    "win7-x86": {},
-    "ubuntu.14.04-x64": {},
-    "osx.10.10-x64": {},
     "centos.7-x64": {},
+    "debian.8-x64": {},
+    "linux-x64": {},
+    "osx.10.10-x64": {},
     "rhel.7-x64": {},
-    "debian.8.2-x64": {}
+    "ubuntu.14.04-x64": {},
+    "win7-x64": {},
+    "win7-x86": {}
   }
 }

--- a/src/System.Private.ServiceModel/tests/Stress/SharedPoolsOfWCFObjects/project.json
+++ b/src/System.Private.ServiceModel/tests/Stress/SharedPoolsOfWCFObjects/project.json
@@ -26,17 +26,21 @@
   },
   "frameworks": {
     "dnxcore50": {
-      "imports": [ "netstandard1.6", "portable-net45+win8" ],
+      "imports": [
+        "netstandard1.6",
+        "portable-net45+win8"
+      ],
       "dependencies": {}
     }
   },
   "runtimes": {
-    "win7-x64": {},
-    "win7-x86": {},
-    "ubuntu.14.04-x64": {},
-    "osx.10.10-x64": {},
     "centos.7-x64": {},
+    "debian.8-x64": {},
+    "linux-x64": {},
+    "osx.10.10-x64": {},
     "rhel.7-x64": {},
-    "debian.8.2-x64": {}
+    "ubuntu.14.04-x64": {},
+    "win7-x64": {},
+    "win7-x86": {}
   }
 }

--- a/src/System.ServiceModel.Duplex/tests/project.json
+++ b/src/System.ServiceModel.Duplex/tests/project.json
@@ -16,13 +16,20 @@
   },
   "frameworks": {
     "dnxcore50": {
-      "imports": [ "netstandard1.6", "portable-net45+win8" ]
+      "imports": [
+        "netstandard1.6",
+        "portable-net45+win8"
+      ]
     }
   },
   "runtimes": {
-    "win7-x64": { },
-    "win7-x86": { },
-    "ubuntu.14.04-x64": { },
-    "osx.10.10-x64": { }
+    "centos.7-x64": {},
+    "debian.8-x64": {},
+    "linux-x64": {},
+    "osx.10.10-x64": {},
+    "rhel.7-x64": {},
+    "ubuntu.14.04-x64": {},
+    "win7-x64": {},
+    "win7-x86": {}
   }
 }

--- a/src/System.ServiceModel.Http/tests/project.json
+++ b/src/System.ServiceModel.Http/tests/project.json
@@ -16,7 +16,10 @@
   },
   "frameworks": {
     "dnxcore50": {
-      "imports": [ "netstandard1.6", "portable-net45+win8" ],
+      "imports": [
+        "netstandard1.6",
+        "portable-net45+win8"
+      ],
       "dependencies": {
         "System.Net.WebSockets": "4.0.0-rc3-24109-00",
         "System.Net.WebSockets.Client": "4.0.0-rc3-24109-00"
@@ -24,12 +27,13 @@
     }
   },
   "runtimes": {
-    "win7-x64": { },
-    "win7-x86": { },
-    "ubuntu.14.04-x64": { },
-    "osx.10.10-x64": { },
-    "centos.7-x64": { },
-    "rhel.7-x64": { },
-    "debian.8.2-x64": { }
+    "centos.7-x64": {},
+    "debian.8-x64": {},
+    "linux-x64": {},
+    "osx.10.10-x64": {},
+    "rhel.7-x64": {},
+    "ubuntu.14.04-x64": {},
+    "win7-x64": {},
+    "win7-x86": {}
   }
 }

--- a/src/System.ServiceModel.NetTcp/tests/project.json
+++ b/src/System.ServiceModel.NetTcp/tests/project.json
@@ -14,13 +14,20 @@
   },
   "frameworks": {
     "dnxcore50": {
-      "imports": [ "netstandard1.6", "portable-net45+win8" ]
+      "imports": [
+        "netstandard1.6",
+        "portable-net45+win8"
+      ]
     }
   },
   "runtimes": {
-    "win7-x64": { },
-    "win7-x86": { },
-    "ubuntu.14.04-x64": { },
-    "osx.10.10-x64": { }
+    "centos.7-x64": {},
+    "debian.8-x64": {},
+    "linux-x64": {},
+    "osx.10.10-x64": {},
+    "rhel.7-x64": {},
+    "ubuntu.14.04-x64": {},
+    "win7-x64": {},
+    "win7-x86": {}
   }
 }

--- a/src/System.ServiceModel.Primitives/tests/project.json
+++ b/src/System.ServiceModel.Primitives/tests/project.json
@@ -19,16 +19,20 @@
   },
   "frameworks": {
     "dnxcore50": {
-      "imports": [ "netstandard1.6", "portable-net45+win8" ]
+      "imports": [
+        "netstandard1.6",
+        "portable-net45+win8"
+      ]
     }
   },
   "runtimes": {
-    "win7-x64": { },
-    "win7-x86": { },
-    "ubuntu.14.04-x64": { },
-    "osx.10.10-x64": { },
-    "centos.7-x64": { },
-    "rhel.7-x64": { },
-    "debian.8.2-x64": { }
+    "centos.7-x64": {},
+    "debian.8-x64": {},
+    "linux-x64": {},
+    "osx.10.10-x64": {},
+    "rhel.7-x64": {},
+    "ubuntu.14.04-x64": {},
+    "win7-x64": {},
+    "win7-x86": {}
   }
 }

--- a/src/System.ServiceModel.Security/tests/project.json
+++ b/src/System.ServiceModel.Security/tests/project.json
@@ -14,16 +14,23 @@
   },
   "frameworks": {
     "dnxcore50": {
-      "imports": [ "netstandard1.6", "portable-net45+win8" ],
+      "imports": [
+        "netstandard1.6",
+        "portable-net45+win8"
+      ],
       "dependencies": {
         "System.Net.Security": "4.0.0-rc3-24109-00"
       }
     }
   },
   "runtimes": {
-    "win7-x86": { },
-    "win7-x64": { },
-    "ubuntu.14.04-x64": { },
-    "osx.10.10-x64": { }
+    "centos.7-x64": {},
+    "debian.8-x64": {},
+    "linux-x64": {},
+    "osx.10.10-x64": {},
+    "rhel.7-x64": {},
+    "ubuntu.14.04-x64": {},
+    "win7-x64": {},
+    "win7-x86": {}
   }
 }


### PR DESCRIPTION
- Add "debian.8-x64". This is the correct rid for Debian. I want to
  remove "debian.8.2-x64" before RTM.

- Add a generic "linux-x64" rid which we can use in cases where we want
  to build for a distro where we don't yet have a set of runtime
  packages. This will let us restore the managed assets (since they are
  specific to "unix" or "linux" and then folks can do a native build to
  get the shims and runtime and copy them over (this is a more
  reasonable approach than our current strategy of just using
  ubuntu.14.04-x64)

- Sort runtime sections