### PR TITLE
Add conditional fact for the tests need root cert

### DIFF
--- a/src/System.Private.ServiceModel/tests/Scenarios/Binding/Http/Binding.Http.Tests.csproj
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Binding/Http/Binding.Http.Tests.csproj
@@ -36,6 +36,10 @@
       <Project>{9098B41C-9C2E-4FC6-B7D8-FC3411736A22}</Project>
       <Name>ScenarioTests.Common</Name>
     </ProjectReference>
+    <ProjectReference Include="$(WcfInfrastructureCommonProj)">
+      <Project>{AFD69665-89A3-42AE-A32E-AB2CBBE6EE7E}</Project>
+      <Name>Infrastructure.Common</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Private.ServiceModel/tests/Scenarios/Binding/Http/NetHttpsBindingTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Binding/Http/NetHttpsBindingTests.cs
@@ -5,15 +5,13 @@
 
 using System;
 using System.ServiceModel;
-using System.ServiceModel.Channels;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
+
+using Infrastructure.Common;
 using Xunit;
 
-public static class Binding_Http_NetHttpsBindingTests
+public class Binding_Http_NetHttpsBindingTests: ConditionalWcfTest
 {
-    [Fact]
+    [ConditionalFact(nameof(Root_Certificate_Installed))]
     [OuterLoop]
     [ActiveIssue(1123, PlatformID.AnyUnix)]
     public static void DefaultCtor_NetHttps_Echo_RoundTrips_String()
@@ -77,7 +75,7 @@ public static class Binding_Http_NetHttpsBindingTests
         });
     }
 
-    [Fact]
+    [ConditionalFact(nameof(Root_Certificate_Installed))]
     [OuterLoop]
     [ActiveIssue(1123, PlatformID.AnyUnix)]
     public static void NonDefaultCtor_NetHttps_Echo_RoundTrips_String()

--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/ChannelLayer/DuplexChannelShapeTests.4.0.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/ChannelLayer/DuplexChannelShapeTests.4.0.0.cs
@@ -134,7 +134,7 @@ public partial class DuplexChannelShapeTests : ConditionalWcfTest
         }
     }
 
-    [Fact]
+    [ConditionalFact(nameof(Root_Certificate_Installed))]
     [OuterLoop]
     [ActiveIssue(1123, PlatformID.AnyUnix)]
     public static void IRequestChannel_Https_NetHttpsBinding()


### PR DESCRIPTION
The tests are failing on CI in release/1.0.0 branch
We need the contitional fact to ensure root certificate is installed to validate server certificate.

```
DuplexChannelShapeTests.IRequestChannel_Https_NetHttpsBinding
Binding_Http_NetHttpsBindingTests.NonDefaultCtor_NetHttps_Echo_RoundTrips_String
Binding_Http_NetHttpsBindingTests.DefaultCtor_NetHttps_Echo_RoundTrips_String
```