### PR TITLE
Fix package baseline - release/1.0.0

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -82,7 +82,7 @@
     <ValidatePackageVersions>true</ValidatePackageVersions>
     <ProhibitFloatingDependencies>true</ProhibitFloatingDependencies>
     <CoreFxExpectedPrerelease>rc3-24109-00</CoreFxExpectedPrerelease>
-    <CoreFxVersionsIdentityRegex>^(?i)((System\..*)|(NETStandard\.Library)|(Microsoft\.CSharp)|(Microsoft\.NETCore.*)|(Microsoft\.TargetingPack\.Private\.(CoreCLR|NETNative))|(Microsoft\.Win32\..*)|(Microsoft\.VisualBasic))(?&lt;!TestData)(?&lt;!System\.Data\.SqlClient)$</CoreFxVersionsIdentityRegex>
+    <CoreFxVersionsIdentityRegex>^(?i)((System\..*)|(NETStandard\.Library)|(Microsoft\.CSharp)|(Microsoft\.Private\.PackageBaseline)|(Microsoft\.NETCore.*)|(Microsoft\.TargetingPack\.Private\.(CoreCLR|NETNative))|(Microsoft\.Win32\..*)|(Microsoft\.VisualBasic))(?&lt;!TestData)(?&lt;!System\.Data\.SqlClient)$</CoreFxVersionsIdentityRegex>
   </PropertyGroup>
 
   <ItemGroup>

--- a/pkg/baseline/baseline.props
+++ b/pkg/baseline/baseline.props
@@ -11,4 +11,9 @@
 
   <!-- bring in common baseline -->
   <Import Condition="Exists('$(CoreFxBaseLinePackageProps)')" Project="$(CoreFxBaseLinePackageProps)" />
+  
+  <Target Name="EnsureCoreFxBaseLine" Condition="'$(MSBuildProjectExtension)' == '.pkgproj'" BeforeTargets="Build">
+    <Error Condition="!Exists('$(CoreFxBaseLinePackageProps)')" 
+           Text="Error '$(CoreFxBaseLinePackageProps)' does not exist, ensure you have restored packages before building this project" />
+  </Target>
 </Project>

--- a/pkg/baseline/project.json
+++ b/pkg/baseline/project.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "Microsoft.Private.PackageBaseline": "1.0.0-rc3-24015-00"
+    "Microsoft.Private.PackageBaseline": "1.0.0-rc3-24109-00"
   },
   "frameworks": {
     "netstandard1.0": {}


### PR DESCRIPTION
Package baselining has been broken since the first package update after
I added it.  The problem was that the package that contains the corefx
baseline was missing from the update list so the update script updated
it to be out of sync with the CoreFxExpectedPrerelease property. I've
added the baseline package to the list of packages coming from CoreFx.

This was silently being dropped because we don't import the target if it
doesn't exist.  I've updated the import condition to be less permissive.
We just need it to not import before the restore so constraining it to
pkgproj will do that, and fail the build if this issue should occur in
the future.

Port of https://github.com/dotnet/wcf/commit/c5118f33c380761e2c738fdeb06e3ec411ab15d2