### PR TITLE
Fix UWP issue #1450 and re-enable tests disabled for it.

### DIFF
--- a/src/System.Private.ServiceModel/tests/Common/Unit/UnitTests.Common.csproj
+++ b/src/System.Private.ServiceModel/tests/Common/Unit/UnitTests.Common.csproj
@@ -23,5 +23,10 @@
   <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>
+  <ItemGroup>  
+    <None Include="UnitTests.Common.rd.xml">  
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>  
+    </None>  
+  </ItemGroup>  
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Private.ServiceModel/tests/Common/Unit/UnitTests.Common.rd.xml
+++ b/src/System.Private.ServiceModel/tests/Common/Unit/UnitTests.Common.rd.xml
@@ -1,0 +1,16 @@
+ <Directives xmlns="http://schemas.microsoft.com/netfx/2013/01/metadata">  
+ 
+   <!-- 
+        Types used in the TestData class via MemberData sometimes
+        require an explicit permission to do Reflection, or xunit
+        may encounter MissingMetadataException enumerating the
+        MemberData values.
+   -->
+
+   <Library Name = "System.Text.Encoding" >  
+     <Type Name="System.Text.Encoding" >
+        <Subtypes Dynamic = "Required All" />
+     </Type>
+   </Library> 
+ </Directives> 
+ 

--- a/src/System.ServiceModel.Http/tests/ServiceModel/BasicHttpBindingTest.cs
+++ b/src/System.ServiceModel.Http/tests/ServiceModel/BasicHttpBindingTest.cs
@@ -239,40 +239,6 @@ public static class BasicHttpBindingTest
         Assert.Throws<ArgumentNullException>(() => binding.Namespace = value);
     }
 
-    public static MemberDataSet<Encoding> ValidEncodings
-    {
-        get
-        {
-            return new MemberDataSet<Encoding>
-                {
-                    { Encoding.BigEndianUnicode },
-                    { Encoding.Unicode },
-                    { Encoding.UTF8 },
-                };
-        }
-    }
-
-    public static MemberDataSet<Encoding> InvalidEncodings
-    {
-        get
-        {
-            MemberDataSet<Encoding> data = new MemberDataSet<Encoding>();
-            foreach (string encodingName in new string[] { "utf-7", "Windows-1252", "us-ascii", "iso-8859-1", "x-Chinese-CNS", "IBM273" })
-            {
-                try
-                {
-                    Encoding encoding = Encoding.GetEncoding(encodingName);
-                    data.Add(encoding);
-                }
-                catch
-                {
-                    // not all encodings are supported on all frameworks
-                }
-            }
-            return data;
-        }
-    }
-
 #if FULLXUNIT_NOTSUPPORTED
     [Fact]
 #endif
@@ -397,7 +363,6 @@ public static class BasicHttpBindingTest
 #endif
     [WcfTheory]
     [MemberData("ValidEncodings", MemberType = typeof(TestData))]
-    [Issue(1450, Framework = FrameworkID.NetNative)]
     public static void TextEncoding_Property_Sets(Encoding encoding)
     {
         var binding = new BasicHttpBinding();
@@ -410,7 +375,6 @@ public static class BasicHttpBindingTest
 #endif
     [WcfTheory]
     [MemberData("InvalidEncodings", MemberType = typeof(TestData))]
-    [Issue(1450, Framework = FrameworkID.NetNative)]
     public static void TextEncoding_Property_Set_Invalid_Value_Throws(Encoding encoding)
     {
         var binding = new BasicHttpBinding();

--- a/src/System.ServiceModel.Primitives/tests/Channels/TextMessageEncodingBindingElementTest.cs
+++ b/src/System.ServiceModel.Primitives/tests/Channels/TextMessageEncodingBindingElementTest.cs
@@ -28,7 +28,6 @@ public static class TextMessageEncodingBindingElementTest
 #endif
     [WcfTheory]
     [MemberData("ValidEncodings", MemberType = typeof(TestData))]
-    [Issue(1450, Framework = FrameworkID.NetNative)]
     public static void WriteEncoding_Property_Sets(Encoding encoding)
     {
         TextMessageEncodingBindingElement element = new TextMessageEncodingBindingElement();
@@ -41,7 +40,6 @@ public static class TextMessageEncodingBindingElementTest
 #endif
     [WcfTheory]
     [MemberData("InvalidEncodings", MemberType = typeof(TestData))]
-    [Issue(1450, Framework = FrameworkID.NetNative)]
     public static void WriteEncoding_Property_Set_Throws_For_Invalid_Encodings(Encoding encoding)
     {
         TextMessageEncodingBindingElement element = new TextMessageEncodingBindingElement();


### PR DESCRIPTION
Issue #1450 was caused in UWP because the MemberData attribute
was hiding specific Encoding types from the reducer, resulting in
MissingMetadataException when xunit was doing test discovery.

The fix is to add back a custom rd.xml file to the project containing
the TestData class to grant Reflection permissions for types affected by this.

Fixes #1450