### PR TITLE
Add better checks for detecting detached HEAD in PRService

### DIFF
--- a/src/System.Private.ServiceModel/tools/PRService/pr.ashx
+++ b/src/System.Private.ServiceModel/tools/PRService/pr.ashx
@@ -258,12 +258,10 @@ public class PullRequestHandler : IHttpHandler
             // Parse for anything that implies a detached HEAD - those are not branches to clean up
             for (int i = 0; i < tempBranches.Length; i++)
             {
-                if (tempBranches[i].Contains("HEAD detached"))
+                if (!tempBranches[i].Contains("HEAD detached"))
                 {
-                    continue;
+                    branchesList.Add(tempBranches[i].Trim('*', ' '));
                 }
-
-                branchesList.Add(tempBranches[i].Trim('*', ' '));
             }
 
             branches = branchesList.ToArray();
@@ -303,11 +301,7 @@ public class PullRequestHandler : IHttpHandler
             for (int i = 0; i < branchesList.Length; i++)
             {
                 // Don't try to delete "master" branch or detached since we're checked out to it
-                if (branchesList[i].Equals("master"))
-                {
-                    continue;
-                }
-                else
+                if (!branchesList[i].Equals("master"))
                 {
                     commands.Add(string.Format("branch -D {0}", branchesList[i]));
                 }

--- a/src/System.Private.ServiceModel/tools/PRService/web.config
+++ b/src/System.Private.ServiceModel/tools/PRService/web.config
@@ -8,6 +8,7 @@
 <configuration>
   <system.web>
     <compilation debug="false" />
+    <trace enabled="false" localOnly="true" />
     <!-- some git syncs may take a long time, so upping the executionTimeout to help with this -->
     <httpRuntime executionTimeout="300" />
   </system.web>


### PR DESCRIPTION
Without the check for a deteached HEAD state, we would attempt to delete some
bogus branches. Now we're a little better about it and so we should see the
PRService fail less often. 

skip ci please