### PR TITLE
Redirect InstallRootCertificate.sh c_rehash output

### DIFF
--- a/src/System.Private.ServiceModel/tools/scripts/InstallRootCertificate.sh
+++ b/src/System.Private.ServiceModel/tools/scripts/InstallRootCertificate.sh
@@ -74,8 +74,9 @@ install_root_cert()
         return $?
     fi
 
+    # Recalculate OpenSSL hashes; redirect stdout to /dev/null but allow stderr to show on console
     echo "Recalculating OpenSSL certificate hashes using c_rehash"
-    $__c_rehash_exec
+    $__c_rehash_exec > /dev/null 
 
     return $?
 }


### PR DESCRIPTION
In InstallRootCertificate.sh, redirect the c_rehash stdout to /dev/null, and
continue to allow the stderr to print to console

This will help reduce clutter in output when in our test setup steps,
especially since in our tests we may run this script more than once and c_rehash
output is quite verbose and prints every root cert out