### PR TITLE
Port to RC2 the OperationContext fix for issue 1137

### DIFF
--- a/src/System.Private.ServiceModel/src/Internals/System/Runtime/TimeoutHelper.cs
+++ b/src/System.Private.ServiceModel/src/Internals/System/Runtime/TimeoutHelper.cs
@@ -298,7 +298,7 @@ namespace System.Runtime
 
             if (!s_tokenCache.TryGetValue(targetTime, out tokenTask))
             {
-                var tcs = new TaskCompletionSource<CancellationToken>();
+                var tcs = new TaskCompletionSource<CancellationToken>(TaskCreationOptions.RunContinuationsAsynchronously);
 
                 // only a single thread may succeed adding its task into the cache
                 if (s_tokenCache.TryAdd(targetTime, tcs.Task))

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/ServiceChannel.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/ServiceChannel.cs
@@ -554,8 +554,7 @@ namespace System.ServiceModel.Channels
                 {
                     if ((context != null) && (!context.IsUserContext) && (context.InternalServiceChannel == this))
                     {
-                        throw ExceptionHelper.PlatformNotSupported();
-                        //throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.SFxCallbackRequestReplyInOrder1, typeof(CallbackBehaviorAttribute).Name)));
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.SFxCallbackRequestReplyInOrder1, typeof(CallbackBehaviorAttribute).Name)));
                     }
                 }
             }

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/ServiceChannelProxy.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/ServiceChannelProxy.cs
@@ -177,15 +177,13 @@ namespace System.ServiceModel.Channels
                     try
                     {
                         object result = channel.EndCall(operation.Action, Array.Empty<object>(), asyncResult);
+                        OperationContext.Current = originalOperationContext;
                         tcsp.TrySetResult(result);
                     }
                     catch (Exception e)
                     {
-                        tcsp.TrySetException(e);
-                    }
-                    finally
-                    {
                         OperationContext.Current = originalOperationContext;
+                        tcsp.TrySetException(e);
                     }
                 };
 
@@ -219,15 +217,13 @@ namespace System.ServiceModel.Channels
                     try
                     {
                         channel.EndCall(operation.Action, Array.Empty<object>(), asyncResult);
+                        OperationContext.Current = originalOperationContext;
                         tcs.TrySetResult(null);
                     }
                     catch (Exception e)
                     {
-                        tcs.TrySetException(e);
-                    }
-                    finally
-                    {
                         OperationContext.Current = originalOperationContext;
+                        tcs.TrySetException(e);
                     }
                 };
 


### PR DESCRIPTION
Original commit text was:
Fix async duplex issue that uses wrong OperationContext

Problem: under heavy load with multi-core machines, it was discovered
the Task used for async operations could be reused by other async
activities, leading to an inapropriate OperationContext.  This was
detected internally and threw PlatformNotSupported.

The fixes are to throw the correct InvalidOperationException, ensure
the OperationContext is set appropriately before any TrySet calls,
and alter the TimeoutHelper TCS to use ConfigureAwait.

Fixes #1137

Make TimeoutHelper continuations run asynchronously