### PR TITLE
Depend on current version of System.NetSecurity

### DIFF
--- a/src/Common/test-runtime/project.json
+++ b/src/Common/test-runtime/project.json
@@ -17,7 +17,8 @@
     "Microsoft.DotNet.xunit.performance.runner.cli": "1.0.0-alpha-build0037",
     "Microsoft.DotNet.xunit.performance.runner.Windows": "1.0.0-alpha-build0037",
     "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00704-04",
-    "xunit.console.netcore": "1.0.3-prerelease-00704-04"
+    "xunit.console.netcore": "1.0.3-prerelease-00704-04",
+    "System.Net.Security": "4.0.1-beta-24322-03"
   },
   "frameworks": {
     "netstandard1.3": { },

--- a/src/System.Private.ServiceModel/src/project.json
+++ b/src/System.Private.ServiceModel/src/project.json
@@ -55,7 +55,7 @@
       ],
       "dependencies": {
         "System.Net.NameResolution": "4.0.0",
-        "System.Net.Security": "4.0.0",
+        "System.Net.Security": "4.0.1-beta-24322-03",
         "System.Net.Sockets": "4.1.0",
         "System.Security.Principal.Windows": "4.0.0"
       }

--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Negotiate/NegotiateStream_Tcp_Tests.4.1.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Negotiate/NegotiateStream_Tcp_Tests.4.1.0.cs
@@ -115,7 +115,6 @@ public class NegotiateStream_Tcp_Tests : ConditionalWcfTest
                nameof(Explicit_Credentials_Available),
                nameof(Domain_Available))]
     [Issue(1235, Framework = FrameworkID.NetNative)]
-    [Issue(1262)]
     [OuterLoop]
     // Test Requirements \\
     // The following environment variables must be set...


### PR DESCRIPTION
* We need the fix for issue https://github.com/dotnet/corefx/issues/9160
* I have verified manually we can now set Explict username/pwd for TCP.

fixes #1262