### PR TITLE
Activate test case, reason for being skipped no longer reproes.

### DIFF
--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/ExpectedExceptions/ExpectedExceptionTests.4.0.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/ExpectedExceptions/ExpectedExceptionTests.4.0.0.cs
@@ -60,7 +60,6 @@ public partial class ExpectedExceptionTests : ConditionalWcfTest
     [ActiveIssue(1250)]
 #endif
     [WcfFact]
-    [Issue(1250, Framework = FrameworkID.NetNative)]
     [OuterLoop]
     public static void SendTimeout_For_Long_Running_Operation_Throws_TimeoutException()
     {


### PR DESCRIPTION
* This test was observed to hang back when it was still being run under the ToF infrastructure.
* Failure has not reproduced in current N run environment.
* Fixes Issue #1250