### PR TITLE
Reenable test disabled by #1347

### DIFF
--- a/src/System.Private.ServiceModel/tests/Scenarios/Infrastructure/SetupValidationTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Infrastructure/SetupValidationTests.cs
@@ -15,7 +15,6 @@ public class SetupValidationTests : ConditionalWcfTest
 #endif
     [WcfFact]
     [Condition(nameof(Root_Certificate_Installed))]
-    [Issue(1347, OS = OSID.AnyUnix)]
     [OuterLoop]
     public static void Root_Certificate_Correctly_Installed()
     {


### PR DESCRIPTION
Issue #1347 was closed but there was still a test being
skipped on *nix machines due to an IssueAttribute for it.

This PR removes the IssueAttribute to re-enable this test.