### PR TITLE
Reset original operation context before causing task continuation to run

### DIFF
--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/ServiceChannelProxy.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/ServiceChannelProxy.cs
@@ -179,15 +179,13 @@ namespace System.ServiceModel.Channels
                     try
                     {
                         object result = channel.EndCall(operation.Action, Array.Empty<object>(), asyncResult);
+                        OperationContext.Current = originalOperationContext;
                         tcsp.TrySetResult(result);
                     }
                     catch (Exception e)
                     {
-                        tcsp.TrySetException(e);
-                    }
-                    finally
-                    {
                         OperationContext.Current = originalOperationContext;
+                        tcsp.TrySetException(e);
                     }
                 };
 
@@ -221,15 +219,13 @@ namespace System.ServiceModel.Channels
                     try
                     {
                         channel.EndCall(operation.Action, Array.Empty<object>(), asyncResult);
+                        OperationContext.Current = originalOperationContext;
                         tcs.TrySetResult(null);
                     }
                     catch (Exception e)
                     {
-                        tcs.TrySetException(e);
-                    }
-                    finally
-                    {
                         OperationContext.Current = originalOperationContext;
+                        tcs.TrySetException(e);
                     }
                 };
 


### PR DESCRIPTION
Addresses the problem with OperationContext.Current being set to the wrong thing in #1137. This doesn't fix the incorrect exception that is thrown.