### PR TITLE
Assert was presuming there would always be a client cert which isn't the case

### DIFF
--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/SslStreamSecurityUpgradeProvider.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/SslStreamSecurityUpgradeProvider.cs
@@ -469,9 +469,10 @@ namespace System.ServiceModel.Channels
                         break;
                     }
                 }
+
+                Contract.Assert(clientCertificate != null, "Missing UWP Certificate as an attachment to X509Certificate2");
             }
 
-            Contract.Assert(clientCertificate != null, "Missing UWP Certificate as an attachment to X509Certificate2");
             try
             {
                 // Fetch the underlying raw transport object. For UWP, this will be a StreamSocket


### PR DESCRIPTION
Net.Tcp with Certificate security and no client certificate as a valid use case. The assert was presuming this would never happen.
Fixes #1467 