### PR TITLE
Replace Fact, ConditionalFact and ActiveIssue

### DIFF
--- a/src/System.Private.ServiceModel/tests/Scenarios/Binding/Custom/CustomBindingTests.4.0.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Binding/Custom/CustomBindingTests.4.0.0.cs
@@ -2,17 +2,20 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-
-using Infrastructure.Common;
 using System;
 using System.ServiceModel;
 using System.ServiceModel.Channels;
+using Infrastructure.Common;
 using Xunit;
 
 public partial class CustomBindingTests : ConditionalWcfTest
 {
     // Http: Client and Server bindings setup exactly the same using default settings.
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+
+    [WcfFact]
     [OuterLoop]
     public static void DefaultSettings_Http_Text_Echo_RoundTrips_String()
     {

--- a/src/System.Private.ServiceModel/tests/Scenarios/Binding/Custom/CustomBindingTests.4.1.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Binding/Custom/CustomBindingTests.4.1.0.cs
@@ -14,9 +14,9 @@ public partial class CustomBindingTests : ConditionalWcfTest
     // Tcp: Client and Server bindings setup exactly the same using default settings.
 #if FULLXUNIT_NOTSUPPORTED
     [Fact]
-#else
-    [ConditionalFact(nameof(Root_Certificate_Installed), nameof(Client_Certificate_Installed))]
 #endif
+    [WcfFact]
+    [Condition(nameof(Root_Certificate_Installed), nameof(Client_Certificate_Installed))]
     [OuterLoop]
     public static void DefaultSettings_Tcp_Binary_Echo_RoundTrips_String()
     {
@@ -64,17 +64,16 @@ public partial class CustomBindingTests : ConditionalWcfTest
             ScenarioTestHelpers.CloseCommunicationObjects((ICommunicationObject)serviceProxy, factory);
         }
     }
-    
 
     // Https: Client and Server bindings setup exactly the same using default settings.
 #if FULLXUNIT_NOTSUPPORTED
     [Fact]
-#else
-    [ConditionalFact(nameof(Root_Certificate_Installed),
-                     nameof(SSL_Available))]
 #endif
+    [WcfFact]
+    [Condition(nameof(Root_Certificate_Installed),
+               nameof(SSL_Available))]
     [OuterLoop]
-    [ActiveIssue(1398, PlatformID.OSX)] // Cert installation on OSX does not work yet
+    [Issue(1398, OS = OSID.AnyOSX)] // Cert installation on OSX does not work yet
     public static void DefaultSettings_Https_Text_Echo_RoundTrips_String()
     {
 #if FULLXUNIT_NOTSUPPORTED

--- a/src/System.Private.ServiceModel/tests/Scenarios/Binding/Http/BasicHttpBindingTests.4.0.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Binding/Http/BasicHttpBindingTests.4.0.0.cs
@@ -2,15 +2,18 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-
 using System;
 using System.ServiceModel;
 using System.ServiceModel.Channels;
+using Infrastructure.Common;
 using Xunit;
 
 public static class Binding_Http_BasicHttpBindingTests
 {
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void DefaultSettings_Echo_RoundTrips_String()
     {

--- a/src/System.Private.ServiceModel/tests/Scenarios/Binding/Http/NetHttpBindingTests.4.0.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Binding/Http/NetHttpBindingTests.4.0.0.cs
@@ -5,15 +5,15 @@
 
 using System;
 using System.ServiceModel;
-using System.ServiceModel.Channels;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
+using Infrastructure.Common;
 using Xunit;
 
 public static class Binding_Http_NetHttpBindingTests
 {
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void DefaultSettings_Echo_RoundTrips_String()
     {

--- a/src/System.Private.ServiceModel/tests/Scenarios/Binding/Http/NetHttpsBindingTests.4.1.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Binding/Http/NetHttpsBindingTests.4.1.0.cs
@@ -5,7 +5,6 @@
 
 using System;
 using System.ServiceModel;
-
 using Infrastructure.Common;
 using Xunit;
 
@@ -13,10 +12,10 @@ public class Binding_Http_NetHttpsBindingTests : ConditionalWcfTest
 {
 #if FULLXUNIT_NOTSUPPORTED
     [Fact]
-#else
-    [ConditionalFact(nameof(Root_Certificate_Installed),
-                     nameof(SSL_Available))]
 #endif
+    [WcfFact]
+    [Condition(nameof(Root_Certificate_Installed),
+               nameof(SSL_Available))]
     [OuterLoop]
     public static void DefaultCtor_NetHttps_Echo_RoundTrips_String()
     {
@@ -62,7 +61,10 @@ public class Binding_Http_NetHttpsBindingTests : ConditionalWcfTest
         }
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void TransportWithMessageCredential_NotSupported_NetHttps()
     {
@@ -95,10 +97,10 @@ public class Binding_Http_NetHttpsBindingTests : ConditionalWcfTest
 
 #if FULLXUNIT_NOTSUPPORTED
     [Fact]
-#else
-    [ConditionalFact(nameof(Root_Certificate_Installed),
-                     nameof(SSL_Available))]
 #endif
+    [WcfFact]
+    [Condition(nameof(Root_Certificate_Installed),
+               nameof(SSL_Available))]
     [OuterLoop]
     public static void NonDefaultCtor_NetHttps_Echo_RoundTrips_String()
     {

--- a/src/System.Private.ServiceModel/tests/Scenarios/Binding/Tcp/NetTcpBindingTests.4.0.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Binding/Tcp/NetTcpBindingTests.4.0.0.cs
@@ -2,14 +2,17 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Infrastructure.Common;
 using System.ServiceModel;
+using Infrastructure.Common;
 using Xunit;
 
 public partial class Binding_Tcp_NetTcpBindingTests : ConditionalWcfTest
 {
     // Simple echo of a string using NetTcpBinding on both client and server with SecurityMode=None
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void SecurityModeNone_Echo_RoundTrips_String()
     {

--- a/src/System.Private.ServiceModel/tests/Scenarios/Binding/Tcp/NetTcpBindingTests.4.1.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Binding/Tcp/NetTcpBindingTests.4.1.0.cs
@@ -16,9 +16,10 @@ public partial class Binding_Tcp_NetTcpBindingTests : ConditionalWcfTest
 #if FULLXUNIT_NOTSUPPORTED
     [Fact]
     [ActiveIssue(832)] // Windows Stream Security is not supported in NET Native
-#else
-    [ConditionalFact(nameof(Windows_Authentication_Available))]
 #endif
+    [WcfFact]
+    [Condition(nameof(Windows_Authentication_Available))]
+    [Issue(832, Framework = FrameworkID.NetNative)] // Windows Stream Security is not supported in NET Native
     [OuterLoop]
     public static void DefaultSettings_Echo_RoundTrips_String()
     {
@@ -66,9 +67,10 @@ public partial class Binding_Tcp_NetTcpBindingTests : ConditionalWcfTest
 #if FULLXUNIT_NOTSUPPORTED
     [Fact]
     [ActiveIssue(832)] // Windows Stream Security is not supported in NET Native
-#else
-    [ConditionalFact(nameof(Windows_Authentication_Available))]
 #endif
+    [WcfFact]
+    [Issue(832, Framework = FrameworkID.NetNative)] // Windows Stream Security is not supported in NET Native
+    [Condition(nameof(Windows_Authentication_Available))]
     [OuterLoop]
     public static void SecurityModeTransport_Echo_RoundTrips_String()
     {

--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/ChannelLayer/DuplexChannelShapeTests.4.0.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/ChannelLayer/DuplexChannelShapeTests.4.0.0.cs
@@ -2,12 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-
 using System;
 using System.ServiceModel;
 using System.ServiceModel.Channels;
-using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
 using System.Xml;
 using Infrastructure.Common;
@@ -22,7 +19,10 @@ public partial class DuplexChannelShapeTests : ConditionalWcfTest
     private const string action = "http://tempuri.org/IWcfService/MessageRequestReply";
     private const string clientMessage = "[client] This is my request.";
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void IDuplexSessionChannel_Tcp_NetTcpBinding()
     {
@@ -77,7 +77,10 @@ public partial class DuplexChannelShapeTests : ConditionalWcfTest
         }
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void IDuplexSessionChannel_Async_Tcp_NetTcpBinding()
     {

--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/ChannelLayer/DuplexChannelShapeTests.4.1.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/ChannelLayer/DuplexChannelShapeTests.4.1.0.cs
@@ -16,6 +16,7 @@ public partial class DuplexChannelShapeTests : ConditionalWcfTest
     // The tests in this file use the IDuplexChannel shape.
 #if FULLXUNIT_NOTSUPPORTED
     [Fact]
+    [ActiveIssue(1157)]    
 #endif
     [WcfFact]
     [Condition(nameof(Root_Certificate_Installed))]
@@ -88,6 +89,7 @@ public partial class DuplexChannelShapeTests : ConditionalWcfTest
 
 #if FULLXUNIT_NOTSUPPORTED
     [Fact]
+    [ActiveIssue(1157)]
 #endif
     [WcfFact]
     [Condition(nameof(Root_Certificate_Installed))]

--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/ChannelLayer/DuplexChannelShapeTests.4.1.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/ChannelLayer/DuplexChannelShapeTests.4.1.0.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-
 using System;
 using System.ServiceModel;
 using System.ServiceModel.Channels;
@@ -17,11 +16,11 @@ public partial class DuplexChannelShapeTests : ConditionalWcfTest
     // The tests in this file use the IDuplexChannel shape.
 #if FULLXUNIT_NOTSUPPORTED
     [Fact]
-#else
-    [ConditionalFact(nameof(Root_Certificate_Installed))]
 #endif
+    [WcfFact]
+    [Condition(nameof(Root_Certificate_Installed))]
     [OuterLoop]
-    [ActiveIssue(1157)]
+    [Issue(1157)]
     public static void IDuplexSessionChannel_Https_NetHttpsBinding()
     {
 #if FULLXUNIT_NOTSUPPORTED
@@ -89,11 +88,11 @@ public partial class DuplexChannelShapeTests : ConditionalWcfTest
 
 #if FULLXUNIT_NOTSUPPORTED
     [Fact]
-#else
-    [ConditionalFact(nameof(Root_Certificate_Installed))]
 #endif
+    [WcfFact]
+    [Condition(nameof(Root_Certificate_Installed))]
     [OuterLoop]
-    [ActiveIssue(1157)]
+    [Issue(1157)]
     public static void IDuplexSessionChannel_Http_BasicHttpBinding()
     {
 #if FULLXUNIT_NOTSUPPORTED

--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/ChannelLayer/RequestReplyChannelShapeTests.4.0.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/ChannelLayer/RequestReplyChannelShapeTests.4.0.0.cs
@@ -6,8 +6,8 @@
 using System;
 using System.ServiceModel;
 using System.ServiceModel.Channels;
-using System.Text;
 using System.Threading.Tasks;
+using Infrastructure.Common;
 using Xunit;
 
 public partial class RequestReplyChannelShapeTests
@@ -19,7 +19,10 @@ public partial class RequestReplyChannelShapeTests
     private const string action = "http://tempuri.org/IWcfService/MessageRequestReply";
     private const string clientMessage = "[client] This is my request.";
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void IRequestChannel_Http_BasicHttpBinding()
     {
@@ -70,7 +73,10 @@ public partial class RequestReplyChannelShapeTests
         }
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void IRequestChannel_Http_CustomBinding()
     {
@@ -125,7 +131,10 @@ public partial class RequestReplyChannelShapeTests
         }
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void IRequestChannel_Async_Http_BasicHttpBinding()
     {
@@ -178,7 +187,10 @@ public partial class RequestReplyChannelShapeTests
         }
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void IRequestChannel_Async_Http_CustomBinding()
     {

--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/ChannelLayer/RequestReplyChannelShapeTests.4.1.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/ChannelLayer/RequestReplyChannelShapeTests.4.1.0.cs
@@ -6,8 +6,6 @@
 using System;
 using System.ServiceModel;
 using System.ServiceModel.Channels;
-using System.Text;
-using System.Threading.Tasks;
 using Infrastructure.Common;
 using Xunit;
 
@@ -19,12 +17,12 @@ public partial class RequestReplyChannelShapeTests : ConditionalWcfTest
 
 #if FULLXUNIT_NOTSUPPORTED
     [Fact]
-#else
-    [ConditionalFact(nameof(Root_Certificate_Installed),
-                     nameof(SSL_Available))]
 #endif
+    [WcfFact]
+    [Condition(nameof(Root_Certificate_Installed),
+               nameof(SSL_Available))]
     [OuterLoop]
-    [ActiveIssue(1398, PlatformID.OSX)] // Cert installation on OSX does not work yet
+    [Issue(1398, OS = OSID.AnyOSX)] // Cert installation on OSX does not work yet
     public static void IRequestChannel_Https_NetHttpsBinding()
     {
 #if FULLXUNIT_NOTSUPPORTED

--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/ClientBase/ClientBaseTests.4.0.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/ClientBase/ClientBaseTests.4.0.0.cs
@@ -3,17 +3,19 @@
 
 using System;
 using System.Collections.Generic;
-using System.Net;
 using System.ServiceModel;
 using System.ServiceModel.Channels;
 using System.ServiceModel.Description;
 using System.ServiceModel.Dispatcher;
-using System.Text;
+using Infrastructure.Common;
 using Xunit;
 
 public static partial class ClientBaseTests
 {
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void MessageProperty_HttpRequestMessageProperty_RoundTrip_Verify()
     {
@@ -52,8 +54,11 @@ public static partial class ClientBaseTests
             ScenarioTestHelpers.CloseCommunicationObjects((ICommunicationObject)serviceProxy, (ICommunicationObject)client);
         }
     }
-    
+
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void ClientMessageInspector_Verify_Invoke()
     {
@@ -101,7 +106,10 @@ public static partial class ClientBaseTests
         }
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void ClientBaseOfT_Sync_RoundTrip_Check_CommunicationState()
     {
@@ -149,7 +157,10 @@ public static partial class ClientBaseTests
         }
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void ClientBaseOfT_Sync_RoundTrip_Call_Using_HttpTransport()
     {
@@ -185,7 +196,10 @@ public static partial class ClientBaseTests
         }
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void ClientBaseOfT_Sync_RoundTrip_Call_Using_NetTcpTransport()
     {
@@ -220,7 +234,10 @@ public static partial class ClientBaseTests
         }
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void OperationContextScope_HttpRequestCustomMessageHeader_RoundTrip_Verify()
     {

--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/ClientBase/ClientBaseTests.4.1.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/ClientBase/ClientBaseTests.4.1.0.cs
@@ -4,18 +4,18 @@
 
 
 using System;
-using System.Collections.Generic;
 using System.Net;
 using System.ServiceModel;
 using System.ServiceModel.Channels;
-using System.ServiceModel.Description;
-using System.ServiceModel.Dispatcher;
-using System.Text;
+using Infrastructure.Common;
 using Xunit;
 
 public static partial class ClientBaseTests
 {
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void DefaultSettings_Echo_Cookie()
     {
@@ -57,7 +57,10 @@ public static partial class ClientBaseTests
         }
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void DefaultSettings_SetCookieOnServerSide()
     {

--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/ClientBase/DuplexClientBaseTests.4.1.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/ClientBase/DuplexClientBaseTests.4.1.0.cs
@@ -6,16 +6,16 @@
 using System;
 using System.ServiceModel;
 using System.Threading.Tasks;
-using Xunit;
 using Infrastructure.Common;
+using Xunit;
 
 public class DuplexClientBaseTests : ConditionalWcfTest
 {
 #if FULLXUNIT_NOTSUPPORTED
     [Fact]
-#else
-    [ConditionalFact(nameof(Root_Certificate_Installed))]
 #endif
+    [WcfFact]
+    [Condition(nameof(Root_Certificate_Installed))]
     [OuterLoop]
     public static void DuplexClientBaseOfT_OverHttp_Call_Throws_InvalidOperation()
     {
@@ -70,7 +70,10 @@ public class DuplexClientBaseTests : ConditionalWcfTest
         }
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void DuplexClientBaseOfT_OverNetTcp_Synchronous_Call()
     {

--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/ExpectedExceptions/ExpectedExceptionTests.4.0.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/ExpectedExceptions/ExpectedExceptionTests.4.0.0.cs
@@ -52,10 +52,12 @@ public partial class ExpectedExceptionTests : ConditionalWcfTest
 
     // SendTimeout is set to 5 seconds, the service waits 10 seconds to respond.
     // The client should throw a TimeoutException
-    [Fact]
 #if FULLXUNIT_NOTSUPPORTED
+    [Fact]
     [ActiveIssue(1250)]
 #endif
+    [WcfFact]
+    [Issue(1250, Framework = FrameworkID.NetNative)]
     [OuterLoop]
     public static void SendTimeout_For_Long_Running_Operation_Throws_TimeoutException()
     {

--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/ExpectedExceptions/ExpectedExceptionTests.4.1.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/ExpectedExceptions/ExpectedExceptionTests.4.1.0.cs
@@ -43,9 +43,12 @@ public partial class ExpectedExceptionTests : ConditionalWcfTest
         Assert.True(exception.Message.Contains(nonExistentHost), string.Format("Expected exception message to contain: '{0}'", nonExistentHost));
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
-    [ActiveIssue(398)]
+    [Issue(398)]
     public static void ServiceRestart_Throws_CommunicationException()
     {
         StringBuilder errorBuilder = new StringBuilder();

--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/ExpectedExceptions/ExpectedExceptionTests.4.1.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/ExpectedExceptions/ExpectedExceptionTests.4.1.0.cs
@@ -45,6 +45,7 @@ public partial class ExpectedExceptionTests : ConditionalWcfTest
 
 #if FULLXUNIT_NOTSUPPORTED
     [Fact]
+    [ActiveIssue(398)]
 #endif
     [WcfFact]
     [OuterLoop]

--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/ExpectedExceptions/ExpectedExceptionTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/ExpectedExceptions/ExpectedExceptionTests.cs
@@ -4,28 +4,18 @@
 
 
 using System;
-using System.Diagnostics;
-using System.Net.Http;
-using System.Security.Cryptography.X509Certificates;
 using System.ServiceModel;
-using System.IdentityModel.Selectors;
 using System.ServiceModel.Security;
-using System.Text;
-using System.Threading.Tasks;
-using Xunit;
-using System.Threading;
-using System.IO;
-
 using Infrastructure.Common;
-
+using Xunit;
 
 public partial class ExpectedExceptionTests : ConditionalWcfTest
 {
 #if FULLXUNIT_NOTSUPPORTED
     [Fact]
-#else
-    [ConditionalFact(nameof(Root_Certificate_Installed), nameof(Client_Certificate_Installed))]
 #endif
+    [WcfFact]
+    [Condition(nameof(Root_Certificate_Installed), nameof(Client_Certificate_Installed))]
     [OuterLoop]
     // Confirm that the Validate method of the custom X509CertificateValidator is called and that an exception thrown there is handled correctly.
     public static void TCP_ServiceCertFailedCustomValidate_Throw_Exception()

--- a/src/System.Private.ServiceModel/tests/Scenarios/Contract/Data/Contract.Data.Tests.csproj
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Contract/Data/Contract.Data.Tests.csproj
@@ -38,6 +38,10 @@
     <ProjectReference Include='$(WcfPrimitivesPkgProj)'>
       <Name>System.ServiceModel.Primitives</Name>
     </ProjectReference>
+    <ProjectReference Include="$(WcfInfrastructureCommonProj)">
+      <Project>{AFD69665-89A3-42AE-A32E-AB2CBBE6EE7E}</Project>
+      <Name>Infrastructure.Common</Name>
+    </ProjectReference>
     <ProjectReference Include='$(WcfScenarioTestCommonProj)'>
       <Project>{9098B41C-9C2E-4FC6-B7D8-FC3411736A22}</Project>
       <Name>ScenarioTests.Common</Name>

--- a/src/System.Private.ServiceModel/tests/Scenarios/Contract/Data/DataContractTests.4.0.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Contract/Data/DataContractTests.4.0.0.cs
@@ -2,17 +2,19 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-
 using System;
 using System.ServiceModel;
 using System.ServiceModel.Channels;
-using TestTypes;
 using System.Text;
+using Infrastructure.Common;
 using Xunit;
 
 public static partial class DataContractTests
 {
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void CustomBinding_DefaultSettings_Echo_RoundTrips_DataContract()
     {

--- a/src/System.Private.ServiceModel/tests/Scenarios/Contract/Data/DataContractTests.4.1.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Contract/Data/DataContractTests.4.1.0.cs
@@ -5,15 +5,16 @@
 
 using System;
 using System.ServiceModel;
-using System.ServiceModel.Channels;
-using TestTypes;
-using System.Text;
+using Infrastructure.Common;
 using Xunit;
 
 public static partial class DataContractTests
 {
     // Verify that a callback contract correctly returns a complex type when this type is not part of the contract with the ServiceContract attribute.
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void NetTcpBinding_DuplexCallback_ReturnsDataContractComplexType()
     {
@@ -51,7 +52,10 @@ public static partial class DataContractTests
     }
 
     // Verify that a callback contract correctly returns a complex type using Xml instead of DataContract when this type is not part of the contract with the ServiceContract attribute.
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void NetTcpBinding_DuplexCallback_ReturnsXmlComplexType()
     {

--- a/src/System.Private.ServiceModel/tests/Scenarios/Contract/Fault/Contract.Fault.Tests.csproj
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Contract/Fault/Contract.Fault.Tests.csproj
@@ -32,6 +32,10 @@
     <ProjectReference Include='$(WcfPrimitivesPkgProj)'>
       <Name>System.ServiceModel.Primitives</Name>
     </ProjectReference>
+    <ProjectReference Include="$(WcfInfrastructureCommonProj)">
+      <Project>{AFD69665-89A3-42AE-A32E-AB2CBBE6EE7E}</Project>
+      <Name>Infrastructure.Common</Name>
+    </ProjectReference>
     <ProjectReference Include='$(WcfScenarioTestCommonProj)'>
       <Project>{9098B41C-9C2E-4FC6-B7D8-FC3411736A22}</Project>
       <Name>ScenarioTests.Common</Name>

--- a/src/System.Private.ServiceModel/tests/Scenarios/Contract/Fault/FaultExceptionTests.4.0.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Contract/Fault/FaultExceptionTests.4.0.0.cs
@@ -6,11 +6,15 @@
 using System;
 using System.ServiceModel;
 using System.Text;
+using Infrastructure.Common;
 using Xunit;
 
 public static class FaultExceptionTests
 {
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void FaultException_Throws_WithFaultDetail()
     {
@@ -53,7 +57,10 @@ public static class FaultExceptionTests
         Assert.True(false, "Expected FaultException<FaultDetail> exception, but no exception thrown.");
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void UnexpectedException_Throws_FaultException()
     {
@@ -92,7 +99,10 @@ public static class FaultExceptionTests
         Assert.True(false, "Expected FaultException<FaultDetail> exception, but no exception thrown.");
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void FaultException_Throws_With_Int()
     {
@@ -130,7 +140,10 @@ public static class FaultExceptionTests
         }
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void FaultException_MultipleFaultContracts_Throws_WithFaultDetail()
     {
@@ -167,7 +180,10 @@ public static class FaultExceptionTests
         Assert.Equal(faultMsg, exception.Detail.Message);
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void FaultException_MultipleFaultContracts_Throws_WithFaultDetail2()
     {
@@ -204,7 +220,10 @@ public static class FaultExceptionTests
         Assert.Equal(faultMsg, exception.Detail.Message);
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void FaultException_FaultContractAndKnownType_Throws_WithFaultDetail()
     {
@@ -241,7 +260,10 @@ public static class FaultExceptionTests
         Assert.Equal(faultMsg, exception.Detail.Message);
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void FaultException_FaultContractAndKnownType_Echo()
     {

--- a/src/System.Private.ServiceModel/tests/Scenarios/Contract/Message/Contract.Message.Tests.csproj
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Contract/Message/Contract.Message.Tests.csproj
@@ -32,6 +32,10 @@
     <ProjectReference Include='$(WcfPrimitivesPkgProj)'>
       <Name>System.ServiceModel.Primitives</Name>
     </ProjectReference>
+    <ProjectReference Include="$(WcfInfrastructureCommonProj)">
+      <Project>{AFD69665-89A3-42AE-A32E-AB2CBBE6EE7E}</Project>
+      <Name>Infrastructure.Common</Name>
+    </ProjectReference>
     <ProjectReference Include='$(WcfScenarioTestCommonProj)'>
       <Project>{9098B41C-9C2E-4FC6-B7D8-FC3411736A22}</Project>
       <Name>ScenarioTests.Common</Name>

--- a/src/System.Private.ServiceModel/tests/Scenarios/Contract/Message/MessageContractCommon.4.1.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Contract/Message/MessageContractCommon.4.1.0.cs
@@ -4,7 +4,6 @@
 
 
 using System;
-using System.Reflection;
 using System.ServiceModel;
 using System.ServiceModel.Channels;
 using System.ServiceModel.Description;

--- a/src/System.Private.ServiceModel/tests/Scenarios/Contract/Message/MessageContractTests.4.1.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Contract/Message/MessageContractTests.4.1.0.cs
@@ -2,17 +2,19 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-
-using MessageContractCommon;
 using System;
 using System.ServiceModel.Channels;
-using System.Text;
 using System.Xml;
+using Infrastructure.Common;
+using MessageContractCommon;
 using Xunit;
 
 public static class MessageContractTests
 {
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void MessageContract_IsWrapped_True()
     {
@@ -29,7 +31,10 @@ public static class MessageContractTests
             string.Format("reader.NamespaceURI - Expected: {0}, Actual: {1}", MessageContractConstants.wrapperNamespace, reader.NamespaceURI));
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void MessageContract_IsWrapped_False()
     {
@@ -43,7 +48,10 @@ public static class MessageContractTests
             "When IsWrapped set to false, the message body should not be wrapped with an extra element.");
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void MessageBody_Elements_Ordered()
     {
@@ -84,7 +92,10 @@ public static class MessageContractTests
             string.Format("Unexpected element order (5/5). Expected: {0}, Actual: {1}", MessageContractConstants.wrapperName, reader.LocalName));
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void MessageBody_Elements_CustomerElement_Value_Matches()
     {
@@ -114,7 +125,10 @@ public static class MessageContractTests
             string.Format("Expected element not found. Looking For: {0} && {1}", MessageContractConstants.customerElementName, MessageContractConstants.customerElementNamespace));
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void MessageHeader_MustUnderstand_True()
     {
@@ -131,7 +145,10 @@ public static class MessageContractTests
         Assert.True(header.MustUnderstand, "Expected MustUnderstand to be true, but it was false.");
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void MessageHeader_MustUnderstand_False()
     {

--- a/src/System.Private.ServiceModel/tests/Scenarios/Contract/Message/MessageTests.4.0.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Contract/Message/MessageTests.4.0.0.cs
@@ -7,6 +7,7 @@ using System.ServiceModel;
 using System.ServiceModel.Channels;
 using System.ServiceModel.Description;
 using System.ServiceModel.Dispatcher;
+using Infrastructure.Common;
 using Xunit;
 
 public static class MessageTests
@@ -14,7 +15,10 @@ public static class MessageTests
     private const string action = "http://tempuri.org/IWcfService/MessageRequestReply";
     private const string clientMessage = "Test Custom_Message_RoundTrips.";
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void Custom_Message_RoundTrips()
     {
@@ -55,7 +59,10 @@ public static class MessageTests
         factory.Close();
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void Echo_With_CustomClientMessageFormatter_RoundTrips_String()
     {

--- a/src/System.Private.ServiceModel/tests/Scenarios/Contract/Service/Contract.Service.Tests.csproj
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Contract/Service/Contract.Service.Tests.csproj
@@ -35,6 +35,10 @@
     <ProjectReference Include='$(WcfPrimitivesPkgProj)'>
       <Name>System.ServiceModel.Primitives</Name>
     </ProjectReference>
+    <ProjectReference Include="$(WcfInfrastructureCommonProj)">
+      <Project>{AFD69665-89A3-42AE-A32E-AB2CBBE6EE7E}</Project>
+      <Name>Infrastructure.Common</Name>
+    </ProjectReference>
     <ProjectReference Include='$(WcfScenarioTestCommonProj)'>
       <Project>{9098B41C-9C2E-4FC6-B7D8-FC3411736A22}</Project>
       <Name>ScenarioTests.Common</Name>

--- a/src/System.Private.ServiceModel/tests/Scenarios/Contract/Service/ServiceContractTests.4.0.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Contract/Service/ServiceContractTests.4.0.0.cs
@@ -7,16 +7,19 @@ using System;
 using System.IO;
 using System.Linq;
 using System.ServiceModel;
-using System.ServiceModel.Channels;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Infrastructure.Common;
 using Xunit;
 
 public static partial class ServiceContractTests
 {
     // End operation includes keyword "out" on an Int as an arg.
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void ServiceContract_TypedProxy_AsyncEndOperation_IntOutArg()
     {
@@ -63,7 +66,10 @@ public static partial class ServiceContractTests
     // End operation includes keyword "out" on a unique type as an arg.
     // The unique type used must not appear anywhere else in any contracts in order
     // test the static analysis logic of the Net Native toolchain.
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void ServiceContract_TypedProxy_AsyncEndOperation_UniqueTypeOutArg()
     {
@@ -109,7 +115,10 @@ public static partial class ServiceContractTests
     }
 
     // End & Begin operations include keyword "ref" on an Int as an arg.
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void ServiceContract_TypedProxy_AsyncEndOperation_IntRefArg()
     {
@@ -157,7 +166,10 @@ public static partial class ServiceContractTests
     // End & Begin operations include keyword "ref" on a unique type as an arg.
     // The unique type used must not appear anywhere else in any contracts in order
     // test the static analysis logic of the Net Native toolchain.
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void ServiceContract_TypedProxy_AsyncEndOperation_UniqueTypeRefArg()
     {
@@ -205,7 +217,10 @@ public static partial class ServiceContractTests
     // Synchronous operation using the keyword "out" on a unique type as an arg.
     // The unique type used must not appear anywhere else in any contracts in order
     // test the static analysis logic of the Net Native toolchain.
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void ServiceContract_TypedProxy_SyncOperation_UniqueTypeOutArg()
     {
@@ -243,7 +258,10 @@ public static partial class ServiceContractTests
     // Synchronous operation using the keyword "ref" on a unique type as an arg.
     // The unique type used must not appear anywhere else in any contracts in order
     // test the static analysis logic of the Net Native toolchain.
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void ServiceContract_TypedProxy_SyncOperation_UniqueTypeRefArg()
     {
@@ -278,7 +296,10 @@ public static partial class ServiceContractTests
         }
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void BasicHttp_Async_Open_ChannelFactory()
     {
@@ -317,7 +338,10 @@ public static partial class ServiceContractTests
         }
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void BasicHttp_Async_Open_ChannelFactory_WithSingleThreadedSyncContext()
     {
@@ -331,7 +355,10 @@ public static partial class ServiceContractTests
         Assert.True(success, "Test Scenario: BasicHttp_Async_Open_ChannelFactory_WithSingleThreadedSyncContext timed-out.");
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void BasicHttp_Async_Open_Proxy()
     {
@@ -370,7 +397,10 @@ public static partial class ServiceContractTests
         }
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void BasicHttp_Async_Open_Proxy_WithSingleThreadedSyncContext()
     {
@@ -384,7 +414,10 @@ public static partial class ServiceContractTests
         Assert.True(success, "Test Scenario: BasicHttp_Async_Open_Proxy_WithSingleThreadedSyncContext timed-out.");
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void BasicHttp_Async_Close_ChannelFactory()
     {
@@ -421,7 +454,10 @@ public static partial class ServiceContractTests
         }
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void BasicHttp_Async_Close_ChannelFactory_WithSingleThreadedSyncContext()
     {
@@ -435,7 +471,10 @@ public static partial class ServiceContractTests
         Assert.True(success, "Test Scenario: BasicHttp_Async_Close_ChannelFactory_WithSingleThreadedSyncContext timed-out.");
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void BasicHttp_Async_Close_Proxy()
     {
@@ -471,7 +510,10 @@ public static partial class ServiceContractTests
         }
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void BasicHttp_Async_Close_Proxy_WithSingleThreadedSyncContext()
     {

--- a/src/System.Private.ServiceModel/tests/Scenarios/Contract/Service/ServiceContractTests.4.1.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Contract/Service/ServiceContractTests.4.1.0.cs
@@ -11,12 +11,16 @@ using System.ServiceModel.Channels;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Infrastructure.Common;
 using ScenarioTests.Common;
 using Xunit;
 
 public static partial class ServiceContractTests
 {
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void BasicHttp_DefaultSettings_Echo_RoundTrips_String_Buffered()
     {
@@ -53,7 +57,10 @@ public static partial class ServiceContractTests
         }
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void BasicHttp_DefaultSettings_Echo_RoundTrips_String_StreamedRequest()
     {
@@ -89,7 +96,10 @@ public static partial class ServiceContractTests
         }
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void BasicHttp_DefaultSettings_Echo_RoundTrips_String_StreamedResponse()
     {
@@ -124,7 +134,10 @@ public static partial class ServiceContractTests
         }
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void BasicHttp_DefaultSettings_Echo_RoundTrips_String_Streamed()
     {
@@ -161,7 +174,10 @@ public static partial class ServiceContractTests
         }
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void BasicHttp_DefaultSettings_Echo_RoundTrips_String_Streamed_Async()
     {
@@ -199,7 +215,10 @@ public static partial class ServiceContractTests
         }
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void BasicHttp_DefaultSettings_Echo_RoundTrips_String_Streamed_WithSingleThreadedSyncContext()
     {
@@ -213,7 +232,10 @@ public static partial class ServiceContractTests
         Assert.True(success, "Test Scenario: BasicHttp_DefaultSettings_Echo_RoundTrips_String_Streamed_WithSingleThreadedSyncContext timed-out.");
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void BasicHttp_DefaultSettings_Echo_RoundTrips_String_Streamed_Async_WithSingleThreadedSyncContext()
     {
@@ -227,8 +249,10 @@ public static partial class ServiceContractTests
         Assert.True(success, "Test Scenario: BasicHttp_DefaultSettings_Echo_RoundTrips_String_Streamed_Async_WithSingleThreadedSyncContext timed-out.");
     }
 
-
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void BasicHttp_Streamed_Async_Delayed_And_Aborted_Request_Throws_TimeoutException()
     {
@@ -292,7 +316,10 @@ public static partial class ServiceContractTests
         }
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void BasicHttp_Streamed_Async_Delayed_Request_Throws_TimeoutException()
     {
@@ -348,7 +375,10 @@ public static partial class ServiceContractTests
         }
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void NetTcp_NoSecurity_Buffered_RoundTrips_String()
     {
@@ -385,7 +415,10 @@ public static partial class ServiceContractTests
         }
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void NetTcp_NoSecurity_StreamedRequest_RoundTrips_String()
     {
@@ -421,7 +454,10 @@ public static partial class ServiceContractTests
         }
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void NetTcp_NoSecurity_StreamedResponse_RoundTrips_String()
     {
@@ -456,7 +492,10 @@ public static partial class ServiceContractTests
         }
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void NetTcp_NoSecurity_Streamed_RoundTrips_String()
     {
@@ -493,7 +532,10 @@ public static partial class ServiceContractTests
         }
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void NetTcp_NoSecurity_Streamed_Async_RoundTrips_String()
     {
@@ -531,7 +573,10 @@ public static partial class ServiceContractTests
         }
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void NetTcp_NoSecurity_StreamedRequest_Async_RoundTrips_String()
     {
@@ -569,7 +614,10 @@ public static partial class ServiceContractTests
         }
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void NetTcp_NoSecurity_StreamedResponse_Async_RoundTrips_String()
     {
@@ -607,7 +655,10 @@ public static partial class ServiceContractTests
         }
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void NetTcp_NoSecurity_Streamed_RoundTrips_String_WithSingleThreadedSyncContext()
     {
@@ -621,7 +672,10 @@ public static partial class ServiceContractTests
         Assert.True(success, "Test Scenario: NetTcp_NoSecurity_String_Streamed_RoundTrips_WithSingleThreadedSyncContext timed-out.");
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void NetTcp_NoSecurity_Streamed_Async_RoundTrips_String_WithSingleThreadedSyncContext()
     {
@@ -635,8 +689,10 @@ public static partial class ServiceContractTests
         Assert.True(success, "Test Scenario: NetTcp_NoSecurity_Streamed_Async_RoundTrips_String_WithSingleThreadedSyncContext timed-out.");
     }
 
-
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void ServiceContract_Call_Operation_With_MessageParameterAttribute()
     {
@@ -672,8 +728,11 @@ public static partial class ServiceContractTests
             ScenarioTestHelpers.CloseCommunicationObjects((ICommunicationObject)serviceProxy, factory);
         }
     }
-    
+
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void BasicHttp_Abort_ChannelFactory_Operations_Active()
     {
@@ -763,7 +822,10 @@ public static partial class ServiceContractTests
         }
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void BasicHttp_Close_ChannelFactory_Operations_Active()
     {
@@ -853,7 +915,10 @@ public static partial class ServiceContractTests
         }
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void BasicHttp_Async_Close_ChannelFactory_Operations_Active()
     {
@@ -943,5 +1008,4 @@ public static partial class ServiceContractTests
                                                           factory);
         }
     }
-
 }

--- a/src/System.Private.ServiceModel/tests/Scenarios/Contract/Service/ServiceKnownTypeTests.4.0.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Contract/Service/ServiceKnownTypeTests.4.0.0.cs
@@ -5,13 +5,17 @@
 
 using System.Runtime.Serialization;
 using System.ServiceModel;
+using Infrastructure.Common;
 using Xunit;
 
 public static class ServiceKnownTypeTests
 {
     public delegate object[] EchoItemsMethod(object[] items);
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void ServiceKnownType_DataContract_AttrOnMethod_Test()
     {
@@ -25,7 +29,10 @@ public static class ServiceKnownTypeTests
         RunTestMethodAndCleanup(factory, serviceProxy, serviceProxy.EchoItems, new Widget0());
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void ServiceKnownType_DataContract_AttrOnType_Test()
     {
@@ -39,7 +46,10 @@ public static class ServiceKnownTypeTests
         RunTestMethodAndCleanup(factory, serviceProxy, serviceProxy.EchoItems, new Widget1());
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void ServiceKnownType_XmlSerializerFormat_AttrOnMethod_Test()
     {
@@ -53,7 +63,10 @@ public static class ServiceKnownTypeTests
         RunTestMethodAndCleanup(factory, serviceProxy, serviceProxy.EchoItems_Xml, new Widget2());
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void ServiceKnownType_XmlSerializerFormat_AttrOnType_Test()
     {
@@ -67,7 +80,10 @@ public static class ServiceKnownTypeTests
         RunTestMethodAndCleanup(factory, serviceProxy, serviceProxy.EchoItems_Xml, new Widget3());
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void ServiceKnownType_XmlSerializerFormat_TwoOperationsShareKnownTypes_Test()
     {

--- a/src/System.Private.ServiceModel/tests/Scenarios/Contract/XmlSerializer/Contract.XmlSerializer.Tests.csproj
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Contract/XmlSerializer/Contract.XmlSerializer.Tests.csproj
@@ -32,6 +32,10 @@
     <ProjectReference Include='$(WcfPrimitivesPkgProj)'>
       <Name>System.ServiceModel.Primitives</Name>
     </ProjectReference>
+    <ProjectReference Include="$(WcfInfrastructureCommonProj)">
+      <Project>{AFD69665-89A3-42AE-A32E-AB2CBBE6EE7E}</Project>
+      <Name>Infrastructure.Common</Name>
+    </ProjectReference>
     <ProjectReference Include='$(WcfScenarioTestCommonProj)'>
       <Project>{9098B41C-9C2E-4FC6-B7D8-FC3411736A22}</Project>
       <Name>ScenarioTests.Common</Name>

--- a/src/System.Private.ServiceModel/tests/Scenarios/Contract/XmlSerializer/XmlSerializerFormatTest.4.0.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Contract/XmlSerializer/XmlSerializerFormatTest.4.0.0.cs
@@ -6,13 +6,17 @@
 using System.ServiceModel;
 using System.ServiceModel.Channels;
 using System.Threading.Tasks;
+using Infrastructure.Common;
 using Xunit;
 
 public static partial class XmlSerializerFormatTests
 {
     private static readonly string s_basicEndpointAddress = Endpoints.HttpBaseAddress_Basic;
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void XmlSerializerFormat_RoundTrips_String()
     {
@@ -25,7 +29,10 @@ public static partial class XmlSerializerFormatTests
         Assert.Equal("message", response);
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void XmlSerializerFormat_Using_SupportsFault_RoundTrips_String()
     {
@@ -38,7 +45,10 @@ public static partial class XmlSerializerFormatTests
         Assert.Equal("message", response);
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void XmlSerializerFormat_Using_SupportsFault_Throws_FaultException()
     {
@@ -63,7 +73,10 @@ public static partial class XmlSerializerFormatTests
         Assert.True(false);
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void XmlSerializerFormat_RoundTrips_Using_Rpc()
     {
@@ -76,7 +89,10 @@ public static partial class XmlSerializerFormatTests
         Assert.Equal("message", response);
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void XmlSerializerFormat_RoundTrips_String_AsyncTask()
     {
@@ -92,7 +108,10 @@ public static partial class XmlSerializerFormatTests
         Assert.Equal("message", response.Result);
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void XmlSerializerFormat_RoundTrips_CompositeType()
     {
@@ -111,7 +130,10 @@ public static partial class XmlSerializerFormatTests
         Assert.True(!input.BoolValue);
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void XmlSerializerFormat_MessageContract_LoginService()
     {
@@ -146,7 +168,10 @@ public static partial class XmlSerializerFormatTests
         }
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     // The test is for the case where a paramerter type contains a field 
     // never used.The test is to make sure the reflection info of the type 
@@ -183,7 +208,10 @@ public static partial class XmlSerializerFormatTests
         }
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void XmlSerializerFormat_SameNamespace_SameOperation()
     {

--- a/src/System.Private.ServiceModel/tests/Scenarios/Contract/XmlSerializer/XmlSerializerFormatTest.4.1.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Contract/XmlSerializer/XmlSerializerFormatTest.4.1.0.cs
@@ -5,12 +5,15 @@
 
 using System.ServiceModel;
 using System.ServiceModel.Channels;
-using System.Threading.Tasks;
+using Infrastructure.Common;
 using Xunit;
 
 public static partial class XmlSerializerFormatTests
 {
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void MessageHeader_ResponseTypeWithUsesMessageHeaderAttribute()
     {
@@ -37,9 +40,13 @@ public static partial class XmlSerializerFormatTests
         }
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
-    [OuterLoop]
     [ActiveIssue(702)]
+#endif
+    [WcfFact]
+    [OuterLoop]
+    [Issue(702, Framework = FrameworkID.NetCore | FrameworkID.NetNative)]
     public static void MessageHeader_RequestTypeWithUsesMessageHeaderAttribute()
     {
         // *** SETUP *** \\
@@ -65,7 +72,10 @@ public static partial class XmlSerializerFormatTests
         }
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void OperationContextScope_HttpRequestCustomMessageHeader_RoundTrip_Verify()
     {

--- a/src/System.Private.ServiceModel/tests/Scenarios/Encoding/Encoders/BinaryEncodingTests.4.0.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Encoding/Encoders/BinaryEncodingTests.4.0.0.cs
@@ -7,13 +7,17 @@ using System;
 using System.ServiceModel;
 using System.ServiceModel.Channels;
 using System.Text;
+using Infrastructure.Common;
 using Xunit;
 
 public static class BinaryEncodingTests
 {
     // Client and Server bindings setup exactly the same using Binary Message encoder
     // and exchanging a basic message
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void SameBinding_Binary_EchoBasicString()
     {
@@ -50,7 +54,10 @@ public static class BinaryEncodingTests
 
     // Client and Server bindings setup exactly the same using Binary Message encoder
     // and exchanging a complicated message
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void SameBinding_Binary_EchoComplexString()
     {

--- a/src/System.Private.ServiceModel/tests/Scenarios/Encoding/Encoders/Encoding.Encoders.Tests.csproj
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Encoding/Encoders/Encoding.Encoders.Tests.csproj
@@ -35,6 +35,10 @@
     <ProjectReference Include='$(WcfPrimitivesPkgProj)'>
       <Name>System.ServiceModel.Primitives</Name>
     </ProjectReference>
+    <ProjectReference Include="$(WcfInfrastructureCommonProj)">
+      <Project>{AFD69665-89A3-42AE-A32E-AB2CBBE6EE7E}</Project>
+      <Name>Infrastructure.Common</Name>
+    </ProjectReference>
     <ProjectReference Include='$(WcfScenarioTestCommonProj)'>
       <Project>{9098B41C-9C2E-4FC6-B7D8-FC3411736A22}</Project>
       <Name>ScenarioTests.Common</Name>

--- a/src/System.Private.ServiceModel/tests/Scenarios/Encoding/Encoders/TextEncodingTests.4.0.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Encoding/Encoders/TextEncodingTests.4.0.0.cs
@@ -5,12 +5,16 @@ using System;
 using System.ServiceModel;
 using System.ServiceModel.Channels;
 using System.Text;
+using Infrastructure.Common;
 using Xunit;
 
 public static partial class TextEncodingTests
 {
     // Simple echo of a string. Same binding on both client and server. CustomBinding with TextMessageEncoding and no WindowsStreamSecurityBindingElement
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void SameBinding_SecurityModeNone_Text_EchoString_Roundtrip()
     {

--- a/src/System.Private.ServiceModel/tests/Scenarios/Encoding/Encoders/TextEncodingTests.4.1.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Encoding/Encoders/TextEncodingTests.4.1.0.cs
@@ -6,12 +6,15 @@
 using System;
 using System.ServiceModel;
 using System.ServiceModel.Channels;
-using System.Text;
+using Infrastructure.Common;
 using Xunit;
 
 public static partial class TextEncodingTests
 {
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void TextMessageEncoder_WrongContentTypeResponse_Throws_ProtocolException()
     {

--- a/src/System.Private.ServiceModel/tests/Scenarios/Encoding/MessageVersion/Encoding.MessageVersion.Tests.csproj
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Encoding/MessageVersion/Encoding.MessageVersion.Tests.csproj
@@ -32,6 +32,10 @@
     <ProjectReference Include='$(WcfPrimitivesPkgProj)'>
       <Name>System.ServiceModel.Primitives</Name>
     </ProjectReference>
+    <ProjectReference Include="$(WcfInfrastructureCommonProj)">
+      <Project>{AFD69665-89A3-42AE-A32E-AB2CBBE6EE7E}</Project>
+      <Name>Infrastructure.Common</Name>
+    </ProjectReference>
     <ProjectReference Include='$(WcfScenarioTestCommonProj)'>
       <Project>{9098B41C-9C2E-4FC6-B7D8-FC3411736A22}</Project>
       <Name>ScenarioTests.Common</Name>

--- a/src/System.Private.ServiceModel/tests/Scenarios/Encoding/MessageVersion/MessageVersionTests.4.0.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Encoding/MessageVersion/MessageVersionTests.4.0.0.cs
@@ -7,12 +7,16 @@ using System;
 using System.ServiceModel;
 using System.ServiceModel.Channels;
 using System.Text;
+using Infrastructure.Common;
 using Xunit;
 
 public static class MessageVersionTests
 {
     // Client and Server bindings setup exactly the same using Soap12WSA10
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void SameBinding_Soap12WSA10_EchoString()
     {
@@ -48,7 +52,10 @@ public static class MessageVersionTests
         Assert.True(errorBuilder.Length == 0, "Test case FAILED with errors: " + errorBuilder.ToString());
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void SameBinding_Soap11_EchoString()
     {

--- a/src/System.Private.ServiceModel/tests/Scenarios/Extensibility/MessageEncoder/Extensibility.MessageEncoder.Tests.csproj
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Extensibility/MessageEncoder/Extensibility.MessageEncoder.Tests.csproj
@@ -38,6 +38,10 @@
     <ProjectReference Include='$(WcfPrimitivesPkgProj)'>
       <Name>System.ServiceModel.Primitives</Name>
     </ProjectReference>
+    <ProjectReference Include="$(WcfInfrastructureCommonProj)">
+      <Project>{AFD69665-89A3-42AE-A32E-AB2CBBE6EE7E}</Project>
+      <Name>Infrastructure.Common</Name>
+    </ProjectReference>
     <ProjectReference Include='$(WcfScenarioTestCommonProj)'>
       <Project>{9098B41C-9C2E-4FC6-B7D8-FC3411736A22}</Project>
       <Name>ScenarioTests.Common</Name>

--- a/src/System.Private.ServiceModel/tests/Scenarios/Extensibility/MessageEncoder/TextTests.4.1.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Extensibility/MessageEncoder/TextTests.4.1.0.cs
@@ -12,12 +12,16 @@ using System.ServiceModel.Channels;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Infrastructure.Common;
 using Extensibility.MessageEncoder.Tests;
 using Xunit;
 
 public static class TextTests
 {
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void CustomTextMessageEncoder_Http_RequestReply_Buffered()
     {
@@ -55,7 +59,10 @@ public static class TextTests
         }
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void CustomTextMessageEncoder_Http_RequestReply_Streamed()
     {

--- a/src/System.Private.ServiceModel/tests/Scenarios/Extensibility/MessageInterceptor/MessageInterceptorTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Extensibility/MessageInterceptor/MessageInterceptorTests.cs
@@ -3,10 +3,10 @@
 // See the LICENSE file in the project root for more information.
 
 
-using Infrastructure.Common;
 using System;
 using System.ServiceModel;
 using System.ServiceModel.Channels;
+using Infrastructure.Common;
 using Xunit;
 
 public partial class MessageInterceptorTests : ConditionalWcfTest
@@ -31,7 +31,10 @@ public partial class MessageInterceptorTests : ConditionalWcfTest
         }
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void CustomBinding_Message_Interceptor()
     {

--- a/src/System.Private.ServiceModel/tests/Scenarios/Extensibility/WebSockets/WebSocketTests.4.1.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Extensibility/WebSockets/WebSocketTests.4.1.0.cs
@@ -7,7 +7,6 @@ using System;
 using System.IO;
 using System.ServiceModel;
 using System.ServiceModel.Channels;
-using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 using Infrastructure.Common;
@@ -177,11 +176,10 @@ public class WebSocketTests : ConditionalWcfTest
 #if FULLXUNIT_NOTSUPPORTED
     [Fact]
     [ActiveIssue(526)]
-#else
+#endif
     [WcfFact]
     [Condition(nameof(Root_Certificate_Installed))]
     [Issue(526, Framework = FrameworkID.NetNative)]
-#endif
     [OuterLoop]
     public static void WebSocket_Https_Duplex_BinaryStreamed()
     {

--- a/src/System.Private.ServiceModel/tests/Scenarios/Extensibility/WebSockets/WebSocketTests.4.1.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Extensibility/WebSockets/WebSocketTests.4.1.0.cs
@@ -14,7 +14,10 @@ using Infrastructure.Common;
 
 public class WebSocketTests : ConditionalWcfTest
 {
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void WebSocket_Http_RequestReply_BinaryStreamed()
     {
@@ -75,11 +78,13 @@ public class WebSocketTests : ConditionalWcfTest
         }
     }
 
-    [Fact]
-    [OuterLoop]
 #if FULLXUNIT_NOTSUPPORTED
+    [Fact]
     [ActiveIssue(526)]
 #endif
+    [WcfFact]
+    [OuterLoop]
+    [Issue(526, Framework = FrameworkID.NetNative)]
     public static void WebSocket_Http_Duplex_BinaryStreamed()
     {
         NetHttpBinding binding = null;
@@ -169,13 +174,15 @@ public class WebSocketTests : ConditionalWcfTest
         }
     }
 
-    [OuterLoop]
 #if FULLXUNIT_NOTSUPPORTED
     [Fact]
     [ActiveIssue(526)]
 #else
-    [ConditionalFact(nameof(Root_Certificate_Installed))]
+    [WcfFact]
+    [Condition(nameof(Root_Certificate_Installed))]
+    [Issue(526, Framework = FrameworkID.NetNative)]
 #endif
+    [OuterLoop]
     public static void WebSocket_Https_Duplex_BinaryStreamed()
     {
 #if FULLXUNIT_NOTSUPPORTED
@@ -278,13 +285,15 @@ public class WebSocketTests : ConditionalWcfTest
         }
     }
 
-    [Fact]
-    [OuterLoop]
 #if FULLXUNIT_NOTSUPPORTED
+    [Fact]
     [ActiveIssue(526)]
-#else
     [ActiveIssue(470)]
 #endif
+    [WcfFact]
+    [Issue(526, Framework = FrameworkID.NetNative)]
+    [Issue(470)]
+    [OuterLoop]
     public static void WebSocket_Https_Duplex_TextStreamed()
     {
         TextMessageEncodingBindingElement textMessageEncodingBindingElement = null;
@@ -377,11 +386,13 @@ public class WebSocketTests : ConditionalWcfTest
         }
     }
 
-    [Fact]
-    [OuterLoop]
 #if FULLXUNIT_NOTSUPPORTED
+    [Fact]
     [ActiveIssue(526)]
 #endif
+    [WcfFact]
+    [Issue(526, Framework = FrameworkID.NetNative)]
+    [OuterLoop]
     public static void WebSocket_Http_Duplex_TextStreamed()
     {
         NetHttpBinding binding = null;
@@ -471,7 +482,10 @@ public class WebSocketTests : ConditionalWcfTest
         }
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void WebSocket_Http_RequestReply_TextStreamed()
     {
@@ -532,7 +546,10 @@ public class WebSocketTests : ConditionalWcfTest
         }
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void WebSocket_Http_WSTransportUsageDefault_DuplexCallback_GuidRoundtrip()
     {
@@ -571,8 +588,10 @@ public class WebSocketTests : ConditionalWcfTest
         }
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
-    [OuterLoop]
+#endif
+    [WcfFact]
     public static void WebSocket_Http_WSTransportUsageAlways_DuplexCallback_GuidRoundtrip()
     {
         DuplexChannelFactory<IWcfDuplexService> factory = null;
@@ -610,7 +629,10 @@ public class WebSocketTests : ConditionalWcfTest
         }
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void WebSocket_WSScheme_WSTransportUsageAlways_DuplexCallback_GuidRoundtrip()
     {
@@ -653,13 +675,14 @@ public class WebSocketTests : ConditionalWcfTest
         }
     }
 
-    [OuterLoop]
 #if FULLXUNIT_NOTSUPPORTED
     [Fact]
     [ActiveIssue(526)]
-#else
-    [ConditionalFact(nameof(Root_Certificate_Installed))]
 #endif
+    [WcfFact]
+    [Condition(nameof(Root_Certificate_Installed))]
+    [Issue(526, Framework = FrameworkID.NetNative)]
+    [OuterLoop]
     public static void WebSocket_Https_RequestReply_BinaryBuffered()
     {
 #if FULLXUNIT_NOTSUPPORTED
@@ -718,13 +741,14 @@ public class WebSocketTests : ConditionalWcfTest
         }
     }
 
-    [OuterLoop]
 #if FULLXUNIT_NOTSUPPORTED
     [Fact]
     [ActiveIssue(526)]
-#else
-    [ConditionalFact(nameof(Root_Certificate_Installed))]
 #endif
+    [WcfFact]
+    [Condition(nameof(Root_Certificate_Installed))]
+    [Issue(526, Framework = FrameworkID.NetNative)]
+    [OuterLoop]
     public static void WebSocket_Https_RequestReply_TextBuffered_KeepAlive()
     {
 #if FULLXUNIT_NOTSUPPORTED
@@ -785,13 +809,14 @@ public class WebSocketTests : ConditionalWcfTest
         }
     }
 
-    [OuterLoop]
 #if FULLXUNIT_NOTSUPPORTED
     [Fact]
     [ActiveIssue(526)]
-#else
-    [ConditionalFact(nameof(Root_Certificate_Installed))]
 #endif
+    [WcfFact]
+    [Condition(nameof(Root_Certificate_Installed))]
+    [Issue(526, Framework = FrameworkID.NetNative)]
+    [OuterLoop]
     public static void WebSocket_Https_Duplex_BinaryBuffered()
     {
 #if FULLXUNIT_NOTSUPPORTED
@@ -865,13 +890,14 @@ public class WebSocketTests : ConditionalWcfTest
         }
     }
 
-    [OuterLoop]
 #if FULLXUNIT_NOTSUPPORTED
     [Fact]
     [ActiveIssue(526)]
-#else
-    [ConditionalFact(nameof(Root_Certificate_Installed))]
 #endif
+    [WcfFact]
+    [Condition(nameof(Root_Certificate_Installed))]
+    [Issue(526, Framework = FrameworkID.NetNative)]
+    [OuterLoop]
     public static void WebSocket_Https_Duplex_TextBuffered_KeepAlive()
     {
 #if FULLXUNIT_NOTSUPPORTED
@@ -945,11 +971,13 @@ public class WebSocketTests : ConditionalWcfTest
         }
     }
 
-    [OuterLoop]
-    [Fact]
 #if FULLXUNIT_NOTSUPPORTED
+    [Fact]
     [ActiveIssue(526)]
 #endif
+    [WcfFact]
+    [Issue(526, Framework = FrameworkID.NetNative)]
+    [OuterLoop]
     public static void WebSocket_Http_RequestReply_TextBuffered()
     {
         NetHttpBinding binding = null;
@@ -996,11 +1024,13 @@ public class WebSocketTests : ConditionalWcfTest
         }
     }
 
-    [OuterLoop]
-    [Fact]
 #if FULLXUNIT_NOTSUPPORTED
+    [Fact]
     [ActiveIssue(526)]
 #endif
+    [WcfFact]
+    [Issue(526, Framework = FrameworkID.NetNative)]
+    [OuterLoop]
     public static void WebSocket_Http_RequestReply_BinaryBuffered_KeepAlive()
     {
         NetHttpBinding binding = null;
@@ -1048,11 +1078,13 @@ public class WebSocketTests : ConditionalWcfTest
         }
     }
 
-    [OuterLoop]
-    [Fact]
 #if FULLXUNIT_NOTSUPPORTED
+    [Fact]
     [ActiveIssue(526)]
 #endif
+    [WcfFact]
+    [Issue(526, Framework = FrameworkID.NetNative)]
+    [OuterLoop]
     public static void WebSocket_Http_Duplex_TextBuffered_KeepAlive()
     {
         NetHttpBinding binding = null;
@@ -1113,11 +1145,13 @@ public class WebSocketTests : ConditionalWcfTest
         }
     }
 
-    [OuterLoop]
-    [Fact]
 #if FULLXUNIT_NOTSUPPORTED
+    [Fact]
     [ActiveIssue(526)]
 #endif
+    [WcfFact]
+    [Issue(526, Framework = FrameworkID.NetNative)]
+    [OuterLoop]
     public static void WebSocket_Http_Duplex_BinaryBuffered()
     {
         NetHttpBinding binding = null;
@@ -1180,11 +1214,13 @@ public class WebSocketTests : ConditionalWcfTest
     // WCF detects when a callback is used in the channel construction process and switches to use WebSockets.
     // When not using a callback you can still force WCF to use WebSockets.
     // This test verifies that it actually uses WebSockets when not using a callback.
-    [OuterLoop]
-    [Fact]
 #if FULLXUNIT_NOTSUPPORTED
+    [Fact]
     [ActiveIssue(526)]
 #endif
+    [WcfFact]
+    [Issue(526, Framework = FrameworkID.NetNative)]
+    [OuterLoop]
     public static void WebSocket_Http_VerifyWebSocketsUsed()
     {
         NetHttpBinding binding = null;

--- a/src/System.Private.ServiceModel/tests/Scenarios/Infrastructure/OSAndFrameworkTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Infrastructure/OSAndFrameworkTests.cs
@@ -9,7 +9,10 @@ using Xunit;
 
 public class OSAndFrameworkTests
 {
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void FrameworkID_Was_Detected()
     {
@@ -18,7 +21,10 @@ public class OSAndFrameworkTests
                                    RuntimeInformation.FrameworkDescription));
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void OSID_Was_Detected()
     {
@@ -29,7 +35,10 @@ public class OSAndFrameworkTests
                                    RuntimeInformation.OSDescription));
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void FrameworkID_Name_Formats_Correctly()
     {
@@ -40,7 +49,10 @@ public class OSAndFrameworkTests
                     String.Format("FrameworkID.Name should have contained NetCore and NetNative, but actual was \"{0}\"", formatted));
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void OSID_Name_Formats_Correctly()
     {

--- a/src/System.Private.ServiceModel/tests/Scenarios/Infrastructure/SetupValidationTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Infrastructure/SetupValidationTests.cs
@@ -3,19 +3,19 @@
 // See the LICENSE file in the project root for more information.
 
 
-using Infrastructure.Common;
 using System;
 using System.Security.Cryptography.X509Certificates;
+using Infrastructure.Common;
 using Xunit;
 
 public class SetupValidationTests : ConditionalWcfTest
 {
 #if FULLXUNIT_NOTSUPPORTED
     [Fact]
-#else
-    [ConditionalFact(nameof(Root_Certificate_Installed))]
-    [ActiveIssue(1347, PlatformID.AnyUnix)]
 #endif
+    [WcfFact]
+    [Condition(nameof(Root_Certificate_Installed))]
+    [Issue(1347, OS = OSID.AnyUnix)]
     [OuterLoop]
     public static void Root_Certificate_Correctly_Installed()
     {
@@ -51,9 +51,9 @@ public class SetupValidationTests : ConditionalWcfTest
 
 #if FULLXUNIT_NOTSUPPORTED
     [Fact]
-#else
-    [ConditionalFact(nameof(Client_Certificate_Installed))]
 #endif
+    [WcfFact]
+    [Condition(nameof(Client_Certificate_Installed))]
     [OuterLoop]
     public static void Client_Certificate_Correctly_Installed()
     {
@@ -88,9 +88,9 @@ public class SetupValidationTests : ConditionalWcfTest
 
 #if FULLXUNIT_NOTSUPPORTED
     [Fact]
-#else
-    [ConditionalFact(nameof(Peer_Certificate_Installed))]
 #endif
+    [WcfFact]
+    [Condition(nameof(Peer_Certificate_Installed))]
     [OuterLoop]
     public static void Peer_Certificate_Correctly_Installed()
     {

--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Http/ClientCredentialTypeTests.4.1.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Http/ClientCredentialTypeTests.4.1.0.cs
@@ -14,7 +14,10 @@ using Xunit;
 
 public static class Http_ClientCredentialTypeTests
 {
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void DigestAuthentication_Echo_RoundTrips_String_No_Domain()
     {

--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Https/ClientCredentialTypeTests.4.1.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Https/ClientCredentialTypeTests.4.1.0.cs
@@ -25,9 +25,9 @@ public class Https_ClientCredentialTypeTests : ConditionalWcfTest
 
 #if FULLXUNIT_NOTSUPPORTED
     [Fact]
-#else
-    [ConditionalFact(nameof(Root_Certificate_Installed))]
 #endif
+    [WcfFact]
+    [Condition(nameof(Root_Certificate_Installed))]
     [OuterLoop]
     public static void BasicAuthentication_RoundTrips_Echo()
     {
@@ -96,9 +96,9 @@ public class Https_ClientCredentialTypeTests : ConditionalWcfTest
 
 #if FULLXUNIT_NOTSUPPORTED
     [Fact]
-#else
-    [ConditionalFact(nameof(Root_Certificate_Installed))]
 #endif
+    [WcfFact]
+    [Condition(nameof(Root_Certificate_Installed))]
     [OuterLoop]
     public static void BasicAuthenticationInvalidPwd_throw_MessageSecurityException()
     {
@@ -157,9 +157,9 @@ public class Https_ClientCredentialTypeTests : ConditionalWcfTest
 
 #if FULLXUNIT_NOTSUPPORTED
     [Fact]
-#else
-    [ConditionalFact(nameof(Root_Certificate_Installed))]
 #endif
+    [WcfFact]
+    [Condition(nameof(Root_Certificate_Installed))]
     [OuterLoop]
     public static void BasicAuthenticationEmptyUser_throw_ArgumentException()
     {
@@ -196,12 +196,12 @@ public class Https_ClientCredentialTypeTests : ConditionalWcfTest
 
 #if FULLXUNIT_NOTSUPPORTED
     [Fact]
-#else
-    [ConditionalFact(nameof(Server_Domain_Joined),
-                     nameof(Root_Certificate_Installed),
-                     nameof(Digest_Authentication_Available),
-                     nameof(Explicit_Credentials_Available))]
 #endif
+    [WcfFact]
+    [Condition(nameof(Server_Domain_Joined),
+               nameof(Root_Certificate_Installed),
+               nameof(Digest_Authentication_Available),
+               nameof(Explicit_Credentials_Available))]
     [OuterLoop]
     // Test Requirements \\
     // The following environment variables must be set...
@@ -254,9 +254,9 @@ public class Https_ClientCredentialTypeTests : ConditionalWcfTest
 
 #if FULLXUNIT_NOTSUPPORTED
     [Fact]
-#else
-    [ConditionalFact(nameof(NTLM_Available), nameof(Root_Certificate_Installed))]
 #endif
+    [WcfFact]
+    [Condition(nameof(NTLM_Available), nameof(Root_Certificate_Installed))]
     [OuterLoop]
     public static void NtlmAuthentication_RoundTrips_Echo()
     {
@@ -292,9 +292,9 @@ public class Https_ClientCredentialTypeTests : ConditionalWcfTest
 
 #if FULLXUNIT_NOTSUPPORTED
     [Fact]
-#else
-    [ConditionalFact(nameof(Windows_Authentication_Available), nameof(Root_Certificate_Installed))]
 #endif
+    [WcfFact]
+    [Condition(nameof(Windows_Authentication_Available), nameof(Root_Certificate_Installed))]
     [OuterLoop]
     public static void WindowsAuthentication_RoundTrips_Echo()
     {

--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Https/HttpsTests.4.1.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Https/HttpsTests.4.1.0.cs
@@ -18,12 +18,12 @@ public partial class HttpsTests : ConditionalWcfTest
     // Server: BasicHttpsBinding default value is Soap11
 #if FULLXUNIT_NOTSUPPORTED
     [Fact]
-#else
-    [ConditionalFact(nameof(Root_Certificate_Installed),
-                     nameof(SSL_Available))]
 #endif
+    [WcfFact]
     [OuterLoop]
-    [ActiveIssue(1398, PlatformID.OSX)] // Cert installation on OSX does not work yet
+    [Issue(1398, OS = OSID.AnyOSX)] // Cert installation on OSX does not work yet
+    [Condition(nameof(Root_Certificate_Installed),
+               nameof(SSL_Available))]
     public static void CrossBinding_Soap11_EchoString()
     {
 #if FULLXUNIT_NOTSUPPORTED
@@ -74,12 +74,12 @@ public partial class HttpsTests : ConditionalWcfTest
     // Client and Server bindings setup exactly the same using default settings.
 #if FULLXUNIT_NOTSUPPORTED
     [Fact]
-#else
-    [ConditionalFact(nameof(Root_Certificate_Installed),
-                     nameof(SSL_Available))]
 #endif
+    [WcfFact]
+    [Condition(nameof(Root_Certificate_Installed),
+               nameof(SSL_Available))]
+    [Issue(1398, OS = OSID.AnyOSX)] // Cert installation on OSX does not work yet
     [OuterLoop]
-    [ActiveIssue(1398, PlatformID.OSX)] // Cert installation on OSX does not work yet
     public static void SameBinding_DefaultSettings_EchoString()
     {
 #if FULLXUNIT_NOTSUPPORTED
@@ -130,12 +130,12 @@ public partial class HttpsTests : ConditionalWcfTest
     // Client and Server bindings setup exactly the same using Soap11
 #if FULLXUNIT_NOTSUPPORTED
     [Fact]
-#else
-    [ConditionalFact(nameof(Root_Certificate_Installed),
-                     nameof(SSL_Available))]
 #endif
+    [WcfFact]
+    [Condition(nameof(Root_Certificate_Installed),
+               nameof(SSL_Available))]
+    [Issue(1398, OS = OSID.AnyOSX)] // Cert installation on OSX does not work yet
     [OuterLoop]
-    [ActiveIssue(1398, PlatformID.OSX)] // Cert installation on OSX does not work yet
     public static void SameBinding_Soap11_EchoString()
     {
 #if FULLXUNIT_NOTSUPPORTED
@@ -186,12 +186,12 @@ public partial class HttpsTests : ConditionalWcfTest
     // Client and Server bindings setup exactly the same using Soap12
 #if FULLXUNIT_NOTSUPPORTED
     [Fact]
-#else
-    [ConditionalFact(nameof(Root_Certificate_Installed),
-                     nameof(SSL_Available))]
 #endif
+    [WcfFact]
+    [Condition(nameof(Root_Certificate_Installed),
+               nameof(SSL_Available))]
+    [Issue(1398, OS = OSID.AnyOSX)] // Cert installation on OSX does not work yet
     [OuterLoop]
-    [ActiveIssue(1398, PlatformID.OSX)] // Cert installation on OSX does not work yet
     public static void SameBinding_Soap12_EchoString()
     {
 #if FULLXUNIT_NOTSUPPORTED
@@ -242,13 +242,14 @@ public partial class HttpsTests : ConditionalWcfTest
 #if FULLXUNIT_NOTSUPPORTED
     [Fact]
     [ActiveIssue(959)] // Server certificate validation not supported in NET Native
-#else
-    [ConditionalFact(nameof(Root_Certificate_Installed),
-                     nameof(Client_Certificate_Installed),
-                     nameof(SSL_Available))]
 #endif
+    [WcfFact]
+    [Condition(nameof(Root_Certificate_Installed),
+               nameof(Client_Certificate_Installed),
+               nameof(SSL_Available))]
+    [Issue(959, Framework = FrameworkID.NetNative)] // Server certificate validation not supported in NET Native
+    [Issue(1295, OS = OSID.AnyUnix)] // A libcurl built with OpenSSL is required
     [OuterLoop]
-    [ActiveIssue(1295, PlatformID.AnyUnix)] // A libcurl built with OpenSSL is required
     public static void ServerCertificateValidation_EchoString()
     {
 #if FULLXUNIT_NOTSUPPORTED
@@ -310,14 +311,14 @@ public partial class HttpsTests : ConditionalWcfTest
 
 #if FULLXUNIT_NOTSUPPORTED
     [Fact]
-#else
-    [ConditionalFact(nameof(Root_Certificate_Installed),
-                     nameof(Client_Certificate_Installed),
-                     nameof(Server_Accepts_Certificates),
-                     nameof(SSL_Available))]
 #endif
+    [WcfFact]
+    [Condition(nameof(Root_Certificate_Installed),
+               nameof(Client_Certificate_Installed),
+               nameof(Server_Accepts_Certificates),
+               nameof(SSL_Available))]
+    [Issue(1295, OS = OSID.AnyUnix)] // A libcurl built with OpenSSL is required
     [OuterLoop]
-    [ActiveIssue(1295, PlatformID.AnyUnix)] // A libcurl built with OpenSSL is required
     public static void ClientCertificate_EchoString()
     {
 #if FULLXUNIT_NOTSUPPORTED

--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Https/HttpsTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Https/HttpsTests.cs
@@ -14,14 +14,16 @@ public partial class HttpsTests : ConditionalWcfTest
 #if FULLXUNIT_NOTSUPPORTED
     [Fact]
     [ActiveIssue(959)] // Server certificate validation not supported in NET Native
-#else
-    [ConditionalFact(nameof(Root_Certificate_Installed),
-                     nameof(Client_Certificate_Installed),
-                     nameof(Peer_Certificate_Installed),
-                     nameof(SSL_Available))]
 #endif
+    [WcfFact]
+    [Condition(nameof(Root_Certificate_Installed),
+               nameof(Client_Certificate_Installed),
+               nameof(Peer_Certificate_Installed),
+               nameof(SSL_Available))]
+    [Issue(1381)] // requires additional SSL configuration of new port to work
+    [Issue(959, Framework = FrameworkID.NetNative)] // Server certificate validation not supported in NET Native
     [OuterLoop]
-    [ActiveIssue(1381)] // requires additional SSL configuration of new port to work
+
     // Asking for PeerTrust alone should succeed
     // if the certificate is in the TrustedPeople store.  For this test
     // we use a certificate we know is in the TrustedPeople store.
@@ -87,19 +89,20 @@ public partial class HttpsTests : ConditionalWcfTest
 #if FULLXUNIT_NOTSUPPORTED
     [Fact]
     [ActiveIssue(959)] // Server certificate validation not supported in NET Native
-#else
-    [ConditionalFact(nameof(Root_Certificate_Installed),
-                     nameof(Client_Certificate_Installed),
-                     nameof(Peer_Certificate_Installed),
-                     nameof(SSL_Available))]
 #endif
+    [WcfFact]
+    [Condition(nameof(Root_Certificate_Installed),
+               nameof(Client_Certificate_Installed),
+               nameof(Peer_Certificate_Installed),
+               nameof(SSL_Available))]
+    [Issue(1398, OS = OSID.AnyOSX)] // Cert installation on OSX does not work yet
+    [Issue(1295, OS = OSID.AnyUnix)] // A libcurl built with OpenSSL is required.
     [OuterLoop]
     // Asking for PeerTrust alone should throw SecurityNegotiationException
     // if the certificate is not in the TrustedPeople store.  For this test
     // we use a valid chain-trusted certificate that we know is not in the
     // TrustedPeople store.
-    [ActiveIssue(1398, PlatformID.OSX)] // Cert installation on OSX does not work yet
-    [ActiveIssue(1295, PlatformID.AnyUnix)] // A libcurl built with OpenSSL is required.
+
     public static void Https_SecModeTrans_CertValMode_PeerTrust_Fails_Not_In_TrustedPeople()
     {
 #if FULLXUNIT_NOTSUPPORTED
@@ -172,13 +175,14 @@ public partial class HttpsTests : ConditionalWcfTest
 #if FULLXUNIT_NOTSUPPORTED
     [Fact]
     [ActiveIssue(959)] // Server certificate validation not supported in NET Native
-#else
-    [ConditionalFact(nameof(Root_Certificate_Installed), 
-                     nameof(Client_Certificate_Installed),
-                     nameof(SSL_Available))]
 #endif
+    [WcfFact]
+    [Condition(nameof(Root_Certificate_Installed),
+               nameof(Client_Certificate_Installed),
+               nameof(SSL_Available))]
+    [Issue(959, Framework = FrameworkID.NetNative)] // Server certificate validation not supported in NET Native
+    [Issue(1295, OS = OSID.AnyUnix)] // A libcurl built with OpenSSL is required.
     [OuterLoop]
-    [ActiveIssue(1295, PlatformID.AnyUnix)] // A libcurl built with OpenSSL is required.
     // Asking for PeerOrChainTrust should succeed if the certificate is
     // chain-trusted, even though it is not in the TrustedPeople store.
     // So we ask for a known chain-trusted certificate that we also know
@@ -241,13 +245,14 @@ public partial class HttpsTests : ConditionalWcfTest
 #if FULLXUNIT_NOTSUPPORTED
     [Fact]
     [ActiveIssue(959)] // Server certificate validation not supported in NET Native
-#else
-    [ConditionalFact(nameof(Root_Certificate_Installed),
-                     nameof(Client_Certificate_Installed),
-                     nameof(SSL_Available))]
 #endif
+    [WcfFact]
+    [Condition(nameof(Root_Certificate_Installed),
+               nameof(Client_Certificate_Installed),
+               nameof(SSL_Available))]
+    [Issue(959, Framework = FrameworkID.NetNative)] // Server certificate validation not supported in NET Native
+    [Issue(1295, OS = OSID.AnyUnix)] // A libcurl built with OpenSSL is required.
     [OuterLoop]
-    [ActiveIssue(1295, PlatformID.AnyUnix)] // A libcurl built with OpenSSL is required.
     // Asking for ChainTrust should succeed if the certificate is
     // chain-trusted.
     public static void Https_SecModeTrans_CertValMode_ChainTrust_Succeeds_ChainTrusted()

--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Negotiate/NegotiateStream_Http_Tests.4.1.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Negotiate/NegotiateStream_Http_Tests.4.1.0.cs
@@ -58,11 +58,11 @@ public class NegotiateStream_Http_Tests : ConditionalWcfTest
 
 #if FULLXUNIT_NOTSUPPORTED
     [Fact]
-#else
-    [ConditionalFact(nameof(Windows_Authentication_Available),
-                     nameof(Root_Certificate_Installed),
-                     nameof(Ambient_Credentials_Available))]
 #endif
+    [WcfFact]
+    [Condition(nameof(Windows_Authentication_Available),
+               nameof(Root_Certificate_Installed),
+               nameof(Ambient_Credentials_Available))]
     [OuterLoop]
     public static void NegotiateStream_Http_AmbientCredentials()
     {
@@ -114,12 +114,12 @@ public class NegotiateStream_Http_Tests : ConditionalWcfTest
 
 #if FULLXUNIT_NOTSUPPORTED
     [Fact]
-#else
-    [ConditionalFact(nameof(Windows_Authentication_Available), 
-                     nameof(Root_Certificate_Installed), 
-                     nameof(Explicit_Credentials_Available),
-                     nameof(Domain_Available))]
 #endif
+    [WcfFact]
+    [Condition(nameof(Windows_Authentication_Available),
+               nameof(Root_Certificate_Installed),
+               nameof(Explicit_Credentials_Available),
+               nameof(Domain_Available))]
     [OuterLoop]
     // Test Requirements \\
     // The following environment variables must be set...
@@ -188,11 +188,11 @@ public class NegotiateStream_Http_Tests : ConditionalWcfTest
 
 #if FULLXUNIT_NOTSUPPORTED
     [Fact]
-#else
-    [ConditionalFact(nameof(Windows_Authentication_Available), 
-                     nameof(Root_Certificate_Installed),
-                     nameof(SPN_Available))]
 #endif
+    [WcfFact]
+    [Condition(nameof(Windows_Authentication_Available),
+               nameof(Root_Certificate_Installed),
+               nameof(SPN_Available))]
     [OuterLoop]
     // Test Requirements \\
     // The following environment variables must be set...
@@ -255,12 +255,12 @@ public class NegotiateStream_Http_Tests : ConditionalWcfTest
 
 #if FULLXUNIT_NOTSUPPORTED
     [Fact]
-    [ActiveIssue(10)]
-#else
-    [ConditionalFact(nameof(Windows_Authentication_Available), 
-                     nameof(Root_Certificate_Installed),
-                     nameof(UPN_Available))]
 #endif
+    [WcfFact]
+    [Condition(nameof(Windows_Authentication_Available),
+               nameof(Root_Certificate_Installed),
+               nameof(UPN_Available))]
+    [Issue(10)]
     [OuterLoop]
     public static void NegotiateStream_Http_With_Upn()
     {
@@ -317,13 +317,13 @@ public class NegotiateStream_Http_Tests : ConditionalWcfTest
 
 #if FULLXUNIT_NOTSUPPORTED
     [Fact]
-#else
-    [ConditionalFact(nameof(Windows_Authentication_Available), 
-                     nameof(Root_Certificate_Installed),
-                     nameof(Explicit_Credentials_Available),
-                     nameof(Domain_Available),
-                     nameof(SPN_Available))]
 #endif
+    [WcfFact]
+    [Condition(nameof(Windows_Authentication_Available),
+               nameof(Root_Certificate_Installed),
+               nameof(Explicit_Credentials_Available),
+               nameof(Domain_Available),
+               nameof(SPN_Available))]
     [OuterLoop]
     // Test Requirements \\
     // The following environment variables must be set...
@@ -399,14 +399,14 @@ public class NegotiateStream_Http_Tests : ConditionalWcfTest
 
 #if FULLXUNIT_NOTSUPPORTED
     [Fact]
-    [ActiveIssue(10)]
-#else
-    [ConditionalFact(nameof(Windows_Authentication_Available), 
-                     nameof(Root_Certificate_Installed),
-                     nameof(Explicit_Credentials_Available),
-                     nameof(Domain_Available),
-                     nameof(UPN_Available))]
 #endif
+    [WcfFact]
+    [Condition(nameof(Windows_Authentication_Available),
+               nameof(Root_Certificate_Installed),
+               nameof(Explicit_Credentials_Available),
+               nameof(Domain_Available),
+               nameof(UPN_Available))]
+    [Issue(10)]
     [OuterLoop]
     public static void NegotiateStream_Http_With_ExplicitUserNameAndPassword_With_Upn()
     {

--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Negotiate/NegotiateStream_Tcp_Tests.4.1.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Negotiate/NegotiateStream_Tcp_Tests.4.1.0.cs
@@ -3,12 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 
-using Infrastructure.Common;
 using System;
-using System.Security.Cryptography.X509Certificates;
 using System.ServiceModel;
-using System.ServiceModel.Channels;
-using System.ServiceModel.Security;
+using Infrastructure.Common;
 using Xunit;
 
 public class NegotiateStream_Tcp_Tests : ConditionalWcfTest
@@ -59,10 +56,11 @@ public class NegotiateStream_Tcp_Tests : ConditionalWcfTest
 #if FULLXUNIT_NOTSUPPORTED
     [Fact]
     [ActiveIssue(1235)]
-#else
-    [ConditionalFact(nameof(Windows_Authentication_Available),
-                     nameof(Ambient_Credentials_Available))]
 #endif
+    [WcfFact]
+    [Condition(nameof(Windows_Authentication_Available),
+               nameof(Ambient_Credentials_Available))]
+    [Issue(1235, Framework = FrameworkID.NetNative)]
     [OuterLoop]
     public static void NegotiateStream_Tcp_AmbientCredentials()
     {
@@ -111,12 +109,13 @@ public class NegotiateStream_Tcp_Tests : ConditionalWcfTest
 #if FULLXUNIT_NOTSUPPORTED
     [Fact]
     [ActiveIssue(1235)]
-#else
-    [ConditionalFact(nameof(Windows_Authentication_Available),
-                     nameof(Explicit_Credentials_Available),
-                     nameof(Domain_Available))]
-    [ActiveIssue(1262)]
 #endif
+    [WcfFact]
+    [Condition(nameof(Windows_Authentication_Available),
+               nameof(Explicit_Credentials_Available),
+               nameof(Domain_Available))]
+    [Issue(1235, Framework = FrameworkID.NetNative)]
+    [Issue(1262)]
     [OuterLoop]
     // Test Requirements \\
     // The following environment variables must be set...
@@ -181,10 +180,11 @@ public class NegotiateStream_Tcp_Tests : ConditionalWcfTest
 #if FULLXUNIT_NOTSUPPORTED
     [Fact]
     [ActiveIssue(1235)]
-#else
-    [ConditionalFact(nameof(Windows_Authentication_Available),
-                     nameof(SPN_Available))]
 #endif
+    [WcfFact]
+    [Condition(nameof(Windows_Authentication_Available),
+               nameof(SPN_Available))]
+    [Issue(1235, Framework = FrameworkID.NetNative)]
     [OuterLoop]
     // Test Requirements \\
     // The following environment variables must be set...
@@ -243,10 +243,11 @@ public class NegotiateStream_Tcp_Tests : ConditionalWcfTest
 #if FULLXUNIT_NOTSUPPORTED
     [Fact]
     [ActiveIssue(1235)]
-#else
-    [ConditionalFact(nameof(Windows_Authentication_Available),
-                     nameof(SPN_Available))]
 #endif
+    [WcfFact]
+    [Condition(nameof(Windows_Authentication_Available),
+               nameof(SPN_Available))]
+    [Issue(1235, Framework = FrameworkID.NetNative)]
     [OuterLoop]
     public static void NegotiateStream_Tcp_With_SPN()
     {
@@ -301,13 +302,14 @@ public class NegotiateStream_Tcp_Tests : ConditionalWcfTest
 #if FULLXUNIT_NOTSUPPORTED
     [Fact]
     [ActiveIssue(1235)]
-#else
-    [ConditionalFact(nameof(Windows_Authentication_Available),
-                     nameof(Explicit_Credentials_Available),
-                     nameof(Domain_Available),
-                     nameof(SPN_Available))]
-    [ActiveIssue(1262)]
 #endif
+    [WcfFact]
+    [Condition(nameof(Windows_Authentication_Available),
+               nameof(Explicit_Credentials_Available),
+               nameof(Domain_Available),
+               nameof(SPN_Available))]
+    [Issue(1235, Framework = FrameworkID.NetNative)]
+    [Issue(1262)]
     [OuterLoop]
     // Test Requirements \\
     // The following environment variables must be set...
@@ -380,13 +382,14 @@ public class NegotiateStream_Tcp_Tests : ConditionalWcfTest
 #if FULLXUNIT_NOTSUPPORTED
     [Fact]
     [ActiveIssue(1235)]
-#else
-    [ConditionalFact(nameof(Windows_Authentication_Available),
-                     nameof(Explicit_Credentials_Available),
-                     nameof(Domain_Available),
-                     nameof(UPN_Available))]
-    [ActiveIssue(1262)]
 #endif
+    [WcfFact]
+    [Condition(nameof(Windows_Authentication_Available),
+               nameof(Explicit_Credentials_Available),
+               nameof(Domain_Available),
+               nameof(UPN_Available))]
+    [Issue(1235, Framework = FrameworkID.NetNative)]
+    [Issue(1262)]
     [OuterLoop]
     public static void NegotiateStream_Tcp_With_ExplicitUserNameAndPassword_With_Upn()
     {

--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Tcp/ClientCredentialTypeCertificateCanonicalNameTests.4.1.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Tcp/ClientCredentialTypeCertificateCanonicalNameTests.4.1.0.cs
@@ -26,9 +26,9 @@ public class Tcp_ClientCredentialTypeCertificateCanonicalNameTests : Conditional
 
 #if FULLXUNIT_NOTSUPPORTED
     [Fact]
-#else
-    [ConditionalFact(nameof(Root_Certificate_Installed))]
 #endif
+    [WcfFact]
+    [Condition(nameof(Root_Certificate_Installed))]
     [OuterLoop]
     public static void Certificate_With_CanonicalName_Localhost_Address_EchoString()
     {
@@ -110,9 +110,9 @@ public class Tcp_ClientCredentialTypeCertificateCanonicalNameTests : Conditional
 
 #if FULLXUNIT_NOTSUPPORTED
     [Fact]
-#else
-    [ConditionalFact(nameof(Root_Certificate_Installed))]
 #endif
+    [WcfFact]
+    [Condition(nameof(Root_Certificate_Installed))]
     [OuterLoop]
     public static void Certificate_With_CanonicalName_DomainName_Address_EchoString()
     {
@@ -199,9 +199,9 @@ public class Tcp_ClientCredentialTypeCertificateCanonicalNameTests : Conditional
 
 #if FULLXUNIT_NOTSUPPORTED
     [Fact]
-#else
-    [ConditionalFact(nameof(Root_Certificate_Installed))]
 #endif
+    [WcfFact]
+    [Condition(nameof(Root_Certificate_Installed))]
     [OuterLoop]
     public static void Certificate_With_CanonicalName_Fqdn_Address_EchoString()
     {

--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Tcp/ClientCredentialTypeTests.4.1.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Tcp/ClientCredentialTypeTests.4.1.0.cs
@@ -14,9 +14,9 @@ public partial class Tcp_ClientCredentialTypeTests : ConditionalWcfTest
 {
 #if FULLXUNIT_NOTSUPPORTED
     [Fact]
-#else
-    [ConditionalFact(nameof(Root_Certificate_Installed), nameof(Client_Certificate_Installed))]
 #endif
+    [WcfFact]
+    [Condition(nameof(Root_Certificate_Installed), nameof(Client_Certificate_Installed))]
     [OuterLoop]
     public static void TcpClientCredentialType_Certificate_EchoString()
     {
@@ -77,9 +77,9 @@ public partial class Tcp_ClientCredentialTypeTests : ConditionalWcfTest
 
 #if FULLXUNIT_NOTSUPPORTED
     [Fact]
-#else
-    [ConditionalFact(nameof(Root_Certificate_Installed), nameof(Client_Certificate_Installed))]
 #endif
+    [WcfFact]
+    [Condition(nameof(Root_Certificate_Installed), nameof(Client_Certificate_Installed))]
     [OuterLoop]
     public static void TcpClientCredentialType_Certificate_CustomValidator_EchoString()
     {
@@ -144,9 +144,9 @@ public partial class Tcp_ClientCredentialTypeTests : ConditionalWcfTest
 
 #if FULLXUNIT_NOTSUPPORTED
     [Fact]
-#else
-    [ConditionalFact(nameof(Root_Certificate_Installed), nameof(Client_Certificate_Installed))]
 #endif
+    [WcfFact]
+    [Condition(nameof(Root_Certificate_Installed), nameof(Client_Certificate_Installed))]
     [OuterLoop]
     public static void TcpClientCredentialType_Certificate_With_ServerAltName_EchoString()
     {

--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Tcp/ClientCredentialTypeTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Tcp/ClientCredentialTypeTests.cs
@@ -14,12 +14,12 @@ public partial class Tcp_ClientCredentialTypeTests : ConditionalWcfTest
 {
 #if FULLXUNIT_NOTSUPPORTED
     [Fact]
-#else
-    [ConditionalFact(nameof(Root_Certificate_Installed), 
-                     nameof(Client_Certificate_Installed),
-                     nameof(Peer_Certificate_Installed),
-                     nameof(SSL_Available))]
 #endif
+    [WcfFact]
+    [Condition(nameof(Root_Certificate_Installed),
+               nameof(Client_Certificate_Installed),
+               nameof(Peer_Certificate_Installed),
+               nameof(SSL_Available))]
     [OuterLoop]
     // Asking for PeerTrust alone should succeed
     // if the certificate is in the TrustedPeople store.  For this test
@@ -85,12 +85,12 @@ public partial class Tcp_ClientCredentialTypeTests : ConditionalWcfTest
 
 #if FULLXUNIT_NOTSUPPORTED
     [Fact]
-#else
-    [ConditionalFact(nameof(Root_Certificate_Installed),
-                     nameof(Client_Certificate_Installed),
-                     nameof(Peer_Certificate_Installed),
-                     nameof(SSL_Available))]
 #endif
+    [WcfFact]
+    [Condition(nameof(Root_Certificate_Installed),
+               nameof(Client_Certificate_Installed),
+               nameof(Peer_Certificate_Installed),
+               nameof(SSL_Available))]
     [OuterLoop]
     // Asking for PeerTrust alone should throw SecurityNegotiationException
     // if the certificate is not in the TrustedPeople store.  For this test
@@ -167,11 +167,11 @@ public partial class Tcp_ClientCredentialTypeTests : ConditionalWcfTest
 
 #if FULLXUNIT_NOTSUPPORTED
     [Fact]
-#else
-    [ConditionalFact(nameof(Root_Certificate_Installed), 
-                     nameof(Client_Certificate_Installed),
-                     nameof(SSL_Available))]
 #endif
+    [WcfFact]
+    [Condition(nameof(Root_Certificate_Installed),
+               nameof(Client_Certificate_Installed),
+               nameof(SSL_Available))]
     [OuterLoop]
     // Asking for PeerOrChainTrust should succeed if the certificate is
     // chain-trusted, even though it is not in the TrustedPeople store.
@@ -234,11 +234,11 @@ public partial class Tcp_ClientCredentialTypeTests : ConditionalWcfTest
 
 #if FULLXUNIT_NOTSUPPORTED
     [Fact]
-#else
-    [ConditionalFact(nameof(Root_Certificate_Installed),
-                     nameof(Client_Certificate_Installed),
-                     nameof(SSL_Available))]
 #endif
+    [WcfFact]
+    [Condition(nameof(Root_Certificate_Installed),
+               nameof(Client_Certificate_Installed),
+               nameof(SSL_Available))]
     [OuterLoop]
     // Asking for ChainTrust only should succeed if the certificate is
     // chain-trusted.

--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Tcp/IdentityTests.4.1.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Tcp/IdentityTests.4.1.0.cs
@@ -14,9 +14,9 @@ public partial class IdentityTests : ConditionalWcfTest
 {
 #if FULLXUNIT_NOTSUPPORTED
     [Fact]
-#else
-    [ConditionalFact(nameof(Root_Certificate_Installed), nameof(Client_Certificate_Installed))]
 #endif
+    [WcfFact]
+    [Condition(nameof(Root_Certificate_Installed), nameof(Client_Certificate_Installed))]
     [OuterLoop]
     // The product code will check the Dns identity from the server and throw if it does not match what is specified in DnsEndpointIdentity
     public static void VerifyServiceIdentityMatchDnsEndpointIdentity()

--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Tcp/IdentityTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Tcp/IdentityTests.cs
@@ -14,9 +14,9 @@ public partial class IdentityTests : ConditionalWcfTest
 {
 #if FULLXUNIT_NOTSUPPORTED
     [Fact]
-#else
-    [ConditionalFact(nameof(Root_Certificate_Installed), nameof(Client_Certificate_Installed))]
 #endif
+    [WcfFact]
+    [Condition(nameof(Root_Certificate_Installed), nameof(Client_Certificate_Installed))]
     [OuterLoop]
     // Verify product throws MessageSecurityException when the Dns identity from the server does not match the expectation
     public static void ServiceIdentityNotMatch_Throw_MessageSecurityException()

--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Tcp/StreamingTests.4.1.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Tcp/StreamingTests.4.1.0.cs
@@ -20,12 +20,13 @@ public class StreamingTests : ConditionalWcfTest
 #if FULLXUNIT_NOTSUPPORTED
     [Fact]
     [ActiveIssue(832)] // Windows Stream Security is not supported in NET Native
-#else
-    [ConditionalFact(nameof(Root_Certificate_Installed),
-                     nameof(Client_Certificate_Installed),
-                     nameof(Windows_Authentication_Available),
-                     nameof(Ambient_Credentials_Available))]
 #endif
+    [WcfFact]
+    [Condition(nameof(Root_Certificate_Installed),
+               nameof(Client_Certificate_Installed),
+               nameof(Windows_Authentication_Available),
+               nameof(Ambient_Credentials_Available))]
+    [Issue(832, Framework = FrameworkID.NetNative)] // Windows Stream Security is not supported in NET Native
     [OuterLoop]
     public static void NetTcp_TransportSecurity_StreamedRequest_RoundTrips_String()
     {
@@ -84,12 +85,13 @@ public class StreamingTests : ConditionalWcfTest
 #if FULLXUNIT_NOTSUPPORTED
     [Fact]
     [ActiveIssue(832)] // Windows Stream Security is not supported in NET Native
-#else
-    [ConditionalFact(nameof(Root_Certificate_Installed),
-                     nameof(Client_Certificate_Installed),
-                     nameof(Windows_Authentication_Available),
-                     nameof(Ambient_Credentials_Available))]
 #endif
+    [WcfFact]
+    [Condition(nameof(Root_Certificate_Installed),
+               nameof(Client_Certificate_Installed),
+               nameof(Windows_Authentication_Available),
+               nameof(Ambient_Credentials_Available))]
+    [Issue(832, Framework = FrameworkID.NetNative)] // Windows Stream Security is not supported in NET Native
     [OuterLoop]
     public static void NetTcp_TransportSecurity_StreamedResponse_RoundTrips_String()
     {
@@ -147,12 +149,13 @@ public class StreamingTests : ConditionalWcfTest
 #if FULLXUNIT_NOTSUPPORTED
     [Fact]
     [ActiveIssue(832)] // Windows Stream Security is not supported in NET Native
-#else
-    [ConditionalFact(nameof(Root_Certificate_Installed),
-                     nameof(Client_Certificate_Installed),
-                     nameof(Windows_Authentication_Available),
-                     nameof(Ambient_Credentials_Available))]
 #endif
+    [WcfFact]
+    [Condition(nameof(Root_Certificate_Installed),
+               nameof(Client_Certificate_Installed),
+               nameof(Windows_Authentication_Available),
+               nameof(Ambient_Credentials_Available))]
+    [Issue(832, Framework = FrameworkID.NetNative)] // Windows Stream Security is not supported in NET Native
     [OuterLoop]
     public static void NetTcp_TransportSecurity_Streamed_RoundTrips_String()
     {
@@ -212,12 +215,13 @@ public class StreamingTests : ConditionalWcfTest
 #if FULLXUNIT_NOTSUPPORTED
     [Fact]
     [ActiveIssue(832)] // Windows Stream Security is not supported in NET Native
-#else
-    [ConditionalFact(nameof(Root_Certificate_Installed),
-                     nameof(Client_Certificate_Installed),
-                     nameof(Windows_Authentication_Available),
-                     nameof(Ambient_Credentials_Available))]
 #endif
+    [WcfFact]
+    [Condition(nameof(Root_Certificate_Installed),
+               nameof(Client_Certificate_Installed),
+               nameof(Windows_Authentication_Available),
+               nameof(Ambient_Credentials_Available))]
+    [Issue(832, Framework = FrameworkID.NetNative)] // Windows Stream Security is not supported in NET Native
     [OuterLoop]
     public static void NetTcp_TransportSecurity_Streamed_TimeOut_Long_Running_Operation()
     {
@@ -293,12 +297,13 @@ public class StreamingTests : ConditionalWcfTest
 #if FULLXUNIT_NOTSUPPORTED
     [Fact]
     [ActiveIssue(832)] // Windows Stream Security is not supported in NET Native
-#else
-    [ConditionalFact(nameof(Root_Certificate_Installed),
-                     nameof(Client_Certificate_Installed),
-                     nameof(Windows_Authentication_Available),
-                     nameof(Ambient_Credentials_Available))]
 #endif
+    [WcfFact]
+    [Condition(nameof(Root_Certificate_Installed),
+               nameof(Client_Certificate_Installed),
+               nameof(Windows_Authentication_Available),
+               nameof(Ambient_Credentials_Available))]
+    [Issue(832, Framework = FrameworkID.NetNative)] // Windows Stream Security is not supported in NET Native
     [OuterLoop]
     public static void NetTcp_TransportSecurity_Streamed_Async_RoundTrips_String()
     {
@@ -359,12 +364,13 @@ public class StreamingTests : ConditionalWcfTest
 #if FULLXUNIT_NOTSUPPORTED
     [Fact]
     [ActiveIssue(832)] // Windows Stream Security is not supported in NET Native
-#else
-    [ConditionalFact(nameof(Root_Certificate_Installed),
-                     nameof(Client_Certificate_Installed),
-                     nameof(Windows_Authentication_Available),
-                     nameof(Ambient_Credentials_Available))]
 #endif
+    [WcfFact]
+    [Condition(nameof(Root_Certificate_Installed),
+               nameof(Client_Certificate_Installed),
+               nameof(Windows_Authentication_Available),
+               nameof(Ambient_Credentials_Available))]
+    [Issue(832, Framework = FrameworkID.NetNative)] // Windows Stream Security is not supported in NET Native
     [OuterLoop]
     public static void NetTcp_TransportSecurity_StreamedRequest_Async_RoundTrips_String()
     {
@@ -425,12 +431,13 @@ public class StreamingTests : ConditionalWcfTest
 #if FULLXUNIT_NOTSUPPORTED
     [Fact]
     [ActiveIssue(832)] // Windows Stream Security is not supported in NET Native
-#else
-    [ConditionalFact(nameof(Root_Certificate_Installed),
-                     nameof(Client_Certificate_Installed),
-                     nameof(Windows_Authentication_Available),
-                     nameof(Ambient_Credentials_Available))]
 #endif
+    [WcfFact]
+    [Condition(nameof(Root_Certificate_Installed),
+               nameof(Client_Certificate_Installed),
+               nameof(Windows_Authentication_Available),
+               nameof(Ambient_Credentials_Available))]
+    [Issue(832, Framework = FrameworkID.NetNative)] // Windows Stream Security is not supported in NET Native
     [OuterLoop]
     public static void NetTcp_TransportSecurity_StreamedResponse_Async_RoundTrips_String()
     {
@@ -491,12 +498,13 @@ public class StreamingTests : ConditionalWcfTest
 #if FULLXUNIT_NOTSUPPORTED
     [Fact]
     [ActiveIssue(832)] // Windows Stream Security is not supported in NET Native
-#else
-    [ConditionalFact(nameof(Root_Certificate_Installed),
-                     nameof(Client_Certificate_Installed),
-                     nameof(Windows_Authentication_Available),
-                     nameof(Ambient_Credentials_Available))]
 #endif
+    [WcfFact]
+    [Condition(nameof(Root_Certificate_Installed),
+               nameof(Client_Certificate_Installed),
+               nameof(Windows_Authentication_Available),
+               nameof(Ambient_Credentials_Available))]
+    [Issue(832, Framework = FrameworkID.NetNative)] // Windows Stream Security is not supported in NET Native
     [OuterLoop]
     public static void NetTcp_TransportSecurity_Streamed_RoundTrips_String_WithSingleThreadedSyncContext()
     {
@@ -533,12 +541,13 @@ public class StreamingTests : ConditionalWcfTest
 #if FULLXUNIT_NOTSUPPORTED
     [Fact]
     [ActiveIssue(832)] // Windows Stream Security is not supported in NET Native
-#else
-    [ConditionalFact(nameof(Root_Certificate_Installed),
-                     nameof(Client_Certificate_Installed),
-                     nameof(Windows_Authentication_Available),
-                     nameof(Ambient_Credentials_Available))]
 #endif
+    [WcfFact]
+    [Condition(nameof(Root_Certificate_Installed),
+               nameof(Client_Certificate_Installed),
+               nameof(Windows_Authentication_Available),
+               nameof(Ambient_Credentials_Available))]
+    [Issue(832, Framework = FrameworkID.NetNative)] // Windows Stream Security is not supported in NET Native
     [OuterLoop]
     public static void NetTcp_TransportSecurity_Streamed_Async_RoundTrips_String_WithSingleThreadedSyncContext()
     {


### PR DESCRIPTION
Replace all FactAttribute usages with WcfFactAttribute
Replace all ConditionalFactAttribute with ConditionAttribute
Replace all ActiveIssueAttribute with IssueAttribute

The exception to this is in the conditional code that compiles
only under ToF, because the pseudo xunit does not support the
xunit types they require.  This will eventually be removed.