### PR TITLE
Provide correct InvalidOperationException in async duplex deadlock sc…

### DIFF
--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/ServiceChannel.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/ServiceChannel.cs
@@ -556,8 +556,7 @@ namespace System.ServiceModel.Channels
                 {
                     if ((context != null) && (!context.IsUserContext) && (context.InternalServiceChannel == this))
                     {
-                        throw ExceptionHelper.PlatformNotSupported();
-                        //throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.SFxCallbackRequestReplyInOrder1, typeof(CallbackBehaviorAttribute).Name)));
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.SFxCallbackRequestReplyInOrder1, typeof(CallbackBehaviorAttribute).Name)));
                     }
                 }
             }

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/ServiceChannelProxy.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/ServiceChannelProxy.cs
@@ -179,15 +179,13 @@ namespace System.ServiceModel.Channels
                     try
                     {
                         object result = channel.EndCall(operation.Action, Array.Empty<object>(), asyncResult);
+                        OperationContext.Current = originalOperationContext;
                         tcsp.TrySetResult(result);
                     }
                     catch (Exception e)
                     {
-                        tcsp.TrySetException(e);
-                    }
-                    finally
-                    {
                         OperationContext.Current = originalOperationContext;
+                        tcsp.TrySetException(e);
                     }
                 };
 
@@ -221,15 +219,13 @@ namespace System.ServiceModel.Channels
                     try
                     {
                         channel.EndCall(operation.Action, Array.Empty<object>(), asyncResult);
+                        OperationContext.Current = originalOperationContext;
                         tcs.TrySetResult(null);
                     }
                     catch (Exception e)
                     {
-                        tcs.TrySetException(e);
-                    }
-                    finally
-                    {
                         OperationContext.Current = originalOperationContext;
+                        tcs.TrySetException(e);
                     }
                 };
 
@@ -836,3 +832,4 @@ namespace System.ServiceModel.Channels
         #endregion // Channel interfaces
     }
 }
+

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/ServiceChannelProxy.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/ServiceChannelProxy.cs
@@ -207,7 +207,9 @@ namespace System.ServiceModel.Channels
 
             private static Task CreateTask(ServiceChannel channel, ProxyOperationRuntime operation, object[] inputParameters)
             {
-                TaskCompletionSource<object> tcs = new TaskCompletionSource<object>();
+                // The Task we create from this must not permit child Tasks to attach to it
+                // because OperationContext is carried in Thread local storage.
+                TaskCompletionSource<object> tcs = new TaskCompletionSource<object>(TaskCreationOptions.DenyChildAttach);
                 bool completedCallback = false;
 
                 Action<IAsyncResult> endCallDelegate = (asyncResult) =>

--- a/src/System.Private.ServiceModel/tests/Common/Scenarios/ScenarioTestHelpers.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Scenarios/ScenarioTestHelpers.cs
@@ -9,6 +9,7 @@ using System.ServiceModel.Channels;
 using System.Text;
 
 using Infrastructure.Common;
+using System.IO;
 
 public static class ScenarioTestHelpers
 {
@@ -242,6 +243,22 @@ public static class ScenarioTestHelpers
         }
 
         return new string(chars, 0, chars.Length);
+    }
+
+    public static string StreamToString(Stream stream)
+    {
+        var reader = new StreamReader(stream, Encoding.UTF8);
+        return reader.ReadToEnd();
+    }
+
+    public static Stream StringToStream(string str)
+    {
+        var ms = new MemoryStream();
+        var sw = new StreamWriter(ms, Encoding.UTF8);
+        sw.Write(str);
+        sw.Flush();
+        ms.Position = 0;
+        return ms;
     }
 }
 

--- a/src/System.Private.ServiceModel/tests/Common/Scenarios/ServiceInterfaces.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Scenarios/ServiceInterfaces.cs
@@ -382,6 +382,12 @@ public interface IWSDuplexService
     [OperationContract]
     string GetExceptionString();
 
+    [OperationContractAttribute(Action = "http://tempuri.org/IWSDuplexService/EchoStream", ReplyAction = "http://tempuri.org/IWSDuplexService/EchoStreamResponse")]
+    Stream EchoStream(Stream stream);
+
+    [OperationContractAttribute(Action = "http://tempuri.org/IWSDuplexService/EchoStream", ReplyAction = "http://tempuri.org/IWSDuplexService/EchoStreamResponse")]
+    Task<Stream> EchoStreamAsync(Stream stream);
+
     [OperationContract]
     void UploadData(string data);
 
@@ -417,6 +423,9 @@ public interface IWSDuplexService
 
 public interface IPushCallback
 {
+    [OperationContract]
+    Stream EchoStream(Stream stream);
+
     [OperationContract(IsOneWay = true)]
     void ReceiveData(string data);
 

--- a/src/System.Private.ServiceModel/tools/IISHostedWcfService/App_code/IPushCallback.cs
+++ b/src/System.Private.ServiceModel/tools/IISHostedWcfService/App_code/IPushCallback.cs
@@ -6,11 +6,15 @@
 using System.Collections.Generic;
 using System.IO;
 using System.ServiceModel;
+using System.Threading.Tasks;
 
 namespace WcfService
 {
     public interface IPushCallback
     {
+        [OperationContract]
+        Stream EchoStream(Stream stream);
+
         [OperationContract(IsOneWay = true)]
         void ReceiveData(string data);
 

--- a/src/System.Private.ServiceModel/tools/IISHostedWcfService/App_code/IWSDuplexService.cs
+++ b/src/System.Private.ServiceModel/tools/IISHostedWcfService/App_code/IWSDuplexService.cs
@@ -16,6 +16,9 @@ namespace WcfService
         string GetExceptionString();
 
         [OperationContract]
+        Stream EchoStream(Stream stream);
+
+        [OperationContract]
         void UploadData(string data);
 
         [OperationContract]

--- a/src/System.Private.ServiceModel/tools/IISHostedWcfService/App_code/WSDuplexService.cs
+++ b/src/System.Private.ServiceModel/tools/IISHostedWcfService/App_code/WSDuplexService.cs
@@ -29,6 +29,12 @@ namespace WcfService
 
         private static FlowControlledStream s_localStream;
 
+        public Stream EchoStream(Stream stream)
+        {
+            IPushCallback pushCallbackChannel = OperationContext.Current.GetCallbackChannel<IPushCallback>();
+            return pushCallbackChannel.EchoStream(stream);
+        }
+
         public void UploadData(string data)
         {
             if (data.Contains(s_contentToReplace) || data.Contains(s_replacedContent) || data.Contains(s_responseReplaceThisContent))


### PR DESCRIPTION
Provide correct InvalidOoperationException in async duplex deadlock scenario.

Issue #1137 exposed the use of an incorrect exception when ServiceModel
detects a potential deadlock in asynchronous operations.  This PR corrects
the exception to match the full framework and adds scenario tests that
demonstrate both success path as well as this deadlock path.