### PR TITLE
Add execution permission to the cert installation file

### DIFF
--- a/src/certtest.props
+++ b/src/certtest.props
@@ -5,6 +5,7 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
+     <TestCommandLines  Condition="'$(TargetOS)'!='Windows_NT'" Include="sudo chmod a+x InstallRootCertificate.sh"/>
      <TestCommandLines  Condition="'$(TargetOS)'!='Windows_NT'" Include="sudo -E -n ./InstallRootCertificate.sh --service-host $(ServiceUri) --cert-file /tmp/wcfrootca.crt"/>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
* I'm getting "Command Not Found" error without this fix.
* After this fix, cert tests are passing in Helix for Ubuntu