### PR TITLE
Verify WebSockets are actually used when not using a callback.

### DIFF
--- a/src/System.Private.ServiceModel/tests/Common/Scenarios/Endpoints.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Scenarios/Endpoints.cs
@@ -108,6 +108,11 @@ public static partial class Endpoints
     {
         get { return GetEndpointAddress("WebSocketHttpDuplexBinaryBuffered.svc//WebSocketHttpDuplexBinaryBufferedResource", protocol: "ws"); }
     }
+
+    public static string WebSocketHttpVerifyWebSocketsUsed_Address
+    {
+        get { return GetEndpointAddress("WebSocketHttpVerifyWebSocketsUsed.svc//WebSocketHttpVerifyWebSocketsUsed", protocol: "ws"); }
+    }
     #endregion WebSocket Addresses
 
     #region Service Contract Addresses

--- a/src/System.Private.ServiceModel/tests/Common/Scenarios/ServiceInterfaces.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Scenarios/ServiceInterfaces.cs
@@ -528,3 +528,10 @@ public interface IWcfChannelExtensibilityContract
     [OperationContract(IsOneWay = true)]
     void ReportWindSpeed(int speed);
 }
+
+[ServiceContract]
+public interface IVerifyWebSockets
+{
+    [OperationContract()]
+    bool ValidateWebSocketsUsed();
+}

--- a/src/System.Private.ServiceModel/tools/IISHostedWcfService/App_code/IVerifyWebSockets.cs
+++ b/src/System.Private.ServiceModel/tools/IISHostedWcfService/App_code/IVerifyWebSockets.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+
+using System;
+using System.ServiceModel;
+using System.ServiceModel.Channels;
+
+namespace WcfService
+{
+    [ServiceContract(SessionMode = SessionMode.Required)]
+    public interface IVerifyWebSockets
+    {
+        // This operation will only get called when using WebSockets and CreateNotificationOnConnection is set to true on the binding WebSocketSettings
+        [OperationContract(Action = WebSocketTransportSettings.ConnectionOpenedAction, IsOneWay = true, IsInitiating = true)]
+        void ForceWebSocketsUse();
+
+        [OperationContract()]
+        bool ValidateWebSocketsUsed();
+    }
+}

--- a/src/System.Private.ServiceModel/tools/IISHostedWcfService/App_code/VerifyWebSockets.cs
+++ b/src/System.Private.ServiceModel/tools/IISHostedWcfService/App_code/VerifyWebSockets.cs
@@ -1,0 +1,28 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+
+using System;
+using System.ServiceModel;
+
+namespace WcfService
+{
+    [ServiceBehavior(InstanceContextMode = InstanceContextMode.PerSession, AddressFilterMode = AddressFilterMode.Any)]
+    public class VerifyWebSockets : IVerifyWebSockets
+    {
+        private bool successMessage;
+
+        // This operation cannot return anything so in order to validate that it was called set the InstanceContextMode
+        //  to PerSession and set a variable that we can get with a call to the ValidateWebSocketsUsed operation.
+        public void ForceWebSocketsUse()
+        {
+            successMessage = true;
+        }
+
+        public bool ValidateWebSocketsUsed()
+        {
+            return successMessage;
+        }
+    }
+}

--- a/src/System.Private.ServiceModel/tools/IISHostedWcfService/App_code/testhosts/WebSocketTestServiceHosts.cs
+++ b/src/System.Private.ServiceModel/tools/IISHostedWcfService/App_code/testhosts/WebSocketTestServiceHosts.cs
@@ -489,4 +489,32 @@ namespace WcfService
         {
         }
     }
+
+    public class WebSocketHttpVerifyWebSocketsUsedTestServiceHostFactory : ServiceHostFactory
+    {
+        protected override ServiceHost CreateServiceHost(Type serviceType, Uri[] baseAddresses)
+        {
+            WebSocketHttpVerifyWebSocketsUsedTestServiceHost serviceHost = new WebSocketHttpVerifyWebSocketsUsedTestServiceHost(serviceType, baseAddresses);
+            return serviceHost;
+        }
+    }
+
+    public class WebSocketHttpVerifyWebSocketsUsedTestServiceHost : TestServiceHostBase<IVerifyWebSockets>
+    {
+        protected override string Address { get { return "WebSocketHttpVerifyWebSocketsUsed"; } }
+
+        protected override Binding GetBinding()
+        {
+            NetHttpBinding binding = new NetHttpBinding();
+            binding.WebSocketSettings.TransportUsage = WebSocketTransportUsage.Always;
+            // This setting lights up the code path that calls the operation attributed with ConnectionOpenedAction
+            binding.WebSocketSettings.CreateNotificationOnConnection = true;
+            return binding;
+        }
+
+        public WebSocketHttpVerifyWebSocketsUsedTestServiceHost(Type serviceType, params Uri[] baseAddresses)
+            : base(serviceType, baseAddresses)
+        {
+        }
+    }
 }

--- a/src/System.Private.ServiceModel/tools/IISHostedWcfService/Web.config
+++ b/src/System.Private.ServiceModel/tools/IISHostedWcfService/Web.config
@@ -87,6 +87,7 @@
         <add factory="WcfService.WebSocketHttpsRequestReplyTextBufferedTestServiceHostFactory" service="WcfService.WSRequestReplyService" relativeAddress="~\WebSocketHttpsRequestReplyTextBuffered.svc" />
         <add factory="WcfService.WebSocketHttpsDuplexBinaryBufferedTestServiceHostFactory" service="WcfService.WSDuplexService" relativeAddress="~\WebSocketHttpsDuplexBinaryBuffered.svc" />
         <add factory="WcfService.WebSocketHttpsDuplexTextBufferedTestServiceHostFactory" service="WcfService.WSDuplexService" relativeAddress="~\WebSocketHttpsDuplexTextBuffered.svc" />
+        <add factory="WcfService.WebSocketHttpVerifyWebSocketsUsedTestServiceHostFactory" service="WcfService.VerifyWebSockets" relativeAddress="~\WebSocketHttpVerifyWebSocketsUsed.svc" />
       </serviceActivations>
     </serviceHostingEnvironment>
   </system.serviceModel>

--- a/src/System.Private.ServiceModel/tools/SelfHostedWcfService/Program.cs
+++ b/src/System.Private.ServiceModel/tools/SelfHostedWcfService/Program.cs
@@ -298,6 +298,10 @@ namespace SelfHostedWCFService
             ChannelExtensibilityServiceHost channelExtensiblityTestServiceHostServiceHost = new ChannelExtensibilityServiceHost(typeof(WcfService.WcfChannelExtensiblityService), channelExtensibilityTestServiceHostbaseAddress);
             channelExtensiblityTestServiceHostServiceHost.Open();
 
+            Uri[] webSocketHttpVerifyWebSocketsUsedTestServiceHostbaseAddress = new Uri[] { new Uri(string.Format("{0}/WebSocketHttpVerifyWebSocketsUsed.svc", websocketBaseAddress)) };
+            WebSocketHttpVerifyWebSocketsUsedTestServiceHost webSocketHttpVerifyWebSocketsUsedTestServiceHostServiceHost = new WebSocketHttpVerifyWebSocketsUsedTestServiceHost(typeof(WcfService.VerifyWebSockets), webSocketHttpVerifyWebSocketsUsedTestServiceHostbaseAddress);
+            webSocketHttpVerifyWebSocketsUsedTestServiceHostServiceHost.Open();
+
             //Start the crlUrl service last as the client use it to ensure all services have been started
             Uri crlUrl = new Uri(string.Format("http://localhost/CrlService.svc", s_httpPort));
             WebServiceHost host = new WebServiceHost(typeof(CrlService), crlUrl);


### PR DESCRIPTION
* Verify WebSockets are actually being used when WebSocketTransportUsage is set to Always.
* Wcf automatically uses WebSockets when a callback is used, but this test verifies that it still uses
  WebSockets when not using a callback.
* Fixes Issue #486