### PR TITLE
Exclude scenario tests if not building for OuterLoop

### DIFF
--- a/src/System.Private.ServiceModel/tests/Scenarios/ServiceModel.Scenario.Tests.builds
+++ b/src/System.Private.ServiceModel/tests/Scenarios/ServiceModel.Scenario.Tests.builds
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
-  <ItemGroup>
+  <ItemGroup Condition="($(WithCategories.Contains('OuterLoop'))) or ('$(OuterLoop)' == 'true')">
     <Project Include="**\*.csproj" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />


### PR DESCRIPTION
The ConditionalFact detectors were being executed during
innerloop-only test runs. This is due to the fact we build
all test projects unconditionally and because xunit's trait
and Fact discoverers are executed before deciding whether
there are any tests to run. But unless the Self-host WCF
service was running (which happens only during OuterLoop
runs), this generated many exceptions in the console log.

With this change, all projects under tests\Scenarios are
excluded from the build unless OuterLoop has been requested.
This means there are no are no binaries containing
ConditionalFact when a normal non-OuterLoop build is done.

Fixes #1224