### PR TITLE
Convert FactAttributes to WcfFactAttribute in missed files

### DIFF
--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/ExpectedExceptions/ExpectedExceptionTests.4.0.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/ExpectedExceptions/ExpectedExceptionTests.4.0.0.cs
@@ -19,7 +19,10 @@ using Infrastructure.Common;
 
 public partial class ExpectedExceptionTests : ConditionalWcfTest
 {
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void NonExistentAction_Throws_ActionNotSupportedException()
     {
@@ -87,7 +90,10 @@ public partial class ExpectedExceptionTests : ConditionalWcfTest
     }
     
     // SendTimeout is set to 0, this should trigger a TimeoutException before even attempting to call the service.
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void SendTimeout_Zero_Throws_TimeoutException_Immediately()
     {
@@ -116,7 +122,10 @@ public partial class ExpectedExceptionTests : ConditionalWcfTest
         Assert.InRange<long>(watch.ElapsedMilliseconds, 0, 2000);
     }
     
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void FaultException_Throws_WithFaultDetail()
     {
@@ -159,7 +168,10 @@ public partial class ExpectedExceptionTests : ConditionalWcfTest
         Assert.True(false, "Expected FaultException<FaultDetail> exception, but no exception thrown.");
     }
     
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void UnexpectedException_Throws_FaultException()
     {
@@ -198,7 +210,10 @@ public partial class ExpectedExceptionTests : ConditionalWcfTest
         Assert.True(false, "Expected FaultException<FaultDetail> exception, but no exception thrown.");
     }
     
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void Abort_During_Implicit_Open_Closes_Async_Waiters()
     {

--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/ExpectedExceptions/ExpectedExceptionTests.4.1.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/ExpectedExceptions/ExpectedExceptionTests.4.1.0.cs
@@ -21,7 +21,10 @@ using Infrastructure.Common;
 
 public partial class ExpectedExceptionTests : ConditionalWcfTest
 {
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void NotExistentHost_Throws_EndpointNotFoundException()
     {
@@ -119,7 +122,10 @@ public partial class ExpectedExceptionTests : ConditionalWcfTest
         Assert.True(errorBuilder.Length == 0, string.Format("Test Scenario: ServiceRestart_Throws_CommunicationException FAILED with the following errors: {0}", errorBuilder));
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void UnknownUrl_Throws_EndpointNotFoundException()
     {
@@ -169,7 +175,10 @@ public partial class ExpectedExceptionTests : ConditionalWcfTest
         Assert.True(exception.Message.Contains(notFoundUrl), string.Format("Expected exception message to contain: '{0}'", notFoundUrl));
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void UnknownUrl_Throws_ProtocolException()
     {
@@ -191,7 +200,10 @@ public partial class ExpectedExceptionTests : ConditionalWcfTest
         }
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void DuplexCallback_Throws_FaultException_DirectThrow()
     {
@@ -236,7 +248,10 @@ public partial class ExpectedExceptionTests : ConditionalWcfTest
         }
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void DuplexCallback_Throws_FaultException_ReturnsFaultedTask()
     {
@@ -281,7 +296,10 @@ public partial class ExpectedExceptionTests : ConditionalWcfTest
         }
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     // Verify product throws MessageSecurityException when the Dns identity from the server does not match the expectation
     public static void TCP_ServiceCertExpired_Throw_MessageSecurityException()
@@ -315,7 +333,10 @@ public partial class ExpectedExceptionTests : ConditionalWcfTest
         }
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     // Verify product throws SecurityNegotiationException when the service cert is revoked
     public static void TCP_ServiceCertRevoked_Throw_SecurityNegotiationException()
@@ -351,7 +372,10 @@ public partial class ExpectedExceptionTests : ConditionalWcfTest
         }
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void Abort_During_Implicit_Open_Closes_Sync_Waiters()
     {

--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/TypedClient/Client.TypedClient.Tests.csproj
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/TypedClient/Client.TypedClient.Tests.csproj
@@ -42,6 +42,10 @@
       <Project>{9098B41C-9C2E-4FC6-B7D8-FC3411736A22}</Project>
       <Name>ScenarioTests.Common</Name>
     </ProjectReference>
+        <ProjectReference Include="$(WcfInfrastructureCommonProj)">
+      <Project>{AFD69665-89A3-42AE-A32E-AB2CBBE6EE7E}</Project>
+      <Name>Infrastructure.Common</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/TypedClient/TypedProxyDuplexTests.4.1.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/TypedClient/TypedProxyDuplexTests.4.1.0.cs
@@ -6,6 +6,7 @@
 using System;
 using System.ServiceModel;
 using System.Threading.Tasks;
+using Infrastructure.Common;
 using Xunit;
 
 public static class TypedProxyDuplexTests
@@ -17,7 +18,10 @@ public static class TypedProxyDuplexTests
     //              IRequestChannel (for a request-reply message exchange pattern)
     //              IDuplexChannel (for a two-way duplex message exchange pattern)
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void ServiceContract_TypedProxy_AsyncTask_CallbackReturn()
     {

--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/TypedClient/TypedProxyTests.4.0.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/TypedClient/TypedProxyTests.4.0.0.cs
@@ -8,6 +8,7 @@ using TestTypes;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Infrastructure.Common;
 using Xunit;
 
 public static partial class TypedProxyTests
@@ -23,7 +24,10 @@ public static partial class TypedProxyTests
     private const string clientMessage = "[client] This is my request.";
     static TimeSpan maxTestWaitTime = TimeSpan.FromSeconds(10);
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void ServiceContract_TypedProxy_AsyncBeginEnd_Call()
     {
@@ -33,7 +37,10 @@ public static partial class TypedProxyTests
         ServiceContract_TypedProxy_AsyncBeginEnd_Call(customBinding, Endpoints.DefaultCustomHttp_Address, "ServiceContract_TypedProxy_AsyncBeginEnd_Call");
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void ServiceContract_TypedProxy_NetTcpBinding_AsyncBeginEnd_Call()
     {
@@ -41,7 +48,10 @@ public static partial class TypedProxyTests
         ServiceContract_TypedProxy_AsyncBeginEnd_Call(netTcpBinding, Endpoints.Tcp_NoSecurity_Address, "ServiceContract_TypedProxy_NetTcpBinding_AsyncBeginEnd_Call");
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void ServiceContract_TypedProxy_AsyncBeginEnd_Call_WithNoCallback()
     {
@@ -52,7 +62,10 @@ public static partial class TypedProxyTests
         ServiceContract_TypedProxy_AsyncBeginEnd_Call_WithNoCallback(customBinding, Endpoints.DefaultCustomHttp_Address, "ServiceContract_TypedProxy_AsyncBeginEnd_Call_WithNoCallback");
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void ServiceContract_TypedProxy_NetTcpBinding_AsyncBeginEnd_Call_WithNoCallback()
     {
@@ -60,7 +73,10 @@ public static partial class TypedProxyTests
         ServiceContract_TypedProxy_AsyncBeginEnd_Call_WithNoCallback(netTcpBinding, Endpoints.Tcp_NoSecurity_Address, "ServiceContract_TypedProxy_NetTcpBinding_AsyncBeginEnd_Call_WithNoCallback");
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void ServiceContract_TypedProxy_AsyncBeginEnd_Call_WithSingleThreadedSyncContext()
     {
@@ -74,7 +90,10 @@ public static partial class TypedProxyTests
         Assert.True(success, "Test Scenario: TypedProxy_AsyncBeginEnd_Call_WithSingleThreadedSyncContext timed out");
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void ServiceContract_TypedProxy_AsyncTask_Call()
     {
@@ -85,7 +104,10 @@ public static partial class TypedProxyTests
         ServiceContract_TypedProxy_AsyncTask_Call(customBinding, Endpoints.DefaultCustomHttp_Address, "ServiceContract_TypedProxy_AsyncTask_Call");
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void ServiceContract_TypedProxy_NetTcpBinding_AsyncTask_Call()
     {
@@ -94,7 +116,10 @@ public static partial class TypedProxyTests
         ServiceContract_TypedProxy_AsyncTask_Call(netTcpBinding, Endpoints.Tcp_NoSecurity_Address, "ServiceContract_TypedProxy_NetTcpBinding_AsyncTask_Call");
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void ServiceContract_TypedProxy_AsyncTask_Call_WithSingleThreadedSyncContext()
     {
@@ -109,7 +134,10 @@ public static partial class TypedProxyTests
         Assert.True(success, "Test Scenario: TypedProxy_AsyncTask_Call_WithSingleThreadedSyncContext timed out");
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void ServiceContract_TypedProxy_Synchronous_Call()
     {
@@ -141,7 +169,10 @@ public static partial class TypedProxyTests
         Assert.True(errorBuilder.Length == 0, string.Format("Test Scenario: TypedProxySynchronousCall FAILED with the following errors: {0}", errorBuilder));
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void ServiceContract_TypedProxy_Synchronous_Call_WithSingleThreadedSyncContext()
     {
@@ -155,7 +186,10 @@ public static partial class TypedProxyTests
         Assert.True(success, "Test Scenario: TypedProxy_Synchronous_Call_WithSingleThreadedSyncContext timed out");
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void ServiceContract_TypedProxy_Task_Call_WithSyncContext_ContinuesOnSameThread()
     {
@@ -206,7 +240,10 @@ public static partial class TypedProxyTests
         Assert.True(errorBuilder.Length == 0, string.Format("Test Scenario: TaskCallWithSynchContextContinuesOnSameThread FAILED with the following errors: {0}", errorBuilder));
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void ChannelShape_TypedProxy_InvokeIRequestChannel()
     {
@@ -265,7 +302,10 @@ public static partial class TypedProxyTests
         Assert.True(errorBuilder.Length == 0, string.Format("Test Scenario: InvokeRequestChannelViaProxy FAILED with the following errors: {0}", errorBuilder));
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void ChannelShape_TypedProxy_InvokeIRequestChannelTimeout()
     {
@@ -324,7 +364,10 @@ public static partial class TypedProxyTests
         Assert.True(errorBuilder.Length == 0, string.Format("Test Scenario: InvokeIRequestChannelViaProxyTimeout FAILED with the following errors: {0}", errorBuilder));
     }
 
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void ChannelShape_TypedProxy_InvokeIRequestChannelAsync()
     {

--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/TypedClient/TypedProxyTests.4.1.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/TypedClient/TypedProxyTests.4.1.0.cs
@@ -10,11 +10,15 @@ using TestTypes;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Infrastructure.Common;
 using Xunit;
 
 public static partial class TypedProxyTests
 {    
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void ServiceContract_TypedProxy_NetTcpBinding_AsyncBeginEnd_Call_WithSingleThreadedSyncContext()
     {
@@ -28,7 +32,10 @@ public static partial class TypedProxyTests
         Assert.True(success, "Test Scenario: ServiceContract_TypedProxy_NetTcpBinding_AsyncBeginEnd_Call_WithSingleThreadedSyncContext timed out");
     }
     
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void ServiceContract_TypedProxy__NetTcpBinding_AsyncTask_Call_WithSingleThreadedSyncContext()
     {
@@ -43,7 +50,10 @@ public static partial class TypedProxyTests
         Assert.True(success, "Test Scenario: ServiceContract_TypedProxy__NetTcpBinding_AsyncTask_Call_WithSingleThreadedSyncContext timed out");
     }
     
+#if FULLXUNIT_NOTSUPPORTED
     [Fact]
+#endif
+    [WcfFact]
     [OuterLoop]
     public static void ServiceContract_TypedProxy_DuplexCallback()
     {


### PR DESCRIPTION
During the recent migration from using FactAttribute to
WcfFactAttribute, a few files were missed.  This PR just
applies the same manual boiler-plate changes made to all
the others.