### PR TITLE
Disable flaky test in ServiceContractTests

### DIFF
--- a/src/System.Private.ServiceModel/tests/Scenarios/Contract/Service/ServiceContractTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Contract/Service/ServiceContractTests.cs
@@ -54,6 +54,9 @@ public static partial class ServiceContractTests
     }
 
     [Fact]
+#if FULLXUNIT_NOTSUPPORTED
+    [ActiveIssue(1307)]
+#endif 
     [OuterLoop]
     public static void BasicHttp_DefaultSettings_Echo_RoundTrips_String_StreamedRequest()
     {


### PR DESCRIPTION
ServiceContractTests.BasicHttp_DefaultSettings_Echo_RoundTrips_String_StreamedRequest
is failing in ToF due to a timeout, and in the process is bringing down reporting for 45 other tests in the same project.

Disabling this test only in ToF so we can resume reporting on the other affected tests

Related to #1307

/cc: @StephenBonikowsky 