### PR TITLE
Json file was missing the new runtimes and causing VSO failure.

### DIFF
--- a/src/System.Private.ServiceModel/tests/Scenarios/Infrastructure/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Infrastructure/project.json
@@ -24,10 +24,13 @@
   "runtimes": {
     "centos.7-x64": {},
     "debian.8-x64": {},
+    "fedora.23-x64": {},
     "linux-x64": {},
+    "opensuse.13.2-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }


### PR DESCRIPTION
* Just updated the .json file with recently addes runtimes.