### PR TITLE
Fixup InstallRotCertificate.sh hitting old endpoint

### DIFF
--- a/src/System.Private.ServiceModel/tools/scripts/InstallRootCertificate.sh
+++ b/src/System.Private.ServiceModel/tools/scripts/InstallRootCertificate.sh
@@ -22,8 +22,8 @@ acquire_certificate()
    
     # Need to make a call as the original user as we need to write to the cert store for the current 
     # user, not as root
-    echo "Making a call to '${__service_host}/TestHost.svc/GetRootCertificate' as user '$SUDO_USER'"
-    sudo -E -u $SUDO_USER $__curl_exe -o $__cafile "http://${__service_host}/TestHost.svc/GetRootCert?asPem=true" > /dev/null 2> /dev/null
+    echo "Making a call to '${__service_host}/TestHost.svc/RootCert' as user '$SUDO_USER'"
+    sudo -E -u $SUDO_USER $__curl_exe -o $__cafile "http://${__service_host}/TestHost.svc/RootCert?asPem=true" 
     
     return $?
 }


### PR DESCRIPTION
Three changes: 

1. We were masking errors by redirecting the result of cURL to /dev/null. I have removed the redirection
2. The endpoint GetRootCertificate was changed to RootCert
3. InstallRootCertificate.sh was edited in Windows, and so it needs to be chmodded to be executable

skip ci please
Replaces #1364 