### PR TITLE
Emit WCF ETW events whenever a test fail

### DIFF
--- a/src/System.Private.ServiceModel/tests/Common/Infrastructure/TestEventListener.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Infrastructure/TestEventListener.cs
@@ -1,0 +1,92 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.Tracing;
+
+namespace Infrastructure.Common
+{
+    /// <summary>Simple event listener</summary>
+    /// This class is based on https://github.com/dotnet/corefx/blob/master/src/Common/tests/System/Diagnostics/Tracing/TestEventListener.cs
+    public sealed class TestEventListener : EventListener
+    {
+        private Dictionary<string, bool> _targetSourceName = new Dictionary<string, bool>();
+        private readonly EventLevel _level;
+
+        private Action<EventWrittenEventArgs> _eventWritten;
+        private List<EventSource> _tmpEventSourceList = new List<EventSource>();
+
+        public TestEventListener(List<string> targetSourceNames, EventLevel level)
+        {
+            // Store the arguments
+            foreach (var targetSourceName in targetSourceNames)
+            {
+                _targetSourceName.Add(targetSourceName, true);
+            }
+            _level = level;
+
+            LoadSourceList();
+        }
+
+        public Action<EventWrittenEventArgs> EventWritten
+        {
+            get { return _eventWritten; }
+            set { _eventWritten = value; }
+        }
+
+        private void LoadSourceList()
+        {
+            // The base constructor, which is called before this constructor,
+            // will invoke the virtual OnEventSourceCreated method for each
+            // existing EventSource, which means OnEventSourceCreated will be
+            // called before _targetSourceName have been set.  As such,
+            // we store a temporary list that just exists from the moment this instance
+            // is created (instance field initializers run before the base constructor)
+            // and until we finish construction... in that window, OnEventSourceCreated
+            // will store the sources into the list rather than try to enable them directly,
+            // and then here we can enumerate that list, then clear it out.
+            List<EventSource> sources;
+            lock (_tmpEventSourceList)
+            {
+                sources = _tmpEventSourceList;
+                _tmpEventSourceList = null;
+            }
+            foreach (EventSource source in sources)
+            {
+                EnableSourceIfMatch(source);
+            }
+        }
+
+        protected override void OnEventSourceCreated(EventSource eventSource)
+        {
+            List<EventSource> tmp = _tmpEventSourceList;
+            if (tmp != null)
+            {
+                lock (tmp)
+                {
+                    if (_tmpEventSourceList != null)
+                    {
+                        _tmpEventSourceList.Add(eventSource);
+                        return;
+                    }
+                }
+            }
+
+            EnableSourceIfMatch(eventSource);
+        }
+
+        private void EnableSourceIfMatch(EventSource source)
+        {
+            if (_targetSourceName.ContainsKey(source.Name))
+            {
+                EnableEvents(source, _level);
+            }
+        }
+        protected override void OnEventWritten(EventWrittenEventArgs eventData)
+        {
+            _eventWritten?.Invoke(eventData);
+        }
+    }
+}

--- a/src/System.Private.ServiceModel/tests/Common/Infrastructure/project.json
+++ b/src/System.Private.ServiceModel/tests/Common/Infrastructure/project.json
@@ -1,6 +1,8 @@
 {
   "dependencies": {
     "System.Console": "4.0.0",
+    "System.Collections.Concurrent": "4.0.12",
+    "System.Diagnostics.Tracing": "4.1.0",
     "System.Net.Http": "4.1.0",
     "System.ServiceModel.Duplex": "4.0.2-beta-24329-01",
     "System.ServiceModel.Http": "4.1.1-beta-24329-01",

--- a/src/System.Private.ServiceModel/tests/Common/Infrastructure/xunit/WcfTestCase.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Infrastructure/xunit/WcfTestCase.cs
@@ -2,7 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics.Tracing;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit.Abstractions;
@@ -17,6 +21,8 @@ namespace Infrastructure.Common
         private readonly string _skippedReason;
         private readonly bool _isTheory;
         private readonly IMessageSink _diagnosticMessageSink;
+
+        static TestEventListener s_testListener = new TestEventListener(new List<string>() { "Microsoft-Windows-Application Server-Applications" }, EventLevel.Verbose);
 
         internal WcfTestCase(IXunitTestCase testCase, string skippedReason = null, bool isTheory = false, IMessageSink diagnosticMessageSink = null)
         {
@@ -44,13 +50,51 @@ namespace Infrastructure.Common
 
         public void Deserialize(IXunitSerializationInfo info) { _testCase.Deserialize(info); }
 
-        public Task<RunSummary> RunAsync(
+        public async Task<RunSummary> RunAsync(
             IMessageSink diagnosticMessageSink, IMessageBus messageBus, object[] constructorArguments,
             ExceptionAggregator aggregator, CancellationTokenSource cancellationTokenSource)
         {
-            return _isTheory
-                ? new XunitTheoryTestCaseRunner(this, DisplayName, _skippedReason, constructorArguments, _diagnosticMessageSink, messageBus, aggregator, cancellationTokenSource).RunAsync()
-                : new XunitTestCaseRunner(this, DisplayName, _skippedReason, constructorArguments, TestMethodArguments, messageBus, aggregator, cancellationTokenSource).RunAsync();
+            ConcurrentQueue<EventWrittenEventArgs> events = new ConcurrentQueue<EventWrittenEventArgs>();
+	        s_testListener.EventWritten = events.Enqueue;
+
+            RunSummary runsummary = await (_isTheory ? new XunitTheoryTestCaseRunner(this, DisplayName, _skippedReason, constructorArguments, _diagnosticMessageSink, messageBus, aggregator, cancellationTokenSource).RunAsync()
+                                                     : new XunitTestCaseRunner(this, DisplayName, _skippedReason, constructorArguments, TestMethodArguments, messageBus, aggregator, cancellationTokenSource).RunAsync());
+
+            s_testListener.EventWritten = null;
+            if (runsummary.Failed > 0)
+            {
+                StringBuilder etwOutput = new StringBuilder();
+                etwOutput.AppendLine(string.Format("---ETW Trace for Test {0} Begins---", DisplayName));
+                foreach (var item in events)
+                {
+                    try
+                    {
+                        etwOutput.AppendLine(string.Format(DisplayName + ":" + item.Message, item.Payload));
+                    }
+                    //The mumber of parameters in Payload does not match the number of arguments in the item.Message and thus cause a
+                    // FormatException occationally, In this case, we catch and output all items in the payload and the Message without formatting the message.
+                    // https://github.com/dotnet/wcf/issues/1440 is opened to investigate the root cause of the mismatch exception.
+                    catch (Exception e)
+                    {
+                        etwOutput.AppendLine(String.Format("ETW message encountered exception '{0}' using DisplayName '{1}', format '{2}' and {3} payload items",
+                                             e.Message, DisplayName, item.Message, item.Payload.Count));
+
+                        etwOutput.AppendLine(string.Format("ETW message: {0}, payload below was received", item.Message));
+                        foreach (object payloadPara in item.Payload)
+                        {
+                            if (payloadPara != null)
+                            {
+                                etwOutput.AppendLine(string.Format("{0}: {1}", DisplayName, payloadPara.ToString()));
+                            }
+                        }
+                    }
+                }
+                etwOutput.AppendLine(string.Format("---ETW Trace for Test {0} Ends---", DisplayName));
+
+                Console.WriteLine(etwOutput);
+            }
+
+            return runsummary;
         }
 
         public void Serialize(IXunitSerializationInfo info) { _testCase.Serialize(info); }


### PR DESCRIPTION
* This is to help analyze test failures, especially on non window
platforms