### PR TITLE
Make OperationFault public so that we are able to reflect it

### DIFF
--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/MessageFault.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/MessageFault.cs
@@ -396,7 +396,7 @@ namespace System.ServiceModel.Channels
         }
     }
 
-    internal class XmlObjectSerializerFault : MessageFault
+    public class XmlObjectSerializerFault : MessageFault
     {
         private FaultCode _code;
         private FaultReason _reason;

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Dispatcher/FaultFormatter.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Dispatcher/FaultFormatter.cs
@@ -11,7 +11,7 @@ using System.Runtime;
 
 namespace System.ServiceModel.Dispatcher
 {
-    internal class FaultFormatter : IClientFaultFormatter, IDispatchFaultFormatter
+    public class FaultFormatter : IClientFaultFormatter, IDispatchFaultFormatter
     {
         private FaultContractInfo[] _faultContractInfos;
 
@@ -193,7 +193,7 @@ namespace System.ServiceModel.Dispatcher
             return (MessageFault)Activator.CreateInstance(operationFaultType, serializer, faultException);
         }
 
-        internal class OperationFault<T> : XmlObjectSerializerFault
+        public class OperationFault<T> : XmlObjectSerializerFault
         {
             public OperationFault(XmlObjectSerializer serializer, FaultException<T> faultException) :
                 base(faultException.Code, faultException.Reason,

--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/ExpectedExceptions/ExpectedExceptionTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/ExpectedExceptions/ExpectedExceptionTests.cs
@@ -188,9 +188,6 @@ public partial class ExpectedExceptionTests : ConditionalWcfTest
     }
 
     [Fact]
-#if FEATURE_NETNATIVE
-    [ActiveIssue(769)] // Blocked from working in NET Native due to a toolchain issue.
-#endif
     [OuterLoop]
     public static void DuplexCallback_Throws_FaultException_DirectThrow()
     {
@@ -236,9 +233,6 @@ public partial class ExpectedExceptionTests : ConditionalWcfTest
     }
 
     [Fact]
-#if FEATURE_NETNATIVE
-    [ActiveIssue(769)] // Blocked from working in NET Native due to a toolchain issue.
-#endif
     [OuterLoop]
     public static void DuplexCallback_Throws_FaultException_ReturnsFaultedTask()
     {


### PR DESCRIPTION
* We are currently unable to reflect OperationFault. The least risk option is
to make it public.
* In order to make it public, we need to make FaultFormatter and XmlObjectSerializerFault
public as well.

Fix #769 

I have verified the failing tests passed with this fix.