### PR TITLE
Fix Digest authentication test that should not run on NET Native

### DIFF
--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Https/ClientCredentialTypeTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Https/ClientCredentialTypeTests.cs
@@ -178,7 +178,10 @@ public class Https_ClientCredentialTypeTests : ConditionalWcfTest
         bool digest_Authentication_Available = Digest_Authentication_Available();
         bool explicit_Credentials_Available = Explicit_Credentials_Available();
 
-        if (!server_Domain_Joined)
+        if (!server_Domain_Joined ||
+            !root_Certificate_Installed ||
+            !digest_Authentication_Available ||
+            !explicit_Credentials_Available)
         {
             Console.WriteLine("---- Test SKIPPED --------------");
             Console.WriteLine("Attempting to run the test in ToF, a ConditionalFact evaluated as FALSE.");


### PR DESCRIPTION
Adds some NET Native versions of ConditionalFact checking to prevent
this test from running under NET Native.