### PR TITLE
Updating tests with ActiveIssue 1123.

### DIFF
--- a/src/System.Private.ServiceModel/tests/Scenarios/Binding/Http/NetHttpsBindingTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Binding/Http/NetHttpsBindingTests.cs
@@ -15,6 +15,7 @@ public static class Binding_Http_NetHttpsBindingTests
 {
     [Fact]
     [OuterLoop]
+    [ActiveIssue(1123, PlatformID.AnyUnix)]
     public static void DefaultCtor_NetHttps_Echo_RoundTrips_String()
     {
         string testString = "Hello";
@@ -78,6 +79,7 @@ public static class Binding_Http_NetHttpsBindingTests
 
     [Fact]
     [OuterLoop]
+    [ActiveIssue(1123, PlatformID.AnyUnix)]
     public static void NonDefaultCtor_NetHttps_Echo_RoundTrips_String()
     {
         string testString = "Hello";

--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/ChannelLayer/DuplexChannelShapeTests.4.0.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/ChannelLayer/DuplexChannelShapeTests.4.0.0.cs
@@ -136,6 +136,7 @@ public partial class DuplexChannelShapeTests : ConditionalWcfTest
 
     [Fact]
     [OuterLoop]
+    [ActiveIssue(1123, PlatformID.AnyUnix)]
     public static void IRequestChannel_Https_NetHttpsBinding()
     {
         IChannelFactory<IRequestChannel> factory = null;


### PR DESCRIPTION
* Some new tests added recently fail for known Issue 1123 on Linux platforms.
* The correct fix is to create a conditional fact that skips the test based on an invalid environment setup.
* The setup that is causing the failure is currently still under investigation.