### PR TITLE
Install root certificates when running outerloops

### DIFF
--- a/src/System.Private.ServiceModel/tools/scripts/InstallRootCertificate.sh
+++ b/src/System.Private.ServiceModel/tools/scripts/InstallRootCertificate.sh
@@ -22,8 +22,8 @@ acquire_certificate()
    
     # Need to make a call as the original user as we need to write to the cert store for the current 
     # user, not as root
-    echo "Making a call to '${__service_host}/TestHost.svc/GetRootCertificate' as user '$SUDO_USER'"
-    sudo -E -u $SUDO_USER $__curl_exe -o $__cafile "http://${__service_host}/TestHost.svc/GetRootCert?asPem=true" > /dev/null 2> /dev/null
+    echo "Making a call to '${__service_host}/TestHost.svc/RootCert' as user '$SUDO_USER'"
+    sudo -E -u $SUDO_USER $__curl_exe -o $__cafile "http://${__service_host}/TestHost.svc/RootCert?asPem=true" 
     
     return $?
 }


### PR DESCRIPTION
WCF certificate root installer should run under *nix platforms and when the ServiceUri variable is specified. We also have to ensure that we run under superuser priviliges but we cannot fail the build if the command fails - we should output a warning if this is so