### PR TITLE
Wait until message has been sent before completing HttpClient.SendAsync

### DIFF
--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/ServiceModelHttpMessageHandler.NetNative.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/ServiceModelHttpMessageHandler.NetNative.cs
@@ -79,11 +79,6 @@ namespace System.ServiceModel.Channels
         {
             get { return false; }
         }
-
-        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
-        {
-            return base.SendAsync(request, cancellationToken);
-        }
     }
 #endif
 }

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/ServiceModelHttpMessageHandler.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/ServiceModelHttpMessageHandler.cs
@@ -5,6 +5,8 @@
 
 using System.Net;
 using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace System.ServiceModel.Channels
 {
@@ -26,6 +28,14 @@ namespace System.ServiceModel.Channels
         {
             get { return _innerHandler.CookieContainer; }
             set { _innerHandler.CookieContainer = value; }
+        }
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var content = request.Content as MessageContent;
+            var responseMessage = await base.SendAsync(request, cancellationToken);
+            await content.WriteCompletionTask;
+            return responseMessage;
         }
     }
 }


### PR DESCRIPTION
Fixes the problem where HttpClientHandler completes the task returned from SendAsync
once the response headers have be returned when running on Unix.