### PR TITLE
Update PRService to be robust when fetching new branches

### DIFF
--- a/src/System.Private.ServiceModel/tools/PRService/pr.ashx
+++ b/src/System.Private.ServiceModel/tools/PRService/pr.ashx
@@ -109,7 +109,7 @@ public class PullRequestHandler : IHttpHandler
 
         if (!success)
         {
-            // CleanupMergedBranches failed, this is a server issue
+            // CleanupBranches failed, this is a server issue
             context.Response.StatusCode = 500;
             context.Response.Write(HttpUtility.HtmlEncode(result.ToString()));
             return;
@@ -207,12 +207,8 @@ public class PullRequestHandler : IHttpHandler
     {
         string[] gitCommands = new string[]
         {
-            "clean -fdx",
-            "checkout master",
-            "fetch --all --prune",
-            "merge --ff-only origin/master",
             string.Format("fetch origin pull/{0}/head:pr/{0}", pr),
-            string.Format("checkout pr/{0}", pr)
+            string.Format("checkout -f pr/{0}", pr)
         };
 
         return RunGitCommands(gitCommands, gitRepoPath, executionResult);
@@ -222,11 +218,7 @@ public class PullRequestHandler : IHttpHandler
     {
         string[] gitCommands = new string[]
         {
-            "clean -fdx",
-            "checkout master",
-            "fetch --all --prune",
-            "merge --ff-only origin/master",
-            string.Format("checkout {0}", branch)
+            string.Format("checkout -f {0}", branch)
         };
 
         return RunGitCommands(gitCommands, gitRepoPath, executionResult);
@@ -267,8 +259,16 @@ public class PullRequestHandler : IHttpHandler
     private bool CleanupBranches(string gitRepoPath, StringBuilder executionResult)
     {
         bool success = false;
+    
+        string[] gitCommands = new string[] 
+        {
+            "checkout -f master",
+            "clean -fdx",
+            "fetch --all --prune",
+            "merge --ff-only origin/master"
+        };
 
-        success = RunGitCommands(new string[] { "checkout master" }, gitRepoPath, executionResult);
+        success = RunGitCommands(gitCommands, gitRepoPath, executionResult);
 
         string[] branchesList = null;
         if (success)


### PR DESCRIPTION
The PRService looks up a list of valid branches before allowing a checkout to a
branch on the query string. However, when a new branch is created, the PRService
does not do a fetch before doing the branch name check, which means the PRService
is not aware of the new branch and fails the check.

This PR
1. Causes the fetch to happen first
2. Consolidates the fetch/cleanup logic into CleanupBranches

Fixes #1287