### PR TITLE
Improve detection of Windows OS

### DIFF
--- a/src/System.Private.ServiceModel/tests/Common/Infrastructure/OSHelper.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Infrastructure/OSHelper.cs
@@ -54,14 +54,19 @@ namespace Infrastructure.Common
         };
 
         // All Windows version currently use the runtime "win7" so cannot be distinguished by that.
-        // However the windows major and minor versions are known and can be used.
+        // However the windows major and minor versions are known and can be used.  Some versions are
+        // shared by different OSes, so at this level we can only say it is all of them.
+        // Applications that have not been manifested for Win 8.1 or Win 10 will return Win 8.
+        // This lookup table assumes the test running application has been manifested.
+        // This mapping is described at https://msdn.microsoft.com/en-us/library/windows/desktop/ms724832(v=vs.85).aspx
         private static List<Tuple<string, OSID>> _descriptionToOSID = new List<Tuple<string, OSID>>
         {
-            new Tuple<string, OSID>("Microsoft Windows 6.1.", OSID.Windows_7),
-            new Tuple<string, OSID>("Microsoft Windows 6.2.", OSID.Windows_8 | OSID.Windows_2008_R2),
-            new Tuple<string, OSID>("Microsoft Windows 6.3.", OSID.Windows_8_1),
-            new Tuple<string, OSID>("Microsoft Windows 10.", OSID.Windows_10),
-            new Tuple<string, OSID>("Microsoft Windows Phone", OSID.AnyWindows),
+            new Tuple<string, OSID>("Microsoft Windows 6.0.", OSID.Windows_Server_2008),
+            new Tuple<string, OSID>("Microsoft Windows 6.1.", OSID.Windows_7 | OSID.Windows_Server_2008_R2),
+            new Tuple<string, OSID>("Microsoft Windows 6.2.", OSID.Windows_8 | OSID.Windows_Server_2012),
+            new Tuple<string, OSID>("Microsoft Windows 6.3.", OSID.Windows_8_1 | OSID.Windows_Server_2012_R2),
+            new Tuple<string, OSID>("Microsoft Windows 10.", OSID.Windows_10 | OSID.Windows_Server_2016),
+            new Tuple<string, OSID>("Microsoft Windows Phone", OSID.WindowsPhone),
             new Tuple<string, OSID>("Microsoft Windows", OSID.AnyWindows),
         };
 

--- a/src/System.Private.ServiceModel/tests/Common/Infrastructure/OsID.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Infrastructure/OsID.cs
@@ -16,41 +16,43 @@ namespace Infrastructure.Common
     [Flags]
     public enum OSID
     {
-        None =          0x00000000,
+        None =            0x00000000,
 
-        Windows_7 =     0x00000001,
-        Windows_8_1 =   0x00000002,
-        Windows_10 =    0x00000004,
-        WindowsPhone =  0x00000008,
-        Windows_Nano =  0x00000010,
+        Windows_7 =       0x00000001,
+        Windows_8 =       0x00000002,
+        Windows_8_1 =     0x00000004,
+        Windows_10 =      0x00000008,
+        Windows_2008_R2 = 0x00000010,
+        WindowsPhone =    0x00000020,
+        Windows_Nano =    0x00000040,
 
-        CentOS_7 =      0x00000020,
-        CentOS_7_1 =    0x00000040,
+        CentOS_7 =        0x00000080,
+        CentOS_7_1 =      0x00000100,
         AnyCentOS = CentOS_7 | CentOS_7_1,
 
-        Debian_8 =      0x00000080,
-        Debian_8_2 =    0x00000100, 
+        Debian_8 =        0x00000200,
+        Debian_8_2 =      0x00000400, 
         AnyDebian = Debian_8 | Debian_8_2,
 
-        Fedora_23 =     0x00000200,
+        Fedora_23 =       0x00000800,
         AnyFedora = Fedora_23,
 
-        OpenSUSE_13_2 = 0x00000400,
+        OpenSUSE_13_2 =   0x00001000,
         AnyOpenSUSE = OpenSUSE_13_2,
 
-        OSX_10_10 =     0x00000800,
-        OSX_10_11 =     0x00001000,
+        OSX_10_10 =       0x00002000,
+        OSX_10_11 =       0x00004000,
         AnyOSX = OSX_10_10 | OSX_10_11,
 
-        RHEL_7 =        0x00002000,
+        RHEL_7 =          0x00008000,
         AnyRHEL = RHEL_7,
 
-        Ubuntu_14_04 =  0x00004000,
-        Ubuntu_16_04 =  0x00008000,
+        Ubuntu_14_04 =    0x00010000,
+        Ubuntu_16_04 =    0x00020000,
         AnyUbuntu = Ubuntu_14_04 | Ubuntu_16_04,
 
         AnyUnix = AnyCentOS | AnyDebian | AnyFedora | AnyOpenSUSE | AnyOSX | AnyRHEL | AnyUbuntu,
-        AnyWindows = Windows_7 | Windows_8_1 | Windows_10 | WindowsPhone | Windows_Nano,
+        AnyWindows = Windows_7 | Windows_8 | Windows_8_1 | Windows_2008_R2 | Windows_10 | WindowsPhone | Windows_Nano,
 
         // 'Any' explicitly names only known flags so "G" formatting
         // can be used to show a comma separated list of the bitmask.

--- a/src/System.Private.ServiceModel/tests/Common/Infrastructure/OsID.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Infrastructure/OsID.cs
@@ -16,46 +16,55 @@ namespace Infrastructure.Common
     [Flags]
     public enum OSID
     {
-        None =            0x00000000,
+        None =                   0x00000000,
 
-        Windows_7 =       0x00000001,
-        Windows_8 =       0x00000002,
-        Windows_8_1 =     0x00000004,
-        Windows_10 =      0x00000008,
-        Windows_2008_R2 = 0x00000010,
-        WindowsPhone =    0x00000020,
-        Windows_Nano =    0x00000040,
+        Windows_7 =              0x00000001,
+        Windows_8 =              0x00000002,
+        Windows_8_1 =            0x00000004,
+        Windows_10 =             0x00000008,
+        Windows_Server_2008 =    0x00000010,
+        Windows_Server_2008_R2 = 0x00000020,
+        Windows_Server_2012 =    0x00000040,
+        Windows_Server_2012_R2 = 0x00000080,
+        Windows_Server_2016 =    0x00000100,
+        WindowsPhone =           0x00000200,
+        Windows_Nano =           0x00000400,
 
-        CentOS_7 =        0x00000080,
-        CentOS_7_1 =      0x00000100,
+        // 'Any' combinations must explicitly name only known flags so "G" formatting
+        // can be used to show a comma separated list of the bitmask.
+        AnyWindows = Windows_7 | Windows_8 | Windows_8_1 | Windows_10 |
+             Windows_Server_2008 | Windows_Server_2008_R2 | Windows_Server_2012 | Windows_Server_2012_R2 | Windows_Server_2016 |
+             WindowsPhone | Windows_Nano,
+
+        CentOS_7 =               0x00000800,
+        CentOS_7_1 =             0x00001000,
         AnyCentOS = CentOS_7 | CentOS_7_1,
 
-        Debian_8 =        0x00000200,
-        Debian_8_2 =      0x00000400, 
+        Debian_8 =               0x00002000,
+        Debian_8_2 =             0x00004000, 
         AnyDebian = Debian_8 | Debian_8_2,
 
-        Fedora_23 =       0x00000800,
+        Fedora_23 =              0x00008000,
         AnyFedora = Fedora_23,
 
-        OpenSUSE_13_2 =   0x00001000,
+        OpenSUSE_13_2 =          0x00010000,
         AnyOpenSUSE = OpenSUSE_13_2,
 
-        OSX_10_10 =       0x00002000,
-        OSX_10_11 =       0x00004000,
+        OSX_10_10 =              0x00020000,
+        OSX_10_11 =              0x00040000,
         AnyOSX = OSX_10_10 | OSX_10_11,
 
-        RHEL_7 =          0x00008000,
+        RHEL_7 =                 0x00080000,
         AnyRHEL = RHEL_7,
 
-        Ubuntu_14_04 =    0x00010000,
-        Ubuntu_16_04 =    0x00020000,
+        Ubuntu_14_04 =           0x00100000,
+        Ubuntu_16_04 =           0x00200000,
         AnyUbuntu = Ubuntu_14_04 | Ubuntu_16_04,
 
-        AnyUnix = AnyCentOS | AnyDebian | AnyFedora | AnyOpenSUSE | AnyOSX | AnyRHEL | AnyUbuntu,
-        AnyWindows = Windows_7 | Windows_8 | Windows_8_1 | Windows_2008_R2 | Windows_10 | WindowsPhone | Windows_Nano,
-
-        // 'Any' explicitly names only known flags so "G" formatting
+        // 'Any' combinations must explicitly name only known flags so "G" formatting
         // can be used to show a comma separated list of the bitmask.
+        AnyUnix = AnyCentOS | AnyDebian | AnyFedora | AnyOpenSUSE | AnyOSX | AnyRHEL | AnyUbuntu,
+
         Any = AnyUnix | AnyWindows
     }
 }

--- a/src/System.Private.ServiceModel/tests/Scenarios/Infrastructure/OSAndFrameworkTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Infrastructure/OSAndFrameworkTests.cs
@@ -1,0 +1,54 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+using Infrastructure.Common;
+using Xunit;
+
+public class OSAndFrameworkTests
+{
+    [Fact]
+    [OuterLoop]
+    public static void FrameworkID_Was_Detected()
+    {
+        Assert.True(FrameworkHelper.Current != FrameworkID.None,
+                    String.Format("FrameworkID was not properly detected from: RuntimeInformation.FrameworkDescription = \'{0}\"",
+                                   RuntimeInformation.FrameworkDescription));
+    }
+
+    [Fact]
+    [OuterLoop]
+    public static void OSID_Was_Detected()
+    {
+        Assert.True(OSHelper.Current != OSID.None,
+                    String.Format("OSID was not properly detected from:{0}  TestProperties[TestNugetRuntimeId] = \"{1}\"{0}  RuntimeInformation.OSDescription = \'{2}\"",
+                                   Environment.NewLine,
+                                   TestProperties.GetProperty(TestProperties.TestNugetRuntimeId_PropertyName),
+                                   RuntimeInformation.OSDescription));
+    }
+
+    [Fact]
+    [OuterLoop]
+    public static void FrameworkID_Name_Formats_Correctly()
+    {
+        FrameworkID id = FrameworkID.NetCore | FrameworkID.NetNative;
+        string formatted = id.Name();
+
+        Assert.True(formatted.Contains("NetCore") && formatted.Contains("NetNative"),
+                    String.Format("FrameworkID.Name should have contained NetCore and NetNative, but actual was \"{0}\"", formatted));
+    }
+
+    [Fact]
+    [OuterLoop]
+    public static void OSID_Name_Formats_Correctly()
+    {
+        OSID id = OSID.Windows_7 | OSID.Ubuntu_14_04;
+        string formatted = id.Name();
+
+        Assert.True(formatted.Contains("Windows_7") && formatted.Contains("Ubuntu_14_04"),
+                    String.Format("FrameworkID.Name should have contained Windows_7 and Ubuntu_14_04, but actual was \"{0}\"", formatted));
+    }
+}
+

--- a/src/System.Private.ServiceModel/tests/Scenarios/Infrastructure/WcfFactTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Infrastructure/WcfFactTests.cs
@@ -11,13 +11,12 @@
 
 #if !FULLXUNIT_NOTSUPPORTED // Not available in pseudo-xunit
 
-using Infrastructure.Common;
 using System;
-using System.Security.Cryptography.X509Certificates;
 using System.Runtime.InteropServices;
+using Infrastructure.Common;
 using Xunit;
 
-public class WcfFactTests : ConditionalWcfTest
+public class WcfFactTests
 {
     // Tests that do not skip are allowed to run to test [WcfFact]
     // This also triggers lazy initialization of all the skippable
@@ -28,48 +27,6 @@ public class WcfFactTests : ConditionalWcfTest
     [OuterLoop]
     public static void Run_On_True_Condition()
     {
-    }
-
-    [WcfFact]
-    [OuterLoop]
-    public static void FrameworkID_Was_Detected()
-    {
-        Assert.True(FrameworkHelper.Current != FrameworkID.None,
-                    String.Format("FrameworkID was not properly detected from: RuntimeInformation.FrameworkDescription = \'{0}\"",
-                                   RuntimeInformation.FrameworkDescription));
-    }
-
-    [WcfFact]
-    [OuterLoop]
-    public static void OSID_Was_Detected()
-    {
-        Assert.True(OSHelper.Current != OSID.None,
-                    String.Format("OSID was not properly detected from:{0}  TestProperties[TestNugetRuntimeId] = \"{1}\"{0}  RuntimeInformation.OSDescription = \'{2}\"",
-                                   Environment.NewLine,
-                                   TestProperties.GetProperty(TestProperties.TestNugetRuntimeId_PropertyName),
-                                   RuntimeInformation.OSDescription));
-    }
-
-    [WcfFact]
-    [OuterLoop]
-    public static void FrameworkID_Name_Formats_Correctly()
-    {
-        FrameworkID id = FrameworkID.NetCore | FrameworkID.NetNative;
-        string formatted = id.Name();
-
-        Assert.True(formatted.Contains("NetCore") && formatted.Contains("NetNative"),
-                    String.Format("FrameworkID.Name should have contained NetCore and NetNative, but actual was \"{0}\"", formatted));
-    }
-
-    [WcfFact]
-    [OuterLoop]
-    public static void OSID_Name_Formats_Correctly()
-    {
-        OSID id = OSID.Windows_7 | OSID.Ubuntu_14_04;
-        string formatted = id.Name();
-
-        Assert.True(formatted.Contains("Windows_7") && formatted.Contains("Ubuntu_14_04"),
-                    String.Format("FrameworkID.Name should have contained Windows_7 and Ubuntu_14_04, but actual was \"{0}\"", formatted));
     }
 
 #if RUN_WCF_SKIP_TESTS


### PR DESCRIPTION
This PR improves the granularity of the detection of which
version of Windows is currently running. It also moves the
infrastructure tests for detection into a new file that uses
FactAttribute to ensure they run on NET Native.