### PR TITLE
Mark packages stable

### DIFF
--- a/pkg/baseline/stable.packages.props
+++ b/pkg/baseline/stable.packages.props
@@ -34,5 +34,845 @@
     <StablePackage Include="System.ServiceModel.Security">
       <Version>3.9.0</Version>
     </StablePackage>
+    
+    <!-- NETCore 1.0 -->
+    <StablePackage Include="Microsoft.CSharp">
+      <Version>4.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="Microsoft.NETCore.Platforms">
+      <Version>1.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="Microsoft.NETCore.Targets">
+      <Version>1.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="Microsoft.Private.PackageBaseline">
+      <Version>1.0.0</Version>
+    </StablePackage>
+    <StablePackage Include="Microsoft.VisualBasic">
+      <Version>10.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="Microsoft.Win32.Primitives">
+      <Version>4.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="Microsoft.Win32.Registry">
+      <Version>4.0.0</Version>
+    </StablePackage>
+    <StablePackage Include="Microsoft.Win32.Registry.AccessControl">
+      <Version>4.0.0</Version>
+    </StablePackage>
+    <StablePackage Include="NETStandard.Library">
+      <Version>1.6.0</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.any.System.Collections">
+      <Version>4.0.11</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.any.System.Diagnostics.Tools">
+      <Version>4.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.any.System.Diagnostics.Tracing">
+      <Version>4.1.0</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.any.System.Globalization">
+      <Version>4.0.11</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.any.System.Globalization.Calendars">
+      <Version>4.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.any.System.IO">
+      <Version>4.1.0</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.any.System.Reflection">
+      <Version>4.1.0</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.any.System.Reflection.Extensions">
+      <Version>4.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.any.System.Reflection.Primitives">
+      <Version>4.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.any.System.Resources.ResourceManager">
+      <Version>4.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.any.System.Runtime">
+      <Version>4.1.0</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.any.System.Runtime.Handles">
+      <Version>4.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.any.System.Runtime.InteropServices">
+      <Version>4.1.0</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.any.System.Text.Encoding">
+      <Version>4.0.11</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.any.System.Text.Encoding.Extensions">
+      <Version>4.0.11</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.any.System.Threading.Tasks">
+      <Version>4.0.11</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.any.System.Threading.Timer">
+      <Version>4.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.aot.System.Collections">
+      <Version>4.0.10</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.aot.System.Diagnostics.Tools">
+      <Version>4.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.aot.System.Diagnostics.Tracing">
+      <Version>4.0.20</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.aot.System.Globalization">
+      <Version>4.0.11</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.aot.System.Globalization.Calendars">
+      <Version>4.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.aot.System.IO">
+      <Version>4.1.0</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.aot.System.Reflection">
+      <Version>4.0.10</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.aot.System.Reflection.Extensions">
+      <Version>4.0.0</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.aot.System.Reflection.Primitives">
+      <Version>4.0.0</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.aot.System.Resources.ResourceManager">
+      <Version>4.0.0</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.aot.System.Runtime">
+      <Version>4.0.20</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.aot.System.Runtime.Handles">
+      <Version>4.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.aot.System.Runtime.InteropServices">
+      <Version>4.0.20</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.aot.System.Text.Encoding">
+      <Version>4.0.11</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.aot.System.Text.Encoding.Extensions">
+      <Version>4.0.11</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.aot.System.Threading.Tasks">
+      <Version>4.0.11</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.aot.System.Threading.Timer">
+      <Version>4.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.debian.8-x64.runtime.native.System">
+      <Version>1.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.debian.8-x64.runtime.native.System.IO.Compression">
+      <Version>1.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.debian.8-x64.runtime.native.System.Net.Http">
+      <Version>1.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.debian.8-x64.runtime.native.System.Net.Security">
+      <Version>1.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.debian.8-x64.runtime.native.System.Security.Cryptography">
+      <Version>1.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.fedora.23-x64.runtime.native.System">
+      <Version>1.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.fedora.23-x64.runtime.native.System.IO.Compression">
+      <Version>1.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.fedora.23-x64.runtime.native.System.Net.Http">
+      <Version>1.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.fedora.23-x64.runtime.native.System.Net.Security">
+      <Version>1.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.fedora.23-x64.runtime.native.System.Security.Cryptography">
+      <Version>1.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.native.System">
+      <Version>4.0.0</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.native.System.Data.SqlClient.sni">
+      <Version>4.0.0</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.native.System.IO.Compression">
+      <Version>4.1.0</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.native.System.Net.Http">
+      <Version>4.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.native.System.Net.Security">
+      <Version>4.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.native.System.Security.Cryptography">
+      <Version>4.0.0</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.opensuse.13.2-x64.runtime.native.System">
+      <Version>1.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.opensuse.13.2-x64.runtime.native.System.IO.Compression">
+      <Version>1.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.opensuse.13.2-x64.runtime.native.System.Net.Http">
+      <Version>1.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.opensuse.13.2-x64.runtime.native.System.Net.Security">
+      <Version>1.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography">
+      <Version>1.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.osx.10.10-x64.runtime.native.System">
+      <Version>1.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.osx.10.10-x64.runtime.native.System.IO.Compression">
+      <Version>1.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.osx.10.10-x64.runtime.native.System.Net.Http">
+      <Version>1.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.osx.10.10-x64.runtime.native.System.Net.Security">
+      <Version>1.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography">
+      <Version>1.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.rhel.7-x64.runtime.native.System">
+      <Version>1.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.rhel.7-x64.runtime.native.System.IO.Compression">
+      <Version>1.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.rhel.7-x64.runtime.native.System.Net.Http">
+      <Version>1.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.rhel.7-x64.runtime.native.System.Net.Security">
+      <Version>1.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.rhel.7-x64.runtime.native.System.Security.Cryptography">
+      <Version>1.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.ubuntu.14.04-x64.runtime.native.System">
+      <Version>1.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.ubuntu.14.04-x64.runtime.native.System.IO.Compression">
+      <Version>1.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.ubuntu.14.04-x64.runtime.native.System.Net.Http">
+      <Version>1.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.ubuntu.14.04-x64.runtime.native.System.Net.Security">
+      <Version>1.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography">
+      <Version>1.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.ubuntu.16.04-x64.runtime.native.System">
+      <Version>1.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.ubuntu.16.04-x64.runtime.native.System.IO.Compression">
+      <Version>1.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.ubuntu.16.04-x64.runtime.native.System.Net.Http">
+      <Version>1.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.ubuntu.16.04-x64.runtime.native.System.Net.Security">
+      <Version>1.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography">
+      <Version>1.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.unix.Microsoft.Win32.Primitives">
+      <Version>4.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.unix.System.Console">
+      <Version>4.0.0</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.unix.System.Diagnostics.Debug">
+      <Version>4.0.11</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.unix.System.IO.FileSystem">
+      <Version>4.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.unix.System.Net.Primitives">
+      <Version>4.0.11</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.unix.System.Net.Sockets">
+      <Version>4.1.0</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.unix.System.Private.Uri">
+      <Version>4.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.unix.System.Runtime.Extensions">
+      <Version>4.1.0</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.win.Microsoft.Win32.Primitives">
+      <Version>4.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.win.System.Console">
+      <Version>4.0.0</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.win.System.Diagnostics.Debug">
+      <Version>4.0.11</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.win.System.IO.FileSystem">
+      <Version>4.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.win.System.Net.Primitives">
+      <Version>4.0.11</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.win.System.Net.Sockets">
+      <Version>4.1.0</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.win.System.Runtime.Extensions">
+      <Version>4.1.0</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.win7.System.Private.Uri">
+      <Version>4.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.win7-arm.runtime.native.System.IO.Compression">
+      <Version>4.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.win7-x64.runtime.native.System.Data.SqlClient.sni">
+      <Version>4.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.win7-x64.runtime.native.System.IO.Compression">
+      <Version>4.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.win7-x86.runtime.native.System.Data.SqlClient.sni">
+      <Version>4.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.win7-x86.runtime.native.System.IO.Compression">
+      <Version>4.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.win8-arm.runtime.native.System.IO.Compression">
+      <Version>4.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.win8-x64.runtime.native.System.IO.Compression">
+      <Version>4.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.win8-x86.runtime.native.System.IO.Compression">
+      <Version>4.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="System.AppContext">
+      <Version>4.1.0</Version>
+    </StablePackage>
+    <StablePackage Include="System.Buffers">
+      <Version>4.0.0</Version>
+    </StablePackage>
+    <StablePackage Include="System.Collections">
+      <Version>4.0.11</Version>
+    </StablePackage>
+    <StablePackage Include="System.Collections.Concurrent">
+      <Version>4.0.12</Version>
+    </StablePackage>
+    <StablePackage Include="System.Collections.Immutable">
+      <Version>1.2.0</Version>
+    </StablePackage>
+    <StablePackage Include="System.Collections.NonGeneric">
+      <Version>4.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="System.Collections.Specialized">
+      <Version>4.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="System.ComponentModel">
+      <Version>4.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="System.ComponentModel.Annotations">
+      <Version>4.1.0</Version>
+    </StablePackage>
+    <StablePackage Include="System.ComponentModel.EventBasedAsync">
+      <Version>4.0.11</Version>
+    </StablePackage>
+    <StablePackage Include="System.ComponentModel.Primitives">
+      <Version>4.1.0</Version>
+    </StablePackage>
+    <StablePackage Include="System.ComponentModel.TypeConverter">
+      <Version>4.1.0</Version>
+    </StablePackage>
+    <StablePackage Include="System.Console">
+      <Version>4.0.0</Version>
+    </StablePackage>
+    <StablePackage Include="System.Data.Common">
+      <Version>4.1.0</Version>
+    </StablePackage>
+    <StablePackage Include="System.Data.SqlClient">
+      <Version>4.1.0</Version>
+    </StablePackage>
+    <StablePackage Include="System.Diagnostics.Contracts">
+      <Version>4.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="System.Diagnostics.Debug">
+      <Version>4.0.11</Version>
+    </StablePackage>
+    <StablePackage Include="System.Diagnostics.DiagnosticSource">
+      <Version>4.0.0</Version>
+    </StablePackage>
+    <StablePackage Include="System.Diagnostics.FileVersionInfo">
+      <Version>4.0.0</Version>
+    </StablePackage>
+    <StablePackage Include="System.Diagnostics.Process">
+      <Version>4.1.0</Version>
+    </StablePackage>
+    <StablePackage Include="System.Diagnostics.StackTrace">
+      <Version>4.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="System.Diagnostics.TextWriterTraceListener">
+      <Version>4.0.0</Version>
+    </StablePackage>
+    <StablePackage Include="System.Diagnostics.Tools">
+      <Version>4.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="System.Diagnostics.TraceSource">
+      <Version>4.0.0</Version>
+    </StablePackage>
+    <StablePackage Include="System.Diagnostics.Tracing">
+      <Version>4.1.0</Version>
+    </StablePackage>
+    <StablePackage Include="System.Drawing.Primitives">
+      <Version>4.0.0</Version>
+    </StablePackage>
+    <StablePackage Include="System.Dynamic.Runtime">
+      <Version>4.0.11</Version>
+    </StablePackage>
+    <StablePackage Include="System.Globalization">
+      <Version>4.0.11</Version>
+    </StablePackage>
+    <StablePackage Include="System.Globalization.Calendars">
+      <Version>4.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="System.Globalization.Extensions">
+      <Version>4.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="System.IO">
+      <Version>4.1.0</Version>
+    </StablePackage>
+    <StablePackage Include="System.IO.Compression">
+      <Version>4.1.0</Version>
+    </StablePackage>
+    <StablePackage Include="System.IO.Compression.ZipFile">
+      <Version>4.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="System.IO.FileSystem">
+      <Version>4.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="System.IO.FileSystem.AccessControl">
+      <Version>4.0.0</Version>
+    </StablePackage>
+    <StablePackage Include="System.IO.FileSystem.DriveInfo">
+      <Version>4.0.0</Version>
+    </StablePackage>
+    <StablePackage Include="System.IO.FileSystem.Primitives">
+      <Version>4.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="System.IO.FileSystem.Watcher">
+      <Version>4.0.0</Version>
+    </StablePackage>
+    <StablePackage Include="System.IO.IsolatedStorage">
+      <Version>4.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="System.IO.MemoryMappedFiles">
+      <Version>4.0.0</Version>
+    </StablePackage>
+    <StablePackage Include="System.IO.Packaging">
+      <Version>4.0.0</Version>
+    </StablePackage>
+    <StablePackage Include="System.IO.Pipes">
+      <Version>4.0.0</Version>
+    </StablePackage>
+    <StablePackage Include="System.IO.UnmanagedMemoryStream">
+      <Version>4.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="System.Linq">
+      <Version>4.1.0</Version>
+    </StablePackage>
+    <StablePackage Include="System.Linq.Expressions">
+      <Version>4.1.0</Version>
+    </StablePackage>
+    <StablePackage Include="System.Linq.Parallel">
+      <Version>4.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="System.Linq.Queryable">
+      <Version>4.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="System.Net.Http">
+      <Version>4.1.0</Version>
+    </StablePackage>
+    <StablePackage Include="System.Net.Http.Rtc">
+      <Version>4.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="System.Net.Http.WinHttpHandler">
+      <Version>4.0.0</Version>
+    </StablePackage>
+    <StablePackage Include="System.Net.NameResolution">
+      <Version>4.0.0</Version>
+    </StablePackage>
+    <StablePackage Include="System.Net.NetworkInformation">
+      <Version>4.1.0</Version>
+    </StablePackage>
+    <StablePackage Include="System.Net.Ping">
+      <Version>4.0.0</Version>
+    </StablePackage>
+    <StablePackage Include="System.Net.Primitives">
+      <Version>4.0.11</Version>
+    </StablePackage>
+    <StablePackage Include="System.Net.Requests">
+      <Version>4.0.11</Version>
+    </StablePackage>
+    <StablePackage Include="System.Net.Security">
+      <Version>4.0.0</Version>
+    </StablePackage>
+    <StablePackage Include="System.Net.Sockets">
+      <Version>4.1.0</Version>
+    </StablePackage>
+    <StablePackage Include="System.Net.WebHeaderCollection">
+      <Version>4.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="System.Net.WebSockets">
+      <Version>4.0.0</Version>
+    </StablePackage>
+    <StablePackage Include="System.Net.WebSockets.Client">
+      <Version>4.0.0</Version>
+    </StablePackage>
+    <StablePackage Include="System.Numerics.Vectors">
+      <Version>4.1.1</Version>
+    </StablePackage>
+    <StablePackage Include="System.Numerics.Vectors.WindowsRuntime">
+      <Version>4.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="System.ObjectModel">
+      <Version>4.0.12</Version>
+    </StablePackage>
+    <StablePackage Include="System.Private.DataContractSerialization">
+      <Version>4.1.1</Version>
+    </StablePackage>
+    <StablePackage Include="System.Private.Uri">
+      <Version>4.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="System.Reflection">
+      <Version>4.1.0</Version>
+    </StablePackage>
+    <StablePackage Include="System.Reflection.Context">
+      <Version>4.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="System.Reflection.DispatchProxy">
+      <Version>4.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="System.Reflection.Emit">
+      <Version>4.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="System.Reflection.Emit.ILGeneration">
+      <Version>4.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="System.Reflection.Emit.Lightweight">
+      <Version>4.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="System.Reflection.Extensions">
+      <Version>4.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="System.Reflection.Metadata">
+      <Version>1.3.0</Version>
+    </StablePackage>
+    <StablePackage Include="System.Reflection.Primitives">
+      <Version>4.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="System.Reflection.TypeExtensions">
+      <Version>4.1.0</Version>
+    </StablePackage>
+    <StablePackage Include="System.Resources.Reader">
+      <Version>4.0.0</Version>
+    </StablePackage>
+    <StablePackage Include="System.Resources.ResourceManager">
+      <Version>4.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="System.Resources.Writer">
+      <Version>4.0.0</Version>
+    </StablePackage>
+    <StablePackage Include="System.Runtime">
+      <Version>4.1.0</Version>
+    </StablePackage>
+    <StablePackage Include="System.Runtime.CompilerServices.Unsafe">
+      <Version>4.0.0</Version>
+    </StablePackage>
+    <StablePackage Include="System.Runtime.CompilerServices.VisualC">
+      <Version>4.0.0</Version>
+    </StablePackage>
+    <StablePackage Include="System.Runtime.Extensions">
+      <Version>4.1.0</Version>
+    </StablePackage>
+    <StablePackage Include="System.Runtime.Handles">
+      <Version>4.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="System.Runtime.InteropServices">
+      <Version>4.1.0</Version>
+    </StablePackage>
+    <StablePackage Include="System.Runtime.InteropServices.RuntimeInformation">
+      <Version>4.0.0</Version>
+    </StablePackage>
+    <StablePackage Include="System.Runtime.InteropServices.WindowsRuntime">
+      <Version>4.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="System.Runtime.Loader">
+      <Version>4.0.0</Version>
+    </StablePackage>
+    <StablePackage Include="System.Runtime.Numerics">
+      <Version>4.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="System.Runtime.Serialization.Json">
+      <Version>4.0.2</Version>
+    </StablePackage>
+    <StablePackage Include="System.Runtime.Serialization.Primitives">
+      <Version>4.1.1</Version>
+    </StablePackage>
+    <StablePackage Include="System.Runtime.Serialization.Xml">
+      <Version>4.1.1</Version>
+    </StablePackage>
+    <StablePackage Include="System.Runtime.WindowsRuntime">
+      <Version>4.0.11</Version>
+    </StablePackage>
+    <StablePackage Include="System.Runtime.WindowsRuntime.UI.Xaml">
+      <Version>4.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="System.Security.AccessControl">
+      <Version>4.0.0</Version>
+    </StablePackage>
+    <StablePackage Include="System.Security.Claims">
+      <Version>4.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="System.Security.Cryptography.Algorithms">
+      <Version>4.2.0</Version>
+    </StablePackage>
+    <StablePackage Include="System.Security.Cryptography.Cng">
+      <Version>4.2.0</Version>
+    </StablePackage>
+    <StablePackage Include="System.Security.Cryptography.Csp">
+      <Version>4.0.0</Version>
+    </StablePackage>
+    <StablePackage Include="System.Security.Cryptography.Encoding">
+      <Version>4.0.0</Version>
+    </StablePackage>
+    <StablePackage Include="System.Security.Cryptography.OpenSsl">
+      <Version>4.0.0</Version>
+    </StablePackage>
+    <StablePackage Include="System.Security.Cryptography.Pkcs">
+      <Version>4.0.0</Version>
+    </StablePackage>
+    <StablePackage Include="System.Security.Cryptography.Primitives">
+      <Version>4.0.0</Version>
+    </StablePackage>
+    <StablePackage Include="System.Security.Cryptography.ProtectedData">
+      <Version>4.0.0</Version>
+    </StablePackage>
+    <StablePackage Include="System.Security.Cryptography.X509Certificates">
+      <Version>4.1.0</Version>
+    </StablePackage>
+    <StablePackage Include="System.Security.Principal">
+      <Version>4.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="System.Security.Principal.Windows">
+      <Version>4.0.0</Version>
+    </StablePackage>
+    <StablePackage Include="System.Security.SecureString">
+      <Version>4.0.0</Version>
+    </StablePackage>
+    <StablePackage Include="System.ServiceProcess.ServiceController">
+      <Version>4.1.0</Version>
+    </StablePackage>
+    <StablePackage Include="System.Text.Encoding">
+      <Version>4.0.11</Version>
+    </StablePackage>
+    <StablePackage Include="System.Text.Encoding.CodePages">
+      <Version>4.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="System.Text.Encoding.Extensions">
+      <Version>4.0.11</Version>
+    </StablePackage>
+    <StablePackage Include="System.Text.Encodings.Web">
+      <Version>4.0.0</Version>
+    </StablePackage>
+    <StablePackage Include="System.Text.RegularExpressions">
+      <Version>4.1.0</Version>
+    </StablePackage>
+    <StablePackage Include="System.Threading">
+      <Version>4.0.11</Version>
+    </StablePackage>
+    <StablePackage Include="System.Threading.AccessControl">
+      <Version>4.0.0</Version>
+    </StablePackage>
+    <StablePackage Include="System.Threading.Overlapped">
+      <Version>4.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="System.Threading.Tasks">
+      <Version>4.0.11</Version>
+    </StablePackage>
+    <StablePackage Include="System.Threading.Tasks.Dataflow">
+      <Version>4.6.0</Version>
+    </StablePackage>
+    <StablePackage Include="System.Threading.Tasks.Extensions">
+      <Version>4.0.0</Version>
+    </StablePackage>
+    <StablePackage Include="System.Threading.Tasks.Parallel">
+      <Version>4.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="System.Threading.Thread">
+      <Version>4.0.0</Version>
+    </StablePackage>
+    <StablePackage Include="System.Threading.ThreadPool">
+      <Version>4.0.10</Version>
+    </StablePackage>
+    <StablePackage Include="System.Threading.Timer">
+      <Version>4.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="System.Xml.ReaderWriter">
+      <Version>4.0.11</Version>
+    </StablePackage>
+    <StablePackage Include="System.Xml.XDocument">
+      <Version>4.0.11</Version>
+    </StablePackage>
+    <StablePackage Include="System.Xml.XmlDocument">
+      <Version>4.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="System.Xml.XmlSerializer">
+      <Version>4.0.11</Version>
+    </StablePackage>
+    <StablePackage Include="System.Xml.XPath">
+      <Version>4.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="System.Xml.XPath.XDocument">
+      <Version>4.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="System.Xml.XPath.XmlDocument">
+      <Version>4.0.1</Version>
+    </StablePackage>
+
+    <!-- NETCore 1.0 TFS -->
+    <StablePackage Include="Microsoft.NETCore.ConsoleHost">
+      <Version>1.0.0</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.debian.8-x64.Microsoft.NETCore.ConsoleHost">
+      <Version>1.0.0</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.fedora.23-x64.Microsoft.NETCore.ConsoleHost">
+      <Version>1.0.0</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.opensuse.13.2-x64.Microsoft.NETCore.ConsoleHost">
+      <Version>1.0.0</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.osx.10.10-x64.Microsoft.NETCore.ConsoleHost">
+      <Version>1.0.0</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.rhel.7-x64.Microsoft.NETCore.ConsoleHost">
+      <Version>1.0.0</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.ubuntu.14.04-x64.Microsoft.NETCore.ConsoleHost">
+      <Version>1.0.0</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.ubuntu.16.04-x64.Microsoft.NETCore.ConsoleHost">
+      <Version>1.0.0</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.win7-arm.Microsoft.NETCore.ConsoleHost">
+      <Version>1.0.0</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.win7-x64.Microsoft.NETCore.ConsoleHost">
+      <Version>1.0.0</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.win7-x86.Microsoft.NETCore.ConsoleHost">
+      <Version>1.0.0</Version>
+    </StablePackage>
+    <StablePackage Include="Microsoft.NETCore.Portable.Compatibility">
+      <Version>1.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="Microsoft.NETCore.TestHost">
+      <Version>1.0.0</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.debian.8-x64.Microsoft.NETCore.TestHost">
+      <Version>1.0.0</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.fedora.23-x64.Microsoft.NETCore.TestHost">
+      <Version>1.0.0</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.opensuse.13.2-x64.Microsoft.NETCore.TestHost">
+      <Version>1.0.0</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.osx.10.10-x64.Microsoft.NETCore.TestHost">
+      <Version>1.0.0</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.rhel.7-x64.Microsoft.NETCore.TestHost">
+      <Version>1.0.0</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.ubuntu.14.04-x64.Microsoft.NETCore.TestHost">
+      <Version>1.0.0</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.ubuntu.16.04-x64.Microsoft.NETCore.TestHost">
+      <Version>1.0.0</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.win7-arm.Microsoft.NETCore.TestHost">
+      <Version>1.0.0</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.win7-x64.Microsoft.NETCore.TestHost">
+      <Version>1.0.0</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.win7-x86.Microsoft.NETCore.TestHost">
+      <Version>1.0.0</Version>
+    </StablePackage>
+    <StablePackage Include="Microsoft.NETCore.Windows.ApiSets">
+      <Version>1.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.win7-x64.Microsoft.NETCore.Windows.ApiSets">
+      <Version>1.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.win7-x86.Microsoft.NETCore.Windows.ApiSets">
+      <Version>1.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.win8-x64.Microsoft.NETCore.Windows.ApiSets">
+      <Version>1.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.win8-x86.Microsoft.NETCore.Windows.ApiSets">
+      <Version>1.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.win81-x64.Microsoft.NETCore.Windows.ApiSets">
+      <Version>1.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.win81-x86.Microsoft.NETCore.Windows.ApiSets">
+      <Version>1.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.win10-arm-aot.runtime.native.System.IO.Compression">
+      <Version>4.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.win10-x64-aot.runtime.native.System.IO.Compression">
+      <Version>4.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.win10-x86-aot.runtime.native.System.IO.Compression">
+      <Version>4.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.win8-arm.Microsoft.NETCore.Runtime.CoreCLR">
+      <Version>1.0.2</Version>
+    </StablePackage>
+
+    <!-- NETCore 1.0 WCF -->
+    <StablePackage Include="System.Private.ServiceModel">
+      <Version>4.1.0</Version>
+    </StablePackage>
+    <StablePackage Include="System.ServiceModel.Duplex">
+      <Version>4.0.1</Version>
+    </StablePackage>
+    <StablePackage Include="System.ServiceModel.Http">
+      <Version>4.1.0</Version>
+    </StablePackage>
+    <StablePackage Include="System.ServiceModel.NetTcp">
+      <Version>4.1.0</Version>
+    </StablePackage>
+    <StablePackage Include="System.ServiceModel.Primitives">
+      <Version>4.1.0</Version>
+    </StablePackage>
+    <StablePackage Include="System.ServiceModel.Security">
+      <Version>4.0.1</Version>
+    </StablePackage>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Getting this PR ready for when we want to push the button.

Includes more changes than necessary long term.  We can remove all the CoreFx/TFS entries once we pick up the new Baseline package.  That will happen as soon as this branch transitions to servicing.

Alternatively we could a) prime the baseline package by building locally, publishing, then picking up that version or b) serialize WCF after CoreFx and have the RTM build of WCF consume the RTM/escrow build of CoreFx.

/cc @joshfree @weshaggard @roncain 