### PR TITLE
Create security subfolders in IIS host server

### DIFF
--- a/src/System.Private.ServiceModel/tests/Common/Infrastructure/src/ConditionalWcfTest.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Infrastructure/src/ConditionalWcfTest.cs
@@ -153,10 +153,8 @@ namespace Infrastructure.Common
         // Returns 'true' if the server is configured to accept client certificates.
         public static bool Server_Accepts_Certificates()
         {
-            // Temporarily use the simple heuristic that if we are running the services locally, it does.
-            // Refactor this after integration to address https://github.com/dotnet/wcf/issues/1024 
-            return GetConditionValue(nameof(Server_Accepts_Certificates),
-                                     Server_Is_LocalHost);
+            //Both IIS hosted and self hosted servers accept server certificate now
+            return true;
         }
 
         // Returns 'true' if the server is configured to allow Basic Authentication.

--- a/src/System.Private.ServiceModel/tests/Common/Scenarios/Endpoints.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Scenarios/Endpoints.cs
@@ -168,7 +168,7 @@ public static partial class Endpoints
     {
         get
         {
-            return GetEndpointAddress("BasicAuth.svc//https-basic", protocol: "https");
+            return GetEndpointAddress("BasicAuthentication/BasicAuth.svc/https-basic", protocol: "https");
         }
     }
 
@@ -176,7 +176,7 @@ public static partial class Endpoints
     {
         get
         {
-            return GetEndpointAddress("HttpsDigest.svc//https-digest", protocol: "https");
+            return GetEndpointAddress("DigestAuthentication/HttpsDigest.svc/https-digest", protocol: "https");
         }
     }
 
@@ -192,7 +192,7 @@ public static partial class Endpoints
     {
         get
         {
-            return GetEndpointAddress("HttpsNtlm.svc//https-ntlm", protocol: "https");
+            return GetEndpointAddress("WindowAuthenticationNtlm/HttpsNtlm.svc//https-ntlm", protocol: "https");
         }
     }
 
@@ -200,7 +200,7 @@ public static partial class Endpoints
     {
         get
         {
-            return GetEndpointAddress("HttpsWindows.svc//https-windows", protocol: "https");
+            return GetEndpointAddress("WindowAuthenticationNegotiate/HttpsWindows.svc/https-windows", protocol: "https");
         }
     }
 
@@ -208,7 +208,7 @@ public static partial class Endpoints
     {
         get
         {
-            return GetEndpointAddress("HttpsClientCertificate.svc//https-client-certificate", protocol: "https");
+            return GetEndpointAddress("ClientCertificateAccepted/HttpsClientCertificate.svc/https-client-certificate", protocol: "https");
         }
     }
 
@@ -216,7 +216,7 @@ public static partial class Endpoints
     {
         get
         {
-            return GetEndpointAddress("HttpWindows.svc//http-windows");
+            return GetEndpointAddress("WindowAuthenticationNegotiate/HttpWindows.svc/http-windows");
         }
     }
 
@@ -476,7 +476,7 @@ public static partial class Endpoints
     {
         get
         {
-            return GetEndpointAddress("TcpTransportSecurityStreamed.svc//tcp-transport-security-streamed", protocol: "net.tcp");
+            return GetEndpointAddress("WindowAuthenticationNegotiate/TcpTransportSecurityStreamed.svc/tcp-transport-security-streamed", protocol: "net.tcp");
         }
     }
 

--- a/src/System.Private.ServiceModel/tests/Scenarios/Binding/Tcp/NetTcpBindingTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Binding/Tcp/NetTcpBindingTests.cs
@@ -12,7 +12,7 @@ public partial class Binding_Tcp_NetTcpBindingTests : ConditionalWcfTest
     // Default settings are:
     //                         - SecurityMode = Transport
     //                         - ClientCredentialType = Windows
-    [ConditionalFact(nameof(Root_Certificate_Installed), nameof(Server_Accepts_Certificates))]
+    [ConditionalFact(nameof(Root_Certificate_Installed), nameof(Windows_Authentication_Available))]
 #if !FEATURE_NETNATIVE
     [ActiveIssue(945, PlatformID.AnyUnix)] // NegotiateStream works on Windows and Linux, but we have not yet automated ambient credential configuration in Linux
 #else
@@ -52,7 +52,7 @@ public partial class Binding_Tcp_NetTcpBindingTests : ConditionalWcfTest
     // Simple echo of a string using NetTcpBinding on both client and server with SecurityMode=Transport
     // By default ClientCredentialType will be 'Windows'
     // SecurityMode is Transport by default with NetTcpBinding, this test explicitly sets it.
-    [ConditionalFact(nameof(Root_Certificate_Installed), nameof(Server_Accepts_Certificates))]
+    [ConditionalFact(nameof(Root_Certificate_Installed), nameof(Windows_Authentication_Available))]
 #if !FEATURE_NETNATIVE
     [ActiveIssue(945, PlatformID.AnyUnix)] // NegotiateStream works on Windows and Linux, but we have not yet automated ambient credential configuration in Linux
 #else

--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Https/ClientCredentialTypeTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Https/ClientCredentialTypeTests.cs
@@ -34,7 +34,7 @@ public class Https_ClientCredentialTypeTests : ConditionalWcfTest
 
             ChannelFactory<IWcfCustomUserNameService> factory = new ChannelFactory<IWcfCustomUserNameService>(basicHttpBinding, new EndpointAddress(Endpoints.Https_BasicAuth_Address));
             factory.Credentials.UserName.UserName = "test1";
-            factory.Credentials.UserName.Password = "test1pwd";
+            factory.Credentials.UserName.Password = "Mytestpwd1";
 
             IWcfCustomUserNameService serviceProxy = factory.CreateChannel();
 
@@ -124,6 +124,7 @@ public class Https_ClientCredentialTypeTests : ConditionalWcfTest
         {
             BasicHttpBinding basicHttpBinding = new BasicHttpBinding(BasicHttpSecurityMode.Transport);
             basicHttpBinding.Security.Transport.ClientCredentialType = HttpClientCredentialType.Digest;
+
             Action<ChannelFactory> credentials = (factory) =>
             {
                 factory.Credentials.HttpDigest.ClientCredential.UserName = s_username;

--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Https/HttpsTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Https/HttpsTests.cs
@@ -56,7 +56,8 @@ public class HttpsTests : ConditionalWcfTest
     }
 
     // Client and Server bindings setup exactly the same using default settings.
-    [ConditionalFact(nameof(Root_Certificate_Installed), nameof(Server_Accepts_Certificates))]
+    [ConditionalFact(nameof(Root_Certificate_Installed))]
+    [ActiveIssue(1123, PlatformID.AnyUnix)]
     [OuterLoop]
     public static void SameBinding_DefaultSettings_EchoString()
     {

--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Negotiate/NegotiateStream_Http_Tests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Negotiate/NegotiateStream_Http_Tests.cs
@@ -69,6 +69,8 @@ public class NegotiateStream_Http_Tests : ConditionalWcfTest
         {
             // *** SETUP *** \\
             BasicHttpBinding binding = new BasicHttpBinding(BasicHttpSecurityMode.Transport);
+            binding.Security.Transport.ClientCredentialType = HttpClientCredentialType.Windows;
+
             factory = new ChannelFactory<IWcfService>(
                 binding,
                 new EndpointAddress(Endpoints.Https_WindowsAuth_Address));
@@ -104,6 +106,7 @@ public class NegotiateStream_Http_Tests : ConditionalWcfTest
         {
             // *** SETUP *** \\
             BasicHttpBinding binding = new BasicHttpBinding(BasicHttpSecurityMode.Transport);
+            binding.Security.Transport.ClientCredentialType = HttpClientCredentialType.Windows;
             factory = new ChannelFactory<IWcfService>(
                 binding,
                 new EndpointAddress(Endpoints.Https_WindowsAuth_Address));
@@ -144,6 +147,7 @@ public class NegotiateStream_Http_Tests : ConditionalWcfTest
         {
             // *** SETUP *** \\
             BasicHttpBinding binding = new BasicHttpBinding(BasicHttpSecurityMode.Transport);
+            binding.Security.Transport.ClientCredentialType = HttpClientCredentialType.Windows;
             factory = new ChannelFactory<IWcfService>(
                 binding,
                 new EndpointAddress(
@@ -183,6 +187,7 @@ public class NegotiateStream_Http_Tests : ConditionalWcfTest
         {
             // *** SETUP *** \\
             BasicHttpBinding binding = new BasicHttpBinding(BasicHttpSecurityMode.Transport);
+            binding.Security.Transport.ClientCredentialType = HttpClientCredentialType.Windows;
             factory = new ChannelFactory<IWcfService>(
                 binding,
                 new EndpointAddress(
@@ -222,6 +227,7 @@ public class NegotiateStream_Http_Tests : ConditionalWcfTest
         {
             // *** SETUP *** \\
             BasicHttpBinding binding = new BasicHttpBinding(BasicHttpSecurityMode.Transport);
+            binding.Security.Transport.ClientCredentialType = HttpClientCredentialType.Windows;
             factory = new ChannelFactory<IWcfService>(
                 binding,
                 new EndpointAddress(
@@ -265,6 +271,7 @@ public class NegotiateStream_Http_Tests : ConditionalWcfTest
         {
             // *** SETUP *** \\
             BasicHttpBinding binding = new BasicHttpBinding(BasicHttpSecurityMode.Transport);
+            binding.Security.Transport.ClientCredentialType = HttpClientCredentialType.Windows;
             factory = new ChannelFactory<IWcfService>(
                 binding,
                 new EndpointAddress(

--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Negotiate/NegotiateStream_Tcp_Tests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Negotiate/NegotiateStream_Tcp_Tests.cs
@@ -11,7 +11,7 @@ using System.ServiceModel.Channels;
 using System.ServiceModel.Security;
 using Xunit;
 
-public static class NegotiateStream_Tcp_Tests
+public class NegotiateStream_Tcp_Tests: ConditionalWcfTest
 {
     // The tests are as follows:
     //
@@ -56,8 +56,7 @@ public static class NegotiateStream_Tcp_Tests
 
     // These tests are used for testing NegotiateStream (SecurityMode.Transport) 
 
-    [Fact]
-    [ActiveIssue(1046)]
+    [ConditionalFact(nameof(Windows_Authentication_Available))]
     [ActiveIssue(851, PlatformID.AnyUnix)]
     [OuterLoop]
     public static void NegotiateStream_Tcp_AmbientCredentials()

--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Tcp/StreamingTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Tcp/StreamingTests.cs
@@ -17,7 +17,7 @@ using Xunit;
 
 public class StreamingTests : ConditionalWcfTest
 {
-    [ConditionalFact(nameof(Root_Certificate_Installed), nameof(Client_Certificate_Installed), nameof(Server_Accepts_Certificates))]
+    [ConditionalFact(nameof(Root_Certificate_Installed), nameof(Client_Certificate_Installed), nameof(Windows_Authentication_Available))]
     [OuterLoop]
 #if !FEATURE_NETNATIVE
     [ActiveIssue(851, PlatformID.AnyUnix)] // NegotiateStream works on Windows but limitations related to credentials means automated tests can't work on Unix at this point.
@@ -58,7 +58,7 @@ public class StreamingTests : ConditionalWcfTest
         }
     }
 
-    [ConditionalFact(nameof(Root_Certificate_Installed), nameof(Client_Certificate_Installed), nameof(Server_Accepts_Certificates))]
+    [ConditionalFact(nameof(Root_Certificate_Installed), nameof(Client_Certificate_Installed), nameof(Windows_Authentication_Available))]
     [OuterLoop]
 #if !FEATURE_NETNATIVE
     [ActiveIssue(851, PlatformID.AnyUnix)] // NegotiateStream works on Windows but limitations related to credentials means automated tests can't work on Unix at this point.
@@ -98,7 +98,7 @@ public class StreamingTests : ConditionalWcfTest
         }
     }
 
-    [ConditionalFact(nameof(Root_Certificate_Installed), nameof(Client_Certificate_Installed), nameof(Server_Accepts_Certificates))]
+    [ConditionalFact(nameof(Root_Certificate_Installed), nameof(Client_Certificate_Installed), nameof(Windows_Authentication_Available))]
     [OuterLoop]
 #if !FEATURE_NETNATIVE
     [ActiveIssue(851, PlatformID.AnyUnix)] // NegotiateStream works on Windows but limitations related to credentials means automated tests can't work on Unix at this point.
@@ -140,7 +140,7 @@ public class StreamingTests : ConditionalWcfTest
         }
     }
 
-    [ConditionalFact(nameof(Root_Certificate_Installed), nameof(Client_Certificate_Installed), nameof(Server_Accepts_Certificates))]
+    [ConditionalFact(nameof(Root_Certificate_Installed), nameof(Client_Certificate_Installed), nameof(Windows_Authentication_Available))]
     [OuterLoop]
 #if !FEATURE_NETNATIVE
     [ActiveIssue(851, PlatformID.AnyUnix)] // NegotiateStream works on Windows but limitations related to credentials means automated tests can't work on Unix at this point.
@@ -198,7 +198,7 @@ public class StreamingTests : ConditionalWcfTest
         }
     }
 
-    [ConditionalFact(nameof(Root_Certificate_Installed), nameof(Client_Certificate_Installed), nameof(Server_Accepts_Certificates))]
+    [ConditionalFact(nameof(Root_Certificate_Installed), nameof(Client_Certificate_Installed), nameof(Windows_Authentication_Available))]
     [OuterLoop]
 #if !FEATURE_NETNATIVE
     [ActiveIssue(851, PlatformID.AnyUnix)] // NegotiateStream works on Windows but limitations related to credentials means automated tests can't work on Unix at this point.
@@ -241,7 +241,7 @@ public class StreamingTests : ConditionalWcfTest
         }
     }
 
-    [ConditionalFact(nameof(Root_Certificate_Installed), nameof(Client_Certificate_Installed), nameof(Server_Accepts_Certificates))]
+    [ConditionalFact(nameof(Root_Certificate_Installed), nameof(Client_Certificate_Installed), nameof(Windows_Authentication_Available))]
     [OuterLoop]
 #if !FEATURE_NETNATIVE
     [ActiveIssue(851, PlatformID.AnyUnix)] // NegotiateStream works on Windows but limitations related to credentials means automated tests can't work on Unix at this point.
@@ -284,7 +284,7 @@ public class StreamingTests : ConditionalWcfTest
         }
     }
 
-    [ConditionalFact(nameof(Root_Certificate_Installed), nameof(Client_Certificate_Installed), nameof(Server_Accepts_Certificates))]
+    [ConditionalFact(nameof(Root_Certificate_Installed), nameof(Client_Certificate_Installed), nameof(Windows_Authentication_Available))]
     [OuterLoop]
 #if !FEATURE_NETNATIVE
     [ActiveIssue(851, PlatformID.AnyUnix)] // NegotiateStream works on Windows but limitations related to credentials means automated tests can't work on Unix at this point.
@@ -327,7 +327,7 @@ public class StreamingTests : ConditionalWcfTest
         }
     }
 
-    [ConditionalFact(nameof(Root_Certificate_Installed), nameof(Client_Certificate_Installed), nameof(Server_Accepts_Certificates))]
+    [ConditionalFact(nameof(Root_Certificate_Installed), nameof(Client_Certificate_Installed), nameof(Windows_Authentication_Available))]
     [OuterLoop]
 #if !FEATURE_NETNATIVE
     [ActiveIssue(851, PlatformID.AnyUnix)] // NegotiateStream works on Windows but limitations related to credentials means automated tests can't work on Unix at this point.
@@ -346,7 +346,7 @@ public class StreamingTests : ConditionalWcfTest
         Assert.True(success, "Test Scenario: NetTcp_TransportSecurity_String_Streamed_RoundTrips_WithSingleThreadedSyncContext timed-out.");
     }
 
-    [ConditionalFact(nameof(Root_Certificate_Installed), nameof(Client_Certificate_Installed), nameof(Server_Accepts_Certificates))]
+    [ConditionalFact(nameof(Root_Certificate_Installed), nameof(Client_Certificate_Installed), nameof(Windows_Authentication_Available))]
     [OuterLoop]
 #if !FEATURE_NETNATIVE
     [ActiveIssue(851, PlatformID.AnyUnix)] // NegotiateStream works on Windows but limitations related to credentials means automated tests can't work on Unix at this point.

--- a/src/System.Private.ServiceModel/tools/IISHostedWcfService/App_code/WcfUserNameService.cs
+++ b/src/System.Private.ServiceModel/tools/IISHostedWcfService/App_code/WcfUserNameService.cs
@@ -20,7 +20,7 @@ namespace WcfService
                 throw new ArgumentNullException();
             }
 
-            if (!(userName == "test1" && password == "test1pwd") && !(userName == "test2" && password == "test2pwd"))
+            if (!(userName == "test1" && password == "Mytestpwd1") && !(userName == "test2" && password == "test2pwd"))
             {
                 throw new SecurityTokenException("Unknown Username or Incorrect Password");
             }

--- a/src/System.Private.ServiceModel/tools/IISHostedWcfService/App_code/testhosts/TcpTransportSecurityStreamedTestServiceHost.cs
+++ b/src/System.Private.ServiceModel/tools/IISHostedWcfService/App_code/testhosts/TcpTransportSecurityStreamedTestServiceHost.cs
@@ -14,7 +14,7 @@ namespace WcfService
     {
         protected override ServiceHost CreateServiceHost(Type serviceType, Uri[] baseAddresses)
         {
-            TcpTransportSecuritySslCustomCertValidationTestServiceHost serviceHost = new TcpTransportSecuritySslCustomCertValidationTestServiceHost(serviceType, baseAddresses);
+            TcpTransportSecurityStreamedTestServiceHost serviceHost = new TcpTransportSecurityStreamedTestServiceHost(serviceType, baseAddresses);
             return serviceHost;
         }
     }

--- a/src/System.Private.ServiceModel/tools/IISHostedWcfService/BasicAuthentication/web.config
+++ b/src/System.Private.ServiceModel/tools/IISHostedWcfService/BasicAuthentication/web.config
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+ <!--Copyright (c) Microsoft Corporation.  All Rights Reserved.-->
+<configuration>
+
+  <system.webServer>
+        <security>
+            <authentication>
+                <basicAuthentication enabled="true" realm="" defaultLogonDomain="" />
+                <anonymousAuthentication enabled="false" />
+            </authentication>
+        </security>
+  </system.webServer>
+</configuration>

--- a/src/System.Private.ServiceModel/tools/IISHostedWcfService/ClientCertificateAccepted/web.config
+++ b/src/System.Private.ServiceModel/tools/IISHostedWcfService/ClientCertificateAccepted/web.config
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+ <!--Copyright (c) Microsoft Corporation.  All Rights Reserved.-->
+<configuration>
+
+  <system.webServer>
+        <security>
+            <access sslFlags="SslNegotiateCert" />
+        </security>
+  </system.webServer>
+</configuration>

--- a/src/System.Private.ServiceModel/tools/IISHostedWcfService/DigestAuthentication/web.config
+++ b/src/System.Private.ServiceModel/tools/IISHostedWcfService/DigestAuthentication/web.config
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+ <!--Copyright (c) Microsoft Corporation.  All Rights Reserved.-->
+<configuration>
+
+  <system.webServer>
+        <security>
+            <authentication>
+                <digestAuthentication enabled="true" realm="Digest" />
+                <anonymousAuthentication enabled="false" />
+            </authentication>
+        </security>
+  </system.webServer>
+</configuration>

--- a/src/System.Private.ServiceModel/tools/IISHostedWcfService/Web.config
+++ b/src/System.Private.ServiceModel/tools/IISHostedWcfService/Web.config
@@ -23,7 +23,7 @@
       <serviceActivations>
         <add factory="WcfService.CrlTestServiceHostFactory" service="WcfService.CrlService" relativeAddress="~\CrlService.svc" />
         <add factory="WcfService.UtilTestServiceHostFactory" service="WcfService.Util" relativeAddress="~\Util.svc" />
-        <add factory="WcfService.BasicAuthTestServiceHostFactory" service="WcfService.WcfUserNameService" relativeAddress="~\BasicAuth.svc" />
+        <add factory="WcfService.BasicAuthTestServiceHostFactory" service="WcfService.WcfUserNameService" relativeAddress="~\BasicAuthentication\BasicAuth.svc" />
         <add factory="WcfService.BasicHttpsTestServiceHostFactory" service="WcfService.WcfService" relativeAddress="~\BasicHttps.svc" />
         <add factory="WcfService.BasicHttpTestServiceHostFactory" service="WcfService.WcfService" relativeAddress="~\BasicHttp.svc" />
         <add factory="WcfService.ChannelExtensibilityServiceHostFactory" service="WcfService.WcfChannelExtensiblityService" relativeAddress="~\ChannelExtensibility.svc" />
@@ -37,15 +37,15 @@
         <add factory="WcfService.DuplexCallbackXmlComplexTypeTestServiceHostFactory" service="WcfService.WcfDuplexService" relativeAddress="~\DuplexCallbackXmlComplexType.svc" />
         <add factory="WcfService.HttpBinaryTestServiceHostFactory" service="WcfService.WcfService" relativeAddress="~\HttpBinary.svc" />
         <add factory="WcfService.HttpDigestNoDomainTestServiceHostFactory" service="WcfService.WcfService" relativeAddress="~\HttpDigestNoDomain.svc" />
-        <add factory="WcfService.HttpsClientCertificateTestServiceHostFactory" service="WcfService.WcfService" relativeAddress="~\HttpsClientCertificate.svc" />
-        <add factory="WcfService.HttpsDigestTestServiceHostFactory" service="WcfService.WcfService" relativeAddress="~\HttpsDigest.svc" />
-        <add factory="WcfService.HttpsNtlmTestServiceHostFactory" service="WcfService.WcfService" relativeAddress="~\HttpsNtlm.svc" />
+        <add factory="WcfService.HttpsClientCertificateTestServiceHostFactory" service="WcfService.WcfService" relativeAddress="~\ClientCertificateAccepted\HttpsClientCertificate.svc" />
+        <add factory="WcfService.HttpsDigestTestServiceHostFactory" service="WcfService.WcfService" relativeAddress="~\DigestAuthentication\HttpsDigest.svc" />
+        <add factory="WcfService.HttpsNtlmTestServiceHostFactory" service="WcfService.WcfService" relativeAddress="~\WindowAuthenticationNtlm\HttpsNtlm.svc" />
         <add factory="WcfService.HttpSoap11TestServiceHostFactory" service="WcfService.WcfService" relativeAddress="~\HttpSoap11.svc" />
         <add factory="WcfService.HttpsSoap11TestServiceHostFactory" service="WcfService.WcfService" relativeAddress="~\HttpsSoap11.svc" />
         <add factory="WcfService.HttpsSoap12TestServiceHostFactory" service="WcfService.WcfService" relativeAddress="~\HttpsSoap12.svc" />
         <add factory="WcfService.HttpSoap12TestServiceHostFactory" service="WcfService.WcfService" relativeAddress="~\HttpSoap12.svc" />
-        <add factory="WcfService.HttpsWindowsTestServiceHostFactory" service="WcfService.WcfService" relativeAddress="~\HttpsWindows.svc" />
-        <add factory="WcfService.HttpWindowsTestServiceHostFactory" service="WcfService.WcfService" relativeAddress="~\HttpWindows.svc" />
+        <add factory="WcfService.HttpsWindowsTestServiceHostFactory" service="WcfService.WcfService" relativeAddress="~\WindowAuthenticationNegotiate\HttpsWindows.svc" />
+        <add factory="WcfService.HttpWindowsTestServiceHostFactory" service="WcfService.WcfService" relativeAddress="~\WindowAuthenticationNegotiate\HttpWindows.svc" />
         <add factory="WcfService.NetHttpTestServiceHostFactory" service="WcfService.WcfService" relativeAddress="~\NetHttp.svc" />
         <add factory="WcfService.NetHttpsTestServiceHostFactory" service="WcfService.WcfService" relativeAddress="~\NetHttps.svc" />
         <add factory="WcfService.HttpsCertificateValidationPeerTrustTestServiceHostFactory" service="WcfService.WcfService" relativeAddress="~\HttpsCertValModePeerTrust.svc" />
@@ -66,7 +66,7 @@
         <add factory="WcfService.TcpRevokedServerCertTestServiceHostFactory" service="WcfService.WcfService" relativeAddress="~\TcpRevokedServerCert.svc" />
         <add factory="WcfService.TcpStreamedNoSecurityTestServiceHostFactory" service="WcfService.WcfService" relativeAddress="~\TcpStreamedNoSecurity.svc" />
         <add factory="WcfService.TcpTransportSecuritySslCustomCertValidationTestServiceHostFactory" service="WcfService.WcfService" relativeAddress="~\TcpTransportSecuritySslCustomCertValidation.svc" />
-        <add factory="WcfService.TcpTransportSecurityStreamedTestServiceHostFactory" service="WcfService.WcfService" relativeAddress="~\TcpTransportSecurityStreamed.svc" />
+        <add factory="WcfService.TcpTransportSecurityStreamedTestServiceHostFactory" service="WcfService.WcfService" relativeAddress="~\WindowAuthenticationNegotiate\TcpTransportSecurityStreamed.svc" />
         <add factory="WcfService.TcpTransportSecurityWithSslTestServiceHostFactory" service="WcfService.WcfService" relativeAddress="~\TcpTransportSecurityWithSsl.svc" />
         <add factory="WcfService.TcpTransportSecuritySslClientCredentialTypeCertificateTestServiceHostFactory" service="WcfService.WcfService" relativeAddress="~\TcpTransportSecuritySslClientCredentialTypeCertificate.svc" />
         <add factory="WcfService.TcpVerifyDNSTestServiceHostFactory" service="WcfService.WcfService" relativeAddress="~\TcpVerifyDNS.svc" />

--- a/src/System.Private.ServiceModel/tools/IISHostedWcfService/WindowAuthenticationNegotiate/web.config
+++ b/src/System.Private.ServiceModel/tools/IISHostedWcfService/WindowAuthenticationNegotiate/web.config
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+ <!--Copyright (c) Microsoft Corporation.  All Rights Reserved.-->
+<configuration>
+
+  <system.webServer>
+        <security>
+            <authentication>
+                <anonymousAuthentication enabled="false" />
+                <windowsAuthentication enabled="true">
+                    <providers>
+                        <clear />
+                        <add value="Negotiate" />
+                    </providers>
+                </windowsAuthentication>
+            </authentication>
+        </security>
+  </system.webServer>
+</configuration>

--- a/src/System.Private.ServiceModel/tools/IISHostedWcfService/WindowAuthenticationNtlm/web.config
+++ b/src/System.Private.ServiceModel/tools/IISHostedWcfService/WindowAuthenticationNtlm/web.config
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+ <!--Copyright (c) Microsoft Corporation.  All Rights Reserved.-->
+<configuration>
+
+  <system.webServer>
+        <security>
+            <authentication>
+                <anonymousAuthentication enabled="false" />
+                <windowsAuthentication enabled="true">
+                    <providers>
+                        <clear />
+                        <add value="NTLM" />
+                    </providers>
+                </windowsAuthentication>
+            </authentication>
+        </security>
+  </system.webServer>
+</configuration>

--- a/src/System.Private.ServiceModel/tools/SelfHostedWcfService/Program.cs
+++ b/src/System.Private.ServiceModel/tools/SelfHostedWcfService/Program.cs
@@ -42,7 +42,7 @@ namespace SelfHostedWCFService
             UtilTestServiceHost utilTestServiceHostServiceHost = new UtilTestServiceHost(typeof(WcfService.Util), utilTestServiceHostbaseAddress);
             utilTestServiceHostServiceHost.Open();
 
-            Uri[] basicAuthTestServiceHostbaseAddress = new Uri[] { new Uri(string.Format("{0}/BasicAuth.svc", httpsBaseAddress)) };
+            Uri[] basicAuthTestServiceHostbaseAddress = new Uri[] { new Uri(string.Format("{0}/BasicAuthentication/BasicAuth.svc", httpsBaseAddress)) };
             BasicAuthTestServiceHost basicAuthTestServiceHostServiceHost = new BasicAuthTestServiceHost(typeof(WcfService.WcfUserNameService), basicAuthTestServiceHostbaseAddress);
             basicAuthTestServiceHostServiceHost.Open();
 
@@ -94,15 +94,15 @@ namespace SelfHostedWCFService
             HttpDigestNoDomainTestServiceHost httpDigestNoDomainTestServiceHostServiceHost = new HttpDigestNoDomainTestServiceHost(typeof(WcfService.WcfService), httpDigestNoDomainTestServiceHostbaseAddress);
             httpDigestNoDomainTestServiceHostServiceHost.Open();
 
-            Uri[] httpsClientCertificateTestServiceHostbaseAddress = new Uri[] { new Uri(string.Format("{0}/HttpsClientCertificate.svc", httpsBaseAddress)) };
+            Uri[] httpsClientCertificateTestServiceHostbaseAddress = new Uri[] { new Uri(string.Format("{0}/ClientCertificateAccepted/HttpsClientCertificate.svc", httpsBaseAddress)) };
             HttpsClientCertificateTestServiceHost httpsClientCertificateTestServiceHostServiceHost = new HttpsClientCertificateTestServiceHost(typeof(WcfService.WcfService), httpsClientCertificateTestServiceHostbaseAddress);
             httpsClientCertificateTestServiceHostServiceHost.Open();
 
-            Uri[] httpsDigestTestServiceHostbaseAddress = new Uri[] { new Uri(string.Format("{0}/HttpsDigest.svc", httpsBaseAddress)) };
+            Uri[] httpsDigestTestServiceHostbaseAddress = new Uri[] { new Uri(string.Format("{0}/DigestAuthentication/HttpsDigest.svc", httpsBaseAddress)) };
             HttpsDigestTestServiceHost httpsDigestTestServiceHostServiceHost = new HttpsDigestTestServiceHost(typeof(WcfService.WcfService), httpsDigestTestServiceHostbaseAddress);
             httpsDigestTestServiceHostServiceHost.Open();
 
-            Uri[] httpsNtlmTestServiceHostbaseAddress = new Uri[] { new Uri(string.Format("{0}/HttpsNtlm.svc", httpsBaseAddress)) };
+            Uri[] httpsNtlmTestServiceHostbaseAddress = new Uri[] { new Uri(string.Format("{0}/WindowAuthenticationNtlm/HttpsNtlm.svc", httpsBaseAddress)) };
             HttpsNtlmTestServiceHost httpsNtlmTestServiceHostServiceHost = new HttpsNtlmTestServiceHost(typeof(WcfService.WcfService), httpsNtlmTestServiceHostbaseAddress);
             httpsNtlmTestServiceHostServiceHost.Open();
 
@@ -122,11 +122,11 @@ namespace SelfHostedWCFService
             HttpSoap12TestServiceHost httpSoap12TestServiceHostServiceHost = new HttpSoap12TestServiceHost(typeof(WcfService.WcfService), httpSoap12TestServiceHostbaseAddress);
             httpSoap12TestServiceHostServiceHost.Open();
 
-            Uri[] httpsWindowsTestServiceHostbaseAddress = new Uri[] { new Uri(string.Format("{0}/HttpsWindows.svc", httpsBaseAddress)) };
+            Uri[] httpsWindowsTestServiceHostbaseAddress = new Uri[] { new Uri(string.Format("{0}/WindowAuthenticationNegotiate/HttpsWindows.svc", httpsBaseAddress)) };
             HttpsWindowsTestServiceHost httpsWindowsTestServiceHostServiceHost = new HttpsWindowsTestServiceHost(typeof(WcfService.WcfService), httpsWindowsTestServiceHostbaseAddress);
             httpsWindowsTestServiceHostServiceHost.Open();
 
-            Uri[] httpWindowsTestServiceHostbaseAddress = new Uri[] { new Uri(string.Format("{0}/HttpWindows.svc", httpBaseAddress)) };
+            Uri[] httpWindowsTestServiceHostbaseAddress = new Uri[] { new Uri(string.Format("{0}/WindowAuthenticationNegotiate/HttpWindows.svc", httpBaseAddress)) };
             HttpWindowsTestServiceHost httpWindowsTestServiceHostServiceHost = new HttpWindowsTestServiceHost(typeof(WcfService.WcfService), httpWindowsTestServiceHostbaseAddress);
             httpWindowsTestServiceHostServiceHost.Open();
 
@@ -210,7 +210,7 @@ namespace SelfHostedWCFService
             TcpTransportSecuritySslCustomCertValidationTestServiceHost tcpTransportSecuritySslCustomCertValidationTestServiceHostServiceHost = new TcpTransportSecuritySslCustomCertValidationTestServiceHost(typeof(WcfService.WcfService), tcpTransportSecuritySslCustomCertValidationTestServiceHostbaseAddress);
             tcpTransportSecuritySslCustomCertValidationTestServiceHostServiceHost.Open();
 
-            Uri[] tcpTransportSecurityStreamedTestServiceHostbaseAddress = new Uri[] { new Uri(string.Format("{0}/TcpTransportSecurityStreamed.svc", tcpBaseAddress)) };
+            Uri[] tcpTransportSecurityStreamedTestServiceHostbaseAddress = new Uri[] { new Uri(string.Format("{0}/WindowAuthenticationNegotiate/TcpTransportSecurityStreamed.svc", tcpBaseAddress)) };
             TcpTransportSecurityStreamedTestServiceHost tcpTransportSecurityStreamedTestServiceHostServiceHost = new TcpTransportSecurityStreamedTestServiceHost(typeof(WcfService.WcfService), tcpTransportSecurityStreamedTestServiceHostbaseAddress);
             tcpTransportSecurityStreamedTestServiceHostServiceHost.Open();
 


### PR DESCRIPTION
* This will enable most security tests run in Domain machines.
* This will enable client certificate tests in IIS hosted lab runs.
* Fix tests with incorrect conditional fact.
* Fix service side test issue as it's the first time we enable some
of the security tests.