### PR TITLE
Fix WcfTheory discoverer to use theory data

### DIFF
--- a/src/System.Private.ServiceModel/tests/Common/Infrastructure/xunit/WcfTestCase.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Infrastructure/xunit/WcfTestCase.cs
@@ -15,11 +15,15 @@ namespace Infrastructure.Common
     {
         private readonly IXunitTestCase _testCase;
         private readonly string _skippedReason;
+        private readonly bool _isTheory;
+        private readonly IMessageSink _diagnosticMessageSink;
 
-        internal WcfTestCase(IXunitTestCase testCase, string skippedReason)
+        internal WcfTestCase(IXunitTestCase testCase, string skippedReason = null, bool isTheory = false, IMessageSink diagnosticMessageSink = null)
         {
             _testCase = testCase;
             _skippedReason = skippedReason;
+            _isTheory = isTheory;
+            _diagnosticMessageSink = diagnosticMessageSink;
         }
 
         public string DisplayName { get { return _testCase.DisplayName; } }
@@ -44,7 +48,9 @@ namespace Infrastructure.Common
             IMessageSink diagnosticMessageSink, IMessageBus messageBus, object[] constructorArguments,
             ExceptionAggregator aggregator, CancellationTokenSource cancellationTokenSource)
         {
-            return new XunitTestCaseRunner(this, DisplayName, _skippedReason, constructorArguments, TestMethodArguments, messageBus, aggregator, cancellationTokenSource).RunAsync();
+            return _isTheory
+                ? new XunitTheoryTestCaseRunner(this, DisplayName, _skippedReason, constructorArguments, _diagnosticMessageSink, messageBus, aggregator, cancellationTokenSource).RunAsync()
+                : new XunitTestCaseRunner(this, DisplayName, _skippedReason, constructorArguments, TestMethodArguments, messageBus, aggregator, cancellationTokenSource).RunAsync();
         }
 
         public void Serialize(IXunitSerializationInfo info) { _testCase.Serialize(info); }

--- a/src/System.Private.ServiceModel/tests/Common/Infrastructure/xunit/WcfTestDiscoverer.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Infrastructure/xunit/WcfTestDiscoverer.cs
@@ -20,7 +20,8 @@ namespace Infrastructure.Common
                                                         ITestFrameworkDiscoveryOptions discoveryOptions,
                                                         IMessageSink diagnosticMessageSink,
                                                         ITestMethod testMethod,
-                                                        IEnumerable<IXunitTestCase> testCases)
+                                                        IEnumerable<IXunitTestCase> testCases,
+                                                        bool isTheory = false)
         {
             MethodInfo testMethodInfo = testMethod.Method.ToRuntimeMethod();
  
@@ -75,7 +76,10 @@ namespace Infrastructure.Common
             // If we get this far, we have decided to run the test.
             // Still wrap it in a WcfTestCase with a null skip message
             // so that other WcfTestCase customizations are used.
-            return testCases.Select(tc => new WcfTestCase(tc, null));
+            return testCases.Select(tc => new WcfTestCase(tc,
+                                                          skippedReason: null,
+                                                          isTheory: isTheory,
+                                                          diagnosticMessageSink: diagnosticMessageSink));
         }
     }
 }

--- a/src/System.Private.ServiceModel/tests/Common/Infrastructure/xunit/WcfTheoryDiscoverer.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Infrastructure/xunit/WcfTheoryDiscoverer.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Xunit.Abstractions;
 using Xunit.Sdk;
 
@@ -22,7 +23,7 @@ namespace Infrastructure.Common
             ITestFrameworkDiscoveryOptions discoveryOptions, ITestMethod testMethod, IAttributeInfo theoryAttribute)
         {
             IEnumerable<IXunitTestCase> testCases = base.Discover(discoveryOptions, testMethod, theoryAttribute);
-            return WcfTestDiscoverer.Discover(discoveryOptions, _diagnosticMessageSink, testMethod, testCases);
+            return WcfTestDiscoverer.Discover(discoveryOptions, _diagnosticMessageSink, testMethod, testCases, isTheory: true);
         }
     }
 }


### PR DESCRIPTION
The WcfTheoryAttribute test discover was creating an xunit
test runner that worked only for Fact, but not for Theory.

The solution was to refactor slightly and to create a
theory-based xunit test runner for non-skipped tests.