### PR TITLE
Don't wrap all exceptions in SSLStreamSecurityUpgradeProvider

### DIFF
--- a/src/System.Private.ServiceModel/src/System.Private.ServiceModel.csproj
+++ b/src/System.Private.ServiceModel/src/System.Private.ServiceModel.csproj
@@ -46,6 +46,9 @@
     <Compile Include="$(CommonPath)\System\NotImplemented.cs">
       <Link>Common\System\NotImplemented.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\System\__HResults.cs">
+      <Link>Common\System\__HResults.cs</Link>
+    </Compile>    
     <Compile Include="$(MsBuildThisFileDirectory)\**\*.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/System.Private.ServiceModel/tests/Scenarios/Binding/Custom/CustomBindingTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Binding/Custom/CustomBindingTests.cs
@@ -14,7 +14,6 @@ public partial class CustomBindingTests : ConditionalWcfTest
     // Tcp: Client and Server bindings setup exactly the same using default settings.
 #if FULLXUNIT_NOTSUPPORTED
     [Fact]
-    [ActiveIssue(833)] // Not supported in NET Native
 #else
     [ConditionalFact(nameof(Root_Certificate_Installed), nameof(Client_Certificate_Installed))]
 #endif

--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/ExpectedExceptions/ExpectedExceptionTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/ExpectedExceptions/ExpectedExceptionTests.cs
@@ -278,9 +278,6 @@ public partial class ExpectedExceptionTests : ConditionalWcfTest
     }
 
     [Fact]
-#if FULLXUNIT_NOTSUPPORTED
-    [ActiveIssue(833)] // Not supported in NET Native
-#endif
     [OuterLoop]
     // Verify product throws MessageSecurityException when the Dns identity from the server does not match the expectation
     public static void TCP_ServiceCertExpired_Throw_MessageSecurityException()
@@ -307,8 +304,6 @@ public partial class ExpectedExceptionTests : ConditionalWcfTest
             {
                 Assert.True(false, string.Format("Expected type SecurityNegotiationException, Actual: {0}", exceptionType));
             }
-            string exceptionMessage = exception.Message;
-            Assert.True(exceptionMessage.Contains(Endpoints.Tcp_ExpiredServerCertResource_HostName), string.Format("Expected message contains {0}, actual message: {1}", Endpoints.Tcp_ExpiredServerCertResource_HostName, exceptionMessage));
         }
         finally
         {
@@ -318,7 +313,6 @@ public partial class ExpectedExceptionTests : ConditionalWcfTest
 
 #if FULLXUNIT_NOTSUPPORTED
     [Fact]
-    [ActiveIssue(983)]
 #else
     [ConditionalFact(nameof(Root_Certificate_Installed), nameof(Client_Certificate_Installed))]
 #endif
@@ -377,13 +371,10 @@ public partial class ExpectedExceptionTests : ConditionalWcfTest
         Assert.Equal(MyCertificateValidator.exceptionMsg, exception.Message);
     }
 
-#if FULLXUNIT_NOTSUPPORTED
     [Fact]
-    [ActiveIssue(833)] // Not supported in NET Native
-#endif
     [OuterLoop]
-    // Verify product throws MessageSecurityException when the service cert is revoked
-    public static void TCP_ServiceCertRevoked_Throw_MessageSecurityException()
+    // Verify product throws SecurityNegotiationException when the service cert is revoked
+    public static void TCP_ServiceCertRevoked_Throw_SecurityNegotiationException()
     {
         string testString = "Hello";
 

--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Tcp/IdentityTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Tcp/IdentityTests.cs
@@ -14,7 +14,6 @@ public class IdentityTests : ConditionalWcfTest
 {
 #if FULLXUNIT_NOTSUPPORTED
     [Fact]
-    [ActiveIssue(833)] // Not supported in NET Native
 #else
     [ConditionalFact(nameof(Root_Certificate_Installed), nameof(Client_Certificate_Installed))]
 #endif
@@ -59,7 +58,6 @@ public class IdentityTests : ConditionalWcfTest
 
 #if FULLXUNIT_NOTSUPPORTED
     [Fact]
-    [ActiveIssue(833)] // Not supported in NET Native
 #else
     [ConditionalFact(nameof(Root_Certificate_Installed), nameof(Client_Certificate_Installed))]
 #endif


### PR DESCRIPTION
Conditional code for NET Native was catching all exception types
thrown when initiating an upgrade and and wrapping them in
SecurityNegotiationException. This caused a behavioral change
from the CoreCLR version, causing exceptions thrown by custom
validators to be converted into SecurityNegotiationExceptions.

The fix is to not wrap Exception inside SecurityNegotiationException
unless we see a non-default HRESULT.  The modified code runs only
in NET Native.

Fixes #983
Fixes #1220 
Fixes #1320