### PR TITLE
Removing HELIX condition for ServiceModel project reference.

### DIFF
--- a/src/System.Private.ServiceModel/tests/Common/Infrastructure/tests/Infrastructure.Common.Tests.csproj
+++ b/src/System.Private.ServiceModel/tests/Common/Infrastructure/tests/Infrastructure.Common.Tests.csproj
@@ -25,21 +25,17 @@
   <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>
-  <Choose>
-    <When Condition="'$(HELIXBRANCH)' == ''" >
-      <ItemGroup>
-        <!-- Compile tests against the contract, but copy our local-built implementation for testing -->
-        <ProjectReference Include="$(WcfSourceProj)">
-          <Project>{9e50e7bf-cd6e-4269-a6dd-59fd0bd6c0fd}</Project>
-          <Name>System.Private.ServiceModel</Name>
-          <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-          <OutputItemType>Content</OutputItemType>
-          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-          <Targets>Build;DebugSymbolsProjectOutputGroup</Targets>
-        </ProjectReference>
-      </ItemGroup>
-    </When>
-  </Choose>
+  <ItemGroup>
+    <!-- Compile tests against the contract, but copy our local-built implementation for testing -->
+    <ProjectReference Include="$(WcfSourceProj)">
+      <Project>{9e50e7bf-cd6e-4269-a6dd-59fd0bd6c0fd}</Project>
+      <Name>System.Private.ServiceModel</Name>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+      <OutputItemType>Content</OutputItemType>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Targets>Build;DebugSymbolsProjectOutputGroup</Targets>
+    </ProjectReference>
+  </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\src\Infrastructure.Common.csproj">
       <Project>{AFD69665-89A3-42AE-A32E-AB2CBBE6EE7E}</Project>


### PR DESCRIPTION
* For some unknown reason in the VSO build pipeline we get a restore --packages failure if the unit test project for Infrastructure.Common does not have a reference to S.P.SM.
* This un-blocks us for now so we can proceed with updating WCF package versions to the latest.
* Additional changes in the next few days should significantly change how we run tests so this issue will either be addressed there or by-passed entirely.