### PR TITLE
Reactivate unit tests disabled by issue #1449

### DIFF
--- a/src/System.ServiceModel.Http/tests/ServiceModel/BasicHttpBindingTest.cs
+++ b/src/System.ServiceModel.Http/tests/ServiceModel/BasicHttpBindingTest.cs
@@ -204,9 +204,8 @@ public static class BasicHttpBindingTest
     [Theory]
 #endif
     [WcfTheory]
-    [InlineData(null)]
+    [InlineData(new object[] { null } )]  // Work-around issue #1449 with this syntax
     [InlineData("")]
-    [Issue(1449, Framework = FrameworkID.NetNative)]
     public static void Name_Property_Set_Invalid_Value_Throws(string value)
     {
         var binding = new BasicHttpBinding();
@@ -231,8 +230,7 @@ public static class BasicHttpBindingTest
     [Theory]
 #endif
     [WcfTheory]
-    [InlineData(null)]
-    [Issue(1449, Framework = FrameworkID.NetNative)]
+    [InlineData(new object[] { null } )]  // Work-around issue #1449 with this syntax
     public static void Namespace_Property_Set_Invalid_Value_Throws(string value)
     {
         var binding = new BasicHttpBinding();

--- a/src/System.ServiceModel.Primitives/tests/Channels/CustomBindingTest.cs
+++ b/src/System.ServiceModel.Primitives/tests/Channels/CustomBindingTest.cs
@@ -58,8 +58,7 @@ public static class CustomBindingTest
 #endif
     [WcfTheory]
     [InlineData("")]
-    [InlineData(null)]
-    [Issue(1449, Framework = FrameworkID.NetNative)]
+    [InlineData(new object[] { null } )]  // Work-around issue #1449 with this syntax
     public static void CustomBinding_Name_Property_Set_Throws(string bindingName)
     {
         CustomBinding customBinding = new CustomBinding();

--- a/src/System.ServiceModel.Primitives/tests/ServiceModel/MessageContractTest.cs
+++ b/src/System.ServiceModel.Primitives/tests/ServiceModel/MessageContractTest.cs
@@ -68,8 +68,7 @@ public static class MessageContractTest
     [Theory]
 #endif
     [WcfTheory]
-    [InlineData(null)]
-    [Issue(1449, Framework = FrameworkID.NetNative)]
+    [InlineData(new object[] { null } )]  // Work-around issue #1449 with this syntax
     public static void WrapperName_Property_Sets_Throws_ArgumentNull(string wrapperName)
     {
         MessageContractAttribute messageCA = new MessageContractAttribute();
@@ -83,8 +82,7 @@ public static class MessageContractTest
     [InlineData("http://www.contoso.com")]
     [InlineData("testNamespace")]
     [InlineData("")]
-    [InlineData(null)]
-    [Issue(1449, Framework = FrameworkID.NetNative)]
+    [InlineData(new object[] { null } )]  // Work-around issue #1449 with this syntax
     public static void WrapperNamespace_Property_Sets(string wrapperNamespace)
     {
         MessageContractAttribute messageCA = new MessageContractAttribute();


### PR DESCRIPTION
Some unit tests were disabled when run against UWP due to
a known issue in the toolchain with InlineDataAttribute(null).
This PR applies a workaround to that toolchain issue and reactivates
the tests.