### PR TITLE
Disable tests triggering Assert in UWP

### DIFF
--- a/src/System.Private.ServiceModel/tests/Scenarios/Binding/Custom/CustomBindingTests.4.1.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Binding/Custom/CustomBindingTests.4.1.0.cs
@@ -17,6 +17,7 @@ public partial class CustomBindingTests : ConditionalWcfTest
 #endif
     [WcfFact]
     [Condition(nameof(Root_Certificate_Installed), nameof(Client_Certificate_Installed))]
+    [Issue(1467, Framework = FrameworkID.NetNative)]
     [OuterLoop]
     public static void DefaultSettings_Tcp_Binary_Echo_RoundTrips_String()
     {

--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/ExpectedExceptions/ExpectedExceptionTests.4.1.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/ExpectedExceptions/ExpectedExceptionTests.4.1.0.cs
@@ -21,7 +21,10 @@ using Infrastructure.Common;
 
 public partial class ExpectedExceptionTests : ConditionalWcfTest
 {
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void NotExistentHost_Throws_EndpointNotFoundException()
     {
@@ -119,7 +122,10 @@ public partial class ExpectedExceptionTests : ConditionalWcfTest
         Assert.True(errorBuilder.Length == 0, string.Format("Test Scenario: ServiceRestart_Throws_CommunicationException FAILED with the following errors: {0}", errorBuilder));
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void UnknownUrl_Throws_EndpointNotFoundException()
     {
@@ -169,7 +175,10 @@ public partial class ExpectedExceptionTests : ConditionalWcfTest
         Assert.True(exception.Message.Contains(notFoundUrl), string.Format("Expected exception message to contain: '{0}'", notFoundUrl));
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void UnknownUrl_Throws_ProtocolException()
     {
@@ -191,7 +200,10 @@ public partial class ExpectedExceptionTests : ConditionalWcfTest
         }
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void DuplexCallback_Throws_FaultException_DirectThrow()
     {
@@ -236,7 +248,10 @@ public partial class ExpectedExceptionTests : ConditionalWcfTest
         }
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void DuplexCallback_Throws_FaultException_ReturnsFaultedTask()
     {
@@ -281,7 +296,11 @@ public partial class ExpectedExceptionTests : ConditionalWcfTest
         }
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
+    [Issue(1467, Framework = FrameworkID.NetNative)]
     [OuterLoop]
     // Verify product throws MessageSecurityException when the Dns identity from the server does not match the expectation
     public static void TCP_ServiceCertExpired_Throw_MessageSecurityException()
@@ -315,7 +334,11 @@ public partial class ExpectedExceptionTests : ConditionalWcfTest
         }
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
+    [Issue(1467, Framework = FrameworkID.NetNative)]
     [OuterLoop]
     // Verify product throws SecurityNegotiationException when the service cert is revoked
     public static void TCP_ServiceCertRevoked_Throw_SecurityNegotiationException()
@@ -351,7 +374,10 @@ public partial class ExpectedExceptionTests : ConditionalWcfTest
         }
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void Abort_During_Implicit_Open_Closes_Sync_Waiters()
     {

--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/ExpectedExceptions/ExpectedExceptionTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/ExpectedExceptions/ExpectedExceptionTests.cs
@@ -16,6 +16,7 @@ public partial class ExpectedExceptionTests : ConditionalWcfTest
 #endif
     [WcfFact]
     [Condition(nameof(Root_Certificate_Installed), nameof(Client_Certificate_Installed))]
+    [Issue(1467, Framework = FrameworkID.NetNative)]
     [OuterLoop]
     // Confirm that the Validate method of the custom X509CertificateValidator is called and that an exception thrown there is handled correctly.
     public static void TCP_ServiceCertFailedCustomValidate_Throw_Exception()

--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Tcp/ClientCredentialTypeCertificateCanonicalNameTests.4.1.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Tcp/ClientCredentialTypeCertificateCanonicalNameTests.4.1.0.cs
@@ -29,6 +29,7 @@ public class Tcp_ClientCredentialTypeCertificateCanonicalNameTests : Conditional
 #endif
     [WcfFact]
     [Condition(nameof(Root_Certificate_Installed))]
+    [Issue(1467, Framework = FrameworkID.NetNative)]
     [OuterLoop]
     public static void Certificate_With_CanonicalName_Localhost_Address_EchoString()
     {
@@ -113,6 +114,7 @@ public class Tcp_ClientCredentialTypeCertificateCanonicalNameTests : Conditional
 #endif
     [WcfFact]
     [Condition(nameof(Root_Certificate_Installed))]
+    [Issue(1467, Framework = FrameworkID.NetNative)]
     [OuterLoop]
     public static void Certificate_With_CanonicalName_DomainName_Address_EchoString()
     {
@@ -202,6 +204,7 @@ public class Tcp_ClientCredentialTypeCertificateCanonicalNameTests : Conditional
 #endif
     [WcfFact]
     [Condition(nameof(Root_Certificate_Installed))]
+    [Issue(1467, Framework = FrameworkID.NetNative)]
     [OuterLoop]
     public static void Certificate_With_CanonicalName_Fqdn_Address_EchoString()
     {

--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Tcp/ClientCredentialTypeTests.4.1.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Tcp/ClientCredentialTypeTests.4.1.0.cs
@@ -147,6 +147,7 @@ public partial class Tcp_ClientCredentialTypeTests : ConditionalWcfTest
 #endif
     [WcfFact]
     [Condition(nameof(Root_Certificate_Installed), nameof(Client_Certificate_Installed))]
+    [Issue(1467, Framework = FrameworkID.NetNative)]
     [OuterLoop]
     public static void TcpClientCredentialType_Certificate_With_ServerAltName_EchoString()
     {

--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Tcp/ClientCredentialTypeTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Tcp/ClientCredentialTypeTests.cs
@@ -20,6 +20,7 @@ public partial class Tcp_ClientCredentialTypeTests : ConditionalWcfTest
                nameof(Client_Certificate_Installed),
                nameof(Peer_Certificate_Installed),
                nameof(SSL_Available))]
+    [Issue(1467, Framework = FrameworkID.NetNative)]
     [OuterLoop]
     // Asking for PeerTrust alone should succeed
     // if the certificate is in the TrustedPeople store.  For this test
@@ -91,6 +92,7 @@ public partial class Tcp_ClientCredentialTypeTests : ConditionalWcfTest
                nameof(Client_Certificate_Installed),
                nameof(Peer_Certificate_Installed),
                nameof(SSL_Available))]
+    [Issue(1467, Framework = FrameworkID.NetNative)]
     [OuterLoop]
     // Asking for PeerTrust alone should throw SecurityNegotiationException
     // if the certificate is not in the TrustedPeople store.  For this test
@@ -172,6 +174,7 @@ public partial class Tcp_ClientCredentialTypeTests : ConditionalWcfTest
     [Condition(nameof(Root_Certificate_Installed),
                nameof(Client_Certificate_Installed),
                nameof(SSL_Available))]
+    [Issue(1467, Framework = FrameworkID.NetNative)]               
     [OuterLoop]
     // Asking for PeerOrChainTrust should succeed if the certificate is
     // chain-trusted, even though it is not in the TrustedPeople store.
@@ -239,6 +242,7 @@ public partial class Tcp_ClientCredentialTypeTests : ConditionalWcfTest
     [Condition(nameof(Root_Certificate_Installed),
                nameof(Client_Certificate_Installed),
                nameof(SSL_Available))]
+    [Issue(1467, Framework = FrameworkID.NetNative)]               
     [OuterLoop]
     // Asking for ChainTrust only should succeed if the certificate is
     // chain-trusted.

--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Tcp/IdentityTests.4.1.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Tcp/IdentityTests.4.1.0.cs
@@ -17,6 +17,7 @@ public partial class IdentityTests : ConditionalWcfTest
 #endif
     [WcfFact]
     [Condition(nameof(Root_Certificate_Installed), nameof(Client_Certificate_Installed))]
+    [Issue(1467, Framework = FrameworkID.NetNative)]
     [OuterLoop]
     // The product code will check the Dns identity from the server and throw if it does not match what is specified in DnsEndpointIdentity
     public static void VerifyServiceIdentityMatchDnsEndpointIdentity()

--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Tcp/IdentityTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Tcp/IdentityTests.cs
@@ -17,6 +17,7 @@ public partial class IdentityTests : ConditionalWcfTest
 #endif
     [WcfFact]
     [Condition(nameof(Root_Certificate_Installed), nameof(Client_Certificate_Installed))]
+    [Issue(1467, Framework = FrameworkID.NetNative)]
     [OuterLoop]
     // Verify product throws MessageSecurityException when the Dns identity from the server does not match the expectation
     public static void ServiceIdentityNotMatch_Throw_MessageSecurityException()


### PR DESCRIPTION
Several tests are now triggering a Contract.Assert when
run in UWP.  See issue #1467.