### PR TITLE
Temporarily put back project.json files to unblock VSO

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -269,4 +269,4 @@ config.ps1
 **/IISApplications
 
 # WCF copied test project.json files
-src/System.Private.ServiceModel/tests/Scenarios/**/project.json
+# src/System.Private.ServiceModel/tests/Scenarios/**/project.json

--- a/build.override.targets
+++ b/build.override.targets
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <TraversalBuildDependsOn>
-      WcfCopyProjectJson;
+      <!-- WcfCopyProjectJson; -->
       WcfSetup;
       $(TraversalBuildDependsOn);
       WcfCleanup;

--- a/src/System.Private.ServiceModel/tests/Scenarios/Binding/Custom/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Binding/Custom/project.json
@@ -1,0 +1,28 @@
+{
+  "dependencies": {
+    "System.Net.Http": "4.1.0",
+    "System.ServiceModel.Duplex": "4.0.2-beta-24308-02",
+    "System.ServiceModel.Http": "4.1.1-beta-24308-02",
+    "System.ServiceModel.NetTcp": "4.1.1-beta-24308-02",
+    "System.ServiceModel.Primitives": "4.1.1-beta-24308-02",
+    "System.ServiceModel.Security": "4.0.2-beta-24308-02",
+    "System.Threading.Timer": "4.0.1",
+    "test-runtime": {
+      "target": "project",
+      "exclude": "compile"
+    },
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00520-02",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+  },
+  "frameworks": {
+    "netstandard1.3": { }
+  },
+  "supports": {
+    "coreFx.Test.netcore50": { },
+    "coreFx.Test.netcoreapp1.0": { },
+    "coreFx.Test.net46": { },
+    "coreFx.Test.net461": { },
+    "coreFx.Test.net462": { },
+    "coreFx.Test.net463": { }
+  }
+}

--- a/src/System.Private.ServiceModel/tests/Scenarios/Binding/Http/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Binding/Http/project.json
@@ -1,0 +1,28 @@
+{
+  "dependencies": {
+    "System.Net.Http": "4.1.0",
+    "System.ServiceModel.Duplex": "4.0.2-beta-24308-02",
+    "System.ServiceModel.Http": "4.1.1-beta-24308-02",
+    "System.ServiceModel.NetTcp": "4.1.1-beta-24308-02",
+    "System.ServiceModel.Primitives": "4.1.1-beta-24308-02",
+    "System.ServiceModel.Security": "4.0.2-beta-24308-02",
+    "System.Threading.Timer": "4.0.1",
+    "test-runtime": {
+      "target": "project",
+      "exclude": "compile"
+    },
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00520-02",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+  },
+  "frameworks": {
+    "netstandard1.3": { }
+  },
+  "supports": {
+    "coreFx.Test.netcore50": { },
+    "coreFx.Test.netcoreapp1.0": { },
+    "coreFx.Test.net46": { },
+    "coreFx.Test.net461": { },
+    "coreFx.Test.net462": { },
+    "coreFx.Test.net463": { }
+  }
+}

--- a/src/System.Private.ServiceModel/tests/Scenarios/Binding/Tcp/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Binding/Tcp/project.json
@@ -1,0 +1,28 @@
+{
+  "dependencies": {
+    "System.Net.Http": "4.1.0",
+    "System.ServiceModel.Duplex": "4.0.2-beta-24308-02",
+    "System.ServiceModel.Http": "4.1.1-beta-24308-02",
+    "System.ServiceModel.NetTcp": "4.1.1-beta-24308-02",
+    "System.ServiceModel.Primitives": "4.1.1-beta-24308-02",
+    "System.ServiceModel.Security": "4.0.2-beta-24308-02",
+    "System.Threading.Timer": "4.0.1",
+    "test-runtime": {
+      "target": "project",
+      "exclude": "compile"
+    },
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00520-02",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+  },
+  "frameworks": {
+    "netstandard1.3": { }
+  },
+  "supports": {
+    "coreFx.Test.netcore50": { },
+    "coreFx.Test.netcoreapp1.0": { },
+    "coreFx.Test.net46": { },
+    "coreFx.Test.net461": { },
+    "coreFx.Test.net462": { },
+    "coreFx.Test.net463": { }
+  }
+}

--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/ChannelLayer/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/ChannelLayer/project.json
@@ -1,0 +1,28 @@
+{
+  "dependencies": {
+    "System.Net.Http": "4.1.0",
+    "System.ServiceModel.Duplex": "4.0.2-beta-24308-02",
+    "System.ServiceModel.Http": "4.1.1-beta-24308-02",
+    "System.ServiceModel.NetTcp": "4.1.1-beta-24308-02",
+    "System.ServiceModel.Primitives": "4.1.1-beta-24308-02",
+    "System.ServiceModel.Security": "4.0.2-beta-24308-02",
+    "System.Threading.Timer": "4.0.1",
+    "test-runtime": {
+      "target": "project",
+      "exclude": "compile"
+    },
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00520-02",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+  },
+  "frameworks": {
+    "netstandard1.3": { }
+  },
+  "supports": {
+    "coreFx.Test.netcore50": { },
+    "coreFx.Test.netcoreapp1.0": { },
+    "coreFx.Test.net46": { },
+    "coreFx.Test.net461": { },
+    "coreFx.Test.net462": { },
+    "coreFx.Test.net463": { }
+  }
+}

--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/ClientBase/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/ClientBase/project.json
@@ -1,0 +1,28 @@
+{
+  "dependencies": {
+    "System.Net.Http": "4.1.0",
+    "System.ServiceModel.Duplex": "4.0.2-beta-24308-02",
+    "System.ServiceModel.Http": "4.1.1-beta-24308-02",
+    "System.ServiceModel.NetTcp": "4.1.1-beta-24308-02",
+    "System.ServiceModel.Primitives": "4.1.1-beta-24308-02",
+    "System.ServiceModel.Security": "4.0.2-beta-24308-02",
+    "System.Threading.Timer": "4.0.1",
+    "test-runtime": {
+      "target": "project",
+      "exclude": "compile"
+    },
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00520-02",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+  },
+  "frameworks": {
+    "netstandard1.3": { }
+  },
+  "supports": {
+    "coreFx.Test.netcore50": { },
+    "coreFx.Test.netcoreapp1.0": { },
+    "coreFx.Test.net46": { },
+    "coreFx.Test.net461": { },
+    "coreFx.Test.net462": { },
+    "coreFx.Test.net463": { }
+  }
+}

--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/ExpectedExceptions/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/ExpectedExceptions/project.json
@@ -1,0 +1,28 @@
+{
+  "dependencies": {
+    "System.Net.Http": "4.1.0",
+    "System.ServiceModel.Duplex": "4.0.2-beta-24308-02",
+    "System.ServiceModel.Http": "4.1.1-beta-24308-02",
+    "System.ServiceModel.NetTcp": "4.1.1-beta-24308-02",
+    "System.ServiceModel.Primitives": "4.1.1-beta-24308-02",
+    "System.ServiceModel.Security": "4.0.2-beta-24308-02",
+    "System.Threading.Timer": "4.0.1",
+    "test-runtime": {
+      "target": "project",
+      "exclude": "compile"
+    },
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00520-02",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+  },
+  "frameworks": {
+    "netstandard1.3": { }
+  },
+  "supports": {
+    "coreFx.Test.netcore50": { },
+    "coreFx.Test.netcoreapp1.0": { },
+    "coreFx.Test.net46": { },
+    "coreFx.Test.net461": { },
+    "coreFx.Test.net462": { },
+    "coreFx.Test.net463": { }
+  }
+}

--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/TypedClient/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/TypedClient/project.json
@@ -1,0 +1,28 @@
+{
+  "dependencies": {
+    "System.Net.Http": "4.1.0",
+    "System.ServiceModel.Duplex": "4.0.2-beta-24308-02",
+    "System.ServiceModel.Http": "4.1.1-beta-24308-02",
+    "System.ServiceModel.NetTcp": "4.1.1-beta-24308-02",
+    "System.ServiceModel.Primitives": "4.1.1-beta-24308-02",
+    "System.ServiceModel.Security": "4.0.2-beta-24308-02",
+    "System.Threading.Timer": "4.0.1",
+    "test-runtime": {
+      "target": "project",
+      "exclude": "compile"
+    },
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00520-02",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+  },
+  "frameworks": {
+    "netstandard1.3": { }
+  },
+  "supports": {
+    "coreFx.Test.netcore50": { },
+    "coreFx.Test.netcoreapp1.0": { },
+    "coreFx.Test.net46": { },
+    "coreFx.Test.net461": { },
+    "coreFx.Test.net462": { },
+    "coreFx.Test.net463": { }
+  }
+}

--- a/src/System.Private.ServiceModel/tests/Scenarios/Contract/Data/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Contract/Data/project.json
@@ -1,0 +1,28 @@
+{
+  "dependencies": {
+    "System.Net.Http": "4.1.0",
+    "System.ServiceModel.Duplex": "4.0.2-beta-24308-02",
+    "System.ServiceModel.Http": "4.1.1-beta-24308-02",
+    "System.ServiceModel.NetTcp": "4.1.1-beta-24308-02",
+    "System.ServiceModel.Primitives": "4.1.1-beta-24308-02",
+    "System.ServiceModel.Security": "4.0.2-beta-24308-02",
+    "System.Threading.Timer": "4.0.1",
+    "test-runtime": {
+      "target": "project",
+      "exclude": "compile"
+    },
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00520-02",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+  },
+  "frameworks": {
+    "netstandard1.3": { }
+  },
+  "supports": {
+    "coreFx.Test.netcore50": { },
+    "coreFx.Test.netcoreapp1.0": { },
+    "coreFx.Test.net46": { },
+    "coreFx.Test.net461": { },
+    "coreFx.Test.net462": { },
+    "coreFx.Test.net463": { }
+  }
+}

--- a/src/System.Private.ServiceModel/tests/Scenarios/Contract/Fault/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Contract/Fault/project.json
@@ -1,0 +1,28 @@
+{
+  "dependencies": {
+    "System.Net.Http": "4.1.0",
+    "System.ServiceModel.Duplex": "4.0.2-beta-24308-02",
+    "System.ServiceModel.Http": "4.1.1-beta-24308-02",
+    "System.ServiceModel.NetTcp": "4.1.1-beta-24308-02",
+    "System.ServiceModel.Primitives": "4.1.1-beta-24308-02",
+    "System.ServiceModel.Security": "4.0.2-beta-24308-02",
+    "System.Threading.Timer": "4.0.1",
+    "test-runtime": {
+      "target": "project",
+      "exclude": "compile"
+    },
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00520-02",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+  },
+  "frameworks": {
+    "netstandard1.3": { }
+  },
+  "supports": {
+    "coreFx.Test.netcore50": { },
+    "coreFx.Test.netcoreapp1.0": { },
+    "coreFx.Test.net46": { },
+    "coreFx.Test.net461": { },
+    "coreFx.Test.net462": { },
+    "coreFx.Test.net463": { }
+  }
+}

--- a/src/System.Private.ServiceModel/tests/Scenarios/Contract/Message/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Contract/Message/project.json
@@ -1,0 +1,28 @@
+{
+  "dependencies": {
+    "System.Net.Http": "4.1.0",
+    "System.ServiceModel.Duplex": "4.0.2-beta-24308-02",
+    "System.ServiceModel.Http": "4.1.1-beta-24308-02",
+    "System.ServiceModel.NetTcp": "4.1.1-beta-24308-02",
+    "System.ServiceModel.Primitives": "4.1.1-beta-24308-02",
+    "System.ServiceModel.Security": "4.0.2-beta-24308-02",
+    "System.Threading.Timer": "4.0.1",
+    "test-runtime": {
+      "target": "project",
+      "exclude": "compile"
+    },
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00520-02",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+  },
+  "frameworks": {
+    "netstandard1.3": { }
+  },
+  "supports": {
+    "coreFx.Test.netcore50": { },
+    "coreFx.Test.netcoreapp1.0": { },
+    "coreFx.Test.net46": { },
+    "coreFx.Test.net461": { },
+    "coreFx.Test.net462": { },
+    "coreFx.Test.net463": { }
+  }
+}

--- a/src/System.Private.ServiceModel/tests/Scenarios/Contract/Service/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Contract/Service/project.json
@@ -1,0 +1,28 @@
+{
+  "dependencies": {
+    "System.Net.Http": "4.1.0",
+    "System.ServiceModel.Duplex": "4.0.2-beta-24308-02",
+    "System.ServiceModel.Http": "4.1.1-beta-24308-02",
+    "System.ServiceModel.NetTcp": "4.1.1-beta-24308-02",
+    "System.ServiceModel.Primitives": "4.1.1-beta-24308-02",
+    "System.ServiceModel.Security": "4.0.2-beta-24308-02",
+    "System.Threading.Timer": "4.0.1",
+    "test-runtime": {
+      "target": "project",
+      "exclude": "compile"
+    },
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00520-02",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+  },
+  "frameworks": {
+    "netstandard1.3": { }
+  },
+  "supports": {
+    "coreFx.Test.netcore50": { },
+    "coreFx.Test.netcoreapp1.0": { },
+    "coreFx.Test.net46": { },
+    "coreFx.Test.net461": { },
+    "coreFx.Test.net462": { },
+    "coreFx.Test.net463": { }
+  }
+}

--- a/src/System.Private.ServiceModel/tests/Scenarios/Contract/XmlSerializer/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Contract/XmlSerializer/project.json
@@ -1,0 +1,28 @@
+{
+  "dependencies": {
+    "System.Net.Http": "4.1.0",
+    "System.ServiceModel.Duplex": "4.0.2-beta-24308-02",
+    "System.ServiceModel.Http": "4.1.1-beta-24308-02",
+    "System.ServiceModel.NetTcp": "4.1.1-beta-24308-02",
+    "System.ServiceModel.Primitives": "4.1.1-beta-24308-02",
+    "System.ServiceModel.Security": "4.0.2-beta-24308-02",
+    "System.Threading.Timer": "4.0.1",
+    "test-runtime": {
+      "target": "project",
+      "exclude": "compile"
+    },
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00520-02",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+  },
+  "frameworks": {
+    "netstandard1.3": { }
+  },
+  "supports": {
+    "coreFx.Test.netcore50": { },
+    "coreFx.Test.netcoreapp1.0": { },
+    "coreFx.Test.net46": { },
+    "coreFx.Test.net461": { },
+    "coreFx.Test.net462": { },
+    "coreFx.Test.net463": { }
+  }
+}

--- a/src/System.Private.ServiceModel/tests/Scenarios/Encoding/Encoders/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Encoding/Encoders/project.json
@@ -1,0 +1,28 @@
+{
+  "dependencies": {
+    "System.Net.Http": "4.1.0",
+    "System.ServiceModel.Duplex": "4.0.2-beta-24308-02",
+    "System.ServiceModel.Http": "4.1.1-beta-24308-02",
+    "System.ServiceModel.NetTcp": "4.1.1-beta-24308-02",
+    "System.ServiceModel.Primitives": "4.1.1-beta-24308-02",
+    "System.ServiceModel.Security": "4.0.2-beta-24308-02",
+    "System.Threading.Timer": "4.0.1",
+    "test-runtime": {
+      "target": "project",
+      "exclude": "compile"
+    },
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00520-02",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+  },
+  "frameworks": {
+    "netstandard1.3": { }
+  },
+  "supports": {
+    "coreFx.Test.netcore50": { },
+    "coreFx.Test.netcoreapp1.0": { },
+    "coreFx.Test.net46": { },
+    "coreFx.Test.net461": { },
+    "coreFx.Test.net462": { },
+    "coreFx.Test.net463": { }
+  }
+}

--- a/src/System.Private.ServiceModel/tests/Scenarios/Encoding/MessageVersion/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Encoding/MessageVersion/project.json
@@ -1,0 +1,28 @@
+{
+  "dependencies": {
+    "System.Net.Http": "4.1.0",
+    "System.ServiceModel.Duplex": "4.0.2-beta-24308-02",
+    "System.ServiceModel.Http": "4.1.1-beta-24308-02",
+    "System.ServiceModel.NetTcp": "4.1.1-beta-24308-02",
+    "System.ServiceModel.Primitives": "4.1.1-beta-24308-02",
+    "System.ServiceModel.Security": "4.0.2-beta-24308-02",
+    "System.Threading.Timer": "4.0.1",
+    "test-runtime": {
+      "target": "project",
+      "exclude": "compile"
+    },
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00520-02",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+  },
+  "frameworks": {
+    "netstandard1.3": { }
+  },
+  "supports": {
+    "coreFx.Test.netcore50": { },
+    "coreFx.Test.netcoreapp1.0": { },
+    "coreFx.Test.net46": { },
+    "coreFx.Test.net461": { },
+    "coreFx.Test.net462": { },
+    "coreFx.Test.net463": { }
+  }
+}

--- a/src/System.Private.ServiceModel/tests/Scenarios/Extensibility/MessageEncoder/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Extensibility/MessageEncoder/project.json
@@ -1,0 +1,28 @@
+{
+  "dependencies": {
+    "System.Net.Http": "4.1.0",
+    "System.ServiceModel.Duplex": "4.0.2-beta-24308-02",
+    "System.ServiceModel.Http": "4.1.1-beta-24308-02",
+    "System.ServiceModel.NetTcp": "4.1.1-beta-24308-02",
+    "System.ServiceModel.Primitives": "4.1.1-beta-24308-02",
+    "System.ServiceModel.Security": "4.0.2-beta-24308-02",
+    "System.Threading.Timer": "4.0.1",
+    "test-runtime": {
+      "target": "project",
+      "exclude": "compile"
+    },
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00520-02",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+  },
+  "frameworks": {
+    "netstandard1.3": { }
+  },
+  "supports": {
+    "coreFx.Test.netcore50": { },
+    "coreFx.Test.netcoreapp1.0": { },
+    "coreFx.Test.net46": { },
+    "coreFx.Test.net461": { },
+    "coreFx.Test.net462": { },
+    "coreFx.Test.net463": { }
+  }
+}

--- a/src/System.Private.ServiceModel/tests/Scenarios/Extensibility/MessageInterceptor/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Extensibility/MessageInterceptor/project.json
@@ -1,0 +1,28 @@
+{
+  "dependencies": {
+    "System.Net.Http": "4.1.0",
+    "System.ServiceModel.Duplex": "4.0.2-beta-24308-02",
+    "System.ServiceModel.Http": "4.1.1-beta-24308-02",
+    "System.ServiceModel.NetTcp": "4.1.1-beta-24308-02",
+    "System.ServiceModel.Primitives": "4.1.1-beta-24308-02",
+    "System.ServiceModel.Security": "4.0.2-beta-24308-02",
+    "System.Threading.Timer": "4.0.1",
+    "test-runtime": {
+      "target": "project",
+      "exclude": "compile"
+    },
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00520-02",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+  },
+  "frameworks": {
+    "netstandard1.3": { }
+  },
+  "supports": {
+    "coreFx.Test.netcore50": { },
+    "coreFx.Test.netcoreapp1.0": { },
+    "coreFx.Test.net46": { },
+    "coreFx.Test.net461": { },
+    "coreFx.Test.net462": { },
+    "coreFx.Test.net463": { }
+  }
+}

--- a/src/System.Private.ServiceModel/tests/Scenarios/Extensibility/WebSockets/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Extensibility/WebSockets/project.json
@@ -1,0 +1,28 @@
+{
+  "dependencies": {
+    "System.Net.Http": "4.1.0",
+    "System.ServiceModel.Duplex": "4.0.2-beta-24308-02",
+    "System.ServiceModel.Http": "4.1.1-beta-24308-02",
+    "System.ServiceModel.NetTcp": "4.1.1-beta-24308-02",
+    "System.ServiceModel.Primitives": "4.1.1-beta-24308-02",
+    "System.ServiceModel.Security": "4.0.2-beta-24308-02",
+    "System.Threading.Timer": "4.0.1",
+    "test-runtime": {
+      "target": "project",
+      "exclude": "compile"
+    },
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00520-02",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+  },
+  "frameworks": {
+    "netstandard1.3": { }
+  },
+  "supports": {
+    "coreFx.Test.netcore50": { },
+    "coreFx.Test.netcoreapp1.0": { },
+    "coreFx.Test.net46": { },
+    "coreFx.Test.net461": { },
+    "coreFx.Test.net462": { },
+    "coreFx.Test.net463": { }
+  }
+}

--- a/src/System.Private.ServiceModel/tests/Scenarios/Infrastructure/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Infrastructure/project.json
@@ -1,0 +1,28 @@
+{
+  "dependencies": {
+    "System.Net.Http": "4.1.0",
+    "System.ServiceModel.Duplex": "4.0.2-beta-24308-02",
+    "System.ServiceModel.Http": "4.1.1-beta-24308-02",
+    "System.ServiceModel.NetTcp": "4.1.1-beta-24308-02",
+    "System.ServiceModel.Primitives": "4.1.1-beta-24308-02",
+    "System.ServiceModel.Security": "4.0.2-beta-24308-02",
+    "System.Threading.Timer": "4.0.1",
+    "test-runtime": {
+      "target": "project",
+      "exclude": "compile"
+    },
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00520-02",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+  },
+  "frameworks": {
+    "netstandard1.3": { }
+  },
+  "supports": {
+    "coreFx.Test.netcore50": { },
+    "coreFx.Test.netcoreapp1.0": { },
+    "coreFx.Test.net46": { },
+    "coreFx.Test.net461": { },
+    "coreFx.Test.net462": { },
+    "coreFx.Test.net463": { }
+  }
+}

--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/project.json
@@ -1,0 +1,28 @@
+{
+  "dependencies": {
+    "System.Net.Http": "4.1.0",
+    "System.ServiceModel.Duplex": "4.0.2-beta-24308-02",
+    "System.ServiceModel.Http": "4.1.1-beta-24308-02",
+    "System.ServiceModel.NetTcp": "4.1.1-beta-24308-02",
+    "System.ServiceModel.Primitives": "4.1.1-beta-24308-02",
+    "System.ServiceModel.Security": "4.0.2-beta-24308-02",
+    "System.Threading.Timer": "4.0.1",
+    "test-runtime": {
+      "target": "project",
+      "exclude": "compile"
+    },
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00520-02",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+  },
+  "frameworks": {
+    "netstandard1.3": { }
+  },
+  "supports": {
+    "coreFx.Test.netcore50": { },
+    "coreFx.Test.netcoreapp1.0": { },
+    "coreFx.Test.net46": { },
+    "coreFx.Test.net461": { },
+    "coreFx.Test.net462": { },
+    "coreFx.Test.net463": { }
+  }
+}


### PR DESCRIPTION
This PR temporarily puts back the project.json files we removed when moving to a single project.json.  It appears the Build-Test job in VSO does not trigger our logic to copy the project.jsons, and therefore fails to build.  This PR is only temporary to unblock VSO while we decide on the correct fix.