### PR TITLE
Add TestNugetRuntimeId to TestProperties

### DIFF
--- a/src/System.Private.ServiceModel/tests/Common/Infrastructure/testproperties.targets
+++ b/src/System.Private.ServiceModel/tests/Common/Infrastructure/testproperties.targets
@@ -53,6 +53,7 @@ namespace Infrastructure.Common
         public static readonly string ExplicitUserName_PropertyName = "ExplicitUserName"%3B
         public static readonly string ExplicitPassword_PropertyName = "ExplicitPassword"%3B
         public static readonly string SSL_Available_PropertyName = "SSL_Available"%3B
+        public static readonly string TestNugetRuntimeId_PropertyName = "TestNugetRuntimeId"%3B
                 
         static partial void Initialize(Dictionary<string, string> properties)
         {
@@ -91,6 +92,7 @@ namespace Infrastructure.Common
             properties["ExplicitUserName"] = "$(ExplicitUserName)"%3B
             properties["ExplicitPassword"] = "$(ExplicitPassword)"%3B
             properties["SSL_Available"] = "$(SSL_Available)"%3B
+            properties["TestNugetRuntimeId"] = "$(TestNugetRuntimeId)"%3B
         }
     }
 }


### PR DESCRIPTION
This change adds a new entry to TestProperties to capture the
MsBuild property $(TestNugetRuntimeId).  This property is set
by Helix runs to indicate the package name for the runtime to
use when running the tests.  The build tools also already set
this property, so it is correct during the dev experience too.

This provides the extra necessary information for PR #1388 to be
able to provide more accurate values for the OS enum. For example,
we will be able to distintuish Ubuntu 14.04 from 16.04 at test
runtime based on this new TestProperty.

The existing RuntimeInformation support does not provide this
granularity explicitly and would require fragile string matching to
try to extract from the RuntimeInformation's OS description alone.