### PR TITLE
Update the Facade test projects to use .pkgproj references.

### DIFF
--- a/src/System.Private.ServiceModel/tests/Common/Infrastructure/Infrastructure.Common.csproj
+++ b/src/System.Private.ServiceModel/tests/Common/Infrastructure/Infrastructure.Common.csproj
@@ -24,21 +24,6 @@
     <None Include="testproperties.props" />
     <None Include="testproperties.targets" />
   </ItemGroup>
-  <Choose>
-    <When Condition="'$(HELIXBRANCH)' == ''" >
-      <ItemGroup>
-        <!-- Compile tests against the contract, but copy our local-built implementation for testing -->
-        <ProjectReference Include="$(WcfSourceProj)">
-          <Project>{9e50e7bf-cd6e-4269-a6dd-59fd0bd6c0fd}</Project>
-          <Name>System.Private.ServiceModel</Name>
-          <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-          <OutputItemType>Content</OutputItemType>
-          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-          <Targets>Build;DebugSymbolsProjectOutputGroup</Targets>
-        </ProjectReference>
-      </ItemGroup>
-    </When>
-  </Choose>
   <Import Project="testproperties.props" />
   <Import Project="testproperties.targets" />
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/System.Private.ServiceModel/tests/Common/Scenarios/ScenarioTests.Common.csproj
+++ b/src/System.Private.ServiceModel/tests/Common/Scenarios/ScenarioTests.Common.csproj
@@ -22,21 +22,6 @@
   <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>
-  <Choose>
-    <When Condition="'$(HELIXBRANCH)' == ''" >
-      <ItemGroup>
-        <!-- Compile tests against the contract, but copy our local-built implementation for testing -->
-        <ProjectReference Include="$(WcfSourceProj)">
-          <Project>{9e50e7bf-cd6e-4269-a6dd-59fd0bd6c0fd}</Project>
-          <Name>System.Private.ServiceModel</Name>
-          <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-          <OutputItemType>Content</OutputItemType>
-          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-          <Targets>Build;DebugSymbolsProjectOutputGroup</Targets>
-        </ProjectReference>
-      </ItemGroup>
-    </When>
-  </Choose>
   <ItemGroup>
     <ProjectReference Include="$(WcfInfrastructureCommonProj)">
       <Project>{AFD69665-89A3-42AE-A32E-AB2CBBE6EE7E}</Project>

--- a/src/System.Private.ServiceModel/tests/Common/Unit/UnitTests.Common.csproj
+++ b/src/System.Private.ServiceModel/tests/Common/Unit/UnitTests.Common.csproj
@@ -22,20 +22,5 @@
   <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>
-  <Choose>
-    <When Condition="'$(HELIXBRANCH)' == ''" >
-      <ItemGroup>
-        <!-- Compile tests against the contract, but copy our local-built implementation for testing -->
-        <ProjectReference Include="$(WcfSourceProj)">
-          <Project>{9e50e7bf-cd6e-4269-a6dd-59fd0bd6c0fd}</Project>
-          <Name>System.Private.ServiceModel</Name>
-          <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-          <OutputItemType>Content</OutputItemType>
-          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-          <Targets>Build;DebugSymbolsProjectOutputGroup</Targets>
-        </ProjectReference>
-      </ItemGroup>
-    </When>
-  </Choose>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Private.ServiceModel/tests/Common/Unit/project.json
+++ b/src/System.Private.ServiceModel/tests/Common/Unit/project.json
@@ -1,30 +1,26 @@
 {
   "dependencies": {
-    "Microsoft.NETCore.Platforms": "1.0.2-beta-24223-03",
-    "System.Collections": "4.0.12-beta-24223-03",
-    "System.Collections.Concurrent": "4.0.13-beta-24223-03",
-    "System.Linq": "4.1.1-beta-24223-03",
-    "System.Net.Primitives": "4.0.12-beta-24223-03",
-    "System.ObjectModel": "4.0.13-beta-24223-03",
-    "System.Runtime.Serialization.Xml": "4.1.2-beta-24223-03",
+    "System.Collections.Concurrent": "4.0.12",
+    "System.Linq": "4.1.0",
     "System.ServiceModel.Duplex": "4.0.2-beta-24308-02",
     "System.ServiceModel.Http": "4.1.1-beta-24308-02",
+    "System.ServiceModel.NetTcp": "4.1.1-beta-24308-02",
     "System.ServiceModel.Primitives": "4.1.1-beta-24308-02",
-    "System.Threading": "4.0.12-beta-24223-03",
+    "System.ServiceModel.Security": "4.0.2-beta-24308-02",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"
     }
   },
   "frameworks": {
-    "netstandard1.3": {}
+    "netstandard1.3": { }
   },
   "supports": {
-    "coreFx.Test.netcore50": {},
-    "coreFx.Test.netcoreapp1.0": {},
-    "coreFx.Test.net46": {},
-    "coreFx.Test.net461": {},
-    "coreFx.Test.net462": {},
-    "coreFx.Test.net463": {}
+    "coreFx.Test.netcore50": { },
+    "coreFx.Test.netcoreapp1.0": { },
+    "coreFx.Test.net46": { },
+    "coreFx.Test.net461": { },
+    "coreFx.Test.net462": { },
+    "coreFx.Test.net463": { }
   }
 }

--- a/src/System.ServiceModel.Duplex/tests/project.json
+++ b/src/System.ServiceModel.Duplex/tests/project.json
@@ -1,7 +1,6 @@
 {
   "dependencies": {
-    "Microsoft.NETCore.Platforms": "1.0.2-beta-24223-03",
-    "System.Linq.Expressions": "4.1.1-beta-24223-03",
+    "System.ServiceModel.Duplex": "4.0.2-beta-24308-02",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.ServiceModel.Http/tests/project.json
+++ b/src/System.ServiceModel.Http/tests/project.json
@@ -1,11 +1,8 @@
 {
   "dependencies": {
-    "Microsoft.NETCore.Platforms": "1.0.2-beta-24223-03",
-    "System.Linq.Expressions": "4.1.1-beta-24223-03",
-    "System.Net.Http": "4.1.1-beta-24223-03", // Added explicitly due to transitive dependencies issue
-    "System.Net.Security": "4.0.1-beta-24223-03", // Added explicitly due to transitive dependencies issue
-    "System.Net.WebHeaderCollection": "4.0.2-beta-24223-03",
-    "System.Runtime.Serialization.Xml": "4.1.2-beta-24223-03",
+    "System.ServiceModel.Http": "4.1.1-beta-24308-02",
+    "System.ServiceModel.Primitives": "4.1.1-beta-24308-02",
+    "System.ServiceModel.Security": "4.0.2-beta-24308-02",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.ServiceModel.NetTcp/tests/project.json
+++ b/src/System.ServiceModel.NetTcp/tests/project.json
@@ -1,9 +1,9 @@
 {
   "dependencies": {
-    "Microsoft.NETCore.Platforms": "1.0.2-beta-24223-03",
-    "System.Linq.Expressions": "4.1.1-beta-24223-03",
-    "System.Net.Security": "4.0.1-beta-24223-03", // Added explicitly due to transitive dependencies issue
-    "System.Runtime.Serialization.Xml": "4.1.2-beta-24223-03",
+    "System.ServiceModel.Duplex": "4.0.2-beta-24308-02",
+    "System.ServiceModel.NetTcp": "4.1.1-beta-24308-02",
+    "System.ServiceModel.Primitives": "4.1.1-beta-24308-02",
+    "System.ServiceModel.Security": "4.0.2-beta-24308-02",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.ServiceModel.Primitives/tests/project.json
+++ b/src/System.ServiceModel.Primitives/tests/project.json
@@ -1,13 +1,10 @@
 {
   "dependencies": {
-    "Microsoft.NETCore.Platforms": "1.0.2-beta-24223-03",
-    "System.Linq": "4.1.1-beta-24223-03", // Added explicitly due to transitive dependencies issue
-    "System.Linq.Expressions": "4.1.1-beta-24223-03",
-    "System.Net.Http": "4.1.1-beta-24223-03", // Added explicitly due to transitive dependencies issue
-    "System.Net.WebSockets": "4.0.1-beta-24223-03",
-    "System.Net.WebSockets.Client": "4.0.1-beta-24223-03",
-    "System.Reflection.DispatchProxy": "4.0.2-beta-24223-03", // Added explicitly due to transitive dependencies issue
-    "System.Runtime.Serialization.Xml": "4.1.2-beta-24223-03",
+    "System.ServiceModel.Duplex": "4.0.2-beta-24308-02",
+    "System.ServiceModel.Http": "4.1.1-beta-24308-02",
+    "System.ServiceModel.NetTcp": "4.1.1-beta-24308-02",
+    "System.ServiceModel.Primitives": "4.1.1-beta-24308-02",
+    "System.ServiceModel.Security": "4.0.2-beta-24308-02",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.ServiceModel.Security/tests/project.json
+++ b/src/System.ServiceModel.Security/tests/project.json
@@ -1,7 +1,6 @@
 {
   "dependencies": {
-    "Microsoft.NETCore.Platforms": "1.0.2-beta-24223-03",
-    "System.Linq.Expressions": "4.1.1-beta-24223-03",
+    "System.ServiceModel.Security": "4.0.2-beta-24308-02",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"


### PR DESCRIPTION
* Facade test.csproj files now use .pkgproj references.
* Facade project.json files have been cleaned-up.
* UnitTests.Common.csproj and project.json files have been cleaned-up.
* Wherever dependent packages need to be referenced use the last stable released version.

* ToDo: Add a run in VSO to run tests against latest-latest (latest dependencies/latest WCF).
* ToDo: Next PR to make same changes to Scenario test projects and related common code.