### PR TITLE
Change unit tests to use WcfFact

### DIFF
--- a/src/System.ServiceModel.Duplex/tests/ServiceModel/CallbackBehaviorAttributeTest.cs
+++ b/src/System.ServiceModel.Duplex/tests/ServiceModel/CallbackBehaviorAttributeTest.cs
@@ -3,11 +3,15 @@
 // See the LICENSE file in the project root for more information.
 
 using System.ServiceModel;
+using Infrastructure.Common;
 using Xunit;
 
 public static class CallbackBehaviorAttributeTest
 {
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     public static void Default_Ctor_Initializes_Correctly()
     {
         CallbackBehaviorAttribute cba = new CallbackBehaviorAttribute();
@@ -16,7 +20,10 @@ public static class CallbackBehaviorAttributeTest
         Assert.True(cba.UseSynchronizationContext, "UseSynchronizationContext should have been true");
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Theory]
+#endif
+    [WcfTheory]
     [InlineData(false)]
     [InlineData(true)]
     public static void AutomaticSessionShutdown_Property_Is_Settable(bool value)
@@ -26,7 +33,10 @@ public static class CallbackBehaviorAttributeTest
         Assert.Equal(value, cba.AutomaticSessionShutdown);
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Theory]
+#endif
+    [WcfTheory]
     [InlineData(false)]
     [InlineData(true)]
     public static void UseSynchronizationContext_Property_Is_Settable(bool value)

--- a/src/System.ServiceModel.Duplex/tests/System.ServiceModel.Duplex.Tests.csproj
+++ b/src/System.ServiceModel.Duplex/tests/System.ServiceModel.Duplex.Tests.csproj
@@ -29,6 +29,10 @@
     <ProjectReference Include="$(WcfDuplexPkgProj)">
       <Name>System.ServiceModel.Duplex</Name>
     </ProjectReference>
+    <ProjectReference Include="$(WcfInfrastructureCommonProj)">
+      <Project>{AFD69665-89A3-42AE-A32E-AB2CBBE6EE7E}</Project>
+      <Name>Infrastructure.Common</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.ServiceModel.Http/tests/Channels/HttpRequestMessagePropertyTest.cs
+++ b/src/System.ServiceModel.Http/tests/Channels/HttpRequestMessagePropertyTest.cs
@@ -5,11 +5,15 @@
 
 using System;
 using System.ServiceModel.Channels;
+using Infrastructure.Common;
 using Xunit;
 
 public static class HttpRequestMessagePropertyTest
 {
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     public static void Default_Ctor_Initializes_Properties()
     {
         HttpRequestMessageProperty requestMsgProperty = new HttpRequestMessageProperty();
@@ -20,7 +24,10 @@ public static class HttpRequestMessagePropertyTest
         Assert.False(requestMsgProperty.SuppressEntityBody);
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     public static void CreateCopy_Copies_Properties()
     {
         const string testKeyName = "testKey";
@@ -44,13 +51,19 @@ public static class HttpRequestMessagePropertyTest
         Assert.Equal<string>(original.Headers[testKeyName], copy.Headers[testKeyName]);
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     public static void Name_Property()
     {
         Assert.Equal<string>("httpRequest", HttpRequestMessageProperty.Name);
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     public static void Method_Property_Sets()
     {
         const string newMethod = "PUT";
@@ -59,14 +72,20 @@ public static class HttpRequestMessagePropertyTest
         Assert.Equal<string>(newMethod, requestMsgProperty.Method);
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     public static void Method_Property_Set_Null_Throws()
     {
         HttpRequestMessageProperty requestMsgProperty = new HttpRequestMessageProperty();
         Assert.Throws<ArgumentNullException>(() => requestMsgProperty.Method = null);
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     public static void QueryString_Property_Sets()
     {
         const string newQueryString = "name=Mary";
@@ -75,7 +94,10 @@ public static class HttpRequestMessagePropertyTest
         Assert.Equal<string>(newQueryString, requestMsgProperty.QueryString);
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     public static void QueryString_Property_Set_Null_Throws()
     {
         HttpRequestMessageProperty requestMsgProperty = new HttpRequestMessageProperty();

--- a/src/System.ServiceModel.Http/tests/Channels/WebSocketTransportSettingsTest.cs
+++ b/src/System.ServiceModel.Http/tests/Channels/WebSocketTransportSettingsTest.cs
@@ -5,18 +5,25 @@
 
 using System;
 using System.ServiceModel.Channels;
+using Infrastructure.Common;
 using Xunit;
 
 public static class WebSocketTransportSettingsTest
 {
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     public static void DisablePayloadMasking_Property_Set_PNSE_Throws()
     {
         var setting = new WebSocketTransportSettings();
         Assert.Throws<PlatformNotSupportedException>(() => setting.DisablePayloadMasking = true);
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     public static void DisablePayloadMasking_Property_Get_PNSE_Throws()
     {
         var setting = new WebSocketTransportSettings();

--- a/src/System.ServiceModel.Http/tests/ServiceModel/BasicHttpBindingTest.cs
+++ b/src/System.ServiceModel.Http/tests/ServiceModel/BasicHttpBindingTest.cs
@@ -9,11 +9,15 @@ using System.ServiceModel.Channels;
 using System.ServiceModel.Tests.Common;
 using System.Text;
 using System.Xml;
+using Infrastructure.Common;
 using Xunit;
 
 public static class BasicHttpBindingTest
 {
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     public static void Default_Ctor_Initializes_Properties()
     {
         var binding = new BasicHttpBinding();
@@ -37,7 +41,10 @@ public static class BasicHttpBindingTest
         Assert.True(TestHelpers.XmlDictionaryReaderQuotasAreEqual(binding.ReaderQuotas, new XmlDictionaryReaderQuotas()), "XmlDictionaryReaderQuotas");
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     public static void Ctor_With_BasicHttpSecurityMode_Transport_Initializes_Properties()
     {
         var binding = new BasicHttpBinding(BasicHttpSecurityMode.Transport);
@@ -62,7 +69,10 @@ public static class BasicHttpBindingTest
         Assert.True(TestHelpers.XmlDictionaryReaderQuotasAreEqual(binding.ReaderQuotas, new XmlDictionaryReaderQuotas()), "XmlDictionaryReaderQuotas");
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     public static void Ctor_With_BasicHttpSecurityMode_TransportCredentialOnly_Initializes_Properties()
     {
         var binding = new BasicHttpBinding(BasicHttpSecurityMode.TransportCredentialOnly);
@@ -86,7 +96,10 @@ public static class BasicHttpBindingTest
         Assert.True(TestHelpers.XmlDictionaryReaderQuotasAreEqual(binding.ReaderQuotas, new XmlDictionaryReaderQuotas()), "XmlDictionaryReaderQuotas");
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Theory]
+#endif
+    [WcfTheory]
     [InlineData(true)]
     [InlineData(false)]
     public static void AllowCookies_Property_Sets(bool value)
@@ -96,7 +109,10 @@ public static class BasicHttpBindingTest
         Assert.Equal<bool>(value, binding.AllowCookies);
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Theory]
+#endif
+    [WcfTheory]
     [InlineData(0)]
     [InlineData(1)]
     [InlineData(int.MaxValue)]
@@ -108,7 +124,10 @@ public static class BasicHttpBindingTest
     }
 
 
+#if FULLXUNIT_NOTSUPPORTED
     [Theory]
+#endif
+    [WcfTheory]
     [InlineData(-1)]
     [InlineData(int.MinValue)]
     public static void MaxBufferPoolSize_Property_Set_Invalid_Value_Throws(long value)
@@ -117,7 +136,10 @@ public static class BasicHttpBindingTest
         Assert.Throws<ArgumentOutOfRangeException>(() => binding.MaxBufferPoolSize = value);
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Theory]
+#endif
+    [WcfTheory]
     [InlineData(1)]
     [InlineData(int.MaxValue)]
     public static void MaxBufferSize_Property_Sets(int value)
@@ -127,7 +149,10 @@ public static class BasicHttpBindingTest
         Assert.Equal<long>(value, binding.MaxBufferSize);
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Theory]
+#endif
+    [WcfTheory]
     [InlineData(0)]
     [InlineData(-1)]
     [InlineData(int.MinValue)]
@@ -137,7 +162,10 @@ public static class BasicHttpBindingTest
         Assert.Throws<ArgumentOutOfRangeException>(() => binding.MaxBufferSize = value);
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Theory]
+#endif
+    [WcfTheory]
     [InlineData(1)]
     [InlineData(int.MaxValue)]
     public static void MaxReceivedMessageSize_Property_Sets(long value)
@@ -147,7 +175,10 @@ public static class BasicHttpBindingTest
         Assert.Equal<long>(value, binding.MaxReceivedMessageSize);
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Theory]
+#endif
+    [WcfTheory]
     [InlineData(0)]
     [InlineData(-1)]
     [InlineData(int.MinValue)]
@@ -157,7 +188,10 @@ public static class BasicHttpBindingTest
         Assert.Throws<ArgumentOutOfRangeException>(() => binding.MaxReceivedMessageSize = value);
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Theory]
+#endif
+    [WcfTheory]
     [InlineData("testName")]
     public static void Name_Property_Sets(string value)
     {
@@ -166,7 +200,10 @@ public static class BasicHttpBindingTest
         Assert.Equal<string>(value, binding.Name);
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Theory]
+#endif
+    [WcfTheory]
     [InlineData(null)]
     [InlineData("")]
     [ActiveIssue(1449)]
@@ -176,7 +213,10 @@ public static class BasicHttpBindingTest
         Assert.Throws<ArgumentException>(() => binding.Name = value);
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Theory]
+#endif
+    [WcfTheory]
     [InlineData("")]
     [InlineData("http://hello")]
     [InlineData("testNamespace")]
@@ -187,7 +227,10 @@ public static class BasicHttpBindingTest
         Assert.Equal<string>(value, binding.Namespace);
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Theory]
+#endif
+    [WcfTheory]
     [InlineData(null)]
     [ActiveIssue(1449)]
     public static void Namespace_Property_Set_Invalid_Value_Throws(string value)
@@ -230,7 +273,10 @@ public static class BasicHttpBindingTest
         }
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     public static void ReaderQuotas_Property_Sets()
     {
         var binding = new BasicHttpBinding();
@@ -244,14 +290,20 @@ public static class BasicHttpBindingTest
         Assert.True(TestHelpers.XmlDictionaryReaderQuotasAreEqual(binding.ReaderQuotas, maxQuota), "Setting Max ReaderQuota failed");
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     public static void ReaderQuotas_Property_Set_Null_Throws()
     {
         var binding = new BasicHttpBinding();
         Assert.Throws<ArgumentNullException>(() => binding.ReaderQuotas = null);
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Theory]
+#endif
+    [WcfTheory]
     [MemberData("ValidTimeOuts", MemberType = typeof(TestData))]
     public static void CloseTimeout_Property_Sets(TimeSpan timeSpan)
     {
@@ -260,7 +312,10 @@ public static class BasicHttpBindingTest
         Assert.Equal<TimeSpan>(timeSpan, binding.CloseTimeout);
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Theory]
+#endif
+    [WcfTheory]
     [MemberData("InvalidTimeOuts", MemberType = typeof(TestData))]
     public static void CloseTimeout_Property_Set_Invalid_Value_Throws(TimeSpan timeSpan)
     {
@@ -268,7 +323,10 @@ public static class BasicHttpBindingTest
         Assert.Throws<ArgumentOutOfRangeException>(() => binding.CloseTimeout = timeSpan);
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Theory]
+#endif
+    [WcfTheory]
     [MemberData("ValidTimeOuts", MemberType = typeof(TestData))]
     public static void OpenTimeout_Property_Sets(TimeSpan timeSpan)
     {
@@ -277,7 +335,10 @@ public static class BasicHttpBindingTest
         Assert.Equal<TimeSpan>(timeSpan, binding.OpenTimeout);
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Theory]
+#endif
+    [WcfTheory]
     [MemberData("InvalidTimeOuts", MemberType = typeof(TestData))]
     public static void OpenTimeout_Property_Set_Invalid_Value_Throws(TimeSpan timeSpan)
     {
@@ -285,7 +346,10 @@ public static class BasicHttpBindingTest
         Assert.Throws<ArgumentOutOfRangeException>(() => binding.OpenTimeout = timeSpan);
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Theory]
+#endif
+    [WcfTheory]
     [MemberData("ValidTimeOuts", MemberType = typeof(TestData))]
     public static void SendTimeout_Property_Sets(TimeSpan timeSpan)
     {
@@ -294,7 +358,10 @@ public static class BasicHttpBindingTest
         Assert.Equal<TimeSpan>(timeSpan, binding.SendTimeout);
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Theory]
+#endif
+    [WcfTheory]
     [MemberData("InvalidTimeOuts", MemberType = typeof(TestData))]
     public static void SendTimeout_Property_Set_Invalid_Value_Throws(TimeSpan timeSpan)
     {
@@ -302,7 +369,10 @@ public static class BasicHttpBindingTest
         Assert.Throws<ArgumentOutOfRangeException>(() => binding.SendTimeout = timeSpan);
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Theory]
+#endif
+    [WcfTheory]
     [MemberData("ValidTimeOuts", MemberType = typeof(TestData))]
     public static void ReceiveTimeout_Property_Sets(TimeSpan timeSpan)
     {
@@ -311,7 +381,10 @@ public static class BasicHttpBindingTest
         Assert.Equal<TimeSpan>(timeSpan, binding.ReceiveTimeout);
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Theory]
+#endif
+    [WcfTheory]
     [MemberData("InvalidTimeOuts", MemberType = typeof(TestData))]
     public static void ReceiveTimeout_Property_Set_Invalid_Value_Throws(TimeSpan timeSpan)
     {
@@ -319,7 +392,10 @@ public static class BasicHttpBindingTest
         Assert.Throws<ArgumentOutOfRangeException>(() => binding.SendTimeout = timeSpan);
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Theory]
+#endif
+    [WcfTheory]
     [MemberData("ValidEncodings", MemberType = typeof(TestData))]
     [ActiveIssue(1450)]
     public static void TextEncoding_Property_Sets(Encoding encoding)
@@ -329,7 +405,10 @@ public static class BasicHttpBindingTest
         Assert.Equal<Encoding>(encoding, binding.TextEncoding);
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Theory]
+#endif
+    [WcfTheory]
     [MemberData("InvalidEncodings", MemberType = typeof(TestData))]
     [ActiveIssue(1450)]
     public static void TextEncoding_Property_Set_Invalid_Value_Throws(Encoding encoding)
@@ -338,7 +417,10 @@ public static class BasicHttpBindingTest
         Assert.Throws<ArgumentException>(() => binding.TextEncoding = encoding);
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Theory]
+#endif
+    [WcfTheory]
     [InlineData(TransferMode.Buffered)]
     [InlineData(TransferMode.Streamed)]
     [InlineData(TransferMode.StreamedRequest)]

--- a/src/System.ServiceModel.Http/tests/ServiceModel/BasicHttpBindingTest.cs
+++ b/src/System.ServiceModel.Http/tests/ServiceModel/BasicHttpBindingTest.cs
@@ -206,7 +206,7 @@ public static class BasicHttpBindingTest
     [WcfTheory]
     [InlineData(null)]
     [InlineData("")]
-    [ActiveIssue(1449)]
+    [Issue(1449, Framework = FrameworkID.NetNative)]
     public static void Name_Property_Set_Invalid_Value_Throws(string value)
     {
         var binding = new BasicHttpBinding();
@@ -232,7 +232,7 @@ public static class BasicHttpBindingTest
 #endif
     [WcfTheory]
     [InlineData(null)]
-    [ActiveIssue(1449)]
+    [Issue(1449, Framework = FrameworkID.NetNative)]
     public static void Namespace_Property_Set_Invalid_Value_Throws(string value)
     {
         var binding = new BasicHttpBinding();
@@ -397,7 +397,7 @@ public static class BasicHttpBindingTest
 #endif
     [WcfTheory]
     [MemberData("ValidEncodings", MemberType = typeof(TestData))]
-    [ActiveIssue(1450)]
+    [Issue(1450, Framework = FrameworkID.NetNative)]
     public static void TextEncoding_Property_Sets(Encoding encoding)
     {
         var binding = new BasicHttpBinding();
@@ -410,7 +410,7 @@ public static class BasicHttpBindingTest
 #endif
     [WcfTheory]
     [MemberData("InvalidEncodings", MemberType = typeof(TestData))]
-    [ActiveIssue(1450)]
+    [Issue(1450, Framework = FrameworkID.NetNative)]
     public static void TextEncoding_Property_Set_Invalid_Value_Throws(Encoding encoding)
     {
         var binding = new BasicHttpBinding();

--- a/src/System.ServiceModel.Http/tests/ServiceModel/SecurityBindingElementTest.cs
+++ b/src/System.ServiceModel.Http/tests/ServiceModel/SecurityBindingElementTest.cs
@@ -7,11 +7,15 @@ using System;
 using System.Linq;
 using System.ServiceModel;
 using System.ServiceModel.Channels;
+using Infrastructure.Common;
 using Xunit;
 
 public static class SecurityBindingElementTest
 {
+#if FULLXUNIT_NOTSUPPORTED
     [Theory]
+#endif
+    [WcfTheory]
     [InlineData(BasicHttpSecurityMode.TransportCredentialOnly)]
     [InlineData(BasicHttpSecurityMode.Transport)]
     [InlineData(BasicHttpSecurityMode.None)]
@@ -27,7 +31,10 @@ public static class SecurityBindingElementTest
         binding.BuildChannelFactory<IRequestChannel>();
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Theory]
+#endif
+    [WcfTheory]
     [InlineData(BasicHttpSecurityMode.Message)]
     [InlineData(BasicHttpSecurityMode.TransportWithMessageCredential)]
     // BasicHttpSecurityMode.Message is not supported

--- a/src/System.ServiceModel.Http/tests/System.ServiceModel.Http.Tests.csproj
+++ b/src/System.ServiceModel.Http/tests/System.ServiceModel.Http.Tests.csproj
@@ -39,6 +39,10 @@
       <Project>{E896294A-AB4A-4AF5-A01C-A19E3972EFF9}</Project>
       <Name>UnitTests.Common</Name>
     </ProjectReference>
+    <ProjectReference Include="$(WcfInfrastructureCommonProj)">
+      <Project>{AFD69665-89A3-42AE-A32E-AB2CBBE6EE7E}</Project>
+      <Name>Infrastructure.Common</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.ServiceModel.NetTcp/tests/Channels/TcpConnectionPoolSettingsTest.cs
+++ b/src/System.ServiceModel.NetTcp/tests/Channels/TcpConnectionPoolSettingsTest.cs
@@ -6,11 +6,15 @@
 using System;
 using System.ServiceModel.Channels;
 using System.ServiceModel.Tests.Common;
+using Infrastructure.Common;
 using Xunit;
 
 public static class TcpConnectionPoolSettingsTest
 {
+#if FULLXUNIT_NOTSUPPORTED
     [Theory]
+#endif
+    [WcfTheory]
     [InlineData("")]
     [InlineData("testValue")]
     public static void GroupName_Property_Sets(string groupName)
@@ -22,7 +26,10 @@ public static class TcpConnectionPoolSettingsTest
         Assert.Equal<string>(groupName, settings.GroupName);
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     public static void GroupName_Property_Set_Null_Value_Throws()
     {
         // TcpConnectionPoolSettings has no public constructor but we can access it from the TcpTransportBindingElement
@@ -31,7 +38,10 @@ public static class TcpConnectionPoolSettingsTest
         Assert.Throws<ArgumentNullException>(() => settings.GroupName = null);
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Theory]
+#endif
+    [WcfTheory]
     [MemberData("ValidTimeOuts", MemberType = typeof(TestData))]
     public static void IdleTimeout_Property_Sets(TimeSpan timeSpan)
     {
@@ -42,7 +52,10 @@ public static class TcpConnectionPoolSettingsTest
         Assert.Equal<TimeSpan>(timeSpan, settings.IdleTimeout);
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Theory]
+#endif
+    [WcfTheory]
     [MemberData("InvalidTimeOuts", MemberType = typeof(TestData))]
     public static void IdleTimeout_Property_Set_Invalid_Value_Throws(TimeSpan timeSpan)
     {
@@ -52,7 +65,10 @@ public static class TcpConnectionPoolSettingsTest
         Assert.Throws<ArgumentOutOfRangeException>(() => settings.IdleTimeout = timeSpan);
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Theory]
+#endif
+    [WcfTheory]
     [MemberData("ValidTimeOuts", MemberType = typeof(TestData))]
     public static void LeaseTimeout_Property_Sets(TimeSpan timeSpan)
     {
@@ -63,7 +79,10 @@ public static class TcpConnectionPoolSettingsTest
         Assert.Equal<TimeSpan>(timeSpan, settings.LeaseTimeout);
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Theory]
+#endif
+    [WcfTheory]
     [MemberData("InvalidTimeOuts", MemberType = typeof(TestData))]
     public static void LeaseTimeout_Property_Set_Invalid_Value_Throws(TimeSpan timeSpan)
     {
@@ -74,7 +93,10 @@ public static class TcpConnectionPoolSettingsTest
     }
 
 
+#if FULLXUNIT_NOTSUPPORTED
     [Theory]
+#endif
+    [WcfTheory]
     [InlineData(0)]
     [InlineData(1)]
     public static void MaxOutboundConnectionsPerEndpoint_Property_Sets(int value)
@@ -86,7 +108,10 @@ public static class TcpConnectionPoolSettingsTest
         Assert.Equal<int>(value, settings.MaxOutboundConnectionsPerEndpoint);
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Theory]
+#endif
+    [WcfTheory]
     [InlineData(-1)]
     public static void MaxOutboundConnectionsPerEndpoint_Property_Set_Invalid_Value_Throws(int value)
     {

--- a/src/System.ServiceModel.NetTcp/tests/Channels/TcpTransportBindingElementTest.cs
+++ b/src/System.ServiceModel.NetTcp/tests/Channels/TcpTransportBindingElementTest.cs
@@ -5,11 +5,15 @@
 
 using System;
 using System.ServiceModel.Channels;
+using Infrastructure.Common;
 using Xunit;
 
 public static class TcpTransportBindingElementTest
 {
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     public static void Ctor_Default_Properties()
     {
         // Validates new TcpTransportBindingElement() initializes correct default property values

--- a/src/System.ServiceModel.NetTcp/tests/ServiceModel/MessageSecurityOverTcpTest.cs
+++ b/src/System.ServiceModel.NetTcp/tests/ServiceModel/MessageSecurityOverTcpTest.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.ServiceModel;
 using Xunit;
 using Infrastructure.Common;
@@ -19,6 +20,19 @@ public static class MessageSecurityOverTcpTest
     }
 
 #if FULLXUNIT_NOTSUPPORTED
+    [Fact]
+#endif
+    [WcfFact]
+    public static void Ctor_Default_Properties_Not_Supported()
+    {
+        MessageSecurityOverTcp msot = new MessageSecurityOverTcp();
+        Assert.Throws <PlatformNotSupportedException>(() =>
+        {
+            MessageCredentialType unused = msot.ClientCredentialType;
+        });
+    }
+
+#if FULLXUNIT_NOTSUPPORTED
     [Theory]
 #endif
     [WcfTheory]
@@ -26,13 +40,26 @@ public static class MessageSecurityOverTcpTest
     [InlineData(MessageCredentialType.IssuedToken)]
     [InlineData(MessageCredentialType.UserName)]
     [InlineData(MessageCredentialType.Windows)]
-    [Issue(1434, Framework = FrameworkID.NetCore | FrameworkID.NetNative)]
-    public static void ClientCredentialType_Property(MessageCredentialType credentialType)
+    public static void ClientCredentialType_Property_Values_Not_Supported(MessageCredentialType credentialType)
+    {
+        MessageSecurityOverTcp msot = new MessageSecurityOverTcp();
+        Assert.Throws<PlatformNotSupportedException>(() =>
+        {
+            msot.ClientCredentialType = credentialType;
+        });
+    }
+
+#if FULLXUNIT_NOTSUPPORTED
+    [Theory]
+#endif
+    [WcfTheory]
+    [InlineData(MessageCredentialType.None)]
+    public static void ClientCredentialType_Property_Values_Supported(MessageCredentialType credentialType)
     {
         MessageSecurityOverTcp msot = new MessageSecurityOverTcp();
         msot.ClientCredentialType = credentialType;
         MessageCredentialType actual = msot.ClientCredentialType;
         Assert.True(actual == credentialType,
-                    string.Format("ClientCredentialType returned {0} but expected {1}", credentialType, actual));
+                    string.Format("ClientCredentialType returned '{0}' but expected '{1}'", credentialType, actual));
     }
 }

--- a/src/System.ServiceModel.NetTcp/tests/ServiceModel/MessageSecurityOverTcpTest.cs
+++ b/src/System.ServiceModel.NetTcp/tests/ServiceModel/MessageSecurityOverTcpTest.cs
@@ -2,18 +2,37 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-
+using System.ServiceModel;
 using Xunit;
+using Infrastructure.Common;
 
 public static class MessageSecurityOverTcpTest
 {
-    [Fact(Skip = "Not implemented")]
+#if FULLXUNIT_NOTSUPPORTED
+    [Fact]
+#endif
+    [WcfFact]
     public static void Ctor_Default_Properties()
     {
+        MessageSecurityOverTcp msot = new MessageSecurityOverTcp();
+        Assert.True(msot != null, "MessageSecurityOverTcp default ctor failed");
     }
 
-    [Fact(Skip = "Not implemented")]
-    public static void ClientCredentialType_Property()
+#if FULLXUNIT_NOTSUPPORTED
+    [Theory]
+#endif
+    [WcfTheory]
+    [InlineData(MessageCredentialType.Certificate)]
+    [InlineData(MessageCredentialType.IssuedToken)]
+    [InlineData(MessageCredentialType.UserName)]
+    [InlineData(MessageCredentialType.Windows)]
+    [Issue(1434, Framework = FrameworkID.NetCore | FrameworkID.NetNative)]
+    public static void ClientCredentialType_Property(MessageCredentialType credentialType)
     {
+        MessageSecurityOverTcp msot = new MessageSecurityOverTcp();
+        msot.ClientCredentialType = credentialType;
+        MessageCredentialType actual = msot.ClientCredentialType;
+        Assert.True(actual == credentialType,
+                    string.Format("ClientCredentialType returned {0} but expected {1}", credentialType, actual));
     }
 }

--- a/src/System.ServiceModel.NetTcp/tests/ServiceModel/NetTcpBindingTest.cs
+++ b/src/System.ServiceModel.NetTcp/tests/ServiceModel/NetTcpBindingTest.cs
@@ -6,11 +6,15 @@
 using System;
 using System.ServiceModel;
 using System.Xml;
+using Infrastructure.Common;
 using Xunit;
 
 public static class NetTcpBindingTest
 {
+#if FULLXUNIT_NOTSUPPORTED
     [Theory]
+#endif
+    [WcfTheory]
     [InlineData(SecurityMode.None)]
     [InlineData(SecurityMode.Transport)]
     public static void Ctor_Default_Initializes_Properties(SecurityMode securityMode)
@@ -26,7 +30,10 @@ public static class NetTcpBindingTest
         Assert.Equal<SecurityMode>(securityMode, binding.Security.Mode);
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Theory]
+#endif
+    [WcfTheory]
     [InlineData(TransferMode.Buffered)]
     [InlineData(TransferMode.Streamed)]
     [InlineData(TransferMode.StreamedRequest)]
@@ -38,7 +45,10 @@ public static class NetTcpBindingTest
         Assert.Equal<TransferMode>(mode, binding.TransferMode);
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Theory]
+#endif
+    [WcfTheory]
     [InlineData(0)]
     [InlineData(Int64.MaxValue)]
     public static void MaxBufferPoolSize_Property_Sets(long value)
@@ -48,7 +58,10 @@ public static class NetTcpBindingTest
         Assert.Equal<long>(value, binding.MaxBufferPoolSize);
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Theory]
+#endif
+    [WcfTheory]
     [InlineData(1)]
     [InlineData(int.MaxValue)]
     public static void MaxBufferSize_Property_Sets(int value)
@@ -58,7 +71,10 @@ public static class NetTcpBindingTest
         Assert.Equal<int>(value, binding.MaxBufferSize);
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Theory]
+#endif
+    [WcfTheory]
     [InlineData(0)]
     [InlineData(-1)]
     public static void MaxBufferSize_Property_Set_With_Invalid_Value_Throws(int value)
@@ -67,7 +83,10 @@ public static class NetTcpBindingTest
         Assert.Throws<ArgumentOutOfRangeException>(() => binding.MaxBufferSize = value);
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Theory]
+#endif
+    [WcfTheory]
     [InlineData(1)]
     [InlineData(Int64.MaxValue)]
     public static void MaxReceivedMessageSize_Property_Sets(long value)
@@ -77,7 +96,10 @@ public static class NetTcpBindingTest
         Assert.Equal<long>(value, binding.MaxReceivedMessageSize);
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Theory]
+#endif
+    [WcfTheory]
     [InlineData(0)]
     [InlineData(-1)]
     public static void MaxReceivedMessageSize_Property_Set_Invalid_Value_Throws(long value)
@@ -86,7 +108,10 @@ public static class NetTcpBindingTest
         Assert.Throws<ArgumentOutOfRangeException>(() => binding.MaxReceivedMessageSize = value);
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     public static void Security_Property_Sets()
     {
         NetTcpBinding binding = new NetTcpBinding();
@@ -95,7 +120,10 @@ public static class NetTcpBindingTest
         Assert.Equal<NetTcpSecurity>(security, binding.Security);
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     public static void Security_Property_Set_Null_Throws()
     {
         NetTcpBinding binding = new NetTcpBinding();

--- a/src/System.ServiceModel.NetTcp/tests/ServiceModel/NetTcpSecurityTest.cs
+++ b/src/System.ServiceModel.NetTcp/tests/ServiceModel/NetTcpSecurityTest.cs
@@ -5,11 +5,15 @@
 
 using System;
 using System.ServiceModel;
+using Infrastructure.Common;
 using Xunit;
 
 public static class NetTcpSecurityTest
 {
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     public static void Ctor_Default_Initializes_Properties()
     {
         // new NetTcpSecurity() initializes correct defaults
@@ -17,7 +21,10 @@ public static class NetTcpSecurityTest
         Assert.Equal<SecurityMode>(SecurityMode.Transport, security.Mode);
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Theory]
+#endif
+    [WcfTheory]
     [InlineData(SecurityMode.Message)]
     [InlineData(SecurityMode.None)]
     [InlineData(SecurityMode.Transport)]
@@ -29,14 +36,20 @@ public static class NetTcpSecurityTest
         Assert.Equal<SecurityMode>(mode, security.Mode);
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     public static void Mode_Property_Set_Invalid_Value_Throws()
     {
         NetTcpSecurity security = new NetTcpSecurity();
         Assert.Throws<ArgumentOutOfRangeException>(() => security.Mode = (SecurityMode)999);
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     public static void Transport_Property_Sets()
     {
         NetTcpSecurity security = new NetTcpSecurity();

--- a/src/System.ServiceModel.NetTcp/tests/ServiceModel/TcpTransportSecurityTest.cs
+++ b/src/System.ServiceModel.NetTcp/tests/ServiceModel/TcpTransportSecurityTest.cs
@@ -5,11 +5,15 @@
 
 using System;
 using System.ServiceModel;
+using Infrastructure.Common;
 using Xunit;
 
 public static class TcpTransportSecurityTest
 {
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     public static void Ctor_Default_Properties()
     {
         // new TcpTransportSecurity() initializes correct defaults
@@ -19,7 +23,10 @@ public static class TcpTransportSecurityTest
                     String.Format("ClientCredentialType should have been '{0}' but was '{1}'", TcpClientCredentialType.Windows, transport.ClientCredentialType));
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Theory]
+#endif
+    [WcfTheory]
     [InlineData(TcpClientCredentialType.None)]
     [InlineData(TcpClientCredentialType.Windows)]
     [InlineData(TcpClientCredentialType.Certificate)]
@@ -30,7 +37,10 @@ public static class TcpTransportSecurityTest
         Assert.Equal<TcpClientCredentialType>(credentialType, transport.ClientCredentialType);
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     public static void ClientCredentialType_Property_Set_Invalid_Value_Throws()
     {
         TcpTransportSecurity transport = new TcpTransportSecurity();

--- a/src/System.ServiceModel.NetTcp/tests/System.ServiceModel.NetTcp.Tests.csproj
+++ b/src/System.ServiceModel.NetTcp/tests/System.ServiceModel.NetTcp.Tests.csproj
@@ -42,6 +42,10 @@
       <Project>{E896294A-AB4A-4AF5-A01C-A19E3972EFF9}</Project>
       <Name>UnitTests.Common</Name>
     </ProjectReference>
+    <ProjectReference Include="$(WcfInfrastructureCommonProj)">
+      <Project>{AFD69665-89A3-42AE-A32E-AB2CBBE6EE7E}</Project>
+      <Name>Infrastructure.Common</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.ServiceModel.Primitives/tests/Channels/BinaryMessageEncodingBindingElementTest.cs
+++ b/src/System.ServiceModel.Primitives/tests/Channels/BinaryMessageEncodingBindingElementTest.cs
@@ -7,11 +7,15 @@ using System;
 using System.ServiceModel.Channels;
 using System.ServiceModel.Tests.Common;
 using System.Xml;
+using Infrastructure.Common;
 using Xunit;
 
 public static class BinaryMessageEncodingBindingElementTest
 {
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     public static void Default_Ctor_Initializes_Properties()
     {
         BinaryMessageEncodingBindingElement bindingElement = new BinaryMessageEncodingBindingElement();
@@ -24,7 +28,10 @@ public static class BinaryMessageEncodingBindingElementTest
             "BinaryEncodingBindingElement_DefaultCtor: Assert property 'XmlDictionaryReaderQuotas' == default value failed.");
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Theory]
+#endif
+    [WcfTheory]
     [InlineData(CompressionFormat.Deflate)]
     [InlineData(CompressionFormat.GZip)]
     public static void CompressionFormat_Property_Sets(CompressionFormat format)
@@ -37,7 +44,10 @@ public static class BinaryMessageEncodingBindingElementTest
         // whether or not the CompressionFormat is valid for it. 
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Theory]
+#endif
+    [WcfTheory]
     [InlineData(0)]
     [InlineData(1)]
     [InlineData(int.MaxValue)]
@@ -48,7 +58,10 @@ public static class BinaryMessageEncodingBindingElementTest
         Assert.Equal<int>(value, bindingElement.MaxSessionSize);
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Theory]
+#endif
+    [WcfTheory]
     [InlineData(-1)]
     [InlineData(int.MinValue)]
     public static void MaxSessionSize_Property_Set_Invalid_Value_Throws(int value)
@@ -57,7 +70,10 @@ public static class BinaryMessageEncodingBindingElementTest
         Assert.Throws<ArgumentOutOfRangeException>(() => bindingElement.MaxSessionSize = value);
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Theory]
+#endif
+    [WcfTheory]
     [MemberData("ValidBinaryMessageEncoderMessageVersions", MemberType = typeof(TestData))]
     public static void MessageVersion_Property_Sets(MessageVersion version)
     {
@@ -66,7 +82,10 @@ public static class BinaryMessageEncodingBindingElementTest
         Assert.Equal<MessageVersion>(version, bindingElement.MessageVersion);
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Theory]
+#endif
+    [WcfTheory]
     [MemberData("InvalidBinaryMessageEncoderMessageVersions", MemberType = typeof(TestData))]
     public static void MessageVersion_Property_Set_Invalid_Value_Throws(MessageVersion version)
     {
@@ -74,7 +93,10 @@ public static class BinaryMessageEncodingBindingElementTest
         Assert.Throws<InvalidOperationException>(() => bindingElement.MessageVersion = version);
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     public static void MessageVersion_Property_Set_Null_Value_Throws()
     {
         BinaryMessageEncodingBindingElement bindingElement = new BinaryMessageEncodingBindingElement();

--- a/src/System.ServiceModel.Primitives/tests/Channels/CustomBindingTest.cs
+++ b/src/System.ServiceModel.Primitives/tests/Channels/CustomBindingTest.cs
@@ -59,7 +59,7 @@ public static class CustomBindingTest
     [WcfTheory]
     [InlineData("")]
     [InlineData(null)]
-    [ActiveIssue(1449)]
+    [Issue(1449, Framework = FrameworkID.NetNative)]
     public static void CustomBinding_Name_Property_Set_Throws(string bindingName)
     {
         CustomBinding customBinding = new CustomBinding();

--- a/src/System.ServiceModel.Primitives/tests/Channels/CustomBindingTest.cs
+++ b/src/System.ServiceModel.Primitives/tests/Channels/CustomBindingTest.cs
@@ -6,11 +6,15 @@
 using System;
 using System.ServiceModel;
 using System.ServiceModel.Channels;
+using Infrastructure.Common;
 using Xunit;
 
 public static class CustomBindingTest
 {
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     // Create the channel factory and open the channel for the request-reply message exchange pattern.
     public static void RequestReplyChannelFactory_Open()
     {
@@ -35,7 +39,10 @@ public static class CustomBindingTest
         }
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Theory]
+#endif
+    [WcfTheory]
     [InlineData("MyCustomBinding")]
     // Create a CustomBinding and set/get its name to validate it was created and usable.
     public static void CustomBinding_Name_Property(string bindingName)
@@ -46,7 +53,10 @@ public static class CustomBindingTest
         Assert.Equal<string>(bindingName, actualBindingName);
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Theory]
+#endif
+    [WcfTheory]
     [InlineData("")]
     [InlineData(null)]
     [ActiveIssue(1449)]

--- a/src/System.ServiceModel.Primitives/tests/Channels/MessageTest.cs
+++ b/src/System.ServiceModel.Primitives/tests/Channels/MessageTest.cs
@@ -6,13 +6,17 @@
 using System.ServiceModel;
 using System.ServiceModel.Channels;
 using System.ServiceModel.Tests.Common;
+using Infrastructure.Common;
 using Xunit;
 
 public static class MessageTest
 {
     private const string s_action = "http://tempuri.org/someserviceendpoint";
 
+#if FULLXUNIT_NOTSUPPORTED
     [Theory]
+#endif
+    [WcfTheory]
     [MemberData("MessageVersionsWithEnvelopeAndAddressingVersions", MemberType = typeof(TestData))]
     public static void MessageVersion_Verify_AddressingVersions_And_EnvelopeVersions(MessageVersion messageVersion, EnvelopeVersion envelopeVersion, AddressingVersion addressingVersion)
     {
@@ -20,7 +24,10 @@ public static class MessageTest
         Assert.Equal<AddressingVersion>(addressingVersion, messageVersion.Addressing);
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     public static void CreateMessageWithSoap12WSAddressing10_WithNoBody()
     {
         var message = Message.CreateMessage(MessageVersion.Soap12WSAddressing10, s_action);
@@ -45,7 +52,10 @@ public static class MessageTest
         Assert.Equal<string>(content, messageBody);
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     public static void CreateMessageWithSoap12WSAddressing10_WithCustomBodyWriter()
     {
         var message = Message.CreateMessage(MessageVersion.Soap12WSAddressing10, s_action, new CustomBodyWriter());
@@ -60,7 +70,10 @@ public static class MessageTest
         Assert.Equal<string>(string.Empty, messageBody);
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     // Get the MessageVersion from a Custom binding
     public static void GetMessageVersion()
     {

--- a/src/System.ServiceModel.Primitives/tests/Channels/TextMessageEncodingBindingElementTest.cs
+++ b/src/System.ServiceModel.Primitives/tests/Channels/TextMessageEncodingBindingElementTest.cs
@@ -7,11 +7,15 @@ using System;
 using System.ServiceModel.Channels;
 using System.ServiceModel.Tests.Common;
 using System.Text;
+using Infrastructure.Common;
 using Xunit;
 
 public static class TextMessageEncodingBindingElementTest
 {
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     // Create a TextMessageEncodingBindingElement and check it's default encoding is as expected.
     public static void Default_Ctor_Initializes_Properties()
     {
@@ -19,7 +23,10 @@ public static class TextMessageEncodingBindingElementTest
         Assert.Equal<Encoding>(Encoding.UTF8, element.WriteEncoding);
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Theory]
+#endif
+    [WcfTheory]
     [MemberData("ValidEncodings", MemberType = typeof(TestData))]
     [ActiveIssue(1450)]
     public static void WriteEncoding_Property_Sets(Encoding encoding)
@@ -29,7 +36,10 @@ public static class TextMessageEncodingBindingElementTest
         Assert.Equal<Encoding>(encoding, element.WriteEncoding);
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Theory]
+#endif
+    [WcfTheory]
     [MemberData("InvalidEncodings", MemberType = typeof(TestData))]
     [ActiveIssue(1450)]
     public static void WriteEncoding_Property_Set_Throws_For_Invalid_Encodings(Encoding encoding)
@@ -38,7 +48,10 @@ public static class TextMessageEncodingBindingElementTest
         Assert.Throws<ArgumentException>(() => element.WriteEncoding = encoding);
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Theory]
+#endif
+    [WcfTheory]
     [MemberData("ValidTextMessageEncoderMessageVersions", MemberType = typeof(TestData))]
     public static void MessageVersion_Property_Sets(MessageVersion messageVersion)
     {
@@ -47,7 +60,10 @@ public static class TextMessageEncodingBindingElementTest
         Assert.Equal<MessageVersion>(messageVersion, element.MessageVersion);
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     public static void MessageVersion_Property_Set_Null_Throws()
     {
         TextMessageEncodingBindingElement element = new TextMessageEncodingBindingElement();

--- a/src/System.ServiceModel.Primitives/tests/Channels/TextMessageEncodingBindingElementTest.cs
+++ b/src/System.ServiceModel.Primitives/tests/Channels/TextMessageEncodingBindingElementTest.cs
@@ -28,7 +28,7 @@ public static class TextMessageEncodingBindingElementTest
 #endif
     [WcfTheory]
     [MemberData("ValidEncodings", MemberType = typeof(TestData))]
-    [ActiveIssue(1450)]
+    [Issue(1450, Framework = FrameworkID.NetNative)]
     public static void WriteEncoding_Property_Sets(Encoding encoding)
     {
         TextMessageEncodingBindingElement element = new TextMessageEncodingBindingElement();
@@ -41,7 +41,7 @@ public static class TextMessageEncodingBindingElementTest
 #endif
     [WcfTheory]
     [MemberData("InvalidEncodings", MemberType = typeof(TestData))]
-    [ActiveIssue(1450)]
+    [Issue(1450, Framework = FrameworkID.NetNative)]
     public static void WriteEncoding_Property_Set_Throws_For_Invalid_Encodings(Encoding encoding)
     {
         TextMessageEncodingBindingElement element = new TextMessageEncodingBindingElement();

--- a/src/System.ServiceModel.Primitives/tests/Description/ContractDescriptionTest.cs
+++ b/src/System.ServiceModel.Primitives/tests/Description/ContractDescriptionTest.cs
@@ -7,12 +7,16 @@ using System;
 using System.ServiceModel;
 using System.ServiceModel.Channels;
 using System.ServiceModel.Description;
+using Infrastructure.Common;
 using TestTypes;
 using Xunit;
 
 public static class ContractDescriptionTest
 {
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     public static void Manually_Generated_Service_Type()
     {
         // -----------------------------------------------------------------------------------------------
@@ -69,7 +73,10 @@ public static class ContractDescriptionTest
     }
 
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     public static void SvcUtil_Generated_Service_Type()
     {
         // -----------------------------------------------------------------------------------------------
@@ -125,7 +132,10 @@ public static class ContractDescriptionTest
         Assert.True(results == null, results);
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     public static void MessageContract_Service_Type()
     {
         // -----------------------------------------------------------------------------------------------
@@ -165,7 +175,10 @@ public static class ContractDescriptionTest
         Assert.True(results == null, results);
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     public static void Duplex_ContractDescription_Builds_From_ServiceContract()
     {
         // Arrange

--- a/src/System.ServiceModel.Primitives/tests/Description/OperationBehaviorTest.cs
+++ b/src/System.ServiceModel.Primitives/tests/Description/OperationBehaviorTest.cs
@@ -5,11 +5,15 @@
 
 using System.ServiceModel;
 using System.Threading.Tasks;
+using Infrastructure.Common;
 using Xunit;
 
 public static class OperationBehaviorTest
 {
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     public static void IOperationBehavior_Methods_AreCalled()
     {
         DuplexClientBase<ICustomOperationBehaviorDuplexService> duplexService = null;

--- a/src/System.ServiceModel.Primitives/tests/ServiceModel/ChannelFactoryTest.cs
+++ b/src/System.ServiceModel.Primitives/tests/ServiceModel/ChannelFactoryTest.cs
@@ -9,11 +9,15 @@ using System.ServiceModel;
 using System.ServiceModel.Channels;
 using System.Text;
 using System.Threading.Tasks;
+using Infrastructure.Common;
 using Xunit;
 
 public class ChannelFactoryTest
 {
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     public static void CreateChannel_Of_IRequestChannel_Using_CustomBinding()
     {
         ChannelFactory<IRequestChannel> factory = null;
@@ -72,7 +76,10 @@ public class ChannelFactoryTest
         }
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     public static void CreateChannel_Of_IRequestChannel_Using_BasicHttpBinding_Creates_Unique_Instances()
     {
         ChannelFactory<IRequestChannel> factory = null;
@@ -129,7 +136,10 @@ public class ChannelFactoryTest
         }
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     public static void ChannelFactory_Verify_CommunicationStates()
     {
         ChannelFactory<IRequestChannel> factory = null;
@@ -175,7 +185,10 @@ public class ChannelFactoryTest
         }
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     // Create the channel factory using BasicHttpBinding and open the channel using a user generated interface
     public static void CreateChannel_Of_Typed_Proxy_Using_BasicHttpBinding()
     {
@@ -204,7 +217,10 @@ public class ChannelFactoryTest
         }
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     public static void ChannelFactory_Async_Open_Close()
     {
         ChannelFactory<IRequestChannel> factory = null;
@@ -234,7 +250,10 @@ public class ChannelFactoryTest
         }
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Theory]
+#endif
+    [WcfTheory]
     [InlineData(true)]
     [InlineData(false)]
     public static void ChannelFactory_AllowCookies(bool allowCookies)

--- a/src/System.ServiceModel.Primitives/tests/ServiceModel/DuplexChannelFactoryTest.cs
+++ b/src/System.ServiceModel.Primitives/tests/ServiceModel/DuplexChannelFactoryTest.cs
@@ -7,11 +7,15 @@ using System;
 using System.Reflection;
 using System.ServiceModel;
 using System.ServiceModel.Channels;
+using Infrastructure.Common;
 using Xunit;
 
 public class DuplexChannelFactoryTest
 {
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     public static void CreateChannel_EndpointAddress_Null_Throws()
     {
         WcfDuplexServiceCallback callback = new WcfDuplexServiceCallback();
@@ -35,7 +39,10 @@ public class DuplexChannelFactoryTest
         }
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     public static void CreateChannel_InvalidEndpointAddress_AsString_ThrowsUriFormat()
     {
         WcfDuplexServiceCallback callback = new WcfDuplexServiceCallback();
@@ -47,7 +54,10 @@ public class DuplexChannelFactoryTest
         });
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     public static void CreateChannel_EmptyEndpointAddress_AsString_ThrowsUriFormat()
     {
         WcfDuplexServiceCallback callback = new WcfDuplexServiceCallback();
@@ -59,7 +69,10 @@ public class DuplexChannelFactoryTest
         });
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     // valid address, but the scheme is incorrect
     public static void CreateChannel_ExpectedNetTcpScheme_HttpScheme_ThrowsUriFormat()
     {
@@ -74,7 +87,10 @@ public class DuplexChannelFactoryTest
         });
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     // valid address, but the scheme is incorrect
     public static void CreateChannel_ExpectedNetTcpScheme_InvalidScheme_ThrowsUriFormat()
     {
@@ -89,7 +105,10 @@ public class DuplexChannelFactoryTest
         });
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     // valid address, but the scheme is incorrect
     public static void CreateChannel_BasicHttpBinding_Throws_InvalidOperation()
     {
@@ -108,7 +127,10 @@ public class DuplexChannelFactoryTest
             string.Format("InvalidOperationException exception string should contain 'BasicHttpBinding'. Actual message:\r\n" + exception.ToString()));
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     public static void CreateChannel_Address_NullString_ThrowsArgumentNull()
     {
         WcfDuplexServiceCallback callback = new WcfDuplexServiceCallback();
@@ -120,7 +142,10 @@ public class DuplexChannelFactoryTest
         });
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     public static void CreateChannel_Address_NullEndpointAddress_ThrowsArgumentNull()
     {
         WcfDuplexServiceCallback callback = new WcfDuplexServiceCallback();
@@ -134,7 +159,10 @@ public class DuplexChannelFactoryTest
         });
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     public static void CreateChannel_Using_NetTcpBinding_Defaults()
     {
         WcfDuplexServiceCallback callback = new WcfDuplexServiceCallback();
@@ -147,7 +175,10 @@ public class DuplexChannelFactoryTest
         Assert.NotNull(proxy);
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     public static void CreateChannel_Using_NetTcp_NoSecurity()
     {
         WcfDuplexServiceCallback callback = new WcfDuplexServiceCallback();
@@ -158,7 +189,10 @@ public class DuplexChannelFactoryTest
         factory.CreateChannel();
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     public static void CreateChannel_Using_Http_NoSecurity()
     {
         WcfDuplexServiceCallback callback = new WcfDuplexServiceCallback();
@@ -169,7 +203,10 @@ public class DuplexChannelFactoryTest
         factory.CreateChannel();
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     public static void CreateChannel_Of_IDuplexChannel_Using_NetTcpBinding_Creates_Unique_Instances()
     {
         DuplexChannelFactory<IWcfDuplexService> factory = null;

--- a/src/System.ServiceModel.Primitives/tests/ServiceModel/DuplexClientBaseTest.cs
+++ b/src/System.ServiceModel.Primitives/tests/ServiceModel/DuplexClientBaseTest.cs
@@ -7,11 +7,15 @@ using System;
 using System.ServiceModel;
 using System.ServiceModel.Channels;
 using System.Threading.Tasks;
+using Infrastructure.Common;
 using Xunit;
 
 public class DuplexClientBaseTest
 {
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     public static void DuplexClientBase_Ctor_Initializes_State()
     {
         InstanceContext context = new InstanceContext(new WcfDuplexServiceCallback());
@@ -25,7 +29,10 @@ public class DuplexClientBaseTest
         duplexClientBase.Abort();
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     public static void DuplexClientBase_Aborts_Changes_CommunicationState()
     {
         InstanceContext context = new InstanceContext(new WcfDuplexServiceCallback());
@@ -38,7 +45,10 @@ public class DuplexClientBaseTest
         Assert.Equal<CommunicationState>(CommunicationState.Closed, duplexClientBase.State);
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     public static void CreateDuplexClientBase_NullContext_Throws()
     {
         Binding binding = new NetTcpBinding();
@@ -46,7 +56,10 @@ public class DuplexClientBaseTest
         Assert.Throws<ArgumentNullException>("callbackInstance", () => { MyDuplexClientBase<IWcfDuplexService> duplexClientBase = new MyDuplexClientBase<IWcfDuplexService>(null, binding, endpoint); });
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     public static void CreateDuplexClientBase_NullBinding_Throws()
     {
         InstanceContext context = new InstanceContext(new WcfDuplexServiceCallback());
@@ -54,7 +67,10 @@ public class DuplexClientBaseTest
         Assert.Throws<ArgumentNullException>("binding", () => { MyDuplexClientBase<IWcfDuplexService> duplexClientBase = new MyDuplexClientBase<IWcfDuplexService>(context, null, endpoint); });
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     public static void CreateDuplexClientBase_NullEndpoint_Throws()
     {
         InstanceContext context = new InstanceContext(new WcfDuplexServiceCallback());
@@ -62,7 +78,10 @@ public class DuplexClientBaseTest
         Assert.Throws<ArgumentNullException>("remoteAddress", () => { MyDuplexClientBase<IWcfDuplexService> duplexClientBase = new MyDuplexClientBase<IWcfDuplexService>(context, binding, null); });
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     public static void CreateDuplexClientBase_Binding_Url_Mismatch_Throws()
     {
         InstanceContext context = new InstanceContext(new WcfDuplexServiceCallback());

--- a/src/System.ServiceModel.Primitives/tests/ServiceModel/MessageContractTest.cs
+++ b/src/System.ServiceModel.Primitives/tests/ServiceModel/MessageContractTest.cs
@@ -5,11 +5,15 @@
 
 using System;
 using System.ServiceModel;
+using Infrastructure.Common;
 using Xunit;
 
 public static class MessageContractTest
 {
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     public static void Default_Ctor_Initializes_Properties()
     {
         // Verify new MessageContractAttribute() initializes correct defaults.
@@ -22,7 +26,10 @@ public static class MessageContractTest
         Assert.True(messageCA.WrapperNamespace == null, "WrapperNamespace should be null");
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Theory]
+#endif
+    [WcfTheory]
     [InlineData(true)]
     [InlineData(false)]
     public static void IsWrapped_Property_Sets(bool isWrapped)
@@ -33,7 +40,10 @@ public static class MessageContractTest
         Assert.Equal(isWrapped, messageCA.IsWrapped);
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Theory]
+#endif
+    [WcfTheory]
     [InlineData("testWrapperName")]
     public static void WrapperName_Property_Sets(string wrapperName)
     {
@@ -43,7 +53,10 @@ public static class MessageContractTest
         Assert.Equal(wrapperName, messageCA.WrapperName);
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Theory]
+#endif
+    [WcfTheory]
     [InlineData("")]
     public static void WrapperName_Property_Sets_Throws_Argument(string wrapperName)
     {
@@ -51,7 +64,10 @@ public static class MessageContractTest
         Assert.Throws<ArgumentOutOfRangeException>(() => messageCA.WrapperName = wrapperName);
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Theory]
+#endif
+    [WcfTheory]
     [InlineData(null)]
     [ActiveIssue(1449)]
     public static void WrapperName_Property_Sets_Throws_ArgumentNull(string wrapperName)
@@ -60,7 +76,10 @@ public static class MessageContractTest
         Assert.Throws<ArgumentNullException>(() => messageCA.WrapperName = wrapperName);
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Theory]
+#endif
+    [WcfTheory]
     [InlineData("http://www.contoso.com")]
     [InlineData("testNamespace")]
     [InlineData("")]
@@ -74,7 +93,10 @@ public static class MessageContractTest
         Assert.Equal(wrapperNamespace, messageCA.WrapperNamespace);
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Theory]
+#endif
+    [WcfTheory]
     [InlineData(true)]
     [InlineData(false)]
     public static void MessageHeader_MustUnderStand_Sets(bool mustUnderstand)

--- a/src/System.ServiceModel.Primitives/tests/ServiceModel/MessageContractTest.cs
+++ b/src/System.ServiceModel.Primitives/tests/ServiceModel/MessageContractTest.cs
@@ -69,7 +69,7 @@ public static class MessageContractTest
 #endif
     [WcfTheory]
     [InlineData(null)]
-    [ActiveIssue(1449)]
+    [Issue(1449, Framework = FrameworkID.NetNative)]
     public static void WrapperName_Property_Sets_Throws_ArgumentNull(string wrapperName)
     {
         MessageContractAttribute messageCA = new MessageContractAttribute();
@@ -84,7 +84,7 @@ public static class MessageContractTest
     [InlineData("testNamespace")]
     [InlineData("")]
     [InlineData(null)]
-    [ActiveIssue(1449)]
+    [Issue(1449, Framework = FrameworkID.NetNative)]
     public static void WrapperNamespace_Property_Sets(string wrapperNamespace)
     {
         MessageContractAttribute messageCA = new MessageContractAttribute();

--- a/src/System.ServiceModel.Primitives/tests/System.ServiceModel.Primitives.Tests.csproj
+++ b/src/System.ServiceModel.Primitives/tests/System.ServiceModel.Primitives.Tests.csproj
@@ -45,6 +45,10 @@
       <Project>{E896294A-AB4A-4AF5-A01C-A19E3972EFF9}</Project>
       <Name>UnitTests.Common</Name>
     </ProjectReference>
+    <ProjectReference Include="$(WcfInfrastructureCommonProj)">
+      <Project>{AFD69665-89A3-42AE-A32E-AB2CBBE6EE7E}</Project>
+      <Name>Infrastructure.Common</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.ServiceModel.Security/tests/ServiceModel/DnsEndpointIdentityTest.cs
+++ b/src/System.ServiceModel.Security/tests/ServiceModel/DnsEndpointIdentityTest.cs
@@ -5,11 +5,15 @@
 
 using System;
 using System.ServiceModel;
+using Infrastructure.Common;
 using Xunit;
 
 public static class DnsEndpointIdentityTest
 {
+#if FULLXUNIT_NOTSUPPORTED
     [Theory]
+#endif
+    [WcfTheory]
     [InlineData("")]
     [InlineData("wcf")]
     [InlineData("wcf.example.com")]
@@ -18,7 +22,10 @@ public static class DnsEndpointIdentityTest
         DnsEndpointIdentity dnsEndpointEntity = new DnsEndpointIdentity(dnsName);
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     public static void Ctor_NullDnsName()
     {
         string dnsName = null;

--- a/src/System.ServiceModel.Security/tests/ServiceModel/MessageSecurityVersionTest.cs
+++ b/src/System.ServiceModel.Security/tests/ServiceModel/MessageSecurityVersionTest.cs
@@ -4,11 +4,15 @@
 
 
 using System.ServiceModel;
+using Infrastructure.Common;
 using Xunit;
 
 public static class MessageSecurityVersionTest
 {
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     public static void WSSecurity10WSTrustFebruary2005WSSecureConversationFebruary2005WSSecurityPolicy11BasicSecurityProfile10_Property()
     {
         MessageSecurityVersion securityVersion = MessageSecurityVersion.WSSecurity10WSTrustFebruary2005WSSecureConversationFebruary2005WSSecurityPolicy11BasicSecurityProfile10;

--- a/src/System.ServiceModel.Security/tests/ServiceModel/SpnEndpointIdentityTest.cs
+++ b/src/System.ServiceModel.Security/tests/ServiceModel/SpnEndpointIdentityTest.cs
@@ -6,11 +6,15 @@
 using System;
 using System.Collections.Generic;
 using System.ServiceModel;
+using Infrastructure.Common;
 using Xunit;
 
 public static class SpnEndpointIdentityTest
 {
+#if FULLXUNIT_NOTSUPPORTED
     [Theory]
+#endif
+    [WcfTheory]
     [InlineData("")]
     [InlineData("host/wcf")]
     [InlineData("host/wcf.example.com")]
@@ -19,7 +23,10 @@ public static class SpnEndpointIdentityTest
         SpnEndpointIdentity spnEndpointEntity = new SpnEndpointIdentity(spn);
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     public static void Ctor_NullSpn()
     {
         string spnName = null;
@@ -30,14 +37,20 @@ public static class SpnEndpointIdentityTest
         });
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Theory]
+#endif
+    [WcfTheory]
     [MemberData("ValidTimeSpans", MemberType = typeof(TestData))]
     public static void Set_SpnLookupTime_ValidTimes(TimeSpan timeSpan)
     {
         SpnEndpointIdentity.SpnLookupTime = timeSpan;
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Theory]
+#endif
+    [WcfTheory]
     [MemberData("InvalidTimeSpans", MemberType = typeof(TestData))]
     public static void Set_SpnLookupTime_InvalidTimes_Throws(TimeSpan timeSpan)
     {

--- a/src/System.ServiceModel.Security/tests/ServiceModel/UpnEndpointIdentityTest.cs
+++ b/src/System.ServiceModel.Security/tests/ServiceModel/UpnEndpointIdentityTest.cs
@@ -16,7 +16,7 @@ public static class UpnEndpointIdentityTest
     [WcfTheory]
     [InlineData("")]
     [InlineData("test@wcf.example.com")]
-    [ActiveIssue(1454)]
+    [Issue(1454, Framework = FrameworkID.NetNative)]
     public static void Ctor_UpnName(string upn)
     {
         UpnEndpointIdentity upnEndpointEntity = new UpnEndpointIdentity(upn);

--- a/src/System.ServiceModel.Security/tests/ServiceModel/UpnEndpointIdentityTest.cs
+++ b/src/System.ServiceModel.Security/tests/ServiceModel/UpnEndpointIdentityTest.cs
@@ -5,11 +5,15 @@
 
 using System;
 using System.ServiceModel;
+using Infrastructure.Common;
 using Xunit;
 
 public static class UpnEndpointIdentityTest
 {
+#if FULLXUNIT_NOTSUPPORTED
     [Theory]
+#endif
+    [WcfTheory]
     [InlineData("")]
     [InlineData("test@wcf.example.com")]
     [ActiveIssue(1454)]
@@ -18,7 +22,10 @@ public static class UpnEndpointIdentityTest
         UpnEndpointIdentity upnEndpointEntity = new UpnEndpointIdentity(upn);
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     public static void Ctor_NullUpn()
     {
         string upnName = null;

--- a/src/System.ServiceModel.Security/tests/System.ServiceModel.Security.Tests.csproj
+++ b/src/System.ServiceModel.Security/tests/System.ServiceModel.Security.Tests.csproj
@@ -29,6 +29,10 @@
     <ProjectReference Include='$(WcfSecurityPkgProj)'>
       <Name>System.ServiceModel.Security</Name>
     </ProjectReference>
+    <ProjectReference Include="$(WcfInfrastructureCommonProj)">
+      <Project>{AFD69665-89A3-42AE-A32E-AB2CBBE6EE7E}</Project>
+      <Name>Infrastructure.Common</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>


### PR DESCRIPTION
Modifies all the unit tests to use WcfFact instead of Fact
and WcfTheory instead of Theory.

We retain some conditional code temporarily to allow running
in ToF as well as normally in GitHub.