### PR TITLE
Lengthen the ping wait time for starting self-host server

### DIFF
--- a/src/System.Private.ServiceModel/tools/scripts/PingWCFService.ps1
+++ b/src/System.Private.ServiceModel/tools/scripts/PingWCFService.ps1
@@ -3,7 +3,7 @@
     [string] $Url
 )
 $request = New-Object System.Net.WebClient
-For ($i=0; $i -le 10; $i++)
+For ($i=0; $i -le 60; $i++)
 {
     try
     {


### PR DESCRIPTION
The scripts to self-start the self-hosted service will fail if
the service does not respond with a ping in a short time.  But
the script to start the service also builds it, and when package
restore is slow can take longer than the ping time.  When this
happens, the ping script yields control to a 2nd CMD file attempting
to write to the same log file, and the WcfSetup target fails,
causing the build to fail.

This PR just lengthens the time we wait for the service to respond
with a ping when self-starting.  We don't use this ping script for
anything other than self-start, so the longer time will not adversely
affect other "ping" scenarios.