### PR TITLE
Clean packages on official and CI builds

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -73,7 +73,15 @@
 
   <UsingTask TaskName="GatherDirectoriesToRestore" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll" />
 
-  <Target Name="BatchRestorePackages">
+  <!-- by default in the release branch we will re-download packages every time -->
+  <PropertyGroup Condition="'$(SkipCleanPackages)' == ''">
+    <BatchRestorePackagesDepensOn>
+      CleanPackages;
+      CleanPackagesCache;
+      $(BatchRestorePackagesDepensOn);
+    </BatchRestorePackagesDepensOn>
+  </PropertyGroup>
+  <Target Name="BatchRestorePackages" DependsOnTargets="$(BatchRestorePackagesDepensOn)">
     <MakeDir Directories="$(PackagesDir)" Condition="!Exists('$(PackagesDir)')" /> 
 
     <Message Importance="High" Text="[$([System.DateTime]::Now.ToString('HH:mm:ss.ff'))] Restoring all packages..." />


### PR DESCRIPTION
This is needed because we'll be producing packages with constant stable
version and content updates.

/cc @weshaggard @jhendrixMSFT

We'll also need to update the VSO build definitions so pass BuildType=Official.