### PR TITLE
Add new [Fact] and [Theory] attributes to generalize ConditionalFact

### DIFF
--- a/src/System.Private.ServiceModel/tests/Common/Infrastructure/ConditionalTestDetectors.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Infrastructure/ConditionalTestDetectors.cs
@@ -4,7 +4,7 @@
 
 
 using System;
-using System.Runtime.InteropServices;
+using Xunit;
 
 namespace Infrastructure.Common
 {
@@ -117,7 +117,7 @@ namespace Infrastructure.Common
         // Returns 'true' if the client is running on a Windows OS
         public static bool IsWindows()
         {
-            return RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+            return OSID.AnyWindows.MatchesCurrent();
         }
 
         // Returns 'true' if the server is running as localhost.

--- a/src/System.Private.ServiceModel/tests/Common/Infrastructure/FrameworkHelper.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Infrastructure/FrameworkHelper.cs
@@ -1,0 +1,93 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace Infrastructure.Common
+{
+    // Helper class for FrameworkID, an enum created to match
+    // RuntimeInformation.FrameworkDescription
+    public static class FrameworkHelper
+    {
+        // These literals must match those returned from RuntimeInformation.FrameworkDescription.
+        private const string NetNativeFrameworkName = ".NET Native";
+        private const string NetFrameworkFrameworkName = ".NET Framework";
+        private const string NetCoreFrameworkName = ".NET Core";
+
+        private static bool _detectedFrameworkID = false;
+        private static FrameworkID _currentFrameworkID = 0;
+        private static string _currentFrameworkDescription;
+
+        private static string CurrentFrameworkDescription
+        {
+            get
+            {
+                if (_currentFrameworkDescription == null)
+                {
+                    _currentFrameworkDescription = RuntimeInformation.FrameworkDescription;
+                }
+
+                return _currentFrameworkDescription;
+            }
+        }
+
+        public static FrameworkID Current
+        {
+            get
+            {
+                if (!_detectedFrameworkID)
+                {
+                    _currentFrameworkID = DetectCurrentFramework();
+                    _detectedFrameworkID = true;
+
+                    // Log this to the console so that lab run artifacts will show what we detected.
+                    Console.WriteLine(String.Format("Detected current FrameworkID as \"{0}\" from description \"{1}\"",
+                                     _currentFrameworkID.Name(), CurrentFrameworkDescription));
+                }
+
+                return _currentFrameworkID;
+            }
+        }
+
+        // Extension method that returns 'true' if the given FrameworkID
+        // includes the FrameworkID on which this code is currently executing.
+        public static bool MatchesCurrent(this FrameworkID frameworkID)
+        {
+            return ((Current & frameworkID) != 0);
+        }
+
+        // Extension method for FrameworkID to provide name.
+        // "G" formatting will expand to enum's name or collection if multiple.
+        public static string Name(this FrameworkID frameworkID)
+        {
+            return frameworkID.ToString("G");
+        }
+
+        // Detects the FrameworkID associated with the framework
+        // on which this code is running.
+        private static FrameworkID DetectCurrentFramework()
+        {
+            string frameworkName = CurrentFrameworkDescription;
+            if (frameworkName.IndexOf(NetNativeFrameworkName, StringComparison.Ordinal) >= 0)
+            {
+                return FrameworkID.NetNative;
+            }
+
+            if (frameworkName.IndexOf(NetFrameworkFrameworkName, StringComparison.Ordinal) >= 0)
+            {
+                return FrameworkID.NetFramework;
+            }
+
+            if (frameworkName.IndexOf(NetCoreFrameworkName, StringComparison.Ordinal) >= 0)
+            {
+                return FrameworkID.NetCore;
+            }
+
+            // We use "None" when we cannot determine the FrameworkID and rely on
+            // tests to verify detection succeeded.
+            return FrameworkID.None;
+        }
+    }
+}

--- a/src/System.Private.ServiceModel/tests/Common/Infrastructure/FrameworkID.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Infrastructure/FrameworkID.cs
@@ -1,0 +1,26 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace Infrastructure.Common
+{
+    // Enum to indicate a Framework.
+    // There must be a 1:1 match between all the elements in
+    // this enum and RuntimeInformation.FrameworkDescription.
+    // It uses [Flags] because it is a bitmask that allows bitwise
+    // combinations in scenarios like the [Issue] attribute.
+    [Flags]
+    public enum FrameworkID
+    {
+        None =         0x00000000,
+        NetFramework = 0x00000001,   // Net 4.5 || Win8
+        NetCore =      0x00000002,   // netcore50 || wpa81 || other
+        NetNative =    0x00000004,   // netcore50aot
+
+        // 'Any' explicitly names only known flags so "G" formatting
+        // can be used to show a comma separated list of the bitmask.
+        Any = NetFramework | NetCore | NetNative
+    }
+}

--- a/src/System.Private.ServiceModel/tests/Common/Infrastructure/OSHelper.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Infrastructure/OSHelper.cs
@@ -1,0 +1,154 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+
+namespace Infrastructure.Common
+{
+    // Helper class for OSID, an enum created to match
+    // RuntimeInformation.OSDescription
+    public static class OSHelper
+    {
+        // These literals must match those returned from RuntimeInformation.OSDescription.
+        private static string WindowsOsName = "Microsoft Windows"; // netcore50 || win8
+        private static string WindowsPhoneOsName = "Microsoft Windows Phone";    // wpa81
+
+        private static bool _detectedOSID = false;
+        private static OSID _currentOSID = 0;
+        private static string _currentOSDescription;
+
+        // Test runtimes are specified via the $(TestNugetRuntimeId) property.
+        // This list associates names with their corresponding OSID.
+        // It falls back to "any" for partial matches so that future versions
+        // choose at least the correct OS category.
+
+        private static List<Tuple<string, OSID>> _runtimeToOSID = new List<Tuple<string, OSID>>
+        {
+            new Tuple<string, OSID>("centos.7.1", OSID.CentOS_7_1),
+            new Tuple<string, OSID>("centos.7", OSID.CentOS_7),
+            new Tuple<string, OSID>("centos.", OSID.AnyCentOS),
+
+            new Tuple<string, OSID>("debian.8.2", OSID.Debian_8_2),
+            new Tuple<string, OSID>("debian.8", OSID.Debian_8),
+            new Tuple<string, OSID>("debian", OSID.AnyDebian),
+
+            new Tuple<string, OSID>("fedora_23", OSID.Fedora_23),
+            new Tuple<string, OSID>("fedora", OSID.AnyFedora),
+
+            new Tuple<string, OSID>("opensuse.13.2", OSID.OpenSUSE_13_2),
+            new Tuple<string, OSID>("opensuse", OSID.AnyOpenSUSE),
+
+            new Tuple<string, OSID>("osx.10.10", OSID.OSX_10_10),
+            new Tuple<string, OSID>("osx.10.11", OSID.OSX_10_11),
+            new Tuple<string, OSID>("osx", OSID.AnyOSX),
+
+            new Tuple<string, OSID>("rhel.7", OSID.RHEL_7),
+            new Tuple<string, OSID>("rhel", OSID.AnyRHEL),
+
+            new Tuple<string, OSID>("ubuntu.14.04", OSID.Ubuntu_14_04),
+            new Tuple<string, OSID>("ubuntu.16.04", OSID.Ubuntu_16_04),
+            new Tuple<string, OSID>("ubuntu", OSID.AnyUbuntu),
+
+            // Currently, win7 is used for the windows runtime, regardless
+            // which version of Windows is actually used to run the test.
+            // So we can't determine the OS from the runtime in this list.
+        };
+
+        private static string CurrentOSDescription
+        {
+            get
+            {
+                if (_currentOSDescription == null)
+                {
+                    _currentOSDescription = RuntimeInformation.OSDescription;
+                }
+
+                return _currentOSDescription;
+            }
+        }
+
+        public static OSID Current
+        {
+            get
+            {
+                if (!_detectedOSID)
+                {
+                    _currentOSID = DetectCurrentOS();
+                    _detectedOSID = true;
+
+                    // Log this to the console so that lab run artifacts will show what we detected.
+                    Console.WriteLine(String.Format("Detected current OSID as \"{0}\" from test runtime \"{1}\" and description \"{2}\"",
+                                                     _currentOSID.Name(), 
+                                                     TestProperties.GetProperty(TestProperties.TestNugetRuntimeId_PropertyName),
+                                                     CurrentOSDescription));
+                }
+
+                return _currentOSID;
+            }
+        }
+
+        // Extension method that returns 'true' if the given OSID
+        // includes the OSID on which this is currently executing.
+        public static bool MatchesCurrent(this OSID id)
+        {
+            return ((Current & id) != 0);
+        }
+
+        // Extension method for OSID to provide name.
+        // "G" formatting will expand to enum's name or collection if multiple.
+        public static string Name(this OSID id)
+        {
+            return id.ToString("G");
+        }
+
+        private static OSID DetectCurrentOS()
+        {
+            // Attempt to map from the test runtime
+            OSID osid = OSIDfromTestRuntime();
+            if (osid != OSID.None)
+            {
+                return osid;
+            }
+
+            string osName = CurrentOSDescription;
+            if (osName.IndexOf(WindowsOsName, StringComparison.OrdinalIgnoreCase) >= 0)
+            {
+                // We cannot distinguish further from RuntimeInformation.OSDescription alone
+                return OSID.AnyWindows;
+            }
+
+            if (osName.IndexOf(WindowsPhoneOsName, StringComparison.OrdinalIgnoreCase) >= 0)
+            {
+                return OSID.WindowsPhone;
+            }
+
+            // We use "None" when we cannot determine the OSID and rely on
+            // tests to verify detection succeeded.
+            return OSID.None;
+        }
+
+        // Maps from the $(TestNugetRuntimeId) property to corresponding OSID.
+        // Returns OSID.None if cannot determine the OSID.
+        private static OSID OSIDfromTestRuntime()
+        {
+            string testRuntime = TestProperties.GetProperty(TestProperties.TestNugetRuntimeId_PropertyName);
+            if (string.IsNullOrEmpty(testRuntime))
+            {
+                return OSID.None;
+            }
+
+            foreach (var pair in _runtimeToOSID)
+            {
+                string runtime = pair.Item1;
+                if (testRuntime.IndexOf(runtime, StringComparison.OrdinalIgnoreCase) >= 0)
+                {
+                    return pair.Item2;
+                }
+            }
+            return OSID.None;
+        }
+    }
+}

--- a/src/System.Private.ServiceModel/tests/Common/Infrastructure/OsID.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Infrastructure/OsID.cs
@@ -1,0 +1,59 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace Infrastructure.Common
+{
+    // Enum to indicate a known operating system.
+    // The elements in this enum represent all known operating systems
+    // against which the product can be run.  Please update this enum
+    // as new operating systems bceome available for testing.
+    // It uses [Flags] because it is a bitmask that allows bitwise
+    // combinations in scenarios like the [Issue] attribute.
+
+    [Flags]
+    public enum OSID
+    {
+        None =          0x00000000,
+
+        Windows_7 =     0x00000001,
+        Windows_8_1 =   0x00000002,
+        Windows_10 =    0x00000004,
+        WindowsPhone =  0x00000008,
+        Windows_Nano =  0x00000010,
+
+        CentOS_7 =      0x00000020,
+        CentOS_7_1 =    0x00000040,
+        AnyCentOS = CentOS_7 | CentOS_7_1,
+
+        Debian_8 =      0x00000080,
+        Debian_8_2 =    0x00000100, 
+        AnyDebian = Debian_8 | Debian_8_2,
+
+        Fedora_23 =     0x00000200,
+        AnyFedora = Fedora_23,
+
+        OpenSUSE_13_2 = 0x00000400,
+        AnyOpenSUSE = OpenSUSE_13_2,
+
+        OSX_10_10 =     0x00000800,
+        OSX_10_11 =     0x00001000,
+        AnyOSX = OSX_10_10 | OSX_10_11,
+
+        RHEL_7 =        0x00002000,
+        AnyRHEL = RHEL_7,
+
+        Ubuntu_14_04 =  0x00004000,
+        Ubuntu_16_04 =  0x00008000,
+        AnyUbuntu = Ubuntu_14_04 | Ubuntu_16_04,
+
+        AnyUnix = AnyCentOS | AnyDebian | AnyFedora | AnyOpenSUSE | AnyOSX | AnyRHEL | AnyUbuntu,
+        AnyWindows = Windows_7 | Windows_8_1 | Windows_10 | WindowsPhone | Windows_Nano,
+
+        // 'Any' explicitly names only known flags so "G" formatting
+        // can be used to show a comma separated list of the bitmask.
+        Any = AnyUnix | AnyWindows
+    }
+}

--- a/src/System.Private.ServiceModel/tests/Common/Infrastructure/xunit/ConditionAttribute.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Infrastructure/xunit/ConditionAttribute.cs
@@ -1,0 +1,123 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Xunit.Abstractions;
+
+namespace Infrastructure.Common
+{
+    // The [Condition] attribute can be applied to any test method that
+    // is marked with [WcfFact] or [WcfTheory].  It provides zero or more
+    // member names to be evaluated at runtime to determine whether the
+    // test should be run or skipped.
+    // Examples: 
+    //  [Condition(nameof(Root_Certificate_Installed))]
+    //  [Condition(nameof(Root_Certificate_Installed), nameof(Client_Certificate_Installed))]
+
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    public class ConditionAttribute : WcfSkippableAttribute
+    {
+        public string[] Conditions { get; private set; }
+
+        public ConditionAttribute(params string[] conditions)
+        {
+            Conditions = conditions;
+        }
+
+        public override string GetSkipReason(ITestMethod testMethod)
+        {
+            // A null or empty list of conditions is treated as "no conditions",
+            // and the test cases will not be skipped.
+            // Example: [Condition()] or [Condition((string[]) null)]
+            int conditionCount = Conditions == null ? 0 : Conditions.Length;
+            if (conditionCount == 0)
+            {
+                return null;
+            }
+
+            MethodInfo testMethodInfo = testMethod.Method.ToRuntimeMethod();
+            Type testMethodDeclaringType = testMethodInfo.DeclaringType;
+
+            List<string> falseConditions = new List<string>(conditionCount);
+
+            foreach (string entry in Conditions)
+            {
+                string conditionMemberName = entry;
+
+                // Null condition member names are silently tolerated
+                if (string.IsNullOrWhiteSpace(conditionMemberName))
+                {
+                    continue;
+                }
+
+                string[] symbols = conditionMemberName.Split('.');
+                Type declaringType = testMethodDeclaringType;
+
+                if (symbols.Length == 2)
+                {
+                    conditionMemberName = symbols[1];
+                    ITypeInfo type = testMethod.TestClass.Class.Assembly.GetTypes(false).Where(t => t.Name.Contains(symbols[0])).SingleOrDefault();
+                    if (type != null)
+                    {
+                        declaringType = type.ToRuntimeType();
+                    }
+                }
+
+                MethodInfo conditionMethodInfo;
+                if ((conditionMethodInfo = LookupConditionalMethod(declaringType, conditionMemberName)) == null)
+                {
+                    falseConditions.Add(String.Format("Condition \"{0}\" not found in type \"{1}\".",
+                                                      conditionMemberName, testMethodDeclaringType.FullName));
+                    continue;
+                }
+
+                // In the case of multiple conditions, collect the results of all
+                // of them to produce a summary skip reason.
+                try
+                {
+                    if (!(bool)conditionMethodInfo.Invoke(null, null))
+                    {
+                        falseConditions.Add(conditionMemberName);
+                    }
+                }
+                catch (Exception exc)
+                {
+                    falseConditions.Add(String.Format("Condition \"{0}\" threw exception {1}: \"{2}\".",
+                                                      conditionMemberName, 
+                                                      exc.GetType().Name,
+                                                      exc.Message));
+                }
+            }
+
+            if (falseConditions.Count == 0)
+            {
+                return null;
+            }
+
+            return String.Format("{0}", String.Join(", ", falseConditions));
+        }
+
+
+        internal static MethodInfo LookupConditionalMethod(Type t, string name)
+        {
+            if (t == null || name == null)
+                return null;
+
+            TypeInfo ti = t.GetTypeInfo();
+
+            MethodInfo mi = ti.GetDeclaredMethod(name);
+            if (mi != null && mi.IsStatic && mi.GetParameters().Length == 0 && mi.ReturnType == typeof(bool))
+                return mi;
+
+            PropertyInfo pi = ti.GetDeclaredProperty(name);
+            if (pi != null && pi.PropertyType == typeof(bool) && pi.GetMethod != null && pi.GetMethod.IsStatic && pi.GetMethod.GetParameters().Length == 0)
+                return pi.GetMethod;
+
+            return LookupConditionalMethod(ti.BaseType, name);
+        }
+    }
+}

--- a/src/System.Private.ServiceModel/tests/Common/Infrastructure/xunit/IssueAttribute.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Infrastructure/xunit/IssueAttribute.cs
@@ -1,0 +1,77 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Xunit.Abstractions;
+
+namespace Infrastructure.Common
+{
+    // The [Issue] attribute can be applied to any test method that
+    // is marked with [WcfFact] or [WcfTheory].  It indicates the open
+    // issue number and optionally the framework(s), or
+    // OS(s) to which it applies.
+    // Examples: 
+    //  [Issue(999)]
+    //      means this issue applies to all OSes, all Frameworks
+    //  [Issue(999, Framework=FrameworkID.NetNative)]
+    //      means this issue only applies to NET Native
+    //  [Issue(999, OS=OSID.Ubuntu_14_04)]
+    //      means this issue only applies to Ubuntu 14.04
+
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    public class IssueAttribute : WcfSkippableAttribute
+    {
+        public int Issue { get; private set; }
+
+        public FrameworkID Framework {get; set; }
+
+        public OSID OS { get; set; }
+
+        // Short name to repository where the issue exists.
+        // It is not required to be a URL, and it won't be used to create a URL.
+        public string Repository { get; set; }
+
+        public IssueAttribute(int issue)
+        {
+            Issue = issue;
+            Repository = "dotnet/wcf";
+
+            // Default framework and OS to "none" so that they must
+            // be explicitly specified to be more specific.
+            Framework = FrameworkID.None;
+            OS = OSID.None;
+        }
+
+        public override string GetSkipReason(ITestMethod testMethod)
+        {
+            string repositoryAndIssue = String.Format("{0} #{1}", Repository, Issue);
+
+            if (Framework.MatchesCurrent())
+            {
+                return String.Format("{0} on framework \"{1}\" (filter is \"{2}\")",
+                                    repositoryAndIssue,
+                                    FrameworkHelper.Current.Name(),
+                                    Framework.Name());
+            }
+
+            if (OS.MatchesCurrent())
+            {
+                return String.Format("{0} on OS \"{1}\" (filter is \"{2}\")",
+                                    repositoryAndIssue,
+                                    OSHelper.Current.Name(),
+                                    OS.Name());
+            }
+
+            // If no specific OS or Framework filters, it applies to all
+            if (OS == OSID.None && Framework == FrameworkID.None)
+            {
+                return String.Format("{0}",
+                    repositoryAndIssue);
+            }
+
+            // Null means "don't skip"
+            return null;
+        }
+    }
+}

--- a/src/System.Private.ServiceModel/tests/Common/Infrastructure/xunit/WcfFactAttribute.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Infrastructure/xunit/WcfFactAttribute.cs
@@ -1,0 +1,16 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Xunit;
+using Xunit.Sdk;
+
+namespace Infrastructure.Common
+{
+    [XunitTestCaseDiscoverer("Infrastructure.Common.WcfFactDiscoverer", "Infrastructure.Common")]
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+    public class WcfFactAttribute : FactAttribute
+    {
+    }
+}

--- a/src/System.Private.ServiceModel/tests/Common/Infrastructure/xunit/WcfFactDiscoverer.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Infrastructure/xunit/WcfFactDiscoverer.cs
@@ -1,0 +1,28 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Infrastructure.Common
+{
+    public class WcfFactDiscoverer : FactDiscoverer
+    {
+        private readonly IMessageSink _diagnosticMessageSink;
+
+        public WcfFactDiscoverer(IMessageSink diagnosticMessageSink) : base(diagnosticMessageSink)
+        {
+            _diagnosticMessageSink = diagnosticMessageSink;
+        }
+
+        public override IEnumerable<IXunitTestCase> Discover(
+            ITestFrameworkDiscoveryOptions discoveryOptions, ITestMethod testMethod, IAttributeInfo factAttribute)
+        {
+            IEnumerable<IXunitTestCase> testCases = base.Discover(discoveryOptions, testMethod, factAttribute);
+            return WcfTestDiscoverer.Discover(discoveryOptions, _diagnosticMessageSink, testMethod, testCases);
+        }
+    }
+}

--- a/src/System.Private.ServiceModel/tests/Common/Infrastructure/xunit/WcfSkippableAttribute.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Infrastructure/xunit/WcfSkippableAttribute.cs
@@ -1,0 +1,19 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Xunit.Abstractions;
+
+namespace Infrastructure.Common
+{
+    // Abstract base class for attributes that can be used in
+    // combination with [WcfFact] or [WcfTheory] to cause a test
+    // to be skipped
+    public abstract class WcfSkippableAttribute : Attribute
+    {
+        // Return a string describing why the test should be skipped.
+        // Null means it should not be skipped.
+        public abstract string GetSkipReason(ITestMethod testMethod);
+    }
+}

--- a/src/System.Private.ServiceModel/tests/Common/Infrastructure/xunit/WcfTestCase.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Infrastructure/xunit/WcfTestCase.cs
@@ -1,0 +1,52 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Infrastructure.Common
+{
+    /// <summary>Provides for custom IXunitTestCase.</summary>
+    internal class WcfTestCase : IXunitTestCase
+    {
+        private readonly IXunitTestCase _testCase;
+        private readonly string _skippedReason;
+
+        internal WcfTestCase(IXunitTestCase testCase, string skippedReason)
+        {
+            _testCase = testCase;
+            _skippedReason = skippedReason;
+        }
+
+        public string DisplayName { get { return _testCase.DisplayName; } }
+
+        public IMethodInfo Method { get { return _testCase.Method; } }
+
+        public string SkipReason { get { return _skippedReason; } }
+
+        public ISourceInformation SourceInformation { get { return _testCase.SourceInformation; } set { _testCase.SourceInformation = value; } }
+
+        public ITestMethod TestMethod { get { return _testCase.TestMethod; } }
+
+        public object[] TestMethodArguments { get { return _testCase.TestMethodArguments; } }
+
+        public Dictionary<string, List<string>> Traits { get { return _testCase.Traits; } }
+
+        public string UniqueID { get { return _testCase.UniqueID; } }
+
+        public void Deserialize(IXunitSerializationInfo info) { _testCase.Deserialize(info); }
+
+        public Task<RunSummary> RunAsync(
+            IMessageSink diagnosticMessageSink, IMessageBus messageBus, object[] constructorArguments,
+            ExceptionAggregator aggregator, CancellationTokenSource cancellationTokenSource)
+        {
+            return new XunitTestCaseRunner(this, DisplayName, _skippedReason, constructorArguments, TestMethodArguments, messageBus, aggregator, cancellationTokenSource).RunAsync();
+        }
+
+        public void Serialize(IXunitSerializationInfo info) { _testCase.Serialize(info); }
+    }
+}

--- a/src/System.Private.ServiceModel/tests/Common/Infrastructure/xunit/WcfTestDiscoverer.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Infrastructure/xunit/WcfTestDiscoverer.cs
@@ -1,0 +1,81 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Infrastructure.Common
+{
+    // Internal helper class for code common to conditional test discovery through
+    // [WcfFact] and [WcfTheory].  It reflects back onto the test method's attributes
+    // to determine whether the test should be skipped.
+    internal class WcfTestDiscoverer
+    {
+        internal static IEnumerable<IXunitTestCase> Discover(
+                                                        ITestFrameworkDiscoveryOptions discoveryOptions,
+                                                        IMessageSink diagnosticMessageSink,
+                                                        ITestMethod testMethod,
+                                                        IEnumerable<IXunitTestCase> testCases)
+        {
+            MethodInfo testMethodInfo = testMethod.Method.ToRuntimeMethod();
+ 
+            // Evaluate any [Issue] attributes on this method.
+            // We do this first so that tests we know won't be run will avoid calling
+            // their ConditionalFact conditions (below) which could do unnecessary work
+            // and affect other tests that will be run.
+            IssueAttribute[] issues = testMethodInfo.GetCustomAttributes<IssueAttribute>().ToArray();
+            if (issues.Length > 0)
+            {
+                List<string> issueSkipList = new List<string>();
+                foreach (IssueAttribute issue in issues)
+                {
+                    string skipReason = issue.GetSkipReason(testMethod);
+                    if (skipReason != null)
+                    {
+                        issueSkipList.Add(skipReason);
+                    }
+                }
+
+                if (issueSkipList.Count > 0)
+                {
+                    string skippedReason = string.Format("Active issue(s): {0}", string.Join(", ", issueSkipList));
+                    return testCases.Select(tc => new WcfTestCase(tc, skippedReason));
+                }
+            }
+
+            // Finally evaluate all the [Condition] attributes.  These will execute code
+            // that determines whether this test should be run or skipped.
+            ConditionAttribute[] conditions = testMethodInfo.GetCustomAttributes<ConditionAttribute>().ToArray();
+            if (conditions.Length > 0)
+            {
+                List<string> skipReasons = new List<string>(conditions.Length);
+
+                foreach (ConditionAttribute conditionAttribute in conditions)
+                {
+                    string skipReason = conditionAttribute.GetSkipReason(testMethod);
+                    if (skipReason != null)
+                    {
+                        skipReasons.Add(skipReason);
+                    }
+                }
+
+                // Compose a summary of all conditions that returned false.
+                if (skipReasons.Count > 0)
+                {
+                    string skippedReason = string.Format("Condition(s) not met: {0}", string.Join(", ", skipReasons));
+                    return testCases.Select(tc => new WcfTestCase(tc, skippedReason));
+                }
+            }
+
+            // If we get this far, we have decided to run the test.
+            // Still wrap it in a WcfTestCase with a null skip message
+            // so that other WcfTestCase customizations are used.
+            return testCases.Select(tc => new WcfTestCase(tc, null));
+        }
+    }
+}

--- a/src/System.Private.ServiceModel/tests/Common/Infrastructure/xunit/WcfTheoryAttribute.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Infrastructure/xunit/WcfTheoryAttribute.cs
@@ -1,0 +1,16 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Xunit;
+using Xunit.Sdk;
+
+namespace Infrastructure.Common
+{
+    [XunitTestCaseDiscoverer("Infrastructure.Common.WcfTheoryDiscoverer", "Infrastructure.Common")]
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+    public class WcfTheoryAttribute : TheoryAttribute
+    {
+    }
+}

--- a/src/System.Private.ServiceModel/tests/Common/Infrastructure/xunit/WcfTheoryDiscoverer.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Infrastructure/xunit/WcfTheoryDiscoverer.cs
@@ -1,0 +1,28 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Infrastructure.Common
+{
+    public class WcfTheoryDiscoverer : TheoryDiscoverer
+    {
+        private readonly IMessageSink _diagnosticMessageSink;
+
+        public WcfTheoryDiscoverer(IMessageSink diagnosticMessageSink) : base(diagnosticMessageSink)
+        {
+            _diagnosticMessageSink = diagnosticMessageSink;
+        }
+
+        public override IEnumerable<IXunitTestCase> Discover(
+            ITestFrameworkDiscoveryOptions discoveryOptions, ITestMethod testMethod, IAttributeInfo theoryAttribute)
+        {
+            IEnumerable<IXunitTestCase> testCases = base.Discover(discoveryOptions, testMethod, theoryAttribute);
+            return WcfTestDiscoverer.Discover(discoveryOptions, _diagnosticMessageSink, testMethod, testCases);
+        }
+    }
+}

--- a/src/System.Private.ServiceModel/tests/Scenarios/Infrastructure/WcfFactTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Infrastructure/WcfFactTests.cs
@@ -1,0 +1,165 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+// Uncomment the define RUN_WCF_SKIP_TESTS below to run the tests
+// in this file that are skipped based on their attributes.
+// They are normally disabled to prevent spurious numbers of "skip" results.
+// But they are presented here as samples for test skipping semantics.
+
+// #define RUN_WCF_SKIP_TESTS
+
+#if !FULLXUNIT_NOTSUPPORTED // Not available in pseudo-xunit
+
+using Infrastructure.Common;
+using System;
+using System.Security.Cryptography.X509Certificates;
+using System.Runtime.InteropServices;
+using Xunit;
+
+public class WcfFactTests : ConditionalWcfTest
+{
+    // Tests that do not skip are allowed to run to test [WcfFact]
+    // This also triggers lazy initialization of all the skippable
+    // attributes.
+    
+    [WcfFact]
+    [Condition(nameof(Some_True_Condition))]
+    [OuterLoop]
+    public static void Run_On_True_Condition()
+    {
+    }
+
+    [WcfFact]
+    [OuterLoop]
+    public static void FrameworkID_Was_Detected()
+    {
+        Assert.True(FrameworkHelper.Current != FrameworkID.None,
+                    String.Format("FrameworkID was not properly detected from: RuntimeInformation.FrameworkDescription = \'{0}\"",
+                                   RuntimeInformation.FrameworkDescription));
+    }
+
+    [WcfFact]
+    [OuterLoop]
+    public static void OSID_Was_Detected()
+    {
+        Assert.True(OSHelper.Current != OSID.None,
+                    String.Format("OSID was not properly detected from:{0}  TestProperties[TestNugetRuntimeId] = \"{1}\"{0}  RuntimeInformation.OSDescription = \'{2}\"",
+                                   Environment.NewLine,
+                                   TestProperties.GetProperty(TestProperties.TestNugetRuntimeId_PropertyName),
+                                   RuntimeInformation.OSDescription));
+    }
+
+    [WcfFact]
+    [OuterLoop]
+    public static void FrameworkID_Name_Formats_Correctly()
+    {
+        FrameworkID id = FrameworkID.NetCore | FrameworkID.NetNative;
+        string formatted = id.Name();
+
+        Assert.True(formatted.Contains("NetCore") && formatted.Contains("NetNative"),
+                    String.Format("FrameworkID.Name should have contained NetCore and NetNative, but actual was \"{0}\"", formatted));
+    }
+
+    [WcfFact]
+    [OuterLoop]
+    public static void OSID_Name_Formats_Correctly()
+    {
+        OSID id = OSID.Windows_7 | OSID.Ubuntu_14_04;
+        string formatted = id.Name();
+
+        Assert.True(formatted.Contains("Windows_7") && formatted.Contains("Ubuntu_14_04"),
+                    String.Format("FrameworkID.Name should have contained Windows_7 and Ubuntu_14_04, but actual was \"{0}\"", formatted));
+    }
+
+#if RUN_WCF_SKIP_TESTS
+ 
+    [WcfFact]
+    [Condition(nameof(Some_False_Condition))]
+    [OuterLoop]
+    public static void Skip_False_Condition()
+    {
+        Assert.True(false, "Should have been skipped");
+    }
+    
+    [WcfFact]
+    [Issue(999)]
+    [OuterLoop]
+    public static void Skip_Issue_All_Platforms()
+    {
+        Assert.True(false, "Should have been skipped");
+    }
+    
+    [WcfFact]
+    [Issue(999, Framework = FrameworkID.NetCore)]
+    [OuterLoop]
+    public static void Skip_Issue_Framework_NET_Core()
+    {
+        Assert.False(FrameworkID.NetCore.MatchesCurrent(), "Test should have been skipped on NetCore framework");
+    }
+
+    [WcfFact]
+    [Issue(999, OS = OSID.AnyUbuntu)]
+    [OuterLoop]
+    public static void Skip_Issue_OS_AnyUbuntu()
+    {
+        Assert.False(OSID.AnyUbuntu.MatchesCurrent(), "Test should have been skipped on any Ubuntu OS");
+    }
+    
+    [WcfFact]
+    [Issue(999, OS = OSID.Ubuntu_14_04)]
+    [OuterLoop]
+    public static void Skip_Issue_OS_Ubuntu_14_04()
+    {
+        Assert.False(OSID.Ubuntu_14_04.MatchesCurrent(), "Test should have been skipped on Ubuntu 14.04");
+    }
+
+    [WcfFact]
+    [Issue(999, Framework = FrameworkID.Any ^ FrameworkID.NetFramework)]
+    [OuterLoop]
+    public static void Skip_Issue_All_Frameworks_Except_Full_Framework()
+    {
+        Assert.False(FrameworkID.NetFramework.MatchesCurrent(), "Test should have been skipped on all frameworks but the full NET framework");
+    }
+
+    [WcfFact]
+    [Issue(999, OS = OSID.Any ^ OSID.Ubuntu_14_04)]
+    [OuterLoop]
+    public static void Skip_Issue_All_OSes_Except_Ubuntu_14_04()
+    {
+        Assert.False(OSID.Ubuntu_14_04.MatchesCurrent(), "Test should have been skipped on all OSes but Ubuntu_14_04");
+    }
+
+    [WcfFact]
+    [Issue(888, Framework = FrameworkID.NetCore)]
+    [Issue(777, OS = OSID.AnyWindows)]
+    [OuterLoop]
+    public static void Skip_Issue_Platform_Framework_And_OS()
+    {
+        Assert.False(FrameworkID.NetCore.MatchesCurrent(), "Test should have been skipped on NetCore framework");
+        Assert.False(OSID.AnyWindows.MatchesCurrent(), "Test should have been skipped on Windows OS");
+    }
+    
+    [WcfFact]
+    [Issue(999, OS = OSID.AnyWindows)]
+    [Condition(nameof(Some_True_Condition))]
+    [OuterLoop]
+    public static void Skip_Isssue_With_True_Condition()
+    {
+        Assert.True(false, "Should have been skipped");
+    }
+    
+    public static bool Some_False_Condition()
+    {
+        return false;
+    }
+    
+#endif // RUN_WCF_SKIP_TESTS
+    
+    public static bool Some_True_Condition()
+    {
+        return true;
+    }
+}
+
+#endif // !FULLXUNIT_NOTSUPPORTED


### PR DESCRIPTION
This PR adds WcfFact and WcfTheory attributes and discoverers to take the place of
ConditionalFact and ConditionalTheory.  The new discoverers have
been generalized to reflect onto the test method for any of the new
"skip" attributes (IssueAttribute and ConditionAttribute).

For design discussion on this see issue #1034