### PR TITLE
Enable HttpsTests for platforms that support it

### DIFF
--- a/src/Common/test-runtime/project.json
+++ b/src/Common/test-runtime/project.json
@@ -8,6 +8,7 @@
     "System.IO.Compression": "4.1.2-beta-24322-03",
     "System.Runtime.InteropServices.RuntimeInformation": "4.0.1-beta-24322-03",
     "System.Linq.Parallel": "4.0.2-beta-24322-03",
+    "System.Security.Cryptography.X509Certificates": "4.1.1-beta-24322-03",
     "coveralls.io": "1.4",
     "OpenCover": "4.6.519",
     "ReportGenerator": "2.4.3",

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/HttpChannelHelpers.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/HttpChannelHelpers.cs
@@ -44,6 +44,9 @@ namespace System.ServiceModel.Channels
         internal const string MIMEVersionHeader = "MIME-Version";
         internal const string ContentEncodingHeader = "Content-Encoding";
 
+        internal const uint CURLE_SSL_CERTPROBLEM = 58;
+        internal const uint CURLE_SSL_CACERT = 60;
+
         internal const uint WININET_E_NAME_NOT_RESOLVED = 0x80072EE7;
         internal const uint WININET_E_CONNECTION_RESET = 0x80072EFF;
         internal const uint WININET_E_INCORRECT_HANDLE_STATE = 0x80072EF3;
@@ -140,6 +143,8 @@ namespace System.ServiceModel.Channels
                 case UnsafeNativeMethods.ERROR_INVALID_HANDLE:
                 case WININET_E_NAME_NOT_RESOLVED:
                     return new EndpointNotFoundException(SR.Format(SR.EndpointNotFound, request.RequestUri.AbsoluteUri), exception);
+                case CURLE_SSL_CACERT:
+                case CURLE_SSL_CERTPROBLEM:
                 case ERROR_WINHTTP_SECURE_FAILURE:
                     return new SecurityNegotiationException(SR.Format(SR.TrustFailure, request.RequestUri.Authority), exception);
                 default:

--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Https/HttpsTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Https/HttpsTests.cs
@@ -181,7 +181,7 @@ public partial class HttpsTests : ConditionalWcfTest
                nameof(Client_Certificate_Installed),
                nameof(SSL_Available))]
     [Issue(959, Framework = FrameworkID.NetNative)] // Server certificate validation not supported in NET Native
-    [Issue(1295, OS = OSID.AnyUnix)] // A libcurl built with OpenSSL is required.
+    [Issue(1295, OS = OSID.AnyCentOS | OSID.AnyFedora | OSID.AnyOpenSUSE | OSID.AnyOSX | OSID.AnyRHEL)] // A libcurl built with OpenSSL is required.
     [OuterLoop]
     // Asking for PeerOrChainTrust should succeed if the certificate is
     // chain-trusted, even though it is not in the TrustedPeople store.
@@ -251,7 +251,7 @@ public partial class HttpsTests : ConditionalWcfTest
                nameof(Client_Certificate_Installed),
                nameof(SSL_Available))]
     [Issue(959, Framework = FrameworkID.NetNative)] // Server certificate validation not supported in NET Native
-    [Issue(1295, OS = OSID.AnyUnix)] // A libcurl built with OpenSSL is required.
+    [Issue(1295, OS = OSID.AnyCentOS | OSID.AnyFedora | OSID.AnyOpenSUSE | OSID.AnyOSX | OSID.AnyRHEL)] // A libcurl built with OpenSSL is required.
     [OuterLoop]
     // Asking for ChainTrust should succeed if the certificate is
     // chain-trusted.

--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Https/HttpsTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Https/HttpsTests.cs
@@ -95,7 +95,7 @@ public partial class HttpsTests : ConditionalWcfTest
                nameof(Client_Certificate_Installed),
                nameof(Peer_Certificate_Installed),
                nameof(SSL_Available))]
-    [Issue(1295, OS = OSID.AnyUnix)] // A libcurl built with OpenSSL is required.
+    [Issue(1295, OS = OSID.AnyCentOS | OSID.AnyFedora | OSID.AnyOpenSUSE | OSID.AnyOSX | OSID.AnyRHEL)] // A libcurl built with OpenSSL is required.
     [Issue(959, Framework = FrameworkID.NetNative)] // Server certificate validation not supported in NET Native
     [OuterLoop]
     // Asking for PeerTrust alone should throw SecurityNegotiationException


### PR DESCRIPTION
This set of tests should work for Debian and Ubuntu, as they by default have libcurl+OpenSSL installed 