### PR TITLE
Add condition to proj ref of S.P.SM

### DIFF
--- a/src/System.Private.ServiceModel/tests/Common/Infrastructure/src/Infrastructure.Common.csproj
+++ b/src/System.Private.ServiceModel/tests/Common/Infrastructure/src/Infrastructure.Common.csproj
@@ -24,17 +24,21 @@
     <None Include="testproperties.props" />
     <None Include="testproperties.targets" />
   </ItemGroup>
-  <ItemGroup>
-    <!-- Compile tests against the contract, but copy our local-built implementation for testing -->
-    <ProjectReference Include="$(WcfSourceProj)">
-      <Project>{9e50e7bf-cd6e-4269-a6dd-59fd0bd6c0fd}</Project>
-      <Name>System.Private.ServiceModel</Name>
-      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-      <OutputItemType>Content</OutputItemType>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Targets>Build;DebugSymbolsProjectOutputGroup</Targets>
-    </ProjectReference>
-  </ItemGroup>
+  <Choose>
+    <When Condition="'$(HELIXBRANCH)' == ''" >
+      <ItemGroup>
+        <!-- Compile tests against the contract, but copy our local-built implementation for testing -->
+        <ProjectReference Include="$(WcfSourceProj)">
+          <Project>{9e50e7bf-cd6e-4269-a6dd-59fd0bd6c0fd}</Project>
+          <Name>System.Private.ServiceModel</Name>
+          <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+          <OutputItemType>Content</OutputItemType>
+          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+          <Targets>Build;DebugSymbolsProjectOutputGroup</Targets>
+        </ProjectReference>
+      </ItemGroup>
+    </When>
+  </Choose>
   <Import Project="testproperties.props" />
   <Import Project="testproperties.targets" />
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/System.Private.ServiceModel/tests/Common/Infrastructure/tests/Infrastructure.Common.Tests.csproj
+++ b/src/System.Private.ServiceModel/tests/Common/Infrastructure/tests/Infrastructure.Common.Tests.csproj
@@ -25,16 +25,22 @@
   <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>
+  <Choose>
+    <When Condition="'$(HELIXBRANCH)' == ''" >
+      <ItemGroup>
+        <!-- Compile tests against the contract, but copy our local-built implementation for testing -->
+        <ProjectReference Include="$(WcfSourceProj)">
+          <Project>{9e50e7bf-cd6e-4269-a6dd-59fd0bd6c0fd}</Project>
+          <Name>System.Private.ServiceModel</Name>
+          <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+          <OutputItemType>Content</OutputItemType>
+          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+          <Targets>Build;DebugSymbolsProjectOutputGroup</Targets>
+        </ProjectReference>
+      </ItemGroup>
+    </When>
+  </Choose>
   <ItemGroup>
-    <!-- Compile tests against the contract, but copy our local-built implementation for testing -->
-    <ProjectReference Include="$(WcfSourceProj)">
-      <Project>{9e50e7bf-cd6e-4269-a6dd-59fd0bd6c0fd}</Project>
-      <Name>System.Private.ServiceModel</Name>
-      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-      <OutputItemType>Content</OutputItemType>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Targets>Build;DebugSymbolsProjectOutputGroup</Targets>
-    </ProjectReference>
     <ProjectReference Include="..\src\Infrastructure.Common.csproj">
       <Project>{AFD69665-89A3-42AE-A32E-AB2CBBE6EE7E}</Project>
       <Name>Infrastructure.Common</Name>

--- a/src/System.Private.ServiceModel/tests/Common/Scenarios/ScenarioTests.Common.csproj
+++ b/src/System.Private.ServiceModel/tests/Common/Scenarios/ScenarioTests.Common.csproj
@@ -22,16 +22,22 @@
   <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>
+  <Choose>
+    <When Condition="'$(HELIXBRANCH)' == ''" >
+      <ItemGroup>
+        <!-- Compile tests against the contract, but copy our local-built implementation for testing -->
+        <ProjectReference Include="$(WcfSourceProj)">
+          <Project>{9e50e7bf-cd6e-4269-a6dd-59fd0bd6c0fd}</Project>
+          <Name>System.Private.ServiceModel</Name>
+          <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+          <OutputItemType>Content</OutputItemType>
+          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+          <Targets>Build;DebugSymbolsProjectOutputGroup</Targets>
+        </ProjectReference>
+      </ItemGroup>
+    </When>
+  </Choose>
   <ItemGroup>
-    <!-- Compile tests against the contract, but copy our local-built implementation for testing -->
-    <ProjectReference Include="$(WcfSourceProj)">
-      <Project>{9e50e7bf-cd6e-4269-a6dd-59fd0bd6c0fd}</Project>
-      <Name>System.Private.ServiceModel</Name>
-      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-      <OutputItemType>Content</OutputItemType>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Targets>Build;DebugSymbolsProjectOutputGroup</Targets>
-    </ProjectReference>
     <ProjectReference Include="$(WcfInfrastructureCommonProj)">
       <Project>{AFD69665-89A3-42AE-A32E-AB2CBBE6EE7E}</Project>
       <Name>Infrastructure.Common</Name>

--- a/src/System.Private.ServiceModel/tests/Common/Unit/UnitTests.Common.csproj
+++ b/src/System.Private.ServiceModel/tests/Common/Unit/UnitTests.Common.csproj
@@ -22,16 +22,20 @@
   <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>
-  <ItemGroup>
-    <!-- Compile tests against the contract, but copy our local-built implementation for testing -->
-    <ProjectReference Include='$(WcfSourceProj)'>
-      <Project>{9e50e7bf-cd6e-4269-a6dd-59fd0bd6c0fd}</Project>
-      <Name>System.Private.ServiceModel</Name>
-      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-      <OutputItemType>Content</OutputItemType>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Targets>Build;DebugSymbolsProjectOutputGroup</Targets>
-    </ProjectReference>
-  </ItemGroup>
+  <Choose>
+    <When Condition="'$(HELIXBRANCH)' == ''" >
+      <ItemGroup>
+        <!-- Compile tests against the contract, but copy our local-built implementation for testing -->
+        <ProjectReference Include="$(WcfSourceProj)">
+          <Project>{9e50e7bf-cd6e-4269-a6dd-59fd0bd6c0fd}</Project>
+          <Name>System.Private.ServiceModel</Name>
+          <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+          <OutputItemType>Content</OutputItemType>
+          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+          <Targets>Build;DebugSymbolsProjectOutputGroup</Targets>
+        </ProjectReference>
+      </ItemGroup>
+    </When>
+  </Choose>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Private.ServiceModel/tests/Scenarios/Binding/Custom/Binding.Custom.Tests.csproj
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Binding/Custom/Binding.Custom.Tests.csproj
@@ -22,16 +22,22 @@
   <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>
+  <Choose>
+    <When Condition="'$(HELIXBRANCH)' == ''" >
+      <ItemGroup>
+        <!-- Compile tests against the contract, but copy our local-built implementation for testing -->
+        <ProjectReference Include="$(WcfSourceProj)">
+          <Project>{9e50e7bf-cd6e-4269-a6dd-59fd0bd6c0fd}</Project>
+          <Name>System.Private.ServiceModel</Name>
+          <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+          <OutputItemType>Content</OutputItemType>
+          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+          <Targets>Build;DebugSymbolsProjectOutputGroup</Targets>
+        </ProjectReference>
+      </ItemGroup>
+    </When>
+  </Choose>
   <ItemGroup>
-    <!-- Compile tests against the contract, but copy our local-built implementation for testing -->
-    <ProjectReference Include="$(WcfSourceProj)">
-      <Project>{9e50e7bf-cd6e-4269-a6dd-59fd0bd6c0fd}</Project>
-      <Name>System.Private.ServiceModel</Name>
-      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-      <OutputItemType>Content</OutputItemType>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Targets>Build;DebugSymbolsProjectOutputGroup</Targets>
-    </ProjectReference>
     <ProjectReference Include="$(WcfInfrastructureCommonProj)">
       <Project>{AFD69665-89A3-42AE-A32E-AB2CBBE6EE7E}</Project>
       <Name>Infrastructure.Common</Name>

--- a/src/System.Private.ServiceModel/tests/Scenarios/Binding/Http/Binding.Http.Tests.csproj
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Binding/Http/Binding.Http.Tests.csproj
@@ -22,16 +22,22 @@
   <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>
+  <Choose>
+    <When Condition="'$(HELIXBRANCH)' == ''" >
+      <ItemGroup>
+        <!-- Compile tests against the contract, but copy our local-built implementation for testing -->
+        <ProjectReference Include="$(WcfSourceProj)">
+          <Project>{9e50e7bf-cd6e-4269-a6dd-59fd0bd6c0fd}</Project>
+          <Name>System.Private.ServiceModel</Name>
+          <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+          <OutputItemType>Content</OutputItemType>
+          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+          <Targets>Build;DebugSymbolsProjectOutputGroup</Targets>
+        </ProjectReference>
+      </ItemGroup>
+    </When>
+  </Choose>
   <ItemGroup>
-    <!-- Compile tests against the contract, but copy our local-built implementation for testing -->
-    <ProjectReference Include="$(WcfSourceProj)">
-      <Project>{9e50e7bf-cd6e-4269-a6dd-59fd0bd6c0fd}</Project>
-      <Name>System.Private.ServiceModel</Name>
-      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-      <OutputItemType>Content</OutputItemType>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Targets>Build;DebugSymbolsProjectOutputGroup</Targets>
-    </ProjectReference>
     <ProjectReference Include='$(WcfScenarioTestCommonProj)'>
       <Project>{9098B41C-9C2E-4FC6-B7D8-FC3411736A22}</Project>
       <Name>ScenarioTests.Common</Name>

--- a/src/System.Private.ServiceModel/tests/Scenarios/Binding/Tcp/Binding.Tcp.Tests.csproj
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Binding/Tcp/Binding.Tcp.Tests.csproj
@@ -22,16 +22,22 @@
   <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>
+  <Choose>
+    <When Condition="'$(HELIXBRANCH)' == ''" >
+      <ItemGroup>
+        <!-- Compile tests against the contract, but copy our local-built implementation for testing -->
+        <ProjectReference Include="$(WcfSourceProj)">
+          <Project>{9e50e7bf-cd6e-4269-a6dd-59fd0bd6c0fd}</Project>
+          <Name>System.Private.ServiceModel</Name>
+          <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+          <OutputItemType>Content</OutputItemType>
+          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+          <Targets>Build;DebugSymbolsProjectOutputGroup</Targets>
+        </ProjectReference>
+      </ItemGroup>
+    </When>
+  </Choose>
   <ItemGroup>
-    <!-- Compile tests against the contract, but copy our local-built implementation for testing -->
-    <ProjectReference Include="$(WcfSourceProj)">
-      <Project>{9e50e7bf-cd6e-4269-a6dd-59fd0bd6c0fd}</Project>
-      <Name>System.Private.ServiceModel</Name>
-      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-      <OutputItemType>Content</OutputItemType>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Targets>Build;DebugSymbolsProjectOutputGroup</Targets>
-    </ProjectReference>
     <ProjectReference Include='$(WcfScenarioTestCommonProj)'>
       <Project>{9098B41C-9C2E-4FC6-B7D8-FC3411736A22}</Project>
       <Name>ScenarioTests.Common</Name>

--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/ChannelLayer/Client.ChannelLayer.Tests.csproj
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/ChannelLayer/Client.ChannelLayer.Tests.csproj
@@ -22,16 +22,22 @@
   <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>
+  <Choose>
+    <When Condition="'$(HELIXBRANCH)' == ''" >
+      <ItemGroup>
+        <!-- Compile tests against the contract, but copy our local-built implementation for testing -->
+        <ProjectReference Include="$(WcfSourceProj)">
+          <Project>{9e50e7bf-cd6e-4269-a6dd-59fd0bd6c0fd}</Project>
+          <Name>System.Private.ServiceModel</Name>
+          <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+          <OutputItemType>Content</OutputItemType>
+          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+          <Targets>Build;DebugSymbolsProjectOutputGroup</Targets>
+        </ProjectReference>
+      </ItemGroup>
+    </When>
+  </Choose>
   <ItemGroup>
-    <!-- Compile tests against the contract, but copy our local-built implementation for testing -->
-    <ProjectReference Include="$(WcfSourceProj)">
-      <Project>{9e50e7bf-cd6e-4269-a6dd-59fd0bd6c0fd}</Project>
-      <Name>System.Private.ServiceModel</Name>
-      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-      <OutputItemType>Content</OutputItemType>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Targets>Build;DebugSymbolsProjectOutputGroup</Targets>
-    </ProjectReference>
     <ProjectReference Include='$(WcfScenarioTestCommonProj)'>
       <Project>{9098B41C-9C2E-4FC6-B7D8-FC3411736A22}</Project>
       <Name>ScenarioTests.Common</Name>

--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/ClientBase/Client.ClientBase.Tests.csproj
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/ClientBase/Client.ClientBase.Tests.csproj
@@ -19,16 +19,22 @@
   <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>
+  <Choose>
+    <When Condition="'$(HELIXBRANCH)' == ''" >
+      <ItemGroup>
+        <!-- Compile tests against the contract, but copy our local-built implementation for testing -->
+        <ProjectReference Include="$(WcfSourceProj)">
+          <Project>{9e50e7bf-cd6e-4269-a6dd-59fd0bd6c0fd}</Project>
+          <Name>System.Private.ServiceModel</Name>
+          <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+          <OutputItemType>Content</OutputItemType>
+          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+          <Targets>Build;DebugSymbolsProjectOutputGroup</Targets>
+        </ProjectReference>
+      </ItemGroup>
+    </When>
+  </Choose>
   <ItemGroup>
-    <!-- Compile tests against the contract, but copy our local-built implementation for testing -->
-    <ProjectReference Include="$(WcfSourceProj)">
-      <Project>{9e50e7bf-cd6e-4269-a6dd-59fd0bd6c0fd}</Project>
-      <Name>System.Private.ServiceModel</Name>
-      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-      <OutputItemType>Content</OutputItemType>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Targets>Build;DebugSymbolsProjectOutputGroup</Targets>
-    </ProjectReference>
     <ProjectReference Include="$(WcfInfrastructureCommonProj)">
       <Project>{AFD69665-89A3-42AE-A32E-AB2CBBE6EE7E}</Project>
       <Name>Infrastructure.Common</Name>

--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/ExpectedExceptions/Client.ExpectedExceptions.Tests.csproj
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/ExpectedExceptions/Client.ExpectedExceptions.Tests.csproj
@@ -22,16 +22,22 @@
   <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>
+  <Choose>
+    <When Condition="'$(HELIXBRANCH)' == ''" >
+      <ItemGroup>
+        <!-- Compile tests against the contract, but copy our local-built implementation for testing -->
+        <ProjectReference Include="$(WcfSourceProj)">
+          <Project>{9e50e7bf-cd6e-4269-a6dd-59fd0bd6c0fd}</Project>
+          <Name>System.Private.ServiceModel</Name>
+          <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+          <OutputItemType>Content</OutputItemType>
+          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+          <Targets>Build;DebugSymbolsProjectOutputGroup</Targets>
+        </ProjectReference>
+      </ItemGroup>
+    </When>
+  </Choose>
   <ItemGroup>
-    <!-- Compile tests against the contract, but copy our local-built implementation for testing -->
-    <ProjectReference Include="$(WcfSourceProj)">
-      <Project>{9e50e7bf-cd6e-4269-a6dd-59fd0bd6c0fd}</Project>
-      <Name>System.Private.ServiceModel</Name>
-      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-      <OutputItemType>Content</OutputItemType>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Targets>Build;DebugSymbolsProjectOutputGroup</Targets>
-    </ProjectReference>
     <ProjectReference Include="$(WcfInfrastructureCommonProj)">
       <Project>{AFD69665-89A3-42AE-A32E-AB2CBBE6EE7E}</Project>
       <Name>Infrastructure.Common</Name>

--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/TypedClient/Client.TypedClient.Tests.csproj
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/TypedClient/Client.TypedClient.Tests.csproj
@@ -22,16 +22,22 @@
   <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>
+  <Choose>
+    <When Condition="'$(HELIXBRANCH)' == ''" >
+      <ItemGroup>
+        <!-- Compile tests against the contract, but copy our local-built implementation for testing -->
+        <ProjectReference Include="$(WcfSourceProj)">
+          <Project>{9e50e7bf-cd6e-4269-a6dd-59fd0bd6c0fd}</Project>
+          <Name>System.Private.ServiceModel</Name>
+          <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+          <OutputItemType>Content</OutputItemType>
+          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+          <Targets>Build;DebugSymbolsProjectOutputGroup</Targets>
+        </ProjectReference>
+      </ItemGroup>
+    </When>
+  </Choose>
   <ItemGroup>
-    <!-- Compile tests against the contract, but copy our local-built implementation for testing -->
-    <ProjectReference Include="$(WcfSourceProj)">
-      <Project>{9e50e7bf-cd6e-4269-a6dd-59fd0bd6c0fd}</Project>
-      <Name>System.Private.ServiceModel</Name>
-      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-      <OutputItemType>Content</OutputItemType>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Targets>Build;DebugSymbolsProjectOutputGroup</Targets>
-    </ProjectReference>
     <ProjectReference Include='$(WcfScenarioTestCommonProj)'>
       <Project>{9098B41C-9C2E-4FC6-B7D8-FC3411736A22}</Project>
       <Name>ScenarioTests.Common</Name>

--- a/src/System.Private.ServiceModel/tests/Scenarios/Contract/Data/Contract.Data.Tests.csproj
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Contract/Data/Contract.Data.Tests.csproj
@@ -22,16 +22,22 @@
   <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>
+  <Choose>
+    <When Condition="'$(HELIXBRANCH)' == ''" >
+      <ItemGroup>
+        <!-- Compile tests against the contract, but copy our local-built implementation for testing -->
+        <ProjectReference Include="$(WcfSourceProj)">
+          <Project>{9e50e7bf-cd6e-4269-a6dd-59fd0bd6c0fd}</Project>
+          <Name>System.Private.ServiceModel</Name>
+          <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+          <OutputItemType>Content</OutputItemType>
+          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+          <Targets>Build;DebugSymbolsProjectOutputGroup</Targets>
+        </ProjectReference>
+      </ItemGroup>
+    </When>
+  </Choose>
   <ItemGroup>
-    <!-- Compile tests against the contract, but copy our local-built implementation for testing -->
-    <ProjectReference Include="$(WcfSourceProj)">
-      <Project>{9e50e7bf-cd6e-4269-a6dd-59fd0bd6c0fd}</Project>
-      <Name>System.Private.ServiceModel</Name>
-      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-      <OutputItemType>Content</OutputItemType>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Targets>Build;DebugSymbolsProjectOutputGroup</Targets>
-    </ProjectReference>
     <ProjectReference Include="$(WcfScenarioTestCommonProj)">
       <Project>{9098B41C-9C2E-4FC6-B7D8-FC3411736A22}</Project>
       <Name>ScenarioTests.Common</Name>

--- a/src/System.Private.ServiceModel/tests/Scenarios/Contract/Fault/Contract.Fault.Tests.csproj
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Contract/Fault/Contract.Fault.Tests.csproj
@@ -22,16 +22,22 @@
   <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>
+  <Choose>
+    <When Condition="'$(HELIXBRANCH)' == ''" >
+      <ItemGroup>
+        <!-- Compile tests against the contract, but copy our local-built implementation for testing -->
+        <ProjectReference Include="$(WcfSourceProj)">
+          <Project>{9e50e7bf-cd6e-4269-a6dd-59fd0bd6c0fd}</Project>
+          <Name>System.Private.ServiceModel</Name>
+          <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+          <OutputItemType>Content</OutputItemType>
+          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+          <Targets>Build;DebugSymbolsProjectOutputGroup</Targets>
+        </ProjectReference>
+      </ItemGroup>
+    </When>
+  </Choose>
   <ItemGroup>
-    <!-- Compile tests against the contract, but copy our local-built implementation for testing -->
-    <ProjectReference Include="$(WcfSourceProj)">
-      <Project>{9e50e7bf-cd6e-4269-a6dd-59fd0bd6c0fd}</Project>
-      <Name>System.Private.ServiceModel</Name>
-      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-      <OutputItemType>Content</OutputItemType>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Targets>Build;DebugSymbolsProjectOutputGroup</Targets>
-    </ProjectReference>
     <ProjectReference Include="$(WcfScenarioTestCommonProj)">
       <Project>{9098B41C-9C2E-4FC6-B7D8-FC3411736A22}</Project>
       <Name>ScenarioTests.Common</Name>

--- a/src/System.Private.ServiceModel/tests/Scenarios/Contract/Message/Contract.Message.Tests.csproj
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Contract/Message/Contract.Message.Tests.csproj
@@ -22,16 +22,22 @@
   <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>
+  <Choose>
+    <When Condition="'$(HELIXBRANCH)' == ''" >
+      <ItemGroup>
+        <!-- Compile tests against the contract, but copy our local-built implementation for testing -->
+        <ProjectReference Include="$(WcfSourceProj)">
+          <Project>{9e50e7bf-cd6e-4269-a6dd-59fd0bd6c0fd}</Project>
+          <Name>System.Private.ServiceModel</Name>
+          <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+          <OutputItemType>Content</OutputItemType>
+          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+          <Targets>Build;DebugSymbolsProjectOutputGroup</Targets>
+        </ProjectReference>
+      </ItemGroup>
+    </When>
+  </Choose>
   <ItemGroup>
-    <!-- Compile tests against the contract, but copy our local-built implementation for testing -->
-    <ProjectReference Include="$(WcfSourceProj)">
-      <Project>{9e50e7bf-cd6e-4269-a6dd-59fd0bd6c0fd}</Project>
-      <Name>System.Private.ServiceModel</Name>
-      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-      <OutputItemType>Content</OutputItemType>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Targets>Build;DebugSymbolsProjectOutputGroup</Targets>
-    </ProjectReference>
     <ProjectReference Include="$(WcfScenarioTestCommonProj)">
       <Project>{9098B41C-9C2E-4FC6-B7D8-FC3411736A22}</Project>
       <Name>ScenarioTests.Common</Name>

--- a/src/System.Private.ServiceModel/tests/Scenarios/Contract/Service/Contract.Service.Tests.csproj
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Contract/Service/Contract.Service.Tests.csproj
@@ -22,16 +22,22 @@
   <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>
+  <Choose>
+    <When Condition="'$(HELIXBRANCH)' == ''" >
+      <ItemGroup>
+        <!-- Compile tests against the contract, but copy our local-built implementation for testing -->
+        <ProjectReference Include="$(WcfSourceProj)">
+          <Project>{9e50e7bf-cd6e-4269-a6dd-59fd0bd6c0fd}</Project>
+          <Name>System.Private.ServiceModel</Name>
+          <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+          <OutputItemType>Content</OutputItemType>
+          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+          <Targets>Build;DebugSymbolsProjectOutputGroup</Targets>
+        </ProjectReference>
+      </ItemGroup>
+    </When>
+  </Choose>
   <ItemGroup>
-    <!-- Compile tests against the contract, but copy our local-built implementation for testing -->
-    <ProjectReference Include="$(WcfSourceProj)">
-      <Project>{9e50e7bf-cd6e-4269-a6dd-59fd0bd6c0fd}</Project>
-      <Name>System.Private.ServiceModel</Name>
-      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-      <OutputItemType>Content</OutputItemType>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Targets>Build;DebugSymbolsProjectOutputGroup</Targets>
-    </ProjectReference>
     <ProjectReference Include="$(WcfScenarioTestCommonProj)">
       <Project>{9098B41C-9C2E-4FC6-B7D8-FC3411736A22}</Project>
       <Name>ScenarioTests.Common</Name>

--- a/src/System.Private.ServiceModel/tests/Scenarios/Contract/XmlSerializer/Contract.XmlSerializer.Tests.csproj
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Contract/XmlSerializer/Contract.XmlSerializer.Tests.csproj
@@ -22,16 +22,22 @@
   <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>
+  <Choose>
+    <When Condition="'$(HELIXBRANCH)' == ''" >
+      <ItemGroup>
+        <!-- Compile tests against the contract, but copy our local-built implementation for testing -->
+        <ProjectReference Include="$(WcfSourceProj)">
+          <Project>{9e50e7bf-cd6e-4269-a6dd-59fd0bd6c0fd}</Project>
+          <Name>System.Private.ServiceModel</Name>
+          <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+          <OutputItemType>Content</OutputItemType>
+          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+          <Targets>Build;DebugSymbolsProjectOutputGroup</Targets>
+        </ProjectReference>
+      </ItemGroup>
+    </When>
+  </Choose>
   <ItemGroup>
-    <!-- Compile tests against the contract, but copy our local-built implementation for testing -->
-    <ProjectReference Include="$(WcfSourceProj)">
-      <Project>{9e50e7bf-cd6e-4269-a6dd-59fd0bd6c0fd}</Project>
-      <Name>System.Private.ServiceModel</Name>
-      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-      <OutputItemType>Content</OutputItemType>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Targets>Build;DebugSymbolsProjectOutputGroup</Targets>
-    </ProjectReference>
     <ProjectReference Include="$(WcfScenarioTestCommonProj)">
       <Project>{9098B41C-9C2E-4FC6-B7D8-FC3411736A22}</Project>
       <Name>ScenarioTests.Common</Name>

--- a/src/System.Private.ServiceModel/tests/Scenarios/Encoding/Encoders/Encoding.Encoders.Tests.csproj
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Encoding/Encoders/Encoding.Encoders.Tests.csproj
@@ -22,16 +22,22 @@
   <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>
+  <Choose>
+    <When Condition="'$(HELIXBRANCH)' == ''" >
+      <ItemGroup>
+        <!-- Compile tests against the contract, but copy our local-built implementation for testing -->
+        <ProjectReference Include="$(WcfSourceProj)">
+          <Project>{9e50e7bf-cd6e-4269-a6dd-59fd0bd6c0fd}</Project>
+          <Name>System.Private.ServiceModel</Name>
+          <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+          <OutputItemType>Content</OutputItemType>
+          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+          <Targets>Build;DebugSymbolsProjectOutputGroup</Targets>
+        </ProjectReference>
+      </ItemGroup>
+    </When>
+  </Choose>
   <ItemGroup>
-    <!-- Compile tests against the contract, but copy our local-built implementation for testing -->
-    <ProjectReference Include="$(WcfSourceProj)">
-      <Project>{9e50e7bf-cd6e-4269-a6dd-59fd0bd6c0fd}</Project>
-      <Name>System.Private.ServiceModel</Name>
-      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-      <OutputItemType>Content</OutputItemType>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Targets>Build;DebugSymbolsProjectOutputGroup</Targets>
-    </ProjectReference>
     <ProjectReference Include='$(WcfScenarioTestCommonProj)'>
       <Project>{9098B41C-9C2E-4FC6-B7D8-FC3411736A22}</Project>
       <Name>ScenarioTests.Common</Name>

--- a/src/System.Private.ServiceModel/tests/Scenarios/Encoding/MessageVersion/Encoding.MessageVersion.Tests.csproj
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Encoding/MessageVersion/Encoding.MessageVersion.Tests.csproj
@@ -22,16 +22,22 @@
   <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>
+  <Choose>
+    <When Condition="'$(HELIXBRANCH)' == ''" >
+      <ItemGroup>
+        <!-- Compile tests against the contract, but copy our local-built implementation for testing -->
+        <ProjectReference Include="$(WcfSourceProj)">
+          <Project>{9e50e7bf-cd6e-4269-a6dd-59fd0bd6c0fd}</Project>
+          <Name>System.Private.ServiceModel</Name>
+          <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+          <OutputItemType>Content</OutputItemType>
+          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+          <Targets>Build;DebugSymbolsProjectOutputGroup</Targets>
+        </ProjectReference>
+      </ItemGroup>
+    </When>
+  </Choose>
   <ItemGroup>
-    <!-- Compile tests against the contract, but copy our local-built implementation for testing -->
-    <ProjectReference Include="$(WcfSourceProj)">
-      <Project>{9e50e7bf-cd6e-4269-a6dd-59fd0bd6c0fd}</Project>
-      <Name>System.Private.ServiceModel</Name>
-      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-      <OutputItemType>Content</OutputItemType>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Targets>Build;DebugSymbolsProjectOutputGroup</Targets>
-    </ProjectReference>
     <ProjectReference Include='$(WcfScenarioTestCommonProj)'>
       <Project>{9098B41C-9C2E-4FC6-B7D8-FC3411736A22}</Project>
       <Name>ScenarioTests.Common</Name>

--- a/src/System.Private.ServiceModel/tests/Scenarios/Extensibility/MessageEncoder/Extensibility.MessageEncoder.Tests.csproj
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Extensibility/MessageEncoder/Extensibility.MessageEncoder.Tests.csproj
@@ -25,16 +25,22 @@
   <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>
+  <Choose>
+    <When Condition="'$(HELIXBRANCH)' == ''" >
+      <ItemGroup>
+        <!-- Compile tests against the contract, but copy our local-built implementation for testing -->
+        <ProjectReference Include="$(WcfSourceProj)">
+          <Project>{9e50e7bf-cd6e-4269-a6dd-59fd0bd6c0fd}</Project>
+          <Name>System.Private.ServiceModel</Name>
+          <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+          <OutputItemType>Content</OutputItemType>
+          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+          <Targets>Build;DebugSymbolsProjectOutputGroup</Targets>
+        </ProjectReference>
+      </ItemGroup>
+    </When>
+  </Choose>
   <ItemGroup>
-    <!-- Compile tests against the contract, but copy our local-built implementation for testing -->
-    <ProjectReference Include="$(WcfSourceProj)">
-      <Project>{9e50e7bf-cd6e-4269-a6dd-59fd0bd6c0fd}</Project>
-      <Name>System.Private.ServiceModel</Name>
-      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-      <OutputItemType>Content</OutputItemType>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Targets>Build;DebugSymbolsProjectOutputGroup</Targets>
-    </ProjectReference>
     <ProjectReference Include="$(WcfScenarioTestCommonProj)">
       <Project>{9098B41C-9C2E-4FC6-B7D8-FC3411736A22}</Project>
       <Name>ScenarioTests.Common</Name>

--- a/src/System.Private.ServiceModel/tests/Scenarios/Extensibility/MessageInterceptor/Extensibility.MessageInterceptor.Tests.csproj
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Extensibility/MessageInterceptor/Extensibility.MessageInterceptor.Tests.csproj
@@ -22,16 +22,22 @@
   <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>
+  <Choose>
+    <When Condition="'$(HELIXBRANCH)' == ''" >
+      <ItemGroup>
+        <!-- Compile tests against the contract, but copy our local-built implementation for testing -->
+        <ProjectReference Include="$(WcfSourceProj)">
+          <Project>{9e50e7bf-cd6e-4269-a6dd-59fd0bd6c0fd}</Project>
+          <Name>System.Private.ServiceModel</Name>
+          <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+          <OutputItemType>Content</OutputItemType>
+          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+          <Targets>Build;DebugSymbolsProjectOutputGroup</Targets>
+        </ProjectReference>
+      </ItemGroup>
+    </When>
+  </Choose>
   <ItemGroup>
-    <!-- Compile tests against the contract, but copy our local-built implementation for testing -->
-    <ProjectReference Include="$(WcfSourceProj)">
-      <Project>{9e50e7bf-cd6e-4269-a6dd-59fd0bd6c0fd}</Project>
-      <Name>System.Private.ServiceModel</Name>
-      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-      <OutputItemType>Content</OutputItemType>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Targets>Build;DebugSymbolsProjectOutputGroup</Targets>
-    </ProjectReference>
     <ProjectReference Include="$(WcfInfrastructureCommonProj)">
       <Project>{AFD69665-89A3-42AE-A32E-AB2CBBE6EE7E}</Project>
       <Name>Infrastructure.Common</Name>

--- a/src/System.Private.ServiceModel/tests/Scenarios/Extensibility/WebSockets/Extensibility.WebSockets.Tests.csproj
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Extensibility/WebSockets/Extensibility.WebSockets.Tests.csproj
@@ -22,16 +22,22 @@
   <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>
+  <Choose>
+    <When Condition="'$(HELIXBRANCH)' == ''" >
+      <ItemGroup>
+        <!-- Compile tests against the contract, but copy our local-built implementation for testing -->
+        <ProjectReference Include="$(WcfSourceProj)">
+          <Project>{9e50e7bf-cd6e-4269-a6dd-59fd0bd6c0fd}</Project>
+          <Name>System.Private.ServiceModel</Name>
+          <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+          <OutputItemType>Content</OutputItemType>
+          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+          <Targets>Build;DebugSymbolsProjectOutputGroup</Targets>
+        </ProjectReference>
+      </ItemGroup>
+    </When>
+  </Choose>
   <ItemGroup>
-    <!-- Compile tests against the contract, but copy our local-built implementation for testing -->
-    <ProjectReference Include="$(WcfSourceProj)">
-      <Project>{9e50e7bf-cd6e-4269-a6dd-59fd0bd6c0fd}</Project>
-      <Name>System.Private.ServiceModel</Name>
-      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-      <OutputItemType>Content</OutputItemType>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Targets>Build;DebugSymbolsProjectOutputGroup</Targets>
-    </ProjectReference>
     <ProjectReference Include='$(WcfScenarioTestCommonProj)'>
       <Project>{9098B41C-9C2E-4FC6-B7D8-FC3411736A22}</Project>
       <Name>ScenarioTests.Common</Name>

--- a/src/System.Private.ServiceModel/tests/Scenarios/Infrastructure/Infrastructure.Tests.csproj
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Infrastructure/Infrastructure.Tests.csproj
@@ -22,16 +22,22 @@
   <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>
+  <Choose>
+    <When Condition="'$(HELIXBRANCH)' == ''" >
+      <ItemGroup>
+        <!-- Compile tests against the contract, but copy our local-built implementation for testing -->
+        <ProjectReference Include="$(WcfSourceProj)">
+          <Project>{9e50e7bf-cd6e-4269-a6dd-59fd0bd6c0fd}</Project>
+          <Name>System.Private.ServiceModel</Name>
+          <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+          <OutputItemType>Content</OutputItemType>
+          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+          <Targets>Build;DebugSymbolsProjectOutputGroup</Targets>
+        </ProjectReference>
+      </ItemGroup>
+    </When>
+  </Choose>
   <ItemGroup>
-    <!-- Compile tests against the contract, but copy our local-built implementation for testing -->
-    <ProjectReference Include="$(WcfSourceProj)">
-      <Project>{9e50e7bf-cd6e-4269-a6dd-59fd0bd6c0fd}</Project>
-      <Name>System.Private.ServiceModel</Name>
-      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-      <OutputItemType>Content</OutputItemType>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Targets>Build;DebugSymbolsProjectOutputGroup</Targets>
-    </ProjectReference>
     <ProjectReference Include="$(WcfInfrastructureCommonProj)">
       <Project>{AFD69665-89A3-42AE-A32E-AB2CBBE6EE7E}</Project>
       <Name>Infrastructure.Common</Name>

--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Security.TransportSecurity.Tests.csproj
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Security.TransportSecurity.Tests.csproj
@@ -22,16 +22,22 @@
   <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>
+  <Choose>
+    <When Condition="'$(HELIXBRANCH)' == ''" >
+      <ItemGroup>
+        <!-- Compile tests against the contract, but copy our local-built implementation for testing -->
+        <ProjectReference Include="$(WcfSourceProj)">
+          <Project>{9e50e7bf-cd6e-4269-a6dd-59fd0bd6c0fd}</Project>
+          <Name>System.Private.ServiceModel</Name>
+          <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+          <OutputItemType>Content</OutputItemType>
+          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+          <Targets>Build;DebugSymbolsProjectOutputGroup</Targets>
+        </ProjectReference>
+      </ItemGroup>
+    </When>
+  </Choose>
   <ItemGroup>
-    <!-- Compile tests against the contract, but copy our local-built implementation for testing -->
-    <ProjectReference Include="$(WcfSourceProj)">
-      <Project>{9e50e7bf-cd6e-4269-a6dd-59fd0bd6c0fd}</Project>
-      <Name>System.Private.ServiceModel</Name>
-      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-      <OutputItemType>Content</OutputItemType>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Targets>Build;DebugSymbolsProjectOutputGroup</Targets>
-    </ProjectReference>
     <ProjectReference Include="$(WcfScenarioTestCommonProj)">
       <Project>{9098B41C-9C2E-4FC6-B7D8-FC3411736A22}</Project>
       <Name>ScenarioTests.Common</Name>

--- a/src/System.ServiceModel.Duplex/tests/System.ServiceModel.Duplex.Tests.csproj
+++ b/src/System.ServiceModel.Duplex/tests/System.ServiceModel.Duplex.Tests.csproj
@@ -22,16 +22,20 @@
   <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>
-  <ItemGroup>
-    <!-- Compile tests against the contract, but copy our local-built implementation for testing -->
-    <ProjectReference Include='$(WcfSourceProj)'>
-      <Project>{9e50e7bf-cd6e-4269-a6dd-59fd0bd6c0fd}</Project>
-      <Name>System.Private.ServiceModel</Name>
-      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-      <OutputItemType>Content</OutputItemType>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Targets>Build;DebugSymbolsProjectOutputGroup</Targets>
-    </ProjectReference>
-  </ItemGroup>
+  <Choose>
+    <When Condition="'$(HELIXBRANCH)' == ''" >
+      <ItemGroup>
+        <!-- Compile tests against the contract, but copy our local-built implementation for testing -->
+        <ProjectReference Include="$(WcfSourceProj)">
+          <Project>{9e50e7bf-cd6e-4269-a6dd-59fd0bd6c0fd}</Project>
+          <Name>System.Private.ServiceModel</Name>
+          <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+          <OutputItemType>Content</OutputItemType>
+          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+          <Targets>Build;DebugSymbolsProjectOutputGroup</Targets>
+        </ProjectReference>
+      </ItemGroup>
+    </When>
+  </Choose>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.ServiceModel.Http/tests/System.ServiceModel.Http.Tests.csproj
+++ b/src/System.ServiceModel.Http/tests/System.ServiceModel.Http.Tests.csproj
@@ -22,16 +22,22 @@
   <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>
+  <Choose>
+    <When Condition="'$(HELIXBRANCH)' == ''" >
+      <ItemGroup>
+        <!-- Compile tests against the contract, but copy our local-built implementation for testing -->
+        <ProjectReference Include="$(WcfSourceProj)">
+          <Project>{9e50e7bf-cd6e-4269-a6dd-59fd0bd6c0fd}</Project>
+          <Name>System.Private.ServiceModel</Name>
+          <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+          <OutputItemType>Content</OutputItemType>
+          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+          <Targets>Build;DebugSymbolsProjectOutputGroup</Targets>
+        </ProjectReference>
+      </ItemGroup>
+    </When>
+  </Choose>
   <ItemGroup>
-    <!-- Compile tests against the contract, but copy our local-built implementation for testing -->
-    <ProjectReference Include="$(WcfSourceProj)">
-      <Project>{9e50e7bf-cd6e-4269-a6dd-59fd0bd6c0fd}</Project>
-      <Name>System.Private.ServiceModel</Name>
-      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-      <OutputItemType>Content</OutputItemType>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Targets>Build;DebugSymbolsProjectOutputGroup</Targets>
-    </ProjectReference>
     <ProjectReference Include='$(WcfUnitTestCommonProj)'>
       <Project>{E896294A-AB4A-4AF5-A01C-A19E3972EFF9}</Project>
       <Name>UnitTests.Common</Name>

--- a/src/System.ServiceModel.NetTcp/tests/System.ServiceModel.NetTcp.Tests.csproj
+++ b/src/System.ServiceModel.NetTcp/tests/System.ServiceModel.NetTcp.Tests.csproj
@@ -22,16 +22,22 @@
   <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>
+  <Choose>
+    <When Condition="'$(HELIXBRANCH)' == ''" >
+      <ItemGroup>
+        <!-- Compile tests against the contract, but copy our local-built implementation for testing -->
+        <ProjectReference Include="$(WcfSourceProj)">
+          <Project>{9e50e7bf-cd6e-4269-a6dd-59fd0bd6c0fd}</Project>
+          <Name>System.Private.ServiceModel</Name>
+          <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+          <OutputItemType>Content</OutputItemType>
+          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+          <Targets>Build;DebugSymbolsProjectOutputGroup</Targets>
+        </ProjectReference>
+      </ItemGroup>
+    </When>
+  </Choose>
   <ItemGroup>
-    <!-- Compile tests against the contract, but copy our local-built implementation for testing -->
-    <ProjectReference Include="$(WcfSourceProj)">
-      <Project>{9e50e7bf-cd6e-4269-a6dd-59fd0bd6c0fd}</Project>
-      <Name>System.Private.ServiceModel</Name>
-      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-      <OutputItemType>Content</OutputItemType>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Targets>Build;DebugSymbolsProjectOutputGroup</Targets>
-    </ProjectReference>
     <ProjectReference Include='$(WcfUnitTestCommonProj)'>
       <Project>{E896294A-AB4A-4AF5-A01C-A19E3972EFF9}</Project>
       <Name>UnitTests.Common</Name>

--- a/src/System.ServiceModel.Primitives/tests/System.ServiceModel.Primitives.Tests.csproj
+++ b/src/System.ServiceModel.Primitives/tests/System.ServiceModel.Primitives.Tests.csproj
@@ -22,16 +22,22 @@
   <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>
+  <Choose>
+    <When Condition="'$(HELIXBRANCH)' == ''" >
+      <ItemGroup>
+        <!-- Compile tests against the contract, but copy our local-built implementation for testing -->
+        <ProjectReference Include="$(WcfSourceProj)">
+          <Project>{9e50e7bf-cd6e-4269-a6dd-59fd0bd6c0fd}</Project>
+          <Name>System.Private.ServiceModel</Name>
+          <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+          <OutputItemType>Content</OutputItemType>
+          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+          <Targets>Build;DebugSymbolsProjectOutputGroup</Targets>
+        </ProjectReference>
+      </ItemGroup>
+    </When>
+  </Choose>
   <ItemGroup>
-    <!-- Compile tests against the contract, but copy our local-built implementation for testing -->
-    <ProjectReference Include="$(WcfSourceProj)">
-      <Project>{9e50e7bf-cd6e-4269-a6dd-59fd0bd6c0fd}</Project>
-      <Name>System.Private.ServiceModel</Name>
-      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-      <OutputItemType>Content</OutputItemType>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Targets>Build;DebugSymbolsProjectOutputGroup</Targets>
-    </ProjectReference>
     <ProjectReference Include='$(WcfUnitTestCommonProj)'>
       <Project>{E896294A-AB4A-4AF5-A01C-A19E3972EFF9}</Project>
       <Name>UnitTests.Common</Name>

--- a/src/System.ServiceModel.Security/tests/System.ServiceModel.Security.Tests.csproj
+++ b/src/System.ServiceModel.Security/tests/System.ServiceModel.Security.Tests.csproj
@@ -22,16 +22,20 @@
   <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>
-  <ItemGroup>
-    <!-- Compile tests against the contract, but copy our local-built implementation for testing -->
-    <ProjectReference Include='$(WcfSourceProj)'>
-      <Project>{9e50e7bf-cd6e-4269-a6dd-59fd0bd6c0fd}</Project>
-      <Name>System.Private.ServiceModel</Name>
-      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-      <OutputItemType>Content</OutputItemType>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Targets>Build;DebugSymbolsProjectOutputGroup</Targets>
-    </ProjectReference>
-  </ItemGroup>
+  <Choose>
+    <When Condition="'$(HELIXBRANCH)' == ''" >
+      <ItemGroup>
+        <!-- Compile tests against the contract, but copy our local-built implementation for testing -->
+        <ProjectReference Include="$(WcfSourceProj)">
+          <Project>{9e50e7bf-cd6e-4269-a6dd-59fd0bd6c0fd}</Project>
+          <Name>System.Private.ServiceModel</Name>
+          <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+          <OutputItemType>Content</OutputItemType>
+          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+          <Targets>Build;DebugSymbolsProjectOutputGroup</Targets>
+        </ProjectReference>
+      </ItemGroup>
+    </When>
+  </Choose>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>


### PR DESCRIPTION
* This project reference is causing strange build behavior in the VSO build pipeline. Since in that environment it is supposed to build test using the actual packages anyway these project references should not be used.