### PR TITLE
Omit empty ETW "Begin" and "End" messages if no events to report

### DIFF
--- a/src/System.Private.ServiceModel/tests/Common/Infrastructure/xunit/WcfTestCase.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Infrastructure/xunit/WcfTestCase.cs
@@ -61,7 +61,7 @@ namespace Infrastructure.Common
                                                      : new XunitTestCaseRunner(this, DisplayName, _skippedReason, constructorArguments, TestMethodArguments, messageBus, aggregator, cancellationTokenSource).RunAsync());
 
             s_testListener.EventWritten = null;
-            if (runsummary.Failed > 0)
+            if (runsummary.Failed > 0 && events.Count > 0)
             {
                 StringBuilder etwOutput = new StringBuilder();
                 etwOutput.AppendLine(string.Format("---ETW Trace for Test {0} Begins---", DisplayName));


### PR DESCRIPTION
The new logic to Console.WriteLine ETW events for tests that fail
is writing out extraneous empty "Begin" and "End" blocks when run
on UWP.  This is because UWP doesn't currently support ETW, and it
has no events to report.

The fix is to skip the entire Console.WriteLine block of code if
there are no ETW events to report.

Fixes #1465