### PR TITLE
Move to xunit 2.2.0-prerelease to get UWP testing to work

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -120,15 +120,15 @@
     </ValidationPattern>
     <ValidationPattern Include="xUnitStableVersions">
       <IdentityRegex>^(?i)xunit$</IdentityRegex>
-      <ExpectedVersion>2.1.0</ExpectedVersion>
+      <ExpectedVersion>2.2.0-beta2-build3300</ExpectedVersion>
     </ValidationPattern>
     <ValidationPattern Include="xUnitExtensionsVersions">
       <IdentityRegex>^(?i)Microsoft\.xunit\.netcore\.extensions$</IdentityRegex>
-      <ExpectedVersion>1.0.0-prerelease-00520-02</ExpectedVersion>
+      <ExpectedVersion>1.0.0-prerelease-00704-04</ExpectedVersion>
     </ValidationPattern>
     <ValidationPattern Include="buildToolsTestSuiteVersions">
       <IdentityRegex>^(?i)Microsoft\.DotNet\.BuildTools\.TestSuite$</IdentityRegex>
-      <ExpectedVersion>1.0.0-prerelease-00520-02</ExpectedVersion>
+      <ExpectedVersion>1.0.0-prerelease-00704-04</ExpectedVersion>
     </ValidationPattern>
     <ValidationPattern Include="uwpRunnerVersion">
       <IdentityRegex>^(?i)microsoft\.xunit\.runner\.uwp$</IdentityRegex>

--- a/src/Common/test-runtime/project.json
+++ b/src/Common/test-runtime/project.json
@@ -17,9 +17,6 @@
     "Microsoft.DotNet.xunit.performance.runner.cli": "1.0.0-alpha-build0037",
     "Microsoft.DotNet.xunit.performance.runner.Windows": "1.0.0-alpha-build0037",
     "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00704-04",
-    "System.Collections.NonGeneric": "4.0.1",
-    "System.Collections.Specialized": "4.0.1",
-    "System.Xml.XmlDocument": "4.0.1",
     "xunit.console.netcore": "1.0.3-prerelease-00704-04"
   },
   "frameworks": {

--- a/src/Common/test-runtime/project.json
+++ b/src/Common/test-runtime/project.json
@@ -11,12 +11,16 @@
     "coveralls.io": "1.4",
     "OpenCover": "4.6.519",
     "ReportGenerator": "2.4.3",
+    "xunit": "2.2.0-beta2-build3300",
     "Microsoft.DotNet.xunit.performance.analysis": "1.0.0-alpha-build0037",
     "Microsoft.DotNet.xunit.performance.analysis.cli": "1.0.0-alpha-build0037",
     "Microsoft.DotNet.xunit.performance.runner.cli": "1.0.0-alpha-build0037",
     "Microsoft.DotNet.xunit.performance.runner.Windows": "1.0.0-alpha-build0037",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02",
-    "xunit.console.netcore": "1.0.3-prerelease-00607-01"
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00704-04",
+    "System.Collections.NonGeneric": "4.0.1",
+    "System.Collections.Specialized": "4.0.1",
+    "System.Xml.XmlDocument": "4.0.1",
+    "xunit.console.netcore": "1.0.3-prerelease-00704-04"
   },
   "frameworks": {
     "netstandard1.3": { },

--- a/src/System.Private.ServiceModel/tests/Common/Infrastructure/Infrastructure.Common.csproj
+++ b/src/System.Private.ServiceModel/tests/Common/Infrastructure/Infrastructure.Common.csproj
@@ -24,6 +24,11 @@
     <None Include="testproperties.props" />
     <None Include="testproperties.targets" />
   </ItemGroup>
+  <ItemGroup>
+    <Content Include="Infrastructure.Common.rd.xml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
   <Import Project="testproperties.props" />
   <Import Project="testproperties.targets" />
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/System.Private.ServiceModel/tests/Common/Infrastructure/Infrastructure.Common.rd.xml
+++ b/src/System.Private.ServiceModel/tests/Common/Infrastructure/Infrastructure.Common.rd.xml
@@ -1,0 +1,29 @@
+﻿<!--
+    To fully enable reflection for App1.MyClass and all of its public/private members
+    <Type Name="App1.MyClass" Dynamic="Required All"/>
+    
+    To enable dynamic creation of the specific instantiation of AppClass<T> over System.Int32
+    <TypeInstantiation Name="App1.AppClass" Arguments="System.Int32" Activate="Required Public" />
+    
+    Using the Namespace directive to apply reflection policy to all the types in a particular namespace
+    <Namespace Name="DataClasses.ViewModels" Seralize="All" />
+
+    Runtime Directives are documented at http://go.microsoft.com/fwlink/?LinkID=391919
+-->
+
+<Directives xmlns="http://schemas.microsoft.com/netfx/2013/01/metadata">
+
+  <Library Name="Infrastructure.Common" >
+    <Assembly Name="Infrastructure.Common">
+      <Namespace Name="Infrastructure.Common">
+        <Type Name="WcfFactAttribute" Dynamic="Required All" />
+        <Type Name="WcfTheoryAttribute" Dynamic="Required All" />
+        <Type Name="IssueAttribute" Dynamic="Required All" />
+        <Type Name="ConditionAttribute" Dynamic="Required All" />
+        <Type Name="WcfTestDiscoverer" Dynamic="Required All" />
+        <Type Name="WcfFactDiscoverer" Dynamic="Required All" />
+        <Type Name="WcfTheoryDiscoverer" Dynamic="Required All" />
+      </Namespace>
+    </Assembly>
+  </Library>
+</Directives>

--- a/src/System.Private.ServiceModel/tests/Common/Infrastructure/project.json
+++ b/src/System.Private.ServiceModel/tests/Common/Infrastructure/project.json
@@ -11,8 +11,9 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00520-02",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "xunit": "2.2.0-beta2-build3300",
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00704-04",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00704-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Private.ServiceModel/tests/Common/Scenarios/project.json
+++ b/src/System.Private.ServiceModel/tests/Common/Scenarios/project.json
@@ -7,12 +7,11 @@
     "System.ServiceModel.Primitives": "4.1.1-beta-24329-01",
     "System.ServiceModel.Security": "4.0.2-beta-24329-01",
     "System.Xml.XmlSerializer": "4.0.11",
+    "xunit": "2.2.0-beta2-build3300",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"
-    },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00520-02",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    }
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Private.ServiceModel/tests/Scenarios/Binding/Custom/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Binding/Custom/project.json
@@ -11,8 +11,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00520-02",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00704-04",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00704-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Private.ServiceModel/tests/Scenarios/Binding/Http/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Binding/Http/project.json
@@ -11,8 +11,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00520-02",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00704-04",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00704-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Private.ServiceModel/tests/Scenarios/Binding/Tcp/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Binding/Tcp/project.json
@@ -11,8 +11,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00520-02",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00704-04",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00704-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/ChannelLayer/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/ChannelLayer/project.json
@@ -11,8 +11,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00520-02",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00704-04",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00704-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/ClientBase/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/ClientBase/project.json
@@ -11,8 +11,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00520-02",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00704-04",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00704-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/ExpectedExceptions/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/ExpectedExceptions/project.json
@@ -11,8 +11,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00520-02",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00704-04",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00704-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/TypedClient/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/TypedClient/project.json
@@ -11,8 +11,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00520-02",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00704-04",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00704-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Private.ServiceModel/tests/Scenarios/Contract/Data/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Contract/Data/project.json
@@ -11,8 +11,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00520-02",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00704-04",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00704-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Private.ServiceModel/tests/Scenarios/Contract/Fault/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Contract/Fault/project.json
@@ -11,8 +11,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00520-02",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00704-04",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00704-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Private.ServiceModel/tests/Scenarios/Contract/Message/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Contract/Message/project.json
@@ -11,8 +11,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00520-02",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00704-04",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00704-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Private.ServiceModel/tests/Scenarios/Contract/Service/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Contract/Service/project.json
@@ -11,8 +11,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00520-02",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00704-04",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00704-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Private.ServiceModel/tests/Scenarios/Contract/XmlSerializer/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Contract/XmlSerializer/project.json
@@ -11,8 +11,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00520-02",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00704-04",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00704-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Private.ServiceModel/tests/Scenarios/Encoding/Encoders/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Encoding/Encoders/project.json
@@ -11,8 +11,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00520-02",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00704-04",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00704-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Private.ServiceModel/tests/Scenarios/Encoding/MessageVersion/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Encoding/MessageVersion/project.json
@@ -11,8 +11,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00520-02",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00704-04",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00704-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Private.ServiceModel/tests/Scenarios/Extensibility/MessageEncoder/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Extensibility/MessageEncoder/project.json
@@ -11,8 +11,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00520-02",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00704-04",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00704-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Private.ServiceModel/tests/Scenarios/Extensibility/MessageInterceptor/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Extensibility/MessageInterceptor/project.json
@@ -11,8 +11,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00520-02",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00704-04",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00704-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Private.ServiceModel/tests/Scenarios/Extensibility/WebSockets/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Extensibility/WebSockets/project.json
@@ -11,8 +11,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00520-02",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00704-04",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00704-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Private.ServiceModel/tests/Scenarios/Infrastructure/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Infrastructure/project.json
@@ -11,8 +11,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00520-02",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00704-04",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00704-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/project.json
@@ -11,8 +11,8 @@
       "target": "project",
       "exclude": "compile"
     },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00520-02",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00704-04",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00704-04"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.ServiceModel.Duplex/tests/project.json
+++ b/src/System.ServiceModel.Duplex/tests/project.json
@@ -1,11 +1,12 @@
 {
   "dependencies": {
     "System.ServiceModel.Duplex": "4.0.2-beta-24329-01",
-    "xunit": "2.2.0-beta2-build3300",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"
-    }
+    },
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00704-04",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00704-04"
   },
   "frameworks": {
     "netstandard1.3": { }

--- a/src/System.ServiceModel.Duplex/tests/project.json
+++ b/src/System.ServiceModel.Duplex/tests/project.json
@@ -1,12 +1,11 @@
 {
   "dependencies": {
     "System.ServiceModel.Duplex": "4.0.2-beta-24329-01",
+    "xunit": "2.2.0-beta2-build3300",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"
-    },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00520-02",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    }
   },
   "frameworks": {
     "netstandard1.3": { }

--- a/src/System.ServiceModel.Http/tests/project.json
+++ b/src/System.ServiceModel.Http/tests/project.json
@@ -3,12 +3,11 @@
     "System.ServiceModel.Http": "4.1.1-beta-24329-01",
     "System.ServiceModel.Primitives": "4.1.1-beta-24329-01",
     "System.ServiceModel.Security": "4.0.2-beta-24329-01",
+    "xunit": "2.2.0-beta2-build3300",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"
-    },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00520-02",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    }
   },
   "frameworks": {
     "netstandard1.3": { }

--- a/src/System.ServiceModel.Http/tests/project.json
+++ b/src/System.ServiceModel.Http/tests/project.json
@@ -3,11 +3,12 @@
     "System.ServiceModel.Http": "4.1.1-beta-24329-01",
     "System.ServiceModel.Primitives": "4.1.1-beta-24329-01",
     "System.ServiceModel.Security": "4.0.2-beta-24329-01",
-    "xunit": "2.2.0-beta2-build3300",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"
-    }
+    },
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00704-04",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00704-04"
   },
   "frameworks": {
     "netstandard1.3": { }

--- a/src/System.ServiceModel.NetTcp/tests/project.json
+++ b/src/System.ServiceModel.NetTcp/tests/project.json
@@ -4,11 +4,12 @@
     "System.ServiceModel.NetTcp": "4.1.1-beta-24329-01",
     "System.ServiceModel.Primitives": "4.1.1-beta-24329-01",
     "System.ServiceModel.Security": "4.0.2-beta-24329-01",
-    "xunit": "2.2.0-beta2-build3300",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"
-    }
+    },
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00704-04",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00704-04"
   },
   "frameworks": {
     "netstandard1.3": { }

--- a/src/System.ServiceModel.NetTcp/tests/project.json
+++ b/src/System.ServiceModel.NetTcp/tests/project.json
@@ -4,12 +4,11 @@
     "System.ServiceModel.NetTcp": "4.1.1-beta-24329-01",
     "System.ServiceModel.Primitives": "4.1.1-beta-24329-01",
     "System.ServiceModel.Security": "4.0.2-beta-24329-01",
+    "xunit": "2.2.0-beta2-build3300",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"
-    },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00520-02",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    }
   },
   "frameworks": {
     "netstandard1.3": { }

--- a/src/System.ServiceModel.Primitives/tests/project.json
+++ b/src/System.ServiceModel.Primitives/tests/project.json
@@ -5,12 +5,11 @@
     "System.ServiceModel.NetTcp": "4.1.1-beta-24329-01",
     "System.ServiceModel.Primitives": "4.1.1-beta-24329-01",
     "System.ServiceModel.Security": "4.0.2-beta-24329-01",
+    "xunit": "2.2.0-beta2-build3300",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"
-    },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00520-02",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    }
   },
   "frameworks": {
     "netstandard1.3": { }

--- a/src/System.ServiceModel.Primitives/tests/project.json
+++ b/src/System.ServiceModel.Primitives/tests/project.json
@@ -5,11 +5,12 @@
     "System.ServiceModel.NetTcp": "4.1.1-beta-24329-01",
     "System.ServiceModel.Primitives": "4.1.1-beta-24329-01",
     "System.ServiceModel.Security": "4.0.2-beta-24329-01",
-    "xunit": "2.2.0-beta2-build3300",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"
-    }
+    },
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00704-04",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00704-04"
   },
   "frameworks": {
     "netstandard1.3": { }

--- a/src/System.ServiceModel.Security/tests/project.json
+++ b/src/System.ServiceModel.Security/tests/project.json
@@ -1,12 +1,11 @@
 {
   "dependencies": {
     "System.ServiceModel.Security": "4.0.2-beta-24329-01",
+    "xunit": "2.2.0-beta2-build3300",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"
-    },
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00520-02",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00520-02"
+    }
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/System.ServiceModel.Security/tests/project.json
+++ b/src/System.ServiceModel.Security/tests/project.json
@@ -1,11 +1,12 @@
 {
   "dependencies": {
     "System.ServiceModel.Security": "4.0.2-beta-24329-01",
-    "xunit": "2.2.0-beta2-build3300",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"
-    }
+    },
+    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00704-04",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00704-04"
   },
   "frameworks": {
     "netstandard1.3": {}


### PR DESCRIPTION
Preparing to get UWP testing working in Helix discovered
WcfFactAttribute and WcfTheoryAttribute were not working
properly.  One reason was due to mismatched xunit
versions between the UWP runners and our Infrastructure.Common.
Moving to the same xunit version allows that part to work.

The second reason was that our custom Fact and Theory attributes
and their discoverers were not permitted to do Reflection.  The fix
was to add a custom rd.xml that allows that.  With these 2 changes
WcfFact and WcfTheory work in UWP in Helix.