### PR TITLE
Reactivate tests for Certificate Revocation

### DIFF
--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/ExpectedExceptions/ExpectedExceptionTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/ExpectedExceptions/ExpectedExceptionTests.cs
@@ -363,8 +363,6 @@ public partial class ExpectedExceptionTests : ConditionalWcfTest
     [Fact]
 #if FEATURE_NETNATIVE
     [ActiveIssue(833)] // Not supported in NET Native
-#else
-    [ActiveIssue(578)]
 #endif
     [OuterLoop]
     // Verify product throws MessageSecurityException when the service cert is revoked


### PR DESCRIPTION
Tests were previously failing when attempting to check for certificate revocation. After testing, we've found that these tests no longer fail. 

Reactivate these tests so we get coverage again. 