### PR TITLE
Fix exception thrown in .Net native when a certificate has been revoked

### DIFF
--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/SslStreamSecurityUpgradeProvider.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/SslStreamSecurityUpgradeProvider.cs
@@ -486,6 +486,8 @@ namespace System.ServiceModel.Channels
                 // happen after the connection has successfully negotiated. Some certificate errors need to be set to be ignored
                 // to allow the connection to be established so we can retrieve the server certificate and choose whether to
                 // accept the server certificate or not.
+                rtStreamSocket.Control.IgnorableServerCertificateErrors.Add(ChainValidationResult.Untrusted);
+                rtStreamSocket.Control.IgnorableServerCertificateErrors.Add(ChainValidationResult.Expired);
                 rtStreamSocket.Control.IgnorableServerCertificateErrors.Add(ChainValidationResult.InvalidName);
                 rtStreamSocket.Control.IgnorableServerCertificateErrors.Add(ChainValidationResult.IncompleteChain);
                 rtStreamSocket.Control.IgnorableServerCertificateErrors.Add(


### PR DESCRIPTION
Some certificate errors were still being handled by SocketStream. This change
causes SocketStream to ignore more certificate validation errors and allows
the WCF managed validation to be run.

Fixes #1383