### PR TITLE
Removing IssueAttribute as test is working fine

### DIFF
--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Tcp/ClientCredentialTypeTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Tcp/ClientCredentialTypeTests.cs
@@ -305,7 +305,6 @@ public partial class Tcp_ClientCredentialTypeTests : ConditionalWcfTest
     [Condition(nameof(Root_Certificate_Installed),
                nameof(Client_Certificate_Installed),
                nameof(SSL_Available))]
-    [Issue(1482)]
     [OuterLoop]
     // Asking for ChainTrust only should succeed if the certificate is
     // chain-trusted.


### PR DESCRIPTION
Fixes #1482 
This test doesn't fail and the product fix was done a couple of weeks prior. This must be a test runtime issue pulling in an older build of WCF.