### PR TITLE
Fix issue where OnOpen and OnClose were not called on custom channels and factories

### DIFF
--- a/src/System.Private.ServiceModel/src/System/IdentityModel/Selectors/X509CertificateValidator.cs
+++ b/src/System.Private.ServiceModel/src/System/IdentityModel/Selectors/X509CertificateValidator.cs
@@ -67,8 +67,6 @@ namespace System.IdentityModel.Selectors
 
             public ChainTrustValidator(bool useMachineContext, X509ChainPolicy chainPolicy, uint chainPolicyOID)
             {
-                Contract.Assert(useMachineContext == false, "CoreCLR does not have ctor allowing useMachineContext = true");
-
                 _useMachineContext = useMachineContext;
                 _chainPolicy = chainPolicy;
                 _chainPolicyOID = chainPolicyOID;

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/CommunicationObject.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/CommunicationObject.cs
@@ -758,14 +758,22 @@ namespace System.ServiceModel.Channels
 
         internal protected virtual Task OnCloseAsync(TimeSpan timeout)
         {
-            Contract.Requires(false, "OnCloseAsync needs to be implemented on derived classes");
-            return TaskHelpers.CompletedTask();
+            // Derived types aware of IAsyncCommunicationObject should override OnCloseAsync.
+            // However, because IAsyncCommunicationObject is internal, external implementations
+            // such as custom channels and factories cannot override it, yet still expect their OnClose
+            // logic to be called.  Moreover, we cannot know BeginClose is implemented, so run the
+            // synchronous Close asynchronously.
+            return Task.Run(() => OnClose(timeout));
         }
 
         internal protected virtual Task OnOpenAsync(TimeSpan timeout)
         {
-            Contract.Requires(false, "OnOpenAsync needs to be implemented on derived classes");
-            return TaskHelpers.CompletedTask();
+            // Derived types aware of IAsyncCommunicationObject should override OnOpenAsync.
+            // However, because IAsyncCommunicationObject is internal, external implementations
+            // such as custom channels and factories cannot override it, yet still expect their OnOpen
+            // logic to be called.  Moreover, we cannot know BeginOpen is implemented, so run the
+            // synchronous Open asynchronously.
+            return Task.Run(() => OnOpen(timeout));
         }
     }
 

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/RequestChannel.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/RequestChannel.cs
@@ -76,16 +76,6 @@ namespace System.ServiceModel.Channels
             }
         }
 
-        protected IAsyncResult BeginWaitForPendingRequests(TimeSpan timeout, AsyncCallback callback, object state)
-        {
-            return WaitForPendingRequestsAsync(timeout).ToApm(callback, state);
-        }
-
-        protected void EndWaitForPendingRequests(IAsyncResult result)
-        {
-            result.ToApmEnd();
-        }
-
         private void FinishClose()
         {
             lock (_outstandingRequests)

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/SslStreamSecurityUpgradeProvider.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/SslStreamSecurityUpgradeProvider.cs
@@ -226,14 +226,20 @@ namespace System.ServiceModel.Channels
             CleanupServerCertificate();
         }
 
+        protected internal override Task OnCloseAsync(TimeSpan timeout)
+        {
+            OnClose(timeout);
+            return TaskHelpers.CompletedTask();
+        }
+
         protected override IAsyncResult OnBeginClose(TimeSpan timeout, AsyncCallback callback, object state)
         {
-            throw ExceptionHelper.PlatformNotSupported("SslStreamSecurityUpgradeProvider async path");
+            return OnCloseAsync(timeout).ToApm(callback, state);
         }
 
         protected override void OnEndClose(IAsyncResult result)
         {
-            throw ExceptionHelper.PlatformNotSupported("SslStreamSecurityUpgradeProvider async path");
+            result.ToApmEnd();
         }
 
         private void SetupServerCertificate(SecurityToken token)
@@ -275,14 +281,20 @@ namespace System.ServiceModel.Channels
             }
         }
 
+        protected internal override Task OnOpenAsync(TimeSpan timeout)
+        {
+            OnOpen(timeout);
+            return TaskHelpers.CompletedTask();
+        }
+
         protected override IAsyncResult OnBeginOpen(TimeSpan timeout, AsyncCallback callback, object state)
         {
-            throw ExceptionHelper.PlatformNotSupported("SslStreamSecurityUpgradeProvider async path");
+            return OnOpenAsync(timeout).ToApm(callback, state);
         }
 
         protected override void OnEndOpen(IAsyncResult result)
         {
-            throw ExceptionHelper.PlatformNotSupported("SslStreamSecurityUpgradeProvider async path");
+            result.ToApmEnd();
         }
     }
 

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/StreamedFramingRequestChannel.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/StreamedFramingRequestChannel.cs
@@ -39,14 +39,19 @@ namespace System.ServiceModel.Channels
             get { return _startBytes; }
         }
 
+        protected internal override Task OnOpenAsync(TimeSpan timeout)
+        {
+            return TaskHelpers.CompletedTask();
+        }
+
         protected override IAsyncResult OnBeginOpen(TimeSpan timeout, AsyncCallback callback, object state)
         {
-            return new CompletedAsyncResult(callback, state);
+            return OnOpenAsync(timeout).ToApm(callback, state);
         }
 
         protected override void OnEndOpen(IAsyncResult result)
         {
-            CompletedAsyncResult.End(result);
+            result.ToApmEnd();
         }
 
         protected override void OnOpen(TimeSpan timeout)
@@ -175,14 +180,19 @@ namespace System.ServiceModel.Channels
             ChannelBindingUtility.Dispose(ref _channelBindingToken);
         }
 
+        protected internal override Task OnCloseAsync(TimeSpan timeout)
+        {
+            return base.WaitForPendingRequestsAsync(timeout);
+        }
+
         protected override IAsyncResult OnBeginClose(TimeSpan timeout, AsyncCallback callback, object state)
         {
-            return base.BeginWaitForPendingRequests(timeout, callback, state);
+            return OnCloseAsync(timeout).ToApm(callback, state);
         }
 
         protected override void OnEndClose(IAsyncResult result)
         {
-            base.EndWaitForPendingRequests(result);
+            result.ToApmEnd();
         }
 
         internal class StreamedConnectionPoolHelper : ConnectionPoolHelper

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/WindowsStreamSecurityUpgradeProvider.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/WindowsStreamSecurityUpgradeProvider.cs
@@ -128,14 +128,19 @@ namespace System.ServiceModel.Channels
         {
         }
 
+        protected internal override Task OnCloseAsync(TimeSpan timeout)
+        {
+            return TaskHelpers.CompletedTask();
+        }
+
         protected override IAsyncResult OnBeginClose(TimeSpan timeout, AsyncCallback callback, object state)
         {
-            return new CompletedAsyncResult(callback, state);
+            return OnCloseAsync(timeout).ToApm(callback, state);
         }
 
         protected override void OnEndClose(IAsyncResult result)
         {
-            CompletedAsyncResult.End(result);
+            result.ToApmEnd();
         }
 
         protected override void OnOpen(TimeSpan timeout)
@@ -149,15 +154,20 @@ namespace System.ServiceModel.Channels
             }
         }
 
-        protected override IAsyncResult OnBeginOpen(TimeSpan timeout, AsyncCallback callback, object state)
+        protected internal override Task OnOpenAsync(TimeSpan timeout)
         {
             OnOpen(timeout);
-            return new CompletedAsyncResult(callback, state);
+            return TaskHelpers.CompletedTask();
+        }
+
+        protected override IAsyncResult OnBeginOpen(TimeSpan timeout, AsyncCallback callback, object state)
+        {
+            return OnOpenAsync(timeout).ToApm(callback, state);
         }
 
         protected override void OnEndOpen(IAsyncResult result)
         {
-            CompletedAsyncResult.End(result);
+            result.ToApmEnd();
         }
 
         protected override void OnOpened()

--- a/src/System.Private.ServiceModel/tests/Scenarios/Extensibility/MessageInterceptor/AsyncResult.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Extensibility/MessageInterceptor/AsyncResult.cs
@@ -159,7 +159,7 @@ abstract class AsyncResult : IAsyncResult
 
         if (asyncResult.manualResetEvent != null)
         {
-            //asyncResult.manualResetEvent.Close();
+            asyncResult.manualResetEvent.Dispose();
         }
 
         if (asyncResult.exception != null)

--- a/src/System.Private.ServiceModel/tests/Scenarios/Extensibility/MessageInterceptor/InterceptingChannelBase.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Extensibility/MessageInterceptor/InterceptingChannelBase.cs
@@ -26,7 +26,6 @@ class InterceptingChannelBase<TChannel> : ChannelBase
 
         this.interceptor = interceptor;
         this.innerChannel = innerChannel;
-        innerChannel.Open();
     }
 
     protected TChannel InnerChannel

--- a/src/System.Private.ServiceModel/tests/Scenarios/Extensibility/MessageInterceptor/InterceptingChannelFactory.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Extensibility/MessageInterceptor/InterceptingChannelFactory.cs
@@ -24,7 +24,6 @@ class InterceptingChannelFactory<TChannel>
         {
             throw new InvalidOperationException("InterceptingChannelFactory requires an inner IChannelFactory.");
         }
-        this.innerChannelFactory.Open();
     }
 
     public ChannelMessageInterceptor Interceptor


### PR DESCRIPTION
The MessageInterceptor scenario test exposed a product issue where we were not correctly invoking OnOpen or OnClose on custom channels or channel factories.  The test also used a workaround to get past the product issue, and this workaround failed when run on the full framework.

This PR fixes the product issue and removes the workarounds from the MessageInterceptor test.

Fixes #1241