### PR TITLE
Make certificate ConditionalFacts allow explicit overrides

### DIFF
--- a/src/System.Private.ServiceModel/System.Private.ServiceModel.sln
+++ b/src/System.Private.ServiceModel/System.Private.ServiceModel.sln
@@ -125,6 +125,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Extensibility.MessageInterc
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "MessageInterceptor", "MessageInterceptor", "{5F73AD7C-F75A-408B-A981-E163D001AFB2}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Infrastructure", "Infrastructure", "{227ACBA5-80A6-4D18-83A2-E5E6DC6E53A5}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Infrastructure.Tests", "tests\Scenarios\Infrastructure\Infrastructure.Tests.csproj", "{034CA8C4-5C34-40F9-A9B1-09369F8B80B3}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -585,6 +589,22 @@ Global
 		{FDB2A8DE-C0D5-4536-A9CC-126E4A543907}.Windows_netcore50_Release|Any CPU.Build.0 = Debug|Any CPU
 		{FDB2A8DE-C0D5-4536-A9CC-126E4A543907}.Windows_Release|Any CPU.ActiveCfg = Debug|Any CPU
 		{FDB2A8DE-C0D5-4536-A9CC-126E4A543907}.Windows_Release|Any CPU.Build.0 = Debug|Any CPU
+		{034CA8C4-5C34-40F9-A9B1-09369F8B80B3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{034CA8C4-5C34-40F9-A9B1-09369F8B80B3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{034CA8C4-5C34-40F9-A9B1-09369F8B80B3}.Release|Any CPU.ActiveCfg = Debug|Any CPU
+		{034CA8C4-5C34-40F9-A9B1-09369F8B80B3}.Release|Any CPU.Build.0 = Debug|Any CPU
+		{034CA8C4-5C34-40F9-A9B1-09369F8B80B3}.Unix_Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{034CA8C4-5C34-40F9-A9B1-09369F8B80B3}.Unix_Debug|Any CPU.Build.0 = Debug|Any CPU
+		{034CA8C4-5C34-40F9-A9B1-09369F8B80B3}.Unix_Release|Any CPU.ActiveCfg = Debug|Any CPU
+		{034CA8C4-5C34-40F9-A9B1-09369F8B80B3}.Unix_Release|Any CPU.Build.0 = Debug|Any CPU
+		{034CA8C4-5C34-40F9-A9B1-09369F8B80B3}.Windows_Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{034CA8C4-5C34-40F9-A9B1-09369F8B80B3}.Windows_Debug|Any CPU.Build.0 = Debug|Any CPU
+		{034CA8C4-5C34-40F9-A9B1-09369F8B80B3}.Windows_netcore50_Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{034CA8C4-5C34-40F9-A9B1-09369F8B80B3}.Windows_netcore50_Debug|Any CPU.Build.0 = Debug|Any CPU
+		{034CA8C4-5C34-40F9-A9B1-09369F8B80B3}.Windows_netcore50_Release|Any CPU.ActiveCfg = Debug|Any CPU
+		{034CA8C4-5C34-40F9-A9B1-09369F8B80B3}.Windows_netcore50_Release|Any CPU.Build.0 = Debug|Any CPU
+		{034CA8C4-5C34-40F9-A9B1-09369F8B80B3}.Windows_Release|Any CPU.ActiveCfg = Debug|Any CPU
+		{034CA8C4-5C34-40F9-A9B1-09369F8B80B3}.Windows_Release|Any CPU.Build.0 = Debug|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -649,5 +669,7 @@ Global
 		{B10E2B70-C5B6-4824-B8F1-691B1170E4F5} = {FE92F800-1650-4352-85A9-A6D58BDF4D15}
 		{FDB2A8DE-C0D5-4536-A9CC-126E4A543907} = {5F73AD7C-F75A-408B-A981-E163D001AFB2}
 		{5F73AD7C-F75A-408B-A981-E163D001AFB2} = {435745F5-810B-4FFB-B1DC-759001AC3BEF}
+		{227ACBA5-80A6-4D18-83A2-E5E6DC6E53A5} = {7BB991AA-04B4-4858-BB7B-248195B3CAA2}
+		{034CA8C4-5C34-40F9-A9B1-09369F8B80B3} = {227ACBA5-80A6-4D18-83A2-E5E6DC6E53A5}
 	EndGlobalSection
 EndGlobal

--- a/src/System.Private.ServiceModel/tests/Common/Infrastructure/src/ConditionalTestDetectors.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Infrastructure/src/ConditionalTestDetectors.cs
@@ -21,7 +21,19 @@ namespace Infrastructure.Common
         // installed in the root store.
         public static bool IsRootCertificateInstalled()
         {
-            return ServiceUtilHelper.TryEnsureRootCertificateInstalled();
+            try
+            {
+                ServiceUtilHelper.EnsureRootCertificateInstalled();
+                return true;
+            }
+            catch
+            {
+                // Errors installing the certificate are captured and will be
+                // reported when an attempt is made to use it.  But for the
+                // purposes of this detector, a failure only propagates as
+                // a 'false' return.
+                return false;
+            }
         }
 
         // Detector used by [ConditionalFact(nameof(Client_Certificate_Installed)].
@@ -31,7 +43,18 @@ namespace Infrastructure.Common
         // installed in the certificate store.
         public static bool IsClientCertificateInstalled()
         {
-            return ServiceUtilHelper.TryEnsureLocalClientCertificateInstalled();
+            try { 
+                ServiceUtilHelper.EnsureClientCertificateInstalled();
+                return true;
+            }
+            catch
+            {
+                // Errors installing the certificate are captured and will be
+                // reported when an attempt is made to use it.  But for the
+                // purposes of this detector, a failure only propagates as
+                // a 'false' return.
+                return false;
+            }
         }
 
         // Returns 'true' if the server is running IIS-hosted

--- a/src/System.Private.ServiceModel/tests/Common/Infrastructure/src/ConditionalWcfTest.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Infrastructure/src/ConditionalWcfTest.cs
@@ -108,25 +108,71 @@ namespace Infrastructure.Common
         }
 
         // Returns 'true' if the root certificate is installed and
-        // can be used.  This test will attempt to install the root certificate
-        // when necessary.  A 'false' from this test usually indicates that
-        // the root certificate could not be installed and was also not found
-        // in the root store.
+        // can be used.  Precedence based on the current value of this
+        // condition is:
+        //  blank:    attempt to install certificate and return the result
+        //  'true':   attempt to install certificate and return true
+        //  'false':  bypass certificate installation and return false
         public static bool Root_Certificate_Installed()
         {
-            return GetConditionValue(nameof(Root_Certificate_Installed),
-                                     ConditionalTestDetectors.IsRootCertificateInstalled);
+            // If the condition is unknown, attempt to install and use the
+            // results of that install attempt as the value to return.
+            bool result = GetConditionValue(nameof(Root_Certificate_Installed),
+                                            ConditionalTestDetectors.IsRootCertificateInstalled);
+
+            // Regardless whether the value was 'true' on entry or was detected
+            // to be true, ensure we have attempted to install and verify the
+            // certificate is installed.  This guarantees installation errors
+            // are captured and reported in both cases.
+            if (result)
+            {
+                try
+                {
+                    ServiceUtilHelper.EnsureRootCertificateInstalled();
+                }
+                catch
+                {
+                    // Errors in certificate installation are caught and reported
+                    // when an attempt is made to access it.  But for the purposes
+                    // of this conditional test, an error does not affect the result.
+                }
+            }
+
+            return result;
         }
 
         // Returns 'true' if the client certificate is installed and
-        // can be used.  This test will attempt to install the client certificate
-        // when necessary.  A 'false' from this test usually indicates that
-        // the client certificate could not be installed and was also not found
-        // in the client store.
+        // can be used.  Precedence based on the current value of this
+        // condition is:
+        //  blank:    attempt to install certificate and return the result
+        //  'true':   attempt to install certificate and return true
+        //  'false':  bypass certificate installation and return false
         public static bool Client_Certificate_Installed()
         {
-            return GetConditionValue(nameof(Client_Certificate_Installed),
-                                     ConditionalTestDetectors.IsClientCertificateInstalled);
+            // If the condition is unknown, attempt to install and use the
+            // results of that install attempt as the value to return.
+            bool result = GetConditionValue(nameof(Client_Certificate_Installed),
+                                            ConditionalTestDetectors.IsClientCertificateInstalled);
+
+            // Regardless whether the value was 'true' on entry or was detected
+            // to be true, ensure we have attempted to install and verify the
+            // certificate is installed.  This guarantees installation errors
+            // are captured and reported in both cases.
+            if (result)
+            {
+                try
+                {
+                    ServiceUtilHelper.EnsureClientCertificateInstalled();
+                }
+                catch
+                {
+                    // Errors in certificate installation are caught and reported
+                    // when an attempt is made to access it.  But for the purposes
+                    // of this conditional test, an error does not affect the result.
+                }
+            }
+
+            return result;
         }
 
         // Returns 'true' if ambient credentials are available to use.

--- a/src/System.Private.ServiceModel/tests/Common/Infrastructure/src/ServiceUtilHelper.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Infrastructure/src/ServiceUtilHelper.cs
@@ -11,70 +11,93 @@ using Infrastructure.Common;
 
 public static class ServiceUtilHelper
 {
-    private const string ClientCertificateSubject = "WCF Client Certificate";  
-    private const string CertificateIssuer = "DO_NOT_TRUST_WcfBridgeRootCA";  
+    private const string ClientCertificateSubject = "WCF Client Certificate";
+    private const string CertificateIssuer = "DO_NOT_TRUST_WcfBridgeRootCA";
 
     private static object s_certLock = new object();
     private static string s_serviceHostName = string.Empty;
     private static bool s_rootCertAvailabilityChecked = false;
     private static bool s_clientCertAvailabilityChecked = false;
+    private static X509Certificate2 s_rootCertificate = null;
+    private static X509Certificate2 s_clientCertificate = null;
+    private static string s_rootCertInstallErrorMessage = null;
+    private static string s_clientCertInstallErrorMessage = null;
 
-    public static X509Certificate2 RootCertificate { get; private set; }
+    public static X509Certificate2 RootCertificate
+    {
+        get
+        {
+            ThrowIfRootCertificateInstallationError();
+            return s_rootCertificate;
+        }
+    }
 
-    public static X509Certificate2 ClientCertificate { get; private set; }
+    public static X509Certificate2 ClientCertificate
+    {
+        get
+        {
+            ThrowIfClientCertificateInstallationError();
+            return s_clientCertificate;
+        }
+    }
 
     // Tries to ensure that the root certificate is installed into
     // the root store.  It obtains the root certificate from the service
     // utility endpoint and either installs it or verifies that a matching
-    // one is already installed.  A 'true' return indicates there is a root
-    // certificate in the store and available via 'RootCertificate'.
-    public static bool TryEnsureRootCertificateInstalled()
+    // one is already installed.  InvalidOperationException will be thrown
+    // if an error occurred attempting to install the certificate.  This
+    // method may be called multiple times but will attempt the installation
+    // once only.
+    public static void EnsureRootCertificateInstalled()
     {
-        lock (s_certLock)
+        if (!s_rootCertAvailabilityChecked)
         {
-            if (!s_rootCertAvailabilityChecked)
+            lock (s_certLock)
             {
-                X509Certificate2 rootCertificate = null;
-                string thumbprint = null;
+                if (!s_rootCertAvailabilityChecked)
+                {
+                    X509Certificate2 rootCertificate = null;
+                    string thumbprint = null;
 
-                try
-                {
-                    // Once only, we interrogate the service utility endpoint
-                    // for the root certificate and install it locally if it
-                    // is not already in the store.
-                    rootCertificate = InstallRootCertificateFromServer();
-                }
-                catch (Exception ex)
-                {
-                    System.Console.WriteLine(String.Format("Attempt to install root certificate failed:{0}{1}", 
-                                                            Environment.NewLine, ex.ToString()));
-                }
+                    try
+                    {
+                        // Once only, we interrogate the service utility endpoint
+                        // for the root certificate and install it locally if it
+                        // is not already in the store.
+                        rootCertificate = InstallRootCertificateFromServer();
 
-                // If we had a certificate from the service endpoint, verify it was installed
-                // by retrieving it from the store by thumbprint.
-                if (rootCertificate != null)
-                {
-                    thumbprint = rootCertificate.Thumbprint;
-                    rootCertificate = CertificateManager.RootCertificateFromThumprint(thumbprint);
-                }
+                        // If we had a certificate from the service endpoint, verify it was installed
+                        // by retrieving it from the store by thumbprint.
+                        if (rootCertificate != null)
+                        {
+                            thumbprint = rootCertificate.Thumbprint;
+                            rootCertificate = CertificateManager.RootCertificateFromThumprint(thumbprint);
+                            if (rootCertificate != null)
+                            {
+                                System.Console.WriteLine(String.Format("Using root certificate:{0}{1}",
+                                                        Environment.NewLine, rootCertificate));
+                            }
+                            else
+                            {
+                                s_rootCertInstallErrorMessage =
+                                    String.Format("Failed to find a root certificate matching thumbprint '{0}'", thumbprint);
+                            }
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        s_rootCertInstallErrorMessage = ex.ToString();
+                    }
 
-                if (rootCertificate != null)
-                {
-                    System.Console.WriteLine(String.Format("Using root certificate:{0}{1}",
-                                            Environment.NewLine, rootCertificate));
+                    s_rootCertificate = rootCertificate;
+                    s_rootCertAvailabilityChecked = true;
                 }
-                else
-                {
-                    System.Console.WriteLine(
-                        String.Format("Failed to find a root certificate matching thumbprint '{0}'", thumbprint));
-                }
-
-                RootCertificate = rootCertificate;
-                s_rootCertAvailabilityChecked = true;
             }
         }
 
-        return RootCertificate != null;
+        // If the installation failed, throw an exception everytime
+        // this method is called.
+        ThrowIfRootCertificateInstallationError();
     }
 
     // Acquires a root certificate from the service utility endpoint and
@@ -103,63 +126,77 @@ public static class ServiceUtilHelper
     }
 
     // Tries to ensure that the client certificate is installed into
-    // the certificate store.  It obtains the client certificate from the service
+    // the local store.  It obtains the client certificate from the service
     // utility endpoint and either installs it or verifies that a matching
-    // one is already installed.  A 'true' return indicates there is a client
-    // certificate in the store and available via 'ClientCertificate'.
-    public static bool TryEnsureLocalClientCertificateInstalled()
+    // one is already installed.  InvalidOperationException will be thrown
+    // if an error occurred attempting to install the certificate.  This
+    // method may be called multiple times but will attempt the installation
+    // once only.
+    public static void EnsureClientCertificateInstalled()
     {
-        lock (s_certLock)
+        if (!s_clientCertAvailabilityChecked)
         {
-            if (!s_clientCertAvailabilityChecked)
+            lock (s_certLock)
             {
-                X509Certificate2 clientCertificate = null;
-                string thumbprint = null;
-
-                // To be valid, the client certificate also requires the root certificate
-                // to be installed.  But even if the root certificate installation fails,
-                // it is still possible to verify or install the client certificate for
-                // scenarios that don't require chain validation.
-                TryEnsureRootCertificateInstalled();
-
-                try
+                if (!s_clientCertAvailabilityChecked)
                 {
-                    // Once only, we interrogate the service utility endpoint
-                    // for the client certificate and install it locally if it
-                    // is not already in the store.
-                    clientCertificate = InstallClientCertificateFromServer();
-                }
-                catch (Exception ex)
-                {
-                    // Failure currently only shows as a diagnostic and does not propagate the exception
-                    System.Console.WriteLine(String.Format("Attempt to install client certificate failed:{0}{1}", 
-                                             Environment.NewLine, ex.ToString()));
-                }
+                    X509Certificate2 clientCertificate = null;
+                    string thumbprint = null;
 
-                // If we had a certificate from the service endpoint, verify it was installed
-                // by retrieving it from the store by thumbprint.
-                if (clientCertificate != null)
-                {
-                    thumbprint = clientCertificate.Thumbprint;
-                    clientCertificate = CertificateManager.ClientCertificateFromThumprint(thumbprint);
-                }
+                    // To be valid, the client certificate also requires the root certificate
+                    // to be installed.  But even if the root certificate installation fails,
+                    // it is still possible to verify or install the client certificate for
+                    // scenarios that don't require chain validation.
+                    try
+                    {
+                        EnsureRootCertificateInstalled();
+                    }
+                    catch
+                    {
+                        // Exceptions installing the root certificate are captured and
+                        // will be reported if it is requested.  But allow the attempt
+                        // to install the client certificate to succeed or fail independently.
+                    }
 
-                if (clientCertificate != null)
-                {
-                    System.Console.WriteLine(String.Format("Using client certificate:{0}{1}",
-                                            Environment.NewLine, clientCertificate));
-                }
-                else
-                {
-                    System.Console.WriteLine(
-                        String.Format("Failed to find a client certificate matching thumbprint '{0}'", thumbprint));
-                }
+                    try
+                    {
+                        // Once only, we interrogate the service utility endpoint
+                        // for the client certificate and install it locally if it
+                        // is not already in the store.
+                        clientCertificate = InstallClientCertificateFromServer();
 
-                ClientCertificate = clientCertificate;
-                s_clientCertAvailabilityChecked = true;
+                        // If we had a certificate from the service endpoint, verify it was installed
+                        // by retrieving it from the store by thumbprint.
+                        if (clientCertificate != null)
+                        {
+                            thumbprint = clientCertificate.Thumbprint;
+                            clientCertificate = CertificateManager.ClientCertificateFromThumprint(thumbprint);
+                            if (clientCertificate != null)
+                            {
+                                System.Console.WriteLine(String.Format("Using client certificate:{0}{1}",
+                                                        Environment.NewLine, clientCertificate));
+                            }
+                            else
+                            {
+                                s_clientCertInstallErrorMessage =
+                                    String.Format("Failed to find a client certificate matching thumbprint '{0}'", thumbprint);
+                            }
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        s_clientCertInstallErrorMessage = ex.ToString();
+                    }
+
+                    s_clientCertificate = clientCertificate;
+                    s_clientCertAvailabilityChecked = true;
+                }
             }
         }
-        return ClientCertificate != null;
+
+        // If the installation failed, throw an exception everytime
+        // this method is called.
+        ThrowIfClientCertificateInstallationError();
     }
 
     // Acquires a client certificate from the service utility endpoint and
@@ -185,6 +222,24 @@ public static class ServiceUtilHelper
         }
 
         return clientCertificate;
+    }
+
+    private static void ThrowIfRootCertificateInstallationError()
+    {
+        if (s_rootCertInstallErrorMessage != null)
+        {
+            throw new InvalidOperationException(
+                String.Format("The root certificate could not be installed: {0}", s_rootCertInstallErrorMessage));
+        }
+    }
+
+    private static void ThrowIfClientCertificateInstallationError()
+    {
+        if (s_clientCertInstallErrorMessage != null)
+        {
+            throw new InvalidOperationException(
+                String.Format("The client certificate could not be installed: {0}", s_clientCertInstallErrorMessage));
+        }
     }
 
     private static void CloseCommunicationObjects(params ICommunicationObject[] objects)
@@ -304,4 +359,3 @@ public static class ServiceUtilHelper
         get { return GetEndpointAddress("Util.svc//Util"); }
     }
 }
-

--- a/src/System.Private.ServiceModel/tests/Scenarios/Infrastructure/Infrastructure.Tests.csproj
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Infrastructure/Infrastructure.Tests.csproj
@@ -1,0 +1,45 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <TestCategories>OuterLoop</TestCategories>
+    <Configuration Condition="'$(Configuration)'==''">$(OS)_Debug</Configuration>
+  </PropertyGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Infrastructure.Tests</RootNamespace>
+    <AssemblyName>Infrastructure.Tests</AssemblyName>
+    <SignAssembly>false</SignAssembly>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <ProjectGuid>{034CA8C4-5C34-40F9-A9B1-09369F8B80B3}</ProjectGuid>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="**\*.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <ItemGroup>
+    <!-- Compile tests against the contract, but copy our local-built implementation for testing -->
+    <ProjectReference Include="$(WcfSourceProj)">
+      <Project>{9e50e7bf-cd6e-4269-a6dd-59fd0bd6c0fd}</Project>
+      <Name>System.Private.ServiceModel</Name>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+      <OutputItemType>Content</OutputItemType>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Targets>Build;DebugSymbolsProjectOutputGroup</Targets>
+    </ProjectReference>
+    <ProjectReference Include="$(WcfInfrastructureCommonProj)">
+      <Project>{AFD69665-89A3-42AE-A32E-AB2CBBE6EE7E}</Project>
+      <Name>Infrastructure.Common</Name>
+    </ProjectReference>
+    <ProjectReference Include='$(WcfScenarioTestCommonProj)'>
+      <Project>{9098B41C-9C2E-4FC6-B7D8-FC3411736A22}</Project>
+      <Name>ScenarioTests.Common</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Private.ServiceModel/tests/Scenarios/Infrastructure/SetupValidationTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Infrastructure/SetupValidationTests.cs
@@ -1,0 +1,57 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+
+using Infrastructure.Common;
+using System;
+using Xunit;
+
+public class SetupValidationTests : ConditionalWcfTest
+{
+    [ConditionalFact(nameof(Root_Certificate_Installed))]
+    [OuterLoop]
+    public static void Root_Certificate_Correctly_Installed()
+    {
+        // *** SETUP *** \\
+        InvalidOperationException exception = null;
+
+        // *** EXECUTE *** \\
+        try
+        {
+            ServiceUtilHelper.EnsureRootCertificateInstalled();
+        }
+        catch (InvalidOperationException e)
+        {
+            exception = e;
+        }
+
+        // *** VALIDATE *** \\
+        // Validate rather than allowing an exception to propagate
+        // to be clear the exception was anticipated. 
+        Assert.True(exception == null, exception == null ? String.Empty : exception.ToString());
+    }
+
+    [OuterLoop]
+    [ConditionalFact(nameof(Client_Certificate_Installed))]
+    public static void Client_Certificate_Correctly_Installed()
+    {
+        // *** SETUP *** \\
+        InvalidOperationException exception = null;
+
+        // *** EXECUTE *** \\
+        try
+        {
+            ServiceUtilHelper.EnsureClientCertificateInstalled();
+        }
+        catch (InvalidOperationException e)
+        {
+            exception = e;
+        }
+
+        // *** VALIDATE *** \\
+        // Validate rather than allowing an exception to propagate
+        // to be clear the exception was anticipated. 
+        Assert.True(exception == null, exception == null ? String.Empty : exception.ToString());
+    }
+}

--- a/src/System.Private.ServiceModel/tests/Scenarios/Infrastructure/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Infrastructure/project.json
@@ -1,0 +1,34 @@
+{
+  "dependencies": {
+    "Microsoft.NETCore.Platforms": "1.0.1-rc3-24206-00",
+    "System.ServiceModel.Http": "4.1.0-rc3-24206-00",
+    "System.ServiceModel.NetTcp": "4.1.0-rc3-24206-00",
+    "System.ServiceModel.Primitives": "4.1.0-rc3-24206-00",
+    "System.ServiceModel.Security": "4.0.1-rc3-24206-00",
+    "System.Threading.Timer": "4.0.1-rc3-24206-00",
+    "xunit": "2.1.0",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "test-runtime": {
+      "target": "project",
+      "exclude": "compile"
+    }
+  },
+  "frameworks": {
+    "netcoreapp1.0": {
+      "imports": [
+        "dnxcore50",
+        "portable-net45+win8"
+      ]
+    }
+  },
+  "runtimes": {
+    "centos.7-x64": {},
+    "debian.8-x64": {},
+    "linux-x64": {},
+    "osx.10.10-x64": {},
+    "rhel.7-x64": {},
+    "ubuntu.14.04-x64": {},
+    "win7-x64": {},
+    "win7-x86": {}
+  }
+}


### PR DESCRIPTION
This alters the behavior of the ConditionalFact conditions
for Root_Certificate_Installed and Client_Certificate_Installed
to respect if they have been set explicitly via the build or
as Environment variables.  This allows CI or lab runs to
control whether certificate related tests are run or skipped,
independent of auto-detection logic.

If not explicitly set, the prior auto-detection logic works
as it did in the past.  If they can be installed and verified,
then those ConditionalFact tests run, otherwise they are skipped.

If explicitly set to false, those tests are skipped without
attempting any certificate installation.

If explicitly set to true, the ConditionalFact logic will
attempt to install the certificates, and those ConditionalFact
tests will be run, regardless whether the install succeeded.

This PR also adds new ConditionalFact tests to explicitly
validate whether the certificates have been installed
correctly.  This permits easier diagnosis of all certificate
related tests because these tests will report the installation
failure.

Fixes #1291