### PR TITLE
Remove call to sudo when chmodding in certtest.props

### DIFF
--- a/src/certtest.props
+++ b/src/certtest.props
@@ -5,7 +5,7 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-     <TestCommandLines  Condition="'$(TargetOS)'!='Windows_NT'" Include="sudo chmod a+x InstallRootCertificate.sh"/>
-     <TestCommandLines  Condition="'$(TargetOS)'!='Windows_NT'" Include="sudo -E -n ./InstallRootCertificate.sh --service-host $(ServiceUri) --cert-file /tmp/wcfrootca.crt"/>
+     <TestCommandLines Condition="'$(TargetOS)'!='Windows_NT'" Include="chmod a+x InstallRootCertificate.sh"/>
+     <TestCommandLines Condition="'$(TargetOS)'!='Windows_NT'" Include="sudo -E -n ./InstallRootCertificate.sh --service-host $(ServiceUri) --cert-file /tmp/wcfrootca.crt"/>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
There should be no need to call sudo when attmepting to chmod the InstallRootCertificates.sh
script. The file is owned by the text execution user, not root