### PR TITLE
Disable NetTcp duplex callback test that fails in CI and Helix

### DIFF
--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Tcp/ClientCredentialTypeTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Tcp/ClientCredentialTypeTests.cs
@@ -305,6 +305,7 @@ public partial class Tcp_ClientCredentialTypeTests : ConditionalWcfTest
     [Condition(nameof(Root_Certificate_Installed),
                nameof(Client_Certificate_Installed),
                nameof(SSL_Available))]
+    [Issue(1482)]
     [OuterLoop]
     // Asking for ChainTrust only should succeed if the certificate is
     // chain-trusted.


### PR DESCRIPTION
This test was passing 10 days ago when it was first added,
but over the past 2 days it has been failing in both CI and Helix.

Disabling it with IssueAttribute to return to having clean CI runs.