### PR TITLE
Add RunTestsWithIssues TestProperty

### DIFF
--- a/src/System.Private.ServiceModel/tests/Common/Infrastructure/testproperties.props
+++ b/src/System.Private.ServiceModel/tests/Common/Infrastructure/testproperties.props
@@ -150,6 +150,16 @@
     <PropertyGroup Condition="'$(SSL_Available)' == ''">
       <SSL_Available></SSL_Available>
     </PropertyGroup>
+
+    <!-- The default value of $(IncludeTestsWithIssues) is blank, which is equivalent fo 'false'.
+         The check of $(WithCategories) preserves the convention used by other repo's where the
+         keyword 'failing' inside $(WithCategories) asks that tests with [ActiveIssue] be run.
+         Optionally, $(IncludeTestsWithIssues) can be a semicolon-separated list of issue numbers.
+         Tests marked with an [Issue] whose issue number is in this list will be run rather than skipped.
+    -->
+    <PropertyGroup Condition="'$(IncludeTestsWithIssues)' == '' and $(WithCategories.ToLower().Contains('failing'))">
+      <IncludeTestsWithIssues>true</IncludeTestsWithIssues>
+    </PropertyGroup>
   
   <!--
      GeneratedTestPropertiesFileName:

--- a/src/System.Private.ServiceModel/tests/Common/Infrastructure/testproperties.targets
+++ b/src/System.Private.ServiceModel/tests/Common/Infrastructure/testproperties.targets
@@ -54,6 +54,7 @@ namespace Infrastructure.Common
         public static readonly string ExplicitPassword_PropertyName = "ExplicitPassword"%3B
         public static readonly string SSL_Available_PropertyName = "SSL_Available"%3B
         public static readonly string TestNugetRuntimeId_PropertyName = "TestNugetRuntimeId"%3B
+        public static readonly string IncludeTestsWithIssues_PropertyName = "IncludeTestsWithIssues"%3B
                 
         static partial void Initialize(Dictionary<string, string> properties)
         {
@@ -93,6 +94,7 @@ namespace Infrastructure.Common
             properties["ExplicitPassword"] = "$(ExplicitPassword)"%3B
             properties["SSL_Available"] = "$(SSL_Available)"%3B
             properties["TestNugetRuntimeId"] = "$(TestNugetRuntimeId)"%3B
+            properties["IncludeTestsWithIssues"] = "$(IncludeTestsWithIssues)"%3B
         }
     }
 }


### PR DESCRIPTION
Setting this property to 'true' means that tests marked
with IssuesAttribute will not be skipped.