### PR TITLE
Adds IssueAttribute for NET Native inadvertantly omitted

### DIFF
--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Https/HttpsTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Https/HttpsTests.cs
@@ -96,6 +96,7 @@ public partial class HttpsTests : ConditionalWcfTest
                nameof(Peer_Certificate_Installed),
                nameof(SSL_Available))]
     [Issue(1295, OS = OSID.AnyUnix)] // A libcurl built with OpenSSL is required.
+    [Issue(959, Framework = FrameworkID.NetNative)] // Server certificate validation not supported in NET Native
     [OuterLoop]
     // Asking for PeerTrust alone should throw SecurityNegotiationException
     // if the certificate is not in the TrustedPeople store.  For this test


### PR DESCRIPTION
When converting all ActiveIssueAttributes to IssueAttribute in
preparation for UWP testing, one was accidentally omitted. This
test was supposed to be skipped due to this known issue, not
executed and counted as a failure.