### PR TITLE
Enable SecurityBindingElement.CreateUserNameOverTransportBindingElement

### DIFF
--- a/src/System.Private.ServiceModel/src/Internals/System/Runtime/Serialization/XmlMappingTypes.cs
+++ b/src/System.Private.ServiceModel/src/Internals/System/Runtime/Serialization/XmlMappingTypes.cs
@@ -103,7 +103,7 @@ namespace System.Xml.Serialization
 
         public XmlMapping(object thisObject)
         {
-            this._wrapperObject = XmlMappingTypeWrapperFactory.GetWrapper(thisObject);
+            _wrapperObject = XmlMappingTypeWrapperFactory.GetWrapper(thisObject);
         }
 
         public IXmlMappingTypeWrapperObject Object

--- a/src/System.Private.ServiceModel/src/Resources/Strings.resx
+++ b/src/System.Private.ServiceModel/src/Resources/Strings.resx
@@ -6781,6 +6781,6 @@
     <value>There was an error serializing the security key identifier clause. Please see the inner exception for more details.</value>
   </data>
   <data name="CannotReadKeyIdentifierClause" xml:space="preserve">
-    <value>Cannot read KeyIdentifierClause from element '{0}' with namespace '{1}'.  Custom KeyIdentifierClauses require custom SecurityTokenSerializers, please refer to the SDK for examples.</value>
+    <value>Cannot read KeyIdentifierClause from element '{0}' with namespace '{1}'.  Custom KeyIdentifierClauses require custom SecurityTokenSerializers.</value>
   </data>
 </root>

--- a/src/System.Private.ServiceModel/src/Resources/Strings.resx
+++ b/src/System.Private.ServiceModel/src/Resources/Strings.resx
@@ -6771,4 +6771,16 @@
   <data name="Xml_InvalidNodeType" xml:space="preserve">
     <value>'{0}' is an invalid XmlNodeType.</value>
   </data>
+  <data name="ErrorDeserializingKeyIdentifierClause" xml:space="preserve">
+    <value>'There was an error deserializing the security key identifier clause XML. Please see the inner exception for more details.</value>
+  </data>
+  <data name="ErrorSerializingKeyIdentifier" xml:space="preserve">
+    <value>There was an error serializing the security key identifier. Please see the inner exception for more details.</value>
+  </data>
+  <data name="ErrorSerializingKeyIdentifierClause" xml:space="preserve">
+    <value>There was an error serializing the security key identifier clause. Please see the inner exception for more details.</value>
+  </data>
+  <data name="CannotReadKeyIdentifierClause" xml:space="preserve">
+    <value>Cannot read KeyIdentifierClause from element '{0}' with namespace '{1}'.  Custom KeyIdentifierClauses require custom SecurityTokenSerializers, please refer to the SDK for examples.</value>
+  </data>
 </root>

--- a/src/System.Private.ServiceModel/src/System/IdentityModel/IPrefixGenerator.cs
+++ b/src/System.Private.ServiceModel/src/System/IdentityModel/IPrefixGenerator.cs
@@ -1,0 +1,12 @@
+//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace System.IdentityModel
+{
+    interface IPrefixGenerator
+    {
+        string GetPrefix(string namespaceUri, int depth, bool isForAttribute);
+    }
+}
+

--- a/src/System.Private.ServiceModel/src/System/IdentityModel/IPrefixGenerator.cs
+++ b/src/System.Private.ServiceModel/src/System/IdentityModel/IPrefixGenerator.cs
@@ -1,6 +1,6 @@
-//------------------------------------------------------------
-// Copyright (c) Microsoft Corporation.  All rights reserved.
-//------------------------------------------------------------
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace System.IdentityModel
 {
@@ -9,4 +9,3 @@ namespace System.IdentityModel
         string GetPrefix(string namespaceUri, int depth, bool isForAttribute);
     }
 }
-

--- a/src/System.Private.ServiceModel/src/System/IdentityModel/Selectors/KerberosSecurityTokenProvider.cs
+++ b/src/System.Private.ServiceModel/src/System/IdentityModel/Selectors/KerberosSecurityTokenProvider.cs
@@ -70,5 +70,10 @@ namespace System.IdentityModel.Selectors
         {
             return Task.FromResult(GetToken(cancellationToken, null));
         }
+
+        protected override SecurityToken GetTokenCore(TimeSpan timeout)
+        {
+            return GetToken(CancellationToken.None, null);
+        }
     }
 }

--- a/src/System.Private.ServiceModel/src/System/IdentityModel/Selectors/SecurityTokenProvider.cs
+++ b/src/System.Private.ServiceModel/src/System/IdentityModel/Selectors/SecurityTokenProvider.cs
@@ -5,6 +5,7 @@
 
 using System.IdentityModel.Tokens;
 using System.Runtime;
+using System.ServiceModel;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -22,6 +23,16 @@ namespace System.IdentityModel.Selectors
         public virtual bool SupportsTokenCancellation
         {
             get { return false; }
+        }
+
+        public SecurityToken GetToken(TimeSpan timeout)
+        {
+            SecurityToken token = this.GetTokenCore(timeout);
+            if (token == null)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new SecurityTokenException(SR.Format(SR.TokenProviderUnableToGetToken, this)));
+            }
+            return token;
         }
 
         public async Task<SecurityToken> GetTokenAsync(CancellationToken cancellationToken)
@@ -58,6 +69,8 @@ namespace System.IdentityModel.Selectors
         }
 
         // protected methods
+        protected abstract SecurityToken GetTokenCore(TimeSpan timeout);
+
         protected abstract Task<SecurityToken> GetTokenCoreAsync(CancellationToken cancellationToken);
 
         protected virtual Task<SecurityToken> RenewTokenCoreAsync(CancellationToken cancellationToken, SecurityToken tokenToBeRenewed)

--- a/src/System.Private.ServiceModel/src/System/IdentityModel/Selectors/SecurityTokenSerializer.cs
+++ b/src/System.Private.ServiceModel/src/System/IdentityModel/Selectors/SecurityTokenSerializer.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.IdentityModel.Tokens;
 using System.ServiceModel;
 using System.Xml;
+using TokenEntry = System.ServiceModel.Security.WSSecurityTokenSerializer.TokenEntry;
 
 namespace System.IdentityModel.Selectors
 {
@@ -206,42 +207,6 @@ namespace System.IdentityModel.Selectors
             public abstract bool SupportsCore(SecurityKeyIdentifier keyIdentifier);
 
             public abstract void WriteKeyIdentifierCore(XmlDictionaryWriter writer, SecurityKeyIdentifier keyIdentifier);
-        }
-
-        internal abstract class TokenEntry
-        {
-            private Type[] _tokenTypes = null;
-
-            protected abstract XmlDictionaryString LocalName { get; }
-            protected abstract XmlDictionaryString NamespaceUri { get; }
-            public Type TokenType { get { return GetTokenTypes()[0]; } }
-            public abstract string TokenTypeUri { get; }
-            protected abstract string ValueTypeUri { get; }
-
-            public bool SupportsCore(Type tokenType)
-            {
-                Type[] tokenTypes = GetTokenTypes();
-                for (int i = 0; i < tokenTypes.Length; ++i)
-                {
-                    if (tokenTypes[i].IsAssignableFrom(tokenType))
-                        return true;
-                }
-                return false;
-            }
-
-            protected abstract Type[] GetTokenTypesCore();
-
-            public Type[] GetTokenTypes()
-            {
-                if (_tokenTypes == null)
-                    _tokenTypes = GetTokenTypesCore();
-                return _tokenTypes;
-            }
-
-            public virtual bool SupportsTokenTypeUri(string tokenTypeUri)
-            {
-                return (this.TokenTypeUri == tokenTypeUri);
-            }
         }
     }
 }

--- a/src/System.Private.ServiceModel/src/System/IdentityModel/Selectors/UserNameSecurityTokenProvider.cs
+++ b/src/System.Private.ServiceModel/src/System/IdentityModel/Selectors/UserNameSecurityTokenProvider.cs
@@ -28,5 +28,10 @@ namespace System.IdentityModel.Selectors
         {
             return Task.FromResult((SecurityToken)_userNameToken);
         }
+
+        protected override SecurityToken GetTokenCore(TimeSpan timeout)
+        {
+            return _userNameToken;
+        }
     }
 }

--- a/src/System.Private.ServiceModel/src/System/IdentityModel/Selectors/X509SecurityTokenProvider.cs
+++ b/src/System.Private.ServiceModel/src/System/IdentityModel/Selectors/X509SecurityTokenProvider.cs
@@ -41,6 +41,11 @@ namespace System.IdentityModel.Selectors
             return Task.FromResult<SecurityToken>(new X509SecurityToken(certificate: _certificate, clone: _clone, disposable: _clone));
         }
 
+        protected override SecurityToken GetTokenCore(TimeSpan timeout)
+        {
+            return new X509SecurityToken(certificate: _certificate, clone: _clone, disposable: _clone);
+        }
+
         public void Dispose()
         {
             if (_clone)

--- a/src/System.Private.ServiceModel/src/System/IdentityModel/Tokens/GenericXmlSecurityKeyIdentifierClause.cs
+++ b/src/System.Private.ServiceModel/src/System/IdentityModel/Tokens/GenericXmlSecurityKeyIdentifierClause.cs
@@ -1,4 +1,5 @@
 using System.IdentityModel.Tokens;
+using System.ServiceModel;
 using System.Xml;
 
 namespace System.IdentityModel.Tokens

--- a/src/System.Private.ServiceModel/src/System/IdentityModel/Tokens/GenericXmlSecurityKeyIdentifierClause.cs
+++ b/src/System.Private.ServiceModel/src/System/IdentityModel/Tokens/GenericXmlSecurityKeyIdentifierClause.cs
@@ -35,9 +35,6 @@ namespace System.IdentityModel.Tokens
         public override bool Matches(SecurityKeyIdentifierClause keyIdentifierClause)
         {
             GenericXmlSecurityKeyIdentifierClause that = keyIdentifierClause as GenericXmlSecurityKeyIdentifierClause;
-
-            // PreSharp Bug: Parameter 'that' to this public method must be validated: A null-dereference can occur here.
-#pragma warning suppress 56506
             return ReferenceEquals(this, that) || (that != null && that.Matches(this.ReferenceXml));
         }
 

--- a/src/System.Private.ServiceModel/src/System/IdentityModel/Tokens/GenericXmlSecurityKeyIdentifierClause.cs
+++ b/src/System.Private.ServiceModel/src/System/IdentityModel/Tokens/GenericXmlSecurityKeyIdentifierClause.cs
@@ -1,0 +1,78 @@
+using System.IdentityModel.Tokens;
+using System.Xml;
+
+namespace System.IdentityModel.Tokens
+{
+    public class GenericXmlSecurityKeyIdentifierClause : SecurityKeyIdentifierClause
+    {
+        XmlElement referenceXml;
+
+        public GenericXmlSecurityKeyIdentifierClause(XmlElement referenceXml)
+            : this(referenceXml, null, 0)
+        {
+        }
+
+        public GenericXmlSecurityKeyIdentifierClause(XmlElement referenceXml, byte[] derivationNonce, int derivationLength)
+            : base(null, derivationNonce, derivationLength)
+        {
+            if (referenceXml == null)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("referenceXml");
+            }
+            this.referenceXml = referenceXml;
+        }
+
+        public XmlElement ReferenceXml
+        {
+            get { return this.referenceXml; }
+        }
+
+        public override bool Matches(SecurityKeyIdentifierClause keyIdentifierClause)
+        {
+            GenericXmlSecurityKeyIdentifierClause that = keyIdentifierClause as GenericXmlSecurityKeyIdentifierClause;
+
+            // PreSharp Bug: Parameter 'that' to this public method must be validated: A null-dereference can occur here.
+#pragma warning suppress 56506
+            return ReferenceEquals(this, that) || (that != null && that.Matches(this.ReferenceXml));
+        }
+
+        private bool Matches(XmlElement xmlElement)
+        {
+            if (xmlElement == null)
+                return false;
+
+            return CompareNodes(this.referenceXml, xmlElement);
+        }
+
+        private bool CompareNodes(XmlNode originalNode, XmlNode newNode)
+        {
+            if (originalNode.OuterXml == newNode.OuterXml)
+                return true;
+
+            if (originalNode.LocalName != newNode.LocalName || originalNode.InnerText != newNode.InnerText)
+                return false;
+
+            if (originalNode.InnerXml == newNode.InnerXml)
+                return true;
+
+            if (originalNode.HasChildNodes)
+            {
+                if (!newNode.HasChildNodes || originalNode.ChildNodes.Count != newNode.ChildNodes.Count)
+                    return false;
+
+                bool childrenStatus = true;
+                for (int i = 0; i < originalNode.ChildNodes.Count; i++)
+                {
+                    childrenStatus = childrenStatus & CompareNodes(originalNode.ChildNodes[i], newNode.ChildNodes[i]);
+                }
+
+                return childrenStatus;
+            }
+            else if (newNode.HasChildNodes)
+                return false;
+
+            return true;
+        }
+    }
+}
+

--- a/src/System.Private.ServiceModel/src/System/IdentityModel/Tokens/GenericXmlSecurityKeyIdentifierClause.cs
+++ b/src/System.Private.ServiceModel/src/System/IdentityModel/Tokens/GenericXmlSecurityKeyIdentifierClause.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System.IdentityModel.Tokens;
 using System.ServiceModel;
 using System.Xml;

--- a/src/System.Private.ServiceModel/src/System/IdentityModel/Tokens/GenericXmlSecurityKeyIdentifierClause.cs
+++ b/src/System.Private.ServiceModel/src/System/IdentityModel/Tokens/GenericXmlSecurityKeyIdentifierClause.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.IdentityModel.Tokens;
 using System.ServiceModel;
 using System.Xml;
 

--- a/src/System.Private.ServiceModel/src/System/IdentityModel/Tokens/GenericXmlSecurityToken.cs
+++ b/src/System.Private.ServiceModel/src/System/IdentityModel/Tokens/GenericXmlSecurityToken.cs
@@ -1,32 +1,32 @@
-//------------------------------------------------------------
-// Copyright (c) Microsoft Corporation.  All rights reserved.
-//------------------------------------------------------------
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.ObjectModel;
+using System.Globalization;
+using System.IO;
+using System.IdentityModel.Claims;
+using System.IdentityModel.Policy;
+using System.Security.Cryptography;
+using System.Security.Principal;
+using System.Xml;
+using System.Runtime.Serialization;
+using System.Collections.Generic;
 
 namespace System.IdentityModel.Tokens
 {
-    using System;    
-    using System.Collections.ObjectModel;
-    using System.Globalization;
-    using System.IO;
-    using System.IdentityModel.Claims;
-    using System.IdentityModel.Policy;
-    using System.Security.Cryptography;
-    using System.Security.Principal;
-    using System.Xml;
-    using System.Runtime.Serialization;    
-    using System.Collections.Generic;
-
     public class GenericXmlSecurityToken : SecurityToken
     {
         const int SupportedPersistanceVersion = 1;
-        string id;
-        SecurityToken proofToken;
-        SecurityKeyIdentifierClause internalTokenReference;
-        SecurityKeyIdentifierClause externalTokenReference;
-        XmlElement tokenXml;
-        ReadOnlyCollection<IAuthorizationPolicy> authorizationPolicies;
-        DateTime effectiveTime;
-        DateTime expirationTime;
+        private string _id;
+        private SecurityToken _proofToken;
+        private SecurityKeyIdentifierClause _internalTokenReference;
+        private SecurityKeyIdentifierClause _externalTokenReference;
+        private XmlElement _tokenXml;
+        private ReadOnlyCollection<IAuthorizationPolicy> _authorizationPolicies;
+        private DateTime _effectiveTime;
+        private DateTime _expirationTime;
 
         public GenericXmlSecurityToken(
             XmlElement tokenXml,
@@ -40,66 +40,66 @@ namespace System.IdentityModel.Tokens
         {
             if (tokenXml == null)
             {
-                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("tokenXml");
+                throw ServiceModel.DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("tokenXml");
             }
 
-            this.id = GetId(tokenXml);
-            this.tokenXml = tokenXml;
-            this.proofToken = proofToken;
-            this.effectiveTime = effectiveTime.ToUniversalTime();
-            this.expirationTime = expirationTime.ToUniversalTime();
+            _id = GetId(tokenXml);
+            _tokenXml = tokenXml;
+            _proofToken = proofToken;
+            _effectiveTime = effectiveTime.ToUniversalTime();
+            _expirationTime = expirationTime.ToUniversalTime();
 
-            this.internalTokenReference = internalTokenReference;
-            this.externalTokenReference = externalTokenReference;
-            this.authorizationPolicies = authorizationPolicies ?? EmptyReadOnlyCollection<IAuthorizationPolicy>.Instance;
+            _internalTokenReference = internalTokenReference;
+            _externalTokenReference = externalTokenReference;
+            _authorizationPolicies = authorizationPolicies ?? EmptyReadOnlyCollection<IAuthorizationPolicy>.Instance;
         }
 
         public override string Id
         {
-            get { return this.id; }
+            get { return _id; }
         }
 
         public override DateTime ValidFrom
         {
-            get { return this.effectiveTime; }
+            get { return _effectiveTime; }
         }
 
         public override DateTime ValidTo
         {
-            get { return this.expirationTime; }
+            get { return _expirationTime; }
         }
 
         public SecurityKeyIdentifierClause InternalTokenReference
         {
-            get { return this.internalTokenReference; }
+            get { return _internalTokenReference; }
         }
 
         public SecurityKeyIdentifierClause ExternalTokenReference
         {
-            get { return this.externalTokenReference; }
+            get { return _externalTokenReference; }
         }
 
         public XmlElement TokenXml
         {
-            get { return this.tokenXml;  }
+            get { return _tokenXml;  }
         }
 
         public SecurityToken ProofToken
         {
-            get { return this.proofToken; }
+            get { return _proofToken; }
         }
 
         public ReadOnlyCollection<IAuthorizationPolicy> AuthorizationPolicies
         {
-            get { return this.authorizationPolicies; }
+            get { return _authorizationPolicies; }
         }
 
         public override ReadOnlyCollection<SecurityKey> SecurityKeys
         {
             get 
             {
-                if (this.proofToken != null)
-                    return this.proofToken.SecurityKeys;
+                if (_proofToken != null)
+                    return _proofToken.SecurityKeys;
                 else
                     return EmptyReadOnlyCollection<SecurityKey>.Instance;
             }
@@ -111,11 +111,11 @@ namespace System.IdentityModel.Tokens
             writer.WriteLine("Generic XML token:");
             writer.WriteLine("   validFrom: {0}", this.ValidFrom);
             writer.WriteLine("   validTo: {0}", this.ValidTo);
-            if (this.internalTokenReference != null)
-                writer.WriteLine("   InternalTokenReference: {0}", this.internalTokenReference);
-            if (this.externalTokenReference != null)
-                writer.WriteLine("   ExternalTokenReference: {0}", this.externalTokenReference);
-            writer.WriteLine("   Token Element: ({0}, {1})", this.tokenXml.LocalName, this.tokenXml.NamespaceURI);
+            if (_internalTokenReference != null)
+                writer.WriteLine("   InternalTokenReference: {0}", _internalTokenReference);
+            if (_externalTokenReference != null)
+                writer.WriteLine("   ExternalTokenReference: {0}", _externalTokenReference);
+            writer.WriteLine("   Token Element: ({0}, {1})", _tokenXml.LocalName, _tokenXml.NamespaceURI);
             return writer.ToString();
         }
 
@@ -154,10 +154,10 @@ namespace System.IdentityModel.Tokens
 
         public override bool CanCreateKeyIdentifierClause<T>()
         {
-            if (this.internalTokenReference != null && typeof(T) == this.internalTokenReference.GetType())
+            if (_internalTokenReference != null && typeof(T) == _internalTokenReference.GetType())
                 return true;
 
-            if (this.externalTokenReference != null && typeof(T) == this.externalTokenReference.GetType())
+            if (_externalTokenReference != null && typeof(T) == _externalTokenReference.GetType())
                 return true;
 
             return false;
@@ -165,22 +165,22 @@ namespace System.IdentityModel.Tokens
 
         public override T CreateKeyIdentifierClause<T>()
         {
-            if (this.internalTokenReference != null && typeof(T) == this.internalTokenReference.GetType())
-                return (T)this.internalTokenReference;
+            if (_internalTokenReference != null && typeof(T) == _internalTokenReference.GetType())
+                return (T)_internalTokenReference;
 
-            if (this.externalTokenReference != null && typeof(T) == this.externalTokenReference.GetType())
-                return (T)this.externalTokenReference;
+            if (_externalTokenReference != null && typeof(T) == _externalTokenReference.GetType())
+                return (T)_externalTokenReference;
 
-            throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new SecurityTokenException(SR.GetString(SR.UnableToCreateTokenReference)));
+            throw ServiceModel.DiagnosticUtility.ExceptionUtility.ThrowHelperError(new SecurityTokenException(SR.Format(SR.UnableToCreateTokenReference)));
         }
 
         public override bool MatchesKeyIdentifierClause(SecurityKeyIdentifierClause keyIdentifierClause)
         {
-            if (this.internalTokenReference != null && this.internalTokenReference.Matches(keyIdentifierClause))
+            if (_internalTokenReference != null && _internalTokenReference.Matches(keyIdentifierClause))
             {
                 return true;
             }
-            else if (this.externalTokenReference != null && this.externalTokenReference.Matches(keyIdentifierClause))
+            else if (_externalTokenReference != null && _externalTokenReference.Matches(keyIdentifierClause))
             {
                 return true;
             }

--- a/src/System.Private.ServiceModel/src/System/IdentityModel/Tokens/GenericXmlSecurityToken.cs
+++ b/src/System.Private.ServiceModel/src/System/IdentityModel/Tokens/GenericXmlSecurityToken.cs
@@ -13,6 +13,7 @@ using System.Security.Principal;
 using System.Xml;
 using System.Runtime.Serialization;
 using System.Collections.Generic;
+using DiagnosticUtility = System.ServiceModel.DiagnosticUtility;
 
 namespace System.IdentityModel.Tokens
 {
@@ -40,7 +41,7 @@ namespace System.IdentityModel.Tokens
         {
             if (tokenXml == null)
             {
-                throw ServiceModel.DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("tokenXml");
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("tokenXml");
             }
 
             _id = GetId(tokenXml);
@@ -171,7 +172,7 @@ namespace System.IdentityModel.Tokens
             if (_externalTokenReference != null && typeof(T) == _externalTokenReference.GetType())
                 return (T)_externalTokenReference;
 
-            throw ServiceModel.DiagnosticUtility.ExceptionUtility.ThrowHelperError(new SecurityTokenException(SR.Format(SR.UnableToCreateTokenReference)));
+            throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new SecurityTokenException(SR.Format(SR.UnableToCreateTokenReference)));
         }
 
         public override bool MatchesKeyIdentifierClause(SecurityKeyIdentifierClause keyIdentifierClause)

--- a/src/System.Private.ServiceModel/src/System/IdentityModel/Tokens/GenericXmlSecurityToken.cs
+++ b/src/System.Private.ServiceModel/src/System/IdentityModel/Tokens/GenericXmlSecurityToken.cs
@@ -1,0 +1,192 @@
+//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace System.IdentityModel.Tokens
+{
+    using System;    
+    using System.Collections.ObjectModel;
+    using System.Globalization;
+    using System.IO;
+    using System.IdentityModel.Claims;
+    using System.IdentityModel.Policy;
+    using System.Security.Cryptography;
+    using System.Security.Principal;
+    using System.Xml;
+    using System.Runtime.Serialization;    
+    using System.Collections.Generic;
+
+    public class GenericXmlSecurityToken : SecurityToken
+    {
+        const int SupportedPersistanceVersion = 1;
+        string id;
+        SecurityToken proofToken;
+        SecurityKeyIdentifierClause internalTokenReference;
+        SecurityKeyIdentifierClause externalTokenReference;
+        XmlElement tokenXml;
+        ReadOnlyCollection<IAuthorizationPolicy> authorizationPolicies;
+        DateTime effectiveTime;
+        DateTime expirationTime;
+
+        public GenericXmlSecurityToken(
+            XmlElement tokenXml,
+            SecurityToken proofToken,
+            DateTime effectiveTime,
+            DateTime expirationTime,
+            SecurityKeyIdentifierClause internalTokenReference,
+            SecurityKeyIdentifierClause externalTokenReference,
+            ReadOnlyCollection<IAuthorizationPolicy> authorizationPolicies
+            )
+        {
+            if (tokenXml == null)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("tokenXml");
+            }
+
+            this.id = GetId(tokenXml);
+            this.tokenXml = tokenXml;
+            this.proofToken = proofToken;
+            this.effectiveTime = effectiveTime.ToUniversalTime();
+            this.expirationTime = expirationTime.ToUniversalTime();
+
+            this.internalTokenReference = internalTokenReference;
+            this.externalTokenReference = externalTokenReference;
+            this.authorizationPolicies = authorizationPolicies ?? EmptyReadOnlyCollection<IAuthorizationPolicy>.Instance;
+        }
+
+        public override string Id
+        {
+            get { return this.id; }
+        }
+
+        public override DateTime ValidFrom
+        {
+            get { return this.effectiveTime; }
+        }
+
+        public override DateTime ValidTo
+        {
+            get { return this.expirationTime; }
+        }
+
+        public SecurityKeyIdentifierClause InternalTokenReference
+        {
+            get { return this.internalTokenReference; }
+        }
+
+        public SecurityKeyIdentifierClause ExternalTokenReference
+        {
+            get { return this.externalTokenReference; }
+        }
+
+        public XmlElement TokenXml
+        {
+            get { return this.tokenXml;  }
+        }
+
+        public SecurityToken ProofToken
+        {
+            get { return this.proofToken; }
+        }
+
+        public ReadOnlyCollection<IAuthorizationPolicy> AuthorizationPolicies
+        {
+            get { return this.authorizationPolicies; }
+        }
+
+        public override ReadOnlyCollection<SecurityKey> SecurityKeys
+        {
+            get 
+            {
+                if (this.proofToken != null)
+                    return this.proofToken.SecurityKeys;
+                else
+                    return EmptyReadOnlyCollection<SecurityKey>.Instance;
+            }
+        }
+ 
+        public override string ToString()
+        {
+            StringWriter writer = new StringWriter(CultureInfo.InvariantCulture);
+            writer.WriteLine("Generic XML token:");
+            writer.WriteLine("   validFrom: {0}", this.ValidFrom);
+            writer.WriteLine("   validTo: {0}", this.ValidTo);
+            if (this.internalTokenReference != null)
+                writer.WriteLine("   InternalTokenReference: {0}", this.internalTokenReference);
+            if (this.externalTokenReference != null)
+                writer.WriteLine("   ExternalTokenReference: {0}", this.externalTokenReference);
+            writer.WriteLine("   Token Element: ({0}, {1})", this.tokenXml.LocalName, this.tokenXml.NamespaceURI);
+            return writer.ToString();
+        }
+
+        static string GetId(XmlElement tokenXml)
+        {
+            if (tokenXml != null)
+            {
+                string id = tokenXml.GetAttribute(UtilityStrings.IdAttribute, UtilityStrings.Namespace);
+                if ( string.IsNullOrEmpty( id ) )
+                {
+                    // special case SAML 1.1 as this is the only possible ID as
+                    // spec is closed.  SAML 2.0 is xs:ID
+                    id = tokenXml.GetAttribute("AssertionID");
+
+                    // if we are still null, "Id"
+                    if ( string.IsNullOrEmpty( id ) )
+                    {
+                        id = tokenXml.GetAttribute("Id");
+                    }
+
+                    //This fixes the unecnrypted SAML 2.0 case. Eg: <Assertion ID="_05955298-214f-41e7-b4c3-84dbff7f01b9" 
+                    if (string.IsNullOrEmpty(id))
+                    {
+                        id = tokenXml.GetAttribute("ID");
+                    }
+                }
+
+                if ( !string.IsNullOrEmpty(id) )
+                {
+                    return id;
+                }
+            }
+
+            return null;
+        }
+
+        public override bool CanCreateKeyIdentifierClause<T>()
+        {
+            if (this.internalTokenReference != null && typeof(T) == this.internalTokenReference.GetType())
+                return true;
+
+            if (this.externalTokenReference != null && typeof(T) == this.externalTokenReference.GetType())
+                return true;
+
+            return false;
+        }
+
+        public override T CreateKeyIdentifierClause<T>()
+        {
+            if (this.internalTokenReference != null && typeof(T) == this.internalTokenReference.GetType())
+                return (T)this.internalTokenReference;
+
+            if (this.externalTokenReference != null && typeof(T) == this.externalTokenReference.GetType())
+                return (T)this.externalTokenReference;
+
+            throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new SecurityTokenException(SR.GetString(SR.UnableToCreateTokenReference)));
+        }
+
+        public override bool MatchesKeyIdentifierClause(SecurityKeyIdentifierClause keyIdentifierClause)
+        {
+            if (this.internalTokenReference != null && this.internalTokenReference.Matches(keyIdentifierClause))
+            {
+                return true;
+            }
+            else if (this.externalTokenReference != null && this.externalTokenReference.Matches(keyIdentifierClause))
+            {
+                return true;
+            }
+            
+            return false;
+        }
+    }
+}
+

--- a/src/System.Private.ServiceModel/src/System/IdentityModel/Tokens/GenericXmlSecurityToken.cs
+++ b/src/System.Private.ServiceModel/src/System/IdentityModel/Tokens/GenericXmlSecurityToken.cs
@@ -5,14 +5,9 @@
 using System;
 using System.Collections.ObjectModel;
 using System.Globalization;
-using System.IO;
-using System.IdentityModel.Claims;
 using System.IdentityModel.Policy;
-using System.Security.Cryptography;
-using System.Security.Principal;
+using System.IO;
 using System.Xml;
-using System.Runtime.Serialization;
-using System.Collections.Generic;
 using DiagnosticUtility = System.ServiceModel.DiagnosticUtility;
 
 namespace System.IdentityModel.Tokens

--- a/src/System.Private.ServiceModel/src/System/IdentityModel/Tokens/KerberosTicketHashKeyIdentifierClause.cs
+++ b/src/System.Private.ServiceModel/src/System/IdentityModel/Tokens/KerberosTicketHashKeyIdentifierClause.cs
@@ -1,11 +1,11 @@
-//------------------------------------------------------------
-// Copyright (c) Microsoft Corporation.  All rights reserved.
-//------------------------------------------------------------
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Globalization;
 
 namespace System.IdentityModel.Tokens
 {
-    using System.Globalization;
-
     public sealed class KerberosTicketHashKeyIdentifierClause : BinaryKeyIdentifierClause
     {
         public KerberosTicketHashKeyIdentifierClause(byte[] ticketHash)

--- a/src/System.Private.ServiceModel/src/System/IdentityModel/Tokens/KerberosTicketHashKeyIdentifierClause.cs
+++ b/src/System.Private.ServiceModel/src/System/IdentityModel/Tokens/KerberosTicketHashKeyIdentifierClause.cs
@@ -1,0 +1,37 @@
+//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace System.IdentityModel.Tokens
+{
+    using System.Globalization;
+
+    public sealed class KerberosTicketHashKeyIdentifierClause : BinaryKeyIdentifierClause
+    {
+        public KerberosTicketHashKeyIdentifierClause(byte[] ticketHash)
+            : this(ticketHash, null, 0)
+        {
+        }
+
+        public KerberosTicketHashKeyIdentifierClause(byte[] ticketHash, byte[] derivationNonce, int derivationLength)
+            : this(ticketHash, true, derivationNonce, derivationLength)
+        {
+        }
+        
+        internal KerberosTicketHashKeyIdentifierClause(byte[] ticketHash, bool cloneBuffer, byte[] derivationNonce, int derivationLength)
+            : base(null, ticketHash, cloneBuffer, derivationNonce, derivationLength)
+        {           
+        }
+
+        public byte[] GetKerberosTicketHash()
+        {
+            return GetBuffer();
+        }
+
+        public override string ToString()
+        {
+            return string.Format(CultureInfo.InvariantCulture, "KerberosTicketHashKeyIdentifierClause(Hash = {0})", ToBase64String());
+        }        
+    }
+}
+

--- a/src/System.Private.ServiceModel/src/System/IdentityModel/Tokens/KeyInfoSerializer.cs
+++ b/src/System.Private.ServiceModel/src/System/IdentityModel/Tokens/KeyInfoSerializer.cs
@@ -1,0 +1,373 @@
+//------------------------------------------------------------------------------
+//     Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------------------------
+
+namespace System.IdentityModel.Tokens
+{
+    using System.Collections.Generic;
+    using System.IdentityModel;
+    using System.IdentityModel.Security;
+    using System.IdentityModel.Selectors;
+    using System.Runtime;
+    using System.Xml;
+using System.Collections;
+
+    /// <summary>
+    /// Abstract class for SecurityKeyIdentifierClause Serializer.
+    /// </summary>
+    internal class KeyInfoSerializer : SecurityTokenSerializer
+    {
+        readonly List<SecurityTokenSerializer.KeyIdentifierEntry> keyIdentifierEntries;
+        readonly List<SecurityTokenSerializer.KeyIdentifierClauseEntry> keyIdentifierClauseEntries;
+        readonly List<SecurityTokenSerializer.SerializerEntries> serializerEntries;
+        readonly List<TokenEntry> tokenEntries;
+
+
+        DictionaryManager dictionaryManager;
+        bool emitBspRequiredAttributes;
+        SecurityTokenSerializer innerSecurityTokenSerializer;
+
+        /// <summary>
+        /// Creates an instance of <see cref="SecurityKeyIdentifierClauseSerializer"/>
+        /// </summary>
+        public KeyInfoSerializer(bool emitBspRequiredAttributes)
+            : this(emitBspRequiredAttributes, new DictionaryManager(), XD.TrustDec2005Dictionary, null)
+        {
+        }
+
+        public KeyInfoSerializer(
+            bool emitBspRequiredAttributes,
+            DictionaryManager dictionaryManager,
+            TrustDictionary trustDictionary,
+            SecurityTokenSerializer innerSecurityTokenSerializer ) :
+            this( emitBspRequiredAttributes, dictionaryManager, trustDictionary, innerSecurityTokenSerializer, null )
+        {
+        }
+
+        public KeyInfoSerializer(
+            bool emitBspRequiredAttributes,
+            DictionaryManager dictionaryManager,
+            TrustDictionary trustDictionary,
+            SecurityTokenSerializer innerSecurityTokenSerializer,
+            Func<KeyInfoSerializer, IEnumerable<SerializerEntries>> additionalEntries)
+        {
+            this.dictionaryManager = dictionaryManager;
+            this.emitBspRequiredAttributes = emitBspRequiredAttributes;
+            this.innerSecurityTokenSerializer = innerSecurityTokenSerializer;
+
+            this.serializerEntries = new List<SecurityTokenSerializer.SerializerEntries>();
+
+            this.serializerEntries.Add(new XmlDsigSep2000(this));
+            this.serializerEntries.Add(new XmlEncApr2001(this));
+            this.serializerEntries.Add(new System.IdentityModel.Security.WSTrust(this, trustDictionary));
+            if ( additionalEntries != null )
+            {
+                foreach ( SerializerEntries entries in additionalEntries( this ) )
+                {
+                    this.serializerEntries.Add(entries);
+                }
+            }
+
+            bool wsSecuritySerializerFound = false;
+            foreach ( SerializerEntries entry in this.serializerEntries )
+            {
+                if ( ( entry is WSSecurityXXX2005 ) || ( entry is WSSecurityJan2004 ) )
+                {
+                    wsSecuritySerializerFound = true;
+                    break;
+                }
+            }
+
+            if ( !wsSecuritySerializerFound )
+            {
+                this.serializerEntries.Add( new WSSecurityXXX2005( this ) );
+            }
+
+            this.tokenEntries = new List<TokenEntry>();
+            this.keyIdentifierEntries = new List<SecurityTokenSerializer.KeyIdentifierEntry>();
+            this.keyIdentifierClauseEntries = new List<SecurityTokenSerializer.KeyIdentifierClauseEntry>();
+
+            for (int i = 0; i < this.serializerEntries.Count; ++i)
+            {
+                SecurityTokenSerializer.SerializerEntries serializerEntry = this.serializerEntries[i];
+                serializerEntry.PopulateTokenEntries(this.tokenEntries);
+                serializerEntry.PopulateKeyIdentifierEntries(this.keyIdentifierEntries);
+                serializerEntry.PopulateKeyIdentifierClauseEntries(this.keyIdentifierClauseEntries);
+            }
+        }
+
+        public DictionaryManager DictionaryManager
+        {
+            get { return this.dictionaryManager; }
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating if BSP required attributes should be written out.
+        /// </summary>
+        public bool EmitBspRequiredAttributes
+        {
+            get
+            {
+                return this.emitBspRequiredAttributes;
+            }
+        }
+
+        public SecurityTokenSerializer InnerSecurityTokenSerializer
+        {
+            get
+            {
+                return this.innerSecurityTokenSerializer == null ? this : this.innerSecurityTokenSerializer;
+            }
+           set
+            {
+                this.innerSecurityTokenSerializer = value;
+            }
+        }
+
+        protected override bool CanReadTokenCore(XmlReader reader)
+        {
+            return false;
+        }
+
+        protected override SecurityToken ReadTokenCore(XmlReader reader, SecurityTokenResolver tokenResolver)
+        {
+            XmlDictionaryReader localReader = XmlDictionaryReader.CreateDictionaryReader( reader ); 
+            throw DiagnosticUtility.ExceptionUtility.ThrowHelperError( new XmlException( SR.GetString( SR.CannotReadToken, reader.LocalName, reader.NamespaceURI, localReader.GetAttribute( XD.SecurityJan2004Dictionary.ValueType, null ) ) ) );
+        }
+
+        protected override bool CanWriteTokenCore(SecurityToken token)
+        {
+            return false;
+        }
+
+        protected override void WriteTokenCore(XmlWriter writer, SecurityToken token)
+        {
+            throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.GetString(SR.StandardsManagerCannotWriteObject, token.GetType())));
+        }
+
+        protected override bool CanReadKeyIdentifierCore(XmlReader reader)
+        {
+            XmlDictionaryReader localReader = XmlDictionaryReader.CreateDictionaryReader(reader);
+            for (int i = 0; i < this.keyIdentifierEntries.Count; i++)
+            {
+                KeyIdentifierEntry keyIdentifierEntry = this.keyIdentifierEntries[i];
+                if (keyIdentifierEntry.CanReadKeyIdentifierCore(localReader))
+                    return true;
+            }
+            return false;
+        }
+
+        protected override SecurityKeyIdentifier ReadKeyIdentifierCore(XmlReader reader)
+        {
+            XmlDictionaryReader localReader = XmlDictionaryReader.CreateDictionaryReader(reader);
+            localReader.ReadStartElement(XD.XmlSignatureDictionary.KeyInfo, XD.XmlSignatureDictionary.Namespace);
+            SecurityKeyIdentifier keyIdentifier = new SecurityKeyIdentifier();
+            while (localReader.IsStartElement())
+            {
+                SecurityKeyIdentifierClause clause = this.InnerSecurityTokenSerializer.ReadKeyIdentifierClause(localReader);
+                if (clause == null)
+                {
+                    localReader.Skip();
+                }
+                else
+                {
+                    keyIdentifier.Add(clause);
+                }
+            }
+            if (keyIdentifier.Count == 0)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new XmlException(SR.GetString(SR.ErrorDeserializingKeyIdentifierClause)));
+            }
+            localReader.ReadEndElement();
+
+            return keyIdentifier;
+        }
+
+        protected override bool CanWriteKeyIdentifierCore(SecurityKeyIdentifier keyIdentifier)
+        {
+            for (int i = 0; i < this.keyIdentifierEntries.Count; ++i)
+            {
+                KeyIdentifierEntry keyIdentifierEntry = this.keyIdentifierEntries[i];
+                if (keyIdentifierEntry.SupportsCore(keyIdentifier))
+                    return true;
+            }
+            return false;
+        }
+
+        protected override void WriteKeyIdentifierCore(XmlWriter writer, SecurityKeyIdentifier keyIdentifier)
+        {
+            bool wroteKeyIdentifier = false;
+            XmlDictionaryWriter localWriter = XmlDictionaryWriter.CreateDictionaryWriter(writer);
+            for (int i = 0; i < this.keyIdentifierEntries.Count; ++i)
+            {
+                KeyIdentifierEntry keyIdentifierEntry = this.keyIdentifierEntries[i];
+                if (keyIdentifierEntry.SupportsCore(keyIdentifier))
+                {
+                    try
+                    {
+                        keyIdentifierEntry.WriteKeyIdentifierCore(localWriter, keyIdentifier);
+                    }
+#pragma warning suppress 56500 // covered by FxCOP
+                    catch (Exception e)
+                    {
+                        if (Fx.IsFatal(e))
+                            throw;
+                        
+                        if (!ShouldWrapException(e))
+                        {
+                            throw;
+                        }
+
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new XmlException(SR.GetString(SR.ErrorSerializingKeyIdentifier), e));
+                    }
+                    wroteKeyIdentifier = true;
+                    break;
+                }
+            }
+
+            if (!wroteKeyIdentifier)
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.GetString(SR.StandardsManagerCannotWriteObject, keyIdentifier.GetType())));
+
+            localWriter.Flush();
+        }
+
+        protected override bool CanReadKeyIdentifierClauseCore(XmlReader reader)
+        {
+            XmlDictionaryReader localReader = XmlDictionaryReader.CreateDictionaryReader(reader);
+            for (int i = 0; i < this.keyIdentifierClauseEntries.Count; i++)
+            {
+                KeyIdentifierClauseEntry keyIdentifierClauseEntry = this.keyIdentifierClauseEntries[i];
+                if (keyIdentifierClauseEntry.CanReadKeyIdentifierClauseCore(localReader))
+                    return true;
+            }
+            return false;
+        }
+
+        protected override SecurityKeyIdentifierClause ReadKeyIdentifierClauseCore(XmlReader reader)
+        {
+            XmlDictionaryReader localReader = XmlDictionaryReader.CreateDictionaryReader(reader);
+            for (int i = 0; i < this.keyIdentifierClauseEntries.Count; i++)
+            {
+                KeyIdentifierClauseEntry keyIdentifierClauseEntry = this.keyIdentifierClauseEntries[i];
+                if (keyIdentifierClauseEntry.CanReadKeyIdentifierClauseCore(localReader))
+                {
+                    try
+                    {
+                        return keyIdentifierClauseEntry.ReadKeyIdentifierClauseCore(localReader);
+                    }
+#pragma warning suppress 56500 // covered by FxCOP
+                    catch (Exception e)
+                    {
+                        if (Fx.IsFatal(e))
+                            throw;
+
+                        if (!ShouldWrapException(e))
+                        {
+                            throw;
+                        }
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new XmlException(SR.GetString(SR.ErrorDeserializingKeyIdentifierClause), e));
+                    }
+                }
+            }
+            throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new XmlException(SR.GetString(SR.CannotReadKeyIdentifierClause, reader.LocalName, reader.NamespaceURI)));
+        }
+
+        protected override bool CanWriteKeyIdentifierClauseCore(SecurityKeyIdentifierClause keyIdentifierClause)
+        {
+            for (int i = 0; i < this.keyIdentifierClauseEntries.Count; ++i)
+            {
+                KeyIdentifierClauseEntry keyIdentifierClauseEntry = this.keyIdentifierClauseEntries[i];
+                if (keyIdentifierClauseEntry.SupportsCore(keyIdentifierClause))
+                    return true;
+            }
+            return false;
+        }
+
+        protected override void WriteKeyIdentifierClauseCore(XmlWriter writer, SecurityKeyIdentifierClause keyIdentifierClause)
+        {
+            bool wroteKeyIdentifierClause = false;
+            XmlDictionaryWriter localWriter = XmlDictionaryWriter.CreateDictionaryWriter(writer);
+            for (int i = 0; i < this.keyIdentifierClauseEntries.Count; ++i)
+            {
+                KeyIdentifierClauseEntry keyIdentifierClauseEntry = this.keyIdentifierClauseEntries[i];
+                if (keyIdentifierClauseEntry.SupportsCore(keyIdentifierClause))
+                {
+                    try
+                    {
+                        keyIdentifierClauseEntry.WriteKeyIdentifierClauseCore(localWriter, keyIdentifierClause);
+                    }
+#pragma warning suppress 56500 // covered by FxCOP
+                    catch (Exception e)
+                    {
+                        if (Fx.IsFatal(e))
+                            throw;
+
+                        if (!ShouldWrapException(e))
+                        {
+                            throw;
+                        }
+                        
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new XmlException(SR.GetString(SR.ErrorSerializingKeyIdentifierClause), e));
+                    }
+                    wroteKeyIdentifierClause = true;
+                    break;
+                }
+            }
+
+            if (!wroteKeyIdentifierClause)
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.GetString(SR.StandardsManagerCannotWriteObject, keyIdentifierClause.GetType())));
+
+            localWriter.Flush();
+        }
+
+        internal void PopulateStrEntries(IList<StrEntry> strEntries)
+        {
+            foreach (SerializerEntries serializerEntry in serializerEntries)
+            {
+                serializerEntry.PopulateStrEntries(strEntries);
+            }
+        }
+
+        bool ShouldWrapException(Exception e)
+        {
+            return ((e is ArgumentException) || (e is FormatException) || (e is InvalidOperationException));
+        }
+
+        internal Type[] GetTokenTypes(string tokenTypeUri)
+        {
+            if (tokenTypeUri != null)
+            {
+                for (int i = 0; i < this.tokenEntries.Count; i++)
+                {
+                    TokenEntry tokenEntry = this.tokenEntries[i];
+
+                    if (tokenEntry.SupportsTokenTypeUri(tokenTypeUri))
+                    {
+                        return tokenEntry.GetTokenTypes();
+                    }
+                }
+            }
+            return null;
+        }
+
+        protected internal virtual string GetTokenTypeUri(Type tokenType)
+        {
+            if (tokenType != null)
+            {
+                for (int i = 0; i < this.tokenEntries.Count; i++)
+                {
+                    TokenEntry tokenEntry = this.tokenEntries[i];
+
+                    if (tokenEntry.SupportsCore(tokenType))
+                    {
+                        return tokenEntry.TokenTypeUri;
+                    }
+                }
+            }
+            return null;
+        }
+
+    }
+
+}
+

--- a/src/System.Private.ServiceModel/src/System/IdentityModel/Tokens/KeyInfoSerializer.cs
+++ b/src/System.Private.ServiceModel/src/System/IdentityModel/Tokens/KeyInfoSerializer.cs
@@ -56,10 +56,11 @@ namespace System.IdentityModel.Tokens
 
             _serializerEntries = new List<SecurityTokenSerializer.SerializerEntries>();
 
-            // Issue #31 in progress
-            //serializerEntries.Add(new XmlDsigSep2000(this));
-            //serializerEntries.Add(new XmlEncApr2001(this));
-            //serializerEntries.Add(new WSTrust(this, trustDictionary));
+            _serializerEntries.Add(new XmlDsigSep2000(this));
+            _serializerEntries.Add(new XmlEncApr2001(this));
+
+            // Issue #31 in progress (WSTrust is abstract in ServiceModel)
+            //_serializerEntries.Add(new WSTrust(this, trustDictionary));
 
             if (additionalEntries != null)
             {

--- a/src/System.Private.ServiceModel/src/System/IdentityModel/Tokens/KeyInfoSerializer.cs
+++ b/src/System.Private.ServiceModel/src/System/IdentityModel/Tokens/KeyInfoSerializer.cs
@@ -8,6 +8,7 @@ using System.Runtime;
 using System.ServiceModel.Security;
 using System.Xml;
 using TokenEntry = System.ServiceModel.Security.WSSecurityTokenSerializer.TokenEntry;
+using DiagnosticUtility = System.ServiceModel.DiagnosticUtility;
 
 namespace System.IdentityModel.Tokens
 {
@@ -132,7 +133,7 @@ namespace System.IdentityModel.Tokens
         protected override SecurityToken ReadTokenCore(XmlReader reader, SecurityTokenResolver tokenResolver)
         {
             XmlDictionaryReader localReader = XmlDictionaryReader.CreateDictionaryReader( reader ); 
-            throw ServiceModel.DiagnosticUtility.ExceptionUtility.ThrowHelperError( new XmlException( SR.Format( SR.CannotReadToken, reader.LocalName, reader.NamespaceURI, localReader.GetAttribute( XD.SecurityJan2004Dictionary.ValueType, null ) ) ) );
+            throw DiagnosticUtility.ExceptionUtility.ThrowHelperError( new XmlException( SR.Format( SR.CannotReadToken, reader.LocalName, reader.NamespaceURI, localReader.GetAttribute( XD.SecurityJan2004Dictionary.ValueType, null ) ) ) );
         }
 
         protected override bool CanWriteTokenCore(SecurityToken token)
@@ -142,7 +143,7 @@ namespace System.IdentityModel.Tokens
 
         protected override void WriteTokenCore(XmlWriter writer, SecurityToken token)
         {
-            throw ServiceModel.DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.StandardsManagerCannotWriteObject, token.GetType())));
+            throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.StandardsManagerCannotWriteObject, token.GetType())));
         }
 
         protected override bool CanReadKeyIdentifierCore(XmlReader reader)
@@ -176,7 +177,7 @@ namespace System.IdentityModel.Tokens
             }
             if (keyIdentifier.Count == 0)
             {
-                throw ServiceModel.DiagnosticUtility.ExceptionUtility.ThrowHelperError(new XmlException(SR.Format(SR.ErrorDeserializingKeyIdentifierClause)));
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new XmlException(SR.Format(SR.ErrorDeserializingKeyIdentifierClause)));
             }
             localReader.ReadEndElement();
 
@@ -207,7 +208,6 @@ namespace System.IdentityModel.Tokens
                     {
                         keyIdentifierEntry.WriteKeyIdentifierCore(localWriter, keyIdentifier);
                     }
-#pragma warning suppress 56500 // covered by FxCOP
                     catch (Exception e)
                     {
                         if (Fx.IsFatal(e))
@@ -218,7 +218,7 @@ namespace System.IdentityModel.Tokens
                             throw;
                         }
 
-                        throw ServiceModel.DiagnosticUtility.ExceptionUtility.ThrowHelperError(new XmlException(SR.Format(SR.ErrorSerializingKeyIdentifier), e));
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new XmlException(SR.Format(SR.ErrorSerializingKeyIdentifier), e));
                     }
                     wroteKeyIdentifier = true;
                     break;
@@ -226,7 +226,7 @@ namespace System.IdentityModel.Tokens
             }
 
             if (!wroteKeyIdentifier)
-                throw ServiceModel.DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.StandardsManagerCannotWriteObject, keyIdentifier.GetType())));
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.StandardsManagerCannotWriteObject, keyIdentifier.GetType())));
 
             localWriter.Flush();
         }
@@ -255,7 +255,6 @@ namespace System.IdentityModel.Tokens
                     {
                         return keyIdentifierClauseEntry.ReadKeyIdentifierClauseCore(localReader);
                     }
-#pragma warning suppress 56500 // covered by FxCOP
                     catch (Exception e)
                     {
                         if (Fx.IsFatal(e))
@@ -265,11 +264,11 @@ namespace System.IdentityModel.Tokens
                         {
                             throw;
                         }
-                        throw ServiceModel.DiagnosticUtility.ExceptionUtility.ThrowHelperError(new XmlException(SR.Format(SR.ErrorDeserializingKeyIdentifierClause), e));
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new XmlException(SR.Format(SR.ErrorDeserializingKeyIdentifierClause), e));
                     }
                 }
             }
-            throw ServiceModel.DiagnosticUtility.ExceptionUtility.ThrowHelperError(new XmlException(SR.Format(SR.CannotReadKeyIdentifierClause, reader.LocalName, reader.NamespaceURI)));
+            throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new XmlException(SR.Format(SR.CannotReadKeyIdentifierClause, reader.LocalName, reader.NamespaceURI)));
         }
 
         protected override bool CanWriteKeyIdentifierClauseCore(SecurityKeyIdentifierClause keyIdentifierClause)
@@ -296,7 +295,6 @@ namespace System.IdentityModel.Tokens
                     {
                         keyIdentifierClauseEntry.WriteKeyIdentifierClauseCore(localWriter, keyIdentifierClause);
                     }
-#pragma warning suppress 56500 // covered by FxCOP
                     catch (Exception e)
                     {
                         if (Fx.IsFatal(e))
@@ -307,7 +305,7 @@ namespace System.IdentityModel.Tokens
                             throw;
                         }
                         
-                        throw ServiceModel.DiagnosticUtility.ExceptionUtility.ThrowHelperError(new XmlException(SR.Format(SR.ErrorSerializingKeyIdentifierClause), e));
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new XmlException(SR.Format(SR.ErrorSerializingKeyIdentifierClause), e));
                     }
                     wroteKeyIdentifierClause = true;
                     break;
@@ -315,7 +313,7 @@ namespace System.IdentityModel.Tokens
             }
 
             if (!wroteKeyIdentifierClause)
-                throw ServiceModel.DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.StandardsManagerCannotWriteObject, keyIdentifierClause.GetType())));
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.StandardsManagerCannotWriteObject, keyIdentifierClause.GetType())));
 
             localWriter.Flush();
         }

--- a/src/System.Private.ServiceModel/src/System/IdentityModel/Tokens/SamlAssertion.cs
+++ b/src/System.Private.ServiceModel/src/System/IdentityModel/Tokens/SamlAssertion.cs
@@ -1,0 +1,664 @@
+//-----------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//-----------------------------------------------------------------------------
+
+namespace System.IdentityModel.Tokens
+{
+    using System.Collections.Generic;
+    using System.Collections.ObjectModel;
+    using System.Globalization;
+    using System.IO;
+    using System.IdentityModel;
+    using System.IdentityModel.Claims;
+    using System.IdentityModel.Policy;
+    using System.IdentityModel.Selectors;
+    using System.Runtime;
+    using System.Runtime.InteropServices;
+    using System.Security;
+    using System.Security.Cryptography;
+    using System.Xml;
+
+    public class SamlAssertion : ICanonicalWriterEndRootElementCallback
+    {
+        string assertionId = SamlConstants.AssertionIdPrefix + Guid.NewGuid().ToString();
+        string issuer;
+        DateTime issueInstant = DateTime.UtcNow.ToUniversalTime();
+        SamlConditions conditions;
+        SamlAdvice advice;
+        readonly ImmutableCollection<SamlStatement> statements = new ImmutableCollection<SamlStatement>();
+        ReadOnlyCollection<SecurityKey> cryptoList;
+
+        SignedXml signature;
+        SigningCredentials signingCredentials;
+        SecurityKey verificationKey;
+        SecurityToken signingToken;
+
+        HashStream hashStream;
+        XmlTokenStream tokenStream;
+        SecurityTokenSerializer keyInfoSerializer;
+        DictionaryManager dictionaryManager;
+        XmlTokenStream sourceData;
+
+        bool isReadOnly = false;
+
+        public SamlAssertion()
+        {
+        }
+
+        public SamlAssertion(
+            string assertionId,
+            string issuer,
+            DateTime issueInstant,
+            SamlConditions samlConditions,
+            SamlAdvice samlAdvice,
+            IEnumerable<SamlStatement> samlStatements
+            )
+        {
+            if (string.IsNullOrEmpty(assertionId))
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgument(SR.GetString(SR.SAMLAssertionIdRequired));
+
+            if (!IsAssertionIdValid(assertionId))
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgument(SR.GetString(SR.SAMLAssertionIDIsInvalid, assertionId));
+
+            if (string.IsNullOrEmpty(issuer))
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgument(SR.GetString(SR.SAMLAssertionIssuerRequired));
+
+            if (samlStatements == null)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("samlStatements");
+            }
+
+            this.assertionId = assertionId;
+            this.issuer = issuer;
+            this.issueInstant = issueInstant.ToUniversalTime();
+            this.conditions = samlConditions;
+            this.advice = samlAdvice;
+
+            foreach (SamlStatement samlStatement in samlStatements)
+            {
+                if (samlStatement == null)
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgument(SR.GetString(SR.SAMLEntityCannotBeNullOrEmpty, XD.SamlDictionary.Statement.Value));
+
+                this.statements.Add(samlStatement);
+            }
+
+            if (this.statements.Count == 0)
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgument(SR.GetString(SR.SAMLAssertionRequireOneStatement));
+        }
+
+        public int MinorVersion
+        {
+            get { return SamlConstants.MinorVersionValue; }
+        }
+
+        public int MajorVersion
+        {
+            get { return SamlConstants.MajorVersionValue; }
+        }
+
+        public string AssertionId
+        {
+            get { return this.assertionId; }
+            set
+            {
+                if (isReadOnly)
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.GetString(SR.ObjectIsReadOnly)));
+
+                if (string.IsNullOrEmpty(value))
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgument(SR.GetString(SR.SAMLAssertionIdRequired));
+
+                this.assertionId = value;
+            }
+        }
+
+        /// <summary>
+        /// Indicates whether this assertion was deserialized from XML source
+        /// and can re-emit the XML data unchanged.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// The default implementation preserves the source data when read using
+        /// Saml2AssertionSerializer.ReadAssertion and is willing to re-emit the
+        /// original data as long as the Id has not changed from the time that 
+        /// assertion was read.
+        /// </para>
+        /// <para>
+        /// Note that it is vitally important that SAML assertions with different
+        /// data have different IDs. If implementing a scheme whereby an assertion
+        /// "template" is loaded and certain bits of data are filled in, the Id 
+        /// must be changed.
+        /// </para>
+        /// </remarks>
+        /// <returns></returns>
+        public virtual bool CanWriteSourceData
+        {
+            get { return null != this.sourceData; }
+        }
+
+        public string Issuer
+        {
+            get { return this.issuer; }
+            set
+            {
+                if (isReadOnly)
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.GetString(SR.ObjectIsReadOnly)));
+
+                if (string.IsNullOrEmpty(value))
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgument(SR.GetString(SR.SAMLAssertionIssuerRequired));
+
+                this.issuer = value;
+            }
+        }
+
+        public DateTime IssueInstant
+        {
+            get { return this.issueInstant; }
+            set
+            {
+                if (isReadOnly)
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.GetString(SR.ObjectIsReadOnly)));
+
+                this.issueInstant = value;
+            }
+        }
+
+        public SamlConditions Conditions
+        {
+            get { return this.conditions; }
+            set
+            {
+                if (isReadOnly)
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.GetString(SR.ObjectIsReadOnly)));
+
+                this.conditions = value;
+            }
+        }
+
+        public SamlAdvice Advice
+        {
+            get { return this.advice; }
+            set
+            {
+                if (isReadOnly)
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.GetString(SR.ObjectIsReadOnly)));
+
+                this.advice = value;
+            }
+        }
+
+        public IList<SamlStatement> Statements
+        {
+            get
+            {
+                return this.statements;
+            }
+        }
+
+        public SigningCredentials SigningCredentials
+        {
+            get { return this.signingCredentials; }
+            set
+            {
+                if (isReadOnly)
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.GetString(SR.ObjectIsReadOnly)));
+
+                this.signingCredentials = value;
+            }
+        }
+
+        internal SignedXml Signature
+        {
+            get { return this.signature; }
+        }
+
+        internal SecurityKey SignatureVerificationKey
+        {
+            get { return this.verificationKey; }
+        }
+
+        public SecurityToken SigningToken
+        {
+            get { return this.signingToken; }
+            set
+            {
+                if (isReadOnly)
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.GetString(SR.ObjectIsReadOnly)));
+
+                this.signingToken = value;
+            }
+        }
+
+        public bool IsReadOnly
+        {
+            get { return this.isReadOnly; }
+        }
+
+        internal ReadOnlyCollection<SecurityKey> SecurityKeys
+        {
+            get
+            {
+                return this.cryptoList;
+            }
+        }
+
+        public void MakeReadOnly()
+        {
+            if (!this.isReadOnly)
+            {
+                if (this.conditions != null)
+                    this.conditions.MakeReadOnly();
+
+                if (this.advice != null)
+                    this.advice.MakeReadOnly();
+
+                foreach (SamlStatement statement in this.statements)
+                {
+                    statement.MakeReadOnly();
+                }
+
+                this.statements.MakeReadOnly();
+
+                if (this.cryptoList == null)
+                {
+                    this.cryptoList = BuildCryptoList();
+                }
+
+                this.isReadOnly = true;
+            }
+        }
+
+        /// <summary>
+        /// Captures the XML source data from an EnvelopedSignatureReader. 
+        /// </summary>
+        /// <remarks>
+        /// The EnvelopedSignatureReader that was used to read the data for this
+        /// assertion should be passed to this method after the &lt;/Assertion>
+        /// element has been read. This method will preserve the raw XML data
+        /// that was read, including the signature, so that it may be re-emitted
+        /// without changes and without the need to re-sign the data. See 
+        /// CanWriteSourceData and WriteSourceData.
+        /// </remarks>
+        /// <param name="reader"></param>
+        internal virtual void CaptureSourceData(EnvelopedSignatureReader reader)
+        {
+            if (null == reader)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("reader");
+            }
+
+            this.sourceData = reader.XmlTokens;
+        }
+
+        protected void ReadSignature(XmlDictionaryReader reader, SecurityTokenSerializer keyInfoSerializer, SecurityTokenResolver outOfBandTokenResolver, SamlSerializer samlSerializer)
+        {
+            if (reader == null)
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("reader");
+
+            if (samlSerializer == null)
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("samlSerializer");
+
+            if (this.signature != null)
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.GetString(SR.SAMLSignatureAlreadyRead)));
+
+            // If the reader cannot canonicalize then buffer the signature element to a canonicalizing reader.
+            XmlDictionaryReader effectiveReader = reader;
+            if (!effectiveReader.CanCanonicalize)
+            {
+                MemoryStream stream = new MemoryStream();
+                XmlDictionaryWriter writer = XmlDictionaryWriter.CreateBinaryWriter(stream, samlSerializer.DictionaryManager.ParentDictionary);
+                writer.WriteNode(effectiveReader, false);
+                writer.Flush();
+                stream.Position = 0;
+                effectiveReader = XmlDictionaryReader.CreateBinaryReader(stream.GetBuffer(), 0, (int)stream.Length, samlSerializer.DictionaryManager.ParentDictionary, reader.Quotas);
+                effectiveReader.MoveToContent();
+                writer.Close();
+            }
+            SignedXml signedXml = new SignedXml(new StandardSignedInfo(samlSerializer.DictionaryManager), samlSerializer.DictionaryManager, keyInfoSerializer);
+            signedXml.TransformFactory = ExtendedTransformFactory.Instance;
+            signedXml.ReadFrom(effectiveReader);
+            SecurityKeyIdentifier securityKeyIdentifier = signedXml.Signature.KeyIdentifier;
+            this.verificationKey = SamlSerializer.ResolveSecurityKey(securityKeyIdentifier, outOfBandTokenResolver);
+            if (this.verificationKey == null)
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new SecurityTokenException(SR.GetString(SR.SAMLUnableToResolveSignatureKey, this.issuer)));
+
+            this.signature = signedXml;
+            this.signingToken = SamlSerializer.ResolveSecurityToken(securityKeyIdentifier, outOfBandTokenResolver);
+            if (this.signingToken == null)
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new SecurityTokenException(SR.GetString(SR.SamlSigningTokenNotFound)));
+
+            if (!ReferenceEquals(reader, effectiveReader))
+                effectiveReader.Close();
+        }
+
+        void CheckObjectValidity()
+        {
+            if (string.IsNullOrEmpty(this.assertionId))
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new SecurityTokenException(SR.GetString(SR.SAMLAssertionIdRequired)));
+
+            if (!IsAssertionIdValid(this.assertionId))
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new SecurityTokenException(SR.GetString(SR.SAMLAssertionIDIsInvalid, this.assertionId)));
+
+            if (string.IsNullOrEmpty(this.issuer))
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new SecurityTokenException(SR.GetString(SR.SAMLAssertionIssuerRequired)));
+
+            if (this.statements.Count == 0)
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new SecurityTokenException(SR.GetString(SR.SAMLAssertionRequireOneStatement)));
+        }
+
+        bool IsAssertionIdValid(string assertionId)
+        {
+            if (string.IsNullOrEmpty(assertionId))
+                return false;
+
+            // The first character of the Assertion ID should be a letter or a '_'
+            return (((assertionId[0] >= 'A') && (assertionId[0] <= 'Z')) ||
+                ((assertionId[0] >= 'a') && (assertionId[0] <= 'z')) ||
+                (assertionId[0] == '_'));
+        }
+
+        ReadOnlyCollection<SecurityKey> BuildCryptoList()
+        {
+            List<SecurityKey> cryptoList = new List<SecurityKey>();
+
+            for (int i = 0; i < this.statements.Count; ++i)
+            {
+                SamlSubjectStatement statement = this.statements[i] as SamlSubjectStatement;
+                if (statement != null)
+                {
+                    bool skipCrypto = false;
+                    SecurityKey crypto = null;
+                    if (statement.SamlSubject != null)
+                        crypto = statement.SamlSubject.Crypto;
+                    InMemorySymmetricSecurityKey inMemorySymmetricSecurityKey = crypto as InMemorySymmetricSecurityKey;
+                    if (inMemorySymmetricSecurityKey != null)
+                    {
+
+                        // Verify that you have not already added this to crypto list.
+                        for (int j = 0; j < cryptoList.Count; ++j)
+                        {
+                            if ((cryptoList[j] is InMemorySymmetricSecurityKey) && (cryptoList[j].KeySize == inMemorySymmetricSecurityKey.KeySize))
+                            {
+                                byte[] key1 = ((InMemorySymmetricSecurityKey)cryptoList[j]).GetSymmetricKey();
+                                byte[] key2 = inMemorySymmetricSecurityKey.GetSymmetricKey();
+                                int k = 0;
+                                for (k = 0; k < key1.Length; ++k)
+                                {
+                                    if (key1[k] != key2[k])
+                                    {
+                                        break;
+                                    }
+                                }
+                                skipCrypto = (k == key1.Length);
+                            }
+
+                            if (skipCrypto)
+                                break;
+                        }
+                    }
+                    if (!skipCrypto && (crypto != null))
+                    {
+                        cryptoList.Add(crypto);
+                    }
+                }
+            }
+
+            return cryptoList.AsReadOnly();
+
+        }
+
+        void VerifySignature(SignedXml signature, SecurityKey signatureVerificationKey)
+        {
+            if (signature == null)
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("signature");
+
+            if (signatureVerificationKey == null)
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("signatureVerificatonKey");
+
+            signature.StartSignatureVerification(signatureVerificationKey);
+            signature.EnsureDigestValidity(this.assertionId, tokenStream);
+            signature.CompleteSignatureVerification();
+        }
+
+        void ICanonicalWriterEndRootElementCallback.OnEndOfRootElement(XmlDictionaryWriter dictionaryWriter)
+        {
+            byte[] hashValue = this.hashStream.FlushHashAndGetValue();
+
+            PreDigestedSignedInfo signedInfo = new PreDigestedSignedInfo(this.dictionaryManager);
+            signedInfo.AddEnvelopedSignatureTransform = true;
+            signedInfo.CanonicalizationMethod = SecurityAlgorithms.ExclusiveC14n;
+            signedInfo.SignatureMethod = this.signingCredentials.SignatureAlgorithm;
+            signedInfo.DigestMethod = this.signingCredentials.DigestAlgorithm;
+            signedInfo.AddReference(this.assertionId, hashValue);
+
+            SignedXml signedXml = new SignedXml(signedInfo, this.dictionaryManager, this.keyInfoSerializer);
+            signedXml.ComputeSignature(this.signingCredentials.SigningKey);
+            signedXml.Signature.KeyIdentifier = this.signingCredentials.SigningKeyIdentifier;
+            signedXml.WriteTo(dictionaryWriter);
+        }
+
+        public virtual void ReadXml(XmlDictionaryReader reader, SamlSerializer samlSerializer, SecurityTokenSerializer keyInfoSerializer, SecurityTokenResolver outOfBandTokenResolver)
+        {
+            if (reader == null)
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentNullException("ReadXml"));
+
+            if (samlSerializer == null)
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentNullException("samlSerializer"));
+
+            XmlDictionaryReader dictionaryReader = XmlDictionaryReader.CreateDictionaryReader(reader);
+            WrappedReader wrappedReader = new WrappedReader(dictionaryReader);
+#pragma warning suppress 56506 // samlSerializer.DictionaryManager is never null.
+            SamlDictionary dictionary = samlSerializer.DictionaryManager.SamlDictionary;
+
+            if (!wrappedReader.IsStartElement(dictionary.Assertion, dictionary.Namespace))
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new SecurityTokenException(SR.GetString(SR.SAMLElementNotRecognized, wrappedReader.LocalName)));
+
+            string attributeValue = wrappedReader.GetAttribute(dictionary.MajorVersion, null);
+            if (string.IsNullOrEmpty(attributeValue))
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new SecurityTokenException(SR.GetString(SR.SAMLAssertionMissingMajorVersionAttributeOnRead)));
+            int majorVersion = Int32.Parse(attributeValue, CultureInfo.InvariantCulture);
+
+            attributeValue = wrappedReader.GetAttribute(dictionary.MinorVersion, null);
+            if (string.IsNullOrEmpty(attributeValue))
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new SecurityTokenException(SR.GetString(SR.SAMLAssertionMissingMinorVersionAttributeOnRead)));
+
+            int minorVersion = Int32.Parse(attributeValue, CultureInfo.InvariantCulture);
+
+            if ((majorVersion != SamlConstants.MajorVersionValue) || (minorVersion != SamlConstants.MinorVersionValue))
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new SecurityTokenException(SR.GetString(SR.SAMLTokenVersionNotSupported, majorVersion, minorVersion, SamlConstants.MajorVersionValue, SamlConstants.MinorVersionValue)));
+            }
+
+            attributeValue = wrappedReader.GetAttribute(dictionary.AssertionId, null);
+            if (string.IsNullOrEmpty(attributeValue))
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new SecurityTokenException(SR.GetString(SR.SAMLAssertionIdRequired)));
+
+            if (!IsAssertionIdValid(attributeValue))
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new SecurityTokenException(SR.GetString(SR.SAMLAssertionIDIsInvalid, attributeValue)));
+
+            this.assertionId = attributeValue;
+
+            attributeValue = wrappedReader.GetAttribute(dictionary.Issuer, null);
+            if (string.IsNullOrEmpty(attributeValue))
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new SecurityTokenException(SR.GetString(SR.SAMLAssertionMissingIssuerAttributeOnRead)));
+            this.issuer = attributeValue;
+
+            attributeValue = wrappedReader.GetAttribute(dictionary.IssueInstant, null);
+            if (!string.IsNullOrEmpty(attributeValue))
+                this.issueInstant = DateTime.ParseExact(
+                    attributeValue, SamlConstants.AcceptedDateTimeFormats, DateTimeFormatInfo.InvariantInfo, DateTimeStyles.None).ToUniversalTime();
+
+            wrappedReader.MoveToContent();
+            wrappedReader.Read();
+
+            if (wrappedReader.IsStartElement(dictionary.Conditions, dictionary.Namespace))
+            {
+                this.conditions = samlSerializer.LoadConditions(wrappedReader, keyInfoSerializer, outOfBandTokenResolver);
+                if (this.conditions == null)
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new SecurityTokenException(SR.GetString(SR.SAMLUnableToLoadCondtions)));
+            }
+
+            if (wrappedReader.IsStartElement(dictionary.Advice, dictionary.Namespace))
+            {
+                this.advice = samlSerializer.LoadAdvice(wrappedReader, keyInfoSerializer, outOfBandTokenResolver);
+                if (this.advice == null)
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new SecurityTokenException(SR.GetString(SR.SAMLUnableToLoadAdvice)));
+            }
+
+            while (wrappedReader.IsStartElement())
+            {
+#pragma warning suppress 56506 // samlSerializer.DictionaryManager is never null.
+                if (wrappedReader.IsStartElement(samlSerializer.DictionaryManager.XmlSignatureDictionary.Signature, samlSerializer.DictionaryManager.XmlSignatureDictionary.Namespace))
+                {
+                    break;
+                }
+                else
+                {
+                    SamlStatement statement = samlSerializer.LoadStatement(wrappedReader, keyInfoSerializer, outOfBandTokenResolver);
+                    if (statement == null)
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new SecurityTokenException(SR.GetString(SR.SAMLUnableToLoadStatement)));
+                    this.statements.Add(statement);
+                }
+            }
+
+            if (this.statements.Count == 0)
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new SecurityTokenException(SR.GetString(SR.SAMLAssertionRequireOneStatementOnRead)));
+
+            if (wrappedReader.IsStartElement(samlSerializer.DictionaryManager.XmlSignatureDictionary.Signature, samlSerializer.DictionaryManager.XmlSignatureDictionary.Namespace))
+                this.ReadSignature(wrappedReader, keyInfoSerializer, outOfBandTokenResolver, samlSerializer);
+
+            wrappedReader.MoveToContent();
+            wrappedReader.ReadEndElement();
+
+            this.tokenStream = wrappedReader.XmlTokens;
+
+            if (this.signature != null)
+            {
+                VerifySignature(this.signature, this.verificationKey);
+            }
+
+            BuildCryptoList();
+        }
+
+        internal void WriteTo(XmlWriter writer, SamlSerializer samlSerializer, SecurityTokenSerializer keyInfoSerializer)
+        {
+            if (writer == null)
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("writer");
+
+            if ((this.signingCredentials == null) && (this.signature == null))
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.GetString(SR.SamlAssertionMissingSigningCredentials)));
+
+            XmlDictionaryWriter dictionaryWriter = XmlDictionaryWriter.CreateDictionaryWriter(writer);
+
+            if (this.signingCredentials != null)
+            {
+                using (HashAlgorithm hash = CryptoHelper.CreateHashAlgorithm(this.signingCredentials.DigestAlgorithm))
+                {
+                    this.hashStream = new HashStream(hash);
+                    this.keyInfoSerializer = keyInfoSerializer;
+                    this.dictionaryManager = samlSerializer.DictionaryManager;
+                    SamlDelegatingWriter delegatingWriter = new SamlDelegatingWriter(dictionaryWriter, this.hashStream, this, samlSerializer.DictionaryManager.ParentDictionary);
+                    this.WriteXml(delegatingWriter, samlSerializer, keyInfoSerializer);
+                }
+            }
+            else
+            {
+                this.tokenStream.SetElementExclusion(null, null);
+                this.tokenStream.WriteTo(dictionaryWriter, samlSerializer.DictionaryManager);
+            }
+        }
+
+        public virtual void WriteXml(XmlDictionaryWriter writer, SamlSerializer samlSerializer, SecurityTokenSerializer keyInfoSerializer)
+        {
+            CheckObjectValidity();
+
+            if (writer == null)
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("writer");
+
+            if (samlSerializer == null)
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentNullException("samlSerializer"));
+
+#pragma warning suppress 56506 // samlSerializer.DictionaryManager is never null.
+            SamlDictionary dictionary = samlSerializer.DictionaryManager.SamlDictionary;
+
+            try
+            {
+                writer.WriteStartElement(dictionary.PreferredPrefix.Value, dictionary.Assertion, dictionary.Namespace);
+
+                writer.WriteStartAttribute(dictionary.MajorVersion, null);
+                writer.WriteValue(SamlConstants.MajorVersionValue);
+                writer.WriteEndAttribute();
+                writer.WriteStartAttribute(dictionary.MinorVersion, null);
+                writer.WriteValue(SamlConstants.MinorVersionValue);
+                writer.WriteEndAttribute();
+                writer.WriteStartAttribute(dictionary.AssertionId, null);
+                writer.WriteString(this.assertionId);
+                writer.WriteEndAttribute();
+                writer.WriteStartAttribute(dictionary.Issuer, null);
+                writer.WriteString(this.issuer);
+                writer.WriteEndAttribute();
+                writer.WriteStartAttribute(dictionary.IssueInstant, null);
+                writer.WriteString(this.issueInstant.ToString(SamlConstants.GeneratedDateTimeFormat, CultureInfo.InvariantCulture));
+                writer.WriteEndAttribute();
+
+                // Write out conditions
+                if (this.conditions != null)
+                {
+                    this.conditions.WriteXml(writer, samlSerializer, keyInfoSerializer);
+                }
+
+                // Write out advice if there is one
+                if (this.advice != null)
+                {
+                    this.advice.WriteXml(writer, samlSerializer, keyInfoSerializer);
+                }
+
+                for (int i = 0; i < this.statements.Count; i++)
+                {
+                    this.statements[i].WriteXml(writer, samlSerializer, keyInfoSerializer);
+                }
+
+                writer.WriteEndElement();
+            }
+            catch (Exception e)
+            {
+                // Always immediately rethrow fatal exceptions.
+                if (Fx.IsFatal(e)) throw;
+
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.GetString(SR.SAMLTokenNotSerialized), e));
+            }
+        }
+
+        /// <summary>
+        /// Writes the source data, if available.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">When no source data is available</exception>
+        /// <param name="writer"></param>
+        public virtual void WriteSourceData(XmlWriter writer)
+        {
+            if (!this.CanWriteSourceData)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(
+                    new InvalidOperationException(SR.GetString(SR.ID4140)));
+            }
+
+            // This call will properly just reuse the existing writer if it already qualifies
+            XmlDictionaryWriter dictionaryWriter = XmlDictionaryWriter.CreateDictionaryWriter(writer);
+            this.sourceData.SetElementExclusion(null, null);
+            this.sourceData.GetWriter().WriteTo(dictionaryWriter, null );
+        }
+
+        static internal void AddSamlClaimTypes(ICollection<Type> knownClaimTypes)
+        {
+            if (knownClaimTypes == null)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("knownClaimTypes");
+            }
+            knownClaimTypes.Add(typeof(SamlAuthorizationDecisionClaimResource));
+            knownClaimTypes.Add(typeof(SamlAuthenticationClaimResource));
+            knownClaimTypes.Add(typeof(SamlAccessDecision));
+            knownClaimTypes.Add(typeof(SamlAuthorityBinding));
+            knownClaimTypes.Add(typeof(SamlNameIdentifierClaimResource));
+        }
+    }
+}
+

--- a/src/System.Private.ServiceModel/src/System/IdentityModel/Tokens/SamlAssertion.cs
+++ b/src/System.Private.ServiceModel/src/System/IdentityModel/Tokens/SamlAssertion.cs
@@ -22,6 +22,7 @@ namespace System.IdentityModel.Tokens
     {
        string assertionId = SamlConstants.AssertionIdPrefix + Guid.NewGuid().ToString();
 
+        // Issue #31 in progress
         //string issuer;
         //DateTime issueInstant = DateTime.UtcNow.ToUniversalTime();
         //SamlConditions conditions;
@@ -46,6 +47,7 @@ namespace System.IdentityModel.Tokens
         {
         }
 
+        // Issue #31 in progress
         //        public SamlAssertion(
         //            string assertionId,
         //            string issuer,
@@ -102,7 +104,7 @@ namespace System.IdentityModel.Tokens
             get { return this.assertionId; }
             set
             {
-                throw ServiceModel.ExceptionHelper.PlatformNotSupported();
+                throw ServiceModel.ExceptionHelper.PlatformNotSupported();  // Issue #31 in progress
                 //if (isReadOnly)
                 //    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.ObjectIsReadOnly)));
 
@@ -113,6 +115,7 @@ namespace System.IdentityModel.Tokens
             }
         }
 
+        // Issue #31 in progress
         //        /// <summary>
         //        /// Indicates whether this assertion was deserialized from XML source
         //        /// and can re-emit the XML data unchanged.
@@ -245,7 +248,7 @@ namespace System.IdentityModel.Tokens
 
         public void MakeReadOnly()
         {
-            throw ServiceModel.ExceptionHelper.PlatformNotSupported();
+            throw ServiceModel.ExceptionHelper.PlatformNotSupported();  // Issue #31 in progress
             //if (!this.isReadOnly)
             //{
             //    if (this.conditions != null)
@@ -270,6 +273,7 @@ namespace System.IdentityModel.Tokens
             //}
         }
 
+        // Issue #31 in progress
         //        /// <summary>
         //        /// Captures the XML source data from an EnvelopedSignatureReader. 
         //        /// </summary>

--- a/src/System.Private.ServiceModel/src/System/IdentityModel/Tokens/SamlAssertion.cs
+++ b/src/System.Private.ServiceModel/src/System/IdentityModel/Tokens/SamlAssertion.cs
@@ -453,7 +453,6 @@ namespace System.IdentityModel.Tokens
 
         //            XmlDictionaryReader dictionaryReader = XmlDictionaryReader.CreateDictionaryReader(reader);
         //            WrappedReader wrappedReader = new WrappedReader(dictionaryReader);
-        //#pragma warning suppress 56506 // samlSerializer.DictionaryManager is never null.
         //            SamlDictionary dictionary = samlSerializer.DictionaryManager.SamlDictionary;
 
         //            if (!wrappedReader.IsStartElement(dictionary.Assertion, dictionary.Namespace))
@@ -513,7 +512,6 @@ namespace System.IdentityModel.Tokens
 
         //            while (wrappedReader.IsStartElement())
         //            {
-        //#pragma warning suppress 56506 // samlSerializer.DictionaryManager is never null.
         //                if (wrappedReader.IsStartElement(samlSerializer.DictionaryManager.XmlSignatureDictionary.Signature, samlSerializer.DictionaryManager.XmlSignatureDictionary.Namespace))
         //                {
         //                    break;
@@ -584,7 +582,6 @@ namespace System.IdentityModel.Tokens
         //            if (samlSerializer == null)
         //                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentNullException("samlSerializer"));
 
-        //#pragma warning suppress 56506 // samlSerializer.DictionaryManager is never null.
         //            SamlDictionary dictionary = samlSerializer.DictionaryManager.SamlDictionary;
 
         //            try

--- a/src/System.Private.ServiceModel/src/System/IdentityModel/Tokens/SamlAssertion.cs
+++ b/src/System.Private.ServiceModel/src/System/IdentityModel/Tokens/SamlAssertion.cs
@@ -1,664 +1,667 @@
-//-----------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation.  All rights reserved.
-//-----------------------------------------------------------------------------
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Globalization;
+using System.IO;
+using System.IdentityModel;
+using System.IdentityModel.Claims;
+using System.IdentityModel.Policy;
+using System.IdentityModel.Selectors;
+using System.Runtime;
+using System.Runtime.InteropServices;
+using System.Security;
+using System.Security.Cryptography;
+using System.Xml;
 
 namespace System.IdentityModel.Tokens
 {
-    using System.Collections.Generic;
-    using System.Collections.ObjectModel;
-    using System.Globalization;
-    using System.IO;
-    using System.IdentityModel;
-    using System.IdentityModel.Claims;
-    using System.IdentityModel.Policy;
-    using System.IdentityModel.Selectors;
-    using System.Runtime;
-    using System.Runtime.InteropServices;
-    using System.Security;
-    using System.Security.Cryptography;
-    using System.Xml;
-
-    public class SamlAssertion : ICanonicalWriterEndRootElementCallback
+    public class SamlAssertion // : ICanonicalWriterEndRootElementCallback  // Issue #31 in progress
     {
-        string assertionId = SamlConstants.AssertionIdPrefix + Guid.NewGuid().ToString();
-        string issuer;
-        DateTime issueInstant = DateTime.UtcNow.ToUniversalTime();
-        SamlConditions conditions;
-        SamlAdvice advice;
-        readonly ImmutableCollection<SamlStatement> statements = new ImmutableCollection<SamlStatement>();
-        ReadOnlyCollection<SecurityKey> cryptoList;
+       string assertionId = SamlConstants.AssertionIdPrefix + Guid.NewGuid().ToString();
 
-        SignedXml signature;
-        SigningCredentials signingCredentials;
-        SecurityKey verificationKey;
-        SecurityToken signingToken;
+        //string issuer;
+        //DateTime issueInstant = DateTime.UtcNow.ToUniversalTime();
+        //SamlConditions conditions;
+        //SamlAdvice advice;
+        //readonly ImmutableCollection<SamlStatement> statements = new ImmutableCollection<SamlStatement>();
+        //ReadOnlyCollection<SecurityKey> cryptoList;
 
-        HashStream hashStream;
-        XmlTokenStream tokenStream;
-        SecurityTokenSerializer keyInfoSerializer;
-        DictionaryManager dictionaryManager;
-        XmlTokenStream sourceData;
+        //SignedXml signature;
+        //SigningCredentials signingCredentials;
+        //SecurityKey verificationKey;
+        //SecurityToken signingToken;
 
-        bool isReadOnly = false;
+        //HashStream hashStream;
+        //XmlTokenStream tokenStream;
+        //SecurityTokenSerializer keyInfoSerializer;
+        //DictionaryManager dictionaryManager;
+        //XmlTokenStream sourceData;
+
+        //bool isReadOnly = false;
 
         public SamlAssertion()
         {
         }
 
-        public SamlAssertion(
-            string assertionId,
-            string issuer,
-            DateTime issueInstant,
-            SamlConditions samlConditions,
-            SamlAdvice samlAdvice,
-            IEnumerable<SamlStatement> samlStatements
-            )
-        {
-            if (string.IsNullOrEmpty(assertionId))
-                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgument(SR.GetString(SR.SAMLAssertionIdRequired));
+        //        public SamlAssertion(
+        //            string assertionId,
+        //            string issuer,
+        //            DateTime issueInstant,
+        //            SamlConditions samlConditions,
+        //            SamlAdvice samlAdvice,
+        //            IEnumerable<SamlStatement> samlStatements
+        //            )
+        //        {
+        //            if (string.IsNullOrEmpty(assertionId))
+        //                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgument(SR.Format(SR.SAMLAssertionIdRequired));
 
-            if (!IsAssertionIdValid(assertionId))
-                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgument(SR.GetString(SR.SAMLAssertionIDIsInvalid, assertionId));
+        //            if (!IsAssertionIdValid(assertionId))
+        //                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgument(SR.Format(SR.SAMLAssertionIDIsInvalid, assertionId));
 
-            if (string.IsNullOrEmpty(issuer))
-                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgument(SR.GetString(SR.SAMLAssertionIssuerRequired));
+        //            if (string.IsNullOrEmpty(issuer))
+        //                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgument(SR.Format(SR.SAMLAssertionIssuerRequired));
 
-            if (samlStatements == null)
-            {
-                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("samlStatements");
-            }
+        //            if (samlStatements == null)
+        //            {
+        //                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("samlStatements");
+        //            }
 
-            this.assertionId = assertionId;
-            this.issuer = issuer;
-            this.issueInstant = issueInstant.ToUniversalTime();
-            this.conditions = samlConditions;
-            this.advice = samlAdvice;
+        //            this.assertionId = assertionId;
+        //            this.issuer = issuer;
+        //            this.issueInstant = issueInstant.ToUniversalTime();
+        //            this.conditions = samlConditions;
+        //            this.advice = samlAdvice;
 
-            foreach (SamlStatement samlStatement in samlStatements)
-            {
-                if (samlStatement == null)
-                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgument(SR.GetString(SR.SAMLEntityCannotBeNullOrEmpty, XD.SamlDictionary.Statement.Value));
+        //            foreach (SamlStatement samlStatement in samlStatements)
+        //            {
+        //                if (samlStatement == null)
+        //                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgument(SR.Format(SR.SAMLEntityCannotBeNullOrEmpty, XD.SamlDictionary.Statement.Value));
 
-                this.statements.Add(samlStatement);
-            }
+        //                this.statements.Add(samlStatement);
+        //            }
 
-            if (this.statements.Count == 0)
-                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgument(SR.GetString(SR.SAMLAssertionRequireOneStatement));
-        }
+        //            if (this.statements.Count == 0)
+        //                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgument(SR.Format(SR.SAMLAssertionRequireOneStatement));
+        //        }
 
-        public int MinorVersion
-        {
-            get { return SamlConstants.MinorVersionValue; }
-        }
+        //        public int MinorVersion
+        //        {
+        //            get { return SamlConstants.MinorVersionValue; }
+        //        }
 
-        public int MajorVersion
-        {
-            get { return SamlConstants.MajorVersionValue; }
-        }
+        //        public int MajorVersion
+        //        {
+        //            get { return SamlConstants.MajorVersionValue; }
+        //        }
 
         public string AssertionId
         {
             get { return this.assertionId; }
             set
             {
-                if (isReadOnly)
-                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.GetString(SR.ObjectIsReadOnly)));
+                throw ServiceModel.ExceptionHelper.PlatformNotSupported();
+                //if (isReadOnly)
+                //    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.ObjectIsReadOnly)));
 
-                if (string.IsNullOrEmpty(value))
-                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgument(SR.GetString(SR.SAMLAssertionIdRequired));
+                //if (string.IsNullOrEmpty(value))
+                //    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgument(SR.Format(SR.SAMLAssertionIdRequired));
 
-                this.assertionId = value;
+                //this.assertionId = value;
             }
         }
 
-        /// <summary>
-        /// Indicates whether this assertion was deserialized from XML source
-        /// and can re-emit the XML data unchanged.
-        /// </summary>
-        /// <remarks>
-        /// <para>
-        /// The default implementation preserves the source data when read using
-        /// Saml2AssertionSerializer.ReadAssertion and is willing to re-emit the
-        /// original data as long as the Id has not changed from the time that 
-        /// assertion was read.
-        /// </para>
-        /// <para>
-        /// Note that it is vitally important that SAML assertions with different
-        /// data have different IDs. If implementing a scheme whereby an assertion
-        /// "template" is loaded and certain bits of data are filled in, the Id 
-        /// must be changed.
-        /// </para>
-        /// </remarks>
-        /// <returns></returns>
-        public virtual bool CanWriteSourceData
-        {
-            get { return null != this.sourceData; }
-        }
+        //        /// <summary>
+        //        /// Indicates whether this assertion was deserialized from XML source
+        //        /// and can re-emit the XML data unchanged.
+        //        /// </summary>
+        //        /// <remarks>
+        //        /// <para>
+        //        /// The default implementation preserves the source data when read using
+        //        /// Saml2AssertionSerializer.ReadAssertion and is willing to re-emit the
+        //        /// original data as long as the Id has not changed from the time that 
+        //        /// assertion was read.
+        //        /// </para>
+        //        /// <para>
+        //        /// Note that it is vitally important that SAML assertions with different
+        //        /// data have different IDs. If implementing a scheme whereby an assertion
+        //        /// "template" is loaded and certain bits of data are filled in, the Id 
+        //        /// must be changed.
+        //        /// </para>
+        //        /// </remarks>
+        //        /// <returns></returns>
+        //        public virtual bool CanWriteSourceData
+        //        {
+        //            get { return null != this.sourceData; }
+        //        }
 
-        public string Issuer
-        {
-            get { return this.issuer; }
-            set
-            {
-                if (isReadOnly)
-                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.GetString(SR.ObjectIsReadOnly)));
+        //        public string Issuer
+        //        {
+        //            get { return this.issuer; }
+        //            set
+        //            {
+        //                if (isReadOnly)
+        //                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.ObjectIsReadOnly)));
 
-                if (string.IsNullOrEmpty(value))
-                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgument(SR.GetString(SR.SAMLAssertionIssuerRequired));
+        //                if (string.IsNullOrEmpty(value))
+        //                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgument(SR.Format(SR.SAMLAssertionIssuerRequired));
 
-                this.issuer = value;
-            }
-        }
+        //                this.issuer = value;
+        //            }
+        //        }
 
-        public DateTime IssueInstant
-        {
-            get { return this.issueInstant; }
-            set
-            {
-                if (isReadOnly)
-                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.GetString(SR.ObjectIsReadOnly)));
+        //        public DateTime IssueInstant
+        //        {
+        //            get { return this.issueInstant; }
+        //            set
+        //            {
+        //                if (isReadOnly)
+        //                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.ObjectIsReadOnly)));
 
-                this.issueInstant = value;
-            }
-        }
+        //                this.issueInstant = value;
+        //            }
+        //        }
 
-        public SamlConditions Conditions
-        {
-            get { return this.conditions; }
-            set
-            {
-                if (isReadOnly)
-                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.GetString(SR.ObjectIsReadOnly)));
+        //        public SamlConditions Conditions
+        //        {
+        //            get { return this.conditions; }
+        //            set
+        //            {
+        //                if (isReadOnly)
+        //                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.ObjectIsReadOnly)));
 
-                this.conditions = value;
-            }
-        }
+        //                this.conditions = value;
+        //            }
+        //        }
 
-        public SamlAdvice Advice
-        {
-            get { return this.advice; }
-            set
-            {
-                if (isReadOnly)
-                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.GetString(SR.ObjectIsReadOnly)));
+        //        public SamlAdvice Advice
+        //        {
+        //            get { return this.advice; }
+        //            set
+        //            {
+        //                if (isReadOnly)
+        //                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.ObjectIsReadOnly)));
 
-                this.advice = value;
-            }
-        }
+        //                this.advice = value;
+        //            }
+        //        }
 
-        public IList<SamlStatement> Statements
-        {
-            get
-            {
-                return this.statements;
-            }
-        }
+        //        public IList<SamlStatement> Statements
+        //        {
+        //            get
+        //            {
+        //                return this.statements;
+        //            }
+        //        }
 
-        public SigningCredentials SigningCredentials
-        {
-            get { return this.signingCredentials; }
-            set
-            {
-                if (isReadOnly)
-                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.GetString(SR.ObjectIsReadOnly)));
+        //        public SigningCredentials SigningCredentials
+        //        {
+        //            get { return this.signingCredentials; }
+        //            set
+        //            {
+        //                if (isReadOnly)
+        //                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.ObjectIsReadOnly)));
 
-                this.signingCredentials = value;
-            }
-        }
+        //                this.signingCredentials = value;
+        //            }
+        //        }
 
-        internal SignedXml Signature
-        {
-            get { return this.signature; }
-        }
+        //        internal SignedXml Signature
+        //        {
+        //            get { return this.signature; }
+        //        }
 
-        internal SecurityKey SignatureVerificationKey
-        {
-            get { return this.verificationKey; }
-        }
+        //        internal SecurityKey SignatureVerificationKey
+        //        {
+        //            get { return this.verificationKey; }
+        //        }
 
-        public SecurityToken SigningToken
-        {
-            get { return this.signingToken; }
-            set
-            {
-                if (isReadOnly)
-                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.GetString(SR.ObjectIsReadOnly)));
+        //        public SecurityToken SigningToken
+        //        {
+        //            get { return this.signingToken; }
+        //            set
+        //            {
+        //                if (isReadOnly)
+        //                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.ObjectIsReadOnly)));
 
-                this.signingToken = value;
-            }
-        }
+        //                this.signingToken = value;
+        //            }
+        //        }
 
-        public bool IsReadOnly
-        {
-            get { return this.isReadOnly; }
-        }
+        //        public bool IsReadOnly
+        //        {
+        //            get { return this.isReadOnly; }
+        //        }
 
-        internal ReadOnlyCollection<SecurityKey> SecurityKeys
-        {
-            get
-            {
-                return this.cryptoList;
-            }
-        }
+        //        internal ReadOnlyCollection<SecurityKey> SecurityKeys
+        //        {
+        //            get
+        //            {
+        //                return this.cryptoList;
+        //            }
+        //        }
 
         public void MakeReadOnly()
         {
-            if (!this.isReadOnly)
-            {
-                if (this.conditions != null)
-                    this.conditions.MakeReadOnly();
+            throw ServiceModel.ExceptionHelper.PlatformNotSupported();
+            //if (!this.isReadOnly)
+            //{
+            //    if (this.conditions != null)
+            //        this.conditions.MakeReadOnly();
 
-                if (this.advice != null)
-                    this.advice.MakeReadOnly();
+            //    if (this.advice != null)
+            //        this.advice.MakeReadOnly();
 
-                foreach (SamlStatement statement in this.statements)
-                {
-                    statement.MakeReadOnly();
-                }
+            //    foreach (SamlStatement statement in this.statements)
+            //    {
+            //        statement.MakeReadOnly();
+            //    }
 
-                this.statements.MakeReadOnly();
+            //    this.statements.MakeReadOnly();
 
-                if (this.cryptoList == null)
-                {
-                    this.cryptoList = BuildCryptoList();
-                }
+            //    if (this.cryptoList == null)
+            //    {
+            //        this.cryptoList = BuildCryptoList();
+            //    }
 
-                this.isReadOnly = true;
-            }
+            //    this.isReadOnly = true;
+            //}
         }
 
-        /// <summary>
-        /// Captures the XML source data from an EnvelopedSignatureReader. 
-        /// </summary>
-        /// <remarks>
-        /// The EnvelopedSignatureReader that was used to read the data for this
-        /// assertion should be passed to this method after the &lt;/Assertion>
-        /// element has been read. This method will preserve the raw XML data
-        /// that was read, including the signature, so that it may be re-emitted
-        /// without changes and without the need to re-sign the data. See 
-        /// CanWriteSourceData and WriteSourceData.
-        /// </remarks>
-        /// <param name="reader"></param>
-        internal virtual void CaptureSourceData(EnvelopedSignatureReader reader)
-        {
-            if (null == reader)
-            {
-                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("reader");
-            }
-
-            this.sourceData = reader.XmlTokens;
-        }
-
-        protected void ReadSignature(XmlDictionaryReader reader, SecurityTokenSerializer keyInfoSerializer, SecurityTokenResolver outOfBandTokenResolver, SamlSerializer samlSerializer)
-        {
-            if (reader == null)
-                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("reader");
-
-            if (samlSerializer == null)
-                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("samlSerializer");
-
-            if (this.signature != null)
-                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.GetString(SR.SAMLSignatureAlreadyRead)));
-
-            // If the reader cannot canonicalize then buffer the signature element to a canonicalizing reader.
-            XmlDictionaryReader effectiveReader = reader;
-            if (!effectiveReader.CanCanonicalize)
-            {
-                MemoryStream stream = new MemoryStream();
-                XmlDictionaryWriter writer = XmlDictionaryWriter.CreateBinaryWriter(stream, samlSerializer.DictionaryManager.ParentDictionary);
-                writer.WriteNode(effectiveReader, false);
-                writer.Flush();
-                stream.Position = 0;
-                effectiveReader = XmlDictionaryReader.CreateBinaryReader(stream.GetBuffer(), 0, (int)stream.Length, samlSerializer.DictionaryManager.ParentDictionary, reader.Quotas);
-                effectiveReader.MoveToContent();
-                writer.Close();
-            }
-            SignedXml signedXml = new SignedXml(new StandardSignedInfo(samlSerializer.DictionaryManager), samlSerializer.DictionaryManager, keyInfoSerializer);
-            signedXml.TransformFactory = ExtendedTransformFactory.Instance;
-            signedXml.ReadFrom(effectiveReader);
-            SecurityKeyIdentifier securityKeyIdentifier = signedXml.Signature.KeyIdentifier;
-            this.verificationKey = SamlSerializer.ResolveSecurityKey(securityKeyIdentifier, outOfBandTokenResolver);
-            if (this.verificationKey == null)
-                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new SecurityTokenException(SR.GetString(SR.SAMLUnableToResolveSignatureKey, this.issuer)));
-
-            this.signature = signedXml;
-            this.signingToken = SamlSerializer.ResolveSecurityToken(securityKeyIdentifier, outOfBandTokenResolver);
-            if (this.signingToken == null)
-                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new SecurityTokenException(SR.GetString(SR.SamlSigningTokenNotFound)));
-
-            if (!ReferenceEquals(reader, effectiveReader))
-                effectiveReader.Close();
-        }
-
-        void CheckObjectValidity()
-        {
-            if (string.IsNullOrEmpty(this.assertionId))
-                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new SecurityTokenException(SR.GetString(SR.SAMLAssertionIdRequired)));
-
-            if (!IsAssertionIdValid(this.assertionId))
-                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new SecurityTokenException(SR.GetString(SR.SAMLAssertionIDIsInvalid, this.assertionId)));
-
-            if (string.IsNullOrEmpty(this.issuer))
-                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new SecurityTokenException(SR.GetString(SR.SAMLAssertionIssuerRequired)));
-
-            if (this.statements.Count == 0)
-                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new SecurityTokenException(SR.GetString(SR.SAMLAssertionRequireOneStatement)));
-        }
-
-        bool IsAssertionIdValid(string assertionId)
-        {
-            if (string.IsNullOrEmpty(assertionId))
-                return false;
-
-            // The first character of the Assertion ID should be a letter or a '_'
-            return (((assertionId[0] >= 'A') && (assertionId[0] <= 'Z')) ||
-                ((assertionId[0] >= 'a') && (assertionId[0] <= 'z')) ||
-                (assertionId[0] == '_'));
-        }
-
-        ReadOnlyCollection<SecurityKey> BuildCryptoList()
-        {
-            List<SecurityKey> cryptoList = new List<SecurityKey>();
-
-            for (int i = 0; i < this.statements.Count; ++i)
-            {
-                SamlSubjectStatement statement = this.statements[i] as SamlSubjectStatement;
-                if (statement != null)
-                {
-                    bool skipCrypto = false;
-                    SecurityKey crypto = null;
-                    if (statement.SamlSubject != null)
-                        crypto = statement.SamlSubject.Crypto;
-                    InMemorySymmetricSecurityKey inMemorySymmetricSecurityKey = crypto as InMemorySymmetricSecurityKey;
-                    if (inMemorySymmetricSecurityKey != null)
-                    {
-
-                        // Verify that you have not already added this to crypto list.
-                        for (int j = 0; j < cryptoList.Count; ++j)
-                        {
-                            if ((cryptoList[j] is InMemorySymmetricSecurityKey) && (cryptoList[j].KeySize == inMemorySymmetricSecurityKey.KeySize))
-                            {
-                                byte[] key1 = ((InMemorySymmetricSecurityKey)cryptoList[j]).GetSymmetricKey();
-                                byte[] key2 = inMemorySymmetricSecurityKey.GetSymmetricKey();
-                                int k = 0;
-                                for (k = 0; k < key1.Length; ++k)
-                                {
-                                    if (key1[k] != key2[k])
-                                    {
-                                        break;
-                                    }
-                                }
-                                skipCrypto = (k == key1.Length);
-                            }
-
-                            if (skipCrypto)
-                                break;
-                        }
-                    }
-                    if (!skipCrypto && (crypto != null))
-                    {
-                        cryptoList.Add(crypto);
-                    }
-                }
-            }
-
-            return cryptoList.AsReadOnly();
-
-        }
-
-        void VerifySignature(SignedXml signature, SecurityKey signatureVerificationKey)
-        {
-            if (signature == null)
-                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("signature");
-
-            if (signatureVerificationKey == null)
-                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("signatureVerificatonKey");
-
-            signature.StartSignatureVerification(signatureVerificationKey);
-            signature.EnsureDigestValidity(this.assertionId, tokenStream);
-            signature.CompleteSignatureVerification();
-        }
-
-        void ICanonicalWriterEndRootElementCallback.OnEndOfRootElement(XmlDictionaryWriter dictionaryWriter)
-        {
-            byte[] hashValue = this.hashStream.FlushHashAndGetValue();
-
-            PreDigestedSignedInfo signedInfo = new PreDigestedSignedInfo(this.dictionaryManager);
-            signedInfo.AddEnvelopedSignatureTransform = true;
-            signedInfo.CanonicalizationMethod = SecurityAlgorithms.ExclusiveC14n;
-            signedInfo.SignatureMethod = this.signingCredentials.SignatureAlgorithm;
-            signedInfo.DigestMethod = this.signingCredentials.DigestAlgorithm;
-            signedInfo.AddReference(this.assertionId, hashValue);
-
-            SignedXml signedXml = new SignedXml(signedInfo, this.dictionaryManager, this.keyInfoSerializer);
-            signedXml.ComputeSignature(this.signingCredentials.SigningKey);
-            signedXml.Signature.KeyIdentifier = this.signingCredentials.SigningKeyIdentifier;
-            signedXml.WriteTo(dictionaryWriter);
-        }
-
-        public virtual void ReadXml(XmlDictionaryReader reader, SamlSerializer samlSerializer, SecurityTokenSerializer keyInfoSerializer, SecurityTokenResolver outOfBandTokenResolver)
-        {
-            if (reader == null)
-                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentNullException("ReadXml"));
-
-            if (samlSerializer == null)
-                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentNullException("samlSerializer"));
-
-            XmlDictionaryReader dictionaryReader = XmlDictionaryReader.CreateDictionaryReader(reader);
-            WrappedReader wrappedReader = new WrappedReader(dictionaryReader);
-#pragma warning suppress 56506 // samlSerializer.DictionaryManager is never null.
-            SamlDictionary dictionary = samlSerializer.DictionaryManager.SamlDictionary;
-
-            if (!wrappedReader.IsStartElement(dictionary.Assertion, dictionary.Namespace))
-                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new SecurityTokenException(SR.GetString(SR.SAMLElementNotRecognized, wrappedReader.LocalName)));
-
-            string attributeValue = wrappedReader.GetAttribute(dictionary.MajorVersion, null);
-            if (string.IsNullOrEmpty(attributeValue))
-                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new SecurityTokenException(SR.GetString(SR.SAMLAssertionMissingMajorVersionAttributeOnRead)));
-            int majorVersion = Int32.Parse(attributeValue, CultureInfo.InvariantCulture);
-
-            attributeValue = wrappedReader.GetAttribute(dictionary.MinorVersion, null);
-            if (string.IsNullOrEmpty(attributeValue))
-                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new SecurityTokenException(SR.GetString(SR.SAMLAssertionMissingMinorVersionAttributeOnRead)));
-
-            int minorVersion = Int32.Parse(attributeValue, CultureInfo.InvariantCulture);
-
-            if ((majorVersion != SamlConstants.MajorVersionValue) || (minorVersion != SamlConstants.MinorVersionValue))
-            {
-                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new SecurityTokenException(SR.GetString(SR.SAMLTokenVersionNotSupported, majorVersion, minorVersion, SamlConstants.MajorVersionValue, SamlConstants.MinorVersionValue)));
-            }
-
-            attributeValue = wrappedReader.GetAttribute(dictionary.AssertionId, null);
-            if (string.IsNullOrEmpty(attributeValue))
-                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new SecurityTokenException(SR.GetString(SR.SAMLAssertionIdRequired)));
-
-            if (!IsAssertionIdValid(attributeValue))
-                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new SecurityTokenException(SR.GetString(SR.SAMLAssertionIDIsInvalid, attributeValue)));
-
-            this.assertionId = attributeValue;
-
-            attributeValue = wrappedReader.GetAttribute(dictionary.Issuer, null);
-            if (string.IsNullOrEmpty(attributeValue))
-                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new SecurityTokenException(SR.GetString(SR.SAMLAssertionMissingIssuerAttributeOnRead)));
-            this.issuer = attributeValue;
-
-            attributeValue = wrappedReader.GetAttribute(dictionary.IssueInstant, null);
-            if (!string.IsNullOrEmpty(attributeValue))
-                this.issueInstant = DateTime.ParseExact(
-                    attributeValue, SamlConstants.AcceptedDateTimeFormats, DateTimeFormatInfo.InvariantInfo, DateTimeStyles.None).ToUniversalTime();
-
-            wrappedReader.MoveToContent();
-            wrappedReader.Read();
-
-            if (wrappedReader.IsStartElement(dictionary.Conditions, dictionary.Namespace))
-            {
-                this.conditions = samlSerializer.LoadConditions(wrappedReader, keyInfoSerializer, outOfBandTokenResolver);
-                if (this.conditions == null)
-                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new SecurityTokenException(SR.GetString(SR.SAMLUnableToLoadCondtions)));
-            }
-
-            if (wrappedReader.IsStartElement(dictionary.Advice, dictionary.Namespace))
-            {
-                this.advice = samlSerializer.LoadAdvice(wrappedReader, keyInfoSerializer, outOfBandTokenResolver);
-                if (this.advice == null)
-                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new SecurityTokenException(SR.GetString(SR.SAMLUnableToLoadAdvice)));
-            }
-
-            while (wrappedReader.IsStartElement())
-            {
-#pragma warning suppress 56506 // samlSerializer.DictionaryManager is never null.
-                if (wrappedReader.IsStartElement(samlSerializer.DictionaryManager.XmlSignatureDictionary.Signature, samlSerializer.DictionaryManager.XmlSignatureDictionary.Namespace))
-                {
-                    break;
-                }
-                else
-                {
-                    SamlStatement statement = samlSerializer.LoadStatement(wrappedReader, keyInfoSerializer, outOfBandTokenResolver);
-                    if (statement == null)
-                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new SecurityTokenException(SR.GetString(SR.SAMLUnableToLoadStatement)));
-                    this.statements.Add(statement);
-                }
-            }
-
-            if (this.statements.Count == 0)
-                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new SecurityTokenException(SR.GetString(SR.SAMLAssertionRequireOneStatementOnRead)));
-
-            if (wrappedReader.IsStartElement(samlSerializer.DictionaryManager.XmlSignatureDictionary.Signature, samlSerializer.DictionaryManager.XmlSignatureDictionary.Namespace))
-                this.ReadSignature(wrappedReader, keyInfoSerializer, outOfBandTokenResolver, samlSerializer);
-
-            wrappedReader.MoveToContent();
-            wrappedReader.ReadEndElement();
-
-            this.tokenStream = wrappedReader.XmlTokens;
-
-            if (this.signature != null)
-            {
-                VerifySignature(this.signature, this.verificationKey);
-            }
-
-            BuildCryptoList();
-        }
-
-        internal void WriteTo(XmlWriter writer, SamlSerializer samlSerializer, SecurityTokenSerializer keyInfoSerializer)
-        {
-            if (writer == null)
-                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("writer");
-
-            if ((this.signingCredentials == null) && (this.signature == null))
-                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.GetString(SR.SamlAssertionMissingSigningCredentials)));
-
-            XmlDictionaryWriter dictionaryWriter = XmlDictionaryWriter.CreateDictionaryWriter(writer);
-
-            if (this.signingCredentials != null)
-            {
-                using (HashAlgorithm hash = CryptoHelper.CreateHashAlgorithm(this.signingCredentials.DigestAlgorithm))
-                {
-                    this.hashStream = new HashStream(hash);
-                    this.keyInfoSerializer = keyInfoSerializer;
-                    this.dictionaryManager = samlSerializer.DictionaryManager;
-                    SamlDelegatingWriter delegatingWriter = new SamlDelegatingWriter(dictionaryWriter, this.hashStream, this, samlSerializer.DictionaryManager.ParentDictionary);
-                    this.WriteXml(delegatingWriter, samlSerializer, keyInfoSerializer);
-                }
-            }
-            else
-            {
-                this.tokenStream.SetElementExclusion(null, null);
-                this.tokenStream.WriteTo(dictionaryWriter, samlSerializer.DictionaryManager);
-            }
-        }
-
-        public virtual void WriteXml(XmlDictionaryWriter writer, SamlSerializer samlSerializer, SecurityTokenSerializer keyInfoSerializer)
-        {
-            CheckObjectValidity();
-
-            if (writer == null)
-                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("writer");
-
-            if (samlSerializer == null)
-                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentNullException("samlSerializer"));
-
-#pragma warning suppress 56506 // samlSerializer.DictionaryManager is never null.
-            SamlDictionary dictionary = samlSerializer.DictionaryManager.SamlDictionary;
-
-            try
-            {
-                writer.WriteStartElement(dictionary.PreferredPrefix.Value, dictionary.Assertion, dictionary.Namespace);
-
-                writer.WriteStartAttribute(dictionary.MajorVersion, null);
-                writer.WriteValue(SamlConstants.MajorVersionValue);
-                writer.WriteEndAttribute();
-                writer.WriteStartAttribute(dictionary.MinorVersion, null);
-                writer.WriteValue(SamlConstants.MinorVersionValue);
-                writer.WriteEndAttribute();
-                writer.WriteStartAttribute(dictionary.AssertionId, null);
-                writer.WriteString(this.assertionId);
-                writer.WriteEndAttribute();
-                writer.WriteStartAttribute(dictionary.Issuer, null);
-                writer.WriteString(this.issuer);
-                writer.WriteEndAttribute();
-                writer.WriteStartAttribute(dictionary.IssueInstant, null);
-                writer.WriteString(this.issueInstant.ToString(SamlConstants.GeneratedDateTimeFormat, CultureInfo.InvariantCulture));
-                writer.WriteEndAttribute();
-
-                // Write out conditions
-                if (this.conditions != null)
-                {
-                    this.conditions.WriteXml(writer, samlSerializer, keyInfoSerializer);
-                }
-
-                // Write out advice if there is one
-                if (this.advice != null)
-                {
-                    this.advice.WriteXml(writer, samlSerializer, keyInfoSerializer);
-                }
-
-                for (int i = 0; i < this.statements.Count; i++)
-                {
-                    this.statements[i].WriteXml(writer, samlSerializer, keyInfoSerializer);
-                }
-
-                writer.WriteEndElement();
-            }
-            catch (Exception e)
-            {
-                // Always immediately rethrow fatal exceptions.
-                if (Fx.IsFatal(e)) throw;
-
-                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.GetString(SR.SAMLTokenNotSerialized), e));
-            }
-        }
-
-        /// <summary>
-        /// Writes the source data, if available.
-        /// </summary>
-        /// <exception cref="InvalidOperationException">When no source data is available</exception>
-        /// <param name="writer"></param>
-        public virtual void WriteSourceData(XmlWriter writer)
-        {
-            if (!this.CanWriteSourceData)
-            {
-                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(
-                    new InvalidOperationException(SR.GetString(SR.ID4140)));
-            }
-
-            // This call will properly just reuse the existing writer if it already qualifies
-            XmlDictionaryWriter dictionaryWriter = XmlDictionaryWriter.CreateDictionaryWriter(writer);
-            this.sourceData.SetElementExclusion(null, null);
-            this.sourceData.GetWriter().WriteTo(dictionaryWriter, null );
-        }
-
-        static internal void AddSamlClaimTypes(ICollection<Type> knownClaimTypes)
-        {
-            if (knownClaimTypes == null)
-            {
-                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("knownClaimTypes");
-            }
-            knownClaimTypes.Add(typeof(SamlAuthorizationDecisionClaimResource));
-            knownClaimTypes.Add(typeof(SamlAuthenticationClaimResource));
-            knownClaimTypes.Add(typeof(SamlAccessDecision));
-            knownClaimTypes.Add(typeof(SamlAuthorityBinding));
-            knownClaimTypes.Add(typeof(SamlNameIdentifierClaimResource));
-        }
+        //        /// <summary>
+        //        /// Captures the XML source data from an EnvelopedSignatureReader. 
+        //        /// </summary>
+        //        /// <remarks>
+        //        /// The EnvelopedSignatureReader that was used to read the data for this
+        //        /// assertion should be passed to this method after the &lt;/Assertion>
+        //        /// element has been read. This method will preserve the raw XML data
+        //        /// that was read, including the signature, so that it may be re-emitted
+        //        /// without changes and without the need to re-sign the data. See 
+        //        /// CanWriteSourceData and WriteSourceData.
+        //        /// </remarks>
+        //        /// <param name="reader"></param>
+        //        internal virtual void CaptureSourceData(EnvelopedSignatureReader reader)
+        //        {
+        //            if (null == reader)
+        //            {
+        //                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("reader");
+        //            }
+
+        //            this.sourceData = reader.XmlTokens;
+        //        }
+
+        //        protected void ReadSignature(XmlDictionaryReader reader, SecurityTokenSerializer keyInfoSerializer, SecurityTokenResolver outOfBandTokenResolver, SamlSerializer samlSerializer)
+        //        {
+        //            if (reader == null)
+        //                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("reader");
+
+        //            if (samlSerializer == null)
+        //                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("samlSerializer");
+
+        //            if (this.signature != null)
+        //                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.SAMLSignatureAlreadyRead)));
+
+        //            // If the reader cannot canonicalize then buffer the signature element to a canonicalizing reader.
+        //            XmlDictionaryReader effectiveReader = reader;
+        //            if (!effectiveReader.CanCanonicalize)
+        //            {
+        //                MemoryStream stream = new MemoryStream();
+        //                XmlDictionaryWriter writer = XmlDictionaryWriter.CreateBinaryWriter(stream, samlSerializer.DictionaryManager.ParentDictionary);
+        //                writer.WriteNode(effectiveReader, false);
+        //                writer.Flush();
+        //                stream.Position = 0;
+        //                effectiveReader = XmlDictionaryReader.CreateBinaryReader(stream.GetBuffer(), 0, (int)stream.Length, samlSerializer.DictionaryManager.ParentDictionary, reader.Quotas);
+        //                effectiveReader.MoveToContent();
+        //                writer.Close();
+        //            }
+        //            SignedXml signedXml = new SignedXml(new StandardSignedInfo(samlSerializer.DictionaryManager), samlSerializer.DictionaryManager, keyInfoSerializer);
+        //            signedXml.TransformFactory = ExtendedTransformFactory.Instance;
+        //            signedXml.ReadFrom(effectiveReader);
+        //            SecurityKeyIdentifier securityKeyIdentifier = signedXml.Signature.KeyIdentifier;
+        //            this.verificationKey = SamlSerializer.ResolveSecurityKey(securityKeyIdentifier, outOfBandTokenResolver);
+        //            if (this.verificationKey == null)
+        //                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new SecurityTokenException(SR.Format(SR.SAMLUnableToResolveSignatureKey, this.issuer)));
+
+        //            this.signature = signedXml;
+        //            this.signingToken = SamlSerializer.ResolveSecurityToken(securityKeyIdentifier, outOfBandTokenResolver);
+        //            if (this.signingToken == null)
+        //                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new SecurityTokenException(SR.Format(SR.SamlSigningTokenNotFound)));
+
+        //            if (!ReferenceEquals(reader, effectiveReader))
+        //                effectiveReader.Close();
+        //        }
+
+        //        void CheckObjectValidity()
+        //        {
+        //            if (string.IsNullOrEmpty(this.assertionId))
+        //                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new SecurityTokenException(SR.Format(SR.SAMLAssertionIdRequired)));
+
+        //            if (!IsAssertionIdValid(this.assertionId))
+        //                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new SecurityTokenException(SR.Format(SR.SAMLAssertionIDIsInvalid, this.assertionId)));
+
+        //            if (string.IsNullOrEmpty(this.issuer))
+        //                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new SecurityTokenException(SR.Format(SR.SAMLAssertionIssuerRequired)));
+
+        //            if (this.statements.Count == 0)
+        //                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new SecurityTokenException(SR.Format(SR.SAMLAssertionRequireOneStatement)));
+        //        }
+
+        //        bool IsAssertionIdValid(string assertionId)
+        //        {
+        //            if (string.IsNullOrEmpty(assertionId))
+        //                return false;
+
+        //            // The first character of the Assertion ID should be a letter or a '_'
+        //            return (((assertionId[0] >= 'A') && (assertionId[0] <= 'Z')) ||
+        //                ((assertionId[0] >= 'a') && (assertionId[0] <= 'z')) ||
+        //                (assertionId[0] == '_'));
+        //        }
+
+        //        ReadOnlyCollection<SecurityKey> BuildCryptoList()
+        //        {
+        //            List<SecurityKey> cryptoList = new List<SecurityKey>();
+
+        //            for (int i = 0; i < this.statements.Count; ++i)
+        //            {
+        //                SamlSubjectStatement statement = this.statements[i] as SamlSubjectStatement;
+        //                if (statement != null)
+        //                {
+        //                    bool skipCrypto = false;
+        //                    SecurityKey crypto = null;
+        //                    if (statement.SamlSubject != null)
+        //                        crypto = statement.SamlSubject.Crypto;
+        //                    InMemorySymmetricSecurityKey inMemorySymmetricSecurityKey = crypto as InMemorySymmetricSecurityKey;
+        //                    if (inMemorySymmetricSecurityKey != null)
+        //                    {
+
+        //                        // Verify that you have not already added this to crypto list.
+        //                        for (int j = 0; j < cryptoList.Count; ++j)
+        //                        {
+        //                            if ((cryptoList[j] is InMemorySymmetricSecurityKey) && (cryptoList[j].KeySize == inMemorySymmetricSecurityKey.KeySize))
+        //                            {
+        //                                byte[] key1 = ((InMemorySymmetricSecurityKey)cryptoList[j]).GetSymmetricKey();
+        //                                byte[] key2 = inMemorySymmetricSecurityKey.GetSymmetricKey();
+        //                                int k = 0;
+        //                                for (k = 0; k < key1.Length; ++k)
+        //                                {
+        //                                    if (key1[k] != key2[k])
+        //                                    {
+        //                                        break;
+        //                                    }
+        //                                }
+        //                                skipCrypto = (k == key1.Length);
+        //                            }
+
+        //                            if (skipCrypto)
+        //                                break;
+        //                        }
+        //                    }
+        //                    if (!skipCrypto && (crypto != null))
+        //                    {
+        //                        cryptoList.Add(crypto);
+        //                    }
+        //                }
+        //            }
+
+        //            return cryptoList.AsReadOnly();
+
+        //        }
+
+        //        void VerifySignature(SignedXml signature, SecurityKey signatureVerificationKey)
+        //        {
+        //            if (signature == null)
+        //                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("signature");
+
+        //            if (signatureVerificationKey == null)
+        //                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("signatureVerificatonKey");
+
+        //            signature.StartSignatureVerification(signatureVerificationKey);
+        //            signature.EnsureDigestValidity(this.assertionId, tokenStream);
+        //            signature.CompleteSignatureVerification();
+        //        }
+
+        //        void ICanonicalWriterEndRootElementCallback.OnEndOfRootElement(XmlDictionaryWriter dictionaryWriter)
+        //        {
+        //            byte[] hashValue = this.hashStream.FlushHashAndGetValue();
+
+        //            PreDigestedSignedInfo signedInfo = new PreDigestedSignedInfo(this.dictionaryManager);
+        //            signedInfo.AddEnvelopedSignatureTransform = true;
+        //            signedInfo.CanonicalizationMethod = SecurityAlgorithms.ExclusiveC14n;
+        //            signedInfo.SignatureMethod = this.signingCredentials.SignatureAlgorithm;
+        //            signedInfo.DigestMethod = this.signingCredentials.DigestAlgorithm;
+        //            signedInfo.AddReference(this.assertionId, hashValue);
+
+        //            SignedXml signedXml = new SignedXml(signedInfo, this.dictionaryManager, this.keyInfoSerializer);
+        //            signedXml.ComputeSignature(this.signingCredentials.SigningKey);
+        //            signedXml.Signature.KeyIdentifier = this.signingCredentials.SigningKeyIdentifier;
+        //            signedXml.WriteTo(dictionaryWriter);
+        //        }
+
+        //        public virtual void ReadXml(XmlDictionaryReader reader, SamlSerializer samlSerializer, SecurityTokenSerializer keyInfoSerializer, SecurityTokenResolver outOfBandTokenResolver)
+        //        {
+        //            if (reader == null)
+        //                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentNullException("ReadXml"));
+
+        //            if (samlSerializer == null)
+        //                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentNullException("samlSerializer"));
+
+        //            XmlDictionaryReader dictionaryReader = XmlDictionaryReader.CreateDictionaryReader(reader);
+        //            WrappedReader wrappedReader = new WrappedReader(dictionaryReader);
+        //#pragma warning suppress 56506 // samlSerializer.DictionaryManager is never null.
+        //            SamlDictionary dictionary = samlSerializer.DictionaryManager.SamlDictionary;
+
+        //            if (!wrappedReader.IsStartElement(dictionary.Assertion, dictionary.Namespace))
+        //                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new SecurityTokenException(SR.Format(SR.SAMLElementNotRecognized, wrappedReader.LocalName)));
+
+        //            string attributeValue = wrappedReader.GetAttribute(dictionary.MajorVersion, null);
+        //            if (string.IsNullOrEmpty(attributeValue))
+        //                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new SecurityTokenException(SR.Format(SR.SAMLAssertionMissingMajorVersionAttributeOnRead)));
+        //            int majorVersion = Int32.Parse(attributeValue, CultureInfo.InvariantCulture);
+
+        //            attributeValue = wrappedReader.GetAttribute(dictionary.MinorVersion, null);
+        //            if (string.IsNullOrEmpty(attributeValue))
+        //                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new SecurityTokenException(SR.Format(SR.SAMLAssertionMissingMinorVersionAttributeOnRead)));
+
+        //            int minorVersion = Int32.Parse(attributeValue, CultureInfo.InvariantCulture);
+
+        //            if ((majorVersion != SamlConstants.MajorVersionValue) || (minorVersion != SamlConstants.MinorVersionValue))
+        //            {
+        //                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new SecurityTokenException(SR.Format(SR.SAMLTokenVersionNotSupported, majorVersion, minorVersion, SamlConstants.MajorVersionValue, SamlConstants.MinorVersionValue)));
+        //            }
+
+        //            attributeValue = wrappedReader.GetAttribute(dictionary.AssertionId, null);
+        //            if (string.IsNullOrEmpty(attributeValue))
+        //                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new SecurityTokenException(SR.Format(SR.SAMLAssertionIdRequired)));
+
+        //            if (!IsAssertionIdValid(attributeValue))
+        //                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new SecurityTokenException(SR.Format(SR.SAMLAssertionIDIsInvalid, attributeValue)));
+
+        //            this.assertionId = attributeValue;
+
+        //            attributeValue = wrappedReader.GetAttribute(dictionary.Issuer, null);
+        //            if (string.IsNullOrEmpty(attributeValue))
+        //                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new SecurityTokenException(SR.Format(SR.SAMLAssertionMissingIssuerAttributeOnRead)));
+        //            this.issuer = attributeValue;
+
+        //            attributeValue = wrappedReader.GetAttribute(dictionary.IssueInstant, null);
+        //            if (!string.IsNullOrEmpty(attributeValue))
+        //                this.issueInstant = DateTime.ParseExact(
+        //                    attributeValue, SamlConstants.AcceptedDateTimeFormats, DateTimeFormatInfo.InvariantInfo, DateTimeStyles.None).ToUniversalTime();
+
+        //            wrappedReader.MoveToContent();
+        //            wrappedReader.Read();
+
+        //            if (wrappedReader.IsStartElement(dictionary.Conditions, dictionary.Namespace))
+        //            {
+        //                this.conditions = samlSerializer.LoadConditions(wrappedReader, keyInfoSerializer, outOfBandTokenResolver);
+        //                if (this.conditions == null)
+        //                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new SecurityTokenException(SR.Format(SR.SAMLUnableToLoadCondtions)));
+        //            }
+
+        //            if (wrappedReader.IsStartElement(dictionary.Advice, dictionary.Namespace))
+        //            {
+        //                this.advice = samlSerializer.LoadAdvice(wrappedReader, keyInfoSerializer, outOfBandTokenResolver);
+        //                if (this.advice == null)
+        //                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new SecurityTokenException(SR.Format(SR.SAMLUnableToLoadAdvice)));
+        //            }
+
+        //            while (wrappedReader.IsStartElement())
+        //            {
+        //#pragma warning suppress 56506 // samlSerializer.DictionaryManager is never null.
+        //                if (wrappedReader.IsStartElement(samlSerializer.DictionaryManager.XmlSignatureDictionary.Signature, samlSerializer.DictionaryManager.XmlSignatureDictionary.Namespace))
+        //                {
+        //                    break;
+        //                }
+        //                else
+        //                {
+        //                    SamlStatement statement = samlSerializer.LoadStatement(wrappedReader, keyInfoSerializer, outOfBandTokenResolver);
+        //                    if (statement == null)
+        //                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new SecurityTokenException(SR.Format(SR.SAMLUnableToLoadStatement)));
+        //                    this.statements.Add(statement);
+        //                }
+        //            }
+
+        //            if (this.statements.Count == 0)
+        //                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new SecurityTokenException(SR.Format(SR.SAMLAssertionRequireOneStatementOnRead)));
+
+        //            if (wrappedReader.IsStartElement(samlSerializer.DictionaryManager.XmlSignatureDictionary.Signature, samlSerializer.DictionaryManager.XmlSignatureDictionary.Namespace))
+        //                this.ReadSignature(wrappedReader, keyInfoSerializer, outOfBandTokenResolver, samlSerializer);
+
+        //            wrappedReader.MoveToContent();
+        //            wrappedReader.ReadEndElement();
+
+        //            this.tokenStream = wrappedReader.XmlTokens;
+
+        //            if (this.signature != null)
+        //            {
+        //                VerifySignature(this.signature, this.verificationKey);
+        //            }
+
+        //            BuildCryptoList();
+        //        }
+
+        //        internal void WriteTo(XmlWriter writer, SamlSerializer samlSerializer, SecurityTokenSerializer keyInfoSerializer)
+        //        {
+        //            if (writer == null)
+        //                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("writer");
+
+        //            if ((this.signingCredentials == null) && (this.signature == null))
+        //                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.SamlAssertionMissingSigningCredentials)));
+
+        //            XmlDictionaryWriter dictionaryWriter = XmlDictionaryWriter.CreateDictionaryWriter(writer);
+
+        //            if (this.signingCredentials != null)
+        //            {
+        //                using (HashAlgorithm hash = CryptoHelper.CreateHashAlgorithm(this.signingCredentials.DigestAlgorithm))
+        //                {
+        //                    this.hashStream = new HashStream(hash);
+        //                    this.keyInfoSerializer = keyInfoSerializer;
+        //                    this.dictionaryManager = samlSerializer.DictionaryManager;
+        //                    SamlDelegatingWriter delegatingWriter = new SamlDelegatingWriter(dictionaryWriter, this.hashStream, this, samlSerializer.DictionaryManager.ParentDictionary);
+        //                    this.WriteXml(delegatingWriter, samlSerializer, keyInfoSerializer);
+        //                }
+        //            }
+        //            else
+        //            {
+        //                this.tokenStream.SetElementExclusion(null, null);
+        //                this.tokenStream.WriteTo(dictionaryWriter, samlSerializer.DictionaryManager);
+        //            }
+        //        }
+
+        //        public virtual void WriteXml(XmlDictionaryWriter writer, SamlSerializer samlSerializer, SecurityTokenSerializer keyInfoSerializer)
+        //        {
+        //            CheckObjectValidity();
+
+        //            if (writer == null)
+        //                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("writer");
+
+        //            if (samlSerializer == null)
+        //                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentNullException("samlSerializer"));
+
+        //#pragma warning suppress 56506 // samlSerializer.DictionaryManager is never null.
+        //            SamlDictionary dictionary = samlSerializer.DictionaryManager.SamlDictionary;
+
+        //            try
+        //            {
+        //                writer.WriteStartElement(dictionary.PreferredPrefix.Value, dictionary.Assertion, dictionary.Namespace);
+
+        //                writer.WriteStartAttribute(dictionary.MajorVersion, null);
+        //                writer.WriteValue(SamlConstants.MajorVersionValue);
+        //                writer.WriteEndAttribute();
+        //                writer.WriteStartAttribute(dictionary.MinorVersion, null);
+        //                writer.WriteValue(SamlConstants.MinorVersionValue);
+        //                writer.WriteEndAttribute();
+        //                writer.WriteStartAttribute(dictionary.AssertionId, null);
+        //                writer.WriteString(this.assertionId);
+        //                writer.WriteEndAttribute();
+        //                writer.WriteStartAttribute(dictionary.Issuer, null);
+        //                writer.WriteString(this.issuer);
+        //                writer.WriteEndAttribute();
+        //                writer.WriteStartAttribute(dictionary.IssueInstant, null);
+        //                writer.WriteString(this.issueInstant.ToString(SamlConstants.GeneratedDateTimeFormat, CultureInfo.InvariantCulture));
+        //                writer.WriteEndAttribute();
+
+        //                // Write out conditions
+        //                if (this.conditions != null)
+        //                {
+        //                    this.conditions.WriteXml(writer, samlSerializer, keyInfoSerializer);
+        //                }
+
+        //                // Write out advice if there is one
+        //                if (this.advice != null)
+        //                {
+        //                    this.advice.WriteXml(writer, samlSerializer, keyInfoSerializer);
+        //                }
+
+        //                for (int i = 0; i < this.statements.Count; i++)
+        //                {
+        //                    this.statements[i].WriteXml(writer, samlSerializer, keyInfoSerializer);
+        //                }
+
+        //                writer.WriteEndElement();
+        //            }
+        //            catch (Exception e)
+        //            {
+        //                // Always immediately rethrow fatal exceptions.
+        //                if (Fx.IsFatal(e)) throw;
+
+        //                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.SAMLTokenNotSerialized), e));
+        //            }
+        //        }
+
+        //        /// <summary>
+        //        /// Writes the source data, if available.
+        //        /// </summary>
+        //        /// <exception cref="InvalidOperationException">When no source data is available</exception>
+        //        /// <param name="writer"></param>
+        //        public virtual void WriteSourceData(XmlWriter writer)
+        //        {
+        //            if (!this.CanWriteSourceData)
+        //            {
+        //                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(
+        //                    new InvalidOperationException(SR.Format(SR.ID4140)));
+        //            }
+
+        //            // This call will properly just reuse the existing writer if it already qualifies
+        //            XmlDictionaryWriter dictionaryWriter = XmlDictionaryWriter.CreateDictionaryWriter(writer);
+        //            this.sourceData.SetElementExclusion(null, null);
+        //            this.sourceData.GetWriter().WriteTo(dictionaryWriter, null );
+        //        }
+
+        //        static internal void AddSamlClaimTypes(ICollection<Type> knownClaimTypes)
+        //        {
+        //            if (knownClaimTypes == null)
+        //            {
+        //                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("knownClaimTypes");
+        //            }
+        //            knownClaimTypes.Add(typeof(SamlAuthorizationDecisionClaimResource));
+        //            knownClaimTypes.Add(typeof(SamlAuthenticationClaimResource));
+        //            knownClaimTypes.Add(typeof(SamlAccessDecision));
+        //            knownClaimTypes.Add(typeof(SamlAuthorityBinding));
+        //            knownClaimTypes.Add(typeof(SamlNameIdentifierClaimResource));
+        //        }
     }
 }
 

--- a/src/System.Private.ServiceModel/src/System/IdentityModel/Tokens/SamlAssertion.cs
+++ b/src/System.Private.ServiceModel/src/System/IdentityModel/Tokens/SamlAssertion.cs
@@ -2,20 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
-using System.Collections.ObjectModel;
-using System.Globalization;
-using System.IO;
-using System.IdentityModel;
-using System.IdentityModel.Claims;
-using System.IdentityModel.Policy;
-using System.IdentityModel.Selectors;
-using System.Runtime;
-using System.Runtime.InteropServices;
-using System.Security;
-using System.Security.Cryptography;
-using System.Xml;
-
 namespace System.IdentityModel.Tokens
 {
     public class SamlAssertion // : ICanonicalWriterEndRootElementCallback  // Issue #31 in progress

--- a/src/System.Private.ServiceModel/src/System/IdentityModel/Tokens/SamlConstants.cs
+++ b/src/System.Private.ServiceModel/src/System/IdentityModel/Tokens/SamlConstants.cs
@@ -1,11 +1,11 @@
-//-----------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation.  All rights reserved.
-//-----------------------------------------------------------------------------
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 
 namespace System.IdentityModel.Tokens
 {
-    using System;
-
     public static class SamlConstants
     {
         static public int MajorVersionValue { get { return 1; } }
@@ -20,7 +20,7 @@ namespace System.IdentityModel.Tokens
 
         public const string Prefix = "saml";
 
-        internal static string[] AcceptedDateTimeFormats = new string[] {
+        internal static string[] s_AcceptedDateTimeFormats = new string[] {
                 "yyyy-MM-ddTHH:mm:ss.fffffffZ",
                 "yyyy-MM-ddTHH:mm:ss.ffffffZ",
                 "yyyy-MM-ddTHH:mm:ss.fffffZ",

--- a/src/System.Private.ServiceModel/src/System/IdentityModel/Tokens/SamlConstants.cs
+++ b/src/System.Private.ServiceModel/src/System/IdentityModel/Tokens/SamlConstants.cs
@@ -1,0 +1,117 @@
+//-----------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//-----------------------------------------------------------------------------
+
+namespace System.IdentityModel.Tokens
+{
+    using System;
+
+    public static class SamlConstants
+    {
+        static public int MajorVersionValue { get { return 1; } }
+        static public int MinorVersionValue { get { return 1; } }
+        static public string Namespace { get { return SamlStrings.Namespace; } }
+        static public string HolderOfKey { get { return SamlStrings.HolderOfKey; } }
+        static public string SenderVouches { get { return SamlStrings.SenderVouches; } }
+        static public string UserName { get { return SamlStrings.UserName; } }
+        static public string UserNameNamespace { get { return SamlStrings.UserNameNamespace; } }
+        static public string EmailName { get { return SamlStrings.EmailName; } }
+        static public string EmailNamespace { get { return SamlStrings.EmailNamespace; } }
+
+        public const string Prefix = "saml";
+
+        internal static string[] AcceptedDateTimeFormats = new string[] {
+                "yyyy-MM-ddTHH:mm:ss.fffffffZ",
+                "yyyy-MM-ddTHH:mm:ss.ffffffZ",
+                "yyyy-MM-ddTHH:mm:ss.fffffZ",
+                "yyyy-MM-ddTHH:mm:ss.ffffZ",
+                "yyyy-MM-ddTHH:mm:ss.fffZ",
+                "yyyy-MM-ddTHH:mm:ss.ffZ",
+                "yyyy-MM-ddTHH:mm:ss.fZ",
+                "yyyy-MM-ddTHH:mm:ssZ",
+                "yyyy-MM-ddTHH:mm:ss.fffffffzzz",
+                "yyyy-MM-ddTHH:mm:ss.ffffffzzz",
+                "yyyy-MM-ddTHH:mm:ss.fffffzzz",
+                "yyyy-MM-ddTHH:mm:ss.ffffzzz",
+                "yyyy-MM-ddTHH:mm:ss.fffzzz",
+                "yyyy-MM-ddTHH:mm:ss.ffzzz",
+                "yyyy-MM-ddTHH:mm:ss.fzzz",
+                "yyyy-MM-ddTHH:mm:sszzz" };
+        internal const string AssertionIdPrefix = "SamlSecurityToken-";
+        internal const string GeneratedDateTimeFormat = "yyyy-MM-ddTHH:mm:ss.fffZ";
+
+
+        /// <summary>
+        /// Known values for <see cref="System.IdentityModel.Tokens.SamlAuthenticationStatement"/>
+        /// </summary>
+        internal static class AuthenticationMethods
+        {
+            public const string HardwareTokenString = "URI:urn:oasis:names:tc:SAML:1.0:am:HardwareToken";
+            public const string KerberosString = "urn:ietf:rfc:1510";
+            public const string PasswordString = "urn:oasis:names:tc:SAML:1.0:am:password";
+            public const string PgpString = "urn:oasis:names:tc:SAML:1.0:am:PGP";
+            public const string SecureRemotePasswordString = "urn:ietf:rfc:2945";
+            public const string SignatureString = "urn:ietf:rfc:3075";
+            public const string SpkiString = "urn:oasis:names:tc:SAML:1.0:am:SPKI";
+            public const string TlsClientString = "urn:ietf:rfc:2246";
+            public const string UnspecifiedString = "urn:oasis:names:tc:SAML:1.0:am:unspecified";
+            public const string WindowsString = "urn:federation:authentication:windows";
+            public const string X509String = "urn:oasis:names:tc:SAML:1.0:am:X509-PKI";
+            public const string XkmsString = "urn:oasis:names:tc:SAML:1.0:am:XKMS";
+        }
+
+        internal static class ElementNames
+        {
+            public const string Action = "Action";
+            public const string Advice = "Advice";
+            public const string Assertion = "Assertion";
+            public const string AssertionIdReference = "AssertionIDReference";
+            public const string Attribute = "Attribute";
+            public const string AttributeStatement = "AttributeStatement";
+            public const string AttributeValue = "AttributeValue";
+            public const string Audience = "Audience";
+            public const string AudienceRestrictionCondition = "AudienceRestrictionCondition";
+            public const string AuthenticationStatement = "AuthenticationStatement";
+            public const string AuthorityBinding = "AuthorityBinding";
+            public const string AuthorizationDecisionStatement = "AuthorizationDecisionStatement";
+            public const string Conditions = "Conditions";
+            public const string DoNotCacheCondition = "DoNotCacheCondition";
+            public const string Evidence = "Evidence";
+            public const string NameIdentifier = "NameIdentifier";
+            public const string SubjectConfirmation = "SubjectConfirmation";
+            public const string Subject = "Subject";
+            public const string SubjectConfirmationData = "SubjectConfirmationData";
+            public const string SubjectConfirmationMethod = "ConfirmationMethod";
+            public const string SubjectLocality = "SubjectLocality";
+        }
+
+        internal static class AttributeNames
+        {
+            public const string AssertionId = "AssertionID";
+            public const string AttributeName = "AttributeName";
+            public const string AttributeNamespace = "AttributeNamespace";
+            public const string AuthenticationInstant = "AuthenticationInstant";
+            public const string AuthenticationMethod = "AuthenticationMethod";
+            public const string AuthorityBinding = "AuthorityBinding";
+            public const string AuthorityKind = "AuthorityKind";
+            public const string Binding = "Binding";
+            public const string Decision = "Decision";
+            public const string Issuer = "Issuer";
+            public const string IssueInstant = "IssueInstant";
+            public const string Location = "Location";
+            public const string MajorVersion = "MajorVersion";
+            public const string MinorVersion = "MinorVersion";
+            public const string OriginalIssuer = "OriginalIssuer";
+            public const string NamespaceAttributePrefix = "xmlns";
+            public const string NameIdentifierFormat = "Format";
+            public const string NameIdentifierNameQualifier = "NameQualifier";
+            public const string Namespace = "Namespace";
+            public const string NotBefore = "NotBefore";
+            public const string NotOnOrAfter = "NotOnOrAfter";
+            public const string Resource = "Resource";
+            public const string SubjectLocalityDNSAddress = "DNSAddress";
+            public const string SubjectLocalityIPAddress = "IPAddress";
+        }
+    }
+}
+

--- a/src/System.Private.ServiceModel/src/System/IdentityModel/Tokens/SamlSecurityToken.cs
+++ b/src/System.Private.ServiceModel/src/System/IdentityModel/Tokens/SamlSecurityToken.cs
@@ -1,27 +1,27 @@
-//-----------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation.  All rights reserved.
-//-----------------------------------------------------------------------------
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Text;
+using System.Xml.Serialization;
+using System.Xml;
+using System.Xml.Schema;
+using System.CodeDom;
+using System.Runtime.Serialization;
+using System.Globalization;
+using System.Threading;
+using System.IdentityModel.Selectors;
+using System.IdentityModel.Policy;
+using System.Reflection;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using System.IO;
 
 namespace System.IdentityModel.Tokens
 {
-    using System.Collections;
-    using System.Collections.Generic;
-    using System.Collections.ObjectModel;
-    using System.Text;
-    using System.Xml.Serialization;
-    using System.Xml;
-    using System.Xml.Schema;
-    using System.CodeDom;
-    using System.Runtime.Serialization;
-    using System.Globalization;
-    using System.Threading;
-    using System.IdentityModel.Selectors;
-    using System.IdentityModel.Policy;
-    using System.Reflection;
-    using System.Security.Cryptography;
-    using System.Security.Cryptography.X509Certificates;
-    using System.IO;
-
     public class SamlSecurityToken : SecurityToken
     {
         SamlAssertion assertion;
@@ -38,7 +38,7 @@ namespace System.IdentityModel.Tokens
         protected void Initialize(SamlAssertion assertion)
         {
             if (assertion == null)
-                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("assertion");
+                throw ServiceModel.DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("assertion");
 
             this.assertion = assertion;
             this.assertion.MakeReadOnly();
@@ -53,7 +53,8 @@ namespace System.IdentityModel.Tokens
         {
             get
             {
-                return this.assertion.SecurityKeys;
+                throw ServiceModel.ExceptionHelper.PlatformNotSupported();  // Issue #31 in progress
+                //return this.assertion.SecurityKeys;
             }
         }
 
@@ -66,12 +67,13 @@ namespace System.IdentityModel.Tokens
         {
             get
             {
-                if (this.assertion.Conditions != null)
-                {
-                    return this.assertion.Conditions.NotBefore;
-                }
+                throw ServiceModel.ExceptionHelper.PlatformNotSupported();  // Issue #31 in progress
+                //if (this.assertion.Conditions != null)
+                //{
+                //    return this.assertion.Conditions.NotBefore;
+                //}
 
-                return SecurityUtils.MinUtcDateTime;
+                //return SecurityUtils.MinUtcDateTime;
             }
         }
 
@@ -79,40 +81,44 @@ namespace System.IdentityModel.Tokens
         {
             get
             {
-                if (this.assertion.Conditions != null)
-                {
-                    return this.assertion.Conditions.NotOnOrAfter;
-                }
+                throw ServiceModel.ExceptionHelper.PlatformNotSupported();  // Issue #31 in progress
+                //if (this.assertion.Conditions != null)
+                //{
+                //    return this.assertion.Conditions.NotOnOrAfter;
+                //}
 
-                return SecurityUtils.MaxUtcDateTime;
+                //return SecurityUtils.MaxUtcDateTime;
             }
         }
 
         public override bool CanCreateKeyIdentifierClause<T>()
         {
-            if (typeof(T) == typeof(SamlAssertionKeyIdentifierClause))
-                return true;
+            throw ServiceModel.ExceptionHelper.PlatformNotSupported();  // Issue #31 in progress
+            //if (typeof(T) == typeof(SamlAssertionKeyIdentifierClause))
+            //    return true;
 
-            return false;
+            //return false;
         }
 
         public override T CreateKeyIdentifierClause<T>()
         {
-            if (typeof(T) == typeof(SamlAssertionKeyIdentifierClause))
-                return new SamlAssertionKeyIdentifierClause(this.Id) as T;
+            throw ServiceModel.ExceptionHelper.PlatformNotSupported();  // Issue #31 in progress
 
-            throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.GetString(SR.UnableToCreateTokenReference)));
+            //if (typeof(T) == typeof(SamlAssertionKeyIdentifierClause))
+            //    return new SamlAssertionKeyIdentifierClause(this.Id) as T;
+
+            //throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.UnableToCreateTokenReference)));
         }
 
         public override bool MatchesKeyIdentifierClause(SecurityKeyIdentifierClause keyIdentifierClause)
         {
-            SamlAssertionKeyIdentifierClause samlKeyIdentifierClause = keyIdentifierClause as SamlAssertionKeyIdentifierClause;
-            if (samlKeyIdentifierClause != null)
-                return samlKeyIdentifierClause.Matches(this.Id);
+            throw ServiceModel.ExceptionHelper.PlatformNotSupported();  // Issue #31 in progress
+            //SamlAssertionKeyIdentifierClause samlKeyIdentifierClause = keyIdentifierClause as SamlAssertionKeyIdentifierClause;
+            //if (samlKeyIdentifierClause != null)
+            //    return samlKeyIdentifierClause.Matches(this.Id);
 
-            return false;
+            //return false;
         }
     }
-
 }
 

--- a/src/System.Private.ServiceModel/src/System/IdentityModel/Tokens/SamlSecurityToken.cs
+++ b/src/System.Private.ServiceModel/src/System/IdentityModel/Tokens/SamlSecurityToken.cs
@@ -2,23 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections;
-using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Text;
-using System.Xml.Serialization;
-using System.Xml;
-using System.Xml.Schema;
-using System.CodeDom;
-using System.Runtime.Serialization;
-using System.Globalization;
-using System.Threading;
-using System.IdentityModel.Selectors;
-using System.IdentityModel.Policy;
-using System.Reflection;
-using System.Security.Cryptography;
-using System.Security.Cryptography.X509Certificates;
-using System.IO;
 using DiagnosticUtility = System.ServiceModel.DiagnosticUtility;
 
 namespace System.IdentityModel.Tokens

--- a/src/System.Private.ServiceModel/src/System/IdentityModel/Tokens/SamlSecurityToken.cs
+++ b/src/System.Private.ServiceModel/src/System/IdentityModel/Tokens/SamlSecurityToken.cs
@@ -1,0 +1,118 @@
+//-----------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//-----------------------------------------------------------------------------
+
+namespace System.IdentityModel.Tokens
+{
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Collections.ObjectModel;
+    using System.Text;
+    using System.Xml.Serialization;
+    using System.Xml;
+    using System.Xml.Schema;
+    using System.CodeDom;
+    using System.Runtime.Serialization;
+    using System.Globalization;
+    using System.Threading;
+    using System.IdentityModel.Selectors;
+    using System.IdentityModel.Policy;
+    using System.Reflection;
+    using System.Security.Cryptography;
+    using System.Security.Cryptography.X509Certificates;
+    using System.IO;
+
+    public class SamlSecurityToken : SecurityToken
+    {
+        SamlAssertion assertion;
+
+        protected SamlSecurityToken()
+        {
+        }
+
+        public SamlSecurityToken(SamlAssertion assertion)
+        {
+            Initialize(assertion);
+        }
+
+        protected void Initialize(SamlAssertion assertion)
+        {
+            if (assertion == null)
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("assertion");
+
+            this.assertion = assertion;
+            this.assertion.MakeReadOnly();
+        }
+
+        public override string Id
+        {
+            get { return this.assertion.AssertionId; }
+        }
+
+        public override ReadOnlyCollection<SecurityKey> SecurityKeys
+        {
+            get
+            {
+                return this.assertion.SecurityKeys;
+            }
+        }
+
+        public SamlAssertion Assertion
+        {
+            get { return this.assertion; }
+        }
+
+        public override DateTime ValidFrom
+        {
+            get
+            {
+                if (this.assertion.Conditions != null)
+                {
+                    return this.assertion.Conditions.NotBefore;
+                }
+
+                return SecurityUtils.MinUtcDateTime;
+            }
+        }
+
+        public override DateTime ValidTo
+        {
+            get
+            {
+                if (this.assertion.Conditions != null)
+                {
+                    return this.assertion.Conditions.NotOnOrAfter;
+                }
+
+                return SecurityUtils.MaxUtcDateTime;
+            }
+        }
+
+        public override bool CanCreateKeyIdentifierClause<T>()
+        {
+            if (typeof(T) == typeof(SamlAssertionKeyIdentifierClause))
+                return true;
+
+            return false;
+        }
+
+        public override T CreateKeyIdentifierClause<T>()
+        {
+            if (typeof(T) == typeof(SamlAssertionKeyIdentifierClause))
+                return new SamlAssertionKeyIdentifierClause(this.Id) as T;
+
+            throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.GetString(SR.UnableToCreateTokenReference)));
+        }
+
+        public override bool MatchesKeyIdentifierClause(SecurityKeyIdentifierClause keyIdentifierClause)
+        {
+            SamlAssertionKeyIdentifierClause samlKeyIdentifierClause = keyIdentifierClause as SamlAssertionKeyIdentifierClause;
+            if (samlKeyIdentifierClause != null)
+                return samlKeyIdentifierClause.Matches(this.Id);
+
+            return false;
+        }
+    }
+
+}
+

--- a/src/System.Private.ServiceModel/src/System/IdentityModel/Tokens/SamlSecurityToken.cs
+++ b/src/System.Private.ServiceModel/src/System/IdentityModel/Tokens/SamlSecurityToken.cs
@@ -19,6 +19,7 @@ using System.Reflection;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.IO;
+using DiagnosticUtility = System.ServiceModel.DiagnosticUtility;
 
 namespace System.IdentityModel.Tokens
 {
@@ -38,7 +39,7 @@ namespace System.IdentityModel.Tokens
         protected void Initialize(SamlAssertion assertion)
         {
             if (assertion == null)
-                throw ServiceModel.DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("assertion");
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("assertion");
 
             this.assertion = assertion;
             this.assertion.MakeReadOnly();

--- a/src/System.Private.ServiceModel/src/System/IdentityModel/Tokens/SamlSerializer.cs
+++ b/src/System.Private.ServiceModel/src/System/IdentityModel/Tokens/SamlSerializer.cs
@@ -3,18 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
-using System.Collections.ObjectModel;
-using System.IdentityModel;
-using System.IdentityModel.Selectors;
-using System.Runtime.Serialization;
-using System.Security;
-using System.Security.Cryptography;
-using System.Security.Cryptography.X509Certificates;
-using System.ServiceModel;
-using System.Text;
 using System.Xml;
-using DiagnosticUtility = System.ServiceModel.DiagnosticUtility;
 
 namespace System.IdentityModel.Tokens
 {

--- a/src/System.Private.ServiceModel/src/System/IdentityModel/Tokens/SamlSerializer.cs
+++ b/src/System.Private.ServiceModel/src/System/IdentityModel/Tokens/SamlSerializer.cs
@@ -72,7 +72,6 @@ namespace System.IdentityModel.Tokens
         //            if (token == null)
         //                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("token");
 
-        //#pragma warning suppress 56506 // token.Assertion is never null.
         //            token.Assertion.WriteTo(writer, this, keyInfoSerializer);
         //        }
 

--- a/src/System.Private.ServiceModel/src/System/IdentityModel/Tokens/SamlSerializer.cs
+++ b/src/System.Private.ServiceModel/src/System/IdentityModel/Tokens/SamlSerializer.cs
@@ -2,15 +2,249 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-
-using System.IdentityModel;
-
 namespace System.IdentityModel.Tokens
 {
+    using ServiceModel;
+    using System;
+    using System.Collections.Generic;
+    using System.Collections.ObjectModel;
+    using System.IdentityModel;
+    using System.IdentityModel.Selectors;
+    using System.Runtime.Serialization;
+    using System.Security;
+    using System.Security.Cryptography;
+    using System.Security.Cryptography.X509Certificates;
+    using System.Text;
+    using System.Xml;
+
     public class SamlSerializer
     {
+        private DictionaryManager _dictionaryManager;
+
         public SamlSerializer()
         {
         }
+
+        // Interface to plug in external Dictionaries. The external
+        // dictionary should already be populated with all strings 
+        // required by this assembly.
+        public void PopulateDictionary(IXmlDictionary dictionary)
+        {
+            if (dictionary == null)
+                throw ServiceModel.DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("dictionary");
+
+            _dictionaryManager = new DictionaryManager(dictionary);
+        }
+
+        internal DictionaryManager DictionaryManager
+        {
+            get
+            {
+                if (_dictionaryManager == null)
+                    _dictionaryManager = new DictionaryManager();
+
+                return _dictionaryManager;
+            }
+        }
+
+        // Issue #31 in progress
+        //        public virtual SamlSecurityToken ReadToken(XmlReader reader, SecurityTokenSerializer keyInfoSerializer, SecurityTokenResolver outOfBandTokenResolver)
+        //        {
+        //            if (reader == null)
+        //                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("reader");
+
+        //            XmlDictionaryReader dictionaryReader = XmlDictionaryReader.CreateDictionaryReader(reader);
+        //            WrappedReader wrappedReader = new WrappedReader(dictionaryReader);
+
+        //            SamlAssertion assertion = LoadAssertion(wrappedReader, keyInfoSerializer, outOfBandTokenResolver);
+        //            if (assertion == null)
+        //                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new SecurityTokenException(SR.Format(SR.SAMLUnableToLoadAssertion)));
+
+        //            //if (assertion.Signature == null)
+        //            //    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new SecurityTokenException(SR.Format(SR.SamlTokenMissingSignature)));
+
+        //            return new SamlSecurityToken(assertion);
+        //        }
+
+        //        public virtual void WriteToken(SamlSecurityToken token, XmlWriter writer, SecurityTokenSerializer keyInfoSerializer)
+        //        {
+        //            if (token == null)
+        //                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("token");
+
+        //#pragma warning suppress 56506 // token.Assertion is never null.
+        //            token.Assertion.WriteTo(writer, this, keyInfoSerializer);
+        //        }
+
+        //        public virtual SamlAssertion LoadAssertion(XmlDictionaryReader reader, SecurityTokenSerializer keyInfoSerializer, SecurityTokenResolver outOfBandTokenResolver)
+        //        {
+        //            if (reader == null)
+        //                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("reader");
+
+        //            SamlAssertion assertion = new SamlAssertion();
+        //            assertion.ReadXml(reader, this, keyInfoSerializer, outOfBandTokenResolver);
+
+        //            return assertion;
+        //        }
+
+        //        public virtual SamlCondition LoadCondition(XmlDictionaryReader reader, SecurityTokenSerializer keyInfoSerializer, SecurityTokenResolver outOfBandTokenResolver)
+        //        {
+        //            if (reader == null)
+        //                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("reader");
+
+        //            if (reader.IsStartElement(DictionaryManager.SamlDictionary.AudienceRestrictionCondition, DictionaryManager.SamlDictionary.Namespace))
+        //            {
+        //                SamlAudienceRestrictionCondition audienceRestriction = new SamlAudienceRestrictionCondition();
+        //                audienceRestriction.ReadXml(reader, this, keyInfoSerializer, outOfBandTokenResolver);
+        //                return audienceRestriction;
+        //            }
+        //            else if (reader.IsStartElement(DictionaryManager.SamlDictionary.DoNotCacheCondition, DictionaryManager.SamlDictionary.Namespace))
+        //            {
+        //                SamlDoNotCacheCondition doNotCacheCondition = new SamlDoNotCacheCondition();
+        //                doNotCacheCondition.ReadXml(reader, this, keyInfoSerializer, outOfBandTokenResolver);
+        //                return doNotCacheCondition;
+        //            }
+        //            else
+        //                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new XmlException(SR.Format(SR.SAMLUnableToLoadUnknownElement, reader.LocalName)));
+        //        }
+
+        //        public virtual SamlConditions LoadConditions(XmlDictionaryReader reader, SecurityTokenSerializer keyInfoSerializer, SecurityTokenResolver outOfBandTokenResolver)
+        //        {
+        //            if (reader == null)
+        //                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("reader");
+
+        //            SamlConditions conditions = new SamlConditions();
+        //            conditions.ReadXml(reader, this, keyInfoSerializer, outOfBandTokenResolver);
+
+        //            return conditions;
+        //        }
+
+        //        public virtual SamlAdvice LoadAdvice(XmlDictionaryReader reader, SecurityTokenSerializer keyInfoSerializer, SecurityTokenResolver outOfBandTokenResolver)
+        //        {
+        //            if (reader == null)
+        //                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("reader");
+
+        //            SamlAdvice advice = new SamlAdvice();
+        //            advice.ReadXml(reader, this, keyInfoSerializer, outOfBandTokenResolver);
+
+        //            return advice;
+        //        }
+
+        //        public virtual SamlStatement LoadStatement(XmlDictionaryReader reader, SecurityTokenSerializer keyInfoSerializer, SecurityTokenResolver outOfBandTokenResolver)
+        //        {
+        //            if (reader == null)
+        //                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("reader");
+
+        //            if (reader.IsStartElement(DictionaryManager.SamlDictionary.AuthenticationStatement, DictionaryManager.SamlDictionary.Namespace))
+        //            {
+        //                SamlAuthenticationStatement authStatement = new SamlAuthenticationStatement();
+        //                authStatement.ReadXml(reader, this, keyInfoSerializer, outOfBandTokenResolver);
+        //                return authStatement;
+        //            }
+        //            else if (reader.IsStartElement(DictionaryManager.SamlDictionary.AttributeStatement, DictionaryManager.SamlDictionary.Namespace))
+        //            {
+        //                SamlAttributeStatement attrStatement = new SamlAttributeStatement();
+        //                attrStatement.ReadXml(reader, this, keyInfoSerializer, outOfBandTokenResolver);
+        //                return attrStatement;
+        //            }
+        //            else if (reader.IsStartElement(DictionaryManager.SamlDictionary.AuthorizationDecisionStatement, DictionaryManager.SamlDictionary.Namespace))
+        //            {
+        //                SamlAuthorizationDecisionStatement authDecisionStatement = new SamlAuthorizationDecisionStatement();
+        //                authDecisionStatement.ReadXml(reader, this, keyInfoSerializer, outOfBandTokenResolver);
+        //                return authDecisionStatement;
+        //            }
+        //            else
+        //                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new XmlException(SR.Format(SR.SAMLUnableToLoadUnknownElement, reader.LocalName)));
+        //        }
+
+        //        public virtual SamlAttribute LoadAttribute(XmlDictionaryReader reader, SecurityTokenSerializer keyInfoSerializer, SecurityTokenResolver outOfBandTokenResolver)
+        //        {
+        //            // We will load all attributes as string values.
+        //            SamlAttribute attribute = new SamlAttribute();
+        //            attribute.ReadXml(reader, this, keyInfoSerializer, outOfBandTokenResolver);
+
+        //            return attribute;
+        //        }
+
+
+        //        // Helper metods to read and write SecurityKeyIdentifiers.
+        //        internal static SecurityKeyIdentifier ReadSecurityKeyIdentifier(XmlReader reader, SecurityTokenSerializer tokenSerializer)
+        //        {
+        //            if (tokenSerializer == null)
+        //                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("tokenSerializer", SR.Format(SR.SamlSerializerRequiresExternalSerializers));
+
+        //            if (tokenSerializer.CanReadKeyIdentifier(reader))
+        //            {
+        //                return tokenSerializer.ReadKeyIdentifier(reader);
+        //            }
+
+        //            throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.SamlSerializerUnableToReadSecurityKeyIdentifier)));
+        //        }
+
+        //        internal static void WriteSecurityKeyIdentifier(XmlWriter writer, SecurityKeyIdentifier ski, SecurityTokenSerializer tokenSerializer)
+        //        {
+        //            if (tokenSerializer == null)
+        //                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("tokenSerializer", SR.Format(SR.SamlSerializerRequiresExternalSerializers));
+
+        //            bool keyWritten = false;
+        //            if (tokenSerializer.CanWriteKeyIdentifier(ski))
+        //            {
+        //                tokenSerializer.WriteKeyIdentifier(writer, ski);
+        //                keyWritten = true;
+        //            }
+
+        //            if (!keyWritten)
+        //                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.SamlSerializerUnableToWriteSecurityKeyIdentifier, ski.ToString())));
+        //        }
+
+        //        internal static SecurityKey ResolveSecurityKey(SecurityKeyIdentifier ski, SecurityTokenResolver tokenResolver)
+        //        {
+        //            if (ski == null)
+        //                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("ski");
+
+        //            if (tokenResolver != null)
+        //            {
+        //                for (int i = 0; i < ski.Count; ++i)
+        //                {
+        //                    SecurityKey key = null;
+        //                    if (tokenResolver.TryResolveSecurityKey(ski[i], out key))
+        //                        return key;
+        //                }
+        //            }
+
+        //            if (ski.CanCreateKey)
+        //                return ski.CreateKey();
+
+        //            return null;
+        //        }
+
+        //        internal static SecurityToken ResolveSecurityToken(SecurityKeyIdentifier ski, SecurityTokenResolver tokenResolver)
+        //        {
+        //            SecurityToken token = null;
+
+        //            if (tokenResolver != null)
+        //            {
+        //                tokenResolver.TryResolveToken(ski, out token);
+        //            }
+
+        //            if (token == null)
+        //            {
+        //                // Check if this is a RSA key.
+        //                RsaKeyIdentifierClause rsaClause;
+        //                if (ski.TryFind<RsaKeyIdentifierClause>(out rsaClause))
+        //                    token = new RsaSecurityToken(rsaClause.Rsa);
+        //            }
+
+        //            if (token == null)
+        //            {
+        //                // Check if this is a X509RawDataKeyIdentifier Clause.
+        //                X509RawDataKeyIdentifierClause rawDataKeyIdentifierClause;
+        //                if (ski.TryFind<X509RawDataKeyIdentifierClause>(out rawDataKeyIdentifierClause))
+        //                    token = new X509SecurityToken(new X509Certificate2(rawDataKeyIdentifierClause.GetX509RawData()));
+        //            }
+
+        //            return token;
+        //        }
+
     }
+
 }

--- a/src/System.Private.ServiceModel/src/System/IdentityModel/Tokens/SamlSerializer.cs
+++ b/src/System.Private.ServiceModel/src/System/IdentityModel/Tokens/SamlSerializer.cs
@@ -2,21 +2,22 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.IdentityModel;
+using System.IdentityModel.Selectors;
+using System.Runtime.Serialization;
+using System.Security;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using System.ServiceModel;
+using System.Text;
+using System.Xml;
+using DiagnosticUtility = System.ServiceModel.DiagnosticUtility;
+
 namespace System.IdentityModel.Tokens
 {
-    using ServiceModel;
-    using System;
-    using System.Collections.Generic;
-    using System.Collections.ObjectModel;
-    using System.IdentityModel;
-    using System.IdentityModel.Selectors;
-    using System.Runtime.Serialization;
-    using System.Security;
-    using System.Security.Cryptography;
-    using System.Security.Cryptography.X509Certificates;
-    using System.Text;
-    using System.Xml;
-
     public class SamlSerializer
     {
         private DictionaryManager _dictionaryManager;

--- a/src/System.Private.ServiceModel/src/System/IdentityModel/Tokens/SecurityToken.cs
+++ b/src/System.Private.ServiceModel/src/System/IdentityModel/Tokens/SecurityToken.cs
@@ -2,9 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-
 using System.Collections.ObjectModel;
-using System.Runtime;
+using System.ServiceModel;
 
 namespace System.IdentityModel.Tokens
 {
@@ -14,5 +13,42 @@ namespace System.IdentityModel.Tokens
         public abstract ReadOnlyCollection<SecurityKey> SecurityKeys { get; }
         public abstract DateTime ValidFrom { get; }
         public abstract DateTime ValidTo { get; }
+
+        public virtual bool CanCreateKeyIdentifierClause<T>() where T : SecurityKeyIdentifierClause
+        {
+            return ((typeof(T) == typeof(LocalIdKeyIdentifierClause)) && CanCreateLocalKeyIdentifierClause());
+        }
+
+        public virtual T CreateKeyIdentifierClause<T>() where T : SecurityKeyIdentifierClause
+        {
+            if ((typeof(T) == typeof(LocalIdKeyIdentifierClause)) && CanCreateLocalKeyIdentifierClause())
+                return new LocalIdKeyIdentifierClause(this.Id, this.GetType()) as T;
+
+            throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new NotSupportedException(
+                SR.Format(SR.TokenDoesNotSupportKeyIdentifierClauseCreation, GetType().Name, typeof(T).Name)));
+        }
+
+        public virtual bool MatchesKeyIdentifierClause(SecurityKeyIdentifierClause keyIdentifierClause)
+        {
+            LocalIdKeyIdentifierClause localKeyIdentifierClause = keyIdentifierClause as LocalIdKeyIdentifierClause;
+            if (localKeyIdentifierClause != null)
+                return localKeyIdentifierClause.Matches(this.Id, this.GetType());
+
+            return false;
+        }
+
+        public virtual SecurityKey ResolveKeyIdentifierClause(SecurityKeyIdentifierClause keyIdentifierClause)
+        {
+            if (this.SecurityKeys.Count != 0 && MatchesKeyIdentifierClause(keyIdentifierClause))
+                return this.SecurityKeys[0];
+
+            return null;
+        }
+
+        bool CanCreateLocalKeyIdentifierClause()
+        {
+            return (this.Id != null);
+        }
     }
 }
+

--- a/src/System.Private.ServiceModel/src/System/IdentityModel/Tokens/SecurityToken.cs
+++ b/src/System.Private.ServiceModel/src/System/IdentityModel/Tokens/SecurityToken.cs
@@ -22,7 +22,7 @@ namespace System.IdentityModel.Tokens
         public virtual T CreateKeyIdentifierClause<T>() where T : SecurityKeyIdentifierClause
         {
             if ((typeof(T) == typeof(LocalIdKeyIdentifierClause)) && CanCreateLocalKeyIdentifierClause())
-                return new LocalIdKeyIdentifierClause(this.Id, this.GetType()) as T;
+                return new LocalIdKeyIdentifierClause(Id, GetType()) as T;
 
             throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new NotSupportedException(
                 SR.Format(SR.TokenDoesNotSupportKeyIdentifierClauseCreation, GetType().Name, typeof(T).Name)));
@@ -32,22 +32,22 @@ namespace System.IdentityModel.Tokens
         {
             LocalIdKeyIdentifierClause localKeyIdentifierClause = keyIdentifierClause as LocalIdKeyIdentifierClause;
             if (localKeyIdentifierClause != null)
-                return localKeyIdentifierClause.Matches(this.Id, this.GetType());
+                return localKeyIdentifierClause.Matches(Id, GetType());
 
             return false;
         }
 
         public virtual SecurityKey ResolveKeyIdentifierClause(SecurityKeyIdentifierClause keyIdentifierClause)
         {
-            if (this.SecurityKeys.Count != 0 && MatchesKeyIdentifierClause(keyIdentifierClause))
-                return this.SecurityKeys[0];
+            if (SecurityKeys.Count != 0 && MatchesKeyIdentifierClause(keyIdentifierClause))
+                return SecurityKeys[0];
 
             return null;
         }
 
         bool CanCreateLocalKeyIdentifierClause()
         {
-            return (this.Id != null);
+            return (Id != null);
         }
     }
 }

--- a/src/System.Private.ServiceModel/src/System/IdentityModel/Tokens/XmlDsigSep2000.cs
+++ b/src/System.Private.ServiceModel/src/System/IdentityModel/Tokens/XmlDsigSep2000.cs
@@ -5,8 +5,6 @@
 using System;
 using System.Collections.Generic;
 using System.IdentityModel.Selectors;
-using System.Security.Cryptography;
-using System.Security.Cryptography.X509Certificates;
 using System.ServiceModel;
 using System.ServiceModel.Security;
 using System.Xml;

--- a/src/System.Private.ServiceModel/src/System/IdentityModel/Tokens/XmlDsigSep2000.cs
+++ b/src/System.Private.ServiceModel/src/System/IdentityModel/Tokens/XmlDsigSep2000.cs
@@ -1,0 +1,352 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.IdentityModel.Selectors;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using System.ServiceModel;
+using System.ServiceModel.Security;
+using System.Xml;
+using KeyIdentifierEntry = System.IdentityModel.Selectors.SecurityTokenSerializer.KeyIdentifierEntry;
+using DiagnosticUtility = System.ServiceModel.DiagnosticUtility;
+
+namespace System.IdentityModel.Tokens
+{
+    class XmlDsigSep2000 : SecurityTokenSerializer.SerializerEntries
+    {
+        private KeyInfoSerializer _securityTokenSerializer;
+
+        public XmlDsigSep2000( KeyInfoSerializer securityTokenSerializer )
+        {
+            _securityTokenSerializer = securityTokenSerializer;
+        }
+
+        public override void PopulateKeyIdentifierEntries( IList<KeyIdentifierEntry> keyIdentifierEntries )
+        {
+            keyIdentifierEntries.Add( new KeyInfoEntry( _securityTokenSerializer ) );
+        }
+
+        public override void PopulateKeyIdentifierClauseEntries( IList<SecurityTokenSerializer.KeyIdentifierClauseEntry> keyIdentifierClauseEntries )
+        {
+            keyIdentifierClauseEntries.Add( new KeyNameClauseEntry() );
+            keyIdentifierClauseEntries.Add( new KeyValueClauseEntry() );
+            keyIdentifierClauseEntries.Add( new X509CertificateClauseEntry() );
+        }
+
+        internal class KeyInfoEntry : KeyIdentifierEntry
+        {
+            KeyInfoSerializer securityTokenSerializer;
+
+            public KeyInfoEntry( KeyInfoSerializer securityTokenSerializer )
+            {
+                this.securityTokenSerializer = securityTokenSerializer;
+            }
+
+            protected override XmlDictionaryString LocalName
+            {
+                get
+                {
+                    return XD.XmlSignatureDictionary.KeyInfo;
+                }
+            }
+
+            protected override XmlDictionaryString NamespaceUri
+            {
+                get
+                {
+                    return XD.XmlSignatureDictionary.Namespace;
+                }
+            }
+
+            public override SecurityKeyIdentifier ReadKeyIdentifierCore( XmlDictionaryReader reader )
+            {
+                reader.ReadStartElement( LocalName, NamespaceUri );
+                SecurityKeyIdentifier keyIdentifier = new SecurityKeyIdentifier();
+                while ( reader.IsStartElement() )
+                {
+                    SecurityKeyIdentifierClause clause = this.securityTokenSerializer.ReadKeyIdentifierClause( reader );
+                    if ( clause == null )
+                    {
+                        reader.Skip();
+                    }
+                    else
+                    {
+                        keyIdentifier.Add( clause );
+                    }
+                }
+                if ( keyIdentifier.Count == 0 )
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError( new XmlException( SR.Format( SR.ErrorDeserializingKeyIdentifierClause ) ) );
+                }
+                reader.ReadEndElement();
+                return keyIdentifier;
+            }
+
+            public override bool SupportsCore( SecurityKeyIdentifier keyIdentifier )
+            {
+                return true;
+            }
+
+            public override void WriteKeyIdentifierCore( XmlDictionaryWriter writer, SecurityKeyIdentifier keyIdentifier )
+            {
+                writer.WriteStartElement( XD.XmlSignatureDictionary.Prefix.Value, LocalName, NamespaceUri );
+                bool clauseWritten = false;
+                foreach ( SecurityKeyIdentifierClause clause in keyIdentifier )
+                {
+                    this.securityTokenSerializer.InnerSecurityTokenSerializer.WriteKeyIdentifierClause( writer, clause );
+                    clauseWritten = true;
+                }
+                writer.WriteEndElement(); // KeyInfo
+                if ( !clauseWritten )
+                {
+                    throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+                    //throw DiagnosticUtility.ExceptionUtility.ThrowHelperError( new SecurityMessageSerializationException( SR.GetString( SR.NoKeyInfoClausesToWrite ) ) );
+                }
+            }
+        }
+
+        // <ds:KeyName>name</ds:KeyName>
+        internal class KeyNameClauseEntry : SecurityTokenSerializer.KeyIdentifierClauseEntry
+        {
+            protected override XmlDictionaryString LocalName
+            {
+                get
+                {
+                    return XD.XmlSignatureDictionary.KeyName;
+                }
+            }
+
+            protected override XmlDictionaryString NamespaceUri
+            {
+                get
+                {
+                    return XD.XmlSignatureDictionary.Namespace;
+                }
+            }
+
+            public override SecurityKeyIdentifierClause ReadKeyIdentifierClauseCore( XmlDictionaryReader reader )
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+
+                //reader.ReadStartElement( XD.XmlSignatureDictionary.KeyName, NamespaceUri );
+                //string name = reader.ReadString();
+                //reader.ReadEndElement();
+
+                //return new KeyNameIdentifierClause( name );
+            }
+
+            public override bool SupportsCore( SecurityKeyIdentifierClause keyIdentifierClause )
+            {
+                return keyIdentifierClause is KeyNameIdentifierClause;
+            }
+
+            public override void WriteKeyIdentifierClauseCore( XmlDictionaryWriter writer, SecurityKeyIdentifierClause keyIdentifierClause )
+            {
+                KeyNameIdentifierClause nameClause = keyIdentifierClause as KeyNameIdentifierClause;
+
+                writer.WriteElementString( XD.XmlSignatureDictionary.Prefix.Value, XD.XmlSignatureDictionary.KeyName, NamespaceUri, nameClause.KeyName );
+            }
+        }
+        // so far, we only support one type of KeyValue - RSAKeyValue
+        //   <ds:KeyValue>
+        //     <ds:RSAKeyValue>
+        //       <ds:Modulus>xA7SEU+...</ds:Modulus>
+        //         <ds:Exponent>AQAB</Exponent>
+        //     </ds:RSAKeyValue>
+        //   </ds:KeyValue>
+        internal class KeyValueClauseEntry : SecurityTokenSerializer.KeyIdentifierClauseEntry
+        {
+            protected override XmlDictionaryString LocalName
+            {
+                get
+                {
+                    return XD.XmlSignatureDictionary.KeyValue;
+                }
+            }
+
+            protected override XmlDictionaryString NamespaceUri
+            {
+                get
+                {
+                    return XD.XmlSignatureDictionary.Namespace;
+                }
+            }
+
+
+            public override SecurityKeyIdentifierClause ReadKeyIdentifierClauseCore( XmlDictionaryReader reader )
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+
+                //reader.ReadStartElement( XD.XmlSignatureDictionary.KeyValue, NamespaceUri );
+                //reader.ReadStartElement( XD.XmlSignatureDictionary.RsaKeyValue, NamespaceUri );
+                //reader.ReadStartElement( XD.XmlSignatureDictionary.Modulus, NamespaceUri );
+
+                //byte[] modulus = Convert.FromBase64String( reader.ReadString() );
+
+                //reader.ReadEndElement();
+                //reader.ReadStartElement( XD.XmlSignatureDictionary.Exponent, NamespaceUri );
+                //byte[] exponent = Convert.FromBase64String( reader.ReadString() );
+                //reader.ReadEndElement();
+                //reader.ReadEndElement();
+                //reader.ReadEndElement();
+
+                //RSA rsa = new RSACryptoServiceProvider();
+                //RSAParameters rsaParameters = new RSAParameters();
+                //rsaParameters.Modulus = modulus;
+                //rsaParameters.Exponent = exponent;
+                //rsa.ImportParameters( rsaParameters );
+
+                //return new RsaKeyIdentifierClause( rsa );
+            }
+
+            public override bool SupportsCore( SecurityKeyIdentifierClause keyIdentifierClause )
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+                //return keyIdentifierClause is RsaKeyIdentifierClause;
+            }
+
+            public override void WriteKeyIdentifierClauseCore( XmlDictionaryWriter writer, SecurityKeyIdentifierClause keyIdentifierClause )
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+                //RsaKeyIdentifierClause rsaClause = keyIdentifierClause as RsaKeyIdentifierClause;
+
+                //writer.WriteStartElement( XD.XmlSignatureDictionary.Prefix.Value, XD.XmlSignatureDictionary.KeyValue, NamespaceUri );
+                //writer.WriteStartElement( XD.XmlSignatureDictionary.Prefix.Value, XD.XmlSignatureDictionary.RsaKeyValue, NamespaceUri );
+                //writer.WriteStartElement( XD.XmlSignatureDictionary.Prefix.Value, XD.XmlSignatureDictionary.Modulus, NamespaceUri );
+                //rsaClause.WriteModulusAsBase64( writer );
+                //writer.WriteEndElement();
+                //writer.WriteStartElement( XD.XmlSignatureDictionary.Prefix.Value, XD.XmlSignatureDictionary.Exponent, NamespaceUri );
+                //rsaClause.WriteExponentAsBase64( writer );
+                //writer.WriteEndElement();
+                //writer.WriteEndElement();
+                //writer.WriteEndElement();
+            }
+        }
+
+        // so far, we only support two types of X509Data directly under KeyInfo  - X509Certificate and X509SKI
+        //   <ds:X509Data>
+        //     <ds:X509Certificate>...</ds:X509Certificate>
+        //      or
+        //     <X509SKI>... </X509SKI>
+        //   </ds:X509Data>
+        // only support 1 certificate right now
+        internal class X509CertificateClauseEntry : SecurityTokenSerializer.KeyIdentifierClauseEntry
+        {
+            protected override XmlDictionaryString LocalName
+            {
+                get
+                {
+                    return XD.XmlSignatureDictionary.X509Data;
+                }
+            }
+
+            protected override XmlDictionaryString NamespaceUri
+            {
+                get
+                {
+                    return XD.XmlSignatureDictionary.Namespace;
+                }
+            }
+
+            public override SecurityKeyIdentifierClause ReadKeyIdentifierClauseCore( XmlDictionaryReader reader )
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+
+                //SecurityKeyIdentifierClause ski = null;
+                //reader.ReadStartElement( XD.XmlSignatureDictionary.X509Data, NamespaceUri );
+                //while ( reader.IsStartElement() )
+                //{
+                //    if ( ski == null && reader.IsStartElement( XD.XmlSignatureDictionary.X509Certificate, NamespaceUri ) )
+                //    {
+                //        X509Certificate2 certificate = null;
+                //        if ( !SecurityUtils.TryCreateX509CertificateFromRawData( reader.ReadElementContentAsBase64(), out certificate ) )
+                //        {
+                //            throw DiagnosticUtility.ExceptionUtility.ThrowHelperError( new SecurityMessageSerializationException( SR.GetString( SR.InvalidX509RawData ) ) );
+                //        }
+                //        ski = new X509RawDataKeyIdentifierClause( certificate );
+                //    }
+                //    else if ( ski == null && reader.IsStartElement( XmlSignatureStrings.X509Ski, NamespaceUri.ToString() ) )
+                //    {
+                //        ski = new X509SubjectKeyIdentifierClause( reader.ReadElementContentAsBase64() );
+                //    }
+                //    else if ( ( ski == null ) && reader.IsStartElement( XD.XmlSignatureDictionary.X509IssuerSerial, XD.XmlSignatureDictionary.Namespace ) )
+                //    {
+                //        reader.ReadStartElement( XD.XmlSignatureDictionary.X509IssuerSerial, XD.XmlSignatureDictionary.Namespace );
+                //        reader.ReadStartElement( XD.XmlSignatureDictionary.X509IssuerName, XD.XmlSignatureDictionary.Namespace );
+                //        string issuerName = reader.ReadContentAsString();
+                //        reader.ReadEndElement();
+                //        reader.ReadStartElement( XD.XmlSignatureDictionary.X509SerialNumber, XD.XmlSignatureDictionary.Namespace );
+                //        string serialNumber = reader.ReadContentAsString();
+                //        reader.ReadEndElement();
+                //        reader.ReadEndElement();
+
+                //        ski = new X509IssuerSerialKeyIdentifierClause( issuerName, serialNumber );
+                //    }
+                //    else
+                //    {
+                //        reader.Skip();
+                //    }
+                //}
+                //reader.ReadEndElement();
+                //return ski;
+            }
+
+            public override bool SupportsCore( SecurityKeyIdentifierClause keyIdentifierClause )
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+
+                //return (keyIdentifierClause is X509RawDataKeyIdentifierClause);
+                //// This method should not write X509IssuerSerialKeyIdentifierClause or X509SubjectKeyIdentifierClause as that should be written by the WSSecurityXXX classes with SecurityTokenReference tag. 
+                //// The XmlDsig entries are written by the X509SecurityTokenHandler.
+            }
+
+            public override void WriteKeyIdentifierClauseCore( XmlDictionaryWriter writer, SecurityKeyIdentifierClause keyIdentifierClause )
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+
+                //X509RawDataKeyIdentifierClause x509Clause = keyIdentifierClause as X509RawDataKeyIdentifierClause;
+
+                //if ( x509Clause != null )
+                //{
+                //    writer.WriteStartElement( XD.XmlSignatureDictionary.Prefix.Value, XD.XmlSignatureDictionary.X509Data, NamespaceUri );
+
+                //    writer.WriteStartElement( XD.XmlSignatureDictionary.Prefix.Value, XD.XmlSignatureDictionary.X509Certificate, NamespaceUri );
+                //    byte[] certBytes = x509Clause.GetX509RawData();
+                //    writer.WriteBase64( certBytes, 0, certBytes.Length );
+                //    writer.WriteEndElement();
+
+                //    writer.WriteEndElement();
+                //}
+
+                //X509IssuerSerialKeyIdentifierClause issuerSerialClause = keyIdentifierClause as X509IssuerSerialKeyIdentifierClause;
+                //if ( issuerSerialClause != null )
+                //{                    
+                //    writer.WriteStartElement( XD.XmlSignatureDictionary.Prefix.Value, XD.XmlSignatureDictionary.X509Data, XD.XmlSignatureDictionary.Namespace );
+                //    writer.WriteStartElement( XD.XmlSignatureDictionary.Prefix.Value, XD.XmlSignatureDictionary.X509IssuerSerial, XD.XmlSignatureDictionary.Namespace );
+                //    writer.WriteElementString( XD.XmlSignatureDictionary.Prefix.Value, XD.XmlSignatureDictionary.X509IssuerName, XD.XmlSignatureDictionary.Namespace, issuerSerialClause.IssuerName );
+                //    writer.WriteElementString( XD.XmlSignatureDictionary.Prefix.Value, XD.XmlSignatureDictionary.X509SerialNumber, XD.XmlSignatureDictionary.Namespace, issuerSerialClause.IssuerSerialNumber );
+                //    writer.WriteEndElement();
+                //    writer.WriteEndElement();
+                //    return;
+                //}
+
+                //X509SubjectKeyIdentifierClause skiClause = keyIdentifierClause as X509SubjectKeyIdentifierClause;
+                //if ( skiClause != null )
+                //{
+                //    writer.WriteStartElement( XmlSignatureConstants.Prefix, XmlSignatureConstants.Elements.X509Data, XmlSignatureConstants.Namespace );
+                //    writer.WriteStartElement( XmlSignatureConstants.Prefix, XmlSignatureConstants.Elements.X509SKI, XmlSignatureConstants.Namespace );
+                //    byte[] ski = skiClause.GetX509SubjectKeyIdentifier();
+                //    writer.WriteBase64( ski, 0, ski.Length );
+                //    writer.WriteEndElement();
+                //    writer.WriteEndElement();
+                //    return;
+                //}
+            }
+        }
+
+    }
+}
+

--- a/src/System.Private.ServiceModel/src/System/IdentityModel/Tokens/XmlEncApr2001.cs
+++ b/src/System.Private.ServiceModel/src/System/IdentityModel/Tokens/XmlEncApr2001.cs
@@ -1,0 +1,146 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.IdentityModel.Selectors;
+using System.ServiceModel;
+using System.Xml;
+using KeyIdentifierClauseEntry = System.IdentityModel.Selectors.SecurityTokenSerializer.KeyIdentifierClauseEntry;
+
+namespace System.IdentityModel.Tokens
+{
+    class XmlEncApr2001 : SecurityTokenSerializer.SerializerEntries
+    {
+        KeyInfoSerializer _securityTokenSerializer;
+
+        public XmlEncApr2001(KeyInfoSerializer securityTokenSerializer)
+        {
+            _securityTokenSerializer = securityTokenSerializer;
+        }
+        
+        public override void PopulateKeyIdentifierClauseEntries(IList<KeyIdentifierClauseEntry> keyIdentifierClauseEntries)
+        {
+            keyIdentifierClauseEntries.Add(new EncryptedKeyClauseEntry(_securityTokenSerializer));
+        }
+
+        internal class EncryptedKeyClauseEntry : SecurityTokenSerializer.KeyIdentifierClauseEntry
+        {
+            private KeyInfoSerializer _securityTokenSerializer;
+
+            public EncryptedKeyClauseEntry(KeyInfoSerializer securityTokenSerializer)
+            {
+                _securityTokenSerializer = securityTokenSerializer;
+            }
+                        
+            protected override XmlDictionaryString LocalName
+            { 
+                get
+                {
+                    return XD.XmlEncryptionDictionary.EncryptedKey;
+                }
+            }
+            
+            protected override XmlDictionaryString NamespaceUri
+            { 
+                get
+                {
+                    return XD.XmlEncryptionDictionary.Namespace;
+                }
+            }
+            
+            public override SecurityKeyIdentifierClause ReadKeyIdentifierClauseCore(XmlDictionaryReader reader)
+            {
+                string encryptionMethod = null;
+                string carriedKeyName = null;
+                SecurityKeyIdentifier encryptingKeyIdentifier = null;
+                byte[] encryptedKey = null;
+
+                reader.ReadStartElement(XD.XmlEncryptionDictionary.EncryptedKey, NamespaceUri);
+                
+                if (reader.IsStartElement(XD.XmlEncryptionDictionary.EncryptionMethod, NamespaceUri))
+                {
+                    encryptionMethod = reader.GetAttribute(XD.XmlEncryptionDictionary.AlgorithmAttribute, null);
+                    bool isEmptyElement = reader.IsEmptyElement;
+                    reader.ReadStartElement();
+                    if (!isEmptyElement)
+                    {
+                        while (reader.IsStartElement())
+                        {
+                            reader.Skip();
+                        }
+                        reader.ReadEndElement();
+                    }
+                }
+
+                if (this._securityTokenSerializer.CanReadKeyIdentifier(reader))
+                {
+                    encryptingKeyIdentifier = this._securityTokenSerializer.ReadKeyIdentifier(reader);
+                }
+                
+                reader.ReadStartElement(XD.XmlEncryptionDictionary.CipherData, NamespaceUri);
+                reader.ReadStartElement(XD.XmlEncryptionDictionary.CipherValue, NamespaceUri);
+                encryptedKey = reader.ReadContentAsBase64();
+                reader.ReadEndElement();
+                reader.ReadEndElement();
+
+                if (reader.IsStartElement(XD.XmlEncryptionDictionary.CarriedKeyName, NamespaceUri))
+                {
+                    reader.ReadStartElement();
+                    throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+                    //carriedKeyName = reader.ReadString();                    
+                    //reader.ReadEndElement();
+                }
+                
+                reader.ReadEndElement();
+
+                return new EncryptedKeyIdentifierClause(encryptedKey, encryptionMethod, encryptingKeyIdentifier, carriedKeyName);
+            }
+
+            public override bool SupportsCore(SecurityKeyIdentifierClause keyIdentifierClause)
+            {
+                return keyIdentifierClause is EncryptedKeyIdentifierClause;
+            }
+
+            public override void WriteKeyIdentifierClauseCore(XmlDictionaryWriter writer, SecurityKeyIdentifierClause keyIdentifierClause)
+            {
+                EncryptedKeyIdentifierClause encryptedKeyClause = keyIdentifierClause as EncryptedKeyIdentifierClause;
+
+                writer.WriteStartElement(XD.XmlEncryptionDictionary.Prefix.Value, XD.XmlEncryptionDictionary.EncryptedKey, NamespaceUri);
+
+                if (encryptedKeyClause.EncryptionMethod != null)
+                {
+                    writer.WriteStartElement(XD.XmlEncryptionDictionary.Prefix.Value, XD.XmlEncryptionDictionary.EncryptionMethod, NamespaceUri);
+                    writer.WriteAttributeString(XD.XmlEncryptionDictionary.AlgorithmAttribute, null, encryptedKeyClause.EncryptionMethod);
+                    if (encryptedKeyClause.EncryptionMethod == XD.SecurityAlgorithmDictionary.RsaOaepKeyWrap.Value)
+                    {
+                        writer.WriteStartElement(XmlSignatureStrings.Prefix, XD.XmlSignatureDictionary.DigestMethod, XD.XmlSignatureDictionary.Namespace);
+                        writer.WriteAttributeString(XD.XmlSignatureDictionary.Algorithm, null, SecurityAlgorithms.Sha1Digest);
+                        writer.WriteEndElement();
+                    }
+                    writer.WriteEndElement();
+                }
+
+                if (encryptedKeyClause.EncryptingKeyIdentifier != null)
+                {
+                    this._securityTokenSerializer.WriteKeyIdentifier(writer, encryptedKeyClause.EncryptingKeyIdentifier);
+                }
+
+                writer.WriteStartElement(XD.XmlEncryptionDictionary.Prefix.Value, XD.XmlEncryptionDictionary.CipherData, NamespaceUri);
+                writer.WriteStartElement(XD.XmlEncryptionDictionary.Prefix.Value, XD.XmlEncryptionDictionary.CipherValue, NamespaceUri);
+                byte[] encryptedKey = encryptedKeyClause.GetEncryptedKey();
+                writer.WriteBase64(encryptedKey, 0, encryptedKey.Length);
+                writer.WriteEndElement();
+                writer.WriteEndElement();
+
+                if (encryptedKeyClause.CarriedKeyName != null)
+                {
+                    writer.WriteElementString(XD.XmlEncryptionDictionary.Prefix.Value, XD.XmlEncryptionDictionary.CarriedKeyName, NamespaceUri, encryptedKeyClause.CarriedKeyName);
+                }
+
+                writer.WriteEndElement();
+            }
+        }
+    }
+}
+

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/ChannelFactoryBase.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/ChannelFactoryBase.cs
@@ -198,7 +198,7 @@ namespace System.ServiceModel.Channels
             TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
             foreach (IChannel channel in currentChannels)
             {
-                IAsyncCommunicationObject iAsyncChannel = channel as IAsyncCommunicationObject;
+                var iAsyncChannel = channel as IAsyncCommunicationObject;
                 if (iAsyncChannel != null)
                 {
                     await iAsyncChannel.CloseAsync(timeoutHelper.RemainingTime());

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/CommunicationObject.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/CommunicationObject.cs
@@ -9,6 +9,7 @@ using System.Reflection;
 using System.Runtime;
 using System.Threading.Tasks;
 using System.ServiceModel.Diagnostics;
+using System.Collections.Generic;
 
 namespace System.ServiceModel.Channels
 {
@@ -16,6 +17,7 @@ namespace System.ServiceModel.Channels
     {
         private bool _aborted;
         private bool _closeCalled;
+        private ExceptionQueue _exceptionQueue;
         private object _mutex;
         private bool _onClosingCalled;
         private bool _onClosedCalled;
@@ -310,6 +312,18 @@ namespace System.ServiceModel.Channels
             }
 
             OnFaulted();
+        }
+
+        internal void Fault(Exception exception)
+        {
+            lock (this.ThisLock)
+            {
+                if (_exceptionQueue == null)
+                    _exceptionQueue = new ExceptionQueue(this.ThisLock);
+            }
+
+            _exceptionQueue.AddException(exception);
+            this.Fault();
         }
 
         public void Open()
@@ -739,6 +753,17 @@ namespace System.ServiceModel.Channels
 
         internal void ThrowPending()
         {
+            ExceptionQueue queue = _exceptionQueue;
+
+            if (queue != null)
+            {
+                Exception exception = queue.GetException();
+
+                if (exception != null)
+                {
+                    throw TraceUtility.ThrowHelperError(exception, Guid.Empty, this);
+                }
+            }
         }
 
         //
@@ -801,6 +826,48 @@ namespace System.ServiceModel.Channels
             // Redirect this call to the APM path.
             _onOpenAsyncCalled = true;
             return Task.Factory.FromAsync(OnBeginOpen, OnEndOpen, timeout, TaskCreationOptions.RunContinuationsAsynchronously);
+        }
+
+        class ExceptionQueue
+        {
+            Queue<Exception> _exceptions = new Queue<Exception>();
+            object _thisLock;
+
+            internal ExceptionQueue(object thisLock)
+            {
+                this._thisLock = thisLock;
+            }
+
+            object ThisLock
+            {
+                get { return this._thisLock; }
+            }
+
+            public void AddException(Exception exception)
+            {
+                if (exception == null)
+                {
+                    return;
+                }
+
+                lock (this.ThisLock)
+                {
+                    this._exceptions.Enqueue(exception);
+                }
+            }
+
+            public Exception GetException()
+            {
+                lock (this.ThisLock)
+                {
+                    if (this._exceptions.Count > 0)
+                    {
+                        return this._exceptions.Dequeue();
+                    }
+                }
+
+                return null;
+            }
         }
     }
 

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/CommunicationObject.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/CommunicationObject.cs
@@ -835,12 +835,12 @@ namespace System.ServiceModel.Channels
 
             internal ExceptionQueue(object thisLock)
             {
-                this._thisLock = thisLock;
+                _thisLock = thisLock;
             }
 
             object ThisLock
             {
-                get { return this._thisLock; }
+                get { return _thisLock; }
             }
 
             public void AddException(Exception exception)
@@ -850,19 +850,19 @@ namespace System.ServiceModel.Channels
                     return;
                 }
 
-                lock (this.ThisLock)
+                lock (ThisLock)
                 {
-                    this._exceptions.Enqueue(exception);
+                    _exceptions.Enqueue(exception);
                 }
             }
 
             public Exception GetException()
             {
-                lock (this.ThisLock)
+                lock (ThisLock)
                 {
-                    if (this._exceptions.Count > 0)
+                    if (_exceptions.Count > 0)
                     {
-                        return this._exceptions.Dequeue();
+                        return _exceptions.Dequeue();
                     }
                 }
 

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/CommunicationObject.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/CommunicationObject.cs
@@ -2,14 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-
-using System.Diagnostics;
-using System.Diagnostics.Contracts;
-using System.Reflection;
-using System.Runtime;
-using System.Threading.Tasks;
-using System.ServiceModel.Diagnostics;
 using System.Collections.Generic;
+using System.Diagnostics.Contracts;
+using System.Runtime;
+using System.ServiceModel.Diagnostics;
+using System.Threading.Tasks;
 
 namespace System.ServiceModel.Channels
 {

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/DelegatingMessage.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/DelegatingMessage.cs
@@ -1,0 +1,92 @@
+//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+namespace System.ServiceModel.Channels
+{
+    using System.Xml;
+    using System.ServiceModel.Channels;
+
+    abstract class DelegatingMessage : Message
+    {
+        Message innerMessage;
+
+        protected DelegatingMessage(Message innerMessage)
+        {
+            if (innerMessage == null)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("innerMessage");
+            }
+            this.innerMessage = innerMessage;
+        }
+
+        public override bool IsEmpty
+        {
+            get
+            {
+                return this.innerMessage.IsEmpty;
+            }
+        }
+
+        public override bool IsFault
+        {
+            get { return this.innerMessage.IsFault; }
+        }
+
+        public override MessageHeaders Headers
+        {
+            get { return this.innerMessage.Headers; }
+        }
+
+        public override MessageProperties Properties
+        {
+            get { return this.innerMessage.Properties; }
+        }
+
+        public override MessageVersion Version
+        {
+            get { return this.innerMessage.Version; }
+        }
+
+        protected Message InnerMessage
+        {
+            get { return this.innerMessage; }
+        }
+
+        protected override void OnClose()
+        {
+            base.OnClose();
+            this.innerMessage.Close();
+        }
+
+        protected override void OnWriteStartEnvelope(XmlDictionaryWriter writer)
+        {
+            this.innerMessage.WriteStartEnvelope(writer);
+        }
+
+        protected override void OnWriteStartHeaders(XmlDictionaryWriter writer)
+        {
+            this.innerMessage.WriteStartHeaders(writer);
+        }
+
+        protected override void OnWriteStartBody(XmlDictionaryWriter writer)
+        {
+            this.innerMessage.WriteStartBody(writer);
+        }
+
+        protected override void OnWriteBodyContents(XmlDictionaryWriter writer)
+        {
+            this.innerMessage.WriteBodyContents(writer);
+        }
+
+        protected override string OnGetBodyAttribute(string localName, string ns)
+        {
+            return this.innerMessage.GetBodyAttribute(localName, ns);
+        }
+
+        protected override void OnBodyToString(XmlDictionaryWriter writer)
+        {
+            this.innerMessage.BodyToString(writer);
+        }
+    }
+}
+

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/DelegatingMessage.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/DelegatingMessage.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Xml;
-using System.ServiceModel.Channels;
 
 namespace System.ServiceModel.Channels
 {

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/DelegatingMessage.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/DelegatingMessage.cs
@@ -1,14 +1,15 @@
-//------------------------------------------------------------
-// Copyright (c) Microsoft Corporation.  All rights reserved.
-//------------------------------------------------------------
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Xml;
+using System.ServiceModel.Channels;
+
 namespace System.ServiceModel.Channels
 {
-    using System.Xml;
-    using System.ServiceModel.Channels;
-
     abstract class DelegatingMessage : Message
     {
-        Message innerMessage;
+        private Message _innerMessage;
 
         protected DelegatingMessage(Message innerMessage)
         {
@@ -16,76 +17,76 @@ namespace System.ServiceModel.Channels
             {
                 throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("innerMessage");
             }
-            this.innerMessage = innerMessage;
+            _innerMessage = innerMessage;
         }
 
         public override bool IsEmpty
         {
             get
             {
-                return this.innerMessage.IsEmpty;
+                return _innerMessage.IsEmpty;
             }
         }
 
         public override bool IsFault
         {
-            get { return this.innerMessage.IsFault; }
+            get { return _innerMessage.IsFault; }
         }
 
         public override MessageHeaders Headers
         {
-            get { return this.innerMessage.Headers; }
+            get { return _innerMessage.Headers; }
         }
 
         public override MessageProperties Properties
         {
-            get { return this.innerMessage.Properties; }
+            get { return _innerMessage.Properties; }
         }
 
         public override MessageVersion Version
         {
-            get { return this.innerMessage.Version; }
+            get { return _innerMessage.Version; }
         }
 
         protected Message InnerMessage
         {
-            get { return this.innerMessage; }
+            get { return _innerMessage; }
         }
 
         protected override void OnClose()
         {
             base.OnClose();
-            this.innerMessage.Close();
+            _innerMessage.Close();
         }
 
         protected override void OnWriteStartEnvelope(XmlDictionaryWriter writer)
         {
-            this.innerMessage.WriteStartEnvelope(writer);
+            _innerMessage.WriteStartEnvelope(writer);
         }
 
         protected override void OnWriteStartHeaders(XmlDictionaryWriter writer)
         {
-            this.innerMessage.WriteStartHeaders(writer);
+            _innerMessage.WriteStartHeaders(writer);
         }
 
         protected override void OnWriteStartBody(XmlDictionaryWriter writer)
         {
-            this.innerMessage.WriteStartBody(writer);
+            _innerMessage.WriteStartBody(writer);
         }
 
         protected override void OnWriteBodyContents(XmlDictionaryWriter writer)
         {
-            this.innerMessage.WriteBodyContents(writer);
+            _innerMessage.WriteBodyContents(writer);
         }
 
         protected override string OnGetBodyAttribute(string localName, string ns)
         {
-            return this.innerMessage.GetBodyAttribute(localName, ns);
+            return _innerMessage.GetBodyAttribute(localName, ns);
         }
 
         protected override void OnBodyToString(XmlDictionaryWriter writer)
         {
-            this.innerMessage.BodyToString(writer);
+            _innerMessage.BodyToString(writer);
         }
     }
 }

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/IReliableChannelBinder.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/IReliableChannelBinder.cs
@@ -1,0 +1,79 @@
+//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace System.ServiceModel.Channels
+{
+    delegate void BinderExceptionHandler(IReliableChannelBinder sender, Exception exception);
+
+    interface IReliableChannelBinder
+    {
+        bool CanSendAsynchronously { get; }
+        IChannel Channel { get; }
+        bool Connected { get; }
+        TimeSpan DefaultSendTimeout { get; }
+        bool HasSession { get; }
+        EndpointAddress LocalAddress { get; }
+        EndpointAddress RemoteAddress { get; }
+        CommunicationState State { get; }
+
+        event BinderExceptionHandler Faulted;
+        event BinderExceptionHandler OnException;
+
+        void Abort();
+
+        void Close(TimeSpan timeout);
+        void Close(TimeSpan timeout, MaskingMode maskingMode);
+        IAsyncResult BeginClose(TimeSpan timeout, AsyncCallback callback, object state);
+        IAsyncResult BeginClose(TimeSpan timeout, MaskingMode maskingMode, AsyncCallback callback, object state);
+        void EndClose(IAsyncResult result);
+
+        void Open(TimeSpan timeout);
+        IAsyncResult BeginOpen(TimeSpan timeout, AsyncCallback callback, object state);
+        void EndOpen(IAsyncResult result);
+
+        IAsyncResult BeginSend(Message message, TimeSpan timeout, MaskingMode maskingMode, AsyncCallback callback, object state);
+        IAsyncResult BeginSend(Message message, TimeSpan timeout, AsyncCallback callback, object state);
+        void EndSend(IAsyncResult result);
+        void Send(Message message, TimeSpan timeout);
+        void Send(Message message, TimeSpan timeout, MaskingMode maskingMode);
+
+        bool TryReceive(TimeSpan timeout, out RequestContext requestContext);
+        bool TryReceive(TimeSpan timeout, out RequestContext requestContext, MaskingMode maskingMode);
+        IAsyncResult BeginTryReceive(TimeSpan timeout, AsyncCallback callback, object state);
+        IAsyncResult BeginTryReceive(TimeSpan timeout, MaskingMode maskingMode, AsyncCallback callback, object state);
+        bool EndTryReceive(IAsyncResult result, out RequestContext requestContext);
+
+        ISession GetInnerSession();
+        void HandleException(Exception e);
+        bool IsHandleable(Exception e);
+        void SetMaskingMode(RequestContext context, MaskingMode maskingMode);
+        RequestContext WrapRequestContext(RequestContext context);
+    }
+
+    interface IClientReliableChannelBinder : IReliableChannelBinder
+    {
+        Uri Via { get; }
+        event EventHandler ConnectionLost;
+
+        bool EnsureChannelForRequest();
+
+        IAsyncResult BeginRequest(Message message, TimeSpan timeout, AsyncCallback callback, object state);
+        IAsyncResult BeginRequest(Message message, TimeSpan timeout, MaskingMode maskingMode, AsyncCallback callback, object state);
+        Message EndRequest(IAsyncResult result);
+        Message Request(Message message, TimeSpan timeout);
+        Message Request(Message message, TimeSpan timeout, MaskingMode maskingMode);
+
+    }
+
+    interface IServerReliableChannelBinder : IReliableChannelBinder
+    {
+        bool AddressResponse(Message request, Message response);
+        bool UseNewChannel(IChannel channel);
+
+        IAsyncResult BeginWaitForRequest(TimeSpan timeout, AsyncCallback callback, object state);
+        bool EndWaitForRequest(IAsyncResult result);
+        bool WaitForRequest(TimeSpan timeout);
+    }
+}
+

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/IReliableChannelBinder.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/IReliableChannelBinder.cs
@@ -1,6 +1,6 @@
-//------------------------------------------------------------
-// Copyright (c) Microsoft Corporation.  All rights reserved.
-//------------------------------------------------------------
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace System.ServiceModel.Channels
 {
@@ -65,15 +65,4 @@ namespace System.ServiceModel.Channels
         Message Request(Message message, TimeSpan timeout, MaskingMode maskingMode);
 
     }
-
-    interface IServerReliableChannelBinder : IReliableChannelBinder
-    {
-        bool AddressResponse(Message request, Message response);
-        bool UseNewChannel(IChannel channel);
-
-        IAsyncResult BeginWaitForRequest(TimeSpan timeout, AsyncCallback callback, object state);
-        bool EndWaitForRequest(IAsyncResult result);
-        bool WaitForRequest(TimeSpan timeout);
-    }
 }
-

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/LayeredChannel.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/LayeredChannel.cs
@@ -4,6 +4,7 @@
 
 
 using System.Runtime;
+using System.Threading.Tasks;
 
 namespace System.ServiceModel.Channels
 {
@@ -57,12 +58,12 @@ namespace System.ServiceModel.Channels
 
         protected override IAsyncResult OnBeginClose(TimeSpan timeout, AsyncCallback callback, object state)
         {
-            return _innerChannel.BeginClose(timeout, callback, state);
+            throw ExceptionHelper.PlatformNotSupported();
         }
 
         protected override void OnEndClose(IAsyncResult result)
         {
-            _innerChannel.EndClose(result);
+            throw ExceptionHelper.PlatformNotSupported();
         }
 
         protected override void OnOpen(TimeSpan timeout)
@@ -72,12 +73,22 @@ namespace System.ServiceModel.Channels
 
         protected override IAsyncResult OnBeginOpen(TimeSpan timeout, AsyncCallback callback, object state)
         {
-            return _innerChannel.BeginOpen(timeout, callback, state);
+            throw ExceptionHelper.PlatformNotSupported();
         }
 
         protected override void OnEndOpen(IAsyncResult result)
         {
-            _innerChannel.EndOpen(result);
+            throw ExceptionHelper.PlatformNotSupported();
+        }
+
+        protected internal override Task OnOpenAsync(TimeSpan timeout)
+        {
+            return ((IAsyncCommunicationObject)_innerChannel).OpenAsync(timeout);
+        }
+
+        protected internal override Task OnCloseAsync(TimeSpan timeout)
+        {
+            return ((IAsyncCommunicationObject)_innerChannel).CloseAsync(timeout);
         }
 
         private void OnInnerChannelFaulted(object sender, EventArgs e)

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/LayeredChannelFactory.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/LayeredChannelFactory.cs
@@ -4,6 +4,7 @@
 
 
 using System.Runtime;
+using System.Threading.Tasks;
 
 namespace System.ServiceModel.Channels
 {
@@ -40,22 +41,22 @@ namespace System.ServiceModel.Channels
 
         protected override IAsyncResult OnBeginOpen(TimeSpan timeout, AsyncCallback callback, object state)
         {
-            return _innerChannelFactory.BeginOpen(timeout, callback, state);
+            throw ExceptionHelper.PlatformNotSupported();
         }
 
         protected override void OnEndOpen(IAsyncResult result)
         {
-            _innerChannelFactory.EndOpen(result);
+            throw ExceptionHelper.PlatformNotSupported();
         }
 
         protected override IAsyncResult OnBeginClose(TimeSpan timeout, AsyncCallback callback, object state)
         {
-            return new ChainedCloseAsyncResult(timeout, callback, state, base.OnBeginClose, base.OnEndClose, _innerChannelFactory);
+            throw ExceptionHelper.PlatformNotSupported();
         }
 
         protected override void OnEndClose(IAsyncResult result)
         {
-            ChainedCloseAsyncResult.End(result);
+            throw ExceptionHelper.PlatformNotSupported();
         }
 
         protected override void OnClose(TimeSpan timeout)
@@ -65,9 +66,26 @@ namespace System.ServiceModel.Channels
             _innerChannelFactory.Close(timeoutHelper.RemainingTime());
         }
 
+        protected internal override Task OnCloseAsync(TimeSpan timeout)
+        {
+            return OnCloseAsyncInternal(timeout);
+        }
+
+        private async Task OnCloseAsyncInternal(TimeSpan timeout)
+        {
+            TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
+            await base.OnCloseAsync(timeoutHelper.RemainingTime());
+            await ((IAsyncCommunicationObject)_innerChannelFactory).CloseAsync(timeout);
+        }
+
         protected override void OnOpen(TimeSpan timeout)
         {
             _innerChannelFactory.Open(timeout);
+        }
+
+        protected internal override Task OnOpenAsync(TimeSpan timeout)
+        {
+            return ((IAsyncCommunicationObject)_innerChannelFactory).OpenAsync(timeout);
         }
 
         protected override void OnAbort()
@@ -211,12 +229,12 @@ namespace System.ServiceModel.Channels
 
         protected override IAsyncResult OnBeginClose(TimeSpan timeout, AsyncCallback callback, object state)
         {
-            return new ChainedCloseAsyncResult(timeout, callback, state, base.OnBeginClose, base.OnEndClose, _innerOutputChannel);
+            throw ExceptionHelper.PlatformNotSupported();
         }
 
         protected override void OnEndClose(IAsyncResult result)
         {
-            ChainedCloseAsyncResult.End(result);
+            throw ExceptionHelper.PlatformNotSupported();
         }
 
         protected override void OnClose(TimeSpan timeout)
@@ -226,14 +244,26 @@ namespace System.ServiceModel.Channels
             base.OnClose(timeoutHelper.RemainingTime());
         }
 
+        protected internal override Task OnCloseAsync(TimeSpan timeout)
+        {
+            return OnCloseAsyncInternal(timeout);
+        }
+
+        private async Task OnCloseAsyncInternal(TimeSpan timeout)
+        {
+            TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
+            await ((IAsyncCommunicationObject)_innerOutputChannel).CloseAsync(timeoutHelper.RemainingTime());
+            await base.OnCloseAsync(timeoutHelper.RemainingTime());
+        }
+
         protected override IAsyncResult OnBeginOpen(TimeSpan timeout, AsyncCallback callback, object state)
         {
-            return new ChainedOpenAsyncResult(timeout, callback, state, base.OnBeginOpen, base.OnEndOpen, _innerOutputChannel);
+            throw ExceptionHelper.PlatformNotSupported();
         }
 
         protected override void OnEndOpen(IAsyncResult result)
         {
-            ChainedOpenAsyncResult.End(result);
+            throw ExceptionHelper.PlatformNotSupported();
         }
 
         protected override void OnOpen(TimeSpan timeout)
@@ -241,6 +271,18 @@ namespace System.ServiceModel.Channels
             TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
             base.OnOpen(timeoutHelper.RemainingTime());
             _innerOutputChannel.Open(timeoutHelper.RemainingTime());
+        }
+
+        protected internal override Task OnOpenAsync(TimeSpan timeout)
+        {
+            return OnOpenAsyncInternal(timeout);
+        }
+
+        private async Task OnOpenAsyncInternal(TimeSpan timeout)
+        {
+            TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
+            await base.OnOpenAsync(timeoutHelper.RemainingTime());
+            await ((IAsyncCommunicationObject)_innerOutputChannel).OpenAsync(timeoutHelper.RemainingTime());
         }
 
         public void Send(Message message)

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/LayeredChannelFactory.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/LayeredChannelFactory.cs
@@ -75,7 +75,7 @@ namespace System.ServiceModel.Channels
         {
             TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
             await base.OnCloseAsync(timeoutHelper.RemainingTime());
-            await ((IAsyncCommunicationObject)_innerChannelFactory).CloseAsync(timeout);
+            await ((IAsyncCommunicationObject)_innerChannelFactory).CloseAsync(timeoutHelper.RemainingTime());
         }
 
         protected override void OnOpen(TimeSpan timeout)

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/ReliableChannelBinder.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/ReliableChannelBinder.cs
@@ -1,6 +1,6 @@
-//------------------------------------------------------------
-// Copyright (c) Microsoft Corporation.  All rights reserved.
-//------------------------------------------------------------
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace System.ServiceModel.Channels
 {
@@ -25,4263 +25,4264 @@ namespace System.ServiceModel.Channels
         All = Handled | Unhandled
     }
 
-    abstract class ReliableChannelBinder<TChannel> : IReliableChannelBinder
-        where TChannel : class, IChannel
-    {
-        bool aborted = false;
-        TimeSpan defaultCloseTimeout;
-        MaskingMode defaultMaskingMode;
-        TimeSpan defaultSendTimeout;
-        AsyncCallback onCloseChannelComplete;
-        CommunicationState state = CommunicationState.Created;
-        ChannelSynchronizer synchronizer;
-        object thisLock = new object();
-
-        protected ReliableChannelBinder(TChannel channel, MaskingMode maskingMode,
-            TolerateFaultsMode faultMode, TimeSpan defaultCloseTimeout,
-            TimeSpan defaultSendTimeout)
-        {
-            if ((maskingMode != MaskingMode.None) && (maskingMode != MaskingMode.All))
-            {
-                throw Fx.AssertAndThrow("ReliableChannelBinder was implemented with only 2 default masking modes, None and All.");
-            }
-
-            this.defaultMaskingMode = maskingMode;
-            this.defaultCloseTimeout = defaultCloseTimeout;
-            this.defaultSendTimeout = defaultSendTimeout;
-
-            this.synchronizer = new ChannelSynchronizer(this, channel, faultMode);
-        }
-
-        protected abstract bool CanGetChannelForReceive
-        {
-            get;
-        }
-
-        public abstract bool CanSendAsynchronously
-        {
-            get;
-        }
-
-        public virtual ChannelParameterCollection ChannelParameters
-        {
-            get { return null; }
-        }
-
-        public IChannel Channel
-        {
-            get
-            {
-                return this.synchronizer.CurrentChannel;
-            }
-        }
-
-        public bool Connected
-        {
-            get
-            {
-                return this.synchronizer.Connected;
-            }
-        }
-
-        public MaskingMode DefaultMaskingMode
-        {
-            get
-            {
-                return this.defaultMaskingMode;
-            }
-        }
-
-        public TimeSpan DefaultSendTimeout
-        {
-            get
-            {
-                return this.defaultSendTimeout;
-            }
-        }
-
-        public abstract bool HasSession
-        {
-            get;
-        }
-
-        public abstract EndpointAddress LocalAddress
-        {
-            get;
-        }
-
-        protected abstract bool MustCloseChannel
-        {
-            get;
-        }
-
-        protected abstract bool MustOpenChannel
-        {
-            get;
-        }
-
-        public abstract EndpointAddress RemoteAddress
-        {
-            get;
-        }
-
-        public CommunicationState State
-        {
-            get
-            {
-                return this.state;
-            }
-        }
-
-        protected ChannelSynchronizer Synchronizer
-        {
-            get
-            {
-                return this.synchronizer;
-            }
-        }
-
-        protected object ThisLock
-        {
-            get
-            {
-                return this.thisLock;
-            }
-        }
-
-        bool TolerateFaults
-        {
-            get
-            {
-                return this.synchronizer.TolerateFaults;
-            }
-        }
-
-        public event EventHandler ConnectionLost;
-        public event BinderExceptionHandler Faulted;
-        public event BinderExceptionHandler OnException;
-
-
-        public void Abort()
-        {
-            TChannel channel;
-            lock (this.ThisLock)
-            {
-                this.aborted = true;
-
-                if (this.state == CommunicationState.Closed)
-                {
-                    return;
-                }
-
-                this.state = CommunicationState.Closing;
-                channel = this.synchronizer.StopSynchronizing(true);
-
-                if (!this.MustCloseChannel)
-                {
-                    channel = null;
-                }
-            }
-
-            this.synchronizer.UnblockWaiters();
-            this.OnShutdown();
-            this.OnAbort();
-
-            if (channel != null)
-            {
-                channel.Abort();
-            }
-
-            this.TransitionToClosed();
-        }
-
-        protected virtual void AddOutputHeaders(Message message)
-        {
-        }
-
-        public IAsyncResult BeginClose(TimeSpan timeout, AsyncCallback callback,
-            object state)
-        {
-            return this.BeginClose(timeout, this.defaultMaskingMode, callback, state);
-        }
-
-        public IAsyncResult BeginClose(TimeSpan timeout, MaskingMode maskingMode,
-            AsyncCallback callback, object state)
-        {
-            this.ThrowIfTimeoutNegative(timeout);
-            TChannel channel;
-
-            if (this.CloseCore(out channel))
-            {
-                return new CompletedAsyncResult(callback, state);
-            }
-            else
-            {
-                return new CloseAsyncResult(this, channel, timeout, maskingMode, callback, state);
-            }
-        }
-
-        protected virtual IAsyncResult BeginCloseChannel(TChannel channel, TimeSpan timeout,
-            AsyncCallback callback, object state)
-        {
-            return channel.BeginClose(timeout, callback, state);
-        }
-
-        public IAsyncResult BeginOpen(TimeSpan timeout, AsyncCallback callback, object state)
-        {
-            this.ThrowIfTimeoutNegative(timeout);
-
-            if (this.OnOpening(this.defaultMaskingMode))
-            {
-                try
-                {
-                    return this.OnBeginOpen(timeout, callback, state);
-                }
-                catch (Exception e)
-                {
-                    if (Fx.IsFatal(e))
-                    {
-                        throw;
-                    }
-
-                    this.Fault(null);
-
-                    if (this.defaultMaskingMode == MaskingMode.None)
-                    {
-                        throw;
-                    }
-                    else
-                    {
-                        this.RaiseOnException(e);
-                    }
-                }
-            }
-
-            return new BinderCompletedAsyncResult(callback, state);
-        }
-
-        public IAsyncResult BeginSend(Message message, TimeSpan timeout, AsyncCallback callback,
-            object state)
-        {
-            return this.BeginSend(message, timeout, this.defaultMaskingMode, callback, state);
-        }
-
-        public IAsyncResult BeginSend(Message message, TimeSpan timeout, MaskingMode maskingMode,
-            AsyncCallback callback, object state)
-        {
-            SendAsyncResult result = new SendAsyncResult(this, callback, state);
-            result.Start(message, timeout, maskingMode);
-            return result;
-        }
-
-        // ChannelSynchronizer helper, cannot take a lock.
-        protected abstract IAsyncResult BeginTryGetChannel(TimeSpan timeout,
-            AsyncCallback callback, object state);
-
-        public virtual IAsyncResult BeginTryReceive(TimeSpan timeout, AsyncCallback callback,
-            object state)
-        {
-            return this.BeginTryReceive(timeout, this.defaultMaskingMode, callback, state);
-        }
-
-        public virtual IAsyncResult BeginTryReceive(TimeSpan timeout, MaskingMode maskingMode,
-            AsyncCallback callback, object state)
-        {
-            if (this.ValidateInputOperation(timeout))
-                return new TryReceiveAsyncResult(this, timeout, maskingMode, callback, state);
-            else
-                return new CompletedAsyncResult(callback, state);
-        }
-
-        internal IAsyncResult BeginWaitForPendingOperations(TimeSpan timeout,
-            AsyncCallback callback, object state)
-        {
-            return this.synchronizer.BeginWaitForPendingOperations(timeout, callback, state);
-        }
-
-        bool CloseCore(out TChannel channel)
-        {
-            channel = null;
-            bool abort = true;
-            bool abortChannel = false;
-
-            lock (this.ThisLock)
-            {
-                if ((this.state == CommunicationState.Closing)
-                    || (this.state == CommunicationState.Closed))
-                {
-                    return true;
-                }
-
-                if (this.state == CommunicationState.Opened)
-                {
-                    this.state = CommunicationState.Closing;
-                    channel = this.synchronizer.StopSynchronizing(true);
-                    abort = false;
-
-                    if (!this.MustCloseChannel)
-                    {
-                        channel = null;
-                    }
-
-                    if (channel != null)
-                    {
-                        CommunicationState channelState = channel.State;
-
-                        if ((channelState == CommunicationState.Created)
-                            || (channelState == CommunicationState.Opening)
-                            || (channelState == CommunicationState.Faulted))
-                        {
-                            abortChannel = true;
-                        }
-                        else if ((channelState == CommunicationState.Closing)
-                            || (channelState == CommunicationState.Closed))
-                        {
-                            channel = null;
-                        }
-                    }
-                }
-            }
-
-            this.synchronizer.UnblockWaiters();
-
-            if (abort)
-            {
-                this.Abort();
-                return true;
-            }
-            else
-            {
-                if (abortChannel)
-                {
-                    channel.Abort();
-                    channel = null;
-                }
-
-                return false;
-            }
-        }
-
-        public void Close(TimeSpan timeout)
-        {
-            this.Close(timeout, this.defaultMaskingMode);
-        }
-
-        public void Close(TimeSpan timeout, MaskingMode maskingMode)
-        {
-            this.ThrowIfTimeoutNegative(timeout);
-            TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
-            TChannel channel;
-
-            if (this.CloseCore(out channel))
-            {
-                return;
-            }
-
-            try
-            {
-                this.OnShutdown();
-                this.OnClose(timeoutHelper.RemainingTime());
-
-                if (channel != null)
-                {
-                    this.CloseChannel(channel, timeoutHelper.RemainingTime());
-                }
-
-                this.TransitionToClosed();
-            }
-            catch (Exception e)
-            {
-                if (Fx.IsFatal(e))
-                {
-                    throw;
-                }
-
-                this.Abort();
-
-                if (!this.HandleException(e, maskingMode))
-                {
-                    throw;
-                }
-            }
-        }
-
-        // The ChannelSynchronizer calls this from an operation thread so this method must not
-        // block.
-        void CloseChannel(TChannel channel)
-        {
-            if (!this.MustCloseChannel)
-            {
-                throw Fx.AssertAndThrow("MustCloseChannel is false when there is no receive loop and this method is called when there is a receive loop.");
-            }
-
-            if (this.onCloseChannelComplete == null)
-            {
-                this.onCloseChannelComplete = Fx.ThunkCallback(new AsyncCallback(this.OnCloseChannelComplete));
-            }
-
-            try
-            {
-                IAsyncResult result = channel.BeginClose(onCloseChannelComplete, channel);
-
-                if (result.CompletedSynchronously)
-                {
-                    channel.EndClose(result);
-                }
-            }
-#pragma warning suppress 56500 // covered by FxCOP
-            catch (Exception e)
-            {
-                if (Fx.IsFatal(e))
-                {
-                    throw;
-                }
-
-                this.HandleException(e, MaskingMode.All);
-            }
-        }
-
-        protected virtual void CloseChannel(TChannel channel, TimeSpan timeout)
-        {
-            channel.Close(timeout);
-        }
-
-        public void EndClose(IAsyncResult result)
-        {
-            CloseAsyncResult closeResult = result as CloseAsyncResult;
-
-            if (closeResult != null)
-            {
-                closeResult.End();
-            }
-            else
-            {
-                CompletedAsyncResult.End(result);
-            }
-        }
-
-        protected virtual void EndCloseChannel(TChannel channel, IAsyncResult result)
-        {
-            channel.EndClose(result);
-        }
-
-        public void EndOpen(IAsyncResult result)
-        {
-            BinderCompletedAsyncResult completedResult = result as BinderCompletedAsyncResult;
-
-            if (completedResult != null)
-            {
-                completedResult.End();
-            }
-            else
-            {
-                try
-                {
-                    this.OnEndOpen(result);
-                }
-                catch (Exception e)
-                {
-                    if (Fx.IsFatal(e))
-                    {
-                        throw;
-                    }
-
-                    this.Fault(null);
-
-                    if (this.defaultMaskingMode == MaskingMode.None)
-                    {
-                        throw;
-                    }
-                    else
-                    {
-                        this.RaiseOnException(e);
-                        return;
-                    }
-                }
-
-                this.synchronizer.StartSynchronizing();
-                this.OnOpened();
-            }
-        }
-
-        public void EndSend(IAsyncResult result)
-        {
-            SendAsyncResult.End(result);
-        }
-
-        // ChannelSynchronizer helper, cannot take a lock.
-        protected abstract bool EndTryGetChannel(IAsyncResult result);
-
-        public virtual bool EndTryReceive(IAsyncResult result, out RequestContext requestContext)
-        {
-            TryReceiveAsyncResult tryReceiveResult = result as TryReceiveAsyncResult;
-
-            if (tryReceiveResult != null)
-            {
-                return tryReceiveResult.End(out requestContext);
-            }
-            else
-            {
-                CompletedAsyncResult.End(result);
-                requestContext = null;
-                return true;
-            }
-        }
-
-        public void EndWaitForPendingOperations(IAsyncResult result)
-        {
-            this.synchronizer.EndWaitForPendingOperations(result);
-        }
-
-        protected void Fault(Exception e)
-        {
-            lock (this.ThisLock)
-            {
-                if (this.state == CommunicationState.Created)
-                {
-                    throw Fx.AssertAndThrow("The binder should not detect the inner channel's faults until after the binder is opened.");
-                }
-
-                if ((this.state == CommunicationState.Faulted)
-                    || (this.state == CommunicationState.Closed))
-                {
-                    return;
-                }
-
-                this.state = CommunicationState.Faulted;
-                this.synchronizer.StopSynchronizing(false);
-            }
-
-            this.synchronizer.UnblockWaiters();
-
-            BinderExceptionHandler handler = this.Faulted;
-
-            if (handler != null)
-            {
-                handler(this, e);
-            }
-        }
-
-        // ChannelSynchronizer helper, cannot take a lock.
-        Exception GetClosedException(MaskingMode maskingMode)
-        {
-            if (ReliableChannelBinderHelper.MaskHandled(maskingMode))
-            {
-                return null;
-            }
-            else if (this.aborted)
-            {
-                return new CommunicationObjectAbortedException(SR.GetString(
-                    SR.CommunicationObjectAborted1, this.GetType().ToString()));
-            }
-            else
-            {
-                return new ObjectDisposedException(this.GetType().ToString());
-            }
-        }
-
-        // Must be called within lock (this.ThisLock)
-        Exception GetClosedOrFaultedException(MaskingMode maskingMode)
-        {
-            if (this.state == CommunicationState.Faulted)
-            {
-                return this.GetFaultedException(maskingMode);
-            }
-            else if ((this.state == CommunicationState.Closing)
-               || (this.state == CommunicationState.Closed))
-            {
-                return this.GetClosedException(maskingMode);
-            }
-            else
-            {
-                throw Fx.AssertAndThrow("Caller is attempting to get a terminal exception in a non-terminal state.");
-            }
-        }
-
-        // ChannelSynchronizer helper, cannot take a lock.
-        Exception GetFaultedException(MaskingMode maskingMode)
-        {
-            if (ReliableChannelBinderHelper.MaskHandled(maskingMode))
-            {
-                return null;
-            }
-            else
-            {
-                return new CommunicationObjectFaultedException(SR.GetString(
-                    SR.CommunicationObjectFaulted1, this.GetType().ToString()));
-            }
-        }
-
-        public abstract ISession GetInnerSession();
-
-        public void HandleException(Exception e)
-        {
-            this.HandleException(e, MaskingMode.All);
-        }
-
-        protected bool HandleException(Exception e, MaskingMode maskingMode)
-        {
-            if (this.TolerateFaults && (e is CommunicationObjectFaultedException))
-            {
-                return true;
-            }
-
-            if (this.IsHandleable(e))
-            {
-                return ReliableChannelBinderHelper.MaskHandled(maskingMode);
-            }
-
-            bool maskUnhandled = ReliableChannelBinderHelper.MaskUnhandled(maskingMode);
-
-            if (maskUnhandled)
-            {
-                this.RaiseOnException(e);
-            }
-
-            return maskUnhandled;
-        }
-
-        protected bool HandleException(Exception e, MaskingMode maskingMode, bool autoAborted)
-        {
-            if (this.TolerateFaults && autoAborted && e is CommunicationObjectAbortedException)
-            {
-                return true;
-            }
-
-            return this.HandleException(e, maskingMode);
-        }
-
-        // ChannelSynchronizer helper, cannot take a lock.
-        protected abstract bool HasSecuritySession(TChannel channel);
-
-        public bool IsHandleable(Exception e)
-        {
-            if (e is ProtocolException)
-            {
-                return false;
-            }
-
-            return (e is CommunicationException)
-                || (e is TimeoutException);
-        }
-
-        protected abstract void OnAbort();
-        protected abstract IAsyncResult OnBeginClose(TimeSpan timeout, AsyncCallback callback,
-            object state);
-        protected abstract IAsyncResult OnBeginOpen(TimeSpan timeout, AsyncCallback callback,
-            object state);
-
-        protected virtual IAsyncResult OnBeginSend(TChannel channel, Message message,
-            TimeSpan timeout, AsyncCallback callback, object state)
-        {
-            throw Fx.AssertAndThrow("The derived class does not support the BeginSend operation.");
-        }
-
-        protected virtual IAsyncResult OnBeginTryReceive(TChannel channel, TimeSpan timeout,
-            AsyncCallback callback, object state)
-        {
-            throw Fx.AssertAndThrow("The derived class does not support the BeginTryReceive operation.");
-        }
-
-        protected abstract void OnClose(TimeSpan timeout);
-
-        void OnCloseChannelComplete(IAsyncResult result)
-        {
-            if (result.CompletedSynchronously)
-            {
-                return;
-            }
-
-            TChannel channel = (TChannel)result.AsyncState;
-
-            try
-            {
-                channel.EndClose(result);
-            }
-#pragma warning suppress 56500 // covered by FxCOP
-            catch (Exception e)
-            {
-                if (Fx.IsFatal(e))
-                {
-                    throw;
-                }
-
-                this.HandleException(e, MaskingMode.All);
-            }
-        }
-
-        protected abstract void OnEndClose(IAsyncResult result);
-        protected abstract void OnEndOpen(IAsyncResult result);
-
-        protected virtual void OnEndSend(TChannel channel, IAsyncResult result)
-        {
-            throw Fx.AssertAndThrow("The derived class does not support the EndSend operation.");
-        }
-
-        protected virtual bool OnEndTryReceive(TChannel channel, IAsyncResult result,
-            out RequestContext requestContext)
-        {
-            throw Fx.AssertAndThrow("The derived class does not support the EndTryReceive operation.");
-        }
-
-        void OnInnerChannelFaulted()
-        {
-            if (!this.TolerateFaults)
-                return;
-
-            EventHandler handler = this.ConnectionLost;
-
-            if (handler != null)
-                handler(this, EventArgs.Empty);
-        }
-
-        protected abstract void OnOpen(TimeSpan timeout);
-
-        void OnOpened()
-        {
-            lock (this.ThisLock)
-            {
-                if (this.state == CommunicationState.Opening)
-                {
-                    this.state = CommunicationState.Opened;
-                }
-            }
-        }
-
-        bool OnOpening(MaskingMode maskingMode)
-        {
-            lock (this.ThisLock)
-            {
-                if (this.state != CommunicationState.Created)
-                {
-                    Exception e = null;
-
-                    if ((this.state == CommunicationState.Opening)
-                        || (this.state == CommunicationState.Opened))
-                    {
-                        if (!ReliableChannelBinderHelper.MaskUnhandled(maskingMode))
-                        {
-                            e = new InvalidOperationException(SR.GetString(
-                                SR.CommunicationObjectCannotBeModifiedInState,
-                                this.GetType().ToString(), this.state.ToString()));
-                        }
-                    }
-                    else
-                    {
-                        e = this.GetClosedOrFaultedException(maskingMode);
-                    }
-
-                    if (e != null)
-                    {
-                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(e);
-                    }
-
-                    return false;
-                }
-                else
-                {
-                    this.state = CommunicationState.Opening;
-                    return true;
-                }
-            }
-        }
-
-        protected virtual void OnShutdown()
-        {
-        }
-
-        protected virtual void OnSend(TChannel channel, Message message, TimeSpan timeout)
-        {
-            throw Fx.AssertAndThrow("The derived class does not support the Send operation.");
-        }
-
-        protected virtual bool OnTryReceive(TChannel channel, TimeSpan timeout,
-            out RequestContext requestContext)
-        {
-            throw Fx.AssertAndThrow("The derived class does not support the TryReceive operation.");
-        }
-
-        public void Open(TimeSpan timeout)
-        {
-            this.ThrowIfTimeoutNegative(timeout);
-
-            if (!this.OnOpening(this.defaultMaskingMode))
-            {
-                return;
-            }
-
-            try
-            {
-                this.OnOpen(timeout);
-            }
-            catch (Exception e)
-            {
-                if (Fx.IsFatal(e))
-                {
-                    throw;
-                }
-
-                this.Fault(null);
-
-                if (this.defaultMaskingMode == MaskingMode.None)
-                {
-                    throw;
-                }
-                else
-                {
-                    this.RaiseOnException(e);
-                    return;
-                }
-            }
-
-            this.synchronizer.StartSynchronizing();
-            this.OnOpened();
-        }
-
-        void RaiseOnException(Exception e)
-        {
-            BinderExceptionHandler handler = this.OnException;
-
-            if (handler != null)
-            {
-                handler(this, e);
-            }
-        }
-
-        public void Send(Message message, TimeSpan timeout)
-        {
-            this.Send(message, timeout, this.defaultMaskingMode);
-        }
-
-        public void Send(Message message, TimeSpan timeout, MaskingMode maskingMode)
-        {
-            if (!this.ValidateOutputOperation(message, timeout, maskingMode))
-            {
-                return;
-            }
-
-            bool autoAborted = false;
-
-            try
-            {
-                TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
-                TChannel channel;
-
-                if (!this.synchronizer.TryGetChannelForOutput(timeoutHelper.RemainingTime(), maskingMode,
-                    out channel))
-                {
-                    if (!ReliableChannelBinderHelper.MaskHandled(maskingMode))
-                    {
-                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(
-                            new TimeoutException(SR.GetString(SR.TimeoutOnSend, timeout)));
-                    }
-
-                    return;
-                }
-
-                if (channel == null)
-                {
-                    return;
-                }
-
-                this.AddOutputHeaders(message);
-
-                try
-                {
-                    this.OnSend(channel, message, timeoutHelper.RemainingTime());
-                }
-                finally
-                {
-                    autoAborted = this.Synchronizer.Aborting;
-                    this.synchronizer.ReturnChannel();
-                }
-            }
-            catch (Exception e)
-            {
-                if (Fx.IsFatal(e))
-                {
-                    throw;
-                }
-
-                if (!this.HandleException(e, maskingMode, autoAborted))
-                {
-                    throw;
-                }
-            }
-        }
-
-        public void SetMaskingMode(RequestContext context, MaskingMode maskingMode)
-        {
-            BinderRequestContext binderContext = (BinderRequestContext)context;
-            binderContext.SetMaskingMode(maskingMode);
-        }
-
-        // throwDisposed indicates whether to throw in the Faulted, Closing, and Closed states.
-        // returns true if in Opened state
-        bool ThrowIfNotOpenedAndNotMasking(MaskingMode maskingMode, bool throwDisposed)
-        {
-            lock (this.ThisLock)
-            {
-                if (this.State == CommunicationState.Created)
-                {
-                    throw Fx.AssertAndThrow("Messaging operations cannot be called when the binder is in the Created state.");
-                }
-
-                if (this.State == CommunicationState.Opening)
-                {
-                    throw Fx.AssertAndThrow("Messaging operations cannot be called when the binder is in the Opening state.");
-                }
-
-                if (this.State == CommunicationState.Opened)
-                {
-                    return true;
-                }
-
-                // state is Faulted, Closing, or Closed
-                if (throwDisposed)
-                {
-                    Exception e = this.GetClosedOrFaultedException(maskingMode);
-
-                    if (e != null)
-                    {
-                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(e);
-                    }
-                }
-
-                return false;
-            }
-        }
-
-        void ThrowIfTimeoutNegative(TimeSpan timeout)
-        {
-            if (timeout < TimeSpan.Zero)
-            {
-                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(
-                    new ArgumentOutOfRangeException("timeout", timeout, SR.SFxTimeoutOutOfRange0));
-            }
-        }
-
-        void TransitionToClosed()
-        {
-            lock (this.ThisLock)
-            {
-                if ((this.state != CommunicationState.Closing)
-                    && (this.state != CommunicationState.Closed)
-                    && (this.state != CommunicationState.Faulted))
-                {
-                    throw Fx.AssertAndThrow("Caller cannot transition to the Closed state from a non-terminal state.");
-                }
-
-                this.state = CommunicationState.Closed;
-            }
-        }
-
-        // ChannelSynchronizer helper, cannot take a lock.
-        protected abstract bool TryGetChannel(TimeSpan timeout);
-
-        public virtual bool TryReceive(TimeSpan timeout, out RequestContext requestContext)
-        {
-            return this.TryReceive(timeout, out requestContext, this.defaultMaskingMode);
-        }
-
-        public virtual bool TryReceive(TimeSpan timeout, out RequestContext requestContext, MaskingMode maskingMode)
-        {
-            if (maskingMode != MaskingMode.None)
-            {
-                throw Fx.AssertAndThrow("This method was implemented only for the case where we do not mask exceptions.");
-            }
-
-            if (!this.ValidateInputOperation(timeout))
-            {
-                requestContext = null;
-                return true;
-            }
-
-            TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
-
-            while (true)
-            {
-                bool autoAborted = false;
-
-                try
-                {
-                    TChannel channel;
-                    bool success = !this.synchronizer.TryGetChannelForInput(
-                        this.CanGetChannelForReceive, timeoutHelper.RemainingTime(), out channel);
-
-                    if (channel == null)
-                    {
-                        requestContext = null;
-                        return success;
-                    }
-
-                    try
-                    {
-                        success = this.OnTryReceive(channel, timeoutHelper.RemainingTime(),
-                            out requestContext);
-
-                        // timed out || got message, return immediately
-                        if (!success || (requestContext != null))
-                        {
-                            return success;
-                        }
-
-                        // the underlying channel closed or faulted, retry
-                        this.synchronizer.OnReadEof();
-                    }
-                    finally
-                    {
-                        autoAborted = this.Synchronizer.Aborting;
-                        this.synchronizer.ReturnChannel();
-                    }
-                }
-                catch (Exception e)
-                {
-                    if (Fx.IsFatal(e))
-                    {
-                        throw;
-                    }
-
-                    if (!this.HandleException(e, maskingMode, autoAborted))
-                    {
-                        throw;
-                    }
-                }
-            }
-        }
-
-        protected bool ValidateInputOperation(TimeSpan timeout)
-        {
-            if (timeout < TimeSpan.Zero)
-            {
-                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("timeout", timeout,
-                    SR.SFxTimeoutOutOfRange0));
-            }
-
-            return this.ThrowIfNotOpenedAndNotMasking(MaskingMode.All, false);
-        }
-
-        protected bool ValidateOutputOperation(Message message, TimeSpan timeout, MaskingMode maskingMode)
-        {
-            if (message == null)
-            {
-                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("message");
-            }
-
-            if (timeout < TimeSpan.Zero)
-            {
-                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("timeout", timeout,
-                    SR.SFxTimeoutOutOfRange0));
-            }
-
-            return this.ThrowIfNotOpenedAndNotMasking(maskingMode, true);
-        }
-
-        internal void WaitForPendingOperations(TimeSpan timeout)
-        {
-            this.synchronizer.WaitForPendingOperations(timeout);
-        }
-
-        protected RequestContext WrapMessage(Message message)
-        {
-            if (message == null)
-            {
-                return null;
-            }
-
-            return new MessageRequestContext(this, message);
-        }
-
-        public RequestContext WrapRequestContext(RequestContext context)
-        {
-            if (context == null)
-            {
-                return null;
-            }
-
-            if (!this.TolerateFaults && this.defaultMaskingMode == MaskingMode.None)
-            {
-                return context;
-            }
-
-            return new RequestRequestContext(this, context, context.RequestMessage);
-        }
-
-        sealed class BinderCompletedAsyncResult : CompletedAsyncResult
-        {
-            public BinderCompletedAsyncResult(AsyncCallback callback, object state)
-                : base(callback, state)
-            {
-            }
-
-            public void End()
-            {
-                CompletedAsyncResult.End(this);
-            }
-        }
-
-        abstract class BinderRequestContext : RequestContextBase
-        {
-            ReliableChannelBinder<TChannel> binder;
-            MaskingMode maskingMode;
-
-            public BinderRequestContext(ReliableChannelBinder<TChannel> binder, Message message)
-                : base(message, binder.defaultCloseTimeout, binder.defaultSendTimeout)
-            {
-                if (binder == null)
-                {
-                    Fx.Assert("Argument binder cannot be null.");
-                }
-
-                this.binder = binder;
-                this.maskingMode = binder.defaultMaskingMode;
-            }
-
-            protected ReliableChannelBinder<TChannel> Binder
-            {
-                get
-                {
-                    return this.binder;
-                }
-            }
-
-            protected MaskingMode MaskingMode
-            {
-                get
-                {
-                    return this.maskingMode;
-                }
-            }
-
-            public void SetMaskingMode(MaskingMode maskingMode)
-            {
-                if (this.binder.defaultMaskingMode != MaskingMode.All)
-                {
-                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new NotSupportedException());
-                }
-
-                this.maskingMode = maskingMode;
-            }
-        }
-
-        protected class ChannelSynchronizer
-        {
-            bool aborting; // Indicates the current channel is being aborted, not the synchronizer.
-            ReliableChannelBinder<TChannel> binder;
-            int count = 0;
-            TChannel currentChannel;
-            InterruptibleWaitObject drainEvent;
-            static Action<object> asyncGetChannelCallback = new Action<object>(AsyncGetChannelCallback);
-            TolerateFaultsMode faultMode;
-            Queue<IWaiter> getChannelQueue;
-            bool innerChannelFaulted;
-            EventHandler onChannelFaulted;
-            State state = State.Created;
-            bool tolerateFaults = true;
-            object thisLock = new object();
-            Queue<IWaiter> waitQueue;
-
-            public ChannelSynchronizer(ReliableChannelBinder<TChannel> binder, TChannel channel,
-                TolerateFaultsMode faultMode)
-            {
-                this.binder = binder;
-                this.currentChannel = channel;
-                this.faultMode = faultMode;
-            }
-
-            public bool Aborting
-            {
-                get
-                {
-                    return this.aborting;
-                }
-            }
-
-            public bool Connected
-            {
-                get
-                {
-                    return (this.state == State.ChannelOpened ||
-                        this.state == State.ChannelOpening);
-                }
-            }
-
-            public TChannel CurrentChannel
-            {
-                get
-                {
-                    return this.currentChannel;
-                }
-            }
-
-            object ThisLock
-            {
-                get
-                {
-                    return this.thisLock;
-                }
-            }
-
-            public bool TolerateFaults
-            {
-                get
-                {
-                    return this.tolerateFaults;
-                }
-            }
-
-            // Server only API.
-            public TChannel AbortCurentChannel()
-            {
-                lock (this.ThisLock)
-                {
-                    if (!this.tolerateFaults)
-                    {
-                        throw Fx.AssertAndThrow("It is only valid to abort the current channel when masking faults");
-                    }
-
-                    if (this.state == State.ChannelOpening)
-                    {
-                        this.aborting = true;
-                    }
-                    else if (this.state == State.ChannelOpened)
-                    {
-                        if (this.count == 0)
-                        {
-                            this.state = State.NoChannel;
-                        }
-                        else
-                        {
-                            this.aborting = true;
-                            this.state = State.ChannelClosing;
-                        }
-                    }
-                    else
-                    {
-                        return null;
-                    }
-
-                    return this.currentChannel;
-                }
-            }
-
-            static void AsyncGetChannelCallback(object state)
-            {
-                AsyncWaiter waiter = (AsyncWaiter)state;
-                waiter.GetChannel(false);
-            }
-
-            public IAsyncResult BeginTryGetChannelForInput(bool canGetChannel, TimeSpan timeout,
-                AsyncCallback callback, object state)
-            {
-                return this.BeginTryGetChannel(canGetChannel, false, timeout, MaskingMode.All,
-                    callback, state);
-            }
-
-            public IAsyncResult BeginTryGetChannelForOutput(TimeSpan timeout,
-                MaskingMode maskingMode, AsyncCallback callback, object state)
-            {
-                return this.BeginTryGetChannel(true, true, timeout, maskingMode,
-                    callback, state);
-            }
-
-            IAsyncResult BeginTryGetChannel(bool canGetChannel, bool canCauseFault,
-                TimeSpan timeout, MaskingMode maskingMode, AsyncCallback callback, object state)
-            {
-                TChannel channel = null;
-                AsyncWaiter waiter = null;
-                bool getChannel = false;
-                bool faulted = false;
-
-                lock (this.ThisLock)
-                {
-                    if (!this.ThrowIfNecessary(maskingMode))
-                    {
-                        channel = null;
-                    }
-                    else if (this.state == State.ChannelOpened)
-                    {
-                        if (this.currentChannel == null)
-                        {
-                            throw Fx.AssertAndThrow("Field currentChannel cannot be null in the ChannelOpened state.");
-                        }
-
-                        this.count++;
-                        channel = this.currentChannel;
-                    }
-                    else if (!this.tolerateFaults
-                        && ((this.state == State.NoChannel)
-                        || (this.state == State.ChannelClosing)))
-                    {
-                        if (canCauseFault)
-                        {
-                            faulted = true;
-                        }
-
-                        channel = null;
-                    }
-                    else if (!canGetChannel
-                        || (this.state == State.ChannelOpening)
-                        || (this.state == State.ChannelClosing))
-                    {
-                        waiter = new AsyncWaiter(this, canGetChannel, null, timeout, maskingMode,
-                            this.binder.ChannelParameters,
-                            callback, state);
-                        this.GetQueue(canGetChannel).Enqueue(waiter);
-                    }
-                    else
-                    {
-                        if (this.state != State.NoChannel)
-                        {
-                            throw Fx.AssertAndThrow("The state must be NoChannel.");
-                        }
-
-                        waiter = new AsyncWaiter(this, canGetChannel,
-                            this.GetCurrentChannelIfCreated(), timeout, maskingMode,
-                            this.binder.ChannelParameters,
-                            callback, state);
-
-                        this.state = State.ChannelOpening;
-                        getChannel = true;
-                    }
-                }
-
-                if (faulted)
-                {
-                    this.binder.Fault(null);
-                }
-
-                if (waiter == null)
-                {
-                    return new CompletedAsyncResult<TChannel>(channel, callback, state);
-                }
-
-                if (getChannel)
-                {
-                    waiter.GetChannel(true);
-                }
-                else
-                {
-                    waiter.Wait();
-                }
-
-                return waiter;
-            }
-
-            public IAsyncResult BeginWaitForPendingOperations(TimeSpan timeout,
-                AsyncCallback callback, object state)
-            {
-                lock (this.ThisLock)
-                {
-                    if (this.drainEvent != null)
-                    {
-                        throw Fx.AssertAndThrow("The WaitForPendingOperations operation may only be invoked once.");
-                    }
-
-                    if (this.count > 0)
-                    {
-                        this.drainEvent = new InterruptibleWaitObject(false, false);
-                    }
-                }
-
-                if (this.drainEvent != null)
-                {
-                    return this.drainEvent.BeginWait(timeout, callback, state);
-                }
-                else
-                {
-                    return new SynchronizerCompletedAsyncResult(callback, state);
-                }
-            }
-
-            bool CompleteSetChannel(IWaiter waiter, out TChannel channel)
-            {
-                if (waiter == null)
-                {
-                    throw Fx.AssertAndThrow("Argument waiter cannot be null.");
-                }
-
-                bool close = false;
-
-                lock (this.ThisLock)
-                {
-                    if (this.ValidateOpened())
-                    {
-                        channel = this.currentChannel;
-                        return true;
-                    }
-                    else
-                    {
-                        channel = null;
-                        close = this.state == State.Closed;
-                    }
-                }
-
-                if (close)
-                {
-                    waiter.Close();
-                }
-                else
-                {
-                    waiter.Fault();
-                }
-
-                return false;
-            }
-
-            public bool EndTryGetChannel(IAsyncResult result, out TChannel channel)
-            {
-                AsyncWaiter waiter = result as AsyncWaiter;
-
-                if (waiter != null)
-                {
-                    return waiter.End(out channel);
-                }
-                else
-                {
-                    channel = CompletedAsyncResult<TChannel>.End(result);
-                    return true;
-                }
-            }
-
-            public void EndWaitForPendingOperations(IAsyncResult result)
-            {
-                SynchronizerCompletedAsyncResult completedResult =
-                    result as SynchronizerCompletedAsyncResult;
-
-                if (completedResult != null)
-                {
-                    completedResult.End();
-                }
-                else
-                {
-                    this.drainEvent.EndWait(result);
-                }
-            }
-
-            // Client API only.
-            public bool EnsureChannel()
-            {
-                bool fault = false;
-
-                lock (this.ThisLock)
-                {
-                    if (this.ValidateOpened())
-                    {
-                        // This is called only during the RM CS phase. In this phase, there are 2
-                        // valid states between Request calls, ChannelOpened and NoChannel.
-                        if (this.state == State.ChannelOpened)
-                        {
-                            return true;
-                        }
-
-                        if (this.state != State.NoChannel)
-                        {
-                            throw Fx.AssertAndThrow("The caller may only invoke this EnsureChannel during the CreateSequence negotiation. ChannelOpening and ChannelClosing are invalid states during this phase of the negotiation.");
-                        }
-
-                        if (!this.tolerateFaults)
-                        {
-                            fault = true;
-                        }
-                        else
-                        {
-                            if (this.GetCurrentChannelIfCreated() != null)
-                            {
-                                return true;
-                            }
-
-                            if (this.binder.TryGetChannel(TimeSpan.Zero))
-                            {
-                                if (this.currentChannel == null)
-                                {
-                                    return false;
-                                }
-
-                                return true;
-                            }
-                        }
-                    }
-                }
-
-                if (fault)
-                {
-                    this.binder.Fault(null);
-                }
-
-                return false;
-            }
-
-            IWaiter GetChannelWaiter()
-            {
-                if ((this.getChannelQueue == null) || (this.getChannelQueue.Count == 0))
-                {
-                    return null;
-                }
-
-                return this.getChannelQueue.Dequeue();
-            }
-
-            // Must be called within lock (this.ThisLock)
-            TChannel GetCurrentChannelIfCreated()
-            {
-                if (this.state != State.NoChannel)
-                {
-                    throw Fx.AssertAndThrow("This method may only be called in the NoChannel state.");
-                }
-
-                if ((this.currentChannel != null)
-                    && (this.currentChannel.State == CommunicationState.Created))
-                {
-                    return this.currentChannel;
-                }
-                else
-                {
-                    return null;
-                }
-            }
-
-            Queue<IWaiter> GetQueue(bool canGetChannel)
-            {
-                if (canGetChannel)
-                {
-                    if (this.getChannelQueue == null)
-                    {
-                        this.getChannelQueue = new Queue<IWaiter>();
-                    }
-
-                    return this.getChannelQueue;
-                }
-                else
-                {
-                    if (this.waitQueue == null)
-                    {
-                        this.waitQueue = new Queue<IWaiter>();
-                    }
-
-                    return this.waitQueue;
-                }
-            }
-
-            void OnChannelFaulted(object sender, EventArgs e)
-            {
-                TChannel faultedChannel = (TChannel)sender;
-                bool faultBinder = false;
-                bool raiseInnerChannelFaulted = false;
-
-                lock (this.ThisLock)
-                {
-                    if (this.currentChannel != faultedChannel)
-                    {
-                        return;
-                    }
-
-                    // The synchronizer is already closed or aborted.
-                    if (!this.ValidateOpened())
-                    {
-                        return;
-                    }
-
-                    if (this.state == State.ChannelOpened)
-                    {
-                        if (this.count == 0)
-                        {
-                            faultedChannel.Faulted -= this.onChannelFaulted;
-                        }
-
-                        faultBinder = !this.tolerateFaults;
-                        this.state = State.ChannelClosing;
-                        this.innerChannelFaulted = true;
-
-                        if (!faultBinder && this.count == 0)
-                        {
-                            this.state = State.NoChannel;
-                            this.aborting = false;
-                            raiseInnerChannelFaulted = true;
-                            this.innerChannelFaulted = false;
-                        }
-                    }
-                }
-
-                if (faultBinder)
-                {
-                    this.binder.Fault(null);
-                }
-
-                faultedChannel.Abort();
-
-                if (raiseInnerChannelFaulted)
-                {
-                    this.binder.OnInnerChannelFaulted();
-                }
-            }
-
-            bool OnChannelOpened(IWaiter waiter)
-            {
-                if (waiter == null)
-                {
-                    throw Fx.AssertAndThrow("Argument waiter cannot be null.");
-                }
-
-                bool close = false;
-                bool fault = false;
-
-                Queue<IWaiter> temp1 = null;
-                Queue<IWaiter> temp2 = null;
-                TChannel channel = null;
-
-                lock (this.ThisLock)
-                {
-                    if (this.currentChannel == null)
-                    {
-                        throw Fx.AssertAndThrow("Caller must ensure that field currentChannel is set before opening the channel.");
-                    }
-
-                    if (this.ValidateOpened())
-                    {
-                        if (this.state != State.ChannelOpening)
-                        {
-                            throw Fx.AssertAndThrow("This method may only be called in the ChannelOpening state.");
-                        }
-
-                        this.state = State.ChannelOpened;
-                        this.SetTolerateFaults();
-
-                        this.count += 1;
-                        this.count += (this.getChannelQueue == null) ? 0 : this.getChannelQueue.Count;
-                        this.count += (this.waitQueue == null) ? 0 : this.waitQueue.Count;
-
-                        temp1 = this.getChannelQueue;
-                        temp2 = this.waitQueue;
-                        channel = this.currentChannel;
-
-                        this.getChannelQueue = null;
-                        this.waitQueue = null;
-                    }
-                    else
-                    {
-                        close = this.state == State.Closed;
-                        fault = this.state == State.Faulted;
-                    }
-                }
-
-                if (close)
-                {
-                    waiter.Close();
-                    return false;
-                }
-                else if (fault)
-                {
-                    waiter.Fault();
-                    return false;
-                }
-
-                this.SetWaiters(temp1, channel);
-                this.SetWaiters(temp2, channel);
-                return true;
-            }
-
-            void OnGetChannelFailed()
-            {
-                IWaiter waiter = null;
-
-                lock (this.ThisLock)
-                {
-                    if (!this.ValidateOpened())
-                    {
-                        return;
-                    }
-
-                    if (this.state != State.ChannelOpening)
-                    {
-                        throw Fx.AssertAndThrow("The state must be set to ChannelOpening before the caller attempts to open the channel.");
-                    }
-
-                    waiter = this.GetChannelWaiter();
-
-                    if (waiter == null)
-                    {
-                        this.state = State.NoChannel;
-                        return;
-                    }
-                }
-
-                if (waiter is SyncWaiter)
-                {
-                    waiter.GetChannel(false);
-                }
-                else
-                {
-                    ActionItem.Schedule(asyncGetChannelCallback, waiter);
-                }
-            }
-
-            public void OnReadEof()
-            {
-                lock (this.ThisLock)
-                {
-                    if (this.count <= 0)
-                    {
-                        throw Fx.AssertAndThrow("Caller must ensure that OnReadEof is called before ReturnChannel.");
-                    }
-
-                    if (this.ValidateOpened())
-                    {
-                        if ((this.state != State.ChannelOpened) && (this.state != State.ChannelClosing))
-                        {
-                            throw Fx.AssertAndThrow("Since count is positive, the only valid states are ChannelOpened and ChannelClosing.");
-                        }
-
-                        if (this.currentChannel.State != CommunicationState.Faulted)
-                        {
-                            this.state = State.ChannelClosing;
-                        }
-                    }
-                }
-            }
-
-            bool RemoveWaiter(IWaiter waiter)
-            {
-                Queue<IWaiter> waiters = waiter.CanGetChannel ? this.getChannelQueue : this.waitQueue;
-                bool removed = false;
-
-                lock (this.ThisLock)
-                {
-                    if (!this.ValidateOpened())
-                    {
-                        return false;
-                    }
-
-                    for (int i = waiters.Count; i > 0; i--)
-                    {
-                        IWaiter temp = waiters.Dequeue();
-
-                        if (object.ReferenceEquals(waiter, temp))
-                        {
-                            removed = true;
-                        }
-                        else
-                        {
-                            waiters.Enqueue(temp);
-                        }
-                    }
-                }
-
-                return removed;
-            }
-
-            public void ReturnChannel()
-            {
-                TChannel channel = null;
-                IWaiter waiter = null;
-                bool faultBinder = false;
-                bool drained;
-                bool raiseInnerChannelFaulted = false;
-
-                lock (this.ThisLock)
-                {
-                    if (this.count <= 0)
-                    {
-                        throw Fx.AssertAndThrow("Method ReturnChannel() can only be called after TryGetChannel or EndTryGetChannel returns a channel.");
-                    }
-
-                    this.count--;
-                    drained = (this.count == 0) && (this.drainEvent != null);
-
-                    if (this.ValidateOpened())
-                    {
-                        if ((this.state != State.ChannelOpened) && (this.state != State.ChannelClosing))
-                        {
-                            throw Fx.AssertAndThrow("ChannelOpened and ChannelClosing are the only 2 valid states when count is positive.");
-                        }
-
-                        if (this.currentChannel.State == CommunicationState.Faulted)
-                        {
-                            faultBinder = !this.tolerateFaults;
-                            this.innerChannelFaulted = true;
-                            this.state = State.ChannelClosing;
-                        }
-
-                        if (!faultBinder && (this.state == State.ChannelClosing) && (this.count == 0))
-                        {
-                            channel = this.currentChannel;
-                            raiseInnerChannelFaulted = this.innerChannelFaulted;
-                            this.innerChannelFaulted = false;
-
-                            this.state = State.NoChannel;
-                            this.aborting = false;
-
-                            waiter = this.GetChannelWaiter();
-
-                            if (waiter != null)
-                            {
-                                this.state = State.ChannelOpening;
-                            }
-                        }
-                    }
-                }
-
-                if (faultBinder)
-                {
-                    this.binder.Fault(null);
-                }
-
-                if (drained)
-                {
-                    this.drainEvent.Set();
-                }
-
-                if (channel != null)
-                {
-                    channel.Faulted -= this.onChannelFaulted;
-
-                    if (channel.State == CommunicationState.Opened)
-                    {
-                        this.binder.CloseChannel(channel);
-                    }
-                    else
-                    {
-                        channel.Abort();
-                    }
-
-                    if (waiter != null)
-                    {
-                        waiter.GetChannel(false);
-                    }
-                }
-
-                if (raiseInnerChannelFaulted)
-                {
-                    this.binder.OnInnerChannelFaulted();
-                }
-            }
-
-            public bool SetChannel(TChannel channel)
-            {
-                lock (this.ThisLock)
-                {
-                    if (this.state != State.ChannelOpening && this.state != State.NoChannel)
-                    {
-                        throw Fx.AssertAndThrow("SetChannel is only valid in the NoChannel and ChannelOpening states");
-                    }
-
-                    if (!this.tolerateFaults)
-                    {
-                        throw Fx.AssertAndThrow("SetChannel is only valid when masking faults");
-                    }
-
-                    if (this.ValidateOpened())
-                    {
-                        this.currentChannel = channel;
-                        return true;
-                    }
-                    else
-                    {
-                        return false;
-                    }
-                }
-            }
-
-            void SetTolerateFaults()
-            {
-                if (this.faultMode == TolerateFaultsMode.Never)
-                {
-                    this.tolerateFaults = false;
-                }
-                else if (this.faultMode == TolerateFaultsMode.IfNotSecuritySession)
-                {
-                    this.tolerateFaults = !this.binder.HasSecuritySession(this.currentChannel);
-                }
-
-                if (this.onChannelFaulted == null)
-                {
-                    this.onChannelFaulted = new EventHandler(this.OnChannelFaulted);
-                }
-
-                this.currentChannel.Faulted += this.onChannelFaulted;
-            }
-
-            void SetWaiters(Queue<IWaiter> waiters, TChannel channel)
-            {
-                if ((waiters != null) && (waiters.Count > 0))
-                {
-                    foreach (IWaiter waiter in waiters)
-                    {
-                        waiter.Set(channel);
-                    }
-                }
-            }
-
-            public void StartSynchronizing()
-            {
-                lock (this.ThisLock)
-                {
-                    if (this.state == State.Created)
-                    {
-                        this.state = State.NoChannel;
-                    }
-                    else
-                    {
-                        if (this.state != State.Closed)
-                        {
-                            throw Fx.AssertAndThrow("Abort is the only operation that can race with Open.");
-                        }
-
-                        return;
-                    }
-
-                    if (this.currentChannel == null)
-                    {
-                        if (!this.binder.TryGetChannel(TimeSpan.Zero))
-                        {
-                            return;
-                        }
-                    }
-
-                    if (this.currentChannel == null)
-                    {
-                        return;
-                    }
-
-                    if (!this.binder.MustOpenChannel)
-                    {
-                        // Channel is already opened.
-                        this.state = State.ChannelOpened;
-                        this.SetTolerateFaults();
-                    }
-                }
-            }
-
-            public TChannel StopSynchronizing(bool close)
-            {
-                lock (this.ThisLock)
-                {
-                    if ((this.state != State.Faulted) && (this.state != State.Closed))
-                    {
-                        this.state = close ? State.Closed : State.Faulted;
-
-                        if ((this.currentChannel != null) && (this.onChannelFaulted != null))
-                        {
-                            this.currentChannel.Faulted -= this.onChannelFaulted;
-                        }
-                    }
-
-                    return this.currentChannel;
-                }
-            }
-
-            // Must be called under a lock.
-            bool ThrowIfNecessary(MaskingMode maskingMode)
-            {
-                if (this.ValidateOpened())
-                {
-                    return true;
-                }
-
-                // state is Closed or Faulted.
-                Exception e;
-
-                if (this.state == State.Closed)
-                {
-                    e = this.binder.GetClosedException(maskingMode);
-                }
-                else
-                {
-                    e = this.binder.GetFaultedException(maskingMode);
-                }
-
-                if (e != null)
-                {
-                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(e);
-                }
-
-                return false;
-            }
-
-            public bool TryGetChannelForInput(bool canGetChannel, TimeSpan timeout,
-                out TChannel channel)
-            {
-                return this.TryGetChannel(canGetChannel, false, timeout, MaskingMode.All,
-                    out channel);
-            }
-
-            public bool TryGetChannelForOutput(TimeSpan timeout, MaskingMode maskingMode,
-                out TChannel channel)
-            {
-                return this.TryGetChannel(true, true, timeout, maskingMode, out channel);
-            }
-
-            bool TryGetChannel(bool canGetChannel, bool canCauseFault, TimeSpan timeout,
-                MaskingMode maskingMode, out TChannel channel)
-            {
-                SyncWaiter waiter = null;
-                bool faulted = false;
-                bool getChannel = false;
-
-                lock (this.ThisLock)
-                {
-                    if (!this.ThrowIfNecessary(maskingMode))
-                    {
-                        channel = null;
-                        return true;
-                    }
-
-                    if (this.state == State.ChannelOpened)
-                    {
-                        if (this.currentChannel == null)
-                        {
-                            throw Fx.AssertAndThrow("Field currentChannel cannot be null in the ChannelOpened state.");
-                        }
-
-                        this.count++;
-                        channel = this.currentChannel;
-                        return true;
-                    }
-
-                    if (!this.tolerateFaults
-                        && ((this.state == State.ChannelClosing)
-                        || (this.state == State.NoChannel)))
-                    {
-                        if (!canCauseFault)
-                        {
-                            channel = null;
-                            return true;
-                        }
-
-                        faulted = true;
-                    }
-                    else if (!canGetChannel
-                        || (this.state == State.ChannelOpening)
-                        || (this.state == State.ChannelClosing))
-                    {
-                        waiter = new SyncWaiter(this, canGetChannel, null, timeout, maskingMode, this.binder.ChannelParameters);
-                        this.GetQueue(canGetChannel).Enqueue(waiter);
-                    }
-                    else
-                    {
-                        if (this.state != State.NoChannel)
-                        {
-                            throw Fx.AssertAndThrow("The state must be NoChannel.");
-                        }
-
-                        waiter = new SyncWaiter(this, canGetChannel,
-                            this.GetCurrentChannelIfCreated(), timeout, maskingMode,
-                            this.binder.ChannelParameters);
-
-                        this.state = State.ChannelOpening;
-                        getChannel = true;
-                    }
-                }
-
-                if (faulted)
-                {
-                    this.binder.Fault(null);
-                    channel = null;
-                    return true;
-                }
-
-                if (getChannel)
-                {
-                    waiter.GetChannel(true);
-                }
-
-                return waiter.TryWait(out channel);
-            }
-
-            public void UnblockWaiters()
-            {
-                Queue<IWaiter> temp1;
-                Queue<IWaiter> temp2;
-
-                lock (this.ThisLock)
-                {
-                    temp1 = this.getChannelQueue;
-                    temp2 = this.waitQueue;
-
-                    this.getChannelQueue = null;
-                    this.waitQueue = null;
-                }
-
-                bool close = this.state == State.Closed;
-                this.UnblockWaiters(temp1, close);
-                this.UnblockWaiters(temp2, close);
-            }
-
-            void UnblockWaiters(Queue<IWaiter> waiters, bool close)
-            {
-                if ((waiters != null) && (waiters.Count > 0))
-                {
-                    foreach (IWaiter waiter in waiters)
-                    {
-                        if (close)
-                        {
-                            waiter.Close();
-                        }
-                        else
-                        {
-                            waiter.Fault();
-                        }
-                    }
-                }
-            }
-
-            bool ValidateOpened()
-            {
-                if (this.state == State.Created)
-                {
-                    throw Fx.AssertAndThrow("This operation expects that the synchronizer has been opened.");
-                }
-
-                return (this.state != State.Closed) && (this.state != State.Faulted);
-            }
-
-            public void WaitForPendingOperations(TimeSpan timeout)
-            {
-                lock (this.ThisLock)
-                {
-                    if (this.drainEvent != null)
-                    {
-                        throw Fx.AssertAndThrow("The WaitForPendingOperations operation may only be invoked once.");
-                    }
-
-                    if (this.count > 0)
-                    {
-                        this.drainEvent = new InterruptibleWaitObject(false, false);
-                    }
-                }
-
-                if (this.drainEvent != null)
-                {
-                    this.drainEvent.Wait(timeout);
-                }
-            }
-
-            enum State
-            {
-                Created,
-                NoChannel,
-                ChannelOpening,
-                ChannelOpened,
-                ChannelClosing,
-                Faulted,
-                Closed
-            }
-
-            public interface IWaiter
-            {
-                bool CanGetChannel { get; }
-
-                void Close();
-                void Fault();
-                void GetChannel(bool onUserThread);
-                void Set(TChannel channel);
-            }
-
-            public sealed class AsyncWaiter : AsyncResult, IWaiter
-            {
-                bool canGetChannel;
-                TChannel channel;
-                ChannelParameterCollection channelParameters;
-                bool isSynchronous = true;
-                MaskingMode maskingMode;
-                static AsyncCallback onOpenComplete = Fx.ThunkCallback(new AsyncCallback(OnOpenComplete));
-                static Action<object> onTimeoutElapsed = new Action<object>(OnTimeoutElapsed);
-                static AsyncCallback onTryGetChannelComplete = Fx.ThunkCallback(new AsyncCallback(OnTryGetChannelComplete));
-                bool timedOut = false;
-                ChannelSynchronizer synchronizer;
-                TimeoutHelper timeoutHelper;
-                IOThreadTimer timer;
-                bool timerCancelled = false;
-
-                public AsyncWaiter(ChannelSynchronizer synchronizer, bool canGetChannel,
-                    TChannel channel, TimeSpan timeout, MaskingMode maskingMode,
-                    ChannelParameterCollection channelParameters,
-                    AsyncCallback callback, object state)
-                    : base(callback, state)
-                {
-                    if (!canGetChannel)
-                    {
-                        if (channel != null)
-                        {
-                            throw Fx.AssertAndThrow("This waiter must wait for a channel thus argument channel must be null.");
-                        }
-                    }
-
-                    this.synchronizer = synchronizer;
-                    this.canGetChannel = canGetChannel;
-                    this.channel = channel;
-                    this.timeoutHelper = new TimeoutHelper(timeout);
-                    this.maskingMode = maskingMode;
-                    this.channelParameters = channelParameters;
-                }
-
-                public bool CanGetChannel
-                {
-                    get
-                    {
-                        return this.canGetChannel;
-                    }
-                }
-
-                object ThisLock
-                {
-                    get
-                    {
-                        return this;
-                    }
-                }
-
-                void CancelTimer()
-                {
-                    lock (this.ThisLock)
-                    {
-                        if (!this.timerCancelled)
-                        {
-                            if (this.timer != null)
-                            {
-                                this.timer.Cancel();
-                            }
-
-                            this.timerCancelled = true;
-                        }
-                    }
-                }
-
-                public void Close()
-                {
-                    this.CancelTimer();
-                    this.channel = null;
-                    this.Complete(false,
-                        this.synchronizer.binder.GetClosedException(this.maskingMode));
-                }
-
-                bool CompleteOpen(IAsyncResult result)
-                {
-                    this.channel.EndOpen(result);
-                    return this.OnChannelOpened();
-                }
-
-                bool CompleteTryGetChannel(IAsyncResult result)
-                {
-                    if (!this.synchronizer.binder.EndTryGetChannel(result))
-                    {
-                        this.timedOut = true;
-                        this.OnGetChannelFailed();
-                        return true;
-                    }
-
-                    if (!this.synchronizer.CompleteSetChannel(this, out this.channel))
-                    {
-                        if (!this.IsCompleted)
-                        {
-                            throw Fx.AssertAndThrow("CompleteSetChannel must complete the IWaiter if it returns false.");
-                        }
-
-                        return false;
-                    }
-
-                    return this.OpenChannel();
-                }
-
-                public bool End(out TChannel channel)
-                {
-                    AsyncResult.End<AsyncWaiter>(this);
-                    channel = this.channel;
-                    return !this.timedOut;
-                }
-
-                public void Fault()
-                {
-                    this.CancelTimer();
-                    this.channel = null;
-                    this.Complete(false,
-                        this.synchronizer.binder.GetFaultedException(this.maskingMode));
-                }
-
-                bool GetChannel()
-                {
-                    if (this.channel != null)
-                    {
-                        return this.OpenChannel();
-                    }
-                    else
-                    {
-                        IAsyncResult result = this.synchronizer.binder.BeginTryGetChannel(
-                            this.timeoutHelper.RemainingTime(), onTryGetChannelComplete, this);
-
-                        if (result.CompletedSynchronously)
-                        {
-                            return this.CompleteTryGetChannel(result);
-                        }
-                    }
-
-                    return false;
-                }
-
-                public void GetChannel(bool onUserThread)
-                {
-                    if (!this.CanGetChannel)
-                    {
-                        throw Fx.AssertAndThrow("This waiter must wait for a channel thus the caller cannot attempt to get a channel.");
-                    }
-
-                    this.isSynchronous = onUserThread;
-
-                    if (onUserThread)
-                    {
-                        bool throwing = true;
-
-                        try
-                        {
-                            if (this.GetChannel())
-                            {
-                                this.Complete(true);
-                            }
-
-                            throwing = false;
-                        }
-                        finally
-                        {
-                            if (throwing)
-                            {
-                                this.OnGetChannelFailed();
-                            }
-                        }
-                    }
-                    else
-                    {
-                        bool complete = false;
-                        Exception completeException = null;
-
-                        try
-                        {
-                            this.CancelTimer();
-                            complete = this.GetChannel();
-                        }
-#pragma warning suppress 56500 // covered by FxCOP
-                        catch (Exception e)
-                        {
-                            if (Fx.IsFatal(e))
-                            {
-                                throw;
-                            }
-
-                            this.OnGetChannelFailed();
-                            completeException = e;
-                        }
-
-                        if (complete || completeException != null)
-                        {
-                            this.Complete(false, completeException);
-                        }
-                    }
-                }
-
-                bool OnChannelOpened()
-                {
-                    if (this.synchronizer.OnChannelOpened(this))
-                    {
-                        return true;
-                    }
-                    else
-                    {
-                        if (!this.IsCompleted)
-                        {
-                            throw Fx.AssertAndThrow("OnChannelOpened must complete the IWaiter if it returns false.");
-                        }
-
-                        return false;
-                    }
-                }
-
-                void OnGetChannelFailed()
-                {
-                    if (this.channel != null)
-                    {
-                        this.channel.Abort();
-                    }
-
-                    this.synchronizer.OnGetChannelFailed();
-                }
-
-                static void OnOpenComplete(IAsyncResult result)
-                {
-                    if (!result.CompletedSynchronously)
-                    {
-                        AsyncWaiter waiter = (AsyncWaiter)result.AsyncState;
-                        bool complete = false;
-                        Exception completeException = null;
-
-                        waiter.isSynchronous = false;
-
-                        try
-                        {
-                            complete = waiter.CompleteOpen(result);
-                        }
-#pragma warning suppress 56500 // covered by FxCOP
-                        catch (Exception e)
-                        {
-                            if (Fx.IsFatal(e))
-                            {
-                                throw;
-                            }
-
-                            completeException = e;
-                        }
-
-                        if (complete)
-                        {
-                            waiter.Complete(false);
-                        }
-                        else if (completeException != null)
-                        {
-                            waiter.OnGetChannelFailed();
-                            waiter.Complete(false, completeException);
-                        }
-                    }
-                }
-
-                void OnTimeoutElapsed()
-                {
-                    if (this.synchronizer.RemoveWaiter(this))
-                    {
-                        this.timedOut = true;
-                        this.Complete(this.isSynchronous, null);
-                    }
-                }
-
-                static void OnTimeoutElapsed(object state)
-                {
-                    AsyncWaiter waiter = (AsyncWaiter)state;
-                    waiter.isSynchronous = false;
-                    waiter.OnTimeoutElapsed();
-                }
-
-                static void OnTryGetChannelComplete(IAsyncResult result)
-                {
-                    if (!result.CompletedSynchronously)
-                    {
-                        AsyncWaiter waiter = (AsyncWaiter)result.AsyncState;
-                        waiter.isSynchronous = false;
-                        bool complete = false;
-                        Exception completeException = null;
-
-                        try
-                        {
-                            complete = waiter.CompleteTryGetChannel(result);
-                        }
-#pragma warning suppress 56500 // covered by FxCOP
-                        catch (Exception e)
-                        {
-                            if (Fx.IsFatal(e))
-                            {
-                                throw;
-                            }
-
-                            completeException = e;
-                        }
-
-                        if (complete || completeException != null)
-                        {
-                            if (completeException != null)
-                                waiter.OnGetChannelFailed();
-                            waiter.Complete(waiter.isSynchronous, completeException);
-                        }
-                    }
-                }
-
-                bool OpenChannel()
-                {
-                    if (this.synchronizer.binder.MustOpenChannel)
-                    {
-                        if (this.channelParameters != null)
-                        {
-                            this.channelParameters.PropagateChannelParameters(this.channel);
-                        }
-
-                        IAsyncResult result = this.channel.BeginOpen(
-                            this.timeoutHelper.RemainingTime(), onOpenComplete, this);
-
-                        if (result.CompletedSynchronously)
-                        {
-                            return this.CompleteOpen(result);
-                        }
-
-                        return false;
-                    }
-                    else
-                    {
-                        return this.OnChannelOpened();
-                    }
-                }
-
-                public void Set(TChannel channel)
-                {
-                    this.CancelTimer();
-                    this.channel = channel;
-                    this.Complete(false);
-                }
-
-                // Always called from the user's thread.
-                public void Wait()
-                {
-                    lock (this.ThisLock)
-                    {
-                        if (this.timerCancelled)
-                        {
-                            return;
-                        }
-
-                        TimeSpan timeout = this.timeoutHelper.RemainingTime();
-
-                        if (timeout > TimeSpan.Zero)
-                        {
-                            this.timer = new IOThreadTimer(onTimeoutElapsed, this, true);
-                            this.timer.Set(this.timeoutHelper.RemainingTime());
-                            return;
-                        }
-                    }
-
-                    this.OnTimeoutElapsed();
-                }
-            }
-
-            sealed class SynchronizerCompletedAsyncResult : CompletedAsyncResult
-            {
-                public SynchronizerCompletedAsyncResult(AsyncCallback callback, object state)
-                    : base(callback, state)
-                {
-                }
-
-                public void End()
-                {
-                    CompletedAsyncResult.End(this);
-                }
-            }
-
-            sealed class SyncWaiter : IWaiter
-            {
-                bool canGetChannel;
-                TChannel channel;
-                ChannelParameterCollection channelParameters;
-                AutoResetEvent completeEvent = new AutoResetEvent(false);
-                Exception exception;
-                bool getChannel = false;
-                MaskingMode maskingMode;
-                ChannelSynchronizer synchronizer;
-                TimeoutHelper timeoutHelper;
-
-                public SyncWaiter(ChannelSynchronizer synchronizer, bool canGetChannel,
-                    TChannel channel, TimeSpan timeout, MaskingMode maskingMode,
-                    ChannelParameterCollection channelParameters)
-                {
-                    if (!canGetChannel)
-                    {
-                        if (channel != null)
-                        {
-                            throw Fx.AssertAndThrow("This waiter must wait for a channel thus argument channel must be null.");
-                        }
-                    }
-
-                    this.synchronizer = synchronizer;
-                    this.canGetChannel = canGetChannel;
-                    this.channel = channel;
-                    this.timeoutHelper = new TimeoutHelper(timeout);
-                    this.maskingMode = maskingMode;
-                    this.channelParameters = channelParameters;
-                }
-
-                public bool CanGetChannel
-                {
-                    get
-                    {
-                        return this.canGetChannel;
-                    }
-                }
-
-                public void Close()
-                {
-                    this.exception = this.synchronizer.binder.GetClosedException(this.maskingMode);
-                    this.completeEvent.Set();
-                }
-
-                public void Fault()
-                {
-                    this.exception = this.synchronizer.binder.GetFaultedException(this.maskingMode);
-                    this.completeEvent.Set();
-                }
-
-                public void GetChannel(bool onUserThread)
-                {
-                    if (!this.CanGetChannel)
-                    {
-                        throw Fx.AssertAndThrow("This waiter must wait for a channel thus the caller cannot attempt to get a channel.");
-                    }
-
-                    this.getChannel = true;
-                    this.completeEvent.Set();
-                }
-
-                public void Set(TChannel channel)
-                {
-                    if (channel == null)
-                    {
-                        throw Fx.AssertAndThrow("Argument channel cannot be null. Caller must call Fault or Close instead.");
-                    }
-
-                    this.channel = channel;
-                    this.completeEvent.Set();
-                }
-
-                bool TryGetChannel()
-                {
-                    TChannel channel;
-
-                    if (this.channel != null)
-                    {
-                        channel = this.channel;
-                    }
-                    else if (this.synchronizer.binder.TryGetChannel(
-                        this.timeoutHelper.RemainingTime()))
-                    {
-                        if (!this.synchronizer.CompleteSetChannel(this, out channel))
-                        {
-                            return true;
-                        }
-                    }
-                    else
-                    {
-                        this.synchronizer.OnGetChannelFailed();
-                        return false;
-                    }
-
-                    if (this.synchronizer.binder.MustOpenChannel)
-                    {
-                        bool throwing = true;
-
-                        if (this.channelParameters != null)
-                        {
-                            this.channelParameters.PropagateChannelParameters(channel);
-                        }
-
-                        try
-                        {
-                            channel.Open(this.timeoutHelper.RemainingTime());
-                            throwing = false;
-                        }
-                        finally
-                        {
-                            if (throwing)
-                            {
-                                channel.Abort();
-                                this.synchronizer.OnGetChannelFailed();
-                            }
-                        }
-                    }
-
-                    if (this.synchronizer.OnChannelOpened(this))
-                    {
-                        this.Set(channel);
-                    }
-
-                    return true;
-                }
-
-                public bool TryWait(out TChannel channel)
-                {
-                    if (!this.Wait())
-                    {
-                        channel = null;
-                        return false;
-                    }
-                    else if (this.getChannel && !this.TryGetChannel())
-                    {
-                        channel = null;
-                        return false;
-                    }
-
-                    this.completeEvent.Close();
-
-                    if (this.exception != null)
-                    {
-                        if (this.channel != null)
-                        {
-                            throw Fx.AssertAndThrow("User of IWaiter called both Set and Fault or Close.");
-                        }
-
-                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(this.exception);
-                    }
-
-                    channel = this.channel;
-                    return true;
-                }
-
-                bool Wait()
-                {
-                    if (!TimeoutHelper.WaitOne(this.completeEvent, this.timeoutHelper.RemainingTime()))
-                    {
-                        if (this.synchronizer.RemoveWaiter(this))
-                        {
-                            return false;
-                        }
-                        else
-                        {
-                            TimeoutHelper.WaitOne(this.completeEvent, TimeSpan.MaxValue);
-                        }
-                    }
-
-                    return true;
-                }
-            }
-        }
-
-        sealed class CloseAsyncResult : AsyncResult
-        {
-            ReliableChannelBinder<TChannel> binder;
-            TChannel channel;
-            MaskingMode maskingMode;
-            static AsyncCallback onBinderCloseComplete = Fx.ThunkCallback(new AsyncCallback(OnBinderCloseComplete));
-            static AsyncCallback onChannelCloseComplete = Fx.ThunkCallback(new AsyncCallback(OnChannelCloseComplete));
-            TimeoutHelper timeoutHelper;
-
-            public CloseAsyncResult(ReliableChannelBinder<TChannel> binder, TChannel channel,
-                TimeSpan timeout, MaskingMode maskingMode, AsyncCallback callback, object state)
-                : base(callback, state)
-            {
-                this.binder = binder;
-                this.channel = channel;
-                this.timeoutHelper = new TimeoutHelper(timeout);
-                this.maskingMode = maskingMode;
-                bool complete = false;
-
-                try
-                {
-                    this.binder.OnShutdown();
-                    IAsyncResult result = this.binder.OnBeginClose(timeout, onBinderCloseComplete, this);
-
-                    if (result.CompletedSynchronously)
-                    {
-                        complete = this.CompleteBinderClose(true, result);
-                    }
-                }
-                catch (Exception e)
-                {
-                    if (Fx.IsFatal(e))
-                    {
-                        throw;
-                    }
-
-                    this.binder.Abort();
-
-                    if (!this.binder.HandleException(e, this.maskingMode))
-                    {
-                        throw;
-                    }
-                    else
-                    {
-                        complete = true;
-                    }
-                }
-
-                if (complete)
-                {
-                    this.Complete(true);
-                }
-            }
-
-            bool CompleteBinderClose(bool synchronous, IAsyncResult result)
-            {
-                this.binder.OnEndClose(result);
-
-                if (this.channel != null)
-                {
-                    result = this.binder.BeginCloseChannel(this.channel,
-                        this.timeoutHelper.RemainingTime(), onChannelCloseComplete, this);
-
-                    if (result.CompletedSynchronously)
-                    {
-                        return this.CompleteChannelClose(synchronous, result);
-                    }
-                    else
-                    {
-                        return false;
-                    }
-                }
-                else
-                {
-                    this.binder.TransitionToClosed();
-                    return true;
-                }
-            }
-
-            bool CompleteChannelClose(bool synchronous, IAsyncResult result)
-            {
-                this.binder.EndCloseChannel(this.channel, result);
-                this.binder.TransitionToClosed();
-                return true;
-            }
-
-            public void End()
-            {
-                AsyncResult.End<CloseAsyncResult>(this);
-            }
-
-            Exception HandleAsyncException(Exception e)
-            {
-                this.binder.Abort();
-
-                if (this.binder.HandleException(e, this.maskingMode))
-                {
-                    return null;
-                }
-                else
-                {
-                    return e;
-                }
-            }
-
-            static void OnBinderCloseComplete(IAsyncResult result)
-            {
-                if (!result.CompletedSynchronously)
-                {
-                    CloseAsyncResult closeResult = (CloseAsyncResult)result.AsyncState;
-                    bool complete;
-                    Exception completeException;
-
-                    try
-                    {
-                        complete = closeResult.CompleteBinderClose(false, result);
-                        completeException = null;
-                    }
-#pragma warning suppress 56500 // covered by FxCOP
-                    catch (Exception e)
-                    {
-                        if (Fx.IsFatal(e))
-                        {
-                            throw;
-                        }
-
-                        complete = true;
-                        completeException = e;
-                    }
-
-                    if (complete)
-                    {
-                        if (completeException != null)
-                        {
-                            completeException = closeResult.HandleAsyncException(completeException);
-                        }
-
-                        closeResult.Complete(false, completeException);
-                    }
-                }
-            }
-
-            static void OnChannelCloseComplete(IAsyncResult result)
-            {
-                if (!result.CompletedSynchronously)
-                {
-                    CloseAsyncResult closeResult = (CloseAsyncResult)result.AsyncState;
-                    bool complete;
-                    Exception completeException;
-
-                    try
-                    {
-                        complete = closeResult.CompleteChannelClose(false, result);
-                        completeException = null;
-                    }
-#pragma warning suppress 56500 // covered by FxCOP
-                    catch (Exception e)
-                    {
-                        if (Fx.IsFatal(e))
-                        {
-                            throw;
-                        }
-
-                        complete = true;
-                        completeException = e;
-                    }
-
-                    if (complete)
-                    {
-                        if (completeException != null)
-                        {
-                            completeException = closeResult.HandleAsyncException(completeException);
-                        }
-
-                        closeResult.Complete(false, completeException);
-                    }
-                }
-            }
-        }
-
-        protected abstract class InputAsyncResult<TBinder> : AsyncResult
-            where TBinder : ReliableChannelBinder<TChannel>
-        {
-            bool autoAborted;
-            TBinder binder;
-            bool canGetChannel;
-            TChannel channel;
-            bool isSynchronous = true;
-            MaskingMode maskingMode;
-            static AsyncCallback onInputComplete = Fx.ThunkCallback(new AsyncCallback(OnInputCompleteStatic));
-            static AsyncCallback onTryGetChannelComplete = Fx.ThunkCallback(new AsyncCallback(OnTryGetChannelCompleteStatic));
-            bool success;
-            TimeoutHelper timeoutHelper;
-
-            public InputAsyncResult(TBinder binder, bool canGetChannel, TimeSpan timeout,
-                MaskingMode maskingMode, AsyncCallback callback, object state)
-                : base(callback, state)
-            {
-                this.binder = binder;
-                this.canGetChannel = canGetChannel;
-                this.timeoutHelper = new TimeoutHelper(timeout);
-                this.maskingMode = maskingMode;
-            }
-
-            protected abstract IAsyncResult BeginInput(TBinder binder, TChannel channel,
-                TimeSpan timeout, AsyncCallback callback, object state);
-
-            // returns true if the caller should retry
-            bool CompleteInput(IAsyncResult result)
-            {
-                bool complete;
-
-                try
-                {
-                    this.success = this.EndInput(this.binder, this.channel, result, out complete);
-                }
-                finally
-                {
-                    this.autoAborted = this.binder.Synchronizer.Aborting;
-                    this.binder.synchronizer.ReturnChannel();
-                }
-
-                return !complete;
-            }
-
-            // returns true if the caller should retry
-            bool CompleteTryGetChannel(IAsyncResult result, out bool complete)
-            {
-                complete = false;
-                this.success = this.binder.synchronizer.EndTryGetChannel(result, out this.channel);
-
-                // the synchronizer is faulted and not reestablishing or closed, or the call timed
-                // out, complete and don't retry.
-                if (this.channel == null)
-                {
-                    complete = true;
-                    return false;
-                }
-
-                bool throwing = true;
-                IAsyncResult inputResult = null;
-
-                try
-                {
-                    inputResult = this.BeginInput(this.binder, this.channel,
-                        this.timeoutHelper.RemainingTime(), onInputComplete, this);
-                    throwing = false;
-                }
-                finally
-                {
-                    if (throwing)
-                    {
-                        this.autoAborted = this.binder.Synchronizer.Aborting;
-                        this.binder.synchronizer.ReturnChannel();
-                    }
-                }
-
-                if (inputResult.CompletedSynchronously)
-                {
-                    if (this.CompleteInput(inputResult))
-                    {
-                        complete = false;
-                        return true;
-                    }
-                    else
-                    {
-                        complete = true;
-                        return false;
-                    }
-                }
-                else
-                {
-                    complete = false;
-                    return false;
-                }
-            }
-
-            public bool End()
-            {
-                AsyncResult.End<InputAsyncResult<TBinder>>(this);
-                return this.success;
-            }
-
-            protected abstract bool EndInput(TBinder binder, TChannel channel,
-                IAsyncResult result, out bool complete);
-
-            void OnInputComplete(IAsyncResult result)
-            {
-                this.isSynchronous = false;
-                bool retry;
-                Exception completeException = null;
-
-                try
-                {
-                    retry = this.CompleteInput(result);
-                }
-#pragma warning suppress 56500 // covered by FxCOP
-                catch (Exception e)
-                {
-                    if (Fx.IsFatal(e))
-                    {
-                        throw;
-                    }
-
-                    if (!this.binder.HandleException(e, this.maskingMode, this.autoAborted))
-                    {
-                        completeException = e;
-                        retry = false;
-                    }
-                    else
-                    {
-                        retry = true;
-                    }
-                }
-
-                if (retry)
-                {
-                    this.StartOnNonUserThread();
-                }
-                else
-                {
-                    this.Complete(this.isSynchronous, completeException);
-                }
-            }
-
-            static void OnInputCompleteStatic(IAsyncResult result)
-            {
-                if (!result.CompletedSynchronously)
-                {
-                    InputAsyncResult<TBinder> inputResult =
-                        (InputAsyncResult<TBinder>)result.AsyncState;
-                    inputResult.OnInputComplete(result);
-                }
-            }
-
-            void OnTryGetChannelComplete(IAsyncResult result)
-            {
-                this.isSynchronous = false;
-                bool retry = false;
-                bool complete = false;
-                Exception completeException = null;
-
-                try
-                {
-                    retry = this.CompleteTryGetChannel(result, out complete);
-                }
-#pragma warning suppress 56500 // covered by FxCOP
-                catch (Exception e)
-                {
-                    if (Fx.IsFatal(e))
-                    {
-                        throw;
-                    }
-
-                    if (!this.binder.HandleException(e, this.maskingMode, this.autoAborted))
-                    {
-                        completeException = e;
-                        retry = false;
-                    }
-                    else
-                    {
-                        retry = true;
-                    }
-                }
-
-                // Can't complete AND retry.
-                if (complete && retry)
-                {
-                    throw Fx.AssertAndThrow("The derived class' implementation of CompleteTryGetChannel() cannot indicate that the asynchronous operation should complete and retry.");
-                }
-
-                if (retry)
-                {
-                    this.StartOnNonUserThread();
-                }
-                else if (complete || completeException != null)
-                {
-                    this.Complete(this.isSynchronous, completeException);
-                }
-            }
-
-            static void OnTryGetChannelCompleteStatic(IAsyncResult result)
-            {
-                if (!result.CompletedSynchronously)
-                {
-                    InputAsyncResult<TBinder> inputResult =
-                        (InputAsyncResult<TBinder>)result.AsyncState;
-                    inputResult.OnTryGetChannelComplete(result);
-                }
-            }
-
-            protected bool Start()
-            {
-                while (true)
-                {
-                    bool retry = false;
-                    bool complete = false;
-
-                    this.autoAborted = false;
-
-                    try
-                    {
-                        IAsyncResult result = this.binder.synchronizer.BeginTryGetChannelForInput(
-                            canGetChannel, this.timeoutHelper.RemainingTime(),
-                            onTryGetChannelComplete, this);
-
-                        if (result.CompletedSynchronously)
-                        {
-                            retry = this.CompleteTryGetChannel(result, out complete);
-                        }
-                    }
-                    catch (Exception e)
-                    {
-                        if (Fx.IsFatal(e))
-                        {
-                            throw;
-                        }
-
-                        if (!this.binder.HandleException(e, this.maskingMode, this.autoAborted))
-                        {
-                            throw;
-                        }
-                        else
-                        {
-                            retry = true;
-                        }
-                    }
-
-                    // Can't complete AND retry.
-                    if (complete && retry)
-                    {
-                        throw Fx.AssertAndThrow("The derived class' implementation of CompleteTryGetChannel() cannot indicate that the asynchronous operation should complete and retry.");
-                    }
-
-                    if (!retry)
-                    {
-                        return complete;
-                    }
-                }
-            }
-
-            void StartOnNonUserThread()
-            {
-                bool complete = false;
-                Exception completeException = null;
-
-                try
-                {
-                    complete = this.Start();
-                }
-#pragma warning suppress 56500 // covered by FxCOP
-                catch (Exception e)
-                {
-                    if (Fx.IsFatal(e))
-                        throw;
-
-                    completeException = e;
-                }
-
-                if (complete || completeException != null)
-                    this.Complete(false, completeException);
-            }
-        }
-
-        sealed class MessageRequestContext : BinderRequestContext
-        {
-            public MessageRequestContext(ReliableChannelBinder<TChannel> binder, Message message)
-                : base(binder, message)
-            {
-            }
-
-            protected override void OnAbort()
-            {
-            }
-
-            protected override void OnClose(TimeSpan timeout)
-            {
-            }
-
-            protected override IAsyncResult OnBeginReply(Message message, TimeSpan timeout, AsyncCallback callback, object state)
-            {
-                return new ReplyAsyncResult(this, message, timeout, callback, state);
-            }
-
-            protected override void OnEndReply(IAsyncResult result)
-            {
-                ReplyAsyncResult.End(result);
-            }
-
-            protected override void OnReply(Message message, TimeSpan timeout)
-            {
-                if (message != null)
-                {
-                    this.Binder.Send(message, timeout, this.MaskingMode);
-                }
-            }
-
-            class ReplyAsyncResult : AsyncResult
-            {
-                static AsyncCallback onSend;
-                MessageRequestContext context;
-
-                public ReplyAsyncResult(MessageRequestContext context, Message message, TimeSpan timeout, AsyncCallback callback, object state)
-                    : base(callback, state)
-                {
-                    if (message != null)
-                    {
-                        if (onSend == null)
-                        {
-                            onSend = Fx.ThunkCallback(new AsyncCallback(OnSend));
-                        }
-                        this.context = context;
-                        IAsyncResult result = context.Binder.BeginSend(message, timeout, context.MaskingMode, onSend, this);
-                        if (!result.CompletedSynchronously)
-                        {
-                            return;
-                        }
-                        context.Binder.EndSend(result);
-                    }
-
-                    base.Complete(true);
-                }
-
-                public static void End(IAsyncResult result)
-                {
-                    AsyncResult.End<ReplyAsyncResult>(result);
-                }
-
-                static void OnSend(IAsyncResult result)
-                {
-                    if (result.CompletedSynchronously)
-                    {
-                        return;
-                    }
-
-                    Exception completionException = null;
-                    ReplyAsyncResult thisPtr = (ReplyAsyncResult)result.AsyncState;
-                    try
-                    {
-                        thisPtr.context.Binder.EndSend(result);
-                    }
-#pragma warning suppress 56500 // covered by FxCOP
-                    catch (Exception exception)
-                    {
-                        if (Fx.IsFatal(exception))
-                        {
-                            throw;
-                        }
-                        completionException = exception;
-                    }
-
-                    thisPtr.Complete(false, completionException);
-                }
-            }
-        }
-
-        protected abstract class OutputAsyncResult<TBinder> : AsyncResult
-            where TBinder : ReliableChannelBinder<TChannel>
-        {
-            bool autoAborted;
-            TBinder binder;
-            TChannel channel;
-            bool hasChannel = false;
-            MaskingMode maskingMode;
-            Message message;
-            static AsyncCallback onTryGetChannelComplete = Fx.ThunkCallback(new AsyncCallback(OnTryGetChannelCompleteStatic));
-            static AsyncCallback onOutputComplete = Fx.ThunkCallback(new AsyncCallback(OnOutputCompleteStatic));
-            TimeSpan timeout;
-            TimeoutHelper timeoutHelper;
-
-            public OutputAsyncResult(TBinder binder, AsyncCallback callback, object state)
-                : base(callback, state)
-            {
-                this.binder = binder;
-            }
-
-            public MaskingMode MaskingMode
-            {
-                get
-                {
-                    return this.maskingMode;
-                }
-            }
-
-            protected abstract IAsyncResult BeginOutput(TBinder binder, TChannel channel,
-                Message message, TimeSpan timeout, MaskingMode maskingMode, AsyncCallback callback,
-                object state);
-
-            void Cleanup()
-            {
-                if (this.hasChannel)
-                {
-                    this.autoAborted = this.binder.Synchronizer.Aborting;
-                    this.binder.synchronizer.ReturnChannel();
-                }
-            }
-
-            bool CompleteOutput(IAsyncResult result)
-            {
-                this.EndOutput(this.binder, this.channel, this.maskingMode, result);
-                this.Cleanup();
-                return true;
-            }
-
-            bool CompleteTryGetChannel(IAsyncResult result)
-            {
-                bool timedOut = !this.binder.synchronizer.EndTryGetChannel(result,
-                    out this.channel);
-
-                if (timedOut || (this.channel == null))
-                {
-                    this.Cleanup();
-
-                    if (timedOut && !ReliableChannelBinderHelper.MaskHandled(maskingMode))
-                    {
-                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new TimeoutException(this.GetTimeoutString(this.timeout)));
-                    }
-
-                    return true;
-                }
-
-                this.hasChannel = true;
-
-                result = this.BeginOutput(this.binder, this.channel, this.message,
-                    this.timeoutHelper.RemainingTime(), this.maskingMode, onOutputComplete,
-                    this);
-
-                if (result.CompletedSynchronously)
-                {
-                    return this.CompleteOutput(result);
-                }
-                else
-                {
-                    return false;
-                }
-            }
-
-            protected abstract void EndOutput(TBinder binder, TChannel channel,
-                MaskingMode maskingMode, IAsyncResult result);
-
-            protected abstract string GetTimeoutString(TimeSpan timeout);
-
-            void OnOutputComplete(IAsyncResult result)
-            {
-                if (!result.CompletedSynchronously)
-                {
-                    bool complete = false;
-                    Exception completeException = null;
-
-                    try
-                    {
-                        complete = this.CompleteOutput(result);
-                    }
-#pragma warning suppress 56500 // covered by FxCOP
-                    catch (Exception e)
-                    {
-                        if (Fx.IsFatal(e))
-                        {
-                            throw;
-                        }
-
-                        this.Cleanup();
-                        complete = true;
-                        if (!this.binder.HandleException(e, this.maskingMode, this.autoAborted))
-                        {
-                            completeException = e;
-                        }
-                    }
-
-                    if (complete)
-                    {
-                        this.Complete(false, completeException);
-                    }
-                }
-            }
-
-            static void OnOutputCompleteStatic(IAsyncResult result)
-            {
-                OutputAsyncResult<TBinder> outputResult =
-                    (OutputAsyncResult<TBinder>)result.AsyncState;
-
-                outputResult.OnOutputComplete(result);
-            }
-
-            void OnTryGetChannelComplete(IAsyncResult result)
-            {
-                if (!result.CompletedSynchronously)
-                {
-                    bool complete = false;
-                    Exception completeException = null;
-
-                    try
-                    {
-                        complete = this.CompleteTryGetChannel(result);
-                    }
-#pragma warning suppress 56500 // covered by FxCOP
-                    catch (Exception e)
-                    {
-                        if (Fx.IsFatal(e))
-                        {
-                            throw;
-                        }
-
-                        this.Cleanup();
-                        complete = true;
-                        if (!this.binder.HandleException(e, this.maskingMode, this.autoAborted))
-                        {
-                            completeException = e;
-                        }
-                    }
-
-                    if (complete)
-                    {
-                        this.Complete(false, completeException);
-                    }
-                }
-            }
-
-            static void OnTryGetChannelCompleteStatic(IAsyncResult result)
-            {
-                OutputAsyncResult<TBinder> outputResult =
-                    (OutputAsyncResult<TBinder>)result.AsyncState;
-
-                outputResult.OnTryGetChannelComplete(result);
-            }
-
-            public void Start(Message message, TimeSpan timeout, MaskingMode maskingMode)
-            {
-                if (!this.binder.ValidateOutputOperation(message, timeout, maskingMode))
-                {
-                    this.Complete(true);
-                    return;
-                }
-
-                this.message = message;
-                this.timeout = timeout;
-                this.timeoutHelper = new TimeoutHelper(timeout);
-                this.maskingMode = maskingMode;
-
-                bool complete = false;
-
-                try
-                {
-                    IAsyncResult result = this.binder.synchronizer.BeginTryGetChannelForOutput(
-                        timeoutHelper.RemainingTime(), this.maskingMode, onTryGetChannelComplete, this);
-
-                    if (result.CompletedSynchronously)
-                    {
-                        complete = this.CompleteTryGetChannel(result);
-                    }
-                }
-                catch (Exception e)
-                {
-                    if (Fx.IsFatal(e))
-                    {
-                        throw;
-                    }
-
-                    this.Cleanup();
-                    if (this.binder.HandleException(e, this.maskingMode, this.autoAborted))
-                    {
-                        complete = true;
-                    }
-                    else
-                    {
-                        throw;
-                    }
-                }
-
-                if (complete)
-                {
-                    this.Complete(true);
-                }
-            }
-        }
-
-        sealed class RequestRequestContext : BinderRequestContext
-        {
-            RequestContext innerContext;
-
-            public RequestRequestContext(ReliableChannelBinder<TChannel> binder,
-                RequestContext innerContext, Message message)
-                : base(binder, message)
-            {
-                if ((binder.defaultMaskingMode != MaskingMode.All) && !binder.TolerateFaults)
-                {
-                    throw Fx.AssertAndThrow("This request context is designed to catch exceptions. Thus it cannot be used if the caller expects no exception handling.");
-                }
-
-                if (innerContext == null)
-                {
-                    throw Fx.AssertAndThrow("Argument innerContext cannot be null.");
-                }
-
-                this.innerContext = innerContext;
-            }
-
-            protected override void OnAbort()
-            {
-                this.innerContext.Abort();
-            }
-
-            protected override IAsyncResult OnBeginReply(Message message, TimeSpan timeout,
-                AsyncCallback callback, object state)
-            {
-                try
-                {
-                    if (message != null)
-                        this.Binder.AddOutputHeaders(message);
-                    return this.innerContext.BeginReply(message, timeout, callback, state);
-                }
-                catch (ObjectDisposedException) { }
-                catch (Exception e)
-                {
-                    if (Fx.IsFatal(e))
-                    {
-                        throw;
-                    }
-
-                    if (!this.Binder.HandleException(e, this.MaskingMode))
-                    {
-                        throw;
-                    }
-
-                    this.innerContext.Abort();
-                }
-
-                return new BinderCompletedAsyncResult(callback, state);
-            }
-
-            protected override void OnClose(TimeSpan timeout)
-            {
-                try
-                {
-                    this.innerContext.Close(timeout);
-                }
-                catch (ObjectDisposedException) { }
-                catch (Exception e)
-                {
-                    if (Fx.IsFatal(e))
-                    {
-                        throw;
-                    }
-
-                    if (!this.Binder.HandleException(e, this.MaskingMode))
-                    {
-                        throw;
-                    }
-
-                    this.innerContext.Abort();
-                }
-            }
-
-            protected override void OnEndReply(IAsyncResult result)
-            {
-                BinderCompletedAsyncResult completedResult = result as BinderCompletedAsyncResult;
-                if (completedResult != null)
-                {
-                    completedResult.End();
-                    return;
-                }
-
-                try
-                {
-                    this.innerContext.EndReply(result);
-                }
-                catch (ObjectDisposedException) { }
-                catch (Exception e)
-                {
-                    if (Fx.IsFatal(e))
-                    {
-                        throw;
-                    }
-
-                    if (!this.Binder.HandleException(e, this.MaskingMode))
-                    {
-                        throw;
-                    }
-
-                    this.innerContext.Abort();
-                }
-            }
-
-            protected override void OnReply(Message message, TimeSpan timeout)
-            {
-                try
-                {
-                    if (message != null)
-                        this.Binder.AddOutputHeaders(message);
-                    this.innerContext.Reply(message, timeout);
-                }
-                catch (ObjectDisposedException) { }
-                catch (Exception e)
-                {
-                    if (Fx.IsFatal(e))
-                    {
-                        throw;
-                    }
-
-                    if (!this.Binder.HandleException(e, this.MaskingMode))
-                    {
-                        throw;
-                    }
-
-                    this.innerContext.Abort();
-                }
-            }
-        }
-
-        sealed class SendAsyncResult : OutputAsyncResult<ReliableChannelBinder<TChannel>>
-        {
-            public SendAsyncResult(ReliableChannelBinder<TChannel> binder, AsyncCallback callback,
-                object state)
-                : base(binder, callback, state)
-            {
-            }
-
-            protected override IAsyncResult BeginOutput(ReliableChannelBinder<TChannel> binder,
-                TChannel channel, Message message, TimeSpan timeout, MaskingMode maskingMode,
-                AsyncCallback callback, object state)
-            {
-                binder.AddOutputHeaders(message);
-                return binder.OnBeginSend(channel, message, timeout, callback, state);
-            }
-
-            public static void End(IAsyncResult result)
-            {
-                AsyncResult.End<SendAsyncResult>(result);
-            }
-
-            protected override void EndOutput(ReliableChannelBinder<TChannel> binder,
-                TChannel channel, MaskingMode maskingMode, IAsyncResult result)
-            {
-                binder.OnEndSend(channel, result);
-            }
-
-            protected override string GetTimeoutString(TimeSpan timeout)
-            {
-                return SR.GetString(SR.TimeoutOnSend, timeout);
-            }
-        }
-
-        sealed class TryReceiveAsyncResult : InputAsyncResult<ReliableChannelBinder<TChannel>>
-        {
-            RequestContext requestContext;
-
-            public TryReceiveAsyncResult(ReliableChannelBinder<TChannel> binder, TimeSpan timeout,
-                MaskingMode maskingMode, AsyncCallback callback, object state)
-                : base(binder, binder.CanGetChannelForReceive, timeout, maskingMode, callback, state)
-            {
-                if (this.Start())
-                    this.Complete(true);
-            }
-
-            protected override IAsyncResult BeginInput(ReliableChannelBinder<TChannel> binder,
-                TChannel channel, TimeSpan timeout, AsyncCallback callback, object state)
-            {
-                return binder.OnBeginTryReceive(channel, timeout, callback, state);
-            }
-
-            public bool End(out RequestContext requestContext)
-            {
-                requestContext = this.requestContext;
-                return this.End();
-            }
-
-            protected override bool EndInput(ReliableChannelBinder<TChannel> binder,
-                TChannel channel, IAsyncResult result, out bool complete)
-            {
-                bool success = binder.OnEndTryReceive(channel, result, out this.requestContext);
-
-                // timed out || got message, complete immediately
-                complete = !success || (this.requestContext != null);
-
-                if (!complete)
-                {
-                    // the underlying channel closed or faulted
-                    binder.synchronizer.OnReadEof();
-                }
-
-                return success;
-            }
-        }
-    }
-
-    static class ReliableChannelBinderHelper
-    {
-        internal static IAsyncResult BeginCloseDuplexSessionChannel(
-            ReliableChannelBinder<IDuplexSessionChannel> binder, IDuplexSessionChannel channel,
-            TimeSpan timeout, AsyncCallback callback, object state)
-        {
-            return new CloseDuplexSessionChannelAsyncResult(binder, channel, timeout, callback,
-                state);
-        }
-
-        internal static IAsyncResult BeginCloseReplySessionChannel(
-            ReliableChannelBinder<IReplySessionChannel> binder, IReplySessionChannel channel,
-            TimeSpan timeout, AsyncCallback callback, object state)
-        {
-            return new CloseReplySessionChannelAsyncResult(binder, channel, timeout, callback,
-                state);
-        }
-
-        internal static void CloseDuplexSessionChannel(
-            ReliableChannelBinder<IDuplexSessionChannel> binder, IDuplexSessionChannel channel,
-            TimeSpan timeout)
-        {
-            TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
-
-            channel.Session.CloseOutputSession(timeoutHelper.RemainingTime());
-            binder.WaitForPendingOperations(timeoutHelper.RemainingTime());
-
-            TimeSpan iterationTimeout = timeoutHelper.RemainingTime();
-            bool lastIteration = (iterationTimeout == TimeSpan.Zero);
-
-            while (true)
-            {
-                Message message = null;
-                bool receiveThrowing = true;
-
-                try
-                {
-                    bool success = channel.TryReceive(iterationTimeout, out message);
-
-                    receiveThrowing = false;
-                    if (success && message == null)
-                    {
-                        channel.Close(timeoutHelper.RemainingTime());
-                        return;
-                    }
-                }
-                catch (Exception e)
-                {
-                    if (Fx.IsFatal(e))
-                        throw;
-
-                    if (receiveThrowing)
-                    {
-                        if (!MaskHandled(binder.DefaultMaskingMode) || !binder.IsHandleable(e))
-                            throw;
-
-                        receiveThrowing = false;
-                    }
-                    else
-                    {
-                        throw;
-                    }
-                }
-                finally
-                {
-                    if (message != null)
-                        message.Close();
-
-                    if (receiveThrowing)
-                        channel.Abort();
-                }
-
-                if (lastIteration || channel.State != CommunicationState.Opened)
-                    break;
-
-                iterationTimeout = timeoutHelper.RemainingTime();
-                lastIteration = (iterationTimeout == TimeSpan.Zero);
-            }
-
-            channel.Abort();
-        }
-
-        internal static void CloseReplySessionChannel(
-            ReliableChannelBinder<IReplySessionChannel> binder, IReplySessionChannel channel,
-            TimeSpan timeout)
-        {
-            TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
-
-            binder.WaitForPendingOperations(timeoutHelper.RemainingTime());
-
-            TimeSpan iterationTimeout = timeoutHelper.RemainingTime();
-            bool lastIteration = (iterationTimeout == TimeSpan.Zero);
-
-            while (true)
-            {
-                RequestContext context = null;
-                bool receiveThrowing = true;
-
-                try
-                {
-                    bool success = channel.TryReceiveRequest(iterationTimeout, out context);
-
-                    receiveThrowing = false;
-                    if (success && context == null)
-                    {
-                        channel.Close(timeoutHelper.RemainingTime());
-                        return;
-                    }
-                }
-                catch (Exception e)
-                {
-                    if (Fx.IsFatal(e))
-                        throw;
-
-                    if (receiveThrowing)
-                    {
-                        if (!MaskHandled(binder.DefaultMaskingMode) || !binder.IsHandleable(e))
-                            throw;
-
-                        receiveThrowing = false;
-                    }
-                    else
-                    {
-                        throw;
-                    }
-                }
-                finally
-                {
-                    if (context != null)
-                    {
-                        context.RequestMessage.Close();
-                        context.Close();
-                    }
-
-                    if (receiveThrowing)
-                        channel.Abort();
-                }
-
-                if (lastIteration || channel.State != CommunicationState.Opened)
-                    break;
-
-                iterationTimeout = timeoutHelper.RemainingTime();
-                lastIteration = (iterationTimeout == TimeSpan.Zero);
-            }
-
-            channel.Abort();
-        }
-
-        internal static void EndCloseDuplexSessionChannel(IDuplexSessionChannel channel,
-                IAsyncResult result)
-        {
-            CloseDuplexSessionChannelAsyncResult.End(result);
-        }
-
-        internal static void EndCloseReplySessionChannel(IReplySessionChannel channel,
-                IAsyncResult result)
-        {
-            CloseReplySessionChannelAsyncResult.End(result);
-        }
-
-        internal static bool MaskHandled(MaskingMode maskingMode)
-        {
-            return (maskingMode & MaskingMode.Handled) == MaskingMode.Handled;
-        }
-
-        internal static bool MaskUnhandled(MaskingMode maskingMode)
-        {
-            return (maskingMode & MaskingMode.Unhandled) == MaskingMode.Unhandled;
-        }
-
-        abstract class CloseInputSessionChannelAsyncResult<TChannel, TItem> : AsyncResult
-            where TChannel : class, IChannel
-            where TItem : class
-        {
-            static AsyncCallback onChannelCloseCompleteStatic =
-                Fx.ThunkCallback(
-                new AsyncCallback(OnChannelCloseCompleteStatic));
-            static AsyncCallback onInputCompleteStatic =
-                Fx.ThunkCallback(new AsyncCallback(OnInputCompleteStatic));
-            static AsyncCallback onWaitForPendingOperationsCompleteStatic =
-                Fx.ThunkCallback(
-                new AsyncCallback(OnWaitForPendingOperationsCompleteStatic));
-            ReliableChannelBinder<TChannel> binder;
-            TChannel channel;
-            bool lastReceive;
-            TimeoutHelper timeoutHelper;
-
-            protected CloseInputSessionChannelAsyncResult(
-                ReliableChannelBinder<TChannel> binder, TChannel channel,
-                TimeSpan timeout, AsyncCallback callback, object state)
-                : base(callback, state)
-            {
-                this.binder = binder;
-                this.channel = channel;
-                this.timeoutHelper = new TimeoutHelper(timeout);
-            }
-
-            protected TChannel Channel
-            {
-                get
-                {
-                    return this.channel;
-                }
-            }
-
-            protected TimeSpan RemainingTime
-            {
-                get
-                {
-                    return this.timeoutHelper.RemainingTime();
-                }
-            }
-
-            protected bool Begin()
-            {
-                bool complete = false;
-                IAsyncResult result = this.binder.BeginWaitForPendingOperations(
-                    this.RemainingTime, onWaitForPendingOperationsCompleteStatic,
-                    this);
-
-                if (result.CompletedSynchronously)
-                    complete = this.HandleWaitForPendingOperationsComplete(result);
-
-                return complete;
-            }
-
-            protected abstract IAsyncResult BeginTryInput(TimeSpan timeout, AsyncCallback callback,
-                object state);
-
-            protected abstract void DisposeItem(TItem item);
-
-            protected abstract bool EndTryInput(IAsyncResult result, out TItem item);
-
-            void HandleChannelCloseComplete(IAsyncResult result)
-            {
-                this.channel.EndClose(result);
-            }
-
-            bool HandleInputComplete(IAsyncResult result, out bool gotEof)
-            {
-                TItem item = null;
-                bool endThrowing = true;
-
-                gotEof = false;
-
-                try
-                {
-                    bool success = false;
-
-                    success = this.EndTryInput(result, out item);
-                    endThrowing = false;
-
-                    if (!success || item != null)
-                    {
-                        if (this.lastReceive || this.channel.State != CommunicationState.Opened)
-                        {
-                            this.channel.Abort();
-                            return true;
-                        }
-                        else
-                        {
-                            return false;
-                        }
-                    }
-
-                    gotEof = true;
-
-                    result = this.channel.BeginClose(this.RemainingTime,
-                        onChannelCloseCompleteStatic, this);
-                    if (result.CompletedSynchronously)
-                    {
-                        this.HandleChannelCloseComplete(result);
-                        return true;
-                    }
-                    else
-                    {
-                        return false;
-                    }
-                }
-                catch (Exception e)
-                {
-                    if (Fx.IsFatal(e))
-                        throw;
-
-                    if (endThrowing)
-                    {
-                        if (!MaskHandled(binder.DefaultMaskingMode) || !binder.IsHandleable(e))
-                            throw;
-
-                        if (this.lastReceive || this.channel.State != CommunicationState.Opened)
-                        {
-                            this.channel.Abort();
-                            return true;
-                        }
-                        else
-                        {
-                            return false;
-                        }
-                    }
-
-                    throw;
-                }
-                finally
-                {
-                    if (item != null)
-                        this.DisposeItem(item);
-
-                    if (endThrowing)
-                        this.channel.Abort();
-                }
-            }
-
-            bool HandleWaitForPendingOperationsComplete(IAsyncResult result)
-            {
-                this.binder.EndWaitForPendingOperations(result);
-                return this.WaitForEof();
-            }
-
-            static void OnChannelCloseCompleteStatic(IAsyncResult result)
-            {
-                if (result.CompletedSynchronously)
-                    return;
-
-                CloseInputSessionChannelAsyncResult<TChannel, TItem> closeResult =
-                    (CloseInputSessionChannelAsyncResult<TChannel, TItem>)result.AsyncState;
-
-                Exception completeException = null;
-
-                try
-                {
-                    closeResult.HandleChannelCloseComplete(result);
-                }
-                catch (Exception e)
-                {
-                    if (Fx.IsFatal(e))
-                        throw;
-
-                    completeException = e;
-                }
-
-                closeResult.Complete(false, completeException);
-            }
-
-            static void OnInputCompleteStatic(IAsyncResult result)
-            {
-                if (result.CompletedSynchronously)
-                    return;
-
-                CloseInputSessionChannelAsyncResult<TChannel, TItem> closeResult =
-                    (CloseInputSessionChannelAsyncResult<TChannel, TItem>)result.AsyncState;
-
-                bool complete = false;
-                Exception completeException = null;
-
-                try
-                {
-                    bool gotEof;
-
-                    complete = closeResult.HandleInputComplete(result, out gotEof);
-                    if (!complete && !gotEof)
-                        complete = closeResult.WaitForEof();
-                }
-                catch (Exception e)
-                {
-                    if (Fx.IsFatal(e))
-                        throw;
-
-                    completeException = e;
-                }
-
-                if (complete || completeException != null)
-                    closeResult.Complete(false, completeException);
-            }
-
-            static void OnWaitForPendingOperationsCompleteStatic(IAsyncResult result)
-            {
-                if (result.CompletedSynchronously)
-                    return;
-
-                CloseInputSessionChannelAsyncResult<TChannel, TItem> closeResult =
-                    (CloseInputSessionChannelAsyncResult<TChannel, TItem>)result.AsyncState;
-
-                bool complete = false;
-                Exception completeException = null;
-
-                try
-                {
-                    complete = closeResult.HandleWaitForPendingOperationsComplete(result);
-                }
-                catch (Exception e)
-                {
-                    if (Fx.IsFatal(e))
-                        throw;
-
-                    completeException = e;
-                }
-
-                if (complete || completeException != null)
-                    closeResult.Complete(false, completeException);
-            }
-
-            bool WaitForEof()
-            {
-                TimeSpan iterationTimeout = this.RemainingTime;
-                this.lastReceive = (iterationTimeout == TimeSpan.Zero);
-
-                while (true)
-                {
-                    IAsyncResult result = null;
-
-                    try
-                    {
-                        result = this.BeginTryInput(iterationTimeout, onInputCompleteStatic, this);
-                    }
-                    catch (Exception e)
-                    {
-                        if (Fx.IsFatal(e))
-                            throw;
-
-                        if (!MaskHandled(this.binder.DefaultMaskingMode) || !this.binder.IsHandleable(e))
-                            throw;
-                    }
-
-                    if (result != null)
-                    {
-                        if (result.CompletedSynchronously)
-                        {
-                            bool gotEof;
-                            bool complete = this.HandleInputComplete(result, out gotEof);
-
-                            if (complete || gotEof)
-                                return complete;
-                        }
-                        else
-                            return false;
-                    }
-
-                    if (this.lastReceive || this.channel.State != CommunicationState.Opened)
-                    {
-                        this.channel.Abort();
-                        break;
-                    }
-
-                    iterationTimeout = this.RemainingTime;
-                    this.lastReceive = (iterationTimeout == TimeSpan.Zero);
-                }
-
-                return true;
-            }
-        }
-
-        sealed class CloseDuplexSessionChannelAsyncResult :
-            CloseInputSessionChannelAsyncResult<IDuplexSessionChannel, Message>
-        {
-            static AsyncCallback onCloseOutputSessionCompleteStatic =
-                Fx.ThunkCallback(
-                new AsyncCallback(OnCloseOutputSessionCompleteStatic));
-
-            public CloseDuplexSessionChannelAsyncResult(
-                ReliableChannelBinder<IDuplexSessionChannel> binder, IDuplexSessionChannel channel,
-                TimeSpan timeout, AsyncCallback callback, object state)
-                : base(binder, channel, timeout, callback, state)
-            {
-                bool complete = false;
-
-                IAsyncResult result = this.Channel.Session.BeginCloseOutputSession(
-                    this.RemainingTime, onCloseOutputSessionCompleteStatic, this);
-
-                if (result.CompletedSynchronously)
-                    complete = this.HandleCloseOutputSessionComplete(result);
-
-                if (complete)
-                    this.Complete(true);
-            }
-
-            protected override IAsyncResult BeginTryInput(TimeSpan timeout, AsyncCallback callback, object state)
-            {
-                return this.Channel.BeginTryReceive(timeout, callback, state);
-            }
-
-            protected override void DisposeItem(Message item)
-            {
-                item.Close();
-            }
-
-            public static void End(IAsyncResult result)
-            {
-                AsyncResult.End<CloseDuplexSessionChannelAsyncResult>(result);
-            }
-
-            protected override bool EndTryInput(IAsyncResult result, out Message item)
-            {
-                return this.Channel.EndTryReceive(result, out item);
-            }
-
-            bool HandleCloseOutputSessionComplete(IAsyncResult result)
-            {
-                this.Channel.Session.EndCloseOutputSession(result);
-                return this.Begin();
-            }
-
-            static void OnCloseOutputSessionCompleteStatic(IAsyncResult result)
-            {
-                if (result.CompletedSynchronously)
-                    return;
-
-                CloseDuplexSessionChannelAsyncResult closeResult =
-                    (CloseDuplexSessionChannelAsyncResult)result.AsyncState;
-
-                bool complete = false;
-                Exception completeException = null;
-
-                try
-                {
-                    complete = closeResult.HandleCloseOutputSessionComplete(result);
-                }
-                catch (Exception e)
-                {
-                    if (Fx.IsFatal(e))
-                        throw;
-
-                    completeException = e;
-                }
-
-                if (complete || completeException != null)
-                    closeResult.Complete(false, completeException);
-            }
-        }
-
-        sealed class CloseReplySessionChannelAsyncResult :
-            CloseInputSessionChannelAsyncResult<IReplySessionChannel, RequestContext>
-        {
-            public CloseReplySessionChannelAsyncResult(
-                ReliableChannelBinder<IReplySessionChannel> binder, IReplySessionChannel channel,
-                TimeSpan timeout, AsyncCallback callback, object state)
-                : base(binder, channel, timeout, callback, state)
-            {
-                if (this.Begin())
-                    this.Complete(true);
-            }
-
-            protected override IAsyncResult BeginTryInput(TimeSpan timeout, AsyncCallback callback, object state)
-            {
-                return this.Channel.BeginTryReceiveRequest(timeout, callback, state);
-            }
-
-            protected override void DisposeItem(RequestContext item)
-            {
-                item.RequestMessage.Close();
-                item.Close();
-            }
-
-            public static void End(IAsyncResult result)
-            {
-                AsyncResult.End<CloseReplySessionChannelAsyncResult>(result);
-            }
-
-            protected override bool EndTryInput(IAsyncResult result, out RequestContext item)
-            {
-                return this.Channel.EndTryReceiveRequest(result, out item);
-            }
-        }
-    }
+    // Issue #31 in progress
+//    abstract class ReliableChannelBinder<TChannel> : IReliableChannelBinder
+//        where TChannel : class, IChannel
+//    {
+//        bool aborted = false;
+//        TimeSpan defaultCloseTimeout;
+//        MaskingMode defaultMaskingMode;
+//        TimeSpan defaultSendTimeout;
+//        AsyncCallback onCloseChannelComplete;
+//        CommunicationState state = CommunicationState.Created;
+//        ChannelSynchronizer synchronizer;
+//        object thisLock = new object();
+
+//        protected ReliableChannelBinder(TChannel channel, MaskingMode maskingMode,
+//            TolerateFaultsMode faultMode, TimeSpan defaultCloseTimeout,
+//            TimeSpan defaultSendTimeout)
+//        {
+//            if ((maskingMode != MaskingMode.None) && (maskingMode != MaskingMode.All))
+//            {
+//                throw Fx.AssertAndThrow("ReliableChannelBinder was implemented with only 2 default masking modes, None and All.");
+//            }
+
+//            this.defaultMaskingMode = maskingMode;
+//            this.defaultCloseTimeout = defaultCloseTimeout;
+//            this.defaultSendTimeout = defaultSendTimeout;
+
+//            this.synchronizer = new ChannelSynchronizer(this, channel, faultMode);
+//        }
+
+//        protected abstract bool CanGetChannelForReceive
+//        {
+//            get;
+//        }
+
+//        public abstract bool CanSendAsynchronously
+//        {
+//            get;
+//        }
+
+//        public virtual ChannelParameterCollection ChannelParameters
+//        {
+//            get { return null; }
+//        }
+
+//        public IChannel Channel
+//        {
+//            get
+//            {
+//                return this.synchronizer.CurrentChannel;
+//            }
+//        }
+
+//        public bool Connected
+//        {
+//            get
+//            {
+//                return this.synchronizer.Connected;
+//            }
+//        }
+
+//        public MaskingMode DefaultMaskingMode
+//        {
+//            get
+//            {
+//                return this.defaultMaskingMode;
+//            }
+//        }
+
+//        public TimeSpan DefaultSendTimeout
+//        {
+//            get
+//            {
+//                return this.defaultSendTimeout;
+//            }
+//        }
+
+//        public abstract bool HasSession
+//        {
+//            get;
+//        }
+
+//        public abstract EndpointAddress LocalAddress
+//        {
+//            get;
+//        }
+
+//        protected abstract bool MustCloseChannel
+//        {
+//            get;
+//        }
+
+//        protected abstract bool MustOpenChannel
+//        {
+//            get;
+//        }
+
+//        public abstract EndpointAddress RemoteAddress
+//        {
+//            get;
+//        }
+
+//        public CommunicationState State
+//        {
+//            get
+//            {
+//                return this.state;
+//            }
+//        }
+
+//        protected ChannelSynchronizer Synchronizer
+//        {
+//            get
+//            {
+//                return this.synchronizer;
+//            }
+//        }
+
+//        protected object ThisLock
+//        {
+//            get
+//            {
+//                return this.thisLock;
+//            }
+//        }
+
+//        bool TolerateFaults
+//        {
+//            get
+//            {
+//                return this.synchronizer.TolerateFaults;
+//            }
+//        }
+
+//        public event EventHandler ConnectionLost;
+//        public event BinderExceptionHandler Faulted;
+//        public event BinderExceptionHandler OnException;
+
+
+//        public void Abort()
+//        {
+//            TChannel channel;
+//            lock (this.ThisLock)
+//            {
+//                this.aborted = true;
+
+//                if (this.state == CommunicationState.Closed)
+//                {
+//                    return;
+//                }
+
+//                this.state = CommunicationState.Closing;
+//                channel = this.synchronizer.StopSynchronizing(true);
+
+//                if (!this.MustCloseChannel)
+//                {
+//                    channel = null;
+//                }
+//            }
+
+//            this.synchronizer.UnblockWaiters();
+//            this.OnShutdown();
+//            this.OnAbort();
+
+//            if (channel != null)
+//            {
+//                channel.Abort();
+//            }
+
+//            this.TransitionToClosed();
+//        }
+
+//        protected virtual void AddOutputHeaders(Message message)
+//        {
+//        }
+
+//        public IAsyncResult BeginClose(TimeSpan timeout, AsyncCallback callback,
+//            object state)
+//        {
+//            return this.BeginClose(timeout, this.defaultMaskingMode, callback, state);
+//        }
+
+//        public IAsyncResult BeginClose(TimeSpan timeout, MaskingMode maskingMode,
+//            AsyncCallback callback, object state)
+//        {
+//            this.ThrowIfTimeoutNegative(timeout);
+//            TChannel channel;
+
+//            if (this.CloseCore(out channel))
+//            {
+//                return new CompletedAsyncResult(callback, state);
+//            }
+//            else
+//            {
+//                return new CloseAsyncResult(this, channel, timeout, maskingMode, callback, state);
+//            }
+//        }
+
+//        protected virtual IAsyncResult BeginCloseChannel(TChannel channel, TimeSpan timeout,
+//            AsyncCallback callback, object state)
+//        {
+//            return channel.BeginClose(timeout, callback, state);
+//        }
+
+//        public IAsyncResult BeginOpen(TimeSpan timeout, AsyncCallback callback, object state)
+//        {
+//            this.ThrowIfTimeoutNegative(timeout);
+
+//            if (this.OnOpening(this.defaultMaskingMode))
+//            {
+//                try
+//                {
+//                    return this.OnBeginOpen(timeout, callback, state);
+//                }
+//                catch (Exception e)
+//                {
+//                    if (Fx.IsFatal(e))
+//                    {
+//                        throw;
+//                    }
+
+//                    this.Fault(null);
+
+//                    if (this.defaultMaskingMode == MaskingMode.None)
+//                    {
+//                        throw;
+//                    }
+//                    else
+//                    {
+//                        this.RaiseOnException(e);
+//                    }
+//                }
+//            }
+
+//            return new BinderCompletedAsyncResult(callback, state);
+//        }
+
+//        public IAsyncResult BeginSend(Message message, TimeSpan timeout, AsyncCallback callback,
+//            object state)
+//        {
+//            return this.BeginSend(message, timeout, this.defaultMaskingMode, callback, state);
+//        }
+
+//        public IAsyncResult BeginSend(Message message, TimeSpan timeout, MaskingMode maskingMode,
+//            AsyncCallback callback, object state)
+//        {
+//            SendAsyncResult result = new SendAsyncResult(this, callback, state);
+//            result.Start(message, timeout, maskingMode);
+//            return result;
+//        }
+
+//        // ChannelSynchronizer helper, cannot take a lock.
+//        protected abstract IAsyncResult BeginTryGetChannel(TimeSpan timeout,
+//            AsyncCallback callback, object state);
+
+//        public virtual IAsyncResult BeginTryReceive(TimeSpan timeout, AsyncCallback callback,
+//            object state)
+//        {
+//            return this.BeginTryReceive(timeout, this.defaultMaskingMode, callback, state);
+//        }
+
+//        public virtual IAsyncResult BeginTryReceive(TimeSpan timeout, MaskingMode maskingMode,
+//            AsyncCallback callback, object state)
+//        {
+//            if (this.ValidateInputOperation(timeout))
+//                return new TryReceiveAsyncResult(this, timeout, maskingMode, callback, state);
+//            else
+//                return new CompletedAsyncResult(callback, state);
+//        }
+
+//        internal IAsyncResult BeginWaitForPendingOperations(TimeSpan timeout,
+//            AsyncCallback callback, object state)
+//        {
+//            return this.synchronizer.BeginWaitForPendingOperations(timeout, callback, state);
+//        }
+
+//        bool CloseCore(out TChannel channel)
+//        {
+//            channel = null;
+//            bool abort = true;
+//            bool abortChannel = false;
+
+//            lock (this.ThisLock)
+//            {
+//                if ((this.state == CommunicationState.Closing)
+//                    || (this.state == CommunicationState.Closed))
+//                {
+//                    return true;
+//                }
+
+//                if (this.state == CommunicationState.Opened)
+//                {
+//                    this.state = CommunicationState.Closing;
+//                    channel = this.synchronizer.StopSynchronizing(true);
+//                    abort = false;
+
+//                    if (!this.MustCloseChannel)
+//                    {
+//                        channel = null;
+//                    }
+
+//                    if (channel != null)
+//                    {
+//                        CommunicationState channelState = channel.State;
+
+//                        if ((channelState == CommunicationState.Created)
+//                            || (channelState == CommunicationState.Opening)
+//                            || (channelState == CommunicationState.Faulted))
+//                        {
+//                            abortChannel = true;
+//                        }
+//                        else if ((channelState == CommunicationState.Closing)
+//                            || (channelState == CommunicationState.Closed))
+//                        {
+//                            channel = null;
+//                        }
+//                    }
+//                }
+//            }
+
+//            this.synchronizer.UnblockWaiters();
+
+//            if (abort)
+//            {
+//                this.Abort();
+//                return true;
+//            }
+//            else
+//            {
+//                if (abortChannel)
+//                {
+//                    channel.Abort();
+//                    channel = null;
+//                }
+
+//                return false;
+//            }
+//        }
+
+//        public void Close(TimeSpan timeout)
+//        {
+//            this.Close(timeout, this.defaultMaskingMode);
+//        }
+
+//        public void Close(TimeSpan timeout, MaskingMode maskingMode)
+//        {
+//            this.ThrowIfTimeoutNegative(timeout);
+//            TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
+//            TChannel channel;
+
+//            if (this.CloseCore(out channel))
+//            {
+//                return;
+//            }
+
+//            try
+//            {
+//                this.OnShutdown();
+//                this.OnClose(timeoutHelper.RemainingTime());
+
+//                if (channel != null)
+//                {
+//                    this.CloseChannel(channel, timeoutHelper.RemainingTime());
+//                }
+
+//                this.TransitionToClosed();
+//            }
+//            catch (Exception e)
+//            {
+//                if (Fx.IsFatal(e))
+//                {
+//                    throw;
+//                }
+
+//                this.Abort();
+
+//                if (!this.HandleException(e, maskingMode))
+//                {
+//                    throw;
+//                }
+//            }
+//        }
+
+//        // The ChannelSynchronizer calls this from an operation thread so this method must not
+//        // block.
+//        void CloseChannel(TChannel channel)
+//        {
+//            if (!this.MustCloseChannel)
+//            {
+//                throw Fx.AssertAndThrow("MustCloseChannel is false when there is no receive loop and this method is called when there is a receive loop.");
+//            }
+
+//            if (this.onCloseChannelComplete == null)
+//            {
+//                this.onCloseChannelComplete = Fx.ThunkCallback(new AsyncCallback(this.OnCloseChannelComplete));
+//            }
+
+//            try
+//            {
+//                IAsyncResult result = channel.BeginClose(onCloseChannelComplete, channel);
+
+//                if (result.CompletedSynchronously)
+//                {
+//                    channel.EndClose(result);
+//                }
+//            }
+//#pragma warning suppress 56500 // covered by FxCOP
+//            catch (Exception e)
+//            {
+//                if (Fx.IsFatal(e))
+//                {
+//                    throw;
+//                }
+
+//                this.HandleException(e, MaskingMode.All);
+//            }
+//        }
+
+//        protected virtual void CloseChannel(TChannel channel, TimeSpan timeout)
+//        {
+//            channel.Close(timeout);
+//        }
+
+//        public void EndClose(IAsyncResult result)
+//        {
+//            CloseAsyncResult closeResult = result as CloseAsyncResult;
+
+//            if (closeResult != null)
+//            {
+//                closeResult.End();
+//            }
+//            else
+//            {
+//                CompletedAsyncResult.End(result);
+//            }
+//        }
+
+//        protected virtual void EndCloseChannel(TChannel channel, IAsyncResult result)
+//        {
+//            channel.EndClose(result);
+//        }
+
+//        public void EndOpen(IAsyncResult result)
+//        {
+//            BinderCompletedAsyncResult completedResult = result as BinderCompletedAsyncResult;
+
+//            if (completedResult != null)
+//            {
+//                completedResult.End();
+//            }
+//            else
+//            {
+//                try
+//                {
+//                    this.OnEndOpen(result);
+//                }
+//                catch (Exception e)
+//                {
+//                    if (Fx.IsFatal(e))
+//                    {
+//                        throw;
+//                    }
+
+//                    this.Fault(null);
+
+//                    if (this.defaultMaskingMode == MaskingMode.None)
+//                    {
+//                        throw;
+//                    }
+//                    else
+//                    {
+//                        this.RaiseOnException(e);
+//                        return;
+//                    }
+//                }
+
+//                this.synchronizer.StartSynchronizing();
+//                this.OnOpened();
+//            }
+//        }
+
+//        public void EndSend(IAsyncResult result)
+//        {
+//            SendAsyncResult.End(result);
+//        }
+
+//        // ChannelSynchronizer helper, cannot take a lock.
+//        protected abstract bool EndTryGetChannel(IAsyncResult result);
+
+//        public virtual bool EndTryReceive(IAsyncResult result, out RequestContext requestContext)
+//        {
+//            TryReceiveAsyncResult tryReceiveResult = result as TryReceiveAsyncResult;
+
+//            if (tryReceiveResult != null)
+//            {
+//                return tryReceiveResult.End(out requestContext);
+//            }
+//            else
+//            {
+//                CompletedAsyncResult.End(result);
+//                requestContext = null;
+//                return true;
+//            }
+//        }
+
+//        public void EndWaitForPendingOperations(IAsyncResult result)
+//        {
+//            this.synchronizer.EndWaitForPendingOperations(result);
+//        }
+
+//        protected void Fault(Exception e)
+//        {
+//            lock (this.ThisLock)
+//            {
+//                if (this.state == CommunicationState.Created)
+//                {
+//                    throw Fx.AssertAndThrow("The binder should not detect the inner channel's faults until after the binder is opened.");
+//                }
+
+//                if ((this.state == CommunicationState.Faulted)
+//                    || (this.state == CommunicationState.Closed))
+//                {
+//                    return;
+//                }
+
+//                this.state = CommunicationState.Faulted;
+//                this.synchronizer.StopSynchronizing(false);
+//            }
+
+//            this.synchronizer.UnblockWaiters();
+
+//            BinderExceptionHandler handler = this.Faulted;
+
+//            if (handler != null)
+//            {
+//                handler(this, e);
+//            }
+//        }
+
+//        // ChannelSynchronizer helper, cannot take a lock.
+//        Exception GetClosedException(MaskingMode maskingMode)
+//        {
+//            if (ReliableChannelBinderHelper.MaskHandled(maskingMode))
+//            {
+//                return null;
+//            }
+//            else if (this.aborted)
+//            {
+//                return new CommunicationObjectAbortedException(SR.GetString(
+//                    SR.CommunicationObjectAborted1, this.GetType().ToString()));
+//            }
+//            else
+//            {
+//                return new ObjectDisposedException(this.GetType().ToString());
+//            }
+//        }
+
+//        // Must be called within lock (this.ThisLock)
+//        Exception GetClosedOrFaultedException(MaskingMode maskingMode)
+//        {
+//            if (this.state == CommunicationState.Faulted)
+//            {
+//                return this.GetFaultedException(maskingMode);
+//            }
+//            else if ((this.state == CommunicationState.Closing)
+//               || (this.state == CommunicationState.Closed))
+//            {
+//                return this.GetClosedException(maskingMode);
+//            }
+//            else
+//            {
+//                throw Fx.AssertAndThrow("Caller is attempting to get a terminal exception in a non-terminal state.");
+//            }
+//        }
+
+//        // ChannelSynchronizer helper, cannot take a lock.
+//        Exception GetFaultedException(MaskingMode maskingMode)
+//        {
+//            if (ReliableChannelBinderHelper.MaskHandled(maskingMode))
+//            {
+//                return null;
+//            }
+//            else
+//            {
+//                return new CommunicationObjectFaultedException(SR.GetString(
+//                    SR.CommunicationObjectFaulted1, this.GetType().ToString()));
+//            }
+//        }
+
+//        public abstract ISession GetInnerSession();
+
+//        public void HandleException(Exception e)
+//        {
+//            this.HandleException(e, MaskingMode.All);
+//        }
+
+//        protected bool HandleException(Exception e, MaskingMode maskingMode)
+//        {
+//            if (this.TolerateFaults && (e is CommunicationObjectFaultedException))
+//            {
+//                return true;
+//            }
+
+//            if (this.IsHandleable(e))
+//            {
+//                return ReliableChannelBinderHelper.MaskHandled(maskingMode);
+//            }
+
+//            bool maskUnhandled = ReliableChannelBinderHelper.MaskUnhandled(maskingMode);
+
+//            if (maskUnhandled)
+//            {
+//                this.RaiseOnException(e);
+//            }
+
+//            return maskUnhandled;
+//        }
+
+//        protected bool HandleException(Exception e, MaskingMode maskingMode, bool autoAborted)
+//        {
+//            if (this.TolerateFaults && autoAborted && e is CommunicationObjectAbortedException)
+//            {
+//                return true;
+//            }
+
+//            return this.HandleException(e, maskingMode);
+//        }
+
+//        // ChannelSynchronizer helper, cannot take a lock.
+//        protected abstract bool HasSecuritySession(TChannel channel);
+
+//        public bool IsHandleable(Exception e)
+//        {
+//            if (e is ProtocolException)
+//            {
+//                return false;
+//            }
+
+//            return (e is CommunicationException)
+//                || (e is TimeoutException);
+//        }
+
+//        protected abstract void OnAbort();
+//        protected abstract IAsyncResult OnBeginClose(TimeSpan timeout, AsyncCallback callback,
+//            object state);
+//        protected abstract IAsyncResult OnBeginOpen(TimeSpan timeout, AsyncCallback callback,
+//            object state);
+
+//        protected virtual IAsyncResult OnBeginSend(TChannel channel, Message message,
+//            TimeSpan timeout, AsyncCallback callback, object state)
+//        {
+//            throw Fx.AssertAndThrow("The derived class does not support the BeginSend operation.");
+//        }
+
+//        protected virtual IAsyncResult OnBeginTryReceive(TChannel channel, TimeSpan timeout,
+//            AsyncCallback callback, object state)
+//        {
+//            throw Fx.AssertAndThrow("The derived class does not support the BeginTryReceive operation.");
+//        }
+
+//        protected abstract void OnClose(TimeSpan timeout);
+
+//        void OnCloseChannelComplete(IAsyncResult result)
+//        {
+//            if (result.CompletedSynchronously)
+//            {
+//                return;
+//            }
+
+//            TChannel channel = (TChannel)result.AsyncState;
+
+//            try
+//            {
+//                channel.EndClose(result);
+//            }
+//#pragma warning suppress 56500 // covered by FxCOP
+//            catch (Exception e)
+//            {
+//                if (Fx.IsFatal(e))
+//                {
+//                    throw;
+//                }
+
+//                this.HandleException(e, MaskingMode.All);
+//            }
+//        }
+
+//        protected abstract void OnEndClose(IAsyncResult result);
+//        protected abstract void OnEndOpen(IAsyncResult result);
+
+//        protected virtual void OnEndSend(TChannel channel, IAsyncResult result)
+//        {
+//            throw Fx.AssertAndThrow("The derived class does not support the EndSend operation.");
+//        }
+
+//        protected virtual bool OnEndTryReceive(TChannel channel, IAsyncResult result,
+//            out RequestContext requestContext)
+//        {
+//            throw Fx.AssertAndThrow("The derived class does not support the EndTryReceive operation.");
+//        }
+
+//        void OnInnerChannelFaulted()
+//        {
+//            if (!this.TolerateFaults)
+//                return;
+
+//            EventHandler handler = this.ConnectionLost;
+
+//            if (handler != null)
+//                handler(this, EventArgs.Empty);
+//        }
+
+//        protected abstract void OnOpen(TimeSpan timeout);
+
+//        void OnOpened()
+//        {
+//            lock (this.ThisLock)
+//            {
+//                if (this.state == CommunicationState.Opening)
+//                {
+//                    this.state = CommunicationState.Opened;
+//                }
+//            }
+//        }
+
+//        bool OnOpening(MaskingMode maskingMode)
+//        {
+//            lock (this.ThisLock)
+//            {
+//                if (this.state != CommunicationState.Created)
+//                {
+//                    Exception e = null;
+
+//                    if ((this.state == CommunicationState.Opening)
+//                        || (this.state == CommunicationState.Opened))
+//                    {
+//                        if (!ReliableChannelBinderHelper.MaskUnhandled(maskingMode))
+//                        {
+//                            e = new InvalidOperationException(SR.GetString(
+//                                SR.CommunicationObjectCannotBeModifiedInState,
+//                                this.GetType().ToString(), this.state.ToString()));
+//                        }
+//                    }
+//                    else
+//                    {
+//                        e = this.GetClosedOrFaultedException(maskingMode);
+//                    }
+
+//                    if (e != null)
+//                    {
+//                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(e);
+//                    }
+
+//                    return false;
+//                }
+//                else
+//                {
+//                    this.state = CommunicationState.Opening;
+//                    return true;
+//                }
+//            }
+//        }
+
+//        protected virtual void OnShutdown()
+//        {
+//        }
+
+//        protected virtual void OnSend(TChannel channel, Message message, TimeSpan timeout)
+//        {
+//            throw Fx.AssertAndThrow("The derived class does not support the Send operation.");
+//        }
+
+//        protected virtual bool OnTryReceive(TChannel channel, TimeSpan timeout,
+//            out RequestContext requestContext)
+//        {
+//            throw Fx.AssertAndThrow("The derived class does not support the TryReceive operation.");
+//        }
+
+//        public void Open(TimeSpan timeout)
+//        {
+//            this.ThrowIfTimeoutNegative(timeout);
+
+//            if (!this.OnOpening(this.defaultMaskingMode))
+//            {
+//                return;
+//            }
+
+//            try
+//            {
+//                this.OnOpen(timeout);
+//            }
+//            catch (Exception e)
+//            {
+//                if (Fx.IsFatal(e))
+//                {
+//                    throw;
+//                }
+
+//                this.Fault(null);
+
+//                if (this.defaultMaskingMode == MaskingMode.None)
+//                {
+//                    throw;
+//                }
+//                else
+//                {
+//                    this.RaiseOnException(e);
+//                    return;
+//                }
+//            }
+
+//            this.synchronizer.StartSynchronizing();
+//            this.OnOpened();
+//        }
+
+//        void RaiseOnException(Exception e)
+//        {
+//            BinderExceptionHandler handler = this.OnException;
+
+//            if (handler != null)
+//            {
+//                handler(this, e);
+//            }
+//        }
+
+//        public void Send(Message message, TimeSpan timeout)
+//        {
+//            this.Send(message, timeout, this.defaultMaskingMode);
+//        }
+
+//        public void Send(Message message, TimeSpan timeout, MaskingMode maskingMode)
+//        {
+//            if (!this.ValidateOutputOperation(message, timeout, maskingMode))
+//            {
+//                return;
+//            }
+
+//            bool autoAborted = false;
+
+//            try
+//            {
+//                TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
+//                TChannel channel;
+
+//                if (!this.synchronizer.TryGetChannelForOutput(timeoutHelper.RemainingTime(), maskingMode,
+//                    out channel))
+//                {
+//                    if (!ReliableChannelBinderHelper.MaskHandled(maskingMode))
+//                    {
+//                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(
+//                            new TimeoutException(SR.GetString(SR.TimeoutOnSend, timeout)));
+//                    }
+
+//                    return;
+//                }
+
+//                if (channel == null)
+//                {
+//                    return;
+//                }
+
+//                this.AddOutputHeaders(message);
+
+//                try
+//                {
+//                    this.OnSend(channel, message, timeoutHelper.RemainingTime());
+//                }
+//                finally
+//                {
+//                    autoAborted = this.Synchronizer.Aborting;
+//                    this.synchronizer.ReturnChannel();
+//                }
+//            }
+//            catch (Exception e)
+//            {
+//                if (Fx.IsFatal(e))
+//                {
+//                    throw;
+//                }
+
+//                if (!this.HandleException(e, maskingMode, autoAborted))
+//                {
+//                    throw;
+//                }
+//            }
+//        }
+
+//        public void SetMaskingMode(RequestContext context, MaskingMode maskingMode)
+//        {
+//            BinderRequestContext binderContext = (BinderRequestContext)context;
+//            binderContext.SetMaskingMode(maskingMode);
+//        }
+
+//        // throwDisposed indicates whether to throw in the Faulted, Closing, and Closed states.
+//        // returns true if in Opened state
+//        bool ThrowIfNotOpenedAndNotMasking(MaskingMode maskingMode, bool throwDisposed)
+//        {
+//            lock (this.ThisLock)
+//            {
+//                if (this.State == CommunicationState.Created)
+//                {
+//                    throw Fx.AssertAndThrow("Messaging operations cannot be called when the binder is in the Created state.");
+//                }
+
+//                if (this.State == CommunicationState.Opening)
+//                {
+//                    throw Fx.AssertAndThrow("Messaging operations cannot be called when the binder is in the Opening state.");
+//                }
+
+//                if (this.State == CommunicationState.Opened)
+//                {
+//                    return true;
+//                }
+
+//                // state is Faulted, Closing, or Closed
+//                if (throwDisposed)
+//                {
+//                    Exception e = this.GetClosedOrFaultedException(maskingMode);
+
+//                    if (e != null)
+//                    {
+//                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(e);
+//                    }
+//                }
+
+//                return false;
+//            }
+//        }
+
+//        void ThrowIfTimeoutNegative(TimeSpan timeout)
+//        {
+//            if (timeout < TimeSpan.Zero)
+//            {
+//                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(
+//                    new ArgumentOutOfRangeException("timeout", timeout, SR.SFxTimeoutOutOfRange0));
+//            }
+//        }
+
+//        void TransitionToClosed()
+//        {
+//            lock (this.ThisLock)
+//            {
+//                if ((this.state != CommunicationState.Closing)
+//                    && (this.state != CommunicationState.Closed)
+//                    && (this.state != CommunicationState.Faulted))
+//                {
+//                    throw Fx.AssertAndThrow("Caller cannot transition to the Closed state from a non-terminal state.");
+//                }
+
+//                this.state = CommunicationState.Closed;
+//            }
+//        }
+
+//        // ChannelSynchronizer helper, cannot take a lock.
+//        protected abstract bool TryGetChannel(TimeSpan timeout);
+
+//        public virtual bool TryReceive(TimeSpan timeout, out RequestContext requestContext)
+//        {
+//            return this.TryReceive(timeout, out requestContext, this.defaultMaskingMode);
+//        }
+
+//        public virtual bool TryReceive(TimeSpan timeout, out RequestContext requestContext, MaskingMode maskingMode)
+//        {
+//            if (maskingMode != MaskingMode.None)
+//            {
+//                throw Fx.AssertAndThrow("This method was implemented only for the case where we do not mask exceptions.");
+//            }
+
+//            if (!this.ValidateInputOperation(timeout))
+//            {
+//                requestContext = null;
+//                return true;
+//            }
+
+//            TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
+
+//            while (true)
+//            {
+//                bool autoAborted = false;
+
+//                try
+//                {
+//                    TChannel channel;
+//                    bool success = !this.synchronizer.TryGetChannelForInput(
+//                        this.CanGetChannelForReceive, timeoutHelper.RemainingTime(), out channel);
+
+//                    if (channel == null)
+//                    {
+//                        requestContext = null;
+//                        return success;
+//                    }
+
+//                    try
+//                    {
+//                        success = this.OnTryReceive(channel, timeoutHelper.RemainingTime(),
+//                            out requestContext);
+
+//                        // timed out || got message, return immediately
+//                        if (!success || (requestContext != null))
+//                        {
+//                            return success;
+//                        }
+
+//                        // the underlying channel closed or faulted, retry
+//                        this.synchronizer.OnReadEof();
+//                    }
+//                    finally
+//                    {
+//                        autoAborted = this.Synchronizer.Aborting;
+//                        this.synchronizer.ReturnChannel();
+//                    }
+//                }
+//                catch (Exception e)
+//                {
+//                    if (Fx.IsFatal(e))
+//                    {
+//                        throw;
+//                    }
+
+//                    if (!this.HandleException(e, maskingMode, autoAborted))
+//                    {
+//                        throw;
+//                    }
+//                }
+//            }
+//        }
+
+//        protected bool ValidateInputOperation(TimeSpan timeout)
+//        {
+//            if (timeout < TimeSpan.Zero)
+//            {
+//                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("timeout", timeout,
+//                    SR.SFxTimeoutOutOfRange0));
+//            }
+
+//            return this.ThrowIfNotOpenedAndNotMasking(MaskingMode.All, false);
+//        }
+
+//        protected bool ValidateOutputOperation(Message message, TimeSpan timeout, MaskingMode maskingMode)
+//        {
+//            if (message == null)
+//            {
+//                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("message");
+//            }
+
+//            if (timeout < TimeSpan.Zero)
+//            {
+//                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("timeout", timeout,
+//                    SR.SFxTimeoutOutOfRange0));
+//            }
+
+//            return this.ThrowIfNotOpenedAndNotMasking(maskingMode, true);
+//        }
+
+//        internal void WaitForPendingOperations(TimeSpan timeout)
+//        {
+//            this.synchronizer.WaitForPendingOperations(timeout);
+//        }
+
+//        protected RequestContext WrapMessage(Message message)
+//        {
+//            if (message == null)
+//            {
+//                return null;
+//            }
+
+//            return new MessageRequestContext(this, message);
+//        }
+
+//        public RequestContext WrapRequestContext(RequestContext context)
+//        {
+//            if (context == null)
+//            {
+//                return null;
+//            }
+
+//            if (!this.TolerateFaults && this.defaultMaskingMode == MaskingMode.None)
+//            {
+//                return context;
+//            }
+
+//            return new RequestRequestContext(this, context, context.RequestMessage);
+//        }
+
+//        sealed class BinderCompletedAsyncResult : CompletedAsyncResult
+//        {
+//            public BinderCompletedAsyncResult(AsyncCallback callback, object state)
+//                : base(callback, state)
+//            {
+//            }
+
+//            public void End()
+//            {
+//                CompletedAsyncResult.End(this);
+//            }
+//        }
+
+//        abstract class BinderRequestContext : RequestContextBase
+//        {
+//            ReliableChannelBinder<TChannel> binder;
+//            MaskingMode maskingMode;
+
+//            public BinderRequestContext(ReliableChannelBinder<TChannel> binder, Message message)
+//                : base(message, binder.defaultCloseTimeout, binder.defaultSendTimeout)
+//            {
+//                if (binder == null)
+//                {
+//                    Fx.Assert("Argument binder cannot be null.");
+//                }
+
+//                this.binder = binder;
+//                this.maskingMode = binder.defaultMaskingMode;
+//            }
+
+//            protected ReliableChannelBinder<TChannel> Binder
+//            {
+//                get
+//                {
+//                    return this.binder;
+//                }
+//            }
+
+//            protected MaskingMode MaskingMode
+//            {
+//                get
+//                {
+//                    return this.maskingMode;
+//                }
+//            }
+
+//            public void SetMaskingMode(MaskingMode maskingMode)
+//            {
+//                if (this.binder.defaultMaskingMode != MaskingMode.All)
+//                {
+//                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new NotSupportedException());
+//                }
+
+//                this.maskingMode = maskingMode;
+//            }
+//        }
+
+//        protected class ChannelSynchronizer
+//        {
+//            bool aborting; // Indicates the current channel is being aborted, not the synchronizer.
+//            ReliableChannelBinder<TChannel> binder;
+//            int count = 0;
+//            TChannel currentChannel;
+//            InterruptibleWaitObject drainEvent;
+//            static Action<object> asyncGetChannelCallback = new Action<object>(AsyncGetChannelCallback);
+//            TolerateFaultsMode faultMode;
+//            Queue<IWaiter> getChannelQueue;
+//            bool innerChannelFaulted;
+//            EventHandler onChannelFaulted;
+//            State state = State.Created;
+//            bool tolerateFaults = true;
+//            object thisLock = new object();
+//            Queue<IWaiter> waitQueue;
+
+//            public ChannelSynchronizer(ReliableChannelBinder<TChannel> binder, TChannel channel,
+//                TolerateFaultsMode faultMode)
+//            {
+//                this.binder = binder;
+//                this.currentChannel = channel;
+//                this.faultMode = faultMode;
+//            }
+
+//            public bool Aborting
+//            {
+//                get
+//                {
+//                    return this.aborting;
+//                }
+//            }
+
+//            public bool Connected
+//            {
+//                get
+//                {
+//                    return (this.state == State.ChannelOpened ||
+//                        this.state == State.ChannelOpening);
+//                }
+//            }
+
+//            public TChannel CurrentChannel
+//            {
+//                get
+//                {
+//                    return this.currentChannel;
+//                }
+//            }
+
+//            object ThisLock
+//            {
+//                get
+//                {
+//                    return this.thisLock;
+//                }
+//            }
+
+//            public bool TolerateFaults
+//            {
+//                get
+//                {
+//                    return this.tolerateFaults;
+//                }
+//            }
+
+//            // Server only API.
+//            public TChannel AbortCurentChannel()
+//            {
+//                lock (this.ThisLock)
+//                {
+//                    if (!this.tolerateFaults)
+//                    {
+//                        throw Fx.AssertAndThrow("It is only valid to abort the current channel when masking faults");
+//                    }
+
+//                    if (this.state == State.ChannelOpening)
+//                    {
+//                        this.aborting = true;
+//                    }
+//                    else if (this.state == State.ChannelOpened)
+//                    {
+//                        if (this.count == 0)
+//                        {
+//                            this.state = State.NoChannel;
+//                        }
+//                        else
+//                        {
+//                            this.aborting = true;
+//                            this.state = State.ChannelClosing;
+//                        }
+//                    }
+//                    else
+//                    {
+//                        return null;
+//                    }
+
+//                    return this.currentChannel;
+//                }
+//            }
+
+//            static void AsyncGetChannelCallback(object state)
+//            {
+//                AsyncWaiter waiter = (AsyncWaiter)state;
+//                waiter.GetChannel(false);
+//            }
+
+//            public IAsyncResult BeginTryGetChannelForInput(bool canGetChannel, TimeSpan timeout,
+//                AsyncCallback callback, object state)
+//            {
+//                return this.BeginTryGetChannel(canGetChannel, false, timeout, MaskingMode.All,
+//                    callback, state);
+//            }
+
+//            public IAsyncResult BeginTryGetChannelForOutput(TimeSpan timeout,
+//                MaskingMode maskingMode, AsyncCallback callback, object state)
+//            {
+//                return this.BeginTryGetChannel(true, true, timeout, maskingMode,
+//                    callback, state);
+//            }
+
+//            IAsyncResult BeginTryGetChannel(bool canGetChannel, bool canCauseFault,
+//                TimeSpan timeout, MaskingMode maskingMode, AsyncCallback callback, object state)
+//            {
+//                TChannel channel = null;
+//                AsyncWaiter waiter = null;
+//                bool getChannel = false;
+//                bool faulted = false;
+
+//                lock (this.ThisLock)
+//                {
+//                    if (!this.ThrowIfNecessary(maskingMode))
+//                    {
+//                        channel = null;
+//                    }
+//                    else if (this.state == State.ChannelOpened)
+//                    {
+//                        if (this.currentChannel == null)
+//                        {
+//                            throw Fx.AssertAndThrow("Field currentChannel cannot be null in the ChannelOpened state.");
+//                        }
+
+//                        this.count++;
+//                        channel = this.currentChannel;
+//                    }
+//                    else if (!this.tolerateFaults
+//                        && ((this.state == State.NoChannel)
+//                        || (this.state == State.ChannelClosing)))
+//                    {
+//                        if (canCauseFault)
+//                        {
+//                            faulted = true;
+//                        }
+
+//                        channel = null;
+//                    }
+//                    else if (!canGetChannel
+//                        || (this.state == State.ChannelOpening)
+//                        || (this.state == State.ChannelClosing))
+//                    {
+//                        waiter = new AsyncWaiter(this, canGetChannel, null, timeout, maskingMode,
+//                            this.binder.ChannelParameters,
+//                            callback, state);
+//                        this.GetQueue(canGetChannel).Enqueue(waiter);
+//                    }
+//                    else
+//                    {
+//                        if (this.state != State.NoChannel)
+//                        {
+//                            throw Fx.AssertAndThrow("The state must be NoChannel.");
+//                        }
+
+//                        waiter = new AsyncWaiter(this, canGetChannel,
+//                            this.GetCurrentChannelIfCreated(), timeout, maskingMode,
+//                            this.binder.ChannelParameters,
+//                            callback, state);
+
+//                        this.state = State.ChannelOpening;
+//                        getChannel = true;
+//                    }
+//                }
+
+//                if (faulted)
+//                {
+//                    this.binder.Fault(null);
+//                }
+
+//                if (waiter == null)
+//                {
+//                    return new CompletedAsyncResult<TChannel>(channel, callback, state);
+//                }
+
+//                if (getChannel)
+//                {
+//                    waiter.GetChannel(true);
+//                }
+//                else
+//                {
+//                    waiter.Wait();
+//                }
+
+//                return waiter;
+//            }
+
+//            public IAsyncResult BeginWaitForPendingOperations(TimeSpan timeout,
+//                AsyncCallback callback, object state)
+//            {
+//                lock (this.ThisLock)
+//                {
+//                    if (this.drainEvent != null)
+//                    {
+//                        throw Fx.AssertAndThrow("The WaitForPendingOperations operation may only be invoked once.");
+//                    }
+
+//                    if (this.count > 0)
+//                    {
+//                        this.drainEvent = new InterruptibleWaitObject(false, false);
+//                    }
+//                }
+
+//                if (this.drainEvent != null)
+//                {
+//                    return this.drainEvent.BeginWait(timeout, callback, state);
+//                }
+//                else
+//                {
+//                    return new SynchronizerCompletedAsyncResult(callback, state);
+//                }
+//            }
+
+//            bool CompleteSetChannel(IWaiter waiter, out TChannel channel)
+//            {
+//                if (waiter == null)
+//                {
+//                    throw Fx.AssertAndThrow("Argument waiter cannot be null.");
+//                }
+
+//                bool close = false;
+
+//                lock (this.ThisLock)
+//                {
+//                    if (this.ValidateOpened())
+//                    {
+//                        channel = this.currentChannel;
+//                        return true;
+//                    }
+//                    else
+//                    {
+//                        channel = null;
+//                        close = this.state == State.Closed;
+//                    }
+//                }
+
+//                if (close)
+//                {
+//                    waiter.Close();
+//                }
+//                else
+//                {
+//                    waiter.Fault();
+//                }
+
+//                return false;
+//            }
+
+//            public bool EndTryGetChannel(IAsyncResult result, out TChannel channel)
+//            {
+//                AsyncWaiter waiter = result as AsyncWaiter;
+
+//                if (waiter != null)
+//                {
+//                    return waiter.End(out channel);
+//                }
+//                else
+//                {
+//                    channel = CompletedAsyncResult<TChannel>.End(result);
+//                    return true;
+//                }
+//            }
+
+//            public void EndWaitForPendingOperations(IAsyncResult result)
+//            {
+//                SynchronizerCompletedAsyncResult completedResult =
+//                    result as SynchronizerCompletedAsyncResult;
+
+//                if (completedResult != null)
+//                {
+//                    completedResult.End();
+//                }
+//                else
+//                {
+//                    this.drainEvent.EndWait(result);
+//                }
+//            }
+
+//            // Client API only.
+//            public bool EnsureChannel()
+//            {
+//                bool fault = false;
+
+//                lock (this.ThisLock)
+//                {
+//                    if (this.ValidateOpened())
+//                    {
+//                        // This is called only during the RM CS phase. In this phase, there are 2
+//                        // valid states between Request calls, ChannelOpened and NoChannel.
+//                        if (this.state == State.ChannelOpened)
+//                        {
+//                            return true;
+//                        }
+
+//                        if (this.state != State.NoChannel)
+//                        {
+//                            throw Fx.AssertAndThrow("The caller may only invoke this EnsureChannel during the CreateSequence negotiation. ChannelOpening and ChannelClosing are invalid states during this phase of the negotiation.");
+//                        }
+
+//                        if (!this.tolerateFaults)
+//                        {
+//                            fault = true;
+//                        }
+//                        else
+//                        {
+//                            if (this.GetCurrentChannelIfCreated() != null)
+//                            {
+//                                return true;
+//                            }
+
+//                            if (this.binder.TryGetChannel(TimeSpan.Zero))
+//                            {
+//                                if (this.currentChannel == null)
+//                                {
+//                                    return false;
+//                                }
+
+//                                return true;
+//                            }
+//                        }
+//                    }
+//                }
+
+//                if (fault)
+//                {
+//                    this.binder.Fault(null);
+//                }
+
+//                return false;
+//            }
+
+//            IWaiter GetChannelWaiter()
+//            {
+//                if ((this.getChannelQueue == null) || (this.getChannelQueue.Count == 0))
+//                {
+//                    return null;
+//                }
+
+//                return this.getChannelQueue.Dequeue();
+//            }
+
+//            // Must be called within lock (this.ThisLock)
+//            TChannel GetCurrentChannelIfCreated()
+//            {
+//                if (this.state != State.NoChannel)
+//                {
+//                    throw Fx.AssertAndThrow("This method may only be called in the NoChannel state.");
+//                }
+
+//                if ((this.currentChannel != null)
+//                    && (this.currentChannel.State == CommunicationState.Created))
+//                {
+//                    return this.currentChannel;
+//                }
+//                else
+//                {
+//                    return null;
+//                }
+//            }
+
+//            Queue<IWaiter> GetQueue(bool canGetChannel)
+//            {
+//                if (canGetChannel)
+//                {
+//                    if (this.getChannelQueue == null)
+//                    {
+//                        this.getChannelQueue = new Queue<IWaiter>();
+//                    }
+
+//                    return this.getChannelQueue;
+//                }
+//                else
+//                {
+//                    if (this.waitQueue == null)
+//                    {
+//                        this.waitQueue = new Queue<IWaiter>();
+//                    }
+
+//                    return this.waitQueue;
+//                }
+//            }
+
+//            void OnChannelFaulted(object sender, EventArgs e)
+//            {
+//                TChannel faultedChannel = (TChannel)sender;
+//                bool faultBinder = false;
+//                bool raiseInnerChannelFaulted = false;
+
+//                lock (this.ThisLock)
+//                {
+//                    if (this.currentChannel != faultedChannel)
+//                    {
+//                        return;
+//                    }
+
+//                    // The synchronizer is already closed or aborted.
+//                    if (!this.ValidateOpened())
+//                    {
+//                        return;
+//                    }
+
+//                    if (this.state == State.ChannelOpened)
+//                    {
+//                        if (this.count == 0)
+//                        {
+//                            faultedChannel.Faulted -= this.onChannelFaulted;
+//                        }
+
+//                        faultBinder = !this.tolerateFaults;
+//                        this.state = State.ChannelClosing;
+//                        this.innerChannelFaulted = true;
+
+//                        if (!faultBinder && this.count == 0)
+//                        {
+//                            this.state = State.NoChannel;
+//                            this.aborting = false;
+//                            raiseInnerChannelFaulted = true;
+//                            this.innerChannelFaulted = false;
+//                        }
+//                    }
+//                }
+
+//                if (faultBinder)
+//                {
+//                    this.binder.Fault(null);
+//                }
+
+//                faultedChannel.Abort();
+
+//                if (raiseInnerChannelFaulted)
+//                {
+//                    this.binder.OnInnerChannelFaulted();
+//                }
+//            }
+
+//            bool OnChannelOpened(IWaiter waiter)
+//            {
+//                if (waiter == null)
+//                {
+//                    throw Fx.AssertAndThrow("Argument waiter cannot be null.");
+//                }
+
+//                bool close = false;
+//                bool fault = false;
+
+//                Queue<IWaiter> temp1 = null;
+//                Queue<IWaiter> temp2 = null;
+//                TChannel channel = null;
+
+//                lock (this.ThisLock)
+//                {
+//                    if (this.currentChannel == null)
+//                    {
+//                        throw Fx.AssertAndThrow("Caller must ensure that field currentChannel is set before opening the channel.");
+//                    }
+
+//                    if (this.ValidateOpened())
+//                    {
+//                        if (this.state != State.ChannelOpening)
+//                        {
+//                            throw Fx.AssertAndThrow("This method may only be called in the ChannelOpening state.");
+//                        }
+
+//                        this.state = State.ChannelOpened;
+//                        this.SetTolerateFaults();
+
+//                        this.count += 1;
+//                        this.count += (this.getChannelQueue == null) ? 0 : this.getChannelQueue.Count;
+//                        this.count += (this.waitQueue == null) ? 0 : this.waitQueue.Count;
+
+//                        temp1 = this.getChannelQueue;
+//                        temp2 = this.waitQueue;
+//                        channel = this.currentChannel;
+
+//                        this.getChannelQueue = null;
+//                        this.waitQueue = null;
+//                    }
+//                    else
+//                    {
+//                        close = this.state == State.Closed;
+//                        fault = this.state == State.Faulted;
+//                    }
+//                }
+
+//                if (close)
+//                {
+//                    waiter.Close();
+//                    return false;
+//                }
+//                else if (fault)
+//                {
+//                    waiter.Fault();
+//                    return false;
+//                }
+
+//                this.SetWaiters(temp1, channel);
+//                this.SetWaiters(temp2, channel);
+//                return true;
+//            }
+
+//            void OnGetChannelFailed()
+//            {
+//                IWaiter waiter = null;
+
+//                lock (this.ThisLock)
+//                {
+//                    if (!this.ValidateOpened())
+//                    {
+//                        return;
+//                    }
+
+//                    if (this.state != State.ChannelOpening)
+//                    {
+//                        throw Fx.AssertAndThrow("The state must be set to ChannelOpening before the caller attempts to open the channel.");
+//                    }
+
+//                    waiter = this.GetChannelWaiter();
+
+//                    if (waiter == null)
+//                    {
+//                        this.state = State.NoChannel;
+//                        return;
+//                    }
+//                }
+
+//                if (waiter is SyncWaiter)
+//                {
+//                    waiter.GetChannel(false);
+//                }
+//                else
+//                {
+//                    ActionItem.Schedule(asyncGetChannelCallback, waiter);
+//                }
+//            }
+
+//            public void OnReadEof()
+//            {
+//                lock (this.ThisLock)
+//                {
+//                    if (this.count <= 0)
+//                    {
+//                        throw Fx.AssertAndThrow("Caller must ensure that OnReadEof is called before ReturnChannel.");
+//                    }
+
+//                    if (this.ValidateOpened())
+//                    {
+//                        if ((this.state != State.ChannelOpened) && (this.state != State.ChannelClosing))
+//                        {
+//                            throw Fx.AssertAndThrow("Since count is positive, the only valid states are ChannelOpened and ChannelClosing.");
+//                        }
+
+//                        if (this.currentChannel.State != CommunicationState.Faulted)
+//                        {
+//                            this.state = State.ChannelClosing;
+//                        }
+//                    }
+//                }
+//            }
+
+//            bool RemoveWaiter(IWaiter waiter)
+//            {
+//                Queue<IWaiter> waiters = waiter.CanGetChannel ? this.getChannelQueue : this.waitQueue;
+//                bool removed = false;
+
+//                lock (this.ThisLock)
+//                {
+//                    if (!this.ValidateOpened())
+//                    {
+//                        return false;
+//                    }
+
+//                    for (int i = waiters.Count; i > 0; i--)
+//                    {
+//                        IWaiter temp = waiters.Dequeue();
+
+//                        if (object.ReferenceEquals(waiter, temp))
+//                        {
+//                            removed = true;
+//                        }
+//                        else
+//                        {
+//                            waiters.Enqueue(temp);
+//                        }
+//                    }
+//                }
+
+//                return removed;
+//            }
+
+//            public void ReturnChannel()
+//            {
+//                TChannel channel = null;
+//                IWaiter waiter = null;
+//                bool faultBinder = false;
+//                bool drained;
+//                bool raiseInnerChannelFaulted = false;
+
+//                lock (this.ThisLock)
+//                {
+//                    if (this.count <= 0)
+//                    {
+//                        throw Fx.AssertAndThrow("Method ReturnChannel() can only be called after TryGetChannel or EndTryGetChannel returns a channel.");
+//                    }
+
+//                    this.count--;
+//                    drained = (this.count == 0) && (this.drainEvent != null);
+
+//                    if (this.ValidateOpened())
+//                    {
+//                        if ((this.state != State.ChannelOpened) && (this.state != State.ChannelClosing))
+//                        {
+//                            throw Fx.AssertAndThrow("ChannelOpened and ChannelClosing are the only 2 valid states when count is positive.");
+//                        }
+
+//                        if (this.currentChannel.State == CommunicationState.Faulted)
+//                        {
+//                            faultBinder = !this.tolerateFaults;
+//                            this.innerChannelFaulted = true;
+//                            this.state = State.ChannelClosing;
+//                        }
+
+//                        if (!faultBinder && (this.state == State.ChannelClosing) && (this.count == 0))
+//                        {
+//                            channel = this.currentChannel;
+//                            raiseInnerChannelFaulted = this.innerChannelFaulted;
+//                            this.innerChannelFaulted = false;
+
+//                            this.state = State.NoChannel;
+//                            this.aborting = false;
+
+//                            waiter = this.GetChannelWaiter();
+
+//                            if (waiter != null)
+//                            {
+//                                this.state = State.ChannelOpening;
+//                            }
+//                        }
+//                    }
+//                }
+
+//                if (faultBinder)
+//                {
+//                    this.binder.Fault(null);
+//                }
+
+//                if (drained)
+//                {
+//                    this.drainEvent.Set();
+//                }
+
+//                if (channel != null)
+//                {
+//                    channel.Faulted -= this.onChannelFaulted;
+
+//                    if (channel.State == CommunicationState.Opened)
+//                    {
+//                        this.binder.CloseChannel(channel);
+//                    }
+//                    else
+//                    {
+//                        channel.Abort();
+//                    }
+
+//                    if (waiter != null)
+//                    {
+//                        waiter.GetChannel(false);
+//                    }
+//                }
+
+//                if (raiseInnerChannelFaulted)
+//                {
+//                    this.binder.OnInnerChannelFaulted();
+//                }
+//            }
+
+//            public bool SetChannel(TChannel channel)
+//            {
+//                lock (this.ThisLock)
+//                {
+//                    if (this.state != State.ChannelOpening && this.state != State.NoChannel)
+//                    {
+//                        throw Fx.AssertAndThrow("SetChannel is only valid in the NoChannel and ChannelOpening states");
+//                    }
+
+//                    if (!this.tolerateFaults)
+//                    {
+//                        throw Fx.AssertAndThrow("SetChannel is only valid when masking faults");
+//                    }
+
+//                    if (this.ValidateOpened())
+//                    {
+//                        this.currentChannel = channel;
+//                        return true;
+//                    }
+//                    else
+//                    {
+//                        return false;
+//                    }
+//                }
+//            }
+
+//            void SetTolerateFaults()
+//            {
+//                if (this.faultMode == TolerateFaultsMode.Never)
+//                {
+//                    this.tolerateFaults = false;
+//                }
+//                else if (this.faultMode == TolerateFaultsMode.IfNotSecuritySession)
+//                {
+//                    this.tolerateFaults = !this.binder.HasSecuritySession(this.currentChannel);
+//                }
+
+//                if (this.onChannelFaulted == null)
+//                {
+//                    this.onChannelFaulted = new EventHandler(this.OnChannelFaulted);
+//                }
+
+//                this.currentChannel.Faulted += this.onChannelFaulted;
+//            }
+
+//            void SetWaiters(Queue<IWaiter> waiters, TChannel channel)
+//            {
+//                if ((waiters != null) && (waiters.Count > 0))
+//                {
+//                    foreach (IWaiter waiter in waiters)
+//                    {
+//                        waiter.Set(channel);
+//                    }
+//                }
+//            }
+
+//            public void StartSynchronizing()
+//            {
+//                lock (this.ThisLock)
+//                {
+//                    if (this.state == State.Created)
+//                    {
+//                        this.state = State.NoChannel;
+//                    }
+//                    else
+//                    {
+//                        if (this.state != State.Closed)
+//                        {
+//                            throw Fx.AssertAndThrow("Abort is the only operation that can race with Open.");
+//                        }
+
+//                        return;
+//                    }
+
+//                    if (this.currentChannel == null)
+//                    {
+//                        if (!this.binder.TryGetChannel(TimeSpan.Zero))
+//                        {
+//                            return;
+//                        }
+//                    }
+
+//                    if (this.currentChannel == null)
+//                    {
+//                        return;
+//                    }
+
+//                    if (!this.binder.MustOpenChannel)
+//                    {
+//                        // Channel is already opened.
+//                        this.state = State.ChannelOpened;
+//                        this.SetTolerateFaults();
+//                    }
+//                }
+//            }
+
+//            public TChannel StopSynchronizing(bool close)
+//            {
+//                lock (this.ThisLock)
+//                {
+//                    if ((this.state != State.Faulted) && (this.state != State.Closed))
+//                    {
+//                        this.state = close ? State.Closed : State.Faulted;
+
+//                        if ((this.currentChannel != null) && (this.onChannelFaulted != null))
+//                        {
+//                            this.currentChannel.Faulted -= this.onChannelFaulted;
+//                        }
+//                    }
+
+//                    return this.currentChannel;
+//                }
+//            }
+
+//            // Must be called under a lock.
+//            bool ThrowIfNecessary(MaskingMode maskingMode)
+//            {
+//                if (this.ValidateOpened())
+//                {
+//                    return true;
+//                }
+
+//                // state is Closed or Faulted.
+//                Exception e;
+
+//                if (this.state == State.Closed)
+//                {
+//                    e = this.binder.GetClosedException(maskingMode);
+//                }
+//                else
+//                {
+//                    e = this.binder.GetFaultedException(maskingMode);
+//                }
+
+//                if (e != null)
+//                {
+//                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(e);
+//                }
+
+//                return false;
+//            }
+
+//            public bool TryGetChannelForInput(bool canGetChannel, TimeSpan timeout,
+//                out TChannel channel)
+//            {
+//                return this.TryGetChannel(canGetChannel, false, timeout, MaskingMode.All,
+//                    out channel);
+//            }
+
+//            public bool TryGetChannelForOutput(TimeSpan timeout, MaskingMode maskingMode,
+//                out TChannel channel)
+//            {
+//                return this.TryGetChannel(true, true, timeout, maskingMode, out channel);
+//            }
+
+//            bool TryGetChannel(bool canGetChannel, bool canCauseFault, TimeSpan timeout,
+//                MaskingMode maskingMode, out TChannel channel)
+//            {
+//                SyncWaiter waiter = null;
+//                bool faulted = false;
+//                bool getChannel = false;
+
+//                lock (this.ThisLock)
+//                {
+//                    if (!this.ThrowIfNecessary(maskingMode))
+//                    {
+//                        channel = null;
+//                        return true;
+//                    }
+
+//                    if (this.state == State.ChannelOpened)
+//                    {
+//                        if (this.currentChannel == null)
+//                        {
+//                            throw Fx.AssertAndThrow("Field currentChannel cannot be null in the ChannelOpened state.");
+//                        }
+
+//                        this.count++;
+//                        channel = this.currentChannel;
+//                        return true;
+//                    }
+
+//                    if (!this.tolerateFaults
+//                        && ((this.state == State.ChannelClosing)
+//                        || (this.state == State.NoChannel)))
+//                    {
+//                        if (!canCauseFault)
+//                        {
+//                            channel = null;
+//                            return true;
+//                        }
+
+//                        faulted = true;
+//                    }
+//                    else if (!canGetChannel
+//                        || (this.state == State.ChannelOpening)
+//                        || (this.state == State.ChannelClosing))
+//                    {
+//                        waiter = new SyncWaiter(this, canGetChannel, null, timeout, maskingMode, this.binder.ChannelParameters);
+//                        this.GetQueue(canGetChannel).Enqueue(waiter);
+//                    }
+//                    else
+//                    {
+//                        if (this.state != State.NoChannel)
+//                        {
+//                            throw Fx.AssertAndThrow("The state must be NoChannel.");
+//                        }
+
+//                        waiter = new SyncWaiter(this, canGetChannel,
+//                            this.GetCurrentChannelIfCreated(), timeout, maskingMode,
+//                            this.binder.ChannelParameters);
+
+//                        this.state = State.ChannelOpening;
+//                        getChannel = true;
+//                    }
+//                }
+
+//                if (faulted)
+//                {
+//                    this.binder.Fault(null);
+//                    channel = null;
+//                    return true;
+//                }
+
+//                if (getChannel)
+//                {
+//                    waiter.GetChannel(true);
+//                }
+
+//                return waiter.TryWait(out channel);
+//            }
+
+//            public void UnblockWaiters()
+//            {
+//                Queue<IWaiter> temp1;
+//                Queue<IWaiter> temp2;
+
+//                lock (this.ThisLock)
+//                {
+//                    temp1 = this.getChannelQueue;
+//                    temp2 = this.waitQueue;
+
+//                    this.getChannelQueue = null;
+//                    this.waitQueue = null;
+//                }
+
+//                bool close = this.state == State.Closed;
+//                this.UnblockWaiters(temp1, close);
+//                this.UnblockWaiters(temp2, close);
+//            }
+
+//            void UnblockWaiters(Queue<IWaiter> waiters, bool close)
+//            {
+//                if ((waiters != null) && (waiters.Count > 0))
+//                {
+//                    foreach (IWaiter waiter in waiters)
+//                    {
+//                        if (close)
+//                        {
+//                            waiter.Close();
+//                        }
+//                        else
+//                        {
+//                            waiter.Fault();
+//                        }
+//                    }
+//                }
+//            }
+
+//            bool ValidateOpened()
+//            {
+//                if (this.state == State.Created)
+//                {
+//                    throw Fx.AssertAndThrow("This operation expects that the synchronizer has been opened.");
+//                }
+
+//                return (this.state != State.Closed) && (this.state != State.Faulted);
+//            }
+
+//            public void WaitForPendingOperations(TimeSpan timeout)
+//            {
+//                lock (this.ThisLock)
+//                {
+//                    if (this.drainEvent != null)
+//                    {
+//                        throw Fx.AssertAndThrow("The WaitForPendingOperations operation may only be invoked once.");
+//                    }
+
+//                    if (this.count > 0)
+//                    {
+//                        this.drainEvent = new InterruptibleWaitObject(false, false);
+//                    }
+//                }
+
+//                if (this.drainEvent != null)
+//                {
+//                    this.drainEvent.Wait(timeout);
+//                }
+//            }
+
+//            enum State
+//            {
+//                Created,
+//                NoChannel,
+//                ChannelOpening,
+//                ChannelOpened,
+//                ChannelClosing,
+//                Faulted,
+//                Closed
+//            }
+
+//            public interface IWaiter
+//            {
+//                bool CanGetChannel { get; }
+
+//                void Close();
+//                void Fault();
+//                void GetChannel(bool onUserThread);
+//                void Set(TChannel channel);
+//            }
+
+//            public sealed class AsyncWaiter : AsyncResult, IWaiter
+//            {
+//                bool canGetChannel;
+//                TChannel channel;
+//                ChannelParameterCollection channelParameters;
+//                bool isSynchronous = true;
+//                MaskingMode maskingMode;
+//                static AsyncCallback onOpenComplete = Fx.ThunkCallback(new AsyncCallback(OnOpenComplete));
+//                static Action<object> onTimeoutElapsed = new Action<object>(OnTimeoutElapsed);
+//                static AsyncCallback onTryGetChannelComplete = Fx.ThunkCallback(new AsyncCallback(OnTryGetChannelComplete));
+//                bool timedOut = false;
+//                ChannelSynchronizer synchronizer;
+//                TimeoutHelper timeoutHelper;
+//                IOThreadTimer timer;
+//                bool timerCancelled = false;
+
+//                public AsyncWaiter(ChannelSynchronizer synchronizer, bool canGetChannel,
+//                    TChannel channel, TimeSpan timeout, MaskingMode maskingMode,
+//                    ChannelParameterCollection channelParameters,
+//                    AsyncCallback callback, object state)
+//                    : base(callback, state)
+//                {
+//                    if (!canGetChannel)
+//                    {
+//                        if (channel != null)
+//                        {
+//                            throw Fx.AssertAndThrow("This waiter must wait for a channel thus argument channel must be null.");
+//                        }
+//                    }
+
+//                    this.synchronizer = synchronizer;
+//                    this.canGetChannel = canGetChannel;
+//                    this.channel = channel;
+//                    this.timeoutHelper = new TimeoutHelper(timeout);
+//                    this.maskingMode = maskingMode;
+//                    this.channelParameters = channelParameters;
+//                }
+
+//                public bool CanGetChannel
+//                {
+//                    get
+//                    {
+//                        return this.canGetChannel;
+//                    }
+//                }
+
+//                object ThisLock
+//                {
+//                    get
+//                    {
+//                        return this;
+//                    }
+//                }
+
+//                void CancelTimer()
+//                {
+//                    lock (this.ThisLock)
+//                    {
+//                        if (!this.timerCancelled)
+//                        {
+//                            if (this.timer != null)
+//                            {
+//                                this.timer.Cancel();
+//                            }
+
+//                            this.timerCancelled = true;
+//                        }
+//                    }
+//                }
+
+//                public void Close()
+//                {
+//                    this.CancelTimer();
+//                    this.channel = null;
+//                    this.Complete(false,
+//                        this.synchronizer.binder.GetClosedException(this.maskingMode));
+//                }
+
+//                bool CompleteOpen(IAsyncResult result)
+//                {
+//                    this.channel.EndOpen(result);
+//                    return this.OnChannelOpened();
+//                }
+
+//                bool CompleteTryGetChannel(IAsyncResult result)
+//                {
+//                    if (!this.synchronizer.binder.EndTryGetChannel(result))
+//                    {
+//                        this.timedOut = true;
+//                        this.OnGetChannelFailed();
+//                        return true;
+//                    }
+
+//                    if (!this.synchronizer.CompleteSetChannel(this, out this.channel))
+//                    {
+//                        if (!this.IsCompleted)
+//                        {
+//                            throw Fx.AssertAndThrow("CompleteSetChannel must complete the IWaiter if it returns false.");
+//                        }
+
+//                        return false;
+//                    }
+
+//                    return this.OpenChannel();
+//                }
+
+//                public bool End(out TChannel channel)
+//                {
+//                    AsyncResult.End<AsyncWaiter>(this);
+//                    channel = this.channel;
+//                    return !this.timedOut;
+//                }
+
+//                public void Fault()
+//                {
+//                    this.CancelTimer();
+//                    this.channel = null;
+//                    this.Complete(false,
+//                        this.synchronizer.binder.GetFaultedException(this.maskingMode));
+//                }
+
+//                bool GetChannel()
+//                {
+//                    if (this.channel != null)
+//                    {
+//                        return this.OpenChannel();
+//                    }
+//                    else
+//                    {
+//                        IAsyncResult result = this.synchronizer.binder.BeginTryGetChannel(
+//                            this.timeoutHelper.RemainingTime(), onTryGetChannelComplete, this);
+
+//                        if (result.CompletedSynchronously)
+//                        {
+//                            return this.CompleteTryGetChannel(result);
+//                        }
+//                    }
+
+//                    return false;
+//                }
+
+//                public void GetChannel(bool onUserThread)
+//                {
+//                    if (!this.CanGetChannel)
+//                    {
+//                        throw Fx.AssertAndThrow("This waiter must wait for a channel thus the caller cannot attempt to get a channel.");
+//                    }
+
+//                    this.isSynchronous = onUserThread;
+
+//                    if (onUserThread)
+//                    {
+//                        bool throwing = true;
+
+//                        try
+//                        {
+//                            if (this.GetChannel())
+//                            {
+//                                this.Complete(true);
+//                            }
+
+//                            throwing = false;
+//                        }
+//                        finally
+//                        {
+//                            if (throwing)
+//                            {
+//                                this.OnGetChannelFailed();
+//                            }
+//                        }
+//                    }
+//                    else
+//                    {
+//                        bool complete = false;
+//                        Exception completeException = null;
+
+//                        try
+//                        {
+//                            this.CancelTimer();
+//                            complete = this.GetChannel();
+//                        }
+//#pragma warning suppress 56500 // covered by FxCOP
+//                        catch (Exception e)
+//                        {
+//                            if (Fx.IsFatal(e))
+//                            {
+//                                throw;
+//                            }
+
+//                            this.OnGetChannelFailed();
+//                            completeException = e;
+//                        }
+
+//                        if (complete || completeException != null)
+//                        {
+//                            this.Complete(false, completeException);
+//                        }
+//                    }
+//                }
+
+//                bool OnChannelOpened()
+//                {
+//                    if (this.synchronizer.OnChannelOpened(this))
+//                    {
+//                        return true;
+//                    }
+//                    else
+//                    {
+//                        if (!this.IsCompleted)
+//                        {
+//                            throw Fx.AssertAndThrow("OnChannelOpened must complete the IWaiter if it returns false.");
+//                        }
+
+//                        return false;
+//                    }
+//                }
+
+//                void OnGetChannelFailed()
+//                {
+//                    if (this.channel != null)
+//                    {
+//                        this.channel.Abort();
+//                    }
+
+//                    this.synchronizer.OnGetChannelFailed();
+//                }
+
+//                static void OnOpenComplete(IAsyncResult result)
+//                {
+//                    if (!result.CompletedSynchronously)
+//                    {
+//                        AsyncWaiter waiter = (AsyncWaiter)result.AsyncState;
+//                        bool complete = false;
+//                        Exception completeException = null;
+
+//                        waiter.isSynchronous = false;
+
+//                        try
+//                        {
+//                            complete = waiter.CompleteOpen(result);
+//                        }
+//#pragma warning suppress 56500 // covered by FxCOP
+//                        catch (Exception e)
+//                        {
+//                            if (Fx.IsFatal(e))
+//                            {
+//                                throw;
+//                            }
+
+//                            completeException = e;
+//                        }
+
+//                        if (complete)
+//                        {
+//                            waiter.Complete(false);
+//                        }
+//                        else if (completeException != null)
+//                        {
+//                            waiter.OnGetChannelFailed();
+//                            waiter.Complete(false, completeException);
+//                        }
+//                    }
+//                }
+
+//                void OnTimeoutElapsed()
+//                {
+//                    if (this.synchronizer.RemoveWaiter(this))
+//                    {
+//                        this.timedOut = true;
+//                        this.Complete(this.isSynchronous, null);
+//                    }
+//                }
+
+//                static void OnTimeoutElapsed(object state)
+//                {
+//                    AsyncWaiter waiter = (AsyncWaiter)state;
+//                    waiter.isSynchronous = false;
+//                    waiter.OnTimeoutElapsed();
+//                }
+
+//                static void OnTryGetChannelComplete(IAsyncResult result)
+//                {
+//                    if (!result.CompletedSynchronously)
+//                    {
+//                        AsyncWaiter waiter = (AsyncWaiter)result.AsyncState;
+//                        waiter.isSynchronous = false;
+//                        bool complete = false;
+//                        Exception completeException = null;
+
+//                        try
+//                        {
+//                            complete = waiter.CompleteTryGetChannel(result);
+//                        }
+//#pragma warning suppress 56500 // covered by FxCOP
+//                        catch (Exception e)
+//                        {
+//                            if (Fx.IsFatal(e))
+//                            {
+//                                throw;
+//                            }
+
+//                            completeException = e;
+//                        }
+
+//                        if (complete || completeException != null)
+//                        {
+//                            if (completeException != null)
+//                                waiter.OnGetChannelFailed();
+//                            waiter.Complete(waiter.isSynchronous, completeException);
+//                        }
+//                    }
+//                }
+
+//                bool OpenChannel()
+//                {
+//                    if (this.synchronizer.binder.MustOpenChannel)
+//                    {
+//                        if (this.channelParameters != null)
+//                        {
+//                            this.channelParameters.PropagateChannelParameters(this.channel);
+//                        }
+
+//                        IAsyncResult result = this.channel.BeginOpen(
+//                            this.timeoutHelper.RemainingTime(), onOpenComplete, this);
+
+//                        if (result.CompletedSynchronously)
+//                        {
+//                            return this.CompleteOpen(result);
+//                        }
+
+//                        return false;
+//                    }
+//                    else
+//                    {
+//                        return this.OnChannelOpened();
+//                    }
+//                }
+
+//                public void Set(TChannel channel)
+//                {
+//                    this.CancelTimer();
+//                    this.channel = channel;
+//                    this.Complete(false);
+//                }
+
+//                // Always called from the user's thread.
+//                public void Wait()
+//                {
+//                    lock (this.ThisLock)
+//                    {
+//                        if (this.timerCancelled)
+//                        {
+//                            return;
+//                        }
+
+//                        TimeSpan timeout = this.timeoutHelper.RemainingTime();
+
+//                        if (timeout > TimeSpan.Zero)
+//                        {
+//                            this.timer = new IOThreadTimer(onTimeoutElapsed, this, true);
+//                            this.timer.Set(this.timeoutHelper.RemainingTime());
+//                            return;
+//                        }
+//                    }
+
+//                    this.OnTimeoutElapsed();
+//                }
+//            }
+
+//            sealed class SynchronizerCompletedAsyncResult : CompletedAsyncResult
+//            {
+//                public SynchronizerCompletedAsyncResult(AsyncCallback callback, object state)
+//                    : base(callback, state)
+//                {
+//                }
+
+//                public void End()
+//                {
+//                    CompletedAsyncResult.End(this);
+//                }
+//            }
+
+//            sealed class SyncWaiter : IWaiter
+//            {
+//                bool canGetChannel;
+//                TChannel channel;
+//                ChannelParameterCollection channelParameters;
+//                AutoResetEvent completeEvent = new AutoResetEvent(false);
+//                Exception exception;
+//                bool getChannel = false;
+//                MaskingMode maskingMode;
+//                ChannelSynchronizer synchronizer;
+//                TimeoutHelper timeoutHelper;
+
+//                public SyncWaiter(ChannelSynchronizer synchronizer, bool canGetChannel,
+//                    TChannel channel, TimeSpan timeout, MaskingMode maskingMode,
+//                    ChannelParameterCollection channelParameters)
+//                {
+//                    if (!canGetChannel)
+//                    {
+//                        if (channel != null)
+//                        {
+//                            throw Fx.AssertAndThrow("This waiter must wait for a channel thus argument channel must be null.");
+//                        }
+//                    }
+
+//                    this.synchronizer = synchronizer;
+//                    this.canGetChannel = canGetChannel;
+//                    this.channel = channel;
+//                    this.timeoutHelper = new TimeoutHelper(timeout);
+//                    this.maskingMode = maskingMode;
+//                    this.channelParameters = channelParameters;
+//                }
+
+//                public bool CanGetChannel
+//                {
+//                    get
+//                    {
+//                        return this.canGetChannel;
+//                    }
+//                }
+
+//                public void Close()
+//                {
+//                    this.exception = this.synchronizer.binder.GetClosedException(this.maskingMode);
+//                    this.completeEvent.Set();
+//                }
+
+//                public void Fault()
+//                {
+//                    this.exception = this.synchronizer.binder.GetFaultedException(this.maskingMode);
+//                    this.completeEvent.Set();
+//                }
+
+//                public void GetChannel(bool onUserThread)
+//                {
+//                    if (!this.CanGetChannel)
+//                    {
+//                        throw Fx.AssertAndThrow("This waiter must wait for a channel thus the caller cannot attempt to get a channel.");
+//                    }
+
+//                    this.getChannel = true;
+//                    this.completeEvent.Set();
+//                }
+
+//                public void Set(TChannel channel)
+//                {
+//                    if (channel == null)
+//                    {
+//                        throw Fx.AssertAndThrow("Argument channel cannot be null. Caller must call Fault or Close instead.");
+//                    }
+
+//                    this.channel = channel;
+//                    this.completeEvent.Set();
+//                }
+
+//                bool TryGetChannel()
+//                {
+//                    TChannel channel;
+
+//                    if (this.channel != null)
+//                    {
+//                        channel = this.channel;
+//                    }
+//                    else if (this.synchronizer.binder.TryGetChannel(
+//                        this.timeoutHelper.RemainingTime()))
+//                    {
+//                        if (!this.synchronizer.CompleteSetChannel(this, out channel))
+//                        {
+//                            return true;
+//                        }
+//                    }
+//                    else
+//                    {
+//                        this.synchronizer.OnGetChannelFailed();
+//                        return false;
+//                    }
+
+//                    if (this.synchronizer.binder.MustOpenChannel)
+//                    {
+//                        bool throwing = true;
+
+//                        if (this.channelParameters != null)
+//                        {
+//                            this.channelParameters.PropagateChannelParameters(channel);
+//                        }
+
+//                        try
+//                        {
+//                            channel.Open(this.timeoutHelper.RemainingTime());
+//                            throwing = false;
+//                        }
+//                        finally
+//                        {
+//                            if (throwing)
+//                            {
+//                                channel.Abort();
+//                                this.synchronizer.OnGetChannelFailed();
+//                            }
+//                        }
+//                    }
+
+//                    if (this.synchronizer.OnChannelOpened(this))
+//                    {
+//                        this.Set(channel);
+//                    }
+
+//                    return true;
+//                }
+
+//                public bool TryWait(out TChannel channel)
+//                {
+//                    if (!this.Wait())
+//                    {
+//                        channel = null;
+//                        return false;
+//                    }
+//                    else if (this.getChannel && !this.TryGetChannel())
+//                    {
+//                        channel = null;
+//                        return false;
+//                    }
+
+//                    this.completeEvent.Close();
+
+//                    if (this.exception != null)
+//                    {
+//                        if (this.channel != null)
+//                        {
+//                            throw Fx.AssertAndThrow("User of IWaiter called both Set and Fault or Close.");
+//                        }
+
+//                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(this.exception);
+//                    }
+
+//                    channel = this.channel;
+//                    return true;
+//                }
+
+//                bool Wait()
+//                {
+//                    if (!TimeoutHelper.WaitOne(this.completeEvent, this.timeoutHelper.RemainingTime()))
+//                    {
+//                        if (this.synchronizer.RemoveWaiter(this))
+//                        {
+//                            return false;
+//                        }
+//                        else
+//                        {
+//                            TimeoutHelper.WaitOne(this.completeEvent, TimeSpan.MaxValue);
+//                        }
+//                    }
+
+//                    return true;
+//                }
+//            }
+//        }
+
+//        sealed class CloseAsyncResult : AsyncResult
+//        {
+//            ReliableChannelBinder<TChannel> binder;
+//            TChannel channel;
+//            MaskingMode maskingMode;
+//            static AsyncCallback onBinderCloseComplete = Fx.ThunkCallback(new AsyncCallback(OnBinderCloseComplete));
+//            static AsyncCallback onChannelCloseComplete = Fx.ThunkCallback(new AsyncCallback(OnChannelCloseComplete));
+//            TimeoutHelper timeoutHelper;
+
+//            public CloseAsyncResult(ReliableChannelBinder<TChannel> binder, TChannel channel,
+//                TimeSpan timeout, MaskingMode maskingMode, AsyncCallback callback, object state)
+//                : base(callback, state)
+//            {
+//                this.binder = binder;
+//                this.channel = channel;
+//                this.timeoutHelper = new TimeoutHelper(timeout);
+//                this.maskingMode = maskingMode;
+//                bool complete = false;
+
+//                try
+//                {
+//                    this.binder.OnShutdown();
+//                    IAsyncResult result = this.binder.OnBeginClose(timeout, onBinderCloseComplete, this);
+
+//                    if (result.CompletedSynchronously)
+//                    {
+//                        complete = this.CompleteBinderClose(true, result);
+//                    }
+//                }
+//                catch (Exception e)
+//                {
+//                    if (Fx.IsFatal(e))
+//                    {
+//                        throw;
+//                    }
+
+//                    this.binder.Abort();
+
+//                    if (!this.binder.HandleException(e, this.maskingMode))
+//                    {
+//                        throw;
+//                    }
+//                    else
+//                    {
+//                        complete = true;
+//                    }
+//                }
+
+//                if (complete)
+//                {
+//                    this.Complete(true);
+//                }
+//            }
+
+//            bool CompleteBinderClose(bool synchronous, IAsyncResult result)
+//            {
+//                this.binder.OnEndClose(result);
+
+//                if (this.channel != null)
+//                {
+//                    result = this.binder.BeginCloseChannel(this.channel,
+//                        this.timeoutHelper.RemainingTime(), onChannelCloseComplete, this);
+
+//                    if (result.CompletedSynchronously)
+//                    {
+//                        return this.CompleteChannelClose(synchronous, result);
+//                    }
+//                    else
+//                    {
+//                        return false;
+//                    }
+//                }
+//                else
+//                {
+//                    this.binder.TransitionToClosed();
+//                    return true;
+//                }
+//            }
+
+//            bool CompleteChannelClose(bool synchronous, IAsyncResult result)
+//            {
+//                this.binder.EndCloseChannel(this.channel, result);
+//                this.binder.TransitionToClosed();
+//                return true;
+//            }
+
+//            public void End()
+//            {
+//                AsyncResult.End<CloseAsyncResult>(this);
+//            }
+
+//            Exception HandleAsyncException(Exception e)
+//            {
+//                this.binder.Abort();
+
+//                if (this.binder.HandleException(e, this.maskingMode))
+//                {
+//                    return null;
+//                }
+//                else
+//                {
+//                    return e;
+//                }
+//            }
+
+//            static void OnBinderCloseComplete(IAsyncResult result)
+//            {
+//                if (!result.CompletedSynchronously)
+//                {
+//                    CloseAsyncResult closeResult = (CloseAsyncResult)result.AsyncState;
+//                    bool complete;
+//                    Exception completeException;
+
+//                    try
+//                    {
+//                        complete = closeResult.CompleteBinderClose(false, result);
+//                        completeException = null;
+//                    }
+//#pragma warning suppress 56500 // covered by FxCOP
+//                    catch (Exception e)
+//                    {
+//                        if (Fx.IsFatal(e))
+//                        {
+//                            throw;
+//                        }
+
+//                        complete = true;
+//                        completeException = e;
+//                    }
+
+//                    if (complete)
+//                    {
+//                        if (completeException != null)
+//                        {
+//                            completeException = closeResult.HandleAsyncException(completeException);
+//                        }
+
+//                        closeResult.Complete(false, completeException);
+//                    }
+//                }
+//            }
+
+//            static void OnChannelCloseComplete(IAsyncResult result)
+//            {
+//                if (!result.CompletedSynchronously)
+//                {
+//                    CloseAsyncResult closeResult = (CloseAsyncResult)result.AsyncState;
+//                    bool complete;
+//                    Exception completeException;
+
+//                    try
+//                    {
+//                        complete = closeResult.CompleteChannelClose(false, result);
+//                        completeException = null;
+//                    }
+//#pragma warning suppress 56500 // covered by FxCOP
+//                    catch (Exception e)
+//                    {
+//                        if (Fx.IsFatal(e))
+//                        {
+//                            throw;
+//                        }
+
+//                        complete = true;
+//                        completeException = e;
+//                    }
+
+//                    if (complete)
+//                    {
+//                        if (completeException != null)
+//                        {
+//                            completeException = closeResult.HandleAsyncException(completeException);
+//                        }
+
+//                        closeResult.Complete(false, completeException);
+//                    }
+//                }
+//            }
+//        }
+
+//        protected abstract class InputAsyncResult<TBinder> : AsyncResult
+//            where TBinder : ReliableChannelBinder<TChannel>
+//        {
+//            bool autoAborted;
+//            TBinder binder;
+//            bool canGetChannel;
+//            TChannel channel;
+//            bool isSynchronous = true;
+//            MaskingMode maskingMode;
+//            static AsyncCallback onInputComplete = Fx.ThunkCallback(new AsyncCallback(OnInputCompleteStatic));
+//            static AsyncCallback onTryGetChannelComplete = Fx.ThunkCallback(new AsyncCallback(OnTryGetChannelCompleteStatic));
+//            bool success;
+//            TimeoutHelper timeoutHelper;
+
+//            public InputAsyncResult(TBinder binder, bool canGetChannel, TimeSpan timeout,
+//                MaskingMode maskingMode, AsyncCallback callback, object state)
+//                : base(callback, state)
+//            {
+//                this.binder = binder;
+//                this.canGetChannel = canGetChannel;
+//                this.timeoutHelper = new TimeoutHelper(timeout);
+//                this.maskingMode = maskingMode;
+//            }
+
+//            protected abstract IAsyncResult BeginInput(TBinder binder, TChannel channel,
+//                TimeSpan timeout, AsyncCallback callback, object state);
+
+//            // returns true if the caller should retry
+//            bool CompleteInput(IAsyncResult result)
+//            {
+//                bool complete;
+
+//                try
+//                {
+//                    this.success = this.EndInput(this.binder, this.channel, result, out complete);
+//                }
+//                finally
+//                {
+//                    this.autoAborted = this.binder.Synchronizer.Aborting;
+//                    this.binder.synchronizer.ReturnChannel();
+//                }
+
+//                return !complete;
+//            }
+
+//            // returns true if the caller should retry
+//            bool CompleteTryGetChannel(IAsyncResult result, out bool complete)
+//            {
+//                complete = false;
+//                this.success = this.binder.synchronizer.EndTryGetChannel(result, out this.channel);
+
+//                // the synchronizer is faulted and not reestablishing or closed, or the call timed
+//                // out, complete and don't retry.
+//                if (this.channel == null)
+//                {
+//                    complete = true;
+//                    return false;
+//                }
+
+//                bool throwing = true;
+//                IAsyncResult inputResult = null;
+
+//                try
+//                {
+//                    inputResult = this.BeginInput(this.binder, this.channel,
+//                        this.timeoutHelper.RemainingTime(), onInputComplete, this);
+//                    throwing = false;
+//                }
+//                finally
+//                {
+//                    if (throwing)
+//                    {
+//                        this.autoAborted = this.binder.Synchronizer.Aborting;
+//                        this.binder.synchronizer.ReturnChannel();
+//                    }
+//                }
+
+//                if (inputResult.CompletedSynchronously)
+//                {
+//                    if (this.CompleteInput(inputResult))
+//                    {
+//                        complete = false;
+//                        return true;
+//                    }
+//                    else
+//                    {
+//                        complete = true;
+//                        return false;
+//                    }
+//                }
+//                else
+//                {
+//                    complete = false;
+//                    return false;
+//                }
+//            }
+
+//            public bool End()
+//            {
+//                AsyncResult.End<InputAsyncResult<TBinder>>(this);
+//                return this.success;
+//            }
+
+//            protected abstract bool EndInput(TBinder binder, TChannel channel,
+//                IAsyncResult result, out bool complete);
+
+//            void OnInputComplete(IAsyncResult result)
+//            {
+//                this.isSynchronous = false;
+//                bool retry;
+//                Exception completeException = null;
+
+//                try
+//                {
+//                    retry = this.CompleteInput(result);
+//                }
+//#pragma warning suppress 56500 // covered by FxCOP
+//                catch (Exception e)
+//                {
+//                    if (Fx.IsFatal(e))
+//                    {
+//                        throw;
+//                    }
+
+//                    if (!this.binder.HandleException(e, this.maskingMode, this.autoAborted))
+//                    {
+//                        completeException = e;
+//                        retry = false;
+//                    }
+//                    else
+//                    {
+//                        retry = true;
+//                    }
+//                }
+
+//                if (retry)
+//                {
+//                    this.StartOnNonUserThread();
+//                }
+//                else
+//                {
+//                    this.Complete(this.isSynchronous, completeException);
+//                }
+//            }
+
+//            static void OnInputCompleteStatic(IAsyncResult result)
+//            {
+//                if (!result.CompletedSynchronously)
+//                {
+//                    InputAsyncResult<TBinder> inputResult =
+//                        (InputAsyncResult<TBinder>)result.AsyncState;
+//                    inputResult.OnInputComplete(result);
+//                }
+//            }
+
+//            void OnTryGetChannelComplete(IAsyncResult result)
+//            {
+//                this.isSynchronous = false;
+//                bool retry = false;
+//                bool complete = false;
+//                Exception completeException = null;
+
+//                try
+//                {
+//                    retry = this.CompleteTryGetChannel(result, out complete);
+//                }
+//#pragma warning suppress 56500 // covered by FxCOP
+//                catch (Exception e)
+//                {
+//                    if (Fx.IsFatal(e))
+//                    {
+//                        throw;
+//                    }
+
+//                    if (!this.binder.HandleException(e, this.maskingMode, this.autoAborted))
+//                    {
+//                        completeException = e;
+//                        retry = false;
+//                    }
+//                    else
+//                    {
+//                        retry = true;
+//                    }
+//                }
+
+//                // Can't complete AND retry.
+//                if (complete && retry)
+//                {
+//                    throw Fx.AssertAndThrow("The derived class' implementation of CompleteTryGetChannel() cannot indicate that the asynchronous operation should complete and retry.");
+//                }
+
+//                if (retry)
+//                {
+//                    this.StartOnNonUserThread();
+//                }
+//                else if (complete || completeException != null)
+//                {
+//                    this.Complete(this.isSynchronous, completeException);
+//                }
+//            }
+
+//            static void OnTryGetChannelCompleteStatic(IAsyncResult result)
+//            {
+//                if (!result.CompletedSynchronously)
+//                {
+//                    InputAsyncResult<TBinder> inputResult =
+//                        (InputAsyncResult<TBinder>)result.AsyncState;
+//                    inputResult.OnTryGetChannelComplete(result);
+//                }
+//            }
+
+//            protected bool Start()
+//            {
+//                while (true)
+//                {
+//                    bool retry = false;
+//                    bool complete = false;
+
+//                    this.autoAborted = false;
+
+//                    try
+//                    {
+//                        IAsyncResult result = this.binder.synchronizer.BeginTryGetChannelForInput(
+//                            canGetChannel, this.timeoutHelper.RemainingTime(),
+//                            onTryGetChannelComplete, this);
+
+//                        if (result.CompletedSynchronously)
+//                        {
+//                            retry = this.CompleteTryGetChannel(result, out complete);
+//                        }
+//                    }
+//                    catch (Exception e)
+//                    {
+//                        if (Fx.IsFatal(e))
+//                        {
+//                            throw;
+//                        }
+
+//                        if (!this.binder.HandleException(e, this.maskingMode, this.autoAborted))
+//                        {
+//                            throw;
+//                        }
+//                        else
+//                        {
+//                            retry = true;
+//                        }
+//                    }
+
+//                    // Can't complete AND retry.
+//                    if (complete && retry)
+//                    {
+//                        throw Fx.AssertAndThrow("The derived class' implementation of CompleteTryGetChannel() cannot indicate that the asynchronous operation should complete and retry.");
+//                    }
+
+//                    if (!retry)
+//                    {
+//                        return complete;
+//                    }
+//                }
+//            }
+
+//            void StartOnNonUserThread()
+//            {
+//                bool complete = false;
+//                Exception completeException = null;
+
+//                try
+//                {
+//                    complete = this.Start();
+//                }
+//#pragma warning suppress 56500 // covered by FxCOP
+//                catch (Exception e)
+//                {
+//                    if (Fx.IsFatal(e))
+//                        throw;
+
+//                    completeException = e;
+//                }
+
+//                if (complete || completeException != null)
+//                    this.Complete(false, completeException);
+//            }
+//        }
+
+//        sealed class MessageRequestContext : BinderRequestContext
+//        {
+//            public MessageRequestContext(ReliableChannelBinder<TChannel> binder, Message message)
+//                : base(binder, message)
+//            {
+//            }
+
+//            protected override void OnAbort()
+//            {
+//            }
+
+//            protected override void OnClose(TimeSpan timeout)
+//            {
+//            }
+
+//            protected override IAsyncResult OnBeginReply(Message message, TimeSpan timeout, AsyncCallback callback, object state)
+//            {
+//                return new ReplyAsyncResult(this, message, timeout, callback, state);
+//            }
+
+//            protected override void OnEndReply(IAsyncResult result)
+//            {
+//                ReplyAsyncResult.End(result);
+//            }
+
+//            protected override void OnReply(Message message, TimeSpan timeout)
+//            {
+//                if (message != null)
+//                {
+//                    this.Binder.Send(message, timeout, this.MaskingMode);
+//                }
+//            }
+
+//            class ReplyAsyncResult : AsyncResult
+//            {
+//                static AsyncCallback onSend;
+//                MessageRequestContext context;
+
+//                public ReplyAsyncResult(MessageRequestContext context, Message message, TimeSpan timeout, AsyncCallback callback, object state)
+//                    : base(callback, state)
+//                {
+//                    if (message != null)
+//                    {
+//                        if (onSend == null)
+//                        {
+//                            onSend = Fx.ThunkCallback(new AsyncCallback(OnSend));
+//                        }
+//                        this.context = context;
+//                        IAsyncResult result = context.Binder.BeginSend(message, timeout, context.MaskingMode, onSend, this);
+//                        if (!result.CompletedSynchronously)
+//                        {
+//                            return;
+//                        }
+//                        context.Binder.EndSend(result);
+//                    }
+
+//                    base.Complete(true);
+//                }
+
+//                public static void End(IAsyncResult result)
+//                {
+//                    AsyncResult.End<ReplyAsyncResult>(result);
+//                }
+
+//                static void OnSend(IAsyncResult result)
+//                {
+//                    if (result.CompletedSynchronously)
+//                    {
+//                        return;
+//                    }
+
+//                    Exception completionException = null;
+//                    ReplyAsyncResult thisPtr = (ReplyAsyncResult)result.AsyncState;
+//                    try
+//                    {
+//                        thisPtr.context.Binder.EndSend(result);
+//                    }
+//#pragma warning suppress 56500 // covered by FxCOP
+//                    catch (Exception exception)
+//                    {
+//                        if (Fx.IsFatal(exception))
+//                        {
+//                            throw;
+//                        }
+//                        completionException = exception;
+//                    }
+
+//                    thisPtr.Complete(false, completionException);
+//                }
+//            }
+//        }
+
+//        protected abstract class OutputAsyncResult<TBinder> : AsyncResult
+//            where TBinder : ReliableChannelBinder<TChannel>
+//        {
+//            bool autoAborted;
+//            TBinder binder;
+//            TChannel channel;
+//            bool hasChannel = false;
+//            MaskingMode maskingMode;
+//            Message message;
+//            static AsyncCallback onTryGetChannelComplete = Fx.ThunkCallback(new AsyncCallback(OnTryGetChannelCompleteStatic));
+//            static AsyncCallback onOutputComplete = Fx.ThunkCallback(new AsyncCallback(OnOutputCompleteStatic));
+//            TimeSpan timeout;
+//            TimeoutHelper timeoutHelper;
+
+//            public OutputAsyncResult(TBinder binder, AsyncCallback callback, object state)
+//                : base(callback, state)
+//            {
+//                this.binder = binder;
+//            }
+
+//            public MaskingMode MaskingMode
+//            {
+//                get
+//                {
+//                    return this.maskingMode;
+//                }
+//            }
+
+//            protected abstract IAsyncResult BeginOutput(TBinder binder, TChannel channel,
+//                Message message, TimeSpan timeout, MaskingMode maskingMode, AsyncCallback callback,
+//                object state);
+
+//            void Cleanup()
+//            {
+//                if (this.hasChannel)
+//                {
+//                    this.autoAborted = this.binder.Synchronizer.Aborting;
+//                    this.binder.synchronizer.ReturnChannel();
+//                }
+//            }
+
+//            bool CompleteOutput(IAsyncResult result)
+//            {
+//                this.EndOutput(this.binder, this.channel, this.maskingMode, result);
+//                this.Cleanup();
+//                return true;
+//            }
+
+//            bool CompleteTryGetChannel(IAsyncResult result)
+//            {
+//                bool timedOut = !this.binder.synchronizer.EndTryGetChannel(result,
+//                    out this.channel);
+
+//                if (timedOut || (this.channel == null))
+//                {
+//                    this.Cleanup();
+
+//                    if (timedOut && !ReliableChannelBinderHelper.MaskHandled(maskingMode))
+//                    {
+//                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new TimeoutException(this.GetTimeoutString(this.timeout)));
+//                    }
+
+//                    return true;
+//                }
+
+//                this.hasChannel = true;
+
+//                result = this.BeginOutput(this.binder, this.channel, this.message,
+//                    this.timeoutHelper.RemainingTime(), this.maskingMode, onOutputComplete,
+//                    this);
+
+//                if (result.CompletedSynchronously)
+//                {
+//                    return this.CompleteOutput(result);
+//                }
+//                else
+//                {
+//                    return false;
+//                }
+//            }
+
+//            protected abstract void EndOutput(TBinder binder, TChannel channel,
+//                MaskingMode maskingMode, IAsyncResult result);
+
+//            protected abstract string GetTimeoutString(TimeSpan timeout);
+
+//            void OnOutputComplete(IAsyncResult result)
+//            {
+//                if (!result.CompletedSynchronously)
+//                {
+//                    bool complete = false;
+//                    Exception completeException = null;
+
+//                    try
+//                    {
+//                        complete = this.CompleteOutput(result);
+//                    }
+//#pragma warning suppress 56500 // covered by FxCOP
+//                    catch (Exception e)
+//                    {
+//                        if (Fx.IsFatal(e))
+//                        {
+//                            throw;
+//                        }
+
+//                        this.Cleanup();
+//                        complete = true;
+//                        if (!this.binder.HandleException(e, this.maskingMode, this.autoAborted))
+//                        {
+//                            completeException = e;
+//                        }
+//                    }
+
+//                    if (complete)
+//                    {
+//                        this.Complete(false, completeException);
+//                    }
+//                }
+//            }
+
+//            static void OnOutputCompleteStatic(IAsyncResult result)
+//            {
+//                OutputAsyncResult<TBinder> outputResult =
+//                    (OutputAsyncResult<TBinder>)result.AsyncState;
+
+//                outputResult.OnOutputComplete(result);
+//            }
+
+//            void OnTryGetChannelComplete(IAsyncResult result)
+//            {
+//                if (!result.CompletedSynchronously)
+//                {
+//                    bool complete = false;
+//                    Exception completeException = null;
+
+//                    try
+//                    {
+//                        complete = this.CompleteTryGetChannel(result);
+//                    }
+//#pragma warning suppress 56500 // covered by FxCOP
+//                    catch (Exception e)
+//                    {
+//                        if (Fx.IsFatal(e))
+//                        {
+//                            throw;
+//                        }
+
+//                        this.Cleanup();
+//                        complete = true;
+//                        if (!this.binder.HandleException(e, this.maskingMode, this.autoAborted))
+//                        {
+//                            completeException = e;
+//                        }
+//                    }
+
+//                    if (complete)
+//                    {
+//                        this.Complete(false, completeException);
+//                    }
+//                }
+//            }
+
+//            static void OnTryGetChannelCompleteStatic(IAsyncResult result)
+//            {
+//                OutputAsyncResult<TBinder> outputResult =
+//                    (OutputAsyncResult<TBinder>)result.AsyncState;
+
+//                outputResult.OnTryGetChannelComplete(result);
+//            }
+
+//            public void Start(Message message, TimeSpan timeout, MaskingMode maskingMode)
+//            {
+//                if (!this.binder.ValidateOutputOperation(message, timeout, maskingMode))
+//                {
+//                    this.Complete(true);
+//                    return;
+//                }
+
+//                this.message = message;
+//                this.timeout = timeout;
+//                this.timeoutHelper = new TimeoutHelper(timeout);
+//                this.maskingMode = maskingMode;
+
+//                bool complete = false;
+
+//                try
+//                {
+//                    IAsyncResult result = this.binder.synchronizer.BeginTryGetChannelForOutput(
+//                        timeoutHelper.RemainingTime(), this.maskingMode, onTryGetChannelComplete, this);
+
+//                    if (result.CompletedSynchronously)
+//                    {
+//                        complete = this.CompleteTryGetChannel(result);
+//                    }
+//                }
+//                catch (Exception e)
+//                {
+//                    if (Fx.IsFatal(e))
+//                    {
+//                        throw;
+//                    }
+
+//                    this.Cleanup();
+//                    if (this.binder.HandleException(e, this.maskingMode, this.autoAborted))
+//                    {
+//                        complete = true;
+//                    }
+//                    else
+//                    {
+//                        throw;
+//                    }
+//                }
+
+//                if (complete)
+//                {
+//                    this.Complete(true);
+//                }
+//            }
+//        }
+
+//        sealed class RequestRequestContext : BinderRequestContext
+//        {
+//            RequestContext innerContext;
+
+//            public RequestRequestContext(ReliableChannelBinder<TChannel> binder,
+//                RequestContext innerContext, Message message)
+//                : base(binder, message)
+//            {
+//                if ((binder.defaultMaskingMode != MaskingMode.All) && !binder.TolerateFaults)
+//                {
+//                    throw Fx.AssertAndThrow("This request context is designed to catch exceptions. Thus it cannot be used if the caller expects no exception handling.");
+//                }
+
+//                if (innerContext == null)
+//                {
+//                    throw Fx.AssertAndThrow("Argument innerContext cannot be null.");
+//                }
+
+//                this.innerContext = innerContext;
+//            }
+
+//            protected override void OnAbort()
+//            {
+//                this.innerContext.Abort();
+//            }
+
+//            protected override IAsyncResult OnBeginReply(Message message, TimeSpan timeout,
+//                AsyncCallback callback, object state)
+//            {
+//                try
+//                {
+//                    if (message != null)
+//                        this.Binder.AddOutputHeaders(message);
+//                    return this.innerContext.BeginReply(message, timeout, callback, state);
+//                }
+//                catch (ObjectDisposedException) { }
+//                catch (Exception e)
+//                {
+//                    if (Fx.IsFatal(e))
+//                    {
+//                        throw;
+//                    }
+
+//                    if (!this.Binder.HandleException(e, this.MaskingMode))
+//                    {
+//                        throw;
+//                    }
+
+//                    this.innerContext.Abort();
+//                }
+
+//                return new BinderCompletedAsyncResult(callback, state);
+//            }
+
+//            protected override void OnClose(TimeSpan timeout)
+//            {
+//                try
+//                {
+//                    this.innerContext.Close(timeout);
+//                }
+//                catch (ObjectDisposedException) { }
+//                catch (Exception e)
+//                {
+//                    if (Fx.IsFatal(e))
+//                    {
+//                        throw;
+//                    }
+
+//                    if (!this.Binder.HandleException(e, this.MaskingMode))
+//                    {
+//                        throw;
+//                    }
+
+//                    this.innerContext.Abort();
+//                }
+//            }
+
+//            protected override void OnEndReply(IAsyncResult result)
+//            {
+//                BinderCompletedAsyncResult completedResult = result as BinderCompletedAsyncResult;
+//                if (completedResult != null)
+//                {
+//                    completedResult.End();
+//                    return;
+//                }
+
+//                try
+//                {
+//                    this.innerContext.EndReply(result);
+//                }
+//                catch (ObjectDisposedException) { }
+//                catch (Exception e)
+//                {
+//                    if (Fx.IsFatal(e))
+//                    {
+//                        throw;
+//                    }
+
+//                    if (!this.Binder.HandleException(e, this.MaskingMode))
+//                    {
+//                        throw;
+//                    }
+
+//                    this.innerContext.Abort();
+//                }
+//            }
+
+//            protected override void OnReply(Message message, TimeSpan timeout)
+//            {
+//                try
+//                {
+//                    if (message != null)
+//                        this.Binder.AddOutputHeaders(message);
+//                    this.innerContext.Reply(message, timeout);
+//                }
+//                catch (ObjectDisposedException) { }
+//                catch (Exception e)
+//                {
+//                    if (Fx.IsFatal(e))
+//                    {
+//                        throw;
+//                    }
+
+//                    if (!this.Binder.HandleException(e, this.MaskingMode))
+//                    {
+//                        throw;
+//                    }
+
+//                    this.innerContext.Abort();
+//                }
+//            }
+//        }
+
+//        sealed class SendAsyncResult : OutputAsyncResult<ReliableChannelBinder<TChannel>>
+//        {
+//            public SendAsyncResult(ReliableChannelBinder<TChannel> binder, AsyncCallback callback,
+//                object state)
+//                : base(binder, callback, state)
+//            {
+//            }
+
+//            protected override IAsyncResult BeginOutput(ReliableChannelBinder<TChannel> binder,
+//                TChannel channel, Message message, TimeSpan timeout, MaskingMode maskingMode,
+//                AsyncCallback callback, object state)
+//            {
+//                binder.AddOutputHeaders(message);
+//                return binder.OnBeginSend(channel, message, timeout, callback, state);
+//            }
+
+//            public static void End(IAsyncResult result)
+//            {
+//                AsyncResult.End<SendAsyncResult>(result);
+//            }
+
+//            protected override void EndOutput(ReliableChannelBinder<TChannel> binder,
+//                TChannel channel, MaskingMode maskingMode, IAsyncResult result)
+//            {
+//                binder.OnEndSend(channel, result);
+//            }
+
+//            protected override string GetTimeoutString(TimeSpan timeout)
+//            {
+//                return SR.GetString(SR.TimeoutOnSend, timeout);
+//            }
+//        }
+
+//        sealed class TryReceiveAsyncResult : InputAsyncResult<ReliableChannelBinder<TChannel>>
+//        {
+//            RequestContext requestContext;
+
+//            public TryReceiveAsyncResult(ReliableChannelBinder<TChannel> binder, TimeSpan timeout,
+//                MaskingMode maskingMode, AsyncCallback callback, object state)
+//                : base(binder, binder.CanGetChannelForReceive, timeout, maskingMode, callback, state)
+//            {
+//                if (this.Start())
+//                    this.Complete(true);
+//            }
+
+//            protected override IAsyncResult BeginInput(ReliableChannelBinder<TChannel> binder,
+//                TChannel channel, TimeSpan timeout, AsyncCallback callback, object state)
+//            {
+//                return binder.OnBeginTryReceive(channel, timeout, callback, state);
+//            }
+
+//            public bool End(out RequestContext requestContext)
+//            {
+//                requestContext = this.requestContext;
+//                return this.End();
+//            }
+
+//            protected override bool EndInput(ReliableChannelBinder<TChannel> binder,
+//                TChannel channel, IAsyncResult result, out bool complete)
+//            {
+//                bool success = binder.OnEndTryReceive(channel, result, out this.requestContext);
+
+//                // timed out || got message, complete immediately
+//                complete = !success || (this.requestContext != null);
+
+//                if (!complete)
+//                {
+//                    // the underlying channel closed or faulted
+//                    binder.synchronizer.OnReadEof();
+//                }
+
+//                return success;
+//            }
+//        }
+//    }
+
+//    static class ReliableChannelBinderHelper
+//    {
+//        internal static IAsyncResult BeginCloseDuplexSessionChannel(
+//            ReliableChannelBinder<IDuplexSessionChannel> binder, IDuplexSessionChannel channel,
+//            TimeSpan timeout, AsyncCallback callback, object state)
+//        {
+//            return new CloseDuplexSessionChannelAsyncResult(binder, channel, timeout, callback,
+//                state);
+//        }
+
+//        internal static IAsyncResult BeginCloseReplySessionChannel(
+//            ReliableChannelBinder<IReplySessionChannel> binder, IReplySessionChannel channel,
+//            TimeSpan timeout, AsyncCallback callback, object state)
+//        {
+//            return new CloseReplySessionChannelAsyncResult(binder, channel, timeout, callback,
+//                state);
+//        }
+
+//        internal static void CloseDuplexSessionChannel(
+//            ReliableChannelBinder<IDuplexSessionChannel> binder, IDuplexSessionChannel channel,
+//            TimeSpan timeout)
+//        {
+//            TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
+
+//            channel.Session.CloseOutputSession(timeoutHelper.RemainingTime());
+//            binder.WaitForPendingOperations(timeoutHelper.RemainingTime());
+
+//            TimeSpan iterationTimeout = timeoutHelper.RemainingTime();
+//            bool lastIteration = (iterationTimeout == TimeSpan.Zero);
+
+//            while (true)
+//            {
+//                Message message = null;
+//                bool receiveThrowing = true;
+
+//                try
+//                {
+//                    bool success = channel.TryReceive(iterationTimeout, out message);
+
+//                    receiveThrowing = false;
+//                    if (success && message == null)
+//                    {
+//                        channel.Close(timeoutHelper.RemainingTime());
+//                        return;
+//                    }
+//                }
+//                catch (Exception e)
+//                {
+//                    if (Fx.IsFatal(e))
+//                        throw;
+
+//                    if (receiveThrowing)
+//                    {
+//                        if (!MaskHandled(binder.DefaultMaskingMode) || !binder.IsHandleable(e))
+//                            throw;
+
+//                        receiveThrowing = false;
+//                    }
+//                    else
+//                    {
+//                        throw;
+//                    }
+//                }
+//                finally
+//                {
+//                    if (message != null)
+//                        message.Close();
+
+//                    if (receiveThrowing)
+//                        channel.Abort();
+//                }
+
+//                if (lastIteration || channel.State != CommunicationState.Opened)
+//                    break;
+
+//                iterationTimeout = timeoutHelper.RemainingTime();
+//                lastIteration = (iterationTimeout == TimeSpan.Zero);
+//            }
+
+//            channel.Abort();
+//        }
+
+//        internal static void CloseReplySessionChannel(
+//            ReliableChannelBinder<IReplySessionChannel> binder, IReplySessionChannel channel,
+//            TimeSpan timeout)
+//        {
+//            TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
+
+//            binder.WaitForPendingOperations(timeoutHelper.RemainingTime());
+
+//            TimeSpan iterationTimeout = timeoutHelper.RemainingTime();
+//            bool lastIteration = (iterationTimeout == TimeSpan.Zero);
+
+//            while (true)
+//            {
+//                RequestContext context = null;
+//                bool receiveThrowing = true;
+
+//                try
+//                {
+//                    bool success = channel.TryReceiveRequest(iterationTimeout, out context);
+
+//                    receiveThrowing = false;
+//                    if (success && context == null)
+//                    {
+//                        channel.Close(timeoutHelper.RemainingTime());
+//                        return;
+//                    }
+//                }
+//                catch (Exception e)
+//                {
+//                    if (Fx.IsFatal(e))
+//                        throw;
+
+//                    if (receiveThrowing)
+//                    {
+//                        if (!MaskHandled(binder.DefaultMaskingMode) || !binder.IsHandleable(e))
+//                            throw;
+
+//                        receiveThrowing = false;
+//                    }
+//                    else
+//                    {
+//                        throw;
+//                    }
+//                }
+//                finally
+//                {
+//                    if (context != null)
+//                    {
+//                        context.RequestMessage.Close();
+//                        context.Close();
+//                    }
+
+//                    if (receiveThrowing)
+//                        channel.Abort();
+//                }
+
+//                if (lastIteration || channel.State != CommunicationState.Opened)
+//                    break;
+
+//                iterationTimeout = timeoutHelper.RemainingTime();
+//                lastIteration = (iterationTimeout == TimeSpan.Zero);
+//            }
+
+//            channel.Abort();
+//        }
+
+//        internal static void EndCloseDuplexSessionChannel(IDuplexSessionChannel channel,
+//                IAsyncResult result)
+//        {
+//            CloseDuplexSessionChannelAsyncResult.End(result);
+//        }
+
+//        internal static void EndCloseReplySessionChannel(IReplySessionChannel channel,
+//                IAsyncResult result)
+//        {
+//            CloseReplySessionChannelAsyncResult.End(result);
+//        }
+
+//        internal static bool MaskHandled(MaskingMode maskingMode)
+//        {
+//            return (maskingMode & MaskingMode.Handled) == MaskingMode.Handled;
+//        }
+
+//        internal static bool MaskUnhandled(MaskingMode maskingMode)
+//        {
+//            return (maskingMode & MaskingMode.Unhandled) == MaskingMode.Unhandled;
+//        }
+
+//        abstract class CloseInputSessionChannelAsyncResult<TChannel, TItem> : AsyncResult
+//            where TChannel : class, IChannel
+//            where TItem : class
+//        {
+//            static AsyncCallback onChannelCloseCompleteStatic =
+//                Fx.ThunkCallback(
+//                new AsyncCallback(OnChannelCloseCompleteStatic));
+//            static AsyncCallback onInputCompleteStatic =
+//                Fx.ThunkCallback(new AsyncCallback(OnInputCompleteStatic));
+//            static AsyncCallback onWaitForPendingOperationsCompleteStatic =
+//                Fx.ThunkCallback(
+//                new AsyncCallback(OnWaitForPendingOperationsCompleteStatic));
+//            ReliableChannelBinder<TChannel> binder;
+//            TChannel channel;
+//            bool lastReceive;
+//            TimeoutHelper timeoutHelper;
+
+//            protected CloseInputSessionChannelAsyncResult(
+//                ReliableChannelBinder<TChannel> binder, TChannel channel,
+//                TimeSpan timeout, AsyncCallback callback, object state)
+//                : base(callback, state)
+//            {
+//                this.binder = binder;
+//                this.channel = channel;
+//                this.timeoutHelper = new TimeoutHelper(timeout);
+//            }
+
+//            protected TChannel Channel
+//            {
+//                get
+//                {
+//                    return this.channel;
+//                }
+//            }
+
+//            protected TimeSpan RemainingTime
+//            {
+//                get
+//                {
+//                    return this.timeoutHelper.RemainingTime();
+//                }
+//            }
+
+//            protected bool Begin()
+//            {
+//                bool complete = false;
+//                IAsyncResult result = this.binder.BeginWaitForPendingOperations(
+//                    this.RemainingTime, onWaitForPendingOperationsCompleteStatic,
+//                    this);
+
+//                if (result.CompletedSynchronously)
+//                    complete = this.HandleWaitForPendingOperationsComplete(result);
+
+//                return complete;
+//            }
+
+//            protected abstract IAsyncResult BeginTryInput(TimeSpan timeout, AsyncCallback callback,
+//                object state);
+
+//            protected abstract void DisposeItem(TItem item);
+
+//            protected abstract bool EndTryInput(IAsyncResult result, out TItem item);
+
+//            void HandleChannelCloseComplete(IAsyncResult result)
+//            {
+//                this.channel.EndClose(result);
+//            }
+
+//            bool HandleInputComplete(IAsyncResult result, out bool gotEof)
+//            {
+//                TItem item = null;
+//                bool endThrowing = true;
+
+//                gotEof = false;
+
+//                try
+//                {
+//                    bool success = false;
+
+//                    success = this.EndTryInput(result, out item);
+//                    endThrowing = false;
+
+//                    if (!success || item != null)
+//                    {
+//                        if (this.lastReceive || this.channel.State != CommunicationState.Opened)
+//                        {
+//                            this.channel.Abort();
+//                            return true;
+//                        }
+//                        else
+//                        {
+//                            return false;
+//                        }
+//                    }
+
+//                    gotEof = true;
+
+//                    result = this.channel.BeginClose(this.RemainingTime,
+//                        onChannelCloseCompleteStatic, this);
+//                    if (result.CompletedSynchronously)
+//                    {
+//                        this.HandleChannelCloseComplete(result);
+//                        return true;
+//                    }
+//                    else
+//                    {
+//                        return false;
+//                    }
+//                }
+//                catch (Exception e)
+//                {
+//                    if (Fx.IsFatal(e))
+//                        throw;
+
+//                    if (endThrowing)
+//                    {
+//                        if (!MaskHandled(binder.DefaultMaskingMode) || !binder.IsHandleable(e))
+//                            throw;
+
+//                        if (this.lastReceive || this.channel.State != CommunicationState.Opened)
+//                        {
+//                            this.channel.Abort();
+//                            return true;
+//                        }
+//                        else
+//                        {
+//                            return false;
+//                        }
+//                    }
+
+//                    throw;
+//                }
+//                finally
+//                {
+//                    if (item != null)
+//                        this.DisposeItem(item);
+
+//                    if (endThrowing)
+//                        this.channel.Abort();
+//                }
+//            }
+
+//            bool HandleWaitForPendingOperationsComplete(IAsyncResult result)
+//            {
+//                this.binder.EndWaitForPendingOperations(result);
+//                return this.WaitForEof();
+//            }
+
+//            static void OnChannelCloseCompleteStatic(IAsyncResult result)
+//            {
+//                if (result.CompletedSynchronously)
+//                    return;
+
+//                CloseInputSessionChannelAsyncResult<TChannel, TItem> closeResult =
+//                    (CloseInputSessionChannelAsyncResult<TChannel, TItem>)result.AsyncState;
+
+//                Exception completeException = null;
+
+//                try
+//                {
+//                    closeResult.HandleChannelCloseComplete(result);
+//                }
+//                catch (Exception e)
+//                {
+//                    if (Fx.IsFatal(e))
+//                        throw;
+
+//                    completeException = e;
+//                }
+
+//                closeResult.Complete(false, completeException);
+//            }
+
+//            static void OnInputCompleteStatic(IAsyncResult result)
+//            {
+//                if (result.CompletedSynchronously)
+//                    return;
+
+//                CloseInputSessionChannelAsyncResult<TChannel, TItem> closeResult =
+//                    (CloseInputSessionChannelAsyncResult<TChannel, TItem>)result.AsyncState;
+
+//                bool complete = false;
+//                Exception completeException = null;
+
+//                try
+//                {
+//                    bool gotEof;
+
+//                    complete = closeResult.HandleInputComplete(result, out gotEof);
+//                    if (!complete && !gotEof)
+//                        complete = closeResult.WaitForEof();
+//                }
+//                catch (Exception e)
+//                {
+//                    if (Fx.IsFatal(e))
+//                        throw;
+
+//                    completeException = e;
+//                }
+
+//                if (complete || completeException != null)
+//                    closeResult.Complete(false, completeException);
+//            }
+
+//            static void OnWaitForPendingOperationsCompleteStatic(IAsyncResult result)
+//            {
+//                if (result.CompletedSynchronously)
+//                    return;
+
+//                CloseInputSessionChannelAsyncResult<TChannel, TItem> closeResult =
+//                    (CloseInputSessionChannelAsyncResult<TChannel, TItem>)result.AsyncState;
+
+//                bool complete = false;
+//                Exception completeException = null;
+
+//                try
+//                {
+//                    complete = closeResult.HandleWaitForPendingOperationsComplete(result);
+//                }
+//                catch (Exception e)
+//                {
+//                    if (Fx.IsFatal(e))
+//                        throw;
+
+//                    completeException = e;
+//                }
+
+//                if (complete || completeException != null)
+//                    closeResult.Complete(false, completeException);
+//            }
+
+//            bool WaitForEof()
+//            {
+//                TimeSpan iterationTimeout = this.RemainingTime;
+//                this.lastReceive = (iterationTimeout == TimeSpan.Zero);
+
+//                while (true)
+//                {
+//                    IAsyncResult result = null;
+
+//                    try
+//                    {
+//                        result = this.BeginTryInput(iterationTimeout, onInputCompleteStatic, this);
+//                    }
+//                    catch (Exception e)
+//                    {
+//                        if (Fx.IsFatal(e))
+//                            throw;
+
+//                        if (!MaskHandled(this.binder.DefaultMaskingMode) || !this.binder.IsHandleable(e))
+//                            throw;
+//                    }
+
+//                    if (result != null)
+//                    {
+//                        if (result.CompletedSynchronously)
+//                        {
+//                            bool gotEof;
+//                            bool complete = this.HandleInputComplete(result, out gotEof);
+
+//                            if (complete || gotEof)
+//                                return complete;
+//                        }
+//                        else
+//                            return false;
+//                    }
+
+//                    if (this.lastReceive || this.channel.State != CommunicationState.Opened)
+//                    {
+//                        this.channel.Abort();
+//                        break;
+//                    }
+
+//                    iterationTimeout = this.RemainingTime;
+//                    this.lastReceive = (iterationTimeout == TimeSpan.Zero);
+//                }
+
+//                return true;
+//            }
+//        }
+
+//        sealed class CloseDuplexSessionChannelAsyncResult :
+//            CloseInputSessionChannelAsyncResult<IDuplexSessionChannel, Message>
+//        {
+//            static AsyncCallback onCloseOutputSessionCompleteStatic =
+//                Fx.ThunkCallback(
+//                new AsyncCallback(OnCloseOutputSessionCompleteStatic));
+
+//            public CloseDuplexSessionChannelAsyncResult(
+//                ReliableChannelBinder<IDuplexSessionChannel> binder, IDuplexSessionChannel channel,
+//                TimeSpan timeout, AsyncCallback callback, object state)
+//                : base(binder, channel, timeout, callback, state)
+//            {
+//                bool complete = false;
+
+//                IAsyncResult result = this.Channel.Session.BeginCloseOutputSession(
+//                    this.RemainingTime, onCloseOutputSessionCompleteStatic, this);
+
+//                if (result.CompletedSynchronously)
+//                    complete = this.HandleCloseOutputSessionComplete(result);
+
+//                if (complete)
+//                    this.Complete(true);
+//            }
+
+//            protected override IAsyncResult BeginTryInput(TimeSpan timeout, AsyncCallback callback, object state)
+//            {
+//                return this.Channel.BeginTryReceive(timeout, callback, state);
+//            }
+
+//            protected override void DisposeItem(Message item)
+//            {
+//                item.Close();
+//            }
+
+//            public static void End(IAsyncResult result)
+//            {
+//                AsyncResult.End<CloseDuplexSessionChannelAsyncResult>(result);
+//            }
+
+//            protected override bool EndTryInput(IAsyncResult result, out Message item)
+//            {
+//                return this.Channel.EndTryReceive(result, out item);
+//            }
+
+//            bool HandleCloseOutputSessionComplete(IAsyncResult result)
+//            {
+//                this.Channel.Session.EndCloseOutputSession(result);
+//                return this.Begin();
+//            }
+
+//            static void OnCloseOutputSessionCompleteStatic(IAsyncResult result)
+//            {
+//                if (result.CompletedSynchronously)
+//                    return;
+
+//                CloseDuplexSessionChannelAsyncResult closeResult =
+//                    (CloseDuplexSessionChannelAsyncResult)result.AsyncState;
+
+//                bool complete = false;
+//                Exception completeException = null;
+
+//                try
+//                {
+//                    complete = closeResult.HandleCloseOutputSessionComplete(result);
+//                }
+//                catch (Exception e)
+//                {
+//                    if (Fx.IsFatal(e))
+//                        throw;
+
+//                    completeException = e;
+//                }
+
+//                if (complete || completeException != null)
+//                    closeResult.Complete(false, completeException);
+//            }
+//        }
+
+//        sealed class CloseReplySessionChannelAsyncResult :
+//            CloseInputSessionChannelAsyncResult<IReplySessionChannel, RequestContext>
+//        {
+//            public CloseReplySessionChannelAsyncResult(
+//                ReliableChannelBinder<IReplySessionChannel> binder, IReplySessionChannel channel,
+//                TimeSpan timeout, AsyncCallback callback, object state)
+//                : base(binder, channel, timeout, callback, state)
+//            {
+//                if (this.Begin())
+//                    this.Complete(true);
+//            }
+
+//            protected override IAsyncResult BeginTryInput(TimeSpan timeout, AsyncCallback callback, object state)
+//            {
+//                return this.Channel.BeginTryReceiveRequest(timeout, callback, state);
+//            }
+
+//            protected override void DisposeItem(RequestContext item)
+//            {
+//                item.RequestMessage.Close();
+//                item.Close();
+//            }
+
+//            public static void End(IAsyncResult result)
+//            {
+//                AsyncResult.End<CloseReplySessionChannelAsyncResult>(result);
+//            }
+
+//            protected override bool EndTryInput(IAsyncResult result, out RequestContext item)
+//            {
+//                return this.Channel.EndTryReceiveRequest(result, out item);
+//            }
+//        }
+//    }
 }
 

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/ReliableChannelBinder.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/ReliableChannelBinder.cs
@@ -1,0 +1,4287 @@
+//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace System.ServiceModel.Channels
+{
+    using System.Collections.Generic;
+    using System.Runtime;
+    using System.ServiceModel;
+    using System.Threading;
+
+    enum TolerateFaultsMode
+    {
+        Never,
+        IfNotSecuritySession,
+        Always
+    }
+
+    [Flags]
+    enum MaskingMode
+    {
+        None = 0x0,
+        Handled = 0x1,
+        Unhandled = 0x2,
+        All = Handled | Unhandled
+    }
+
+    abstract class ReliableChannelBinder<TChannel> : IReliableChannelBinder
+        where TChannel : class, IChannel
+    {
+        bool aborted = false;
+        TimeSpan defaultCloseTimeout;
+        MaskingMode defaultMaskingMode;
+        TimeSpan defaultSendTimeout;
+        AsyncCallback onCloseChannelComplete;
+        CommunicationState state = CommunicationState.Created;
+        ChannelSynchronizer synchronizer;
+        object thisLock = new object();
+
+        protected ReliableChannelBinder(TChannel channel, MaskingMode maskingMode,
+            TolerateFaultsMode faultMode, TimeSpan defaultCloseTimeout,
+            TimeSpan defaultSendTimeout)
+        {
+            if ((maskingMode != MaskingMode.None) && (maskingMode != MaskingMode.All))
+            {
+                throw Fx.AssertAndThrow("ReliableChannelBinder was implemented with only 2 default masking modes, None and All.");
+            }
+
+            this.defaultMaskingMode = maskingMode;
+            this.defaultCloseTimeout = defaultCloseTimeout;
+            this.defaultSendTimeout = defaultSendTimeout;
+
+            this.synchronizer = new ChannelSynchronizer(this, channel, faultMode);
+        }
+
+        protected abstract bool CanGetChannelForReceive
+        {
+            get;
+        }
+
+        public abstract bool CanSendAsynchronously
+        {
+            get;
+        }
+
+        public virtual ChannelParameterCollection ChannelParameters
+        {
+            get { return null; }
+        }
+
+        public IChannel Channel
+        {
+            get
+            {
+                return this.synchronizer.CurrentChannel;
+            }
+        }
+
+        public bool Connected
+        {
+            get
+            {
+                return this.synchronizer.Connected;
+            }
+        }
+
+        public MaskingMode DefaultMaskingMode
+        {
+            get
+            {
+                return this.defaultMaskingMode;
+            }
+        }
+
+        public TimeSpan DefaultSendTimeout
+        {
+            get
+            {
+                return this.defaultSendTimeout;
+            }
+        }
+
+        public abstract bool HasSession
+        {
+            get;
+        }
+
+        public abstract EndpointAddress LocalAddress
+        {
+            get;
+        }
+
+        protected abstract bool MustCloseChannel
+        {
+            get;
+        }
+
+        protected abstract bool MustOpenChannel
+        {
+            get;
+        }
+
+        public abstract EndpointAddress RemoteAddress
+        {
+            get;
+        }
+
+        public CommunicationState State
+        {
+            get
+            {
+                return this.state;
+            }
+        }
+
+        protected ChannelSynchronizer Synchronizer
+        {
+            get
+            {
+                return this.synchronizer;
+            }
+        }
+
+        protected object ThisLock
+        {
+            get
+            {
+                return this.thisLock;
+            }
+        }
+
+        bool TolerateFaults
+        {
+            get
+            {
+                return this.synchronizer.TolerateFaults;
+            }
+        }
+
+        public event EventHandler ConnectionLost;
+        public event BinderExceptionHandler Faulted;
+        public event BinderExceptionHandler OnException;
+
+
+        public void Abort()
+        {
+            TChannel channel;
+            lock (this.ThisLock)
+            {
+                this.aborted = true;
+
+                if (this.state == CommunicationState.Closed)
+                {
+                    return;
+                }
+
+                this.state = CommunicationState.Closing;
+                channel = this.synchronizer.StopSynchronizing(true);
+
+                if (!this.MustCloseChannel)
+                {
+                    channel = null;
+                }
+            }
+
+            this.synchronizer.UnblockWaiters();
+            this.OnShutdown();
+            this.OnAbort();
+
+            if (channel != null)
+            {
+                channel.Abort();
+            }
+
+            this.TransitionToClosed();
+        }
+
+        protected virtual void AddOutputHeaders(Message message)
+        {
+        }
+
+        public IAsyncResult BeginClose(TimeSpan timeout, AsyncCallback callback,
+            object state)
+        {
+            return this.BeginClose(timeout, this.defaultMaskingMode, callback, state);
+        }
+
+        public IAsyncResult BeginClose(TimeSpan timeout, MaskingMode maskingMode,
+            AsyncCallback callback, object state)
+        {
+            this.ThrowIfTimeoutNegative(timeout);
+            TChannel channel;
+
+            if (this.CloseCore(out channel))
+            {
+                return new CompletedAsyncResult(callback, state);
+            }
+            else
+            {
+                return new CloseAsyncResult(this, channel, timeout, maskingMode, callback, state);
+            }
+        }
+
+        protected virtual IAsyncResult BeginCloseChannel(TChannel channel, TimeSpan timeout,
+            AsyncCallback callback, object state)
+        {
+            return channel.BeginClose(timeout, callback, state);
+        }
+
+        public IAsyncResult BeginOpen(TimeSpan timeout, AsyncCallback callback, object state)
+        {
+            this.ThrowIfTimeoutNegative(timeout);
+
+            if (this.OnOpening(this.defaultMaskingMode))
+            {
+                try
+                {
+                    return this.OnBeginOpen(timeout, callback, state);
+                }
+                catch (Exception e)
+                {
+                    if (Fx.IsFatal(e))
+                    {
+                        throw;
+                    }
+
+                    this.Fault(null);
+
+                    if (this.defaultMaskingMode == MaskingMode.None)
+                    {
+                        throw;
+                    }
+                    else
+                    {
+                        this.RaiseOnException(e);
+                    }
+                }
+            }
+
+            return new BinderCompletedAsyncResult(callback, state);
+        }
+
+        public IAsyncResult BeginSend(Message message, TimeSpan timeout, AsyncCallback callback,
+            object state)
+        {
+            return this.BeginSend(message, timeout, this.defaultMaskingMode, callback, state);
+        }
+
+        public IAsyncResult BeginSend(Message message, TimeSpan timeout, MaskingMode maskingMode,
+            AsyncCallback callback, object state)
+        {
+            SendAsyncResult result = new SendAsyncResult(this, callback, state);
+            result.Start(message, timeout, maskingMode);
+            return result;
+        }
+
+        // ChannelSynchronizer helper, cannot take a lock.
+        protected abstract IAsyncResult BeginTryGetChannel(TimeSpan timeout,
+            AsyncCallback callback, object state);
+
+        public virtual IAsyncResult BeginTryReceive(TimeSpan timeout, AsyncCallback callback,
+            object state)
+        {
+            return this.BeginTryReceive(timeout, this.defaultMaskingMode, callback, state);
+        }
+
+        public virtual IAsyncResult BeginTryReceive(TimeSpan timeout, MaskingMode maskingMode,
+            AsyncCallback callback, object state)
+        {
+            if (this.ValidateInputOperation(timeout))
+                return new TryReceiveAsyncResult(this, timeout, maskingMode, callback, state);
+            else
+                return new CompletedAsyncResult(callback, state);
+        }
+
+        internal IAsyncResult BeginWaitForPendingOperations(TimeSpan timeout,
+            AsyncCallback callback, object state)
+        {
+            return this.synchronizer.BeginWaitForPendingOperations(timeout, callback, state);
+        }
+
+        bool CloseCore(out TChannel channel)
+        {
+            channel = null;
+            bool abort = true;
+            bool abortChannel = false;
+
+            lock (this.ThisLock)
+            {
+                if ((this.state == CommunicationState.Closing)
+                    || (this.state == CommunicationState.Closed))
+                {
+                    return true;
+                }
+
+                if (this.state == CommunicationState.Opened)
+                {
+                    this.state = CommunicationState.Closing;
+                    channel = this.synchronizer.StopSynchronizing(true);
+                    abort = false;
+
+                    if (!this.MustCloseChannel)
+                    {
+                        channel = null;
+                    }
+
+                    if (channel != null)
+                    {
+                        CommunicationState channelState = channel.State;
+
+                        if ((channelState == CommunicationState.Created)
+                            || (channelState == CommunicationState.Opening)
+                            || (channelState == CommunicationState.Faulted))
+                        {
+                            abortChannel = true;
+                        }
+                        else if ((channelState == CommunicationState.Closing)
+                            || (channelState == CommunicationState.Closed))
+                        {
+                            channel = null;
+                        }
+                    }
+                }
+            }
+
+            this.synchronizer.UnblockWaiters();
+
+            if (abort)
+            {
+                this.Abort();
+                return true;
+            }
+            else
+            {
+                if (abortChannel)
+                {
+                    channel.Abort();
+                    channel = null;
+                }
+
+                return false;
+            }
+        }
+
+        public void Close(TimeSpan timeout)
+        {
+            this.Close(timeout, this.defaultMaskingMode);
+        }
+
+        public void Close(TimeSpan timeout, MaskingMode maskingMode)
+        {
+            this.ThrowIfTimeoutNegative(timeout);
+            TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
+            TChannel channel;
+
+            if (this.CloseCore(out channel))
+            {
+                return;
+            }
+
+            try
+            {
+                this.OnShutdown();
+                this.OnClose(timeoutHelper.RemainingTime());
+
+                if (channel != null)
+                {
+                    this.CloseChannel(channel, timeoutHelper.RemainingTime());
+                }
+
+                this.TransitionToClosed();
+            }
+            catch (Exception e)
+            {
+                if (Fx.IsFatal(e))
+                {
+                    throw;
+                }
+
+                this.Abort();
+
+                if (!this.HandleException(e, maskingMode))
+                {
+                    throw;
+                }
+            }
+        }
+
+        // The ChannelSynchronizer calls this from an operation thread so this method must not
+        // block.
+        void CloseChannel(TChannel channel)
+        {
+            if (!this.MustCloseChannel)
+            {
+                throw Fx.AssertAndThrow("MustCloseChannel is false when there is no receive loop and this method is called when there is a receive loop.");
+            }
+
+            if (this.onCloseChannelComplete == null)
+            {
+                this.onCloseChannelComplete = Fx.ThunkCallback(new AsyncCallback(this.OnCloseChannelComplete));
+            }
+
+            try
+            {
+                IAsyncResult result = channel.BeginClose(onCloseChannelComplete, channel);
+
+                if (result.CompletedSynchronously)
+                {
+                    channel.EndClose(result);
+                }
+            }
+#pragma warning suppress 56500 // covered by FxCOP
+            catch (Exception e)
+            {
+                if (Fx.IsFatal(e))
+                {
+                    throw;
+                }
+
+                this.HandleException(e, MaskingMode.All);
+            }
+        }
+
+        protected virtual void CloseChannel(TChannel channel, TimeSpan timeout)
+        {
+            channel.Close(timeout);
+        }
+
+        public void EndClose(IAsyncResult result)
+        {
+            CloseAsyncResult closeResult = result as CloseAsyncResult;
+
+            if (closeResult != null)
+            {
+                closeResult.End();
+            }
+            else
+            {
+                CompletedAsyncResult.End(result);
+            }
+        }
+
+        protected virtual void EndCloseChannel(TChannel channel, IAsyncResult result)
+        {
+            channel.EndClose(result);
+        }
+
+        public void EndOpen(IAsyncResult result)
+        {
+            BinderCompletedAsyncResult completedResult = result as BinderCompletedAsyncResult;
+
+            if (completedResult != null)
+            {
+                completedResult.End();
+            }
+            else
+            {
+                try
+                {
+                    this.OnEndOpen(result);
+                }
+                catch (Exception e)
+                {
+                    if (Fx.IsFatal(e))
+                    {
+                        throw;
+                    }
+
+                    this.Fault(null);
+
+                    if (this.defaultMaskingMode == MaskingMode.None)
+                    {
+                        throw;
+                    }
+                    else
+                    {
+                        this.RaiseOnException(e);
+                        return;
+                    }
+                }
+
+                this.synchronizer.StartSynchronizing();
+                this.OnOpened();
+            }
+        }
+
+        public void EndSend(IAsyncResult result)
+        {
+            SendAsyncResult.End(result);
+        }
+
+        // ChannelSynchronizer helper, cannot take a lock.
+        protected abstract bool EndTryGetChannel(IAsyncResult result);
+
+        public virtual bool EndTryReceive(IAsyncResult result, out RequestContext requestContext)
+        {
+            TryReceiveAsyncResult tryReceiveResult = result as TryReceiveAsyncResult;
+
+            if (tryReceiveResult != null)
+            {
+                return tryReceiveResult.End(out requestContext);
+            }
+            else
+            {
+                CompletedAsyncResult.End(result);
+                requestContext = null;
+                return true;
+            }
+        }
+
+        public void EndWaitForPendingOperations(IAsyncResult result)
+        {
+            this.synchronizer.EndWaitForPendingOperations(result);
+        }
+
+        protected void Fault(Exception e)
+        {
+            lock (this.ThisLock)
+            {
+                if (this.state == CommunicationState.Created)
+                {
+                    throw Fx.AssertAndThrow("The binder should not detect the inner channel's faults until after the binder is opened.");
+                }
+
+                if ((this.state == CommunicationState.Faulted)
+                    || (this.state == CommunicationState.Closed))
+                {
+                    return;
+                }
+
+                this.state = CommunicationState.Faulted;
+                this.synchronizer.StopSynchronizing(false);
+            }
+
+            this.synchronizer.UnblockWaiters();
+
+            BinderExceptionHandler handler = this.Faulted;
+
+            if (handler != null)
+            {
+                handler(this, e);
+            }
+        }
+
+        // ChannelSynchronizer helper, cannot take a lock.
+        Exception GetClosedException(MaskingMode maskingMode)
+        {
+            if (ReliableChannelBinderHelper.MaskHandled(maskingMode))
+            {
+                return null;
+            }
+            else if (this.aborted)
+            {
+                return new CommunicationObjectAbortedException(SR.GetString(
+                    SR.CommunicationObjectAborted1, this.GetType().ToString()));
+            }
+            else
+            {
+                return new ObjectDisposedException(this.GetType().ToString());
+            }
+        }
+
+        // Must be called within lock (this.ThisLock)
+        Exception GetClosedOrFaultedException(MaskingMode maskingMode)
+        {
+            if (this.state == CommunicationState.Faulted)
+            {
+                return this.GetFaultedException(maskingMode);
+            }
+            else if ((this.state == CommunicationState.Closing)
+               || (this.state == CommunicationState.Closed))
+            {
+                return this.GetClosedException(maskingMode);
+            }
+            else
+            {
+                throw Fx.AssertAndThrow("Caller is attempting to get a terminal exception in a non-terminal state.");
+            }
+        }
+
+        // ChannelSynchronizer helper, cannot take a lock.
+        Exception GetFaultedException(MaskingMode maskingMode)
+        {
+            if (ReliableChannelBinderHelper.MaskHandled(maskingMode))
+            {
+                return null;
+            }
+            else
+            {
+                return new CommunicationObjectFaultedException(SR.GetString(
+                    SR.CommunicationObjectFaulted1, this.GetType().ToString()));
+            }
+        }
+
+        public abstract ISession GetInnerSession();
+
+        public void HandleException(Exception e)
+        {
+            this.HandleException(e, MaskingMode.All);
+        }
+
+        protected bool HandleException(Exception e, MaskingMode maskingMode)
+        {
+            if (this.TolerateFaults && (e is CommunicationObjectFaultedException))
+            {
+                return true;
+            }
+
+            if (this.IsHandleable(e))
+            {
+                return ReliableChannelBinderHelper.MaskHandled(maskingMode);
+            }
+
+            bool maskUnhandled = ReliableChannelBinderHelper.MaskUnhandled(maskingMode);
+
+            if (maskUnhandled)
+            {
+                this.RaiseOnException(e);
+            }
+
+            return maskUnhandled;
+        }
+
+        protected bool HandleException(Exception e, MaskingMode maskingMode, bool autoAborted)
+        {
+            if (this.TolerateFaults && autoAborted && e is CommunicationObjectAbortedException)
+            {
+                return true;
+            }
+
+            return this.HandleException(e, maskingMode);
+        }
+
+        // ChannelSynchronizer helper, cannot take a lock.
+        protected abstract bool HasSecuritySession(TChannel channel);
+
+        public bool IsHandleable(Exception e)
+        {
+            if (e is ProtocolException)
+            {
+                return false;
+            }
+
+            return (e is CommunicationException)
+                || (e is TimeoutException);
+        }
+
+        protected abstract void OnAbort();
+        protected abstract IAsyncResult OnBeginClose(TimeSpan timeout, AsyncCallback callback,
+            object state);
+        protected abstract IAsyncResult OnBeginOpen(TimeSpan timeout, AsyncCallback callback,
+            object state);
+
+        protected virtual IAsyncResult OnBeginSend(TChannel channel, Message message,
+            TimeSpan timeout, AsyncCallback callback, object state)
+        {
+            throw Fx.AssertAndThrow("The derived class does not support the BeginSend operation.");
+        }
+
+        protected virtual IAsyncResult OnBeginTryReceive(TChannel channel, TimeSpan timeout,
+            AsyncCallback callback, object state)
+        {
+            throw Fx.AssertAndThrow("The derived class does not support the BeginTryReceive operation.");
+        }
+
+        protected abstract void OnClose(TimeSpan timeout);
+
+        void OnCloseChannelComplete(IAsyncResult result)
+        {
+            if (result.CompletedSynchronously)
+            {
+                return;
+            }
+
+            TChannel channel = (TChannel)result.AsyncState;
+
+            try
+            {
+                channel.EndClose(result);
+            }
+#pragma warning suppress 56500 // covered by FxCOP
+            catch (Exception e)
+            {
+                if (Fx.IsFatal(e))
+                {
+                    throw;
+                }
+
+                this.HandleException(e, MaskingMode.All);
+            }
+        }
+
+        protected abstract void OnEndClose(IAsyncResult result);
+        protected abstract void OnEndOpen(IAsyncResult result);
+
+        protected virtual void OnEndSend(TChannel channel, IAsyncResult result)
+        {
+            throw Fx.AssertAndThrow("The derived class does not support the EndSend operation.");
+        }
+
+        protected virtual bool OnEndTryReceive(TChannel channel, IAsyncResult result,
+            out RequestContext requestContext)
+        {
+            throw Fx.AssertAndThrow("The derived class does not support the EndTryReceive operation.");
+        }
+
+        void OnInnerChannelFaulted()
+        {
+            if (!this.TolerateFaults)
+                return;
+
+            EventHandler handler = this.ConnectionLost;
+
+            if (handler != null)
+                handler(this, EventArgs.Empty);
+        }
+
+        protected abstract void OnOpen(TimeSpan timeout);
+
+        void OnOpened()
+        {
+            lock (this.ThisLock)
+            {
+                if (this.state == CommunicationState.Opening)
+                {
+                    this.state = CommunicationState.Opened;
+                }
+            }
+        }
+
+        bool OnOpening(MaskingMode maskingMode)
+        {
+            lock (this.ThisLock)
+            {
+                if (this.state != CommunicationState.Created)
+                {
+                    Exception e = null;
+
+                    if ((this.state == CommunicationState.Opening)
+                        || (this.state == CommunicationState.Opened))
+                    {
+                        if (!ReliableChannelBinderHelper.MaskUnhandled(maskingMode))
+                        {
+                            e = new InvalidOperationException(SR.GetString(
+                                SR.CommunicationObjectCannotBeModifiedInState,
+                                this.GetType().ToString(), this.state.ToString()));
+                        }
+                    }
+                    else
+                    {
+                        e = this.GetClosedOrFaultedException(maskingMode);
+                    }
+
+                    if (e != null)
+                    {
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(e);
+                    }
+
+                    return false;
+                }
+                else
+                {
+                    this.state = CommunicationState.Opening;
+                    return true;
+                }
+            }
+        }
+
+        protected virtual void OnShutdown()
+        {
+        }
+
+        protected virtual void OnSend(TChannel channel, Message message, TimeSpan timeout)
+        {
+            throw Fx.AssertAndThrow("The derived class does not support the Send operation.");
+        }
+
+        protected virtual bool OnTryReceive(TChannel channel, TimeSpan timeout,
+            out RequestContext requestContext)
+        {
+            throw Fx.AssertAndThrow("The derived class does not support the TryReceive operation.");
+        }
+
+        public void Open(TimeSpan timeout)
+        {
+            this.ThrowIfTimeoutNegative(timeout);
+
+            if (!this.OnOpening(this.defaultMaskingMode))
+            {
+                return;
+            }
+
+            try
+            {
+                this.OnOpen(timeout);
+            }
+            catch (Exception e)
+            {
+                if (Fx.IsFatal(e))
+                {
+                    throw;
+                }
+
+                this.Fault(null);
+
+                if (this.defaultMaskingMode == MaskingMode.None)
+                {
+                    throw;
+                }
+                else
+                {
+                    this.RaiseOnException(e);
+                    return;
+                }
+            }
+
+            this.synchronizer.StartSynchronizing();
+            this.OnOpened();
+        }
+
+        void RaiseOnException(Exception e)
+        {
+            BinderExceptionHandler handler = this.OnException;
+
+            if (handler != null)
+            {
+                handler(this, e);
+            }
+        }
+
+        public void Send(Message message, TimeSpan timeout)
+        {
+            this.Send(message, timeout, this.defaultMaskingMode);
+        }
+
+        public void Send(Message message, TimeSpan timeout, MaskingMode maskingMode)
+        {
+            if (!this.ValidateOutputOperation(message, timeout, maskingMode))
+            {
+                return;
+            }
+
+            bool autoAborted = false;
+
+            try
+            {
+                TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
+                TChannel channel;
+
+                if (!this.synchronizer.TryGetChannelForOutput(timeoutHelper.RemainingTime(), maskingMode,
+                    out channel))
+                {
+                    if (!ReliableChannelBinderHelper.MaskHandled(maskingMode))
+                    {
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(
+                            new TimeoutException(SR.GetString(SR.TimeoutOnSend, timeout)));
+                    }
+
+                    return;
+                }
+
+                if (channel == null)
+                {
+                    return;
+                }
+
+                this.AddOutputHeaders(message);
+
+                try
+                {
+                    this.OnSend(channel, message, timeoutHelper.RemainingTime());
+                }
+                finally
+                {
+                    autoAborted = this.Synchronizer.Aborting;
+                    this.synchronizer.ReturnChannel();
+                }
+            }
+            catch (Exception e)
+            {
+                if (Fx.IsFatal(e))
+                {
+                    throw;
+                }
+
+                if (!this.HandleException(e, maskingMode, autoAborted))
+                {
+                    throw;
+                }
+            }
+        }
+
+        public void SetMaskingMode(RequestContext context, MaskingMode maskingMode)
+        {
+            BinderRequestContext binderContext = (BinderRequestContext)context;
+            binderContext.SetMaskingMode(maskingMode);
+        }
+
+        // throwDisposed indicates whether to throw in the Faulted, Closing, and Closed states.
+        // returns true if in Opened state
+        bool ThrowIfNotOpenedAndNotMasking(MaskingMode maskingMode, bool throwDisposed)
+        {
+            lock (this.ThisLock)
+            {
+                if (this.State == CommunicationState.Created)
+                {
+                    throw Fx.AssertAndThrow("Messaging operations cannot be called when the binder is in the Created state.");
+                }
+
+                if (this.State == CommunicationState.Opening)
+                {
+                    throw Fx.AssertAndThrow("Messaging operations cannot be called when the binder is in the Opening state.");
+                }
+
+                if (this.State == CommunicationState.Opened)
+                {
+                    return true;
+                }
+
+                // state is Faulted, Closing, or Closed
+                if (throwDisposed)
+                {
+                    Exception e = this.GetClosedOrFaultedException(maskingMode);
+
+                    if (e != null)
+                    {
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(e);
+                    }
+                }
+
+                return false;
+            }
+        }
+
+        void ThrowIfTimeoutNegative(TimeSpan timeout)
+        {
+            if (timeout < TimeSpan.Zero)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(
+                    new ArgumentOutOfRangeException("timeout", timeout, SR.SFxTimeoutOutOfRange0));
+            }
+        }
+
+        void TransitionToClosed()
+        {
+            lock (this.ThisLock)
+            {
+                if ((this.state != CommunicationState.Closing)
+                    && (this.state != CommunicationState.Closed)
+                    && (this.state != CommunicationState.Faulted))
+                {
+                    throw Fx.AssertAndThrow("Caller cannot transition to the Closed state from a non-terminal state.");
+                }
+
+                this.state = CommunicationState.Closed;
+            }
+        }
+
+        // ChannelSynchronizer helper, cannot take a lock.
+        protected abstract bool TryGetChannel(TimeSpan timeout);
+
+        public virtual bool TryReceive(TimeSpan timeout, out RequestContext requestContext)
+        {
+            return this.TryReceive(timeout, out requestContext, this.defaultMaskingMode);
+        }
+
+        public virtual bool TryReceive(TimeSpan timeout, out RequestContext requestContext, MaskingMode maskingMode)
+        {
+            if (maskingMode != MaskingMode.None)
+            {
+                throw Fx.AssertAndThrow("This method was implemented only for the case where we do not mask exceptions.");
+            }
+
+            if (!this.ValidateInputOperation(timeout))
+            {
+                requestContext = null;
+                return true;
+            }
+
+            TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
+
+            while (true)
+            {
+                bool autoAborted = false;
+
+                try
+                {
+                    TChannel channel;
+                    bool success = !this.synchronizer.TryGetChannelForInput(
+                        this.CanGetChannelForReceive, timeoutHelper.RemainingTime(), out channel);
+
+                    if (channel == null)
+                    {
+                        requestContext = null;
+                        return success;
+                    }
+
+                    try
+                    {
+                        success = this.OnTryReceive(channel, timeoutHelper.RemainingTime(),
+                            out requestContext);
+
+                        // timed out || got message, return immediately
+                        if (!success || (requestContext != null))
+                        {
+                            return success;
+                        }
+
+                        // the underlying channel closed or faulted, retry
+                        this.synchronizer.OnReadEof();
+                    }
+                    finally
+                    {
+                        autoAborted = this.Synchronizer.Aborting;
+                        this.synchronizer.ReturnChannel();
+                    }
+                }
+                catch (Exception e)
+                {
+                    if (Fx.IsFatal(e))
+                    {
+                        throw;
+                    }
+
+                    if (!this.HandleException(e, maskingMode, autoAborted))
+                    {
+                        throw;
+                    }
+                }
+            }
+        }
+
+        protected bool ValidateInputOperation(TimeSpan timeout)
+        {
+            if (timeout < TimeSpan.Zero)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("timeout", timeout,
+                    SR.SFxTimeoutOutOfRange0));
+            }
+
+            return this.ThrowIfNotOpenedAndNotMasking(MaskingMode.All, false);
+        }
+
+        protected bool ValidateOutputOperation(Message message, TimeSpan timeout, MaskingMode maskingMode)
+        {
+            if (message == null)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("message");
+            }
+
+            if (timeout < TimeSpan.Zero)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("timeout", timeout,
+                    SR.SFxTimeoutOutOfRange0));
+            }
+
+            return this.ThrowIfNotOpenedAndNotMasking(maskingMode, true);
+        }
+
+        internal void WaitForPendingOperations(TimeSpan timeout)
+        {
+            this.synchronizer.WaitForPendingOperations(timeout);
+        }
+
+        protected RequestContext WrapMessage(Message message)
+        {
+            if (message == null)
+            {
+                return null;
+            }
+
+            return new MessageRequestContext(this, message);
+        }
+
+        public RequestContext WrapRequestContext(RequestContext context)
+        {
+            if (context == null)
+            {
+                return null;
+            }
+
+            if (!this.TolerateFaults && this.defaultMaskingMode == MaskingMode.None)
+            {
+                return context;
+            }
+
+            return new RequestRequestContext(this, context, context.RequestMessage);
+        }
+
+        sealed class BinderCompletedAsyncResult : CompletedAsyncResult
+        {
+            public BinderCompletedAsyncResult(AsyncCallback callback, object state)
+                : base(callback, state)
+            {
+            }
+
+            public void End()
+            {
+                CompletedAsyncResult.End(this);
+            }
+        }
+
+        abstract class BinderRequestContext : RequestContextBase
+        {
+            ReliableChannelBinder<TChannel> binder;
+            MaskingMode maskingMode;
+
+            public BinderRequestContext(ReliableChannelBinder<TChannel> binder, Message message)
+                : base(message, binder.defaultCloseTimeout, binder.defaultSendTimeout)
+            {
+                if (binder == null)
+                {
+                    Fx.Assert("Argument binder cannot be null.");
+                }
+
+                this.binder = binder;
+                this.maskingMode = binder.defaultMaskingMode;
+            }
+
+            protected ReliableChannelBinder<TChannel> Binder
+            {
+                get
+                {
+                    return this.binder;
+                }
+            }
+
+            protected MaskingMode MaskingMode
+            {
+                get
+                {
+                    return this.maskingMode;
+                }
+            }
+
+            public void SetMaskingMode(MaskingMode maskingMode)
+            {
+                if (this.binder.defaultMaskingMode != MaskingMode.All)
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new NotSupportedException());
+                }
+
+                this.maskingMode = maskingMode;
+            }
+        }
+
+        protected class ChannelSynchronizer
+        {
+            bool aborting; // Indicates the current channel is being aborted, not the synchronizer.
+            ReliableChannelBinder<TChannel> binder;
+            int count = 0;
+            TChannel currentChannel;
+            InterruptibleWaitObject drainEvent;
+            static Action<object> asyncGetChannelCallback = new Action<object>(AsyncGetChannelCallback);
+            TolerateFaultsMode faultMode;
+            Queue<IWaiter> getChannelQueue;
+            bool innerChannelFaulted;
+            EventHandler onChannelFaulted;
+            State state = State.Created;
+            bool tolerateFaults = true;
+            object thisLock = new object();
+            Queue<IWaiter> waitQueue;
+
+            public ChannelSynchronizer(ReliableChannelBinder<TChannel> binder, TChannel channel,
+                TolerateFaultsMode faultMode)
+            {
+                this.binder = binder;
+                this.currentChannel = channel;
+                this.faultMode = faultMode;
+            }
+
+            public bool Aborting
+            {
+                get
+                {
+                    return this.aborting;
+                }
+            }
+
+            public bool Connected
+            {
+                get
+                {
+                    return (this.state == State.ChannelOpened ||
+                        this.state == State.ChannelOpening);
+                }
+            }
+
+            public TChannel CurrentChannel
+            {
+                get
+                {
+                    return this.currentChannel;
+                }
+            }
+
+            object ThisLock
+            {
+                get
+                {
+                    return this.thisLock;
+                }
+            }
+
+            public bool TolerateFaults
+            {
+                get
+                {
+                    return this.tolerateFaults;
+                }
+            }
+
+            // Server only API.
+            public TChannel AbortCurentChannel()
+            {
+                lock (this.ThisLock)
+                {
+                    if (!this.tolerateFaults)
+                    {
+                        throw Fx.AssertAndThrow("It is only valid to abort the current channel when masking faults");
+                    }
+
+                    if (this.state == State.ChannelOpening)
+                    {
+                        this.aborting = true;
+                    }
+                    else if (this.state == State.ChannelOpened)
+                    {
+                        if (this.count == 0)
+                        {
+                            this.state = State.NoChannel;
+                        }
+                        else
+                        {
+                            this.aborting = true;
+                            this.state = State.ChannelClosing;
+                        }
+                    }
+                    else
+                    {
+                        return null;
+                    }
+
+                    return this.currentChannel;
+                }
+            }
+
+            static void AsyncGetChannelCallback(object state)
+            {
+                AsyncWaiter waiter = (AsyncWaiter)state;
+                waiter.GetChannel(false);
+            }
+
+            public IAsyncResult BeginTryGetChannelForInput(bool canGetChannel, TimeSpan timeout,
+                AsyncCallback callback, object state)
+            {
+                return this.BeginTryGetChannel(canGetChannel, false, timeout, MaskingMode.All,
+                    callback, state);
+            }
+
+            public IAsyncResult BeginTryGetChannelForOutput(TimeSpan timeout,
+                MaskingMode maskingMode, AsyncCallback callback, object state)
+            {
+                return this.BeginTryGetChannel(true, true, timeout, maskingMode,
+                    callback, state);
+            }
+
+            IAsyncResult BeginTryGetChannel(bool canGetChannel, bool canCauseFault,
+                TimeSpan timeout, MaskingMode maskingMode, AsyncCallback callback, object state)
+            {
+                TChannel channel = null;
+                AsyncWaiter waiter = null;
+                bool getChannel = false;
+                bool faulted = false;
+
+                lock (this.ThisLock)
+                {
+                    if (!this.ThrowIfNecessary(maskingMode))
+                    {
+                        channel = null;
+                    }
+                    else if (this.state == State.ChannelOpened)
+                    {
+                        if (this.currentChannel == null)
+                        {
+                            throw Fx.AssertAndThrow("Field currentChannel cannot be null in the ChannelOpened state.");
+                        }
+
+                        this.count++;
+                        channel = this.currentChannel;
+                    }
+                    else if (!this.tolerateFaults
+                        && ((this.state == State.NoChannel)
+                        || (this.state == State.ChannelClosing)))
+                    {
+                        if (canCauseFault)
+                        {
+                            faulted = true;
+                        }
+
+                        channel = null;
+                    }
+                    else if (!canGetChannel
+                        || (this.state == State.ChannelOpening)
+                        || (this.state == State.ChannelClosing))
+                    {
+                        waiter = new AsyncWaiter(this, canGetChannel, null, timeout, maskingMode,
+                            this.binder.ChannelParameters,
+                            callback, state);
+                        this.GetQueue(canGetChannel).Enqueue(waiter);
+                    }
+                    else
+                    {
+                        if (this.state != State.NoChannel)
+                        {
+                            throw Fx.AssertAndThrow("The state must be NoChannel.");
+                        }
+
+                        waiter = new AsyncWaiter(this, canGetChannel,
+                            this.GetCurrentChannelIfCreated(), timeout, maskingMode,
+                            this.binder.ChannelParameters,
+                            callback, state);
+
+                        this.state = State.ChannelOpening;
+                        getChannel = true;
+                    }
+                }
+
+                if (faulted)
+                {
+                    this.binder.Fault(null);
+                }
+
+                if (waiter == null)
+                {
+                    return new CompletedAsyncResult<TChannel>(channel, callback, state);
+                }
+
+                if (getChannel)
+                {
+                    waiter.GetChannel(true);
+                }
+                else
+                {
+                    waiter.Wait();
+                }
+
+                return waiter;
+            }
+
+            public IAsyncResult BeginWaitForPendingOperations(TimeSpan timeout,
+                AsyncCallback callback, object state)
+            {
+                lock (this.ThisLock)
+                {
+                    if (this.drainEvent != null)
+                    {
+                        throw Fx.AssertAndThrow("The WaitForPendingOperations operation may only be invoked once.");
+                    }
+
+                    if (this.count > 0)
+                    {
+                        this.drainEvent = new InterruptibleWaitObject(false, false);
+                    }
+                }
+
+                if (this.drainEvent != null)
+                {
+                    return this.drainEvent.BeginWait(timeout, callback, state);
+                }
+                else
+                {
+                    return new SynchronizerCompletedAsyncResult(callback, state);
+                }
+            }
+
+            bool CompleteSetChannel(IWaiter waiter, out TChannel channel)
+            {
+                if (waiter == null)
+                {
+                    throw Fx.AssertAndThrow("Argument waiter cannot be null.");
+                }
+
+                bool close = false;
+
+                lock (this.ThisLock)
+                {
+                    if (this.ValidateOpened())
+                    {
+                        channel = this.currentChannel;
+                        return true;
+                    }
+                    else
+                    {
+                        channel = null;
+                        close = this.state == State.Closed;
+                    }
+                }
+
+                if (close)
+                {
+                    waiter.Close();
+                }
+                else
+                {
+                    waiter.Fault();
+                }
+
+                return false;
+            }
+
+            public bool EndTryGetChannel(IAsyncResult result, out TChannel channel)
+            {
+                AsyncWaiter waiter = result as AsyncWaiter;
+
+                if (waiter != null)
+                {
+                    return waiter.End(out channel);
+                }
+                else
+                {
+                    channel = CompletedAsyncResult<TChannel>.End(result);
+                    return true;
+                }
+            }
+
+            public void EndWaitForPendingOperations(IAsyncResult result)
+            {
+                SynchronizerCompletedAsyncResult completedResult =
+                    result as SynchronizerCompletedAsyncResult;
+
+                if (completedResult != null)
+                {
+                    completedResult.End();
+                }
+                else
+                {
+                    this.drainEvent.EndWait(result);
+                }
+            }
+
+            // Client API only.
+            public bool EnsureChannel()
+            {
+                bool fault = false;
+
+                lock (this.ThisLock)
+                {
+                    if (this.ValidateOpened())
+                    {
+                        // This is called only during the RM CS phase. In this phase, there are 2
+                        // valid states between Request calls, ChannelOpened and NoChannel.
+                        if (this.state == State.ChannelOpened)
+                        {
+                            return true;
+                        }
+
+                        if (this.state != State.NoChannel)
+                        {
+                            throw Fx.AssertAndThrow("The caller may only invoke this EnsureChannel during the CreateSequence negotiation. ChannelOpening and ChannelClosing are invalid states during this phase of the negotiation.");
+                        }
+
+                        if (!this.tolerateFaults)
+                        {
+                            fault = true;
+                        }
+                        else
+                        {
+                            if (this.GetCurrentChannelIfCreated() != null)
+                            {
+                                return true;
+                            }
+
+                            if (this.binder.TryGetChannel(TimeSpan.Zero))
+                            {
+                                if (this.currentChannel == null)
+                                {
+                                    return false;
+                                }
+
+                                return true;
+                            }
+                        }
+                    }
+                }
+
+                if (fault)
+                {
+                    this.binder.Fault(null);
+                }
+
+                return false;
+            }
+
+            IWaiter GetChannelWaiter()
+            {
+                if ((this.getChannelQueue == null) || (this.getChannelQueue.Count == 0))
+                {
+                    return null;
+                }
+
+                return this.getChannelQueue.Dequeue();
+            }
+
+            // Must be called within lock (this.ThisLock)
+            TChannel GetCurrentChannelIfCreated()
+            {
+                if (this.state != State.NoChannel)
+                {
+                    throw Fx.AssertAndThrow("This method may only be called in the NoChannel state.");
+                }
+
+                if ((this.currentChannel != null)
+                    && (this.currentChannel.State == CommunicationState.Created))
+                {
+                    return this.currentChannel;
+                }
+                else
+                {
+                    return null;
+                }
+            }
+
+            Queue<IWaiter> GetQueue(bool canGetChannel)
+            {
+                if (canGetChannel)
+                {
+                    if (this.getChannelQueue == null)
+                    {
+                        this.getChannelQueue = new Queue<IWaiter>();
+                    }
+
+                    return this.getChannelQueue;
+                }
+                else
+                {
+                    if (this.waitQueue == null)
+                    {
+                        this.waitQueue = new Queue<IWaiter>();
+                    }
+
+                    return this.waitQueue;
+                }
+            }
+
+            void OnChannelFaulted(object sender, EventArgs e)
+            {
+                TChannel faultedChannel = (TChannel)sender;
+                bool faultBinder = false;
+                bool raiseInnerChannelFaulted = false;
+
+                lock (this.ThisLock)
+                {
+                    if (this.currentChannel != faultedChannel)
+                    {
+                        return;
+                    }
+
+                    // The synchronizer is already closed or aborted.
+                    if (!this.ValidateOpened())
+                    {
+                        return;
+                    }
+
+                    if (this.state == State.ChannelOpened)
+                    {
+                        if (this.count == 0)
+                        {
+                            faultedChannel.Faulted -= this.onChannelFaulted;
+                        }
+
+                        faultBinder = !this.tolerateFaults;
+                        this.state = State.ChannelClosing;
+                        this.innerChannelFaulted = true;
+
+                        if (!faultBinder && this.count == 0)
+                        {
+                            this.state = State.NoChannel;
+                            this.aborting = false;
+                            raiseInnerChannelFaulted = true;
+                            this.innerChannelFaulted = false;
+                        }
+                    }
+                }
+
+                if (faultBinder)
+                {
+                    this.binder.Fault(null);
+                }
+
+                faultedChannel.Abort();
+
+                if (raiseInnerChannelFaulted)
+                {
+                    this.binder.OnInnerChannelFaulted();
+                }
+            }
+
+            bool OnChannelOpened(IWaiter waiter)
+            {
+                if (waiter == null)
+                {
+                    throw Fx.AssertAndThrow("Argument waiter cannot be null.");
+                }
+
+                bool close = false;
+                bool fault = false;
+
+                Queue<IWaiter> temp1 = null;
+                Queue<IWaiter> temp2 = null;
+                TChannel channel = null;
+
+                lock (this.ThisLock)
+                {
+                    if (this.currentChannel == null)
+                    {
+                        throw Fx.AssertAndThrow("Caller must ensure that field currentChannel is set before opening the channel.");
+                    }
+
+                    if (this.ValidateOpened())
+                    {
+                        if (this.state != State.ChannelOpening)
+                        {
+                            throw Fx.AssertAndThrow("This method may only be called in the ChannelOpening state.");
+                        }
+
+                        this.state = State.ChannelOpened;
+                        this.SetTolerateFaults();
+
+                        this.count += 1;
+                        this.count += (this.getChannelQueue == null) ? 0 : this.getChannelQueue.Count;
+                        this.count += (this.waitQueue == null) ? 0 : this.waitQueue.Count;
+
+                        temp1 = this.getChannelQueue;
+                        temp2 = this.waitQueue;
+                        channel = this.currentChannel;
+
+                        this.getChannelQueue = null;
+                        this.waitQueue = null;
+                    }
+                    else
+                    {
+                        close = this.state == State.Closed;
+                        fault = this.state == State.Faulted;
+                    }
+                }
+
+                if (close)
+                {
+                    waiter.Close();
+                    return false;
+                }
+                else if (fault)
+                {
+                    waiter.Fault();
+                    return false;
+                }
+
+                this.SetWaiters(temp1, channel);
+                this.SetWaiters(temp2, channel);
+                return true;
+            }
+
+            void OnGetChannelFailed()
+            {
+                IWaiter waiter = null;
+
+                lock (this.ThisLock)
+                {
+                    if (!this.ValidateOpened())
+                    {
+                        return;
+                    }
+
+                    if (this.state != State.ChannelOpening)
+                    {
+                        throw Fx.AssertAndThrow("The state must be set to ChannelOpening before the caller attempts to open the channel.");
+                    }
+
+                    waiter = this.GetChannelWaiter();
+
+                    if (waiter == null)
+                    {
+                        this.state = State.NoChannel;
+                        return;
+                    }
+                }
+
+                if (waiter is SyncWaiter)
+                {
+                    waiter.GetChannel(false);
+                }
+                else
+                {
+                    ActionItem.Schedule(asyncGetChannelCallback, waiter);
+                }
+            }
+
+            public void OnReadEof()
+            {
+                lock (this.ThisLock)
+                {
+                    if (this.count <= 0)
+                    {
+                        throw Fx.AssertAndThrow("Caller must ensure that OnReadEof is called before ReturnChannel.");
+                    }
+
+                    if (this.ValidateOpened())
+                    {
+                        if ((this.state != State.ChannelOpened) && (this.state != State.ChannelClosing))
+                        {
+                            throw Fx.AssertAndThrow("Since count is positive, the only valid states are ChannelOpened and ChannelClosing.");
+                        }
+
+                        if (this.currentChannel.State != CommunicationState.Faulted)
+                        {
+                            this.state = State.ChannelClosing;
+                        }
+                    }
+                }
+            }
+
+            bool RemoveWaiter(IWaiter waiter)
+            {
+                Queue<IWaiter> waiters = waiter.CanGetChannel ? this.getChannelQueue : this.waitQueue;
+                bool removed = false;
+
+                lock (this.ThisLock)
+                {
+                    if (!this.ValidateOpened())
+                    {
+                        return false;
+                    }
+
+                    for (int i = waiters.Count; i > 0; i--)
+                    {
+                        IWaiter temp = waiters.Dequeue();
+
+                        if (object.ReferenceEquals(waiter, temp))
+                        {
+                            removed = true;
+                        }
+                        else
+                        {
+                            waiters.Enqueue(temp);
+                        }
+                    }
+                }
+
+                return removed;
+            }
+
+            public void ReturnChannel()
+            {
+                TChannel channel = null;
+                IWaiter waiter = null;
+                bool faultBinder = false;
+                bool drained;
+                bool raiseInnerChannelFaulted = false;
+
+                lock (this.ThisLock)
+                {
+                    if (this.count <= 0)
+                    {
+                        throw Fx.AssertAndThrow("Method ReturnChannel() can only be called after TryGetChannel or EndTryGetChannel returns a channel.");
+                    }
+
+                    this.count--;
+                    drained = (this.count == 0) && (this.drainEvent != null);
+
+                    if (this.ValidateOpened())
+                    {
+                        if ((this.state != State.ChannelOpened) && (this.state != State.ChannelClosing))
+                        {
+                            throw Fx.AssertAndThrow("ChannelOpened and ChannelClosing are the only 2 valid states when count is positive.");
+                        }
+
+                        if (this.currentChannel.State == CommunicationState.Faulted)
+                        {
+                            faultBinder = !this.tolerateFaults;
+                            this.innerChannelFaulted = true;
+                            this.state = State.ChannelClosing;
+                        }
+
+                        if (!faultBinder && (this.state == State.ChannelClosing) && (this.count == 0))
+                        {
+                            channel = this.currentChannel;
+                            raiseInnerChannelFaulted = this.innerChannelFaulted;
+                            this.innerChannelFaulted = false;
+
+                            this.state = State.NoChannel;
+                            this.aborting = false;
+
+                            waiter = this.GetChannelWaiter();
+
+                            if (waiter != null)
+                            {
+                                this.state = State.ChannelOpening;
+                            }
+                        }
+                    }
+                }
+
+                if (faultBinder)
+                {
+                    this.binder.Fault(null);
+                }
+
+                if (drained)
+                {
+                    this.drainEvent.Set();
+                }
+
+                if (channel != null)
+                {
+                    channel.Faulted -= this.onChannelFaulted;
+
+                    if (channel.State == CommunicationState.Opened)
+                    {
+                        this.binder.CloseChannel(channel);
+                    }
+                    else
+                    {
+                        channel.Abort();
+                    }
+
+                    if (waiter != null)
+                    {
+                        waiter.GetChannel(false);
+                    }
+                }
+
+                if (raiseInnerChannelFaulted)
+                {
+                    this.binder.OnInnerChannelFaulted();
+                }
+            }
+
+            public bool SetChannel(TChannel channel)
+            {
+                lock (this.ThisLock)
+                {
+                    if (this.state != State.ChannelOpening && this.state != State.NoChannel)
+                    {
+                        throw Fx.AssertAndThrow("SetChannel is only valid in the NoChannel and ChannelOpening states");
+                    }
+
+                    if (!this.tolerateFaults)
+                    {
+                        throw Fx.AssertAndThrow("SetChannel is only valid when masking faults");
+                    }
+
+                    if (this.ValidateOpened())
+                    {
+                        this.currentChannel = channel;
+                        return true;
+                    }
+                    else
+                    {
+                        return false;
+                    }
+                }
+            }
+
+            void SetTolerateFaults()
+            {
+                if (this.faultMode == TolerateFaultsMode.Never)
+                {
+                    this.tolerateFaults = false;
+                }
+                else if (this.faultMode == TolerateFaultsMode.IfNotSecuritySession)
+                {
+                    this.tolerateFaults = !this.binder.HasSecuritySession(this.currentChannel);
+                }
+
+                if (this.onChannelFaulted == null)
+                {
+                    this.onChannelFaulted = new EventHandler(this.OnChannelFaulted);
+                }
+
+                this.currentChannel.Faulted += this.onChannelFaulted;
+            }
+
+            void SetWaiters(Queue<IWaiter> waiters, TChannel channel)
+            {
+                if ((waiters != null) && (waiters.Count > 0))
+                {
+                    foreach (IWaiter waiter in waiters)
+                    {
+                        waiter.Set(channel);
+                    }
+                }
+            }
+
+            public void StartSynchronizing()
+            {
+                lock (this.ThisLock)
+                {
+                    if (this.state == State.Created)
+                    {
+                        this.state = State.NoChannel;
+                    }
+                    else
+                    {
+                        if (this.state != State.Closed)
+                        {
+                            throw Fx.AssertAndThrow("Abort is the only operation that can race with Open.");
+                        }
+
+                        return;
+                    }
+
+                    if (this.currentChannel == null)
+                    {
+                        if (!this.binder.TryGetChannel(TimeSpan.Zero))
+                        {
+                            return;
+                        }
+                    }
+
+                    if (this.currentChannel == null)
+                    {
+                        return;
+                    }
+
+                    if (!this.binder.MustOpenChannel)
+                    {
+                        // Channel is already opened.
+                        this.state = State.ChannelOpened;
+                        this.SetTolerateFaults();
+                    }
+                }
+            }
+
+            public TChannel StopSynchronizing(bool close)
+            {
+                lock (this.ThisLock)
+                {
+                    if ((this.state != State.Faulted) && (this.state != State.Closed))
+                    {
+                        this.state = close ? State.Closed : State.Faulted;
+
+                        if ((this.currentChannel != null) && (this.onChannelFaulted != null))
+                        {
+                            this.currentChannel.Faulted -= this.onChannelFaulted;
+                        }
+                    }
+
+                    return this.currentChannel;
+                }
+            }
+
+            // Must be called under a lock.
+            bool ThrowIfNecessary(MaskingMode maskingMode)
+            {
+                if (this.ValidateOpened())
+                {
+                    return true;
+                }
+
+                // state is Closed or Faulted.
+                Exception e;
+
+                if (this.state == State.Closed)
+                {
+                    e = this.binder.GetClosedException(maskingMode);
+                }
+                else
+                {
+                    e = this.binder.GetFaultedException(maskingMode);
+                }
+
+                if (e != null)
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(e);
+                }
+
+                return false;
+            }
+
+            public bool TryGetChannelForInput(bool canGetChannel, TimeSpan timeout,
+                out TChannel channel)
+            {
+                return this.TryGetChannel(canGetChannel, false, timeout, MaskingMode.All,
+                    out channel);
+            }
+
+            public bool TryGetChannelForOutput(TimeSpan timeout, MaskingMode maskingMode,
+                out TChannel channel)
+            {
+                return this.TryGetChannel(true, true, timeout, maskingMode, out channel);
+            }
+
+            bool TryGetChannel(bool canGetChannel, bool canCauseFault, TimeSpan timeout,
+                MaskingMode maskingMode, out TChannel channel)
+            {
+                SyncWaiter waiter = null;
+                bool faulted = false;
+                bool getChannel = false;
+
+                lock (this.ThisLock)
+                {
+                    if (!this.ThrowIfNecessary(maskingMode))
+                    {
+                        channel = null;
+                        return true;
+                    }
+
+                    if (this.state == State.ChannelOpened)
+                    {
+                        if (this.currentChannel == null)
+                        {
+                            throw Fx.AssertAndThrow("Field currentChannel cannot be null in the ChannelOpened state.");
+                        }
+
+                        this.count++;
+                        channel = this.currentChannel;
+                        return true;
+                    }
+
+                    if (!this.tolerateFaults
+                        && ((this.state == State.ChannelClosing)
+                        || (this.state == State.NoChannel)))
+                    {
+                        if (!canCauseFault)
+                        {
+                            channel = null;
+                            return true;
+                        }
+
+                        faulted = true;
+                    }
+                    else if (!canGetChannel
+                        || (this.state == State.ChannelOpening)
+                        || (this.state == State.ChannelClosing))
+                    {
+                        waiter = new SyncWaiter(this, canGetChannel, null, timeout, maskingMode, this.binder.ChannelParameters);
+                        this.GetQueue(canGetChannel).Enqueue(waiter);
+                    }
+                    else
+                    {
+                        if (this.state != State.NoChannel)
+                        {
+                            throw Fx.AssertAndThrow("The state must be NoChannel.");
+                        }
+
+                        waiter = new SyncWaiter(this, canGetChannel,
+                            this.GetCurrentChannelIfCreated(), timeout, maskingMode,
+                            this.binder.ChannelParameters);
+
+                        this.state = State.ChannelOpening;
+                        getChannel = true;
+                    }
+                }
+
+                if (faulted)
+                {
+                    this.binder.Fault(null);
+                    channel = null;
+                    return true;
+                }
+
+                if (getChannel)
+                {
+                    waiter.GetChannel(true);
+                }
+
+                return waiter.TryWait(out channel);
+            }
+
+            public void UnblockWaiters()
+            {
+                Queue<IWaiter> temp1;
+                Queue<IWaiter> temp2;
+
+                lock (this.ThisLock)
+                {
+                    temp1 = this.getChannelQueue;
+                    temp2 = this.waitQueue;
+
+                    this.getChannelQueue = null;
+                    this.waitQueue = null;
+                }
+
+                bool close = this.state == State.Closed;
+                this.UnblockWaiters(temp1, close);
+                this.UnblockWaiters(temp2, close);
+            }
+
+            void UnblockWaiters(Queue<IWaiter> waiters, bool close)
+            {
+                if ((waiters != null) && (waiters.Count > 0))
+                {
+                    foreach (IWaiter waiter in waiters)
+                    {
+                        if (close)
+                        {
+                            waiter.Close();
+                        }
+                        else
+                        {
+                            waiter.Fault();
+                        }
+                    }
+                }
+            }
+
+            bool ValidateOpened()
+            {
+                if (this.state == State.Created)
+                {
+                    throw Fx.AssertAndThrow("This operation expects that the synchronizer has been opened.");
+                }
+
+                return (this.state != State.Closed) && (this.state != State.Faulted);
+            }
+
+            public void WaitForPendingOperations(TimeSpan timeout)
+            {
+                lock (this.ThisLock)
+                {
+                    if (this.drainEvent != null)
+                    {
+                        throw Fx.AssertAndThrow("The WaitForPendingOperations operation may only be invoked once.");
+                    }
+
+                    if (this.count > 0)
+                    {
+                        this.drainEvent = new InterruptibleWaitObject(false, false);
+                    }
+                }
+
+                if (this.drainEvent != null)
+                {
+                    this.drainEvent.Wait(timeout);
+                }
+            }
+
+            enum State
+            {
+                Created,
+                NoChannel,
+                ChannelOpening,
+                ChannelOpened,
+                ChannelClosing,
+                Faulted,
+                Closed
+            }
+
+            public interface IWaiter
+            {
+                bool CanGetChannel { get; }
+
+                void Close();
+                void Fault();
+                void GetChannel(bool onUserThread);
+                void Set(TChannel channel);
+            }
+
+            public sealed class AsyncWaiter : AsyncResult, IWaiter
+            {
+                bool canGetChannel;
+                TChannel channel;
+                ChannelParameterCollection channelParameters;
+                bool isSynchronous = true;
+                MaskingMode maskingMode;
+                static AsyncCallback onOpenComplete = Fx.ThunkCallback(new AsyncCallback(OnOpenComplete));
+                static Action<object> onTimeoutElapsed = new Action<object>(OnTimeoutElapsed);
+                static AsyncCallback onTryGetChannelComplete = Fx.ThunkCallback(new AsyncCallback(OnTryGetChannelComplete));
+                bool timedOut = false;
+                ChannelSynchronizer synchronizer;
+                TimeoutHelper timeoutHelper;
+                IOThreadTimer timer;
+                bool timerCancelled = false;
+
+                public AsyncWaiter(ChannelSynchronizer synchronizer, bool canGetChannel,
+                    TChannel channel, TimeSpan timeout, MaskingMode maskingMode,
+                    ChannelParameterCollection channelParameters,
+                    AsyncCallback callback, object state)
+                    : base(callback, state)
+                {
+                    if (!canGetChannel)
+                    {
+                        if (channel != null)
+                        {
+                            throw Fx.AssertAndThrow("This waiter must wait for a channel thus argument channel must be null.");
+                        }
+                    }
+
+                    this.synchronizer = synchronizer;
+                    this.canGetChannel = canGetChannel;
+                    this.channel = channel;
+                    this.timeoutHelper = new TimeoutHelper(timeout);
+                    this.maskingMode = maskingMode;
+                    this.channelParameters = channelParameters;
+                }
+
+                public bool CanGetChannel
+                {
+                    get
+                    {
+                        return this.canGetChannel;
+                    }
+                }
+
+                object ThisLock
+                {
+                    get
+                    {
+                        return this;
+                    }
+                }
+
+                void CancelTimer()
+                {
+                    lock (this.ThisLock)
+                    {
+                        if (!this.timerCancelled)
+                        {
+                            if (this.timer != null)
+                            {
+                                this.timer.Cancel();
+                            }
+
+                            this.timerCancelled = true;
+                        }
+                    }
+                }
+
+                public void Close()
+                {
+                    this.CancelTimer();
+                    this.channel = null;
+                    this.Complete(false,
+                        this.synchronizer.binder.GetClosedException(this.maskingMode));
+                }
+
+                bool CompleteOpen(IAsyncResult result)
+                {
+                    this.channel.EndOpen(result);
+                    return this.OnChannelOpened();
+                }
+
+                bool CompleteTryGetChannel(IAsyncResult result)
+                {
+                    if (!this.synchronizer.binder.EndTryGetChannel(result))
+                    {
+                        this.timedOut = true;
+                        this.OnGetChannelFailed();
+                        return true;
+                    }
+
+                    if (!this.synchronizer.CompleteSetChannel(this, out this.channel))
+                    {
+                        if (!this.IsCompleted)
+                        {
+                            throw Fx.AssertAndThrow("CompleteSetChannel must complete the IWaiter if it returns false.");
+                        }
+
+                        return false;
+                    }
+
+                    return this.OpenChannel();
+                }
+
+                public bool End(out TChannel channel)
+                {
+                    AsyncResult.End<AsyncWaiter>(this);
+                    channel = this.channel;
+                    return !this.timedOut;
+                }
+
+                public void Fault()
+                {
+                    this.CancelTimer();
+                    this.channel = null;
+                    this.Complete(false,
+                        this.synchronizer.binder.GetFaultedException(this.maskingMode));
+                }
+
+                bool GetChannel()
+                {
+                    if (this.channel != null)
+                    {
+                        return this.OpenChannel();
+                    }
+                    else
+                    {
+                        IAsyncResult result = this.synchronizer.binder.BeginTryGetChannel(
+                            this.timeoutHelper.RemainingTime(), onTryGetChannelComplete, this);
+
+                        if (result.CompletedSynchronously)
+                        {
+                            return this.CompleteTryGetChannel(result);
+                        }
+                    }
+
+                    return false;
+                }
+
+                public void GetChannel(bool onUserThread)
+                {
+                    if (!this.CanGetChannel)
+                    {
+                        throw Fx.AssertAndThrow("This waiter must wait for a channel thus the caller cannot attempt to get a channel.");
+                    }
+
+                    this.isSynchronous = onUserThread;
+
+                    if (onUserThread)
+                    {
+                        bool throwing = true;
+
+                        try
+                        {
+                            if (this.GetChannel())
+                            {
+                                this.Complete(true);
+                            }
+
+                            throwing = false;
+                        }
+                        finally
+                        {
+                            if (throwing)
+                            {
+                                this.OnGetChannelFailed();
+                            }
+                        }
+                    }
+                    else
+                    {
+                        bool complete = false;
+                        Exception completeException = null;
+
+                        try
+                        {
+                            this.CancelTimer();
+                            complete = this.GetChannel();
+                        }
+#pragma warning suppress 56500 // covered by FxCOP
+                        catch (Exception e)
+                        {
+                            if (Fx.IsFatal(e))
+                            {
+                                throw;
+                            }
+
+                            this.OnGetChannelFailed();
+                            completeException = e;
+                        }
+
+                        if (complete || completeException != null)
+                        {
+                            this.Complete(false, completeException);
+                        }
+                    }
+                }
+
+                bool OnChannelOpened()
+                {
+                    if (this.synchronizer.OnChannelOpened(this))
+                    {
+                        return true;
+                    }
+                    else
+                    {
+                        if (!this.IsCompleted)
+                        {
+                            throw Fx.AssertAndThrow("OnChannelOpened must complete the IWaiter if it returns false.");
+                        }
+
+                        return false;
+                    }
+                }
+
+                void OnGetChannelFailed()
+                {
+                    if (this.channel != null)
+                    {
+                        this.channel.Abort();
+                    }
+
+                    this.synchronizer.OnGetChannelFailed();
+                }
+
+                static void OnOpenComplete(IAsyncResult result)
+                {
+                    if (!result.CompletedSynchronously)
+                    {
+                        AsyncWaiter waiter = (AsyncWaiter)result.AsyncState;
+                        bool complete = false;
+                        Exception completeException = null;
+
+                        waiter.isSynchronous = false;
+
+                        try
+                        {
+                            complete = waiter.CompleteOpen(result);
+                        }
+#pragma warning suppress 56500 // covered by FxCOP
+                        catch (Exception e)
+                        {
+                            if (Fx.IsFatal(e))
+                            {
+                                throw;
+                            }
+
+                            completeException = e;
+                        }
+
+                        if (complete)
+                        {
+                            waiter.Complete(false);
+                        }
+                        else if (completeException != null)
+                        {
+                            waiter.OnGetChannelFailed();
+                            waiter.Complete(false, completeException);
+                        }
+                    }
+                }
+
+                void OnTimeoutElapsed()
+                {
+                    if (this.synchronizer.RemoveWaiter(this))
+                    {
+                        this.timedOut = true;
+                        this.Complete(this.isSynchronous, null);
+                    }
+                }
+
+                static void OnTimeoutElapsed(object state)
+                {
+                    AsyncWaiter waiter = (AsyncWaiter)state;
+                    waiter.isSynchronous = false;
+                    waiter.OnTimeoutElapsed();
+                }
+
+                static void OnTryGetChannelComplete(IAsyncResult result)
+                {
+                    if (!result.CompletedSynchronously)
+                    {
+                        AsyncWaiter waiter = (AsyncWaiter)result.AsyncState;
+                        waiter.isSynchronous = false;
+                        bool complete = false;
+                        Exception completeException = null;
+
+                        try
+                        {
+                            complete = waiter.CompleteTryGetChannel(result);
+                        }
+#pragma warning suppress 56500 // covered by FxCOP
+                        catch (Exception e)
+                        {
+                            if (Fx.IsFatal(e))
+                            {
+                                throw;
+                            }
+
+                            completeException = e;
+                        }
+
+                        if (complete || completeException != null)
+                        {
+                            if (completeException != null)
+                                waiter.OnGetChannelFailed();
+                            waiter.Complete(waiter.isSynchronous, completeException);
+                        }
+                    }
+                }
+
+                bool OpenChannel()
+                {
+                    if (this.synchronizer.binder.MustOpenChannel)
+                    {
+                        if (this.channelParameters != null)
+                        {
+                            this.channelParameters.PropagateChannelParameters(this.channel);
+                        }
+
+                        IAsyncResult result = this.channel.BeginOpen(
+                            this.timeoutHelper.RemainingTime(), onOpenComplete, this);
+
+                        if (result.CompletedSynchronously)
+                        {
+                            return this.CompleteOpen(result);
+                        }
+
+                        return false;
+                    }
+                    else
+                    {
+                        return this.OnChannelOpened();
+                    }
+                }
+
+                public void Set(TChannel channel)
+                {
+                    this.CancelTimer();
+                    this.channel = channel;
+                    this.Complete(false);
+                }
+
+                // Always called from the user's thread.
+                public void Wait()
+                {
+                    lock (this.ThisLock)
+                    {
+                        if (this.timerCancelled)
+                        {
+                            return;
+                        }
+
+                        TimeSpan timeout = this.timeoutHelper.RemainingTime();
+
+                        if (timeout > TimeSpan.Zero)
+                        {
+                            this.timer = new IOThreadTimer(onTimeoutElapsed, this, true);
+                            this.timer.Set(this.timeoutHelper.RemainingTime());
+                            return;
+                        }
+                    }
+
+                    this.OnTimeoutElapsed();
+                }
+            }
+
+            sealed class SynchronizerCompletedAsyncResult : CompletedAsyncResult
+            {
+                public SynchronizerCompletedAsyncResult(AsyncCallback callback, object state)
+                    : base(callback, state)
+                {
+                }
+
+                public void End()
+                {
+                    CompletedAsyncResult.End(this);
+                }
+            }
+
+            sealed class SyncWaiter : IWaiter
+            {
+                bool canGetChannel;
+                TChannel channel;
+                ChannelParameterCollection channelParameters;
+                AutoResetEvent completeEvent = new AutoResetEvent(false);
+                Exception exception;
+                bool getChannel = false;
+                MaskingMode maskingMode;
+                ChannelSynchronizer synchronizer;
+                TimeoutHelper timeoutHelper;
+
+                public SyncWaiter(ChannelSynchronizer synchronizer, bool canGetChannel,
+                    TChannel channel, TimeSpan timeout, MaskingMode maskingMode,
+                    ChannelParameterCollection channelParameters)
+                {
+                    if (!canGetChannel)
+                    {
+                        if (channel != null)
+                        {
+                            throw Fx.AssertAndThrow("This waiter must wait for a channel thus argument channel must be null.");
+                        }
+                    }
+
+                    this.synchronizer = synchronizer;
+                    this.canGetChannel = canGetChannel;
+                    this.channel = channel;
+                    this.timeoutHelper = new TimeoutHelper(timeout);
+                    this.maskingMode = maskingMode;
+                    this.channelParameters = channelParameters;
+                }
+
+                public bool CanGetChannel
+                {
+                    get
+                    {
+                        return this.canGetChannel;
+                    }
+                }
+
+                public void Close()
+                {
+                    this.exception = this.synchronizer.binder.GetClosedException(this.maskingMode);
+                    this.completeEvent.Set();
+                }
+
+                public void Fault()
+                {
+                    this.exception = this.synchronizer.binder.GetFaultedException(this.maskingMode);
+                    this.completeEvent.Set();
+                }
+
+                public void GetChannel(bool onUserThread)
+                {
+                    if (!this.CanGetChannel)
+                    {
+                        throw Fx.AssertAndThrow("This waiter must wait for a channel thus the caller cannot attempt to get a channel.");
+                    }
+
+                    this.getChannel = true;
+                    this.completeEvent.Set();
+                }
+
+                public void Set(TChannel channel)
+                {
+                    if (channel == null)
+                    {
+                        throw Fx.AssertAndThrow("Argument channel cannot be null. Caller must call Fault or Close instead.");
+                    }
+
+                    this.channel = channel;
+                    this.completeEvent.Set();
+                }
+
+                bool TryGetChannel()
+                {
+                    TChannel channel;
+
+                    if (this.channel != null)
+                    {
+                        channel = this.channel;
+                    }
+                    else if (this.synchronizer.binder.TryGetChannel(
+                        this.timeoutHelper.RemainingTime()))
+                    {
+                        if (!this.synchronizer.CompleteSetChannel(this, out channel))
+                        {
+                            return true;
+                        }
+                    }
+                    else
+                    {
+                        this.synchronizer.OnGetChannelFailed();
+                        return false;
+                    }
+
+                    if (this.synchronizer.binder.MustOpenChannel)
+                    {
+                        bool throwing = true;
+
+                        if (this.channelParameters != null)
+                        {
+                            this.channelParameters.PropagateChannelParameters(channel);
+                        }
+
+                        try
+                        {
+                            channel.Open(this.timeoutHelper.RemainingTime());
+                            throwing = false;
+                        }
+                        finally
+                        {
+                            if (throwing)
+                            {
+                                channel.Abort();
+                                this.synchronizer.OnGetChannelFailed();
+                            }
+                        }
+                    }
+
+                    if (this.synchronizer.OnChannelOpened(this))
+                    {
+                        this.Set(channel);
+                    }
+
+                    return true;
+                }
+
+                public bool TryWait(out TChannel channel)
+                {
+                    if (!this.Wait())
+                    {
+                        channel = null;
+                        return false;
+                    }
+                    else if (this.getChannel && !this.TryGetChannel())
+                    {
+                        channel = null;
+                        return false;
+                    }
+
+                    this.completeEvent.Close();
+
+                    if (this.exception != null)
+                    {
+                        if (this.channel != null)
+                        {
+                            throw Fx.AssertAndThrow("User of IWaiter called both Set and Fault or Close.");
+                        }
+
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(this.exception);
+                    }
+
+                    channel = this.channel;
+                    return true;
+                }
+
+                bool Wait()
+                {
+                    if (!TimeoutHelper.WaitOne(this.completeEvent, this.timeoutHelper.RemainingTime()))
+                    {
+                        if (this.synchronizer.RemoveWaiter(this))
+                        {
+                            return false;
+                        }
+                        else
+                        {
+                            TimeoutHelper.WaitOne(this.completeEvent, TimeSpan.MaxValue);
+                        }
+                    }
+
+                    return true;
+                }
+            }
+        }
+
+        sealed class CloseAsyncResult : AsyncResult
+        {
+            ReliableChannelBinder<TChannel> binder;
+            TChannel channel;
+            MaskingMode maskingMode;
+            static AsyncCallback onBinderCloseComplete = Fx.ThunkCallback(new AsyncCallback(OnBinderCloseComplete));
+            static AsyncCallback onChannelCloseComplete = Fx.ThunkCallback(new AsyncCallback(OnChannelCloseComplete));
+            TimeoutHelper timeoutHelper;
+
+            public CloseAsyncResult(ReliableChannelBinder<TChannel> binder, TChannel channel,
+                TimeSpan timeout, MaskingMode maskingMode, AsyncCallback callback, object state)
+                : base(callback, state)
+            {
+                this.binder = binder;
+                this.channel = channel;
+                this.timeoutHelper = new TimeoutHelper(timeout);
+                this.maskingMode = maskingMode;
+                bool complete = false;
+
+                try
+                {
+                    this.binder.OnShutdown();
+                    IAsyncResult result = this.binder.OnBeginClose(timeout, onBinderCloseComplete, this);
+
+                    if (result.CompletedSynchronously)
+                    {
+                        complete = this.CompleteBinderClose(true, result);
+                    }
+                }
+                catch (Exception e)
+                {
+                    if (Fx.IsFatal(e))
+                    {
+                        throw;
+                    }
+
+                    this.binder.Abort();
+
+                    if (!this.binder.HandleException(e, this.maskingMode))
+                    {
+                        throw;
+                    }
+                    else
+                    {
+                        complete = true;
+                    }
+                }
+
+                if (complete)
+                {
+                    this.Complete(true);
+                }
+            }
+
+            bool CompleteBinderClose(bool synchronous, IAsyncResult result)
+            {
+                this.binder.OnEndClose(result);
+
+                if (this.channel != null)
+                {
+                    result = this.binder.BeginCloseChannel(this.channel,
+                        this.timeoutHelper.RemainingTime(), onChannelCloseComplete, this);
+
+                    if (result.CompletedSynchronously)
+                    {
+                        return this.CompleteChannelClose(synchronous, result);
+                    }
+                    else
+                    {
+                        return false;
+                    }
+                }
+                else
+                {
+                    this.binder.TransitionToClosed();
+                    return true;
+                }
+            }
+
+            bool CompleteChannelClose(bool synchronous, IAsyncResult result)
+            {
+                this.binder.EndCloseChannel(this.channel, result);
+                this.binder.TransitionToClosed();
+                return true;
+            }
+
+            public void End()
+            {
+                AsyncResult.End<CloseAsyncResult>(this);
+            }
+
+            Exception HandleAsyncException(Exception e)
+            {
+                this.binder.Abort();
+
+                if (this.binder.HandleException(e, this.maskingMode))
+                {
+                    return null;
+                }
+                else
+                {
+                    return e;
+                }
+            }
+
+            static void OnBinderCloseComplete(IAsyncResult result)
+            {
+                if (!result.CompletedSynchronously)
+                {
+                    CloseAsyncResult closeResult = (CloseAsyncResult)result.AsyncState;
+                    bool complete;
+                    Exception completeException;
+
+                    try
+                    {
+                        complete = closeResult.CompleteBinderClose(false, result);
+                        completeException = null;
+                    }
+#pragma warning suppress 56500 // covered by FxCOP
+                    catch (Exception e)
+                    {
+                        if (Fx.IsFatal(e))
+                        {
+                            throw;
+                        }
+
+                        complete = true;
+                        completeException = e;
+                    }
+
+                    if (complete)
+                    {
+                        if (completeException != null)
+                        {
+                            completeException = closeResult.HandleAsyncException(completeException);
+                        }
+
+                        closeResult.Complete(false, completeException);
+                    }
+                }
+            }
+
+            static void OnChannelCloseComplete(IAsyncResult result)
+            {
+                if (!result.CompletedSynchronously)
+                {
+                    CloseAsyncResult closeResult = (CloseAsyncResult)result.AsyncState;
+                    bool complete;
+                    Exception completeException;
+
+                    try
+                    {
+                        complete = closeResult.CompleteChannelClose(false, result);
+                        completeException = null;
+                    }
+#pragma warning suppress 56500 // covered by FxCOP
+                    catch (Exception e)
+                    {
+                        if (Fx.IsFatal(e))
+                        {
+                            throw;
+                        }
+
+                        complete = true;
+                        completeException = e;
+                    }
+
+                    if (complete)
+                    {
+                        if (completeException != null)
+                        {
+                            completeException = closeResult.HandleAsyncException(completeException);
+                        }
+
+                        closeResult.Complete(false, completeException);
+                    }
+                }
+            }
+        }
+
+        protected abstract class InputAsyncResult<TBinder> : AsyncResult
+            where TBinder : ReliableChannelBinder<TChannel>
+        {
+            bool autoAborted;
+            TBinder binder;
+            bool canGetChannel;
+            TChannel channel;
+            bool isSynchronous = true;
+            MaskingMode maskingMode;
+            static AsyncCallback onInputComplete = Fx.ThunkCallback(new AsyncCallback(OnInputCompleteStatic));
+            static AsyncCallback onTryGetChannelComplete = Fx.ThunkCallback(new AsyncCallback(OnTryGetChannelCompleteStatic));
+            bool success;
+            TimeoutHelper timeoutHelper;
+
+            public InputAsyncResult(TBinder binder, bool canGetChannel, TimeSpan timeout,
+                MaskingMode maskingMode, AsyncCallback callback, object state)
+                : base(callback, state)
+            {
+                this.binder = binder;
+                this.canGetChannel = canGetChannel;
+                this.timeoutHelper = new TimeoutHelper(timeout);
+                this.maskingMode = maskingMode;
+            }
+
+            protected abstract IAsyncResult BeginInput(TBinder binder, TChannel channel,
+                TimeSpan timeout, AsyncCallback callback, object state);
+
+            // returns true if the caller should retry
+            bool CompleteInput(IAsyncResult result)
+            {
+                bool complete;
+
+                try
+                {
+                    this.success = this.EndInput(this.binder, this.channel, result, out complete);
+                }
+                finally
+                {
+                    this.autoAborted = this.binder.Synchronizer.Aborting;
+                    this.binder.synchronizer.ReturnChannel();
+                }
+
+                return !complete;
+            }
+
+            // returns true if the caller should retry
+            bool CompleteTryGetChannel(IAsyncResult result, out bool complete)
+            {
+                complete = false;
+                this.success = this.binder.synchronizer.EndTryGetChannel(result, out this.channel);
+
+                // the synchronizer is faulted and not reestablishing or closed, or the call timed
+                // out, complete and don't retry.
+                if (this.channel == null)
+                {
+                    complete = true;
+                    return false;
+                }
+
+                bool throwing = true;
+                IAsyncResult inputResult = null;
+
+                try
+                {
+                    inputResult = this.BeginInput(this.binder, this.channel,
+                        this.timeoutHelper.RemainingTime(), onInputComplete, this);
+                    throwing = false;
+                }
+                finally
+                {
+                    if (throwing)
+                    {
+                        this.autoAborted = this.binder.Synchronizer.Aborting;
+                        this.binder.synchronizer.ReturnChannel();
+                    }
+                }
+
+                if (inputResult.CompletedSynchronously)
+                {
+                    if (this.CompleteInput(inputResult))
+                    {
+                        complete = false;
+                        return true;
+                    }
+                    else
+                    {
+                        complete = true;
+                        return false;
+                    }
+                }
+                else
+                {
+                    complete = false;
+                    return false;
+                }
+            }
+
+            public bool End()
+            {
+                AsyncResult.End<InputAsyncResult<TBinder>>(this);
+                return this.success;
+            }
+
+            protected abstract bool EndInput(TBinder binder, TChannel channel,
+                IAsyncResult result, out bool complete);
+
+            void OnInputComplete(IAsyncResult result)
+            {
+                this.isSynchronous = false;
+                bool retry;
+                Exception completeException = null;
+
+                try
+                {
+                    retry = this.CompleteInput(result);
+                }
+#pragma warning suppress 56500 // covered by FxCOP
+                catch (Exception e)
+                {
+                    if (Fx.IsFatal(e))
+                    {
+                        throw;
+                    }
+
+                    if (!this.binder.HandleException(e, this.maskingMode, this.autoAborted))
+                    {
+                        completeException = e;
+                        retry = false;
+                    }
+                    else
+                    {
+                        retry = true;
+                    }
+                }
+
+                if (retry)
+                {
+                    this.StartOnNonUserThread();
+                }
+                else
+                {
+                    this.Complete(this.isSynchronous, completeException);
+                }
+            }
+
+            static void OnInputCompleteStatic(IAsyncResult result)
+            {
+                if (!result.CompletedSynchronously)
+                {
+                    InputAsyncResult<TBinder> inputResult =
+                        (InputAsyncResult<TBinder>)result.AsyncState;
+                    inputResult.OnInputComplete(result);
+                }
+            }
+
+            void OnTryGetChannelComplete(IAsyncResult result)
+            {
+                this.isSynchronous = false;
+                bool retry = false;
+                bool complete = false;
+                Exception completeException = null;
+
+                try
+                {
+                    retry = this.CompleteTryGetChannel(result, out complete);
+                }
+#pragma warning suppress 56500 // covered by FxCOP
+                catch (Exception e)
+                {
+                    if (Fx.IsFatal(e))
+                    {
+                        throw;
+                    }
+
+                    if (!this.binder.HandleException(e, this.maskingMode, this.autoAborted))
+                    {
+                        completeException = e;
+                        retry = false;
+                    }
+                    else
+                    {
+                        retry = true;
+                    }
+                }
+
+                // Can't complete AND retry.
+                if (complete && retry)
+                {
+                    throw Fx.AssertAndThrow("The derived class' implementation of CompleteTryGetChannel() cannot indicate that the asynchronous operation should complete and retry.");
+                }
+
+                if (retry)
+                {
+                    this.StartOnNonUserThread();
+                }
+                else if (complete || completeException != null)
+                {
+                    this.Complete(this.isSynchronous, completeException);
+                }
+            }
+
+            static void OnTryGetChannelCompleteStatic(IAsyncResult result)
+            {
+                if (!result.CompletedSynchronously)
+                {
+                    InputAsyncResult<TBinder> inputResult =
+                        (InputAsyncResult<TBinder>)result.AsyncState;
+                    inputResult.OnTryGetChannelComplete(result);
+                }
+            }
+
+            protected bool Start()
+            {
+                while (true)
+                {
+                    bool retry = false;
+                    bool complete = false;
+
+                    this.autoAborted = false;
+
+                    try
+                    {
+                        IAsyncResult result = this.binder.synchronizer.BeginTryGetChannelForInput(
+                            canGetChannel, this.timeoutHelper.RemainingTime(),
+                            onTryGetChannelComplete, this);
+
+                        if (result.CompletedSynchronously)
+                        {
+                            retry = this.CompleteTryGetChannel(result, out complete);
+                        }
+                    }
+                    catch (Exception e)
+                    {
+                        if (Fx.IsFatal(e))
+                        {
+                            throw;
+                        }
+
+                        if (!this.binder.HandleException(e, this.maskingMode, this.autoAborted))
+                        {
+                            throw;
+                        }
+                        else
+                        {
+                            retry = true;
+                        }
+                    }
+
+                    // Can't complete AND retry.
+                    if (complete && retry)
+                    {
+                        throw Fx.AssertAndThrow("The derived class' implementation of CompleteTryGetChannel() cannot indicate that the asynchronous operation should complete and retry.");
+                    }
+
+                    if (!retry)
+                    {
+                        return complete;
+                    }
+                }
+            }
+
+            void StartOnNonUserThread()
+            {
+                bool complete = false;
+                Exception completeException = null;
+
+                try
+                {
+                    complete = this.Start();
+                }
+#pragma warning suppress 56500 // covered by FxCOP
+                catch (Exception e)
+                {
+                    if (Fx.IsFatal(e))
+                        throw;
+
+                    completeException = e;
+                }
+
+                if (complete || completeException != null)
+                    this.Complete(false, completeException);
+            }
+        }
+
+        sealed class MessageRequestContext : BinderRequestContext
+        {
+            public MessageRequestContext(ReliableChannelBinder<TChannel> binder, Message message)
+                : base(binder, message)
+            {
+            }
+
+            protected override void OnAbort()
+            {
+            }
+
+            protected override void OnClose(TimeSpan timeout)
+            {
+            }
+
+            protected override IAsyncResult OnBeginReply(Message message, TimeSpan timeout, AsyncCallback callback, object state)
+            {
+                return new ReplyAsyncResult(this, message, timeout, callback, state);
+            }
+
+            protected override void OnEndReply(IAsyncResult result)
+            {
+                ReplyAsyncResult.End(result);
+            }
+
+            protected override void OnReply(Message message, TimeSpan timeout)
+            {
+                if (message != null)
+                {
+                    this.Binder.Send(message, timeout, this.MaskingMode);
+                }
+            }
+
+            class ReplyAsyncResult : AsyncResult
+            {
+                static AsyncCallback onSend;
+                MessageRequestContext context;
+
+                public ReplyAsyncResult(MessageRequestContext context, Message message, TimeSpan timeout, AsyncCallback callback, object state)
+                    : base(callback, state)
+                {
+                    if (message != null)
+                    {
+                        if (onSend == null)
+                        {
+                            onSend = Fx.ThunkCallback(new AsyncCallback(OnSend));
+                        }
+                        this.context = context;
+                        IAsyncResult result = context.Binder.BeginSend(message, timeout, context.MaskingMode, onSend, this);
+                        if (!result.CompletedSynchronously)
+                        {
+                            return;
+                        }
+                        context.Binder.EndSend(result);
+                    }
+
+                    base.Complete(true);
+                }
+
+                public static void End(IAsyncResult result)
+                {
+                    AsyncResult.End<ReplyAsyncResult>(result);
+                }
+
+                static void OnSend(IAsyncResult result)
+                {
+                    if (result.CompletedSynchronously)
+                    {
+                        return;
+                    }
+
+                    Exception completionException = null;
+                    ReplyAsyncResult thisPtr = (ReplyAsyncResult)result.AsyncState;
+                    try
+                    {
+                        thisPtr.context.Binder.EndSend(result);
+                    }
+#pragma warning suppress 56500 // covered by FxCOP
+                    catch (Exception exception)
+                    {
+                        if (Fx.IsFatal(exception))
+                        {
+                            throw;
+                        }
+                        completionException = exception;
+                    }
+
+                    thisPtr.Complete(false, completionException);
+                }
+            }
+        }
+
+        protected abstract class OutputAsyncResult<TBinder> : AsyncResult
+            where TBinder : ReliableChannelBinder<TChannel>
+        {
+            bool autoAborted;
+            TBinder binder;
+            TChannel channel;
+            bool hasChannel = false;
+            MaskingMode maskingMode;
+            Message message;
+            static AsyncCallback onTryGetChannelComplete = Fx.ThunkCallback(new AsyncCallback(OnTryGetChannelCompleteStatic));
+            static AsyncCallback onOutputComplete = Fx.ThunkCallback(new AsyncCallback(OnOutputCompleteStatic));
+            TimeSpan timeout;
+            TimeoutHelper timeoutHelper;
+
+            public OutputAsyncResult(TBinder binder, AsyncCallback callback, object state)
+                : base(callback, state)
+            {
+                this.binder = binder;
+            }
+
+            public MaskingMode MaskingMode
+            {
+                get
+                {
+                    return this.maskingMode;
+                }
+            }
+
+            protected abstract IAsyncResult BeginOutput(TBinder binder, TChannel channel,
+                Message message, TimeSpan timeout, MaskingMode maskingMode, AsyncCallback callback,
+                object state);
+
+            void Cleanup()
+            {
+                if (this.hasChannel)
+                {
+                    this.autoAborted = this.binder.Synchronizer.Aborting;
+                    this.binder.synchronizer.ReturnChannel();
+                }
+            }
+
+            bool CompleteOutput(IAsyncResult result)
+            {
+                this.EndOutput(this.binder, this.channel, this.maskingMode, result);
+                this.Cleanup();
+                return true;
+            }
+
+            bool CompleteTryGetChannel(IAsyncResult result)
+            {
+                bool timedOut = !this.binder.synchronizer.EndTryGetChannel(result,
+                    out this.channel);
+
+                if (timedOut || (this.channel == null))
+                {
+                    this.Cleanup();
+
+                    if (timedOut && !ReliableChannelBinderHelper.MaskHandled(maskingMode))
+                    {
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new TimeoutException(this.GetTimeoutString(this.timeout)));
+                    }
+
+                    return true;
+                }
+
+                this.hasChannel = true;
+
+                result = this.BeginOutput(this.binder, this.channel, this.message,
+                    this.timeoutHelper.RemainingTime(), this.maskingMode, onOutputComplete,
+                    this);
+
+                if (result.CompletedSynchronously)
+                {
+                    return this.CompleteOutput(result);
+                }
+                else
+                {
+                    return false;
+                }
+            }
+
+            protected abstract void EndOutput(TBinder binder, TChannel channel,
+                MaskingMode maskingMode, IAsyncResult result);
+
+            protected abstract string GetTimeoutString(TimeSpan timeout);
+
+            void OnOutputComplete(IAsyncResult result)
+            {
+                if (!result.CompletedSynchronously)
+                {
+                    bool complete = false;
+                    Exception completeException = null;
+
+                    try
+                    {
+                        complete = this.CompleteOutput(result);
+                    }
+#pragma warning suppress 56500 // covered by FxCOP
+                    catch (Exception e)
+                    {
+                        if (Fx.IsFatal(e))
+                        {
+                            throw;
+                        }
+
+                        this.Cleanup();
+                        complete = true;
+                        if (!this.binder.HandleException(e, this.maskingMode, this.autoAborted))
+                        {
+                            completeException = e;
+                        }
+                    }
+
+                    if (complete)
+                    {
+                        this.Complete(false, completeException);
+                    }
+                }
+            }
+
+            static void OnOutputCompleteStatic(IAsyncResult result)
+            {
+                OutputAsyncResult<TBinder> outputResult =
+                    (OutputAsyncResult<TBinder>)result.AsyncState;
+
+                outputResult.OnOutputComplete(result);
+            }
+
+            void OnTryGetChannelComplete(IAsyncResult result)
+            {
+                if (!result.CompletedSynchronously)
+                {
+                    bool complete = false;
+                    Exception completeException = null;
+
+                    try
+                    {
+                        complete = this.CompleteTryGetChannel(result);
+                    }
+#pragma warning suppress 56500 // covered by FxCOP
+                    catch (Exception e)
+                    {
+                        if (Fx.IsFatal(e))
+                        {
+                            throw;
+                        }
+
+                        this.Cleanup();
+                        complete = true;
+                        if (!this.binder.HandleException(e, this.maskingMode, this.autoAborted))
+                        {
+                            completeException = e;
+                        }
+                    }
+
+                    if (complete)
+                    {
+                        this.Complete(false, completeException);
+                    }
+                }
+            }
+
+            static void OnTryGetChannelCompleteStatic(IAsyncResult result)
+            {
+                OutputAsyncResult<TBinder> outputResult =
+                    (OutputAsyncResult<TBinder>)result.AsyncState;
+
+                outputResult.OnTryGetChannelComplete(result);
+            }
+
+            public void Start(Message message, TimeSpan timeout, MaskingMode maskingMode)
+            {
+                if (!this.binder.ValidateOutputOperation(message, timeout, maskingMode))
+                {
+                    this.Complete(true);
+                    return;
+                }
+
+                this.message = message;
+                this.timeout = timeout;
+                this.timeoutHelper = new TimeoutHelper(timeout);
+                this.maskingMode = maskingMode;
+
+                bool complete = false;
+
+                try
+                {
+                    IAsyncResult result = this.binder.synchronizer.BeginTryGetChannelForOutput(
+                        timeoutHelper.RemainingTime(), this.maskingMode, onTryGetChannelComplete, this);
+
+                    if (result.CompletedSynchronously)
+                    {
+                        complete = this.CompleteTryGetChannel(result);
+                    }
+                }
+                catch (Exception e)
+                {
+                    if (Fx.IsFatal(e))
+                    {
+                        throw;
+                    }
+
+                    this.Cleanup();
+                    if (this.binder.HandleException(e, this.maskingMode, this.autoAborted))
+                    {
+                        complete = true;
+                    }
+                    else
+                    {
+                        throw;
+                    }
+                }
+
+                if (complete)
+                {
+                    this.Complete(true);
+                }
+            }
+        }
+
+        sealed class RequestRequestContext : BinderRequestContext
+        {
+            RequestContext innerContext;
+
+            public RequestRequestContext(ReliableChannelBinder<TChannel> binder,
+                RequestContext innerContext, Message message)
+                : base(binder, message)
+            {
+                if ((binder.defaultMaskingMode != MaskingMode.All) && !binder.TolerateFaults)
+                {
+                    throw Fx.AssertAndThrow("This request context is designed to catch exceptions. Thus it cannot be used if the caller expects no exception handling.");
+                }
+
+                if (innerContext == null)
+                {
+                    throw Fx.AssertAndThrow("Argument innerContext cannot be null.");
+                }
+
+                this.innerContext = innerContext;
+            }
+
+            protected override void OnAbort()
+            {
+                this.innerContext.Abort();
+            }
+
+            protected override IAsyncResult OnBeginReply(Message message, TimeSpan timeout,
+                AsyncCallback callback, object state)
+            {
+                try
+                {
+                    if (message != null)
+                        this.Binder.AddOutputHeaders(message);
+                    return this.innerContext.BeginReply(message, timeout, callback, state);
+                }
+                catch (ObjectDisposedException) { }
+                catch (Exception e)
+                {
+                    if (Fx.IsFatal(e))
+                    {
+                        throw;
+                    }
+
+                    if (!this.Binder.HandleException(e, this.MaskingMode))
+                    {
+                        throw;
+                    }
+
+                    this.innerContext.Abort();
+                }
+
+                return new BinderCompletedAsyncResult(callback, state);
+            }
+
+            protected override void OnClose(TimeSpan timeout)
+            {
+                try
+                {
+                    this.innerContext.Close(timeout);
+                }
+                catch (ObjectDisposedException) { }
+                catch (Exception e)
+                {
+                    if (Fx.IsFatal(e))
+                    {
+                        throw;
+                    }
+
+                    if (!this.Binder.HandleException(e, this.MaskingMode))
+                    {
+                        throw;
+                    }
+
+                    this.innerContext.Abort();
+                }
+            }
+
+            protected override void OnEndReply(IAsyncResult result)
+            {
+                BinderCompletedAsyncResult completedResult = result as BinderCompletedAsyncResult;
+                if (completedResult != null)
+                {
+                    completedResult.End();
+                    return;
+                }
+
+                try
+                {
+                    this.innerContext.EndReply(result);
+                }
+                catch (ObjectDisposedException) { }
+                catch (Exception e)
+                {
+                    if (Fx.IsFatal(e))
+                    {
+                        throw;
+                    }
+
+                    if (!this.Binder.HandleException(e, this.MaskingMode))
+                    {
+                        throw;
+                    }
+
+                    this.innerContext.Abort();
+                }
+            }
+
+            protected override void OnReply(Message message, TimeSpan timeout)
+            {
+                try
+                {
+                    if (message != null)
+                        this.Binder.AddOutputHeaders(message);
+                    this.innerContext.Reply(message, timeout);
+                }
+                catch (ObjectDisposedException) { }
+                catch (Exception e)
+                {
+                    if (Fx.IsFatal(e))
+                    {
+                        throw;
+                    }
+
+                    if (!this.Binder.HandleException(e, this.MaskingMode))
+                    {
+                        throw;
+                    }
+
+                    this.innerContext.Abort();
+                }
+            }
+        }
+
+        sealed class SendAsyncResult : OutputAsyncResult<ReliableChannelBinder<TChannel>>
+        {
+            public SendAsyncResult(ReliableChannelBinder<TChannel> binder, AsyncCallback callback,
+                object state)
+                : base(binder, callback, state)
+            {
+            }
+
+            protected override IAsyncResult BeginOutput(ReliableChannelBinder<TChannel> binder,
+                TChannel channel, Message message, TimeSpan timeout, MaskingMode maskingMode,
+                AsyncCallback callback, object state)
+            {
+                binder.AddOutputHeaders(message);
+                return binder.OnBeginSend(channel, message, timeout, callback, state);
+            }
+
+            public static void End(IAsyncResult result)
+            {
+                AsyncResult.End<SendAsyncResult>(result);
+            }
+
+            protected override void EndOutput(ReliableChannelBinder<TChannel> binder,
+                TChannel channel, MaskingMode maskingMode, IAsyncResult result)
+            {
+                binder.OnEndSend(channel, result);
+            }
+
+            protected override string GetTimeoutString(TimeSpan timeout)
+            {
+                return SR.GetString(SR.TimeoutOnSend, timeout);
+            }
+        }
+
+        sealed class TryReceiveAsyncResult : InputAsyncResult<ReliableChannelBinder<TChannel>>
+        {
+            RequestContext requestContext;
+
+            public TryReceiveAsyncResult(ReliableChannelBinder<TChannel> binder, TimeSpan timeout,
+                MaskingMode maskingMode, AsyncCallback callback, object state)
+                : base(binder, binder.CanGetChannelForReceive, timeout, maskingMode, callback, state)
+            {
+                if (this.Start())
+                    this.Complete(true);
+            }
+
+            protected override IAsyncResult BeginInput(ReliableChannelBinder<TChannel> binder,
+                TChannel channel, TimeSpan timeout, AsyncCallback callback, object state)
+            {
+                return binder.OnBeginTryReceive(channel, timeout, callback, state);
+            }
+
+            public bool End(out RequestContext requestContext)
+            {
+                requestContext = this.requestContext;
+                return this.End();
+            }
+
+            protected override bool EndInput(ReliableChannelBinder<TChannel> binder,
+                TChannel channel, IAsyncResult result, out bool complete)
+            {
+                bool success = binder.OnEndTryReceive(channel, result, out this.requestContext);
+
+                // timed out || got message, complete immediately
+                complete = !success || (this.requestContext != null);
+
+                if (!complete)
+                {
+                    // the underlying channel closed or faulted
+                    binder.synchronizer.OnReadEof();
+                }
+
+                return success;
+            }
+        }
+    }
+
+    static class ReliableChannelBinderHelper
+    {
+        internal static IAsyncResult BeginCloseDuplexSessionChannel(
+            ReliableChannelBinder<IDuplexSessionChannel> binder, IDuplexSessionChannel channel,
+            TimeSpan timeout, AsyncCallback callback, object state)
+        {
+            return new CloseDuplexSessionChannelAsyncResult(binder, channel, timeout, callback,
+                state);
+        }
+
+        internal static IAsyncResult BeginCloseReplySessionChannel(
+            ReliableChannelBinder<IReplySessionChannel> binder, IReplySessionChannel channel,
+            TimeSpan timeout, AsyncCallback callback, object state)
+        {
+            return new CloseReplySessionChannelAsyncResult(binder, channel, timeout, callback,
+                state);
+        }
+
+        internal static void CloseDuplexSessionChannel(
+            ReliableChannelBinder<IDuplexSessionChannel> binder, IDuplexSessionChannel channel,
+            TimeSpan timeout)
+        {
+            TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
+
+            channel.Session.CloseOutputSession(timeoutHelper.RemainingTime());
+            binder.WaitForPendingOperations(timeoutHelper.RemainingTime());
+
+            TimeSpan iterationTimeout = timeoutHelper.RemainingTime();
+            bool lastIteration = (iterationTimeout == TimeSpan.Zero);
+
+            while (true)
+            {
+                Message message = null;
+                bool receiveThrowing = true;
+
+                try
+                {
+                    bool success = channel.TryReceive(iterationTimeout, out message);
+
+                    receiveThrowing = false;
+                    if (success && message == null)
+                    {
+                        channel.Close(timeoutHelper.RemainingTime());
+                        return;
+                    }
+                }
+                catch (Exception e)
+                {
+                    if (Fx.IsFatal(e))
+                        throw;
+
+                    if (receiveThrowing)
+                    {
+                        if (!MaskHandled(binder.DefaultMaskingMode) || !binder.IsHandleable(e))
+                            throw;
+
+                        receiveThrowing = false;
+                    }
+                    else
+                    {
+                        throw;
+                    }
+                }
+                finally
+                {
+                    if (message != null)
+                        message.Close();
+
+                    if (receiveThrowing)
+                        channel.Abort();
+                }
+
+                if (lastIteration || channel.State != CommunicationState.Opened)
+                    break;
+
+                iterationTimeout = timeoutHelper.RemainingTime();
+                lastIteration = (iterationTimeout == TimeSpan.Zero);
+            }
+
+            channel.Abort();
+        }
+
+        internal static void CloseReplySessionChannel(
+            ReliableChannelBinder<IReplySessionChannel> binder, IReplySessionChannel channel,
+            TimeSpan timeout)
+        {
+            TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
+
+            binder.WaitForPendingOperations(timeoutHelper.RemainingTime());
+
+            TimeSpan iterationTimeout = timeoutHelper.RemainingTime();
+            bool lastIteration = (iterationTimeout == TimeSpan.Zero);
+
+            while (true)
+            {
+                RequestContext context = null;
+                bool receiveThrowing = true;
+
+                try
+                {
+                    bool success = channel.TryReceiveRequest(iterationTimeout, out context);
+
+                    receiveThrowing = false;
+                    if (success && context == null)
+                    {
+                        channel.Close(timeoutHelper.RemainingTime());
+                        return;
+                    }
+                }
+                catch (Exception e)
+                {
+                    if (Fx.IsFatal(e))
+                        throw;
+
+                    if (receiveThrowing)
+                    {
+                        if (!MaskHandled(binder.DefaultMaskingMode) || !binder.IsHandleable(e))
+                            throw;
+
+                        receiveThrowing = false;
+                    }
+                    else
+                    {
+                        throw;
+                    }
+                }
+                finally
+                {
+                    if (context != null)
+                    {
+                        context.RequestMessage.Close();
+                        context.Close();
+                    }
+
+                    if (receiveThrowing)
+                        channel.Abort();
+                }
+
+                if (lastIteration || channel.State != CommunicationState.Opened)
+                    break;
+
+                iterationTimeout = timeoutHelper.RemainingTime();
+                lastIteration = (iterationTimeout == TimeSpan.Zero);
+            }
+
+            channel.Abort();
+        }
+
+        internal static void EndCloseDuplexSessionChannel(IDuplexSessionChannel channel,
+                IAsyncResult result)
+        {
+            CloseDuplexSessionChannelAsyncResult.End(result);
+        }
+
+        internal static void EndCloseReplySessionChannel(IReplySessionChannel channel,
+                IAsyncResult result)
+        {
+            CloseReplySessionChannelAsyncResult.End(result);
+        }
+
+        internal static bool MaskHandled(MaskingMode maskingMode)
+        {
+            return (maskingMode & MaskingMode.Handled) == MaskingMode.Handled;
+        }
+
+        internal static bool MaskUnhandled(MaskingMode maskingMode)
+        {
+            return (maskingMode & MaskingMode.Unhandled) == MaskingMode.Unhandled;
+        }
+
+        abstract class CloseInputSessionChannelAsyncResult<TChannel, TItem> : AsyncResult
+            where TChannel : class, IChannel
+            where TItem : class
+        {
+            static AsyncCallback onChannelCloseCompleteStatic =
+                Fx.ThunkCallback(
+                new AsyncCallback(OnChannelCloseCompleteStatic));
+            static AsyncCallback onInputCompleteStatic =
+                Fx.ThunkCallback(new AsyncCallback(OnInputCompleteStatic));
+            static AsyncCallback onWaitForPendingOperationsCompleteStatic =
+                Fx.ThunkCallback(
+                new AsyncCallback(OnWaitForPendingOperationsCompleteStatic));
+            ReliableChannelBinder<TChannel> binder;
+            TChannel channel;
+            bool lastReceive;
+            TimeoutHelper timeoutHelper;
+
+            protected CloseInputSessionChannelAsyncResult(
+                ReliableChannelBinder<TChannel> binder, TChannel channel,
+                TimeSpan timeout, AsyncCallback callback, object state)
+                : base(callback, state)
+            {
+                this.binder = binder;
+                this.channel = channel;
+                this.timeoutHelper = new TimeoutHelper(timeout);
+            }
+
+            protected TChannel Channel
+            {
+                get
+                {
+                    return this.channel;
+                }
+            }
+
+            protected TimeSpan RemainingTime
+            {
+                get
+                {
+                    return this.timeoutHelper.RemainingTime();
+                }
+            }
+
+            protected bool Begin()
+            {
+                bool complete = false;
+                IAsyncResult result = this.binder.BeginWaitForPendingOperations(
+                    this.RemainingTime, onWaitForPendingOperationsCompleteStatic,
+                    this);
+
+                if (result.CompletedSynchronously)
+                    complete = this.HandleWaitForPendingOperationsComplete(result);
+
+                return complete;
+            }
+
+            protected abstract IAsyncResult BeginTryInput(TimeSpan timeout, AsyncCallback callback,
+                object state);
+
+            protected abstract void DisposeItem(TItem item);
+
+            protected abstract bool EndTryInput(IAsyncResult result, out TItem item);
+
+            void HandleChannelCloseComplete(IAsyncResult result)
+            {
+                this.channel.EndClose(result);
+            }
+
+            bool HandleInputComplete(IAsyncResult result, out bool gotEof)
+            {
+                TItem item = null;
+                bool endThrowing = true;
+
+                gotEof = false;
+
+                try
+                {
+                    bool success = false;
+
+                    success = this.EndTryInput(result, out item);
+                    endThrowing = false;
+
+                    if (!success || item != null)
+                    {
+                        if (this.lastReceive || this.channel.State != CommunicationState.Opened)
+                        {
+                            this.channel.Abort();
+                            return true;
+                        }
+                        else
+                        {
+                            return false;
+                        }
+                    }
+
+                    gotEof = true;
+
+                    result = this.channel.BeginClose(this.RemainingTime,
+                        onChannelCloseCompleteStatic, this);
+                    if (result.CompletedSynchronously)
+                    {
+                        this.HandleChannelCloseComplete(result);
+                        return true;
+                    }
+                    else
+                    {
+                        return false;
+                    }
+                }
+                catch (Exception e)
+                {
+                    if (Fx.IsFatal(e))
+                        throw;
+
+                    if (endThrowing)
+                    {
+                        if (!MaskHandled(binder.DefaultMaskingMode) || !binder.IsHandleable(e))
+                            throw;
+
+                        if (this.lastReceive || this.channel.State != CommunicationState.Opened)
+                        {
+                            this.channel.Abort();
+                            return true;
+                        }
+                        else
+                        {
+                            return false;
+                        }
+                    }
+
+                    throw;
+                }
+                finally
+                {
+                    if (item != null)
+                        this.DisposeItem(item);
+
+                    if (endThrowing)
+                        this.channel.Abort();
+                }
+            }
+
+            bool HandleWaitForPendingOperationsComplete(IAsyncResult result)
+            {
+                this.binder.EndWaitForPendingOperations(result);
+                return this.WaitForEof();
+            }
+
+            static void OnChannelCloseCompleteStatic(IAsyncResult result)
+            {
+                if (result.CompletedSynchronously)
+                    return;
+
+                CloseInputSessionChannelAsyncResult<TChannel, TItem> closeResult =
+                    (CloseInputSessionChannelAsyncResult<TChannel, TItem>)result.AsyncState;
+
+                Exception completeException = null;
+
+                try
+                {
+                    closeResult.HandleChannelCloseComplete(result);
+                }
+                catch (Exception e)
+                {
+                    if (Fx.IsFatal(e))
+                        throw;
+
+                    completeException = e;
+                }
+
+                closeResult.Complete(false, completeException);
+            }
+
+            static void OnInputCompleteStatic(IAsyncResult result)
+            {
+                if (result.CompletedSynchronously)
+                    return;
+
+                CloseInputSessionChannelAsyncResult<TChannel, TItem> closeResult =
+                    (CloseInputSessionChannelAsyncResult<TChannel, TItem>)result.AsyncState;
+
+                bool complete = false;
+                Exception completeException = null;
+
+                try
+                {
+                    bool gotEof;
+
+                    complete = closeResult.HandleInputComplete(result, out gotEof);
+                    if (!complete && !gotEof)
+                        complete = closeResult.WaitForEof();
+                }
+                catch (Exception e)
+                {
+                    if (Fx.IsFatal(e))
+                        throw;
+
+                    completeException = e;
+                }
+
+                if (complete || completeException != null)
+                    closeResult.Complete(false, completeException);
+            }
+
+            static void OnWaitForPendingOperationsCompleteStatic(IAsyncResult result)
+            {
+                if (result.CompletedSynchronously)
+                    return;
+
+                CloseInputSessionChannelAsyncResult<TChannel, TItem> closeResult =
+                    (CloseInputSessionChannelAsyncResult<TChannel, TItem>)result.AsyncState;
+
+                bool complete = false;
+                Exception completeException = null;
+
+                try
+                {
+                    complete = closeResult.HandleWaitForPendingOperationsComplete(result);
+                }
+                catch (Exception e)
+                {
+                    if (Fx.IsFatal(e))
+                        throw;
+
+                    completeException = e;
+                }
+
+                if (complete || completeException != null)
+                    closeResult.Complete(false, completeException);
+            }
+
+            bool WaitForEof()
+            {
+                TimeSpan iterationTimeout = this.RemainingTime;
+                this.lastReceive = (iterationTimeout == TimeSpan.Zero);
+
+                while (true)
+                {
+                    IAsyncResult result = null;
+
+                    try
+                    {
+                        result = this.BeginTryInput(iterationTimeout, onInputCompleteStatic, this);
+                    }
+                    catch (Exception e)
+                    {
+                        if (Fx.IsFatal(e))
+                            throw;
+
+                        if (!MaskHandled(this.binder.DefaultMaskingMode) || !this.binder.IsHandleable(e))
+                            throw;
+                    }
+
+                    if (result != null)
+                    {
+                        if (result.CompletedSynchronously)
+                        {
+                            bool gotEof;
+                            bool complete = this.HandleInputComplete(result, out gotEof);
+
+                            if (complete || gotEof)
+                                return complete;
+                        }
+                        else
+                            return false;
+                    }
+
+                    if (this.lastReceive || this.channel.State != CommunicationState.Opened)
+                    {
+                        this.channel.Abort();
+                        break;
+                    }
+
+                    iterationTimeout = this.RemainingTime;
+                    this.lastReceive = (iterationTimeout == TimeSpan.Zero);
+                }
+
+                return true;
+            }
+        }
+
+        sealed class CloseDuplexSessionChannelAsyncResult :
+            CloseInputSessionChannelAsyncResult<IDuplexSessionChannel, Message>
+        {
+            static AsyncCallback onCloseOutputSessionCompleteStatic =
+                Fx.ThunkCallback(
+                new AsyncCallback(OnCloseOutputSessionCompleteStatic));
+
+            public CloseDuplexSessionChannelAsyncResult(
+                ReliableChannelBinder<IDuplexSessionChannel> binder, IDuplexSessionChannel channel,
+                TimeSpan timeout, AsyncCallback callback, object state)
+                : base(binder, channel, timeout, callback, state)
+            {
+                bool complete = false;
+
+                IAsyncResult result = this.Channel.Session.BeginCloseOutputSession(
+                    this.RemainingTime, onCloseOutputSessionCompleteStatic, this);
+
+                if (result.CompletedSynchronously)
+                    complete = this.HandleCloseOutputSessionComplete(result);
+
+                if (complete)
+                    this.Complete(true);
+            }
+
+            protected override IAsyncResult BeginTryInput(TimeSpan timeout, AsyncCallback callback, object state)
+            {
+                return this.Channel.BeginTryReceive(timeout, callback, state);
+            }
+
+            protected override void DisposeItem(Message item)
+            {
+                item.Close();
+            }
+
+            public static void End(IAsyncResult result)
+            {
+                AsyncResult.End<CloseDuplexSessionChannelAsyncResult>(result);
+            }
+
+            protected override bool EndTryInput(IAsyncResult result, out Message item)
+            {
+                return this.Channel.EndTryReceive(result, out item);
+            }
+
+            bool HandleCloseOutputSessionComplete(IAsyncResult result)
+            {
+                this.Channel.Session.EndCloseOutputSession(result);
+                return this.Begin();
+            }
+
+            static void OnCloseOutputSessionCompleteStatic(IAsyncResult result)
+            {
+                if (result.CompletedSynchronously)
+                    return;
+
+                CloseDuplexSessionChannelAsyncResult closeResult =
+                    (CloseDuplexSessionChannelAsyncResult)result.AsyncState;
+
+                bool complete = false;
+                Exception completeException = null;
+
+                try
+                {
+                    complete = closeResult.HandleCloseOutputSessionComplete(result);
+                }
+                catch (Exception e)
+                {
+                    if (Fx.IsFatal(e))
+                        throw;
+
+                    completeException = e;
+                }
+
+                if (complete || completeException != null)
+                    closeResult.Complete(false, completeException);
+            }
+        }
+
+        sealed class CloseReplySessionChannelAsyncResult :
+            CloseInputSessionChannelAsyncResult<IReplySessionChannel, RequestContext>
+        {
+            public CloseReplySessionChannelAsyncResult(
+                ReliableChannelBinder<IReplySessionChannel> binder, IReplySessionChannel channel,
+                TimeSpan timeout, AsyncCallback callback, object state)
+                : base(binder, channel, timeout, callback, state)
+            {
+                if (this.Begin())
+                    this.Complete(true);
+            }
+
+            protected override IAsyncResult BeginTryInput(TimeSpan timeout, AsyncCallback callback, object state)
+            {
+                return this.Channel.BeginTryReceiveRequest(timeout, callback, state);
+            }
+
+            protected override void DisposeItem(RequestContext item)
+            {
+                item.RequestMessage.Close();
+                item.Close();
+            }
+
+            public static void End(IAsyncResult result)
+            {
+                AsyncResult.End<CloseReplySessionChannelAsyncResult>(result);
+            }
+
+            protected override bool EndTryInput(IAsyncResult result, out RequestContext item)
+            {
+                return this.Channel.EndTryReceiveRequest(result, out item);
+            }
+        }
+    }
+}
+

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/ReliableChannelBinder.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/ReliableChannelBinder.cs
@@ -47,11 +47,11 @@ namespace System.ServiceModel.Channels
 //                throw Fx.AssertAndThrow("ReliableChannelBinder was implemented with only 2 default masking modes, None and All.");
 //            }
 
-//            this.defaultMaskingMode = maskingMode;
-//            this.defaultCloseTimeout = defaultCloseTimeout;
-//            this.defaultSendTimeout = defaultSendTimeout;
+//            defaultMaskingMode = maskingMode;
+//            defaultCloseTimeout = defaultCloseTimeout;
+//            defaultSendTimeout = defaultSendTimeout;
 
-//            this.synchronizer = new ChannelSynchronizer(this, channel, faultMode);
+//            synchronizer = new ChannelSynchronizer(this, channel, faultMode);
 //        }
 
 //        protected abstract bool CanGetChannelForReceive
@@ -73,7 +73,7 @@ namespace System.ServiceModel.Channels
 //        {
 //            get
 //            {
-//                return this.synchronizer.CurrentChannel;
+//                return synchronizer.CurrentChannel;
 //            }
 //        }
 
@@ -81,7 +81,7 @@ namespace System.ServiceModel.Channels
 //        {
 //            get
 //            {
-//                return this.synchronizer.Connected;
+//                return synchronizer.Connected;
 //            }
 //        }
 
@@ -89,7 +89,7 @@ namespace System.ServiceModel.Channels
 //        {
 //            get
 //            {
-//                return this.defaultMaskingMode;
+//                return defaultMaskingMode;
 //            }
 //        }
 
@@ -97,7 +97,7 @@ namespace System.ServiceModel.Channels
 //        {
 //            get
 //            {
-//                return this.defaultSendTimeout;
+//                return defaultSendTimeout;
 //            }
 //        }
 
@@ -130,7 +130,7 @@ namespace System.ServiceModel.Channels
 //        {
 //            get
 //            {
-//                return this.state;
+//                return state;
 //            }
 //        }
 
@@ -138,7 +138,7 @@ namespace System.ServiceModel.Channels
 //        {
 //            get
 //            {
-//                return this.synchronizer;
+//                return synchronizer;
 //            }
 //        }
 
@@ -146,7 +146,7 @@ namespace System.ServiceModel.Channels
 //        {
 //            get
 //            {
-//                return this.thisLock;
+//                return thisLock;
 //            }
 //        }
 
@@ -154,7 +154,7 @@ namespace System.ServiceModel.Channels
 //        {
 //            get
 //            {
-//                return this.synchronizer.TolerateFaults;
+//                return synchronizer.TolerateFaults;
 //            }
 //        }
 
@@ -166,34 +166,34 @@ namespace System.ServiceModel.Channels
 //        public void Abort()
 //        {
 //            TChannel channel;
-//            lock (this.ThisLock)
+//            lock (ThisLock)
 //            {
-//                this.aborted = true;
+//                aborted = true;
 
-//                if (this.state == CommunicationState.Closed)
+//                if (state == CommunicationState.Closed)
 //                {
 //                    return;
 //                }
 
-//                this.state = CommunicationState.Closing;
-//                channel = this.synchronizer.StopSynchronizing(true);
+//                state = CommunicationState.Closing;
+//                channel = synchronizer.StopSynchronizing(true);
 
-//                if (!this.MustCloseChannel)
+//                if (!MustCloseChannel)
 //                {
 //                    channel = null;
 //                }
 //            }
 
-//            this.synchronizer.UnblockWaiters();
-//            this.OnShutdown();
-//            this.OnAbort();
+//            synchronizer.UnblockWaiters();
+//            OnShutdown();
+//            OnAbort();
 
 //            if (channel != null)
 //            {
 //                channel.Abort();
 //            }
 
-//            this.TransitionToClosed();
+//            TransitionToClosed();
 //        }
 
 //        protected virtual void AddOutputHeaders(Message message)
@@ -203,16 +203,16 @@ namespace System.ServiceModel.Channels
 //        public IAsyncResult BeginClose(TimeSpan timeout, AsyncCallback callback,
 //            object state)
 //        {
-//            return this.BeginClose(timeout, this.defaultMaskingMode, callback, state);
+//            return BeginClose(timeout, defaultMaskingMode, callback, state);
 //        }
 
 //        public IAsyncResult BeginClose(TimeSpan timeout, MaskingMode maskingMode,
 //            AsyncCallback callback, object state)
 //        {
-//            this.ThrowIfTimeoutNegative(timeout);
+//            ThrowIfTimeoutNegative(timeout);
 //            TChannel channel;
 
-//            if (this.CloseCore(out channel))
+//            if (CloseCore(out channel))
 //            {
 //                return new CompletedAsyncResult(callback, state);
 //            }
@@ -230,13 +230,13 @@ namespace System.ServiceModel.Channels
 
 //        public IAsyncResult BeginOpen(TimeSpan timeout, AsyncCallback callback, object state)
 //        {
-//            this.ThrowIfTimeoutNegative(timeout);
+//            ThrowIfTimeoutNegative(timeout);
 
-//            if (this.OnOpening(this.defaultMaskingMode))
+//            if (OnOpening(defaultMaskingMode))
 //            {
 //                try
 //                {
-//                    return this.OnBeginOpen(timeout, callback, state);
+//                    return OnBeginOpen(timeout, callback, state);
 //                }
 //                catch (Exception e)
 //                {
@@ -245,15 +245,15 @@ namespace System.ServiceModel.Channels
 //                        throw;
 //                    }
 
-//                    this.Fault(null);
+//                    Fault(null);
 
-//                    if (this.defaultMaskingMode == MaskingMode.None)
+//                    if (defaultMaskingMode == MaskingMode.None)
 //                    {
 //                        throw;
 //                    }
 //                    else
 //                    {
-//                        this.RaiseOnException(e);
+//                        RaiseOnException(e);
 //                    }
 //                }
 //            }
@@ -264,7 +264,7 @@ namespace System.ServiceModel.Channels
 //        public IAsyncResult BeginSend(Message message, TimeSpan timeout, AsyncCallback callback,
 //            object state)
 //        {
-//            return this.BeginSend(message, timeout, this.defaultMaskingMode, callback, state);
+//            return BeginSend(message, timeout, defaultMaskingMode, callback, state);
 //        }
 
 //        public IAsyncResult BeginSend(Message message, TimeSpan timeout, MaskingMode maskingMode,
@@ -282,13 +282,13 @@ namespace System.ServiceModel.Channels
 //        public virtual IAsyncResult BeginTryReceive(TimeSpan timeout, AsyncCallback callback,
 //            object state)
 //        {
-//            return this.BeginTryReceive(timeout, this.defaultMaskingMode, callback, state);
+//            return BeginTryReceive(timeout, defaultMaskingMode, callback, state);
 //        }
 
 //        public virtual IAsyncResult BeginTryReceive(TimeSpan timeout, MaskingMode maskingMode,
 //            AsyncCallback callback, object state)
 //        {
-//            if (this.ValidateInputOperation(timeout))
+//            if (ValidateInputOperation(timeout))
 //                return new TryReceiveAsyncResult(this, timeout, maskingMode, callback, state);
 //            else
 //                return new CompletedAsyncResult(callback, state);
@@ -297,7 +297,7 @@ namespace System.ServiceModel.Channels
 //        internal IAsyncResult BeginWaitForPendingOperations(TimeSpan timeout,
 //            AsyncCallback callback, object state)
 //        {
-//            return this.synchronizer.BeginWaitForPendingOperations(timeout, callback, state);
+//            return synchronizer.BeginWaitForPendingOperations(timeout, callback, state);
 //        }
 
 //        bool CloseCore(out TChannel channel)
@@ -306,21 +306,21 @@ namespace System.ServiceModel.Channels
 //            bool abort = true;
 //            bool abortChannel = false;
 
-//            lock (this.ThisLock)
+//            lock (ThisLock)
 //            {
-//                if ((this.state == CommunicationState.Closing)
-//                    || (this.state == CommunicationState.Closed))
+//                if ((state == CommunicationState.Closing)
+//                    || (state == CommunicationState.Closed))
 //                {
 //                    return true;
 //                }
 
-//                if (this.state == CommunicationState.Opened)
+//                if (state == CommunicationState.Opened)
 //                {
-//                    this.state = CommunicationState.Closing;
-//                    channel = this.synchronizer.StopSynchronizing(true);
+//                    state = CommunicationState.Closing;
+//                    channel = synchronizer.StopSynchronizing(true);
 //                    abort = false;
 
-//                    if (!this.MustCloseChannel)
+//                    if (!MustCloseChannel)
 //                    {
 //                        channel = null;
 //                    }
@@ -344,11 +344,11 @@ namespace System.ServiceModel.Channels
 //                }
 //            }
 
-//            this.synchronizer.UnblockWaiters();
+//            synchronizer.UnblockWaiters();
 
 //            if (abort)
 //            {
-//                this.Abort();
+//                Abort();
 //                return true;
 //            }
 //            else
@@ -365,31 +365,31 @@ namespace System.ServiceModel.Channels
 
 //        public void Close(TimeSpan timeout)
 //        {
-//            this.Close(timeout, this.defaultMaskingMode);
+//            Close(timeout, defaultMaskingMode);
 //        }
 
 //        public void Close(TimeSpan timeout, MaskingMode maskingMode)
 //        {
-//            this.ThrowIfTimeoutNegative(timeout);
+//            ThrowIfTimeoutNegative(timeout);
 //            TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
 //            TChannel channel;
 
-//            if (this.CloseCore(out channel))
+//            if (CloseCore(out channel))
 //            {
 //                return;
 //            }
 
 //            try
 //            {
-//                this.OnShutdown();
-//                this.OnClose(timeoutHelper.RemainingTime());
+//                OnShutdown();
+//                OnClose(timeoutHelper.RemainingTime());
 
 //                if (channel != null)
 //                {
-//                    this.CloseChannel(channel, timeoutHelper.RemainingTime());
+//                    CloseChannel(channel, timeoutHelper.RemainingTime());
 //                }
 
-//                this.TransitionToClosed();
+//                TransitionToClosed();
 //            }
 //            catch (Exception e)
 //            {
@@ -398,9 +398,9 @@ namespace System.ServiceModel.Channels
 //                    throw;
 //                }
 
-//                this.Abort();
+//                Abort();
 
-//                if (!this.HandleException(e, maskingMode))
+//                if (!HandleException(e, maskingMode))
 //                {
 //                    throw;
 //                }
@@ -411,14 +411,14 @@ namespace System.ServiceModel.Channels
 //        // block.
 //        void CloseChannel(TChannel channel)
 //        {
-//            if (!this.MustCloseChannel)
+//            if (!MustCloseChannel)
 //            {
 //                throw Fx.AssertAndThrow("MustCloseChannel is false when there is no receive loop and this method is called when there is a receive loop.");
 //            }
 
-//            if (this.onCloseChannelComplete == null)
+//            if (onCloseChannelComplete == null)
 //            {
-//                this.onCloseChannelComplete = Fx.ThunkCallback(new AsyncCallback(this.OnCloseChannelComplete));
+//                onCloseChannelComplete = Fx.ThunkCallback(new AsyncCallback(OnCloseChannelComplete));
 //            }
 
 //            try
@@ -430,7 +430,6 @@ namespace System.ServiceModel.Channels
 //                    channel.EndClose(result);
 //                }
 //            }
-//#pragma warning suppress 56500 // covered by FxCOP
 //            catch (Exception e)
 //            {
 //                if (Fx.IsFatal(e))
@@ -438,7 +437,7 @@ namespace System.ServiceModel.Channels
 //                    throw;
 //                }
 
-//                this.HandleException(e, MaskingMode.All);
+//                HandleException(e, MaskingMode.All);
 //            }
 //        }
 
@@ -478,7 +477,7 @@ namespace System.ServiceModel.Channels
 //            {
 //                try
 //                {
-//                    this.OnEndOpen(result);
+//                    OnEndOpen(result);
 //                }
 //                catch (Exception e)
 //                {
@@ -487,21 +486,21 @@ namespace System.ServiceModel.Channels
 //                        throw;
 //                    }
 
-//                    this.Fault(null);
+//                    Fault(null);
 
-//                    if (this.defaultMaskingMode == MaskingMode.None)
+//                    if (defaultMaskingMode == MaskingMode.None)
 //                    {
 //                        throw;
 //                    }
 //                    else
 //                    {
-//                        this.RaiseOnException(e);
+//                        RaiseOnException(e);
 //                        return;
 //                    }
 //                }
 
-//                this.synchronizer.StartSynchronizing();
-//                this.OnOpened();
+//                synchronizer.StartSynchronizing();
+//                OnOpened();
 //            }
 //        }
 
@@ -531,31 +530,31 @@ namespace System.ServiceModel.Channels
 
 //        public void EndWaitForPendingOperations(IAsyncResult result)
 //        {
-//            this.synchronizer.EndWaitForPendingOperations(result);
+//            synchronizer.EndWaitForPendingOperations(result);
 //        }
 
 //        protected void Fault(Exception e)
 //        {
-//            lock (this.ThisLock)
+//            lock (ThisLock)
 //            {
-//                if (this.state == CommunicationState.Created)
+//                if (state == CommunicationState.Created)
 //                {
 //                    throw Fx.AssertAndThrow("The binder should not detect the inner channel's faults until after the binder is opened.");
 //                }
 
-//                if ((this.state == CommunicationState.Faulted)
-//                    || (this.state == CommunicationState.Closed))
+//                if ((state == CommunicationState.Faulted)
+//                    || (state == CommunicationState.Closed))
 //                {
 //                    return;
 //                }
 
-//                this.state = CommunicationState.Faulted;
-//                this.synchronizer.StopSynchronizing(false);
+//                state = CommunicationState.Faulted;
+//                synchronizer.StopSynchronizing(false);
 //            }
 
-//            this.synchronizer.UnblockWaiters();
+//            synchronizer.UnblockWaiters();
 
-//            BinderExceptionHandler handler = this.Faulted;
+//            BinderExceptionHandler handler = Faulted;
 
 //            if (handler != null)
 //            {
@@ -570,28 +569,28 @@ namespace System.ServiceModel.Channels
 //            {
 //                return null;
 //            }
-//            else if (this.aborted)
+//            else if (aborted)
 //            {
 //                return new CommunicationObjectAbortedException(SR.GetString(
-//                    SR.CommunicationObjectAborted1, this.GetType().ToString()));
+//                    SR.CommunicationObjectAborted1, GetType().ToString()));
 //            }
 //            else
 //            {
-//                return new ObjectDisposedException(this.GetType().ToString());
+//                return new ObjectDisposedException(GetType().ToString());
 //            }
 //        }
 
-//        // Must be called within lock (this.ThisLock)
+//        // Must be called within lock (ThisLock)
 //        Exception GetClosedOrFaultedException(MaskingMode maskingMode)
 //        {
-//            if (this.state == CommunicationState.Faulted)
+//            if (state == CommunicationState.Faulted)
 //            {
-//                return this.GetFaultedException(maskingMode);
+//                return GetFaultedException(maskingMode);
 //            }
-//            else if ((this.state == CommunicationState.Closing)
-//               || (this.state == CommunicationState.Closed))
+//            else if ((state == CommunicationState.Closing)
+//               || (state == CommunicationState.Closed))
 //            {
-//                return this.GetClosedException(maskingMode);
+//                return GetClosedException(maskingMode);
 //            }
 //            else
 //            {
@@ -609,7 +608,7 @@ namespace System.ServiceModel.Channels
 //            else
 //            {
 //                return new CommunicationObjectFaultedException(SR.GetString(
-//                    SR.CommunicationObjectFaulted1, this.GetType().ToString()));
+//                    SR.CommunicationObjectFaulted1, GetType().ToString()));
 //            }
 //        }
 
@@ -617,17 +616,17 @@ namespace System.ServiceModel.Channels
 
 //        public void HandleException(Exception e)
 //        {
-//            this.HandleException(e, MaskingMode.All);
+//            HandleException(e, MaskingMode.All);
 //        }
 
 //        protected bool HandleException(Exception e, MaskingMode maskingMode)
 //        {
-//            if (this.TolerateFaults && (e is CommunicationObjectFaultedException))
+//            if (TolerateFaults && (e is CommunicationObjectFaultedException))
 //            {
 //                return true;
 //            }
 
-//            if (this.IsHandleable(e))
+//            if (IsHandleable(e))
 //            {
 //                return ReliableChannelBinderHelper.MaskHandled(maskingMode);
 //            }
@@ -636,7 +635,7 @@ namespace System.ServiceModel.Channels
 
 //            if (maskUnhandled)
 //            {
-//                this.RaiseOnException(e);
+//                RaiseOnException(e);
 //            }
 
 //            return maskUnhandled;
@@ -644,12 +643,12 @@ namespace System.ServiceModel.Channels
 
 //        protected bool HandleException(Exception e, MaskingMode maskingMode, bool autoAborted)
 //        {
-//            if (this.TolerateFaults && autoAborted && e is CommunicationObjectAbortedException)
+//            if (TolerateFaults && autoAborted && e is CommunicationObjectAbortedException)
 //            {
 //                return true;
 //            }
 
-//            return this.HandleException(e, maskingMode);
+//            return HandleException(e, maskingMode);
 //        }
 
 //        // ChannelSynchronizer helper, cannot take a lock.
@@ -699,7 +698,6 @@ namespace System.ServiceModel.Channels
 //            {
 //                channel.EndClose(result);
 //            }
-//#pragma warning suppress 56500 // covered by FxCOP
 //            catch (Exception e)
 //            {
 //                if (Fx.IsFatal(e))
@@ -707,7 +705,7 @@ namespace System.ServiceModel.Channels
 //                    throw;
 //                }
 
-//                this.HandleException(e, MaskingMode.All);
+//                HandleException(e, MaskingMode.All);
 //            }
 //        }
 
@@ -727,10 +725,10 @@ namespace System.ServiceModel.Channels
 
 //        void OnInnerChannelFaulted()
 //        {
-//            if (!this.TolerateFaults)
+//            if (!TolerateFaults)
 //                return;
 
-//            EventHandler handler = this.ConnectionLost;
+//            EventHandler handler = ConnectionLost;
 
 //            if (handler != null)
 //                handler(this, EventArgs.Empty);
@@ -740,36 +738,36 @@ namespace System.ServiceModel.Channels
 
 //        void OnOpened()
 //        {
-//            lock (this.ThisLock)
+//            lock (ThisLock)
 //            {
-//                if (this.state == CommunicationState.Opening)
+//                if (state == CommunicationState.Opening)
 //                {
-//                    this.state = CommunicationState.Opened;
+//                    state = CommunicationState.Opened;
 //                }
 //            }
 //        }
 
 //        bool OnOpening(MaskingMode maskingMode)
 //        {
-//            lock (this.ThisLock)
+//            lock (ThisLock)
 //            {
-//                if (this.state != CommunicationState.Created)
+//                if (state != CommunicationState.Created)
 //                {
 //                    Exception e = null;
 
-//                    if ((this.state == CommunicationState.Opening)
-//                        || (this.state == CommunicationState.Opened))
+//                    if ((state == CommunicationState.Opening)
+//                        || (state == CommunicationState.Opened))
 //                    {
 //                        if (!ReliableChannelBinderHelper.MaskUnhandled(maskingMode))
 //                        {
 //                            e = new InvalidOperationException(SR.GetString(
 //                                SR.CommunicationObjectCannotBeModifiedInState,
-//                                this.GetType().ToString(), this.state.ToString()));
+//                                GetType().ToString(), state.ToString()));
 //                        }
 //                    }
 //                    else
 //                    {
-//                        e = this.GetClosedOrFaultedException(maskingMode);
+//                        e = GetClosedOrFaultedException(maskingMode);
 //                    }
 
 //                    if (e != null)
@@ -781,7 +779,7 @@ namespace System.ServiceModel.Channels
 //                }
 //                else
 //                {
-//                    this.state = CommunicationState.Opening;
+//                    state = CommunicationState.Opening;
 //                    return true;
 //                }
 //            }
@@ -804,16 +802,16 @@ namespace System.ServiceModel.Channels
 
 //        public void Open(TimeSpan timeout)
 //        {
-//            this.ThrowIfTimeoutNegative(timeout);
+//            ThrowIfTimeoutNegative(timeout);
 
-//            if (!this.OnOpening(this.defaultMaskingMode))
+//            if (!OnOpening(defaultMaskingMode))
 //            {
 //                return;
 //            }
 
 //            try
 //            {
-//                this.OnOpen(timeout);
+//                OnOpen(timeout);
 //            }
 //            catch (Exception e)
 //            {
@@ -822,26 +820,26 @@ namespace System.ServiceModel.Channels
 //                    throw;
 //                }
 
-//                this.Fault(null);
+//                Fault(null);
 
-//                if (this.defaultMaskingMode == MaskingMode.None)
+//                if (defaultMaskingMode == MaskingMode.None)
 //                {
 //                    throw;
 //                }
 //                else
 //                {
-//                    this.RaiseOnException(e);
+//                    RaiseOnException(e);
 //                    return;
 //                }
 //            }
 
-//            this.synchronizer.StartSynchronizing();
-//            this.OnOpened();
+//            synchronizer.StartSynchronizing();
+//            OnOpened();
 //        }
 
 //        void RaiseOnException(Exception e)
 //        {
-//            BinderExceptionHandler handler = this.OnException;
+//            BinderExceptionHandler handler = OnException;
 
 //            if (handler != null)
 //            {
@@ -851,12 +849,12 @@ namespace System.ServiceModel.Channels
 
 //        public void Send(Message message, TimeSpan timeout)
 //        {
-//            this.Send(message, timeout, this.defaultMaskingMode);
+//            Send(message, timeout, defaultMaskingMode);
 //        }
 
 //        public void Send(Message message, TimeSpan timeout, MaskingMode maskingMode)
 //        {
-//            if (!this.ValidateOutputOperation(message, timeout, maskingMode))
+//            if (!ValidateOutputOperation(message, timeout, maskingMode))
 //            {
 //                return;
 //            }
@@ -868,7 +866,7 @@ namespace System.ServiceModel.Channels
 //                TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
 //                TChannel channel;
 
-//                if (!this.synchronizer.TryGetChannelForOutput(timeoutHelper.RemainingTime(), maskingMode,
+//                if (!synchronizer.TryGetChannelForOutput(timeoutHelper.RemainingTime(), maskingMode,
 //                    out channel))
 //                {
 //                    if (!ReliableChannelBinderHelper.MaskHandled(maskingMode))
@@ -885,16 +883,16 @@ namespace System.ServiceModel.Channels
 //                    return;
 //                }
 
-//                this.AddOutputHeaders(message);
+//                AddOutputHeaders(message);
 
 //                try
 //                {
-//                    this.OnSend(channel, message, timeoutHelper.RemainingTime());
+//                    OnSend(channel, message, timeoutHelper.RemainingTime());
 //                }
 //                finally
 //                {
-//                    autoAborted = this.Synchronizer.Aborting;
-//                    this.synchronizer.ReturnChannel();
+//                    autoAborted = Synchronizer.Aborting;
+//                    synchronizer.ReturnChannel();
 //                }
 //            }
 //            catch (Exception e)
@@ -904,7 +902,7 @@ namespace System.ServiceModel.Channels
 //                    throw;
 //                }
 
-//                if (!this.HandleException(e, maskingMode, autoAborted))
+//                if (!HandleException(e, maskingMode, autoAborted))
 //                {
 //                    throw;
 //                }
@@ -921,19 +919,19 @@ namespace System.ServiceModel.Channels
 //        // returns true if in Opened state
 //        bool ThrowIfNotOpenedAndNotMasking(MaskingMode maskingMode, bool throwDisposed)
 //        {
-//            lock (this.ThisLock)
+//            lock (ThisLock)
 //            {
-//                if (this.State == CommunicationState.Created)
+//                if (State == CommunicationState.Created)
 //                {
 //                    throw Fx.AssertAndThrow("Messaging operations cannot be called when the binder is in the Created state.");
 //                }
 
-//                if (this.State == CommunicationState.Opening)
+//                if (State == CommunicationState.Opening)
 //                {
 //                    throw Fx.AssertAndThrow("Messaging operations cannot be called when the binder is in the Opening state.");
 //                }
 
-//                if (this.State == CommunicationState.Opened)
+//                if (State == CommunicationState.Opened)
 //                {
 //                    return true;
 //                }
@@ -941,7 +939,7 @@ namespace System.ServiceModel.Channels
 //                // state is Faulted, Closing, or Closed
 //                if (throwDisposed)
 //                {
-//                    Exception e = this.GetClosedOrFaultedException(maskingMode);
+//                    Exception e = GetClosedOrFaultedException(maskingMode);
 
 //                    if (e != null)
 //                    {
@@ -964,16 +962,16 @@ namespace System.ServiceModel.Channels
 
 //        void TransitionToClosed()
 //        {
-//            lock (this.ThisLock)
+//            lock (ThisLock)
 //            {
-//                if ((this.state != CommunicationState.Closing)
-//                    && (this.state != CommunicationState.Closed)
-//                    && (this.state != CommunicationState.Faulted))
+//                if ((state != CommunicationState.Closing)
+//                    && (state != CommunicationState.Closed)
+//                    && (state != CommunicationState.Faulted))
 //                {
 //                    throw Fx.AssertAndThrow("Caller cannot transition to the Closed state from a non-terminal state.");
 //                }
 
-//                this.state = CommunicationState.Closed;
+//                state = CommunicationState.Closed;
 //            }
 //        }
 
@@ -982,7 +980,7 @@ namespace System.ServiceModel.Channels
 
 //        public virtual bool TryReceive(TimeSpan timeout, out RequestContext requestContext)
 //        {
-//            return this.TryReceive(timeout, out requestContext, this.defaultMaskingMode);
+//            return TryReceive(timeout, out requestContext, defaultMaskingMode);
 //        }
 
 //        public virtual bool TryReceive(TimeSpan timeout, out RequestContext requestContext, MaskingMode maskingMode)
@@ -992,7 +990,7 @@ namespace System.ServiceModel.Channels
 //                throw Fx.AssertAndThrow("This method was implemented only for the case where we do not mask exceptions.");
 //            }
 
-//            if (!this.ValidateInputOperation(timeout))
+//            if (!ValidateInputOperation(timeout))
 //            {
 //                requestContext = null;
 //                return true;
@@ -1007,8 +1005,8 @@ namespace System.ServiceModel.Channels
 //                try
 //                {
 //                    TChannel channel;
-//                    bool success = !this.synchronizer.TryGetChannelForInput(
-//                        this.CanGetChannelForReceive, timeoutHelper.RemainingTime(), out channel);
+//                    bool success = !synchronizer.TryGetChannelForInput(
+//                        CanGetChannelForReceive, timeoutHelper.RemainingTime(), out channel);
 
 //                    if (channel == null)
 //                    {
@@ -1018,7 +1016,7 @@ namespace System.ServiceModel.Channels
 
 //                    try
 //                    {
-//                        success = this.OnTryReceive(channel, timeoutHelper.RemainingTime(),
+//                        success = OnTryReceive(channel, timeoutHelper.RemainingTime(),
 //                            out requestContext);
 
 //                        // timed out || got message, return immediately
@@ -1028,12 +1026,12 @@ namespace System.ServiceModel.Channels
 //                        }
 
 //                        // the underlying channel closed or faulted, retry
-//                        this.synchronizer.OnReadEof();
+//                        synchronizer.OnReadEof();
 //                    }
 //                    finally
 //                    {
-//                        autoAborted = this.Synchronizer.Aborting;
-//                        this.synchronizer.ReturnChannel();
+//                        autoAborted = Synchronizer.Aborting;
+//                        synchronizer.ReturnChannel();
 //                    }
 //                }
 //                catch (Exception e)
@@ -1043,7 +1041,7 @@ namespace System.ServiceModel.Channels
 //                        throw;
 //                    }
 
-//                    if (!this.HandleException(e, maskingMode, autoAborted))
+//                    if (!HandleException(e, maskingMode, autoAborted))
 //                    {
 //                        throw;
 //                    }
@@ -1059,7 +1057,7 @@ namespace System.ServiceModel.Channels
 //                    SR.SFxTimeoutOutOfRange0));
 //            }
 
-//            return this.ThrowIfNotOpenedAndNotMasking(MaskingMode.All, false);
+//            return ThrowIfNotOpenedAndNotMasking(MaskingMode.All, false);
 //        }
 
 //        protected bool ValidateOutputOperation(Message message, TimeSpan timeout, MaskingMode maskingMode)
@@ -1075,12 +1073,12 @@ namespace System.ServiceModel.Channels
 //                    SR.SFxTimeoutOutOfRange0));
 //            }
 
-//            return this.ThrowIfNotOpenedAndNotMasking(maskingMode, true);
+//            return ThrowIfNotOpenedAndNotMasking(maskingMode, true);
 //        }
 
 //        internal void WaitForPendingOperations(TimeSpan timeout)
 //        {
-//            this.synchronizer.WaitForPendingOperations(timeout);
+//            synchronizer.WaitForPendingOperations(timeout);
 //        }
 
 //        protected RequestContext WrapMessage(Message message)
@@ -1100,7 +1098,7 @@ namespace System.ServiceModel.Channels
 //                return null;
 //            }
 
-//            if (!this.TolerateFaults && this.defaultMaskingMode == MaskingMode.None)
+//            if (!TolerateFaults && defaultMaskingMode == MaskingMode.None)
 //            {
 //                return context;
 //            }
@@ -1134,15 +1132,15 @@ namespace System.ServiceModel.Channels
 //                    Fx.Assert("Argument binder cannot be null.");
 //                }
 
-//                this.binder = binder;
-//                this.maskingMode = binder.defaultMaskingMode;
+//                binder = binder;
+//                maskingMode = binder.defaultMaskingMode;
 //            }
 
 //            protected ReliableChannelBinder<TChannel> Binder
 //            {
 //                get
 //                {
-//                    return this.binder;
+//                    return binder;
 //                }
 //            }
 
@@ -1150,18 +1148,18 @@ namespace System.ServiceModel.Channels
 //            {
 //                get
 //                {
-//                    return this.maskingMode;
+//                    return maskingMode;
 //                }
 //            }
 
 //            public void SetMaskingMode(MaskingMode maskingMode)
 //            {
-//                if (this.binder.defaultMaskingMode != MaskingMode.All)
+//                if (binder.defaultMaskingMode != MaskingMode.All)
 //                {
 //                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new NotSupportedException());
 //                }
 
-//                this.maskingMode = maskingMode;
+//                maskingMode = maskingMode;
 //            }
 //        }
 
@@ -1185,16 +1183,16 @@ namespace System.ServiceModel.Channels
 //            public ChannelSynchronizer(ReliableChannelBinder<TChannel> binder, TChannel channel,
 //                TolerateFaultsMode faultMode)
 //            {
-//                this.binder = binder;
-//                this.currentChannel = channel;
-//                this.faultMode = faultMode;
+//                binder = binder;
+//                currentChannel = channel;
+//                faultMode = faultMode;
 //            }
 
 //            public bool Aborting
 //            {
 //                get
 //                {
-//                    return this.aborting;
+//                    return aborting;
 //                }
 //            }
 
@@ -1202,8 +1200,8 @@ namespace System.ServiceModel.Channels
 //            {
 //                get
 //                {
-//                    return (this.state == State.ChannelOpened ||
-//                        this.state == State.ChannelOpening);
+//                    return (state == State.ChannelOpened ||
+//                        state == State.ChannelOpening);
 //                }
 //            }
 
@@ -1211,7 +1209,7 @@ namespace System.ServiceModel.Channels
 //            {
 //                get
 //                {
-//                    return this.currentChannel;
+//                    return currentChannel;
 //                }
 //            }
 
@@ -1219,7 +1217,7 @@ namespace System.ServiceModel.Channels
 //            {
 //                get
 //                {
-//                    return this.thisLock;
+//                    return thisLock;
 //                }
 //            }
 
@@ -1227,34 +1225,34 @@ namespace System.ServiceModel.Channels
 //            {
 //                get
 //                {
-//                    return this.tolerateFaults;
+//                    return tolerateFaults;
 //                }
 //            }
 
 //            // Server only API.
 //            public TChannel AbortCurentChannel()
 //            {
-//                lock (this.ThisLock)
+//                lock (ThisLock)
 //                {
-//                    if (!this.tolerateFaults)
+//                    if (!tolerateFaults)
 //                    {
 //                        throw Fx.AssertAndThrow("It is only valid to abort the current channel when masking faults");
 //                    }
 
-//                    if (this.state == State.ChannelOpening)
+//                    if (state == State.ChannelOpening)
 //                    {
-//                        this.aborting = true;
+//                        aborting = true;
 //                    }
-//                    else if (this.state == State.ChannelOpened)
+//                    else if (state == State.ChannelOpened)
 //                    {
-//                        if (this.count == 0)
+//                        if (count == 0)
 //                        {
-//                            this.state = State.NoChannel;
+//                            state = State.NoChannel;
 //                        }
 //                        else
 //                        {
-//                            this.aborting = true;
-//                            this.state = State.ChannelClosing;
+//                            aborting = true;
+//                            state = State.ChannelClosing;
 //                        }
 //                    }
 //                    else
@@ -1262,7 +1260,7 @@ namespace System.ServiceModel.Channels
 //                        return null;
 //                    }
 
-//                    return this.currentChannel;
+//                    return currentChannel;
 //                }
 //            }
 
@@ -1275,14 +1273,14 @@ namespace System.ServiceModel.Channels
 //            public IAsyncResult BeginTryGetChannelForInput(bool canGetChannel, TimeSpan timeout,
 //                AsyncCallback callback, object state)
 //            {
-//                return this.BeginTryGetChannel(canGetChannel, false, timeout, MaskingMode.All,
+//                return BeginTryGetChannel(canGetChannel, false, timeout, MaskingMode.All,
 //                    callback, state);
 //            }
 
 //            public IAsyncResult BeginTryGetChannelForOutput(TimeSpan timeout,
 //                MaskingMode maskingMode, AsyncCallback callback, object state)
 //            {
-//                return this.BeginTryGetChannel(true, true, timeout, maskingMode,
+//                return BeginTryGetChannel(true, true, timeout, maskingMode,
 //                    callback, state);
 //            }
 
@@ -1294,25 +1292,25 @@ namespace System.ServiceModel.Channels
 //                bool getChannel = false;
 //                bool faulted = false;
 
-//                lock (this.ThisLock)
+//                lock (ThisLock)
 //                {
-//                    if (!this.ThrowIfNecessary(maskingMode))
+//                    if (!ThrowIfNecessary(maskingMode))
 //                    {
 //                        channel = null;
 //                    }
-//                    else if (this.state == State.ChannelOpened)
+//                    else if (state == State.ChannelOpened)
 //                    {
-//                        if (this.currentChannel == null)
+//                        if (currentChannel == null)
 //                        {
 //                            throw Fx.AssertAndThrow("Field currentChannel cannot be null in the ChannelOpened state.");
 //                        }
 
-//                        this.count++;
-//                        channel = this.currentChannel;
+//                        count++;
+//                        channel = currentChannel;
 //                    }
-//                    else if (!this.tolerateFaults
-//                        && ((this.state == State.NoChannel)
-//                        || (this.state == State.ChannelClosing)))
+//                    else if (!tolerateFaults
+//                        && ((state == State.NoChannel)
+//                        || (state == State.ChannelClosing)))
 //                    {
 //                        if (canCauseFault)
 //                        {
@@ -1322,34 +1320,34 @@ namespace System.ServiceModel.Channels
 //                        channel = null;
 //                    }
 //                    else if (!canGetChannel
-//                        || (this.state == State.ChannelOpening)
-//                        || (this.state == State.ChannelClosing))
+//                        || (state == State.ChannelOpening)
+//                        || (state == State.ChannelClosing))
 //                    {
 //                        waiter = new AsyncWaiter(this, canGetChannel, null, timeout, maskingMode,
-//                            this.binder.ChannelParameters,
+//                            binder.ChannelParameters,
 //                            callback, state);
-//                        this.GetQueue(canGetChannel).Enqueue(waiter);
+//                        GetQueue(canGetChannel).Enqueue(waiter);
 //                    }
 //                    else
 //                    {
-//                        if (this.state != State.NoChannel)
+//                        if (state != State.NoChannel)
 //                        {
 //                            throw Fx.AssertAndThrow("The state must be NoChannel.");
 //                        }
 
 //                        waiter = new AsyncWaiter(this, canGetChannel,
-//                            this.GetCurrentChannelIfCreated(), timeout, maskingMode,
-//                            this.binder.ChannelParameters,
+//                            GetCurrentChannelIfCreated(), timeout, maskingMode,
+//                            binder.ChannelParameters,
 //                            callback, state);
 
-//                        this.state = State.ChannelOpening;
+//                        state = State.ChannelOpening;
 //                        getChannel = true;
 //                    }
 //                }
 
 //                if (faulted)
 //                {
-//                    this.binder.Fault(null);
+//                    binder.Fault(null);
 //                }
 
 //                if (waiter == null)
@@ -1372,22 +1370,22 @@ namespace System.ServiceModel.Channels
 //            public IAsyncResult BeginWaitForPendingOperations(TimeSpan timeout,
 //                AsyncCallback callback, object state)
 //            {
-//                lock (this.ThisLock)
+//                lock (ThisLock)
 //                {
-//                    if (this.drainEvent != null)
+//                    if (drainEvent != null)
 //                    {
 //                        throw Fx.AssertAndThrow("The WaitForPendingOperations operation may only be invoked once.");
 //                    }
 
-//                    if (this.count > 0)
+//                    if (count > 0)
 //                    {
-//                        this.drainEvent = new InterruptibleWaitObject(false, false);
+//                        drainEvent = new InterruptibleWaitObject(false, false);
 //                    }
 //                }
 
-//                if (this.drainEvent != null)
+//                if (drainEvent != null)
 //                {
-//                    return this.drainEvent.BeginWait(timeout, callback, state);
+//                    return drainEvent.BeginWait(timeout, callback, state);
 //                }
 //                else
 //                {
@@ -1404,17 +1402,17 @@ namespace System.ServiceModel.Channels
 
 //                bool close = false;
 
-//                lock (this.ThisLock)
+//                lock (ThisLock)
 //                {
-//                    if (this.ValidateOpened())
+//                    if (ValidateOpened())
 //                    {
-//                        channel = this.currentChannel;
+//                        channel = currentChannel;
 //                        return true;
 //                    }
 //                    else
 //                    {
 //                        channel = null;
-//                        close = this.state == State.Closed;
+//                        close = state == State.Closed;
 //                    }
 //                }
 
@@ -1456,7 +1454,7 @@ namespace System.ServiceModel.Channels
 //                }
 //                else
 //                {
-//                    this.drainEvent.EndWait(result);
+//                    drainEvent.EndWait(result);
 //                }
 //            }
 
@@ -1465,36 +1463,36 @@ namespace System.ServiceModel.Channels
 //            {
 //                bool fault = false;
 
-//                lock (this.ThisLock)
+//                lock (ThisLock)
 //                {
-//                    if (this.ValidateOpened())
+//                    if (ValidateOpened())
 //                    {
 //                        // This is called only during the RM CS phase. In this phase, there are 2
 //                        // valid states between Request calls, ChannelOpened and NoChannel.
-//                        if (this.state == State.ChannelOpened)
+//                        if (state == State.ChannelOpened)
 //                        {
 //                            return true;
 //                        }
 
-//                        if (this.state != State.NoChannel)
+//                        if (state != State.NoChannel)
 //                        {
 //                            throw Fx.AssertAndThrow("The caller may only invoke this EnsureChannel during the CreateSequence negotiation. ChannelOpening and ChannelClosing are invalid states during this phase of the negotiation.");
 //                        }
 
-//                        if (!this.tolerateFaults)
+//                        if (!tolerateFaults)
 //                        {
 //                            fault = true;
 //                        }
 //                        else
 //                        {
-//                            if (this.GetCurrentChannelIfCreated() != null)
+//                            if (GetCurrentChannelIfCreated() != null)
 //                            {
 //                                return true;
 //                            }
 
-//                            if (this.binder.TryGetChannel(TimeSpan.Zero))
+//                            if (binder.TryGetChannel(TimeSpan.Zero))
 //                            {
-//                                if (this.currentChannel == null)
+//                                if (currentChannel == null)
 //                                {
 //                                    return false;
 //                                }
@@ -1507,7 +1505,7 @@ namespace System.ServiceModel.Channels
 
 //                if (fault)
 //                {
-//                    this.binder.Fault(null);
+//                    binder.Fault(null);
 //                }
 
 //                return false;
@@ -1515,26 +1513,26 @@ namespace System.ServiceModel.Channels
 
 //            IWaiter GetChannelWaiter()
 //            {
-//                if ((this.getChannelQueue == null) || (this.getChannelQueue.Count == 0))
+//                if ((getChannelQueue == null) || (getChannelQueue.Count == 0))
 //                {
 //                    return null;
 //                }
 
-//                return this.getChannelQueue.Dequeue();
+//                return getChannelQueue.Dequeue();
 //            }
 
-//            // Must be called within lock (this.ThisLock)
+//            // Must be called within lock (ThisLock)
 //            TChannel GetCurrentChannelIfCreated()
 //            {
-//                if (this.state != State.NoChannel)
+//                if (state != State.NoChannel)
 //                {
 //                    throw Fx.AssertAndThrow("This method may only be called in the NoChannel state.");
 //                }
 
-//                if ((this.currentChannel != null)
-//                    && (this.currentChannel.State == CommunicationState.Created))
+//                if ((currentChannel != null)
+//                    && (currentChannel.State == CommunicationState.Created))
 //                {
-//                    return this.currentChannel;
+//                    return currentChannel;
 //                }
 //                else
 //                {
@@ -1546,21 +1544,21 @@ namespace System.ServiceModel.Channels
 //            {
 //                if (canGetChannel)
 //                {
-//                    if (this.getChannelQueue == null)
+//                    if (getChannelQueue == null)
 //                    {
-//                        this.getChannelQueue = new Queue<IWaiter>();
+//                        getChannelQueue = new Queue<IWaiter>();
 //                    }
 
-//                    return this.getChannelQueue;
+//                    return getChannelQueue;
 //                }
 //                else
 //                {
-//                    if (this.waitQueue == null)
+//                    if (waitQueue == null)
 //                    {
-//                        this.waitQueue = new Queue<IWaiter>();
+//                        waitQueue = new Queue<IWaiter>();
 //                    }
 
-//                    return this.waitQueue;
+//                    return waitQueue;
 //                }
 //            }
 
@@ -1570,50 +1568,50 @@ namespace System.ServiceModel.Channels
 //                bool faultBinder = false;
 //                bool raiseInnerChannelFaulted = false;
 
-//                lock (this.ThisLock)
+//                lock (ThisLock)
 //                {
-//                    if (this.currentChannel != faultedChannel)
+//                    if (currentChannel != faultedChannel)
 //                    {
 //                        return;
 //                    }
 
 //                    // The synchronizer is already closed or aborted.
-//                    if (!this.ValidateOpened())
+//                    if (!ValidateOpened())
 //                    {
 //                        return;
 //                    }
 
-//                    if (this.state == State.ChannelOpened)
+//                    if (state == State.ChannelOpened)
 //                    {
-//                        if (this.count == 0)
+//                        if (count == 0)
 //                        {
-//                            faultedChannel.Faulted -= this.onChannelFaulted;
+//                            faultedChannel.Faulted -= onChannelFaulted;
 //                        }
 
-//                        faultBinder = !this.tolerateFaults;
-//                        this.state = State.ChannelClosing;
-//                        this.innerChannelFaulted = true;
+//                        faultBinder = !tolerateFaults;
+//                        state = State.ChannelClosing;
+//                        innerChannelFaulted = true;
 
-//                        if (!faultBinder && this.count == 0)
+//                        if (!faultBinder && count == 0)
 //                        {
-//                            this.state = State.NoChannel;
-//                            this.aborting = false;
+//                            state = State.NoChannel;
+//                            aborting = false;
 //                            raiseInnerChannelFaulted = true;
-//                            this.innerChannelFaulted = false;
+//                            innerChannelFaulted = false;
 //                        }
 //                    }
 //                }
 
 //                if (faultBinder)
 //                {
-//                    this.binder.Fault(null);
+//                    binder.Fault(null);
 //                }
 
 //                faultedChannel.Abort();
 
 //                if (raiseInnerChannelFaulted)
 //                {
-//                    this.binder.OnInnerChannelFaulted();
+//                    binder.OnInnerChannelFaulted();
 //                }
 //            }
 
@@ -1631,38 +1629,38 @@ namespace System.ServiceModel.Channels
 //                Queue<IWaiter> temp2 = null;
 //                TChannel channel = null;
 
-//                lock (this.ThisLock)
+//                lock (ThisLock)
 //                {
-//                    if (this.currentChannel == null)
+//                    if (currentChannel == null)
 //                    {
 //                        throw Fx.AssertAndThrow("Caller must ensure that field currentChannel is set before opening the channel.");
 //                    }
 
-//                    if (this.ValidateOpened())
+//                    if (ValidateOpened())
 //                    {
-//                        if (this.state != State.ChannelOpening)
+//                        if (state != State.ChannelOpening)
 //                        {
 //                            throw Fx.AssertAndThrow("This method may only be called in the ChannelOpening state.");
 //                        }
 
-//                        this.state = State.ChannelOpened;
-//                        this.SetTolerateFaults();
+//                        state = State.ChannelOpened;
+//                        SetTolerateFaults();
 
-//                        this.count += 1;
-//                        this.count += (this.getChannelQueue == null) ? 0 : this.getChannelQueue.Count;
-//                        this.count += (this.waitQueue == null) ? 0 : this.waitQueue.Count;
+//                        count += 1;
+//                        count += (getChannelQueue == null) ? 0 : getChannelQueue.Count;
+//                        count += (waitQueue == null) ? 0 : waitQueue.Count;
 
-//                        temp1 = this.getChannelQueue;
-//                        temp2 = this.waitQueue;
-//                        channel = this.currentChannel;
+//                        temp1 = getChannelQueue;
+//                        temp2 = waitQueue;
+//                        channel = currentChannel;
 
-//                        this.getChannelQueue = null;
-//                        this.waitQueue = null;
+//                        getChannelQueue = null;
+//                        waitQueue = null;
 //                    }
 //                    else
 //                    {
-//                        close = this.state == State.Closed;
-//                        fault = this.state == State.Faulted;
+//                        close = state == State.Closed;
+//                        fault = state == State.Faulted;
 //                    }
 //                }
 
@@ -1677,8 +1675,8 @@ namespace System.ServiceModel.Channels
 //                    return false;
 //                }
 
-//                this.SetWaiters(temp1, channel);
-//                this.SetWaiters(temp2, channel);
+//                SetWaiters(temp1, channel);
+//                SetWaiters(temp2, channel);
 //                return true;
 //            }
 
@@ -1686,23 +1684,23 @@ namespace System.ServiceModel.Channels
 //            {
 //                IWaiter waiter = null;
 
-//                lock (this.ThisLock)
+//                lock (ThisLock)
 //                {
-//                    if (!this.ValidateOpened())
+//                    if (!ValidateOpened())
 //                    {
 //                        return;
 //                    }
 
-//                    if (this.state != State.ChannelOpening)
+//                    if (state != State.ChannelOpening)
 //                    {
 //                        throw Fx.AssertAndThrow("The state must be set to ChannelOpening before the caller attempts to open the channel.");
 //                    }
 
-//                    waiter = this.GetChannelWaiter();
+//                    waiter = GetChannelWaiter();
 
 //                    if (waiter == null)
 //                    {
-//                        this.state = State.NoChannel;
+//                        state = State.NoChannel;
 //                        return;
 //                    }
 //                }
@@ -1719,23 +1717,23 @@ namespace System.ServiceModel.Channels
 
 //            public void OnReadEof()
 //            {
-//                lock (this.ThisLock)
+//                lock (ThisLock)
 //                {
-//                    if (this.count <= 0)
+//                    if (count <= 0)
 //                    {
 //                        throw Fx.AssertAndThrow("Caller must ensure that OnReadEof is called before ReturnChannel.");
 //                    }
 
-//                    if (this.ValidateOpened())
+//                    if (ValidateOpened())
 //                    {
-//                        if ((this.state != State.ChannelOpened) && (this.state != State.ChannelClosing))
+//                        if ((state != State.ChannelOpened) && (state != State.ChannelClosing))
 //                        {
 //                            throw Fx.AssertAndThrow("Since count is positive, the only valid states are ChannelOpened and ChannelClosing.");
 //                        }
 
-//                        if (this.currentChannel.State != CommunicationState.Faulted)
+//                        if (currentChannel.State != CommunicationState.Faulted)
 //                        {
-//                            this.state = State.ChannelClosing;
+//                            state = State.ChannelClosing;
 //                        }
 //                    }
 //                }
@@ -1743,12 +1741,12 @@ namespace System.ServiceModel.Channels
 
 //            bool RemoveWaiter(IWaiter waiter)
 //            {
-//                Queue<IWaiter> waiters = waiter.CanGetChannel ? this.getChannelQueue : this.waitQueue;
+//                Queue<IWaiter> waiters = waiter.CanGetChannel ? getChannelQueue : waitQueue;
 //                bool removed = false;
 
-//                lock (this.ThisLock)
+//                lock (ThisLock)
 //                {
-//                    if (!this.ValidateOpened())
+//                    if (!ValidateOpened())
 //                    {
 //                        return false;
 //                    }
@@ -1779,44 +1777,44 @@ namespace System.ServiceModel.Channels
 //                bool drained;
 //                bool raiseInnerChannelFaulted = false;
 
-//                lock (this.ThisLock)
+//                lock (ThisLock)
 //                {
-//                    if (this.count <= 0)
+//                    if (count <= 0)
 //                    {
 //                        throw Fx.AssertAndThrow("Method ReturnChannel() can only be called after TryGetChannel or EndTryGetChannel returns a channel.");
 //                    }
 
-//                    this.count--;
-//                    drained = (this.count == 0) && (this.drainEvent != null);
+//                    count--;
+//                    drained = (count == 0) && (drainEvent != null);
 
-//                    if (this.ValidateOpened())
+//                    if (ValidateOpened())
 //                    {
-//                        if ((this.state != State.ChannelOpened) && (this.state != State.ChannelClosing))
+//                        if ((state != State.ChannelOpened) && (state != State.ChannelClosing))
 //                        {
 //                            throw Fx.AssertAndThrow("ChannelOpened and ChannelClosing are the only 2 valid states when count is positive.");
 //                        }
 
-//                        if (this.currentChannel.State == CommunicationState.Faulted)
+//                        if (currentChannel.State == CommunicationState.Faulted)
 //                        {
-//                            faultBinder = !this.tolerateFaults;
-//                            this.innerChannelFaulted = true;
-//                            this.state = State.ChannelClosing;
+//                            faultBinder = !tolerateFaults;
+//                            innerChannelFaulted = true;
+//                            state = State.ChannelClosing;
 //                        }
 
-//                        if (!faultBinder && (this.state == State.ChannelClosing) && (this.count == 0))
+//                        if (!faultBinder && (state == State.ChannelClosing) && (count == 0))
 //                        {
-//                            channel = this.currentChannel;
-//                            raiseInnerChannelFaulted = this.innerChannelFaulted;
-//                            this.innerChannelFaulted = false;
+//                            channel = currentChannel;
+//                            raiseInnerChannelFaulted = innerChannelFaulted;
+//                            innerChannelFaulted = false;
 
-//                            this.state = State.NoChannel;
-//                            this.aborting = false;
+//                            state = State.NoChannel;
+//                            aborting = false;
 
-//                            waiter = this.GetChannelWaiter();
+//                            waiter = GetChannelWaiter();
 
 //                            if (waiter != null)
 //                            {
-//                                this.state = State.ChannelOpening;
+//                                state = State.ChannelOpening;
 //                            }
 //                        }
 //                    }
@@ -1824,21 +1822,21 @@ namespace System.ServiceModel.Channels
 
 //                if (faultBinder)
 //                {
-//                    this.binder.Fault(null);
+//                    binder.Fault(null);
 //                }
 
 //                if (drained)
 //                {
-//                    this.drainEvent.Set();
+//                    drainEvent.Set();
 //                }
 
 //                if (channel != null)
 //                {
-//                    channel.Faulted -= this.onChannelFaulted;
+//                    channel.Faulted -= onChannelFaulted;
 
 //                    if (channel.State == CommunicationState.Opened)
 //                    {
-//                        this.binder.CloseChannel(channel);
+//                        binder.CloseChannel(channel);
 //                    }
 //                    else
 //                    {
@@ -1853,27 +1851,27 @@ namespace System.ServiceModel.Channels
 
 //                if (raiseInnerChannelFaulted)
 //                {
-//                    this.binder.OnInnerChannelFaulted();
+//                    binder.OnInnerChannelFaulted();
 //                }
 //            }
 
 //            public bool SetChannel(TChannel channel)
 //            {
-//                lock (this.ThisLock)
+//                lock (ThisLock)
 //                {
-//                    if (this.state != State.ChannelOpening && this.state != State.NoChannel)
+//                    if (state != State.ChannelOpening && state != State.NoChannel)
 //                    {
 //                        throw Fx.AssertAndThrow("SetChannel is only valid in the NoChannel and ChannelOpening states");
 //                    }
 
-//                    if (!this.tolerateFaults)
+//                    if (!tolerateFaults)
 //                    {
 //                        throw Fx.AssertAndThrow("SetChannel is only valid when masking faults");
 //                    }
 
-//                    if (this.ValidateOpened())
+//                    if (ValidateOpened())
 //                    {
-//                        this.currentChannel = channel;
+//                        currentChannel = channel;
 //                        return true;
 //                    }
 //                    else
@@ -1885,21 +1883,21 @@ namespace System.ServiceModel.Channels
 
 //            void SetTolerateFaults()
 //            {
-//                if (this.faultMode == TolerateFaultsMode.Never)
+//                if (faultMode == TolerateFaultsMode.Never)
 //                {
-//                    this.tolerateFaults = false;
+//                    tolerateFaults = false;
 //                }
-//                else if (this.faultMode == TolerateFaultsMode.IfNotSecuritySession)
+//                else if (faultMode == TolerateFaultsMode.IfNotSecuritySession)
 //                {
-//                    this.tolerateFaults = !this.binder.HasSecuritySession(this.currentChannel);
-//                }
-
-//                if (this.onChannelFaulted == null)
-//                {
-//                    this.onChannelFaulted = new EventHandler(this.OnChannelFaulted);
+//                    tolerateFaults = !binder.HasSecuritySession(currentChannel);
 //                }
 
-//                this.currentChannel.Faulted += this.onChannelFaulted;
+//                if (onChannelFaulted == null)
+//                {
+//                    onChannelFaulted = new EventHandler(OnChannelFaulted);
+//                }
+
+//                currentChannel.Faulted += onChannelFaulted;
 //            }
 
 //            void SetWaiters(Queue<IWaiter> waiters, TChannel channel)
@@ -1915,15 +1913,15 @@ namespace System.ServiceModel.Channels
 
 //            public void StartSynchronizing()
 //            {
-//                lock (this.ThisLock)
+//                lock (ThisLock)
 //                {
-//                    if (this.state == State.Created)
+//                    if (state == State.Created)
 //                    {
-//                        this.state = State.NoChannel;
+//                        state = State.NoChannel;
 //                    }
 //                    else
 //                    {
-//                        if (this.state != State.Closed)
+//                        if (state != State.Closed)
 //                        {
 //                            throw Fx.AssertAndThrow("Abort is the only operation that can race with Open.");
 //                        }
@@ -1931,50 +1929,50 @@ namespace System.ServiceModel.Channels
 //                        return;
 //                    }
 
-//                    if (this.currentChannel == null)
+//                    if (currentChannel == null)
 //                    {
-//                        if (!this.binder.TryGetChannel(TimeSpan.Zero))
+//                        if (!binder.TryGetChannel(TimeSpan.Zero))
 //                        {
 //                            return;
 //                        }
 //                    }
 
-//                    if (this.currentChannel == null)
+//                    if (currentChannel == null)
 //                    {
 //                        return;
 //                    }
 
-//                    if (!this.binder.MustOpenChannel)
+//                    if (!binder.MustOpenChannel)
 //                    {
 //                        // Channel is already opened.
-//                        this.state = State.ChannelOpened;
-//                        this.SetTolerateFaults();
+//                        state = State.ChannelOpened;
+//                        SetTolerateFaults();
 //                    }
 //                }
 //            }
 
 //            public TChannel StopSynchronizing(bool close)
 //            {
-//                lock (this.ThisLock)
+//                lock (ThisLock)
 //                {
-//                    if ((this.state != State.Faulted) && (this.state != State.Closed))
+//                    if ((state != State.Faulted) && (state != State.Closed))
 //                    {
-//                        this.state = close ? State.Closed : State.Faulted;
+//                        state = close ? State.Closed : State.Faulted;
 
-//                        if ((this.currentChannel != null) && (this.onChannelFaulted != null))
+//                        if ((currentChannel != null) && (onChannelFaulted != null))
 //                        {
-//                            this.currentChannel.Faulted -= this.onChannelFaulted;
+//                            currentChannel.Faulted -= onChannelFaulted;
 //                        }
 //                    }
 
-//                    return this.currentChannel;
+//                    return currentChannel;
 //                }
 //            }
 
 //            // Must be called under a lock.
 //            bool ThrowIfNecessary(MaskingMode maskingMode)
 //            {
-//                if (this.ValidateOpened())
+//                if (ValidateOpened())
 //                {
 //                    return true;
 //                }
@@ -1982,13 +1980,13 @@ namespace System.ServiceModel.Channels
 //                // state is Closed or Faulted.
 //                Exception e;
 
-//                if (this.state == State.Closed)
+//                if (state == State.Closed)
 //                {
-//                    e = this.binder.GetClosedException(maskingMode);
+//                    e = binder.GetClosedException(maskingMode);
 //                }
 //                else
 //                {
-//                    e = this.binder.GetFaultedException(maskingMode);
+//                    e = binder.GetFaultedException(maskingMode);
 //                }
 
 //                if (e != null)
@@ -2002,14 +2000,14 @@ namespace System.ServiceModel.Channels
 //            public bool TryGetChannelForInput(bool canGetChannel, TimeSpan timeout,
 //                out TChannel channel)
 //            {
-//                return this.TryGetChannel(canGetChannel, false, timeout, MaskingMode.All,
+//                return TryGetChannel(canGetChannel, false, timeout, MaskingMode.All,
 //                    out channel);
 //            }
 
 //            public bool TryGetChannelForOutput(TimeSpan timeout, MaskingMode maskingMode,
 //                out TChannel channel)
 //            {
-//                return this.TryGetChannel(true, true, timeout, maskingMode, out channel);
+//                return TryGetChannel(true, true, timeout, maskingMode, out channel);
 //            }
 
 //            bool TryGetChannel(bool canGetChannel, bool canCauseFault, TimeSpan timeout,
@@ -2019,29 +2017,29 @@ namespace System.ServiceModel.Channels
 //                bool faulted = false;
 //                bool getChannel = false;
 
-//                lock (this.ThisLock)
+//                lock (ThisLock)
 //                {
-//                    if (!this.ThrowIfNecessary(maskingMode))
+//                    if (!ThrowIfNecessary(maskingMode))
 //                    {
 //                        channel = null;
 //                        return true;
 //                    }
 
-//                    if (this.state == State.ChannelOpened)
+//                    if (state == State.ChannelOpened)
 //                    {
-//                        if (this.currentChannel == null)
+//                        if (currentChannel == null)
 //                        {
 //                            throw Fx.AssertAndThrow("Field currentChannel cannot be null in the ChannelOpened state.");
 //                        }
 
-//                        this.count++;
-//                        channel = this.currentChannel;
+//                        count++;
+//                        channel = currentChannel;
 //                        return true;
 //                    }
 
-//                    if (!this.tolerateFaults
-//                        && ((this.state == State.ChannelClosing)
-//                        || (this.state == State.NoChannel)))
+//                    if (!tolerateFaults
+//                        && ((state == State.ChannelClosing)
+//                        || (state == State.NoChannel)))
 //                    {
 //                        if (!canCauseFault)
 //                        {
@@ -2052,31 +2050,31 @@ namespace System.ServiceModel.Channels
 //                        faulted = true;
 //                    }
 //                    else if (!canGetChannel
-//                        || (this.state == State.ChannelOpening)
-//                        || (this.state == State.ChannelClosing))
+//                        || (state == State.ChannelOpening)
+//                        || (state == State.ChannelClosing))
 //                    {
-//                        waiter = new SyncWaiter(this, canGetChannel, null, timeout, maskingMode, this.binder.ChannelParameters);
-//                        this.GetQueue(canGetChannel).Enqueue(waiter);
+//                        waiter = new SyncWaiter(this, canGetChannel, null, timeout, maskingMode, binder.ChannelParameters);
+//                        GetQueue(canGetChannel).Enqueue(waiter);
 //                    }
 //                    else
 //                    {
-//                        if (this.state != State.NoChannel)
+//                        if (state != State.NoChannel)
 //                        {
 //                            throw Fx.AssertAndThrow("The state must be NoChannel.");
 //                        }
 
 //                        waiter = new SyncWaiter(this, canGetChannel,
-//                            this.GetCurrentChannelIfCreated(), timeout, maskingMode,
-//                            this.binder.ChannelParameters);
+//                            GetCurrentChannelIfCreated(), timeout, maskingMode,
+//                            binder.ChannelParameters);
 
-//                        this.state = State.ChannelOpening;
+//                        state = State.ChannelOpening;
 //                        getChannel = true;
 //                    }
 //                }
 
 //                if (faulted)
 //                {
-//                    this.binder.Fault(null);
+//                    binder.Fault(null);
 //                    channel = null;
 //                    return true;
 //                }
@@ -2094,18 +2092,18 @@ namespace System.ServiceModel.Channels
 //                Queue<IWaiter> temp1;
 //                Queue<IWaiter> temp2;
 
-//                lock (this.ThisLock)
+//                lock (ThisLock)
 //                {
-//                    temp1 = this.getChannelQueue;
-//                    temp2 = this.waitQueue;
+//                    temp1 = getChannelQueue;
+//                    temp2 = waitQueue;
 
-//                    this.getChannelQueue = null;
-//                    this.waitQueue = null;
+//                    getChannelQueue = null;
+//                    waitQueue = null;
 //                }
 
-//                bool close = this.state == State.Closed;
-//                this.UnblockWaiters(temp1, close);
-//                this.UnblockWaiters(temp2, close);
+//                bool close = state == State.Closed;
+//                UnblockWaiters(temp1, close);
+//                UnblockWaiters(temp2, close);
 //            }
 
 //            void UnblockWaiters(Queue<IWaiter> waiters, bool close)
@@ -2128,32 +2126,32 @@ namespace System.ServiceModel.Channels
 
 //            bool ValidateOpened()
 //            {
-//                if (this.state == State.Created)
+//                if (state == State.Created)
 //                {
 //                    throw Fx.AssertAndThrow("This operation expects that the synchronizer has been opened.");
 //                }
 
-//                return (this.state != State.Closed) && (this.state != State.Faulted);
+//                return (state != State.Closed) && (state != State.Faulted);
 //            }
 
 //            public void WaitForPendingOperations(TimeSpan timeout)
 //            {
-//                lock (this.ThisLock)
+//                lock (ThisLock)
 //                {
-//                    if (this.drainEvent != null)
+//                    if (drainEvent != null)
 //                    {
 //                        throw Fx.AssertAndThrow("The WaitForPendingOperations operation may only be invoked once.");
 //                    }
 
-//                    if (this.count > 0)
+//                    if (count > 0)
 //                    {
-//                        this.drainEvent = new InterruptibleWaitObject(false, false);
+//                        drainEvent = new InterruptibleWaitObject(false, false);
 //                    }
 //                }
 
-//                if (this.drainEvent != null)
+//                if (drainEvent != null)
 //                {
-//                    this.drainEvent.Wait(timeout);
+//                    drainEvent.Wait(timeout);
 //                }
 //            }
 
@@ -2208,19 +2206,19 @@ namespace System.ServiceModel.Channels
 //                        }
 //                    }
 
-//                    this.synchronizer = synchronizer;
-//                    this.canGetChannel = canGetChannel;
-//                    this.channel = channel;
-//                    this.timeoutHelper = new TimeoutHelper(timeout);
-//                    this.maskingMode = maskingMode;
-//                    this.channelParameters = channelParameters;
+//                    synchronizer = synchronizer;
+//                    canGetChannel = canGetChannel;
+//                    channel = channel;
+//                    timeoutHelper = new TimeoutHelper(timeout);
+//                    maskingMode = maskingMode;
+//                    channelParameters = channelParameters;
 //                }
 
 //                public bool CanGetChannel
 //                {
 //                    get
 //                    {
-//                        return this.canGetChannel;
+//                        return canGetChannel;
 //                    }
 //                }
 
@@ -2234,46 +2232,46 @@ namespace System.ServiceModel.Channels
 
 //                void CancelTimer()
 //                {
-//                    lock (this.ThisLock)
+//                    lock (ThisLock)
 //                    {
-//                        if (!this.timerCancelled)
+//                        if (!timerCancelled)
 //                        {
-//                            if (this.timer != null)
+//                            if (timer != null)
 //                            {
-//                                this.timer.Cancel();
+//                                timer.Cancel();
 //                            }
 
-//                            this.timerCancelled = true;
+//                            timerCancelled = true;
 //                        }
 //                    }
 //                }
 
 //                public void Close()
 //                {
-//                    this.CancelTimer();
-//                    this.channel = null;
-//                    this.Complete(false,
-//                        this.synchronizer.binder.GetClosedException(this.maskingMode));
+//                    CancelTimer();
+//                    channel = null;
+//                    Complete(false,
+//                        synchronizer.binder.GetClosedException(maskingMode));
 //                }
 
 //                bool CompleteOpen(IAsyncResult result)
 //                {
-//                    this.channel.EndOpen(result);
-//                    return this.OnChannelOpened();
+//                    channel.EndOpen(result);
+//                    return OnChannelOpened();
 //                }
 
 //                bool CompleteTryGetChannel(IAsyncResult result)
 //                {
-//                    if (!this.synchronizer.binder.EndTryGetChannel(result))
+//                    if (!synchronizer.binder.EndTryGetChannel(result))
 //                    {
-//                        this.timedOut = true;
-//                        this.OnGetChannelFailed();
+//                        timedOut = true;
+//                        OnGetChannelFailed();
 //                        return true;
 //                    }
 
-//                    if (!this.synchronizer.CompleteSetChannel(this, out this.channel))
+//                    if (!synchronizer.CompleteSetChannel(this, out channel))
 //                    {
-//                        if (!this.IsCompleted)
+//                        if (!IsCompleted)
 //                        {
 //                            throw Fx.AssertAndThrow("CompleteSetChannel must complete the IWaiter if it returns false.");
 //                        }
@@ -2281,38 +2279,38 @@ namespace System.ServiceModel.Channels
 //                        return false;
 //                    }
 
-//                    return this.OpenChannel();
+//                    return OpenChannel();
 //                }
 
 //                public bool End(out TChannel channel)
 //                {
 //                    AsyncResult.End<AsyncWaiter>(this);
-//                    channel = this.channel;
-//                    return !this.timedOut;
+//                    channel = channel;
+//                    return !timedOut;
 //                }
 
 //                public void Fault()
 //                {
-//                    this.CancelTimer();
-//                    this.channel = null;
-//                    this.Complete(false,
-//                        this.synchronizer.binder.GetFaultedException(this.maskingMode));
+//                    CancelTimer();
+//                    channel = null;
+//                    Complete(false,
+//                        synchronizer.binder.GetFaultedException(maskingMode));
 //                }
 
 //                bool GetChannel()
 //                {
-//                    if (this.channel != null)
+//                    if (channel != null)
 //                    {
-//                        return this.OpenChannel();
+//                        return OpenChannel();
 //                    }
 //                    else
 //                    {
-//                        IAsyncResult result = this.synchronizer.binder.BeginTryGetChannel(
-//                            this.timeoutHelper.RemainingTime(), onTryGetChannelComplete, this);
+//                        IAsyncResult result = synchronizer.binder.BeginTryGetChannel(
+//                            timeoutHelper.RemainingTime(), onTryGetChannelComplete, this);
 
 //                        if (result.CompletedSynchronously)
 //                        {
-//                            return this.CompleteTryGetChannel(result);
+//                            return CompleteTryGetChannel(result);
 //                        }
 //                    }
 
@@ -2321,12 +2319,12 @@ namespace System.ServiceModel.Channels
 
 //                public void GetChannel(bool onUserThread)
 //                {
-//                    if (!this.CanGetChannel)
+//                    if (!CanGetChannel)
 //                    {
 //                        throw Fx.AssertAndThrow("This waiter must wait for a channel thus the caller cannot attempt to get a channel.");
 //                    }
 
-//                    this.isSynchronous = onUserThread;
+//                    isSynchronous = onUserThread;
 
 //                    if (onUserThread)
 //                    {
@@ -2334,9 +2332,9 @@ namespace System.ServiceModel.Channels
 
 //                        try
 //                        {
-//                            if (this.GetChannel())
+//                            if (GetChannel())
 //                            {
-//                                this.Complete(true);
+//                                Complete(true);
 //                            }
 
 //                            throwing = false;
@@ -2345,7 +2343,7 @@ namespace System.ServiceModel.Channels
 //                        {
 //                            if (throwing)
 //                            {
-//                                this.OnGetChannelFailed();
+//                                OnGetChannelFailed();
 //                            }
 //                        }
 //                    }
@@ -2356,10 +2354,9 @@ namespace System.ServiceModel.Channels
 
 //                        try
 //                        {
-//                            this.CancelTimer();
-//                            complete = this.GetChannel();
+//                            CancelTimer();
+//                            complete = GetChannel();
 //                        }
-//#pragma warning suppress 56500 // covered by FxCOP
 //                        catch (Exception e)
 //                        {
 //                            if (Fx.IsFatal(e))
@@ -2367,26 +2364,26 @@ namespace System.ServiceModel.Channels
 //                                throw;
 //                            }
 
-//                            this.OnGetChannelFailed();
+//                            OnGetChannelFailed();
 //                            completeException = e;
 //                        }
 
 //                        if (complete || completeException != null)
 //                        {
-//                            this.Complete(false, completeException);
+//                            Complete(false, completeException);
 //                        }
 //                    }
 //                }
 
 //                bool OnChannelOpened()
 //                {
-//                    if (this.synchronizer.OnChannelOpened(this))
+//                    if (synchronizer.OnChannelOpened(this))
 //                    {
 //                        return true;
 //                    }
 //                    else
 //                    {
-//                        if (!this.IsCompleted)
+//                        if (!IsCompleted)
 //                        {
 //                            throw Fx.AssertAndThrow("OnChannelOpened must complete the IWaiter if it returns false.");
 //                        }
@@ -2397,12 +2394,12 @@ namespace System.ServiceModel.Channels
 
 //                void OnGetChannelFailed()
 //                {
-//                    if (this.channel != null)
+//                    if (channel != null)
 //                    {
-//                        this.channel.Abort();
+//                        channel.Abort();
 //                    }
 
-//                    this.synchronizer.OnGetChannelFailed();
+//                    synchronizer.OnGetChannelFailed();
 //                }
 
 //                static void OnOpenComplete(IAsyncResult result)
@@ -2419,7 +2416,6 @@ namespace System.ServiceModel.Channels
 //                        {
 //                            complete = waiter.CompleteOpen(result);
 //                        }
-//#pragma warning suppress 56500 // covered by FxCOP
 //                        catch (Exception e)
 //                        {
 //                            if (Fx.IsFatal(e))
@@ -2444,10 +2440,10 @@ namespace System.ServiceModel.Channels
 
 //                void OnTimeoutElapsed()
 //                {
-//                    if (this.synchronizer.RemoveWaiter(this))
+//                    if (synchronizer.RemoveWaiter(this))
 //                    {
-//                        this.timedOut = true;
-//                        this.Complete(this.isSynchronous, null);
+//                        timedOut = true;
+//                        Complete(isSynchronous, null);
 //                    }
 //                }
 
@@ -2471,7 +2467,6 @@ namespace System.ServiceModel.Channels
 //                        {
 //                            complete = waiter.CompleteTryGetChannel(result);
 //                        }
-//#pragma warning suppress 56500 // covered by FxCOP
 //                        catch (Exception e)
 //                        {
 //                            if (Fx.IsFatal(e))
@@ -2493,57 +2488,57 @@ namespace System.ServiceModel.Channels
 
 //                bool OpenChannel()
 //                {
-//                    if (this.synchronizer.binder.MustOpenChannel)
+//                    if (synchronizer.binder.MustOpenChannel)
 //                    {
-//                        if (this.channelParameters != null)
+//                        if (channelParameters != null)
 //                        {
-//                            this.channelParameters.PropagateChannelParameters(this.channel);
+//                            channelParameters.PropagateChannelParameters(channel);
 //                        }
 
-//                        IAsyncResult result = this.channel.BeginOpen(
-//                            this.timeoutHelper.RemainingTime(), onOpenComplete, this);
+//                        IAsyncResult result = channel.BeginOpen(
+//                            timeoutHelper.RemainingTime(), onOpenComplete, this);
 
 //                        if (result.CompletedSynchronously)
 //                        {
-//                            return this.CompleteOpen(result);
+//                            return CompleteOpen(result);
 //                        }
 
 //                        return false;
 //                    }
 //                    else
 //                    {
-//                        return this.OnChannelOpened();
+//                        return OnChannelOpened();
 //                    }
 //                }
 
 //                public void Set(TChannel channel)
 //                {
-//                    this.CancelTimer();
-//                    this.channel = channel;
-//                    this.Complete(false);
+//                    CancelTimer();
+//                    channel = channel;
+//                    Complete(false);
 //                }
 
 //                // Always called from the user's thread.
 //                public void Wait()
 //                {
-//                    lock (this.ThisLock)
+//                    lock (ThisLock)
 //                    {
-//                        if (this.timerCancelled)
+//                        if (timerCancelled)
 //                        {
 //                            return;
 //                        }
 
-//                        TimeSpan timeout = this.timeoutHelper.RemainingTime();
+//                        TimeSpan timeout = timeoutHelper.RemainingTime();
 
 //                        if (timeout > TimeSpan.Zero)
 //                        {
-//                            this.timer = new IOThreadTimer(onTimeoutElapsed, this, true);
-//                            this.timer.Set(this.timeoutHelper.RemainingTime());
+//                            timer = new IOThreadTimer(onTimeoutElapsed, this, true);
+//                            timer.Set(timeoutHelper.RemainingTime());
 //                            return;
 //                        }
 //                    }
 
-//                    this.OnTimeoutElapsed();
+//                    OnTimeoutElapsed();
 //                }
 //            }
 
@@ -2584,43 +2579,43 @@ namespace System.ServiceModel.Channels
 //                        }
 //                    }
 
-//                    this.synchronizer = synchronizer;
-//                    this.canGetChannel = canGetChannel;
-//                    this.channel = channel;
-//                    this.timeoutHelper = new TimeoutHelper(timeout);
-//                    this.maskingMode = maskingMode;
-//                    this.channelParameters = channelParameters;
+//                    synchronizer = synchronizer;
+//                    canGetChannel = canGetChannel;
+//                    channel = channel;
+//                    timeoutHelper = new TimeoutHelper(timeout);
+//                    maskingMode = maskingMode;
+//                    channelParameters = channelParameters;
 //                }
 
 //                public bool CanGetChannel
 //                {
 //                    get
 //                    {
-//                        return this.canGetChannel;
+//                        return canGetChannel;
 //                    }
 //                }
 
 //                public void Close()
 //                {
-//                    this.exception = this.synchronizer.binder.GetClosedException(this.maskingMode);
-//                    this.completeEvent.Set();
+//                    exception = synchronizer.binder.GetClosedException(maskingMode);
+//                    completeEvent.Set();
 //                }
 
 //                public void Fault()
 //                {
-//                    this.exception = this.synchronizer.binder.GetFaultedException(this.maskingMode);
-//                    this.completeEvent.Set();
+//                    exception = synchronizer.binder.GetFaultedException(maskingMode);
+//                    completeEvent.Set();
 //                }
 
 //                public void GetChannel(bool onUserThread)
 //                {
-//                    if (!this.CanGetChannel)
+//                    if (!CanGetChannel)
 //                    {
 //                        throw Fx.AssertAndThrow("This waiter must wait for a channel thus the caller cannot attempt to get a channel.");
 //                    }
 
-//                    this.getChannel = true;
-//                    this.completeEvent.Set();
+//                    getChannel = true;
+//                    completeEvent.Set();
 //                }
 
 //                public void Set(TChannel channel)
@@ -2630,44 +2625,44 @@ namespace System.ServiceModel.Channels
 //                        throw Fx.AssertAndThrow("Argument channel cannot be null. Caller must call Fault or Close instead.");
 //                    }
 
-//                    this.channel = channel;
-//                    this.completeEvent.Set();
+//                    channel = channel;
+//                    completeEvent.Set();
 //                }
 
 //                bool TryGetChannel()
 //                {
 //                    TChannel channel;
 
-//                    if (this.channel != null)
+//                    if (channel != null)
 //                    {
-//                        channel = this.channel;
+//                        channel = channel;
 //                    }
-//                    else if (this.synchronizer.binder.TryGetChannel(
-//                        this.timeoutHelper.RemainingTime()))
+//                    else if (synchronizer.binder.TryGetChannel(
+//                        timeoutHelper.RemainingTime()))
 //                    {
-//                        if (!this.synchronizer.CompleteSetChannel(this, out channel))
+//                        if (!synchronizer.CompleteSetChannel(this, out channel))
 //                        {
 //                            return true;
 //                        }
 //                    }
 //                    else
 //                    {
-//                        this.synchronizer.OnGetChannelFailed();
+//                        synchronizer.OnGetChannelFailed();
 //                        return false;
 //                    }
 
-//                    if (this.synchronizer.binder.MustOpenChannel)
+//                    if (synchronizer.binder.MustOpenChannel)
 //                    {
 //                        bool throwing = true;
 
-//                        if (this.channelParameters != null)
+//                        if (channelParameters != null)
 //                        {
-//                            this.channelParameters.PropagateChannelParameters(channel);
+//                            channelParameters.PropagateChannelParameters(channel);
 //                        }
 
 //                        try
 //                        {
-//                            channel.Open(this.timeoutHelper.RemainingTime());
+//                            channel.Open(timeoutHelper.RemainingTime());
 //                            throwing = false;
 //                        }
 //                        finally
@@ -2675,14 +2670,14 @@ namespace System.ServiceModel.Channels
 //                            if (throwing)
 //                            {
 //                                channel.Abort();
-//                                this.synchronizer.OnGetChannelFailed();
+//                                synchronizer.OnGetChannelFailed();
 //                            }
 //                        }
 //                    }
 
-//                    if (this.synchronizer.OnChannelOpened(this))
+//                    if (synchronizer.OnChannelOpened(this))
 //                    {
-//                        this.Set(channel);
+//                        Set(channel);
 //                    }
 
 //                    return true;
@@ -2690,44 +2685,44 @@ namespace System.ServiceModel.Channels
 
 //                public bool TryWait(out TChannel channel)
 //                {
-//                    if (!this.Wait())
+//                    if (!Wait())
 //                    {
 //                        channel = null;
 //                        return false;
 //                    }
-//                    else if (this.getChannel && !this.TryGetChannel())
+//                    else if (getChannel && !TryGetChannel())
 //                    {
 //                        channel = null;
 //                        return false;
 //                    }
 
-//                    this.completeEvent.Close();
+//                    completeEvent.Close();
 
-//                    if (this.exception != null)
+//                    if (exception != null)
 //                    {
-//                        if (this.channel != null)
+//                        if (channel != null)
 //                        {
 //                            throw Fx.AssertAndThrow("User of IWaiter called both Set and Fault or Close.");
 //                        }
 
-//                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(this.exception);
+//                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(exception);
 //                    }
 
-//                    channel = this.channel;
+//                    channel = channel;
 //                    return true;
 //                }
 
 //                bool Wait()
 //                {
-//                    if (!TimeoutHelper.WaitOne(this.completeEvent, this.timeoutHelper.RemainingTime()))
+//                    if (!TimeoutHelper.WaitOne(completeEvent, timeoutHelper.RemainingTime()))
 //                    {
-//                        if (this.synchronizer.RemoveWaiter(this))
+//                        if (synchronizer.RemoveWaiter(this))
 //                        {
 //                            return false;
 //                        }
 //                        else
 //                        {
-//                            TimeoutHelper.WaitOne(this.completeEvent, TimeSpan.MaxValue);
+//                            TimeoutHelper.WaitOne(completeEvent, TimeSpan.MaxValue);
 //                        }
 //                    }
 
@@ -2749,20 +2744,20 @@ namespace System.ServiceModel.Channels
 //                TimeSpan timeout, MaskingMode maskingMode, AsyncCallback callback, object state)
 //                : base(callback, state)
 //            {
-//                this.binder = binder;
-//                this.channel = channel;
-//                this.timeoutHelper = new TimeoutHelper(timeout);
-//                this.maskingMode = maskingMode;
+//                binder = binder;
+//                channel = channel;
+//                timeoutHelper = new TimeoutHelper(timeout);
+//                maskingMode = maskingMode;
 //                bool complete = false;
 
 //                try
 //                {
-//                    this.binder.OnShutdown();
-//                    IAsyncResult result = this.binder.OnBeginClose(timeout, onBinderCloseComplete, this);
+//                    binder.OnShutdown();
+//                    IAsyncResult result = binder.OnBeginClose(timeout, onBinderCloseComplete, this);
 
 //                    if (result.CompletedSynchronously)
 //                    {
-//                        complete = this.CompleteBinderClose(true, result);
+//                        complete = CompleteBinderClose(true, result);
 //                    }
 //                }
 //                catch (Exception e)
@@ -2772,9 +2767,9 @@ namespace System.ServiceModel.Channels
 //                        throw;
 //                    }
 
-//                    this.binder.Abort();
+//                    binder.Abort();
 
-//                    if (!this.binder.HandleException(e, this.maskingMode))
+//                    if (!binder.HandleException(e, maskingMode))
 //                    {
 //                        throw;
 //                    }
@@ -2786,22 +2781,22 @@ namespace System.ServiceModel.Channels
 
 //                if (complete)
 //                {
-//                    this.Complete(true);
+//                    Complete(true);
 //                }
 //            }
 
 //            bool CompleteBinderClose(bool synchronous, IAsyncResult result)
 //            {
-//                this.binder.OnEndClose(result);
+//                binder.OnEndClose(result);
 
-//                if (this.channel != null)
+//                if (channel != null)
 //                {
-//                    result = this.binder.BeginCloseChannel(this.channel,
-//                        this.timeoutHelper.RemainingTime(), onChannelCloseComplete, this);
+//                    result = binder.BeginCloseChannel(channel,
+//                        timeoutHelper.RemainingTime(), onChannelCloseComplete, this);
 
 //                    if (result.CompletedSynchronously)
 //                    {
-//                        return this.CompleteChannelClose(synchronous, result);
+//                        return CompleteChannelClose(synchronous, result);
 //                    }
 //                    else
 //                    {
@@ -2810,15 +2805,15 @@ namespace System.ServiceModel.Channels
 //                }
 //                else
 //                {
-//                    this.binder.TransitionToClosed();
+//                    binder.TransitionToClosed();
 //                    return true;
 //                }
 //            }
 
 //            bool CompleteChannelClose(bool synchronous, IAsyncResult result)
 //            {
-//                this.binder.EndCloseChannel(this.channel, result);
-//                this.binder.TransitionToClosed();
+//                binder.EndCloseChannel(channel, result);
+//                binder.TransitionToClosed();
 //                return true;
 //            }
 
@@ -2829,9 +2824,9 @@ namespace System.ServiceModel.Channels
 
 //            Exception HandleAsyncException(Exception e)
 //            {
-//                this.binder.Abort();
+//                binder.Abort();
 
-//                if (this.binder.HandleException(e, this.maskingMode))
+//                if (binder.HandleException(e, maskingMode))
 //                {
 //                    return null;
 //                }
@@ -2854,7 +2849,6 @@ namespace System.ServiceModel.Channels
 //                        complete = closeResult.CompleteBinderClose(false, result);
 //                        completeException = null;
 //                    }
-//#pragma warning suppress 56500 // covered by FxCOP
 //                    catch (Exception e)
 //                    {
 //                        if (Fx.IsFatal(e))
@@ -2891,7 +2885,6 @@ namespace System.ServiceModel.Channels
 //                        complete = closeResult.CompleteChannelClose(false, result);
 //                        completeException = null;
 //                    }
-//#pragma warning suppress 56500 // covered by FxCOP
 //                    catch (Exception e)
 //                    {
 //                        if (Fx.IsFatal(e))
@@ -2934,10 +2927,10 @@ namespace System.ServiceModel.Channels
 //                MaskingMode maskingMode, AsyncCallback callback, object state)
 //                : base(callback, state)
 //            {
-//                this.binder = binder;
-//                this.canGetChannel = canGetChannel;
-//                this.timeoutHelper = new TimeoutHelper(timeout);
-//                this.maskingMode = maskingMode;
+//                binder = binder;
+//                canGetChannel = canGetChannel;
+//                timeoutHelper = new TimeoutHelper(timeout);
+//                maskingMode = maskingMode;
 //            }
 
 //            protected abstract IAsyncResult BeginInput(TBinder binder, TChannel channel,
@@ -2950,12 +2943,12 @@ namespace System.ServiceModel.Channels
 
 //                try
 //                {
-//                    this.success = this.EndInput(this.binder, this.channel, result, out complete);
+//                    success = EndInput(binder, channel, result, out complete);
 //                }
 //                finally
 //                {
-//                    this.autoAborted = this.binder.Synchronizer.Aborting;
-//                    this.binder.synchronizer.ReturnChannel();
+//                    autoAborted = binder.Synchronizer.Aborting;
+//                    binder.synchronizer.ReturnChannel();
 //                }
 
 //                return !complete;
@@ -2965,11 +2958,11 @@ namespace System.ServiceModel.Channels
 //            bool CompleteTryGetChannel(IAsyncResult result, out bool complete)
 //            {
 //                complete = false;
-//                this.success = this.binder.synchronizer.EndTryGetChannel(result, out this.channel);
+//                success = binder.synchronizer.EndTryGetChannel(result, out channel);
 
 //                // the synchronizer is faulted and not reestablishing or closed, or the call timed
 //                // out, complete and don't retry.
-//                if (this.channel == null)
+//                if (channel == null)
 //                {
 //                    complete = true;
 //                    return false;
@@ -2980,22 +2973,22 @@ namespace System.ServiceModel.Channels
 
 //                try
 //                {
-//                    inputResult = this.BeginInput(this.binder, this.channel,
-//                        this.timeoutHelper.RemainingTime(), onInputComplete, this);
+//                    inputResult = BeginInput(binder, channel,
+//                        timeoutHelper.RemainingTime(), onInputComplete, this);
 //                    throwing = false;
 //                }
 //                finally
 //                {
 //                    if (throwing)
 //                    {
-//                        this.autoAborted = this.binder.Synchronizer.Aborting;
-//                        this.binder.synchronizer.ReturnChannel();
+//                        autoAborted = binder.Synchronizer.Aborting;
+//                        binder.synchronizer.ReturnChannel();
 //                    }
 //                }
 
 //                if (inputResult.CompletedSynchronously)
 //                {
-//                    if (this.CompleteInput(inputResult))
+//                    if (CompleteInput(inputResult))
 //                    {
 //                        complete = false;
 //                        return true;
@@ -3016,7 +3009,7 @@ namespace System.ServiceModel.Channels
 //            public bool End()
 //            {
 //                AsyncResult.End<InputAsyncResult<TBinder>>(this);
-//                return this.success;
+//                return success;
 //            }
 
 //            protected abstract bool EndInput(TBinder binder, TChannel channel,
@@ -3024,15 +3017,14 @@ namespace System.ServiceModel.Channels
 
 //            void OnInputComplete(IAsyncResult result)
 //            {
-//                this.isSynchronous = false;
+//                isSynchronous = false;
 //                bool retry;
 //                Exception completeException = null;
 
 //                try
 //                {
-//                    retry = this.CompleteInput(result);
+//                    retry = CompleteInput(result);
 //                }
-//#pragma warning suppress 56500 // covered by FxCOP
 //                catch (Exception e)
 //                {
 //                    if (Fx.IsFatal(e))
@@ -3040,7 +3032,7 @@ namespace System.ServiceModel.Channels
 //                        throw;
 //                    }
 
-//                    if (!this.binder.HandleException(e, this.maskingMode, this.autoAborted))
+//                    if (!binder.HandleException(e, maskingMode, autoAborted))
 //                    {
 //                        completeException = e;
 //                        retry = false;
@@ -3053,11 +3045,11 @@ namespace System.ServiceModel.Channels
 
 //                if (retry)
 //                {
-//                    this.StartOnNonUserThread();
+//                    StartOnNonUserThread();
 //                }
 //                else
 //                {
-//                    this.Complete(this.isSynchronous, completeException);
+//                    Complete(isSynchronous, completeException);
 //                }
 //            }
 
@@ -3073,16 +3065,15 @@ namespace System.ServiceModel.Channels
 
 //            void OnTryGetChannelComplete(IAsyncResult result)
 //            {
-//                this.isSynchronous = false;
+//                isSynchronous = false;
 //                bool retry = false;
 //                bool complete = false;
 //                Exception completeException = null;
 
 //                try
 //                {
-//                    retry = this.CompleteTryGetChannel(result, out complete);
+//                    retry = CompleteTryGetChannel(result, out complete);
 //                }
-//#pragma warning suppress 56500 // covered by FxCOP
 //                catch (Exception e)
 //                {
 //                    if (Fx.IsFatal(e))
@@ -3090,7 +3081,7 @@ namespace System.ServiceModel.Channels
 //                        throw;
 //                    }
 
-//                    if (!this.binder.HandleException(e, this.maskingMode, this.autoAborted))
+//                    if (!binder.HandleException(e, maskingMode, autoAborted))
 //                    {
 //                        completeException = e;
 //                        retry = false;
@@ -3109,11 +3100,11 @@ namespace System.ServiceModel.Channels
 
 //                if (retry)
 //                {
-//                    this.StartOnNonUserThread();
+//                    StartOnNonUserThread();
 //                }
 //                else if (complete || completeException != null)
 //                {
-//                    this.Complete(this.isSynchronous, completeException);
+//                    Complete(isSynchronous, completeException);
 //                }
 //            }
 
@@ -3134,17 +3125,17 @@ namespace System.ServiceModel.Channels
 //                    bool retry = false;
 //                    bool complete = false;
 
-//                    this.autoAborted = false;
+//                    autoAborted = false;
 
 //                    try
 //                    {
-//                        IAsyncResult result = this.binder.synchronizer.BeginTryGetChannelForInput(
-//                            canGetChannel, this.timeoutHelper.RemainingTime(),
+//                        IAsyncResult result = binder.synchronizer.BeginTryGetChannelForInput(
+//                            canGetChannel, timeoutHelper.RemainingTime(),
 //                            onTryGetChannelComplete, this);
 
 //                        if (result.CompletedSynchronously)
 //                        {
-//                            retry = this.CompleteTryGetChannel(result, out complete);
+//                            retry = CompleteTryGetChannel(result, out complete);
 //                        }
 //                    }
 //                    catch (Exception e)
@@ -3154,7 +3145,7 @@ namespace System.ServiceModel.Channels
 //                            throw;
 //                        }
 
-//                        if (!this.binder.HandleException(e, this.maskingMode, this.autoAborted))
+//                        if (!binder.HandleException(e, maskingMode, autoAborted))
 //                        {
 //                            throw;
 //                        }
@@ -3184,9 +3175,8 @@ namespace System.ServiceModel.Channels
 
 //                try
 //                {
-//                    complete = this.Start();
+//                    complete = Start();
 //                }
-//#pragma warning suppress 56500 // covered by FxCOP
 //                catch (Exception e)
 //                {
 //                    if (Fx.IsFatal(e))
@@ -3196,7 +3186,7 @@ namespace System.ServiceModel.Channels
 //                }
 
 //                if (complete || completeException != null)
-//                    this.Complete(false, completeException);
+//                    Complete(false, completeException);
 //            }
 //        }
 
@@ -3229,7 +3219,7 @@ namespace System.ServiceModel.Channels
 //            {
 //                if (message != null)
 //                {
-//                    this.Binder.Send(message, timeout, this.MaskingMode);
+//                    Binder.Send(message, timeout, MaskingMode);
 //                }
 //            }
 
@@ -3247,7 +3237,7 @@ namespace System.ServiceModel.Channels
 //                        {
 //                            onSend = Fx.ThunkCallback(new AsyncCallback(OnSend));
 //                        }
-//                        this.context = context;
+//                        context = context;
 //                        IAsyncResult result = context.Binder.BeginSend(message, timeout, context.MaskingMode, onSend, this);
 //                        if (!result.CompletedSynchronously)
 //                        {
@@ -3277,7 +3267,6 @@ namespace System.ServiceModel.Channels
 //                    {
 //                        thisPtr.context.Binder.EndSend(result);
 //                    }
-//#pragma warning suppress 56500 // covered by FxCOP
 //                    catch (Exception exception)
 //                    {
 //                        if (Fx.IsFatal(exception))
@@ -3309,14 +3298,14 @@ namespace System.ServiceModel.Channels
 //            public OutputAsyncResult(TBinder binder, AsyncCallback callback, object state)
 //                : base(callback, state)
 //            {
-//                this.binder = binder;
+//                binder = binder;
 //            }
 
 //            public MaskingMode MaskingMode
 //            {
 //                get
 //                {
-//                    return this.maskingMode;
+//                    return maskingMode;
 //                }
 //            }
 
@@ -3326,46 +3315,46 @@ namespace System.ServiceModel.Channels
 
 //            void Cleanup()
 //            {
-//                if (this.hasChannel)
+//                if (hasChannel)
 //                {
-//                    this.autoAborted = this.binder.Synchronizer.Aborting;
-//                    this.binder.synchronizer.ReturnChannel();
+//                    autoAborted = binder.Synchronizer.Aborting;
+//                    binder.synchronizer.ReturnChannel();
 //                }
 //            }
 
 //            bool CompleteOutput(IAsyncResult result)
 //            {
-//                this.EndOutput(this.binder, this.channel, this.maskingMode, result);
-//                this.Cleanup();
+//                EndOutput(binder, channel, maskingMode, result);
+//                Cleanup();
 //                return true;
 //            }
 
 //            bool CompleteTryGetChannel(IAsyncResult result)
 //            {
-//                bool timedOut = !this.binder.synchronizer.EndTryGetChannel(result,
-//                    out this.channel);
+//                bool timedOut = !binder.synchronizer.EndTryGetChannel(result,
+//                    out channel);
 
-//                if (timedOut || (this.channel == null))
+//                if (timedOut || (channel == null))
 //                {
-//                    this.Cleanup();
+//                    Cleanup();
 
 //                    if (timedOut && !ReliableChannelBinderHelper.MaskHandled(maskingMode))
 //                    {
-//                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new TimeoutException(this.GetTimeoutString(this.timeout)));
+//                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new TimeoutException(GetTimeoutString(timeout)));
 //                    }
 
 //                    return true;
 //                }
 
-//                this.hasChannel = true;
+//                hasChannel = true;
 
-//                result = this.BeginOutput(this.binder, this.channel, this.message,
-//                    this.timeoutHelper.RemainingTime(), this.maskingMode, onOutputComplete,
+//                result = BeginOutput(binder, channel, message,
+//                    timeoutHelper.RemainingTime(), maskingMode, onOutputComplete,
 //                    this);
 
 //                if (result.CompletedSynchronously)
 //                {
-//                    return this.CompleteOutput(result);
+//                    return CompleteOutput(result);
 //                }
 //                else
 //                {
@@ -3387,9 +3376,8 @@ namespace System.ServiceModel.Channels
 
 //                    try
 //                    {
-//                        complete = this.CompleteOutput(result);
+//                        complete = CompleteOutput(result);
 //                    }
-//#pragma warning suppress 56500 // covered by FxCOP
 //                    catch (Exception e)
 //                    {
 //                        if (Fx.IsFatal(e))
@@ -3397,9 +3385,9 @@ namespace System.ServiceModel.Channels
 //                            throw;
 //                        }
 
-//                        this.Cleanup();
+//                        Cleanup();
 //                        complete = true;
-//                        if (!this.binder.HandleException(e, this.maskingMode, this.autoAborted))
+//                        if (!binder.HandleException(e, maskingMode, autoAborted))
 //                        {
 //                            completeException = e;
 //                        }
@@ -3407,7 +3395,7 @@ namespace System.ServiceModel.Channels
 
 //                    if (complete)
 //                    {
-//                        this.Complete(false, completeException);
+//                        Complete(false, completeException);
 //                    }
 //                }
 //            }
@@ -3429,9 +3417,8 @@ namespace System.ServiceModel.Channels
 
 //                    try
 //                    {
-//                        complete = this.CompleteTryGetChannel(result);
+//                        complete = CompleteTryGetChannel(result);
 //                    }
-//#pragma warning suppress 56500 // covered by FxCOP
 //                    catch (Exception e)
 //                    {
 //                        if (Fx.IsFatal(e))
@@ -3439,9 +3426,9 @@ namespace System.ServiceModel.Channels
 //                            throw;
 //                        }
 
-//                        this.Cleanup();
+//                        Cleanup();
 //                        complete = true;
-//                        if (!this.binder.HandleException(e, this.maskingMode, this.autoAborted))
+//                        if (!binder.HandleException(e, maskingMode, autoAborted))
 //                        {
 //                            completeException = e;
 //                        }
@@ -3449,7 +3436,7 @@ namespace System.ServiceModel.Channels
 
 //                    if (complete)
 //                    {
-//                        this.Complete(false, completeException);
+//                        Complete(false, completeException);
 //                    }
 //                }
 //            }
@@ -3464,27 +3451,27 @@ namespace System.ServiceModel.Channels
 
 //            public void Start(Message message, TimeSpan timeout, MaskingMode maskingMode)
 //            {
-//                if (!this.binder.ValidateOutputOperation(message, timeout, maskingMode))
+//                if (!binder.ValidateOutputOperation(message, timeout, maskingMode))
 //                {
-//                    this.Complete(true);
+//                    Complete(true);
 //                    return;
 //                }
 
-//                this.message = message;
-//                this.timeout = timeout;
-//                this.timeoutHelper = new TimeoutHelper(timeout);
-//                this.maskingMode = maskingMode;
+//                message = message;
+//                timeout = timeout;
+//                timeoutHelper = new TimeoutHelper(timeout);
+//                maskingMode = maskingMode;
 
 //                bool complete = false;
 
 //                try
 //                {
-//                    IAsyncResult result = this.binder.synchronizer.BeginTryGetChannelForOutput(
-//                        timeoutHelper.RemainingTime(), this.maskingMode, onTryGetChannelComplete, this);
+//                    IAsyncResult result = binder.synchronizer.BeginTryGetChannelForOutput(
+//                        timeoutHelper.RemainingTime(), maskingMode, onTryGetChannelComplete, this);
 
 //                    if (result.CompletedSynchronously)
 //                    {
-//                        complete = this.CompleteTryGetChannel(result);
+//                        complete = CompleteTryGetChannel(result);
 //                    }
 //                }
 //                catch (Exception e)
@@ -3494,8 +3481,8 @@ namespace System.ServiceModel.Channels
 //                        throw;
 //                    }
 
-//                    this.Cleanup();
-//                    if (this.binder.HandleException(e, this.maskingMode, this.autoAborted))
+//                    Cleanup();
+//                    if (binder.HandleException(e, maskingMode, autoAborted))
 //                    {
 //                        complete = true;
 //                    }
@@ -3507,7 +3494,7 @@ namespace System.ServiceModel.Channels
 
 //                if (complete)
 //                {
-//                    this.Complete(true);
+//                    Complete(true);
 //                }
 //            }
 //        }
@@ -3530,12 +3517,12 @@ namespace System.ServiceModel.Channels
 //                    throw Fx.AssertAndThrow("Argument innerContext cannot be null.");
 //                }
 
-//                this.innerContext = innerContext;
+//                innerContext = innerContext;
 //            }
 
 //            protected override void OnAbort()
 //            {
-//                this.innerContext.Abort();
+//                innerContext.Abort();
 //            }
 
 //            protected override IAsyncResult OnBeginReply(Message message, TimeSpan timeout,
@@ -3544,8 +3531,8 @@ namespace System.ServiceModel.Channels
 //                try
 //                {
 //                    if (message != null)
-//                        this.Binder.AddOutputHeaders(message);
-//                    return this.innerContext.BeginReply(message, timeout, callback, state);
+//                        Binder.AddOutputHeaders(message);
+//                    return innerContext.BeginReply(message, timeout, callback, state);
 //                }
 //                catch (ObjectDisposedException) { }
 //                catch (Exception e)
@@ -3555,12 +3542,12 @@ namespace System.ServiceModel.Channels
 //                        throw;
 //                    }
 
-//                    if (!this.Binder.HandleException(e, this.MaskingMode))
+//                    if (!Binder.HandleException(e, MaskingMode))
 //                    {
 //                        throw;
 //                    }
 
-//                    this.innerContext.Abort();
+//                    innerContext.Abort();
 //                }
 
 //                return new BinderCompletedAsyncResult(callback, state);
@@ -3570,7 +3557,7 @@ namespace System.ServiceModel.Channels
 //            {
 //                try
 //                {
-//                    this.innerContext.Close(timeout);
+//                    innerContext.Close(timeout);
 //                }
 //                catch (ObjectDisposedException) { }
 //                catch (Exception e)
@@ -3580,12 +3567,12 @@ namespace System.ServiceModel.Channels
 //                        throw;
 //                    }
 
-//                    if (!this.Binder.HandleException(e, this.MaskingMode))
+//                    if (!Binder.HandleException(e, MaskingMode))
 //                    {
 //                        throw;
 //                    }
 
-//                    this.innerContext.Abort();
+//                    innerContext.Abort();
 //                }
 //            }
 
@@ -3600,7 +3587,7 @@ namespace System.ServiceModel.Channels
 
 //                try
 //                {
-//                    this.innerContext.EndReply(result);
+//                    innerContext.EndReply(result);
 //                }
 //                catch (ObjectDisposedException) { }
 //                catch (Exception e)
@@ -3610,12 +3597,12 @@ namespace System.ServiceModel.Channels
 //                        throw;
 //                    }
 
-//                    if (!this.Binder.HandleException(e, this.MaskingMode))
+//                    if (!Binder.HandleException(e, MaskingMode))
 //                    {
 //                        throw;
 //                    }
 
-//                    this.innerContext.Abort();
+//                    innerContext.Abort();
 //                }
 //            }
 
@@ -3624,8 +3611,8 @@ namespace System.ServiceModel.Channels
 //                try
 //                {
 //                    if (message != null)
-//                        this.Binder.AddOutputHeaders(message);
-//                    this.innerContext.Reply(message, timeout);
+//                        Binder.AddOutputHeaders(message);
+//                    innerContext.Reply(message, timeout);
 //                }
 //                catch (ObjectDisposedException) { }
 //                catch (Exception e)
@@ -3635,12 +3622,12 @@ namespace System.ServiceModel.Channels
 //                        throw;
 //                    }
 
-//                    if (!this.Binder.HandleException(e, this.MaskingMode))
+//                    if (!Binder.HandleException(e, MaskingMode))
 //                    {
 //                        throw;
 //                    }
 
-//                    this.innerContext.Abort();
+//                    innerContext.Abort();
 //                }
 //            }
 //        }
@@ -3686,8 +3673,8 @@ namespace System.ServiceModel.Channels
 //                MaskingMode maskingMode, AsyncCallback callback, object state)
 //                : base(binder, binder.CanGetChannelForReceive, timeout, maskingMode, callback, state)
 //            {
-//                if (this.Start())
-//                    this.Complete(true);
+//                if (Start())
+//                    Complete(true);
 //            }
 
 //            protected override IAsyncResult BeginInput(ReliableChannelBinder<TChannel> binder,
@@ -3698,17 +3685,17 @@ namespace System.ServiceModel.Channels
 
 //            public bool End(out RequestContext requestContext)
 //            {
-//                requestContext = this.requestContext;
-//                return this.End();
+//                requestContext = requestContext;
+//                return End();
 //            }
 
 //            protected override bool EndInput(ReliableChannelBinder<TChannel> binder,
 //                TChannel channel, IAsyncResult result, out bool complete)
 //            {
-//                bool success = binder.OnEndTryReceive(channel, result, out this.requestContext);
+//                bool success = binder.OnEndTryReceive(channel, result, out requestContext);
 
 //                // timed out || got message, complete immediately
-//                complete = !success || (this.requestContext != null);
+//                complete = !success || (requestContext != null);
 
 //                if (!complete)
 //                {
@@ -3913,16 +3900,16 @@ namespace System.ServiceModel.Channels
 //                TimeSpan timeout, AsyncCallback callback, object state)
 //                : base(callback, state)
 //            {
-//                this.binder = binder;
-//                this.channel = channel;
-//                this.timeoutHelper = new TimeoutHelper(timeout);
+//                binder = binder;
+//                channel = channel;
+//                timeoutHelper = new TimeoutHelper(timeout);
 //            }
 
 //            protected TChannel Channel
 //            {
 //                get
 //                {
-//                    return this.channel;
+//                    return channel;
 //                }
 //            }
 
@@ -3930,19 +3917,19 @@ namespace System.ServiceModel.Channels
 //            {
 //                get
 //                {
-//                    return this.timeoutHelper.RemainingTime();
+//                    return timeoutHelper.RemainingTime();
 //                }
 //            }
 
 //            protected bool Begin()
 //            {
 //                bool complete = false;
-//                IAsyncResult result = this.binder.BeginWaitForPendingOperations(
-//                    this.RemainingTime, onWaitForPendingOperationsCompleteStatic,
+//                IAsyncResult result = binder.BeginWaitForPendingOperations(
+//                    RemainingTime, onWaitForPendingOperationsCompleteStatic,
 //                    this);
 
 //                if (result.CompletedSynchronously)
-//                    complete = this.HandleWaitForPendingOperationsComplete(result);
+//                    complete = HandleWaitForPendingOperationsComplete(result);
 
 //                return complete;
 //            }
@@ -3956,7 +3943,7 @@ namespace System.ServiceModel.Channels
 
 //            void HandleChannelCloseComplete(IAsyncResult result)
 //            {
-//                this.channel.EndClose(result);
+//                channel.EndClose(result);
 //            }
 
 //            bool HandleInputComplete(IAsyncResult result, out bool gotEof)
@@ -3970,14 +3957,14 @@ namespace System.ServiceModel.Channels
 //                {
 //                    bool success = false;
 
-//                    success = this.EndTryInput(result, out item);
+//                    success = EndTryInput(result, out item);
 //                    endThrowing = false;
 
 //                    if (!success || item != null)
 //                    {
-//                        if (this.lastReceive || this.channel.State != CommunicationState.Opened)
+//                        if (lastReceive || channel.State != CommunicationState.Opened)
 //                        {
-//                            this.channel.Abort();
+//                            channel.Abort();
 //                            return true;
 //                        }
 //                        else
@@ -3988,11 +3975,11 @@ namespace System.ServiceModel.Channels
 
 //                    gotEof = true;
 
-//                    result = this.channel.BeginClose(this.RemainingTime,
+//                    result = channel.BeginClose(RemainingTime,
 //                        onChannelCloseCompleteStatic, this);
 //                    if (result.CompletedSynchronously)
 //                    {
-//                        this.HandleChannelCloseComplete(result);
+//                        HandleChannelCloseComplete(result);
 //                        return true;
 //                    }
 //                    else
@@ -4010,9 +3997,9 @@ namespace System.ServiceModel.Channels
 //                        if (!MaskHandled(binder.DefaultMaskingMode) || !binder.IsHandleable(e))
 //                            throw;
 
-//                        if (this.lastReceive || this.channel.State != CommunicationState.Opened)
+//                        if (lastReceive || channel.State != CommunicationState.Opened)
 //                        {
-//                            this.channel.Abort();
+//                            channel.Abort();
 //                            return true;
 //                        }
 //                        else
@@ -4026,17 +4013,17 @@ namespace System.ServiceModel.Channels
 //                finally
 //                {
 //                    if (item != null)
-//                        this.DisposeItem(item);
+//                        DisposeItem(item);
 
 //                    if (endThrowing)
-//                        this.channel.Abort();
+//                        channel.Abort();
 //                }
 //            }
 
 //            bool HandleWaitForPendingOperationsComplete(IAsyncResult result)
 //            {
-//                this.binder.EndWaitForPendingOperations(result);
-//                return this.WaitForEof();
+//                binder.EndWaitForPendingOperations(result);
+//                return WaitForEof();
 //            }
 
 //            static void OnChannelCloseCompleteStatic(IAsyncResult result)
@@ -4124,8 +4111,8 @@ namespace System.ServiceModel.Channels
 
 //            bool WaitForEof()
 //            {
-//                TimeSpan iterationTimeout = this.RemainingTime;
-//                this.lastReceive = (iterationTimeout == TimeSpan.Zero);
+//                TimeSpan iterationTimeout = RemainingTime;
+//                lastReceive = (iterationTimeout == TimeSpan.Zero);
 
 //                while (true)
 //                {
@@ -4133,14 +4120,14 @@ namespace System.ServiceModel.Channels
 
 //                    try
 //                    {
-//                        result = this.BeginTryInput(iterationTimeout, onInputCompleteStatic, this);
+//                        result = BeginTryInput(iterationTimeout, onInputCompleteStatic, this);
 //                    }
 //                    catch (Exception e)
 //                    {
 //                        if (Fx.IsFatal(e))
 //                            throw;
 
-//                        if (!MaskHandled(this.binder.DefaultMaskingMode) || !this.binder.IsHandleable(e))
+//                        if (!MaskHandled(binder.DefaultMaskingMode) || !binder.IsHandleable(e))
 //                            throw;
 //                    }
 
@@ -4149,7 +4136,7 @@ namespace System.ServiceModel.Channels
 //                        if (result.CompletedSynchronously)
 //                        {
 //                            bool gotEof;
-//                            bool complete = this.HandleInputComplete(result, out gotEof);
+//                            bool complete = HandleInputComplete(result, out gotEof);
 
 //                            if (complete || gotEof)
 //                                return complete;
@@ -4158,14 +4145,14 @@ namespace System.ServiceModel.Channels
 //                            return false;
 //                    }
 
-//                    if (this.lastReceive || this.channel.State != CommunicationState.Opened)
+//                    if (lastReceive || channel.State != CommunicationState.Opened)
 //                    {
-//                        this.channel.Abort();
+//                        channel.Abort();
 //                        break;
 //                    }
 
-//                    iterationTimeout = this.RemainingTime;
-//                    this.lastReceive = (iterationTimeout == TimeSpan.Zero);
+//                    iterationTimeout = RemainingTime;
+//                    lastReceive = (iterationTimeout == TimeSpan.Zero);
 //                }
 
 //                return true;
@@ -4186,19 +4173,19 @@ namespace System.ServiceModel.Channels
 //            {
 //                bool complete = false;
 
-//                IAsyncResult result = this.Channel.Session.BeginCloseOutputSession(
-//                    this.RemainingTime, onCloseOutputSessionCompleteStatic, this);
+//                IAsyncResult result = Channel.Session.BeginCloseOutputSession(
+//                    RemainingTime, onCloseOutputSessionCompleteStatic, this);
 
 //                if (result.CompletedSynchronously)
-//                    complete = this.HandleCloseOutputSessionComplete(result);
+//                    complete = HandleCloseOutputSessionComplete(result);
 
 //                if (complete)
-//                    this.Complete(true);
+//                    Complete(true);
 //            }
 
 //            protected override IAsyncResult BeginTryInput(TimeSpan timeout, AsyncCallback callback, object state)
 //            {
-//                return this.Channel.BeginTryReceive(timeout, callback, state);
+//                return Channel.BeginTryReceive(timeout, callback, state);
 //            }
 
 //            protected override void DisposeItem(Message item)
@@ -4213,13 +4200,13 @@ namespace System.ServiceModel.Channels
 
 //            protected override bool EndTryInput(IAsyncResult result, out Message item)
 //            {
-//                return this.Channel.EndTryReceive(result, out item);
+//                return Channel.EndTryReceive(result, out item);
 //            }
 
 //            bool HandleCloseOutputSessionComplete(IAsyncResult result)
 //            {
-//                this.Channel.Session.EndCloseOutputSession(result);
-//                return this.Begin();
+//                Channel.Session.EndCloseOutputSession(result);
+//                return Begin();
 //            }
 
 //            static void OnCloseOutputSessionCompleteStatic(IAsyncResult result)
@@ -4258,13 +4245,13 @@ namespace System.ServiceModel.Channels
 //                TimeSpan timeout, AsyncCallback callback, object state)
 //                : base(binder, channel, timeout, callback, state)
 //            {
-//                if (this.Begin())
-//                    this.Complete(true);
+//                if (Begin())
+//                    Complete(true);
 //            }
 
 //            protected override IAsyncResult BeginTryInput(TimeSpan timeout, AsyncCallback callback, object state)
 //            {
-//                return this.Channel.BeginTryReceiveRequest(timeout, callback, state);
+//                return Channel.BeginTryReceiveRequest(timeout, callback, state);
 //            }
 
 //            protected override void DisposeItem(RequestContext item)
@@ -4280,7 +4267,7 @@ namespace System.ServiceModel.Channels
 
 //            protected override bool EndTryInput(IAsyncResult result, out RequestContext item)
 //            {
-//                return this.Channel.EndTryReceiveRequest(result, out item);
+//                return Channel.EndTryReceiveRequest(result, out item);
 //            }
 //        }
 //    }

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/ReliableChannelBinder.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/ReliableChannelBinder.cs
@@ -4,11 +4,6 @@
 
 namespace System.ServiceModel.Channels
 {
-    using System.Collections.Generic;
-    using System.Runtime;
-    using System.ServiceModel;
-    using System.Threading;
-
     enum TolerateFaultsMode
     {
         Never,

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/SecurityBindingElement.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/SecurityBindingElement.cs
@@ -26,8 +26,8 @@ namespace System.ServiceModel.Channels
         private SupportingTokenParameters _endpointSupportingTokenParameters;
         private SupportingTokenParameters _optionalEndpointSupportingTokenParameters;
         private bool _includeTimestamp;
-        Dictionary<string, SupportingTokenParameters> _operationSupportingTokenParameters;
-        Dictionary<string, SupportingTokenParameters> _optionalOperationSupportingTokenParameters;
+        private Dictionary<string, SupportingTokenParameters> _operationSupportingTokenParameters;
+        private Dictionary<string, SupportingTokenParameters> _optionalOperationSupportingTokenParameters;
         private LocalClientSecuritySettings _localClientSettings;
 
         private MessageSecurityVersion _messageSecurityVersion;

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/SecurityBindingElement.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/SecurityBindingElement.cs
@@ -5,6 +5,7 @@
 
 using System.Collections.Generic;
 using System.Globalization;
+using System.IdentityModel.Selectors;
 using System.Net.Security;
 using System.ServiceModel.Security;
 using System.ServiceModel.Security.Tokens;
@@ -21,15 +22,19 @@ namespace System.ServiceModel.Channels
         internal const bool defaultEnableUnsecuredResponse = false;
         internal const bool defaultProtectTokens = false;
 
+        private SecurityAlgorithmSuite _defaultAlgorithmSuite;
         private SupportingTokenParameters _endpointSupportingTokenParameters;
+        private SupportingTokenParameters _optionalEndpointSupportingTokenParameters;
         private bool _includeTimestamp;
-
+        Dictionary<string, SupportingTokenParameters> _operationSupportingTokenParameters;
+        Dictionary<string, SupportingTokenParameters> _optionalOperationSupportingTokenParameters;
         private LocalClientSecuritySettings _localClientSettings;
 
         private MessageSecurityVersion _messageSecurityVersion;
         private SecurityHeaderLayout _securityHeaderLayout;
         private long _maxReceivedMessageSize = TransportDefaults.MaxReceivedMessageSize;
         private XmlDictionaryReaderQuotas _readerQuotas;
+        private bool _enableUnsecuredResponse;
         private bool _protectTokens = defaultProtectTokens;
 
         internal SecurityBindingElement()
@@ -37,9 +42,14 @@ namespace System.ServiceModel.Channels
         {
             _messageSecurityVersion = MessageSecurityVersion.Default;
             _includeTimestamp = defaultIncludeTimestamp;
+            _defaultAlgorithmSuite = SecurityAlgorithmSuite.Default;
             _localClientSettings = new LocalClientSecuritySettings();
             _endpointSupportingTokenParameters = new SupportingTokenParameters();
+            _optionalEndpointSupportingTokenParameters = new SupportingTokenParameters();
+            _operationSupportingTokenParameters = new Dictionary<string, SupportingTokenParameters>();
+            _optionalOperationSupportingTokenParameters = new Dictionary<string, SupportingTokenParameters>();
             _securityHeaderLayout = SecurityProtocolFactory.defaultSecurityHeaderLayout;
+            _enableUnsecuredResponse = defaultEnableUnsecuredResponse;
         }
 
         internal SecurityBindingElement(SecurityBindingElement elementToBeCloned)
@@ -49,12 +59,25 @@ namespace System.ServiceModel.Channels
                 throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("elementToBeCloned");
 
             _includeTimestamp = elementToBeCloned._includeTimestamp;
+            _defaultAlgorithmSuite = elementToBeCloned._defaultAlgorithmSuite;
             _messageSecurityVersion = elementToBeCloned._messageSecurityVersion;
             _securityHeaderLayout = elementToBeCloned._securityHeaderLayout;
             _endpointSupportingTokenParameters = elementToBeCloned._endpointSupportingTokenParameters.Clone();
+            _optionalEndpointSupportingTokenParameters = (SupportingTokenParameters)elementToBeCloned._optionalEndpointSupportingTokenParameters.Clone();
+            _operationSupportingTokenParameters = new Dictionary<string, SupportingTokenParameters>();
+            foreach (string key in elementToBeCloned._operationSupportingTokenParameters.Keys)
+            {
+                _operationSupportingTokenParameters[key] = (SupportingTokenParameters)elementToBeCloned._operationSupportingTokenParameters[key].Clone();
+            }
+            _optionalOperationSupportingTokenParameters = new Dictionary<string, SupportingTokenParameters>();
+            foreach (string key in elementToBeCloned._optionalOperationSupportingTokenParameters.Keys)
+            {
+                _optionalOperationSupportingTokenParameters[key] = (SupportingTokenParameters)elementToBeCloned._optionalOperationSupportingTokenParameters[key].Clone();
+            }
             _localClientSettings = elementToBeCloned._localClientSettings.Clone();
             _maxReceivedMessageSize = elementToBeCloned._maxReceivedMessageSize;
             _readerQuotas = elementToBeCloned._readerQuotas;
+            _enableUnsecuredResponse = elementToBeCloned._enableUnsecuredResponse;
         }
 
         public SupportingTokenParameters EndpointSupportingTokenParameters
@@ -62,6 +85,30 @@ namespace System.ServiceModel.Channels
             get
             {
                 return _endpointSupportingTokenParameters;
+            }
+        }
+
+        public SupportingTokenParameters OptionalEndpointSupportingTokenParameters
+        {
+            get
+            {
+                return _optionalEndpointSupportingTokenParameters;
+            }
+        }
+
+        public IDictionary<string, SupportingTokenParameters> OperationSupportingTokenParameters
+        {
+            get
+            {
+                return _operationSupportingTokenParameters;
+            }
+        }
+
+        public IDictionary<string, SupportingTokenParameters> OptionalOperationSupportingTokenParameters
+        {
+            get
+            {
+                return _optionalOperationSupportingTokenParameters;
             }
         }
 
@@ -94,6 +141,18 @@ namespace System.ServiceModel.Channels
             }
         }
 
+        public bool EnableUnsecuredResponse
+        {
+            get
+            {
+                return _enableUnsecuredResponse;
+            }
+            set
+            {
+                _enableUnsecuredResponse = value;
+            }
+        }
+
         public bool IncludeTimestamp
         {
             get
@@ -103,6 +162,20 @@ namespace System.ServiceModel.Channels
             set
             {
                 _includeTimestamp = value;
+            }
+        }
+
+        public SecurityAlgorithmSuite DefaultAlgorithmSuite
+        {
+            get
+            {
+                return _defaultAlgorithmSuite;
+            }
+            set
+            {
+                if (value == null)
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentNullException("value"));
+                _defaultAlgorithmSuite = value;
             }
         }
 
@@ -178,9 +251,90 @@ namespace System.ServiceModel.Channels
             this.GetSupportingTokensCapabilities(this.EndpointSupportingTokenParameters, out supportsClientAuth, out supportsWindowsIdentity);
         }
 
+        static BindingContext CreateIssuerBindingContextForNegotiation(BindingContext issuerBindingContext)
+        {
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+            //TransportBindingElement transport = issuerBindingContext.RemainingBindingElements.Find<TransportBindingElement>();
+            //if (transport == null)
+            //{
+            //    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.TransportBindingElementNotFound)));
+            //}
+            //ChannelDemuxerBindingElement demuxer = null;
+            //// pick the demuxer above transport (i.e. the last demuxer in the array)
+            //for (int i = 0; i < issuerBindingContext.RemainingBindingElements.Count; ++i)
+            //{
+            //    if (issuerBindingContext.RemainingBindingElements[i] is ChannelDemuxerBindingElement)
+            //    {
+            //        demuxer = (ChannelDemuxerBindingElement)issuerBindingContext.RemainingBindingElements[i];
+            //    }
+            //}
+            //if (demuxer == null)
+            //{
+            //    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.ChannelDemuxerBindingElementNotFound)));
+            //}
+            //BindingElementCollection negotiationBindingElements = new BindingElementCollection();
+            //negotiationBindingElements.Add(demuxer.Clone());
+            //negotiationBindingElements.Add(transport.Clone());
+            //CustomBinding binding = new CustomBinding(negotiationBindingElements);
+            //binding.OpenTimeout = issuerBindingContext.Binding.OpenTimeout;
+            //binding.CloseTimeout = issuerBindingContext.Binding.CloseTimeout;
+            //binding.SendTimeout = issuerBindingContext.Binding.SendTimeout;
+            //binding.ReceiveTimeout = issuerBindingContext.Binding.ReceiveTimeout;
+            //if (issuerBindingContext.ListenUriBaseAddress != null)
+            //{
+            //    return new BindingContext(binding, new BindingParameterCollection(issuerBindingContext.BindingParameters), issuerBindingContext.ListenUriBaseAddress,
+            //        issuerBindingContext.ListenUriRelativeAddress, issuerBindingContext.ListenUriMode);
+            //}
+            //else
+            //{
+            //    return new BindingContext(binding, new BindingParameterCollection(issuerBindingContext.BindingParameters));
+            //}
+        }
+
         protected static void SetIssuerBindingContextIfRequired(SecurityTokenParameters parameters, BindingContext issuerBindingContext)
         {
-            throw ExceptionHelper.PlatformNotSupported("SetIssuerBindingContextIfRequired is not supported.");
+            if (parameters is SslSecurityTokenParameters)
+            {
+                ((SslSecurityTokenParameters)parameters).IssuerBindingContext = CreateIssuerBindingContextForNegotiation(issuerBindingContext);
+            }
+            else if (parameters is SspiSecurityTokenParameters)
+            {
+                ((SspiSecurityTokenParameters)parameters).IssuerBindingContext = CreateIssuerBindingContextForNegotiation(issuerBindingContext);
+            }
+        }
+
+        static void SetIssuerBindingContextIfRequired(SupportingTokenParameters supportingParameters, BindingContext issuerBindingContext)
+        {
+            for (int i = 0; i < supportingParameters.Endorsing.Count; ++i)
+            {
+                SetIssuerBindingContextIfRequired(supportingParameters.Endorsing[i], issuerBindingContext);
+            }
+            for (int i = 0; i < supportingParameters.SignedEndorsing.Count; ++i)
+            {
+                SetIssuerBindingContextIfRequired(supportingParameters.SignedEndorsing[i], issuerBindingContext);
+            }
+            for (int i = 0; i < supportingParameters.Signed.Count; ++i)
+            {
+                SetIssuerBindingContextIfRequired(supportingParameters.Signed[i], issuerBindingContext);
+            }
+            for (int i = 0; i < supportingParameters.SignedEncrypted.Count; ++i)
+            {
+                SetIssuerBindingContextIfRequired(supportingParameters.SignedEncrypted[i], issuerBindingContext);
+            }
+        }
+
+        void SetIssuerBindingContextIfRequired(BindingContext issuerBindingContext)
+        {
+            SetIssuerBindingContextIfRequired(this.EndpointSupportingTokenParameters, issuerBindingContext);
+            SetIssuerBindingContextIfRequired(this.OptionalEndpointSupportingTokenParameters, issuerBindingContext);
+            foreach (SupportingTokenParameters parameters in this.OperationSupportingTokenParameters.Values)
+            {
+                SetIssuerBindingContextIfRequired(parameters, issuerBindingContext);
+            }
+            foreach (SupportingTokenParameters parameters in this.OptionalOperationSupportingTokenParameters.Values)
+            {
+                SetIssuerBindingContextIfRequired(parameters, issuerBindingContext);
+            }
         }
 
         internal bool RequiresChannelDemuxer(SecurityTokenParameters parameters)
@@ -207,6 +361,9 @@ namespace System.ServiceModel.Channels
 
             return false;
         }
+
+        internal abstract SecurityProtocolFactory CreateSecurityProtocolFactory<TChannel>(BindingContext context, SecurityCredentialsManager credentialsManager,
+                                                                                          bool isForService, BindingContext issuanceBindingContext);
 
         public override IChannelFactory<TChannel> BuildChannelFactory<TChannel>(BindingContext context)
         {
@@ -445,6 +602,69 @@ namespace System.ServiceModel.Channels
             throw ExceptionHelper.PlatformNotSupported("SecurityBindingElement.CreateSecureConversatationBindingElement is not supported.");
         }
 
+        void SetPrivacyNoticeUriIfRequired(SecurityProtocolFactory factory, Binding binding)
+        {
+            // Issue #31 in progress (don't throw here to allow further processing)
+            //PrivacyNoticeBindingElement privacyElement = binding.CreateBindingElements().Find<PrivacyNoticeBindingElement>();
+            //if (privacyElement != null)
+            //{
+            //    factory.PrivacyNoticeUri = privacyElement.Url;
+            //    factory.PrivacyNoticeVersion = privacyElement.Version;
+            //}
+        }
+
+        internal void ConfigureProtocolFactory(SecurityProtocolFactory factory, SecurityCredentialsManager credentialsManager, bool isForService, BindingContext issuerBindingContext, Binding binding)
+        {
+            if (factory == null)
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentNullException("factory"));
+            if (credentialsManager == null)
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentNullException("credentialsManager"));
+
+            factory.AddTimestamp = this.IncludeTimestamp;
+            factory.IncomingAlgorithmSuite = this.DefaultAlgorithmSuite;
+            factory.OutgoingAlgorithmSuite = this.DefaultAlgorithmSuite;
+            factory.SecurityHeaderLayout = this.SecurityHeaderLayout;
+
+            if (!isForService)
+            {
+                factory.TimestampValidityDuration = this.LocalClientSettings.TimestampValidityDuration;
+                factory.DetectReplays = this.LocalClientSettings.DetectReplays;
+                factory.MaxCachedNonces = this.LocalClientSettings.ReplayCacheSize;
+                factory.MaxClockSkew = this.LocalClientSettings.MaxClockSkew;
+                factory.ReplayWindow = this.LocalClientSettings.ReplayWindow;
+
+                if (this.LocalClientSettings.DetectReplays)
+                {
+                    factory.NonceCache = this.LocalClientSettings.NonceCache;
+                }
+            }
+            else
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+
+                //factory.TimestampValidityDuration = this.LocalServiceSettings.TimestampValidityDuration;
+                //factory.DetectReplays = this.LocalServiceSettings.DetectReplays;
+                //factory.MaxCachedNonces = this.LocalServiceSettings.ReplayCacheSize;
+                //factory.MaxClockSkew = this.LocalServiceSettings.MaxClockSkew;
+                //factory.ReplayWindow = this.LocalServiceSettings.ReplayWindow;
+
+                //if (this.LocalServiceSettings.DetectReplays)
+                //{
+                //    factory.NonceCache = this.LocalServiceSettings.NonceCache;
+                //}
+            }
+
+            factory.SecurityBindingElement = (SecurityBindingElement)this.Clone();
+            factory.SecurityBindingElement.SetIssuerBindingContextIfRequired(issuerBindingContext);
+            factory.SecurityTokenManager = credentialsManager.CreateSecurityTokenManager();
+            SecurityTokenSerializer tokenSerializer = factory.SecurityTokenManager.CreateSecurityTokenSerializer(_messageSecurityVersion.SecurityTokenVersion);
+            factory.StandardsManager = new SecurityStandardsManager(_messageSecurityVersion, tokenSerializer);
+            if (!isForService)
+            {
+                SetPrivacyNoticeUriIfRequired(factory, binding);
+            }
+        }
+
         public override string ToString()
         {
             StringBuilder sb = new StringBuilder();
@@ -458,6 +678,26 @@ namespace System.ServiceModel.Channels
             sb.AppendLine("  " + this.EndpointSupportingTokenParameters.ToString().Trim().Replace("\n", "\n  "));
 
             return sb.ToString().Trim();
+        }
+
+        internal void ApplyAuditBehaviorSettings(BindingContext context, SecurityProtocolFactory factory)
+        {
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+            //ServiceSecurityAuditBehavior auditBehavior = context.BindingParameters.Find<ServiceSecurityAuditBehavior>();
+            //if (auditBehavior != null)
+            //{
+            //    factory.AuditLogLocation = auditBehavior.AuditLogLocation;
+            //    factory.SuppressAuditFailure = auditBehavior.SuppressAuditFailure;
+            //    factory.ServiceAuthorizationAuditLevel = auditBehavior.ServiceAuthorizationAuditLevel;
+            //    factory.MessageAuthenticationAuditLevel = auditBehavior.MessageAuthenticationAuditLevel;
+            //}
+            //else
+            //{
+            //    factory.AuditLogLocation = ServiceSecurityAuditBehavior.defaultAuditLogLocation;
+            //    factory.SuppressAuditFailure = ServiceSecurityAuditBehavior.defaultSuppressAuditFailure;
+            //    factory.ServiceAuthorizationAuditLevel = ServiceSecurityAuditBehavior.defaultServiceAuthorizationAuditLevel;
+            //    factory.MessageAuthenticationAuditLevel = ServiceSecurityAuditBehavior.defaultMessageAuthenticationAuditLevel;
+            //}
         }
     }
 }

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/SecurityBindingElement.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/SecurityBindingElement.cs
@@ -233,22 +233,22 @@ namespace System.ServiceModel.Channels
             supportsWindowsIdentity = false;
             bool tmpSupportsClientAuth;
             bool tmpSupportsWindowsIdentity;
-            this.GetSupportingTokensCapabilities(requirements.Endorsing, out tmpSupportsClientAuth, out tmpSupportsWindowsIdentity);
+            GetSupportingTokensCapabilities(requirements.Endorsing, out tmpSupportsClientAuth, out tmpSupportsWindowsIdentity);
             supportsClientAuth = supportsClientAuth || tmpSupportsClientAuth;
             supportsWindowsIdentity = supportsWindowsIdentity || tmpSupportsWindowsIdentity;
 
-            this.GetSupportingTokensCapabilities(requirements.SignedEndorsing, out tmpSupportsClientAuth, out tmpSupportsWindowsIdentity);
+            GetSupportingTokensCapabilities(requirements.SignedEndorsing, out tmpSupportsClientAuth, out tmpSupportsWindowsIdentity);
             supportsClientAuth = supportsClientAuth || tmpSupportsClientAuth;
             supportsWindowsIdentity = supportsWindowsIdentity || tmpSupportsWindowsIdentity;
 
-            this.GetSupportingTokensCapabilities(requirements.SignedEncrypted, out tmpSupportsClientAuth, out tmpSupportsWindowsIdentity);
+            GetSupportingTokensCapabilities(requirements.SignedEncrypted, out tmpSupportsClientAuth, out tmpSupportsWindowsIdentity);
             supportsClientAuth = supportsClientAuth || tmpSupportsClientAuth;
             supportsWindowsIdentity = supportsWindowsIdentity || tmpSupportsWindowsIdentity;
         }
 
         internal void GetSupportingTokensCapabilities(out bool supportsClientAuth, out bool supportsWindowsIdentity)
         {
-            this.GetSupportingTokensCapabilities(this.EndpointSupportingTokenParameters, out supportsClientAuth, out supportsWindowsIdentity);
+            GetSupportingTokensCapabilities(EndpointSupportingTokenParameters, out supportsClientAuth, out supportsWindowsIdentity);
         }
 
         static BindingContext CreateIssuerBindingContextForNegotiation(BindingContext issuerBindingContext)
@@ -325,13 +325,13 @@ namespace System.ServiceModel.Channels
 
         void SetIssuerBindingContextIfRequired(BindingContext issuerBindingContext)
         {
-            SetIssuerBindingContextIfRequired(this.EndpointSupportingTokenParameters, issuerBindingContext);
-            SetIssuerBindingContextIfRequired(this.OptionalEndpointSupportingTokenParameters, issuerBindingContext);
-            foreach (SupportingTokenParameters parameters in this.OperationSupportingTokenParameters.Values)
+            SetIssuerBindingContextIfRequired(EndpointSupportingTokenParameters, issuerBindingContext);
+            SetIssuerBindingContextIfRequired(OptionalEndpointSupportingTokenParameters, issuerBindingContext);
+            foreach (SupportingTokenParameters parameters in OperationSupportingTokenParameters.Values)
             {
                 SetIssuerBindingContextIfRequired(parameters, issuerBindingContext);
             }
-            foreach (SupportingTokenParameters parameters in this.OptionalOperationSupportingTokenParameters.Values)
+            foreach (SupportingTokenParameters parameters in OptionalOperationSupportingTokenParameters.Values)
             {
                 SetIssuerBindingContextIfRequired(parameters, issuerBindingContext);
             }
@@ -370,7 +370,7 @@ namespace System.ServiceModel.Channels
             if (context == null)
                 throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("context");
 
-            if (!this.CanBuildChannelFactory<TChannel>(context))
+            if (!CanBuildChannelFactory<TChannel>(context))
             {
                 throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentException(SR.Format(SR.ChannelTypeNotSupported, typeof(TChannel)), "TChannel"));
             }
@@ -389,7 +389,7 @@ namespace System.ServiceModel.Channels
             if (transportBindingElement != null)
                 _maxReceivedMessageSize = transportBindingElement.MaxReceivedMessageSize;
 
-            IChannelFactory<TChannel> result = this.BuildChannelFactoryCore<TChannel>(context);
+            IChannelFactory<TChannel> result = BuildChannelFactoryCore<TChannel>(context);
 
             return result;
         }
@@ -401,9 +401,9 @@ namespace System.ServiceModel.Channels
             if (context == null)
                 throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("context");
 
-            if (this.SessionMode)
+            if (SessionMode)
             {
-                return this.CanBuildSessionChannelFactory<TChannel>(context);
+                return CanBuildSessionChannelFactory<TChannel>(context);
             }
 
             if (!context.CanBuildInnerChannelFactory<TChannel>())
@@ -412,8 +412,8 @@ namespace System.ServiceModel.Channels
             }
 
             return typeof(TChannel) == typeof(IOutputChannel) || typeof(TChannel) == typeof(IOutputSessionChannel) ||
-                (this.SupportsDuplex && (typeof(TChannel) == typeof(IDuplexChannel) || typeof(TChannel) == typeof(IDuplexSessionChannel))) ||
-                (this.SupportsRequestReply && (typeof(TChannel) == typeof(IRequestChannel) || typeof(TChannel) == typeof(IRequestSessionChannel)));
+                (SupportsDuplex && (typeof(TChannel) == typeof(IDuplexChannel) || typeof(TChannel) == typeof(IDuplexSessionChannel))) ||
+                (SupportsRequestReply && (typeof(TChannel) == typeof(IRequestChannel) || typeof(TChannel) == typeof(IRequestSessionChannel)));
         }
 
         private bool CanBuildSessionChannelFactory<TChannel>(BindingContext context)
@@ -477,7 +477,7 @@ namespace System.ServiceModel.Channels
 
         private ISecurityCapabilities GetSecurityCapabilities(BindingContext context)
         {
-            ISecurityCapabilities thisSecurityCapability = this.GetIndividualISecurityCapabilities();
+            ISecurityCapabilities thisSecurityCapability = GetIndividualISecurityCapabilities();
             ISecurityCapabilities lowerSecurityCapability = context.GetInnerProperty<ISecurityCapabilities>();
             if (lowerSecurityCapability == null)
             {
@@ -620,41 +620,41 @@ namespace System.ServiceModel.Channels
             if (credentialsManager == null)
                 throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentNullException("credentialsManager"));
 
-            factory.AddTimestamp = this.IncludeTimestamp;
-            factory.IncomingAlgorithmSuite = this.DefaultAlgorithmSuite;
-            factory.OutgoingAlgorithmSuite = this.DefaultAlgorithmSuite;
-            factory.SecurityHeaderLayout = this.SecurityHeaderLayout;
+            factory.AddTimestamp = IncludeTimestamp;
+            factory.IncomingAlgorithmSuite = DefaultAlgorithmSuite;
+            factory.OutgoingAlgorithmSuite = DefaultAlgorithmSuite;
+            factory.SecurityHeaderLayout = SecurityHeaderLayout;
 
             if (!isForService)
             {
-                factory.TimestampValidityDuration = this.LocalClientSettings.TimestampValidityDuration;
-                factory.DetectReplays = this.LocalClientSettings.DetectReplays;
-                factory.MaxCachedNonces = this.LocalClientSettings.ReplayCacheSize;
-                factory.MaxClockSkew = this.LocalClientSettings.MaxClockSkew;
-                factory.ReplayWindow = this.LocalClientSettings.ReplayWindow;
+                factory.TimestampValidityDuration = LocalClientSettings.TimestampValidityDuration;
+                factory.DetectReplays = LocalClientSettings.DetectReplays;
+                factory.MaxCachedNonces = LocalClientSettings.ReplayCacheSize;
+                factory.MaxClockSkew = LocalClientSettings.MaxClockSkew;
+                factory.ReplayWindow = LocalClientSettings.ReplayWindow;
 
-                if (this.LocalClientSettings.DetectReplays)
+                if (LocalClientSettings.DetectReplays)
                 {
-                    factory.NonceCache = this.LocalClientSettings.NonceCache;
+                    factory.NonceCache = LocalClientSettings.NonceCache;
                 }
             }
             else
             {
                 throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
 
-                //factory.TimestampValidityDuration = this.LocalServiceSettings.TimestampValidityDuration;
-                //factory.DetectReplays = this.LocalServiceSettings.DetectReplays;
-                //factory.MaxCachedNonces = this.LocalServiceSettings.ReplayCacheSize;
-                //factory.MaxClockSkew = this.LocalServiceSettings.MaxClockSkew;
-                //factory.ReplayWindow = this.LocalServiceSettings.ReplayWindow;
+                //factory.TimestampValidityDuration = LocalServiceSettings.TimestampValidityDuration;
+                //factory.DetectReplays = LocalServiceSettings.DetectReplays;
+                //factory.MaxCachedNonces = LocalServiceSettings.ReplayCacheSize;
+                //factory.MaxClockSkew = LocalServiceSettings.MaxClockSkew;
+                //factory.ReplayWindow = LocalServiceSettings.ReplayWindow;
 
-                //if (this.LocalServiceSettings.DetectReplays)
+                //if (LocalServiceSettings.DetectReplays)
                 //{
-                //    factory.NonceCache = this.LocalServiceSettings.NonceCache;
+                //    factory.NonceCache = LocalServiceSettings.NonceCache;
                 //}
             }
 
-            factory.SecurityBindingElement = (SecurityBindingElement)this.Clone();
+            factory.SecurityBindingElement = (SecurityBindingElement)Clone();
             factory.SecurityBindingElement.SetIssuerBindingContextIfRequired(issuerBindingContext);
             factory.SecurityTokenManager = credentialsManager.CreateSecurityTokenManager();
             SecurityTokenSerializer tokenSerializer = factory.SecurityTokenManager.CreateSecurityTokenSerializer(_messageSecurityVersion.SecurityTokenVersion);
@@ -669,13 +669,13 @@ namespace System.ServiceModel.Channels
         {
             StringBuilder sb = new StringBuilder();
 
-            sb.AppendLine(String.Format(CultureInfo.InvariantCulture, "{0}:", this.GetType().ToString()));
+            sb.AppendLine(String.Format(CultureInfo.InvariantCulture, "{0}:", GetType().ToString()));
             sb.AppendLine(String.Format(CultureInfo.InvariantCulture, "IncludeTimestamp: {0}", _includeTimestamp.ToString()));
-            sb.AppendLine(String.Format(CultureInfo.InvariantCulture, "MessageSecurityVersion: {0}", this.MessageSecurityVersion.ToString()));
+            sb.AppendLine(String.Format(CultureInfo.InvariantCulture, "MessageSecurityVersion: {0}", MessageSecurityVersion.ToString()));
             sb.AppendLine(String.Format(CultureInfo.InvariantCulture, "SecurityHeaderLayout: {0}", _securityHeaderLayout.ToString()));
             sb.AppendLine(String.Format(CultureInfo.InvariantCulture, "ProtectTokens: {0}", _protectTokens.ToString()));
             sb.AppendLine("EndpointSupportingTokenParameters:");
-            sb.AppendLine("  " + this.EndpointSupportingTokenParameters.ToString().Trim().Replace("\n", "\n  "));
+            sb.AppendLine("  " + EndpointSupportingTokenParameters.ToString().Trim().Replace("\n", "\n  "));
 
             return sb.ToString().Trim();
         }

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/SecurityCapabilities.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/SecurityCapabilities.cs
@@ -9,27 +9,27 @@ namespace System.ServiceModel.Channels
 {
     public class SecurityCapabilities : ISecurityCapabilities
     {
-        internal bool supportsServerAuth;
-        internal bool supportsClientAuth;
-        internal bool supportsClientWindowsIdentity;
-        internal ProtectionLevel requestProtectionLevel;
-        internal ProtectionLevel responseProtectionLevel;
+        internal bool _supportsServerAuth;
+        internal bool _supportsClientAuth;
+        internal bool _supportsClientWindowsIdentity;
+        internal ProtectionLevel _requestProtectionLevel;
+        internal ProtectionLevel _responseProtectionLevel;
 
         public SecurityCapabilities(bool supportsClientAuth, bool supportsServerAuth, bool supportsClientWindowsIdentity,
             ProtectionLevel requestProtectionLevel, ProtectionLevel responseProtectionLevel)
         {
-            this.supportsClientAuth = supportsClientAuth;
-            this.supportsServerAuth = supportsServerAuth;
-            this.supportsClientWindowsIdentity = supportsClientWindowsIdentity;
-            this.requestProtectionLevel = requestProtectionLevel;
-            this.responseProtectionLevel = responseProtectionLevel;
+            _supportsClientAuth = supportsClientAuth;
+            _supportsServerAuth = supportsServerAuth;
+            _supportsClientWindowsIdentity = supportsClientWindowsIdentity;
+            _requestProtectionLevel = requestProtectionLevel;
+            _responseProtectionLevel = responseProtectionLevel;
         }
 
-        public ProtectionLevel SupportedRequestProtectionLevel { get { return requestProtectionLevel; } }
-        public ProtectionLevel SupportedResponseProtectionLevel { get { return responseProtectionLevel; } }
-        public bool SupportsClientAuthentication { get { return supportsClientAuth; } }
-        public bool SupportsClientWindowsIdentity { get { return supportsClientWindowsIdentity; } }
-        public bool SupportsServerAuthentication { get { return supportsServerAuth; } }
+        public ProtectionLevel SupportedRequestProtectionLevel { get { return _requestProtectionLevel; } }
+        public ProtectionLevel SupportedResponseProtectionLevel { get { return _responseProtectionLevel; } }
+        public bool SupportsClientAuthentication { get { return _supportsClientAuth; } }
+        public bool SupportsClientWindowsIdentity { get { return _supportsClientWindowsIdentity; } }
+        public bool SupportsServerAuthentication { get { return _supportsServerAuth; } }
 
         public static SecurityCapabilities None
         {

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/SecurityChannelFactory.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/SecurityChannelFactory.cs
@@ -122,18 +122,20 @@ namespace System.ServiceModel.Channels
 
         void CloseProtocolFactory(bool aborted, TimeSpan timeout)
         {
-            if (_securityProtocolFactory != null && !SessionMode)
+            SecurityProtocolFactory factory = _securityProtocolFactory;
+            if (factory != null && !SessionMode)
             {
-                _securityProtocolFactory.Close(aborted, timeout);
+                factory.Close(aborted, timeout);
                 _securityProtocolFactory = null;
             }
         }
 
         async Task CloseProtocolFactoryAsync(TimeSpan timeout)
         {
-            if (_securityProtocolFactory != null && !SessionMode)
+            SecurityProtocolFactory factory = _securityProtocolFactory;
+            if (factory != null && !SessionMode)
             {
-                await _securityProtocolFactory.CloseAsync(timeout);
+                await factory.CloseAsync(timeout);
                 _securityProtocolFactory = null;
             }
         }
@@ -212,7 +214,7 @@ namespace System.ServiceModel.Channels
         private async Task OnCloseAsyncInternal(TimeSpan timeout)
         {
             TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
-            await base.OnCloseAsync(timeout);
+            await base.OnCloseAsync(timeoutHelper.RemainingTime());
             await CloseProtocolFactoryAsync(timeoutHelper.RemainingTime());
             if (_sessionClientSettings != null)
             {

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/SecurityChannelFactory.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/SecurityChannelFactory.cs
@@ -561,7 +561,7 @@ namespace System.ServiceModel.Channels
             }
         }
 
-        class SecurityRequestChannel : ClientSecurityChannel<IRequestChannel>, IRequestChannel
+        class SecurityRequestChannel : ClientSecurityChannel<IRequestChannel>, IAsyncRequestChannel
         {
             public SecurityRequestChannel(ChannelManagerBase factory, SecurityProtocolFactory securityProtocolFactory, IRequestChannel innerChannel, EndpointAddress to, Uri via)
                 : base(factory, securityProtocolFactory, innerChannel, to, via)
@@ -654,6 +654,16 @@ namespace System.ServiceModel.Channels
                 SecurityProtocolCorrelationState correlationState = SecurityProtocol.SecureOutgoingMessage(ref message, timeoutHelper.RemainingTime(), null);
                 Message reply = InnerChannel.Request(message, timeoutHelper.RemainingTime());
                 return ProcessReply(reply, correlationState, timeoutHelper.RemainingTime());
+            }
+
+            public Task<Message> RequestAsync(Message message)
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+            }
+
+            public Task<Message> RequestAsync(Message message, TimeSpan timeout)
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
             }
         }
 

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/SecurityChannelFactory.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/SecurityChannelFactory.cs
@@ -1,0 +1,918 @@
+//----------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace System.ServiceModel.Channels
+{
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.Runtime;
+    using System.Runtime.InteropServices;
+    //using System.Runtime.Remoting.Messaging;
+    using System.Security.Authentication.ExtendedProtection;
+    using System.ServiceModel;
+    using System.ServiceModel.Diagnostics.Application;
+    using System.ServiceModel.Dispatcher;
+    using System.ServiceModel.Security;
+
+    using ServiceModelActivity = System.ServiceModel.Diagnostics.ServiceModelActivity;
+    using TraceUtility = System.ServiceModel.Diagnostics.TraceUtility;
+
+    sealed class SecurityChannelFactory<TChannel>
+        : LayeredChannelFactory<TChannel>
+    {
+        ChannelBuilder channelBuilder;
+        SecurityProtocolFactory securityProtocolFactory;
+        SecuritySessionClientSettings<TChannel> sessionClientSettings;
+        bool sessionMode;
+        MessageVersion messageVersion;
+        ISecurityCapabilities securityCapabilities;
+
+        public SecurityChannelFactory(ISecurityCapabilities securityCapabilities, BindingContext context,
+            SecuritySessionClientSettings<TChannel> sessionClientSettings)
+            : this(securityCapabilities, context, sessionClientSettings.ChannelBuilder, sessionClientSettings.CreateInnerChannelFactory())
+        {
+            this.sessionMode = true;
+            this.sessionClientSettings = sessionClientSettings;
+        }
+
+        public SecurityChannelFactory(ISecurityCapabilities securityCapabilities, BindingContext context, ChannelBuilder channelBuilder, SecurityProtocolFactory protocolFactory)
+            : this(securityCapabilities, context, channelBuilder, protocolFactory, channelBuilder.BuildChannelFactory<TChannel>())
+        {
+        }
+
+        public SecurityChannelFactory(ISecurityCapabilities securityCapabilities, BindingContext context, ChannelBuilder channelBuilder, SecurityProtocolFactory protocolFactory, IChannelFactory innerChannelFactory)
+            : this(securityCapabilities, context, channelBuilder, innerChannelFactory)
+        {
+            this.securityProtocolFactory = protocolFactory;
+        }
+
+        SecurityChannelFactory(ISecurityCapabilities securityCapabilities, BindingContext context, ChannelBuilder channelBuilder, IChannelFactory innerChannelFactory)
+            : base(context.Binding, innerChannelFactory)
+        {
+            this.channelBuilder = channelBuilder;
+            this.messageVersion = context.Binding.MessageVersion;
+            this.securityCapabilities = securityCapabilities;
+        }
+
+        // used by internal test code
+        internal SecurityChannelFactory(Binding binding, SecurityProtocolFactory protocolFactory, IChannelFactory innerChannelFactory)
+            : base(binding, innerChannelFactory)
+        {
+            this.securityProtocolFactory = protocolFactory;
+        }
+
+        public ChannelBuilder ChannelBuilder
+        {
+            get
+            {
+                return this.channelBuilder;
+            }
+        }
+
+        public SecurityProtocolFactory SecurityProtocolFactory
+        {
+            get
+            {
+                return this.securityProtocolFactory;
+            }
+        }
+
+        public SecuritySessionClientSettings<TChannel> SessionClientSettings
+        {
+            get
+            {
+                Fx.Assert(SessionMode == true, "SessionClientSettings can only be used if SessionMode == true");
+                return this.sessionClientSettings;
+            }
+        }
+
+        public bool SessionMode
+        {
+            get
+            {
+                return this.sessionMode;
+            }
+        }
+
+        bool SupportsDuplex
+        {
+            get
+            {
+                ThrowIfProtocolFactoryNotSet();
+                return this.securityProtocolFactory.SupportsDuplex;
+            }
+        }
+
+        bool SupportsRequestReply
+        {
+            get
+            {
+                ThrowIfProtocolFactoryNotSet();
+                return this.securityProtocolFactory.SupportsRequestReply;
+            }
+        }
+
+        public MessageVersion MessageVersion
+        {
+            get
+            {
+                return this.messageVersion;
+            }
+        }
+
+        void CloseProtocolFactory(bool aborted, TimeSpan timeout)
+        {
+            if (this.securityProtocolFactory != null && !this.SessionMode)
+            {
+                this.securityProtocolFactory.Close(aborted, timeout);
+                this.securityProtocolFactory = null;
+            }
+        }
+
+        public override T GetProperty<T>()
+        {
+            if (this.SessionMode && (typeof(T) == typeof(IChannelSecureConversationSessionSettings)))
+            {
+                return (T)(object)this.SessionClientSettings;
+            }
+            else if (typeof(T) == typeof(ISecurityCapabilities))
+            {
+                return (T)(object)this.securityCapabilities;
+            }
+
+            return base.GetProperty<T>();
+        }
+
+        protected override void OnAbort()
+        {
+            base.OnAbort();
+            CloseProtocolFactory(true, TimeSpan.Zero);
+            if (this.sessionClientSettings != null)
+            {
+                this.sessionClientSettings.Abort();
+            }
+        }
+
+        protected override IAsyncResult OnBeginClose(TimeSpan timeout, AsyncCallback callback, object state)
+        {
+            List<OperationWithTimeoutBeginCallback> begins = new List<OperationWithTimeoutBeginCallback>();
+            List<OperationEndCallback> ends = new List<OperationEndCallback>();
+            begins.Add(new OperationWithTimeoutBeginCallback(base.OnBeginClose));
+            ends.Add(new OperationEndCallback(base.OnEndClose));
+
+            if (this.securityProtocolFactory != null && !this.SessionMode)
+            {
+                begins.Add(new OperationWithTimeoutBeginCallback(this.securityProtocolFactory.BeginClose));
+                ends.Add(new OperationEndCallback(this.securityProtocolFactory.EndClose));
+            }
+
+            if (this.sessionClientSettings != null)
+            {
+                begins.Add(new OperationWithTimeoutBeginCallback(this.sessionClientSettings.BeginClose));
+                ends.Add(new OperationEndCallback(this.sessionClientSettings.EndClose));
+            }
+
+            return OperationWithTimeoutComposer.BeginComposeAsyncOperations(timeout, begins.ToArray(), ends.ToArray(), callback, state);
+        }
+
+        protected override void OnEndClose(IAsyncResult result)
+        {
+            OperationWithTimeoutComposer.EndComposeAsyncOperations(result);
+        }
+
+        protected override void OnClose(TimeSpan timeout)
+        {
+            TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
+            base.OnClose(timeout);
+            CloseProtocolFactory(false, timeoutHelper.RemainingTime());
+            if (this.sessionClientSettings != null)
+            {
+                this.sessionClientSettings.Close(timeoutHelper.RemainingTime());
+            }
+        }
+
+        protected override TChannel OnCreateChannel(EndpointAddress address, Uri via)
+        {
+            ThrowIfDisposed();
+            if (this.SessionMode)
+            {
+                return this.sessionClientSettings.OnCreateChannel(address, via);
+            }
+
+            if (typeof(TChannel) == typeof(IOutputChannel))
+            {
+                return (TChannel)(object)new SecurityOutputChannel(this, this.securityProtocolFactory, ((IChannelFactory<IOutputChannel>)this.InnerChannelFactory).CreateChannel(address, via), address, via);
+            }
+            else if (typeof(TChannel) == typeof(IOutputSessionChannel))
+            {
+                return (TChannel)(object)new SecurityOutputSessionChannel(this, this.securityProtocolFactory, ((IChannelFactory<IOutputSessionChannel>)this.InnerChannelFactory).CreateChannel(address, via), address, via);
+            }
+            else if (typeof(TChannel) == typeof(IDuplexChannel))
+            {
+                return (TChannel)(object)new SecurityDuplexChannel(this, this.securityProtocolFactory, ((IChannelFactory<IDuplexChannel>)this.InnerChannelFactory).CreateChannel(address, via), address, via);
+            }
+            else if (typeof(TChannel) == typeof(IDuplexSessionChannel))
+            {
+                return (TChannel)(object)new SecurityDuplexSessionChannel(this, this.securityProtocolFactory, ((IChannelFactory<IDuplexSessionChannel>)this.InnerChannelFactory).CreateChannel(address, via), address, via);
+            }
+            else if (typeof(TChannel) == typeof(IRequestChannel))
+            {
+                return (TChannel)(object)new SecurityRequestChannel(this, this.securityProtocolFactory, ((IChannelFactory<IRequestChannel>)this.InnerChannelFactory).CreateChannel(address, via), address, via);
+            }
+
+            //typeof(TChannel) == typeof(IRequestSessionChannel)
+            return (TChannel)(object)new SecurityRequestSessionChannel(this, this.securityProtocolFactory, ((IChannelFactory<IRequestSessionChannel>)this.InnerChannelFactory).CreateChannel(address, via), address, via);
+        }
+
+        protected override void OnOpen(TimeSpan timeout)
+        {
+            TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
+            OnOpenCore(timeoutHelper.RemainingTime());
+            base.OnOpen(timeoutHelper.RemainingTime());
+            this.SetBufferManager();
+        }
+
+        void SetBufferManager()
+        {
+            ITransportFactorySettings transportSettings = this.GetProperty<ITransportFactorySettings>();
+
+            if (transportSettings == null)
+                return;
+
+            BufferManager bufferManager = transportSettings.BufferManager;
+
+            if (bufferManager == null)
+                return;
+
+            if (this.SessionMode && this.SessionClientSettings != null && this.SessionClientSettings.SessionProtocolFactory != null)
+            {
+                this.SessionClientSettings.SessionProtocolFactory.StreamBufferManager = bufferManager;
+            }
+            else
+            {
+                ThrowIfProtocolFactoryNotSet();
+                this.securityProtocolFactory.StreamBufferManager = bufferManager;
+            }
+        }
+
+        protected override IAsyncResult OnBeginOpen(TimeSpan timeout, AsyncCallback callback, object state)
+        {
+            return new OperationWithTimeoutAsyncResult(new OperationWithTimeoutCallback(this.OnOpen), timeout, callback, state);
+        }
+
+        protected override void OnEndOpen(IAsyncResult result)
+        {
+            OperationWithTimeoutAsyncResult.End(result);
+        }
+
+        void OnOpenCore(TimeSpan timeout)
+        {
+            TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
+            if (this.SessionMode)
+            {
+                this.SessionClientSettings.Open(this, this.InnerChannelFactory, this.ChannelBuilder, timeoutHelper.RemainingTime());
+            }
+            else
+            {
+                ThrowIfProtocolFactoryNotSet();
+                this.securityProtocolFactory.Open(true, timeoutHelper.RemainingTime());
+            }
+        }
+
+        void ThrowIfDuplexNotSupported()
+        {
+            if (!this.SupportsDuplex)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(
+                    SR.GetString(SR.SecurityProtocolFactoryDoesNotSupportDuplex, this.securityProtocolFactory)));
+            }
+        }
+
+        void ThrowIfProtocolFactoryNotSet()
+        {
+            if (this.securityProtocolFactory == null)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(
+                    SR.GetString(SR.SecurityProtocolFactoryShouldBeSetBeforeThisOperation)));
+            }
+        }
+
+        void ThrowIfRequestReplyNotSupported()
+        {
+            if (!this.SupportsRequestReply)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(
+                    SR.GetString(SR.SecurityProtocolFactoryDoesNotSupportRequestReply, this.securityProtocolFactory)));
+            }
+        }
+
+
+        abstract class ClientSecurityChannel<UChannel> : SecurityChannel<UChannel>
+            where UChannel : class, IChannel
+        {
+            EndpointAddress to;
+            Uri via;
+            SecurityProtocolFactory securityProtocolFactory;
+            ChannelParameterCollection channelParameters;
+
+            protected ClientSecurityChannel(ChannelManagerBase factory, SecurityProtocolFactory securityProtocolFactory,
+                UChannel innerChannel, EndpointAddress to, Uri via)
+                : base(factory, innerChannel)
+            {
+                this.to = to;
+                this.via = via;
+                this.securityProtocolFactory = securityProtocolFactory;
+                this.channelParameters = new ChannelParameterCollection(this);
+            }
+
+            protected SecurityProtocolFactory SecurityProtocolFactory
+            {
+                get { return this.securityProtocolFactory; }
+            }
+
+            public EndpointAddress RemoteAddress
+            {
+                get { return this.to; }
+            }
+
+            public Uri Via
+            {
+                get { return this.via; }
+            }
+
+            protected bool TryGetSecurityFaultException(Message faultMessage, out Exception faultException)
+            {
+                faultException = null;
+                if (!faultMessage.IsFault)
+                {
+                    return false;
+                }
+                MessageFault fault = MessageFault.CreateFault(faultMessage, TransportDefaults.MaxSecurityFaultSize);
+                faultException = SecurityUtils.CreateSecurityFaultException(fault);
+                return true;
+            }
+
+            protected override IAsyncResult OnBeginOpen(TimeSpan timeout, AsyncCallback callback, object state)
+            {
+                EnableChannelBindingSupport();
+
+                return new OpenAsyncResult(this, timeout, callback, state);
+            }
+
+            protected override void OnEndOpen(IAsyncResult result)
+            {
+                OpenAsyncResult.End(result);
+            }
+
+            protected override void OnOpen(TimeSpan timeout)
+            {
+                TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
+                EnableChannelBindingSupport();
+
+                SecurityProtocol securityProtocol = this.SecurityProtocolFactory.CreateSecurityProtocol(
+                    this.to,
+                    this.Via,
+                    null,
+                    typeof(TChannel) == typeof(IRequestChannel),
+                    timeoutHelper.RemainingTime());
+                OnProtocolCreationComplete(securityProtocol);
+                this.SecurityProtocol.Open(timeoutHelper.RemainingTime());
+                base.OnOpen(timeoutHelper.RemainingTime());
+            }
+
+            void EnableChannelBindingSupport()
+            {
+                if (this.securityProtocolFactory != null && this.securityProtocolFactory.ExtendedProtectionPolicy != null && this.securityProtocolFactory.ExtendedProtectionPolicy.CustomChannelBinding != null)
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new NotSupportedException(SR.GetString(SR.ExtendedProtectionPolicyCustomChannelBindingNotSupported)));
+                }
+
+                // Do not enable channel binding if there is no reason as it sets up chunking mode.
+                if ((SecurityUtils.IsChannelBindingDisabled) || (!SecurityUtils.IsSecurityBindingSuitableForChannelBinding(this.SecurityProtocolFactory.SecurityBindingElement as TransportSecurityBindingElement)))
+                    return;
+
+                if (InnerChannel != null)
+                {
+                    IChannelBindingProvider cbp = InnerChannel.GetProperty<IChannelBindingProvider>();
+                    if (cbp != null)
+                    {
+                        cbp.EnableChannelBindingSupport();
+                    }
+                }
+            }
+
+            void OnProtocolCreationComplete(SecurityProtocol securityProtocol)
+            {
+                this.SecurityProtocol = securityProtocol;
+                this.SecurityProtocol.ChannelParameters = this.channelParameters;
+            }
+
+            public override T GetProperty<T>()
+            {
+                if (typeof(T) == typeof(ChannelParameterCollection))
+                {
+                    return (T)(object)this.channelParameters;
+                }
+
+                return base.GetProperty<T>();
+            }
+
+            sealed class OpenAsyncResult : AsyncResult
+            {
+                readonly ClientSecurityChannel<UChannel> clientChannel;
+                TimeoutHelper timeoutHelper;
+                static readonly AsyncCallback openInnerChannelCallback = Fx.ThunkCallback(new AsyncCallback(OpenInnerChannelCallback));
+                static readonly AsyncCallback openSecurityProtocolCallback = Fx.ThunkCallback(new AsyncCallback(OpenSecurityProtocolCallback));
+
+                public OpenAsyncResult(ClientSecurityChannel<UChannel> clientChannel, TimeSpan timeout,
+                    AsyncCallback callback, object state)
+                    : base(callback, state)
+                {
+                    this.timeoutHelper = new TimeoutHelper(timeout);
+                    this.clientChannel = clientChannel;
+                    SecurityProtocol securityProtocol = this.clientChannel.SecurityProtocolFactory.CreateSecurityProtocol(this.clientChannel.to,
+                        this.clientChannel.Via,
+                        null, typeof(TChannel) == typeof(IRequestChannel), timeoutHelper.RemainingTime());
+                    bool completeSelf = this.OnCreateSecurityProtocolComplete(securityProtocol);
+                    if (completeSelf)
+                    {
+                        Complete(true);
+                    }
+                }
+
+                internal static void End(IAsyncResult result)
+                {
+                    AsyncResult.End<OpenAsyncResult>(result);
+                }
+
+                bool OnCreateSecurityProtocolComplete(SecurityProtocol securityProtocol)
+                {
+                    this.clientChannel.OnProtocolCreationComplete(securityProtocol);
+                    IAsyncResult result = securityProtocol.BeginOpen(timeoutHelper.RemainingTime(), openSecurityProtocolCallback, this);
+                    if (!result.CompletedSynchronously)
+                    {
+                        return false;
+                    }
+                    securityProtocol.EndOpen(result);
+                    return this.OnSecurityProtocolOpenComplete();
+                }
+
+                static void OpenSecurityProtocolCallback(IAsyncResult result)
+                {
+                    if (result.CompletedSynchronously)
+                    {
+                        return;
+                    }
+                    OpenAsyncResult self = result.AsyncState as OpenAsyncResult;
+                    if (self == null)
+                    {
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentException(SR.GetString(SR.InvalidAsyncResult), "result"));
+                    }
+                    Exception completionException = null;
+                    bool completeSelf = false;
+                    try
+                    {
+                        self.clientChannel.SecurityProtocol.EndOpen(result);
+                        completeSelf = self.OnSecurityProtocolOpenComplete();
+                    }
+#pragma warning suppress 56500 // covered by FxCOP
+                    catch (Exception e)
+                    {
+                        if (Fx.IsFatal(e))
+                        {
+                            throw;
+                        }
+                        completionException = e;
+                        completeSelf = true;
+                    }
+                    if (completeSelf)
+                    {
+                        self.Complete(false, completionException);
+                    }
+                }
+
+                bool OnSecurityProtocolOpenComplete()
+                {
+                    IAsyncResult result = this.clientChannel.InnerChannel.BeginOpen(this.timeoutHelper.RemainingTime(), openInnerChannelCallback, this);
+                    if (!result.CompletedSynchronously)
+                    {
+                        return false;
+                    }
+                    this.clientChannel.InnerChannel.EndOpen(result);
+                    return true;
+                }
+
+                static void OpenInnerChannelCallback(IAsyncResult result)
+                {
+                    if (result == null)
+                    {
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentNullException("result"));
+                    }
+                    if (result.CompletedSynchronously)
+                    {
+                        return;
+                    }
+                    OpenAsyncResult self = result.AsyncState as OpenAsyncResult;
+                    if (self == null)
+                    {
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentException(SR.GetString(SR.InvalidAsyncResult), "result"));
+                    }
+                    Exception completionException = null;
+                    try
+                    {
+                        self.clientChannel.InnerChannel.EndOpen(result);
+                    }
+#pragma warning suppress 56500 // covered by FxCOP
+                    catch (Exception e)
+                    {
+                        if (Fx.IsFatal(e))
+                        {
+                            throw;
+                        }
+                        completionException = e;
+                    }
+                    self.Complete(false, completionException);
+                }
+            }
+        }
+
+        class SecurityOutputChannel : ClientSecurityChannel<IOutputChannel>, IOutputChannel
+        {
+            public SecurityOutputChannel(ChannelManagerBase factory, SecurityProtocolFactory securityProtocolFactory, IOutputChannel innerChannel, EndpointAddress to, Uri via)
+                : base(factory, securityProtocolFactory, innerChannel, to, via)
+            {
+            }
+
+            public IAsyncResult BeginSend(Message message, AsyncCallback callback, object state)
+            {
+                return this.BeginSend(message, this.DefaultSendTimeout, callback, state);
+            }
+
+            public IAsyncResult BeginSend(Message message, TimeSpan timeout, AsyncCallback callback, object state)
+            {
+                ThrowIfFaulted();
+                ThrowIfDisposedOrNotOpen(message);
+                return new OutputChannelSendAsyncResult(message, this.SecurityProtocol, this.InnerChannel, timeout, callback, state);
+            }
+
+            public void EndSend(IAsyncResult result)
+            {
+                OutputChannelSendAsyncResult.End(result);
+            }
+
+            public void Send(Message message)
+            {
+                this.Send(message, this.DefaultSendTimeout);
+            }
+
+            public void Send(Message message, TimeSpan timeout)
+            {
+                ThrowIfFaulted();
+                ThrowIfDisposedOrNotOpen(message);
+                TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
+                this.SecurityProtocol.SecureOutgoingMessage(ref message, timeoutHelper.RemainingTime());
+                this.InnerChannel.Send(message, timeoutHelper.RemainingTime());
+            }
+        }
+
+        sealed class SecurityOutputSessionChannel : SecurityOutputChannel, IOutputSessionChannel
+        {
+            public SecurityOutputSessionChannel(ChannelManagerBase factory, SecurityProtocolFactory securityProtocolFactory, IOutputSessionChannel innerChannel, EndpointAddress to, Uri via)
+                : base(factory, securityProtocolFactory, innerChannel, to, via)
+            {
+            }
+
+            public IOutputSession Session
+            {
+                get
+                {
+                    return ((IOutputSessionChannel)this.InnerChannel).Session;
+                }
+            }
+        }
+
+        class SecurityRequestChannel : ClientSecurityChannel<IRequestChannel>, IRequestChannel
+        {
+            public SecurityRequestChannel(ChannelManagerBase factory, SecurityProtocolFactory securityProtocolFactory, IRequestChannel innerChannel, EndpointAddress to, Uri via)
+                : base(factory, securityProtocolFactory, innerChannel, to, via)
+            {
+            }
+
+            public IAsyncResult BeginRequest(Message message, AsyncCallback callback, object state)
+            {
+                return this.BeginRequest(message, this.DefaultSendTimeout, callback, state);
+            }
+
+            public IAsyncResult BeginRequest(Message message, TimeSpan timeout, AsyncCallback callback, object state)
+            {
+                ThrowIfFaulted();
+                ThrowIfDisposedOrNotOpen(message);
+                return new RequestChannelSendAsyncResult(message, this.SecurityProtocol, this.InnerChannel, this, timeout, callback, state);
+            }
+
+            public Message EndRequest(IAsyncResult result)
+            {
+                return RequestChannelSendAsyncResult.End(result);
+            }
+
+            public Message Request(Message message)
+            {
+                return this.Request(message, this.DefaultSendTimeout);
+            }
+
+            internal Message ProcessReply(Message reply, SecurityProtocolCorrelationState correlationState, TimeSpan timeout)
+            {
+                if (reply != null)
+                {
+                    if (DiagnosticUtility.ShouldUseActivity)
+                    {
+                        ServiceModelActivity replyActivity = TraceUtility.ExtractActivity(reply);
+                        if (replyActivity != null &&
+                            correlationState != null &&
+                            correlationState.Activity != null &&
+                            replyActivity.Id != correlationState.Activity.Id)
+                        {
+                            using (ServiceModelActivity.BoundOperation(replyActivity))
+                            {
+                                if (null != FxTrace.Trace)
+                                {
+                                    FxTrace.Trace.TraceTransfer(correlationState.Activity.Id);
+                                }
+                                replyActivity.Stop();
+                            }
+                        }
+                    }
+                    ServiceModelActivity activity = correlationState == null ? null : correlationState.Activity;
+                    using (ServiceModelActivity.BoundOperation(activity))
+                    {
+                        if (DiagnosticUtility.ShouldUseActivity)
+                        {
+                            TraceUtility.SetActivity(reply, activity);
+                        }
+                        Message unverifiedMessage = reply;
+                        Exception faultException = null;
+                        try
+                        {
+                            this.SecurityProtocol.VerifyIncomingMessage(ref reply, timeout, correlationState);
+                        }
+                        catch (MessageSecurityException)
+                        {
+                            TryGetSecurityFaultException(unverifiedMessage, out faultException);
+                            if (faultException == null)
+                            {
+                                throw;
+                            }
+                        }
+                        if (faultException != null)
+                        {
+                            this.Fault(faultException);
+                            throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(faultException);
+                        }
+                    }
+                }
+                return reply;
+            }
+
+            public Message Request(Message message, TimeSpan timeout)
+            {
+                ThrowIfFaulted();
+                ThrowIfDisposedOrNotOpen(message);
+                TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
+                SecurityProtocolCorrelationState correlationState = this.SecurityProtocol.SecureOutgoingMessage(ref message, timeoutHelper.RemainingTime(), null);
+                Message reply = this.InnerChannel.Request(message, timeoutHelper.RemainingTime());
+                return ProcessReply(reply, correlationState, timeoutHelper.RemainingTime());
+            }
+        }
+
+        sealed class SecurityRequestSessionChannel : SecurityRequestChannel, IRequestSessionChannel
+        {
+            public SecurityRequestSessionChannel(ChannelManagerBase factory, SecurityProtocolFactory securityProtocolFactory, IRequestSessionChannel innerChannel, EndpointAddress to, Uri via)
+                : base(factory, securityProtocolFactory, innerChannel, to, via)
+            {
+            }
+
+            public IOutputSession Session
+            {
+                get
+                {
+                    return ((IRequestSessionChannel)this.InnerChannel).Session;
+                }
+            }
+        }
+
+        class SecurityDuplexChannel : SecurityOutputChannel, IDuplexChannel
+        {
+            public SecurityDuplexChannel(ChannelManagerBase factory, SecurityProtocolFactory securityProtocolFactory, IDuplexChannel innerChannel, EndpointAddress to, Uri via)
+                : base(factory, securityProtocolFactory, innerChannel, to, via)
+            {
+            }
+
+            internal IDuplexChannel InnerDuplexChannel
+            {
+                get { return (IDuplexChannel)this.InnerChannel; }
+            }
+
+            public EndpointAddress LocalAddress
+            {
+                get
+                {
+                    return this.InnerDuplexChannel.LocalAddress;
+                }
+            }
+
+            internal virtual bool AcceptUnsecuredFaults
+            {
+                get { return false; }
+            }
+
+            public Message Receive()
+            {
+                return this.Receive(this.DefaultReceiveTimeout);
+            }
+
+            public Message Receive(TimeSpan timeout)
+            {
+                return InputChannel.HelpReceive(this, timeout);
+            }
+
+            public IAsyncResult BeginReceive(AsyncCallback callback, object state)
+            {
+                return this.BeginReceive(this.DefaultReceiveTimeout, callback, state);
+            }
+
+            public IAsyncResult BeginReceive(TimeSpan timeout, AsyncCallback callback, object state)
+            {
+                return InputChannel.HelpBeginReceive(this, timeout, callback, state);
+            }
+
+            public Message EndReceive(IAsyncResult result)
+            {
+                return InputChannel.HelpEndReceive(result);
+            }
+
+            public virtual IAsyncResult BeginTryReceive(TimeSpan timeout, AsyncCallback callback, object state)
+            {
+                if (DoneReceivingInCurrentState())
+                {
+                    return new DoneReceivingAsyncResult(callback, state);
+                }
+
+                ClientDuplexReceiveMessageAndVerifySecurityAsyncResult result =
+                    new ClientDuplexReceiveMessageAndVerifySecurityAsyncResult(this, this.InnerDuplexChannel, timeout, callback, state);
+                result.Start();
+                return result;
+            }
+
+            public virtual bool EndTryReceive(IAsyncResult result, out Message message)
+            {
+                DoneReceivingAsyncResult doneRecevingResult = result as DoneReceivingAsyncResult;
+                if (doneRecevingResult != null)
+                {
+                    return DoneReceivingAsyncResult.End(doneRecevingResult, out message);
+                }
+
+                return ClientDuplexReceiveMessageAndVerifySecurityAsyncResult.End(result, out message);
+            }
+
+            internal Message ProcessMessage(Message message, TimeSpan timeout)
+            {
+                if (message == null)
+                {
+                    return null;
+                }
+                Message unverifiedMessage = message;
+                Exception faultException = null;
+                try
+                {
+                    this.SecurityProtocol.VerifyIncomingMessage(ref message, timeout);
+                }
+                catch (MessageSecurityException)
+                {
+                    TryGetSecurityFaultException(unverifiedMessage, out faultException);
+                    if (faultException == null)
+                    {
+                        throw;
+                    }
+                }
+                if (faultException != null)
+                {
+                    if (AcceptUnsecuredFaults)
+                    {
+                        Fault(faultException);
+                    }
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(faultException);
+                }
+                return message;
+            }
+
+
+            public bool TryReceive(TimeSpan timeout, out Message message)
+            {
+                if (DoneReceivingInCurrentState())
+                {
+                    message = null;
+                    return true;
+                }
+
+                TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
+                if (!this.InnerDuplexChannel.TryReceive(timeoutHelper.RemainingTime(), out message))
+                {
+                    return false;
+                }
+                message = ProcessMessage(message, timeoutHelper.RemainingTime());
+                return true;
+            }
+
+            public bool WaitForMessage(TimeSpan timeout)
+            {
+                return this.InnerDuplexChannel.WaitForMessage(timeout);
+            }
+
+            public IAsyncResult BeginWaitForMessage(TimeSpan timeout, AsyncCallback callback, object state)
+            {
+                return this.InnerDuplexChannel.BeginWaitForMessage(timeout, callback, state);
+            }
+
+            public bool EndWaitForMessage(IAsyncResult result)
+            {
+                return this.InnerDuplexChannel.EndWaitForMessage(result);
+            }
+        }
+
+        sealed class SecurityDuplexSessionChannel : SecurityDuplexChannel, IDuplexSessionChannel
+        {
+            public SecurityDuplexSessionChannel(ChannelManagerBase factory, SecurityProtocolFactory securityProtocolFactory, IDuplexSessionChannel innerChannel, EndpointAddress to, Uri via)
+                : base(factory, securityProtocolFactory, innerChannel, to, via)
+            {
+            }
+
+            public IDuplexSession Session
+            {
+                get
+                {
+                    return ((IDuplexSessionChannel)this.InnerChannel).Session;
+                }
+            }
+
+            internal override bool AcceptUnsecuredFaults
+            {
+                get { return true; }
+            }
+        }
+
+        sealed class RequestChannelSendAsyncResult : ApplySecurityAndSendAsyncResult<IRequestChannel>
+        {
+            Message reply;
+            SecurityRequestChannel securityChannel;
+
+            public RequestChannelSendAsyncResult(Message message, SecurityProtocol protocol, IRequestChannel channel, SecurityRequestChannel securityChannel, TimeSpan timeout,
+                AsyncCallback callback, object state)
+                : base(protocol, channel, timeout, callback, state)
+            {
+                this.securityChannel = securityChannel;
+                this.Begin(message, null);
+            }
+
+            protected override IAsyncResult BeginSendCore(IRequestChannel channel, Message message, TimeSpan timeout, AsyncCallback callback, object state)
+            {
+                return channel.BeginRequest(message, timeout, callback, state);
+            }
+
+            internal static Message End(IAsyncResult result)
+            {
+                RequestChannelSendAsyncResult self = result as RequestChannelSendAsyncResult;
+                OnEnd(self);
+                return self.reply;
+            }
+
+            protected override void EndSendCore(IRequestChannel channel, IAsyncResult result)
+            {
+                this.reply = channel.EndRequest(result);
+            }
+
+            protected override void OnSendCompleteCore(TimeSpan timeout)
+            {
+                this.reply = securityChannel.ProcessReply(reply, this.CorrelationState, timeout);
+            }
+        }
+
+        class ClientDuplexReceiveMessageAndVerifySecurityAsyncResult : ReceiveMessageAndVerifySecurityAsyncResultBase
+        {
+            SecurityDuplexChannel channel;
+
+            public ClientDuplexReceiveMessageAndVerifySecurityAsyncResult(SecurityDuplexChannel channel, IDuplexChannel innerChannel, TimeSpan timeout, AsyncCallback callback, object state)
+                : base(innerChannel, timeout, callback, state)
+            {
+                this.channel = channel;
+            }
+
+            protected override bool OnInnerReceiveDone(ref Message message, TimeSpan timeout)
+            {
+                message = this.channel.ProcessMessage(message, timeout);
+                return true;
+            }
+        }
+    }
+}
+

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/SecurityChannelFactory.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/SecurityChannelFactory.cs
@@ -8,12 +8,10 @@ using System.Runtime;
 using System.Runtime.InteropServices;
 using System.Security.Authentication.ExtendedProtection;
 using System.ServiceModel;
-//using System.ServiceModel.Diagnostics.Application;
+using System.ServiceModel.Diagnostics;
 using System.ServiceModel.Dispatcher;
 using System.ServiceModel.Security;
 using System.Threading.Tasks;
-using ServiceModelActivity = System.ServiceModel.Diagnostics.ServiceModelActivity;
-using TraceUtility = System.ServiceModel.Diagnostics.TraceUtility;
 
 namespace System.ServiceModel.Channels
 {

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/ServiceChannel.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/ServiceChannel.cs
@@ -1222,12 +1222,12 @@ namespace System.ServiceModel.Channels
             return (Message)Call(message.Headers.Action, false, operation, new object[] { message }, Array.Empty<object>(), timeout);
         }
 
-        public virtual Task<Message> RequestAsync(Message message)
+        public Task<Message> RequestAsync(Message message)
         {
             return RequestAsync(message, OperationTimeout);
         }
 
-        public virtual Task<Message> RequestAsync(Message message, TimeSpan timeout)
+        public Task<Message> RequestAsync(Message message, TimeSpan timeout)
         {
             throw ExceptionHelper.PlatformNotSupported();   // Issue #1494
         }

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/ServiceChannel.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/ServiceChannel.cs
@@ -18,7 +18,7 @@ using System.Threading.Tasks;
 namespace System.ServiceModel.Channels
 {
     // This class is sealed because the constructor could call Abort, which is virtual
-    internal sealed class ServiceChannel : CommunicationObject, IChannel, IClientChannel, IDuplexContextChannel, IOutputChannel, IRequestChannel, IServiceChannel
+    internal /*sealed*/ class ServiceChannel : CommunicationObject, IChannel, IClientChannel, IDuplexContextChannel, IOutputChannel, IAsyncRequestChannel, IServiceChannel
     {
         private int _activityCount = 0;
         private bool _allowInitializationUI = true;
@@ -1219,6 +1219,16 @@ namespace System.ServiceModel.Channels
         {
             ProxyOperationRuntime operation = UnhandledProxyOperation;
             return (Message)Call(message.Headers.Action, false, operation, new object[] { message }, Array.Empty<object>(), timeout);
+        }
+
+        public virtual Task<Message> RequestAsync(Message message)
+        {
+            return RequestAsync(message, OperationTimeout);
+        }
+
+        public virtual Task<Message> RequestAsync(Message message, TimeSpan timeout)
+        {
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #1494
         }
 
         public IAsyncResult BeginRequest(Message message, AsyncCallback callback, object state)

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/ServiceChannel.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/ServiceChannel.cs
@@ -17,8 +17,9 @@ using System.Threading.Tasks;
 
 namespace System.ServiceModel.Channels
 {
-    // This class is sealed because the constructor could call Abort, which is virtual
-    internal /*sealed*/ class ServiceChannel : CommunicationObject, IChannel, IClientChannel, IDuplexContextChannel, IOutputChannel, IAsyncRequestChannel, IServiceChannel
+    // This class should be sealed because the constructor could call Abort, which is virtual.
+    // But .NET Core is adding some new virtual methods.
+    internal class ServiceChannel : CommunicationObject, IChannel, IClientChannel, IDuplexContextChannel, IOutputChannel, IAsyncRequestChannel, IServiceChannel
     {
         private int _activityCount = 0;
         private bool _allowInitializationUI = true;

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/ServiceChannelFactory.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/ServiceChannelFactory.cs
@@ -412,7 +412,7 @@ namespace System.ServiceModel.Channels
                     channel = _channelsList[0];
                 }
 
-                IAsyncCommunicationObject asyncChannel = channel as IAsyncCommunicationObject;
+                var asyncChannel = channel as IAsyncCommunicationObject;
                 if (asyncChannel != null)
                 {
                     await asyncChannel.CloseAsync(timeoutHelper.RemainingTime());
@@ -454,14 +454,21 @@ namespace System.ServiceModel.Channels
                 _innerChannelFactory.Open(timeout);
             }
 
+            protected internal override Task OnOpenAsync(TimeSpan timeout)
+            {
+                return ((IAsyncCommunicationObject)_innerChannelFactory).OpenAsync(timeout);
+            }
+
             protected override IAsyncResult OnBeginOpen(TimeSpan timeout, AsyncCallback callback, object state)
             {
-                return _innerChannelFactory.BeginOpen(timeout, callback, state);
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+                //return _innerChannelFactory.BeginOpen(timeout, callback, state);
             }
 
             protected override void OnEndOpen(IAsyncResult result)
             {
-                _innerChannelFactory.EndOpen(result);
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+                //_innerChannelFactory.EndOpen(result);
             }
 
             protected override void OnClose(TimeSpan timeout)
@@ -471,26 +478,23 @@ namespace System.ServiceModel.Channels
                 _innerChannelFactory.Close(timeoutHelper.RemainingTime());
             }
 
+
             protected override IAsyncResult OnBeginClose(TimeSpan timeout, AsyncCallback callback, object state)
             {
-                return new ChainedAsyncResult(timeout, callback, state, base.OnBeginClose, base.OnEndClose,
-                    _innerChannelFactory.BeginClose, _innerChannelFactory.EndClose);
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+                //return new ChainedAsyncResult(timeout, callback, state, base.OnBeginClose, base.OnEndClose,
+                //    _innerChannelFactory.BeginClose, _innerChannelFactory.EndClose);
             }
 
             protected override void OnEndClose(IAsyncResult result)
             {
-                ChainedAsyncResult.End(result);
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+                //ChainedAsyncResult.End(result);
             }
 
             protected internal override Task OnCloseAsync(TimeSpan timeout)
             {
                 return OnCloseAsyncInternal(timeout);
-            }
-
-            protected internal override Task OnOpenAsync(TimeSpan timeout)
-            {
-                this.OnOpen(timeout);
-                return TaskHelpers.CompletedTask();
             }
 
             public override T GetProperty<T>()

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/TransportSecurityBindingElement.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/TransportSecurityBindingElement.cs
@@ -5,7 +5,9 @@
 
 
 using System.Net.Security;
+using System.ServiceModel.Description;
 using System.ServiceModel.Security;
+using System.ServiceModel.Security.Tokens;
 
 namespace System.ServiceModel.Channels
 {
@@ -49,10 +51,113 @@ namespace System.ServiceModel.Channels
             get { return true; }
         }
 
+        internal override SecurityProtocolFactory CreateSecurityProtocolFactory<TChannel>(BindingContext context, SecurityCredentialsManager credentialsManager, bool isForService, BindingContext issuerBindingContext)
+        {
+            if (context == null)
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("context");
+            if (credentialsManager == null)
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("credentialsManager");
+
+            TransportSecurityProtocolFactory protocolFactory = new TransportSecurityProtocolFactory();
+            if (isForService)
+                base.ApplyAuditBehaviorSettings(context, protocolFactory);
+            base.ConfigureProtocolFactory(protocolFactory, credentialsManager, isForService, issuerBindingContext, context.Binding);
+            protocolFactory.DetectReplays = false;
+
+            return protocolFactory;
+        }
 
         protected override IChannelFactory<TChannel> BuildChannelFactoryCore<TChannel>(BindingContext context)
         {
-            throw ExceptionHelper.PlatformNotSupported("TransportSecurityBindingElement.BuildChannelFactoryCore is not supported.");
+            ISecurityCapabilities securityCapabilities = this.GetProperty<ISecurityCapabilities>(context);
+            SecurityCredentialsManager credentialsManager = context.BindingParameters.Find<SecurityCredentialsManager>();
+            if (credentialsManager == null)
+            {
+                credentialsManager = ClientCredentials.CreateDefaultCredentials();
+            }
+
+            SecureConversationSecurityTokenParameters scParameters = null;
+            if (this.EndpointSupportingTokenParameters.Endorsing.Count > 0)
+            {
+                scParameters = this.EndpointSupportingTokenParameters.Endorsing[0] as SecureConversationSecurityTokenParameters;
+            }
+
+            // This adds the demuxer element to the context
+
+            bool requireDemuxer = RequiresChannelDemuxer();
+            ChannelBuilder channelBuilder = new ChannelBuilder(context, requireDemuxer);
+
+            if (requireDemuxer)
+            {
+                throw ExceptionHelper.PlatformNotSupported("TransportSecurityBindingElement demuxing is not supported"); // Issue #31 in progress
+                // ApplyPropertiesOnDemuxer(channelBuilder, context);
+            }
+            BindingContext issuerBindingContext = context.Clone();
+
+            SecurityChannelFactory<TChannel> channelFactory;
+            if (scParameters != null)
+            {
+                if (scParameters.BootstrapSecurityBindingElement == null)
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.SecureConversationSecurityTokenParametersRequireBootstrapBinding)));
+
+                scParameters.IssuerBindingContext = issuerBindingContext;
+                if (scParameters.RequireCancellation)
+                {
+                    throw ExceptionHelper.PlatformNotSupported("TransportSecurityBindingElement RequireCancellation is not supported"); // Issue #31 in progress
+
+                    //SessionSymmetricTransportSecurityProtocolFactory sessionFactory = new SessionSymmetricTransportSecurityProtocolFactory();
+                    //sessionFactory.SecurityTokenParameters = scParameters.Clone();
+                    //((SecureConversationSecurityTokenParameters)sessionFactory.SecurityTokenParameters).IssuerBindingContext = issuerBindingContext;
+                    //this.EndpointSupportingTokenParameters.Endorsing.RemoveAt(0);
+                    //try
+                    //{
+                    //    base.ConfigureProtocolFactory(sessionFactory, credentialsManager, false, issuerBindingContext, context.Binding);
+                    //}
+                    //finally
+                    //{
+                    //    this.EndpointSupportingTokenParameters.Endorsing.Insert(0, scParameters);
+                    //}
+
+                    //SecuritySessionClientSettings<TChannel> sessionClientSettings = new SecuritySessionClientSettings<TChannel>();
+                    //sessionClientSettings.ChannelBuilder = channelBuilder;
+                    //sessionClientSettings.KeyRenewalInterval = this.LocalClientSettings.SessionKeyRenewalInterval;
+                    //sessionClientSettings.KeyRolloverInterval = this.LocalClientSettings.SessionKeyRolloverInterval;
+                    //sessionClientSettings.TolerateTransportFailures = this.LocalClientSettings.ReconnectTransportOnFailure;
+                    //sessionClientSettings.CanRenewSession = scParameters.CanRenewSession;
+                    //sessionClientSettings.IssuedSecurityTokenParameters = scParameters.Clone();
+                    //((SecureConversationSecurityTokenParameters)sessionClientSettings.IssuedSecurityTokenParameters).IssuerBindingContext = issuerBindingContext;
+                    //sessionClientSettings.SecurityStandardsManager = sessionFactory.StandardsManager;
+                    //sessionClientSettings.SessionProtocolFactory = sessionFactory;
+                    //channelFactory = new SecurityChannelFactory<TChannel>(securityCapabilities, context, sessionClientSettings);
+                }
+                else
+                {
+                    TransportSecurityProtocolFactory protocolFactory = new TransportSecurityProtocolFactory();
+                    this.EndpointSupportingTokenParameters.Endorsing.RemoveAt(0);
+                    try
+                    {
+                        base.ConfigureProtocolFactory(protocolFactory, credentialsManager, false, issuerBindingContext, context.Binding);
+                        SecureConversationSecurityTokenParameters acceleratedTokenParameters = (SecureConversationSecurityTokenParameters)scParameters.Clone();
+                        acceleratedTokenParameters.IssuerBindingContext = issuerBindingContext;
+                        protocolFactory.SecurityBindingElement.EndpointSupportingTokenParameters.Endorsing.Insert(0, acceleratedTokenParameters);
+                    }
+                    finally
+                    {
+                        this.EndpointSupportingTokenParameters.Endorsing.Insert(0, scParameters);
+                    }
+
+                    channelFactory = new SecurityChannelFactory<TChannel>(securityCapabilities, context, channelBuilder, protocolFactory);
+                }
+            }
+            else
+            {
+                SecurityProtocolFactory protocolFactory = this.CreateSecurityProtocolFactory<TChannel>(
+                    context, credentialsManager, false, issuerBindingContext);
+                channelFactory = new SecurityChannelFactory<TChannel>(securityCapabilities, context, channelBuilder, protocolFactory);
+            }
+
+            return channelFactory;
+
         }
 
         public override T GetProperty<T>(BindingContext context)

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Description/ClientCredentials.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Description/ClientCredentials.cs
@@ -18,7 +18,6 @@ namespace System.ServiceModel.Description
         private WindowsClientCredential _windows;
         private HttpDigestClientCredential _httpDigest;
         private bool _isReadOnly;
-        private bool _useIdentityConfiguration = false;
 
         public ClientCredentials()
         {
@@ -38,7 +37,6 @@ namespace System.ServiceModel.Description
                 _windows = new WindowsClientCredential(other._windows);
             if (other._httpDigest != null)
                 _httpDigest = new HttpDigestClientCredential(other._httpDigest);
-            _useIdentityConfiguration = other._useIdentityConfiguration;
             _isReadOnly = other._isReadOnly;
         }
 
@@ -116,7 +114,7 @@ namespace System.ServiceModel.Description
         {
             get
             {
-                return _useIdentityConfiguration;
+                return false;
             }
             set
             {
@@ -124,7 +122,11 @@ namespace System.ServiceModel.Description
                 {
                     throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.ObjectIsReadOnly)));
                 }
-                _useIdentityConfiguration = value;
+                
+                if (value)
+                {
+                    throw ExceptionHelper.PlatformNotSupported();
+                }
             }
         }
 

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Description/ClientCredentials.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Description/ClientCredentials.cs
@@ -18,6 +18,7 @@ namespace System.ServiceModel.Description
         private WindowsClientCredential _windows;
         private HttpDigestClientCredential _httpDigest;
         private bool _isReadOnly;
+        private bool _useIdentityConfiguration = false;
 
         public ClientCredentials()
         {
@@ -37,7 +38,7 @@ namespace System.ServiceModel.Description
                 _windows = new WindowsClientCredential(other._windows);
             if (other._httpDigest != null)
                 _httpDigest = new HttpDigestClientCredential(other._httpDigest);
-
+            _useIdentityConfiguration = other._useIdentityConfiguration;
             _isReadOnly = other._isReadOnly;
         }
 
@@ -111,6 +112,21 @@ namespace System.ServiceModel.Description
             }
         }
 
+        public bool UseIdentityConfiguration
+        {
+            get
+            {
+                return _useIdentityConfiguration;
+            }
+            set
+            {
+                if (_isReadOnly)
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.ObjectIsReadOnly)));
+                }
+                _useIdentityConfiguration = value;
+            }
+        }
 
         internal static ClientCredentials CreateDefaultCredentials()
         {

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Diagnostics/SecurityTraceRecordHelper.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Diagnostics/SecurityTraceRecordHelper.cs
@@ -5,7 +5,10 @@
 
 using System.IdentityModel.Claims;
 using System.IdentityModel.Policy;
+using System.IdentityModel.Tokens;
 using System.Runtime.Diagnostics;
+using System.ServiceModel.Channels;
+using System.ServiceModel.Security;
 
 namespace System.ServiceModel.Diagnostics
 {
@@ -38,6 +41,30 @@ namespace System.ServiceModel.Diagnostics
         }
 
         internal static void TraceIdentityDeterminationFailure(EndpointAddress epr, Type identityVerifier)
+        {
+        }
+
+        internal static void TraceOutgoingMessageSecured(SecurityProtocol binding, Message message)
+        {
+        }
+
+        internal static void TraceVerifyIncomingMessageFailure(SecurityProtocol binding, Message message)
+        {
+        }
+
+        internal static void TraceSecureOutgoingMessageFailure(SecurityProtocol binding, Message message)
+        {
+        }
+
+        internal static void TraceIncomingMessageVerified(SecurityProtocol binding, Message message)
+        {
+        }
+
+        internal static void TraceCloseMessageSent(SecurityToken sessionToken, EndpointAddress remoteTarget)
+        {
+        }
+
+        internal static void TraceCloseResponseMessageSent(SecurityToken sessionToken, EndpointAddress remoteTarget)
         {
         }
     }

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/ClientCredentialsSecurityTokenManager.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/ClientCredentialsSecurityTokenManager.cs
@@ -176,8 +176,26 @@ namespace System.ServiceModel
 
         public override SecurityTokenSerializer CreateSecurityTokenSerializer(SecurityTokenVersion version)
         {
-            // not referenced anywhere in current code, but must implement abstract. 
-            throw ExceptionHelper.PlatformNotSupported("CreateSecurityTokenSerializer(SecurityTokenVersion version) not supported");
+            if (version == null)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("version");
+            }
+
+            if (_parent != null && _parent.UseIdentityConfiguration)
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+                // this.WrapTokenHandlersAsSecurityTokenSerializer(version);
+            }
+
+            MessageSecurityTokenVersion wsVersion = version as MessageSecurityTokenVersion;
+            if (wsVersion != null)
+            {
+                return new WSSecurityTokenSerializer(wsVersion.SecurityVersion, wsVersion.TrustVersion, wsVersion.SecureConversationVersion, wsVersion.EmitBspRequiredAttributes, null, null, null);
+            }
+            else
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new NotSupportedException(SR.Format(SR.SecurityTokenManagerCannotCreateSerializerForVersion, version)));
+            }
         }
 
         private X509SecurityTokenAuthenticator CreateServerX509TokenAuthenticator()
@@ -259,26 +277,33 @@ namespace System.ServiceModel
 
             return result;
         }
-    }
 
-    internal class KerberosSecurityTokenProviderWrapper : CommunicationObjectSecurityTokenProvider
-    {
-        private KerberosSecurityTokenProvider _innerProvider;
+        internal class KerberosSecurityTokenProviderWrapper : CommunicationObjectSecurityTokenProvider
+        {
+            private KerberosSecurityTokenProvider _innerProvider;
 
-        public KerberosSecurityTokenProviderWrapper(KerberosSecurityTokenProvider innerProvider)
-        {
-            _innerProvider = innerProvider;
-        }
+            public KerberosSecurityTokenProviderWrapper(KerberosSecurityTokenProvider innerProvider)
+            {
+                _innerProvider = innerProvider;
+            }
 
-        internal Task<SecurityToken> GetTokenAsync(CancellationToken cancellationToken, ChannelBinding channelbinding)
-        {
-            return Task.FromResult((SecurityToken)new KerberosRequestorSecurityToken(_innerProvider.ServicePrincipalName,
-                _innerProvider.TokenImpersonationLevel, _innerProvider.NetworkCredential,
-                SecurityUniqueId.Create().Value));
-        }
-        protected override Task<SecurityToken> GetTokenCoreAsync(CancellationToken cancellationToken)
-        {
-            return GetTokenAsync(cancellationToken, null);
+            internal Task<SecurityToken> GetTokenAsync(CancellationToken cancellationToken, ChannelBinding channelbinding)
+            {
+                return Task.FromResult((SecurityToken)new KerberosRequestorSecurityToken(_innerProvider.ServicePrincipalName,
+                    _innerProvider.TokenImpersonationLevel, _innerProvider.NetworkCredential,
+                    SecurityUniqueId.Create().Value));
+            }
+            protected override Task<SecurityToken> GetTokenCoreAsync(CancellationToken cancellationToken)
+            {
+                return GetTokenAsync(cancellationToken, null);
+            }
+
+            protected override SecurityToken GetTokenCore(TimeSpan timeout)
+            {
+                return new KerberosRequestorSecurityToken(_innerProvider.ServicePrincipalName,
+                    _innerProvider.TokenImpersonationLevel, _innerProvider.NetworkCredential,
+                    SecurityUniqueId.Create().Value);
+            }
         }
     }
 }

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/CryptoHelper.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/CryptoHelper.cs
@@ -2,19 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections;
-using System.Collections.Generic;
-using System.ServiceModel.Channels;
-using System.ServiceModel;
-using System.Reflection;
-using System.Threading;
-using System.IO;
 
-using System.Runtime.InteropServices;
 using System.IdentityModel.Tokens;
-using System.Text;
-using System.Xml;
-using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Security.Cryptography;
 

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/CryptoHelper.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/CryptoHelper.cs
@@ -1,32 +1,36 @@
-//------------------------------------------------------------
-// Copyright (c) Microsoft Corporation.  All rights reserved.
-//------------------------------------------------------------
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections;
+using System.Collections.Generic;
+using System.ServiceModel.Channels;
+using System.ServiceModel;
+using System.Reflection;
+using System.Threading;
+using System.IO;
+
+using System.Runtime.InteropServices;
+using System.IdentityModel.Tokens;
+using System.Text;
+using System.Xml;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Security.Cryptography;
+
+// Issue #31 in progress
+// using Psha1DerivedKeyGenerator = System.IdentityModel.Psha1DerivedKeyGenerator;
+using CryptoAlgorithms = System.IdentityModel.CryptoHelper;
+using System.Runtime;
 
 namespace System.ServiceModel.Security
 {
-    using System.Collections;
-    using System.Collections.Generic;
-    using System.ServiceModel.Channels;
-    using System.ServiceModel;
-    using System.Reflection;
-    using System.Threading;
-    using System.IO;
-
-    using System.Runtime.InteropServices;
-    using System.IdentityModel.Tokens;
-    using System.Text;
-    using System.Xml;
-    using System.Diagnostics;
-    using System.Diagnostics.CodeAnalysis;
-    using System.Security.Cryptography;
-
-    using Psha1DerivedKeyGenerator = System.IdentityModel.Psha1DerivedKeyGenerator;
-    using CryptoAlgorithms = System.IdentityModel.CryptoHelper;
-
     static class CryptoHelper
     {
-        static byte[] emptyBuffer;
-        static readonly RandomNumberGenerator random = new RNGCryptoServiceProvider();
+        private static byte[] s_emptyBuffer;
+
+        // Issue #31 in progress
+        // static readonly RandomNumberGenerator random = new RNGCryptoServiceProvider();
 
         enum CryptoAlgorithmType
         {
@@ -39,12 +43,12 @@ namespace System.ServiceModel.Security
         {
             get
             {
-                if (emptyBuffer == null)
+                if (s_emptyBuffer == null)
                 {
                     byte[] tmp = new byte[0];
-                    emptyBuffer = tmp;
+                    s_emptyBuffer = tmp;
                 }
-                return emptyBuffer;
+                return s_emptyBuffer;
             }
         }
 
@@ -61,169 +65,178 @@ namespace System.ServiceModel.Security
         [SuppressMessage("Microsoft.Security.Cryptography", "CA5354:DoNotUseSHA1", Justification = "Cannot change. Required as SOAP spec requires supporting SHA1.")]
         internal static HashAlgorithm CreateHashAlgorithm(string digestMethod)
         {
-            object algorithmObject = CryptoAlgorithms.GetAlgorithmFromConfig(digestMethod);
-            if (algorithmObject != null)
-            {
-                HashAlgorithm hashAlgorithm = algorithmObject as HashAlgorithm;
-                if (hashAlgorithm != null)
-                    return hashAlgorithm;
-                throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new MessageSecurityException(SR.GetString(SR.CustomCryptoAlgorithmIsNotValidHashAlgorithm, digestMethod)));
-            }
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
 
-            switch (digestMethod)
-            {
-                case SecurityAlgorithms.Sha1Digest:
-                    if (SecurityUtilsEx.RequiresFipsCompliance)
-                        return new SHA1CryptoServiceProvider();
-                    else
-                        return new SHA1Managed();
-                case SecurityAlgorithms.Sha256Digest:
-                    if (SecurityUtilsEx.RequiresFipsCompliance)
-                        return new SHA256CryptoServiceProvider();
-                    else
-                        return new SHA256Managed();
-                default:
-                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new MessageSecurityException(SR.GetString(SR.UnsupportedCryptoAlgorithm, digestMethod)));
+            //object algorithmObject = CryptoAlgorithms.GetAlgorithmFromConfig(digestMethod);
+            //if (algorithmObject != null)
+            //{
+            //    HashAlgorithm hashAlgorithm = algorithmObject as HashAlgorithm;
+            //    if (hashAlgorithm != null)
+            //        return hashAlgorithm;
+            //    throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new MessageSecurityException(SR.GetString(SR.CustomCryptoAlgorithmIsNotValidHashAlgorithm, digestMethod)));
+            //}
 
-            }
+            //switch (digestMethod)
+            //{
+            //    case SecurityAlgorithms.Sha1Digest:
+            //        if (SecurityUtilsEx.RequiresFipsCompliance)
+            //            return new SHA1CryptoServiceProvider();
+            //        else
+            //            return new SHA1Managed();
+            //    case SecurityAlgorithms.Sha256Digest:
+            //        if (SecurityUtilsEx.RequiresFipsCompliance)
+            //            return new SHA256CryptoServiceProvider();
+            //        else
+            //            return new SHA256Managed();
+            //    default:
+            //        throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new MessageSecurityException(SR.GetString(SR.UnsupportedCryptoAlgorithm, digestMethod)));
+
+            //}
         }
 
         [SuppressMessage("Microsoft.Security.Cryptography", "CA5354:DoNotUseSHA1", Justification = "Cannot change. Required as SOAP spec requires supporting SHA1.")]
         internal static HashAlgorithm CreateHashForAsymmetricSignature(string signatureMethod)
         {
-            object algorithmObject = CryptoAlgorithms.GetAlgorithmFromConfig(signatureMethod);
-            if (algorithmObject != null)
-            {
-                HashAlgorithm hashAlgorithm;
-                SignatureDescription signatureDescription = algorithmObject as SignatureDescription;
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
 
-                if (signatureDescription != null)
-                {
-                    hashAlgorithm = signatureDescription.CreateDigest();
-                    if (hashAlgorithm != null)
-                        return hashAlgorithm;
-                }
+            //object algorithmObject = CryptoAlgorithms.GetAlgorithmFromConfig(signatureMethod);
+            //if (algorithmObject != null)
+            //{
+            //    HashAlgorithm hashAlgorithm;
+            //    SignatureDescription signatureDescription = algorithmObject as SignatureDescription;
 
-                hashAlgorithm = algorithmObject as HashAlgorithm;
-                if (hashAlgorithm != null)
-                    return hashAlgorithm;
+            //    if (signatureDescription != null)
+            //    {
+            //        hashAlgorithm = signatureDescription.CreateDigest();
+            //        if (hashAlgorithm != null)
+            //            return hashAlgorithm;
+            //    }
 
-                throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new MessageSecurityException(SR.GetString(SR.CustomCryptoAlgorithmIsNotValidAsymmetricSignature, signatureMethod)));
-            }
+            //    hashAlgorithm = algorithmObject as HashAlgorithm;
+            //    if (hashAlgorithm != null)
+            //        return hashAlgorithm;
 
-            switch (signatureMethod)
-            {
-                case SecurityAlgorithms.RsaSha1Signature:
-                case SecurityAlgorithms.DsaSha1Signature:
-                    if (SecurityUtilsEx.RequiresFipsCompliance)
-                        return new SHA1CryptoServiceProvider();
-                    else
-                        return new SHA1Managed();
+            //    throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new MessageSecurityException(SR.GetString(SR.CustomCryptoAlgorithmIsNotValidAsymmetricSignature, signatureMethod)));
+            //}
 
-                case SecurityAlgorithms.RsaSha256Signature:
-                    if (SecurityUtilsEx.RequiresFipsCompliance)
-                        return new SHA256CryptoServiceProvider();
-                    else
-                        return new SHA256Managed();
+            //switch (signatureMethod)
+            //{
+            //    case SecurityAlgorithms.RsaSha1Signature:
+            //    case SecurityAlgorithms.DsaSha1Signature:
+            //        if (SecurityUtilsEx.RequiresFipsCompliance)
+            //            return new SHA1CryptoServiceProvider();
+            //        else
+            //            return new SHA1Managed();
 
-                default:
-                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new MessageSecurityException(SR.GetString(SR.UnsupportedCryptoAlgorithm, signatureMethod)));
-            }
+            //    case SecurityAlgorithms.RsaSha256Signature:
+            //        if (SecurityUtilsEx.RequiresFipsCompliance)
+            //            return new SHA256CryptoServiceProvider();
+            //        else
+            //            return new SHA256Managed();
+
+            //    default:
+            //        throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new MessageSecurityException(SR.GetString(SR.UnsupportedCryptoAlgorithm, signatureMethod)));
+            //}
         }
 
         internal static byte[] ExtractIVAndDecrypt(SymmetricAlgorithm algorithm, byte[] cipherText, int offset, int count)
         {
-            if (cipherText == null)
-            {
-                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("cipherText");
-            }
-            if (count < 0 || count > cipherText.Length)
-            {
-                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("count", SR.GetString(SR.ValueMustBeInRange, 0, cipherText.Length)));
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
 
-            }
-            if (offset < 0 || offset > cipherText.Length - count)
-            {
-                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("offset", SR.GetString(SR.ValueMustBeInRange, 0, cipherText.Length - count)));
-            }
+            //if (cipherText == null)
+            //{
+            //    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("cipherText");
+            //}
+            //if (count < 0 || count > cipherText.Length)
+            //{
+            //    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("count", SR.GetString(SR.ValueMustBeInRange, 0, cipherText.Length)));
 
-            int ivSize = algorithm.BlockSize / 8;
-            byte[] iv = new byte[ivSize];
-            Buffer.BlockCopy(cipherText, offset, iv, 0, iv.Length);
-            algorithm.Padding = PaddingMode.ISO10126;
-            algorithm.Mode = CipherMode.CBC;
-            try
-            {
-                using (ICryptoTransform decrTransform = algorithm.CreateDecryptor(algorithm.Key, iv))
-                {
-                    return decrTransform.TransformFinalBlock(cipherText, offset + iv.Length, count - iv.Length);
-                }
-            }
-            catch (CryptographicException ex)
-            {
-                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new MessageSecurityException(SR.GetString(SR.DecryptionFailed), ex));
-            }
+            //}
+            //if (offset < 0 || offset > cipherText.Length - count)
+            //{
+            //    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("offset", SR.GetString(SR.ValueMustBeInRange, 0, cipherText.Length - count)));
+            //}
+
+            //int ivSize = algorithm.BlockSize / 8;
+            //byte[] iv = new byte[ivSize];
+            //Buffer.BlockCopy(cipherText, offset, iv, 0, iv.Length);
+            //algorithm.Padding = PaddingMode.ISO10126;
+            //algorithm.Mode = CipherMode.CBC;
+            //try
+            //{
+            //    using (ICryptoTransform decrTransform = algorithm.CreateDecryptor(algorithm.Key, iv))
+            //    {
+            //        return decrTransform.TransformFinalBlock(cipherText, offset + iv.Length, count - iv.Length);
+            //    }
+            //}
+            //catch (CryptographicException ex)
+            //{
+            //    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new MessageSecurityException(SR.GetString(SR.DecryptionFailed), ex));
+            //}
         }
 
         internal static void FillRandomBytes(byte[] buffer)
         {
-            random.GetBytes(buffer);
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+            //random.GetBytes(buffer);
         }
 
         static CryptoAlgorithmType GetAlgorithmType(string algorithm)
         {
-            object algorithmObject = null;
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
 
-            try
-            {
-                algorithmObject = CryptoAlgorithms.GetAlgorithmFromConfig(algorithm);
-            }
-            catch (InvalidOperationException)
-            {
-                algorithmObject = null;
-                // We swallow the exception and continue.
-            }
-            if (algorithmObject != null)
-            {
-                SymmetricAlgorithm symmetricAlgorithm = algorithmObject as SymmetricAlgorithm;
-                KeyedHashAlgorithm keyedHashAlgorithm = algorithmObject as KeyedHashAlgorithm;
-                if (symmetricAlgorithm != null || keyedHashAlgorithm != null)
-                    return CryptoAlgorithmType.Symmetric;
+            //object algorithmObject = null;
 
-                // NOTE: A KeyedHashAlgorithm is symmetric in nature.
+            //try
+            //{
+            //    algorithmObject = CryptoAlgorithms.GetAlgorithmFromConfig(algorithm);
+            //}
+            //catch (InvalidOperationException)
+            //{
+            //    algorithmObject = null;
+            //    // We swallow the exception and continue.
+            //}
+            //if (algorithmObject != null)
+            //{
+            //    SymmetricAlgorithm symmetricAlgorithm = algorithmObject as SymmetricAlgorithm;
+            //    KeyedHashAlgorithm keyedHashAlgorithm = algorithmObject as KeyedHashAlgorithm;
+            //    if (symmetricAlgorithm != null || keyedHashAlgorithm != null)
+            //        return CryptoAlgorithmType.Symmetric;
 
-                AsymmetricAlgorithm asymmetricAlgorithm = algorithmObject as AsymmetricAlgorithm;
-                SignatureDescription signatureDescription = algorithmObject as SignatureDescription;
-                if (asymmetricAlgorithm != null || signatureDescription != null)
-                    return CryptoAlgorithmType.Asymmetric;
+            //    // NOTE: A KeyedHashAlgorithm is symmetric in nature.
 
-                return CryptoAlgorithmType.Unknown;
-            }
+            //    AsymmetricAlgorithm asymmetricAlgorithm = algorithmObject as AsymmetricAlgorithm;
+            //    SignatureDescription signatureDescription = algorithmObject as SignatureDescription;
+            //    if (asymmetricAlgorithm != null || signatureDescription != null)
+            //        return CryptoAlgorithmType.Asymmetric;
 
-            switch (algorithm)
-            {
-                case SecurityAlgorithms.DsaSha1Signature:
-                case SecurityAlgorithms.RsaSha1Signature:
-                case SecurityAlgorithms.RsaSha256Signature:
-                case SecurityAlgorithms.RsaOaepKeyWrap:
-                case SecurityAlgorithms.RsaV15KeyWrap:
-                    return CryptoAlgorithmType.Asymmetric;
-                case SecurityAlgorithms.HmacSha1Signature:
-                case SecurityAlgorithms.HmacSha256Signature:
-                case SecurityAlgorithms.Aes128Encryption:
-                case SecurityAlgorithms.Aes192Encryption:
-                case SecurityAlgorithms.Aes256Encryption:
-                case SecurityAlgorithms.TripleDesEncryption:
-                case SecurityAlgorithms.Aes128KeyWrap:
-                case SecurityAlgorithms.Aes192KeyWrap:
-                case SecurityAlgorithms.Aes256KeyWrap:
-                case SecurityAlgorithms.TripleDesKeyWrap:
-                case SecurityAlgorithms.Psha1KeyDerivation:
-                case SecurityAlgorithms.Psha1KeyDerivationDec2005:
-                    return CryptoAlgorithmType.Symmetric;
-                default:
-                    return CryptoAlgorithmType.Unknown;
-            }
+            //    return CryptoAlgorithmType.Unknown;
+            //}
+
+            //switch (algorithm)
+            //{
+            //    case SecurityAlgorithms.DsaSha1Signature:
+            //    case SecurityAlgorithms.RsaSha1Signature:
+            //    case SecurityAlgorithms.RsaSha256Signature:
+            //    case SecurityAlgorithms.RsaOaepKeyWrap:
+            //    case SecurityAlgorithms.RsaV15KeyWrap:
+            //        return CryptoAlgorithmType.Asymmetric;
+            //    case SecurityAlgorithms.HmacSha1Signature:
+            //    case SecurityAlgorithms.HmacSha256Signature:
+            //    case SecurityAlgorithms.Aes128Encryption:
+            //    case SecurityAlgorithms.Aes192Encryption:
+            //    case SecurityAlgorithms.Aes256Encryption:
+            //    case SecurityAlgorithms.TripleDesEncryption:
+            //    case SecurityAlgorithms.Aes128KeyWrap:
+            //    case SecurityAlgorithms.Aes192KeyWrap:
+            //    case SecurityAlgorithms.Aes256KeyWrap:
+            //    case SecurityAlgorithms.TripleDesKeyWrap:
+            //    case SecurityAlgorithms.Psha1KeyDerivation:
+            //    case SecurityAlgorithms.Psha1KeyDerivationDec2005:
+            //        return CryptoAlgorithmType.Symmetric;
+            //    default:
+            //        return CryptoAlgorithmType.Unknown;
+            //}
         }
 
         internal static byte[] GenerateIVAndEncrypt(SymmetricAlgorithm algorithm, byte[] plainText, int offset, int count)
@@ -231,7 +244,7 @@ namespace System.ServiceModel.Security
             byte[] iv;
             byte[] cipherText;
             GenerateIVAndEncrypt(algorithm, new ArraySegment<byte>(plainText, offset, count), out iv, out cipherText);
-            byte[] output = DiagnosticUtility.Utility.AllocateByteArray(checked(iv.Length + cipherText.Length));
+            byte[] output = Fx.AllocateByteArray(checked(iv.Length + cipherText.Length));
             Buffer.BlockCopy(iv, 0, output, 0, iv.Length);
             Buffer.BlockCopy(cipherText, 0, output, iv.Length, cipherText.Length);
             return output;
@@ -274,56 +287,58 @@ namespace System.ServiceModel.Security
 
         internal static bool IsSymmetricSupportedAlgorithm(string algorithm, int keySize)
         {
-            bool found = false;
-            object algorithmObject = null;
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
 
-            try
-            {
-                algorithmObject = CryptoAlgorithms.GetAlgorithmFromConfig(algorithm);
-            }
-            catch (InvalidOperationException)
-            {
-                algorithmObject = null;
-                // We swallow the exception and continue.
-            }
-            if (algorithmObject != null)
-            {
-                SymmetricAlgorithm symmetricAlgorithm = algorithmObject as SymmetricAlgorithm;
-                KeyedHashAlgorithm keyedHashAlgorithm = algorithmObject as KeyedHashAlgorithm;
-                if (symmetricAlgorithm != null || keyedHashAlgorithm != null)
-                    found = true;
-            }
+            //bool found = false;
+            //object algorithmObject = null;
 
-            switch (algorithm)
-            {
-                case SecurityAlgorithms.DsaSha1Signature:
-                case SecurityAlgorithms.RsaSha1Signature:
-                case SecurityAlgorithms.RsaSha256Signature:
-                case SecurityAlgorithms.RsaOaepKeyWrap:
-                case SecurityAlgorithms.RsaV15KeyWrap:
-                    return false;
-                case SecurityAlgorithms.HmacSha1Signature:
-                case SecurityAlgorithms.HmacSha256Signature:
-                case SecurityAlgorithms.Psha1KeyDerivation:
-                case SecurityAlgorithms.Psha1KeyDerivationDec2005:
-                    return true;
-                case SecurityAlgorithms.Aes128Encryption:
-                case SecurityAlgorithms.Aes128KeyWrap:
-                    return keySize == 128;
-                case SecurityAlgorithms.Aes192Encryption:
-                case SecurityAlgorithms.Aes192KeyWrap:
-                    return keySize == 192;
-                case SecurityAlgorithms.Aes256Encryption:
-                case SecurityAlgorithms.Aes256KeyWrap:
-                    return keySize == 256;
-                case SecurityAlgorithms.TripleDesEncryption:
-                case SecurityAlgorithms.TripleDesKeyWrap:
-                    return keySize == 128 || keySize == 192;
-                default:
-                    if (found)
-                        return true;
-                    return false;
-            }
+            //try
+            //{
+            //    algorithmObject = CryptoAlgorithms.GetAlgorithmFromConfig(algorithm);
+            //}
+            //catch (InvalidOperationException)
+            //{
+            //    algorithmObject = null;
+            //    // We swallow the exception and continue.
+            //}
+            //if (algorithmObject != null)
+            //{
+            //    SymmetricAlgorithm symmetricAlgorithm = algorithmObject as SymmetricAlgorithm;
+            //    KeyedHashAlgorithm keyedHashAlgorithm = algorithmObject as KeyedHashAlgorithm;
+            //    if (symmetricAlgorithm != null || keyedHashAlgorithm != null)
+            //        found = true;
+            //}
+
+            //switch (algorithm)
+            //{
+            //    case SecurityAlgorithms.DsaSha1Signature:
+            //    case SecurityAlgorithms.RsaSha1Signature:
+            //    case SecurityAlgorithms.RsaSha256Signature:
+            //    case SecurityAlgorithms.RsaOaepKeyWrap:
+            //    case SecurityAlgorithms.RsaV15KeyWrap:
+            //        return false;
+            //    case SecurityAlgorithms.HmacSha1Signature:
+            //    case SecurityAlgorithms.HmacSha256Signature:
+            //    case SecurityAlgorithms.Psha1KeyDerivation:
+            //    case SecurityAlgorithms.Psha1KeyDerivationDec2005:
+            //        return true;
+            //    case SecurityAlgorithms.Aes128Encryption:
+            //    case SecurityAlgorithms.Aes128KeyWrap:
+            //        return keySize == 128;
+            //    case SecurityAlgorithms.Aes192Encryption:
+            //    case SecurityAlgorithms.Aes192KeyWrap:
+            //        return keySize == 192;
+            //    case SecurityAlgorithms.Aes256Encryption:
+            //    case SecurityAlgorithms.Aes256KeyWrap:
+            //        return keySize == 256;
+            //    case SecurityAlgorithms.TripleDesEncryption:
+            //    case SecurityAlgorithms.TripleDesKeyWrap:
+            //        return keySize == 128 || keySize == 192;
+            //    default:
+            //        if (found)
+            //            return true;
+            //        return false;
+            //}
         }
 
         internal static void ValidateBufferBounds(Array buffer, int offset, int count)
@@ -334,11 +349,11 @@ namespace System.ServiceModel.Security
             }
             if (count < 0 || count > buffer.Length)
             {
-                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("count", SR.GetString(SR.ValueMustBeInRange, 0, buffer.Length)));
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("count", SR.Format(SR.ValueMustBeInRange, 0, buffer.Length)));
             }
             if (offset < 0 || offset > buffer.Length - count)
             {
-                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("offset", SR.GetString(SR.ValueMustBeInRange, 0, buffer.Length - count)));
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("offset", SR.Format(SR.ValueMustBeInRange, 0, buffer.Length - count)));
             }
         }
 
@@ -347,15 +362,14 @@ namespace System.ServiceModel.Security
             if (!algorithmSuite.IsSymmetricKeyLengthSupported(keyLength))
             {
                 throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new ArgumentOutOfRangeException("algorithmSuite",
-                   SR.GetString(SR.UnsupportedKeyLength, keyLength, algorithmSuite.ToString())));
+                   SR.Format(SR.UnsupportedKeyLength, keyLength, algorithmSuite.ToString())));
             }
             if (keyLength % 8 != 0)
             {
                 throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new ArgumentOutOfRangeException("algorithmSuite",
-                   SR.GetString(SR.KeyLengthMustBeMultipleOfEight, keyLength)));
+                   SR.Format(SR.KeyLengthMustBeMultipleOfEight, keyLength)));
             }
         }
-
     }
 }
 

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/CryptoHelper.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/CryptoHelper.cs
@@ -1,0 +1,361 @@
+//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace System.ServiceModel.Security
+{
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.ServiceModel.Channels;
+    using System.ServiceModel;
+    using System.Reflection;
+    using System.Threading;
+    using System.IO;
+
+    using System.Runtime.InteropServices;
+    using System.IdentityModel.Tokens;
+    using System.Text;
+    using System.Xml;
+    using System.Diagnostics;
+    using System.Diagnostics.CodeAnalysis;
+    using System.Security.Cryptography;
+
+    using Psha1DerivedKeyGenerator = System.IdentityModel.Psha1DerivedKeyGenerator;
+    using CryptoAlgorithms = System.IdentityModel.CryptoHelper;
+
+    static class CryptoHelper
+    {
+        static byte[] emptyBuffer;
+        static readonly RandomNumberGenerator random = new RNGCryptoServiceProvider();
+
+        enum CryptoAlgorithmType
+        {
+            Unknown,
+            Symmetric,
+            Asymmetric
+        }
+
+        internal static byte[] EmptyBuffer
+        {
+            get
+            {
+                if (emptyBuffer == null)
+                {
+                    byte[] tmp = new byte[0];
+                    emptyBuffer = tmp;
+                }
+                return emptyBuffer;
+            }
+        }
+
+        internal static HashAlgorithm NewSha1HashAlgorithm()
+        {
+            return CryptoHelper.CreateHashAlgorithm(SecurityAlgorithms.Sha1Digest);
+        }
+
+        internal static HashAlgorithm NewSha256HashAlgorithm()
+        {
+            return CryptoHelper.CreateHashAlgorithm(SecurityAlgorithms.Sha256Digest);
+        }
+
+        [SuppressMessage("Microsoft.Security.Cryptography", "CA5354:DoNotUseSHA1", Justification = "Cannot change. Required as SOAP spec requires supporting SHA1.")]
+        internal static HashAlgorithm CreateHashAlgorithm(string digestMethod)
+        {
+            object algorithmObject = CryptoAlgorithms.GetAlgorithmFromConfig(digestMethod);
+            if (algorithmObject != null)
+            {
+                HashAlgorithm hashAlgorithm = algorithmObject as HashAlgorithm;
+                if (hashAlgorithm != null)
+                    return hashAlgorithm;
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new MessageSecurityException(SR.GetString(SR.CustomCryptoAlgorithmIsNotValidHashAlgorithm, digestMethod)));
+            }
+
+            switch (digestMethod)
+            {
+                case SecurityAlgorithms.Sha1Digest:
+                    if (SecurityUtilsEx.RequiresFipsCompliance)
+                        return new SHA1CryptoServiceProvider();
+                    else
+                        return new SHA1Managed();
+                case SecurityAlgorithms.Sha256Digest:
+                    if (SecurityUtilsEx.RequiresFipsCompliance)
+                        return new SHA256CryptoServiceProvider();
+                    else
+                        return new SHA256Managed();
+                default:
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new MessageSecurityException(SR.GetString(SR.UnsupportedCryptoAlgorithm, digestMethod)));
+
+            }
+        }
+
+        [SuppressMessage("Microsoft.Security.Cryptography", "CA5354:DoNotUseSHA1", Justification = "Cannot change. Required as SOAP spec requires supporting SHA1.")]
+        internal static HashAlgorithm CreateHashForAsymmetricSignature(string signatureMethod)
+        {
+            object algorithmObject = CryptoAlgorithms.GetAlgorithmFromConfig(signatureMethod);
+            if (algorithmObject != null)
+            {
+                HashAlgorithm hashAlgorithm;
+                SignatureDescription signatureDescription = algorithmObject as SignatureDescription;
+
+                if (signatureDescription != null)
+                {
+                    hashAlgorithm = signatureDescription.CreateDigest();
+                    if (hashAlgorithm != null)
+                        return hashAlgorithm;
+                }
+
+                hashAlgorithm = algorithmObject as HashAlgorithm;
+                if (hashAlgorithm != null)
+                    return hashAlgorithm;
+
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new MessageSecurityException(SR.GetString(SR.CustomCryptoAlgorithmIsNotValidAsymmetricSignature, signatureMethod)));
+            }
+
+            switch (signatureMethod)
+            {
+                case SecurityAlgorithms.RsaSha1Signature:
+                case SecurityAlgorithms.DsaSha1Signature:
+                    if (SecurityUtilsEx.RequiresFipsCompliance)
+                        return new SHA1CryptoServiceProvider();
+                    else
+                        return new SHA1Managed();
+
+                case SecurityAlgorithms.RsaSha256Signature:
+                    if (SecurityUtilsEx.RequiresFipsCompliance)
+                        return new SHA256CryptoServiceProvider();
+                    else
+                        return new SHA256Managed();
+
+                default:
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new MessageSecurityException(SR.GetString(SR.UnsupportedCryptoAlgorithm, signatureMethod)));
+            }
+        }
+
+        internal static byte[] ExtractIVAndDecrypt(SymmetricAlgorithm algorithm, byte[] cipherText, int offset, int count)
+        {
+            if (cipherText == null)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("cipherText");
+            }
+            if (count < 0 || count > cipherText.Length)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("count", SR.GetString(SR.ValueMustBeInRange, 0, cipherText.Length)));
+
+            }
+            if (offset < 0 || offset > cipherText.Length - count)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("offset", SR.GetString(SR.ValueMustBeInRange, 0, cipherText.Length - count)));
+            }
+
+            int ivSize = algorithm.BlockSize / 8;
+            byte[] iv = new byte[ivSize];
+            Buffer.BlockCopy(cipherText, offset, iv, 0, iv.Length);
+            algorithm.Padding = PaddingMode.ISO10126;
+            algorithm.Mode = CipherMode.CBC;
+            try
+            {
+                using (ICryptoTransform decrTransform = algorithm.CreateDecryptor(algorithm.Key, iv))
+                {
+                    return decrTransform.TransformFinalBlock(cipherText, offset + iv.Length, count - iv.Length);
+                }
+            }
+            catch (CryptographicException ex)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new MessageSecurityException(SR.GetString(SR.DecryptionFailed), ex));
+            }
+        }
+
+        internal static void FillRandomBytes(byte[] buffer)
+        {
+            random.GetBytes(buffer);
+        }
+
+        static CryptoAlgorithmType GetAlgorithmType(string algorithm)
+        {
+            object algorithmObject = null;
+
+            try
+            {
+                algorithmObject = CryptoAlgorithms.GetAlgorithmFromConfig(algorithm);
+            }
+            catch (InvalidOperationException)
+            {
+                algorithmObject = null;
+                // We swallow the exception and continue.
+            }
+            if (algorithmObject != null)
+            {
+                SymmetricAlgorithm symmetricAlgorithm = algorithmObject as SymmetricAlgorithm;
+                KeyedHashAlgorithm keyedHashAlgorithm = algorithmObject as KeyedHashAlgorithm;
+                if (symmetricAlgorithm != null || keyedHashAlgorithm != null)
+                    return CryptoAlgorithmType.Symmetric;
+
+                // NOTE: A KeyedHashAlgorithm is symmetric in nature.
+
+                AsymmetricAlgorithm asymmetricAlgorithm = algorithmObject as AsymmetricAlgorithm;
+                SignatureDescription signatureDescription = algorithmObject as SignatureDescription;
+                if (asymmetricAlgorithm != null || signatureDescription != null)
+                    return CryptoAlgorithmType.Asymmetric;
+
+                return CryptoAlgorithmType.Unknown;
+            }
+
+            switch (algorithm)
+            {
+                case SecurityAlgorithms.DsaSha1Signature:
+                case SecurityAlgorithms.RsaSha1Signature:
+                case SecurityAlgorithms.RsaSha256Signature:
+                case SecurityAlgorithms.RsaOaepKeyWrap:
+                case SecurityAlgorithms.RsaV15KeyWrap:
+                    return CryptoAlgorithmType.Asymmetric;
+                case SecurityAlgorithms.HmacSha1Signature:
+                case SecurityAlgorithms.HmacSha256Signature:
+                case SecurityAlgorithms.Aes128Encryption:
+                case SecurityAlgorithms.Aes192Encryption:
+                case SecurityAlgorithms.Aes256Encryption:
+                case SecurityAlgorithms.TripleDesEncryption:
+                case SecurityAlgorithms.Aes128KeyWrap:
+                case SecurityAlgorithms.Aes192KeyWrap:
+                case SecurityAlgorithms.Aes256KeyWrap:
+                case SecurityAlgorithms.TripleDesKeyWrap:
+                case SecurityAlgorithms.Psha1KeyDerivation:
+                case SecurityAlgorithms.Psha1KeyDerivationDec2005:
+                    return CryptoAlgorithmType.Symmetric;
+                default:
+                    return CryptoAlgorithmType.Unknown;
+            }
+        }
+
+        internal static byte[] GenerateIVAndEncrypt(SymmetricAlgorithm algorithm, byte[] plainText, int offset, int count)
+        {
+            byte[] iv;
+            byte[] cipherText;
+            GenerateIVAndEncrypt(algorithm, new ArraySegment<byte>(plainText, offset, count), out iv, out cipherText);
+            byte[] output = DiagnosticUtility.Utility.AllocateByteArray(checked(iv.Length + cipherText.Length));
+            Buffer.BlockCopy(iv, 0, output, 0, iv.Length);
+            Buffer.BlockCopy(cipherText, 0, output, iv.Length, cipherText.Length);
+            return output;
+        }
+
+        internal static void GenerateIVAndEncrypt(SymmetricAlgorithm algorithm, ArraySegment<byte> plainText, out byte[] iv, out byte[] cipherText)
+        {
+            int ivSize = algorithm.BlockSize / 8;
+            iv = new byte[ivSize];
+            FillRandomBytes(iv);
+            algorithm.Padding = PaddingMode.PKCS7;
+            algorithm.Mode = CipherMode.CBC;
+            using (ICryptoTransform encrTransform = algorithm.CreateEncryptor(algorithm.Key, iv))
+            {
+                cipherText = encrTransform.TransformFinalBlock(plainText.Array, plainText.Offset, plainText.Count);
+            }
+        }
+
+        internal static bool IsEqual(byte[] a, byte[] b)
+        {
+            if (a == null || b == null || a.Length != b.Length)
+            {
+                return false;
+            }
+
+            for (int i = 0; i < a.Length; i++)
+            {
+                if (a[i] != b[i])
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        internal static bool IsSymmetricAlgorithm(string algorithm)
+        {
+            return GetAlgorithmType(algorithm) == CryptoAlgorithmType.Symmetric;
+        }
+
+        internal static bool IsSymmetricSupportedAlgorithm(string algorithm, int keySize)
+        {
+            bool found = false;
+            object algorithmObject = null;
+
+            try
+            {
+                algorithmObject = CryptoAlgorithms.GetAlgorithmFromConfig(algorithm);
+            }
+            catch (InvalidOperationException)
+            {
+                algorithmObject = null;
+                // We swallow the exception and continue.
+            }
+            if (algorithmObject != null)
+            {
+                SymmetricAlgorithm symmetricAlgorithm = algorithmObject as SymmetricAlgorithm;
+                KeyedHashAlgorithm keyedHashAlgorithm = algorithmObject as KeyedHashAlgorithm;
+                if (symmetricAlgorithm != null || keyedHashAlgorithm != null)
+                    found = true;
+            }
+
+            switch (algorithm)
+            {
+                case SecurityAlgorithms.DsaSha1Signature:
+                case SecurityAlgorithms.RsaSha1Signature:
+                case SecurityAlgorithms.RsaSha256Signature:
+                case SecurityAlgorithms.RsaOaepKeyWrap:
+                case SecurityAlgorithms.RsaV15KeyWrap:
+                    return false;
+                case SecurityAlgorithms.HmacSha1Signature:
+                case SecurityAlgorithms.HmacSha256Signature:
+                case SecurityAlgorithms.Psha1KeyDerivation:
+                case SecurityAlgorithms.Psha1KeyDerivationDec2005:
+                    return true;
+                case SecurityAlgorithms.Aes128Encryption:
+                case SecurityAlgorithms.Aes128KeyWrap:
+                    return keySize == 128;
+                case SecurityAlgorithms.Aes192Encryption:
+                case SecurityAlgorithms.Aes192KeyWrap:
+                    return keySize == 192;
+                case SecurityAlgorithms.Aes256Encryption:
+                case SecurityAlgorithms.Aes256KeyWrap:
+                    return keySize == 256;
+                case SecurityAlgorithms.TripleDesEncryption:
+                case SecurityAlgorithms.TripleDesKeyWrap:
+                    return keySize == 128 || keySize == 192;
+                default:
+                    if (found)
+                        return true;
+                    return false;
+            }
+        }
+
+        internal static void ValidateBufferBounds(Array buffer, int offset, int count)
+        {
+            if (buffer == null)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentNullException("buffer"));
+            }
+            if (count < 0 || count > buffer.Length)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("count", SR.GetString(SR.ValueMustBeInRange, 0, buffer.Length)));
+            }
+            if (offset < 0 || offset > buffer.Length - count)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("offset", SR.GetString(SR.ValueMustBeInRange, 0, buffer.Length - count)));
+            }
+        }
+
+        internal static void ValidateSymmetricKeyLength(int keyLength, SecurityAlgorithmSuite algorithmSuite)
+        {
+            if (!algorithmSuite.IsSymmetricKeyLengthSupported(keyLength))
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new ArgumentOutOfRangeException("algorithmSuite",
+                   SR.GetString(SR.UnsupportedKeyLength, keyLength, algorithmSuite.ToString())));
+            }
+            if (keyLength % 8 != 0)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new ArgumentOutOfRangeException("algorithmSuite",
+                   SR.GetString(SR.KeyLengthMustBeMultipleOfEight, keyLength)));
+            }
+        }
+
+    }
+}
+

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/DataProtectionSecurityStateEncoder.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/DataProtectionSecurityStateEncoder.cs
@@ -2,9 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Text;
-using System.Security.Cryptography;
 using System.Runtime;
+using System.Security.Cryptography;
+using System.Text;
 
 namespace System.ServiceModel.Security
 {

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/DataProtectionSecurityStateEncoder.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/DataProtectionSecurityStateEncoder.cs
@@ -1,0 +1,93 @@
+//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace System.ServiceModel.Security
+{
+    using System.Text;
+    using System.Security.Cryptography;
+
+    public class DataProtectionSecurityStateEncoder : SecurityStateEncoder
+    {
+        byte[] entropy;
+        bool useCurrentUserProtectionScope;
+
+        public DataProtectionSecurityStateEncoder()
+            : this(true)
+        {
+            // empty
+        }
+
+        public DataProtectionSecurityStateEncoder(bool useCurrentUserProtectionScope)
+            : this(useCurrentUserProtectionScope, null)
+        { }
+
+        public DataProtectionSecurityStateEncoder(bool useCurrentUserProtectionScope, byte[] entropy)
+        {
+            this.useCurrentUserProtectionScope = useCurrentUserProtectionScope;
+            if (entropy == null)
+            {
+                this.entropy = null;
+            }
+            else
+            {
+                this.entropy = DiagnosticUtility.Utility.AllocateByteArray(entropy.Length);
+                Buffer.BlockCopy(entropy, 0, this.entropy, 0, entropy.Length);
+            }
+        }
+
+        public bool UseCurrentUserProtectionScope
+        {
+            get
+            {
+                return this.useCurrentUserProtectionScope;
+            }
+        }
+
+        public byte[] GetEntropy()
+        {
+            byte[] result = null;
+            if (this.entropy != null)
+            {
+                result = DiagnosticUtility.Utility.AllocateByteArray(this.entropy.Length);
+                Buffer.BlockCopy(this.entropy, 0, result, 0, this.entropy.Length);
+            }
+            return result;
+        }
+
+        public override string ToString()
+        {
+            StringBuilder result = new StringBuilder();
+            result.Append(this.GetType().ToString());
+            result.AppendFormat("{0}  UseCurrentUserProtectionScope={1}", Environment.NewLine, this.useCurrentUserProtectionScope);
+            result.AppendFormat("{0}  Entropy Length={1}", Environment.NewLine, (this.entropy == null) ? 0 : this.entropy.Length);
+            return result.ToString();
+        }
+
+        protected internal override byte[] DecodeSecurityState( byte[] data )
+        {
+            try
+            {
+                return ProtectedData.Unprotect(data, this.entropy, (this.useCurrentUserProtectionScope) ? DataProtectionScope.CurrentUser : DataProtectionScope.LocalMachine);
+            }
+            catch (CryptographicException exception)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new CryptographicException(SR.GetString(SR.SecurityStateEncoderDecodingFailure), exception));
+            }
+
+        }
+
+        protected internal override byte[] EncodeSecurityState( byte[] data )
+        {
+            try
+            {
+                return ProtectedData.Protect(data, this.entropy, (this.useCurrentUserProtectionScope) ? DataProtectionScope.CurrentUser : DataProtectionScope.LocalMachine);
+            }
+            catch (CryptographicException exception)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new CryptographicException(SR.GetString(SR.SecurityStateEncoderEncodingFailure), exception));
+            }
+        }
+    }
+}
+

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/DataProtectionSecurityStateEncoder.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/DataProtectionSecurityStateEncoder.cs
@@ -1,16 +1,17 @@
-//------------------------------------------------------------
-// Copyright (c) Microsoft Corporation.  All rights reserved.
-//------------------------------------------------------------
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Text;
+using System.Security.Cryptography;
+using System.Runtime;
 
 namespace System.ServiceModel.Security
 {
-    using System.Text;
-    using System.Security.Cryptography;
-
     public class DataProtectionSecurityStateEncoder : SecurityStateEncoder
     {
-        byte[] entropy;
-        bool useCurrentUserProtectionScope;
+        private byte[] _entropy;
+        private bool _useCurrentUserProtectionScope;
 
         public DataProtectionSecurityStateEncoder()
             : this(true)
@@ -24,15 +25,15 @@ namespace System.ServiceModel.Security
 
         public DataProtectionSecurityStateEncoder(bool useCurrentUserProtectionScope, byte[] entropy)
         {
-            this.useCurrentUserProtectionScope = useCurrentUserProtectionScope;
+            _useCurrentUserProtectionScope = useCurrentUserProtectionScope;
             if (entropy == null)
             {
-                this.entropy = null;
+                _entropy = null;
             }
             else
             {
-                this.entropy = DiagnosticUtility.Utility.AllocateByteArray(entropy.Length);
-                Buffer.BlockCopy(entropy, 0, this.entropy, 0, entropy.Length);
+                _entropy = Fx.AllocateByteArray(entropy.Length);
+                Buffer.BlockCopy(entropy, 0, _entropy, 0, entropy.Length);
             }
         }
 
@@ -40,17 +41,17 @@ namespace System.ServiceModel.Security
         {
             get
             {
-                return this.useCurrentUserProtectionScope;
+                return _useCurrentUserProtectionScope;
             }
         }
 
         public byte[] GetEntropy()
         {
             byte[] result = null;
-            if (this.entropy != null)
+            if (_entropy != null)
             {
-                result = DiagnosticUtility.Utility.AllocateByteArray(this.entropy.Length);
-                Buffer.BlockCopy(this.entropy, 0, result, 0, this.entropy.Length);
+                result = Fx.AllocateByteArray(_entropy.Length);
+                Buffer.BlockCopy(_entropy, 0, result, 0, _entropy.Length);
             }
             return result;
         }
@@ -59,8 +60,8 @@ namespace System.ServiceModel.Security
         {
             StringBuilder result = new StringBuilder();
             result.Append(this.GetType().ToString());
-            result.AppendFormat("{0}  UseCurrentUserProtectionScope={1}", Environment.NewLine, this.useCurrentUserProtectionScope);
-            result.AppendFormat("{0}  Entropy Length={1}", Environment.NewLine, (this.entropy == null) ? 0 : this.entropy.Length);
+            result.AppendFormat("{0}  UseCurrentUserProtectionScope={1}", Environment.NewLine, _useCurrentUserProtectionScope);
+            result.AppendFormat("{0}  Entropy Length={1}", Environment.NewLine, (_entropy == null) ? 0 : _entropy.Length);
             return result.ToString();
         }
 
@@ -68,11 +69,12 @@ namespace System.ServiceModel.Security
         {
             try
             {
-                return ProtectedData.Unprotect(data, this.entropy, (this.useCurrentUserProtectionScope) ? DataProtectionScope.CurrentUser : DataProtectionScope.LocalMachine);
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+                //return ProtectedData.Unprotect(data, this.entropy, (this.useCurrentUserProtectionScope) ? DataProtectionScope.CurrentUser : DataProtectionScope.LocalMachine);
             }
             catch (CryptographicException exception)
             {
-                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new CryptographicException(SR.GetString(SR.SecurityStateEncoderDecodingFailure), exception));
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new CryptographicException(SR.Format(SR.SecurityStateEncoderDecodingFailure), exception));
             }
 
         }
@@ -81,11 +83,12 @@ namespace System.ServiceModel.Security
         {
             try
             {
-                return ProtectedData.Protect(data, this.entropy, (this.useCurrentUserProtectionScope) ? DataProtectionScope.CurrentUser : DataProtectionScope.LocalMachine);
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+                //return ProtectedData.Protect(data, this.entropy, (this.useCurrentUserProtectionScope) ? DataProtectionScope.CurrentUser : DataProtectionScope.LocalMachine);
             }
             catch (CryptographicException exception)
             {
-                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new CryptographicException(SR.GetString(SR.SecurityStateEncoderEncodingFailure), exception));
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new CryptographicException(SR.Format(SR.SecurityStateEncoderEncodingFailure), exception));
             }
         }
     }

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/DelegatingHeader.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/DelegatingHeader.cs
@@ -1,0 +1,83 @@
+//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace System.ServiceModel.Security
+{
+    using System.Xml;
+    using System.ServiceModel.Channels;
+    using System.ServiceModel;
+
+    abstract class DelegatingHeader : MessageHeader
+    {
+        MessageHeader innerHeader;
+
+        protected DelegatingHeader(MessageHeader innerHeader)
+        {
+            if (innerHeader == null)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("innerHeader");
+            }
+            this.innerHeader = innerHeader;
+        }
+
+        public override bool MustUnderstand
+        {
+            get
+            {
+                return this.innerHeader.MustUnderstand;
+            }
+        }
+
+        public override string Name
+        {
+            get
+            {
+                return this.innerHeader.Name;
+            }
+        }
+
+        public override string Namespace
+        {
+            get
+            {
+                return this.innerHeader.Namespace;
+            }
+        }
+
+        public override bool Relay
+        {
+            get
+            {
+                return this.innerHeader.Relay;
+            }
+        }
+
+        public override string Actor
+        {
+            get
+            {
+                return this.innerHeader.Actor;
+            }
+        }
+
+        protected MessageHeader InnerHeader
+        {
+            get
+            {
+                return this.innerHeader;
+            }
+        }
+
+        protected override void OnWriteStartHeader(XmlDictionaryWriter writer, MessageVersion messageVersion)
+        {
+            this.innerHeader.WriteStartHeader(writer, messageVersion);
+        }
+
+        protected override void OnWriteHeaderContents(XmlDictionaryWriter writer, MessageVersion messageVersion)
+        {
+            this.innerHeader.WriteHeaderContents(writer, messageVersion);
+        }
+    }
+}
+

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/DelegatingHeader.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/DelegatingHeader.cs
@@ -1,16 +1,16 @@
-//------------------------------------------------------------
-// Copyright (c) Microsoft Corporation.  All rights reserved.
-//------------------------------------------------------------
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Xml;
+using System.ServiceModel.Channels;
+using System.ServiceModel;
 
 namespace System.ServiceModel.Security
 {
-    using System.Xml;
-    using System.ServiceModel.Channels;
-    using System.ServiceModel;
-
     abstract class DelegatingHeader : MessageHeader
     {
-        MessageHeader innerHeader;
+        MessageHeader _innerHeader;
 
         protected DelegatingHeader(MessageHeader innerHeader)
         {
@@ -18,14 +18,14 @@ namespace System.ServiceModel.Security
             {
                 throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("innerHeader");
             }
-            this.innerHeader = innerHeader;
+            _innerHeader = innerHeader;
         }
 
         public override bool MustUnderstand
         {
             get
             {
-                return this.innerHeader.MustUnderstand;
+                return _innerHeader.MustUnderstand;
             }
         }
 
@@ -33,7 +33,7 @@ namespace System.ServiceModel.Security
         {
             get
             {
-                return this.innerHeader.Name;
+                return _innerHeader.Name;
             }
         }
 
@@ -41,7 +41,7 @@ namespace System.ServiceModel.Security
         {
             get
             {
-                return this.innerHeader.Namespace;
+                return _innerHeader.Namespace;
             }
         }
 
@@ -49,7 +49,7 @@ namespace System.ServiceModel.Security
         {
             get
             {
-                return this.innerHeader.Relay;
+                return _innerHeader.Relay;
             }
         }
 
@@ -57,7 +57,7 @@ namespace System.ServiceModel.Security
         {
             get
             {
-                return this.innerHeader.Actor;
+                return _innerHeader.Actor;
             }
         }
 
@@ -65,18 +65,18 @@ namespace System.ServiceModel.Security
         {
             get
             {
-                return this.innerHeader;
+                return _innerHeader;
             }
         }
 
         protected override void OnWriteStartHeader(XmlDictionaryWriter writer, MessageVersion messageVersion)
         {
-            this.innerHeader.WriteStartHeader(writer, messageVersion);
+            _innerHeader.WriteStartHeader(writer, messageVersion);
         }
 
         protected override void OnWriteHeaderContents(XmlDictionaryWriter writer, MessageVersion messageVersion)
         {
-            this.innerHeader.WriteHeaderContents(writer, messageVersion);
+            _innerHeader.WriteHeaderContents(writer, messageVersion);
         }
     }
 }

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/DelegatingHeader.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/DelegatingHeader.cs
@@ -2,9 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Xml;
-using System.ServiceModel.Channels;
 using System.ServiceModel;
+using System.ServiceModel.Channels;
+using System.Xml;
 
 namespace System.ServiceModel.Security
 {

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/EncryptedData.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/EncryptedData.cs
@@ -1,0 +1,104 @@
+//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace System.ServiceModel.Security
+{
+    using System.Security.Cryptography;
+    using System.ServiceModel.Channels;
+    using System.Xml;
+
+    class EncryptedData : EncryptedType
+    {
+        internal static readonly XmlDictionaryString ElementName = XD.XmlEncryptionDictionary.EncryptedData;
+        internal static readonly string ElementType = XmlEncryptionStrings.ElementType;
+        internal static readonly string ContentType = XmlEncryptionStrings.ContentType;
+        SymmetricAlgorithm algorithm;
+        byte[] decryptedBuffer;
+        ArraySegment<byte> buffer;
+        byte[] iv;
+        byte[] cipherText;
+
+        protected override XmlDictionaryString OpeningElementName
+        {
+            get { return ElementName; }
+        }
+
+        void EnsureDecryptionSet()
+        {
+            if (this.State == EncryptionState.DecryptionSetup)
+            {
+                SetPlainText();
+            }
+            else if (this.State != EncryptionState.Decrypted)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new MessageSecurityException(SR.GetString(SR.BadEncryptionState)));
+            }
+        }
+
+        protected override void ForceEncryption()
+        {
+            CryptoHelper.GenerateIVAndEncrypt(this.algorithm, this.buffer, out this.iv, out this.cipherText);
+            this.State = EncryptionState.Encrypted;
+            this.buffer = new ArraySegment<byte>(CryptoHelper.EmptyBuffer);
+        }
+
+        public byte[] GetDecryptedBuffer()
+        {
+            EnsureDecryptionSet();
+            return this.decryptedBuffer;
+        }
+
+        protected override void ReadCipherData(XmlDictionaryReader reader)
+        {
+            this.cipherText = reader.ReadContentAsBase64();
+        }
+
+        protected override void ReadCipherData(XmlDictionaryReader reader, long maxBufferSize)
+        {
+            this.cipherText = SecurityUtils.ReadContentAsBase64(reader, maxBufferSize);
+        }
+
+        void SetPlainText()
+        {
+            this.decryptedBuffer = CryptoHelper.ExtractIVAndDecrypt(this.algorithm, this.cipherText, 0, this.cipherText.Length);
+            this.State = EncryptionState.Decrypted;
+        }
+
+        public void SetUpDecryption(SymmetricAlgorithm algorithm)
+        {
+            if (this.State != EncryptionState.Read)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new MessageSecurityException(SR.GetString(SR.BadEncryptionState)));
+            }
+            if (algorithm == null)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("algorithm");
+            }
+            this.algorithm = algorithm;
+            this.State = EncryptionState.DecryptionSetup;
+        }
+
+        public void SetUpEncryption(SymmetricAlgorithm algorithm, ArraySegment<byte> buffer)
+        {
+            if (this.State != EncryptionState.New)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new MessageSecurityException(SR.GetString(SR.BadEncryptionState)));
+            }
+            if (algorithm == null)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("algorithm");
+            }
+            this.algorithm = algorithm;
+            this.buffer = buffer;
+            this.State = EncryptionState.EncryptionSetup;
+        }
+
+        protected override void WriteCipherData(XmlDictionaryWriter writer)
+        {
+            writer.WriteBase64(this.iv, 0, this.iv.Length);
+            writer.WriteBase64(this.cipherText, 0, this.cipherText.Length);
+        }
+    }
+}
+

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/EncryptedData.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/EncryptedData.cs
@@ -1,27 +1,28 @@
-//------------------------------------------------------------
-// Copyright (c) Microsoft Corporation.  All rights reserved.
-//------------------------------------------------------------
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.IdentityModel;
+using System.Security.Cryptography;
+using System.ServiceModel.Channels;
+using System.Xml;
 
 namespace System.ServiceModel.Security
 {
-    using System.Security.Cryptography;
-    using System.ServiceModel.Channels;
-    using System.Xml;
-
     class EncryptedData : EncryptedType
     {
-        internal static readonly XmlDictionaryString ElementName = XD.XmlEncryptionDictionary.EncryptedData;
-        internal static readonly string ElementType = XmlEncryptionStrings.ElementType;
-        internal static readonly string ContentType = XmlEncryptionStrings.ContentType;
-        SymmetricAlgorithm algorithm;
-        byte[] decryptedBuffer;
-        ArraySegment<byte> buffer;
-        byte[] iv;
-        byte[] cipherText;
+        internal static readonly XmlDictionaryString s_ElementName = System.IdentityModel.XD.XmlEncryptionDictionary.EncryptedData;
+        internal static readonly string s_ElementType = XmlEncryptionStrings.ElementType;
+        internal static readonly string s_ContentType = XmlEncryptionStrings.ContentType;
+        private SymmetricAlgorithm _algorithm;
+        private byte[] _decryptedBuffer;
+        private ArraySegment<byte> _buffer;
+        private byte[] _iv;
+        private byte[] _cipherText;
 
         protected override XmlDictionaryString OpeningElementName
         {
-            get { return ElementName; }
+            get { return s_ElementName; }
         }
 
         void EnsureDecryptionSet()
@@ -32,50 +33,52 @@ namespace System.ServiceModel.Security
             }
             else if (this.State != EncryptionState.Decrypted)
             {
-                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new MessageSecurityException(SR.GetString(SR.BadEncryptionState)));
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new MessageSecurityException(SR.Format(SR.BadEncryptionState)));
             }
         }
 
         protected override void ForceEncryption()
         {
-            CryptoHelper.GenerateIVAndEncrypt(this.algorithm, this.buffer, out this.iv, out this.cipherText);
-            this.State = EncryptionState.Encrypted;
-            this.buffer = new ArraySegment<byte>(CryptoHelper.EmptyBuffer);
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+            //CryptoHelper.GenerateIVAndEncrypt(this.algorithm, this.buffer, out this.iv, out this.cipherText);
+            //this.State = EncryptionState.Encrypted;
+            //this.buffer = new ArraySegment<byte>(CryptoHelper.EmptyBuffer);
         }
 
         public byte[] GetDecryptedBuffer()
         {
             EnsureDecryptionSet();
-            return this.decryptedBuffer;
+            return _decryptedBuffer;
         }
 
         protected override void ReadCipherData(XmlDictionaryReader reader)
         {
-            this.cipherText = reader.ReadContentAsBase64();
+            _cipherText = reader.ReadContentAsBase64();
         }
 
         protected override void ReadCipherData(XmlDictionaryReader reader, long maxBufferSize)
         {
-            this.cipherText = SecurityUtils.ReadContentAsBase64(reader, maxBufferSize);
+            _cipherText = SecurityUtils.ReadContentAsBase64(reader, maxBufferSize);
         }
 
         void SetPlainText()
         {
-            this.decryptedBuffer = CryptoHelper.ExtractIVAndDecrypt(this.algorithm, this.cipherText, 0, this.cipherText.Length);
-            this.State = EncryptionState.Decrypted;
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+            //this.decryptedBuffer = CryptoHelper.ExtractIVAndDecrypt(this.algorithm, this.cipherText, 0, this.cipherText.Length);
+            //this.State = EncryptionState.Decrypted;
         }
 
         public void SetUpDecryption(SymmetricAlgorithm algorithm)
         {
             if (this.State != EncryptionState.Read)
             {
-                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new MessageSecurityException(SR.GetString(SR.BadEncryptionState)));
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new MessageSecurityException(SR.Format(SR.BadEncryptionState)));
             }
             if (algorithm == null)
             {
                 throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("algorithm");
             }
-            this.algorithm = algorithm;
+            _algorithm = algorithm;
             this.State = EncryptionState.DecryptionSetup;
         }
 
@@ -83,21 +86,21 @@ namespace System.ServiceModel.Security
         {
             if (this.State != EncryptionState.New)
             {
-                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new MessageSecurityException(SR.GetString(SR.BadEncryptionState)));
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new MessageSecurityException(SR.Format(SR.BadEncryptionState)));
             }
             if (algorithm == null)
             {
                 throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("algorithm");
             }
-            this.algorithm = algorithm;
-            this.buffer = buffer;
+            _algorithm = algorithm;
+            _buffer = buffer;
             this.State = EncryptionState.EncryptionSetup;
         }
 
         protected override void WriteCipherData(XmlDictionaryWriter writer)
         {
-            writer.WriteBase64(this.iv, 0, this.iv.Length);
-            writer.WriteBase64(this.cipherText, 0, this.cipherText.Length);
+            writer.WriteBase64(_iv, 0, _iv.Length);
+            writer.WriteBase64(_cipherText, 0, _cipherText.Length);
         }
     }
 }

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/EncryptedData.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/EncryptedData.cs
@@ -3,8 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using System.IdentityModel;
-using System.Security.Cryptography;
 using System.ServiceModel.Channels;
+using System.Security.Cryptography;
 using System.Xml;
 
 namespace System.ServiceModel.Security

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/EncryptedHeader.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/EncryptedHeader.cs
@@ -1,0 +1,103 @@
+//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace System.ServiceModel.Security
+{
+    using System.Diagnostics;
+    using System.ServiceModel.Channels;
+    using System.ServiceModel;
+    using System.Globalization;    
+    using System.Xml;
+    using System.IO;
+
+    using ISecurityElement = System.IdentityModel.ISecurityElement;
+
+    sealed class EncryptedHeader : DelegatingHeader
+    {
+        EncryptedHeaderXml headerXml;
+        string name;
+        string namespaceUri;
+        MessageVersion version;
+
+        public EncryptedHeader(MessageHeader plainTextHeader, EncryptedHeaderXml headerXml, string name, string namespaceUri, MessageVersion version)
+            : base(plainTextHeader)
+        {
+            if (!headerXml.HasId || headerXml.Id == null)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new MessageSecurityException(SR.GetString(SR.EncryptedHeaderXmlMustHaveId)));
+            }
+            this.headerXml = headerXml;
+            this.name = name;
+            this.namespaceUri = namespaceUri;
+            this.version = version;
+        }
+
+        public string Id
+        {
+            get { return this.headerXml.Id; }
+        }
+
+        public override string Name
+        {
+            get { return this.name; }
+        }
+
+        public override string Namespace
+        {
+            get { return this.namespaceUri; }
+        }
+
+        public override string Actor
+        {
+            get
+            {
+                return this.headerXml.Actor;
+            }
+        }
+
+        public override bool MustUnderstand
+        {
+            get
+            {
+                return this.headerXml.MustUnderstand;
+            }
+        }
+
+        public override bool Relay
+        {
+            get
+            {
+                return this.headerXml.Relay;
+            }
+        }
+
+        internal MessageHeader OriginalHeader
+        {
+            get { return this.InnerHeader; }
+        }
+
+        public override bool IsMessageVersionSupported(MessageVersion messageVersion)
+        {
+            return this.version.Equals( messageVersion );
+        }
+
+        protected override void OnWriteStartHeader(XmlDictionaryWriter writer, MessageVersion messageVersion)
+        {
+            if (!IsMessageVersionSupported(messageVersion))
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentException(SR.GetString(SR.MessageHeaderVersionNotSupported, String.Format(CultureInfo.InvariantCulture, "{0}:{1}", this.Namespace, this.Name), version.ToString()), "version"));
+            }
+
+            this.headerXml.WriteHeaderElement(writer);
+            WriteHeaderAttributes(writer, messageVersion);
+            this.headerXml.WriteHeaderId(writer);
+        }
+
+        protected override void OnWriteHeaderContents(XmlDictionaryWriter writer, MessageVersion messageVersion)
+        {
+            this.headerXml.WriteHeaderContents(writer);
+        }
+    }
+}
+

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/EncryptedHeader.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/EncryptedHeader.cs
@@ -3,12 +3,10 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Diagnostics;
-using System.ServiceModel.Channels;
-using System.ServiceModel;
 using System.Globalization;
+using System.ServiceModel;
+using System.ServiceModel.Channels;
 using System.Xml;
-using System.IO;
-
 using ISecurityElement = System.IdentityModel.ISecurityElement;
 
 namespace System.ServiceModel.Security

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/EncryptedHeader.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/EncryptedHeader.cs
@@ -1,58 +1,58 @@
-//------------------------------------------------------------
-// Copyright (c) Microsoft Corporation.  All rights reserved.
-//------------------------------------------------------------
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+using System.ServiceModel.Channels;
+using System.ServiceModel;
+using System.Globalization;
+using System.Xml;
+using System.IO;
+
+using ISecurityElement = System.IdentityModel.ISecurityElement;
 
 namespace System.ServiceModel.Security
 {
-    using System.Diagnostics;
-    using System.ServiceModel.Channels;
-    using System.ServiceModel;
-    using System.Globalization;    
-    using System.Xml;
-    using System.IO;
-
-    using ISecurityElement = System.IdentityModel.ISecurityElement;
-
     sealed class EncryptedHeader : DelegatingHeader
     {
-        EncryptedHeaderXml headerXml;
-        string name;
-        string namespaceUri;
-        MessageVersion version;
+        private EncryptedHeaderXml _headerXml;
+        private string _name;
+        private string _namespaceUri;
+        private MessageVersion _version;
 
         public EncryptedHeader(MessageHeader plainTextHeader, EncryptedHeaderXml headerXml, string name, string namespaceUri, MessageVersion version)
             : base(plainTextHeader)
         {
             if (!headerXml.HasId || headerXml.Id == null)
             {
-                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new MessageSecurityException(SR.GetString(SR.EncryptedHeaderXmlMustHaveId)));
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new MessageSecurityException(SR.Format(SR.EncryptedHeaderXmlMustHaveId)));
             }
-            this.headerXml = headerXml;
-            this.name = name;
-            this.namespaceUri = namespaceUri;
-            this.version = version;
+            _headerXml = headerXml;
+            _name = name;
+            _namespaceUri = namespaceUri;
+            _version = version;
         }
 
         public string Id
         {
-            get { return this.headerXml.Id; }
+            get { return _headerXml.Id; }
         }
 
         public override string Name
         {
-            get { return this.name; }
+            get { return _name; }
         }
 
         public override string Namespace
         {
-            get { return this.namespaceUri; }
+            get { return _namespaceUri; }
         }
 
         public override string Actor
         {
             get
             {
-                return this.headerXml.Actor;
+                return _headerXml.Actor;
             }
         }
 
@@ -60,7 +60,7 @@ namespace System.ServiceModel.Security
         {
             get
             {
-                return this.headerXml.MustUnderstand;
+                return _headerXml.MustUnderstand;
             }
         }
 
@@ -68,7 +68,7 @@ namespace System.ServiceModel.Security
         {
             get
             {
-                return this.headerXml.Relay;
+                return _headerXml.Relay;
             }
         }
 
@@ -79,24 +79,24 @@ namespace System.ServiceModel.Security
 
         public override bool IsMessageVersionSupported(MessageVersion messageVersion)
         {
-            return this.version.Equals( messageVersion );
+            return _version.Equals( messageVersion );
         }
 
         protected override void OnWriteStartHeader(XmlDictionaryWriter writer, MessageVersion messageVersion)
         {
             if (!IsMessageVersionSupported(messageVersion))
             {
-                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentException(SR.GetString(SR.MessageHeaderVersionNotSupported, String.Format(CultureInfo.InvariantCulture, "{0}:{1}", this.Namespace, this.Name), version.ToString()), "version"));
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentException(SR.Format(SR.MessageHeaderVersionNotSupported, String.Format(CultureInfo.InvariantCulture, "{0}:{1}", this.Namespace, this.Name), _version.ToString()), "version"));
             }
 
-            this.headerXml.WriteHeaderElement(writer);
+            _headerXml.WriteHeaderElement(writer);
             WriteHeaderAttributes(writer, messageVersion);
-            this.headerXml.WriteHeaderId(writer);
+            _headerXml.WriteHeaderId(writer);
         }
 
         protected override void OnWriteHeaderContents(XmlDictionaryWriter writer, MessageVersion messageVersion)
         {
-            this.headerXml.WriteHeaderContents(writer);
+            _headerXml.WriteHeaderContents(writer);
         }
     }
 }

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/EncryptedHeaderXml.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/EncryptedHeaderXml.cs
@@ -1,51 +1,51 @@
-//------------------------------------------------------------
-// Copyright (c) Microsoft Corporation.  All rights reserved.
-//------------------------------------------------------------
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.IO;
+using System.ServiceModel.Channels;
+using System.ServiceModel;
+using System.IdentityModel.Tokens;
+using System.IdentityModel.Selectors;
+using System.Security.Cryptography;
+using System.Xml;
+
+using DictionaryManager = System.IdentityModel.DictionaryManager;
+using ISecurityElement = System.IdentityModel.ISecurityElement;
 
 namespace System.ServiceModel.Security
 {
-    using System.IO;
-    using System.ServiceModel.Channels;
-    using System.ServiceModel;
-    using System.IdentityModel.Tokens;
-    using System.IdentityModel.Selectors;
-    using System.Security.Cryptography;
-    using System.Xml;
-
-    using DictionaryManager = System.IdentityModel.DictionaryManager;
-    using ISecurityElement = System.IdentityModel.ISecurityElement;
-
     sealed class EncryptedHeaderXml
     {
-        internal static readonly XmlDictionaryString ElementName = XD.SecurityXXX2005Dictionary.EncryptedHeader;
-        internal static readonly XmlDictionaryString NamespaceUri = XD.SecurityXXX2005Dictionary.Namespace;
+        internal static readonly XmlDictionaryString s_ElementName = XD.SecurityXXX2005Dictionary.EncryptedHeader;
+        internal static readonly XmlDictionaryString s_NamespaceUri = XD.SecurityXXX2005Dictionary.Namespace;
         const string Prefix = SecurityXXX2005Strings.Prefix;
 
-        string id;
-        bool mustUnderstand;
-        bool relay;
-        string actor;
-        MessageVersion version;
-        EncryptedData encryptedData;
+        private string _id;
+        private bool _mustUnderstand;
+        private bool _relay;
+        private string _actor;
+        private MessageVersion _version;
+        private EncryptedData _encryptedData;
 
         public EncryptedHeaderXml(MessageVersion version, bool shouldReadXmlReferenceKeyInfoClause)
         {
-            this.version = version;
-            encryptedData = new EncryptedData();
+            _version = version;
+            _encryptedData = new EncryptedData();
             
             // This is for the case when the service send an EncryptedHeader to the client where the KeyInfo clause contains referenceXml clause.
-            encryptedData.ShouldReadXmlReferenceKeyInfoClause = shouldReadXmlReferenceKeyInfoClause;
+            _encryptedData.ShouldReadXmlReferenceKeyInfoClause = shouldReadXmlReferenceKeyInfoClause;
         }
 
         public string Actor
         {
             get
             {
-                return this.actor;
+                return _actor;
             }
             set
             {
-                this.actor = value;
+                _actor = value;
             }
         }
 
@@ -53,11 +53,11 @@ namespace System.ServiceModel.Security
         {
             get
             {
-                return encryptedData.EncryptionMethod;
+                return _encryptedData.EncryptionMethod;
             }
             set
             {
-                encryptedData.EncryptionMethod = value;
+                _encryptedData.EncryptionMethod = value;
             }
         }
 
@@ -65,11 +65,11 @@ namespace System.ServiceModel.Security
         {
             get
             {
-                return encryptedData.EncryptionMethodDictionaryString;
+                return _encryptedData.EncryptionMethodDictionaryString;
             }
             set
             {
-                encryptedData.EncryptionMethodDictionaryString = value;
+                _encryptedData.EncryptionMethodDictionaryString = value;
             }
         }
 
@@ -85,11 +85,11 @@ namespace System.ServiceModel.Security
         {
             get
             {
-                return id;
+                return _id;
             }
             set
             {
-                id = value;
+                _id = value;
             }
         }
 
@@ -97,11 +97,11 @@ namespace System.ServiceModel.Security
         {
             get
             {
-                return encryptedData.KeyIdentifier;
+                return _encryptedData.KeyIdentifier;
             }
             set
             {
-                encryptedData.KeyIdentifier = value;
+                _encryptedData.KeyIdentifier = value;
             }
         }
 
@@ -109,11 +109,11 @@ namespace System.ServiceModel.Security
         {
             get
             {
-                return this.mustUnderstand;
+                return _mustUnderstand;
             }
             set
             {
-                this.mustUnderstand = value;
+                _mustUnderstand = value;
             }
         }
 
@@ -121,11 +121,11 @@ namespace System.ServiceModel.Security
         {
             get
             {
-                return this.relay;
+                return _relay;
             }
             set
             {
-                this.relay = value;
+                _relay = value;
             }
         }
 
@@ -133,54 +133,56 @@ namespace System.ServiceModel.Security
         {
             get
             {
-                return encryptedData.SecurityTokenSerializer;
+                return _encryptedData.SecurityTokenSerializer;
             }
             set
             {
-                encryptedData.SecurityTokenSerializer = value;
+                _encryptedData.SecurityTokenSerializer = value;
             }
         }
 
         public byte[] GetDecryptedBuffer()
         {
-            return encryptedData.GetDecryptedBuffer();
+            return _encryptedData.GetDecryptedBuffer();
         }
 
         public void ReadFrom(XmlDictionaryReader reader, long maxBufferSize)
         {
-            reader.MoveToStartElement(ElementName, NamespaceUri);
+            reader.MoveToStartElement(s_ElementName, s_NamespaceUri);
             bool isReferenceParameter;
-            MessageHeader.GetHeaderAttributes(reader, version, out this.actor, out this.mustUnderstand, out this.relay, out isReferenceParameter);
-            this.id = reader.GetAttribute(XD.UtilityDictionary.IdAttribute, XD.UtilityDictionary.Namespace);
+            MessageHeader.GetHeaderAttributes(reader, _version, out _actor, out _mustUnderstand, out _relay, out isReferenceParameter);
+            _id = reader.GetAttribute(XD.UtilityDictionary.IdAttribute, XD.UtilityDictionary.Namespace);
 
             reader.ReadStartElement();
-            encryptedData.ReadFrom(reader, maxBufferSize);
+            _encryptedData.ReadFrom(reader, maxBufferSize);
             reader.ReadEndElement();
         }
 
         public void SetUpDecryption(SymmetricAlgorithm algorithm)
         {
-            encryptedData.SetUpDecryption(algorithm);
+            _encryptedData.SetUpDecryption(algorithm);
         }
 
         public void SetUpEncryption(SymmetricAlgorithm algorithm, MemoryStream source)
         {
-            encryptedData.SetUpEncryption(algorithm, new ArraySegment<byte>(source.GetBuffer(), 0, (int) source.Length));
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+            //encryptedData.SetUpEncryption(algorithm, new ArraySegment<byte>(source.GetBuffer(), 0, (int) source.Length));
         }
 
         public void WriteHeaderElement(XmlDictionaryWriter writer)
         {
-            writer.WriteStartElement(Prefix, ElementName, NamespaceUri);
+            writer.WriteStartElement(Prefix, s_ElementName, s_NamespaceUri);
         }
 
         public void WriteHeaderId(XmlDictionaryWriter writer)
         {
-            writer.WriteAttributeString(XD.UtilityDictionary.Prefix.Value, XD.UtilityDictionary.IdAttribute, XD.UtilityDictionary.Namespace, id);
+            writer.WriteAttributeString(XD.UtilityDictionary.Prefix.Value, XD.UtilityDictionary.IdAttribute, XD.UtilityDictionary.Namespace, _id);
         }
 
         public void WriteHeaderContents(XmlDictionaryWriter writer)
         {
-            this.encryptedData.WriteTo(writer, ServiceModelDictionaryManager.Instance);
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+            //this.encryptedData.WriteTo(writer, ServiceModelDictionaryManager.Instance);
         }
     }
 }

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/EncryptedHeaderXml.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/EncryptedHeaderXml.cs
@@ -2,12 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.IO;
-using System.ServiceModel.Channels;
-using System.ServiceModel;
 using System.IdentityModel.Tokens;
 using System.IdentityModel.Selectors;
+using System.IO;
 using System.Security.Cryptography;
+using System.ServiceModel;
+using System.ServiceModel.Channels;
 using System.Xml;
 
 using DictionaryManager = System.IdentityModel.DictionaryManager;

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/EncryptedHeaderXml.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/EncryptedHeaderXml.cs
@@ -1,0 +1,187 @@
+//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace System.ServiceModel.Security
+{
+    using System.IO;
+    using System.ServiceModel.Channels;
+    using System.ServiceModel;
+    using System.IdentityModel.Tokens;
+    using System.IdentityModel.Selectors;
+    using System.Security.Cryptography;
+    using System.Xml;
+
+    using DictionaryManager = System.IdentityModel.DictionaryManager;
+    using ISecurityElement = System.IdentityModel.ISecurityElement;
+
+    sealed class EncryptedHeaderXml
+    {
+        internal static readonly XmlDictionaryString ElementName = XD.SecurityXXX2005Dictionary.EncryptedHeader;
+        internal static readonly XmlDictionaryString NamespaceUri = XD.SecurityXXX2005Dictionary.Namespace;
+        const string Prefix = SecurityXXX2005Strings.Prefix;
+
+        string id;
+        bool mustUnderstand;
+        bool relay;
+        string actor;
+        MessageVersion version;
+        EncryptedData encryptedData;
+
+        public EncryptedHeaderXml(MessageVersion version, bool shouldReadXmlReferenceKeyInfoClause)
+        {
+            this.version = version;
+            encryptedData = new EncryptedData();
+            
+            // This is for the case when the service send an EncryptedHeader to the client where the KeyInfo clause contains referenceXml clause.
+            encryptedData.ShouldReadXmlReferenceKeyInfoClause = shouldReadXmlReferenceKeyInfoClause;
+        }
+
+        public string Actor
+        {
+            get
+            {
+                return this.actor;
+            }
+            set
+            {
+                this.actor = value;
+            }
+        }
+
+        public string EncryptionMethod
+        {
+            get
+            {
+                return encryptedData.EncryptionMethod;
+            }
+            set
+            {
+                encryptedData.EncryptionMethod = value;
+            }
+        }
+
+        public XmlDictionaryString EncryptionMethodDictionaryString
+        {
+            get
+            {
+                return encryptedData.EncryptionMethodDictionaryString;
+            }
+            set
+            {
+                encryptedData.EncryptionMethodDictionaryString = value;
+            }
+        }
+
+        public bool HasId
+        {
+            get
+            {
+                return true;
+            }
+        }
+
+        public string Id
+        {
+            get
+            {
+                return id;
+            }
+            set
+            {
+                id = value;
+            }
+        }
+
+        public SecurityKeyIdentifier KeyIdentifier
+        {
+            get
+            {
+                return encryptedData.KeyIdentifier;
+            }
+            set
+            {
+                encryptedData.KeyIdentifier = value;
+            }
+        }
+
+        public bool MustUnderstand
+        {
+            get
+            {
+                return this.mustUnderstand;
+            }
+            set
+            {
+                this.mustUnderstand = value;
+            }
+        }
+
+        public bool Relay
+        {
+            get
+            {
+                return this.relay;
+            }
+            set
+            {
+                this.relay = value;
+            }
+        }
+
+        public SecurityTokenSerializer SecurityTokenSerializer
+        {
+            get
+            {
+                return encryptedData.SecurityTokenSerializer;
+            }
+            set
+            {
+                encryptedData.SecurityTokenSerializer = value;
+            }
+        }
+
+        public byte[] GetDecryptedBuffer()
+        {
+            return encryptedData.GetDecryptedBuffer();
+        }
+
+        public void ReadFrom(XmlDictionaryReader reader, long maxBufferSize)
+        {
+            reader.MoveToStartElement(ElementName, NamespaceUri);
+            bool isReferenceParameter;
+            MessageHeader.GetHeaderAttributes(reader, version, out this.actor, out this.mustUnderstand, out this.relay, out isReferenceParameter);
+            this.id = reader.GetAttribute(XD.UtilityDictionary.IdAttribute, XD.UtilityDictionary.Namespace);
+
+            reader.ReadStartElement();
+            encryptedData.ReadFrom(reader, maxBufferSize);
+            reader.ReadEndElement();
+        }
+
+        public void SetUpDecryption(SymmetricAlgorithm algorithm)
+        {
+            encryptedData.SetUpDecryption(algorithm);
+        }
+
+        public void SetUpEncryption(SymmetricAlgorithm algorithm, MemoryStream source)
+        {
+            encryptedData.SetUpEncryption(algorithm, new ArraySegment<byte>(source.GetBuffer(), 0, (int) source.Length));
+        }
+
+        public void WriteHeaderElement(XmlDictionaryWriter writer)
+        {
+            writer.WriteStartElement(Prefix, ElementName, NamespaceUri);
+        }
+
+        public void WriteHeaderId(XmlDictionaryWriter writer)
+        {
+            writer.WriteAttributeString(XD.UtilityDictionary.Prefix.Value, XD.UtilityDictionary.IdAttribute, XD.UtilityDictionary.Namespace, id);
+        }
+
+        public void WriteHeaderContents(XmlDictionaryWriter writer)
+        {
+            this.encryptedData.WriteTo(writer, ServiceModelDictionaryManager.Instance);
+        }
+    }
+}
+

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/EncryptedKey.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/EncryptedKey.cs
@@ -77,19 +77,18 @@ namespace System.ServiceModel.Security
 
         protected override void ReadAdditionalElements(XmlDictionaryReader reader)
         {
-            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
-
-            //if (reader.IsStartElement(ReferenceList.ElementName, EncryptedType.NamespaceUri))
-            //{
-            //    this.referenceList = new ReferenceList();
-            //    this.referenceList.ReadFrom(reader);
-            //}
-            //if (reader.IsStartElement(CarriedKeyElementName, EncryptedType.NamespaceUri))
-            //{
-            //    reader.ReadStartElement(CarriedKeyElementName, EncryptedType.NamespaceUri);
-            //    this.carriedKeyName = reader.ReadString();
-            //    reader.ReadEndElement();
-            //}
+            if (reader.IsStartElement(ReferenceList.s_ElementName, EncryptedType.s_NamespaceUri))
+            {
+                _referenceList = new ReferenceList();
+                _referenceList.ReadFrom(reader);
+            }
+            if (reader.IsStartElement(s_CarriedKeyElementName, EncryptedType.s_NamespaceUri))
+            {
+                reader.ReadStartElement(s_CarriedKeyElementName, EncryptedType.s_NamespaceUri);
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress (NET Standard 2.0: needs ReadString() API)
+                //_carriedKeyName = reader.ReadString();
+                //reader.ReadEndElement();
+            }
         }
 
         protected override void ReadCipherData(XmlDictionaryReader reader)

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/EncryptedKey.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/EncryptedKey.cs
@@ -1,46 +1,45 @@
-//------------------------------------------------------------
-// Copyright (c) Microsoft Corporation.  All rights reserved.
-//------------------------------------------------------------
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.IdentityModel;
+using System.Runtime.CompilerServices;
+using System.Xml;
 
 namespace System.ServiceModel.Security
 {
-    using System.IdentityModel;
-    using System.Runtime.CompilerServices;
-    using System.Xml;
-
-    [TypeForwardedFrom("System.ServiceModel, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     sealed class EncryptedKey : EncryptedType
     {
-        internal static readonly XmlDictionaryString CarriedKeyElementName = XD.XmlEncryptionDictionary.CarriedKeyName;
-        internal static readonly XmlDictionaryString ElementName = XD.XmlEncryptionDictionary.EncryptedKey;
-        internal static readonly XmlDictionaryString RecipientAttribute = XD.XmlEncryptionDictionary.Recipient;
+        internal static readonly XmlDictionaryString s_CarriedKeyElementName = System.IdentityModel.XD.XmlEncryptionDictionary.CarriedKeyName;
+        internal static readonly XmlDictionaryString s_ElementName = System.IdentityModel.XD.XmlEncryptionDictionary.EncryptedKey;
+        internal static readonly XmlDictionaryString s_RecipientAttribute = System.IdentityModel.XD.XmlEncryptionDictionary.Recipient;
 
-        string carriedKeyName;
-        string recipient;
-        ReferenceList referenceList;
-        byte[] wrappedKey;
+        private string _carriedKeyName;
+        private string _recipient;
+        private ReferenceList _referenceList;
+        private byte[] _wrappedKey;
 
         public string CarriedKeyName
         {
-            get { return this.carriedKeyName; }
-            set { this.carriedKeyName = value; }
+            get { return _carriedKeyName; }
+            set { _carriedKeyName = value; }
         }
 
         public string Recipient
         {
-            get { return this.recipient; }
-            set { this.recipient = value; }
+            get { return _recipient; }
+            set { _recipient = value; }
         }
 
         public ReferenceList ReferenceList
         {
-            get { return this.referenceList; }
-            set { this.referenceList = value; }
+            get { return _referenceList; }
+            set { _referenceList = value; }
         }
 
         protected override XmlDictionaryString OpeningElementName
         {
-            get { return ElementName; }
+            get { return s_ElementName; }
         }
 
         protected override void ForceEncryption()
@@ -52,81 +51,82 @@ namespace System.ServiceModel.Security
         {
             if (this.State == EncryptionState.New)
             {
-                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.GetString(SR.BadEncryptionState)));
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.BadEncryptionState)));
             }
-            return this.wrappedKey;
+            return _wrappedKey;
         }
 
         public void SetUpKeyWrap(byte[] wrappedKey)
         {
             if (this.State != EncryptionState.New)
             {
-                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.GetString(SR.BadEncryptionState)));
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.BadEncryptionState)));
             }
             if (wrappedKey == null)
             {
                 throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("wrappedKey");
             }
-            this.wrappedKey = wrappedKey;
+            _wrappedKey = wrappedKey;
             this.State = EncryptionState.Encrypted;
         }
 
         protected override void ReadAdditionalAttributes(XmlDictionaryReader reader)
         {
-            this.recipient = reader.GetAttribute(RecipientAttribute, null);
+            _recipient = reader.GetAttribute(s_RecipientAttribute, null);
         }
 
         protected override void ReadAdditionalElements(XmlDictionaryReader reader)
         {
-            if (reader.IsStartElement(ReferenceList.ElementName, EncryptedType.NamespaceUri))
-            {
-                this.referenceList = new ReferenceList();
-                this.referenceList.ReadFrom(reader);
-            }
-            if (reader.IsStartElement(CarriedKeyElementName, EncryptedType.NamespaceUri))
-            {
-                reader.ReadStartElement(CarriedKeyElementName, EncryptedType.NamespaceUri);
-                this.carriedKeyName = reader.ReadString();
-                reader.ReadEndElement();
-            }
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+
+            //if (reader.IsStartElement(ReferenceList.ElementName, EncryptedType.NamespaceUri))
+            //{
+            //    this.referenceList = new ReferenceList();
+            //    this.referenceList.ReadFrom(reader);
+            //}
+            //if (reader.IsStartElement(CarriedKeyElementName, EncryptedType.NamespaceUri))
+            //{
+            //    reader.ReadStartElement(CarriedKeyElementName, EncryptedType.NamespaceUri);
+            //    this.carriedKeyName = reader.ReadString();
+            //    reader.ReadEndElement();
+            //}
         }
 
         protected override void ReadCipherData(XmlDictionaryReader reader)
         {
-            this.wrappedKey = reader.ReadContentAsBase64();
+            _wrappedKey = reader.ReadContentAsBase64();
         }
 
         protected override void ReadCipherData(XmlDictionaryReader reader, long maxBufferSize)
         {
-            this.wrappedKey = SecurityUtils.ReadContentAsBase64(reader, maxBufferSize);
+            _wrappedKey = SecurityUtils.ReadContentAsBase64(reader, maxBufferSize);
         }
 
         protected override void WriteAdditionalAttributes(XmlDictionaryWriter writer, DictionaryManager dictionaryManager)
         {
-            if (this.recipient != null)
+            if (_recipient != null)
             {
-                writer.WriteAttributeString(RecipientAttribute, null, this.recipient);
+                writer.WriteAttributeString(s_RecipientAttribute, null, _recipient);
             }
         }
 
         protected override void WriteAdditionalElements(XmlDictionaryWriter writer, DictionaryManager dictionaryManager)
         {
-            if (this.carriedKeyName != null)
+            if (_carriedKeyName != null)
             {
-                writer.WriteStartElement(CarriedKeyElementName, EncryptedType.NamespaceUri);
-                writer.WriteString(this.carriedKeyName);
+                writer.WriteStartElement(s_CarriedKeyElementName, EncryptedType.s_NamespaceUri);
+                writer.WriteString(_carriedKeyName);
                 writer.WriteEndElement(); // CarriedKeyName
             }
-            if (this.referenceList != null)
+            if (_referenceList != null)
             {
-                this.referenceList.WriteTo(writer, dictionaryManager);
+                _referenceList.WriteTo(writer, dictionaryManager);
             }
         }
 
         protected override void WriteCipherData(XmlDictionaryWriter writer)
         {
-            writer.WriteBase64(this.wrappedKey, 0, this.wrappedKey.Length);
+            writer.WriteBase64(_wrappedKey, 0, _wrappedKey.Length);
         }
     }
 }
-

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/EncryptedKey.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/EncryptedKey.cs
@@ -1,0 +1,132 @@
+//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace System.ServiceModel.Security
+{
+    using System.IdentityModel;
+    using System.Runtime.CompilerServices;
+    using System.Xml;
+
+    [TypeForwardedFrom("System.ServiceModel, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
+    sealed class EncryptedKey : EncryptedType
+    {
+        internal static readonly XmlDictionaryString CarriedKeyElementName = XD.XmlEncryptionDictionary.CarriedKeyName;
+        internal static readonly XmlDictionaryString ElementName = XD.XmlEncryptionDictionary.EncryptedKey;
+        internal static readonly XmlDictionaryString RecipientAttribute = XD.XmlEncryptionDictionary.Recipient;
+
+        string carriedKeyName;
+        string recipient;
+        ReferenceList referenceList;
+        byte[] wrappedKey;
+
+        public string CarriedKeyName
+        {
+            get { return this.carriedKeyName; }
+            set { this.carriedKeyName = value; }
+        }
+
+        public string Recipient
+        {
+            get { return this.recipient; }
+            set { this.recipient = value; }
+        }
+
+        public ReferenceList ReferenceList
+        {
+            get { return this.referenceList; }
+            set { this.referenceList = value; }
+        }
+
+        protected override XmlDictionaryString OpeningElementName
+        {
+            get { return ElementName; }
+        }
+
+        protected override void ForceEncryption()
+        {
+            // no work to be done here since, unlike bulk encryption, key wrapping is done eagerly
+        }
+
+        public byte[] GetWrappedKey()
+        {
+            if (this.State == EncryptionState.New)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.GetString(SR.BadEncryptionState)));
+            }
+            return this.wrappedKey;
+        }
+
+        public void SetUpKeyWrap(byte[] wrappedKey)
+        {
+            if (this.State != EncryptionState.New)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.GetString(SR.BadEncryptionState)));
+            }
+            if (wrappedKey == null)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("wrappedKey");
+            }
+            this.wrappedKey = wrappedKey;
+            this.State = EncryptionState.Encrypted;
+        }
+
+        protected override void ReadAdditionalAttributes(XmlDictionaryReader reader)
+        {
+            this.recipient = reader.GetAttribute(RecipientAttribute, null);
+        }
+
+        protected override void ReadAdditionalElements(XmlDictionaryReader reader)
+        {
+            if (reader.IsStartElement(ReferenceList.ElementName, EncryptedType.NamespaceUri))
+            {
+                this.referenceList = new ReferenceList();
+                this.referenceList.ReadFrom(reader);
+            }
+            if (reader.IsStartElement(CarriedKeyElementName, EncryptedType.NamespaceUri))
+            {
+                reader.ReadStartElement(CarriedKeyElementName, EncryptedType.NamespaceUri);
+                this.carriedKeyName = reader.ReadString();
+                reader.ReadEndElement();
+            }
+        }
+
+        protected override void ReadCipherData(XmlDictionaryReader reader)
+        {
+            this.wrappedKey = reader.ReadContentAsBase64();
+        }
+
+        protected override void ReadCipherData(XmlDictionaryReader reader, long maxBufferSize)
+        {
+            this.wrappedKey = SecurityUtils.ReadContentAsBase64(reader, maxBufferSize);
+        }
+
+        protected override void WriteAdditionalAttributes(XmlDictionaryWriter writer, DictionaryManager dictionaryManager)
+        {
+            if (this.recipient != null)
+            {
+                writer.WriteAttributeString(RecipientAttribute, null, this.recipient);
+            }
+        }
+
+        protected override void WriteAdditionalElements(XmlDictionaryWriter writer, DictionaryManager dictionaryManager)
+        {
+            if (this.carriedKeyName != null)
+            {
+                writer.WriteStartElement(CarriedKeyElementName, EncryptedType.NamespaceUri);
+                writer.WriteString(this.carriedKeyName);
+                writer.WriteEndElement(); // CarriedKeyName
+            }
+            if (this.referenceList != null)
+            {
+                this.referenceList.WriteTo(writer, dictionaryManager);
+            }
+        }
+
+        protected override void WriteCipherData(XmlDictionaryWriter writer)
+        {
+            writer.WriteBase64(this.wrappedKey, 0, this.wrappedKey.Length);
+        }
+    }
+}
+

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/EncryptedType.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/EncryptedType.cs
@@ -1,55 +1,54 @@
-//------------------------------------------------------------
-// Copyright (c) Microsoft Corporation.  All rights reserved.
-//------------------------------------------------------------
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.IdentityModel;
+using System.IdentityModel.Selectors;
+using System.IdentityModel.Tokens;
+using System.Runtime;
+using System.Runtime.CompilerServices;
+using System.Xml;
+using DictionaryManager = System.IdentityModel.DictionaryManager;
+using ISecurityElement = System.IdentityModel.ISecurityElement;
 
 namespace System.ServiceModel.Security
 {
-    using System.IdentityModel;
-    using System.IdentityModel.Selectors;
-    using System.IdentityModel.Tokens;
-    using System.Runtime;
-    using System.Runtime.CompilerServices;
-    using System.Xml;
-    using DictionaryManager = System.IdentityModel.DictionaryManager;
-    using ISecurityElement = System.IdentityModel.ISecurityElement;
-
-    [TypeForwardedFrom("System.ServiceModel, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     abstract class EncryptedType : ISecurityElement
     {
-        internal static readonly XmlDictionaryString NamespaceUri = XD.XmlEncryptionDictionary.Namespace;
-        internal static readonly XmlDictionaryString EncodingAttribute = XD.XmlEncryptionDictionary.Encoding;
-        internal static readonly XmlDictionaryString MimeTypeAttribute = XD.XmlEncryptionDictionary.MimeType;
-        internal static readonly XmlDictionaryString TypeAttribute = XD.XmlEncryptionDictionary.Type;
-        internal static readonly XmlDictionaryString CipherDataElementName = XD.XmlEncryptionDictionary.CipherData;
-        internal static readonly XmlDictionaryString CipherValueElementName = XD.XmlEncryptionDictionary.CipherValue;
+        internal static readonly XmlDictionaryString s_NamespaceUri = System.IdentityModel.XD.XmlEncryptionDictionary.Namespace;
+        internal static readonly XmlDictionaryString s_EncodingAttribute = System.IdentityModel.XD.XmlEncryptionDictionary.Encoding;
+        internal static readonly XmlDictionaryString s_MimeTypeAttribute = System.IdentityModel.XD.XmlEncryptionDictionary.MimeType;
+        internal static readonly XmlDictionaryString s_TypeAttribute = System.IdentityModel.XD.XmlEncryptionDictionary.Type;
+        internal static readonly XmlDictionaryString s_CipherDataElementName = System.IdentityModel.XD.XmlEncryptionDictionary.CipherData;
+        internal static readonly XmlDictionaryString s_CipherValueElementName = System.IdentityModel.XD.XmlEncryptionDictionary.CipherValue;
 
-        string encoding;
-        EncryptionMethodElement encryptionMethod;
-        string id;
-        string wsuId;
-        SecurityKeyIdentifier keyIdentifier;
-        string mimeType;
-        EncryptionState state;
-        string type;
-        SecurityTokenSerializer tokenSerializer;
-        bool shouldReadXmlReferenceKeyInfoClause;
+        private string _encoding;
+        private EncryptionMethodElement _encryptionMethod;
+        private string _id;
+        private string _wsuId;
+        private SecurityKeyIdentifier _keyIdentifier;
+        private string _mimeType;
+        private EncryptionState _state;
+        private string _type;
+        private SecurityTokenSerializer _tokenSerializer;
+        private bool _shouldReadXmlReferenceKeyInfoClause;
 
         protected EncryptedType()
         {
-            this.encryptionMethod.Init();
-            this.state = EncryptionState.New;
-            this.tokenSerializer = new KeyInfoSerializer(false);
+            _encryptionMethod.Init();
+            _state = EncryptionState.New;
+            _tokenSerializer = new KeyInfoSerializer(false);
         }
 
         public string Encoding
         {
             get
             {
-                return this.encoding;
+                return _encoding;
             }
             set
             {
-                this.encoding = value;
+                _encoding = value;
             }
         }
 
@@ -57,11 +56,11 @@ namespace System.ServiceModel.Security
         {
             get
             {
-                return this.encryptionMethod.algorithm;
+                return _encryptionMethod.algorithm;
             }
             set
             {
-                this.encryptionMethod.algorithm = value;
+                _encryptionMethod.algorithm = value;
             }
         }
 
@@ -69,11 +68,11 @@ namespace System.ServiceModel.Security
         {
             get
             {
-                return this.encryptionMethod.algorithmDictionaryString;
+                return _encryptionMethod.algorithmDictionaryString;
             }
             set
             {
-                this.encryptionMethod.algorithmDictionaryString = value;
+                _encryptionMethod.algorithmDictionaryString = value;
             }
         }
 
@@ -89,11 +88,11 @@ namespace System.ServiceModel.Security
         {
             get
             {
-                return this.id;
+                return _id;
             }
             set
             {
-                this.id = value;
+                _id = value;
             }
         }
 
@@ -104,11 +103,11 @@ namespace System.ServiceModel.Security
         {
             get
             {
-                return this.shouldReadXmlReferenceKeyInfoClause;
+                return _shouldReadXmlReferenceKeyInfoClause;
             }
             set
             {
-                this.shouldReadXmlReferenceKeyInfoClause = value;
+                _shouldReadXmlReferenceKeyInfoClause = value;
             }
         }
 
@@ -116,11 +115,11 @@ namespace System.ServiceModel.Security
         {
             get
             {
-                return this.wsuId;
+                return _wsuId;
             }
             set
             {
-                this.wsuId = value;
+                _wsuId = value;
             }
         }
 
@@ -128,11 +127,11 @@ namespace System.ServiceModel.Security
         {
             get
             {
-                return this.keyIdentifier;
+                return _keyIdentifier;
             }
             set
             {
-                this.keyIdentifier = value;
+                _keyIdentifier = value;
             }
         }
 
@@ -140,11 +139,11 @@ namespace System.ServiceModel.Security
         {
             get
             {
-                return this.mimeType;
+                return _mimeType;
             }
             set
             {
-                this.mimeType = value;
+                _mimeType = value;
             }
         }
 
@@ -152,11 +151,11 @@ namespace System.ServiceModel.Security
         {
             get
             {
-                return this.type;
+                return _type;
             }
             set
             {
-                this.type = value;
+                _type = value;
             }
         }
 
@@ -169,11 +168,11 @@ namespace System.ServiceModel.Security
         {
             get
             {
-                return this.state;
+                return _state;
             }
             set
             {
-                this.state = value;
+                _state = value;
             }
         }
 
@@ -181,11 +180,11 @@ namespace System.ServiceModel.Security
         {
             get
             {
-                return this.tokenSerializer;
+                return _tokenSerializer;
             }
             set
             {
-                this.tokenSerializer = value ?? new KeyInfoSerializer(false);
+                _tokenSerializer = value ?? new KeyInfoSerializer(false);
             }
         }
 
@@ -220,31 +219,32 @@ namespace System.ServiceModel.Security
         public void ReadFrom(XmlDictionaryReader reader, long maxBufferSize)
         {
             ValidateReadState();
-            reader.MoveToStartElement(OpeningElementName, NamespaceUri);
-            this.encoding = reader.GetAttribute(EncodingAttribute, null);
-            this.id = reader.GetAttribute(XD.XmlEncryptionDictionary.Id, null) ?? SecurityUniqueId.Create().Value;
-            this.wsuId = reader.GetAttribute(XD.XmlEncryptionDictionary.Id, XD.UtilityDictionary.Namespace) ?? SecurityUniqueId.Create().Value;
-            this.mimeType = reader.GetAttribute(MimeTypeAttribute, null);
-            this.type = reader.GetAttribute(TypeAttribute, null);
+            reader.MoveToStartElement(OpeningElementName, s_NamespaceUri);
+            _encoding = reader.GetAttribute(s_EncodingAttribute, null);
+            _id = reader.GetAttribute(System.IdentityModel.XD.XmlEncryptionDictionary.Id, null) ?? SecurityUniqueId.Create().Value;
+            _wsuId = reader.GetAttribute(System.IdentityModel.XD.XmlEncryptionDictionary.Id, XD.UtilityDictionary.Namespace) ?? SecurityUniqueId.Create().Value;
+            _mimeType = reader.GetAttribute(s_MimeTypeAttribute, null);
+            _type = reader.GetAttribute(s_TypeAttribute, null);
             ReadAdditionalAttributes(reader);
             reader.Read();
 
-            if (reader.IsStartElement(EncryptionMethodElement.ElementName, NamespaceUri))
+            if (reader.IsStartElement(EncryptionMethodElement.ElementName, s_NamespaceUri))
             {
-                this.encryptionMethod.ReadFrom(reader);
+                _encryptionMethod.ReadFrom(reader);
             }
 
-            if (this.tokenSerializer.CanReadKeyIdentifier(reader))
+            if (_tokenSerializer.CanReadKeyIdentifier(reader))
             {
-                XmlElement xml = null;
+                // XmlElement xml = null;
                 XmlDictionaryReader localReader;
 
                 if (this.ShouldReadXmlReferenceKeyInfoClause)
                 {
                     // We create the dom only when needed to not affect perf.
-                    XmlDocument doc = new XmlDocument();
-                    xml = (doc.ReadNode(reader) as XmlElement);
-                    localReader = XmlDictionaryReader.CreateDictionaryReader(new XmlNodeReader(xml));
+                    throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+                    //XmlDocument doc = new XmlDocument();
+                    //xml = (doc.ReadNode(reader) as XmlElement);
+                    //localReader = XmlDictionaryReader.CreateDictionaryReader(new XmlNodeReader(xml));
                 }
                 else
                 {
@@ -253,7 +253,7 @@ namespace System.ServiceModel.Security
 
                 try
                 {
-                    this.KeyIdentifier = this.tokenSerializer.ReadKeyIdentifier(localReader);
+                    this.KeyIdentifier = _tokenSerializer.ReadKeyIdentifier(localReader);
                 }
                 catch (Exception e)
                 {
@@ -266,12 +266,13 @@ namespace System.ServiceModel.Security
                         throw;
                     }
 
-                    this.keyIdentifier = ReadGenericXmlSecurityKeyIdentifier( XmlDictionaryReader.CreateDictionaryReader( new XmlNodeReader(xml)), e);
+                    throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+                    //this.keyIdentifier = ReadGenericXmlSecurityKeyIdentifier( XmlDictionaryReader.CreateDictionaryReader( new XmlNodeReader(xml)), e);
                 }
             }
 
-            reader.ReadStartElement(CipherDataElementName, EncryptedType.NamespaceUri);
-            reader.ReadStartElement(CipherValueElementName, EncryptedType.NamespaceUri);
+            reader.ReadStartElement(s_CipherDataElementName, EncryptedType.s_NamespaceUri);
+            reader.ReadStartElement(s_CipherValueElementName, EncryptedType.s_NamespaceUri);
             if (maxBufferSize == 0)
                 ReadCipherData(reader);
             else
@@ -330,35 +331,35 @@ namespace System.ServiceModel.Security
                 throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("writer");
             }
             ValidateWriteState();
-            writer.WriteStartElement(XmlEncryptionStrings.Prefix, this.OpeningElementName, NamespaceUri);
-            if (this.id != null && this.id.Length != 0)
+            writer.WriteStartElement(XmlEncryptionStrings.Prefix, this.OpeningElementName, s_NamespaceUri);
+            if (_id != null && _id.Length != 0)
             {
-                writer.WriteAttributeString(XD.XmlEncryptionDictionary.Id, null, this.Id);
+                writer.WriteAttributeString(System.IdentityModel.XD.XmlEncryptionDictionary.Id, null, this.Id);
             }
-            if (this.type != null)
+            if (_type != null)
             {
-                writer.WriteAttributeString(TypeAttribute, null, this.Type);
+                writer.WriteAttributeString(s_TypeAttribute, null, this.Type);
             }
-            if (this.mimeType != null)
+            if (_mimeType != null)
             {
-                writer.WriteAttributeString(MimeTypeAttribute, null, this.MimeType);
+                writer.WriteAttributeString(s_MimeTypeAttribute, null, this.MimeType);
             }
-            if (this.encoding != null)
+            if (_encoding != null)
             {
-                writer.WriteAttributeString(EncodingAttribute, null, this.Encoding);
+                writer.WriteAttributeString(s_EncodingAttribute, null, this.Encoding);
             }
             WriteAdditionalAttributes(writer, dictionaryManager);
-            if (this.encryptionMethod.algorithm != null)
+            if (_encryptionMethod.algorithm != null)
             {
-                this.encryptionMethod.WriteTo(writer);
+                _encryptionMethod.WriteTo(writer);
             }
             if (this.KeyIdentifier != null)
             {
-                this.tokenSerializer.WriteKeyIdentifier(writer, this.KeyIdentifier);
+                _tokenSerializer.WriteKeyIdentifier(writer, this.KeyIdentifier);
             }
 
-            writer.WriteStartElement(CipherDataElementName, NamespaceUri);
-            writer.WriteStartElement(CipherValueElementName, NamespaceUri);
+            writer.WriteStartElement(s_CipherDataElementName, s_NamespaceUri);
+            writer.WriteStartElement(s_CipherValueElementName, s_NamespaceUri);
             WriteCipherData(writer);
             writer.WriteEndElement(); // CipherValue
             writer.WriteEndElement(); // CipherData
@@ -371,7 +372,7 @@ namespace System.ServiceModel.Security
         {
             if (this.State != EncryptionState.New)
             {
-                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new SecurityMessageSerializationException(SR.GetString(SR.BadEncryptionState)));
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new SecurityMessageSerializationException(SR.Format(SR.BadEncryptionState)));
             }
         }
 
@@ -383,7 +384,7 @@ namespace System.ServiceModel.Security
             }
             else if (this.State == EncryptionState.New)
             {
-                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new SecurityMessageSerializationException(SR.GetString(SR.BadEncryptionState)));
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new SecurityMessageSerializationException(SR.Format(SR.BadEncryptionState)));
             }
         }
 
@@ -401,7 +402,7 @@ namespace System.ServiceModel.Security
         {
             internal string algorithm;
             internal XmlDictionaryString algorithmDictionaryString;
-            internal static readonly XmlDictionaryString ElementName = XD.XmlEncryptionDictionary.EncryptionMethod;
+            internal static readonly XmlDictionaryString ElementName = System.IdentityModel.XD.XmlEncryptionDictionary.EncryptionMethod;
 
             public void Init()
             {
@@ -410,13 +411,13 @@ namespace System.ServiceModel.Security
 
             public void ReadFrom(XmlDictionaryReader reader)
             {
-                reader.MoveToStartElement(ElementName, XD.XmlEncryptionDictionary.Namespace);
+                reader.MoveToStartElement(ElementName, System.IdentityModel.XD.XmlEncryptionDictionary.Namespace);
                 bool isEmptyElement = reader.IsEmptyElement;
                 this.algorithm = reader.GetAttribute(XD.XmlSignatureDictionary.Algorithm, null);
                 if (this.algorithm == null)
                 {
                     throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new SecurityMessageSerializationException(
-                        SR.GetString(SR.RequiredAttributeMissing, XD.XmlSignatureDictionary.Algorithm.Value, ElementName.Value)));
+                        SR.Format(SR.RequiredAttributeMissing, XD.XmlSignatureDictionary.Algorithm.Value, ElementName.Value)));
                 }
                 reader.Read();
                 if (!isEmptyElement)
@@ -431,7 +432,7 @@ namespace System.ServiceModel.Security
 
             public void WriteTo(XmlDictionaryWriter writer)
             {
-                writer.WriteStartElement(XmlEncryptionStrings.Prefix, ElementName, XD.XmlEncryptionDictionary.Namespace);
+                writer.WriteStartElement(XmlEncryptionStrings.Prefix, ElementName, System.IdentityModel.XD.XmlEncryptionDictionary.Namespace);
                 if (this.algorithmDictionaryString != null)
                 {
                     writer.WriteStartAttribute(XD.XmlSignatureDictionary.Algorithm, null);

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/EncryptedType.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/EncryptedType.cs
@@ -1,0 +1,458 @@
+//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace System.ServiceModel.Security
+{
+    using System.IdentityModel;
+    using System.IdentityModel.Selectors;
+    using System.IdentityModel.Tokens;
+    using System.Runtime;
+    using System.Runtime.CompilerServices;
+    using System.Xml;
+    using DictionaryManager = System.IdentityModel.DictionaryManager;
+    using ISecurityElement = System.IdentityModel.ISecurityElement;
+
+    [TypeForwardedFrom("System.ServiceModel, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
+    abstract class EncryptedType : ISecurityElement
+    {
+        internal static readonly XmlDictionaryString NamespaceUri = XD.XmlEncryptionDictionary.Namespace;
+        internal static readonly XmlDictionaryString EncodingAttribute = XD.XmlEncryptionDictionary.Encoding;
+        internal static readonly XmlDictionaryString MimeTypeAttribute = XD.XmlEncryptionDictionary.MimeType;
+        internal static readonly XmlDictionaryString TypeAttribute = XD.XmlEncryptionDictionary.Type;
+        internal static readonly XmlDictionaryString CipherDataElementName = XD.XmlEncryptionDictionary.CipherData;
+        internal static readonly XmlDictionaryString CipherValueElementName = XD.XmlEncryptionDictionary.CipherValue;
+
+        string encoding;
+        EncryptionMethodElement encryptionMethod;
+        string id;
+        string wsuId;
+        SecurityKeyIdentifier keyIdentifier;
+        string mimeType;
+        EncryptionState state;
+        string type;
+        SecurityTokenSerializer tokenSerializer;
+        bool shouldReadXmlReferenceKeyInfoClause;
+
+        protected EncryptedType()
+        {
+            this.encryptionMethod.Init();
+            this.state = EncryptionState.New;
+            this.tokenSerializer = new KeyInfoSerializer(false);
+        }
+
+        public string Encoding
+        {
+            get
+            {
+                return this.encoding;
+            }
+            set
+            {
+                this.encoding = value;
+            }
+        }
+
+        public string EncryptionMethod
+        {
+            get
+            {
+                return this.encryptionMethod.algorithm;
+            }
+            set
+            {
+                this.encryptionMethod.algorithm = value;
+            }
+        }
+
+        public XmlDictionaryString EncryptionMethodDictionaryString
+        {
+            get
+            {
+                return this.encryptionMethod.algorithmDictionaryString;
+            }
+            set
+            {
+                this.encryptionMethod.algorithmDictionaryString = value;
+            }
+        }
+
+        public bool HasId
+        {
+            get
+            {
+                return true;
+            }
+        }
+
+        public string Id
+        {
+            get
+            {
+                return this.id;
+            }
+            set
+            {
+                this.id = value;
+            }
+        }
+
+        // This is set to true on the client side. And this means that when this knob is set to true and the default serializers on the client side fail 
+        // to read the KeyInfo clause from the incoming response message from a service; then the ckient should 
+        // try to read the keyInfo clause as GenericXmlSecurityKeyIdentifierClause before throwing.
+        public bool ShouldReadXmlReferenceKeyInfoClause
+        {
+            get
+            {
+                return this.shouldReadXmlReferenceKeyInfoClause;
+            }
+            set
+            {
+                this.shouldReadXmlReferenceKeyInfoClause = value;
+            }
+        }
+
+        public string WsuId
+        {
+            get
+            {
+                return this.wsuId;
+            }
+            set
+            {
+                this.wsuId = value;
+            }
+        }
+
+        public SecurityKeyIdentifier KeyIdentifier
+        {
+            get
+            {
+                return this.keyIdentifier;
+            }
+            set
+            {
+                this.keyIdentifier = value;
+            }
+        }
+
+        public string MimeType
+        {
+            get
+            {
+                return this.mimeType;
+            }
+            set
+            {
+                this.mimeType = value;
+            }
+        }
+
+        public string Type
+        {
+            get
+            {
+                return this.type;
+            }
+            set
+            {
+                this.type = value;
+            }
+        }
+
+        protected abstract XmlDictionaryString OpeningElementName
+        {
+            get;
+        }
+
+        protected EncryptionState State
+        {
+            get
+            {
+                return this.state;
+            }
+            set
+            {
+                this.state = value;
+            }
+        }
+
+        public SecurityTokenSerializer SecurityTokenSerializer
+        {
+            get
+            {
+                return this.tokenSerializer;
+            }
+            set
+            {
+                this.tokenSerializer = value ?? new KeyInfoSerializer(false);
+            }
+        }
+
+        protected abstract void ForceEncryption();
+
+        protected virtual void ReadAdditionalAttributes(XmlDictionaryReader reader)
+        {
+        }
+
+        protected virtual void ReadAdditionalElements(XmlDictionaryReader reader)
+        {
+        }
+
+        protected abstract void ReadCipherData(XmlDictionaryReader reader);
+        protected abstract void ReadCipherData(XmlDictionaryReader reader, long maxBufferSize);
+
+        public void ReadFrom(XmlReader reader)
+        {
+            ReadFrom(reader, 0);
+        }
+
+        public void ReadFrom(XmlDictionaryReader reader)
+        {
+            ReadFrom(reader, 0);
+        }
+
+        public void ReadFrom(XmlReader reader, long maxBufferSize)
+        {
+            ReadFrom(XmlDictionaryReader.CreateDictionaryReader(reader), maxBufferSize);
+        }
+
+        public void ReadFrom(XmlDictionaryReader reader, long maxBufferSize)
+        {
+            ValidateReadState();
+            reader.MoveToStartElement(OpeningElementName, NamespaceUri);
+            this.encoding = reader.GetAttribute(EncodingAttribute, null);
+            this.id = reader.GetAttribute(XD.XmlEncryptionDictionary.Id, null) ?? SecurityUniqueId.Create().Value;
+            this.wsuId = reader.GetAttribute(XD.XmlEncryptionDictionary.Id, XD.UtilityDictionary.Namespace) ?? SecurityUniqueId.Create().Value;
+            this.mimeType = reader.GetAttribute(MimeTypeAttribute, null);
+            this.type = reader.GetAttribute(TypeAttribute, null);
+            ReadAdditionalAttributes(reader);
+            reader.Read();
+
+            if (reader.IsStartElement(EncryptionMethodElement.ElementName, NamespaceUri))
+            {
+                this.encryptionMethod.ReadFrom(reader);
+            }
+
+            if (this.tokenSerializer.CanReadKeyIdentifier(reader))
+            {
+                XmlElement xml = null;
+                XmlDictionaryReader localReader;
+
+                if (this.ShouldReadXmlReferenceKeyInfoClause)
+                {
+                    // We create the dom only when needed to not affect perf.
+                    XmlDocument doc = new XmlDocument();
+                    xml = (doc.ReadNode(reader) as XmlElement);
+                    localReader = XmlDictionaryReader.CreateDictionaryReader(new XmlNodeReader(xml));
+                }
+                else
+                {
+                    localReader = reader;
+                }
+
+                try
+                {
+                    this.KeyIdentifier = this.tokenSerializer.ReadKeyIdentifier(localReader);
+                }
+                catch (Exception e)
+                {
+                    // In case when the issued token ( custom token) is used as an initiator token; we will fail 
+                    // to read the keyIdentifierClause using the plugged in default serializer. So We need to try to read it as an XmlReferencekeyIdentifierClause 
+                    // if it is the client side.
+
+                    if (Fx.IsFatal(e) || !this.ShouldReadXmlReferenceKeyInfoClause)
+                    {
+                        throw;
+                    }
+
+                    this.keyIdentifier = ReadGenericXmlSecurityKeyIdentifier( XmlDictionaryReader.CreateDictionaryReader( new XmlNodeReader(xml)), e);
+                }
+            }
+
+            reader.ReadStartElement(CipherDataElementName, EncryptedType.NamespaceUri);
+            reader.ReadStartElement(CipherValueElementName, EncryptedType.NamespaceUri);
+            if (maxBufferSize == 0)
+                ReadCipherData(reader);
+            else
+                ReadCipherData(reader, maxBufferSize);
+            reader.ReadEndElement(); // CipherValue
+            reader.ReadEndElement(); // CipherData
+
+            ReadAdditionalElements(reader);
+            reader.ReadEndElement(); // OpeningElementName
+            this.State = EncryptionState.Read;
+        }
+
+        private SecurityKeyIdentifier ReadGenericXmlSecurityKeyIdentifier(XmlDictionaryReader localReader, Exception previousException)
+        {
+            if (!localReader.IsStartElement(XD.XmlSignatureDictionary.KeyInfo, XD.XmlSignatureDictionary.Namespace))
+            {
+                return null;
+            }
+
+            localReader.ReadStartElement(XD.XmlSignatureDictionary.KeyInfo, XD.XmlSignatureDictionary.Namespace);
+            SecurityKeyIdentifier keyIdentifier = new SecurityKeyIdentifier();
+          
+            if (localReader.IsStartElement())
+            {
+                SecurityKeyIdentifierClause clause = null;
+                string strId = localReader.GetAttribute(XD.UtilityDictionary.IdAttribute, XD.UtilityDictionary.Namespace);
+                XmlDocument doc = new XmlDocument();
+                XmlElement keyIdentifierReferenceXml = (doc.ReadNode(localReader) as XmlElement);
+                clause = new GenericXmlSecurityKeyIdentifierClause(keyIdentifierReferenceXml);
+                if (!string.IsNullOrEmpty(strId))
+                    clause.Id = strId;
+                keyIdentifier.Add(clause);
+            }
+
+            if (keyIdentifier.Count == 0)
+                throw previousException;
+
+            localReader.ReadEndElement();
+            return keyIdentifier;
+        }
+
+        protected virtual void WriteAdditionalAttributes(XmlDictionaryWriter writer, DictionaryManager dictionaryManager)
+        {
+        }
+
+        protected virtual void WriteAdditionalElements(XmlDictionaryWriter writer, DictionaryManager dictionaryManager)
+        {
+        }
+
+        protected abstract void WriteCipherData(XmlDictionaryWriter writer);
+
+        public void WriteTo(XmlDictionaryWriter writer, DictionaryManager dictionaryManager)
+        {
+            if (writer == null)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("writer");
+            }
+            ValidateWriteState();
+            writer.WriteStartElement(XmlEncryptionStrings.Prefix, this.OpeningElementName, NamespaceUri);
+            if (this.id != null && this.id.Length != 0)
+            {
+                writer.WriteAttributeString(XD.XmlEncryptionDictionary.Id, null, this.Id);
+            }
+            if (this.type != null)
+            {
+                writer.WriteAttributeString(TypeAttribute, null, this.Type);
+            }
+            if (this.mimeType != null)
+            {
+                writer.WriteAttributeString(MimeTypeAttribute, null, this.MimeType);
+            }
+            if (this.encoding != null)
+            {
+                writer.WriteAttributeString(EncodingAttribute, null, this.Encoding);
+            }
+            WriteAdditionalAttributes(writer, dictionaryManager);
+            if (this.encryptionMethod.algorithm != null)
+            {
+                this.encryptionMethod.WriteTo(writer);
+            }
+            if (this.KeyIdentifier != null)
+            {
+                this.tokenSerializer.WriteKeyIdentifier(writer, this.KeyIdentifier);
+            }
+
+            writer.WriteStartElement(CipherDataElementName, NamespaceUri);
+            writer.WriteStartElement(CipherValueElementName, NamespaceUri);
+            WriteCipherData(writer);
+            writer.WriteEndElement(); // CipherValue
+            writer.WriteEndElement(); // CipherData
+
+            WriteAdditionalElements(writer, dictionaryManager);
+            writer.WriteEndElement(); // OpeningElementName
+        }
+
+        void ValidateReadState()
+        {
+            if (this.State != EncryptionState.New)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new SecurityMessageSerializationException(SR.GetString(SR.BadEncryptionState)));
+            }
+        }
+
+        void ValidateWriteState()
+        {
+            if (this.State == EncryptionState.EncryptionSetup)
+            {
+                ForceEncryption();
+            }
+            else if (this.State == EncryptionState.New)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new SecurityMessageSerializationException(SR.GetString(SR.BadEncryptionState)));
+            }
+        }
+
+        protected enum EncryptionState
+        {
+            New,
+            Read,
+            DecryptionSetup,
+            Decrypted,
+            EncryptionSetup,
+            Encrypted
+        }
+        
+        struct EncryptionMethodElement
+        {
+            internal string algorithm;
+            internal XmlDictionaryString algorithmDictionaryString;
+            internal static readonly XmlDictionaryString ElementName = XD.XmlEncryptionDictionary.EncryptionMethod;
+
+            public void Init()
+            {
+                this.algorithm = null;
+            }
+
+            public void ReadFrom(XmlDictionaryReader reader)
+            {
+                reader.MoveToStartElement(ElementName, XD.XmlEncryptionDictionary.Namespace);
+                bool isEmptyElement = reader.IsEmptyElement;
+                this.algorithm = reader.GetAttribute(XD.XmlSignatureDictionary.Algorithm, null);
+                if (this.algorithm == null)
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new SecurityMessageSerializationException(
+                        SR.GetString(SR.RequiredAttributeMissing, XD.XmlSignatureDictionary.Algorithm.Value, ElementName.Value)));
+                }
+                reader.Read();
+                if (!isEmptyElement)
+                {
+                    while (reader.IsStartElement())
+                    {
+                        reader.Skip();
+                    }
+                    reader.ReadEndElement();
+                }
+            }
+
+            public void WriteTo(XmlDictionaryWriter writer)
+            {
+                writer.WriteStartElement(XmlEncryptionStrings.Prefix, ElementName, XD.XmlEncryptionDictionary.Namespace);
+                if (this.algorithmDictionaryString != null)
+                {
+                    writer.WriteStartAttribute(XD.XmlSignatureDictionary.Algorithm, null);
+                    writer.WriteString(this.algorithmDictionaryString);
+                    writer.WriteEndAttribute();
+                }
+                else
+                {
+                    writer.WriteAttributeString(XD.XmlSignatureDictionary.Algorithm, null, this.algorithm);
+                }
+                if (this.algorithm == XD.SecurityAlgorithmDictionary.RsaOaepKeyWrap.Value)
+                {
+                    writer.WriteStartElement(XmlSignatureStrings.Prefix, XD.XmlSignatureDictionary.DigestMethod, XD.XmlSignatureDictionary.Namespace);
+                    writer.WriteStartAttribute(XD.XmlSignatureDictionary.Algorithm, null);
+                    writer.WriteString(XD.SecurityAlgorithmDictionary.Sha1Digest);
+                    writer.WriteEndAttribute();
+                    writer.WriteEndElement();
+                }
+                writer.WriteEndElement(); // EncryptionMethod
+            }
+        }
+    }
+}
+

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/IChannelSecureConversationSessionSettings.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/IChannelSecureConversationSessionSettings.cs
@@ -1,0 +1,28 @@
+//-----------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//-----------------------------------------------------------------------------
+
+namespace System.ServiceModel.Security
+{
+    interface IChannelSecureConversationSessionSettings
+    {
+        TimeSpan KeyRenewalInterval
+        {
+            get;
+            set;
+        }
+
+        TimeSpan KeyRolloverInterval
+        {
+            get;
+            set;
+        }
+
+        bool TolerateTransportFailures
+        {
+            get;
+            set;
+        }
+    }
+}
+

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/IChannelSecureConversationSessionSettings.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/IChannelSecureConversationSessionSettings.cs
@@ -1,6 +1,6 @@
-//-----------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation.  All rights reserved.
-//-----------------------------------------------------------------------------
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace System.ServiceModel.Security
 {
@@ -25,4 +25,3 @@ namespace System.ServiceModel.Security
         }
     }
 }
-

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/ISecureConversationSession.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/ISecureConversationSession.cs
@@ -2,8 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Xml;
 using System.ServiceModel;
+using System.Xml;
 
 namespace System.ServiceModel.Security
 {

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/ISecureConversationSession.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/ISecureConversationSession.cs
@@ -1,15 +1,15 @@
-//----------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation.  All rights reserved.
-//----------------------------------------------------------------------------
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Xml;
+using System.ServiceModel;
+
 namespace System.ServiceModel.Security
 {
-    using System.Xml;
-    using System.ServiceModel;
-
     public interface ISecureConversationSession : ISecuritySession
     {
         void WriteSessionTokenIdentifier(XmlDictionaryWriter writer);
         bool TryReadSessionTokenIdentifier(XmlReader reader);
     }
 }
-

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/ISecureConversationSession.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/ISecureConversationSession.cs
@@ -1,0 +1,15 @@
+//----------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//----------------------------------------------------------------------------
+namespace System.ServiceModel.Security
+{
+    using System.Xml;
+    using System.ServiceModel;
+
+    public interface ISecureConversationSession : ISecuritySession
+    {
+        void WriteSessionTokenIdentifier(XmlDictionaryWriter writer);
+        bool TryReadSessionTokenIdentifier(XmlReader reader);
+    }
+}
+

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/ISecurityCommunicationObject.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/ISecurityCommunicationObject.cs
@@ -3,6 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 
+using System.Threading.Tasks;
+
 namespace System.ServiceModel.Security
 {
     internal interface ISecurityCommunicationObject
@@ -10,15 +12,18 @@ namespace System.ServiceModel.Security
         TimeSpan DefaultOpenTimeout { get; }
         TimeSpan DefaultCloseTimeout { get; }
         void OnAbort();
-        IAsyncResult OnBeginClose(TimeSpan timeout, AsyncCallback callback, object state);
-        IAsyncResult OnBeginOpen(TimeSpan timeout, AsyncCallback callback, object state);
+
+        Task CloseAsync(TimeSpan timeout);
+        Task OpenAsync(TimeSpan timeout);
+
         void OnClose(TimeSpan timeout);
         void OnClosed();
         void OnClosing();
-        void OnEndClose(IAsyncResult result);
-        void OnEndOpen(IAsyncResult result);
+
         void OnFaulted();
         void OnOpen(TimeSpan timeout);
+        Task OnOpenAsync(TimeSpan timeout);
+        Task OnCloseAsync(TimeSpan timeout);
         void OnOpened();
         void OnOpening();
     }

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/ISspiNegotiation.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/ISspiNegotiation.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Runtime.CompilerServices;
 using System.Security.Authentication.ExtendedProtection;
 
 namespace System.ServiceModel.Security

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/ISspiNegotiation.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/ISspiNegotiation.cs
@@ -1,0 +1,54 @@
+//-----------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//-----------------------------------------------------------------------------
+
+namespace System.ServiceModel.Security
+{
+    using System;
+    using System.Runtime.CompilerServices;
+    using System.Security.Authentication.ExtendedProtection;
+
+    [TypeForwardedFrom("System.ServiceModel, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
+    interface ISspiNegotiation : IDisposable
+    {
+
+        DateTime ExpirationTimeUtc
+        {
+            get;
+        }
+        /// <summary>
+        /// This indicates if the handshake is complete or not. 
+        /// Note that the IsValidContext flag indicates if the handshake ended in
+        /// success or failure
+        /// </summary>
+        bool IsCompleted
+        {
+            get;
+        }
+
+        bool IsValidContext
+        {
+            get;
+        }
+
+        string KeyEncryptionAlgorithm
+        {
+            get;
+        }
+
+        byte[] Decrypt(byte[] encryptedData);
+
+        byte[] Encrypt(byte[] data);
+
+        byte[] GetOutgoingBlob(byte[] incomingBlob, ChannelBinding channelbinding, ExtendedProtectionPolicy protectionPolicy);
+
+        string GetRemoteIdentityName();
+    }
+
+    [TypeForwardedFrom("System.ServiceModel, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
+    interface ISspiNegotiationInfo
+    {
+        ISspiNegotiation SspiNegotiation { get; }
+    }
+}
+

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/ISspiNegotiation.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/ISspiNegotiation.cs
@@ -1,14 +1,13 @@
-//-----------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation.  All rights reserved.
-//-----------------------------------------------------------------------------
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Security.Authentication.ExtendedProtection;
 
 namespace System.ServiceModel.Security
 {
-    using System;
-    using System.Runtime.CompilerServices;
-    using System.Security.Authentication.ExtendedProtection;
-
-    [TypeForwardedFrom("System.ServiceModel, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     interface ISspiNegotiation : IDisposable
     {
 
@@ -45,7 +44,6 @@ namespace System.ServiceModel.Security
         string GetRemoteIdentityName();
     }
 
-    [TypeForwardedFrom("System.ServiceModel, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     interface ISspiNegotiationInfo
     {
         ISspiNegotiation SspiNegotiation { get; }

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/KeyNameIdentifierClause.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/KeyNameIdentifierClause.cs
@@ -3,9 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Globalization;
-using System.IdentityModel;
 using System.IdentityModel.Tokens;
-using System.Runtime.CompilerServices;
 
 namespace System.ServiceModel.Security
 {

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/KeyNameIdentifierClause.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/KeyNameIdentifierClause.cs
@@ -1,0 +1,48 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Globalization;
+using System.IdentityModel;
+using System.IdentityModel.Tokens;
+using System.Runtime.CompilerServices;
+
+namespace System.ServiceModel.Security
+{
+    public class KeyNameIdentifierClause : SecurityKeyIdentifierClause
+    {
+        private string _keyName;
+
+        public KeyNameIdentifierClause(string keyName)
+            : base(null)
+        {
+            if (keyName == null)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("keyName");
+            }
+            _keyName = keyName;
+        }
+
+        public string KeyName
+        {
+            get { return _keyName; }
+        }
+
+        public override bool Matches(SecurityKeyIdentifierClause keyIdentifierClause)
+        {
+            KeyNameIdentifierClause that = keyIdentifierClause as KeyNameIdentifierClause;
+            return ReferenceEquals(this, that) || (that != null && that.Matches(_keyName));
+        }
+
+        public bool Matches(string keyName)
+        {
+            return _keyName == keyName;
+        }
+
+        public override string ToString()
+        {
+            return string.Format(CultureInfo.InvariantCulture, "KeyNameIdentifierClause(KeyName = '{0}')", this.KeyName);
+        }
+    }
+}
+

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/MessagePartProtectionMode.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/MessagePartProtectionMode.cs
@@ -1,0 +1,49 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.ServiceModel.Security
+{
+    enum MessagePartProtectionMode
+    {
+        None,
+        Sign,
+        Encrypt,
+        SignThenEncrypt,
+        EncryptThenSign,
+    }
+
+    static class MessagePartProtectionModeHelper
+    {
+        public static MessagePartProtectionMode GetProtectionMode(bool sign, bool encrypt, bool signThenEncrypt)
+        {
+            if (sign)
+            {
+                if (encrypt)
+                {
+                    if (signThenEncrypt)
+                    {
+                        return MessagePartProtectionMode.SignThenEncrypt;
+                    }
+                    else
+                    {
+                        return MessagePartProtectionMode.EncryptThenSign;
+                    }
+                }
+                else
+                {
+                    return MessagePartProtectionMode.Sign;
+                }
+            }
+            else if (encrypt)
+            {
+                return MessagePartProtectionMode.Encrypt;
+            }
+            else
+            {
+                return MessagePartProtectionMode.None;
+            }
+        }
+    }
+}
+

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/ReceiveSecurityHeader.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/ReceiveSecurityHeader.cs
@@ -3,6 +3,13 @@
 // See the LICENSE file in the project root for more information.
 
 
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Diagnostics.Contracts;
+using System.IdentityModel.Policy;
+using System.IdentityModel.Selectors;
+using System.IdentityModel.Tokens;
+using System.Security.Authentication.ExtendedProtection;
 using System.ServiceModel.Channels;
 using System.ServiceModel.Description;
 using System.Xml;
@@ -11,6 +18,25 @@ namespace System.ServiceModel.Security
 {
     internal abstract class ReceiveSecurityHeader : SecurityHeader
     {
+        private bool _expectBasicTokens;
+        private bool _expectSignedTokens;
+        private bool _expectEndorsingTokens;
+        private long _maxReceivedMessageSize = TransportDefaults.MaxReceivedMessageSize;
+        private XmlDictionaryReaderQuotas _readerQuotas;
+        private IList<SupportingTokenAuthenticatorSpecification> _supportingTokenAuthenticators;
+        private ReadOnlyCollection<SecurityTokenResolver> _outOfBandTokenResolver;
+        private SecurityTokenAuthenticator _derivedTokenAuthenticator;
+        private bool _replayDetectionEnabled = false;
+        private NonceCache _nonceCache;
+        private TimeSpan _replayWindow;
+        private TimeSpan _clockSkew;
+        private Collection<SecurityToken> _basicTokens;
+        private Collection<SecurityToken> _signedTokens;
+        private Collection<SecurityToken> _endorsingTokens;
+        private Collection<SecurityToken> _signedEndorsingTokens;
+        private Dictionary<SecurityToken, ReadOnlyCollection<IAuthorizationPolicy>> _tokenPoliciesMapping;
+        private bool _enforceDerivedKeyRequirement = true;
+
         protected ReceiveSecurityHeader(Message message, string actor, bool mustUnderstand, bool relay,
             SecurityStandardsManager standardsManager,
             SecurityAlgorithmSuite algorithmSuite,
@@ -31,9 +57,589 @@ namespace System.ServiceModel.Security
             get { return this.StandardsManager.SecurityVersion.HeaderNamespace.Value; }
         }
 
+        public Collection<SecurityToken> BasicSupportingTokens
+        {
+            get
+            {
+                return _basicTokens;
+            }
+        }
+
+        public Collection<SecurityToken> SignedSupportingTokens
+        {
+            get
+            {
+                return _signedTokens;
+            }
+        }
+
+        public Collection<SecurityToken> EndorsingSupportingTokens
+        {
+            get
+            {
+                return _endorsingTokens;
+            }
+        }
+
+        public Collection<SecurityToken> SignedEndorsingSupportingTokens
+        {
+            get
+            {
+                return _signedEndorsingTokens;
+            }
+        }
+
+        public Message ProcessedMessage
+        {
+            get { return Message; }
+        }
+
+        public SecurityTokenAuthenticator DerivedTokenAuthenticator
+        {
+            get
+            {
+                return _derivedTokenAuthenticator;
+            }
+            set
+            {
+                ThrowIfProcessingStarted();
+                _derivedTokenAuthenticator = value;
+            }
+        }
+
+        public bool EnforceDerivedKeyRequirement
+        {
+            get
+            {
+                return _enforceDerivedKeyRequirement;
+            }
+            set
+            {
+                ThrowIfProcessingStarted();
+                _enforceDerivedKeyRequirement = value;
+            }
+        }
+
+        public bool ReplayDetectionEnabled
+        {
+            get { return _replayDetectionEnabled; }
+            set
+            {
+                ThrowIfProcessingStarted();
+                _replayDetectionEnabled = value;
+            }
+        }
+
         protected override void OnWriteHeaderContents(XmlDictionaryWriter writer, MessageVersion messageVersion)
         {
             throw ExceptionHelper.PlatformNotSupported();
         }
+
+        public bool ExpectBasicTokens
+        {
+            get { return _expectBasicTokens; }
+            set
+            {
+                ThrowIfProcessingStarted();
+                _expectBasicTokens = value;
+            }
+        }
+
+        public bool ExpectSignedTokens
+        {
+            get { return _expectSignedTokens; }
+            set
+            {
+                ThrowIfProcessingStarted();
+                _expectSignedTokens = value;
+            }
+        }
+
+        public bool ExpectEndorsingTokens
+        {
+            get { return _expectEndorsingTokens; }
+            set
+            {
+                ThrowIfProcessingStarted();
+                _expectEndorsingTokens = value;
+            }
+        }
+
+        internal long MaxReceivedMessageSize
+        {
+            get
+            {
+                return _maxReceivedMessageSize;
+            }
+            set
+            {
+                ThrowIfProcessingStarted();
+                _maxReceivedMessageSize = value;
+            }
+        }
+
+        internal XmlDictionaryReaderQuotas ReaderQuotas
+        {
+            get { return _readerQuotas; }
+            set
+            {
+                ThrowIfProcessingStarted();
+
+                if (value == null)
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("value");
+
+                _readerQuotas = value;
+            }
+        }
+
+        public Dictionary<SecurityToken, ReadOnlyCollection<IAuthorizationPolicy>> SecurityTokenAuthorizationPoliciesMapping
+        {
+            get
+            {
+                if (_tokenPoliciesMapping == null)
+                {
+                    _tokenPoliciesMapping = new Dictionary<SecurityToken, ReadOnlyCollection<IAuthorizationPolicy>>();
+                }
+                return _tokenPoliciesMapping;
+            }
+        }
+
+        public void ConfigureTransportBindingServerReceiveHeader(IList<SupportingTokenAuthenticatorSpecification> supportingTokenAuthenticators)
+        {
+            _supportingTokenAuthenticators = supportingTokenAuthenticators;
+        }
+
+        public void ConfigureOutOfBandTokenResolver(ReadOnlyCollection<SecurityTokenResolver> outOfBandResolvers)
+        {
+            if (outOfBandResolvers == null)
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull(nameof(outOfBandResolvers));
+            if (outOfBandResolvers.Count == 0)
+            {
+                return;
+            }
+            _outOfBandTokenResolver = outOfBandResolvers;
+        }
+
+        Collection<SecurityToken> EnsureSupportingTokens(ref Collection<SecurityToken> list)
+        {
+            if (list == null)
+                list = new Collection<SecurityToken>();
+            return list;
+        }
+
+        void VerifySupportingToken(TokenTracker tracker)
+        {
+            if (tracker == null)
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("tracker");
+
+            Contract.Assert(tracker._spec != null, "Supporting token trackers cannot have null specification.");
+
+            SupportingTokenAuthenticatorSpecification spec = tracker._spec;
+
+            if (tracker._token == null)
+            {
+                if (spec.IsTokenOptional)
+                    return;
+                else
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new MessageSecurityException(SR.Format(SR.SupportingTokenNotProvided, spec.TokenParameters, spec.SecurityTokenAttachmentMode)));
+            }
+            switch (spec.SecurityTokenAttachmentMode)
+            {
+                case SecurityTokenAttachmentMode.Endorsing:
+                    if (!tracker._IsEndorsing)
+                    {
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new MessageSecurityException(SR.Format(SR.SupportingTokenIsNotEndorsing, spec.TokenParameters)));
+                    }
+                    if (this.EnforceDerivedKeyRequirement && spec.TokenParameters.RequireDerivedKeys && !spec.TokenParameters.HasAsymmetricKey && !tracker._IsDerivedFrom)
+                    {
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new MessageSecurityException(SR.Format(SR.SupportingSignatureIsNotDerivedFrom, spec.TokenParameters)));
+                    }
+                    EnsureSupportingTokens(ref _endorsingTokens).Add(tracker._token);
+                    break;
+                case SecurityTokenAttachmentMode.Signed:
+                    if (!tracker._IsSigned && this.RequireMessageProtection)
+                    {
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new MessageSecurityException(SR.Format(SR.SupportingTokenIsNotSigned, spec.TokenParameters)));
+                    }
+                    EnsureSupportingTokens(ref _signedTokens).Add(tracker._token);
+                    break;
+                case SecurityTokenAttachmentMode.SignedEncrypted:
+                    if (!tracker._IsSigned && this.RequireMessageProtection)
+                    {
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new MessageSecurityException(SR.Format(SR.SupportingTokenIsNotSigned, spec.TokenParameters)));
+                    }
+                    if (!tracker._IsEncrypted && this.RequireMessageProtection)
+                    {
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new MessageSecurityException(SR.Format(SR.SupportingTokenIsNotEncrypted, spec.TokenParameters)));
+                    }
+                    EnsureSupportingTokens(ref _basicTokens).Add(tracker._token);
+                    break;
+                case SecurityTokenAttachmentMode.SignedEndorsing:
+                    if (!tracker._IsSigned && this.RequireMessageProtection)
+                    {
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new MessageSecurityException(SR.Format(SR.SupportingTokenIsNotSigned, spec.TokenParameters)));
+                    }
+                    if (!tracker._IsEndorsing)
+                    {
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new MessageSecurityException(SR.Format(SR.SupportingTokenIsNotEndorsing, spec.TokenParameters)));
+                    }
+                    if (this.EnforceDerivedKeyRequirement && spec.TokenParameters.RequireDerivedKeys && !spec.TokenParameters.HasAsymmetricKey && !tracker._IsDerivedFrom)
+                    {
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new MessageSecurityException(SR.Format(SR.SupportingSignatureIsNotDerivedFrom, spec.TokenParameters)));
+                    }
+                    EnsureSupportingTokens(ref _signedEndorsingTokens).Add(tracker._token);
+                    break;
+
+                default:
+                    Contract.Assert(false, "Unknown token attachment mode " + spec.SecurityTokenAttachmentMode);
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new NotSupportedException(SR.Format(SR.UnknownTokenAttachmentMode, spec.SecurityTokenAttachmentMode)));
+            }
+        }
+
+        // replay detection done if enableReplayDetection is set to true.
+        public void SetTimeParameters(NonceCache nonceCache, TimeSpan replayWindow, TimeSpan clockSkew)
+        {
+            _nonceCache = nonceCache;
+            _replayWindow = replayWindow;
+            _clockSkew = clockSkew;
+        }
+
+        public void Process(TimeSpan timeout, ChannelBinding channelBinding, ExtendedProtectionPolicy extendedProtectionPolicy)
+        {
+            Contract.Assert(this.ReaderQuotas != null, "Reader quotas must be set before processing");
+
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+
+        //    MessageProtectionOrder actualProtectionOrder = this.protectionOrder;
+        //    bool wasProtectionOrderDowngraded = false;
+        //    if (this.protectionOrder == MessageProtectionOrder.SignBeforeEncryptAndEncryptSignature)
+        //    {
+        //        if (this.RequiredEncryptionParts == null || !this.RequiredEncryptionParts.IsBodyIncluded)
+        //        {
+        //            // Let's downgrade for now. If after signature verification we find a header that 
+        //            // is signed and encrypted, we will check for signature encryption too.
+        //            actualProtectionOrder = MessageProtectionOrder.SignBeforeEncrypt;
+        //            wasProtectionOrderDowngraded = true;
+        //        }
+        //    }
+
+        //    this.channelBinding = channelBinding;
+        //    this.extendedProtectionPolicy = extendedProtectionPolicy;
+        //    this.orderTracker.SetRequiredProtectionOrder(actualProtectionOrder);
+
+        //    SetProcessingStarted();
+        //    this.timeoutHelper = new TimeoutHelper(timeout);
+        //    this.Message = this.securityVerifiedMessage = new SecurityVerifiedMessage(this.Message, this);
+        //    XmlDictionaryReader reader = CreateSecurityHeaderReader();
+        //    reader.MoveToStartElement();
+        //    if (reader.IsEmptyElement)
+        //    {
+        //        throw TraceUtility.ThrowHelperError(new MessageSecurityException(SR.Format(SR.SecurityHeaderIsEmpty)), this.Message);
+        //    }
+        //    if (this.RequireMessageProtection)
+        //    {
+        //        this.securityElementAttributes = XmlAttributeHolder.ReadAttributes(reader);
+        //    }
+        //    else
+        //    {
+        //        this.securityElementAttributes = XmlAttributeHolder.emptyArray;
+        //    }
+        //    reader.ReadStartElement();
+
+        //    if (this.primaryTokenParameters != null)
+        //    {
+        //        this.primaryTokenTracker = new TokenTracker(null, this.outOfBandPrimaryToken, this.allowFirstTokenMismatch);
+        //    }
+        //    // universalTokenResolver is used for resolving tokens
+        //    universalTokenResolver = new SecurityHeaderTokenResolver(this);
+        //    // primary token resolver is used for resolving primary signature and decryption
+        //    primaryTokenResolver = new SecurityHeaderTokenResolver(this);
+        //    if (this.outOfBandPrimaryToken != null)
+        //    {
+        //        universalTokenResolver.Add(this.outOfBandPrimaryToken, SecurityTokenReferenceStyle.External, this.primaryTokenParameters);
+        //        primaryTokenResolver.Add(this.outOfBandPrimaryToken, SecurityTokenReferenceStyle.External, this.primaryTokenParameters);
+        //    }
+        //    else if (this.outOfBandPrimaryTokenCollection != null)
+        //    {
+        //        for (int i = 0; i < this.outOfBandPrimaryTokenCollection.Count; ++i)
+        //        {
+        //            universalTokenResolver.Add(this.outOfBandPrimaryTokenCollection[i], SecurityTokenReferenceStyle.External, this.primaryTokenParameters);
+        //            primaryTokenResolver.Add(this.outOfBandPrimaryTokenCollection[i], SecurityTokenReferenceStyle.External, this.primaryTokenParameters);
+        //        }
+        //    }
+        //    if (this.wrappingToken != null)
+        //    {
+        //        universalTokenResolver.ExpectedWrapper = this.wrappingToken;
+        //        universalTokenResolver.ExpectedWrapperTokenParameters = this.wrappingTokenParameters;
+        //        primaryTokenResolver.ExpectedWrapper = this.wrappingToken;
+        //        primaryTokenResolver.ExpectedWrapperTokenParameters = this.wrappingTokenParameters;
+        //    }
+        //    else if (expectedEncryptionToken != null)
+        //    {
+        //        universalTokenResolver.Add(expectedEncryptionToken, SecurityTokenReferenceStyle.External, expectedEncryptionTokenParameters);
+        //        primaryTokenResolver.Add(expectedEncryptionToken, SecurityTokenReferenceStyle.External, expectedEncryptionTokenParameters);
+        //    }
+
+        //    if (this.outOfBandTokenResolver == null)
+        //    {
+        //        this.combinedUniversalTokenResolver = this.universalTokenResolver;
+        //        this.combinedPrimaryTokenResolver = this.primaryTokenResolver;
+        //    }
+        //    else
+        //    {
+        //        this.combinedUniversalTokenResolver = new AggregateSecurityHeaderTokenResolver(this.universalTokenResolver, this.outOfBandTokenResolver);
+        //        this.combinedPrimaryTokenResolver = new AggregateSecurityHeaderTokenResolver(this.primaryTokenResolver, this.outOfBandTokenResolver);
+        //    }
+
+        //    allowedAuthenticators = new List<SecurityTokenAuthenticator>();
+        //    if (this.primaryTokenAuthenticator != null)
+        //    {
+        //        allowedAuthenticators.Add(this.primaryTokenAuthenticator);
+        //    }
+        //    if (this.DerivedTokenAuthenticator != null)
+        //    {
+        //        allowedAuthenticators.Add(this.DerivedTokenAuthenticator);
+        //    }
+        //    pendingSupportingTokenAuthenticator = null;
+        //    int numSupportingTokensRequiringDerivation = 0;
+        //    if (this.supportingTokenAuthenticators != null && this.supportingTokenAuthenticators.Count > 0)
+        //    {
+        //        this.supportingTokenTrackers = new List<TokenTracker>(this.supportingTokenAuthenticators.Count);
+        //        for (int i = 0; i < this.supportingTokenAuthenticators.Count; ++i)
+        //        {
+        //            SupportingTokenAuthenticatorSpecification spec = this.supportingTokenAuthenticators[i];
+        //            switch (spec.SecurityTokenAttachmentMode)
+        //            {
+        //                case SecurityTokenAttachmentMode.Endorsing:
+        //                    this.hasEndorsingOrSignedEndorsingSupportingTokens = true;
+        //                    break;
+        //                case SecurityTokenAttachmentMode.Signed:
+        //                    this.hasAtLeastOneSupportingTokenExpectedToBeSigned = true;
+        //                    break;
+        //                case SecurityTokenAttachmentMode.SignedEndorsing:
+        //                    this.hasEndorsingOrSignedEndorsingSupportingTokens = true;
+        //                    this.hasAtLeastOneSupportingTokenExpectedToBeSigned = true;
+        //                    break;
+        //                case SecurityTokenAttachmentMode.SignedEncrypted:
+        //                    this.hasAtLeastOneSupportingTokenExpectedToBeSigned = true;
+        //                    break;
+        //            }
+
+        //            if ((this.primaryTokenAuthenticator != null) && (this.primaryTokenAuthenticator.GetType().Equals(spec.TokenAuthenticator.GetType())))
+        //            {
+        //                pendingSupportingTokenAuthenticator = spec.TokenAuthenticator;
+        //            }
+        //            else
+        //            {
+        //                allowedAuthenticators.Add(spec.TokenAuthenticator);
+        //            }
+        //            if (spec.TokenParameters.RequireDerivedKeys && !spec.TokenParameters.HasAsymmetricKey &&
+        //                (spec.SecurityTokenAttachmentMode == SecurityTokenAttachmentMode.Endorsing || spec.SecurityTokenAttachmentMode == SecurityTokenAttachmentMode.SignedEndorsing))
+        //            {
+        //                ++numSupportingTokensRequiringDerivation;
+        //            }
+        //            this.supportingTokenTrackers.Add(new TokenTracker(spec));
+        //        }
+        //    }
+
+        //    if (this.DerivedTokenAuthenticator != null)
+        //    {
+        //        // we expect key derivation. Compute quotas for derived keys
+        //        int maxKeyDerivationLengthInBits = this.AlgorithmSuite.DefaultEncryptionKeyDerivationLength >= this.AlgorithmSuite.DefaultSignatureKeyDerivationLength ?
+        //            this.AlgorithmSuite.DefaultEncryptionKeyDerivationLength : this.AlgorithmSuite.DefaultSignatureKeyDerivationLength;
+        //        this.maxDerivedKeyLength = maxKeyDerivationLengthInBits / 8;
+        //        // the upper bound of derived keys is (1 for primary signature + 1 for encryption + supporting token signatures requiring derivation)*2
+        //        // the multiplication by 2 is to take care of interop scenarios that may arise that require more derived keys than the lower bound.
+        //        this.maxDerivedKeys = (1 + 1 + numSupportingTokensRequiringDerivation) * 2;
+        //    }
+
+        //    SecurityHeaderElementInferenceEngine engine = SecurityHeaderElementInferenceEngine.GetInferenceEngine(this.Layout);
+        //    engine.ExecuteProcessingPasses(this, reader);
+        //    if (this.RequireMessageProtection)
+        //    {
+        //        this.ElementManager.EnsureAllRequiredSecurityHeaderTargetsWereProtected();
+        //        ExecuteMessageProtectionPass(this.hasAtLeastOneSupportingTokenExpectedToBeSigned);
+        //        if (this.RequiredSignatureParts != null && this.SignatureToken == null)
+        //        {
+        //            throw TraceUtility.ThrowHelperError(new MessageSecurityException(SR.Format(SR.RequiredSignatureMissing)), this.Message);
+        //        }
+        //    }
+
+        //    EnsureDecryptionComplete();
+
+        //    this.signatureTracker.SetDerivationSourceIfRequired();
+        //    this.encryptionTracker.SetDerivationSourceIfRequired();
+        //    if (this.EncryptionToken != null)
+        //    {
+        //        if (wrappingToken != null)
+        //        {
+        //            if (!(this.EncryptionToken is WrappedKeySecurityToken) || ((WrappedKeySecurityToken)this.EncryptionToken).WrappingToken != this.wrappingToken)
+        //            {
+        //                throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new MessageSecurityException(SR.Format(SR.EncryptedKeyWasNotEncryptedWithTheRequiredEncryptingToken, this.wrappingToken)));
+        //            }
+        //        }
+        //        else if (expectedEncryptionToken != null)
+        //        {
+        //            if (this.EncryptionToken != expectedEncryptionToken)
+        //            {
+        //                throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new MessageSecurityException(SR.Format(SR.MessageWasNotEncryptedWithTheRequiredEncryptingToken)));
+        //            }
+        //        }
+        //        else if (this.SignatureToken != null && this.EncryptionToken != this.SignatureToken)
+        //        {
+        //            throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new MessageSecurityException(SR.Format(SR.SignatureAndEncryptionTokenMismatch, this.SignatureToken, this.EncryptionToken)));
+        //        }
+        //    }
+
+        //    // ensure that the primary signature was signed with derived keys if required
+        //    if (this.EnforceDerivedKeyRequirement)
+        //    {
+        //        if (this.SignatureToken != null)
+        //        {
+        //            if (this.primaryTokenParameters != null)
+        //            {
+        //                if (this.primaryTokenParameters.RequireDerivedKeys && !this.primaryTokenParameters.HasAsymmetricKey && !this.primaryTokenTracker.IsDerivedFrom)
+        //                {
+        //                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new MessageSecurityException(SR.Format(SR.PrimarySignatureWasNotSignedByDerivedKey, this.primaryTokenParameters)));
+        //                }
+        //            }
+        //            else if (this.wrappingTokenParameters != null && this.wrappingTokenParameters.RequireDerivedKeys)
+        //            {
+        //                if (!this.signatureTracker.IsDerivedToken)
+        //                {
+        //                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new MessageSecurityException(SR.Format(SR.PrimarySignatureWasNotSignedByDerivedWrappedKey, this.wrappingTokenParameters)));
+        //                }
+        //            }
+        //        }
+
+        //        // verify that the encryption is using key derivation
+        //        if (this.EncryptionToken != null)
+        //        {
+        //            if (wrappingTokenParameters != null)
+        //            {
+        //                if (wrappingTokenParameters.RequireDerivedKeys && !this.encryptionTracker.IsDerivedToken)
+        //                {
+        //                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new MessageSecurityException(SR.Format(SR.MessageWasNotEncryptedByDerivedWrappedKey, this.wrappingTokenParameters)));
+        //                }
+        //            }
+        //            else if (expectedEncryptionTokenParameters != null)
+        //            {
+        //                if (expectedEncryptionTokenParameters.RequireDerivedKeys && !this.encryptionTracker.IsDerivedToken)
+        //                {
+        //                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new MessageSecurityException(SR.Format(SR.MessageWasNotEncryptedByDerivedEncryptionToken, this.expectedEncryptionTokenParameters)));
+        //                }
+        //            }
+        //            else if (primaryTokenParameters != null && !primaryTokenParameters.HasAsymmetricKey && primaryTokenParameters.RequireDerivedKeys && !this.encryptionTracker.IsDerivedToken)
+        //            {
+        //                throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new MessageSecurityException(SR.Format(SR.MessageWasNotEncryptedByDerivedEncryptionToken, this.primaryTokenParameters)));
+        //            }
+        //        }
+        //    }
+
+        //    if (wasProtectionOrderDowngraded && (this.BasicSupportingTokens != null) && (this.BasicSupportingTokens.Count > 0))
+        //    {
+        //        // Basic tokens are always signed and encrypted. So check if Signatures 
+        //        // are encrypted as well.
+        //        this.VerifySignatureEncryption();
+        //    }
+
+        //    // verify all supporting token parameters have their requirements met
+        //    if (this.supportingTokenTrackers != null)
+        //    {
+        //        for (int i = 0; i < this.supportingTokenTrackers.Count; ++i)
+        //        {
+        //            VerifySupportingToken(this.supportingTokenTrackers[i]);
+        //        }
+        //    }
+
+        //    if (this.replayDetectionEnabled)
+        //    {
+        //        if (this.timestamp == null)
+        //        {
+        //            throw TraceUtility.ThrowHelperError(new MessageSecurityException(
+        //                SR.Format(SR.NoTimestampAvailableInSecurityHeaderToDoReplayDetection)), this.Message);
+        //        }
+        //        if (this.primarySignatureValue == null)
+        //        {
+        //            throw TraceUtility.ThrowHelperError(new MessageSecurityException(
+        //                SR.Format(SR.NoSignatureAvailableInSecurityHeaderToDoReplayDetection)), this.Message);
+        //        }
+
+        //        AddNonce(this.nonceCache, this.primarySignatureValue);
+
+        //        // if replay detection is on, redo creation range checks to ensure full coverage
+        //        this.timestamp.ValidateFreshness(this.replayWindow, this.clockSkew);
+        //    }
+
+        //    if (this.ExpectSignatureConfirmation)
+        //    {
+        //        this.ElementManager.VerifySignatureConfirmationWasFound();
+        //    }
+
+        //    MarkHeaderAsUnderstood();
+        }
+
     }
+
+    class TokenTracker
+    {
+        public SecurityToken _token;
+        public bool _IsDerivedFrom;
+        public bool _IsSigned;
+        public bool _IsEncrypted;
+        public bool _IsEndorsing;
+        public bool _AlreadyReadEndorsingSignature;
+        private bool _allowFirstTokenMismatch;
+        public SupportingTokenAuthenticatorSpecification _spec;
+
+        public TokenTracker(SupportingTokenAuthenticatorSpecification spec)
+            : this(spec, null, false)
+        {
+        }
+
+        public TokenTracker(SupportingTokenAuthenticatorSpecification spec, SecurityToken token, bool allowFirstTokenMismatch)
+        {
+            _spec = spec;
+            _token = token;
+            _allowFirstTokenMismatch = allowFirstTokenMismatch;
+        }
+
+        public void RecordToken(SecurityToken token)
+        {
+            if (_token == null)
+            {
+                _token = token;
+            }
+            else if (_allowFirstTokenMismatch)
+            {
+                if (!AreTokensEqual(_token, token))
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new MessageSecurityException(SR.Format(SR.MismatchInSecurityOperationToken)));
+                }
+                _token = token;
+                _allowFirstTokenMismatch = false;
+            }
+            else if (!object.ReferenceEquals(_token, token))
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new MessageSecurityException(SR.Format(SR.MismatchInSecurityOperationToken)));
+            }
+        }
+
+        static bool AreTokensEqual(SecurityToken outOfBandToken, SecurityToken replyToken)
+        {
+            // we support the serialized reply token legacy feature only for X509 certificates.
+            // in this case the thumbprint of the reply certificate must match the outofband certificate's thumbprint
+            if ((outOfBandToken is X509SecurityToken) && (replyToken is X509SecurityToken))
+            {
+                byte[] outOfBandCertificateThumbprint = ((X509SecurityToken)outOfBandToken).Certificate.GetCertHash();
+                byte[] replyCertificateThumbprint = ((X509SecurityToken)replyToken).Certificate.GetCertHash();
+                return (CryptoHelper.IsEqual(outOfBandCertificateThumbprint, replyCertificateThumbprint));
+            }
+            else
+            {
+                return false;
+            }
+        }
+    }
+
 }

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/ReceiveSecurityHeader.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/ReceiveSecurityHeader.cs
@@ -132,7 +132,28 @@ namespace System.ServiceModel.Security
 
         protected override void OnWriteHeaderContents(XmlDictionaryWriter writer, MessageVersion messageVersion)
         {
-            throw ExceptionHelper.PlatformNotSupported();
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+
+            //XmlDictionaryReader securityHeaderReader = GetReaderAtSecurityHeader();
+            //securityHeaderReader.ReadStartElement();
+            //for (int i = 0; i < this.ElementManager.Count; ++i)
+            //{
+            //    ReceiveSecurityHeaderEntry entry;
+            //    this.ElementManager.GetElementEntry(i, out entry);
+            //    XmlDictionaryReader reader = null;
+            //    if (entry.encrypted)
+            //    {
+            //        reader = this.ElementManager.GetReader(i, false);
+            //        writer.WriteNode(reader, false);
+            //        reader.Close();
+            //        securityHeaderReader.Skip();
+            //    }
+            //    else
+            //    {
+            //        writer.WriteNode(securityHeaderReader, false);
+            //    }
+            //}
+            //securityHeaderReader.Close();
         }
 
         public bool ExpectBasicTokens

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/ReceiveSecurityHeader.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/ReceiveSecurityHeader.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics.Contracts;

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/ReferenceList.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/ReferenceList.cs
@@ -1,0 +1,142 @@
+//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace System.ServiceModel.Security
+{
+    using System.Collections.Generic;
+    using System.IdentityModel;
+    using System.Runtime.CompilerServices;
+    using System.Xml;
+    using DictionaryManager = System.IdentityModel.DictionaryManager;
+    using ISecurityElement = System.IdentityModel.ISecurityElement;
+
+    [TypeForwardedFrom("System.ServiceModel, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
+    sealed class ReferenceList : ISecurityElement
+    {
+        internal static readonly XmlDictionaryString ElementName = XD.XmlEncryptionDictionary.ReferenceList;
+        const string NamespacePrefix = XmlEncryptionStrings.Prefix;
+        internal static readonly XmlDictionaryString NamespaceUri = EncryptedType.NamespaceUri;
+        internal static readonly XmlDictionaryString UriAttribute = XD.XmlEncryptionDictionary.URI;
+        List<string> referredIds = new List<string>();
+
+        public ReferenceList()
+        {
+        }
+
+        public int DataReferenceCount
+        {
+            get { return this.referredIds.Count; }
+        }
+
+        public bool HasId
+        {
+            get { return false; }
+        }
+
+        public string Id
+        {
+            get
+            {
+                // PreSharp Bug: Property get methods should not throw exceptions.
+                #pragma warning suppress 56503
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new NotSupportedException());
+            }
+        }
+
+        public void AddReferredId(string id)
+        {
+            if (id == null)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentNullException("id"));
+            }
+            this.referredIds.Add(id);
+        }
+
+        public bool ContainsReferredId(string id)
+        {
+            if (id == null)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentNullException("id"));
+            }
+            return this.referredIds.Contains(id);
+        }
+
+        public string GetReferredId(int index)
+        {
+            return this.referredIds[index];
+        }
+
+        public void ReadFrom(XmlDictionaryReader reader)
+        {
+            reader.ReadStartElement(ElementName, NamespaceUri);
+            while (reader.IsStartElement())
+            {
+                string id = DataReference.ReadFrom(reader);
+                if (this.referredIds.Contains(id))
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(
+                        new SecurityMessageSerializationException(SR.GetString(SR.InvalidDataReferenceInReferenceList, "#" + id)));
+                }
+                this.referredIds.Add(id);
+            }
+            reader.ReadEndElement(); // ReferenceList
+            if (this.DataReferenceCount == 0)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new SecurityMessageSerializationException(SR.GetString(SR.ReferenceListCannotBeEmpty)));
+            }
+        }
+
+        public bool TryRemoveReferredId(string id)
+        {
+            if (id == null)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentNullException("id"));
+            }
+            return this.referredIds.Remove(id);
+        }
+
+        public void WriteTo(XmlDictionaryWriter writer, DictionaryManager dictionaryManager)
+        {
+            if (this.DataReferenceCount == 0)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.GetString(SR.ReferenceListCannotBeEmpty)));
+            }
+            writer.WriteStartElement(NamespacePrefix, ElementName, NamespaceUri);
+            for (int i = 0; i < this.DataReferenceCount; i++)
+            {
+                DataReference.WriteTo(writer, this.referredIds[i]);
+            }
+            writer.WriteEndElement(); // ReferenceList
+        }
+
+        static class DataReference
+        {
+            internal static readonly XmlDictionaryString ElementName = XD.XmlEncryptionDictionary.DataReference;
+            internal static readonly XmlDictionaryString NamespaceUri = EncryptedType.NamespaceUri;
+
+            public static string ReadFrom(XmlDictionaryReader reader)
+            {
+                string prefix;
+                string uri = XmlHelper.ReadEmptyElementAndRequiredAttribute(reader, ElementName, NamespaceUri, ReferenceList.UriAttribute, out prefix);
+                if (uri.Length < 2 || uri[0] != '#')
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(
+                        new SecurityMessageSerializationException(SR.GetString(SR.InvalidDataReferenceInReferenceList, uri)));
+                }
+                return uri.Substring(1);
+            }
+
+            public static void WriteTo(XmlDictionaryWriter writer, string referredId)
+            {
+                writer.WriteStartElement(XD.XmlEncryptionDictionary.Prefix.Value, ElementName, NamespaceUri);
+                writer.WriteStartAttribute(ReferenceList.UriAttribute, null);
+                writer.WriteString("#");
+                writer.WriteString(referredId);
+                writer.WriteEndAttribute();
+                writer.WriteEndElement();
+            }
+        }
+    }
+}
+

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/ReferenceList.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/ReferenceList.cs
@@ -1,24 +1,23 @@
-//------------------------------------------------------------
-// Copyright (c) Microsoft Corporation.  All rights reserved.
-//------------------------------------------------------------
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.IdentityModel;
+using System.Runtime.CompilerServices;
+using System.Xml;
+using DictionaryManager = System.IdentityModel.DictionaryManager;
+using ISecurityElement = System.IdentityModel.ISecurityElement;
 
 namespace System.ServiceModel.Security
 {
-    using System.Collections.Generic;
-    using System.IdentityModel;
-    using System.Runtime.CompilerServices;
-    using System.Xml;
-    using DictionaryManager = System.IdentityModel.DictionaryManager;
-    using ISecurityElement = System.IdentityModel.ISecurityElement;
-
-    [TypeForwardedFrom("System.ServiceModel, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     sealed class ReferenceList : ISecurityElement
     {
-        internal static readonly XmlDictionaryString ElementName = XD.XmlEncryptionDictionary.ReferenceList;
+        internal static readonly XmlDictionaryString s_ElementName = System.IdentityModel.XD.XmlEncryptionDictionary.ReferenceList;
         const string NamespacePrefix = XmlEncryptionStrings.Prefix;
-        internal static readonly XmlDictionaryString NamespaceUri = EncryptedType.NamespaceUri;
-        internal static readonly XmlDictionaryString UriAttribute = XD.XmlEncryptionDictionary.URI;
-        List<string> referredIds = new List<string>();
+        internal static readonly XmlDictionaryString s_NamespaceUri = EncryptedType.s_NamespaceUri;
+        internal static readonly XmlDictionaryString s_UriAttribute = System.IdentityModel.XD.XmlEncryptionDictionary.URI;
+        private List<string> _referredIds = new List<string>();
 
         public ReferenceList()
         {
@@ -26,7 +25,7 @@ namespace System.ServiceModel.Security
 
         public int DataReferenceCount
         {
-            get { return this.referredIds.Count; }
+            get { return _referredIds.Count; }
         }
 
         public bool HasId
@@ -50,7 +49,7 @@ namespace System.ServiceModel.Security
             {
                 throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentNullException("id"));
             }
-            this.referredIds.Add(id);
+            _referredIds.Add(id);
         }
 
         public bool ContainsReferredId(string id)
@@ -59,32 +58,34 @@ namespace System.ServiceModel.Security
             {
                 throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentNullException("id"));
             }
-            return this.referredIds.Contains(id);
+            return _referredIds.Contains(id);
         }
 
         public string GetReferredId(int index)
         {
-            return this.referredIds[index];
+            return _referredIds[index];
         }
 
         public void ReadFrom(XmlDictionaryReader reader)
         {
-            reader.ReadStartElement(ElementName, NamespaceUri);
-            while (reader.IsStartElement())
-            {
-                string id = DataReference.ReadFrom(reader);
-                if (this.referredIds.Contains(id))
-                {
-                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(
-                        new SecurityMessageSerializationException(SR.GetString(SR.InvalidDataReferenceInReferenceList, "#" + id)));
-                }
-                this.referredIds.Add(id);
-            }
-            reader.ReadEndElement(); // ReferenceList
-            if (this.DataReferenceCount == 0)
-            {
-                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new SecurityMessageSerializationException(SR.GetString(SR.ReferenceListCannotBeEmpty)));
-            }
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+
+            //reader.ReadStartElement(ElementName, NamespaceUri);
+            //while (reader.IsStartElement())
+            //{
+            //    string id = DataReference.ReadFrom(reader);
+            //    if (this.referredIds.Contains(id))
+            //    {
+            //        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(
+            //            new SecurityMessageSerializationException(SR.Format(SR.InvalidDataReferenceInReferenceList, "#" + id)));
+            //    }
+            //    this.referredIds.Add(id);
+            //}
+            //reader.ReadEndElement(); // ReferenceList
+            //if (this.DataReferenceCount == 0)
+            //{
+            //    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new SecurityMessageSerializationException(SR.Format(SR.ReferenceListCannotBeEmpty)));
+            //}
         }
 
         public bool TryRemoveReferredId(string id)
@@ -93,44 +94,48 @@ namespace System.ServiceModel.Security
             {
                 throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentNullException("id"));
             }
-            return this.referredIds.Remove(id);
+            return _referredIds.Remove(id);
         }
 
         public void WriteTo(XmlDictionaryWriter writer, DictionaryManager dictionaryManager)
         {
-            if (this.DataReferenceCount == 0)
-            {
-                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.GetString(SR.ReferenceListCannotBeEmpty)));
-            }
-            writer.WriteStartElement(NamespacePrefix, ElementName, NamespaceUri);
-            for (int i = 0; i < this.DataReferenceCount; i++)
-            {
-                DataReference.WriteTo(writer, this.referredIds[i]);
-            }
-            writer.WriteEndElement(); // ReferenceList
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+
+            //if (this.DataReferenceCount == 0)
+            //{
+            //    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.ReferenceListCannotBeEmpty)));
+            //}
+            //writer.WriteStartElement(NamespacePrefix, ElementName, NamespaceUri);
+            //for (int i = 0; i < this.DataReferenceCount; i++)
+            //{
+            //    DataReference.WriteTo(writer, this.referredIds[i]);
+            //}
+            //writer.WriteEndElement(); // ReferenceList
         }
 
         static class DataReference
         {
-            internal static readonly XmlDictionaryString ElementName = XD.XmlEncryptionDictionary.DataReference;
-            internal static readonly XmlDictionaryString NamespaceUri = EncryptedType.NamespaceUri;
+            internal static readonly XmlDictionaryString s_ElementName = System.IdentityModel.XD.XmlEncryptionDictionary.DataReference;
+            internal static readonly XmlDictionaryString s_NamespaceUri = EncryptedType.s_NamespaceUri;
 
             public static string ReadFrom(XmlDictionaryReader reader)
             {
-                string prefix;
-                string uri = XmlHelper.ReadEmptyElementAndRequiredAttribute(reader, ElementName, NamespaceUri, ReferenceList.UriAttribute, out prefix);
-                if (uri.Length < 2 || uri[0] != '#')
-                {
-                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(
-                        new SecurityMessageSerializationException(SR.GetString(SR.InvalidDataReferenceInReferenceList, uri)));
-                }
-                return uri.Substring(1);
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+
+                //string prefix;
+                //string uri = XmlHelper.ReadEmptyElementAndRequiredAttribute(reader, ElementName, NamespaceUri, ReferenceList.UriAttribute, out prefix);
+                //if (uri.Length < 2 || uri[0] != '#')
+                //{
+                //    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(
+                //        new SecurityMessageSerializationException(SR.Format(SR.InvalidDataReferenceInReferenceList, uri)));
+                //}
+                //return uri.Substring(1);
             }
 
             public static void WriteTo(XmlDictionaryWriter writer, string referredId)
             {
-                writer.WriteStartElement(XD.XmlEncryptionDictionary.Prefix.Value, ElementName, NamespaceUri);
-                writer.WriteStartAttribute(ReferenceList.UriAttribute, null);
+                writer.WriteStartElement(System.IdentityModel.XD.XmlEncryptionDictionary.Prefix.Value, s_ElementName, s_NamespaceUri);
+                writer.WriteStartAttribute(ReferenceList.s_UriAttribute, null);
                 writer.WriteString("#");
                 writer.WriteString(referredId);
                 writer.WriteEndAttribute();

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/ReferenceList.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/ReferenceList.cs
@@ -3,8 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-using System.IdentityModel;
-using System.Runtime.CompilerServices;
 using System.Xml;
 using DictionaryManager = System.IdentityModel.DictionaryManager;
 using ISecurityElement = System.IdentityModel.ISecurityElement;

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/ReferenceList.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/ReferenceList.cs
@@ -37,8 +37,6 @@ namespace System.ServiceModel.Security
         {
             get
             {
-                // PreSharp Bug: Property get methods should not throw exceptions.
-                #pragma warning suppress 56503
                 throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new NotSupportedException());
             }
         }

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SecurityAppliedMessage.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SecurityAppliedMessage.cs
@@ -12,7 +12,6 @@ using System.IdentityModel.Tokens;
 using System.Collections.Generic;
 using IPrefixGenerator = System.IdentityModel.IPrefixGenerator;
 using ISecurityElement = System.IdentityModel.ISecurityElement;
-// using XmlAttributeHolder = System.IdentityModel.XmlAttributeHolder;
 
 namespace System.ServiceModel.Security
 {

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SecurityAppliedMessage.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SecurityAppliedMessage.cs
@@ -2,14 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.IdentityModel.Tokens;
 using System.IO;
 using System.Runtime;
 using System.Security.Cryptography;
 using System.ServiceModel.Channels;
 using System.ServiceModel.Security.Tokens;
 using System.Xml;
-using System.IdentityModel.Tokens;
-using System.Collections.Generic;
 using IPrefixGenerator = System.IdentityModel.IPrefixGenerator;
 using ISecurityElement = System.IdentityModel.ISecurityElement;
 

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SecurityAppliedMessage.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SecurityAppliedMessage.cs
@@ -1,0 +1,457 @@
+//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace System.ServiceModel.Security
+{
+    using System.IO;
+    using System.Runtime;
+    using System.Security.Cryptography;
+    using System.ServiceModel.Channels;
+    using System.ServiceModel.Security.Tokens;
+    using System.Xml;
+    using System.IdentityModel.Tokens;
+    using System.Collections.Generic;
+    using IPrefixGenerator = System.IdentityModel.IPrefixGenerator;
+    using ISecurityElement = System.IdentityModel.ISecurityElement;
+    using XmlAttributeHolder = System.IdentityModel.XmlAttributeHolder;
+
+    sealed class SecurityAppliedMessage : DelegatingMessage
+    {
+        string bodyId;
+        bool bodyIdInserted;
+        string bodyPrefix = MessageStrings.Prefix;
+        XmlBuffer fullBodyBuffer;
+        ISecurityElement encryptedBodyContent;
+        XmlAttributeHolder[] bodyAttributes;
+        bool delayedApplicationHandled;
+        readonly MessagePartProtectionMode bodyProtectionMode;
+        BodyState state = BodyState.Created;
+        readonly SendSecurityHeader securityHeader;
+        MemoryStream startBodyFragment;
+        MemoryStream endBodyFragment;
+        byte[] fullBodyFragment;
+        int fullBodyFragmentLength;
+
+        public SecurityAppliedMessage(Message messageToProcess, SendSecurityHeader securityHeader, bool signBody, bool encryptBody)
+            : base(messageToProcess)
+        {
+            Fx.Assert(!(messageToProcess is SecurityAppliedMessage), "SecurityAppliedMessage should not be wrapped");
+            this.securityHeader = securityHeader;
+            this.bodyProtectionMode = MessagePartProtectionModeHelper.GetProtectionMode(signBody, encryptBody, securityHeader.SignThenEncrypt);
+        }
+
+        public string BodyId
+        {
+            get { return this.bodyId; }
+        }
+
+        public MessagePartProtectionMode BodyProtectionMode
+        {
+            get { return this.bodyProtectionMode; }
+        }
+
+        internal byte[] PrimarySignatureValue
+        {
+            get { return this.securityHeader.PrimarySignatureValue; }
+        }
+
+        Exception CreateBadStateException(string operation)
+        {
+            return new InvalidOperationException(SR.GetString(SR.MessageBodyOperationNotValidInBodyState,
+                operation, this.state));
+        }
+
+        void EnsureUniqueSecurityApplication()
+        {
+            if (this.delayedApplicationHandled)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.GetString(SR.DelayedSecurityApplicationAlreadyCompleted)));
+            }
+            this.delayedApplicationHandled = true;
+        }
+
+        protected override void OnBodyToString(XmlDictionaryWriter writer)
+        {
+            if (this.state == BodyState.Created || this.fullBodyFragment != null)
+            {
+                base.OnBodyToString(writer);
+            }
+            else
+            {
+                OnWriteBodyContents(writer);
+            }
+        }
+
+        protected override void OnClose()
+        {
+            try
+            {
+                this.InnerMessage.Close();
+            }
+            finally
+            {
+                this.fullBodyBuffer = null;
+                this.bodyAttributes = null;
+                this.encryptedBodyContent = null;
+                this.state = BodyState.Disposed;
+            }
+        }
+
+        protected override void OnWriteStartBody(XmlDictionaryWriter writer)
+        {
+            if (this.startBodyFragment != null || this.fullBodyFragment != null)
+            {
+                WriteStartInnerMessageWithId(writer);
+                return;
+            }
+
+            switch (this.state)
+            {
+                case BodyState.Created:
+                case BodyState.Encrypted:
+                    this.InnerMessage.WriteStartBody(writer);
+                    return;
+                case BodyState.Signed:
+                case BodyState.EncryptedThenSigned:
+                    XmlDictionaryReader reader = fullBodyBuffer.GetReader(0);
+                    writer.WriteStartElement(reader.Prefix, reader.LocalName, reader.NamespaceURI);
+                    writer.WriteAttributes(reader, false);
+                    reader.Close();
+                    return;
+                case BodyState.SignedThenEncrypted:
+                    writer.WriteStartElement(this.bodyPrefix, XD.MessageDictionary.Body, this.Version.Envelope.DictionaryNamespace);
+                    if (this.bodyAttributes != null)
+                    {
+                        XmlAttributeHolder.WriteAttributes(this.bodyAttributes, writer);
+                    }
+                    return;
+                default:
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(CreateBadStateException("OnWriteStartBody"));
+            }
+        }
+
+        protected override void OnWriteBodyContents(XmlDictionaryWriter writer)
+        {
+            switch (this.state)
+            {
+                case BodyState.Created:
+                    this.InnerMessage.WriteBodyContents(writer);
+                    return;
+                case BodyState.Signed:
+                case BodyState.EncryptedThenSigned:
+                    XmlDictionaryReader reader = fullBodyBuffer.GetReader(0);
+                    reader.ReadStartElement();
+                    while (reader.NodeType != XmlNodeType.EndElement)
+                        writer.WriteNode(reader, false);
+                    reader.ReadEndElement();
+                    reader.Close();
+                    return;
+                case BodyState.Encrypted:
+                case BodyState.SignedThenEncrypted:
+                    this.encryptedBodyContent.WriteTo(writer, ServiceModelDictionaryManager.Instance);
+                    break;
+                default:
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(CreateBadStateException("OnWriteBodyContents"));
+            }
+        }
+
+        protected override void OnWriteMessage(XmlDictionaryWriter writer)
+        {
+            // For Kerb one shot, the channel binding will be need to be fished out of the message, cached and added to the
+            // token before calling ISC.
+
+            AttachChannelBindingTokenIfFound();
+
+            EnsureUniqueSecurityApplication();
+
+            MessagePrefixGenerator prefixGenerator = new MessagePrefixGenerator(writer);
+            this.securityHeader.StartSecurityApplication();
+
+            this.Headers.Add(this.securityHeader);
+
+            this.InnerMessage.WriteStartEnvelope(writer);
+
+            this.Headers.RemoveAt(this.Headers.Count - 1);
+
+            this.securityHeader.ApplyBodySecurity(writer, prefixGenerator);
+
+            this.InnerMessage.WriteStartHeaders(writer);
+            this.securityHeader.ApplySecurityAndWriteHeaders(this.Headers, writer, prefixGenerator);
+
+            this.securityHeader.RemoveSignatureEncryptionIfAppropriate();
+
+            this.securityHeader.CompleteSecurityApplication();
+            this.securityHeader.WriteHeader(writer, this.Version);
+            writer.WriteEndElement();
+
+            if (this.fullBodyFragment != null)
+            {
+                ((IFragmentCapableXmlDictionaryWriter) writer).WriteFragment(this.fullBodyFragment, 0, this.fullBodyFragmentLength);
+            }
+            else
+            {
+                if (this.startBodyFragment != null)
+                {
+                    ((IFragmentCapableXmlDictionaryWriter) writer).WriteFragment(this.startBodyFragment.GetBuffer(), 0, (int) this.startBodyFragment.Length);
+                }
+                else
+                {
+                    OnWriteStartBody(writer);
+                }
+
+                OnWriteBodyContents(writer);
+
+                if (this.endBodyFragment != null)
+                {
+                    ((IFragmentCapableXmlDictionaryWriter) writer).WriteFragment(this.endBodyFragment.GetBuffer(), 0, (int) this.endBodyFragment.Length);
+                }
+                else
+                {
+                    writer.WriteEndElement();
+                }
+            }
+
+            writer.WriteEndElement();
+        }
+
+        void AttachChannelBindingTokenIfFound()
+        {
+            ChannelBindingMessageProperty cbmp = null;
+            ChannelBindingMessageProperty.TryGet(this.InnerMessage, out cbmp);
+
+            if (cbmp != null)
+            {
+                if (this.securityHeader.ElementContainer != null && this.securityHeader.ElementContainer.EndorsingSupportingTokens != null)
+                {
+                    foreach (SecurityToken token in this.securityHeader.ElementContainer.EndorsingSupportingTokens)
+                    {
+                        ProviderBackedSecurityToken pbst = token as ProviderBackedSecurityToken;
+                        if (pbst != null)
+                        {
+                            pbst.ChannelBinding = cbmp.ChannelBinding;
+                        }
+                    }
+                }
+            }
+        }
+
+        void SetBodyId()
+        {
+            this.bodyId = this.InnerMessage.GetBodyAttribute(
+                UtilityStrings.IdAttribute,
+                this.securityHeader.StandardsManager.IdManager.DefaultIdNamespaceUri);
+            if (this.bodyId == null)
+            {
+                this.bodyId = this.securityHeader.GenerateId();
+                this.bodyIdInserted = true;
+            }
+        }
+
+        public void WriteBodyToEncrypt(EncryptedData encryptedData, SymmetricAlgorithm algorithm)
+        {
+            encryptedData.Id = this.securityHeader.GenerateId();
+
+            BodyContentHelper helper = new BodyContentHelper();
+            XmlDictionaryWriter encryptingWriter = helper.CreateWriter();
+            this.InnerMessage.WriteBodyContents(encryptingWriter);
+            encryptedData.SetUpEncryption(algorithm, helper.ExtractResult());
+            this.encryptedBodyContent = encryptedData;
+
+            this.state = BodyState.Encrypted;
+        }
+
+        public void WriteBodyToEncryptThenSign(Stream canonicalStream, EncryptedData encryptedData, SymmetricAlgorithm algorithm)
+        {
+            encryptedData.Id = this.securityHeader.GenerateId();
+            SetBodyId();
+
+            XmlDictionaryWriter encryptingWriter = XmlDictionaryWriter.CreateTextWriter(Stream.Null);
+            // The XmlSerializer body formatter would add a
+            // document declaration to the body fragment when a fresh writer 
+            // is provided. Hence, insert a dummy element here and capture 
+            // the body contents as a fragment.
+            encryptingWriter.WriteStartElement("a");
+            MemoryStream ms = new MemoryStream();
+            ((IFragmentCapableXmlDictionaryWriter)encryptingWriter).StartFragment(ms, true);
+
+            this.InnerMessage.WriteBodyContents(encryptingWriter);
+            ((IFragmentCapableXmlDictionaryWriter)encryptingWriter).EndFragment();
+            encryptingWriter.WriteEndElement();
+            ms.Flush();
+            encryptedData.SetUpEncryption(algorithm, new ArraySegment<byte>(ms.GetBuffer(), 0, (int) ms.Length));
+
+            this.fullBodyBuffer = new XmlBuffer(int.MaxValue);
+            XmlDictionaryWriter canonicalWriter = this.fullBodyBuffer.OpenSection(XmlDictionaryReaderQuotas.Max);
+
+            canonicalWriter.StartCanonicalization(canonicalStream, false, null);
+            WriteStartInnerMessageWithId(canonicalWriter);
+            encryptedData.WriteTo(canonicalWriter, ServiceModelDictionaryManager.Instance);
+            canonicalWriter.WriteEndElement();
+            canonicalWriter.EndCanonicalization();
+            canonicalWriter.Flush();
+
+            this.fullBodyBuffer.CloseSection();
+            this.fullBodyBuffer.Close();
+
+            this.state = BodyState.EncryptedThenSigned;
+        }
+
+        public void WriteBodyToSign(Stream canonicalStream)
+        {
+            SetBodyId();
+
+            this.fullBodyBuffer = new XmlBuffer(int.MaxValue);
+            XmlDictionaryWriter canonicalWriter = this.fullBodyBuffer.OpenSection(XmlDictionaryReaderQuotas.Max);
+            canonicalWriter.StartCanonicalization(canonicalStream, false, null);
+            WriteInnerMessageWithId(canonicalWriter);
+            canonicalWriter.EndCanonicalization();
+            canonicalWriter.Flush();
+            this.fullBodyBuffer.CloseSection();
+            this.fullBodyBuffer.Close();
+
+            this.state = BodyState.Signed;
+        }
+
+        public void WriteBodyToSignThenEncrypt(Stream canonicalStream, EncryptedData encryptedData, SymmetricAlgorithm algorithm)
+        {
+            XmlBuffer buffer = new XmlBuffer(int.MaxValue);
+            XmlDictionaryWriter fragmentingWriter = buffer.OpenSection(XmlDictionaryReaderQuotas.Max);
+            WriteBodyToSignThenEncryptWithFragments(canonicalStream, false, null, encryptedData, algorithm, fragmentingWriter);
+            ((IFragmentCapableXmlDictionaryWriter)fragmentingWriter).WriteFragment(this.startBodyFragment.GetBuffer(), 0, (int)this.startBodyFragment.Length);
+            ((IFragmentCapableXmlDictionaryWriter)fragmentingWriter).WriteFragment(this.endBodyFragment.GetBuffer(), 0, (int)this.endBodyFragment.Length);
+            buffer.CloseSection();
+            buffer.Close();
+
+            this.startBodyFragment = null;
+            this.endBodyFragment = null;
+
+            XmlDictionaryReader reader = buffer.GetReader(0);
+            reader.MoveToContent();
+            this.bodyPrefix = reader.Prefix;
+            if (reader.HasAttributes)
+            {
+                this.bodyAttributes = XmlAttributeHolder.ReadAttributes(reader);
+            }
+            reader.Close();
+        }
+
+        public void WriteBodyToSignThenEncryptWithFragments(
+            Stream stream, bool includeComments, string[] inclusivePrefixes,
+            EncryptedData encryptedData, SymmetricAlgorithm algorithm, XmlDictionaryWriter writer)
+        {
+            IFragmentCapableXmlDictionaryWriter fragmentingWriter = (IFragmentCapableXmlDictionaryWriter) writer;
+
+            SetBodyId();
+            encryptedData.Id = this.securityHeader.GenerateId();
+
+            this.startBodyFragment = new MemoryStream();
+            BufferedOutputStream bodyContentFragment = new BufferManagerOutputStream(SR.XmlBufferQuotaExceeded, 1024, int.MaxValue, this.securityHeader.StreamBufferManager);
+            this.endBodyFragment = new MemoryStream();
+
+            writer.StartCanonicalization(stream, includeComments, inclusivePrefixes);
+
+            fragmentingWriter.StartFragment(this.startBodyFragment, false);
+            WriteStartInnerMessageWithId(writer);
+            fragmentingWriter.EndFragment();
+
+            fragmentingWriter.StartFragment(bodyContentFragment, true);
+            this.InnerMessage.WriteBodyContents(writer);
+            fragmentingWriter.EndFragment();
+
+            fragmentingWriter.StartFragment(this.endBodyFragment, false);
+            writer.WriteEndElement();
+            fragmentingWriter.EndFragment();
+
+            writer.EndCanonicalization();
+
+            int bodyLength;
+            byte[] bodyBuffer = bodyContentFragment.ToArray(out bodyLength);
+
+            encryptedData.SetUpEncryption(algorithm, new ArraySegment<byte>(bodyBuffer, 0, bodyLength));
+            this.encryptedBodyContent = encryptedData;
+
+            this.state = BodyState.SignedThenEncrypted;
+        }
+
+        public void WriteBodyToSignWithFragments(Stream stream, bool includeComments, string[] inclusivePrefixes, XmlDictionaryWriter writer)
+        {
+            IFragmentCapableXmlDictionaryWriter fragmentingWriter = (IFragmentCapableXmlDictionaryWriter) writer;
+
+            SetBodyId();
+            BufferedOutputStream fullBodyFragment = new BufferManagerOutputStream(SR.XmlBufferQuotaExceeded, 1024, int.MaxValue, this.securityHeader.StreamBufferManager);
+            writer.StartCanonicalization(stream, includeComments, inclusivePrefixes);
+            fragmentingWriter.StartFragment(fullBodyFragment, false);
+            WriteStartInnerMessageWithId(writer);
+            this.InnerMessage.WriteBodyContents(writer);
+            writer.WriteEndElement();
+            fragmentingWriter.EndFragment();
+            writer.EndCanonicalization();
+
+            this.fullBodyFragment = fullBodyFragment.ToArray(out this.fullBodyFragmentLength);
+
+            this.state = BodyState.Signed;
+        }
+
+        void WriteInnerMessageWithId(XmlDictionaryWriter writer)
+        {
+            WriteStartInnerMessageWithId(writer);
+            this.InnerMessage.WriteBodyContents(writer);
+            writer.WriteEndElement();
+        }
+
+        void WriteStartInnerMessageWithId(XmlDictionaryWriter writer)
+        {
+            this.InnerMessage.WriteStartBody(writer);
+            if (this.bodyIdInserted)
+            {
+                this.securityHeader.StandardsManager.IdManager.WriteIdAttribute(writer, this.bodyId);
+            }
+        }
+
+        enum BodyState
+        {
+            Created,
+            Signed,
+            SignedThenEncrypted,
+            EncryptedThenSigned,
+            Encrypted,
+            Disposed,
+        }
+
+        struct BodyContentHelper
+        {
+            MemoryStream stream;
+            XmlDictionaryWriter writer;
+
+            public XmlDictionaryWriter CreateWriter()
+            {
+                this.stream = new MemoryStream();
+                this.writer = XmlDictionaryWriter.CreateTextWriter(stream);
+                return this.writer;
+            }
+
+            public ArraySegment<byte> ExtractResult()
+            {
+                this.writer.Flush();
+                return new ArraySegment<byte>(this.stream.GetBuffer(), 0, (int) this.stream.Length);
+            }
+        }
+
+        sealed class MessagePrefixGenerator : IPrefixGenerator
+        {
+            XmlWriter writer;
+
+            public MessagePrefixGenerator(XmlWriter writer)
+            {
+                this.writer = writer;
+            }
+
+            public string GetPrefix(string namespaceUri, int depth, bool isForAttribute)
+            {
+                return this.writer.LookupPrefix(namespaceUri);
+            }
+        }
+    }
+}
+

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SecurityAuditHelper.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SecurityAuditHelper.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-
 using System.ServiceModel.Channels;
 
 namespace System.ServiceModel.Security

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SecurityAuditHelper.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SecurityAuditHelper.cs
@@ -18,13 +18,14 @@ namespace System.ServiceModel.Security
         }
 
         public static void WriteMessageAuthenticationSuccessEvent(AuditLogLocation auditLogLocation, bool suppressAuditFailure, Message message,
-    Uri serviceUri, string action, string clientIdentity)
+                                                                  Uri serviceUri, string action, string clientIdentity)
         {
         }
 
         public static void WriteMessageAuthenticationFailureEvent(AuditLogLocation auditLogLocation, bool suppressAuditFailure, Message message,
-     Uri serviceUri, string action, string clientIdentity, Exception exception)
+                                                                  Uri serviceUri, string action, string clientIdentity, Exception exception)
         {
         }
     }
 }
+

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SecurityAuditHelper.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SecurityAuditHelper.cs
@@ -3,6 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 
+using System.ServiceModel.Channels;
+
 namespace System.ServiceModel.Security
 {
     internal static class SecurityAuditHelper
@@ -13,6 +15,16 @@ namespace System.ServiceModel.Security
             {
                 return false;
             }
+        }
+
+        public static void WriteMessageAuthenticationSuccessEvent(AuditLogLocation auditLogLocation, bool suppressAuditFailure, Message message,
+    Uri serviceUri, string action, string clientIdentity)
+        {
+        }
+
+        public static void WriteMessageAuthenticationFailureEvent(AuditLogLocation auditLogLocation, bool suppressAuditFailure, Message message,
+     Uri serviceUri, string action, string clientIdentity, Exception exception)
+        {
         }
     }
 }

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SecurityChannel.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SecurityChannel.cs
@@ -5,6 +5,7 @@
 
 using System.Runtime;
 using System.ServiceModel.Channels;
+using System.Threading.Tasks;
 
 namespace System.ServiceModel.Security
 {
@@ -90,6 +91,22 @@ namespace System.ServiceModel.Security
                 _securityProtocol.Close(false, timeoutHelper.RemainingTime());
             }
             base.OnClose(timeoutHelper.RemainingTime());
+        }
+
+        protected internal override Task OnCloseAsync(TimeSpan timeout)
+        {
+            return OnCloseAsyncInternal(timeout);
+        }
+
+        private async Task OnCloseAsyncInternal(TimeSpan timeout)
+        {
+            TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
+            if (_securityProtocol != null)
+            {
+                await _securityProtocol.CloseAsync(false, timeoutHelper.RemainingTime());
+            }
+
+            await base.OnCloseAsync(timeoutHelper.RemainingTime());
         }
 
         protected void ThrowIfDisposedOrNotOpen(Message message)

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SecurityContextKeyIdentifierClause.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SecurityContextKeyIdentifierClause.cs
@@ -2,16 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Globalization;
+using System.IdentityModel.Tokens;
+using System.Xml;
+using DiagnosticUtility = System.ServiceModel.DiagnosticUtility;
 
 namespace System.ServiceModel.Security
 {
-    using System.Globalization;
-    using System.IdentityModel.Tokens;
-    using System.Runtime.CompilerServices;
-    using System.Xml;
-    using DiagnosticUtility = System.ServiceModel.DiagnosticUtility;
-
-    [TypeForwardedFrom("System.ServiceModel, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public class SecurityContextKeyIdentifierClause : SecurityKeyIdentifierClause
     {
         private readonly UniqueId _contextId;

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SecurityContextKeyIdentifierClause.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SecurityContextKeyIdentifierClause.cs
@@ -5,7 +5,6 @@
 using System.Globalization;
 using System.IdentityModel.Tokens;
 using System.Xml;
-using DiagnosticUtility = System.ServiceModel.DiagnosticUtility;
 
 namespace System.ServiceModel.Security
 {

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SecurityProtocol.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SecurityProtocol.cs
@@ -2,15 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Diagnostics;
 using System.IdentityModel.Policy;
 using System.IdentityModel.Selectors;
 using System.IdentityModel.Tokens;
 using System.Runtime;
-using System.ServiceModel;
 using System.ServiceModel.Channels;
 using System.ServiceModel.Description;
 using System.ServiceModel.Diagnostics;

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SecurityProtocol.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SecurityProtocol.cs
@@ -982,7 +982,6 @@ namespace System.ServiceModel.Security
                     SecurityAuditHelper.WriteMessageAuthenticationFailureEvent(this.factory.AuditLogLocation,
                         this.factory.SuppressAuditFailure, message, message.Headers.To, message.Headers.Action, primaryIdentity, exception);
                 }
-#pragma warning suppress 56500
                 catch (Exception auditException)
                 {
                     if (Fx.IsFatal(auditException))
@@ -1033,7 +1032,6 @@ namespace System.ServiceModel.Security
                     self.AddSupportingToken(result);
                     completeSelf = self.AddSupportingTokens();
                 }
-#pragma warning suppress 56500 // covered by FxCOP
                 catch (Exception e)
                 {
                     if (Fx.IsFatal(e))

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SecurityProtocol.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SecurityProtocol.cs
@@ -15,6 +15,7 @@ using System.ServiceModel.Channels;
 using System.ServiceModel.Description;
 using System.ServiceModel.Diagnostics;
 using System.ServiceModel.Security.Tokens;
+using System.Threading.Tasks;
 
 namespace System.ServiceModel.Security
 {
@@ -30,40 +31,1092 @@ namespace System.ServiceModel.Security
     // of simple return values.
     internal abstract class SecurityProtocol : ISecurityCommunicationObject
     {
-        private WrapperSecurityCommunicationObject _communicationObject;
+        static ReadOnlyCollection<SupportingTokenProviderSpecification> emptyTokenProviders;
+
+        ICollection<SupportingTokenProviderSpecification> channelSupportingTokenProviderSpecification;
+        Dictionary<string, ICollection<SupportingTokenProviderSpecification>> scopedSupportingTokenProviderSpecification;
+        Dictionary<string, Collection<SupportingTokenProviderSpecification>> mergedSupportingTokenProvidersMap;
+        SecurityProtocolFactory factory;
+        EndpointAddress target;
+        Uri via;
+        WrapperSecurityCommunicationObject communicationObject;
+        ChannelParameterCollection channelParameters;
+
+        protected SecurityProtocol(SecurityProtocolFactory factory, EndpointAddress target, Uri via)
+        {
+            this.factory = factory;
+            this.target = target;
+            this.via = via;
+            this.communicationObject = new WrapperSecurityCommunicationObject(this);
+        }
+
+        protected WrapperSecurityCommunicationObject CommunicationObject
+        {
+            get { return this.communicationObject; }
+        }
+
+        public SecurityProtocolFactory SecurityProtocolFactory
+        {
+            get { return this.factory; }
+        }
+
+        public EndpointAddress Target
+        {
+            get { return this.target; }
+        }
+
+        public Uri Via
+        {
+            get { return this.via; }
+        }
+
+        public ICollection<SupportingTokenProviderSpecification> ChannelSupportingTokenProviderSpecification
+        {
+            get
+            {
+                return this.channelSupportingTokenProviderSpecification;
+            }
+        }
+
+        public Dictionary<string, ICollection<SupportingTokenProviderSpecification>> ScopedSupportingTokenProviderSpecification
+        {
+            get
+            {
+                return this.scopedSupportingTokenProviderSpecification;
+            }
+        }
+
+        static ReadOnlyCollection<SupportingTokenProviderSpecification> EmptyTokenProviders
+        {
+            get
+            {
+                if (emptyTokenProviders == null)
+                {
+                    emptyTokenProviders = new ReadOnlyCollection<SupportingTokenProviderSpecification>(new List<SupportingTokenProviderSpecification>());
+                }
+                return emptyTokenProviders;
+            }
+        }
+
+        public ChannelParameterCollection ChannelParameters
+        {
+            get
+            {
+                return this.channelParameters;
+            }
+            set
+            {
+                this.communicationObject.ThrowIfDisposedOrImmutable();
+                this.channelParameters = value;
+            }
+        }
+
+        // ISecurityCommunicationObject members
+        public TimeSpan DefaultOpenTimeout
+        {
+            get { return ServiceDefaults.OpenTimeout; }
+        }
 
         public TimeSpan DefaultCloseTimeout
         {
-            get { throw ExceptionHelper.PlatformNotSupported(); }
+            get { return ServiceDefaults.CloseTimeout; }
         }
 
-        public TimeSpan DefaultOpenTimeout
+
+        public Task CloseAsync(TimeSpan timeout)
         {
-            get { throw ExceptionHelper.PlatformNotSupported(); }
+            return ((IAsyncCommunicationObject)this.communicationObject).CloseAsync(timeout);
         }
 
-        public void OnAbort() { throw ExceptionHelper.PlatformNotSupported(); }
-        public IAsyncResult OnBeginClose(TimeSpan timeout, AsyncCallback callback, object state) { throw ExceptionHelper.PlatformNotSupported(); }
-        public IAsyncResult OnBeginOpen(TimeSpan timeout, AsyncCallback callback, object state) { throw ExceptionHelper.PlatformNotSupported(); }
-        public void OnClose(TimeSpan timeout) { throw ExceptionHelper.PlatformNotSupported(); }
-        public void OnClosed() { throw ExceptionHelper.PlatformNotSupported(); }
-        public void OnClosing() { throw ExceptionHelper.PlatformNotSupported(); }
-        public void OnEndClose(IAsyncResult result) { throw ExceptionHelper.PlatformNotSupported(); }
-        public void OnEndOpen(IAsyncResult result) { throw ExceptionHelper.PlatformNotSupported(); }
-        public void OnFaulted() { throw ExceptionHelper.PlatformNotSupported(); }
-        public void OnOpen(TimeSpan timeout) { throw ExceptionHelper.PlatformNotSupported(); }
-        public void OnOpened() { throw ExceptionHelper.PlatformNotSupported(); }
-        public void OnOpening() { throw ExceptionHelper.PlatformNotSupported(); }
+        public Task OpenAsync(TimeSpan timeout)
+        {
+            return ((IAsyncCommunicationObject)this.communicationObject).OpenAsync(timeout);
+        }
+
+        public void OnClosed()
+        {
+        }
+
+        public void OnClosing()
+        {
+        }
+
+        public void OnEndClose(IAsyncResult result)
+        {
+            OperationWithTimeoutAsyncResult.End(result);
+        }
+
+        public void OnEndOpen(IAsyncResult result)
+        {
+            OperationWithTimeoutAsyncResult.End(result);
+        }
+
+        public void OnFaulted()
+        {
+        }
+
+        public void OnOpened()
+        {
+        }
+
+        public void OnOpening()
+        {
+        }
+
+        internal IList<SupportingTokenProviderSpecification> GetSupportingTokenProviders(string action)
+        {
+            if (this.mergedSupportingTokenProvidersMap != null && this.mergedSupportingTokenProvidersMap.Count > 0)
+            {
+                if (action != null && this.mergedSupportingTokenProvidersMap.ContainsKey(action))
+                {
+                    return this.mergedSupportingTokenProvidersMap[action];
+                }
+                else if (this.mergedSupportingTokenProvidersMap.ContainsKey(MessageHeaders.WildcardAction))
+                {
+                    return this.mergedSupportingTokenProvidersMap[MessageHeaders.WildcardAction];
+                }
+            }
+            // return null if the token providers list is empty - this gets a perf benefit since calling Count is expensive for an empty
+            // ReadOnlyCollection
+            return (this.channelSupportingTokenProviderSpecification == EmptyTokenProviders) ? null : (IList<SupportingTokenProviderSpecification>)this.channelSupportingTokenProviderSpecification;
+        }
+
+        protected InitiatorServiceModelSecurityTokenRequirement CreateInitiatorSecurityTokenRequirement()
+        {
+            InitiatorServiceModelSecurityTokenRequirement requirement = new InitiatorServiceModelSecurityTokenRequirement();
+            requirement.TargetAddress = this.Target;
+            requirement.Via = this.via;
+            requirement.SecurityBindingElement = this.factory.SecurityBindingElement;
+            requirement.SecurityAlgorithmSuite = this.factory.OutgoingAlgorithmSuite;
+            requirement.MessageSecurityVersion = this.factory.MessageSecurityVersion.SecurityTokenVersion;
+            if (this.factory.PrivacyNoticeUri != null)
+            {
+                requirement.Properties[ServiceModelSecurityTokenRequirement.PrivacyNoticeUriProperty] = this.factory.PrivacyNoticeUri;
+            }
+            if (this.channelParameters != null)
+            {
+                requirement.Properties[ServiceModelSecurityTokenRequirement.ChannelParametersCollectionProperty] = this.channelParameters;
+            }
+
+            requirement.Properties[ServiceModelSecurityTokenRequirement.PrivacyNoticeVersionProperty] = this.factory.PrivacyNoticeVersion;
+
+            return requirement;
+        }
+
+        InitiatorServiceModelSecurityTokenRequirement CreateInitiatorSecurityTokenRequirement(SecurityTokenParameters parameters, SecurityTokenAttachmentMode attachmentMode)
+        {
+            InitiatorServiceModelSecurityTokenRequirement requirement = CreateInitiatorSecurityTokenRequirement();
+            parameters.InitializeSecurityTokenRequirement(requirement);
+            requirement.KeyUsage = SecurityKeyUsage.Signature;
+            requirement.Properties[ServiceModelSecurityTokenRequirement.MessageDirectionProperty] = MessageDirection.Output;
+            requirement.Properties[ServiceModelSecurityTokenRequirement.SupportingTokenAttachmentModeProperty] = attachmentMode;
+            return requirement;
+        }
+
+        void AddSupportingTokenProviders(SupportingTokenParameters supportingTokenParameters, bool isOptional, IList<SupportingTokenProviderSpecification> providerSpecList)
+        {
+            for (int i = 0; i < supportingTokenParameters.Endorsing.Count; ++i)
+            {
+                SecurityTokenRequirement requirement = this.CreateInitiatorSecurityTokenRequirement(supportingTokenParameters.Endorsing[i], SecurityTokenAttachmentMode.Endorsing);
+                try
+                {
+                    if (isOptional)
+                    {
+                        requirement.IsOptionalToken = true;
+                    }
+                    System.IdentityModel.Selectors.SecurityTokenProvider provider = this.factory.SecurityTokenManager.CreateSecurityTokenProvider(requirement);
+                    if (provider == null)
+                    {
+                        continue;
+                    }
+                    SupportingTokenProviderSpecification providerSpec = new SupportingTokenProviderSpecification(provider, SecurityTokenAttachmentMode.Endorsing, supportingTokenParameters.Endorsing[i]);
+                    providerSpecList.Add(providerSpec);
+                }
+                catch (Exception e)
+                {
+                    if (!isOptional || Fx.IsFatal(e))
+                    {
+                        throw;
+                    }
+                }
+            }
+            for (int i = 0; i < supportingTokenParameters.SignedEndorsing.Count; ++i)
+            {
+                SecurityTokenRequirement requirement = this.CreateInitiatorSecurityTokenRequirement(supportingTokenParameters.SignedEndorsing[i], SecurityTokenAttachmentMode.SignedEndorsing);
+                try
+                {
+                    if (isOptional)
+                    {
+                        requirement.IsOptionalToken = true;
+                    }
+                    System.IdentityModel.Selectors.SecurityTokenProvider provider = this.factory.SecurityTokenManager.CreateSecurityTokenProvider(requirement);
+                    if (provider == null)
+                    {
+                        continue;
+                    }
+                    SupportingTokenProviderSpecification providerSpec = new SupportingTokenProviderSpecification(provider, SecurityTokenAttachmentMode.SignedEndorsing, supportingTokenParameters.SignedEndorsing[i]);
+                    providerSpecList.Add(providerSpec);
+                }
+                catch (Exception e)
+                {
+                    if (!isOptional || Fx.IsFatal(e))
+                    {
+                        throw;
+                    }
+                }
+            }
+            for (int i = 0; i < supportingTokenParameters.SignedEncrypted.Count; ++i)
+            {
+                SecurityTokenRequirement requirement = this.CreateInitiatorSecurityTokenRequirement(supportingTokenParameters.SignedEncrypted[i], SecurityTokenAttachmentMode.SignedEncrypted);
+                try
+                {
+                    if (isOptional)
+                    {
+                        requirement.IsOptionalToken = true;
+                    }
+                    System.IdentityModel.Selectors.SecurityTokenProvider provider = this.factory.SecurityTokenManager.CreateSecurityTokenProvider(requirement);
+                    if (provider == null)
+                    {
+                        continue;
+                    }
+                    SupportingTokenProviderSpecification providerSpec = new SupportingTokenProviderSpecification(provider, SecurityTokenAttachmentMode.SignedEncrypted, supportingTokenParameters.SignedEncrypted[i]);
+                    providerSpecList.Add(providerSpec);
+                }
+                catch (Exception e)
+                {
+                    if (!isOptional || Fx.IsFatal(e))
+                    {
+                        throw;
+                    }
+                }
+            }
+            for (int i = 0; i < supportingTokenParameters.Signed.Count; ++i)
+            {
+                SecurityTokenRequirement requirement = this.CreateInitiatorSecurityTokenRequirement(supportingTokenParameters.Signed[i], SecurityTokenAttachmentMode.Signed);
+                try
+                {
+                    if (isOptional)
+                    {
+                        requirement.IsOptionalToken = true;
+                    }
+                    System.IdentityModel.Selectors.SecurityTokenProvider provider = this.factory.SecurityTokenManager.CreateSecurityTokenProvider(requirement);
+                    if (provider == null)
+                    {
+                        continue;
+                    }
+                    SupportingTokenProviderSpecification providerSpec = new SupportingTokenProviderSpecification(provider, SecurityTokenAttachmentMode.Signed, supportingTokenParameters.Signed[i]);
+                    providerSpecList.Add(providerSpec);
+                }
+                catch (Exception e)
+                {
+                    if (!isOptional || Fx.IsFatal(e))
+                    {
+                        throw;
+                    }
+                }
+            }
+        }
+
+        void MergeSupportingTokenProviders(TimeSpan timeout)
+        {
+            if (this.ScopedSupportingTokenProviderSpecification.Count == 0)
+            {
+                this.mergedSupportingTokenProvidersMap = null;
+            }
+            else
+            {
+                TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
+                this.factory.ExpectSupportingTokens = true;
+                this.mergedSupportingTokenProvidersMap = new Dictionary<string, Collection<SupportingTokenProviderSpecification>>();
+                foreach (string action in this.ScopedSupportingTokenProviderSpecification.Keys)
+                {
+                    ICollection<SupportingTokenProviderSpecification> scopedProviders = this.ScopedSupportingTokenProviderSpecification[action];
+                    if (scopedProviders == null || scopedProviders.Count == 0)
+                    {
+                        continue;
+                    }
+                    Collection<SupportingTokenProviderSpecification> mergedProviders = new Collection<SupportingTokenProviderSpecification>();
+                    foreach (SupportingTokenProviderSpecification spec in this.channelSupportingTokenProviderSpecification)
+                    {
+                        mergedProviders.Add(spec);
+                    }
+                    foreach (SupportingTokenProviderSpecification spec in scopedProviders)
+                    {
+                        SecurityUtils.OpenTokenProviderIfRequired(spec.TokenProvider, timeoutHelper.RemainingTime());
+                        if (spec.SecurityTokenAttachmentMode == SecurityTokenAttachmentMode.Endorsing || spec.SecurityTokenAttachmentMode == SecurityTokenAttachmentMode.SignedEndorsing)
+                        {
+                            if (spec.TokenParameters.RequireDerivedKeys && !spec.TokenParameters.HasAsymmetricKey)
+                            {
+                                this.factory.ExpectKeyDerivation = true;
+                            }
+                        }
+                        mergedProviders.Add(spec);
+                    }
+                    this.mergedSupportingTokenProvidersMap.Add(action, mergedProviders);
+                }
+            }
+        }
+
+        private async Task MergeSupportingTokenProvidersAsync(TimeSpan timeout)
+        {
+            if (this.ScopedSupportingTokenProviderSpecification.Count == 0)
+            {
+                this.mergedSupportingTokenProvidersMap = null;
+            }
+            else
+            {
+                TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
+                this.factory.ExpectSupportingTokens = true;
+                this.mergedSupportingTokenProvidersMap = new Dictionary<string, Collection<SupportingTokenProviderSpecification>>();
+                foreach (string action in this.ScopedSupportingTokenProviderSpecification.Keys)
+                {
+                    ICollection<SupportingTokenProviderSpecification> scopedProviders = this.ScopedSupportingTokenProviderSpecification[action];
+                    if (scopedProviders == null || scopedProviders.Count == 0)
+                    {
+                        continue;
+                    }
+                    Collection<SupportingTokenProviderSpecification> mergedProviders = new Collection<SupportingTokenProviderSpecification>();
+                    foreach (SupportingTokenProviderSpecification spec in this.channelSupportingTokenProviderSpecification)
+                    {
+                        mergedProviders.Add(spec);
+                    }
+                    foreach (SupportingTokenProviderSpecification spec in scopedProviders)
+                    {
+                        await SecurityUtils.OpenTokenProviderIfRequiredAsync(spec.TokenProvider, timeoutHelper.RemainingTime());
+                        if (spec.SecurityTokenAttachmentMode == SecurityTokenAttachmentMode.Endorsing || spec.SecurityTokenAttachmentMode == SecurityTokenAttachmentMode.SignedEndorsing)
+                        {
+                            if (spec.TokenParameters.RequireDerivedKeys && !spec.TokenParameters.HasAsymmetricKey)
+                            {
+                                this.factory.ExpectKeyDerivation = true;
+                            }
+                        }
+                        mergedProviders.Add(spec);
+                    }
+                    this.mergedSupportingTokenProvidersMap.Add(action, mergedProviders);
+                }
+            }
+        }
+
+        public void Open(TimeSpan timeout)
+        {
+            this.communicationObject.Open(timeout);
+        }
+
+        public virtual void OnOpen(TimeSpan timeout)
+        {
+            TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
+            if (this.factory.ActAsInitiator)
+            {
+                throw ExceptionHelper.PlatformNotSupported("SecurityProtocol OnOpen ActAsInitiator not supported.");
+
+                //this.channelSupportingTokenProviderSpecification = new Collection<SupportingTokenProviderSpecification>();
+                //this.scopedSupportingTokenProviderSpecification = new Dictionary<string, ICollection<SupportingTokenProviderSpecification>>();
+
+                //AddSupportingTokenProviders(this.factory.SecurityBindingElement.EndpointSupportingTokenParameters, false, (IList<SupportingTokenProviderSpecification>)this.channelSupportingTokenProviderSpecification);
+                //AddSupportingTokenProviders(this.factory.SecurityBindingElement.OptionalEndpointSupportingTokenParameters, true, (IList<SupportingTokenProviderSpecification>)this.channelSupportingTokenProviderSpecification);
+                //foreach (string action in this.factory.SecurityBindingElement.OperationSupportingTokenParameters.Keys)
+                //{
+                //    Collection<SupportingTokenProviderSpecification> providerSpecList = new Collection<SupportingTokenProviderSpecification>();
+                //    AddSupportingTokenProviders(this.factory.SecurityBindingElement.OperationSupportingTokenParameters[action], false, providerSpecList);
+                //    this.scopedSupportingTokenProviderSpecification.Add(action, providerSpecList);
+                //}
+                //foreach (string action in this.factory.SecurityBindingElement.OptionalOperationSupportingTokenParameters.Keys)
+                //{
+                //    Collection<SupportingTokenProviderSpecification> providerSpecList;
+                //    ICollection<SupportingTokenProviderSpecification> existingList;
+                //    if (this.scopedSupportingTokenProviderSpecification.TryGetValue(action, out existingList))
+                //    {
+                //        providerSpecList = ((Collection<SupportingTokenProviderSpecification>)existingList);
+                //    }
+                //    else
+                //    {
+                //        providerSpecList = new Collection<SupportingTokenProviderSpecification>();
+                //        this.scopedSupportingTokenProviderSpecification.Add(action, providerSpecList);
+                //    }
+                //    this.AddSupportingTokenProviders(this.factory.SecurityBindingElement.OptionalOperationSupportingTokenParameters[action], true, providerSpecList);
+                //}
+
+                //if (!this.channelSupportingTokenProviderSpecification.IsReadOnly)
+                //{
+                //    if (this.channelSupportingTokenProviderSpecification.Count == 0)
+                //    {
+                //        this.channelSupportingTokenProviderSpecification = EmptyTokenProviders;
+                //    }
+                //    else
+                //    {
+                //        this.factory.ExpectSupportingTokens = true;
+                //        foreach (SupportingTokenProviderSpecification tokenProviderSpec in this.channelSupportingTokenProviderSpecification)
+                //        {
+                //            SecurityUtils.OpenTokenProviderIfRequired(tokenProviderSpec.TokenProvider, timeoutHelper.RemainingTime());
+                //            if (tokenProviderSpec.SecurityTokenAttachmentMode == SecurityTokenAttachmentMode.Endorsing || tokenProviderSpec.SecurityTokenAttachmentMode == SecurityTokenAttachmentMode.SignedEndorsing)
+                //            {
+                //                if (tokenProviderSpec.TokenParameters.RequireDerivedKeys && !tokenProviderSpec.TokenParameters.HasAsymmetricKey)
+                //                {
+                //                    this.factory.ExpectKeyDerivation = true;
+                //                }
+                //            }
+                //        }
+                //        this.channelSupportingTokenProviderSpecification =
+                //            new ReadOnlyCollection<SupportingTokenProviderSpecification>((Collection<SupportingTokenProviderSpecification>)this.channelSupportingTokenProviderSpecification);
+                //    }
+                //}
+                //// create a merged map of the per operation supporting tokens
+                //MergeSupportingTokenProviders(timeoutHelper.RemainingTime());
+            }
+        }
+
+        public virtual Task OnOpenAsync(TimeSpan timeout)
+        {
+            return OnOpenAsyncInternal(timeout);
+        }
+
+        private async Task OnOpenAsyncInternal(TimeSpan timeout)
+        {
+            TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
+            if (this.factory.ActAsInitiator)
+            {
+                this.channelSupportingTokenProviderSpecification = new Collection<SupportingTokenProviderSpecification>();
+                this.scopedSupportingTokenProviderSpecification = new Dictionary<string, ICollection<SupportingTokenProviderSpecification>>();
+
+                AddSupportingTokenProviders(this.factory.SecurityBindingElement.EndpointSupportingTokenParameters, false, (IList<SupportingTokenProviderSpecification>)this.channelSupportingTokenProviderSpecification);
+                AddSupportingTokenProviders(this.factory.SecurityBindingElement.OptionalEndpointSupportingTokenParameters, true, (IList<SupportingTokenProviderSpecification>)this.channelSupportingTokenProviderSpecification);
+                foreach (string action in this.factory.SecurityBindingElement.OperationSupportingTokenParameters.Keys)
+                {
+                    Collection<SupportingTokenProviderSpecification> providerSpecList = new Collection<SupportingTokenProviderSpecification>();
+                    AddSupportingTokenProviders(this.factory.SecurityBindingElement.OperationSupportingTokenParameters[action], false, providerSpecList);
+                    this.scopedSupportingTokenProviderSpecification.Add(action, providerSpecList);
+                }
+                foreach (string action in this.factory.SecurityBindingElement.OptionalOperationSupportingTokenParameters.Keys)
+                {
+                    Collection<SupportingTokenProviderSpecification> providerSpecList;
+                    ICollection<SupportingTokenProviderSpecification> existingList;
+                    if (this.scopedSupportingTokenProviderSpecification.TryGetValue(action, out existingList))
+                    {
+                        providerSpecList = ((Collection<SupportingTokenProviderSpecification>)existingList);
+                    }
+                    else
+                    {
+                        providerSpecList = new Collection<SupportingTokenProviderSpecification>();
+                        this.scopedSupportingTokenProviderSpecification.Add(action, providerSpecList);
+                    }
+                    this.AddSupportingTokenProviders(this.factory.SecurityBindingElement.OptionalOperationSupportingTokenParameters[action], true, providerSpecList);
+                }
+
+                if (!this.channelSupportingTokenProviderSpecification.IsReadOnly)
+                {
+                    if (this.channelSupportingTokenProviderSpecification.Count == 0)
+                    {
+                        this.channelSupportingTokenProviderSpecification = EmptyTokenProviders;
+                    }
+                    else
+                    {
+                        this.factory.ExpectSupportingTokens = true;
+                        foreach (SupportingTokenProviderSpecification tokenProviderSpec in this.channelSupportingTokenProviderSpecification)
+                        {
+                            await SecurityUtils.OpenTokenProviderIfRequiredAsync(tokenProviderSpec.TokenProvider, timeoutHelper.RemainingTime());
+                            if (tokenProviderSpec.SecurityTokenAttachmentMode == SecurityTokenAttachmentMode.Endorsing || tokenProviderSpec.SecurityTokenAttachmentMode == SecurityTokenAttachmentMode.SignedEndorsing)
+                            {
+                                if (tokenProviderSpec.TokenParameters.RequireDerivedKeys && !tokenProviderSpec.TokenParameters.HasAsymmetricKey)
+                                {
+                                    this.factory.ExpectKeyDerivation = true;
+                                }
+                            }
+                        }
+                        this.channelSupportingTokenProviderSpecification =
+                            new ReadOnlyCollection<SupportingTokenProviderSpecification>((Collection<SupportingTokenProviderSpecification>)this.channelSupportingTokenProviderSpecification);
+                    }
+                }
+                // create a merged map of the per operation supporting tokens
+                await MergeSupportingTokenProvidersAsync(timeoutHelper.RemainingTime());
+            }
+        }
 
         public void Close(bool aborted, TimeSpan timeout)
         {
             if (aborted)
             {
-                _communicationObject.Abort();
+                this.communicationObject.Abort();
             }
             else
             {
-                _communicationObject.Close(timeout);
+                this.communicationObject.Close(timeout);
+            }
+        }
+
+        public Task CloseAsync(bool aborted, TimeSpan timeout)
+        {
+            if (aborted)
+            {
+                this.communicationObject.Abort();
+                return TaskHelpers.CompletedTask();
+            }
+            else
+            {
+                return ((IAsyncCommunicationObject)this.communicationObject).CloseAsync(timeout);
+            }
+        }
+
+        public virtual void OnAbort()
+        {
+            if (this.factory.ActAsInitiator)
+            {
+                if (this.channelSupportingTokenProviderSpecification != null)
+                {
+                    foreach (SupportingTokenProviderSpecification spec in this.channelSupportingTokenProviderSpecification)
+                    {
+                        SecurityUtils.AbortTokenProviderIfRequired(spec.TokenProvider);
+                    }
+                }
+
+                if (this.scopedSupportingTokenProviderSpecification != null)
+                {
+                    foreach (string action in this.scopedSupportingTokenProviderSpecification.Keys)
+                    {
+                        ICollection<SupportingTokenProviderSpecification> supportingProviders = this.scopedSupportingTokenProviderSpecification[action];
+                        foreach (SupportingTokenProviderSpecification spec in supportingProviders)
+                        {
+                            SecurityUtils.AbortTokenProviderIfRequired(spec.TokenProvider);
+                        }
+                    }
+                }
+            }
+        }
+
+        public virtual void OnClose(TimeSpan timeout)
+        {
+            if (this.factory.ActAsInitiator)
+            {
+                TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
+                foreach (SupportingTokenProviderSpecification spec in this.channelSupportingTokenProviderSpecification)
+                {
+                    SecurityUtils.CloseTokenProviderIfRequired(spec.TokenProvider, timeoutHelper.RemainingTime());
+                }
+                foreach (string action in this.scopedSupportingTokenProviderSpecification.Keys)
+                {
+                    ICollection<SupportingTokenProviderSpecification> supportingProviders = this.scopedSupportingTokenProviderSpecification[action];
+                    foreach (SupportingTokenProviderSpecification spec in supportingProviders)
+                    {
+                        SecurityUtils.CloseTokenProviderIfRequired(spec.TokenProvider, timeoutHelper.RemainingTime());
+                    }
+                }
+            }
+        }
+
+        public virtual Task OnCloseAsync(TimeSpan timeout)
+        {
+            return OnCloseAsyncInternal(timeout);
+        }
+
+        private async Task OnCloseAsyncInternal(TimeSpan timeout)
+        {
+            if (this.factory.ActAsInitiator)
+            {
+                TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
+                foreach (SupportingTokenProviderSpecification spec in this.channelSupportingTokenProviderSpecification)
+                {
+                    await SecurityUtils.CloseTokenProviderIfRequiredAsync(spec.TokenProvider, timeoutHelper.RemainingTime());
+                }
+                foreach (string action in this.scopedSupportingTokenProviderSpecification.Keys)
+                {
+                    ICollection<SupportingTokenProviderSpecification> supportingProviders = this.scopedSupportingTokenProviderSpecification[action];
+                    foreach (SupportingTokenProviderSpecification spec in supportingProviders)
+                    {
+                        await SecurityUtils.CloseTokenProviderIfRequiredAsync(spec.TokenProvider, timeoutHelper.RemainingTime());
+                    }
+                }
+            }
+        }
+
+        public IAsyncResult BeginClose(TimeSpan timeout, AsyncCallback callback, object state)
+        {
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+            //return this.communicationObject.BeginClose(timeout, callback, state);
+        }
+
+        public void EndClose(IAsyncResult result)
+        {
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+            //this.communicationObject.EndClose(result);
+        }
+
+        static void SetSecurityHeaderId(SendSecurityHeader securityHeader, Message message)
+        {
+            SecurityMessageProperty messageProperty = message.Properties.Security;
+            if (messageProperty != null)
+            {
+                securityHeader.IdPrefix = messageProperty.SenderIdPrefix;
+            }
+        }
+
+        void AddSupportingTokenSpecification(SecurityMessageProperty security, IList<SecurityToken> tokens, SecurityTokenAttachmentMode attachmentMode, IDictionary<SecurityToken, ReadOnlyCollection<IAuthorizationPolicy>> tokenPoliciesMapping)
+        {
+            if (tokens == null || tokens.Count == 0)
+            {
+                return;
+            }
+            for (int i = 0; i < tokens.Count; ++i)
+            {
+                security.IncomingSupportingTokens.Add(new SupportingTokenSpecification(tokens[i], tokenPoliciesMapping[tokens[i]], attachmentMode));
+            }
+        }
+
+        protected void AddSupportingTokenSpecification(SecurityMessageProperty security, IList<SecurityToken> basicTokens, IList<SecurityToken> endorsingTokens, IList<SecurityToken> signedEndorsingTokens, IList<SecurityToken> signedTokens, IDictionary<SecurityToken, ReadOnlyCollection<IAuthorizationPolicy>> tokenPoliciesMapping)
+        {
+            AddSupportingTokenSpecification(security, basicTokens, SecurityTokenAttachmentMode.SignedEncrypted, tokenPoliciesMapping);
+            AddSupportingTokenSpecification(security, endorsingTokens, SecurityTokenAttachmentMode.Endorsing, tokenPoliciesMapping);
+            AddSupportingTokenSpecification(security, signedEndorsingTokens, SecurityTokenAttachmentMode.SignedEndorsing, tokenPoliciesMapping);
+            AddSupportingTokenSpecification(security, signedTokens, SecurityTokenAttachmentMode.Signed, tokenPoliciesMapping);
+        }
+
+        protected SendSecurityHeader CreateSendSecurityHeader(Message message, string actor, SecurityProtocolFactory factory)
+        {
+            return CreateSendSecurityHeader(message, actor, factory, true);
+        }
+
+        protected SendSecurityHeader CreateSendSecurityHeaderForTransportProtocol(Message message, string actor, SecurityProtocolFactory factory)
+        {
+            return CreateSendSecurityHeader(message, actor, factory, false);
+        }
+
+        SendSecurityHeader CreateSendSecurityHeader(Message message, string actor, SecurityProtocolFactory factory, bool requireMessageProtection)
+        {
+            // throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+
+            MessageDirection transferDirection = factory.ActAsInitiator ? MessageDirection.Input : MessageDirection.Output;
+            SendSecurityHeader sendSecurityHeader = factory.StandardsManager.CreateSendSecurityHeader(
+                message,
+                actor, true, false,
+                factory.OutgoingAlgorithmSuite, transferDirection);
+            sendSecurityHeader.Layout = factory.SecurityHeaderLayout;
+            sendSecurityHeader.RequireMessageProtection = requireMessageProtection;
+            SetSecurityHeaderId(sendSecurityHeader, message);
+            if (factory.AddTimestamp)
+            {
+                sendSecurityHeader.AddTimestamp(factory.TimestampValidityDuration);
+            }
+
+            sendSecurityHeader.StreamBufferManager = factory.StreamBufferManager;
+            return sendSecurityHeader;
+        }
+
+        internal void AddMessageSupportingTokens(Message message, ref IList<SupportingTokenSpecification> supportingTokens)
+        {
+            SecurityMessageProperty supportingTokensProperty = message.Properties.Security;
+            if (supportingTokensProperty != null && supportingTokensProperty.HasOutgoingSupportingTokens)
+            {
+                if (supportingTokens == null)
+                {
+                    supportingTokens = new Collection<SupportingTokenSpecification>();
+                }
+                for (int i = 0; i < supportingTokensProperty.OutgoingSupportingTokens.Count; ++i)
+                {
+                    SupportingTokenSpecification spec = supportingTokensProperty.OutgoingSupportingTokens[i];
+                    if (spec.SecurityTokenParameters == null)
+                    {
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new MessageSecurityException(SR.Format(SR.SenderSideSupportingTokensMustSpecifySecurityTokenParameters)));
+                    }
+                    supportingTokens.Add(spec);
+                }
+            }
+        }
+
+        internal bool TryGetSupportingTokens(SecurityProtocolFactory factory, EndpointAddress target, Uri via, Message message, TimeSpan timeout, bool isBlockingCall, out IList<SupportingTokenSpecification> supportingTokens)
+        {
+            if (!factory.ActAsInitiator)
+            {
+                supportingTokens = null;
+                return true;
+            }
+            if (message == null)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("message");
+            }
+            TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
+            supportingTokens = null;
+            IList<SupportingTokenProviderSpecification> supportingTokenProviders = this.GetSupportingTokenProviders(message.Headers.Action);
+            if (supportingTokenProviders != null && supportingTokenProviders.Count > 0)
+            {
+                // dont do anything if blocking is not allowed
+                if (!isBlockingCall)
+                {
+                    return false;
+                }
+
+                supportingTokens = new Collection<SupportingTokenSpecification>();
+                for (int i = 0; i < supportingTokenProviders.Count; ++i)
+                {
+                    SupportingTokenProviderSpecification spec = supportingTokenProviders[i];
+                    SecurityToken supportingToken;
+                    // The ProviderBackedSecurityToken was added in Win7 to allow KerberosRequestorSecurity 
+                    // to pass a channel binding to InitializeSecurityContext.
+                    if ((this is TransportSecurityProtocol) && (spec.TokenParameters is KerberosSecurityTokenParameters))
+                    {
+                        supportingToken = new ProviderBackedSecurityToken(spec.TokenProvider, timeoutHelper.RemainingTime());
+                    }
+                    else
+                    {
+                        supportingToken = spec.TokenProvider.GetToken(timeoutHelper.RemainingTime());
+                    }
+
+                    supportingTokens.Add(new SupportingTokenSpecification(supportingToken, EmptyReadOnlyCollection<IAuthorizationPolicy>.Instance, spec.SecurityTokenAttachmentMode, spec.TokenParameters));
+                }
+            }
+            // add any runtime supporting tokens
+            AddMessageSupportingTokens(message, ref supportingTokens);
+
+            return true;
+        }
+
+        protected IList<SupportingTokenAuthenticatorSpecification> GetSupportingTokenAuthenticatorsAndSetExpectationFlags(SecurityProtocolFactory factory, Message message,
+            ReceiveSecurityHeader securityHeader)
+        {
+            if (factory.ActAsInitiator)
+            {
+                return null;
+            }
+            if (message == null)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("message");
+            }
+            bool expectBasicTokens;
+            bool expectSignedTokens;
+            bool expectEndorsingTokens;
+            IList<SupportingTokenAuthenticatorSpecification> authenticators = factory.GetSupportingTokenAuthenticators(message.Headers.Action,
+                out expectSignedTokens, out expectBasicTokens, out expectEndorsingTokens);
+            securityHeader.ExpectBasicTokens = expectBasicTokens;
+            securityHeader.ExpectEndorsingTokens = expectEndorsingTokens;
+            securityHeader.ExpectSignedTokens = expectSignedTokens;
+            return authenticators;
+        }
+
+
+        protected ReadOnlyCollection<SecurityTokenResolver> MergeOutOfBandResolvers(IList<SupportingTokenAuthenticatorSpecification> supportingAuthenticators, ReadOnlyCollection<SecurityTokenResolver> primaryResolvers)
+        {
+            Collection<SecurityTokenResolver> outOfBandResolvers = null;
+            if (supportingAuthenticators != null && supportingAuthenticators.Count > 0)
+            {
+                for (int i = 0; i < supportingAuthenticators.Count; ++i)
+                {
+                    if (supportingAuthenticators[i].TokenResolver != null)
+                    {
+                        outOfBandResolvers = outOfBandResolvers ?? new Collection<SecurityTokenResolver>();
+                        outOfBandResolvers.Add(supportingAuthenticators[i].TokenResolver);
+                    }
+                }
+            }
+            if (outOfBandResolvers != null)
+            {
+                if (primaryResolvers != null)
+                {
+                    for (int i = 0; i < primaryResolvers.Count; ++i)
+                    {
+                        outOfBandResolvers.Insert(0, primaryResolvers[i]);
+                    }
+                }
+                return new ReadOnlyCollection<SecurityTokenResolver>(outOfBandResolvers);
+            }
+            else
+            {
+                return primaryResolvers ?? EmptyReadOnlyCollection<SecurityTokenResolver>.Instance;
+            }
+        }
+
+
+        protected void AddSupportingTokens(SendSecurityHeader securityHeader, IList<SupportingTokenSpecification> supportingTokens)
+        {
+            if (supportingTokens != null)
+            {
+                for (int i = 0; i < supportingTokens.Count; ++i)
+                {
+                    SecurityToken token = supportingTokens[i].SecurityToken;
+                    SecurityTokenParameters tokenParameters = supportingTokens[i].SecurityTokenParameters;
+                    switch (supportingTokens[i].SecurityTokenAttachmentMode)
+                    {
+                        case SecurityTokenAttachmentMode.Signed:
+                            securityHeader.AddSignedSupportingToken(token, tokenParameters);
+                            break;
+                        case SecurityTokenAttachmentMode.Endorsing:
+                            securityHeader.AddEndorsingSupportingToken(token, tokenParameters);
+                            break;
+                        case SecurityTokenAttachmentMode.SignedEncrypted:
+                            securityHeader.AddBasicSupportingToken(token, tokenParameters);
+                            break;
+                        case SecurityTokenAttachmentMode.SignedEndorsing:
+                            securityHeader.AddSignedEndorsingSupportingToken(token, tokenParameters);
+                            break;
+                        default:
+                            Fx.Assert("Unknown token attachment mode " + supportingTokens[i].SecurityTokenAttachmentMode.ToString());
+                            throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new NotSupportedException(SR.Format(SR.UnknownTokenAttachmentMode, supportingTokens[i].SecurityTokenAttachmentMode.ToString())));
+                    }
+                }
+            }
+        }
+
+        public virtual IAsyncResult BeginSecureOutgoingMessage(Message message, TimeSpan timeout, AsyncCallback callback, object state)
+        {
+            SecureOutgoingMessage(ref message, timeout);
+            return new CompletedAsyncResult<Message>(message, callback, state);
+        }
+
+        public virtual IAsyncResult BeginSecureOutgoingMessage(Message message, TimeSpan timeout, SecurityProtocolCorrelationState correlationState, AsyncCallback callback, object state)
+        {
+            SecurityProtocolCorrelationState newCorrelationState = SecureOutgoingMessage(ref message, timeout, correlationState);
+            return new CompletedAsyncResult<Message, SecurityProtocolCorrelationState>(message, newCorrelationState, callback, state);
+        }
+
+        public virtual IAsyncResult BeginVerifyIncomingMessage(Message message, TimeSpan timeout, AsyncCallback callback, object state)
+        {
+            VerifyIncomingMessage(ref message, timeout);
+            return new CompletedAsyncResult<Message>(message, callback, state);
+        }
+
+        public virtual IAsyncResult BeginVerifyIncomingMessage(Message message, TimeSpan timeout, SecurityProtocolCorrelationState[] correlationStates, AsyncCallback callback, object state)
+        {
+            SecurityProtocolCorrelationState newCorrelationState = VerifyIncomingMessage(ref message, timeout, correlationStates);
+            return new CompletedAsyncResult<Message, SecurityProtocolCorrelationState>(message, newCorrelationState, callback, state);
+        }
+
+        public virtual void EndSecureOutgoingMessage(IAsyncResult result, out Message message)
+        {
+            message = CompletedAsyncResult<Message>.End(result);
+        }
+
+        public virtual void EndSecureOutgoingMessage(IAsyncResult result, out Message message, out SecurityProtocolCorrelationState newCorrelationState)
+        {
+            message = CompletedAsyncResult<Message, SecurityProtocolCorrelationState>.End(result, out newCorrelationState);
+        }
+
+        public virtual void EndVerifyIncomingMessage(IAsyncResult result, out Message message)
+        {
+            message = CompletedAsyncResult<Message>.End(result);
+        }
+
+        public virtual void EndVerifyIncomingMessage(IAsyncResult result, out Message message, out SecurityProtocolCorrelationState newCorrelationState)
+        {
+            message = CompletedAsyncResult<Message, SecurityProtocolCorrelationState>.End(result, out newCorrelationState);
+        }
+
+        internal static SecurityToken GetToken(SecurityTokenProvider provider, EndpointAddress target, TimeSpan timeout)
+        {
+            if (provider == null)
+            {
+                // should this be an ArgumentNullException ?
+                // throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentNullException("provider"));
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new MessageSecurityException(SR.Format(SR.TokenProviderCannotGetTokensForTarget, target)));
+            }
+
+            SecurityToken token = null;
+
+            try
+            {
+                token = provider.GetToken(timeout);
+            }
+            catch (SecurityTokenException exception)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new MessageSecurityException(SR.Format(SR.TokenProviderCannotGetTokensForTarget, target), exception));
+            }
+            catch (SecurityNegotiationException sne)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new SecurityNegotiationException(SR.Format(SR.TokenProviderCannotGetTokensForTarget, target), sne));
+            }
+
+            return token;
+        }
+
+        public abstract void SecureOutgoingMessage(ref Message message, TimeSpan timeout);
+
+        // subclasses that offer correlation should override this version
+        public virtual SecurityProtocolCorrelationState SecureOutgoingMessage(ref Message message, TimeSpan timeout, SecurityProtocolCorrelationState correlationState)
+        {
+            SecureOutgoingMessage(ref message, timeout);
+            return null;
+        }
+
+        protected virtual void OnOutgoingMessageSecured(Message securedMessage)
+        {
+            SecurityTraceRecordHelper.TraceOutgoingMessageSecured(this, securedMessage);
+        }
+
+        protected virtual void OnSecureOutgoingMessageFailure(Message message)
+        {
+            SecurityTraceRecordHelper.TraceSecureOutgoingMessageFailure(this, message);
+        }
+
+        public abstract void VerifyIncomingMessage(ref Message message, TimeSpan timeout);
+
+        // subclasses that offer correlation should override this version
+        public virtual SecurityProtocolCorrelationState VerifyIncomingMessage(ref Message message, TimeSpan timeout, params SecurityProtocolCorrelationState[] correlationStates)
+        {
+            VerifyIncomingMessage(ref message, timeout);
+
+            return null;
+        }
+
+        protected virtual void OnIncomingMessageVerified(Message verifiedMessage)
+        {
+            SecurityTraceRecordHelper.TraceIncomingMessageVerified(this, verifiedMessage);
+
+            if (AuditLevel.Success == (this.factory.MessageAuthenticationAuditLevel & AuditLevel.Success))
+            {
+                SecurityAuditHelper.WriteMessageAuthenticationSuccessEvent(this.factory.AuditLogLocation,
+                    this.factory.SuppressAuditFailure, verifiedMessage, verifiedMessage.Headers.To, verifiedMessage.Headers.Action,
+                    SecurityUtils.GetIdentityNamesFromContext(verifiedMessage.Properties.Security.ServiceSecurityContext.AuthorizationContext));
+            }
+        }
+
+        protected virtual void OnVerifyIncomingMessageFailure(Message message, Exception exception)
+        {
+            SecurityTraceRecordHelper.TraceVerifyIncomingMessageFailure(this, message);
+
+            if (AuditLevel.Failure == (this.factory.MessageAuthenticationAuditLevel & AuditLevel.Failure))
+            {
+                try
+                {
+                    SecurityMessageProperty security = message.Properties.Security;
+                    string primaryIdentity;
+                    if (security != null && security.ServiceSecurityContext != null)
+                        primaryIdentity = SecurityUtils.GetIdentityNamesFromContext(security.ServiceSecurityContext.AuthorizationContext);
+                    else
+                        primaryIdentity = SecurityUtils.AnonymousIdentity.Name;
+
+                    SecurityAuditHelper.WriteMessageAuthenticationFailureEvent(this.factory.AuditLogLocation,
+                        this.factory.SuppressAuditFailure, message, message.Headers.To, message.Headers.Action, primaryIdentity, exception);
+                }
+#pragma warning suppress 56500
+                catch (Exception auditException)
+                {
+                    if (Fx.IsFatal(auditException))
+                        throw;
+
+                    // Issue #31 in progress
+                    //DiagnosticUtility.TraceHandledException(auditException, TraceEventType.Error);
+                }
+            }
+        }
+
+        protected abstract class GetSupportingTokensAsyncResult : AsyncResult
+        {
+            static AsyncCallback getSupportingTokensCallback = Fx.ThunkCallback(new AsyncCallback(GetSupportingTokenCallback));
+            SecurityProtocol binding;
+            Message message;
+            IList<SupportingTokenSpecification> supportingTokens;
+            int currentTokenProviderIndex = 0;
+            IList<SupportingTokenProviderSpecification> supportingTokenProviders;
+            TimeoutHelper timeoutHelper;
+
+            public GetSupportingTokensAsyncResult(Message m, SecurityProtocol binding, TimeSpan timeout, AsyncCallback callback, object state)
+                : base(callback, state)
+            {
+                this.message = m;
+                this.binding = binding;
+                this.timeoutHelper = new TimeoutHelper(timeout);
+            }
+
+            protected IList<SupportingTokenSpecification> SupportingTokens
+            {
+                get { return this.supportingTokens; }
+            }
+
+            protected abstract bool OnGetSupportingTokensDone(TimeSpan timeout);
+
+            static void GetSupportingTokenCallback(IAsyncResult result)
+            {
+                if (result.CompletedSynchronously)
+                {
+                    return;
+                }
+                GetSupportingTokensAsyncResult self = (GetSupportingTokensAsyncResult)result.AsyncState;
+                bool completeSelf;
+                Exception completionException = null;
+                try
+                {
+                    self.AddSupportingToken(result);
+                    completeSelf = self.AddSupportingTokens();
+                }
+#pragma warning suppress 56500 // covered by FxCOP
+                catch (Exception e)
+                {
+                    if (Fx.IsFatal(e))
+                    {
+                        throw;
+                    }
+
+                    completeSelf = true;
+                    completionException = e;
+                }
+                if (completeSelf)
+                {
+                    self.Complete(false, completionException);
+                }
+            }
+
+            void AddSupportingToken(IAsyncResult result)
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // #31 and #1494 in progress
+
+                //SupportingTokenProviderSpecification spec = supportingTokenProviders[this.currentTokenProviderIndex];
+                //SecurityTokenProvider.SecurityTokenAsyncResult securityTokenAsyncResult = result as SecurityTokenProvider.SecurityTokenAsyncResult;
+                //if (securityTokenAsyncResult != null)
+                //{
+                //    this.supportingTokens.Add(new SupportingTokenSpecification(SecurityTokenProvider.SecurityTokenAsyncResult.End(result), EmptyReadOnlyCollection<IAuthorizationPolicy>.Instance, spec.SecurityTokenAttachmentMode, spec.TokenParameters));
+                //}
+                //else
+                //{
+                //    this.supportingTokens.Add(new SupportingTokenSpecification(spec.TokenProvider.EndGetToken(result), EmptyReadOnlyCollection<IAuthorizationPolicy>.Instance, spec.SecurityTokenAttachmentMode, spec.TokenParameters));
+                //}
+
+                //++this.currentTokenProviderIndex;
+            }
+
+            bool AddSupportingTokens()
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // #31 and #1494 in progress
+
+                //while (this.currentTokenProviderIndex < supportingTokenProviders.Count)
+                //{
+                //    SupportingTokenProviderSpecification spec = supportingTokenProviders[this.currentTokenProviderIndex];
+                //    IAsyncResult result = null;
+                //    if ((this.binding is TransportSecurityProtocol) && (spec.TokenParameters is KerberosSecurityTokenParameters))
+                //    {
+                //        result = new SecurityTokenProvider.SecurityTokenAsyncResult(new ProviderBackedSecurityToken(spec.TokenProvider, timeoutHelper.RemainingTime()), null, this);
+                //    }
+                //    else
+                //    {
+                //        result = spec.TokenProvider.BeginGetToken(timeoutHelper.RemainingTime(), getSupportingTokensCallback, this);
+                //    }
+
+                //    if (!result.CompletedSynchronously)
+                //    {
+                //        return false;
+                //    }
+                //    this.AddSupportingToken(result);
+                //}
+                //this.binding.AddMessageSupportingTokens(message, ref this.supportingTokens);
+                //return this.OnGetSupportingTokensDone(timeoutHelper.RemainingTime());
+            }
+
+            protected void Start()
+            {
+                bool completeSelf;
+                if (this.binding.TryGetSupportingTokens(this.binding.SecurityProtocolFactory, this.binding.Target, this.binding.Via, this.message, timeoutHelper.RemainingTime(), false, out supportingTokens))
+                {
+                    completeSelf = this.OnGetSupportingTokensDone(timeoutHelper.RemainingTime());
+                }
+                else
+                {
+                    this.supportingTokens = new Collection<SupportingTokenSpecification>();
+                    this.supportingTokenProviders = this.binding.GetSupportingTokenProviders(message.Headers.Action);
+                    if (!(this.supportingTokenProviders != null && this.supportingTokenProviders.Count > 0))
+                    {
+                        Fx.Assert("There must be at least 1 supporting token provider");
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new NotSupportedException("There must be at least 1 supporting token provider"));
+                    }
+                    completeSelf = this.AddSupportingTokens();
+                }
+                if (completeSelf)
+                {
+                    base.Complete(true);
+                }
             }
         }
     }

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SecurityProtocolCorrelationState.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SecurityProtocolCorrelationState.cs
@@ -1,43 +1,42 @@
-//----------------------------------------------------------
-// Copyright (c) Microsoft Corporation.  All rights reserved.
-//------------------------------------------------------------
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.IdentityModel.Claims;
+using System.ServiceModel;
+using System.IdentityModel.Policy;
+using System.IdentityModel.Tokens;
+using System.ServiceModel.Security.Tokens;
+using System.ServiceModel.Diagnostics;
 
 namespace System.ServiceModel.Security
 {
-    using System.IdentityModel.Claims;
-    using System.ServiceModel;
-    using System.IdentityModel.Policy;
-    using System.IdentityModel.Tokens;
-    using System.ServiceModel.Security.Tokens;
-    using System.ServiceModel.Diagnostics;
-
     class SecurityProtocolCorrelationState
     {
-        SecurityToken token;
-        SignatureConfirmations signatureConfirmations;
-        ServiceModelActivity activity;
+        private SecurityToken _token;
+        private SignatureConfirmations _signatureConfirmations;
+        private ServiceModelActivity _activity;
 
         public SecurityProtocolCorrelationState(SecurityToken token)
         {
-            this.token = token;
-            this.activity = DiagnosticUtility.ShouldUseActivity ? ServiceModelActivity.Current : null;
+            _token = token;
+            _activity = DiagnosticUtility.ShouldUseActivity ? ServiceModelActivity.Current : null;
         }
 
         public SecurityToken Token
         {
-            get { return this.token; }
+            get { return _token; }
         }
 
         internal SignatureConfirmations SignatureConfirmations
         {
-            get { return this.signatureConfirmations; }
-            set { this.signatureConfirmations = value; }
+            get { return _signatureConfirmations; }
+            set { _signatureConfirmations = value; }
         }
 
         internal ServiceModelActivity Activity
         {
-            get { return this.activity; }
+            get { return _activity; }
         }
     }
 }
-

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SecurityProtocolCorrelationState.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SecurityProtocolCorrelationState.cs
@@ -1,0 +1,43 @@
+//----------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace System.ServiceModel.Security
+{
+    using System.IdentityModel.Claims;
+    using System.ServiceModel;
+    using System.IdentityModel.Policy;
+    using System.IdentityModel.Tokens;
+    using System.ServiceModel.Security.Tokens;
+    using System.ServiceModel.Diagnostics;
+
+    class SecurityProtocolCorrelationState
+    {
+        SecurityToken token;
+        SignatureConfirmations signatureConfirmations;
+        ServiceModelActivity activity;
+
+        public SecurityProtocolCorrelationState(SecurityToken token)
+        {
+            this.token = token;
+            this.activity = DiagnosticUtility.ShouldUseActivity ? ServiceModelActivity.Current : null;
+        }
+
+        public SecurityToken Token
+        {
+            get { return this.token; }
+        }
+
+        internal SignatureConfirmations SignatureConfirmations
+        {
+            get { return this.signatureConfirmations; }
+            set { this.signatureConfirmations = value; }
+        }
+
+        internal ServiceModelActivity Activity
+        {
+            get { return this.activity; }
+        }
+    }
+}
+

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SecurityProtocolCorrelationState.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SecurityProtocolCorrelationState.cs
@@ -2,11 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.IdentityModel.Claims;
-using System.ServiceModel;
-using System.IdentityModel.Policy;
 using System.IdentityModel.Tokens;
-using System.ServiceModel.Security.Tokens;
 using System.ServiceModel.Diagnostics;
 
 namespace System.ServiceModel.Security

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SecurityProtocolFactory.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SecurityProtocolFactory.cs
@@ -2,9 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Globalization;
 using System.IdentityModel.Selectors;
 using System.IdentityModel.Tokens;
 using System.Runtime;
@@ -12,7 +12,6 @@ using System.Security.Authentication.ExtendedProtection;
 using System.ServiceModel.Channels;
 using System.ServiceModel.Description;
 using System.ServiceModel.Security.Tokens;
-using System.Globalization;
 using System.Threading.Tasks;
 
 namespace System.ServiceModel.Security

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SecurityProtocolFactory.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SecurityProtocolFactory.cs
@@ -13,6 +13,7 @@ using System.ServiceModel.Channels;
 using System.ServiceModel.Description;
 using System.ServiceModel.Security.Tokens;
 using System.Globalization;
+using System.Threading.Tasks;
 
 namespace System.ServiceModel.Security
 {
@@ -194,6 +195,12 @@ namespace System.ServiceModel.Security
             {
                 _streamBufferManager = value;
             }
+        }
+
+        public ExtendedProtectionPolicy ExtendedProtectionPolicy
+        {
+            get { return _extendedProtectionPolicy; }
+            set { _extendedProtectionPolicy = value; }
         }
 
         internal bool IsDuplexReply
@@ -686,6 +693,31 @@ namespace System.ServiceModel.Security
             }
         }
 
+        public virtual Task OnCloseAsync(TimeSpan timeout)
+        {
+            return OnCloseAsyncInternal(timeout);
+        }
+
+        private async Task OnCloseAsyncInternal(TimeSpan timeout)
+        {
+            TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
+            if (!_actAsInitiator)
+            {
+                foreach (SupportingTokenAuthenticatorSpecification spec in _channelSupportingTokenAuthenticatorSpecification)
+                {
+                    await SecurityUtils.CloseTokenAuthenticatorIfRequiredAsync(spec.TokenAuthenticator, timeoutHelper.RemainingTime());
+                }
+                foreach (string action in _scopedSupportingTokenAuthenticatorSpecification.Keys)
+                {
+                    ICollection<SupportingTokenAuthenticatorSpecification> supportingAuthenticators = _scopedSupportingTokenAuthenticatorSpecification[action];
+                    foreach (SupportingTokenAuthenticatorSpecification spec in supportingAuthenticators)
+                    {
+                        await SecurityUtils.CloseTokenAuthenticatorIfRequiredAsync(spec.TokenAuthenticator, timeoutHelper.RemainingTime());
+                    }
+                }
+            }
+        }
+
         public virtual object CreateListenerSecurityState()
         {
             return null;
@@ -817,6 +849,71 @@ namespace System.ServiceModel.Security
                     foreach (SupportingTokenAuthenticatorSpecification spec in scopedAuthenticators)
                     {
                         SecurityUtils.OpenTokenAuthenticatorIfRequired(spec.TokenAuthenticator, timeoutHelper.RemainingTime());
+                        mergedAuthenticators.Add(spec);
+                        if (spec.SecurityTokenAttachmentMode == SecurityTokenAttachmentMode.Endorsing ||
+                            spec.SecurityTokenAttachmentMode == SecurityTokenAttachmentMode.SignedEndorsing)
+                        {
+                            if (spec.TokenParameters.RequireDerivedKeys && !spec.TokenParameters.HasAsymmetricKey)
+                            {
+                                _expectKeyDerivation = true;
+                            }
+                        }
+                        SecurityTokenAttachmentMode mode = spec.SecurityTokenAttachmentMode;
+                        if (mode == SecurityTokenAttachmentMode.SignedEncrypted
+                            || mode == SecurityTokenAttachmentMode.Signed
+                            || mode == SecurityTokenAttachmentMode.SignedEndorsing)
+                        {
+                            expectSignedTokens = true;
+                            if (mode == SecurityTokenAttachmentMode.SignedEncrypted)
+                            {
+                                expectBasicTokens = true;
+                            }
+                        }
+                        if (mode == SecurityTokenAttachmentMode.Endorsing || mode == SecurityTokenAttachmentMode.SignedEndorsing)
+                        {
+                            expectEndorsingTokens = true;
+                        }
+                    }
+                    VerifyTypeUniqueness(mergedAuthenticators);
+                    MergedSupportingTokenAuthenticatorSpecification mergedSpec = new MergedSupportingTokenAuthenticatorSpecification();
+                    mergedSpec.SupportingTokenAuthenticators = mergedAuthenticators;
+                    mergedSpec.ExpectBasicTokens = expectBasicTokens;
+                    mergedSpec.ExpectEndorsingTokens = expectEndorsingTokens;
+                    mergedSpec.ExpectSignedTokens = expectSignedTokens;
+                    _mergedSupportingTokenAuthenticatorsMap.Add(action, mergedSpec);
+                }
+            }
+        }
+
+        private async Task MergeSupportingTokenAuthenticatorsAsync(TimeSpan timeout)
+        {
+            if (_scopedSupportingTokenAuthenticatorSpecification.Count == 0)
+            {
+                _mergedSupportingTokenAuthenticatorsMap = null;
+            }
+            else
+            {
+                TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
+                _expectSupportingTokens = true;
+                _mergedSupportingTokenAuthenticatorsMap = new Dictionary<string, MergedSupportingTokenAuthenticatorSpecification>();
+                foreach (string action in _scopedSupportingTokenAuthenticatorSpecification.Keys)
+                {
+                    ICollection<SupportingTokenAuthenticatorSpecification> scopedAuthenticators = _scopedSupportingTokenAuthenticatorSpecification[action];
+                    if (scopedAuthenticators == null || scopedAuthenticators.Count == 0)
+                    {
+                        continue;
+                    }
+                    Collection<SupportingTokenAuthenticatorSpecification> mergedAuthenticators = new Collection<SupportingTokenAuthenticatorSpecification>();
+                    bool expectSignedTokens = _expectChannelSignedTokens;
+                    bool expectBasicTokens = _expectChannelBasicTokens;
+                    bool expectEndorsingTokens = _expectChannelEndorsingTokens;
+                    foreach (SupportingTokenAuthenticatorSpecification spec in _channelSupportingTokenAuthenticatorSpecification)
+                    {
+                        mergedAuthenticators.Add(spec);
+                    }
+                    foreach (SupportingTokenAuthenticatorSpecification spec in scopedAuthenticators)
+                    {
+                        await SecurityUtils.OpenTokenAuthenticatorIfRequiredAsync(spec.TokenAuthenticator, timeoutHelper.RemainingTime());
                         mergedAuthenticators.Add(spec);
                         if (spec.SecurityTokenAttachmentMode == SecurityTokenAttachmentMode.Endorsing ||
                             spec.SecurityTokenAttachmentMode == SecurityTokenAttachmentMode.SignedEndorsing)
@@ -1035,21 +1132,112 @@ namespace System.ServiceModel.Security
             _derivedKeyTokenAuthenticator = new NonValidatingSecurityTokenAuthenticator<DerivedKeySecurityToken>();
         }
 
+        public virtual Task OnOpenAsync(TimeSpan timeout)
+        {
+            return OnOpenAsyncInternal(timeout);
+        }
+
+        private async Task OnOpenAsyncInternal(TimeSpan timeout)
+        { 
+            if (this.SecurityBindingElement == null)
+            {
+                this.OnPropertySettingsError("SecurityBindingElement", true);
+            }
+            if (this.SecurityTokenManager == null)
+            {
+                this.OnPropertySettingsError("SecurityTokenManager", true);
+            }
+            _messageSecurityVersion = _standardsManager.MessageSecurityVersion;
+            TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
+            _expectOutgoingMessages = this.ActAsInitiator || this.SupportsRequestReply;
+            _expectIncomingMessages = !this.ActAsInitiator || this.SupportsRequestReply;
+            if (!_actAsInitiator)
+            {
+                AddSupportingTokenAuthenticators(_securityBindingElement.EndpointSupportingTokenParameters, false, (IList<SupportingTokenAuthenticatorSpecification>)_channelSupportingTokenAuthenticatorSpecification);
+                // validate the token authenticator types and create a merged map if needed.
+                if (!_channelSupportingTokenAuthenticatorSpecification.IsReadOnly)
+                {
+                    if (_channelSupportingTokenAuthenticatorSpecification.Count == 0)
+                    {
+                        _channelSupportingTokenAuthenticatorSpecification = EmptyTokenAuthenticators;
+                    }
+                    else
+                    {
+                        _expectSupportingTokens = true;
+                        foreach (SupportingTokenAuthenticatorSpecification tokenAuthenticatorSpec in _channelSupportingTokenAuthenticatorSpecification)
+                        {
+                            SecurityUtils.OpenTokenAuthenticatorIfRequired(tokenAuthenticatorSpec.TokenAuthenticator, timeoutHelper.RemainingTime());
+                            if (tokenAuthenticatorSpec.SecurityTokenAttachmentMode == SecurityTokenAttachmentMode.Endorsing
+                                || tokenAuthenticatorSpec.SecurityTokenAttachmentMode == SecurityTokenAttachmentMode.SignedEndorsing)
+                            {
+                                if (tokenAuthenticatorSpec.TokenParameters.RequireDerivedKeys && !tokenAuthenticatorSpec.TokenParameters.HasAsymmetricKey)
+                                {
+                                    _expectKeyDerivation = true;
+                                }
+                            }
+                            SecurityTokenAttachmentMode mode = tokenAuthenticatorSpec.SecurityTokenAttachmentMode;
+                            if (mode == SecurityTokenAttachmentMode.SignedEncrypted
+                                || mode == SecurityTokenAttachmentMode.Signed
+                                || mode == SecurityTokenAttachmentMode.SignedEndorsing)
+                            {
+                                _expectChannelSignedTokens = true;
+                                if (mode == SecurityTokenAttachmentMode.SignedEncrypted)
+                                {
+                                    _expectChannelBasicTokens = true;
+                                }
+                            }
+                            if (mode == SecurityTokenAttachmentMode.Endorsing || mode == SecurityTokenAttachmentMode.SignedEndorsing)
+                            {
+                                _expectChannelEndorsingTokens = true;
+                            }
+                        }
+                        _channelSupportingTokenAuthenticatorSpecification =
+                            new ReadOnlyCollection<SupportingTokenAuthenticatorSpecification>((Collection<SupportingTokenAuthenticatorSpecification>)_channelSupportingTokenAuthenticatorSpecification);
+                    }
+                }
+                VerifyTypeUniqueness(_channelSupportingTokenAuthenticatorSpecification);
+
+                await MergeSupportingTokenAuthenticatorsAsync(timeoutHelper.RemainingTime());
+            }
+
+            if (this.DetectReplays)
+            {
+                if (!this.SupportsReplayDetection)
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgument("DetectReplays", SR.Format(SR.SecurityProtocolCannotDoReplayDetection, this));
+                }
+                if (this.MaxClockSkew == TimeSpan.MaxValue || this.ReplayWindow == TimeSpan.MaxValue)
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.NoncesCachedInfinitely));
+                }
+
+                // If DetectReplays is true and nonceCache is null then use the default InMemoryNonceCache. 
+                if (_nonceCache == null)
+                {
+                    // The nonce needs to be cached for replayWindow + 2*clockSkew to eliminate replays
+                    _nonceCache = new InMemoryNonceCache(this.ReplayWindow + this.MaxClockSkew + this.MaxClockSkew, this.MaxCachedNonces);
+                }
+            }
+
+            _derivedKeyTokenAuthenticator = new NonValidatingSecurityTokenAuthenticator<DerivedKeySecurityToken>();
+        }
+
+
         public void Open(bool actAsInitiator, TimeSpan timeout)
         {
             _actAsInitiator = actAsInitiator;
             _communicationObject.Open(timeout);
         }
 
-        public IAsyncResult BeginOpen(bool actAsInitiator, TimeSpan timeout, AsyncCallback callback, object state)
+        public Task OpenAsync(TimeSpan timeout)
         {
-            _actAsInitiator = actAsInitiator;
-            return this.CommunicationObject.BeginOpen(timeout, callback, state);
+            return ((IAsyncCommunicationObject)_communicationObject).OpenAsync(timeout);
         }
 
-        public void EndOpen(IAsyncResult result)
+        public Task OpenAsync(bool actAsInitiator, TimeSpan timeout)
         {
-            this.CommunicationObject.EndOpen(result);
+            _actAsInitiator = actAsInitiator;
+            return OpenAsync(timeout);
         }
 
         public void Close(bool aborted, TimeSpan timeout)
@@ -1064,14 +1252,9 @@ namespace System.ServiceModel.Security
             }
         }
 
-        public IAsyncResult BeginClose(TimeSpan timeout, AsyncCallback callback, object state)
+        public Task CloseAsync(TimeSpan timeout)
         {
-            return this.CommunicationObject.BeginClose(timeout, callback, state);
-        }
-
-        public void EndClose(IAsyncResult result)
-        {
-            this.CommunicationObject.EndClose(result);
+            return ((IAsyncCommunicationObject)_communicationObject).CloseAsync(timeout);
         }
 
         internal void Open(string propertyName, bool requiredForForwardDirection, SecurityTokenAuthenticator authenticator, TimeSpan timeout)

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SecuritySessionClientSettings.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SecuritySessionClientSettings.cs
@@ -3,20 +3,16 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.IdentityModel.Claims;
+using System.Globalization;
 using System.IdentityModel.Selectors;
 using System.IdentityModel.Tokens;
+using System.Net;
 using System.Runtime;
 using System.ServiceModel.Channels;
 using System.ServiceModel.Diagnostics;
-using System.ServiceModel.Dispatcher;
 using System.ServiceModel.Security.Tokens;
-using System.Net;
-using System.Threading;
-using System.Xml;
-using System.Globalization;
 using System.Threading.Tasks;
+using System.Xml;
 
 namespace System.ServiceModel.Security
 {

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SecuritySessionClientSettings.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SecuritySessionClientSettings.cs
@@ -1160,7 +1160,6 @@ namespace System.ServiceModel.Security
 //                        return message;
 //                    }
 //                }
-//#pragma warning suppress 56500 // covered by FxCOP
 //                catch (Exception e)
 //                {
 //                    if ((e is CommunicationException) || (e is TimeoutException) || (Fx.IsFatal(e)) || !ShouldWrapException(e))
@@ -1833,7 +1832,6 @@ namespace System.ServiceModel.Security
                             completeSelf = self.OnChannelBinderClosed();
                         }
                     }
-#pragma warning suppress 56500 // covered by FxCOP
                     catch (Exception e)
                     {
                         if (Fx.IsFatal(e))
@@ -1906,7 +1904,6 @@ namespace System.ServiceModel.Security
 //                            completeSelf = self.OnTokenProviderClosed();
 //                        }
 //                    }
-//#pragma warning suppress 56500 // covered by FxCOP
 //                    catch (Exception e)
 //                    {
 //                        if (Fx.IsFatal(e))
@@ -2013,7 +2010,6 @@ namespace System.ServiceModel.Security
                     {
                         completeSelf = self.CompleteReceive(result);
                     }
-#pragma warning suppress 56500 // covered by FxCOP
                     catch (Exception e)
                     {
                         if (Fx.IsFatal(e))
@@ -2104,7 +2100,6 @@ namespace System.ServiceModel.Security
                             completeSelf = thisResult.OnOutputSessionClosed();
                         }
                     }
-#pragma warning suppress 56500 // covered by FxCOP
                     catch (Exception e)
                     {
                         if (Fx.IsFatal(e))
@@ -2179,7 +2174,6 @@ namespace System.ServiceModel.Security
 //                    {
 //                        thisResult.closeCompleted = false;
 //                    }
-//#pragma warning suppress 56500 // covered by FxCOP
 //                    catch (Exception e)
 //                    {
 //                        if (Fx.IsFatal(e))
@@ -2279,7 +2273,6 @@ namespace System.ServiceModel.Security
                             }
                         }
                     }
-#pragma warning suppress 56500 // covered by FxCOP
                     catch (Exception e)
                     {
                         if (Fx.IsFatal(e))
@@ -2390,7 +2383,6 @@ namespace System.ServiceModel.Security
 //                            completeSelf = true;
 //                        }
 //                    }
-//#pragma warning suppress 56500 // covered by FxCOP
 //                    catch (Exception e)
 //                    {
 //                        if (Fx.IsFatal(e))
@@ -2429,7 +2421,6 @@ namespace System.ServiceModel.Security
                     {
                         self.sessionChannel.EndCloseCore(result);
                     }
-#pragma warning suppress 56500 // covered by FxCOP
                     catch (Exception e)
                     {
                         if (Fx.IsFatal(e))
@@ -2475,7 +2466,6 @@ namespace System.ServiceModel.Security
                             thisResult.sessionChannel.RenewKey(thisResult.timeoutHelper.RemainingTime());
                         }
                     }
-#pragma warning suppress 56500 // covered by FxCOP
                     catch (Exception e)
                     {
                         if (Fx.IsFatal(e))
@@ -2576,7 +2566,6 @@ namespace System.ServiceModel.Security
                         thisResult.message = thisResult.sessionChannel.EndSecureOutgoingMessage(result, out thisResult.correlationState);
                         completeSelf = thisResult.OnMessageSecured();
                     }
-#pragma warning suppress 56500 // covered by FxCOP
                     catch (Exception e)
                     {
                         if (Fx.IsFatal(e))
@@ -2651,7 +2640,6 @@ namespace System.ServiceModel.Security
                     {
                         thisResult.ChannelBinder.EndSend(result);
                     }
-#pragma warning suppress 56500 // covered by FxCOP
                     catch (Exception e)
                     {
                         if (Fx.IsFatal(e))
@@ -2989,7 +2977,6 @@ namespace System.ServiceModel.Security
                     {
                         thisAsyncResult.reply = thisAsyncResult.ChannelBinder.EndRequest(result);
                     }
-#pragma warning suppress 56500 // covered by FxCOP
                     catch (Exception e)
                     {
                         if (Fx.IsFatal(e))
@@ -3051,7 +3038,6 @@ namespace System.ServiceModel.Security
                         thisAsyncResult.correlationState = thisAsyncResult.requestChannel.EndBaseCloseOutputSession(result);
                         completeSelf = thisAsyncResult.OnBaseOutputSessionClosed();
                     }
-#pragma warning suppress 56500 // covered by FxCOP
                     catch (Exception e)
                     {
                         if (Fx.IsFatal(e))
@@ -3093,7 +3079,6 @@ namespace System.ServiceModel.Security
                         Message message = thisAsyncResult.requestChannel.EndReceiveInternal(result);
                         completeSelf = thisAsyncResult.OnMessageReceived(message);
                     }
-#pragma warning suppress 56500 // covered by FxCOP
                     catch (Exception e)
                     {
                         if (Fx.IsFatal(e))
@@ -3376,7 +3361,6 @@ namespace System.ServiceModel.Security
 //                    {
 //                        this.queue.EnqueueAndDispatch(message);
 //                    }
-//#pragma warning suppress 56500 // covered by FxCOP
 //                    catch (Exception e)
 //                    {
 //                        if (Fx.IsFatal(e)) throw;
@@ -3504,7 +3488,6 @@ namespace System.ServiceModel.Security
 //                            throw;
 //                        }
 //                    }
-//#pragma warning suppress 56500 // covered by FxCOP
 //                    catch (Exception e)
 //                    {
 //                        if (Fx.IsFatal(e)) throw;
@@ -3544,7 +3527,6 @@ namespace System.ServiceModel.Security
 //                        // gracefully
 //                        return new CompletedAsyncResult(callback, state);
 //                    }
-//#pragma warning suppress 56500 // covered by FxCOP
 //                    catch (Exception e)
 //                    {
 //                        if (Fx.IsFatal(e)) throw;
@@ -3590,7 +3572,6 @@ namespace System.ServiceModel.Security
 //                        // another thread must have aborted the channel. Allow the close to complete
 //                        // gracefully
 //                    }
-//#pragma warning suppress 56500 // covered by FxCOP
 //                    catch (Exception e)
 //                    {
 //                        if (Fx.IsFatal(e)) throw;

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SecuritySessionClientSettings.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SecuritySessionClientSettings.cs
@@ -1,27 +1,25 @@
-//----------------------------------------------------------
-// Copyright (c) Microsoft Corporation.  All rights reserved.
-//------------------------------------------------------------
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IdentityModel.Claims;
+using System.IdentityModel.Selectors;
+using System.IdentityModel.Tokens;
+using System.Runtime;
+using System.ServiceModel.Channels;
+using System.ServiceModel.Diagnostics;
+using System.ServiceModel.Dispatcher;
+using System.ServiceModel.Security.Tokens;
+using System.Net;
+using System.Threading;
+using System.Xml;
+using System.Globalization;
+using System.Threading.Tasks;
 
 namespace System.ServiceModel.Security
 {
-    using System.Collections.Generic;
-    using System.Diagnostics;
-    using System.IdentityModel.Claims;
-    using System.IdentityModel.Selectors;
-    using System.IdentityModel.Tokens;
-    using System.Runtime;
-    using System.ServiceModel.Channels;
-    using System.ServiceModel.Diagnostics;
-    using System.ServiceModel.Dispatcher;
-    using System.ServiceModel.Security.Tokens;
-    using System.Net;
-    using System.Threading;
-    using System.Xml;
-    using System.Globalization;
-    using System.ServiceModel.Diagnostics.Application;
-
-    // Please use 'sdv //depot/devdiv/private/indigo_xws/ndp/indigo/src/ServiceModel/System/ServiceModel/Security/SecuritySessionChannelFactory.cs' 
-    // to see version history before the file was renamed
     // This class is named Settings since the only public APIs are for
     // settings; however, this class also manages all functionality
     // for session channels through internal APIs
@@ -31,40 +29,40 @@ namespace System.ServiceModel.Security
         internal const string defaultKeyRenewalIntervalString = "10:00:00";
         internal const string defaultKeyRolloverIntervalString = "00:05:00";
 
-        internal static readonly TimeSpan defaultKeyRenewalInterval = TimeSpan.Parse(defaultKeyRenewalIntervalString, CultureInfo.InvariantCulture);
-        internal static readonly TimeSpan defaultKeyRolloverInterval = TimeSpan.Parse(defaultKeyRolloverIntervalString, CultureInfo.InvariantCulture);
+        internal static readonly TimeSpan s_defaultKeyRenewalInterval = TimeSpan.Parse(defaultKeyRenewalIntervalString, CultureInfo.InvariantCulture);
+        internal static readonly TimeSpan s_defaultKeyRolloverInterval = TimeSpan.Parse(defaultKeyRolloverIntervalString, CultureInfo.InvariantCulture);
         internal const bool defaultTolerateTransportFailures = true;
     }
 
     sealed class SecuritySessionClientSettings<TChannel> : IChannelSecureConversationSessionSettings, ISecurityCommunicationObject
     {
-        SecurityProtocolFactory sessionProtocolFactory;
-        TimeSpan keyRenewalInterval;
-        TimeSpan keyRolloverInterval;
-        bool tolerateTransportFailures;
-        SecurityChannelFactory<TChannel> securityChannelFactory;
-        IChannelFactory innerChannelFactory;
-        ChannelBuilder channelBuilder;
-        WrapperSecurityCommunicationObject communicationObject;
-        SecurityStandardsManager standardsManager;
-        SecurityTokenParameters issuedTokenParameters;
-        int issuedTokenRenewalThreshold;
-        bool canRenewSession = true;
-        object thisLock = new object();
+        private SecurityProtocolFactory _sessionProtocolFactory;
+        private TimeSpan _keyRenewalInterval;
+        private TimeSpan _keyRolloverInterval;
+        private bool _tolerateTransportFailures;
+        private SecurityChannelFactory<TChannel> _securityChannelFactory;
+        private IChannelFactory _innerChannelFactory;
+        private ChannelBuilder _channelBuilder;
+        private WrapperSecurityCommunicationObject _communicationObject;
+        private SecurityStandardsManager _standardsManager;
+        private SecurityTokenParameters _issuedTokenParameters;
+        private int _issuedTokenRenewalThreshold;
+        private bool _canRenewSession = true;
+        private object _thisLock = new object();
 
         public SecuritySessionClientSettings()
         {
-            this.keyRenewalInterval = SecuritySessionClientSettings.defaultKeyRenewalInterval;
-            this.keyRolloverInterval = SecuritySessionClientSettings.defaultKeyRolloverInterval;
-            this.tolerateTransportFailures = SecuritySessionClientSettings.defaultTolerateTransportFailures;
-            this.communicationObject = new WrapperSecurityCommunicationObject(this);
+            _keyRenewalInterval = SecuritySessionClientSettings.s_defaultKeyRenewalInterval;
+            _keyRolloverInterval = SecuritySessionClientSettings.s_defaultKeyRolloverInterval;
+            _tolerateTransportFailures = SecuritySessionClientSettings.defaultTolerateTransportFailures;
+            _communicationObject = new WrapperSecurityCommunicationObject(this);
         }
 
         IChannelFactory InnerChannelFactory
         {
             get
             {
-                return this.innerChannelFactory;
+                return _innerChannelFactory;
             }
         }
 
@@ -72,11 +70,11 @@ namespace System.ServiceModel.Security
         {
             get
             {
-                return this.channelBuilder;
+                return _channelBuilder;
             }
             set
             {
-                this.channelBuilder = value;
+                _channelBuilder = value;
             }
         }
 
@@ -84,7 +82,7 @@ namespace System.ServiceModel.Security
         {
             get
             {
-                return this.securityChannelFactory;
+                return _securityChannelFactory;
             }
         }
 
@@ -92,12 +90,12 @@ namespace System.ServiceModel.Security
         {
             get
             {
-                return this.sessionProtocolFactory;
+                return _sessionProtocolFactory;
             }
             set
             {
-                this.communicationObject.ThrowIfDisposedOrImmutable();
-                this.sessionProtocolFactory = value;
+                _communicationObject.ThrowIfDisposedOrImmutable();
+                _sessionProtocolFactory = value;
             }
         }
 
@@ -105,16 +103,16 @@ namespace System.ServiceModel.Security
         {
             get
             {
-                return this.keyRenewalInterval;
+                return _keyRenewalInterval;
             }
             set
             {
                 if (value <= TimeSpan.Zero)
                 {
-                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("value", SR.GetString(SR.TimeSpanMustbeGreaterThanTimeSpanZero)));
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("value", SR.Format(SR.TimeSpanMustbeGreaterThanTimeSpanZero)));
                 }
-                this.communicationObject.ThrowIfDisposedOrImmutable();
-                this.keyRenewalInterval = value;
+                _communicationObject.ThrowIfDisposedOrImmutable();
+                _keyRenewalInterval = value;
             }
         }
 
@@ -122,16 +120,16 @@ namespace System.ServiceModel.Security
         {
             get
             {
-                return this.keyRolloverInterval;
+                return _keyRolloverInterval;
             }
             set
             {
                 if (value <= TimeSpan.Zero)
                 {
-                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("value", SR.GetString(SR.TimeSpanMustbeGreaterThanTimeSpanZero)));
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("value", SR.Format(SR.TimeSpanMustbeGreaterThanTimeSpanZero)));
                 }
-                this.communicationObject.ThrowIfDisposedOrImmutable();
-                this.keyRolloverInterval = value;
+                _communicationObject.ThrowIfDisposedOrImmutable();
+                _keyRolloverInterval = value;
             }
         }
 
@@ -139,12 +137,12 @@ namespace System.ServiceModel.Security
         {
             get
             {
-                return this.tolerateTransportFailures;
+                return _tolerateTransportFailures;
             }
             set
             {
-                this.communicationObject.ThrowIfDisposedOrImmutable();
-                this.tolerateTransportFailures = value;
+                _communicationObject.ThrowIfDisposedOrImmutable();
+                _tolerateTransportFailures = value;
             }
         }
 
@@ -152,11 +150,11 @@ namespace System.ServiceModel.Security
         {
             get
             {
-                return this.canRenewSession;
+                return _canRenewSession;
             }
             set
             {
-                this.canRenewSession = value;
+                _canRenewSession = value;
             }
         }
 
@@ -164,12 +162,12 @@ namespace System.ServiceModel.Security
         {
             get
             {
-                return this.issuedTokenParameters;
+                return _issuedTokenParameters;
             }
             set
             {
-                this.communicationObject.ThrowIfDisposedOrImmutable();
-                this.issuedTokenParameters = value;
+                _communicationObject.ThrowIfDisposedOrImmutable();
+                _issuedTokenParameters = value;
             }
         }
 
@@ -177,12 +175,12 @@ namespace System.ServiceModel.Security
         {
             get
             {
-                return this.standardsManager;
+                return _standardsManager;
             }
             set
             {
-                this.communicationObject.ThrowIfDisposedOrImmutable();
-                this.standardsManager = value;
+                _communicationObject.ThrowIfDisposedOrImmutable();
+                _standardsManager = value;
             }
         }
 
@@ -217,24 +215,33 @@ namespace System.ServiceModel.Security
             }
         }
 
-        public IAsyncResult BeginClose(TimeSpan timeout, AsyncCallback callback, object state)
+        public Task CloseAsync(TimeSpan timeout)
         {
-            return this.communicationObject.BeginClose(timeout, callback, state);
+            return ((IAsyncCommunicationObject)_communicationObject).CloseAsync(timeout);
         }
 
-        public void EndClose(IAsyncResult result)
+        public Task OpenAsync(TimeSpan timeout)
         {
-            this.communicationObject.EndClose(result);
-        }
-
-        IAsyncResult ISecurityCommunicationObject.OnBeginClose(TimeSpan timeout, AsyncCallback callback, object state)
-        {
-            return new OperationWithTimeoutAsyncResult(new OperationWithTimeoutCallback(this.OnClose), timeout, callback, state);
-        }
-
-        IAsyncResult ISecurityCommunicationObject.OnBeginOpen(TimeSpan timeout, AsyncCallback callback, object state)
-        {
-            return new OperationWithTimeoutAsyncResult(new OperationWithTimeoutCallback(this.OnOpen), timeout, callback, state);
+            TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
+            if (_sessionProtocolFactory == null)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.SecuritySessionProtocolFactoryShouldBeSetBeforeThisOperation)));
+            }
+            if (_standardsManager == null)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.SecurityStandardsManagerNotSet, this.GetType().ToString())));
+            }
+            if (_issuedTokenParameters == null)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.IssuedSecurityTokenParametersNotSet, this.GetType())));
+            }
+            if (_keyRenewalInterval < _keyRolloverInterval)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.KeyRolloverGreaterThanKeyRenewal)));
+            }
+            _issuedTokenRenewalThreshold = _sessionProtocolFactory.SecurityBindingElement.LocalClientSettings.CookieRenewalThresholdPercentage;
+            this.ConfigureSessionProtocolFactory();
+            return _sessionProtocolFactory.OpenAsync(true, timeoutHelper.RemainingTime());
         }
 
         public void OnClosed()
@@ -243,16 +250,6 @@ namespace System.ServiceModel.Security
 
         public void OnClosing()
         {
-        }
-
-        void ISecurityCommunicationObject.OnEndClose(IAsyncResult result)
-        {
-            OperationWithTimeoutAsyncResult.End(result);
-        }
-
-        void ISecurityCommunicationObject.OnEndOpen(IAsyncResult result)
-        {
-            OperationWithTimeoutAsyncResult.End(result);
         }
 
         public void OnFaulted()
@@ -269,75 +266,118 @@ namespace System.ServiceModel.Security
 
         public void OnClose(TimeSpan timeout)
         {
-            if (this.sessionProtocolFactory != null)
+            if (_sessionProtocolFactory != null)
             {
-                this.sessionProtocolFactory.Close(false, timeout);
+                _sessionProtocolFactory.Close(false, timeout);
+            }
+        }
+
+        public Task OnCloseAsync(TimeSpan timeout)
+        {
+            return OnCloseAsyncInternal(timeout);
+        }
+
+        private async Task OnCloseAsyncInternal(TimeSpan timeout)
+        {
+            if (_sessionProtocolFactory != null)
+            {
+                await _sessionProtocolFactory.CloseAsync(timeout);
             }
         }
 
         public void OnAbort()
         {
-            if (this.sessionProtocolFactory != null)
+            if (_sessionProtocolFactory != null)
             {
-                this.sessionProtocolFactory.Close(true, TimeSpan.Zero);
+                _sessionProtocolFactory.Close(true, TimeSpan.Zero);
             }
         }
 
         public void OnOpen(TimeSpan timeout)
         {
             TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
-            if (this.sessionProtocolFactory == null)
+            if (_sessionProtocolFactory == null)
             {
-                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.GetString(SR.SecuritySessionProtocolFactoryShouldBeSetBeforeThisOperation)));
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.SecuritySessionProtocolFactoryShouldBeSetBeforeThisOperation)));
             }
-            if (this.standardsManager == null)
+            if (_standardsManager == null)
             {
-                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.GetString(SR.SecurityStandardsManagerNotSet, this.GetType().ToString())));
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.SecurityStandardsManagerNotSet, this.GetType().ToString())));
             }
-            if (this.issuedTokenParameters == null)
+            if (_issuedTokenParameters == null)
             {
-                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.GetString(SR.IssuedSecurityTokenParametersNotSet, this.GetType())));
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.IssuedSecurityTokenParametersNotSet, this.GetType())));
             }
-            if (this.keyRenewalInterval < this.keyRolloverInterval)
+            if (_keyRenewalInterval < _keyRolloverInterval)
             {
-                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.GetString(SR.KeyRolloverGreaterThanKeyRenewal)));
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.KeyRolloverGreaterThanKeyRenewal)));
             }
-            this.issuedTokenRenewalThreshold = this.sessionProtocolFactory.SecurityBindingElement.LocalClientSettings.CookieRenewalThresholdPercentage;
+            _issuedTokenRenewalThreshold = _sessionProtocolFactory.SecurityBindingElement.LocalClientSettings.CookieRenewalThresholdPercentage;
             this.ConfigureSessionProtocolFactory();
-            this.sessionProtocolFactory.Open(true, timeoutHelper.RemainingTime());
+            _sessionProtocolFactory.Open(true, timeoutHelper.RemainingTime());
+        }
+
+
+        public Task OnOpenAsync(TimeSpan timeout)
+        {
+            return OnOpenAsyncInternal(timeout);
+        }
+
+        private async Task OnOpenAsyncInternal(TimeSpan timeout)
+        {
+            TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
+            if (_sessionProtocolFactory == null)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.SecuritySessionProtocolFactoryShouldBeSetBeforeThisOperation)));
+            }
+            if (_standardsManager == null)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.SecurityStandardsManagerNotSet, this.GetType().ToString())));
+            }
+            if (_issuedTokenParameters == null)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.IssuedSecurityTokenParametersNotSet, this.GetType())));
+            }
+            if (_keyRenewalInterval < _keyRolloverInterval)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.KeyRolloverGreaterThanKeyRenewal)));
+            }
+            _issuedTokenRenewalThreshold = _sessionProtocolFactory.SecurityBindingElement.LocalClientSettings.CookieRenewalThresholdPercentage;
+            this.ConfigureSessionProtocolFactory();
+            await _sessionProtocolFactory.OpenAsync(true, timeoutHelper.RemainingTime());
         }
 
         internal void Close(TimeSpan timeout)
         {
-            this.communicationObject.Close(timeout);
+            _communicationObject.Close(timeout);
         }
 
         internal void Abort()
         {
-            this.communicationObject.Abort();
+            _communicationObject.Abort();
         }
 
         internal void Open(SecurityChannelFactory<TChannel> securityChannelFactory,
             IChannelFactory innerChannelFactory, ChannelBuilder channelBuilder, TimeSpan timeout)
         {
-            this.securityChannelFactory = securityChannelFactory;
-            this.innerChannelFactory = innerChannelFactory;
-            this.channelBuilder = channelBuilder;
-            this.communicationObject.Open(timeout);
+            _securityChannelFactory = securityChannelFactory;
+            _innerChannelFactory = innerChannelFactory;
+            _channelBuilder = channelBuilder;
+            _communicationObject.Open(timeout);
+        }
+
+        internal Task OpenAsync(SecurityChannelFactory<TChannel> securityChannelFactory,
+                                IChannelFactory innerChannelFactory, ChannelBuilder channelBuilder, TimeSpan timeout)
+        {
+            _securityChannelFactory = securityChannelFactory;
+            _innerChannelFactory = innerChannelFactory;
+            _channelBuilder = channelBuilder;
+            return ((IAsyncCommunicationObject)_communicationObject).OpenAsync(timeout);
         }
 
         internal TChannel OnCreateChannel(EndpointAddress remoteAddress, Uri via)
         {
-            return OnCreateChannel(remoteAddress, via, null);
-        }
-
-        internal TChannel OnCreateChannel(EndpointAddress remoteAddress, Uri via, MessageFilter filter)
-        {
-            this.communicationObject.ThrowIfClosed();
-            if (filter != null)
-            {
-                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new NotSupportedException());
-            }
+            _communicationObject.ThrowIfClosed();
 
             if (typeof(TChannel) == typeof(IRequestSessionChannel))
             {
@@ -350,65 +390,67 @@ namespace System.ServiceModel.Security
             }
             else
             {
-                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentException(SR.GetString(SR.ChannelTypeNotSupported, typeof(TChannel)), "TChannel"));
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentException(SR.Format(SR.ChannelTypeNotSupported, typeof(TChannel)), "TChannel"));
             }
         }
 
         void ConfigureSessionProtocolFactory()
         {
-            if (this.sessionProtocolFactory is SessionSymmetricMessageSecurityProtocolFactory)
-            {
-                AddressingVersion addressing = MessageVersion.Default.Addressing;
-                if (this.channelBuilder != null)
-                {
-                    MessageEncodingBindingElement encoding = this.channelBuilder.Binding.Elements.Find<MessageEncodingBindingElement>();
-                    if (encoding != null)
-                    {
-                        addressing = encoding.MessageVersion.Addressing;
-                    }
-                }
+            throw ExceptionHelper.PlatformNotSupported();   // #31 in progress
 
-                if (addressing != AddressingVersion.WSAddressing10 && addressing != AddressingVersion.WSAddressingAugust2004)
-                {
-                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(
-                        new ProtocolException(SR.GetString(SR.AddressingVersionNotSupported, addressing)));
-                }
+            //if (this.sessionProtocolFactory is SessionSymmetricMessageSecurityProtocolFactory)
+            //{
+            //    AddressingVersion addressing = MessageVersion.Default.Addressing;
+            //    if (this.channelBuilder != null)
+            //    {
+            //        MessageEncodingBindingElement encoding = this.channelBuilder.Binding.Elements.Find<MessageEncodingBindingElement>();
+            //        if (encoding != null)
+            //        {
+            //            addressing = encoding.MessageVersion.Addressing;
+            //        }
+            //    }
 
-                SessionSymmetricMessageSecurityProtocolFactory symmetric = (SessionSymmetricMessageSecurityProtocolFactory)this.sessionProtocolFactory;
-                if (!symmetric.ApplyIntegrity || !symmetric.RequireIntegrity)
-                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.GetString(SR.SecuritySessionRequiresMessageIntegrity)));
-                MessagePartSpecification bodyPart = new MessagePartSpecification(true);
-                symmetric.ProtectionRequirements.OutgoingSignatureParts.AddParts(bodyPart, this.SecurityStandardsManager.SecureConversationDriver.CloseResponseAction);
-                symmetric.ProtectionRequirements.OutgoingSignatureParts.AddParts(bodyPart, this.SecurityStandardsManager.SecureConversationDriver.CloseAction);
-                symmetric.ProtectionRequirements.OutgoingSignatureParts.AddParts(bodyPart, addressing.FaultAction);
-                symmetric.ProtectionRequirements.OutgoingSignatureParts.AddParts(bodyPart, addressing.DefaultFaultAction);
-                symmetric.ProtectionRequirements.OutgoingSignatureParts.AddParts(bodyPart, DotNetSecurityStrings.SecuritySessionFaultAction);
-                symmetric.ProtectionRequirements.IncomingSignatureParts.AddParts(bodyPart, this.SecurityStandardsManager.SecureConversationDriver.CloseAction);
-                symmetric.ProtectionRequirements.IncomingSignatureParts.AddParts(bodyPart, this.SecurityStandardsManager.SecureConversationDriver.CloseResponseAction);
-                if (symmetric.ApplyConfidentiality)
-                {
-                    symmetric.ProtectionRequirements.IncomingEncryptionParts.AddParts(MessagePartSpecification.NoParts, this.SecurityStandardsManager.SecureConversationDriver.CloseAction);
-                    symmetric.ProtectionRequirements.IncomingEncryptionParts.AddParts(MessagePartSpecification.NoParts, this.SecurityStandardsManager.SecureConversationDriver.CloseResponseAction);
-                }
-                if (symmetric.RequireConfidentiality)
-                {
-                    symmetric.ProtectionRequirements.OutgoingEncryptionParts.AddParts(MessagePartSpecification.NoParts, this.SecurityStandardsManager.SecureConversationDriver.CloseResponseAction);
-                    symmetric.ProtectionRequirements.OutgoingEncryptionParts.AddParts(MessagePartSpecification.NoParts, this.SecurityStandardsManager.SecureConversationDriver.CloseAction);
-                    symmetric.ProtectionRequirements.OutgoingEncryptionParts.AddParts(bodyPart, addressing.FaultAction);
-                    symmetric.ProtectionRequirements.OutgoingEncryptionParts.AddParts(bodyPart, addressing.DefaultFaultAction);
-                    symmetric.ProtectionRequirements.OutgoingEncryptionParts.AddParts(bodyPart, DotNetSecurityStrings.SecuritySessionFaultAction);
-                }
-            }
-            else if (this.sessionProtocolFactory is SessionSymmetricTransportSecurityProtocolFactory)
-            {
-                SessionSymmetricTransportSecurityProtocolFactory transport = (SessionSymmetricTransportSecurityProtocolFactory)this.sessionProtocolFactory;
-                transport.AddTimestamp = true;
-                transport.SecurityTokenParameters.RequireDerivedKeys = false;
-            }
-            else
-            {
-                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new NotSupportedException());
-            }
+            //    if (addressing != AddressingVersion.WSAddressing10 && addressing != AddressingVersion.WSAddressingAugust2004)
+            //    {
+            //        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(
+            //            new ProtocolException(SR.Format(SR.AddressingVersionNotSupported, addressing)));
+            //    }
+
+            //    SessionSymmetricMessageSecurityProtocolFactory symmetric = (SessionSymmetricMessageSecurityProtocolFactory)this.sessionProtocolFactory;
+            //    if (!symmetric.ApplyIntegrity || !symmetric.RequireIntegrity)
+            //        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.SecuritySessionRequiresMessageIntegrity)));
+            //    MessagePartSpecification bodyPart = new MessagePartSpecification(true);
+            //    symmetric.ProtectionRequirements.OutgoingSignatureParts.AddParts(bodyPart, this.SecurityStandardsManager.SecureConversationDriver.CloseResponseAction);
+            //    symmetric.ProtectionRequirements.OutgoingSignatureParts.AddParts(bodyPart, this.SecurityStandardsManager.SecureConversationDriver.CloseAction);
+            //    symmetric.ProtectionRequirements.OutgoingSignatureParts.AddParts(bodyPart, addressing.FaultAction);
+            //    symmetric.ProtectionRequirements.OutgoingSignatureParts.AddParts(bodyPart, addressing.DefaultFaultAction);
+            //    symmetric.ProtectionRequirements.OutgoingSignatureParts.AddParts(bodyPart, DotNetSecurityStrings.SecuritySessionFaultAction);
+            //    symmetric.ProtectionRequirements.IncomingSignatureParts.AddParts(bodyPart, this.SecurityStandardsManager.SecureConversationDriver.CloseAction);
+            //    symmetric.ProtectionRequirements.IncomingSignatureParts.AddParts(bodyPart, this.SecurityStandardsManager.SecureConversationDriver.CloseResponseAction);
+            //    if (symmetric.ApplyConfidentiality)
+            //    {
+            //        symmetric.ProtectionRequirements.IncomingEncryptionParts.AddParts(MessagePartSpecification.NoParts, this.SecurityStandardsManager.SecureConversationDriver.CloseAction);
+            //        symmetric.ProtectionRequirements.IncomingEncryptionParts.AddParts(MessagePartSpecification.NoParts, this.SecurityStandardsManager.SecureConversationDriver.CloseResponseAction);
+            //    }
+            //    if (symmetric.RequireConfidentiality)
+            //    {
+            //        symmetric.ProtectionRequirements.OutgoingEncryptionParts.AddParts(MessagePartSpecification.NoParts, this.SecurityStandardsManager.SecureConversationDriver.CloseResponseAction);
+            //        symmetric.ProtectionRequirements.OutgoingEncryptionParts.AddParts(MessagePartSpecification.NoParts, this.SecurityStandardsManager.SecureConversationDriver.CloseAction);
+            //        symmetric.ProtectionRequirements.OutgoingEncryptionParts.AddParts(bodyPart, addressing.FaultAction);
+            //        symmetric.ProtectionRequirements.OutgoingEncryptionParts.AddParts(bodyPart, addressing.DefaultFaultAction);
+            //        symmetric.ProtectionRequirements.OutgoingEncryptionParts.AddParts(bodyPart, DotNetSecurityStrings.SecuritySessionFaultAction);
+            //    }
+            //}
+            //else if (this.sessionProtocolFactory is SessionSymmetricTransportSecurityProtocolFactory)
+            //{
+            //    SessionSymmetricTransportSecurityProtocolFactory transport = (SessionSymmetricTransportSecurityProtocolFactory)this.sessionProtocolFactory;
+            //    transport.AddTimestamp = true;
+            //    transport.SecurityTokenParameters.RequireDerivedKeys = false;
+            //}
+            //else
+            //{
+            //    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new NotSupportedException());
+            //}
         }
 
         abstract class ClientSecuritySessionChannel : ChannelBase
@@ -425,17 +467,19 @@ namespace System.ServiceModel.Security
             SecuritySessionClientSettings<TChannel> settings;
             SecurityTokenProvider sessionTokenProvider;
             bool isKeyRenewalOngoing = false;
-            InterruptibleWaitObject keyRenewalCompletedEvent;
+            // InterruptibleWaitObject keyRenewalCompletedEvent;    // #31 in progress
+            // InterruptibleWaitObject outputSessionCloseHandle = new InterruptibleWaitObject(true);
+            // InterruptibleWaitObject inputSessionClosedHandle = new InterruptibleWaitObject(false);
             bool sentClose;
             bool receivedClose;
             volatile bool isOutputClosed;
             volatile bool isInputClosed;
-            InterruptibleWaitObject inputSessionClosedHandle = new InterruptibleWaitObject(false);
+
             bool sendCloseHandshake = false;
             MessageVersion messageVersion;
             bool isCompositeDuplexConnection;
             Message closeResponse;
-            InterruptibleWaitObject outputSessionCloseHandle = new InterruptibleWaitObject(true);
+
             WebHeaderCollection webHeaderCollection;
 
             protected ClientSecuritySessionChannel(SecuritySessionClientSettings<TChannel> settings, EndpointAddress to, Uri via)
@@ -444,7 +488,7 @@ namespace System.ServiceModel.Security
                 this.settings = settings;
                 this.to = to;
                 this.via = via;
-                this.keyRenewalCompletedEvent = new InterruptibleWaitObject(false);
+                // this.keyRenewalCompletedEvent = new InterruptibleWaitObject(false);
                 this.messageVersion = settings.SecurityChannelFactory.MessageVersion;
                 this.channelParameters = new ChannelParameterCollection(this);
                 this.InitializeChannelBinder();
@@ -564,68 +608,76 @@ namespace System.ServiceModel.Security
 
             void InitializeSecurityState(SecurityToken sessionToken)
             {
-                InitializeSession(sessionToken);
-                this.currentSessionToken = sessionToken;
-                this.previousSessionToken = null;
-                List<SecurityToken> incomingSessionTokens = new List<SecurityToken>(1);
-                incomingSessionTokens.Add(sessionToken);
-                ((IInitiatorSecuritySessionProtocol)this.securityProtocol).SetIdentityCheckAuthenticator(new GenericXmlSecurityTokenAuthenticator());
-                ((IInitiatorSecuritySessionProtocol)this.securityProtocol).SetIncomingSessionTokens(incomingSessionTokens);
-                ((IInitiatorSecuritySessionProtocol)this.securityProtocol).SetOutgoingSessionToken(sessionToken);
-                if (this.CanDoSecurityCorrelation)
-                {
-                    ((IInitiatorSecuritySessionProtocol)this.securityProtocol).ReturnCorrelationState = true;
-                }
-                this.keyRenewalTime = GetKeyRenewalTime(sessionToken);
+                throw ExceptionHelper.PlatformNotSupported();   // #31 in progress
+
+                //InitializeSession(sessionToken);
+                //this.currentSessionToken = sessionToken;
+                //this.previousSessionToken = null;
+                //List<SecurityToken> incomingSessionTokens = new List<SecurityToken>(1);
+                //incomingSessionTokens.Add(sessionToken);
+                //((IInitiatorSecuritySessionProtocol)this.securityProtocol).SetIdentityCheckAuthenticator(new GenericXmlSecurityTokenAuthenticator());
+                //((IInitiatorSecuritySessionProtocol)this.securityProtocol).SetIncomingSessionTokens(incomingSessionTokens);
+                //((IInitiatorSecuritySessionProtocol)this.securityProtocol).SetOutgoingSessionToken(sessionToken);
+                //if (this.CanDoSecurityCorrelation)
+                //{
+                //    ((IInitiatorSecuritySessionProtocol)this.securityProtocol).ReturnCorrelationState = true;
+                //}
+                //this.keyRenewalTime = GetKeyRenewalTime(sessionToken);
             }
 
             void SetupSessionTokenProvider()
             {
-                InitiatorServiceModelSecurityTokenRequirement requirement = new InitiatorServiceModelSecurityTokenRequirement();
-                this.Settings.IssuedSecurityTokenParameters.InitializeSecurityTokenRequirement(requirement);
-                requirement.KeyUsage = SecurityKeyUsage.Signature;
-                requirement.SupportSecurityContextCancellation = true;
-                requirement.SecurityAlgorithmSuite = this.Settings.SessionProtocolFactory.OutgoingAlgorithmSuite;
-                requirement.SecurityBindingElement = this.Settings.SessionProtocolFactory.SecurityBindingElement;
-                requirement.TargetAddress = this.to;
-                requirement.Via = this.Via;
-                requirement.MessageSecurityVersion = this.Settings.SessionProtocolFactory.MessageSecurityVersion.SecurityTokenVersion;
-                requirement.Properties[ServiceModelSecurityTokenRequirement.PrivacyNoticeUriProperty] = this.Settings.SessionProtocolFactory.PrivacyNoticeUri;
-                requirement.WebHeaders = this.webHeaderCollection;
+                throw ExceptionHelper.PlatformNotSupported();   // #31 in progress
 
-                if (this.channelParameters != null)
-                {
-                    requirement.Properties[ServiceModelSecurityTokenRequirement.ChannelParametersCollectionProperty] = this.channelParameters;
-                }
-                requirement.Properties[ServiceModelSecurityTokenRequirement.PrivacyNoticeVersionProperty] = this.Settings.SessionProtocolFactory.PrivacyNoticeVersion;
-                if (this.channelBinder.LocalAddress != null)
-                {
-                    requirement.DuplexClientLocalAddress = this.channelBinder.LocalAddress;
-                }
-                this.sessionTokenProvider = this.Settings.SessionProtocolFactory.SecurityTokenManager.CreateSecurityTokenProvider(requirement);
+                //InitiatorServiceModelSecurityTokenRequirement requirement = new InitiatorServiceModelSecurityTokenRequirement();
+                //this.Settings.IssuedSecurityTokenParameters.InitializeSecurityTokenRequirement(requirement);
+                //requirement.KeyUsage = SecurityKeyUsage.Signature;
+                //requirement.SupportSecurityContextCancellation = true;
+                //requirement.SecurityAlgorithmSuite = this.Settings.SessionProtocolFactory.OutgoingAlgorithmSuite;
+                //requirement.SecurityBindingElement = this.Settings.SessionProtocolFactory.SecurityBindingElement;
+                //requirement.TargetAddress = this.to;
+                //requirement.Via = this.Via;
+                //requirement.MessageSecurityVersion = this.Settings.SessionProtocolFactory.MessageSecurityVersion.SecurityTokenVersion;
+                //requirement.Properties[ServiceModelSecurityTokenRequirement.PrivacyNoticeUriProperty] = this.Settings.SessionProtocolFactory.PrivacyNoticeUri;
+                //requirement.WebHeaders = this.webHeaderCollection;
+
+                //if (this.channelParameters != null)
+                //{
+                //    requirement.Properties[ServiceModelSecurityTokenRequirement.ChannelParametersCollectionProperty] = this.channelParameters;
+                //}
+                //requirement.Properties[ServiceModelSecurityTokenRequirement.PrivacyNoticeVersionProperty] = this.Settings.SessionProtocolFactory.PrivacyNoticeVersion;
+                //if (this.channelBinder.LocalAddress != null)
+                //{
+                //    requirement.DuplexClientLocalAddress = this.channelBinder.LocalAddress;
+                //}
+                //this.sessionTokenProvider = this.Settings.SessionProtocolFactory.SecurityTokenManager.CreateSecurityTokenProvider(requirement);
             }
 
             void OpenCore(SecurityToken sessionToken, TimeSpan timeout)
             {
-                TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
-                this.securityProtocol = this.Settings.SessionProtocolFactory.CreateSecurityProtocol(this.to, this.Via, null, true, timeoutHelper.RemainingTime());
-                if (!(this.securityProtocol is IInitiatorSecuritySessionProtocol))
-                {
-                    Fx.Assert("Security protocol must be IInitiatorSecuritySessionProtocol.");
-                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.GetString(SR.ProtocolMisMatch, "IInitiatorSecuritySessionProtocol", this.GetType().ToString())));
-                }
-                this.securityProtocol.Open(timeoutHelper.RemainingTime());
-                this.channelBinder.Open(timeoutHelper.RemainingTime());
-                this.InitializeSecurityState(sessionToken);
+                throw ExceptionHelper.PlatformNotSupported();   // #31 in progress
+
+                //TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
+                //this.securityProtocol = this.Settings.SessionProtocolFactory.CreateSecurityProtocol(this.to, this.Via, null, true, timeoutHelper.RemainingTime());
+                //if (!(this.securityProtocol is IInitiatorSecuritySessionProtocol))
+                //{
+                //    Fx.Assert("Security protocol must be IInitiatorSecuritySessionProtocol.");
+                //    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.ProtocolMisMatch, "IInitiatorSecuritySessionProtocol", this.GetType().ToString())));
+                //}
+                //this.securityProtocol.Open(timeoutHelper.RemainingTime());
+                //this.channelBinder.Open(timeoutHelper.RemainingTime());
+                //this.InitializeSecurityState(sessionToken);
             }
 
             protected override void OnFaulted()
             {
-                this.AbortCore();
-                this.inputSessionClosedHandle.Fault(this);
-                this.keyRenewalCompletedEvent.Fault(this);
-                this.outputSessionCloseHandle.Fault(this);
-                base.OnFaulted();
+                throw ExceptionHelper.PlatformNotSupported();   // #31 in progress
+
+                //this.AbortCore();
+                //_inputSessionClosedHandle.Fault(this);
+                //_keyRenewalCompletedEvent.Fault(this);
+                //_outputSessionCloseHandle.Fault(this);
+                //base.OnFaulted();
             }
 
             protected override void OnOpen(TimeSpan timeout)
@@ -638,7 +690,7 @@ namespace System.ServiceModel.Security
                 {
                     if (DiagnosticUtility.ShouldUseActivity)
                     {
-                        ServiceModelActivity.Start(activity, SR.GetString(SR.ActivitySecuritySetup), ActivityType.SecuritySetup);
+                        ServiceModelActivity.Start(activity, SR.Format(SR.ActivitySecuritySetup), ActivityType.SecuritySetup);
                     }
                     SecurityToken sessionToken = this.sessionTokenProvider.GetToken(timeoutHelper.RemainingTime());
                     // Token was issued, do send cancel on close;
@@ -649,165 +701,165 @@ namespace System.ServiceModel.Security
 
             protected override IAsyncResult OnBeginOpen(TimeSpan timeout, AsyncCallback callback, object state)
             {
-                ServiceModelActivity activity = DiagnosticUtility.ShouldUseActivity ?
-                    ServiceModelActivity.CreateAsyncActivity() : null;
-                using (ServiceModelActivity.BoundOperation(activity, true))
-                {
-                    if (DiagnosticUtility.ShouldUseActivity)
-                    {
-                        ServiceModelActivity.Start(activity, SR.GetString(SR.ActivitySecuritySetup), ActivityType.SecuritySetup);
-                    }
-                    return new OpenAsyncResult(this, timeout, callback, state);
-                }
+                throw ExceptionHelper.PlatformNotSupported();
             }
 
             protected override void OnEndOpen(IAsyncResult result)
             {
-                OpenAsyncResult.End(result);
+                throw ExceptionHelper.PlatformNotSupported();
             }
 
             void InitializeChannelBinder()
             {
-                ChannelBuilder channelBuilder = this.Settings.ChannelBuilder;
-                TolerateFaultsMode faultMode = this.Settings.TolerateTransportFailures ? TolerateFaultsMode.Always : TolerateFaultsMode.Never;
-                if (channelBuilder.CanBuildChannelFactory<IDuplexSessionChannel>())
-                {
-                    this.channelBinder = ClientReliableChannelBinder<IDuplexSessionChannel>.CreateBinder(this.RemoteAddress, this.Via, (IChannelFactory<IDuplexSessionChannel>)(object)this.Settings.InnerChannelFactory,
-                        MaskingMode.None, faultMode, this.channelParameters, this.DefaultCloseTimeout, this.DefaultSendTimeout);
-                }
-                else if (channelBuilder.CanBuildChannelFactory<IDuplexChannel>())
-                {
-                    this.channelBinder = ClientReliableChannelBinder<IDuplexChannel>.CreateBinder(this.RemoteAddress, this.Via, (IChannelFactory<IDuplexChannel>)(object)this.Settings.InnerChannelFactory,
-                        MaskingMode.None, faultMode, this.channelParameters, this.DefaultCloseTimeout, this.DefaultSendTimeout);
-                    this.isCompositeDuplexConnection = true;
-                }
-                else if (channelBuilder.CanBuildChannelFactory<IRequestChannel>())
-                {
-                    this.channelBinder = ClientReliableChannelBinder<IRequestChannel>.CreateBinder(this.RemoteAddress, this.Via, (IChannelFactory<IRequestChannel>)(object)this.Settings.InnerChannelFactory,
-                        MaskingMode.None, faultMode, this.channelParameters, this.DefaultCloseTimeout, this.DefaultSendTimeout);
-                }
-                else if (channelBuilder.CanBuildChannelFactory<IRequestSessionChannel>())
-                {
-                    this.channelBinder = ClientReliableChannelBinder<IRequestSessionChannel>.CreateBinder(this.RemoteAddress, this.Via, (IChannelFactory<IRequestSessionChannel>)(object)this.Settings.InnerChannelFactory,
-                        MaskingMode.None, faultMode, this.channelParameters, this.DefaultCloseTimeout, this.DefaultSendTimeout);
-                }
-                this.channelBinder.Faulted += this.OnInnerFaulted;
+                throw ExceptionHelper.PlatformNotSupported();   // #31 in progress
+
+                //ChannelBuilder channelBuilder = this.Settings.ChannelBuilder;
+                //TolerateFaultsMode faultMode = this.Settings.TolerateTransportFailures ? TolerateFaultsMode.Always : TolerateFaultsMode.Never;
+                //if (channelBuilder.CanBuildChannelFactory<IDuplexSessionChannel>())
+                //{
+                //    this.channelBinder = ClientReliableChannelBinder<IDuplexSessionChannel>.CreateBinder(this.RemoteAddress, this.Via, (IChannelFactory<IDuplexSessionChannel>)(object)this.Settings.InnerChannelFactory,
+                //        MaskingMode.None, faultMode, this.channelParameters, this.DefaultCloseTimeout, this.DefaultSendTimeout);
+                //}
+                //else if (channelBuilder.CanBuildChannelFactory<IDuplexChannel>())
+                //{
+                //    this.channelBinder = ClientReliableChannelBinder<IDuplexChannel>.CreateBinder(this.RemoteAddress, this.Via, (IChannelFactory<IDuplexChannel>)(object)this.Settings.InnerChannelFactory,
+                //        MaskingMode.None, faultMode, this.channelParameters, this.DefaultCloseTimeout, this.DefaultSendTimeout);
+                //    this.isCompositeDuplexConnection = true;
+                //}
+                //else if (channelBuilder.CanBuildChannelFactory<IRequestChannel>())
+                //{
+                //    this.channelBinder = ClientReliableChannelBinder<IRequestChannel>.CreateBinder(this.RemoteAddress, this.Via, (IChannelFactory<IRequestChannel>)(object)this.Settings.InnerChannelFactory,
+                //        MaskingMode.None, faultMode, this.channelParameters, this.DefaultCloseTimeout, this.DefaultSendTimeout);
+                //}
+                //else if (channelBuilder.CanBuildChannelFactory<IRequestSessionChannel>())
+                //{
+                //    this.channelBinder = ClientReliableChannelBinder<IRequestSessionChannel>.CreateBinder(this.RemoteAddress, this.Via, (IChannelFactory<IRequestSessionChannel>)(object)this.Settings.InnerChannelFactory,
+                //        MaskingMode.None, faultMode, this.channelParameters, this.DefaultCloseTimeout, this.DefaultSendTimeout);
+                //}
+                //this.channelBinder.Faulted += this.OnInnerFaulted;
             }
 
-            void OnInnerFaulted(IReliableChannelBinder sender, Exception exception)
-            {
-                this.Fault(exception);
-            }
+            //void OnInnerFaulted(IReliableChannelBinder sender, Exception exception)
+            //{
+            //    throw ExceptionHelper.PlatformNotSupported();   // #31 in progress
+            //    //this.Fault(exception);
+            //}
 
             protected virtual bool OnCloseResponseReceived()
             {
-                bool setInputSessionClosedHandle = false;
-                bool isCloseResponseExpected = false;
-                lock (ThisLock)
-                {
-                    isCloseResponseExpected = this.sentClose;
-                    if (isCloseResponseExpected && !this.isInputClosed)
-                    {
-                        this.isInputClosed = true;
-                        setInputSessionClosedHandle = true;
-                    }
-                }
-                if (!isCloseResponseExpected)
-                {
-                    this.Fault(new ProtocolException(SR.GetString(SR.UnexpectedSecuritySessionCloseResponse)));
-                    return false;
-                }
-                if (setInputSessionClosedHandle)
-                {
-                    this.inputSessionClosedHandle.Set();
-                }
-                return true;
+                throw ExceptionHelper.PlatformNotSupported();   // #31 in progress
+
+                //bool setInputSessionClosedHandle = false;
+                //bool isCloseResponseExpected = false;
+                //lock (ThisLock)
+                //{
+                //    isCloseResponseExpected = this.sentClose;
+                //    if (isCloseResponseExpected && !this.isInputClosed)
+                //    {
+                //        this.isInputClosed = true;
+                //        setInputSessionClosedHandle = true;
+                //    }
+                //}
+                //if (!isCloseResponseExpected)
+                //{
+                //    this.Fault(new ProtocolException(SR.Format(SR.UnexpectedSecuritySessionCloseResponse)));
+                //    return false;
+                //}
+                //if (setInputSessionClosedHandle)
+                //{
+                //    this.inputSessionClosedHandle.Set();
+                //}
+                //return true;
             }
 
             protected virtual bool OnCloseReceived()
             {
-                if (!ExpectClose)
-                {
-                    this.Fault(new ProtocolException(SR.GetString(SR.UnexpectedSecuritySessionClose)));
-                    return false;
-                }
-                bool setInputSessionClosedHandle = false;
-                lock (ThisLock)
-                {
-                    if (!this.isInputClosed)
-                    {
-                        this.isInputClosed = true;
-                        this.receivedClose = true;
-                        setInputSessionClosedHandle = true;
-                    }
-                }
-                if (setInputSessionClosedHandle)
-                {
-                    this.inputSessionClosedHandle.Set();
-                }
-                return true;
+                throw ExceptionHelper.PlatformNotSupported();   // #31 in progress
+
+                //if (!ExpectClose)
+                //{
+                //    this.Fault(new ProtocolException(SR.Format(SR.UnexpectedSecuritySessionClose)));
+                //    return false;
+                //}
+                //bool setInputSessionClosedHandle = false;
+                //lock (ThisLock)
+                //{
+                //    if (!this.isInputClosed)
+                //    {
+                //        this.isInputClosed = true;
+                //        this.receivedClose = true;
+                //        setInputSessionClosedHandle = true;
+                //    }
+                //}
+                //if (setInputSessionClosedHandle)
+                //{
+                //    this.inputSessionClosedHandle.Set();
+                //}
+                //return true;
             }
 
             Message PrepareCloseMessage()
             {
-                SecurityToken tokenToClose;
-                lock (ThisLock)
-                {
-                    tokenToClose = this.currentSessionToken;
-                }
-                RequestSecurityToken rst = new RequestSecurityToken(this.Settings.SecurityStandardsManager);
-                rst.RequestType = this.Settings.SecurityStandardsManager.TrustDriver.RequestTypeClose;
-                rst.CloseTarget = this.Settings.IssuedSecurityTokenParameters.CreateKeyIdentifierClause(tokenToClose, SecurityTokenReferenceStyle.External);
-                rst.MakeReadOnly();
-                Message closeMessage = Message.CreateMessage(this.MessageVersion, ActionHeader.Create(this.Settings.SecurityStandardsManager.SecureConversationDriver.CloseAction, this.MessageVersion.Addressing), rst);
+                throw ExceptionHelper.PlatformNotSupported();   // #31 in progress
 
-                RequestReplyCorrelator.PrepareRequest(closeMessage);
-                if (this.webHeaderCollection != null && this.webHeaderCollection.Count > 0)
-                {
-                    object prop = null;
-                    HttpRequestMessageProperty rmp = null;
-                    if (closeMessage.Properties.TryGetValue(HttpRequestMessageProperty.Name, out prop))
-                    {
-                        rmp = prop as HttpRequestMessageProperty;
-                    }
-                    else
-                    {
-                        rmp = new HttpRequestMessageProperty();
-                        closeMessage.Properties.Add(HttpRequestMessageProperty.Name, rmp);
-                    }
+                //SecurityToken tokenToClose;
+                //lock (ThisLock)
+                //{
+                //    tokenToClose = this.currentSessionToken;
+                //}
+                //RequestSecurityToken rst = new RequestSecurityToken(this.Settings.SecurityStandardsManager);
+                //rst.RequestType = this.Settings.SecurityStandardsManager.TrustDriver.RequestTypeClose;
+                //rst.CloseTarget = this.Settings.IssuedSecurityTokenParameters.CreateKeyIdentifierClause(tokenToClose, SecurityTokenReferenceStyle.External);
+                //rst.MakeReadOnly();
+                //Message closeMessage = Message.CreateMessage(this.MessageVersion, ActionHeader.Create(this.Settings.SecurityStandardsManager.SecureConversationDriver.CloseAction, this.MessageVersion.Addressing), rst);
 
-                    if (rmp != null && rmp.Headers != null)
-                    {
-                        rmp.Headers.Add(this.webHeaderCollection);
-                    }
-                }
+                //RequestReplyCorrelator.PrepareRequest(closeMessage);
+                //if (this.webHeaderCollection != null && this.webHeaderCollection.Count > 0)
+                //{
+                //    object prop = null;
+                //    HttpRequestMessageProperty rmp = null;
+                //    if (closeMessage.Properties.TryGetValue(HttpRequestMessageProperty.Name, out prop))
+                //    {
+                //        rmp = prop as HttpRequestMessageProperty;
+                //    }
+                //    else
+                //    {
+                //        rmp = new HttpRequestMessageProperty();
+                //        closeMessage.Properties.Add(HttpRequestMessageProperty.Name, rmp);
+                //    }
+
+                //    if (rmp != null && rmp.Headers != null)
+                //    {
+                //        rmp.Headers.Add(this.webHeaderCollection);
+                //    }
+                //}
 
 
-                if (this.InternalLocalAddress != null)
-                {
-                    closeMessage.Headers.ReplyTo = this.InternalLocalAddress;
-                }
-                else
-                {
-                    if (closeMessage.Version.Addressing == AddressingVersion.WSAddressing10)
-                    {
-                        closeMessage.Headers.ReplyTo = null;
-                    }
-                    else if (closeMessage.Version.Addressing == AddressingVersion.WSAddressingAugust2004)
-                    {
-                        closeMessage.Headers.ReplyTo = EndpointAddress.AnonymousAddress;
-                    }
-                    else
-                    {
-                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(
-                            new ProtocolException(SR.GetString(SR.AddressingVersionNotSupported, closeMessage.Version.Addressing)));
-                    }
-                }
-                if (TraceUtility.PropagateUserActivity || TraceUtility.ShouldPropagateActivity)
-                {
-                    TraceUtility.AddAmbientActivityToMessage(closeMessage);
-                }
-                return closeMessage;
+                //if (this.InternalLocalAddress != null)
+                //{
+                //    closeMessage.Headers.ReplyTo = this.InternalLocalAddress;
+                //}
+                //else
+                //{
+                //    if (closeMessage.Version.Addressing == AddressingVersion.WSAddressing10)
+                //    {
+                //        closeMessage.Headers.ReplyTo = null;
+                //    }
+                //    else if (closeMessage.Version.Addressing == AddressingVersion.WSAddressingAugust2004)
+                //    {
+                //        closeMessage.Headers.ReplyTo = EndpointAddress.AnonymousAddress;
+                //    }
+                //    else
+                //    {
+                //        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(
+                //            new ProtocolException(SR.Format(SR.AddressingVersionNotSupported, closeMessage.Version.Addressing)));
+                //    }
+                //}
+                //if (TraceUtility.PropagateUserActivity || TraceUtility.ShouldPropagateActivity)
+                //{
+                //    TraceUtility.AddAmbientActivityToMessage(closeMessage);
+                //}
+                //return closeMessage;
             }
 
             protected SecurityProtocolCorrelationState SendCloseMessage(TimeSpan timeout)
@@ -854,7 +906,7 @@ namespace System.ServiceModel.Security
                 {
                     if (DiagnosticUtility.ShouldUseActivity)
                     {
-                        ServiceModelActivity.Start(activity, SR.GetString(SR.ActivitySecurityClose), ActivityType.SecuritySetup);
+                        ServiceModelActivity.Start(activity, SR.Format(SR.ActivitySecurityClose), ActivityType.SecuritySetup);
                     }
                     Message closeMessage = PrepareCloseMessage();
                     return new SecureSendAsyncResult(closeMessage, this, timeout, callback, state, true);
@@ -881,90 +933,97 @@ namespace System.ServiceModel.Security
 
             MessageFault GetProtocolFault(ref Message message, out bool isKeyRenewalFault, out bool isSessionAbortedFault)
             {
-                isKeyRenewalFault = false;
-                isSessionAbortedFault = false;
-                MessageFault result = null;
-                using (MessageBuffer buffer = message.CreateBufferedCopy(int.MaxValue))
-                {
-                    message = buffer.CreateMessage();
-                    Message copy = buffer.CreateMessage();
-                    MessageFault fault = MessageFault.CreateFault(copy, TransportDefaults.MaxSecurityFaultSize);
-                    if (fault.Code.IsSenderFault)
-                    {
-                        FaultCode subCode = fault.Code.SubCode;
-                        if (subCode != null)
-                        {
-                            SecurityStandardsManager standardsManager = this.securityProtocol.SecurityProtocolFactory.StandardsManager;
-                            SecureConversationDriver scDriver = standardsManager.SecureConversationDriver;
-                            if (subCode.Namespace == scDriver.Namespace.Value && subCode.Name == scDriver.RenewNeededFaultCode.Value)
-                            {
-                                result = fault;
-                                isKeyRenewalFault = true;
-                            }
-                            else if (subCode.Namespace == DotNetSecurityStrings.Namespace && subCode.Name == DotNetSecurityStrings.SecuritySessionAbortedFault)
-                            {
-                                result = fault;
-                                isSessionAbortedFault = true;
-                            }
-                        }
-                    }
-                }
-                return result;
+                throw ExceptionHelper.PlatformNotSupported();   // #31 in progress
+                //isKeyRenewalFault = false;
+                //isSessionAbortedFault = false;
+                //MessageFault result = null;
+                //using (MessageBuffer buffer = message.CreateBufferedCopy(int.MaxValue))
+                //{
+                //    message = buffer.CreateMessage();
+                //    Message copy = buffer.CreateMessage();
+                //    MessageFault fault = MessageFault.CreateFault(copy, TransportDefaults.MaxSecurityFaultSize);
+                //    if (fault.Code.IsSenderFault)
+                //    {
+                //        FaultCode subCode = fault.Code.SubCode;
+                //        if (subCode != null)
+                //        {
+                //            SecurityStandardsManager standardsManager = this.securityProtocol.SecurityProtocolFactory.StandardsManager;
+                //            SecureConversationDriver scDriver = standardsManager.SecureConversationDriver;
+                //            if (subCode.Namespace == scDriver.Namespace.Value && subCode.Name == scDriver.RenewNeededFaultCode.Value)
+                //            {
+                //                result = fault;
+                //                isKeyRenewalFault = true;
+                //            }
+                //            else if (subCode.Namespace == DotNetSecurityStrings.Namespace && subCode.Name == DotNetSecurityStrings.SecuritySessionAbortedFault)
+                //            {
+                //                result = fault;
+                //                isSessionAbortedFault = true;
+                //            }
+                //        }
+                //    }
+                //}
+                //return result;
             }
 
 
             void ProcessKeyRenewalFault()
             {
-                SecurityTraceRecordHelper.TraceSessionKeyRenewalFault(this.currentSessionToken, this.RemoteAddress);
-                lock (ThisLock)
-                {
-                    this.keyRenewalTime = DateTime.UtcNow;
-                }
+                throw ExceptionHelper.PlatformNotSupported();   // #31 in progress
+
+                //SecurityTraceRecordHelper.TraceSessionKeyRenewalFault(this.currentSessionToken, this.RemoteAddress);
+                //lock (ThisLock)
+                //{
+                //    this.keyRenewalTime = DateTime.UtcNow;
+                //}
             }
 
             void ProcessSessionAbortedFault(MessageFault sessionAbortedFault)
             {
-                SecurityTraceRecordHelper.TraceRemoteSessionAbortedFault(this.currentSessionToken, this.RemoteAddress);
-                this.Fault(new FaultException(sessionAbortedFault));
+                throw ExceptionHelper.PlatformNotSupported();   // #31 in progress
+
+                //SecurityTraceRecordHelper.TraceRemoteSessionAbortedFault(this.currentSessionToken, this.RemoteAddress);
+                //this.Fault(new FaultException(sessionAbortedFault));
             }
 
             void ProcessCloseResponse(Message response)
             {
-                // the close message may have been received by the channel after the channel factory has been closed
-                if (response.Headers.Action != this.Settings.SecurityStandardsManager.SecureConversationDriver.CloseResponseAction.Value)
-                {
-                    throw TraceUtility.ThrowHelperError(new MessageSecurityException(SR.GetString(SR.InvalidCloseResponseAction, response.Headers.Action)), response);
-                }
-                RequestSecurityTokenResponse rstr = null;
-                XmlDictionaryReader bodyReader = response.GetReaderAtBodyContents();
-                using (bodyReader)
-                {
-                    if (this.Settings.SecurityStandardsManager.MessageSecurityVersion.TrustVersion == TrustVersion.WSTrustFeb2005)
-                        rstr = this.Settings.SecurityStandardsManager.TrustDriver.CreateRequestSecurityTokenResponse(bodyReader);
-                    else if (this.Settings.SecurityStandardsManager.MessageSecurityVersion.TrustVersion == TrustVersion.WSTrust13)
-                    {
-                        RequestSecurityTokenResponseCollection rstrc = this.Settings.SecurityStandardsManager.TrustDriver.CreateRequestSecurityTokenResponseCollection(bodyReader);
-                        foreach (RequestSecurityTokenResponse rstrItem in rstrc.RstrCollection)
-                        {
-                            if (rstr != null)
-                            {
-                                // More than one RSTR is found. So throw an exception.
-                                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new MessageSecurityException(SR.GetString(SR.MoreThanOneRSTRInRSTRC)));
-                            }
-                            rstr = rstrItem;
-                        }
-                    }
-                    else
-                    {
-                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new NotSupportedException());
-                    }
+                throw ExceptionHelper.PlatformNotSupported();   // #31 in progress
 
-                    response.ReadFromBodyContentsToEnd(bodyReader);
-                }
-                if (!rstr.IsRequestedTokenClosed)
-                {
-                    throw TraceUtility.ThrowHelperError(new MessageSecurityException(SR.GetString(SR.SessionTokenWasNotClosed)), response);
-                }
+                //// the close message may have been received by the channel after the channel factory has been closed
+                //if (response.Headers.Action != this.Settings.SecurityStandardsManager.SecureConversationDriver.CloseResponseAction.Value)
+                //{
+                //    throw TraceUtility.ThrowHelperError(new MessageSecurityException(SR.Format(SR.InvalidCloseResponseAction, response.Headers.Action)), response);
+                //}
+                //RequestSecurityTokenResponse rstr = null;
+                //XmlDictionaryReader bodyReader = response.GetReaderAtBodyContents();
+                //using (bodyReader)
+                //{
+                //    if (this.Settings.SecurityStandardsManager.MessageSecurityVersion.TrustVersion == TrustVersion.WSTrustFeb2005)
+                //        rstr = this.Settings.SecurityStandardsManager.TrustDriver.CreateRequestSecurityTokenResponse(bodyReader);
+                //    else if (this.Settings.SecurityStandardsManager.MessageSecurityVersion.TrustVersion == TrustVersion.WSTrust13)
+                //    {
+                //        RequestSecurityTokenResponseCollection rstrc = this.Settings.SecurityStandardsManager.TrustDriver.CreateRequestSecurityTokenResponseCollection(bodyReader);
+                //        foreach (RequestSecurityTokenResponse rstrItem in rstrc.RstrCollection)
+                //        {
+                //            if (rstr != null)
+                //            {
+                //                // More than one RSTR is found. So throw an exception.
+                //                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new MessageSecurityException(SR.Format(SR.MoreThanOneRSTRInRSTRC)));
+                //            }
+                //            rstr = rstrItem;
+                //        }
+                //    }
+                //    else
+                //    {
+                //        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new NotSupportedException());
+                //    }
+
+                //    response.ReadFromBodyContentsToEnd(bodyReader);
+                //}
+                //if (!rstr.IsRequestedTokenClosed)
+                //{
+                //    throw TraceUtility.ThrowHelperError(new MessageSecurityException(SR.Format(SR.SessionTokenWasNotClosed)), response);
+                //}
             }
 
             void PrepareReply(Message request, Message reply)
@@ -1008,16 +1067,16 @@ namespace System.ServiceModel.Security
                 }
                 if (rst.RequestType != null && rst.RequestType != this.Settings.SecurityStandardsManager.TrustDriver.RequestTypeClose)
                 {
-                    throw TraceUtility.ThrowHelperWarning(new MessageSecurityException(SR.GetString(SR.InvalidRstRequestType, rst.RequestType)), message);
+                    throw TraceUtility.ThrowHelperWarning(new MessageSecurityException(SR.Format(SR.InvalidRstRequestType, rst.RequestType)), message);
                 }
                 if (rst.CloseTarget == null)
                 {
-                    throw TraceUtility.ThrowHelperWarning(new MessageSecurityException(SR.GetString(SR.NoCloseTargetSpecified)), message);
+                    throw TraceUtility.ThrowHelperWarning(new MessageSecurityException(SR.Format(SR.NoCloseTargetSpecified)), message);
                 }
                 SecurityContextKeyIdentifierClause sctSkiClause = rst.CloseTarget as SecurityContextKeyIdentifierClause;
                 if (sctSkiClause == null || !DoesSkiClauseMatchSigningToken(sctSkiClause, message))
                 {
-                    throw TraceUtility.ThrowHelperWarning(new MessageSecurityException(SR.GetString(SR.BadCloseTarget, rst.CloseTarget)), message);
+                    throw TraceUtility.ThrowHelperWarning(new MessageSecurityException(SR.Format(SR.BadCloseTarget, rst.CloseTarget)), message);
                 }
                 // prepare the close response
                 RequestSecurityTokenResponse rstr = new RequestSecurityTokenResponse(this.Settings.SecurityStandardsManager);
@@ -1026,7 +1085,9 @@ namespace System.ServiceModel.Security
                 rstr.MakeReadOnly();
                 Message response = null;
                 if (this.Settings.SecurityStandardsManager.MessageSecurityVersion.TrustVersion == TrustVersion.WSTrustFeb2005)
+                {
                     response = Message.CreateMessage(message.Version, ActionHeader.Create(this.Settings.SecurityStandardsManager.SecureConversationDriver.CloseResponseAction, message.Version.Addressing), rstr);
+                }
                 else if (this.Settings.SecurityStandardsManager.MessageSecurityVersion.TrustVersion == TrustVersion.WSTrust13)
                 {
                     List<RequestSecurityTokenResponse> rstrList = new List<RequestSecurityTokenResponse>();
@@ -1038,6 +1099,7 @@ namespace System.ServiceModel.Security
                 {
                     throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new NotSupportedException());
                 }
+
                 PrepareReply(message, response);
                 this.closeResponse = response;
             }
@@ -1049,114 +1111,118 @@ namespace System.ServiceModel.Security
 
             protected Message ProcessIncomingMessage(Message message, TimeSpan timeout, SecurityProtocolCorrelationState correlationState, out MessageFault protocolFault)
             {
-                protocolFault = null;
-                lock (ThisLock)
-                {
-                    DoKeyRolloverIfNeeded();
-                }
+                throw ExceptionHelper.PlatformNotSupported();   // #31 in progress
 
-                try
-                {
-                    VerifyIncomingMessage(ref message, timeout, correlationState);
+//                protocolFault = null;
+//                lock (ThisLock)
+//                {
+//                    DoKeyRolloverIfNeeded();
+//                }
 
-                    string action = message.Headers.Action;
+//                try
+//                {
+//                    VerifyIncomingMessage(ref message, timeout, correlationState);
 
-                    if (action == this.Settings.SecurityStandardsManager.SecureConversationDriver.CloseResponseAction.Value)
-                    {
-                        SecurityTraceRecordHelper.TraceCloseResponseReceived(this.currentSessionToken, this.RemoteAddress);
-                        this.ProcessCloseResponse(message);
-                        this.OnCloseResponseReceived();
-                    }
-                    else if (action == this.Settings.SecurityStandardsManager.SecureConversationDriver.CloseAction.Value)
-                    {
-                        SecurityTraceRecordHelper.TraceCloseMessageReceived(this.currentSessionToken, this.RemoteAddress);
-                        this.ProcessCloseMessage(message);
-                        this.OnCloseReceived();
-                    }
-                    else if (action == DotNetSecurityStrings.SecuritySessionFaultAction)
-                    {
-                        bool isKeyRenewalFault;
-                        bool isSessionAbortedFault;
-                        protocolFault = GetProtocolFault(ref message, out isKeyRenewalFault, out isSessionAbortedFault);
-                        if (isKeyRenewalFault)
-                        {
-                            ProcessKeyRenewalFault();
-                        }
-                        else if (isSessionAbortedFault)
-                        {
-                            ProcessSessionAbortedFault(protocolFault);
-                        }
-                        else
-                        {
-                            return message;
-                        }
-                    }
-                    else
-                    {
-                        return message;
-                    }
-                }
-#pragma warning suppress 56500 // covered by FxCOP
-                catch (Exception e)
-                {
-                    if ((e is CommunicationException) || (e is TimeoutException) || (Fx.IsFatal(e)) || !ShouldWrapException(e))
-                    {
-                        throw;
-                    }
-                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new MessageSecurityException(SR.GetString(SR.MessageSecurityVerificationFailed), e));
-                }
+//                    string action = message.Headers.Action;
 
-                message.Close();
-                return null;
+//                    if (action == this.Settings.SecurityStandardsManager.SecureConversationDriver.CloseResponseAction.Value)
+//                    {
+//                        SecurityTraceRecordHelper.TraceCloseResponseReceived(this.currentSessionToken, this.RemoteAddress);
+//                        this.ProcessCloseResponse(message);
+//                        this.OnCloseResponseReceived();
+//                    }
+//                    else if (action == this.Settings.SecurityStandardsManager.SecureConversationDriver.CloseAction.Value)
+//                    {
+//                        SecurityTraceRecordHelper.TraceCloseMessageReceived(this.currentSessionToken, this.RemoteAddress);
+//                        this.ProcessCloseMessage(message);
+//                        this.OnCloseReceived();
+//                    }
+//                    else if (action == DotNetSecurityStrings.SecuritySessionFaultAction)
+//                    {
+//                        bool isKeyRenewalFault;
+//                        bool isSessionAbortedFault;
+//                        protocolFault = GetProtocolFault(ref message, out isKeyRenewalFault, out isSessionAbortedFault);
+//                        if (isKeyRenewalFault)
+//                        {
+//                            ProcessKeyRenewalFault();
+//                        }
+//                        else if (isSessionAbortedFault)
+//                        {
+//                            ProcessSessionAbortedFault(protocolFault);
+//                        }
+//                        else
+//                        {
+//                            return message;
+//                        }
+//                    }
+//                    else
+//                    {
+//                        return message;
+//                    }
+//                }
+//#pragma warning suppress 56500 // covered by FxCOP
+//                catch (Exception e)
+//                {
+//                    if ((e is CommunicationException) || (e is TimeoutException) || (Fx.IsFatal(e)) || !ShouldWrapException(e))
+//                    {
+//                        throw;
+//                    }
+//                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new MessageSecurityException(SR.Format(SR.MessageSecurityVerificationFailed), e));
+//                }
+
+//                message.Close();
+//                return null;
             }
 
             protected Message ProcessRequestContext(RequestContext requestContext, TimeSpan timeout, SecurityProtocolCorrelationState correlationState)
             {
-                if (requestContext == null)
-                {
-                    return null;
-                }
-                TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
-                Message message = requestContext.RequestMessage;
-                Message unverifiedMessage = message;
-                try
-                {
-                    Exception faultException = null;
-                    try
-                    {
-                        MessageFault dummyProtocolFault;
-                        return ProcessIncomingMessage(message, timeoutHelper.RemainingTime(), correlationState, out dummyProtocolFault);
-                    }
-                    catch (MessageSecurityException e)
-                    {
-                        // if the message is an unsecured security fault from the other party over the same connection then fault the session
-                        if (!isCompositeDuplexConnection)
-                        {
-                            if (unverifiedMessage.IsFault)
-                            {
-                                MessageFault fault = MessageFault.CreateFault(unverifiedMessage, TransportDefaults.MaxSecurityFaultSize);
-                                if (SecurityUtils.IsSecurityFault(fault, this.settings.sessionProtocolFactory.StandardsManager))
-                                {
-                                    faultException = SecurityUtils.CreateSecurityFaultException(fault);
-                                }
-                            }
-                            else
-                            {
-                                faultException = e;
-                            }
-                        }
-                    }
-                    if (faultException != null)
-                    {
-                        this.Fault(faultException);
-                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(faultException);
-                    }
-                    return null;
-                }
-                finally
-                {
-                    requestContext.Close(timeoutHelper.RemainingTime());
-                }
+                throw ExceptionHelper.PlatformNotSupported();   // #31 in progres
+
+                //if (requestContext == null)
+                //{
+                //    return null;
+                //}
+                //TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
+                //Message message = requestContext.RequestMessage;
+                //Message unverifiedMessage = message;
+                //try
+                //{
+                //    Exception faultException = null;
+                //    try
+                //    {
+                //        MessageFault dummyProtocolFault;
+                //        return ProcessIncomingMessage(message, timeoutHelper.RemainingTime(), correlationState, out dummyProtocolFault);
+                //    }
+                //    catch (MessageSecurityException e)
+                //    {
+                //        // if the message is an unsecured security fault from the other party over the same connection then fault the session
+                //        if (!isCompositeDuplexConnection)
+                //        {
+                //            if (unverifiedMessage.IsFault)
+                //            {
+                //                MessageFault fault = MessageFault.CreateFault(unverifiedMessage, TransportDefaults.MaxSecurityFaultSize);
+                //                if (SecurityUtils.IsSecurityFault(fault, this.settings.sessionProtocolFactory.StandardsManager))
+                //                {
+                //                    faultException = SecurityUtils.CreateSecurityFaultException(fault);
+                //                }
+                //            }
+                //            else
+                //            {
+                //                faultException = e;
+                //            }
+                //        }
+                //    }
+                //    if (faultException != null)
+                //    {
+                //        this.Fault(faultException);
+                //        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(faultException);
+                //    }
+                //    return null;
+                //}
+                //finally
+                //{
+                //    requestContext.Close(timeoutHelper.RemainingTime());
+                //}
             }
 
             /// <summary>
@@ -1165,22 +1231,24 @@ namespace System.ServiceModel.Security
             /// </summary>
             void DoKeyRolloverIfNeeded()
             {
-                if (DateTime.UtcNow >= this.keyRolloverTime && this.previousSessionToken != null)
-                {
-                    SecurityTraceRecordHelper.TracePreviousSessionKeyDiscarded(this.previousSessionToken, this.currentSessionToken, this.RemoteAddress);
-                    // forget the previous session token 
-                    this.previousSessionToken = null;
-                    List<SecurityToken> incomingTokens = new List<SecurityToken>(1);
-                    incomingTokens.Add(this.currentSessionToken);
-                    ((IInitiatorSecuritySessionProtocol)this.securityProtocol).SetIncomingSessionTokens(incomingTokens);
-                }
+                throw ExceptionHelper.PlatformNotSupported();   // #31 in progres
+
+                //if (DateTime.UtcNow >= this.keyRolloverTime && this.previousSessionToken != null)
+                //{
+                //    SecurityTraceRecordHelper.TracePreviousSessionKeyDiscarded(this.previousSessionToken, this.currentSessionToken, this.RemoteAddress);
+                //    // forget the previous session token 
+                //    this.previousSessionToken = null;
+                //    List<SecurityToken> incomingTokens = new List<SecurityToken>(1);
+                //    incomingTokens.Add(this.currentSessionToken);
+                //    ((IInitiatorSecuritySessionProtocol)this.securityProtocol).SetIncomingSessionTokens(incomingTokens);
+                //}
             }
 
             DateTime GetKeyRenewalTime(SecurityToken token)
             {
-                TimeSpan tokenValidityInterval = TimeSpan.FromTicks((long)(((token.ValidTo.Ticks - token.ValidFrom.Ticks) * this.settings.issuedTokenRenewalThreshold) / 100));
+                TimeSpan tokenValidityInterval = TimeSpan.FromTicks((long)(((token.ValidTo.Ticks - token.ValidFrom.Ticks) * this.settings._issuedTokenRenewalThreshold) / 100));
                 DateTime keyRenewalTime1 = TimeoutHelper.Add(token.ValidFrom, tokenValidityInterval);
-                DateTime keyRenewalTime2 = TimeoutHelper.Add(token.ValidFrom, this.settings.keyRenewalInterval);
+                DateTime keyRenewalTime2 = TimeoutHelper.Add(token.ValidFrom, this.settings._keyRenewalInterval);
                 if (keyRenewalTime1 < keyRenewalTime2)
                 {
                     return keyRenewalTime1;
@@ -1206,78 +1274,82 @@ namespace System.ServiceModel.Security
             /// </summary>
             void UpdateSessionTokens(SecurityToken newToken)
             {
-                lock (ThisLock)
-                {
-                    this.previousSessionToken = this.currentSessionToken;
-                    this.keyRolloverTime = TimeoutHelper.Add(DateTime.UtcNow, this.Settings.KeyRolloverInterval);
-                    this.currentSessionToken = newToken;
-                    this.keyRenewalTime = GetKeyRenewalTime(newToken);
-                    List<SecurityToken> incomingTokens = new List<SecurityToken>(2);
-                    incomingTokens.Add(this.previousSessionToken);
-                    incomingTokens.Add(this.currentSessionToken);
-                    ((IInitiatorSecuritySessionProtocol)this.securityProtocol).SetIncomingSessionTokens(incomingTokens);
-                    ((IInitiatorSecuritySessionProtocol)this.securityProtocol).SetOutgoingSessionToken(this.currentSessionToken);
-                    SecurityTraceRecordHelper.TraceSessionKeyRenewed(this.currentSessionToken, this.previousSessionToken, this.RemoteAddress);
-                }
+                throw ExceptionHelper.PlatformNotSupported();   // #31 in progres
+
+                //lock (ThisLock)
+                //{
+                //    this.previousSessionToken = this.currentSessionToken;
+                //    this.keyRolloverTime = TimeoutHelper.Add(DateTime.UtcNow, this.Settings.KeyRolloverInterval);
+                //    this.currentSessionToken = newToken;
+                //    this.keyRenewalTime = GetKeyRenewalTime(newToken);
+                //    List<SecurityToken> incomingTokens = new List<SecurityToken>(2);
+                //    incomingTokens.Add(this.previousSessionToken);
+                //    incomingTokens.Add(this.currentSessionToken);
+                //    ((IInitiatorSecuritySessionProtocol)this.securityProtocol).SetIncomingSessionTokens(incomingTokens);
+                //    ((IInitiatorSecuritySessionProtocol)this.securityProtocol).SetOutgoingSessionToken(this.currentSessionToken);
+                //    SecurityTraceRecordHelper.TraceSessionKeyRenewed(this.currentSessionToken, this.previousSessionToken, this.RemoteAddress);
+                //}
             }
 
             void RenewKey(TimeSpan timeout)
             {
-                if (!this.settings.CanRenewSession)
-                {
-                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new SessionKeyExpiredException(SR.GetString(SR.SessionKeyRenewalNotSupported)));
-                }
+                throw ExceptionHelper.PlatformNotSupported();   // #31 in progres
 
-                bool startKeyRenewal;
-                lock (ThisLock)
-                {
-                    if (!this.isKeyRenewalOngoing)
-                    {
-                        this.isKeyRenewalOngoing = true;
-                        this.keyRenewalCompletedEvent.Reset();
-                        startKeyRenewal = true;
-                    }
-                    else
-                    {
-                        startKeyRenewal = false;
-                    }
-                }
-                if (startKeyRenewal == true)
-                {
-                    try
-                    {
-                        using (ServiceModelActivity activity = DiagnosticUtility.ShouldUseActivity ?
-                            ServiceModelActivity.CreateBoundedActivity() : null)
-                        {
-                            if (DiagnosticUtility.ShouldUseActivity)
-                            {
-                                ServiceModelActivity.Start(activity, SR.GetString(SR.ActivitySecurityRenew), ActivityType.SecuritySetup);
-                            }
-                            SecurityToken renewedToken = this.sessionTokenProvider.RenewToken(timeout, this.currentSessionToken);
-                            UpdateSessionTokens(renewedToken);
-                        }
-                    }
-                    finally
-                    {
-                        lock (ThisLock)
-                        {
-                            this.isKeyRenewalOngoing = false;
-                            this.keyRenewalCompletedEvent.Set();
-                        }
-                    }
-                }
-                else
-                {
-                    this.keyRenewalCompletedEvent.Wait(timeout);
-                    lock (ThisLock)
-                    {
-                        if (IsKeyRenewalNeeded())
-                        {
-                            // the key renewal attempt failed. Throw an exception to the user
-                            throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new SessionKeyExpiredException(SR.GetString(SR.UnableToRenewSessionKey)));
-                        }
-                    }
-                }
+                //if (!this.settings.CanRenewSession)
+                //{
+                //    throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new SessionKeyExpiredException(SR.Format(SR.SessionKeyRenewalNotSupported)));
+                //}
+
+                //bool startKeyRenewal;
+                //lock (ThisLock)
+                //{
+                //    if (!this.isKeyRenewalOngoing)
+                //    {
+                //        this.isKeyRenewalOngoing = true;
+                //        this.keyRenewalCompletedEvent.Reset();
+                //        startKeyRenewal = true;
+                //    }
+                //    else
+                //    {
+                //        startKeyRenewal = false;
+                //    }
+                //}
+                //if (startKeyRenewal == true)
+                //{
+                //    try
+                //    {
+                //        using (ServiceModelActivity activity = DiagnosticUtility.ShouldUseActivity ?
+                //            ServiceModelActivity.CreateBoundedActivity() : null)
+                //        {
+                //            if (DiagnosticUtility.ShouldUseActivity)
+                //            {
+                //                ServiceModelActivity.Start(activity, SR.Format(SR.ActivitySecurityRenew), ActivityType.SecuritySetup);
+                //            }
+                //            SecurityToken renewedToken = this.sessionTokenProvider.RenewToken(timeout, this.currentSessionToken);
+                //            UpdateSessionTokens(renewedToken);
+                //        }
+                //    }
+                //    finally
+                //    {
+                //        lock (ThisLock)
+                //        {
+                //            this.isKeyRenewalOngoing = false;
+                //            this.keyRenewalCompletedEvent.Set();
+                //        }
+                //    }
+                //}
+                //else
+                //{
+                //    this.keyRenewalCompletedEvent.Wait(timeout);
+                //    lock (ThisLock)
+                //    {
+                //        if (IsKeyRenewalNeeded())
+                //        {
+                //            // the key renewal attempt failed. Throw an exception to the user
+                //            throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new SessionKeyExpiredException(SR.Format(SR.UnableToRenewSessionKey)));
+                //        }
+                //    }
+                //}
             }
 
             bool CheckIfKeyRenewalNeeded()
@@ -1350,38 +1422,42 @@ namespace System.ServiceModel.Security
 
             protected virtual void CloseCore(TimeSpan timeout)
             {
-                TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
+                throw ExceptionHelper.PlatformNotSupported();   // #31 in progres
 
-                try
-                {
-                    if (this.channelBinder != null)
-                    {
-                        this.channelBinder.Close(timeoutHelper.RemainingTime());
-                    }
-                    if (this.sessionTokenProvider != null)
-                    {
-                        SecurityUtils.CloseTokenProviderIfRequired(this.sessionTokenProvider, timeoutHelper.RemainingTime());
-                    }
-                    this.keyRenewalCompletedEvent.Abort(this);
-                    this.inputSessionClosedHandle.Abort(this);
-                }
-                catch (CommunicationObjectAbortedException)
-                {
-                    if (this.State != CommunicationState.Closed)
-                    {
-                        throw;
-                    }
-                }
+                //TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
+
+                //try
+                //{
+                //    if (this.channelBinder != null)
+                //    {
+                //        this.channelBinder.Close(timeoutHelper.RemainingTime());
+                //    }
+                //    if (this.sessionTokenProvider != null)
+                //    {
+                //        SecurityUtils.CloseTokenProviderIfRequired(this.sessionTokenProvider, timeoutHelper.RemainingTime());
+                //    }
+                //    this.keyRenewalCompletedEvent.Abort(this);
+                //    this.inputSessionClosedHandle.Abort(this);
+                //}
+                //catch (CommunicationObjectAbortedException)
+                //{
+                //    if (this.State != CommunicationState.Closed)
+                //    {
+                //        throw;
+                //    }
+                //}
             }
 
             protected virtual IAsyncResult BeginCloseCore(TimeSpan timeout, AsyncCallback callback, object state)
             {
-                return new CloseCoreAsyncResult(this, timeout, callback, state);
+                throw ExceptionHelper.PlatformNotSupported(); // Issue #31 in progress
+                //return new CloseCoreAsyncResult(this, timeout, callback, state);
             }
 
             protected virtual void EndCloseCore(IAsyncResult result)
             {
-                CloseCoreAsyncResult.End(result);
+                throw ExceptionHelper.PlatformNotSupported(); // Issue #31 in progress
+                //CloseCoreAsyncResult.End(result);
             }
 
             protected IAsyncResult BeginReceiveInternal(TimeSpan timeout, SecurityProtocolCorrelationState correlationState, AsyncCallback callback, object state)
@@ -1428,31 +1504,33 @@ namespace System.ServiceModel.Security
 
             protected bool CloseSession(TimeSpan timeout, out bool wasAborted)
             {
-                using (ServiceModelActivity activity = DiagnosticUtility.ShouldUseActivity ?
-                    ServiceModelActivity.CreateBoundedActivity() : null)
-                {
-                    if (DiagnosticUtility.ShouldUseActivity)
-                    {
-                        ServiceModelActivity.Start(activity, SR.GetString(SR.ActivitySecurityClose), ActivityType.SecuritySetup);
-                    }
+                throw ExceptionHelper.PlatformNotSupported();   // #31 in progress
 
-                    TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
-                    wasAborted = false;
-                    try
-                    {
-                        this.CloseOutputSession(timeoutHelper.RemainingTime());
-                        return this.inputSessionClosedHandle.Wait(timeoutHelper.RemainingTime(), false);
-                    }
-                    catch (CommunicationObjectAbortedException)
-                    {
-                        if (this.State != CommunicationState.Closed)
-                        {
-                            throw;
-                        }
-                        wasAborted = true;
-                    }
-                    return false;
-                }
+                //using (ServiceModelActivity activity = DiagnosticUtility.ShouldUseActivity ?
+                //    ServiceModelActivity.CreateBoundedActivity() : null)
+                //{
+                //    if (DiagnosticUtility.ShouldUseActivity)
+                //    {
+                //        ServiceModelActivity.Start(activity, SR.Format(SR.ActivitySecurityClose), ActivityType.SecuritySetup);
+                //    }
+
+                //    TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
+                //    wasAborted = false;
+                //    try
+                //    {
+                //        this.CloseOutputSession(timeoutHelper.RemainingTime());
+                //        return this.inputSessionClosedHandle.Wait(timeoutHelper.RemainingTime(), false);
+                //    }
+                //    catch (CommunicationObjectAbortedException)
+                //    {
+                //        if (this.State != CommunicationState.Closed)
+                //        {
+                //            throw;
+                //        }
+                //        wasAborted = true;
+                //    }
+                //    return false;
+                //}
             }
 
             protected IAsyncResult BeginCloseSession(TimeSpan timeout, AsyncCallback callback, object state)
@@ -1462,7 +1540,7 @@ namespace System.ServiceModel.Security
                 {
                     if (DiagnosticUtility.ShouldUseActivity)
                     {
-                        ServiceModelActivity.Start(activity, SR.GetString(SR.ActivitySecurityClose), ActivityType.SecuritySetup);
+                        ServiceModelActivity.Start(activity, SR.Format(SR.ActivitySecurityClose), ActivityType.SecuritySetup);
                     }
                     return new CloseSessionAsyncResult(timeout, this, callback, state);
                 }
@@ -1475,131 +1553,139 @@ namespace System.ServiceModel.Security
 
             void DetermineCloseMessageToSend(out bool sendClose, out bool sendCloseResponse)
             {
-                sendClose = false;
-                sendCloseResponse = false;
-                lock (ThisLock)
-                {
-                    if (!this.isOutputClosed)
-                    {
-                        this.isOutputClosed = true;
-                        if (this.receivedClose)
-                        {
-                            sendCloseResponse = true;
-                        }
-                        else
-                        {
-                            sendClose = true;
-                            this.sentClose = true;
-                        }
-                        this.outputSessionCloseHandle.Reset();
-                    }
-                }
+                throw ExceptionHelper.PlatformNotSupported();   // #31 in progress
+
+                //sendClose = false;
+                //sendCloseResponse = false;
+                //lock (ThisLock)
+                //{
+                //    if (!this.isOutputClosed)
+                //    {
+                //        this.isOutputClosed = true;
+                //        if (this.receivedClose)
+                //        {
+                //            sendCloseResponse = true;
+                //        }
+                //        else
+                //        {
+                //            sendClose = true;
+                //            this.sentClose = true;
+                //        }
+                //        this.outputSessionCloseHandle.Reset();
+                //    }
+                //}
             }
 
             protected virtual SecurityProtocolCorrelationState CloseOutputSession(TimeSpan timeout)
             {
-                ThrowIfFaulted();
-                if (!this.SendCloseHandshake)
-                {
-                    return null;
-                }
-                bool sendClose;
-                bool sendCloseResponse;
-                DetermineCloseMessageToSend(out sendClose, out sendCloseResponse);
-                if (sendClose || sendCloseResponse)
-                {
-                    try
-                    {
-                        if (sendClose)
-                        {
-                            return this.SendCloseMessage(timeout);
-                        }
-                        else
-                        {
-                            this.SendCloseResponseMessage(timeout);
-                            return null;
-                        }
-                    }
-                    finally
-                    {
-                        this.outputSessionCloseHandle.Set();
-                    }
-                }
-                else
-                {
-                    return null;
-                }
+                throw ExceptionHelper.PlatformNotSupported();   // #31 in progress
+
+                //ThrowIfFaulted();
+                //if (!this.SendCloseHandshake)
+                //{
+                //    return null;
+                //}
+                //bool sendClose;
+                //bool sendCloseResponse;
+                //DetermineCloseMessageToSend(out sendClose, out sendCloseResponse);
+                //if (sendClose || sendCloseResponse)
+                //{
+                //    try
+                //    {
+                //        if (sendClose)
+                //        {
+                //            return this.SendCloseMessage(timeout);
+                //        }
+                //        else
+                //        {
+                //            this.SendCloseResponseMessage(timeout);
+                //            return null;
+                //        }
+                //    }
+                //    finally
+                //    {
+                //        this.outputSessionCloseHandle.Set();
+                //    }
+                //}
+                //else
+                //{
+                //    return null;
+                //}
             }
 
             protected virtual IAsyncResult BeginCloseOutputSession(TimeSpan timeout, AsyncCallback callback, object state)
             {
-                ThrowIfFaulted();
-                if (!this.SendCloseHandshake)
-                {
-                    return new CompletedAsyncResult(callback, state);
-                }
-                bool sendClose;
-                bool sendCloseResponse;
-                DetermineCloseMessageToSend(out sendClose, out sendCloseResponse);
-                if (sendClose || sendCloseResponse)
-                {
-                    bool setOutputSessionCloseHandle = true;
-                    try
-                    {
-                        IAsyncResult result;
-                        if (sendClose)
-                        {
-                            result = this.BeginSendCloseMessage(timeout, callback, state);
-                        }
-                        else
-                        {
-                            result = this.BeginSendCloseResponseMessage(timeout, callback, state);
-                        }
-                        setOutputSessionCloseHandle = false;
-                        return result;
-                    }
-                    finally
-                    {
-                        if (setOutputSessionCloseHandle)
-                        {
-                            this.outputSessionCloseHandle.Set();
-                        }
-                    }
-                }
-                else
-                {
-                    return new CompletedAsyncResult(callback, state);
-                }
+                throw ExceptionHelper.PlatformNotSupported();   // #31 in progress
+
+                //ThrowIfFaulted();
+                //if (!this.SendCloseHandshake)
+                //{
+                //    return new CompletedAsyncResult(callback, state);
+                //}
+                //bool sendClose;
+                //bool sendCloseResponse;
+                //DetermineCloseMessageToSend(out sendClose, out sendCloseResponse);
+                //if (sendClose || sendCloseResponse)
+                //{
+                //    bool setOutputSessionCloseHandle = true;
+                //    try
+                //    {
+                //        IAsyncResult result;
+                //        if (sendClose)
+                //        {
+                //            result = this.BeginSendCloseMessage(timeout, callback, state);
+                //        }
+                //        else
+                //        {
+                //            result = this.BeginSendCloseResponseMessage(timeout, callback, state);
+                //        }
+                //        setOutputSessionCloseHandle = false;
+                //        return result;
+                //    }
+                //    finally
+                //    {
+                //        if (setOutputSessionCloseHandle)
+                //        {
+                //            this.outputSessionCloseHandle.Set();
+                //        }
+                //    }
+                //}
+                //else
+                //{
+                //    return new CompletedAsyncResult(callback, state);
+                //}
             }
 
             protected virtual SecurityProtocolCorrelationState EndCloseOutputSession(IAsyncResult result)
             {
-                if (result is CompletedAsyncResult)
-                {
-                    CompletedAsyncResult.End(result);
-                    return null;
-                }
-                bool sentCloseLocal;
-                lock (ThisLock)
-                {
-                    sentCloseLocal = this.sentClose;
-                }
-                try
-                {
-                    if (sentCloseLocal)
-                    {
-                        return this.EndSendCloseMessage(result);
-                    }
-                    else
-                    {
-                        this.EndSendCloseResponseMessage(result);
-                        return null;
-                    }
-                }
-                finally
-                {
-                    this.outputSessionCloseHandle.Set();
-                }
+                throw ExceptionHelper.PlatformNotSupported();   // #31 in progress
+
+                //if (result is CompletedAsyncResult)
+                //{
+                //    CompletedAsyncResult.End(result);
+                //    return null;
+                //}
+                //bool sentCloseLocal;
+                //lock (ThisLock)
+                //{
+                //    sentCloseLocal = this.sentClose;
+                //}
+                //try
+                //{
+                //    if (sentCloseLocal)
+                //    {
+                //        return this.EndSendCloseMessage(result);
+                //    }
+                //    else
+                //    {
+                //        this.EndSendCloseResponseMessage(result);
+                //        return null;
+                //    }
+                //}
+                //finally
+                //{
+                //    this.outputSessionCloseHandle.Set();
+                //}
             }
 
             protected void CheckOutputOpen()
@@ -1609,66 +1695,70 @@ namespace System.ServiceModel.Security
                 {
                     if (isOutputClosed)
                     {
-                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new CommunicationException(SR.GetString(SR.OutputNotExpected)));
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new CommunicationException(SR.Format(SR.OutputNotExpected)));
                     }
                 }
             }
 
             protected override void OnAbort()
             {
-                this.AbortCore();
-                this.inputSessionClosedHandle.Abort(this);
-                this.keyRenewalCompletedEvent.Abort(this);
-                this.outputSessionCloseHandle.Abort(this);
+                throw ExceptionHelper.PlatformNotSupported();   // #31 in progress
+
+                //this.AbortCore();
+                //this.inputSessionClosedHandle.Abort(this);
+                //this.keyRenewalCompletedEvent.Abort(this);
+                //this.outputSessionCloseHandle.Abort(this);
             }
 
             protected override void OnClose(TimeSpan timeout)
             {
-                TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
-                if (this.SendCloseHandshake)
-                {
-                    bool wasAborted;
-                    bool wasSessionClosed = this.CloseSession(timeout, out wasAborted);
-                    if (wasAborted)
-                    {
-                        return;
-                    }
-                    if (!wasSessionClosed)
-                    {
-                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new TimeoutException(SR.GetString(SR.ClientSecurityCloseTimeout, timeout)));
-                    }
-                    // wait for any concurrent output session close to finish
-                    try
-                    {
-                        if (!this.outputSessionCloseHandle.Wait(timeoutHelper.RemainingTime(), false))
-                        {
-                            throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new TimeoutException(SR.GetString(SR.ClientSecurityOutputSessionCloseTimeout, timeoutHelper.OriginalTimeout)));
-                        }
-                    }
-                    catch (CommunicationObjectAbortedException)
-                    {
-                        if (this.State == CommunicationState.Closed)
-                        {
-                            return;
-                        }
-                        else
-                        {
-                            throw;
-                        }
-                    }
-                }
+                throw ExceptionHelper.PlatformNotSupported();   // #31 in progress
 
-                this.CloseCore(timeoutHelper.RemainingTime());
+                //TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
+                //if (this.SendCloseHandshake)
+                //{
+                //    bool wasAborted;
+                //    bool wasSessionClosed = this.CloseSession(timeout, out wasAborted);
+                //    if (wasAborted)
+                //    {
+                //        return;
+                //    }
+                //    if (!wasSessionClosed)
+                //    {
+                //        throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new TimeoutException(SR.Format(SR.ClientSecurityCloseTimeout, timeout)));
+                //    }
+                //    // wait for any concurrent output session close to finish
+                //    try
+                //    {
+                //        if (!this.outputSessionCloseHandle.Wait(timeoutHelper.RemainingTime(), false))
+                //        {
+                //            throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new TimeoutException(SR.Format(SR.ClientSecurityOutputSessionCloseTimeout, timeoutHelper.OriginalTimeout)));
+                //        }
+                //    }
+                //    catch (CommunicationObjectAbortedException)
+                //    {
+                //        if (this.State == CommunicationState.Closed)
+                //        {
+                //            return;
+                //        }
+                //        else
+                //        {
+                //            throw;
+                //        }
+                //    }
+                //}
+
+                //this.CloseCore(timeoutHelper.RemainingTime());
             }
 
             protected override IAsyncResult OnBeginClose(TimeSpan timeout, AsyncCallback callback, object state)
             {
-                return new CloseAsyncResult(this, timeout, callback, state);
+                throw ExceptionHelper.PlatformNotSupported();
             }
 
             protected override void OnEndClose(IAsyncResult result)
             {
-                CloseAsyncResult.End(result);
+                throw ExceptionHelper.PlatformNotSupported();
             }
 
             class CloseCoreAsyncResult : TraceAsyncResult
@@ -1761,78 +1851,84 @@ namespace System.ServiceModel.Security
 
                 bool OnChannelBinderClosed()
                 {
-                    if (channel.sessionTokenProvider != null)
-                    {
-                        try
-                        {
-                            IAsyncResult result = SecurityUtils.BeginCloseTokenProviderIfRequired(this.channel.sessionTokenProvider, timeoutHelper.RemainingTime(), closeTokenProviderCallback, this);
-                            if (!result.CompletedSynchronously)
-                            {
-                                return false;
-                            }
-                            SecurityUtils.EndCloseTokenProviderIfRequired(result);
-                        }
-                        catch (CommunicationObjectAbortedException)
-                        {
-                            if (channel.State != CommunicationState.Closed)
-                            {
-                                throw;
-                            }
-                            return true;
-                        }
-                    }
-                    return this.OnTokenProviderClosed();
+                    throw ExceptionHelper.PlatformNotSupported();   // #31 in progress
+
+                    //if (channel.sessionTokenProvider != null)
+                    //{
+                    //    try
+                    //    {
+                    //        IAsyncResult result = SecurityUtils.BeginCloseTokenProviderIfRequired(this.channel.sessionTokenProvider, timeoutHelper.RemainingTime(), closeTokenProviderCallback, this);
+                    //        if (!result.CompletedSynchronously)
+                    //        {
+                    //            return false;
+                    //        }
+                    //        SecurityUtils.EndCloseTokenProviderIfRequired(result);
+                    //    }
+                    //    catch (CommunicationObjectAbortedException)
+                    //    {
+                    //        if (channel.State != CommunicationState.Closed)
+                    //        {
+                    //            throw;
+                    //        }
+                    //        return true;
+                    //    }
+                    //}
+                    //return this.OnTokenProviderClosed();
                 }
 
                 static void CloseTokenProviderCallback(IAsyncResult result)
                 {
-                    if (result.CompletedSynchronously)
-                    {
-                        return;
-                    }
-                    CloseCoreAsyncResult self = (CloseCoreAsyncResult)(result.AsyncState);
-                    Exception completionException = null;
-                    bool completeSelf = false;
-                    try
-                    {
-                        try
-                        {
-                            SecurityUtils.EndCloseTokenProviderIfRequired(result);
-                        }
-                        catch (CommunicationObjectAbortedException)
-                        {
-                            if (self.channel.State != CommunicationState.Closed)
-                            {
-                                throw;
-                            }
-                            completeSelf = true;
-                        }
-                        if (!completeSelf)
-                        {
-                            completeSelf = self.OnTokenProviderClosed();
-                        }
-                    }
-#pragma warning suppress 56500 // covered by FxCOP
-                    catch (Exception e)
-                    {
-                        if (Fx.IsFatal(e))
-                        {
-                            throw;
-                        }
-                        completeSelf = true;
-                        completionException = e;
-                    }
-                    if (completeSelf)
-                    {
-                        self.Complete(false, completionException);
-                    }
+                    throw ExceptionHelper.PlatformNotSupported();   // #31 in progress
+
+//                    if (result.CompletedSynchronously)
+//                    {
+//                        return;
+//                    }
+//                    CloseCoreAsyncResult self = (CloseCoreAsyncResult)(result.AsyncState);
+//                    Exception completionException = null;
+//                    bool completeSelf = false;
+//                    try
+//                    {
+//                        try
+//                        {
+//                            SecurityUtils.EndCloseTokenProviderIfRequired(result);
+//                        }
+//                        catch (CommunicationObjectAbortedException)
+//                        {
+//                            if (self.channel.State != CommunicationState.Closed)
+//                            {
+//                                throw;
+//                            }
+//                            completeSelf = true;
+//                        }
+//                        if (!completeSelf)
+//                        {
+//                            completeSelf = self.OnTokenProviderClosed();
+//                        }
+//                    }
+//#pragma warning suppress 56500 // covered by FxCOP
+//                    catch (Exception e)
+//                    {
+//                        if (Fx.IsFatal(e))
+//                        {
+//                            throw;
+//                        }
+//                        completeSelf = true;
+//                        completionException = e;
+//                    }
+//                    if (completeSelf)
+//                    {
+//                        self.Complete(false, completionException);
+//                    }
                 }
 
                 bool OnTokenProviderClosed()
                 {
-                    this.channel.keyRenewalCompletedEvent.Abort(this.channel);
-                    this.channel.inputSessionClosedHandle.Abort(this.channel);
-                    return true;
+                    throw ExceptionHelper.PlatformNotSupported();   // #31 in progress
+
+                    //this.channel.keyRenewalCompletedEvent.Abort(this.channel);
+                    //this.channel.inputSessionClosedHandle.Abort(this.channel);
+                    //return true;
                 }
 
                 public static void End(IAsyncResult result)
@@ -1935,135 +2031,6 @@ namespace System.ServiceModel.Security
                 }
             }
 
-            class OpenAsyncResult : TraceAsyncResult
-            {
-                static readonly AsyncCallback getTokenCallback = Fx.ThunkCallback(new AsyncCallback(GetTokenCallback));
-                static readonly AsyncCallback openTokenProviderCallback = Fx.ThunkCallback(new AsyncCallback(OpenTokenProviderCallback));
-                ClientSecuritySessionChannel sessionChannel;
-                TimeoutHelper timeoutHelper;
-
-                public OpenAsyncResult(ClientSecuritySessionChannel sessionChannel, TimeSpan timeout, AsyncCallback callback, object state)
-                    : base(callback, state)
-                {
-                    this.timeoutHelper = new TimeoutHelper(timeout);
-                    this.sessionChannel = sessionChannel;
-                    this.sessionChannel.SetupSessionTokenProvider();
-                    IAsyncResult result = SecurityUtils.BeginOpenTokenProviderIfRequired(this.sessionChannel.sessionTokenProvider, timeoutHelper.RemainingTime(), openTokenProviderCallback, this);
-                    if (!result.CompletedSynchronously)
-                    {
-                        return;
-                    }
-                    SecurityUtils.EndOpenTokenProviderIfRequired(result);
-                    bool completeSelf = this.OnTokenProviderOpened();
-                    if (completeSelf)
-                    {
-                        Complete(true);
-                    }
-                }
-
-                static void OpenTokenProviderCallback(IAsyncResult result)
-                {
-                    if (result.CompletedSynchronously)
-                    {
-                        return;
-                    }
-                    OpenAsyncResult thisAsyncResult = (OpenAsyncResult)result.AsyncState;
-                    bool completeSelf = false;
-                    Exception completionException = null;
-                    try
-                    {
-                        SecurityUtils.EndOpenTokenProviderIfRequired(result);
-                        completeSelf = thisAsyncResult.OnTokenProviderOpened();
-                    }
-#pragma warning suppress 56500 // covered by FxCOP
-                    catch (Exception e)
-                    {
-                        if (Fx.IsFatal(e))
-                        {
-                            throw;
-                        }
-
-                        completeSelf = true;
-                        completionException = e;
-                    }
-                    if (completeSelf)
-                    {
-                        thisAsyncResult.Complete(false, completionException);
-                    }
-                }
-
-                bool OnTokenProviderOpened()
-                {
-                    IAsyncResult result = this.sessionChannel.sessionTokenProvider.BeginGetToken(timeoutHelper.RemainingTime(), getTokenCallback, this);
-                    if (!result.CompletedSynchronously)
-                    {
-                        return false;
-                    }
-
-                    SecurityToken sessionToken = this.sessionChannel.sessionTokenProvider.EndGetToken(result);
-                    return this.OnTokenObtained(sessionToken);
-                }
-
-
-                bool OnTokenObtained(SecurityToken sessionToken)
-                {
-                    // Token was issued, do send cancel on close;
-                    this.sessionChannel.sendCloseHandshake = true;
-                    this.sessionChannel.OpenCore(sessionToken, timeoutHelper.RemainingTime());
-                    return true;
-                }
-
-                static void GetTokenCallback(IAsyncResult result)
-                {
-                    if (result.CompletedSynchronously)
-                    {
-                        return;
-                    }
-                    OpenAsyncResult thisAsyncResult = (OpenAsyncResult)result.AsyncState;
-                    try
-                    {
-                        using (ServiceModelActivity.BoundOperation(thisAsyncResult.CallbackActivity))
-                        {
-                            bool completeSelf = false;
-                            Exception completionException = null;
-                            try
-                            {
-                                SecurityToken sessionToken = thisAsyncResult.sessionChannel.sessionTokenProvider.EndGetToken(result);
-                                completeSelf = thisAsyncResult.OnTokenObtained(sessionToken);
-                            }
-#pragma warning suppress 56500 // covered by FxCOP
-                            catch (Exception e)
-                            {
-                                if (Fx.IsFatal(e))
-                                {
-                                    throw;
-                                }
-
-                                completeSelf = true;
-                                completionException = e;
-                            }
-                            if (completeSelf)
-                            {
-                                thisAsyncResult.Complete(false, completionException);
-                            }
-                        }
-                    }
-                    finally
-                    {
-                        if (thisAsyncResult.CallbackActivity != null)
-                        {
-                            thisAsyncResult.CallbackActivity.Dispose();
-                        }
-                    }
-                }
-
-                public static void End(IAsyncResult result)
-                {
-                    AsyncResult.End<OpenAsyncResult>(result);
-                    ServiceModelActivity.Stop(((OpenAsyncResult)result).CallbackActivity);
-                }
-            }
-
             class CloseSessionAsyncResult : TraceAsyncResult
             {
                 static readonly AsyncCallback closeOutputSessionCallback = Fx.ThunkCallback(new AsyncCallback(CloseOutputSessionCallback));
@@ -2156,68 +2123,72 @@ namespace System.ServiceModel.Security
 
                 bool OnOutputSessionClosed()
                 {
-                    try
-                    {
-                        IAsyncResult result = this.sessionChannel.inputSessionClosedHandle.BeginWait(this.timeoutHelper.RemainingTime(), true, shutdownWaitCallback, this);
-                        if (!result.CompletedSynchronously)
-                        {
-                            return false;
-                        }
-                        this.sessionChannel.inputSessionClosedHandle.EndWait(result);
-                        this.closeCompleted = true;
-                    }
-                    catch (CommunicationObjectAbortedException)
-                    {
-                        if (this.sessionChannel.State != CommunicationState.Closed)
-                        {
-                            throw;
-                        }
-                        // if the channel was aborted by a parallel thread, allow the Close to
-                        // complete cleanly
-                        this.wasAborted = true;
-                    }
-                    catch (TimeoutException)
-                    {
-                        this.closeCompleted = false;
-                    }
-                    return true;
+                    throw ExceptionHelper.PlatformNotSupported();   // #31 in progress
+
+                    //try
+                    //{
+                    //    IAsyncResult result = this.sessionChannel.inputSessionClosedHandle.BeginWait(this.timeoutHelper.RemainingTime(), true, shutdownWaitCallback, this);
+                    //    if (!result.CompletedSynchronously)
+                    //    {
+                    //        return false;
+                    //    }
+                    //    this.sessionChannel.inputSessionClosedHandle.EndWait(result);
+                    //    this.closeCompleted = true;
+                    //}
+                    //catch (CommunicationObjectAbortedException)
+                    //{
+                    //    if (this.sessionChannel.State != CommunicationState.Closed)
+                    //    {
+                    //        throw;
+                    //    }
+                    //    // if the channel was aborted by a parallel thread, allow the Close to
+                    //    // complete cleanly
+                    //    this.wasAborted = true;
+                    //}
+                    //catch (TimeoutException)
+                    //{
+                    //    this.closeCompleted = false;
+                    //}
+                    //return true;
                 }
 
                 static void ShutdownWaitCallback(IAsyncResult result)
                 {
-                    if (result.CompletedSynchronously)
-                    {
-                        return;
-                    }
-                    CloseSessionAsyncResult thisResult = (CloseSessionAsyncResult)result.AsyncState;
-                    Exception completionException = null;
-                    try
-                    {
-                        thisResult.sessionChannel.inputSessionClosedHandle.EndWait(result);
-                        thisResult.closeCompleted = true;
-                    }
-                    catch (CommunicationObjectAbortedException)
-                    {
-                        if (thisResult.sessionChannel.State != CommunicationState.Closed)
-                        {
-                            throw;
-                        }
-                        thisResult.wasAborted = true;
-                    }
-                    catch (TimeoutException)
-                    {
-                        thisResult.closeCompleted = false;
-                    }
-#pragma warning suppress 56500 // covered by FxCOP
-                    catch (Exception e)
-                    {
-                        if (Fx.IsFatal(e))
-                        {
-                            throw;
-                        }
-                        completionException = e;
-                    }
-                    thisResult.Complete(false, completionException);
+                    throw ExceptionHelper.PlatformNotSupported();   // #31 in progress
+
+//                    if (result.CompletedSynchronously)
+//                    {
+//                        return;
+//                    }
+//                    CloseSessionAsyncResult thisResult = (CloseSessionAsyncResult)result.AsyncState;
+//                    Exception completionException = null;
+//                    try
+//                    {
+//                        thisResult.sessionChannel.inputSessionClosedHandle.EndWait(result);
+//                        thisResult.closeCompleted = true;
+//                    }
+//                    catch (CommunicationObjectAbortedException)
+//                    {
+//                        if (thisResult.sessionChannel.State != CommunicationState.Closed)
+//                        {
+//                            throw;
+//                        }
+//                        thisResult.wasAborted = true;
+//                    }
+//                    catch (TimeoutException)
+//                    {
+//                        thisResult.closeCompleted = false;
+//                    }
+//#pragma warning suppress 56500 // covered by FxCOP
+//                    catch (Exception e)
+//                    {
+//                        if (Fx.IsFatal(e))
+//                        {
+//                            throw;
+//                        }
+//                        completionException = e;
+//                    }
+//                    thisResult.Complete(false, completionException);
                 }
 
                 public static bool End(IAsyncResult result, out bool wasAborted)
@@ -2269,7 +2240,7 @@ namespace System.ServiceModel.Security
                     }
                     if (!wasClosed)
                     {
-                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new TimeoutException(SR.GetString(SR.ClientSecurityCloseTimeout, timeout)));
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new TimeoutException(SR.Format(SR.ClientSecurityCloseTimeout, timeout)));
                     }
                     bool completeSelf = this.OnWaitForOutputSessionClose(out wasAborted);
                     if (wasAborted || completeSelf)
@@ -2299,7 +2270,7 @@ namespace System.ServiceModel.Security
                         {
                             if (!wasClosed)
                             {
-                                throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new TimeoutException(SR.GetString(SR.ClientSecurityCloseTimeout, thisResult.timeoutHelper.OriginalTimeout)));
+                                throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new TimeoutException(SR.Format(SR.ClientSecurityCloseTimeout, thisResult.timeoutHelper.OriginalTimeout)));
                             }
                             completeSelf = thisResult.OnWaitForOutputSessionClose(out wasAborted);
                             if (wasAborted)
@@ -2327,108 +2298,112 @@ namespace System.ServiceModel.Security
 
                 bool OnWaitForOutputSessionClose(out bool wasAborted)
                 {
-                    wasAborted = false;
-                    bool wasOutputSessionClosed = false;
-                    // wait for pending output sessions to finish
-                    try
-                    {
-                        IAsyncResult result = this.sessionChannel.outputSessionCloseHandle.BeginWait(timeoutHelper.RemainingTime(), true, outputSessionClosedCallback, this);
-                        if (!result.CompletedSynchronously)
-                        {
-                            return false;
-                        }
-                        this.sessionChannel.outputSessionCloseHandle.EndWait(result);
-                        wasOutputSessionClosed = true;
-                    }
-                    catch (TimeoutException)
-                    {
-                        wasOutputSessionClosed = false;
-                    }
-                    catch (CommunicationObjectAbortedException)
-                    {
-                        if (this.sessionChannel.State == CommunicationState.Closed)
-                        {
-                            wasAborted = true;
-                        }
-                        else
-                        {
-                            throw;
-                        }
-                    }
-                    if (wasAborted)
-                    {
-                        return true;
-                    }
-                    if (!wasOutputSessionClosed)
-                    {
-                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new TimeoutException(SR.GetString(SR.ClientSecurityOutputSessionCloseTimeout, timeoutHelper.OriginalTimeout)));
-                    }
-                    else
-                    {
-                        return this.CloseCore();
-                    }
+                    throw ExceptionHelper.PlatformNotSupported();   // #31 in progress
+
+                    //wasAborted = false;
+                    //bool wasOutputSessionClosed = false;
+                    //// wait for pending output sessions to finish
+                    //try
+                    //{
+                    //    IAsyncResult result = this.sessionChannel.outputSessionCloseHandle.BeginWait(timeoutHelper.RemainingTime(), true, outputSessionClosedCallback, this);
+                    //    if (!result.CompletedSynchronously)
+                    //    {
+                    //        return false;
+                    //    }
+                    //    this.sessionChannel.outputSessionCloseHandle.EndWait(result);
+                    //    wasOutputSessionClosed = true;
+                    //}
+                    //catch (TimeoutException)
+                    //{
+                    //    wasOutputSessionClosed = false;
+                    //}
+                    //catch (CommunicationObjectAbortedException)
+                    //{
+                    //    if (this.sessionChannel.State == CommunicationState.Closed)
+                    //    {
+                    //        wasAborted = true;
+                    //    }
+                    //    else
+                    //    {
+                    //        throw;
+                    //    }
+                    //}
+                    //if (wasAborted)
+                    //{
+                    //    return true;
+                    //}
+                    //if (!wasOutputSessionClosed)
+                    //{
+                    //    throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new TimeoutException(SR.Format(SR.ClientSecurityOutputSessionCloseTimeout, timeoutHelper.OriginalTimeout)));
+                    //}
+                    //else
+                    //{
+                    //    return this.CloseCore();
+                    //}
                 }
 
                 static void OutputSessionClosedCallback(IAsyncResult result)
                 {
-                    if (result.CompletedSynchronously)
-                    {
-                        return;
-                    }
-                    CloseAsyncResult self = (CloseAsyncResult)(result.AsyncState);
-                    Exception completionException = null;
-                    bool completeSelf = false;
-                    try
-                    {
-                        bool wasOutputSessionClosed = false;
-                        bool wasAborted = false;
-                        try
-                        {
-                            self.sessionChannel.outputSessionCloseHandle.EndWait(result);
-                            wasOutputSessionClosed = true;
-                        }
-                        catch (TimeoutException)
-                        {
-                            wasOutputSessionClosed = false;
-                        }
-                        catch (CommunicationObjectFaultedException)
-                        {
-                            if (self.sessionChannel.State == CommunicationState.Closed)
-                            {
-                                wasAborted = true;
-                            }
-                            else
-                            {
-                                throw;
-                            }
-                        }
-                        if (!wasAborted)
-                        {
-                            if (!wasOutputSessionClosed)
-                            {
-                                throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new TimeoutException(SR.GetString(SR.ClientSecurityOutputSessionCloseTimeout, self.timeoutHelper.OriginalTimeout)));
-                            }
-                            completeSelf = self.CloseCore();
-                        }
-                        else
-                        {
-                            completeSelf = true;
-                        }
-                    }
-#pragma warning suppress 56500 // covered by FxCOP
-                    catch (Exception e)
-                    {
-                        if (Fx.IsFatal(e))
-                        {
-                            throw;
-                        }
-                        completionException = e;
-                        completeSelf = true;
-                    }
-                    if (completeSelf)
-                    {
-                        self.Complete(false, completionException);
-                    }
+                    throw ExceptionHelper.PlatformNotSupported();   // #31 in progress
+
+//                    if (result.CompletedSynchronously)
+//                    {
+//                        return;
+//                    }
+//                    CloseAsyncResult self = (CloseAsyncResult)(result.AsyncState);
+//                    Exception completionException = null;
+//                    bool completeSelf = false;
+//                    try
+//                    {
+//                        bool wasOutputSessionClosed = false;
+//                        bool wasAborted = false;
+//                        try
+//                        {
+//                            self.sessionChannel.outputSessionCloseHandle.EndWait(result);
+//                            wasOutputSessionClosed = true;
+//                        }
+//                        catch (TimeoutException)
+//                        {
+//                            wasOutputSessionClosed = false;
+//                        }
+//                        catch (CommunicationObjectFaultedException)
+//                        {
+//                            if (self.sessionChannel.State == CommunicationState.Closed)
+//                            {
+//                                wasAborted = true;
+//                            }
+//                            else
+//                            {
+//                                throw;
+//                            }
+//                        }
+//                        if (!wasAborted)
+//                        {
+//                            if (!wasOutputSessionClosed)
+//                            {
+//                                throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new TimeoutException(SR.Format(SR.ClientSecurityOutputSessionCloseTimeout, self.timeoutHelper.OriginalTimeout)));
+//                            }
+//                            completeSelf = self.CloseCore();
+//                        }
+//                        else
+//                        {
+//                            completeSelf = true;
+//                        }
+//                    }
+//#pragma warning suppress 56500 // covered by FxCOP
+//                    catch (Exception e)
+//                    {
+//                        if (Fx.IsFatal(e))
+//                        {
+//                            throw;
+//                        }
+//                        completionException = e;
+//                        completeSelf = true;
+//                    }
+//                    if (completeSelf)
+//                    {
+//                        self.Complete(false, completionException);
+//                    }
                 }
 
                 bool CloseCore()
@@ -2710,59 +2685,64 @@ namespace System.ServiceModel.Security
 
             protected class SoapSecurityOutputSession : ISecureConversationSession, IOutputSession
             {
-                ClientSecuritySessionChannel channel;
-                EndpointIdentity remoteIdentity;
-                UniqueId sessionId;
-                SecurityKeyIdentifierClause sessionTokenIdentifier;
-                SecurityStandardsManager standardsManager;
+                private ClientSecuritySessionChannel _channel;
+                private EndpointIdentity _remoteIdentity;
+                private UniqueId _sessionId;
+                // #31 in progress
+                // private SecurityKeyIdentifierClause _sessionTokenIdentifier;
+                // private SecurityStandardsManager _standardsManager;
 
                 public SoapSecurityOutputSession(ClientSecuritySessionChannel channel)
                 {
-                    this.channel = channel;
+                    _channel = channel;
                 }
 
                 internal void Initialize(SecurityToken sessionToken, SecuritySessionClientSettings<TChannel> settings)
                 {
-                    if (sessionToken == null)
-                    {
-                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("sessionToken");
-                    }
-                    if (settings == null)
-                    {
-                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("settings");
-                    }
-                    Claim identityClaim = SecurityUtils.GetPrimaryIdentityClaim(((GenericXmlSecurityToken)sessionToken).AuthorizationPolicies);
-                    if (identityClaim != null)
-                    {
-                        this.remoteIdentity = EndpointIdentity.CreateIdentity(identityClaim);
-                    }
-                    this.standardsManager = settings.SessionProtocolFactory.StandardsManager;
-                    this.sessionId = GetSessionId(sessionToken, this.standardsManager);
-                    this.sessionTokenIdentifier = settings.IssuedSecurityTokenParameters.CreateKeyIdentifierClause(sessionToken,
-                        SecurityTokenReferenceStyle.External);
+                    throw ExceptionHelper.PlatformNotSupported();   // #31 in progress
+
+                    //if (sessionToken == null)
+                    //{
+                    //    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("sessionToken");
+                    //}
+                    //if (settings == null)
+                    //{
+                    //    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("settings");
+                    //}
+                    //Claim identityClaim = SecurityUtils.GetPrimaryIdentityClaim(((GenericXmlSecurityToken)sessionToken).AuthorizationPolicies);
+                    //if (identityClaim != null)
+                    //{
+                    //    this.remoteIdentity = EndpointIdentity.CreateIdentity(identityClaim);
+                    //}
+                    //this.standardsManager = settings.SessionProtocolFactory.StandardsManager;
+                    //this.sessionId = GetSessionId(sessionToken, this.standardsManager);
+                    //this.sessionTokenIdentifier = settings.IssuedSecurityTokenParameters.CreateKeyIdentifierClause(sessionToken,
+                    //    SecurityTokenReferenceStyle.External);
                 }
 
                 UniqueId GetSessionId(SecurityToken sessionToken, SecurityStandardsManager standardsManager)
                 {
-                    GenericXmlSecurityToken gxt = sessionToken as GenericXmlSecurityToken;
-                    if (gxt == null)
-                    {
-                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new NotSupportedException(SR.GetString(SR.SessionTokenIsNotGenericXmlToken, sessionToken, typeof(GenericXmlSecurityToken))));
-                    }
-                    return standardsManager.SecureConversationDriver.GetSecurityContextTokenId(XmlDictionaryReader.CreateDictionaryReader(new XmlNodeReader(gxt.TokenXml)));
+                    throw ExceptionHelper.PlatformNotSupported();   // #31 in progress
+
+                    //GenericXmlSecurityToken gxt = sessionToken as GenericXmlSecurityToken;
+                    //if (gxt == null)
+                    //{
+                    //    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new NotSupportedException(SR.Format(SR.SessionTokenIsNotGenericXmlToken, sessionToken, typeof(GenericXmlSecurityToken))));
+                    //}
+                    //return standardsManager.SecureConversationDriver.GetSecurityContextTokenId(XmlDictionaryReader.CreateDictionaryReader(new XmlNodeReader(gxt.TokenXml)));
                 }
 
                 public string Id
                 {
                     get
                     {
-                        if (this.sessionId == null)
+                        if (_sessionId == null)
                         {
                             // PreSharp Bug: Property get methods should not throw exceptions.
 #pragma warning suppress 56503
-                            throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.GetString(SR.ChannelMustBeOpenedToGetSessionId)));
+                            throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.ChannelMustBeOpenedToGetSessionId)));
                         }
-                        return this.sessionId.ToString();
+                        return _sessionId.ToString();
                     }
                 }
 
@@ -2770,26 +2750,30 @@ namespace System.ServiceModel.Security
                 {
                     get
                     {
-                        return this.remoteIdentity;
+                        return _remoteIdentity;
                     }
                 }
 
                 public void WriteSessionTokenIdentifier(XmlDictionaryWriter writer)
                 {
-                    this.channel.ThrowIfDisposedOrNotOpen();
-                    this.standardsManager.SecurityTokenSerializer.WriteKeyIdentifierClause(writer, this.sessionTokenIdentifier);
+                    throw ExceptionHelper.PlatformNotSupported();   // #31 in progress
+
+                    //this.channel.ThrowIfDisposedOrNotOpen();
+                    //this.standardsManager.SecurityTokenSerializer.WriteKeyIdentifierClause(writer, this.sessionTokenIdentifier);
                 }
 
                 public bool TryReadSessionTokenIdentifier(XmlReader reader)
                 {
-                    this.channel.ThrowIfDisposedOrNotOpen();
-                    if (!this.standardsManager.SecurityTokenSerializer.CanReadKeyIdentifierClause(reader))
-                    {
-                        return false;
-                    }
-                    SecurityContextKeyIdentifierClause incomingTokenIdentifier =
-                        this.standardsManager.SecurityTokenSerializer.ReadKeyIdentifierClause(reader) as SecurityContextKeyIdentifierClause;
-                    return incomingTokenIdentifier != null && incomingTokenIdentifier.Matches(sessionId, null);
+                    throw ExceptionHelper.PlatformNotSupported();   // #31 in progress
+
+                    //this.channel.ThrowIfDisposedOrNotOpen();
+                    //if (!this.standardsManager.SecurityTokenSerializer.CanReadKeyIdentifierClause(reader))
+                    //{
+                    //    return false;
+                    //}
+                    //SecurityContextKeyIdentifierClause incomingTokenIdentifier =
+                    //    this.standardsManager.SecurityTokenSerializer.ReadKeyIdentifierClause(reader) as SecurityContextKeyIdentifierClause;
+                    //return incomingTokenIdentifier != null && incomingTokenIdentifier.Matches(sessionId, null);
                 }
             }
         }
@@ -2891,43 +2875,45 @@ namespace System.ServiceModel.Security
 
             Message ProcessReply(Message reply, TimeSpan timeout, SecurityProtocolCorrelationState correlationState)
             {
-                if (reply == null)
-                {
-                    return null;
-                }
-                Message unverifiedReply = reply;
-                Message processedReply = null;
-                MessageFault protocolFault = null;
-                Exception faultException = null;
-                try
-                {
-                    processedReply = this.ProcessIncomingMessage(reply, timeout, correlationState, out protocolFault);
-                }
-                catch (MessageSecurityException)
-                {
-                    if (unverifiedReply.IsFault)
-                    {
-                        MessageFault fault = MessageFault.CreateFault(unverifiedReply, TransportDefaults.MaxSecurityFaultSize);
-                        if (SecurityUtils.IsSecurityFault(fault, this.Settings.standardsManager))
-                        {
-                            faultException = SecurityUtils.CreateSecurityFaultException(fault);
-                        }
-                    }
-                    if (faultException == null)
-                    {
-                        throw;
-                    }
-                }
-                if (faultException != null)
-                {
-                    Fault(faultException);
-                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(faultException);
-                }
-                if (processedReply == null && protocolFault != null)
-                {
-                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new MessageSecurityException(SR.GetString(SR.SecuritySessionFaultReplyWasSent), new FaultException(protocolFault)));
-                }
-                return processedReply;
+                throw ExceptionHelper.PlatformNotSupported();   // #31 in progress
+
+                //if (reply == null)
+                //{
+                //    return null;
+                //}
+                //Message unverifiedReply = reply;
+                //Message processedReply = null;
+                //MessageFault protocolFault = null;
+                //Exception faultException = null;
+                //try
+                //{
+                //    processedReply = this.ProcessIncomingMessage(reply, timeout, correlationState, out protocolFault);
+                //}
+                //catch (MessageSecurityException)
+                //{
+                //    if (unverifiedReply.IsFault)
+                //    {
+                //        MessageFault fault = MessageFault.CreateFault(unverifiedReply, TransportDefaults.MaxSecurityFaultSize);
+                //        if (SecurityUtils.IsSecurityFault(fault, this.Settings.standardsManager))
+                //        {
+                //            faultException = SecurityUtils.CreateSecurityFaultException(fault);
+                //        }
+                //    }
+                //    if (faultException == null)
+                //    {
+                //        throw;
+                //    }
+                //}
+                //if (faultException != null)
+                //{
+                //    Fault(faultException);
+                //    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(faultException);
+                //}
+                //if (processedReply == null && protocolFault != null)
+                //{
+                //    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new MessageSecurityException(SR.Format(SR.SecuritySessionFaultReplyWasSent), new FaultException(protocolFault)));
+                //}
+                //return processedReply;
             }
 
 
@@ -3146,19 +3132,22 @@ namespace System.ServiceModel.Security
 
         class ClientSecurityDuplexSessionChannel : ClientSecuritySessionChannel, IDuplexSessionChannel
         {
-            static AsyncCallback onReceive = Fx.ThunkCallback(new AsyncCallback(OnReceive));
-            SoapSecurityClientDuplexSession session;
-            InputQueue<Message> queue;
-            Action startReceiving;
-            Action<object> completeLater;
+            private static AsyncCallback s_onReceive = Fx.ThunkCallback(new AsyncCallback(OnReceive));
+            private SoapSecurityClientDuplexSession _session;
+            private InputQueue<Message> _queue;
+            // #31 in progress
+            //private Action _startReceiving;
+            private Action<object> _completeLater;
 
             public ClientSecurityDuplexSessionChannel(SecuritySessionClientSettings<TChannel> settings, EndpointAddress to, Uri via)
                 : base(settings, to, via)
             {
-                this.session = new SoapSecurityClientDuplexSession(this);
-                this.queue = TraceUtility.CreateInputQueue<Message>();
-                this.startReceiving = new Action(StartReceiving);
-                this.completeLater = new Action<object>(CompleteLater);
+                throw ExceptionHelper.PlatformNotSupported();   // #31 in progress
+
+                //this.session = new SoapSecurityClientDuplexSession(this);
+                //this.queue = TraceUtility.CreateInputQueue<Message>();
+                //this.startReceiving = new Action(StartReceiving);
+                //this.completeLater = new Action<object>(CompleteLater);
             }
 
             public EndpointAddress LocalAddress
@@ -3173,7 +3162,7 @@ namespace System.ServiceModel.Security
             {
                 get
                 {
-                    return this.session;
+                    return _session;
                 }
             }
 
@@ -3184,7 +3173,7 @@ namespace System.ServiceModel.Security
 
             protected override string SessionId
             {
-                get { return this.session.Id; }
+                get { return _session.Id; }
             }
 
             public Message Receive()
@@ -3194,7 +3183,8 @@ namespace System.ServiceModel.Security
 
             public Message Receive(TimeSpan timeout)
             {
-                return InputChannel.HelpReceive(this, timeout);
+                throw ExceptionHelper.PlatformNotSupported();   // #31 in progress
+                //return InputChannel.HelpReceive(this, timeout);
             }
 
             public IAsyncResult BeginReceive(AsyncCallback callback, object state)
@@ -3204,23 +3194,25 @@ namespace System.ServiceModel.Security
 
             public IAsyncResult BeginReceive(TimeSpan timeout, AsyncCallback callback, object state)
             {
-                return InputChannel.HelpBeginReceive(this, timeout, callback, state);
+                throw ExceptionHelper.PlatformNotSupported();   // #31 in progress
+                //return InputChannel.HelpBeginReceive(this, timeout, callback, state);
             }
 
             public Message EndReceive(IAsyncResult result)
             {
-                return InputChannel.HelpEndReceive(result);
+                throw ExceptionHelper.PlatformNotSupported();   // #31 in progress
+                //return InputChannel.HelpEndReceive(result);
             }
 
             public IAsyncResult BeginTryReceive(TimeSpan timeout, AsyncCallback callback, object state)
             {
                 ThrowIfFaulted();
-                return queue.BeginDequeue(timeout, callback, state);
+                return _queue.BeginDequeue(timeout, callback, state);
             }
 
             public bool EndTryReceive(IAsyncResult result, out Message message)
             {
-                bool wasDequeued = queue.EndDequeue(result, out message);
+                bool wasDequeued = _queue.EndDequeue(result, out message);
                 if (message == null)
                 {
                     // the channel could have faulted, shutting down the input queue
@@ -3238,7 +3230,7 @@ namespace System.ServiceModel.Security
             public bool TryReceive(TimeSpan timeout, out Message message)
             {
                 ThrowIfFaulted();
-                bool wasDequeued = queue.Dequeue(timeout, out message);
+                bool wasDequeued = _queue.Dequeue(timeout, out message);
                 if (message == null)
                 {
                     // the channel could have faulted, shutting down the input queue
@@ -3280,7 +3272,7 @@ namespace System.ServiceModel.Security
 
             protected override void InitializeSession(SecurityToken sessionToken)
             {
-                this.session.Initialize(sessionToken, this.Settings);
+                _session.Initialize(sessionToken, this.Settings);
             }
 
             void StartReceiving()
@@ -3288,7 +3280,7 @@ namespace System.ServiceModel.Security
                 IAsyncResult result = this.IssueReceive();
                 if (result != null && result.CompletedSynchronously)
                 {
-                    ActionItem.Schedule(completeLater, result);
+                    ActionItem.Schedule(_completeLater, result);
                 }
             }
 
@@ -3303,22 +3295,22 @@ namespace System.ServiceModel.Security
                     }
                     try
                     {
-                        return this.BeginReceiveInternal(TimeSpan.MaxValue, null, onReceive, this);
+                        return this.BeginReceiveInternal(TimeSpan.MaxValue, null, s_onReceive, this);
 
                     }
-                    catch (CommunicationException e)
+                    catch (CommunicationException /* #31 in progress e */)
                     {
                         // BeginReceive failed. ignore the exception and start another receive
-                        DiagnosticUtility.TraceHandledException(e, TraceEventType.Information);
+                        // DiagnosticUtility.TraceHandledException(e, TraceEventType.Information);
                     }
-                    catch (TimeoutException e)
+                    catch (TimeoutException /* #31 in progress e */)
                     {
                         // BeginReceive failed. ignore the exception and start another receive
-                        if (TD.ReceiveTimeoutIsEnabled())
-                        {
-                            TD.ReceiveTimeout(e.Message);
-                        }
-                        DiagnosticUtility.TraceHandledException(e, TraceEventType.Information);
+                        //if (TD.ReceiveTimeoutIsEnabled())
+                        //{
+                        //    TD.ReceiveTimeout(e.Message);
+                        //}
+                        //DiagnosticUtility.TraceHandledException(e, TraceEventType.Information);
                     }
                 }
             }
@@ -3338,107 +3330,110 @@ namespace System.ServiceModel.Security
 
             void CompleteReceive(IAsyncResult result)
             {
-                Message message = null;
-                bool issueAnotherReceive = false;
-                try
-                {
-                    message = this.EndReceiveInternal(result);
-                    issueAnotherReceive = true;
-                }
-                catch (MessageSecurityException)
-                {
-                    // a messagesecurityexception will only be thrown if the channel received a fault
-                    // from the other side, in which case the channel would have faulted
-                    issueAnotherReceive = false;
-                }
-                catch (CommunicationException e)
-                {
-                    issueAnotherReceive = true;
-                    // EndReceive failed. ignore the exception and start another receive
-                    DiagnosticUtility.TraceHandledException(e, TraceEventType.Information);
-                }
-                catch (TimeoutException e)
-                {
-                    issueAnotherReceive = true;
-                    // EndReceive failed. ignore the exception and start another receive
-                    if (TD.ReceiveTimeoutIsEnabled())
-                    {
-                        TD.ReceiveTimeout(e.Message);
-                    }
-                    DiagnosticUtility.TraceHandledException(e, TraceEventType.Information);
-                }
-                IAsyncResult nextReceiveResult = null;
-                if (issueAnotherReceive)
-                {
-                    nextReceiveResult = this.IssueReceive();
-                    if (nextReceiveResult != null && nextReceiveResult.CompletedSynchronously)
-                    {
-                        ActionItem.Schedule(completeLater, nextReceiveResult);
-                    }
-                }
-                if (message != null)
-                {
-                    // since we may be dispatching to user code swallow non-fatal exceptions
-                    try
-                    {
-                        this.queue.EnqueueAndDispatch(message);
-                    }
-#pragma warning suppress 56500 // covered by FxCOP
-                    catch (Exception e)
-                    {
-                        if (Fx.IsFatal(e)) throw;
-                        DiagnosticUtility.TraceHandledException(e, TraceEventType.Warning);
-                    }
-                }
+                throw ExceptionHelper.PlatformNotSupported();   // #31 in progress
+//                Message message = null;
+//                bool issueAnotherReceive = false;
+//                try
+//                {
+//                    message = this.EndReceiveInternal(result);
+//                    issueAnotherReceive = true;
+//                }
+//                catch (MessageSecurityException)
+//                {
+//                    // a messagesecurityexception will only be thrown if the channel received a fault
+//                    // from the other side, in which case the channel would have faulted
+//                    issueAnotherReceive = false;
+//                }
+//                catch (CommunicationException e)
+//                {
+//                    issueAnotherReceive = true;
+//                    // EndReceive failed. ignore the exception and start another receive
+//                    DiagnosticUtility.TraceHandledException(e, TraceEventType.Information);
+//                }
+//                catch (TimeoutException e)
+//                {
+//                    issueAnotherReceive = true;
+//                    // EndReceive failed. ignore the exception and start another receive
+//                    if (TD.ReceiveTimeoutIsEnabled())
+//                    {
+//                        TD.ReceiveTimeout(e.Message);
+//                    }
+//                    DiagnosticUtility.TraceHandledException(e, TraceEventType.Information);
+//                }
+//                IAsyncResult nextReceiveResult = null;
+//                if (issueAnotherReceive)
+//                {
+//                    nextReceiveResult = this.IssueReceive();
+//                    if (nextReceiveResult != null && nextReceiveResult.CompletedSynchronously)
+//                    {
+//                        ActionItem.Schedule(completeLater, nextReceiveResult);
+//                    }
+//                }
+//                if (message != null)
+//                {
+//                    // since we may be dispatching to user code swallow non-fatal exceptions
+//                    try
+//                    {
+//                        this.queue.EnqueueAndDispatch(message);
+//                    }
+//#pragma warning suppress 56500 // covered by FxCOP
+//                    catch (Exception e)
+//                    {
+//                        if (Fx.IsFatal(e)) throw;
+//                        DiagnosticUtility.TraceHandledException(e, TraceEventType.Warning);
+//                    }
+//                }
             }
 
             protected override void AbortCore()
             {
-                try
-                {
-                    this.queue.Dispose();
-                }
-                catch (CommunicationException e)
-                {
-                    DiagnosticUtility.TraceHandledException(e, TraceEventType.Information);
-                }
-                catch (TimeoutException e)
-                {
-                    if (TD.CloseTimeoutIsEnabled())
-                    {
-                        TD.CloseTimeout(e.Message);
-                    }
-                    DiagnosticUtility.TraceHandledException(e, TraceEventType.Information);
-                }
-                base.AbortCore();
+                throw ExceptionHelper.PlatformNotSupported();   // #31 in progress
+                //try
+                //{
+                //    this.queue.Dispose();
+                //}
+                //catch (CommunicationException e)
+                //{
+                //    DiagnosticUtility.TraceHandledException(e, TraceEventType.Information);
+                //}
+                //catch (TimeoutException e)
+                //{
+                //    if (TD.CloseTimeoutIsEnabled())
+                //    {
+                //        TD.CloseTimeout(e.Message);
+                //    }
+                //    DiagnosticUtility.TraceHandledException(e, TraceEventType.Information);
+                //}
+                //base.AbortCore();
             }
 
             public bool WaitForMessage(TimeSpan timeout)
             {
-                return this.queue.WaitForItem(timeout);
+                return _queue.WaitForItem(timeout);
             }
 
             public IAsyncResult BeginWaitForMessage(TimeSpan timeout, AsyncCallback callback, object state)
             {
-                return this.queue.BeginWaitForItem(timeout, callback, state);
+                return _queue.BeginWaitForItem(timeout, callback, state);
             }
 
             public bool EndWaitForMessage(IAsyncResult result)
             {
-                return this.queue.EndWaitForItem(result);
+                return _queue.EndWaitForItem(result);
             }
 
             protected override void OnFaulted()
             {
-                queue.Shutdown(() => this.GetPendingException());
-                base.OnFaulted();
+                throw ExceptionHelper.PlatformNotSupported();   // #31 in progress
+                //_queue.Shutdown(() => this.GetPendingException());
+                //base.OnFaulted();
             }
 
             protected override bool OnCloseResponseReceived()
             {
                 if (base.OnCloseResponseReceived())
                 {
-                    this.queue.Shutdown();
+                    _queue.Shutdown();
                     return true;
                 }
                 else
@@ -3451,7 +3446,7 @@ namespace System.ServiceModel.Security
             {
                 if (base.OnCloseReceived())
                 {
-                    this.queue.Shutdown();
+                    _queue.Shutdown();
                     return true;
                 }
                 else
@@ -3481,7 +3476,7 @@ namespace System.ServiceModel.Security
                 {
                     if (!this.initialized)
                     {
-                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.GetString(SR.ChannelNotOpen)));
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.ChannelNotOpen)));
                     }
                 }
 
@@ -3492,32 +3487,34 @@ namespace System.ServiceModel.Security
 
                 public void CloseOutputSession(TimeSpan timeout)
                 {
-                    CheckInitialized();
-                    this.channel.ThrowIfFaulted();
-                    this.channel.ThrowIfNotOpened();
-                    Exception pendingException = null;
-                    try
-                    {
-                        this.channel.CloseOutputSession(timeout);
-                    }
-                    catch (CommunicationObjectAbortedException)
-                    {
-                        if (this.channel.State != CommunicationState.Closed)
-                        {
-                            throw;
-                        }
-                    }
-#pragma warning suppress 56500 // covered by FxCOP
-                    catch (Exception e)
-                    {
-                        if (Fx.IsFatal(e)) throw;
-                        pendingException = e;
-                    }
-                    if (pendingException != null)
-                    {
-                        this.channel.Fault(pendingException);
-                        throw pendingException;
-                    }
+                    throw ExceptionHelper.PlatformNotSupported();   // #31 in progress
+
+//                    CheckInitialized();
+//                    this.channel.ThrowIfFaulted();
+//                    this.channel.ThrowIfNotOpened();
+//                    Exception pendingException = null;
+//                    try
+//                    {
+//                        this.channel.CloseOutputSession(timeout);
+//                    }
+//                    catch (CommunicationObjectAbortedException)
+//                    {
+//                        if (this.channel.State != CommunicationState.Closed)
+//                        {
+//                            throw;
+//                        }
+//                    }
+//#pragma warning suppress 56500 // covered by FxCOP
+//                    catch (Exception e)
+//                    {
+//                        if (Fx.IsFatal(e)) throw;
+//                        pendingException = e;
+//                    }
+//                    if (pendingException != null)
+//                    {
+//                        this.channel.Fault(pendingException);
+//                        throw pendingException;
+//                    }
                 }
 
                 public IAsyncResult BeginCloseOutputSession(AsyncCallback callback, object state)
@@ -3527,86 +3524,90 @@ namespace System.ServiceModel.Security
 
                 public IAsyncResult BeginCloseOutputSession(TimeSpan timeout, AsyncCallback callback, object state)
                 {
-                    CheckInitialized();
-                    this.channel.ThrowIfFaulted();
-                    this.channel.ThrowIfNotOpened();
-                    Exception pendingException = null;
-                    try
-                    {
-                        return this.channel.BeginCloseOutputSession(timeout, callback, state);
-                    }
-                    catch (CommunicationObjectAbortedException)
-                    {
-                        if (this.channel.State != CommunicationState.Closed)
-                        {
-                            throw;
-                        }
-                        // another thread must have aborted the channel. Allow the close to complete
-                        // gracefully
-                        return new CompletedAsyncResult(callback, state);
-                    }
-#pragma warning suppress 56500 // covered by FxCOP
-                    catch (Exception e)
-                    {
-                        if (Fx.IsFatal(e)) throw;
-                        pendingException = e;
-                    }
-                    if (pendingException != null)
-                    {
-                        this.channel.Fault(pendingException);
-                        if (pendingException is CommunicationException)
-                        {
-                            throw pendingException;
-                        }
-                        else
-                        {
-                            throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(pendingException);
-                        }
-                    }
-                    // we should never reach here
-                    Fx.Assert("Unexpected control flow");
-                    return null;
+                    throw ExceptionHelper.PlatformNotSupported();   // #31 in progress
+
+//                    CheckInitialized();
+//                    this.channel.ThrowIfFaulted();
+//                    this.channel.ThrowIfNotOpened();
+//                    Exception pendingException = null;
+//                    try
+//                    {
+//                        return this.channel.BeginCloseOutputSession(timeout, callback, state);
+//                    }
+//                    catch (CommunicationObjectAbortedException)
+//                    {
+//                        if (this.channel.State != CommunicationState.Closed)
+//                        {
+//                            throw;
+//                        }
+//                        // another thread must have aborted the channel. Allow the close to complete
+//                        // gracefully
+//                        return new CompletedAsyncResult(callback, state);
+//                    }
+//#pragma warning suppress 56500 // covered by FxCOP
+//                    catch (Exception e)
+//                    {
+//                        if (Fx.IsFatal(e)) throw;
+//                        pendingException = e;
+//                    }
+//                    if (pendingException != null)
+//                    {
+//                        this.channel.Fault(pendingException);
+//                        if (pendingException is CommunicationException)
+//                        {
+//                            throw pendingException;
+//                        }
+//                        else
+//                        {
+//                            throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(pendingException);
+//                        }
+//                    }
+//                    // we should never reach here
+//                    Fx.Assert("Unexpected control flow");
+//                    return null;
                 }
 
                 public void EndCloseOutputSession(IAsyncResult result)
                 {
-                    if (result is CompletedAsyncResult)
-                    {
-                        CompletedAsyncResult.End(result);
-                        return;
-                    }
-                    Exception pendingException = null;
-                    try
-                    {
-                        this.channel.EndCloseOutputSession(result);
-                    }
-                    catch (CommunicationObjectAbortedException)
-                    {
-                        if (this.channel.State != CommunicationState.Closed)
-                        {
-                            throw;
-                        }
-                        // another thread must have aborted the channel. Allow the close to complete
-                        // gracefully
-                    }
-#pragma warning suppress 56500 // covered by FxCOP
-                    catch (Exception e)
-                    {
-                        if (Fx.IsFatal(e)) throw;
-                        pendingException = e;
-                    }
-                    if (pendingException != null)
-                    {
-                        this.channel.Fault(pendingException);
-                        if (pendingException is CommunicationException)
-                        {
-                            throw pendingException;
-                        }
-                        else
-                        {
-                            throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(pendingException);
-                        }
-                    }
+                    throw ExceptionHelper.PlatformNotSupported();   // #31 in progress
+
+//                    if (result is CompletedAsyncResult)
+//                    {
+//                        CompletedAsyncResult.End(result);
+//                        return;
+//                    }
+//                    Exception pendingException = null;
+//                    try
+//                    {
+//                        this.channel.EndCloseOutputSession(result);
+//                    }
+//                    catch (CommunicationObjectAbortedException)
+//                    {
+//                        if (this.channel.State != CommunicationState.Closed)
+//                        {
+//                            throw;
+//                        }
+//                        // another thread must have aborted the channel. Allow the close to complete
+//                        // gracefully
+//                    }
+//#pragma warning suppress 56500 // covered by FxCOP
+//                    catch (Exception e)
+//                    {
+//                        if (Fx.IsFatal(e)) throw;
+//                        pendingException = e;
+//                    }
+//                    if (pendingException != null)
+//                    {
+//                        this.channel.Fault(pendingException);
+//                        if (pendingException is CommunicationException)
+//                        {
+//                            throw pendingException;
+//                        }
+//                        else
+//                        {
+//                            throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(pendingException);
+//                        }
+//                    }
                 }
             }
         }

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SecuritySessionClientSettings.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SecuritySessionClientSettings.cs
@@ -1,0 +1,3615 @@
+//----------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace System.ServiceModel.Security
+{
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.IdentityModel.Claims;
+    using System.IdentityModel.Selectors;
+    using System.IdentityModel.Tokens;
+    using System.Runtime;
+    using System.ServiceModel.Channels;
+    using System.ServiceModel.Diagnostics;
+    using System.ServiceModel.Dispatcher;
+    using System.ServiceModel.Security.Tokens;
+    using System.Net;
+    using System.Threading;
+    using System.Xml;
+    using System.Globalization;
+    using System.ServiceModel.Diagnostics.Application;
+
+    // Please use 'sdv //depot/devdiv/private/indigo_xws/ndp/indigo/src/ServiceModel/System/ServiceModel/Security/SecuritySessionChannelFactory.cs' 
+    // to see version history before the file was renamed
+    // This class is named Settings since the only public APIs are for
+    // settings; however, this class also manages all functionality
+    // for session channels through internal APIs
+
+    static class SecuritySessionClientSettings
+    {
+        internal const string defaultKeyRenewalIntervalString = "10:00:00";
+        internal const string defaultKeyRolloverIntervalString = "00:05:00";
+
+        internal static readonly TimeSpan defaultKeyRenewalInterval = TimeSpan.Parse(defaultKeyRenewalIntervalString, CultureInfo.InvariantCulture);
+        internal static readonly TimeSpan defaultKeyRolloverInterval = TimeSpan.Parse(defaultKeyRolloverIntervalString, CultureInfo.InvariantCulture);
+        internal const bool defaultTolerateTransportFailures = true;
+    }
+
+    sealed class SecuritySessionClientSettings<TChannel> : IChannelSecureConversationSessionSettings, ISecurityCommunicationObject
+    {
+        SecurityProtocolFactory sessionProtocolFactory;
+        TimeSpan keyRenewalInterval;
+        TimeSpan keyRolloverInterval;
+        bool tolerateTransportFailures;
+        SecurityChannelFactory<TChannel> securityChannelFactory;
+        IChannelFactory innerChannelFactory;
+        ChannelBuilder channelBuilder;
+        WrapperSecurityCommunicationObject communicationObject;
+        SecurityStandardsManager standardsManager;
+        SecurityTokenParameters issuedTokenParameters;
+        int issuedTokenRenewalThreshold;
+        bool canRenewSession = true;
+        object thisLock = new object();
+
+        public SecuritySessionClientSettings()
+        {
+            this.keyRenewalInterval = SecuritySessionClientSettings.defaultKeyRenewalInterval;
+            this.keyRolloverInterval = SecuritySessionClientSettings.defaultKeyRolloverInterval;
+            this.tolerateTransportFailures = SecuritySessionClientSettings.defaultTolerateTransportFailures;
+            this.communicationObject = new WrapperSecurityCommunicationObject(this);
+        }
+
+        IChannelFactory InnerChannelFactory
+        {
+            get
+            {
+                return this.innerChannelFactory;
+            }
+        }
+
+        internal ChannelBuilder ChannelBuilder
+        {
+            get
+            {
+                return this.channelBuilder;
+            }
+            set
+            {
+                this.channelBuilder = value;
+            }
+        }
+
+        SecurityChannelFactory<TChannel> SecurityChannelFactory
+        {
+            get
+            {
+                return this.securityChannelFactory;
+            }
+        }
+
+        public SecurityProtocolFactory SessionProtocolFactory
+        {
+            get
+            {
+                return this.sessionProtocolFactory;
+            }
+            set
+            {
+                this.communicationObject.ThrowIfDisposedOrImmutable();
+                this.sessionProtocolFactory = value;
+            }
+        }
+
+        public TimeSpan KeyRenewalInterval
+        {
+            get
+            {
+                return this.keyRenewalInterval;
+            }
+            set
+            {
+                if (value <= TimeSpan.Zero)
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("value", SR.GetString(SR.TimeSpanMustbeGreaterThanTimeSpanZero)));
+                }
+                this.communicationObject.ThrowIfDisposedOrImmutable();
+                this.keyRenewalInterval = value;
+            }
+        }
+
+        public TimeSpan KeyRolloverInterval
+        {
+            get
+            {
+                return this.keyRolloverInterval;
+            }
+            set
+            {
+                if (value <= TimeSpan.Zero)
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("value", SR.GetString(SR.TimeSpanMustbeGreaterThanTimeSpanZero)));
+                }
+                this.communicationObject.ThrowIfDisposedOrImmutable();
+                this.keyRolloverInterval = value;
+            }
+        }
+
+        public bool TolerateTransportFailures
+        {
+            get
+            {
+                return this.tolerateTransportFailures;
+            }
+            set
+            {
+                this.communicationObject.ThrowIfDisposedOrImmutable();
+                this.tolerateTransportFailures = value;
+            }
+        }
+
+        public bool CanRenewSession
+        {
+            get
+            {
+                return this.canRenewSession;
+            }
+            set
+            {
+                this.canRenewSession = value;
+            }
+        }
+
+        public SecurityTokenParameters IssuedSecurityTokenParameters
+        {
+            get
+            {
+                return this.issuedTokenParameters;
+            }
+            set
+            {
+                this.communicationObject.ThrowIfDisposedOrImmutable();
+                this.issuedTokenParameters = value;
+            }
+        }
+
+        public SecurityStandardsManager SecurityStandardsManager
+        {
+            get
+            {
+                return this.standardsManager;
+            }
+            set
+            {
+                this.communicationObject.ThrowIfDisposedOrImmutable();
+                this.standardsManager = value;
+            }
+        }
+
+        // ISecurityCommunicationObject members
+        public TimeSpan DefaultOpenTimeout
+        {
+            get { return ServiceDefaults.OpenTimeout; }
+        }
+
+        public TimeSpan DefaultCloseTimeout
+        {
+            get { return ServiceDefaults.CloseTimeout; }
+        }
+
+        internal IChannelFactory CreateInnerChannelFactory()
+        {
+            if (this.ChannelBuilder.CanBuildChannelFactory<IDuplexSessionChannel>())
+            {
+                return this.ChannelBuilder.BuildChannelFactory<IDuplexSessionChannel>();
+            }
+            else if (this.ChannelBuilder.CanBuildChannelFactory<IDuplexChannel>())
+            {
+                return this.ChannelBuilder.BuildChannelFactory<IDuplexChannel>();
+            }
+            else if (this.ChannelBuilder.CanBuildChannelFactory<IRequestChannel>())
+            {
+                return this.ChannelBuilder.BuildChannelFactory<IRequestChannel>();
+            }
+            else
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new NotSupportedException());
+            }
+        }
+
+        public IAsyncResult BeginClose(TimeSpan timeout, AsyncCallback callback, object state)
+        {
+            return this.communicationObject.BeginClose(timeout, callback, state);
+        }
+
+        public void EndClose(IAsyncResult result)
+        {
+            this.communicationObject.EndClose(result);
+        }
+
+        IAsyncResult ISecurityCommunicationObject.OnBeginClose(TimeSpan timeout, AsyncCallback callback, object state)
+        {
+            return new OperationWithTimeoutAsyncResult(new OperationWithTimeoutCallback(this.OnClose), timeout, callback, state);
+        }
+
+        IAsyncResult ISecurityCommunicationObject.OnBeginOpen(TimeSpan timeout, AsyncCallback callback, object state)
+        {
+            return new OperationWithTimeoutAsyncResult(new OperationWithTimeoutCallback(this.OnOpen), timeout, callback, state);
+        }
+
+        public void OnClosed()
+        {
+        }
+
+        public void OnClosing()
+        {
+        }
+
+        void ISecurityCommunicationObject.OnEndClose(IAsyncResult result)
+        {
+            OperationWithTimeoutAsyncResult.End(result);
+        }
+
+        void ISecurityCommunicationObject.OnEndOpen(IAsyncResult result)
+        {
+            OperationWithTimeoutAsyncResult.End(result);
+        }
+
+        public void OnFaulted()
+        {
+        }
+
+        public void OnOpened()
+        {
+        }
+
+        public void OnOpening()
+        {
+        }
+
+        public void OnClose(TimeSpan timeout)
+        {
+            if (this.sessionProtocolFactory != null)
+            {
+                this.sessionProtocolFactory.Close(false, timeout);
+            }
+        }
+
+        public void OnAbort()
+        {
+            if (this.sessionProtocolFactory != null)
+            {
+                this.sessionProtocolFactory.Close(true, TimeSpan.Zero);
+            }
+        }
+
+        public void OnOpen(TimeSpan timeout)
+        {
+            TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
+            if (this.sessionProtocolFactory == null)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.GetString(SR.SecuritySessionProtocolFactoryShouldBeSetBeforeThisOperation)));
+            }
+            if (this.standardsManager == null)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.GetString(SR.SecurityStandardsManagerNotSet, this.GetType().ToString())));
+            }
+            if (this.issuedTokenParameters == null)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.GetString(SR.IssuedSecurityTokenParametersNotSet, this.GetType())));
+            }
+            if (this.keyRenewalInterval < this.keyRolloverInterval)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.GetString(SR.KeyRolloverGreaterThanKeyRenewal)));
+            }
+            this.issuedTokenRenewalThreshold = this.sessionProtocolFactory.SecurityBindingElement.LocalClientSettings.CookieRenewalThresholdPercentage;
+            this.ConfigureSessionProtocolFactory();
+            this.sessionProtocolFactory.Open(true, timeoutHelper.RemainingTime());
+        }
+
+        internal void Close(TimeSpan timeout)
+        {
+            this.communicationObject.Close(timeout);
+        }
+
+        internal void Abort()
+        {
+            this.communicationObject.Abort();
+        }
+
+        internal void Open(SecurityChannelFactory<TChannel> securityChannelFactory,
+            IChannelFactory innerChannelFactory, ChannelBuilder channelBuilder, TimeSpan timeout)
+        {
+            this.securityChannelFactory = securityChannelFactory;
+            this.innerChannelFactory = innerChannelFactory;
+            this.channelBuilder = channelBuilder;
+            this.communicationObject.Open(timeout);
+        }
+
+        internal TChannel OnCreateChannel(EndpointAddress remoteAddress, Uri via)
+        {
+            return OnCreateChannel(remoteAddress, via, null);
+        }
+
+        internal TChannel OnCreateChannel(EndpointAddress remoteAddress, Uri via, MessageFilter filter)
+        {
+            this.communicationObject.ThrowIfClosed();
+            if (filter != null)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new NotSupportedException());
+            }
+
+            if (typeof(TChannel) == typeof(IRequestSessionChannel))
+            {
+                return (TChannel)((object)(new SecurityRequestSessionChannel(this, remoteAddress, via)));
+            }
+            else if (typeof(TChannel) == typeof(IDuplexSessionChannel))
+            {
+                // typeof(TChannel) == typeof(IDuplexSessionChannel)
+                return (TChannel)((object)(new ClientSecurityDuplexSessionChannel(this, remoteAddress, via)));
+            }
+            else
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentException(SR.GetString(SR.ChannelTypeNotSupported, typeof(TChannel)), "TChannel"));
+            }
+        }
+
+        void ConfigureSessionProtocolFactory()
+        {
+            if (this.sessionProtocolFactory is SessionSymmetricMessageSecurityProtocolFactory)
+            {
+                AddressingVersion addressing = MessageVersion.Default.Addressing;
+                if (this.channelBuilder != null)
+                {
+                    MessageEncodingBindingElement encoding = this.channelBuilder.Binding.Elements.Find<MessageEncodingBindingElement>();
+                    if (encoding != null)
+                    {
+                        addressing = encoding.MessageVersion.Addressing;
+                    }
+                }
+
+                if (addressing != AddressingVersion.WSAddressing10 && addressing != AddressingVersion.WSAddressingAugust2004)
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(
+                        new ProtocolException(SR.GetString(SR.AddressingVersionNotSupported, addressing)));
+                }
+
+                SessionSymmetricMessageSecurityProtocolFactory symmetric = (SessionSymmetricMessageSecurityProtocolFactory)this.sessionProtocolFactory;
+                if (!symmetric.ApplyIntegrity || !symmetric.RequireIntegrity)
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.GetString(SR.SecuritySessionRequiresMessageIntegrity)));
+                MessagePartSpecification bodyPart = new MessagePartSpecification(true);
+                symmetric.ProtectionRequirements.OutgoingSignatureParts.AddParts(bodyPart, this.SecurityStandardsManager.SecureConversationDriver.CloseResponseAction);
+                symmetric.ProtectionRequirements.OutgoingSignatureParts.AddParts(bodyPart, this.SecurityStandardsManager.SecureConversationDriver.CloseAction);
+                symmetric.ProtectionRequirements.OutgoingSignatureParts.AddParts(bodyPart, addressing.FaultAction);
+                symmetric.ProtectionRequirements.OutgoingSignatureParts.AddParts(bodyPart, addressing.DefaultFaultAction);
+                symmetric.ProtectionRequirements.OutgoingSignatureParts.AddParts(bodyPart, DotNetSecurityStrings.SecuritySessionFaultAction);
+                symmetric.ProtectionRequirements.IncomingSignatureParts.AddParts(bodyPart, this.SecurityStandardsManager.SecureConversationDriver.CloseAction);
+                symmetric.ProtectionRequirements.IncomingSignatureParts.AddParts(bodyPart, this.SecurityStandardsManager.SecureConversationDriver.CloseResponseAction);
+                if (symmetric.ApplyConfidentiality)
+                {
+                    symmetric.ProtectionRequirements.IncomingEncryptionParts.AddParts(MessagePartSpecification.NoParts, this.SecurityStandardsManager.SecureConversationDriver.CloseAction);
+                    symmetric.ProtectionRequirements.IncomingEncryptionParts.AddParts(MessagePartSpecification.NoParts, this.SecurityStandardsManager.SecureConversationDriver.CloseResponseAction);
+                }
+                if (symmetric.RequireConfidentiality)
+                {
+                    symmetric.ProtectionRequirements.OutgoingEncryptionParts.AddParts(MessagePartSpecification.NoParts, this.SecurityStandardsManager.SecureConversationDriver.CloseResponseAction);
+                    symmetric.ProtectionRequirements.OutgoingEncryptionParts.AddParts(MessagePartSpecification.NoParts, this.SecurityStandardsManager.SecureConversationDriver.CloseAction);
+                    symmetric.ProtectionRequirements.OutgoingEncryptionParts.AddParts(bodyPart, addressing.FaultAction);
+                    symmetric.ProtectionRequirements.OutgoingEncryptionParts.AddParts(bodyPart, addressing.DefaultFaultAction);
+                    symmetric.ProtectionRequirements.OutgoingEncryptionParts.AddParts(bodyPart, DotNetSecurityStrings.SecuritySessionFaultAction);
+                }
+            }
+            else if (this.sessionProtocolFactory is SessionSymmetricTransportSecurityProtocolFactory)
+            {
+                SessionSymmetricTransportSecurityProtocolFactory transport = (SessionSymmetricTransportSecurityProtocolFactory)this.sessionProtocolFactory;
+                transport.AddTimestamp = true;
+                transport.SecurityTokenParameters.RequireDerivedKeys = false;
+            }
+            else
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new NotSupportedException());
+            }
+        }
+
+        abstract class ClientSecuritySessionChannel : ChannelBase
+        {
+            EndpointAddress to;
+            Uri via;
+            IClientReliableChannelBinder channelBinder;
+            ChannelParameterCollection channelParameters;
+            SecurityToken currentSessionToken;
+            SecurityToken previousSessionToken;
+            DateTime keyRenewalTime;
+            DateTime keyRolloverTime;
+            SecurityProtocol securityProtocol;
+            SecuritySessionClientSettings<TChannel> settings;
+            SecurityTokenProvider sessionTokenProvider;
+            bool isKeyRenewalOngoing = false;
+            InterruptibleWaitObject keyRenewalCompletedEvent;
+            bool sentClose;
+            bool receivedClose;
+            volatile bool isOutputClosed;
+            volatile bool isInputClosed;
+            InterruptibleWaitObject inputSessionClosedHandle = new InterruptibleWaitObject(false);
+            bool sendCloseHandshake = false;
+            MessageVersion messageVersion;
+            bool isCompositeDuplexConnection;
+            Message closeResponse;
+            InterruptibleWaitObject outputSessionCloseHandle = new InterruptibleWaitObject(true);
+            WebHeaderCollection webHeaderCollection;
+
+            protected ClientSecuritySessionChannel(SecuritySessionClientSettings<TChannel> settings, EndpointAddress to, Uri via)
+                : base(settings.SecurityChannelFactory)
+            {
+                this.settings = settings;
+                this.to = to;
+                this.via = via;
+                this.keyRenewalCompletedEvent = new InterruptibleWaitObject(false);
+                this.messageVersion = settings.SecurityChannelFactory.MessageVersion;
+                this.channelParameters = new ChannelParameterCollection(this);
+                this.InitializeChannelBinder();
+                this.webHeaderCollection = new WebHeaderCollection();
+            }
+
+            protected SecuritySessionClientSettings<TChannel> Settings
+            {
+                get
+                {
+                    return this.settings;
+                }
+            }
+
+            protected IClientReliableChannelBinder ChannelBinder
+            {
+                get
+                {
+                    return this.channelBinder;
+                }
+            }
+
+            public EndpointAddress RemoteAddress
+            {
+                get
+                {
+                    return this.to;
+                }
+            }
+
+            public Uri Via
+            {
+                get
+                {
+                    return this.via;
+                }
+            }
+
+            protected bool SendCloseHandshake
+            {
+                get
+                {
+                    return this.sendCloseHandshake;
+                }
+            }
+
+            protected EndpointAddress InternalLocalAddress
+            {
+                get
+                {
+                    if (this.channelBinder != null)
+                        return this.channelBinder.LocalAddress;
+                    return null;
+                }
+            }
+
+            protected virtual bool CanDoSecurityCorrelation
+            {
+                get
+                {
+                    return false;
+                }
+            }
+
+            public MessageVersion MessageVersion
+            {
+                get { return this.messageVersion; }
+            }
+
+            protected bool IsInputClosed
+            {
+                get { return isInputClosed; }
+            }
+
+            protected bool IsOutputClosed
+            {
+                get { return isOutputClosed; }
+            }
+
+            protected abstract bool ExpectClose
+            {
+                get;
+            }
+
+            protected abstract string SessionId
+            {
+                get;
+            }
+
+            public override T GetProperty<T>()
+            {
+                if (typeof(T) == typeof(ChannelParameterCollection))
+                {
+                    return this.channelParameters as T;
+                }
+
+                if (typeof(T) == typeof(FaultConverter) && (this.channelBinder != null))
+                {
+                    return new SecurityChannelFaultConverter(this.channelBinder.Channel) as T;
+                }
+                else if (typeof(T) == typeof(WebHeaderCollection))
+                {
+                    return (T)(object)this.webHeaderCollection;
+                }
+
+
+                T result = base.GetProperty<T>();
+                if ((result == null) && (channelBinder != null) && (channelBinder.Channel != null))
+                {
+                    result = channelBinder.Channel.GetProperty<T>();
+                }
+
+                return result;
+            }
+
+            protected abstract void InitializeSession(SecurityToken sessionToken);
+
+            void InitializeSecurityState(SecurityToken sessionToken)
+            {
+                InitializeSession(sessionToken);
+                this.currentSessionToken = sessionToken;
+                this.previousSessionToken = null;
+                List<SecurityToken> incomingSessionTokens = new List<SecurityToken>(1);
+                incomingSessionTokens.Add(sessionToken);
+                ((IInitiatorSecuritySessionProtocol)this.securityProtocol).SetIdentityCheckAuthenticator(new GenericXmlSecurityTokenAuthenticator());
+                ((IInitiatorSecuritySessionProtocol)this.securityProtocol).SetIncomingSessionTokens(incomingSessionTokens);
+                ((IInitiatorSecuritySessionProtocol)this.securityProtocol).SetOutgoingSessionToken(sessionToken);
+                if (this.CanDoSecurityCorrelation)
+                {
+                    ((IInitiatorSecuritySessionProtocol)this.securityProtocol).ReturnCorrelationState = true;
+                }
+                this.keyRenewalTime = GetKeyRenewalTime(sessionToken);
+            }
+
+            void SetupSessionTokenProvider()
+            {
+                InitiatorServiceModelSecurityTokenRequirement requirement = new InitiatorServiceModelSecurityTokenRequirement();
+                this.Settings.IssuedSecurityTokenParameters.InitializeSecurityTokenRequirement(requirement);
+                requirement.KeyUsage = SecurityKeyUsage.Signature;
+                requirement.SupportSecurityContextCancellation = true;
+                requirement.SecurityAlgorithmSuite = this.Settings.SessionProtocolFactory.OutgoingAlgorithmSuite;
+                requirement.SecurityBindingElement = this.Settings.SessionProtocolFactory.SecurityBindingElement;
+                requirement.TargetAddress = this.to;
+                requirement.Via = this.Via;
+                requirement.MessageSecurityVersion = this.Settings.SessionProtocolFactory.MessageSecurityVersion.SecurityTokenVersion;
+                requirement.Properties[ServiceModelSecurityTokenRequirement.PrivacyNoticeUriProperty] = this.Settings.SessionProtocolFactory.PrivacyNoticeUri;
+                requirement.WebHeaders = this.webHeaderCollection;
+
+                if (this.channelParameters != null)
+                {
+                    requirement.Properties[ServiceModelSecurityTokenRequirement.ChannelParametersCollectionProperty] = this.channelParameters;
+                }
+                requirement.Properties[ServiceModelSecurityTokenRequirement.PrivacyNoticeVersionProperty] = this.Settings.SessionProtocolFactory.PrivacyNoticeVersion;
+                if (this.channelBinder.LocalAddress != null)
+                {
+                    requirement.DuplexClientLocalAddress = this.channelBinder.LocalAddress;
+                }
+                this.sessionTokenProvider = this.Settings.SessionProtocolFactory.SecurityTokenManager.CreateSecurityTokenProvider(requirement);
+            }
+
+            void OpenCore(SecurityToken sessionToken, TimeSpan timeout)
+            {
+                TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
+                this.securityProtocol = this.Settings.SessionProtocolFactory.CreateSecurityProtocol(this.to, this.Via, null, true, timeoutHelper.RemainingTime());
+                if (!(this.securityProtocol is IInitiatorSecuritySessionProtocol))
+                {
+                    Fx.Assert("Security protocol must be IInitiatorSecuritySessionProtocol.");
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.GetString(SR.ProtocolMisMatch, "IInitiatorSecuritySessionProtocol", this.GetType().ToString())));
+                }
+                this.securityProtocol.Open(timeoutHelper.RemainingTime());
+                this.channelBinder.Open(timeoutHelper.RemainingTime());
+                this.InitializeSecurityState(sessionToken);
+            }
+
+            protected override void OnFaulted()
+            {
+                this.AbortCore();
+                this.inputSessionClosedHandle.Fault(this);
+                this.keyRenewalCompletedEvent.Fault(this);
+                this.outputSessionCloseHandle.Fault(this);
+                base.OnFaulted();
+            }
+
+            protected override void OnOpen(TimeSpan timeout)
+            {
+                TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
+                SetupSessionTokenProvider();
+                SecurityUtils.OpenTokenProviderIfRequired(this.sessionTokenProvider, timeoutHelper.RemainingTime());
+                using (ServiceModelActivity activity = DiagnosticUtility.ShouldUseActivity ?
+                    ServiceModelActivity.CreateBoundedActivity() : null)
+                {
+                    if (DiagnosticUtility.ShouldUseActivity)
+                    {
+                        ServiceModelActivity.Start(activity, SR.GetString(SR.ActivitySecuritySetup), ActivityType.SecuritySetup);
+                    }
+                    SecurityToken sessionToken = this.sessionTokenProvider.GetToken(timeoutHelper.RemainingTime());
+                    // Token was issued, do send cancel on close;
+                    this.sendCloseHandshake = true;
+                    this.OpenCore(sessionToken, timeoutHelper.RemainingTime());
+                }
+            }
+
+            protected override IAsyncResult OnBeginOpen(TimeSpan timeout, AsyncCallback callback, object state)
+            {
+                ServiceModelActivity activity = DiagnosticUtility.ShouldUseActivity ?
+                    ServiceModelActivity.CreateAsyncActivity() : null;
+                using (ServiceModelActivity.BoundOperation(activity, true))
+                {
+                    if (DiagnosticUtility.ShouldUseActivity)
+                    {
+                        ServiceModelActivity.Start(activity, SR.GetString(SR.ActivitySecuritySetup), ActivityType.SecuritySetup);
+                    }
+                    return new OpenAsyncResult(this, timeout, callback, state);
+                }
+            }
+
+            protected override void OnEndOpen(IAsyncResult result)
+            {
+                OpenAsyncResult.End(result);
+            }
+
+            void InitializeChannelBinder()
+            {
+                ChannelBuilder channelBuilder = this.Settings.ChannelBuilder;
+                TolerateFaultsMode faultMode = this.Settings.TolerateTransportFailures ? TolerateFaultsMode.Always : TolerateFaultsMode.Never;
+                if (channelBuilder.CanBuildChannelFactory<IDuplexSessionChannel>())
+                {
+                    this.channelBinder = ClientReliableChannelBinder<IDuplexSessionChannel>.CreateBinder(this.RemoteAddress, this.Via, (IChannelFactory<IDuplexSessionChannel>)(object)this.Settings.InnerChannelFactory,
+                        MaskingMode.None, faultMode, this.channelParameters, this.DefaultCloseTimeout, this.DefaultSendTimeout);
+                }
+                else if (channelBuilder.CanBuildChannelFactory<IDuplexChannel>())
+                {
+                    this.channelBinder = ClientReliableChannelBinder<IDuplexChannel>.CreateBinder(this.RemoteAddress, this.Via, (IChannelFactory<IDuplexChannel>)(object)this.Settings.InnerChannelFactory,
+                        MaskingMode.None, faultMode, this.channelParameters, this.DefaultCloseTimeout, this.DefaultSendTimeout);
+                    this.isCompositeDuplexConnection = true;
+                }
+                else if (channelBuilder.CanBuildChannelFactory<IRequestChannel>())
+                {
+                    this.channelBinder = ClientReliableChannelBinder<IRequestChannel>.CreateBinder(this.RemoteAddress, this.Via, (IChannelFactory<IRequestChannel>)(object)this.Settings.InnerChannelFactory,
+                        MaskingMode.None, faultMode, this.channelParameters, this.DefaultCloseTimeout, this.DefaultSendTimeout);
+                }
+                else if (channelBuilder.CanBuildChannelFactory<IRequestSessionChannel>())
+                {
+                    this.channelBinder = ClientReliableChannelBinder<IRequestSessionChannel>.CreateBinder(this.RemoteAddress, this.Via, (IChannelFactory<IRequestSessionChannel>)(object)this.Settings.InnerChannelFactory,
+                        MaskingMode.None, faultMode, this.channelParameters, this.DefaultCloseTimeout, this.DefaultSendTimeout);
+                }
+                this.channelBinder.Faulted += this.OnInnerFaulted;
+            }
+
+            void OnInnerFaulted(IReliableChannelBinder sender, Exception exception)
+            {
+                this.Fault(exception);
+            }
+
+            protected virtual bool OnCloseResponseReceived()
+            {
+                bool setInputSessionClosedHandle = false;
+                bool isCloseResponseExpected = false;
+                lock (ThisLock)
+                {
+                    isCloseResponseExpected = this.sentClose;
+                    if (isCloseResponseExpected && !this.isInputClosed)
+                    {
+                        this.isInputClosed = true;
+                        setInputSessionClosedHandle = true;
+                    }
+                }
+                if (!isCloseResponseExpected)
+                {
+                    this.Fault(new ProtocolException(SR.GetString(SR.UnexpectedSecuritySessionCloseResponse)));
+                    return false;
+                }
+                if (setInputSessionClosedHandle)
+                {
+                    this.inputSessionClosedHandle.Set();
+                }
+                return true;
+            }
+
+            protected virtual bool OnCloseReceived()
+            {
+                if (!ExpectClose)
+                {
+                    this.Fault(new ProtocolException(SR.GetString(SR.UnexpectedSecuritySessionClose)));
+                    return false;
+                }
+                bool setInputSessionClosedHandle = false;
+                lock (ThisLock)
+                {
+                    if (!this.isInputClosed)
+                    {
+                        this.isInputClosed = true;
+                        this.receivedClose = true;
+                        setInputSessionClosedHandle = true;
+                    }
+                }
+                if (setInputSessionClosedHandle)
+                {
+                    this.inputSessionClosedHandle.Set();
+                }
+                return true;
+            }
+
+            Message PrepareCloseMessage()
+            {
+                SecurityToken tokenToClose;
+                lock (ThisLock)
+                {
+                    tokenToClose = this.currentSessionToken;
+                }
+                RequestSecurityToken rst = new RequestSecurityToken(this.Settings.SecurityStandardsManager);
+                rst.RequestType = this.Settings.SecurityStandardsManager.TrustDriver.RequestTypeClose;
+                rst.CloseTarget = this.Settings.IssuedSecurityTokenParameters.CreateKeyIdentifierClause(tokenToClose, SecurityTokenReferenceStyle.External);
+                rst.MakeReadOnly();
+                Message closeMessage = Message.CreateMessage(this.MessageVersion, ActionHeader.Create(this.Settings.SecurityStandardsManager.SecureConversationDriver.CloseAction, this.MessageVersion.Addressing), rst);
+
+                RequestReplyCorrelator.PrepareRequest(closeMessage);
+                if (this.webHeaderCollection != null && this.webHeaderCollection.Count > 0)
+                {
+                    object prop = null;
+                    HttpRequestMessageProperty rmp = null;
+                    if (closeMessage.Properties.TryGetValue(HttpRequestMessageProperty.Name, out prop))
+                    {
+                        rmp = prop as HttpRequestMessageProperty;
+                    }
+                    else
+                    {
+                        rmp = new HttpRequestMessageProperty();
+                        closeMessage.Properties.Add(HttpRequestMessageProperty.Name, rmp);
+                    }
+
+                    if (rmp != null && rmp.Headers != null)
+                    {
+                        rmp.Headers.Add(this.webHeaderCollection);
+                    }
+                }
+
+
+                if (this.InternalLocalAddress != null)
+                {
+                    closeMessage.Headers.ReplyTo = this.InternalLocalAddress;
+                }
+                else
+                {
+                    if (closeMessage.Version.Addressing == AddressingVersion.WSAddressing10)
+                    {
+                        closeMessage.Headers.ReplyTo = null;
+                    }
+                    else if (closeMessage.Version.Addressing == AddressingVersion.WSAddressingAugust2004)
+                    {
+                        closeMessage.Headers.ReplyTo = EndpointAddress.AnonymousAddress;
+                    }
+                    else
+                    {
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(
+                            new ProtocolException(SR.GetString(SR.AddressingVersionNotSupported, closeMessage.Version.Addressing)));
+                    }
+                }
+                if (TraceUtility.PropagateUserActivity || TraceUtility.ShouldPropagateActivity)
+                {
+                    TraceUtility.AddAmbientActivityToMessage(closeMessage);
+                }
+                return closeMessage;
+            }
+
+            protected SecurityProtocolCorrelationState SendCloseMessage(TimeSpan timeout)
+            {
+                TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
+                SecurityProtocolCorrelationState closeCorrelationState;
+                Message closeMessage = PrepareCloseMessage();
+                try
+                {
+                    closeCorrelationState = this.securityProtocol.SecureOutgoingMessage(ref closeMessage, timeoutHelper.RemainingTime(), null);
+                    this.ChannelBinder.Send(closeMessage, timeoutHelper.RemainingTime());
+                }
+                finally
+                {
+                    closeMessage.Close();
+                }
+
+                SecurityTraceRecordHelper.TraceCloseMessageSent(this.currentSessionToken, this.RemoteAddress);
+                return closeCorrelationState;
+            }
+
+            protected void SendCloseResponseMessage(TimeSpan timeout)
+            {
+                TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
+
+                Message message = null;
+                try
+                {
+                    message = this.closeResponse;
+                    this.securityProtocol.SecureOutgoingMessage(ref message, timeoutHelper.RemainingTime(), null);
+                    this.ChannelBinder.Send(message, timeoutHelper.RemainingTime());
+                    SecurityTraceRecordHelper.TraceCloseResponseMessageSent(this.currentSessionToken, this.RemoteAddress);
+                }
+                finally
+                {
+                    message.Close();
+                }
+            }
+
+            IAsyncResult BeginSendCloseMessage(TimeSpan timeout, AsyncCallback callback, object state)
+            {
+                using (ServiceModelActivity activity = DiagnosticUtility.ShouldUseActivity ?
+                    ServiceModelActivity.CreateBoundedActivity() : null)
+                {
+                    if (DiagnosticUtility.ShouldUseActivity)
+                    {
+                        ServiceModelActivity.Start(activity, SR.GetString(SR.ActivitySecurityClose), ActivityType.SecuritySetup);
+                    }
+                    Message closeMessage = PrepareCloseMessage();
+                    return new SecureSendAsyncResult(closeMessage, this, timeout, callback, state, true);
+                }
+            }
+
+            SecurityProtocolCorrelationState EndSendCloseMessage(IAsyncResult result)
+            {
+                SecurityProtocolCorrelationState correlationState = SecureSendAsyncResult.End(result);
+                SecurityTraceRecordHelper.TraceCloseMessageSent(this.currentSessionToken, this.RemoteAddress);
+                return correlationState;
+            }
+
+            IAsyncResult BeginSendCloseResponseMessage(TimeSpan timeout, AsyncCallback callback, object state)
+            {
+                return new SecureSendAsyncResult(this.closeResponse, this, timeout, callback, state, true);
+            }
+
+            void EndSendCloseResponseMessage(IAsyncResult result)
+            {
+                SecureSendAsyncResult.End(result);
+                SecurityTraceRecordHelper.TraceCloseResponseMessageSent(this.currentSessionToken, this.RemoteAddress);
+            }
+
+            MessageFault GetProtocolFault(ref Message message, out bool isKeyRenewalFault, out bool isSessionAbortedFault)
+            {
+                isKeyRenewalFault = false;
+                isSessionAbortedFault = false;
+                MessageFault result = null;
+                using (MessageBuffer buffer = message.CreateBufferedCopy(int.MaxValue))
+                {
+                    message = buffer.CreateMessage();
+                    Message copy = buffer.CreateMessage();
+                    MessageFault fault = MessageFault.CreateFault(copy, TransportDefaults.MaxSecurityFaultSize);
+                    if (fault.Code.IsSenderFault)
+                    {
+                        FaultCode subCode = fault.Code.SubCode;
+                        if (subCode != null)
+                        {
+                            SecurityStandardsManager standardsManager = this.securityProtocol.SecurityProtocolFactory.StandardsManager;
+                            SecureConversationDriver scDriver = standardsManager.SecureConversationDriver;
+                            if (subCode.Namespace == scDriver.Namespace.Value && subCode.Name == scDriver.RenewNeededFaultCode.Value)
+                            {
+                                result = fault;
+                                isKeyRenewalFault = true;
+                            }
+                            else if (subCode.Namespace == DotNetSecurityStrings.Namespace && subCode.Name == DotNetSecurityStrings.SecuritySessionAbortedFault)
+                            {
+                                result = fault;
+                                isSessionAbortedFault = true;
+                            }
+                        }
+                    }
+                }
+                return result;
+            }
+
+
+            void ProcessKeyRenewalFault()
+            {
+                SecurityTraceRecordHelper.TraceSessionKeyRenewalFault(this.currentSessionToken, this.RemoteAddress);
+                lock (ThisLock)
+                {
+                    this.keyRenewalTime = DateTime.UtcNow;
+                }
+            }
+
+            void ProcessSessionAbortedFault(MessageFault sessionAbortedFault)
+            {
+                SecurityTraceRecordHelper.TraceRemoteSessionAbortedFault(this.currentSessionToken, this.RemoteAddress);
+                this.Fault(new FaultException(sessionAbortedFault));
+            }
+
+            void ProcessCloseResponse(Message response)
+            {
+                // the close message may have been received by the channel after the channel factory has been closed
+                if (response.Headers.Action != this.Settings.SecurityStandardsManager.SecureConversationDriver.CloseResponseAction.Value)
+                {
+                    throw TraceUtility.ThrowHelperError(new MessageSecurityException(SR.GetString(SR.InvalidCloseResponseAction, response.Headers.Action)), response);
+                }
+                RequestSecurityTokenResponse rstr = null;
+                XmlDictionaryReader bodyReader = response.GetReaderAtBodyContents();
+                using (bodyReader)
+                {
+                    if (this.Settings.SecurityStandardsManager.MessageSecurityVersion.TrustVersion == TrustVersion.WSTrustFeb2005)
+                        rstr = this.Settings.SecurityStandardsManager.TrustDriver.CreateRequestSecurityTokenResponse(bodyReader);
+                    else if (this.Settings.SecurityStandardsManager.MessageSecurityVersion.TrustVersion == TrustVersion.WSTrust13)
+                    {
+                        RequestSecurityTokenResponseCollection rstrc = this.Settings.SecurityStandardsManager.TrustDriver.CreateRequestSecurityTokenResponseCollection(bodyReader);
+                        foreach (RequestSecurityTokenResponse rstrItem in rstrc.RstrCollection)
+                        {
+                            if (rstr != null)
+                            {
+                                // More than one RSTR is found. So throw an exception.
+                                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new MessageSecurityException(SR.GetString(SR.MoreThanOneRSTRInRSTRC)));
+                            }
+                            rstr = rstrItem;
+                        }
+                    }
+                    else
+                    {
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new NotSupportedException());
+                    }
+
+                    response.ReadFromBodyContentsToEnd(bodyReader);
+                }
+                if (!rstr.IsRequestedTokenClosed)
+                {
+                    throw TraceUtility.ThrowHelperError(new MessageSecurityException(SR.GetString(SR.SessionTokenWasNotClosed)), response);
+                }
+            }
+
+            void PrepareReply(Message request, Message reply)
+            {
+                if (request.Headers.ReplyTo != null)
+                {
+                    request.Headers.ReplyTo.ApplyTo(reply);
+                }
+                else if (request.Headers.From != null)
+                {
+                    request.Headers.From.ApplyTo(reply);
+                }
+                if (request.Headers.MessageId != null)
+                {
+                    reply.Headers.RelatesTo = request.Headers.MessageId;
+                }
+                TraceUtility.CopyActivity(request, reply);
+                if (TraceUtility.PropagateUserActivity || TraceUtility.ShouldPropagateActivity)
+                {
+                    TraceUtility.AddActivityHeader(reply);
+                }
+            }
+
+            bool DoesSkiClauseMatchSigningToken(SecurityContextKeyIdentifierClause skiClause, Message request)
+            {
+                if (this.SessionId == null)
+                {
+                    return false;
+                }
+                return (skiClause.ContextId.ToString() == this.SessionId);
+            }
+
+            void ProcessCloseMessage(Message message)
+            {
+                RequestSecurityToken rst;
+                XmlDictionaryReader bodyReader = message.GetReaderAtBodyContents();
+                using (bodyReader)
+                {
+                    rst = this.Settings.SecurityStandardsManager.TrustDriver.CreateRequestSecurityToken(bodyReader);
+                    message.ReadFromBodyContentsToEnd(bodyReader);
+                }
+                if (rst.RequestType != null && rst.RequestType != this.Settings.SecurityStandardsManager.TrustDriver.RequestTypeClose)
+                {
+                    throw TraceUtility.ThrowHelperWarning(new MessageSecurityException(SR.GetString(SR.InvalidRstRequestType, rst.RequestType)), message);
+                }
+                if (rst.CloseTarget == null)
+                {
+                    throw TraceUtility.ThrowHelperWarning(new MessageSecurityException(SR.GetString(SR.NoCloseTargetSpecified)), message);
+                }
+                SecurityContextKeyIdentifierClause sctSkiClause = rst.CloseTarget as SecurityContextKeyIdentifierClause;
+                if (sctSkiClause == null || !DoesSkiClauseMatchSigningToken(sctSkiClause, message))
+                {
+                    throw TraceUtility.ThrowHelperWarning(new MessageSecurityException(SR.GetString(SR.BadCloseTarget, rst.CloseTarget)), message);
+                }
+                // prepare the close response
+                RequestSecurityTokenResponse rstr = new RequestSecurityTokenResponse(this.Settings.SecurityStandardsManager);
+                rstr.Context = rst.Context;
+                rstr.IsRequestedTokenClosed = true;
+                rstr.MakeReadOnly();
+                Message response = null;
+                if (this.Settings.SecurityStandardsManager.MessageSecurityVersion.TrustVersion == TrustVersion.WSTrustFeb2005)
+                    response = Message.CreateMessage(message.Version, ActionHeader.Create(this.Settings.SecurityStandardsManager.SecureConversationDriver.CloseResponseAction, message.Version.Addressing), rstr);
+                else if (this.Settings.SecurityStandardsManager.MessageSecurityVersion.TrustVersion == TrustVersion.WSTrust13)
+                {
+                    List<RequestSecurityTokenResponse> rstrList = new List<RequestSecurityTokenResponse>();
+                    rstrList.Add(rstr);
+                    RequestSecurityTokenResponseCollection rstrCollection = new RequestSecurityTokenResponseCollection(rstrList, this.Settings.SecurityStandardsManager);
+                    response = Message.CreateMessage(message.Version, ActionHeader.Create(this.Settings.SecurityStandardsManager.SecureConversationDriver.CloseResponseAction, message.Version.Addressing), rstrCollection);
+                }
+                else
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new NotSupportedException());
+                }
+                PrepareReply(message, response);
+                this.closeResponse = response;
+            }
+
+            bool ShouldWrapException(Exception e)
+            {
+                return ((e is FormatException) || (e is XmlException));
+            }
+
+            protected Message ProcessIncomingMessage(Message message, TimeSpan timeout, SecurityProtocolCorrelationState correlationState, out MessageFault protocolFault)
+            {
+                protocolFault = null;
+                lock (ThisLock)
+                {
+                    DoKeyRolloverIfNeeded();
+                }
+
+                try
+                {
+                    VerifyIncomingMessage(ref message, timeout, correlationState);
+
+                    string action = message.Headers.Action;
+
+                    if (action == this.Settings.SecurityStandardsManager.SecureConversationDriver.CloseResponseAction.Value)
+                    {
+                        SecurityTraceRecordHelper.TraceCloseResponseReceived(this.currentSessionToken, this.RemoteAddress);
+                        this.ProcessCloseResponse(message);
+                        this.OnCloseResponseReceived();
+                    }
+                    else if (action == this.Settings.SecurityStandardsManager.SecureConversationDriver.CloseAction.Value)
+                    {
+                        SecurityTraceRecordHelper.TraceCloseMessageReceived(this.currentSessionToken, this.RemoteAddress);
+                        this.ProcessCloseMessage(message);
+                        this.OnCloseReceived();
+                    }
+                    else if (action == DotNetSecurityStrings.SecuritySessionFaultAction)
+                    {
+                        bool isKeyRenewalFault;
+                        bool isSessionAbortedFault;
+                        protocolFault = GetProtocolFault(ref message, out isKeyRenewalFault, out isSessionAbortedFault);
+                        if (isKeyRenewalFault)
+                        {
+                            ProcessKeyRenewalFault();
+                        }
+                        else if (isSessionAbortedFault)
+                        {
+                            ProcessSessionAbortedFault(protocolFault);
+                        }
+                        else
+                        {
+                            return message;
+                        }
+                    }
+                    else
+                    {
+                        return message;
+                    }
+                }
+#pragma warning suppress 56500 // covered by FxCOP
+                catch (Exception e)
+                {
+                    if ((e is CommunicationException) || (e is TimeoutException) || (Fx.IsFatal(e)) || !ShouldWrapException(e))
+                    {
+                        throw;
+                    }
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new MessageSecurityException(SR.GetString(SR.MessageSecurityVerificationFailed), e));
+                }
+
+                message.Close();
+                return null;
+            }
+
+            protected Message ProcessRequestContext(RequestContext requestContext, TimeSpan timeout, SecurityProtocolCorrelationState correlationState)
+            {
+                if (requestContext == null)
+                {
+                    return null;
+                }
+                TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
+                Message message = requestContext.RequestMessage;
+                Message unverifiedMessage = message;
+                try
+                {
+                    Exception faultException = null;
+                    try
+                    {
+                        MessageFault dummyProtocolFault;
+                        return ProcessIncomingMessage(message, timeoutHelper.RemainingTime(), correlationState, out dummyProtocolFault);
+                    }
+                    catch (MessageSecurityException e)
+                    {
+                        // if the message is an unsecured security fault from the other party over the same connection then fault the session
+                        if (!isCompositeDuplexConnection)
+                        {
+                            if (unverifiedMessage.IsFault)
+                            {
+                                MessageFault fault = MessageFault.CreateFault(unverifiedMessage, TransportDefaults.MaxSecurityFaultSize);
+                                if (SecurityUtils.IsSecurityFault(fault, this.settings.sessionProtocolFactory.StandardsManager))
+                                {
+                                    faultException = SecurityUtils.CreateSecurityFaultException(fault);
+                                }
+                            }
+                            else
+                            {
+                                faultException = e;
+                            }
+                        }
+                    }
+                    if (faultException != null)
+                    {
+                        this.Fault(faultException);
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(faultException);
+                    }
+                    return null;
+                }
+                finally
+                {
+                    requestContext.Close(timeoutHelper.RemainingTime());
+                }
+            }
+
+            /// <summary>
+            /// This method removes the previous session key when the key rollover time is past.
+            /// It must be called within a lock
+            /// </summary>
+            void DoKeyRolloverIfNeeded()
+            {
+                if (DateTime.UtcNow >= this.keyRolloverTime && this.previousSessionToken != null)
+                {
+                    SecurityTraceRecordHelper.TracePreviousSessionKeyDiscarded(this.previousSessionToken, this.currentSessionToken, this.RemoteAddress);
+                    // forget the previous session token 
+                    this.previousSessionToken = null;
+                    List<SecurityToken> incomingTokens = new List<SecurityToken>(1);
+                    incomingTokens.Add(this.currentSessionToken);
+                    ((IInitiatorSecuritySessionProtocol)this.securityProtocol).SetIncomingSessionTokens(incomingTokens);
+                }
+            }
+
+            DateTime GetKeyRenewalTime(SecurityToken token)
+            {
+                TimeSpan tokenValidityInterval = TimeSpan.FromTicks((long)(((token.ValidTo.Ticks - token.ValidFrom.Ticks) * this.settings.issuedTokenRenewalThreshold) / 100));
+                DateTime keyRenewalTime1 = TimeoutHelper.Add(token.ValidFrom, tokenValidityInterval);
+                DateTime keyRenewalTime2 = TimeoutHelper.Add(token.ValidFrom, this.settings.keyRenewalInterval);
+                if (keyRenewalTime1 < keyRenewalTime2)
+                {
+                    return keyRenewalTime1;
+                }
+                else
+                {
+                    return keyRenewalTime2;
+                }
+            }
+
+            /// <summary>
+            /// This method returns true if key renewal is needed.
+            /// It must be called within a lock
+            /// </summary>
+            bool IsKeyRenewalNeeded()
+            {
+                return DateTime.UtcNow >= this.keyRenewalTime;
+            }
+
+            /// <summary>
+            /// When the new session token is obtained, mark the current token as previous and remove it
+            /// after KeyRolloverTime. Mark the new current as pending and update the next key renewal time
+            /// </summary>
+            void UpdateSessionTokens(SecurityToken newToken)
+            {
+                lock (ThisLock)
+                {
+                    this.previousSessionToken = this.currentSessionToken;
+                    this.keyRolloverTime = TimeoutHelper.Add(DateTime.UtcNow, this.Settings.KeyRolloverInterval);
+                    this.currentSessionToken = newToken;
+                    this.keyRenewalTime = GetKeyRenewalTime(newToken);
+                    List<SecurityToken> incomingTokens = new List<SecurityToken>(2);
+                    incomingTokens.Add(this.previousSessionToken);
+                    incomingTokens.Add(this.currentSessionToken);
+                    ((IInitiatorSecuritySessionProtocol)this.securityProtocol).SetIncomingSessionTokens(incomingTokens);
+                    ((IInitiatorSecuritySessionProtocol)this.securityProtocol).SetOutgoingSessionToken(this.currentSessionToken);
+                    SecurityTraceRecordHelper.TraceSessionKeyRenewed(this.currentSessionToken, this.previousSessionToken, this.RemoteAddress);
+                }
+            }
+
+            void RenewKey(TimeSpan timeout)
+            {
+                if (!this.settings.CanRenewSession)
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new SessionKeyExpiredException(SR.GetString(SR.SessionKeyRenewalNotSupported)));
+                }
+
+                bool startKeyRenewal;
+                lock (ThisLock)
+                {
+                    if (!this.isKeyRenewalOngoing)
+                    {
+                        this.isKeyRenewalOngoing = true;
+                        this.keyRenewalCompletedEvent.Reset();
+                        startKeyRenewal = true;
+                    }
+                    else
+                    {
+                        startKeyRenewal = false;
+                    }
+                }
+                if (startKeyRenewal == true)
+                {
+                    try
+                    {
+                        using (ServiceModelActivity activity = DiagnosticUtility.ShouldUseActivity ?
+                            ServiceModelActivity.CreateBoundedActivity() : null)
+                        {
+                            if (DiagnosticUtility.ShouldUseActivity)
+                            {
+                                ServiceModelActivity.Start(activity, SR.GetString(SR.ActivitySecurityRenew), ActivityType.SecuritySetup);
+                            }
+                            SecurityToken renewedToken = this.sessionTokenProvider.RenewToken(timeout, this.currentSessionToken);
+                            UpdateSessionTokens(renewedToken);
+                        }
+                    }
+                    finally
+                    {
+                        lock (ThisLock)
+                        {
+                            this.isKeyRenewalOngoing = false;
+                            this.keyRenewalCompletedEvent.Set();
+                        }
+                    }
+                }
+                else
+                {
+                    this.keyRenewalCompletedEvent.Wait(timeout);
+                    lock (ThisLock)
+                    {
+                        if (IsKeyRenewalNeeded())
+                        {
+                            // the key renewal attempt failed. Throw an exception to the user
+                            throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new SessionKeyExpiredException(SR.GetString(SR.UnableToRenewSessionKey)));
+                        }
+                    }
+                }
+            }
+
+            bool CheckIfKeyRenewalNeeded()
+            {
+                bool doKeyRenewal = false;
+                lock (ThisLock)
+                {
+                    doKeyRenewal = IsKeyRenewalNeeded();
+                    DoKeyRolloverIfNeeded();
+                }
+                return doKeyRenewal;
+            }
+
+            protected IAsyncResult BeginSecureOutgoingMessage(Message message, TimeSpan timeout, AsyncCallback callback, object state)
+            {
+                bool doKeyRenewal = CheckIfKeyRenewalNeeded();
+                if (!doKeyRenewal)
+                {
+                    SecurityProtocolCorrelationState correlationState = this.securityProtocol.SecureOutgoingMessage(ref message, timeout, null);
+                    return new CompletedAsyncResult<Message, SecurityProtocolCorrelationState>(message, correlationState, callback, state);
+                }
+                else
+                {
+                    return new KeyRenewalAsyncResult(message, this, timeout, callback, state);
+                }
+            }
+
+            protected Message EndSecureOutgoingMessage(IAsyncResult result, out SecurityProtocolCorrelationState correlationState)
+            {
+                if (result is CompletedAsyncResult<Message, SecurityProtocolCorrelationState>)
+                {
+                    return CompletedAsyncResult<Message, SecurityProtocolCorrelationState>.End(result, out correlationState);
+                }
+                else
+                {
+                    TimeSpan remainingTime;
+                    Message message = KeyRenewalAsyncResult.End(result, out remainingTime);
+                    correlationState = this.securityProtocol.SecureOutgoingMessage(ref message, remainingTime, null);
+                    return message;
+                }
+            }
+
+            protected SecurityProtocolCorrelationState SecureOutgoingMessage(ref Message message, TimeSpan timeout)
+            {
+                bool doKeyRenewal = CheckIfKeyRenewalNeeded();
+                TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
+                if (doKeyRenewal)
+                {
+                    RenewKey(timeoutHelper.RemainingTime());
+                }
+                return this.securityProtocol.SecureOutgoingMessage(ref message, timeoutHelper.RemainingTime(), null);
+            }
+
+            protected void VerifyIncomingMessage(ref Message message, TimeSpan timeout, SecurityProtocolCorrelationState correlationState)
+            {
+                this.securityProtocol.VerifyIncomingMessage(ref message, timeout, correlationState);
+            }
+
+            protected virtual void AbortCore()
+            {
+                if (this.channelBinder != null)
+                {
+                    this.channelBinder.Abort();
+                }
+                if (this.sessionTokenProvider != null)
+                {
+                    SecurityUtils.AbortTokenProviderIfRequired(this.sessionTokenProvider);
+                }
+            }
+
+            protected virtual void CloseCore(TimeSpan timeout)
+            {
+                TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
+
+                try
+                {
+                    if (this.channelBinder != null)
+                    {
+                        this.channelBinder.Close(timeoutHelper.RemainingTime());
+                    }
+                    if (this.sessionTokenProvider != null)
+                    {
+                        SecurityUtils.CloseTokenProviderIfRequired(this.sessionTokenProvider, timeoutHelper.RemainingTime());
+                    }
+                    this.keyRenewalCompletedEvent.Abort(this);
+                    this.inputSessionClosedHandle.Abort(this);
+                }
+                catch (CommunicationObjectAbortedException)
+                {
+                    if (this.State != CommunicationState.Closed)
+                    {
+                        throw;
+                    }
+                }
+            }
+
+            protected virtual IAsyncResult BeginCloseCore(TimeSpan timeout, AsyncCallback callback, object state)
+            {
+                return new CloseCoreAsyncResult(this, timeout, callback, state);
+            }
+
+            protected virtual void EndCloseCore(IAsyncResult result)
+            {
+                CloseCoreAsyncResult.End(result);
+            }
+
+            protected IAsyncResult BeginReceiveInternal(TimeSpan timeout, SecurityProtocolCorrelationState correlationState, AsyncCallback callback, object state)
+            {
+                return new ReceiveAsyncResult(this, timeout, correlationState, callback, state);
+            }
+
+            protected Message EndReceiveInternal(IAsyncResult result)
+            {
+                return ReceiveAsyncResult.End(result);
+            }
+
+            protected Message ReceiveInternal(TimeSpan timeout, SecurityProtocolCorrelationState correlationState)
+            {
+                TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
+                while (!this.isInputClosed)
+                {
+                    RequestContext requestContext;
+
+                    if (this.ChannelBinder.TryReceive(timeoutHelper.RemainingTime(), out requestContext))
+                    {
+                        if (requestContext == null)
+                        {
+                            return null;
+                        }
+
+                        Message message = ProcessRequestContext(requestContext, timeoutHelper.RemainingTime(), correlationState);
+
+                        if (message != null)
+                        {
+                            return message;
+                        }
+                    }
+
+                    if (timeoutHelper.RemainingTime() == TimeSpan.Zero)
+                    {
+                        // we timed out
+                        break;
+                    }
+                }
+
+                return null;
+            }
+
+            protected bool CloseSession(TimeSpan timeout, out bool wasAborted)
+            {
+                using (ServiceModelActivity activity = DiagnosticUtility.ShouldUseActivity ?
+                    ServiceModelActivity.CreateBoundedActivity() : null)
+                {
+                    if (DiagnosticUtility.ShouldUseActivity)
+                    {
+                        ServiceModelActivity.Start(activity, SR.GetString(SR.ActivitySecurityClose), ActivityType.SecuritySetup);
+                    }
+
+                    TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
+                    wasAborted = false;
+                    try
+                    {
+                        this.CloseOutputSession(timeoutHelper.RemainingTime());
+                        return this.inputSessionClosedHandle.Wait(timeoutHelper.RemainingTime(), false);
+                    }
+                    catch (CommunicationObjectAbortedException)
+                    {
+                        if (this.State != CommunicationState.Closed)
+                        {
+                            throw;
+                        }
+                        wasAborted = true;
+                    }
+                    return false;
+                }
+            }
+
+            protected IAsyncResult BeginCloseSession(TimeSpan timeout, AsyncCallback callback, object state)
+            {
+                using (ServiceModelActivity activity = DiagnosticUtility.ShouldUseActivity ?
+                    ServiceModelActivity.CreateAsyncActivity() : null)
+                {
+                    if (DiagnosticUtility.ShouldUseActivity)
+                    {
+                        ServiceModelActivity.Start(activity, SR.GetString(SR.ActivitySecurityClose), ActivityType.SecuritySetup);
+                    }
+                    return new CloseSessionAsyncResult(timeout, this, callback, state);
+                }
+            }
+
+            protected bool EndCloseSession(IAsyncResult result, out bool wasAborted)
+            {
+                return CloseSessionAsyncResult.End(result, out wasAborted);
+            }
+
+            void DetermineCloseMessageToSend(out bool sendClose, out bool sendCloseResponse)
+            {
+                sendClose = false;
+                sendCloseResponse = false;
+                lock (ThisLock)
+                {
+                    if (!this.isOutputClosed)
+                    {
+                        this.isOutputClosed = true;
+                        if (this.receivedClose)
+                        {
+                            sendCloseResponse = true;
+                        }
+                        else
+                        {
+                            sendClose = true;
+                            this.sentClose = true;
+                        }
+                        this.outputSessionCloseHandle.Reset();
+                    }
+                }
+            }
+
+            protected virtual SecurityProtocolCorrelationState CloseOutputSession(TimeSpan timeout)
+            {
+                ThrowIfFaulted();
+                if (!this.SendCloseHandshake)
+                {
+                    return null;
+                }
+                bool sendClose;
+                bool sendCloseResponse;
+                DetermineCloseMessageToSend(out sendClose, out sendCloseResponse);
+                if (sendClose || sendCloseResponse)
+                {
+                    try
+                    {
+                        if (sendClose)
+                        {
+                            return this.SendCloseMessage(timeout);
+                        }
+                        else
+                        {
+                            this.SendCloseResponseMessage(timeout);
+                            return null;
+                        }
+                    }
+                    finally
+                    {
+                        this.outputSessionCloseHandle.Set();
+                    }
+                }
+                else
+                {
+                    return null;
+                }
+            }
+
+            protected virtual IAsyncResult BeginCloseOutputSession(TimeSpan timeout, AsyncCallback callback, object state)
+            {
+                ThrowIfFaulted();
+                if (!this.SendCloseHandshake)
+                {
+                    return new CompletedAsyncResult(callback, state);
+                }
+                bool sendClose;
+                bool sendCloseResponse;
+                DetermineCloseMessageToSend(out sendClose, out sendCloseResponse);
+                if (sendClose || sendCloseResponse)
+                {
+                    bool setOutputSessionCloseHandle = true;
+                    try
+                    {
+                        IAsyncResult result;
+                        if (sendClose)
+                        {
+                            result = this.BeginSendCloseMessage(timeout, callback, state);
+                        }
+                        else
+                        {
+                            result = this.BeginSendCloseResponseMessage(timeout, callback, state);
+                        }
+                        setOutputSessionCloseHandle = false;
+                        return result;
+                    }
+                    finally
+                    {
+                        if (setOutputSessionCloseHandle)
+                        {
+                            this.outputSessionCloseHandle.Set();
+                        }
+                    }
+                }
+                else
+                {
+                    return new CompletedAsyncResult(callback, state);
+                }
+            }
+
+            protected virtual SecurityProtocolCorrelationState EndCloseOutputSession(IAsyncResult result)
+            {
+                if (result is CompletedAsyncResult)
+                {
+                    CompletedAsyncResult.End(result);
+                    return null;
+                }
+                bool sentCloseLocal;
+                lock (ThisLock)
+                {
+                    sentCloseLocal = this.sentClose;
+                }
+                try
+                {
+                    if (sentCloseLocal)
+                    {
+                        return this.EndSendCloseMessage(result);
+                    }
+                    else
+                    {
+                        this.EndSendCloseResponseMessage(result);
+                        return null;
+                    }
+                }
+                finally
+                {
+                    this.outputSessionCloseHandle.Set();
+                }
+            }
+
+            protected void CheckOutputOpen()
+            {
+                ThrowIfClosedOrNotOpen();
+                lock (ThisLock)
+                {
+                    if (isOutputClosed)
+                    {
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new CommunicationException(SR.GetString(SR.OutputNotExpected)));
+                    }
+                }
+            }
+
+            protected override void OnAbort()
+            {
+                this.AbortCore();
+                this.inputSessionClosedHandle.Abort(this);
+                this.keyRenewalCompletedEvent.Abort(this);
+                this.outputSessionCloseHandle.Abort(this);
+            }
+
+            protected override void OnClose(TimeSpan timeout)
+            {
+                TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
+                if (this.SendCloseHandshake)
+                {
+                    bool wasAborted;
+                    bool wasSessionClosed = this.CloseSession(timeout, out wasAborted);
+                    if (wasAborted)
+                    {
+                        return;
+                    }
+                    if (!wasSessionClosed)
+                    {
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new TimeoutException(SR.GetString(SR.ClientSecurityCloseTimeout, timeout)));
+                    }
+                    // wait for any concurrent output session close to finish
+                    try
+                    {
+                        if (!this.outputSessionCloseHandle.Wait(timeoutHelper.RemainingTime(), false))
+                        {
+                            throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new TimeoutException(SR.GetString(SR.ClientSecurityOutputSessionCloseTimeout, timeoutHelper.OriginalTimeout)));
+                        }
+                    }
+                    catch (CommunicationObjectAbortedException)
+                    {
+                        if (this.State == CommunicationState.Closed)
+                        {
+                            return;
+                        }
+                        else
+                        {
+                            throw;
+                        }
+                    }
+                }
+
+                this.CloseCore(timeoutHelper.RemainingTime());
+            }
+
+            protected override IAsyncResult OnBeginClose(TimeSpan timeout, AsyncCallback callback, object state)
+            {
+                return new CloseAsyncResult(this, timeout, callback, state);
+            }
+
+            protected override void OnEndClose(IAsyncResult result)
+            {
+                CloseAsyncResult.End(result);
+            }
+
+            class CloseCoreAsyncResult : TraceAsyncResult
+            {
+                static AsyncCallback closeChannelBinderCallback = Fx.ThunkCallback(new AsyncCallback(ChannelBinderCloseCallback));
+                static AsyncCallback closeTokenProviderCallback = Fx.ThunkCallback(new AsyncCallback(CloseTokenProviderCallback));
+
+                TimeoutHelper timeoutHelper;
+                ClientSecuritySessionChannel channel;
+
+                public CloseCoreAsyncResult(ClientSecuritySessionChannel channel, TimeSpan timeout, AsyncCallback callback, object state)
+                    : base(callback, state)
+                {
+                    this.channel = channel;
+                    this.timeoutHelper = new TimeoutHelper(timeout);
+                    bool completeSelf = false;
+                    if (channel.channelBinder != null)
+                    {
+                        try
+                        {
+                            IAsyncResult result = this.channel.channelBinder.BeginClose(timeoutHelper.RemainingTime(), closeChannelBinderCallback, this);
+                            if (!result.CompletedSynchronously)
+                            {
+                                return;
+                            }
+                            this.channel.channelBinder.EndClose(result);
+                        }
+                        catch (CommunicationObjectAbortedException)
+                        {
+                            if (this.channel.State != CommunicationState.Closed)
+                            {
+                                throw;
+                            }
+                            completeSelf = true;
+                        }
+                    }
+                    if (!completeSelf)
+                    {
+                        completeSelf = this.OnChannelBinderClosed();
+                    }
+                    if (completeSelf)
+                    {
+                        Complete(true);
+                    }
+                }
+
+                static void ChannelBinderCloseCallback(IAsyncResult result)
+                {
+                    if (result.CompletedSynchronously)
+                    {
+                        return;
+                    }
+                    CloseCoreAsyncResult self = (CloseCoreAsyncResult)(result.AsyncState);
+                    Exception completionException = null;
+                    bool completeSelf = false;
+                    try
+                    {
+                        try
+                        {
+                            self.channel.channelBinder.EndClose(result);
+                        }
+                        catch (CommunicationObjectAbortedException)
+                        {
+                            if (self.channel.State != CommunicationState.Closed)
+                            {
+                                throw;
+                            }
+                            completeSelf = true;
+                        }
+                        if (!completeSelf)
+                        {
+                            completeSelf = self.OnChannelBinderClosed();
+                        }
+                    }
+#pragma warning suppress 56500 // covered by FxCOP
+                    catch (Exception e)
+                    {
+                        if (Fx.IsFatal(e))
+                        {
+                            throw;
+                        }
+                        completeSelf = true;
+                        completionException = e;
+                    }
+                    if (completeSelf)
+                    {
+                        self.Complete(false, completionException);
+                    }
+                }
+
+                bool OnChannelBinderClosed()
+                {
+                    if (channel.sessionTokenProvider != null)
+                    {
+                        try
+                        {
+                            IAsyncResult result = SecurityUtils.BeginCloseTokenProviderIfRequired(this.channel.sessionTokenProvider, timeoutHelper.RemainingTime(), closeTokenProviderCallback, this);
+                            if (!result.CompletedSynchronously)
+                            {
+                                return false;
+                            }
+                            SecurityUtils.EndCloseTokenProviderIfRequired(result);
+                        }
+                        catch (CommunicationObjectAbortedException)
+                        {
+                            if (channel.State != CommunicationState.Closed)
+                            {
+                                throw;
+                            }
+                            return true;
+                        }
+                    }
+                    return this.OnTokenProviderClosed();
+                }
+
+                static void CloseTokenProviderCallback(IAsyncResult result)
+                {
+                    if (result.CompletedSynchronously)
+                    {
+                        return;
+                    }
+                    CloseCoreAsyncResult self = (CloseCoreAsyncResult)(result.AsyncState);
+                    Exception completionException = null;
+                    bool completeSelf = false;
+                    try
+                    {
+                        try
+                        {
+                            SecurityUtils.EndCloseTokenProviderIfRequired(result);
+                        }
+                        catch (CommunicationObjectAbortedException)
+                        {
+                            if (self.channel.State != CommunicationState.Closed)
+                            {
+                                throw;
+                            }
+                            completeSelf = true;
+                        }
+                        if (!completeSelf)
+                        {
+                            completeSelf = self.OnTokenProviderClosed();
+                        }
+                    }
+#pragma warning suppress 56500 // covered by FxCOP
+                    catch (Exception e)
+                    {
+                        if (Fx.IsFatal(e))
+                        {
+                            throw;
+                        }
+                        completeSelf = true;
+                        completionException = e;
+                    }
+                    if (completeSelf)
+                    {
+                        self.Complete(false, completionException);
+                    }
+                }
+
+                bool OnTokenProviderClosed()
+                {
+                    this.channel.keyRenewalCompletedEvent.Abort(this.channel);
+                    this.channel.inputSessionClosedHandle.Abort(this.channel);
+                    return true;
+                }
+
+                public static void End(IAsyncResult result)
+                {
+                    AsyncResult.End<CloseCoreAsyncResult>(result);
+                }
+            }
+
+            class ReceiveAsyncResult : TraceAsyncResult
+            {
+                static AsyncCallback onReceive = Fx.ThunkCallback(new AsyncCallback(OnReceive));
+                ClientSecuritySessionChannel channel;
+                Message message;
+                SecurityProtocolCorrelationState correlationState;
+                TimeoutHelper timeoutHelper;
+
+                public ReceiveAsyncResult(ClientSecuritySessionChannel channel, TimeSpan timeout, SecurityProtocolCorrelationState correlationState, AsyncCallback callback, object state)
+                    : base(callback, state)
+                {
+                    this.channel = channel;
+                    this.correlationState = correlationState;
+                    this.timeoutHelper = new TimeoutHelper(timeout);
+
+                    IAsyncResult result = channel.ChannelBinder.BeginTryReceive(timeoutHelper.RemainingTime(), onReceive, this);
+
+                    if (!result.CompletedSynchronously)
+                        return;
+
+                    bool completedSynchronously = CompleteReceive(result);
+                    if (completedSynchronously)
+                    {
+                        Complete(true);
+                    }
+                }
+
+                bool CompleteReceive(IAsyncResult result)
+                {
+                    while (!channel.isInputClosed)
+                    {
+                        RequestContext requestContext;
+                        if (channel.ChannelBinder.EndTryReceive(result, out requestContext))
+                        {
+                            if (requestContext == null)
+                                break;
+
+                            message = channel.ProcessRequestContext(requestContext, timeoutHelper.RemainingTime(), this.correlationState);
+
+                            if (message != null || channel.isInputClosed)
+                                break;
+                        }
+
+                        TimeSpan timeout = timeoutHelper.RemainingTime();
+                        if (timeout == TimeSpan.Zero)
+                        {
+                            // we timed out
+                            break;
+                        }
+
+                        result = channel.ChannelBinder.BeginTryReceive(timeoutHelper.RemainingTime(), onReceive, this);
+
+                        if (!result.CompletedSynchronously)
+                            return false;
+                    }
+
+                    return true;
+                }
+
+                public static Message End(IAsyncResult result)
+                {
+                    ReceiveAsyncResult receiveResult = AsyncResult.End<ReceiveAsyncResult>(result);
+                    return receiveResult.message;
+                }
+
+                static void OnReceive(IAsyncResult result)
+                {
+                    if (result.CompletedSynchronously)
+                        return;
+                    ReceiveAsyncResult self = (ReceiveAsyncResult)result.AsyncState;
+                    bool completeSelf = false;
+                    Exception completionException = null;
+                    try
+                    {
+                        completeSelf = self.CompleteReceive(result);
+                    }
+#pragma warning suppress 56500 // covered by FxCOP
+                    catch (Exception e)
+                    {
+                        if (Fx.IsFatal(e))
+                        {
+                            throw;
+                        }
+
+                        completeSelf = true;
+                        completionException = e;
+                    }
+                    if (completeSelf)
+                    {
+                        self.Complete(false, completionException);
+                    }
+                }
+            }
+
+            class OpenAsyncResult : TraceAsyncResult
+            {
+                static readonly AsyncCallback getTokenCallback = Fx.ThunkCallback(new AsyncCallback(GetTokenCallback));
+                static readonly AsyncCallback openTokenProviderCallback = Fx.ThunkCallback(new AsyncCallback(OpenTokenProviderCallback));
+                ClientSecuritySessionChannel sessionChannel;
+                TimeoutHelper timeoutHelper;
+
+                public OpenAsyncResult(ClientSecuritySessionChannel sessionChannel, TimeSpan timeout, AsyncCallback callback, object state)
+                    : base(callback, state)
+                {
+                    this.timeoutHelper = new TimeoutHelper(timeout);
+                    this.sessionChannel = sessionChannel;
+                    this.sessionChannel.SetupSessionTokenProvider();
+                    IAsyncResult result = SecurityUtils.BeginOpenTokenProviderIfRequired(this.sessionChannel.sessionTokenProvider, timeoutHelper.RemainingTime(), openTokenProviderCallback, this);
+                    if (!result.CompletedSynchronously)
+                    {
+                        return;
+                    }
+                    SecurityUtils.EndOpenTokenProviderIfRequired(result);
+                    bool completeSelf = this.OnTokenProviderOpened();
+                    if (completeSelf)
+                    {
+                        Complete(true);
+                    }
+                }
+
+                static void OpenTokenProviderCallback(IAsyncResult result)
+                {
+                    if (result.CompletedSynchronously)
+                    {
+                        return;
+                    }
+                    OpenAsyncResult thisAsyncResult = (OpenAsyncResult)result.AsyncState;
+                    bool completeSelf = false;
+                    Exception completionException = null;
+                    try
+                    {
+                        SecurityUtils.EndOpenTokenProviderIfRequired(result);
+                        completeSelf = thisAsyncResult.OnTokenProviderOpened();
+                    }
+#pragma warning suppress 56500 // covered by FxCOP
+                    catch (Exception e)
+                    {
+                        if (Fx.IsFatal(e))
+                        {
+                            throw;
+                        }
+
+                        completeSelf = true;
+                        completionException = e;
+                    }
+                    if (completeSelf)
+                    {
+                        thisAsyncResult.Complete(false, completionException);
+                    }
+                }
+
+                bool OnTokenProviderOpened()
+                {
+                    IAsyncResult result = this.sessionChannel.sessionTokenProvider.BeginGetToken(timeoutHelper.RemainingTime(), getTokenCallback, this);
+                    if (!result.CompletedSynchronously)
+                    {
+                        return false;
+                    }
+
+                    SecurityToken sessionToken = this.sessionChannel.sessionTokenProvider.EndGetToken(result);
+                    return this.OnTokenObtained(sessionToken);
+                }
+
+
+                bool OnTokenObtained(SecurityToken sessionToken)
+                {
+                    // Token was issued, do send cancel on close;
+                    this.sessionChannel.sendCloseHandshake = true;
+                    this.sessionChannel.OpenCore(sessionToken, timeoutHelper.RemainingTime());
+                    return true;
+                }
+
+                static void GetTokenCallback(IAsyncResult result)
+                {
+                    if (result.CompletedSynchronously)
+                    {
+                        return;
+                    }
+                    OpenAsyncResult thisAsyncResult = (OpenAsyncResult)result.AsyncState;
+                    try
+                    {
+                        using (ServiceModelActivity.BoundOperation(thisAsyncResult.CallbackActivity))
+                        {
+                            bool completeSelf = false;
+                            Exception completionException = null;
+                            try
+                            {
+                                SecurityToken sessionToken = thisAsyncResult.sessionChannel.sessionTokenProvider.EndGetToken(result);
+                                completeSelf = thisAsyncResult.OnTokenObtained(sessionToken);
+                            }
+#pragma warning suppress 56500 // covered by FxCOP
+                            catch (Exception e)
+                            {
+                                if (Fx.IsFatal(e))
+                                {
+                                    throw;
+                                }
+
+                                completeSelf = true;
+                                completionException = e;
+                            }
+                            if (completeSelf)
+                            {
+                                thisAsyncResult.Complete(false, completionException);
+                            }
+                        }
+                    }
+                    finally
+                    {
+                        if (thisAsyncResult.CallbackActivity != null)
+                        {
+                            thisAsyncResult.CallbackActivity.Dispose();
+                        }
+                    }
+                }
+
+                public static void End(IAsyncResult result)
+                {
+                    AsyncResult.End<OpenAsyncResult>(result);
+                    ServiceModelActivity.Stop(((OpenAsyncResult)result).CallbackActivity);
+                }
+            }
+
+            class CloseSessionAsyncResult : TraceAsyncResult
+            {
+                static readonly AsyncCallback closeOutputSessionCallback = Fx.ThunkCallback(new AsyncCallback(CloseOutputSessionCallback));
+                static readonly AsyncCallback shutdownWaitCallback = Fx.ThunkCallback(new AsyncCallback(ShutdownWaitCallback));
+
+                ClientSecuritySessionChannel sessionChannel;
+                bool closeCompleted;
+                bool wasAborted;
+                TimeoutHelper timeoutHelper;
+
+                public CloseSessionAsyncResult(TimeSpan timeout, ClientSecuritySessionChannel sessionChannel, AsyncCallback callback, object state)
+                    : base(callback, state)
+                {
+                    this.timeoutHelper = new TimeoutHelper(timeout);
+                    this.sessionChannel = sessionChannel;
+                    bool completeSelf = false;
+                    try
+                    {
+                        IAsyncResult result = this.sessionChannel.BeginCloseOutputSession(timeoutHelper.RemainingTime(), closeOutputSessionCallback, this);
+                        if (!result.CompletedSynchronously)
+                        {
+                            return;
+                        }
+                        this.sessionChannel.EndCloseOutputSession(result);
+                    }
+                    catch (CommunicationObjectAbortedException)
+                    {
+                        if (this.sessionChannel.State != CommunicationState.Closed)
+                        {
+                            throw;
+                        }
+                        completeSelf = true;
+                        wasAborted = true;
+                    }
+                    if (!wasAborted)
+                    {
+                        completeSelf = this.OnOutputSessionClosed();
+                    }
+                    if (completeSelf)
+                    {
+                        Complete(true);
+                    }
+                }
+
+                static void CloseOutputSessionCallback(IAsyncResult result)
+                {
+                    if (result.CompletedSynchronously)
+                    {
+                        return;
+                    }
+                    CloseSessionAsyncResult thisResult = (CloseSessionAsyncResult)result.AsyncState;
+                    bool completeSelf = false;
+                    Exception completionException = null;
+                    try
+                    {
+                        try
+                        {
+                            thisResult.sessionChannel.EndCloseOutputSession(result);
+                        }
+                        catch (CommunicationObjectAbortedException)
+                        {
+                            if (thisResult.sessionChannel.State != CommunicationState.Closed)
+                            {
+                                throw;
+                            }
+                            thisResult.wasAborted = true;
+                            completeSelf = true;
+                        }
+                        if (!thisResult.wasAborted)
+                        {
+                            completeSelf = thisResult.OnOutputSessionClosed();
+                        }
+                    }
+#pragma warning suppress 56500 // covered by FxCOP
+                    catch (Exception e)
+                    {
+                        if (Fx.IsFatal(e))
+                        {
+                            throw;
+                        }
+
+                        completeSelf = true;
+                        completionException = e;
+                    }
+                    if (completeSelf)
+                    {
+                        thisResult.Complete(false, completionException);
+                    }
+                }
+
+                bool OnOutputSessionClosed()
+                {
+                    try
+                    {
+                        IAsyncResult result = this.sessionChannel.inputSessionClosedHandle.BeginWait(this.timeoutHelper.RemainingTime(), true, shutdownWaitCallback, this);
+                        if (!result.CompletedSynchronously)
+                        {
+                            return false;
+                        }
+                        this.sessionChannel.inputSessionClosedHandle.EndWait(result);
+                        this.closeCompleted = true;
+                    }
+                    catch (CommunicationObjectAbortedException)
+                    {
+                        if (this.sessionChannel.State != CommunicationState.Closed)
+                        {
+                            throw;
+                        }
+                        // if the channel was aborted by a parallel thread, allow the Close to
+                        // complete cleanly
+                        this.wasAborted = true;
+                    }
+                    catch (TimeoutException)
+                    {
+                        this.closeCompleted = false;
+                    }
+                    return true;
+                }
+
+                static void ShutdownWaitCallback(IAsyncResult result)
+                {
+                    if (result.CompletedSynchronously)
+                    {
+                        return;
+                    }
+                    CloseSessionAsyncResult thisResult = (CloseSessionAsyncResult)result.AsyncState;
+                    Exception completionException = null;
+                    try
+                    {
+                        thisResult.sessionChannel.inputSessionClosedHandle.EndWait(result);
+                        thisResult.closeCompleted = true;
+                    }
+                    catch (CommunicationObjectAbortedException)
+                    {
+                        if (thisResult.sessionChannel.State != CommunicationState.Closed)
+                        {
+                            throw;
+                        }
+                        thisResult.wasAborted = true;
+                    }
+                    catch (TimeoutException)
+                    {
+                        thisResult.closeCompleted = false;
+                    }
+#pragma warning suppress 56500 // covered by FxCOP
+                    catch (Exception e)
+                    {
+                        if (Fx.IsFatal(e))
+                        {
+                            throw;
+                        }
+                        completionException = e;
+                    }
+                    thisResult.Complete(false, completionException);
+                }
+
+                public static bool End(IAsyncResult result, out bool wasAborted)
+                {
+                    CloseSessionAsyncResult thisResult = AsyncResult.End<CloseSessionAsyncResult>(result);
+                    wasAborted = thisResult.wasAborted;
+                    ServiceModelActivity.Stop(thisResult.CallbackActivity);
+                    return thisResult.closeCompleted;
+                }
+            }
+
+            class CloseAsyncResult : TraceAsyncResult
+            {
+                static readonly AsyncCallback closeSessionCallback = Fx.ThunkCallback(new AsyncCallback(CloseSessionCallback));
+                static readonly AsyncCallback outputSessionClosedCallback = Fx.ThunkCallback(new AsyncCallback(OutputSessionClosedCallback));
+                static readonly AsyncCallback closeCoreCallback = Fx.ThunkCallback(new AsyncCallback(CloseCoreCallback));
+
+                ClientSecuritySessionChannel sessionChannel;
+                TimeoutHelper timeoutHelper;
+
+                public CloseAsyncResult(ClientSecuritySessionChannel sessionChannel, TimeSpan timeout, AsyncCallback callback, object state)
+                    : base(callback, state)
+                {
+                    sessionChannel.ThrowIfFaulted();
+                    this.timeoutHelper = new TimeoutHelper(timeout);
+                    this.sessionChannel = sessionChannel;
+
+                    if (!sessionChannel.SendCloseHandshake)
+                    {
+                        if (this.CloseCore())
+                        {
+                            Complete(true);
+                        }
+                        return;
+                    }
+
+                    bool wasClosed;
+                    bool wasAborted = false;
+                    IAsyncResult result = this.sessionChannel.BeginCloseSession(this.timeoutHelper.RemainingTime(), closeSessionCallback, this);
+                    if (!result.CompletedSynchronously)
+                    {
+                        return;
+                    }
+                    wasClosed = this.sessionChannel.EndCloseSession(result, out wasAborted);
+                    if (wasAborted)
+                    {
+                        Complete(true);
+                        return;
+                    }
+                    if (!wasClosed)
+                    {
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new TimeoutException(SR.GetString(SR.ClientSecurityCloseTimeout, timeout)));
+                    }
+                    bool completeSelf = this.OnWaitForOutputSessionClose(out wasAborted);
+                    if (wasAborted || completeSelf)
+                    {
+                        Complete(true);
+                    }
+                }
+
+                static void CloseSessionCallback(IAsyncResult result)
+                {
+                    if (result.CompletedSynchronously)
+                    {
+                        return;
+                    }
+                    CloseAsyncResult thisResult = (CloseAsyncResult)result.AsyncState;
+                    bool completeSelf = false;
+                    Exception completionException = null;
+                    try
+                    {
+                        bool wasAborted;
+                        bool wasClosed = thisResult.sessionChannel.EndCloseSession(result, out wasAborted);
+                        if (wasAborted)
+                        {
+                            completeSelf = true;
+                        }
+                        else
+                        {
+                            if (!wasClosed)
+                            {
+                                throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new TimeoutException(SR.GetString(SR.ClientSecurityCloseTimeout, thisResult.timeoutHelper.OriginalTimeout)));
+                            }
+                            completeSelf = thisResult.OnWaitForOutputSessionClose(out wasAborted);
+                            if (wasAborted)
+                            {
+                                completeSelf = true;
+                            }
+                        }
+                    }
+#pragma warning suppress 56500 // covered by FxCOP
+                    catch (Exception e)
+                    {
+                        if (Fx.IsFatal(e))
+                        {
+                            throw;
+                        }
+
+                        completeSelf = true;
+                        completionException = e;
+                    }
+                    if (completeSelf)
+                    {
+                        thisResult.Complete(false, completionException);
+                    }
+                }
+
+                bool OnWaitForOutputSessionClose(out bool wasAborted)
+                {
+                    wasAborted = false;
+                    bool wasOutputSessionClosed = false;
+                    // wait for pending output sessions to finish
+                    try
+                    {
+                        IAsyncResult result = this.sessionChannel.outputSessionCloseHandle.BeginWait(timeoutHelper.RemainingTime(), true, outputSessionClosedCallback, this);
+                        if (!result.CompletedSynchronously)
+                        {
+                            return false;
+                        }
+                        this.sessionChannel.outputSessionCloseHandle.EndWait(result);
+                        wasOutputSessionClosed = true;
+                    }
+                    catch (TimeoutException)
+                    {
+                        wasOutputSessionClosed = false;
+                    }
+                    catch (CommunicationObjectAbortedException)
+                    {
+                        if (this.sessionChannel.State == CommunicationState.Closed)
+                        {
+                            wasAborted = true;
+                        }
+                        else
+                        {
+                            throw;
+                        }
+                    }
+                    if (wasAborted)
+                    {
+                        return true;
+                    }
+                    if (!wasOutputSessionClosed)
+                    {
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new TimeoutException(SR.GetString(SR.ClientSecurityOutputSessionCloseTimeout, timeoutHelper.OriginalTimeout)));
+                    }
+                    else
+                    {
+                        return this.CloseCore();
+                    }
+                }
+
+                static void OutputSessionClosedCallback(IAsyncResult result)
+                {
+                    if (result.CompletedSynchronously)
+                    {
+                        return;
+                    }
+                    CloseAsyncResult self = (CloseAsyncResult)(result.AsyncState);
+                    Exception completionException = null;
+                    bool completeSelf = false;
+                    try
+                    {
+                        bool wasOutputSessionClosed = false;
+                        bool wasAborted = false;
+                        try
+                        {
+                            self.sessionChannel.outputSessionCloseHandle.EndWait(result);
+                            wasOutputSessionClosed = true;
+                        }
+                        catch (TimeoutException)
+                        {
+                            wasOutputSessionClosed = false;
+                        }
+                        catch (CommunicationObjectFaultedException)
+                        {
+                            if (self.sessionChannel.State == CommunicationState.Closed)
+                            {
+                                wasAborted = true;
+                            }
+                            else
+                            {
+                                throw;
+                            }
+                        }
+                        if (!wasAborted)
+                        {
+                            if (!wasOutputSessionClosed)
+                            {
+                                throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new TimeoutException(SR.GetString(SR.ClientSecurityOutputSessionCloseTimeout, self.timeoutHelper.OriginalTimeout)));
+                            }
+                            completeSelf = self.CloseCore();
+                        }
+                        else
+                        {
+                            completeSelf = true;
+                        }
+                    }
+#pragma warning suppress 56500 // covered by FxCOP
+                    catch (Exception e)
+                    {
+                        if (Fx.IsFatal(e))
+                        {
+                            throw;
+                        }
+                        completionException = e;
+                        completeSelf = true;
+                    }
+                    if (completeSelf)
+                    {
+                        self.Complete(false, completionException);
+                    }
+                }
+
+                bool CloseCore()
+                {
+                    IAsyncResult result = this.sessionChannel.BeginCloseCore(timeoutHelper.RemainingTime(), closeCoreCallback, this);
+                    if (!result.CompletedSynchronously)
+                    {
+                        return false;
+                    }
+                    this.sessionChannel.EndCloseCore(result);
+                    return true;
+                }
+
+                static void CloseCoreCallback(IAsyncResult result)
+                {
+                    if (result.CompletedSynchronously)
+                    {
+                        return;
+                    }
+                    CloseAsyncResult self = (CloseAsyncResult)(result.AsyncState);
+                    Exception completionException = null;
+                    try
+                    {
+                        self.sessionChannel.EndCloseCore(result);
+                    }
+#pragma warning suppress 56500 // covered by FxCOP
+                    catch (Exception e)
+                    {
+                        if (Fx.IsFatal(e))
+                        {
+                            throw;
+                        }
+                        completionException = e;
+                    }
+                    self.Complete(false, completionException);
+                }
+
+                public static void End(IAsyncResult result)
+                {
+                    AsyncResult.End<CloseAsyncResult>(result);
+                }
+            }
+
+            class KeyRenewalAsyncResult : TraceAsyncResult
+            {
+                static readonly Action<object> renewKeyCallback = new Action<object>(RenewKeyCallback);
+                Message message;
+                ClientSecuritySessionChannel sessionChannel;
+                TimeoutHelper timeoutHelper;
+
+                public KeyRenewalAsyncResult(Message message, ClientSecuritySessionChannel sessionChannel, TimeSpan timeout, AsyncCallback callback, object state)
+                    : base(callback, state)
+                {
+                    timeoutHelper = new TimeoutHelper(timeout);
+                    this.message = message;
+                    this.sessionChannel = sessionChannel;
+                    // its ok to start up a separate thread for this since this is a very rare event.
+                    ActionItem.Schedule(renewKeyCallback, this);
+                }
+
+                static void RenewKeyCallback(object state)
+                {
+                    KeyRenewalAsyncResult thisResult = (KeyRenewalAsyncResult)state;
+                    Exception completionException = null;
+                    try
+                    {
+                        using (thisResult.CallbackActivity == null ? null : ServiceModelActivity.BoundOperation(thisResult.CallbackActivity))
+                        {
+                            thisResult.sessionChannel.RenewKey(thisResult.timeoutHelper.RemainingTime());
+                        }
+                    }
+#pragma warning suppress 56500 // covered by FxCOP
+                    catch (Exception e)
+                    {
+                        if (Fx.IsFatal(e))
+                        {
+                            throw;
+                        }
+
+                        completionException = e;
+                    }
+                    thisResult.Complete(false, completionException);
+                }
+
+                public static Message End(IAsyncResult result, out TimeSpan remainingTime)
+                {
+                    KeyRenewalAsyncResult thisResult = AsyncResult.End<KeyRenewalAsyncResult>(result);
+                    remainingTime = thisResult.timeoutHelper.RemainingTime();
+                    return thisResult.message;
+                }
+            }
+
+            internal abstract class SecureSendAsyncResultBase : TraceAsyncResult
+            {
+                static readonly AsyncCallback secureOutgoingMessageCallback = Fx.ThunkCallback(new AsyncCallback(SecureOutgoingMessageCallback));
+                Message message;
+                SecurityProtocolCorrelationState correlationState;
+                ClientSecuritySessionChannel sessionChannel;
+                bool didSecureOutgoingMessageCompleteSynchronously = false;
+                TimeoutHelper timeoutHelper;
+
+                protected SecureSendAsyncResultBase(Message message, ClientSecuritySessionChannel sessionChannel, TimeSpan timeout, AsyncCallback callback, object state)
+                    : base(callback, state)
+                {
+                    this.message = message;
+                    this.sessionChannel = sessionChannel;
+                    this.timeoutHelper = new TimeoutHelper(timeout);
+                    IAsyncResult result = this.sessionChannel.BeginSecureOutgoingMessage(message, timeoutHelper.RemainingTime(), secureOutgoingMessageCallback, this);
+                    if (!result.CompletedSynchronously)
+                    {
+                        return;
+                    }
+                    this.message = this.sessionChannel.EndSecureOutgoingMessage(result, out this.correlationState);
+                    this.didSecureOutgoingMessageCompleteSynchronously = true;
+                }
+
+                protected bool DidSecureOutgoingMessageCompleteSynchronously
+                {
+                    get
+                    {
+                        return this.didSecureOutgoingMessageCompleteSynchronously;
+                    }
+                }
+
+                protected TimeoutHelper TimeoutHelper
+                {
+                    get
+                    {
+                        return this.timeoutHelper;
+                    }
+                }
+
+                protected IClientReliableChannelBinder ChannelBinder
+                {
+                    get
+                    {
+                        return this.sessionChannel.ChannelBinder;
+                    }
+                }
+
+                protected Message Message
+                {
+                    get
+                    {
+                        return this.message;
+                    }
+                }
+
+                protected SecurityProtocolCorrelationState SecurityCorrelationState
+                {
+                    get
+                    {
+                        return this.correlationState;
+                    }
+                }
+
+                protected abstract bool OnMessageSecured();
+
+                static void SecureOutgoingMessageCallback(IAsyncResult result)
+                {
+                    if (result.CompletedSynchronously)
+                    {
+                        return;
+                    }
+                    SecureSendAsyncResultBase thisResult = (SecureSendAsyncResultBase)result.AsyncState;
+                    bool completeSelf = false;
+                    Exception completionException = null;
+                    try
+                    {
+                        thisResult.message = thisResult.sessionChannel.EndSecureOutgoingMessage(result, out thisResult.correlationState);
+                        completeSelf = thisResult.OnMessageSecured();
+                    }
+#pragma warning suppress 56500 // covered by FxCOP
+                    catch (Exception e)
+                    {
+                        if (Fx.IsFatal(e))
+                        {
+                            throw;
+                        }
+
+                        completeSelf = true;
+                        completionException = e;
+                    }
+                    if (completeSelf)
+                    {
+                        thisResult.Complete(false, completionException);
+                    }
+                }
+            }
+
+            internal sealed class SecureSendAsyncResult : SecureSendAsyncResultBase
+            {
+                static readonly AsyncCallback sendCallback = Fx.ThunkCallback(new AsyncCallback(SendCallback));
+
+                bool autoCloseMessage;
+
+                public SecureSendAsyncResult(Message message, ClientSecuritySessionChannel sessionChannel, TimeSpan timeout, AsyncCallback callback, object state, bool autoCloseMessage)
+                    : base(message, sessionChannel, timeout, callback, state)
+                {
+                    this.autoCloseMessage = autoCloseMessage;
+
+                    if (!this.DidSecureOutgoingMessageCompleteSynchronously)
+                    {
+                        return;
+                    }
+                    bool completeSelf = this.OnMessageSecured();
+                    if (completeSelf)
+                    {
+                        Complete(true);
+                    }
+                }
+
+                protected override bool OnMessageSecured()
+                {
+                    bool closeMessage = true;
+                    try
+                    {
+                        IAsyncResult result = this.ChannelBinder.BeginSend(this.Message, this.TimeoutHelper.RemainingTime(), sendCallback, this);
+                        if (!result.CompletedSynchronously)
+                        {
+                            closeMessage = false;
+                            return false;
+                        }
+                        this.ChannelBinder.EndSend(result);
+                        return true;
+                    }
+                    finally
+                    {
+                        if (closeMessage && this.autoCloseMessage && this.Message != null)
+                        {
+                            this.Message.Close();
+                        }
+                    }
+                }
+
+                static void SendCallback(IAsyncResult result)
+                {
+                    if (result.CompletedSynchronously)
+                    {
+                        return;
+                    }
+                    SecureSendAsyncResult thisResult = (SecureSendAsyncResult)result.AsyncState;
+                    Exception completionException = null;
+                    try
+                    {
+                        thisResult.ChannelBinder.EndSend(result);
+                    }
+#pragma warning suppress 56500 // covered by FxCOP
+                    catch (Exception e)
+                    {
+                        if (Fx.IsFatal(e))
+                        {
+                            throw;
+                        }
+
+                        completionException = e;
+                    }
+                    finally
+                    {
+                        if (thisResult.autoCloseMessage && thisResult.Message != null)
+                        {
+                            thisResult.Message.Close();
+                        }
+                        if (thisResult.CallbackActivity != null && DiagnosticUtility.ShouldUseActivity)
+                        {
+                            thisResult.CallbackActivity.Stop();
+                        }
+                    }
+
+                    thisResult.Complete(false, completionException);
+                }
+
+                public static SecurityProtocolCorrelationState End(IAsyncResult result)
+                {
+                    SecureSendAsyncResult thisResult = AsyncResult.End<SecureSendAsyncResult>(result);
+                    return thisResult.SecurityCorrelationState;
+                }
+            }
+
+            protected class SoapSecurityOutputSession : ISecureConversationSession, IOutputSession
+            {
+                ClientSecuritySessionChannel channel;
+                EndpointIdentity remoteIdentity;
+                UniqueId sessionId;
+                SecurityKeyIdentifierClause sessionTokenIdentifier;
+                SecurityStandardsManager standardsManager;
+
+                public SoapSecurityOutputSession(ClientSecuritySessionChannel channel)
+                {
+                    this.channel = channel;
+                }
+
+                internal void Initialize(SecurityToken sessionToken, SecuritySessionClientSettings<TChannel> settings)
+                {
+                    if (sessionToken == null)
+                    {
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("sessionToken");
+                    }
+                    if (settings == null)
+                    {
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("settings");
+                    }
+                    Claim identityClaim = SecurityUtils.GetPrimaryIdentityClaim(((GenericXmlSecurityToken)sessionToken).AuthorizationPolicies);
+                    if (identityClaim != null)
+                    {
+                        this.remoteIdentity = EndpointIdentity.CreateIdentity(identityClaim);
+                    }
+                    this.standardsManager = settings.SessionProtocolFactory.StandardsManager;
+                    this.sessionId = GetSessionId(sessionToken, this.standardsManager);
+                    this.sessionTokenIdentifier = settings.IssuedSecurityTokenParameters.CreateKeyIdentifierClause(sessionToken,
+                        SecurityTokenReferenceStyle.External);
+                }
+
+                UniqueId GetSessionId(SecurityToken sessionToken, SecurityStandardsManager standardsManager)
+                {
+                    GenericXmlSecurityToken gxt = sessionToken as GenericXmlSecurityToken;
+                    if (gxt == null)
+                    {
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new NotSupportedException(SR.GetString(SR.SessionTokenIsNotGenericXmlToken, sessionToken, typeof(GenericXmlSecurityToken))));
+                    }
+                    return standardsManager.SecureConversationDriver.GetSecurityContextTokenId(XmlDictionaryReader.CreateDictionaryReader(new XmlNodeReader(gxt.TokenXml)));
+                }
+
+                public string Id
+                {
+                    get
+                    {
+                        if (this.sessionId == null)
+                        {
+                            // PreSharp Bug: Property get methods should not throw exceptions.
+#pragma warning suppress 56503
+                            throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.GetString(SR.ChannelMustBeOpenedToGetSessionId)));
+                        }
+                        return this.sessionId.ToString();
+                    }
+                }
+
+                public EndpointIdentity RemoteIdentity
+                {
+                    get
+                    {
+                        return this.remoteIdentity;
+                    }
+                }
+
+                public void WriteSessionTokenIdentifier(XmlDictionaryWriter writer)
+                {
+                    this.channel.ThrowIfDisposedOrNotOpen();
+                    this.standardsManager.SecurityTokenSerializer.WriteKeyIdentifierClause(writer, this.sessionTokenIdentifier);
+                }
+
+                public bool TryReadSessionTokenIdentifier(XmlReader reader)
+                {
+                    this.channel.ThrowIfDisposedOrNotOpen();
+                    if (!this.standardsManager.SecurityTokenSerializer.CanReadKeyIdentifierClause(reader))
+                    {
+                        return false;
+                    }
+                    SecurityContextKeyIdentifierClause incomingTokenIdentifier =
+                        this.standardsManager.SecurityTokenSerializer.ReadKeyIdentifierClause(reader) as SecurityContextKeyIdentifierClause;
+                    return incomingTokenIdentifier != null && incomingTokenIdentifier.Matches(sessionId, null);
+                }
+            }
+        }
+
+        abstract class ClientSecuritySimplexSessionChannel : ClientSecuritySessionChannel
+        {
+            SoapSecurityOutputSession outputSession;
+
+            protected ClientSecuritySimplexSessionChannel(SecuritySessionClientSettings<TChannel> settings, EndpointAddress to, Uri via)
+                : base(settings, to, via)
+            {
+                this.outputSession = new SoapSecurityOutputSession(this);
+            }
+
+            public IOutputSession Session
+            {
+                get
+                {
+                    return this.outputSession;
+                }
+            }
+
+            protected override bool ExpectClose
+            {
+                get { return false; }
+            }
+
+            protected override string SessionId
+            {
+                get { return this.Session.Id; }
+            }
+
+            protected override void InitializeSession(SecurityToken sessionToken)
+            {
+                this.outputSession.Initialize(sessionToken, this.Settings);
+            }
+        }
+
+        sealed class SecurityRequestSessionChannel : ClientSecuritySimplexSessionChannel, IRequestSessionChannel
+        {
+            public SecurityRequestSessionChannel(SecuritySessionClientSettings<TChannel> settings, EndpointAddress to, Uri via)
+                : base(settings, to, via)
+            {
+            }
+
+            protected override bool CanDoSecurityCorrelation
+            {
+                get
+                {
+                    return true;
+                }
+            }
+
+            protected override SecurityProtocolCorrelationState CloseOutputSession(TimeSpan timeout)
+            {
+                ThrowIfFaulted();
+                TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
+                SecurityProtocolCorrelationState correlationState = base.CloseOutputSession(timeoutHelper.RemainingTime());
+
+                Message message = ReceiveInternal(timeoutHelper.RemainingTime(), correlationState);
+
+                if (message != null)
+                {
+                    using (message)
+                    {
+                        ProtocolException error = ProtocolException.ReceiveShutdownReturnedNonNull(message);
+                        throw TraceUtility.ThrowHelperWarning(error, message);
+                    }
+                }
+                return null;
+            }
+
+            protected override IAsyncResult BeginCloseOutputSession(TimeSpan timeout, AsyncCallback callback, object state)
+            {
+                ThrowIfFaulted();
+                return new CloseOutputSessionAsyncResult(this, timeout, callback, state);
+            }
+
+            protected override SecurityProtocolCorrelationState EndCloseOutputSession(IAsyncResult result)
+            {
+                CloseOutputSessionAsyncResult.End(result);
+                return null;
+            }
+
+            IAsyncResult BeginBaseCloseOutputSession(TimeSpan timeout, AsyncCallback callback, object state)
+            {
+                return base.BeginCloseOutputSession(timeout, callback, state);
+            }
+
+            SecurityProtocolCorrelationState EndBaseCloseOutputSession(IAsyncResult result)
+            {
+                return base.EndCloseOutputSession(result);
+            }
+
+            public Message Request(Message message)
+            {
+                return this.Request(message, this.DefaultSendTimeout);
+            }
+
+            Message ProcessReply(Message reply, TimeSpan timeout, SecurityProtocolCorrelationState correlationState)
+            {
+                if (reply == null)
+                {
+                    return null;
+                }
+                Message unverifiedReply = reply;
+                Message processedReply = null;
+                MessageFault protocolFault = null;
+                Exception faultException = null;
+                try
+                {
+                    processedReply = this.ProcessIncomingMessage(reply, timeout, correlationState, out protocolFault);
+                }
+                catch (MessageSecurityException)
+                {
+                    if (unverifiedReply.IsFault)
+                    {
+                        MessageFault fault = MessageFault.CreateFault(unverifiedReply, TransportDefaults.MaxSecurityFaultSize);
+                        if (SecurityUtils.IsSecurityFault(fault, this.Settings.standardsManager))
+                        {
+                            faultException = SecurityUtils.CreateSecurityFaultException(fault);
+                        }
+                    }
+                    if (faultException == null)
+                    {
+                        throw;
+                    }
+                }
+                if (faultException != null)
+                {
+                    Fault(faultException);
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(faultException);
+                }
+                if (processedReply == null && protocolFault != null)
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new MessageSecurityException(SR.GetString(SR.SecuritySessionFaultReplyWasSent), new FaultException(protocolFault)));
+                }
+                return processedReply;
+            }
+
+
+            public Message Request(Message message, TimeSpan timeout)
+            {
+                ThrowIfFaulted();
+                CheckOutputOpen();
+                TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
+                SecurityProtocolCorrelationState correlationState = this.SecureOutgoingMessage(ref message, timeoutHelper.RemainingTime());
+                Message reply = this.ChannelBinder.Request(message, timeoutHelper.RemainingTime());
+                return ProcessReply(reply, timeoutHelper.RemainingTime(), correlationState);
+            }
+
+            public IAsyncResult BeginRequest(Message message, AsyncCallback callback, object state)
+            {
+                return this.BeginRequest(message, this.DefaultSendTimeout, callback, state);
+            }
+
+            public IAsyncResult BeginRequest(Message message, TimeSpan timeout, AsyncCallback callback, object state)
+            {
+                ThrowIfFaulted();
+                CheckOutputOpen();
+                return new SecureRequestAsyncResult(message, this, timeout, callback, state);
+            }
+
+            public Message EndRequest(IAsyncResult result)
+            {
+                SecurityProtocolCorrelationState requestCorrelationState;
+                TimeSpan remainingTime;
+                Message reply = SecureRequestAsyncResult.EndAsReply(result, out requestCorrelationState, out remainingTime);
+                return ProcessReply(reply, remainingTime, requestCorrelationState);
+            }
+
+            sealed class SecureRequestAsyncResult : SecureSendAsyncResultBase
+            {
+                static readonly AsyncCallback requestCallback = Fx.ThunkCallback(new AsyncCallback(RequestCallback));
+                Message reply;
+
+                public SecureRequestAsyncResult(Message request, ClientSecuritySessionChannel sessionChannel, TimeSpan timeout, AsyncCallback callback, object state)
+                    : base(request, sessionChannel, timeout, callback, state)
+                {
+                    if (!this.DidSecureOutgoingMessageCompleteSynchronously)
+                    {
+                        return;
+                    }
+                    bool completeSelf = OnMessageSecured();
+                    if (completeSelf)
+                    {
+                        Complete(true);
+                    }
+                }
+
+                protected override bool OnMessageSecured()
+                {
+                    IAsyncResult result = this.ChannelBinder.BeginRequest(this.Message, this.TimeoutHelper.RemainingTime(), requestCallback, this);
+                    if (!result.CompletedSynchronously)
+                    {
+                        return false;
+                    }
+                    this.reply = this.ChannelBinder.EndRequest(result);
+                    return true;
+                }
+
+                static void RequestCallback(IAsyncResult result)
+                {
+                    if (result.CompletedSynchronously)
+                    {
+                        return;
+                    }
+                    SecureRequestAsyncResult thisAsyncResult = (SecureRequestAsyncResult)result.AsyncState;
+                    Exception completionException = null;
+                    try
+                    {
+                        thisAsyncResult.reply = thisAsyncResult.ChannelBinder.EndRequest(result);
+                    }
+#pragma warning suppress 56500 // covered by FxCOP
+                    catch (Exception e)
+                    {
+                        if (Fx.IsFatal(e))
+                        {
+                            throw;
+                        }
+
+                        completionException = e;
+                    }
+                    thisAsyncResult.Complete(false, completionException);
+                }
+
+                public static Message EndAsReply(IAsyncResult result, out SecurityProtocolCorrelationState correlationState, out TimeSpan remainingTime)
+                {
+                    SecureRequestAsyncResult thisResult = AsyncResult.End<SecureRequestAsyncResult>(result);
+                    correlationState = thisResult.SecurityCorrelationState;
+                    remainingTime = thisResult.TimeoutHelper.RemainingTime();
+                    return thisResult.reply;
+                }
+            }
+
+            class CloseOutputSessionAsyncResult : TraceAsyncResult
+            {
+                static readonly AsyncCallback baseCloseOutputSessionCallback = Fx.ThunkCallback(new AsyncCallback(BaseCloseOutputSessionCallback));
+                static readonly AsyncCallback receiveInternalCallback = Fx.ThunkCallback(new AsyncCallback(ReceiveInternalCallback));
+                SecurityRequestSessionChannel requestChannel;
+                SecurityProtocolCorrelationState correlationState;
+                TimeoutHelper timeoutHelper;
+
+                public CloseOutputSessionAsyncResult(SecurityRequestSessionChannel requestChannel, TimeSpan timeout, AsyncCallback callback, object state)
+                    : base(callback, state)
+                {
+                    this.timeoutHelper = new TimeoutHelper(timeout);
+                    this.requestChannel = requestChannel;
+                    IAsyncResult result = this.requestChannel.BeginBaseCloseOutputSession(timeoutHelper.RemainingTime(), baseCloseOutputSessionCallback, this);
+                    if (!result.CompletedSynchronously)
+                    {
+                        return;
+                    }
+                    this.correlationState = this.requestChannel.EndBaseCloseOutputSession(result);
+                    bool completeSelf = this.OnBaseOutputSessionClosed();
+                    if (completeSelf)
+                    {
+                        Complete(true);
+                    }
+                }
+
+                static void BaseCloseOutputSessionCallback(IAsyncResult result)
+                {
+                    if (result.CompletedSynchronously)
+                    {
+                        return;
+                    }
+                    CloseOutputSessionAsyncResult thisAsyncResult = (CloseOutputSessionAsyncResult)result.AsyncState;
+                    bool completeSelf = false;
+                    Exception completionException = null;
+                    try
+                    {
+                        thisAsyncResult.correlationState = thisAsyncResult.requestChannel.EndBaseCloseOutputSession(result);
+                        completeSelf = thisAsyncResult.OnBaseOutputSessionClosed();
+                    }
+#pragma warning suppress 56500 // covered by FxCOP
+                    catch (Exception e)
+                    {
+                        if (Fx.IsFatal(e))
+                        {
+                            throw;
+                        }
+
+                        completeSelf = true;
+                        completionException = e;
+                    }
+                    if (completeSelf)
+                    {
+                        thisAsyncResult.Complete(false, completionException);
+                    }
+                }
+
+                bool OnBaseOutputSessionClosed()
+                {
+                    IAsyncResult result = this.requestChannel.BeginReceiveInternal(this.timeoutHelper.RemainingTime(), this.correlationState, receiveInternalCallback, this);
+                    if (!result.CompletedSynchronously)
+                    {
+                        return false;
+                    }
+                    Message message = this.requestChannel.EndReceiveInternal(result);
+                    return this.OnMessageReceived(message);
+                }
+
+                static void ReceiveInternalCallback(IAsyncResult result)
+                {
+                    if (result.CompletedSynchronously)
+                    {
+                        return;
+                    }
+                    CloseOutputSessionAsyncResult thisAsyncResult = (CloseOutputSessionAsyncResult)result.AsyncState;
+                    bool completeSelf = false;
+                    Exception completionException = null;
+                    try
+                    {
+                        Message message = thisAsyncResult.requestChannel.EndReceiveInternal(result);
+                        completeSelf = thisAsyncResult.OnMessageReceived(message);
+                    }
+#pragma warning suppress 56500 // covered by FxCOP
+                    catch (Exception e)
+                    {
+                        if (Fx.IsFatal(e))
+                        {
+                            throw;
+                        }
+
+                        completeSelf = true;
+                        completionException = e;
+                    }
+                    if (completeSelf)
+                    {
+                        thisAsyncResult.Complete(false, completionException);
+                    }
+                }
+
+                bool OnMessageReceived(Message message)
+                {
+                    if (message != null)
+                    {
+                        using (message)
+                        {
+                            ProtocolException error = ProtocolException.ReceiveShutdownReturnedNonNull(message);
+                            throw TraceUtility.ThrowHelperWarning(error, message);
+                        }
+                    }
+                    return true;
+                }
+
+                public static void End(IAsyncResult result)
+                {
+                    AsyncResult.End<CloseOutputSessionAsyncResult>(result);
+                }
+            }
+        }
+
+        class ClientSecurityDuplexSessionChannel : ClientSecuritySessionChannel, IDuplexSessionChannel
+        {
+            static AsyncCallback onReceive = Fx.ThunkCallback(new AsyncCallback(OnReceive));
+            SoapSecurityClientDuplexSession session;
+            InputQueue<Message> queue;
+            Action startReceiving;
+            Action<object> completeLater;
+
+            public ClientSecurityDuplexSessionChannel(SecuritySessionClientSettings<TChannel> settings, EndpointAddress to, Uri via)
+                : base(settings, to, via)
+            {
+                this.session = new SoapSecurityClientDuplexSession(this);
+                this.queue = TraceUtility.CreateInputQueue<Message>();
+                this.startReceiving = new Action(StartReceiving);
+                this.completeLater = new Action<object>(CompleteLater);
+            }
+
+            public EndpointAddress LocalAddress
+            {
+                get
+                {
+                    return base.InternalLocalAddress;
+                }
+            }
+
+            public IDuplexSession Session
+            {
+                get
+                {
+                    return this.session;
+                }
+            }
+
+            protected override bool ExpectClose
+            {
+                get { return true; }
+            }
+
+            protected override string SessionId
+            {
+                get { return this.session.Id; }
+            }
+
+            public Message Receive()
+            {
+                return this.Receive(this.DefaultReceiveTimeout);
+            }
+
+            public Message Receive(TimeSpan timeout)
+            {
+                return InputChannel.HelpReceive(this, timeout);
+            }
+
+            public IAsyncResult BeginReceive(AsyncCallback callback, object state)
+            {
+                return this.BeginReceive(this.DefaultReceiveTimeout, callback, state);
+            }
+
+            public IAsyncResult BeginReceive(TimeSpan timeout, AsyncCallback callback, object state)
+            {
+                return InputChannel.HelpBeginReceive(this, timeout, callback, state);
+            }
+
+            public Message EndReceive(IAsyncResult result)
+            {
+                return InputChannel.HelpEndReceive(result);
+            }
+
+            public IAsyncResult BeginTryReceive(TimeSpan timeout, AsyncCallback callback, object state)
+            {
+                ThrowIfFaulted();
+                return queue.BeginDequeue(timeout, callback, state);
+            }
+
+            public bool EndTryReceive(IAsyncResult result, out Message message)
+            {
+                bool wasDequeued = queue.EndDequeue(result, out message);
+                if (message == null)
+                {
+                    // the channel could have faulted, shutting down the input queue
+                    ThrowIfFaulted();
+                }
+                return wasDequeued;
+            }
+
+            protected override void OnOpened()
+            {
+                base.OnOpened();
+                StartReceiving();
+            }
+
+            public bool TryReceive(TimeSpan timeout, out Message message)
+            {
+                ThrowIfFaulted();
+                bool wasDequeued = queue.Dequeue(timeout, out message);
+                if (message == null)
+                {
+                    // the channel could have faulted, shutting down the input queue
+                    ThrowIfFaulted();
+                }
+                return wasDequeued;
+            }
+
+            public void Send(Message message)
+            {
+                this.Send(message, this.DefaultSendTimeout);
+            }
+
+            public void Send(Message message, TimeSpan timeout)
+            {
+                ThrowIfFaulted();
+                CheckOutputOpen();
+                TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
+                this.SecureOutgoingMessage(ref message, timeoutHelper.RemainingTime());
+                this.ChannelBinder.Send(message, timeoutHelper.RemainingTime());
+            }
+
+            public IAsyncResult BeginSend(Message message, AsyncCallback callback, object state)
+            {
+                return this.BeginSend(message, this.DefaultSendTimeout, callback, state);
+            }
+
+            public IAsyncResult BeginSend(Message message, TimeSpan timeout, AsyncCallback callback, object state)
+            {
+                ThrowIfFaulted();
+                CheckOutputOpen();
+                return new SecureSendAsyncResult(message, this, timeout, callback, state, false);
+            }
+
+            public void EndSend(IAsyncResult result)
+            {
+                SecureSendAsyncResult.End(result);
+            }
+
+            protected override void InitializeSession(SecurityToken sessionToken)
+            {
+                this.session.Initialize(sessionToken, this.Settings);
+            }
+
+            void StartReceiving()
+            {
+                IAsyncResult result = this.IssueReceive();
+                if (result != null && result.CompletedSynchronously)
+                {
+                    ActionItem.Schedule(completeLater, result);
+                }
+            }
+
+            IAsyncResult IssueReceive()
+            {
+                while (true)
+                {
+                    // no need to receive anymore if in the closed state
+                    if (this.State == CommunicationState.Closed || this.State == CommunicationState.Faulted || this.IsInputClosed)
+                    {
+                        return null;
+                    }
+                    try
+                    {
+                        return this.BeginReceiveInternal(TimeSpan.MaxValue, null, onReceive, this);
+
+                    }
+                    catch (CommunicationException e)
+                    {
+                        // BeginReceive failed. ignore the exception and start another receive
+                        DiagnosticUtility.TraceHandledException(e, TraceEventType.Information);
+                    }
+                    catch (TimeoutException e)
+                    {
+                        // BeginReceive failed. ignore the exception and start another receive
+                        if (TD.ReceiveTimeoutIsEnabled())
+                        {
+                            TD.ReceiveTimeout(e.Message);
+                        }
+                        DiagnosticUtility.TraceHandledException(e, TraceEventType.Information);
+                    }
+                }
+            }
+
+            void CompleteLater(object obj)
+            {
+                CompleteReceive((IAsyncResult)obj);
+            }
+
+            static void OnReceive(IAsyncResult result)
+            {
+                if (result.CompletedSynchronously)
+                    return;
+
+                ((ClientSecurityDuplexSessionChannel)result.AsyncState).CompleteReceive(result);
+            }
+
+            void CompleteReceive(IAsyncResult result)
+            {
+                Message message = null;
+                bool issueAnotherReceive = false;
+                try
+                {
+                    message = this.EndReceiveInternal(result);
+                    issueAnotherReceive = true;
+                }
+                catch (MessageSecurityException)
+                {
+                    // a messagesecurityexception will only be thrown if the channel received a fault
+                    // from the other side, in which case the channel would have faulted
+                    issueAnotherReceive = false;
+                }
+                catch (CommunicationException e)
+                {
+                    issueAnotherReceive = true;
+                    // EndReceive failed. ignore the exception and start another receive
+                    DiagnosticUtility.TraceHandledException(e, TraceEventType.Information);
+                }
+                catch (TimeoutException e)
+                {
+                    issueAnotherReceive = true;
+                    // EndReceive failed. ignore the exception and start another receive
+                    if (TD.ReceiveTimeoutIsEnabled())
+                    {
+                        TD.ReceiveTimeout(e.Message);
+                    }
+                    DiagnosticUtility.TraceHandledException(e, TraceEventType.Information);
+                }
+                IAsyncResult nextReceiveResult = null;
+                if (issueAnotherReceive)
+                {
+                    nextReceiveResult = this.IssueReceive();
+                    if (nextReceiveResult != null && nextReceiveResult.CompletedSynchronously)
+                    {
+                        ActionItem.Schedule(completeLater, nextReceiveResult);
+                    }
+                }
+                if (message != null)
+                {
+                    // since we may be dispatching to user code swallow non-fatal exceptions
+                    try
+                    {
+                        this.queue.EnqueueAndDispatch(message);
+                    }
+#pragma warning suppress 56500 // covered by FxCOP
+                    catch (Exception e)
+                    {
+                        if (Fx.IsFatal(e)) throw;
+                        DiagnosticUtility.TraceHandledException(e, TraceEventType.Warning);
+                    }
+                }
+            }
+
+            protected override void AbortCore()
+            {
+                try
+                {
+                    this.queue.Dispose();
+                }
+                catch (CommunicationException e)
+                {
+                    DiagnosticUtility.TraceHandledException(e, TraceEventType.Information);
+                }
+                catch (TimeoutException e)
+                {
+                    if (TD.CloseTimeoutIsEnabled())
+                    {
+                        TD.CloseTimeout(e.Message);
+                    }
+                    DiagnosticUtility.TraceHandledException(e, TraceEventType.Information);
+                }
+                base.AbortCore();
+            }
+
+            public bool WaitForMessage(TimeSpan timeout)
+            {
+                return this.queue.WaitForItem(timeout);
+            }
+
+            public IAsyncResult BeginWaitForMessage(TimeSpan timeout, AsyncCallback callback, object state)
+            {
+                return this.queue.BeginWaitForItem(timeout, callback, state);
+            }
+
+            public bool EndWaitForMessage(IAsyncResult result)
+            {
+                return this.queue.EndWaitForItem(result);
+            }
+
+            protected override void OnFaulted()
+            {
+                queue.Shutdown(() => this.GetPendingException());
+                base.OnFaulted();
+            }
+
+            protected override bool OnCloseResponseReceived()
+            {
+                if (base.OnCloseResponseReceived())
+                {
+                    this.queue.Shutdown();
+                    return true;
+                }
+                else
+                {
+                    return false;
+                }
+            }
+
+            protected override bool OnCloseReceived()
+            {
+                if (base.OnCloseReceived())
+                {
+                    this.queue.Shutdown();
+                    return true;
+                }
+                else
+                {
+                    return false;
+                }
+            }
+
+            class SoapSecurityClientDuplexSession : SoapSecurityOutputSession, IDuplexSession
+            {
+                ClientSecurityDuplexSessionChannel channel;
+                bool initialized = false;
+
+                public SoapSecurityClientDuplexSession(ClientSecurityDuplexSessionChannel channel)
+                    : base(channel)
+                {
+                    this.channel = channel;
+                }
+
+                internal new void Initialize(SecurityToken sessionToken, SecuritySessionClientSettings<TChannel> settings)
+                {
+                    base.Initialize(sessionToken, settings);
+                    this.initialized = true;
+                }
+
+                void CheckInitialized()
+                {
+                    if (!this.initialized)
+                    {
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.GetString(SR.ChannelNotOpen)));
+                    }
+                }
+
+                public void CloseOutputSession()
+                {
+                    this.CloseOutputSession(this.channel.DefaultCloseTimeout);
+                }
+
+                public void CloseOutputSession(TimeSpan timeout)
+                {
+                    CheckInitialized();
+                    this.channel.ThrowIfFaulted();
+                    this.channel.ThrowIfNotOpened();
+                    Exception pendingException = null;
+                    try
+                    {
+                        this.channel.CloseOutputSession(timeout);
+                    }
+                    catch (CommunicationObjectAbortedException)
+                    {
+                        if (this.channel.State != CommunicationState.Closed)
+                        {
+                            throw;
+                        }
+                    }
+#pragma warning suppress 56500 // covered by FxCOP
+                    catch (Exception e)
+                    {
+                        if (Fx.IsFatal(e)) throw;
+                        pendingException = e;
+                    }
+                    if (pendingException != null)
+                    {
+                        this.channel.Fault(pendingException);
+                        throw pendingException;
+                    }
+                }
+
+                public IAsyncResult BeginCloseOutputSession(AsyncCallback callback, object state)
+                {
+                    return this.BeginCloseOutputSession(this.channel.DefaultCloseTimeout, callback, state);
+                }
+
+                public IAsyncResult BeginCloseOutputSession(TimeSpan timeout, AsyncCallback callback, object state)
+                {
+                    CheckInitialized();
+                    this.channel.ThrowIfFaulted();
+                    this.channel.ThrowIfNotOpened();
+                    Exception pendingException = null;
+                    try
+                    {
+                        return this.channel.BeginCloseOutputSession(timeout, callback, state);
+                    }
+                    catch (CommunicationObjectAbortedException)
+                    {
+                        if (this.channel.State != CommunicationState.Closed)
+                        {
+                            throw;
+                        }
+                        // another thread must have aborted the channel. Allow the close to complete
+                        // gracefully
+                        return new CompletedAsyncResult(callback, state);
+                    }
+#pragma warning suppress 56500 // covered by FxCOP
+                    catch (Exception e)
+                    {
+                        if (Fx.IsFatal(e)) throw;
+                        pendingException = e;
+                    }
+                    if (pendingException != null)
+                    {
+                        this.channel.Fault(pendingException);
+                        if (pendingException is CommunicationException)
+                        {
+                            throw pendingException;
+                        }
+                        else
+                        {
+                            throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(pendingException);
+                        }
+                    }
+                    // we should never reach here
+                    Fx.Assert("Unexpected control flow");
+                    return null;
+                }
+
+                public void EndCloseOutputSession(IAsyncResult result)
+                {
+                    if (result is CompletedAsyncResult)
+                    {
+                        CompletedAsyncResult.End(result);
+                        return;
+                    }
+                    Exception pendingException = null;
+                    try
+                    {
+                        this.channel.EndCloseOutputSession(result);
+                    }
+                    catch (CommunicationObjectAbortedException)
+                    {
+                        if (this.channel.State != CommunicationState.Closed)
+                        {
+                            throw;
+                        }
+                        // another thread must have aborted the channel. Allow the close to complete
+                        // gracefully
+                    }
+#pragma warning suppress 56500 // covered by FxCOP
+                    catch (Exception e)
+                    {
+                        if (Fx.IsFatal(e)) throw;
+                        pendingException = e;
+                    }
+                    if (pendingException != null)
+                    {
+                        this.channel.Fault(pendingException);
+                        if (pendingException is CommunicationException)
+                        {
+                            throw pendingException;
+                        }
+                        else
+                        {
+                            throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(pendingException);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SecuritySessionClientSettings.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SecuritySessionClientSettings.cs
@@ -2726,8 +2726,6 @@ namespace System.ServiceModel.Security
                     {
                         if (_sessionId == null)
                         {
-                            // PreSharp Bug: Property get methods should not throw exceptions.
-#pragma warning suppress 56503
                             throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.ChannelMustBeOpenedToGetSessionId)));
                         }
                         return _sessionId.ToString();

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SecurityStandardsManager.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SecurityStandardsManager.cs
@@ -2,18 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-
 using System.Collections.Generic;
-using System.ServiceModel.Channels;
-using System.ServiceModel;
-using System.ServiceModel.Description;
-using System.ServiceModel.Security.Tokens;
-using System.Collections.ObjectModel;
-using System.IdentityModel.Policy;
 using System.IdentityModel.Selectors;
 using System.IdentityModel.Tokens;
-using System.Xml;
 using System.Runtime.CompilerServices;
+using System.ServiceModel.Channels;
+using System.ServiceModel.Description;
+using System.ServiceModel.Security.Tokens;
+using System.Xml;
 
 namespace System.ServiceModel.Security
 {

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SecurityStandardsManager.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SecurityStandardsManager.cs
@@ -19,12 +19,14 @@ namespace System.ServiceModel.Security
 {
     internal class SecurityStandardsManager
     {
-#pragma warning disable 0649 // Remove this once we do real implementation, this prevents "field is never assigned to" warning
         private static SecurityStandardsManager s_instance;
         private readonly MessageSecurityVersion _messageSecurityVersion;
+        private readonly WSUtilitySpecificationVersion _wsUtilitySpecificationVersion;
+        private readonly SecureConversationDriver _secureConversationDriver;
         private readonly TrustDriver _trustDriver;
-#pragma warning restore 0649
-
+        private readonly SignatureTargetIdManager _idManager;
+        private readonly SecurityTokenSerializer _tokenSerializer;
+        private WSSecurityTokenSerializer _wsSecurityTokenSerializer;
 
         [MethodImpl(MethodImplOptions.NoInlining)]
         public SecurityStandardsManager()
@@ -39,7 +41,32 @@ namespace System.ServiceModel.Security
 
         public SecurityStandardsManager(MessageSecurityVersion messageSecurityVersion, SecurityTokenSerializer tokenSerializer)
         {
-            throw ExceptionHelper.PlatformNotSupported();
+            if (messageSecurityVersion == null)
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentNullException("messageSecurityVersion"));
+            if (tokenSerializer == null)
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("tokenSerializer");
+
+            _messageSecurityVersion = messageSecurityVersion;
+            _tokenSerializer = tokenSerializer;
+            if (messageSecurityVersion.SecureConversationVersion == SecureConversationVersion.WSSecureConversation13)
+                _secureConversationDriver = new WSSecureConversationDec2005.DriverDec2005();
+            else
+                _secureConversationDriver = new WSSecureConversationFeb2005.DriverFeb2005();
+
+            if (this.SecurityVersion == SecurityVersion.WSSecurity10 || this.SecurityVersion == SecurityVersion.WSSecurity11)
+            {
+                _idManager = WSSecurityJan2004.IdManager.Instance;
+            }
+            else
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("messageSecurityVersion", SR.Format(SR.MessageSecurityVersionOutOfRange)));
+            }
+
+            _wsUtilitySpecificationVersion = WSUtilitySpecificationVersion.Default;
+            if (messageSecurityVersion.MessageSecurityTokenVersion.TrustVersion == TrustVersion.WSTrust13)
+                _trustDriver = new WSTrustDec2005.DriverDec2005(this);
+            else
+                _trustDriver = new WSTrustFeb2005.DriverFeb2005(this);
         }
 
         public static SecurityStandardsManager DefaultInstance
@@ -62,9 +89,147 @@ namespace System.ServiceModel.Security
             get { return _messageSecurityVersion; }
         }
 
+        public TrustVersion TrustVersion
+        {
+            get { return _messageSecurityVersion.TrustVersion; }
+        }
+
+        public SecureConversationVersion SecureConversationVersion
+        {
+            get { return _messageSecurityVersion.SecureConversationVersion; }
+        }
+
+        internal SecurityTokenSerializer SecurityTokenSerializer
+        {
+            get { return _tokenSerializer; }
+        }
+
+        internal WSUtilitySpecificationVersion WSUtilitySpecificationVersion
+        {
+            get { return _wsUtilitySpecificationVersion; }
+        }
+
+        internal SignatureTargetIdManager IdManager
+        {
+            get { return _idManager; }
+        }
+
+        internal SecureConversationDriver SecureConversationDriver
+        {
+            get { return _secureConversationDriver; }
+        }
+
         internal TrustDriver TrustDriver
         {
             get { return _trustDriver; }
         }
+
+        WSSecurityTokenSerializer WSSecurityTokenSerializer
+        {
+            get
+            {
+                if (_wsSecurityTokenSerializer == null)
+                {
+                    WSSecurityTokenSerializer wsSecurityTokenSerializer = _tokenSerializer as WSSecurityTokenSerializer;
+                    if (wsSecurityTokenSerializer == null)
+                    {
+                        wsSecurityTokenSerializer = new WSSecurityTokenSerializer(SecurityVersion);
+                    }
+                    _wsSecurityTokenSerializer = wsSecurityTokenSerializer;
+                }
+                return _wsSecurityTokenSerializer;
+            }
+        }
+
+        internal bool TryCreateKeyIdentifierClauseFromTokenXml(XmlElement element, SecurityTokenReferenceStyle tokenReferenceStyle, out SecurityKeyIdentifierClause securityKeyIdentifierClause)
+        {
+            return WSSecurityTokenSerializer.TryCreateKeyIdentifierClauseFromTokenXml(element, tokenReferenceStyle, out securityKeyIdentifierClause);
+        }
+
+        internal SecurityKeyIdentifierClause CreateKeyIdentifierClauseFromTokenXml(XmlElement element, SecurityTokenReferenceStyle tokenReferenceStyle)
+        {
+            return WSSecurityTokenSerializer.CreateKeyIdentifierClauseFromTokenXml(element, tokenReferenceStyle);
+        }
+
+        internal SendSecurityHeader CreateSendSecurityHeader(Message message,
+            string actor, bool mustUnderstand, bool relay,
+            SecurityAlgorithmSuite algorithmSuite, MessageDirection direction)
+        {
+            return SecurityVersion.CreateSendSecurityHeader(message, actor, mustUnderstand, relay, this, algorithmSuite, direction);
+        }
+
+        internal ReceiveSecurityHeader CreateReceiveSecurityHeader(Message message,
+            string actor,
+            SecurityAlgorithmSuite algorithmSuite, MessageDirection direction)
+        {
+            ReceiveSecurityHeader header = TryCreateReceiveSecurityHeader(message, actor, algorithmSuite, direction);
+            if (header == null)
+            {
+                if (String.IsNullOrEmpty(actor))
+                    throw System.ServiceModel.Diagnostics.TraceUtility.ThrowHelperError(new MessageSecurityException(
+                        SR.Format(SR.UnableToFindSecurityHeaderInMessageNoActor)), message);
+                else
+                    throw System.ServiceModel.Diagnostics.TraceUtility.ThrowHelperError(new MessageSecurityException(
+                        SR.Format(SR.UnableToFindSecurityHeaderInMessage, actor)), message);
+            }
+            return header;
+        }
+
+        internal ReceiveSecurityHeader TryCreateReceiveSecurityHeader(Message message,
+            string actor,
+            SecurityAlgorithmSuite algorithmSuite, MessageDirection direction)
+        {
+            return this.SecurityVersion.TryCreateReceiveSecurityHeader(message, actor, this, algorithmSuite, direction);
+        }
+
+        internal bool DoesMessageContainSecurityHeader(Message message)
+        {
+            return this.SecurityVersion.DoesMessageContainSecurityHeader(message);
+        }
+
+        internal bool TryGetSecurityContextIds(Message message, string[] actors, bool isStrictMode, ICollection<UniqueId> results)
+        {
+            if (results == null)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("results");
+            }
+            SecureConversationDriver driver = this.SecureConversationDriver;
+            int securityHeaderIndex = this.SecurityVersion.FindIndexOfSecurityHeader(message, actors);
+            if (securityHeaderIndex < 0)
+            {
+                return false;
+            }
+            bool addedContextIds = false;
+            using (XmlDictionaryReader reader = message.Headers.GetReaderAtHeader(securityHeaderIndex))
+            {
+                if (!reader.IsStartElement())
+                {
+                    return false;
+                }
+                if (reader.IsEmptyElement)
+                {
+                    return false;
+                }
+                reader.ReadStartElement();
+                while (reader.IsStartElement())
+                {
+                    if (driver.IsAtSecurityContextToken(reader))
+                    {
+                        results.Add(driver.GetSecurityContextTokenId(reader));
+                        addedContextIds = true;
+                        if (isStrictMode)
+                        {
+                            break;
+                        }
+                    }
+                    else
+                    {
+                        reader.Skip();
+                    }
+                }
+            }
+            return addedContextIds;
+        }
+
     }
 }

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SecurityUtils.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SecurityUtils.cs
@@ -652,7 +652,6 @@ namespace System.ServiceModel.Security
             {
                 name = identity.Name;
             }
-#pragma warning suppress 56500
             catch (Exception e)
             {
                 if (Fx.IsFatal(e))
@@ -1285,7 +1284,6 @@ namespace System.ServiceModel.Security
                     thisResult._operationWithTimeout(thisResult._timeoutHelper.RemainingTime());
                 }
             }
-#pragma warning suppress 56500 // covered by FxCOP
             catch (Exception e)
             {
                 if (Fx.IsFatal(e))

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SendSecurityHeader.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SendSecurityHeader.cs
@@ -4,6 +4,7 @@
 
 
 using System.Collections.Generic;
+using System.Diagnostics.Contracts;
 using System.IdentityModel;
 using System.IdentityModel.Tokens;
 using System.ServiceModel.Channels;
@@ -939,24 +940,27 @@ namespace System.ServiceModel.Security
 
     class TokenElement : ISecurityElement
     {
-        SecurityStandardsManager standardsManager;
-        SecurityToken token;
+        SecurityStandardsManager _standardsManager;
+        SecurityToken _token;
 
         public TokenElement(SecurityToken token, SecurityStandardsManager standardsManager)
         {
-            this.token = token;
-            this.standardsManager = standardsManager;
+            Contract.Assert(token != null);
+            Contract.Assert(standardsManager != null);
+
+            _token = token;
+            _standardsManager = standardsManager;
         }
 
         public override bool Equals(object item)
         {
             TokenElement element = item as TokenElement;
-            return (element != null && this.token == element.token && this.standardsManager == element.standardsManager);
+            return (element != null && this._token == element._token && this._standardsManager == element._standardsManager);
         }
 
         public override int GetHashCode()
         {
-            return token.GetHashCode() ^ standardsManager.GetHashCode();
+            return _token.GetHashCode() ^ _standardsManager.GetHashCode();
         }
 
         public bool HasId
@@ -966,17 +970,17 @@ namespace System.ServiceModel.Security
 
         public string Id
         {
-            get { return token.Id; }
+            get { return _token.Id; }
         }
 
         public SecurityToken Token
         {
-            get { return token; }
+            get { return _token; }
         }
 
         public void WriteTo(XmlDictionaryWriter writer, DictionaryManager dictionaryManager)
         {
-            standardsManager.SecurityTokenSerializer.WriteToken(writer, token);
+            _standardsManager.SecurityTokenSerializer.WriteToken(writer, _token);
         }
     }
 }

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SendSecurityHeader.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SendSecurityHeader.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-
 using System.Collections.Generic;
 using System.Diagnostics.Contracts;
 using System.IdentityModel;

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SendSecurityHeader.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SendSecurityHeader.cs
@@ -3,21 +3,111 @@
 // See the LICENSE file in the project root for more information.
 
 
+using System.Collections.Generic;
+using System.IdentityModel;
+using System.IdentityModel.Tokens;
 using System.ServiceModel.Channels;
 using System.ServiceModel.Description;
+using System.ServiceModel.Diagnostics;
+using System.ServiceModel.Security.Tokens;
 using System.Xml;
 
 namespace System.ServiceModel.Security
 {
     internal abstract class SendSecurityHeader : SecurityHeader, IMessageHeaderWithSharedNamespace
     {
+        private bool _basicTokenEncrypted;
+        private SendSecurityHeaderElementContainer _elementContainer;
+        private bool _primarySignatureDone;
+        bool _encryptSignature;
+        private SignatureConfirmations _signatureValuesGenerated;
+        private SignatureConfirmations _signatureConfirmationsToSend;
+        private int _idCounter;
+        private string _idPrefix;
+        private bool _hasSignedTokens;
+        private bool _hasEncryptedTokens;
+        private MessagePartSpecification _signatureParts;
+        private MessagePartSpecification _encryptionParts;
+        private SecurityTokenParameters _signingTokenParameters;
+        private SecurityTokenParameters _encryptingTokenParameters;
+        private List<SecurityToken> _basicTokens = null;
+        private List<SecurityTokenParameters> _basicSupportingTokenParameters = null;
+        private List<SecurityTokenParameters> _endorsingTokenParameters = null;
+        private List<SecurityTokenParameters> _signedEndorsingTokenParameters = null;
+        private List<SecurityTokenParameters> _signedTokenParameters = null;
+        private SecurityToken _encryptingToken;
+        private bool _skipKeyInfoForEncryption;
+        private byte[] _primarySignatureValue = null;
+        private bool _shouldProtectTokens;
+        private BufferManager _bufferManager;
+        private bool _shouldSignToHeader = false;
+        private SecurityProtocolCorrelationState _correlationState;
+        private bool _signThenEncrypt = true;
+        private static readonly string[] s_ids = new string[] { "_0", "_1", "_2", "_3", "_4", "_5", "_6", "_7", "_8", "_9" };
+
         protected SendSecurityHeader(Message message, string actor, bool mustUnderstand, bool relay,
             SecurityStandardsManager standardsManager,
             SecurityAlgorithmSuite algorithmSuite,
             MessageDirection transferDirection)
             : base(message, actor, mustUnderstand, relay, standardsManager, algorithmSuite, transferDirection)
         {
-            throw ExceptionHelper.PlatformNotSupported();
+            _elementContainer = new SendSecurityHeaderElementContainer();
+        }
+
+        public SendSecurityHeaderElementContainer ElementContainer
+        {
+            get { return _elementContainer; }
+        }
+
+        public BufferManager StreamBufferManager
+        {
+            get
+            {
+                if (_bufferManager == null)
+                {
+                    _bufferManager = BufferManager.CreateBufferManager(0, int.MaxValue);
+                }
+
+                return _bufferManager;
+            }
+            set
+            {
+                _bufferManager = value;
+            }
+        }
+
+        public MessagePartSpecification EncryptionParts
+        {
+            get { return _encryptionParts; }
+            set
+            {
+                ThrowIfProcessingStarted();
+                if (value == null)
+                {
+                    throw TraceUtility.ThrowHelperError(new ArgumentNullException("value"), this.Message);
+                }
+                if (!value.IsReadOnly)
+                {
+                    throw TraceUtility.ThrowHelperError(new InvalidOperationException(
+                        SR.Format(SR.MessagePartSpecificationMustBeImmutable)), this.Message);
+                }
+                _encryptionParts = value;
+            }
+        }
+
+        public bool EncryptPrimarySignature
+        {
+            get { return _encryptSignature; }
+            set
+            {
+                ThrowIfProcessingStarted();
+                _encryptSignature = value;
+            }
+        }
+
+        internal byte[] PrimarySignatureValue
+        {
+            get { return _primarySignatureValue; }
         }
 
         XmlDictionaryString IMessageHeaderWithSharedNamespace.SharedNamespace
@@ -40,9 +130,853 @@ namespace System.ServiceModel.Security
             get { return this.StandardsManager.SecurityVersion.HeaderNamespace.Value; }
         }
 
+        protected SecurityAppliedMessage SecurityAppliedMessage
+        {
+            get { return (SecurityAppliedMessage)this.Message; }
+        }
+
+        public bool ShouldProtectTokens
+        {
+            get { return _shouldProtectTokens; }
+            set
+            {
+                ThrowIfProcessingStarted();
+                _shouldProtectTokens = value;
+            }
+        }
+
+        public bool SignThenEncrypt
+        {
+            get { return _signThenEncrypt; }
+            set
+            {
+                ThrowIfProcessingStarted();
+                _signThenEncrypt = value;
+            }
+        }
+
+        public MessagePartSpecification SignatureParts
+        {
+            get { return _signatureParts; }
+            set
+            {
+                ThrowIfProcessingStarted();
+                if (value == null)
+                {
+                    throw TraceUtility.ThrowHelperError(new ArgumentNullException("value"), this.Message);
+                }
+                if (!value.IsReadOnly)
+                {
+                    throw TraceUtility.ThrowHelperError(new InvalidOperationException(
+                        SR.Format(SR.MessagePartSpecificationMustBeImmutable)), this.Message);
+                }
+                _signatureParts = value;
+            }
+        }
+
+        public SecurityTimestamp Timestamp
+        {
+            get { return _elementContainer.Timestamp; }
+        }
+
+        public bool HasSignedTokens
+        {
+            get
+            {
+                return _hasSignedTokens;
+            }
+        }
+
+        public bool HasEncryptedTokens
+        {
+            get
+            {
+                return _hasEncryptedTokens;
+            }
+        }
+
+        void AddParameters(ref List<SecurityTokenParameters> list, SecurityTokenParameters item)
+        {
+            if (list == null)
+            {
+                list = new List<SecurityTokenParameters>();
+            }
+            list.Add(item);
+        }
+
+        public abstract void ApplyBodySecurity(XmlDictionaryWriter writer, IPrefixGenerator prefixGenerator);
+
+        public abstract void ApplySecurityAndWriteHeaders(MessageHeaders headers, XmlDictionaryWriter writer, IPrefixGenerator prefixGenerator);
+
+        protected virtual bool HasSignedEncryptedMessagePart
+        {
+            get { return false; }
+        }
+
         protected override void OnWriteHeaderContents(XmlDictionaryWriter writer, MessageVersion messageVersion)
         {
+            if (_basicSupportingTokenParameters != null && _basicSupportingTokenParameters.Count > 0
+                && this.RequireMessageProtection && !_basicTokenEncrypted)
+            {
+                throw TraceUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.BasicTokenCannotBeWrittenWithoutEncryption)), this.Message);
+            }
+
+            if (_elementContainer.Timestamp != null && this.Layout != SecurityHeaderLayout.LaxTimestampLast)
+            {
+                this.StandardsManager.WSUtilitySpecificationVersion.WriteTimestamp(writer, _elementContainer.Timestamp);
+            }
+            if (_elementContainer.PrerequisiteToken != null)
+            {
+                this.StandardsManager.SecurityTokenSerializer.WriteToken(writer, _elementContainer.PrerequisiteToken);
+            }
+            if (_elementContainer.SourceSigningToken != null)
+            {
+                if (ShouldSerializeToken(this._signingTokenParameters, this.MessageDirection))
+                {
+                    this.StandardsManager.SecurityTokenSerializer.WriteToken(writer, _elementContainer.SourceSigningToken);
+
+                    // Implement Protect token 
+                    // NOTE: The spec says sign the primary token if it is not included in the message. But we currently are not supporting it
+                    // as we do not support STR-Transform for external references. Hence we can not sign the token which is external ie not in the message.
+                    // This only affects the messages from service to client where 
+                    // 1. allowSerializedSigningTokenOnReply is false.
+                    // 2. SymmetricSecurityBindingElement with IssuedTokens binding where the issued token has a symmetric key.
+
+                    if (this.ShouldProtectTokens)
+                    {
+                        this.WriteSecurityTokenReferencyEntry(writer, _elementContainer.SourceSigningToken, _signingTokenParameters);
+                    }
+                }
+            }
+            if (_elementContainer.DerivedSigningToken != null)
+            {
+                this.StandardsManager.SecurityTokenSerializer.WriteToken(writer, _elementContainer.DerivedSigningToken);
+            }
+            if (_elementContainer.SourceEncryptionToken != null && _elementContainer.SourceEncryptionToken != _elementContainer.SourceSigningToken && ShouldSerializeToken(_encryptingTokenParameters, this.MessageDirection))
+            {
+                this.StandardsManager.SecurityTokenSerializer.WriteToken(writer, _elementContainer.SourceEncryptionToken);
+            }
+            if (_elementContainer.WrappedEncryptionToken != null)
+            {
+                this.StandardsManager.SecurityTokenSerializer.WriteToken(writer, _elementContainer.WrappedEncryptionToken);
+            }
+            if (_elementContainer.DerivedEncryptionToken != null)
+            {
+                this.StandardsManager.SecurityTokenSerializer.WriteToken(writer, _elementContainer.DerivedEncryptionToken);
+            }
+            if (this.SignThenEncrypt)
+            {
+                if (_elementContainer.ReferenceList != null)
+                {
+                    _elementContainer.ReferenceList.WriteTo(writer, ServiceModelDictionaryManager.Instance);
+                }
+            }
+
+            SecurityToken[] signedTokens = _elementContainer.GetSignedSupportingTokens();
+            if (signedTokens != null)
+            {
+                for (int i = 0; i < signedTokens.Length; ++i)
+                {
+                    this.StandardsManager.SecurityTokenSerializer.WriteToken(writer, signedTokens[i]);
+                    this.WriteSecurityTokenReferencyEntry(writer, signedTokens[i], _signedTokenParameters[i]);
+                }
+            }
+            SendSecurityHeaderElement[] basicTokensXml = _elementContainer.GetBasicSupportingTokens();
+            if (basicTokensXml != null)
+            {
+                for (int i = 0; i < basicTokensXml.Length; ++i)
+                {
+                    basicTokensXml[i].Item.WriteTo(writer, ServiceModelDictionaryManager.Instance);
+                    if (this.SignThenEncrypt)
+                    {
+                        this.WriteSecurityTokenReferencyEntry(writer, _basicTokens[i], _basicSupportingTokenParameters[i]);
+                    }
+                }
+            }
+            SecurityToken[] endorsingTokens = _elementContainer.GetEndorsingSupportingTokens();
+            if (endorsingTokens != null)
+            {
+                for (int i = 0; i < endorsingTokens.Length; ++i)
+                {
+                    if (ShouldSerializeToken(_endorsingTokenParameters[i], this.MessageDirection))
+                    {
+                        this.StandardsManager.SecurityTokenSerializer.WriteToken(writer, endorsingTokens[i]);
+                    }
+                }
+            }
+            SecurityToken[] endorsingDerivedTokens = _elementContainer.GetEndorsingDerivedSupportingTokens();
+            if (endorsingDerivedTokens != null)
+            {
+                for (int i = 0; i < endorsingDerivedTokens.Length; ++i)
+                {
+                    this.StandardsManager.SecurityTokenSerializer.WriteToken(writer, endorsingDerivedTokens[i]);
+                }
+            }
+            SecurityToken[] signedEndorsingTokens = _elementContainer.GetSignedEndorsingSupportingTokens();
+            if (signedEndorsingTokens != null)
+            {
+                for (int i = 0; i < signedEndorsingTokens.Length; ++i)
+                {
+                    this.StandardsManager.SecurityTokenSerializer.WriteToken(writer, signedEndorsingTokens[i]);
+                    this.WriteSecurityTokenReferencyEntry(writer, signedEndorsingTokens[i], _signedEndorsingTokenParameters[i]);
+                }
+            }
+            SecurityToken[] signedEndorsingDerivedTokens = _elementContainer.GetSignedEndorsingDerivedSupportingTokens();
+            if (signedEndorsingDerivedTokens != null)
+            {
+                for (int i = 0; i < signedEndorsingDerivedTokens.Length; ++i)
+                {
+                    this.StandardsManager.SecurityTokenSerializer.WriteToken(writer, signedEndorsingDerivedTokens[i]);
+                }
+            }
+            SendSecurityHeaderElement[] signatureConfirmations = _elementContainer.GetSignatureConfirmations();
+            if (signatureConfirmations != null)
+            {
+                for (int i = 0; i < signatureConfirmations.Length; ++i)
+                {
+                    signatureConfirmations[i].Item.WriteTo(writer, ServiceModelDictionaryManager.Instance);
+                }
+            }
+            if (_elementContainer.PrimarySignature != null && _elementContainer.PrimarySignature.Item != null)
+            {
+                _elementContainer.PrimarySignature.Item.WriteTo(writer, ServiceModelDictionaryManager.Instance);
+            }
+            SendSecurityHeaderElement[] endorsingSignatures = _elementContainer.GetEndorsingSignatures();
+            if (endorsingSignatures != null)
+            {
+                for (int i = 0; i < endorsingSignatures.Length; ++i)
+                {
+                    endorsingSignatures[i].Item.WriteTo(writer, ServiceModelDictionaryManager.Instance);
+                }
+            }
+            if (!this.SignThenEncrypt)
+            {
+                if (_elementContainer.ReferenceList != null)
+                {
+                    _elementContainer.ReferenceList.WriteTo(writer, ServiceModelDictionaryManager.Instance);
+                }
+            }
+            if (_elementContainer.Timestamp != null && this.Layout == SecurityHeaderLayout.LaxTimestampLast)
+            {
+                this.StandardsManager.WSUtilitySpecificationVersion.WriteTimestamp(writer, _elementContainer.Timestamp);
+            }
+        }
+
+        protected bool ShouldSignToHeader
+        {
+            get { return this._shouldSignToHeader; }
+        }
+
+        public string IdPrefix
+        {
+            get { return _idPrefix; }
+            set
+            {
+                ThrowIfProcessingStarted();
+                _idPrefix = string.IsNullOrEmpty(value) || value == "_" ? null : value;
+            }
+        }
+
+        public void AddTimestamp(TimeSpan timestampValidityDuration)
+        {
+            DateTime now = DateTime.UtcNow;
+            string id = this.RequireMessageProtection ? SecurityUtils.GenerateId() : GenerateId();
+            AddTimestamp(new SecurityTimestamp(now, now + timestampValidityDuration, id));
+        }
+
+        public void AddTimestamp(SecurityTimestamp timestamp)
+        {
+            ThrowIfProcessingStarted();
+            if (_elementContainer.Timestamp != null)
+            {
+                throw TraceUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.TimestampAlreadySetForSecurityHeader)), this.Message);
+            }
+            if (timestamp == null)
+            {
+                throw TraceUtility.ThrowHelperArgumentNull("timestamp", this.Message);
+            }
+
+            _elementContainer.Timestamp = timestamp;
+        }
+
+        public void AddBasicSupportingToken(SecurityToken token, SecurityTokenParameters parameters)
+        {
+            if (token == null)
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("token");
+            if (parameters == null)
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("parameters");
+            ThrowIfProcessingStarted();
+            SendSecurityHeaderElement tokenElement = new SendSecurityHeaderElement(token.Id, new TokenElement(token, this.StandardsManager));
+            tokenElement.MarkedForEncryption = true;
+            _elementContainer.AddBasicSupportingToken(tokenElement);
+            _hasEncryptedTokens = true;
+            _hasSignedTokens = true;
+            AddParameters(ref _basicSupportingTokenParameters, parameters);
+            if (_basicTokens == null)
+            {
+                _basicTokens = new List<SecurityToken>();
+            }
+
+            //  We maintain a list of the basic tokens for the SignThenEncrypt case as we will 
+            //  need this token to write STR entry on OnWriteHeaderContents. 
+            _basicTokens.Add(token);
+
+        }
+
+        public void AddEndorsingSupportingToken(SecurityToken token, SecurityTokenParameters parameters)
+        {
             throw ExceptionHelper.PlatformNotSupported();
+
+            // Issue #31 in progress
+
+            //if (token == null)
+            //    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("token");
+            //if (parameters == null)
+            //    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("parameters");
+            //ThrowIfProcessingStarted();
+            //this.elementContainer.AddEndorsingSupportingToken(token);
+            //// The ProviderBackedSecurityToken was added for the ChannelBindingToken (CBT) effort for win7.  
+            //// We can assume the key is of type symmetric key.
+            ////
+            //// Asking for the key type from the token will cause the ProviderBackedSecurityToken 
+            //// to attempt to resolve the token and the nego will start.  
+            ////
+            //// We don't want that.  
+            //// We want to defer the nego until after the CBT is available in SecurityAppliedMessage.OnWriteMessage.
+            //if (!(token is ProviderBackedSecurityToken))
+            //{
+            //    this.shouldSignToHeader |= (!this.RequireMessageProtection) && (SecurityUtils.GetSecurityKey<AsymmetricSecurityKey>(token) != null);
+            //}
+            //this.AddParameters(ref this.endorsingTokenParameters, parameters);
+        }
+
+        public void AddSignedEndorsingSupportingToken(SecurityToken token, SecurityTokenParameters parameters)
+        {
+            throw ExceptionHelper.PlatformNotSupported();    // Issue #31 in progress
+            //if (token == null)
+            //    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("token");
+            //if (parameters == null)
+            //    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("parameters");
+            //ThrowIfProcessingStarted();
+            //this.elementContainer.AddSignedEndorsingSupportingToken(token);
+            //hasSignedTokens = true;
+            //this.shouldSignToHeader |= (!this.RequireMessageProtection) && (SecurityUtils.GetSecurityKey<AsymmetricSecurityKey>(token) != null);
+            //this.AddParameters(ref this.signedEndorsingTokenParameters, parameters);
+        }
+
+        public void AddSignedSupportingToken(SecurityToken token, SecurityTokenParameters parameters)
+        {
+            throw ExceptionHelper.PlatformNotSupported();
+
+            // Issue #31 in progress
+            //if (token == null)
+            //    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("token");
+            //if (parameters == null)
+            //    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("parameters");
+            //ThrowIfProcessingStarted();
+            //this.elementContainer.AddSignedSupportingToken(token);
+            //hasSignedTokens = true;
+            //this.AddParameters(ref this.signedTokenParameters, parameters);
+        }
+
+        public void RemoveSignatureEncryptionIfAppropriate()
+        {
+            if (this.SignThenEncrypt &&
+                this.EncryptPrimarySignature &&
+                (this.SecurityAppliedMessage.BodyProtectionMode != MessagePartProtectionMode.SignThenEncrypt) &&
+                (_basicSupportingTokenParameters == null || _basicSupportingTokenParameters.Count == 0) &&
+                (_signatureConfirmationsToSend == null || _signatureConfirmationsToSend.Count == 0 || !_signatureConfirmationsToSend.IsMarkedForEncryption) &&
+                !this.HasSignedEncryptedMessagePart)
+            {
+                _encryptSignature = false;
+            }
+        }
+
+        public string GenerateId()
+        {
+            int id = _idCounter++;
+
+            if (_idPrefix != null)
+            {
+                return _idPrefix + id;
+            }
+
+            if (id < s_ids.Length)
+            {
+                return s_ids[id];
+            }
+            else
+            {
+                return "_" + id;
+            }
+        }
+
+        SignatureConfirmations GetSignatureValues()
+        {
+            return _signatureValuesGenerated;
+        }
+
+        internal static bool ShouldSerializeToken(SecurityTokenParameters parameters, MessageDirection transferDirection)
+        {
+            switch (parameters.InclusionMode)
+            {
+                case SecurityTokenInclusionMode.AlwaysToInitiator:
+                    return (transferDirection == MessageDirection.Output);
+                case SecurityTokenInclusionMode.Once:
+                case SecurityTokenInclusionMode.AlwaysToRecipient:
+                    return (transferDirection == MessageDirection.Input);
+                case SecurityTokenInclusionMode.Never:
+                    return false;
+                default:
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new NotSupportedException(SR.Format(SR.UnsupportedTokenInclusionMode, parameters.InclusionMode)));
+            }
+        }
+
+        protected abstract void WriteSecurityTokenReferencyEntry(XmlDictionaryWriter writer, SecurityToken securityToken, SecurityTokenParameters securityTokenParameters);
+
+        public Message SetupExecution()
+        {
+            ThrowIfProcessingStarted();
+            SetProcessingStarted();
+
+            bool signBody = false;
+            if (_elementContainer.SourceSigningToken != null)
+            {
+                if (_signatureParts == null)
+                {
+                    throw TraceUtility.ThrowHelperError(new ArgumentNullException("SignatureParts"), this.Message);
+                }
+                signBody = _signatureParts.IsBodyIncluded;
+            }
+
+            bool encryptBody = false;
+            if (_elementContainer.SourceEncryptionToken != null)
+            {
+                if (_encryptionParts == null)
+                {
+                    throw TraceUtility.ThrowHelperError(new ArgumentNullException("EncryptionParts"), this.Message);
+                }
+                encryptBody = _encryptionParts.IsBodyIncluded;
+            }
+
+            SecurityAppliedMessage message = new SecurityAppliedMessage(this.Message, this, signBody, encryptBody);
+            this.Message = message;
+            return message;
+        }
+
+        protected internal SecurityTokenReferenceStyle GetTokenReferenceStyle(SecurityTokenParameters parameters)
+        {
+            return (ShouldSerializeToken(parameters, this.MessageDirection)) ? SecurityTokenReferenceStyle.Internal : SecurityTokenReferenceStyle.External;
+        }
+
+        void StartSignature()
+        {
+            if (_elementContainer.SourceSigningToken == null)
+            {
+                return;
+            }
+
+            // determine the key identifier clause to use for the source
+            SecurityTokenReferenceStyle sourceSigningKeyReferenceStyle = GetTokenReferenceStyle(_signingTokenParameters);
+            SecurityKeyIdentifierClause sourceSigningKeyIdentifierClause = _signingTokenParameters.CreateKeyIdentifierClause(_elementContainer.SourceSigningToken, sourceSigningKeyReferenceStyle);
+            if (sourceSigningKeyIdentifierClause == null)
+            {
+                throw TraceUtility.ThrowHelperError(new MessageSecurityException(SR.Format(SR.TokenManagerCannotCreateTokenReference)), this.Message);
+            }
+
+            SecurityToken signingToken;
+            SecurityKeyIdentifierClause signingKeyIdentifierClause;
+
+            // determine if a token needs to be derived
+            if (_signingTokenParameters.RequireDerivedKeys && !_signingTokenParameters.HasAsymmetricKey)
+            {
+                string derivationAlgorithm = this.AlgorithmSuite.GetSignatureKeyDerivationAlgorithm(_elementContainer.SourceSigningToken, this.StandardsManager.MessageSecurityVersion.SecureConversationVersion);
+                string expectedDerivationAlgorithm = SecurityUtils.GetKeyDerivationAlgorithm(this.StandardsManager.MessageSecurityVersion.SecureConversationVersion);
+                if (derivationAlgorithm == expectedDerivationAlgorithm)
+                {
+                    DerivedKeySecurityToken derivedSigningToken = new DerivedKeySecurityToken(-1, 0, this.AlgorithmSuite.GetSignatureKeyDerivationLength(_elementContainer.SourceSigningToken, this.StandardsManager.MessageSecurityVersion.SecureConversationVersion), null, DerivedKeySecurityToken.DefaultNonceLength, _elementContainer.SourceSigningToken,
+                        sourceSigningKeyIdentifierClause, derivationAlgorithm, GenerateId());
+                    signingToken = _elementContainer.DerivedSigningToken = derivedSigningToken;
+                    signingKeyIdentifierClause = new LocalIdKeyIdentifierClause(signingToken.Id, signingToken.GetType());
+                }
+                else
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new NotSupportedException(SR.Format(SR.UnsupportedCryptoAlgorithm, derivationAlgorithm)));
+                }
+            }
+            else
+            {
+                signingToken = _elementContainer.SourceSigningToken;
+                signingKeyIdentifierClause = sourceSigningKeyIdentifierClause;
+            }
+
+            SecurityKeyIdentifier signingKeyIdentifier = new SecurityKeyIdentifier(signingKeyIdentifierClause);
+
+            if (_signatureConfirmationsToSend != null && _signatureConfirmationsToSend.Count > 0)
+            {
+                ISecurityElement[] signatureConfirmationElements;
+                signatureConfirmationElements = CreateSignatureConfirmationElements(_signatureConfirmationsToSend);
+                for (int i = 0; i < signatureConfirmationElements.Length; ++i)
+                {
+                    SendSecurityHeaderElement sigConfElement = new SendSecurityHeaderElement(signatureConfirmationElements[i].Id, signatureConfirmationElements[i]);
+                    sigConfElement.MarkedForEncryption = _signatureConfirmationsToSend.IsMarkedForEncryption;
+                    _elementContainer.AddSignatureConfirmation(sigConfElement);
+                }
+            }
+
+            bool generateTargettablePrimarySignature = ((_endorsingTokenParameters != null) || (_signedEndorsingTokenParameters != null));
+            this.StartPrimarySignatureCore(signingToken, signingKeyIdentifier, _signatureParts, generateTargettablePrimarySignature);
+        }
+
+        void CompleteSignature()
+        {
+            ISignatureValueSecurityElement signedXml = CompletePrimarySignatureCore(
+                _elementContainer.GetSignatureConfirmations(), _elementContainer.GetSignedEndorsingSupportingTokens(),
+                _elementContainer.GetSignedSupportingTokens(), _elementContainer.GetBasicSupportingTokens(), true);
+            if (signedXml == null)
+            {
+                return;
+            }
+            _elementContainer.PrimarySignature = new SendSecurityHeaderElement(signedXml.Id, signedXml);
+            _elementContainer.PrimarySignature.MarkedForEncryption = _encryptSignature;
+            AddGeneratedSignatureValue(signedXml.GetSignatureValue(), this.EncryptPrimarySignature);
+            _primarySignatureDone = true;
+            _primarySignatureValue = signedXml.GetSignatureValue();
+        }
+
+        protected abstract void StartPrimarySignatureCore(SecurityToken token, SecurityKeyIdentifier identifier, MessagePartSpecification signatureParts, bool generateTargettablePrimarySignature);
+
+        protected abstract ISignatureValueSecurityElement CompletePrimarySignatureCore(SendSecurityHeaderElement[] signatureConfirmations,
+           SecurityToken[] signedEndorsingTokens, SecurityToken[] signedTokens, SendSecurityHeaderElement[] basicTokens, bool isPrimarySignature);
+
+
+        protected abstract ISignatureValueSecurityElement CreateSupportingSignature(SecurityToken token, SecurityKeyIdentifier identifier);
+
+        protected abstract ISignatureValueSecurityElement CreateSupportingSignature(SecurityToken token, SecurityKeyIdentifier identifier, ISecurityElement primarySignature);
+
+        protected abstract void StartEncryptionCore(SecurityToken token, SecurityKeyIdentifier keyIdentifier);
+
+        protected abstract ISecurityElement CompleteEncryptionCore(SendSecurityHeaderElement primarySignature,
+            SendSecurityHeaderElement[] basicTokens, SendSecurityHeaderElement[] signatureConfirmations, SendSecurityHeaderElement[] endorsingSignatures);
+
+        void SignWithSupportingToken(SecurityToken token, SecurityKeyIdentifierClause identifierClause)
+        {
+            if (token == null)
+            {
+                throw TraceUtility.ThrowHelperArgumentNull("token", this.Message);
+            }
+            if (identifierClause == null)
+            {
+                throw TraceUtility.ThrowHelperError(new MessageSecurityException(SR.Format(SR.TokenManagerCannotCreateTokenReference)), this.Message);
+            }
+            if (!this.RequireMessageProtection)
+            {
+                if (_elementContainer.Timestamp == null)
+                {
+                    throw TraceUtility.ThrowHelperError(new InvalidOperationException(
+                        SR.Format(SR.SigningWithoutPrimarySignatureRequiresTimestamp)), this.Message);
+                }
+            }
+            else
+            {
+                if (!_primarySignatureDone)
+                {
+                    throw TraceUtility.ThrowHelperError(new InvalidOperationException(
+                        SR.Format(SR.PrimarySignatureMustBeComputedBeforeSupportingTokenSignatures)), this.Message);
+                }
+                if (_elementContainer.PrimarySignature.Item == null)
+                {
+                    throw TraceUtility.ThrowHelperError(new InvalidOperationException(
+                        SR.Format(SR.SupportingTokenSignaturesNotExpected)), this.Message);
+                }
+            }
+
+            SecurityKeyIdentifier identifier = new SecurityKeyIdentifier(identifierClause);
+            ISignatureValueSecurityElement supportingSignature;
+            if (!this.RequireMessageProtection)
+            {
+                supportingSignature = CreateSupportingSignature(token, identifier);
+            }
+            else
+            {
+                supportingSignature = CreateSupportingSignature(token, identifier, _elementContainer.PrimarySignature.Item);
+            }
+            AddGeneratedSignatureValue(supportingSignature.GetSignatureValue(), _encryptSignature);
+            SendSecurityHeaderElement supportingSignatureElement = new SendSecurityHeaderElement(supportingSignature.Id, supportingSignature);
+            supportingSignatureElement.MarkedForEncryption = _encryptSignature;
+            _elementContainer.AddEndorsingSignature(supportingSignatureElement);
+        }
+
+        void SignWithSupportingTokens()
+        {
+            SecurityToken[] endorsingTokens = _elementContainer.GetEndorsingSupportingTokens();
+            if (endorsingTokens != null)
+            {
+                for (int i = 0; i < endorsingTokens.Length; ++i)
+                {
+                    SecurityToken source = endorsingTokens[i];
+                    SecurityKeyIdentifierClause sourceKeyClause = _endorsingTokenParameters[i].CreateKeyIdentifierClause(source, GetTokenReferenceStyle(_endorsingTokenParameters[i]));
+                    if (sourceKeyClause == null)
+                    {
+                        throw TraceUtility.ThrowHelperError(new MessageSecurityException(SR.Format(SR.TokenManagerCannotCreateTokenReference)), this.Message);
+                    }
+                    SecurityToken signingToken;
+                    SecurityKeyIdentifierClause signingKeyClause;
+                    if (_endorsingTokenParameters[i].RequireDerivedKeys && !_endorsingTokenParameters[i].HasAsymmetricKey)
+                    {
+                        string derivationAlgorithm = SecurityUtils.GetKeyDerivationAlgorithm(this.StandardsManager.MessageSecurityVersion.SecureConversationVersion);
+                        DerivedKeySecurityToken dkt = new DerivedKeySecurityToken(-1, 0,
+                            this.AlgorithmSuite.GetSignatureKeyDerivationLength(source, this.StandardsManager.MessageSecurityVersion.SecureConversationVersion), null,
+                            DerivedKeySecurityToken.DefaultNonceLength, source, sourceKeyClause, derivationAlgorithm, GenerateId());
+                        signingToken = dkt;
+                        signingKeyClause = new LocalIdKeyIdentifierClause(dkt.Id, dkt.GetType());
+                        _elementContainer.AddEndorsingDerivedSupportingToken(dkt);
+                    }
+                    else
+                    {
+                        signingToken = source;
+                        signingKeyClause = sourceKeyClause;
+                    }
+                    SignWithSupportingToken(signingToken, signingKeyClause);
+                }
+            }
+            SecurityToken[] signedEndorsingSupportingTokens = _elementContainer.GetSignedEndorsingSupportingTokens();
+            if (signedEndorsingSupportingTokens != null)
+            {
+                for (int i = 0; i < signedEndorsingSupportingTokens.Length; ++i)
+                {
+                    SecurityToken source = signedEndorsingSupportingTokens[i];
+                    SecurityKeyIdentifierClause sourceKeyClause = _signedEndorsingTokenParameters[i].CreateKeyIdentifierClause(source, GetTokenReferenceStyle(_signedEndorsingTokenParameters[i]));
+                    if (sourceKeyClause == null)
+                    {
+                        throw TraceUtility.ThrowHelperError(new MessageSecurityException(SR.Format(SR.TokenManagerCannotCreateTokenReference)), this.Message);
+                    }
+                    SecurityToken signingToken;
+                    SecurityKeyIdentifierClause signingKeyClause;
+                    if (_signedEndorsingTokenParameters[i].RequireDerivedKeys && !_signedEndorsingTokenParameters[i].HasAsymmetricKey)
+                    {
+                        string derivationAlgorithm = SecurityUtils.GetKeyDerivationAlgorithm(this.StandardsManager.MessageSecurityVersion.SecureConversationVersion);
+                        DerivedKeySecurityToken dkt = new DerivedKeySecurityToken(-1, 0,
+                            this.AlgorithmSuite.GetSignatureKeyDerivationLength(source, this.StandardsManager.MessageSecurityVersion.SecureConversationVersion), null,
+                            DerivedKeySecurityToken.DefaultNonceLength, source, sourceKeyClause, derivationAlgorithm, GenerateId());
+                        signingToken = dkt;
+                        signingKeyClause = new LocalIdKeyIdentifierClause(dkt.Id, dkt.GetType());
+                        _elementContainer.AddSignedEndorsingDerivedSupportingToken(dkt);
+                    }
+                    else
+                    {
+                        signingToken = source;
+                        signingKeyClause = sourceKeyClause;
+                    }
+                    SignWithSupportingToken(signingToken, signingKeyClause);
+                }
+            }
+        }
+
+        protected virtual ISignatureValueSecurityElement[] CreateSignatureConfirmationElements(SignatureConfirmations signatureConfirmations)
+        {
+            throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(
+                SR.Format(SR.SignatureConfirmationNotSupported)));
+        }
+
+        void StartEncryption()
+        {
+            if (_elementContainer.SourceEncryptionToken == null)
+            {
+                return;
+            }
+            // determine the key identifier clause to use for the source
+            SecurityTokenReferenceStyle sourceEncryptingKeyReferenceStyle = GetTokenReferenceStyle(_encryptingTokenParameters);
+            bool encryptionTokenSerialized = sourceEncryptingKeyReferenceStyle == SecurityTokenReferenceStyle.Internal;
+            SecurityKeyIdentifierClause sourceEncryptingKeyIdentifierClause = _encryptingTokenParameters.CreateKeyIdentifierClause(_elementContainer.SourceEncryptionToken, sourceEncryptingKeyReferenceStyle);
+            if (sourceEncryptingKeyIdentifierClause == null)
+            {
+                throw TraceUtility.ThrowHelperError(new MessageSecurityException(SR.Format(SR.TokenManagerCannotCreateTokenReference)), this.Message);
+            }
+            SecurityToken sourceToken;
+            SecurityKeyIdentifierClause sourceTokenIdentifierClause;
+
+            // if the source token cannot do symmetric crypto, create a wrapped key
+            if (!SecurityUtils.HasSymmetricSecurityKey(_elementContainer.SourceEncryptionToken))
+            {
+                int keyLength = Math.Max(128, this.AlgorithmSuite.DefaultSymmetricKeyLength);
+                CryptoHelper.ValidateSymmetricKeyLength(keyLength, this.AlgorithmSuite);
+                byte[] key = new byte[keyLength / 8];
+                CryptoHelper.FillRandomBytes(key);
+                string keyWrapAlgorithm;
+                XmlDictionaryString keyWrapAlgorithmDictionaryString;
+                this.AlgorithmSuite.GetKeyWrapAlgorithm(_elementContainer.SourceEncryptionToken, out keyWrapAlgorithm, out keyWrapAlgorithmDictionaryString);
+                WrappedKeySecurityToken wrappedKey = new WrappedKeySecurityToken(GenerateId(), key, keyWrapAlgorithm, keyWrapAlgorithmDictionaryString,
+                    _elementContainer.SourceEncryptionToken, new SecurityKeyIdentifier(sourceEncryptingKeyIdentifierClause));
+                _elementContainer.WrappedEncryptionToken = wrappedKey;
+                sourceToken = wrappedKey;
+                sourceTokenIdentifierClause = new LocalIdKeyIdentifierClause(wrappedKey.Id, wrappedKey.GetType());
+                encryptionTokenSerialized = true;
+            }
+            else
+            {
+                sourceToken = _elementContainer.SourceEncryptionToken;
+                sourceTokenIdentifierClause = sourceEncryptingKeyIdentifierClause;
+            }
+
+            // determine if a key needs to be derived
+            SecurityKeyIdentifierClause encryptingKeyIdentifierClause;
+            // determine if a token needs to be derived
+            if (_encryptingTokenParameters.RequireDerivedKeys)
+            {
+                string derivationAlgorithm = this.AlgorithmSuite.GetEncryptionKeyDerivationAlgorithm(sourceToken, this.StandardsManager.MessageSecurityVersion.SecureConversationVersion);
+                string expectedDerivationAlgorithm = SecurityUtils.GetKeyDerivationAlgorithm(this.StandardsManager.MessageSecurityVersion.SecureConversationVersion);
+                if (derivationAlgorithm == expectedDerivationAlgorithm)
+                {
+                    DerivedKeySecurityToken derivedEncryptingToken = new DerivedKeySecurityToken(-1, 0,
+                        this.AlgorithmSuite.GetEncryptionKeyDerivationLength(sourceToken, this.StandardsManager.MessageSecurityVersion.SecureConversationVersion), null, DerivedKeySecurityToken.DefaultNonceLength, sourceToken, sourceTokenIdentifierClause, derivationAlgorithm, GenerateId());
+                    _encryptingToken = _elementContainer.DerivedEncryptionToken = derivedEncryptingToken;
+                    encryptingKeyIdentifierClause = new LocalIdKeyIdentifierClause(derivedEncryptingToken.Id, derivedEncryptingToken.GetType());
+                }
+                else
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new NotSupportedException(SR.Format(SR.UnsupportedCryptoAlgorithm, derivationAlgorithm)));
+                }
+            }
+            else
+            {
+                _encryptingToken = sourceToken;
+                encryptingKeyIdentifierClause = sourceTokenIdentifierClause;
+            }
+
+            _skipKeyInfoForEncryption = encryptionTokenSerialized && this.EncryptedKeyContainsReferenceList && (_encryptingToken is WrappedKeySecurityToken) && _signThenEncrypt;
+            SecurityKeyIdentifier identifier;
+            if (_skipKeyInfoForEncryption)
+            {
+                identifier = null;
+            }
+            else
+            {
+                identifier = new SecurityKeyIdentifier(encryptingKeyIdentifierClause);
+            }
+
+            StartEncryptionCore(_encryptingToken, identifier);
+        }
+
+        void CompleteEncryption()
+        {
+            ISecurityElement referenceList = CompleteEncryptionCore(
+                _elementContainer.PrimarySignature,
+                _elementContainer.GetBasicSupportingTokens(),
+                _elementContainer.GetSignatureConfirmations(),
+                _elementContainer.GetEndorsingSignatures());
+
+            if (referenceList == null)
+            {
+                // null out all the encryption fields since there is no encryption needed
+                _elementContainer.SourceEncryptionToken = null;
+                _elementContainer.WrappedEncryptionToken = null;
+                _elementContainer.DerivedEncryptionToken = null;
+                return;
+            }
+
+            if (_skipKeyInfoForEncryption)
+            {
+                WrappedKeySecurityToken wrappedKeyToken = _encryptingToken as WrappedKeySecurityToken;
+                wrappedKeyToken.EnsureEncryptedKeySetUp();
+                wrappedKeyToken.EncryptedKey.ReferenceList = (ReferenceList)referenceList;
+            }
+            else
+            {
+                _elementContainer.ReferenceList = referenceList;
+            }
+            _basicTokenEncrypted = true;
+        }
+
+        internal void StartSecurityApplication()
+        {
+            if (this.SignThenEncrypt)
+            {
+                StartSignature();
+                StartEncryption();
+            }
+            else
+            {
+                StartEncryption();
+                StartSignature();
+            }
+        }
+
+        internal void CompleteSecurityApplication()
+        {
+            if (this.SignThenEncrypt)
+            {
+                CompleteSignature();
+                SignWithSupportingTokens();
+                CompleteEncryption();
+            }
+            else
+            {
+                CompleteEncryption();
+                CompleteSignature();
+                SignWithSupportingTokens();
+            }
+
+            if (_correlationState != null)
+            {
+                _correlationState.SignatureConfirmations = GetSignatureValues();
+            }
+        }
+
+        void AddGeneratedSignatureValue(byte[] signatureValue, bool wasEncrypted)
+        {
+            // cache outgoing signatures only on the client side
+            if (this.MaintainSignatureConfirmationState && (_signatureConfirmationsToSend == null))
+            {
+                if (_signatureValuesGenerated == null)
+                {
+                    _signatureValuesGenerated = new SignatureConfirmations();
+                }
+                _signatureValuesGenerated.AddConfirmation(signatureValue, wasEncrypted);
+            }
+        }
+    }
+
+    class TokenElement : ISecurityElement
+    {
+        SecurityStandardsManager standardsManager;
+        SecurityToken token;
+
+        public TokenElement(SecurityToken token, SecurityStandardsManager standardsManager)
+        {
+            this.token = token;
+            this.standardsManager = standardsManager;
+        }
+
+        public override bool Equals(object item)
+        {
+            TokenElement element = item as TokenElement;
+            return (element != null && this.token == element.token && this.standardsManager == element.standardsManager);
+        }
+
+        public override int GetHashCode()
+        {
+            return token.GetHashCode() ^ standardsManager.GetHashCode();
+        }
+
+        public bool HasId
+        {
+            get { return true; }
+        }
+
+        public string Id
+        {
+            get { return token.Id; }
+        }
+
+        public SecurityToken Token
+        {
+            get { return token; }
+        }
+
+        public void WriteTo(XmlDictionaryWriter writer, DictionaryManager dictionaryManager)
+        {
+            standardsManager.SecurityTokenSerializer.WriteToken(writer, token);
         }
     }
 }

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SendSecurityHeaderElement.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SendSecurityHeaderElement.cs
@@ -2,12 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.IdentityModel.Claims;
-using System.ServiceModel;
-using System.IdentityModel.Policy;
-using System.ServiceModel.Security.Tokens;
-using System.Xml;
-
 using ISecurityElement = System.IdentityModel.ISecurityElement;
 
 namespace System.ServiceModel.Security

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SendSecurityHeaderElement.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SendSecurityHeaderElement.cs
@@ -1,0 +1,56 @@
+//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace System.ServiceModel.Security
+{
+    using System.IdentityModel.Claims;
+    using System.ServiceModel;
+    using System.IdentityModel.Policy;
+    using System.ServiceModel.Security.Tokens;
+    using System.Xml;
+
+    using ISecurityElement = System.IdentityModel.ISecurityElement;
+
+    class SendSecurityHeaderElement
+    {
+        string id;
+        ISecurityElement item;
+        bool markedForEncryption;
+
+        public SendSecurityHeaderElement(string id, ISecurityElement item)
+        {
+            this.id = id;
+            this.item = item;
+            markedForEncryption = false;
+        }
+
+        public string Id
+        {
+            get { return this.id; }
+        }
+
+        public ISecurityElement Item
+        {
+            get { return this.item; }
+        }
+
+        public bool MarkedForEncryption
+        {
+            get { return this.markedForEncryption; }
+            set { this.markedForEncryption = value; }
+        }
+
+        public bool IsSameItem(ISecurityElement item)
+        {
+            return this.item == item || this.item.Equals(item);
+        }
+
+        public void Replace(string id, ISecurityElement item)
+        {
+            this.item = item;
+            this.id = id;
+        }
+    }
+}
+

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SendSecurityHeaderElement.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SendSecurityHeaderElement.cs
@@ -1,55 +1,55 @@
-//------------------------------------------------------------
-// Copyright (c) Microsoft Corporation.  All rights reserved.
-//------------------------------------------------------------
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.IdentityModel.Claims;
+using System.ServiceModel;
+using System.IdentityModel.Policy;
+using System.ServiceModel.Security.Tokens;
+using System.Xml;
+
+using ISecurityElement = System.IdentityModel.ISecurityElement;
 
 namespace System.ServiceModel.Security
 {
-    using System.IdentityModel.Claims;
-    using System.ServiceModel;
-    using System.IdentityModel.Policy;
-    using System.ServiceModel.Security.Tokens;
-    using System.Xml;
-
-    using ISecurityElement = System.IdentityModel.ISecurityElement;
-
     class SendSecurityHeaderElement
     {
-        string id;
-        ISecurityElement item;
-        bool markedForEncryption;
+        private string _id;
+        private ISecurityElement _item;
+        private bool _markedForEncryption;
 
         public SendSecurityHeaderElement(string id, ISecurityElement item)
         {
-            this.id = id;
-            this.item = item;
-            markedForEncryption = false;
+            _id = id;
+            _item = item;
+            _markedForEncryption = false;
         }
 
         public string Id
         {
-            get { return this.id; }
+            get { return _id; }
         }
 
         public ISecurityElement Item
         {
-            get { return this.item; }
+            get { return _item; }
         }
 
         public bool MarkedForEncryption
         {
-            get { return this.markedForEncryption; }
-            set { this.markedForEncryption = value; }
+            get { return _markedForEncryption; }
+            set { _markedForEncryption = value; }
         }
 
         public bool IsSameItem(ISecurityElement item)
         {
-            return this.item == item || this.item.Equals(item);
+            return _item == item || _item.Equals(item);
         }
 
         public void Replace(string id, ISecurityElement item)
         {
-            this.item = item;
-            this.id = id;
+            _item = item;
+            _id = id;
         }
     }
 }

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SendSecurityHeaderElementContainer.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SendSecurityHeaderElementContainer.cs
@@ -1,30 +1,30 @@
-//------------------------------------------------------------
-// Copyright (c) Microsoft Corporation.  All rights reserved.
-//------------------------------------------------------------
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.IdentityModel.Claims;
+using System.ServiceModel;
+using System.IdentityModel.Policy;
+using System.IdentityModel.Tokens;
+using System.ServiceModel.Security.Tokens;
+using System.Xml;
+using System.Collections.Generic;
+
+using ISecurityElement = System.IdentityModel.ISecurityElement;
 
 namespace System.ServiceModel.Security
 {
-    using System.IdentityModel.Claims;
-    using System.ServiceModel;
-    using System.IdentityModel.Policy;
-    using System.IdentityModel.Tokens;
-    using System.ServiceModel.Security.Tokens;
-    using System.Xml;
-    using System.Collections.Generic;
-
-    using ISecurityElement = System.IdentityModel.ISecurityElement;
-
     class SendSecurityHeaderElementContainer
     {
-        List<SecurityToken> signedSupportingTokens = null;
-        List<SendSecurityHeaderElement> basicSupportingTokens = null;
-        List<SecurityToken> endorsingSupportingTokens = null;
-        List<SecurityToken> endorsingDerivedSupportingTokens = null;
-        List<SecurityToken> signedEndorsingSupportingTokens = null;
-        List<SecurityToken> signedEndorsingDerivedSupportingTokens = null;
-        List<SendSecurityHeaderElement> signatureConfirmations = null;
-        List<SendSecurityHeaderElement> endorsingSignatures = null;
-        Dictionary<SecurityToken, SecurityKeyIdentifierClause> securityTokenMappedToIdentifierClause = null;
+        private List<SecurityToken> _signedSupportingTokens = null;
+        private List<SendSecurityHeaderElement> _basicSupportingTokens = null;
+        private List<SecurityToken> _endorsingSupportingTokens = null;
+        private List<SecurityToken> _endorsingDerivedSupportingTokens = null;
+        private List<SecurityToken> _signedEndorsingSupportingTokens = null;
+        private List<SecurityToken> _signedEndorsingDerivedSupportingTokens = null;
+        private List<SendSecurityHeaderElement> _signatureConfirmations = null;
+        private List<SendSecurityHeaderElement> _endorsingSignatures = null;
+        private Dictionary<SecurityToken, SecurityKeyIdentifierClause> _securityTokenMappedToIdentifierClause = null;
 
         public SecurityTimestamp Timestamp;
         public SecurityToken PrerequisiteToken;
@@ -47,99 +47,99 @@ namespace System.ServiceModel.Security
 
         public SecurityToken[] GetSignedSupportingTokens()
         {
-            return (this.signedSupportingTokens != null) ? this.signedSupportingTokens.ToArray() : null;
+            return (_signedSupportingTokens != null) ? _signedSupportingTokens.ToArray() : null;
         }
 
         public void AddSignedSupportingToken(SecurityToken token)
         {
-            Add<SecurityToken>(ref this.signedSupportingTokens, token);
+            Add<SecurityToken>(ref _signedSupportingTokens, token);
         }
 
         public List<SecurityToken> EndorsingSupportingTokens
         {
-            get { return this.endorsingSupportingTokens; }
+            get { return _endorsingSupportingTokens; }
         }
 
         public SendSecurityHeaderElement[] GetBasicSupportingTokens()
         {
-            return (this.basicSupportingTokens != null) ? this.basicSupportingTokens.ToArray() : null;
+            return (_basicSupportingTokens != null) ? _basicSupportingTokens.ToArray() : null;
         }
 
         public void AddBasicSupportingToken(SendSecurityHeaderElement tokenElement)
         {
-            Add<SendSecurityHeaderElement>(ref this.basicSupportingTokens, tokenElement);
+            Add<SendSecurityHeaderElement>(ref _basicSupportingTokens, tokenElement);
         }
 
         public SecurityToken[] GetSignedEndorsingSupportingTokens()
         {
-            return (this.signedEndorsingSupportingTokens != null) ? this.signedEndorsingSupportingTokens.ToArray() : null;
+            return (_signedEndorsingSupportingTokens != null) ? _signedEndorsingSupportingTokens.ToArray() : null;
         }
 
         public void AddSignedEndorsingSupportingToken(SecurityToken token)
         {
-            Add<SecurityToken>(ref this.signedEndorsingSupportingTokens, token);
+            Add<SecurityToken>(ref _signedEndorsingSupportingTokens, token);
         }
 
         public SecurityToken[] GetSignedEndorsingDerivedSupportingTokens()
         {
-            return (this.signedEndorsingDerivedSupportingTokens != null) ? this.signedEndorsingDerivedSupportingTokens.ToArray() : null;
+            return (_signedEndorsingDerivedSupportingTokens != null) ? _signedEndorsingDerivedSupportingTokens.ToArray() : null;
         }
 
         public void AddSignedEndorsingDerivedSupportingToken(SecurityToken token)
         {
-            Add<SecurityToken>(ref this.signedEndorsingDerivedSupportingTokens, token);
+            Add<SecurityToken>(ref _signedEndorsingDerivedSupportingTokens, token);
         }
 
         public SecurityToken[] GetEndorsingSupportingTokens()
         {
-            return (this.endorsingSupportingTokens != null) ? this.endorsingSupportingTokens.ToArray() : null;
+            return (_endorsingSupportingTokens != null) ? _endorsingSupportingTokens.ToArray() : null;
         }
 
         public void AddEndorsingSupportingToken(SecurityToken token)
         {
-            Add<SecurityToken>(ref this.endorsingSupportingTokens, token);
+            Add<SecurityToken>(ref _endorsingSupportingTokens, token);
         }
 
         public SecurityToken[] GetEndorsingDerivedSupportingTokens()
         {
-            return (this.endorsingDerivedSupportingTokens != null) ? this.endorsingDerivedSupportingTokens.ToArray() : null;
+            return (_endorsingDerivedSupportingTokens != null) ? _endorsingDerivedSupportingTokens.ToArray() : null;
         }
 
         public void AddEndorsingDerivedSupportingToken(SecurityToken token)
         {
-            Add<SecurityToken>(ref this.endorsingDerivedSupportingTokens, token);
+            Add<SecurityToken>(ref _endorsingDerivedSupportingTokens, token);
         }
 
         public SendSecurityHeaderElement[] GetSignatureConfirmations()
         {
-            return (this.signatureConfirmations != null) ? this.signatureConfirmations.ToArray() : null;
+            return (_signatureConfirmations != null) ? _signatureConfirmations.ToArray() : null;
         }
 
         public void AddSignatureConfirmation(SendSecurityHeaderElement confirmation)
         {
-            Add<SendSecurityHeaderElement>(ref this.signatureConfirmations, confirmation);
+            Add<SendSecurityHeaderElement>(ref _signatureConfirmations, confirmation);
         }
 
         public SendSecurityHeaderElement[] GetEndorsingSignatures()
         {
-            return (this.endorsingSignatures != null) ? this.endorsingSignatures.ToArray() : null;
+            return (_endorsingSignatures != null) ? _endorsingSignatures.ToArray() : null;
         }
 
         public void AddEndorsingSignature(SendSecurityHeaderElement signature)
         {
-            Add<SendSecurityHeaderElement>(ref this.endorsingSignatures, signature);
+            Add<SendSecurityHeaderElement>(ref _endorsingSignatures, signature);
         }
 
         public void MapSecurityTokenToStrClause(SecurityToken securityToken, SecurityKeyIdentifierClause keyIdentifierClause)
         {
-            if (this.securityTokenMappedToIdentifierClause == null)
+            if (_securityTokenMappedToIdentifierClause == null)
             {
-                this.securityTokenMappedToIdentifierClause = new Dictionary<SecurityToken, SecurityKeyIdentifierClause>();
+                _securityTokenMappedToIdentifierClause = new Dictionary<SecurityToken, SecurityKeyIdentifierClause>();
             }
 
-            if (!this.securityTokenMappedToIdentifierClause.ContainsKey(securityToken))
+            if (!_securityTokenMappedToIdentifierClause.ContainsKey(securityToken))
             {
-                this.securityTokenMappedToIdentifierClause.Add(securityToken, keyIdentifierClause);
+                _securityTokenMappedToIdentifierClause.Add(securityToken, keyIdentifierClause);
             }
         }
 
@@ -147,8 +147,8 @@ namespace System.ServiceModel.Security
         {
             keyIdentifierClause = null;
             if (securityToken == null
-                || this.securityTokenMappedToIdentifierClause == null
-                || !this.securityTokenMappedToIdentifierClause.TryGetValue(securityToken, out keyIdentifierClause))
+                || _securityTokenMappedToIdentifierClause == null
+                || !_securityTokenMappedToIdentifierClause.TryGetValue(securityToken, out keyIdentifierClause))
             {
                 return false;
             }

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SendSecurityHeaderElementContainer.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SendSecurityHeaderElementContainer.cs
@@ -1,0 +1,159 @@
+//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace System.ServiceModel.Security
+{
+    using System.IdentityModel.Claims;
+    using System.ServiceModel;
+    using System.IdentityModel.Policy;
+    using System.IdentityModel.Tokens;
+    using System.ServiceModel.Security.Tokens;
+    using System.Xml;
+    using System.Collections.Generic;
+
+    using ISecurityElement = System.IdentityModel.ISecurityElement;
+
+    class SendSecurityHeaderElementContainer
+    {
+        List<SecurityToken> signedSupportingTokens = null;
+        List<SendSecurityHeaderElement> basicSupportingTokens = null;
+        List<SecurityToken> endorsingSupportingTokens = null;
+        List<SecurityToken> endorsingDerivedSupportingTokens = null;
+        List<SecurityToken> signedEndorsingSupportingTokens = null;
+        List<SecurityToken> signedEndorsingDerivedSupportingTokens = null;
+        List<SendSecurityHeaderElement> signatureConfirmations = null;
+        List<SendSecurityHeaderElement> endorsingSignatures = null;
+        Dictionary<SecurityToken, SecurityKeyIdentifierClause> securityTokenMappedToIdentifierClause = null;
+
+        public SecurityTimestamp Timestamp;
+        public SecurityToken PrerequisiteToken;
+        public SecurityToken SourceSigningToken;
+        public SecurityToken DerivedSigningToken;
+        public SecurityToken SourceEncryptionToken;
+        public SecurityToken WrappedEncryptionToken;
+        public SecurityToken DerivedEncryptionToken;
+        public ISecurityElement ReferenceList;
+        public SendSecurityHeaderElement PrimarySignature;
+
+        void Add<T>(ref List<T> list, T item)
+        {
+            if (list == null)
+            {
+                list = new List<T>();
+            }
+            list.Add(item);
+        }
+
+        public SecurityToken[] GetSignedSupportingTokens()
+        {
+            return (this.signedSupportingTokens != null) ? this.signedSupportingTokens.ToArray() : null;
+        }
+
+        public void AddSignedSupportingToken(SecurityToken token)
+        {
+            Add<SecurityToken>(ref this.signedSupportingTokens, token);
+        }
+
+        public List<SecurityToken> EndorsingSupportingTokens
+        {
+            get { return this.endorsingSupportingTokens; }
+        }
+
+        public SendSecurityHeaderElement[] GetBasicSupportingTokens()
+        {
+            return (this.basicSupportingTokens != null) ? this.basicSupportingTokens.ToArray() : null;
+        }
+
+        public void AddBasicSupportingToken(SendSecurityHeaderElement tokenElement)
+        {
+            Add<SendSecurityHeaderElement>(ref this.basicSupportingTokens, tokenElement);
+        }
+
+        public SecurityToken[] GetSignedEndorsingSupportingTokens()
+        {
+            return (this.signedEndorsingSupportingTokens != null) ? this.signedEndorsingSupportingTokens.ToArray() : null;
+        }
+
+        public void AddSignedEndorsingSupportingToken(SecurityToken token)
+        {
+            Add<SecurityToken>(ref this.signedEndorsingSupportingTokens, token);
+        }
+
+        public SecurityToken[] GetSignedEndorsingDerivedSupportingTokens()
+        {
+            return (this.signedEndorsingDerivedSupportingTokens != null) ? this.signedEndorsingDerivedSupportingTokens.ToArray() : null;
+        }
+
+        public void AddSignedEndorsingDerivedSupportingToken(SecurityToken token)
+        {
+            Add<SecurityToken>(ref this.signedEndorsingDerivedSupportingTokens, token);
+        }
+
+        public SecurityToken[] GetEndorsingSupportingTokens()
+        {
+            return (this.endorsingSupportingTokens != null) ? this.endorsingSupportingTokens.ToArray() : null;
+        }
+
+        public void AddEndorsingSupportingToken(SecurityToken token)
+        {
+            Add<SecurityToken>(ref this.endorsingSupportingTokens, token);
+        }
+
+        public SecurityToken[] GetEndorsingDerivedSupportingTokens()
+        {
+            return (this.endorsingDerivedSupportingTokens != null) ? this.endorsingDerivedSupportingTokens.ToArray() : null;
+        }
+
+        public void AddEndorsingDerivedSupportingToken(SecurityToken token)
+        {
+            Add<SecurityToken>(ref this.endorsingDerivedSupportingTokens, token);
+        }
+
+        public SendSecurityHeaderElement[] GetSignatureConfirmations()
+        {
+            return (this.signatureConfirmations != null) ? this.signatureConfirmations.ToArray() : null;
+        }
+
+        public void AddSignatureConfirmation(SendSecurityHeaderElement confirmation)
+        {
+            Add<SendSecurityHeaderElement>(ref this.signatureConfirmations, confirmation);
+        }
+
+        public SendSecurityHeaderElement[] GetEndorsingSignatures()
+        {
+            return (this.endorsingSignatures != null) ? this.endorsingSignatures.ToArray() : null;
+        }
+
+        public void AddEndorsingSignature(SendSecurityHeaderElement signature)
+        {
+            Add<SendSecurityHeaderElement>(ref this.endorsingSignatures, signature);
+        }
+
+        public void MapSecurityTokenToStrClause(SecurityToken securityToken, SecurityKeyIdentifierClause keyIdentifierClause)
+        {
+            if (this.securityTokenMappedToIdentifierClause == null)
+            {
+                this.securityTokenMappedToIdentifierClause = new Dictionary<SecurityToken, SecurityKeyIdentifierClause>();
+            }
+
+            if (!this.securityTokenMappedToIdentifierClause.ContainsKey(securityToken))
+            {
+                this.securityTokenMappedToIdentifierClause.Add(securityToken, keyIdentifierClause);
+            }
+        }
+
+        public bool TryGetIdentifierClauseFromSecurityToken(SecurityToken securityToken, out SecurityKeyIdentifierClause keyIdentifierClause)
+        {
+            keyIdentifierClause = null;
+            if (securityToken == null
+                || this.securityTokenMappedToIdentifierClause == null
+                || !this.securityTokenMappedToIdentifierClause.TryGetValue(securityToken, out keyIdentifierClause))
+            {
+                return false;
+            }
+            return true;
+        }       
+    }
+}
+

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SendSecurityHeaderElementContainer.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SendSecurityHeaderElementContainer.cs
@@ -2,14 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.IdentityModel.Claims;
-using System.ServiceModel;
-using System.IdentityModel.Policy;
-using System.IdentityModel.Tokens;
-using System.ServiceModel.Security.Tokens;
-using System.Xml;
 using System.Collections.Generic;
-
+using System.IdentityModel.Tokens;
 using ISecurityElement = System.IdentityModel.ISecurityElement;
 
 namespace System.ServiceModel.Security

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SignatureConfirmations.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SignatureConfirmations.cs
@@ -1,16 +1,16 @@
-//------------------------------------------------------------
-// Copyright (c) Microsoft Corporation.  All rights reserved.
-//------------------------------------------------------------
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 
 namespace System.ServiceModel.Security
 {
-    using System;
-
     class SignatureConfirmations
     {
-        SignatureConfirmation[] confirmations;
-        int length;
-        bool encrypted;
+        private SignatureConfirmation[] _confirmations;
+        private int _length;
+        private bool _encrypted;
 
         struct SignatureConfirmation
         {
@@ -24,42 +24,42 @@ namespace System.ServiceModel.Security
 
         public SignatureConfirmations()
         {
-            confirmations = new SignatureConfirmation[1];
-            length = 0;
+            _confirmations = new SignatureConfirmation[1];
+            _length = 0;
         }
 
         public int Count
         {
-            get { return length; }
+            get { return _length; }
         }
 
         public void AddConfirmation(byte[] value, bool encrypted)
         {
-            if (confirmations.Length == length)
+            if (_confirmations.Length == _length)
             {
-                SignatureConfirmation[] newConfirmations = new SignatureConfirmation[length * 2];
-                Array.Copy(confirmations, 0, newConfirmations, 0, length);
-                confirmations = newConfirmations;
+                SignatureConfirmation[] newConfirmations = new SignatureConfirmation[_length * 2];
+                Array.Copy(_confirmations, 0, newConfirmations, 0, _length);
+                _confirmations = newConfirmations;
             }
-            confirmations[length] = new SignatureConfirmation(value);
-            ++length;
-            this.encrypted |= encrypted;
+            _confirmations[_length] = new SignatureConfirmation(value);
+            ++_length;
+            _encrypted |= encrypted;
         }
 
         public void GetConfirmation(int index, out byte[] value, out bool encrypted)
         {
-            if (index < 0 || index >= length)
+            if (index < 0 || index >= _length)
             {
-                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("index", SR.GetString(SR.ValueMustBeInRange, 0, length)));
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("index", SR.Format(SR.ValueMustBeInRange, 0, _length)));
             }
 
-            value = confirmations[index].value;
-            encrypted = this.encrypted;
+            value = _confirmations[index].value;
+            encrypted = _encrypted;
         }
 
         public bool IsMarkedForEncryption
         {
-            get { return this.encrypted; }
+            get { return _encrypted; }
         }
     }
 }

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SignatureConfirmations.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SignatureConfirmations.cs
@@ -1,0 +1,66 @@
+//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace System.ServiceModel.Security
+{
+    using System;
+
+    class SignatureConfirmations
+    {
+        SignatureConfirmation[] confirmations;
+        int length;
+        bool encrypted;
+
+        struct SignatureConfirmation
+        {
+            public byte[] value;
+
+            public SignatureConfirmation(byte[] value)
+            {
+                this.value = value;
+            }
+        }
+
+        public SignatureConfirmations()
+        {
+            confirmations = new SignatureConfirmation[1];
+            length = 0;
+        }
+
+        public int Count
+        {
+            get { return length; }
+        }
+
+        public void AddConfirmation(byte[] value, bool encrypted)
+        {
+            if (confirmations.Length == length)
+            {
+                SignatureConfirmation[] newConfirmations = new SignatureConfirmation[length * 2];
+                Array.Copy(confirmations, 0, newConfirmations, 0, length);
+                confirmations = newConfirmations;
+            }
+            confirmations[length] = new SignatureConfirmation(value);
+            ++length;
+            this.encrypted |= encrypted;
+        }
+
+        public void GetConfirmation(int index, out byte[] value, out bool encrypted)
+        {
+            if (index < 0 || index >= length)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("index", SR.GetString(SR.ValueMustBeInRange, 0, length)));
+            }
+
+            value = confirmations[index].value;
+            encrypted = this.encrypted;
+        }
+
+        public bool IsMarkedForEncryption
+        {
+            get { return this.encrypted; }
+        }
+    }
+}
+

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SspiSecurityTokenProvider.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SspiSecurityTokenProvider.cs
@@ -36,5 +36,10 @@ namespace System.ServiceModel.Security
         {
             return Task.FromResult<SecurityToken>(_token);
         }
+
+        protected override SecurityToken GetTokenCore(TimeSpan timeout)
+        {
+            return _token;
+        }
     }
 }

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SspiSecurityTokenProvider.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SspiSecurityTokenProvider.cs
@@ -2,12 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-
 using System.IdentityModel.Selectors;
 using System.IdentityModel.Tokens;
-using System.ServiceModel.Security.Tokens;
 using System.Net;
 using System.Security.Principal;
+using System.ServiceModel.Security.Tokens;
 using System.Threading;
 using System.Threading.Tasks;
 

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/Tokens/DerivedKeySecurityToken.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/Tokens/DerivedKeySecurityToken.cs
@@ -1,21 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+// See the LICENSE file in the project root for more information
 
-
-using System.Collections;
-using System.ServiceModel;
-using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Globalization;
-using System.IO;
-using System.IdentityModel.Claims;
-using System.IdentityModel.Policy;
 using System.IdentityModel.Tokens;
-using System.IdentityModel.Selectors;
-using System.Security.Cryptography;
-using System.Text;
-using System.Xml;
 
 namespace System.ServiceModel.Security.Tokens
 {
@@ -33,7 +21,7 @@ namespace System.ServiceModel.Security.Tokens
         public const int DefaultNonceLength = 16;
         public const int DefaultDerivedKeyLength = 32;
 
-#pragma warning disable 0649 // Remove this once we do real implementation, this prevents "field is never assigned to" warning. 
+#pragma warning disable 0649 // Issue #31 in progress. Remove this once we do real implementation, this prevents "field is never assigned to" warning. 
         // fields are read from in this class, but lack of implemenation means we never assign them yet. 
         private string _id;
         private byte[] _key;

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/Tokens/IssuedSecurityTokenParameters.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/Tokens/IssuedSecurityTokenParameters.cs
@@ -1,0 +1,987 @@
+//-----------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//-----------------------------------------------------------------------------
+
+
+namespace System.ServiceModel.Security.Tokens
+{
+    using System.Collections.ObjectModel;
+    using System.Globalization;
+    using System.IdentityModel.Selectors;
+    using System.IdentityModel.Tokens;
+    using System.Runtime;
+    using System.ServiceModel;
+    using System.ServiceModel.Channels;
+    using System.ServiceModel.Security;
+    using System.Text;
+    using System.Xml;
+
+    public class IssuedSecurityTokenParameters : SecurityTokenParameters
+    {
+        const string wsidPrefix = "wsid";
+        const string wsidNamespace = "http://schemas.xmlsoap.org/ws/2005/05/identity";
+        static readonly string wsidPPIClaim = String.Format(CultureInfo.InvariantCulture, "{0}/claims/privatepersonalidentifier", wsidNamespace);
+        internal const SecurityKeyType defaultKeyType = SecurityKeyType.SymmetricKey;
+        internal const bool defaultUseStrTransform = false;
+
+        internal struct AlternativeIssuerEndpoint
+        {
+            public EndpointAddress IssuerAddress;
+            public EndpointAddress IssuerMetadataAddress;
+            public Binding IssuerBinding;
+        }
+
+        Collection<XmlElement> additionalRequestParameters = new Collection<XmlElement>();
+        Collection<AlternativeIssuerEndpoint> alternativeIssuerEndpoints = new Collection<AlternativeIssuerEndpoint>();
+        MessageSecurityVersion defaultMessageSecurityVersion;
+        EndpointAddress issuerAddress;
+        EndpointAddress issuerMetadataAddress;
+        Binding issuerBinding;
+        int keySize;
+        SecurityKeyType keyType = defaultKeyType;
+        Collection<ClaimTypeRequirement> claimTypeRequirements = new Collection<ClaimTypeRequirement>();
+        bool useStrTransform = defaultUseStrTransform;
+        string tokenType;
+
+        protected IssuedSecurityTokenParameters(IssuedSecurityTokenParameters other)
+            : base(other)
+        {
+            this.defaultMessageSecurityVersion = other.defaultMessageSecurityVersion;
+            this.issuerAddress = other.issuerAddress;
+            this.keyType = other.keyType;
+            this.tokenType = other.tokenType;
+            this.keySize = other.keySize;
+            this.useStrTransform = other.useStrTransform;
+
+            foreach (XmlElement parameter in other.additionalRequestParameters)
+            {
+                this.additionalRequestParameters.Add((XmlElement)parameter.Clone());
+            }
+            foreach (ClaimTypeRequirement c in other.claimTypeRequirements)
+            {
+                this.claimTypeRequirements.Add(c);
+            }
+            if (other.issuerBinding != null)
+            {
+                this.issuerBinding = new CustomBinding(other.issuerBinding);
+            }
+            this.issuerMetadataAddress = other.issuerMetadataAddress;
+        }
+
+        public IssuedSecurityTokenParameters()
+            : this(null, null, null)
+        {
+            // empty
+        }
+
+        public IssuedSecurityTokenParameters(string tokenType)
+            : this(tokenType, null, null)
+        {
+            // empty
+        }
+
+        public IssuedSecurityTokenParameters(string tokenType, EndpointAddress issuerAddress)
+            : this(tokenType, issuerAddress, null)
+        {
+            // empty
+        }
+
+        public IssuedSecurityTokenParameters(string tokenType, EndpointAddress issuerAddress, Binding issuerBinding)
+            : base()
+        {
+            this.tokenType = tokenType;
+            this.issuerAddress = issuerAddress;
+            this.issuerBinding = issuerBinding;
+        }
+
+        internal protected override bool HasAsymmetricKey { get { return this.KeyType == SecurityKeyType.AsymmetricKey; } }
+
+        public Collection<XmlElement> AdditionalRequestParameters
+        {
+            get
+            {
+                return this.additionalRequestParameters;
+            }
+        }
+
+        public MessageSecurityVersion DefaultMessageSecurityVersion
+        {
+            get
+            {
+                return this.defaultMessageSecurityVersion;
+            }
+
+            set
+            {
+                defaultMessageSecurityVersion = value;
+            }
+        }
+
+        internal Collection<AlternativeIssuerEndpoint> AlternativeIssuerEndpoints
+        {
+            get
+            {
+                return this.alternativeIssuerEndpoints;
+            }
+        }
+
+        public EndpointAddress IssuerAddress
+        {
+            get
+            {
+                return this.issuerAddress;
+            }
+            set
+            {
+                this.issuerAddress = value;
+            }
+        }
+
+        public EndpointAddress IssuerMetadataAddress
+        {
+            get
+            {
+                return this.issuerMetadataAddress;
+            }
+            set
+            {
+                this.issuerMetadataAddress = value;
+            }
+        }
+
+        public Binding IssuerBinding
+        {
+            get
+            {
+                return this.issuerBinding;
+            }
+            set
+            {
+                this.issuerBinding = value;
+            }
+        }
+
+        public SecurityKeyType KeyType
+        {
+            get
+            {
+                return this.keyType;
+            }
+            set
+            {
+                SecurityKeyTypeHelper.Validate(value);
+                this.keyType = value;
+            }
+        }
+
+        public int KeySize
+        {
+            get
+            {
+                return this.keySize;
+            }
+            set
+            {
+                if (value < 0)
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("value", SR.GetString(SR.ValueMustBeNonNegative)));
+                this.keySize = value;
+            }
+        }
+
+        public bool UseStrTransform
+        {
+            get
+            {
+                return this.useStrTransform;
+            }
+            set
+            {
+                this.useStrTransform = value;
+            }
+        }
+
+        public Collection<ClaimTypeRequirement> ClaimTypeRequirements
+        {
+            get
+            {
+                return this.claimTypeRequirements;
+            }
+        }
+
+        public string TokenType
+        {
+            get
+            {
+                return this.tokenType;
+            }
+            set
+            {
+                this.tokenType = value;
+            }
+        }
+
+        internal protected override bool SupportsClientAuthentication { get { return true; } }
+        internal protected override bool SupportsServerAuthentication { get { return true; } }
+        internal protected override bool SupportsClientWindowsIdentity { get { return false; } }
+
+        protected override SecurityTokenParameters CloneCore()
+        {
+            return new IssuedSecurityTokenParameters(this);
+        }
+
+        internal protected override SecurityKeyIdentifierClause CreateKeyIdentifierClause(SecurityToken token, SecurityTokenReferenceStyle referenceStyle)
+        {
+            if (token is GenericXmlSecurityToken)
+                return base.CreateGenericXmlTokenKeyIdentifierClause(token, referenceStyle);
+            else
+                return this.CreateKeyIdentifierClause<SamlAssertionKeyIdentifierClause, SamlAssertionKeyIdentifierClause>(token, referenceStyle);
+        }
+
+        internal void SetRequestParameters(Collection<XmlElement> requestParameters, TrustDriver trustDriver)
+        {
+            if (requestParameters == null)
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("requestParameters");
+
+            if (trustDriver == null)
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("trustDriver");
+
+            Collection<XmlElement> unknownRequestParameters = new Collection<XmlElement>();
+
+            foreach (XmlElement element in requestParameters)
+            {
+                int keySize;
+                string tokenType;
+                SecurityKeyType keyType;
+                Collection<XmlElement> requiredClaims;
+                if (trustDriver.TryParseKeySizeElement(element, out keySize))
+                    this.keySize = keySize;
+                else if (trustDriver.TryParseKeyTypeElement(element, out keyType))
+                    this.KeyType = keyType;
+                else if (trustDriver.TryParseTokenTypeElement(element, out tokenType))
+                    this.TokenType = tokenType;
+                // Only copy RP policy to client policy for TrustFeb2005
+                else if (trustDriver.StandardsManager.TrustVersion == TrustVersion.WSTrustFeb2005)
+                {
+                    if (trustDriver.TryParseRequiredClaimsElement(element, out requiredClaims))
+                    {
+                        Collection<XmlElement> unrecognizedRequiredClaims = new Collection<XmlElement>();
+                        foreach (XmlElement claimRequirement in requiredClaims)
+                        {
+                            if (claimRequirement.LocalName == "ClaimType" && claimRequirement.NamespaceURI == wsidNamespace)
+                            {
+                                string claimValue = claimRequirement.GetAttribute("Uri", string.Empty);
+                                if (!string.IsNullOrEmpty(claimValue))
+                                {
+                                    ClaimTypeRequirement claimTypeRequirement;
+                                    string optional = claimRequirement.GetAttribute("Optional", string.Empty);
+                                    if (String.IsNullOrEmpty(optional))
+                                    {
+                                        claimTypeRequirement = new ClaimTypeRequirement(claimValue);
+                                    }
+                                    else
+                                    {
+                                        claimTypeRequirement = new ClaimTypeRequirement(claimValue, XmlConvert.ToBoolean(optional));
+                                    }
+
+                                    this.claimTypeRequirements.Add(claimTypeRequirement);
+                                }
+                            }
+                            else
+                            {
+                                unrecognizedRequiredClaims.Add(claimRequirement);
+                            }
+                        }
+                        if (unrecognizedRequiredClaims.Count > 0)
+                            unknownRequestParameters.Add(trustDriver.CreateRequiredClaimsElement(unrecognizedRequiredClaims));
+                    }
+                    else
+                    {
+                        unknownRequestParameters.Add(element);
+                    }
+                }
+            }
+
+            unknownRequestParameters = trustDriver.ProcessUnknownRequestParameters(unknownRequestParameters, requestParameters);
+            if (unknownRequestParameters.Count > 0)
+            {
+                for (int i = 0; i < unknownRequestParameters.Count; ++i)
+                    this.AdditionalRequestParameters.Add(unknownRequestParameters[i]);
+            }
+        }
+
+        public Collection<XmlElement> CreateRequestParameters(MessageSecurityVersion messageSecurityVersion, SecurityTokenSerializer securityTokenSerializer)
+        {
+            return CreateRequestParameters(SecurityUtils.CreateSecurityStandardsManager(messageSecurityVersion, securityTokenSerializer).TrustDriver);
+        }
+
+        internal Collection<XmlElement> CreateRequestParameters(TrustDriver driver)
+        {
+            if (driver == null)
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("driver");
+
+            Collection<XmlElement> result = new Collection<XmlElement>();
+
+            if (this.tokenType != null)
+            {
+                result.Add(driver.CreateTokenTypeElement(tokenType));
+            }
+
+            result.Add(driver.CreateKeyTypeElement(this.keyType));
+
+            if (this.keySize != 0)
+            {
+                result.Add(driver.CreateKeySizeElement(keySize));
+            }
+            if (this.claimTypeRequirements.Count > 0)
+            {
+                Collection<XmlElement> claimsElements = new Collection<XmlElement>();
+                XmlDocument doc = new XmlDocument();
+                foreach (ClaimTypeRequirement claimType in this.claimTypeRequirements)
+                {
+                    XmlElement element = doc.CreateElement(wsidPrefix, "ClaimType", wsidNamespace);
+                    XmlAttribute attr = doc.CreateAttribute("Uri");
+                    attr.Value = claimType.ClaimType;
+                    element.Attributes.Append(attr);
+                    if (claimType.IsOptional != ClaimTypeRequirement.DefaultIsOptional)
+                    {
+                        attr = doc.CreateAttribute("Optional");
+                        attr.Value = XmlConvert.ToString(claimType.IsOptional);
+                        element.Attributes.Append(attr);
+                    }
+                    claimsElements.Add(element);
+                }
+                result.Add(driver.CreateRequiredClaimsElement(claimsElements));
+            }
+
+            if (this.additionalRequestParameters.Count > 0)
+            {
+                Collection<XmlElement> trustNormalizedParameters = NormalizeAdditionalParameters(this.additionalRequestParameters,
+                                                                                                 driver,
+                                                                                                 (this.claimTypeRequirements.Count > 0));
+
+                foreach (XmlElement parameter in trustNormalizedParameters)
+                {
+                    result.Add(parameter);
+                }
+            }
+
+            return result;
+        }
+
+        private Collection<XmlElement> NormalizeAdditionalParameters(Collection<XmlElement> additionalParameters,
+                                                                     TrustDriver driver,
+                                                                     bool clientSideClaimTypeRequirementsSpecified)
+        {
+            // Ensure STS trust version is one of the currently supported versions: Feb 05 / Trust 1.3
+            Fx.Assert(((driver.StandardsManager.TrustVersion == TrustVersion.WSTrustFeb2005) ||
+                                           (driver.StandardsManager.TrustVersion == TrustVersion.WSTrust13)),
+                                           "Unsupported trust version specified for the STS.");
+
+            // We have a mismatch. Make a local copy of additionalParameters for making any potential modifications 
+            // as part of normalization
+            Collection<XmlElement> tmpCollection = new Collection<XmlElement>();
+            foreach (XmlElement e in additionalParameters)
+            {
+                tmpCollection.Add(e);
+            }
+
+
+            // 1. For Trust 1.3 EncryptionAlgorithm, CanonicalizationAlgorithm and KeyWrapAlgorithm should not be
+            //    specified as top-level element if "SecondaryParameters" element already specifies this.
+            if (driver.StandardsManager.TrustVersion == TrustVersion.WSTrust13)
+            {
+                Fx.Assert(driver.GetType() == typeof(WSTrustDec2005.DriverDec2005), "Invalid Trust Driver specified for Trust 1.3.");
+
+                XmlElement encryptionAlgorithmElement = null;
+                XmlElement canonicalizationAlgorithmElement = null;
+                XmlElement keyWrapAlgorithmElement = null;
+                XmlElement secondaryParameter = null;
+
+                for (int i = 0; i < tmpCollection.Count; ++i)
+                {
+                    string algorithm;
+
+                    if (driver.IsEncryptionAlgorithmElement(tmpCollection[i], out algorithm))
+                    {
+                        encryptionAlgorithmElement = tmpCollection[i];
+                    }
+                    else if (driver.IsCanonicalizationAlgorithmElement(tmpCollection[i], out algorithm))
+                    {
+                        canonicalizationAlgorithmElement = tmpCollection[i];
+                    }
+                    else if (driver.IsKeyWrapAlgorithmElement(tmpCollection[i], out algorithm))
+                    {
+                        keyWrapAlgorithmElement = tmpCollection[i];
+                    }
+                    else if (((WSTrustDec2005.DriverDec2005)driver).IsSecondaryParametersElement(tmpCollection[i]))
+                    {
+                        secondaryParameter = tmpCollection[i];
+                    }
+                }
+
+                if (secondaryParameter != null)
+                {
+                    foreach (XmlNode node in secondaryParameter.ChildNodes)
+                    {
+                        XmlElement child = node as XmlElement;
+                        if (child != null)
+                        {
+                            string algorithm = null;
+
+                            if (driver.IsEncryptionAlgorithmElement(child, out algorithm) && (encryptionAlgorithmElement != null))
+                            {
+                                tmpCollection.Remove(encryptionAlgorithmElement);
+                            }
+                            else if (driver.IsCanonicalizationAlgorithmElement(child, out algorithm) && (canonicalizationAlgorithmElement != null))
+                            {
+                                tmpCollection.Remove(canonicalizationAlgorithmElement);
+                            }
+                            else if (driver.IsKeyWrapAlgorithmElement(child, out algorithm) && (keyWrapAlgorithmElement != null))
+                            {
+                                tmpCollection.Remove(keyWrapAlgorithmElement);
+                            }
+                        }
+                    }
+                }
+            }
+
+            // 2. Check for Mismatch.
+            //      a. Trust Feb 2005 -> Trust 1.3. do the following,
+            //          (i) Copy EncryptionAlgorithm and CanonicalizationAlgorithm as the top-level elements.
+            //              Note, this is in contradiction to step 1. But we don't have a choice here as we cannot say from the 
+            //              Additional Parameters section in the config what came from the service and what came from the client.
+            //          (ii) Convert SignWith and EncryptWith elements to Trust 1.3 namespace.
+            //      b. For Trust 1.3 -> Trust Feb 2005, do the following,
+            //          (i) Find EncryptionAlgorithm, CanonicalizationAlgorithm from inside the "SecondaryParameters" element. 
+            //              If found, then promote these as the top-level elements replacing the existing values.
+            //          (ii) Convert the SignWith and EncryptWith elements to the Trust Feb 2005 namespace and drop the KeyWrapAlgorithm
+            //               element.
+
+            // make an optimistic check to detect mismatched trust-versions between STS and RP
+            bool mismatch = (((driver.StandardsManager.TrustVersion == TrustVersion.WSTrustFeb2005) &&
+                              !CollectionContainsElementsWithTrustNamespace(additionalParameters, TrustFeb2005Strings.Namespace)) ||
+                             ((driver.StandardsManager.TrustVersion == TrustVersion.WSTrust13) &&
+                              !CollectionContainsElementsWithTrustNamespace(additionalParameters, TrustDec2005Strings.Namespace)));
+            // if no mismatch, return unmodified collection
+            if (!mismatch)
+            {
+                return tmpCollection;
+            }
+
+            // 2.a
+            // If we are talking to a Trust 1.3 STS, replace any Feb '05 algorithm parameters with their Trust 1.3 counterparts
+            if (driver.StandardsManager.TrustVersion == TrustVersion.WSTrust13)
+            {
+                SecurityStandardsManager trustFeb2005StandardsManager = SecurityStandardsManager.DefaultInstance;
+                // the following cast is guaranteed to succeed
+                WSTrustFeb2005.DriverFeb2005 trustFeb2005Driver = (WSTrustFeb2005.DriverFeb2005)trustFeb2005StandardsManager.TrustDriver;
+
+                for (int i = 0; i < tmpCollection.Count; i++)
+                {
+                    string algorithmParameter = string.Empty;
+
+                    if (trustFeb2005Driver.IsSignWithElement(tmpCollection[i], out algorithmParameter))
+                    {
+                        tmpCollection[i] = driver.CreateSignWithElement(algorithmParameter);
+                    }
+                    else if (trustFeb2005Driver.IsEncryptWithElement(tmpCollection[i], out algorithmParameter))
+                    {
+                        tmpCollection[i] = driver.CreateEncryptWithElement(algorithmParameter);
+                    }
+                    else if (trustFeb2005Driver.IsEncryptionAlgorithmElement(tmpCollection[i], out algorithmParameter))
+                    {
+                        tmpCollection[i] = driver.CreateEncryptionAlgorithmElement(algorithmParameter);
+                    }
+                    else if (trustFeb2005Driver.IsCanonicalizationAlgorithmElement(tmpCollection[i], out algorithmParameter))
+                    {
+                        tmpCollection[i] = driver.CreateCanonicalizationAlgorithmElement(algorithmParameter);
+                    }
+                }
+            }
+            else
+            {
+                // 2.b
+                // We are talking to a Feb 05 STS. Filter out any SecondaryParameters element.
+                Collection<XmlElement> childrenToPromote = null;
+                WSSecurityTokenSerializer trust13Serializer = new WSSecurityTokenSerializer(SecurityVersion.WSSecurity11,
+                                                                                            TrustVersion.WSTrust13,
+                                                                                            SecureConversationVersion.WSSecureConversation13,
+                                                                                            true, null, null, null);
+                SecurityStandardsManager trust13StandardsManager = new SecurityStandardsManager(MessageSecurityVersion.WSSecurity11WSTrust13WSSecureConversation13WSSecurityPolicy12, trust13Serializer);
+                // the following cast is guaranteed to succeed
+                WSTrustDec2005.DriverDec2005 trust13Driver = (WSTrustDec2005.DriverDec2005)trust13StandardsManager.TrustDriver;
+
+                foreach (XmlElement parameter in tmpCollection)
+                {
+                    // check if SecondaryParameters is present
+                    if (trust13Driver.IsSecondaryParametersElement(parameter))
+                    {
+                        childrenToPromote = new Collection<XmlElement>();
+                        // walk SecondaryParameters and collect any 'non-standard' children
+                        foreach (XmlNode innerNode in parameter.ChildNodes)
+                        {
+                            XmlElement innerElement = innerNode as XmlElement;
+                            if ((innerElement != null) && CanPromoteToRoot(innerElement, trust13Driver, clientSideClaimTypeRequirementsSpecified))
+                            {
+                                childrenToPromote.Add(innerElement);
+                            }
+                        }
+
+                        // remove SecondaryParameters element
+                        tmpCollection.Remove(parameter);
+
+                        // we are done - break out of the loop
+                        break;
+                    }
+                }
+
+                // Probe of standard Trust elements and remember them.
+                if ((childrenToPromote != null) && (childrenToPromote.Count > 0))
+                {
+                    XmlElement encryptionElement = null;
+                    string encryptionAlgorithm = String.Empty;
+
+                    XmlElement canonicalizationElement = null;
+                    string canonicalizationAlgoritm = String.Empty;
+
+                    XmlElement requiredClaimsElement = null;
+                    Collection<XmlElement> requiredClaims = null;
+
+                    Collection<XmlElement> processedElements = new Collection<XmlElement>();
+
+                    foreach (XmlElement e in childrenToPromote)
+                    {
+                        if ((encryptionElement == null) && trust13Driver.IsEncryptionAlgorithmElement(e, out encryptionAlgorithm))
+                        {
+                            encryptionElement = driver.CreateEncryptionAlgorithmElement(encryptionAlgorithm);
+                            processedElements.Add(e);
+                        }
+                        else if ((canonicalizationElement == null) && trust13Driver.IsCanonicalizationAlgorithmElement(e, out canonicalizationAlgoritm))
+                        {
+                            canonicalizationElement = driver.CreateCanonicalizationAlgorithmElement(canonicalizationAlgoritm);
+                            processedElements.Add(e);
+                        }
+                        else if ((requiredClaimsElement == null) && trust13Driver.TryParseRequiredClaimsElement(e, out requiredClaims))
+                        {
+                            requiredClaimsElement = driver.CreateRequiredClaimsElement(requiredClaims);
+                            processedElements.Add(e);
+                        }
+                    }
+
+                    for (int i = 0; i < processedElements.Count; ++i)
+                    {
+                        childrenToPromote.Remove(processedElements[i]);
+                    }
+
+                    XmlElement keyWrapAlgorithmElement = null;
+
+                    // Replace the appropriate elements.
+                    for (int i = 0; i < tmpCollection.Count; ++i)
+                    {
+                        string algorithmParameter;
+                        Collection<XmlElement> reqClaims;
+
+                        if (trust13Driver.IsSignWithElement(tmpCollection[i], out algorithmParameter))
+                        {
+                            tmpCollection[i] = driver.CreateSignWithElement(algorithmParameter);
+                        }
+                        else if (trust13Driver.IsEncryptWithElement(tmpCollection[i], out algorithmParameter))
+                        {
+                            tmpCollection[i] = driver.CreateEncryptWithElement(algorithmParameter);
+                        }
+                        else if (trust13Driver.IsEncryptionAlgorithmElement(tmpCollection[i], out algorithmParameter) && (encryptionElement != null))
+                        {
+                            tmpCollection[i] = encryptionElement;
+                            encryptionElement = null;
+                        }
+                        else if (trust13Driver.IsCanonicalizationAlgorithmElement(tmpCollection[i], out algorithmParameter) && (canonicalizationElement != null))
+                        {
+                            tmpCollection[i] = canonicalizationElement;
+                            canonicalizationElement = null;
+                        }
+                        else if (trust13Driver.IsKeyWrapAlgorithmElement(tmpCollection[i], out algorithmParameter) && (keyWrapAlgorithmElement == null))
+                        {
+                            keyWrapAlgorithmElement = tmpCollection[i];
+                        }
+                        else if (trust13Driver.TryParseRequiredClaimsElement(tmpCollection[i], out reqClaims) && (requiredClaimsElement != null))
+                        {
+                            tmpCollection[i] = requiredClaimsElement;
+                            requiredClaimsElement = null;
+                        }
+                    }
+
+                    if (keyWrapAlgorithmElement != null)
+                    {
+                        // Remove KeyWrapAlgorithmElement as this is not define in Trust Feb 2005.
+                        tmpCollection.Remove(keyWrapAlgorithmElement);
+                    }
+
+                    // Add the remaining elements to the additionaParameters list to the end.
+                    if (encryptionElement != null) tmpCollection.Add(encryptionElement);
+                    if (canonicalizationElement != null) tmpCollection.Add(canonicalizationElement);
+                    if (requiredClaimsElement != null) tmpCollection.Add(requiredClaimsElement);
+
+                    if (childrenToPromote.Count > 0)
+                    {
+                        // There are some non-standard elements. Just bump them to the top-level element.
+                        for (int i = 0; i < childrenToPromote.Count; ++i)
+                        {
+                            tmpCollection.Add(childrenToPromote[i]);
+                        }
+                    }
+                }
+
+            }
+
+            return tmpCollection;
+        }
+
+        private bool CollectionContainsElementsWithTrustNamespace(Collection<XmlElement> collection, string trustNamespace)
+        {
+            for (int i = 0; i < collection.Count; i++)
+            {
+                if ((collection[i] != null) && (collection[i].NamespaceURI == trustNamespace))
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        private bool CanPromoteToRoot(XmlElement innerElement, WSTrustDec2005.DriverDec2005 trust13Driver, bool clientSideClaimTypeRequirementsSpecified)
+        {
+            SecurityKeyType dummyOutParamForKeyType;
+            int dummyOutParamForKeySize;
+            string dummyStringOutParam;
+            Collection<XmlElement> dummyOutParamForRequiredClaims = null;
+
+            // check if SecondaryParameters has claim requirements specified
+            if (trust13Driver.TryParseRequiredClaimsElement(innerElement, out dummyOutParamForRequiredClaims))
+            {
+                // if client has not specified any claim requirements, promote claim requirements 
+                // in SecondaryParameters to root level (and subsequently fix up the trust namespace)
+                return !clientSideClaimTypeRequirementsSpecified;
+            }
+
+            // KeySize, KeyType and TokenType were converted to top-level property values when the WSDL was
+            // imported, so drop it here. We check for EncryptWith and SignWith as these are Client specific algorithm values and we
+            // don't have to promote the service specified values. KeyWrapAlgorithm was never sent in the RST
+            // in V1 and hence we are dropping it here as well.
+            return (!trust13Driver.TryParseKeyTypeElement(innerElement, out dummyOutParamForKeyType) &&
+                    !trust13Driver.TryParseKeySizeElement(innerElement, out dummyOutParamForKeySize) &&
+                    !trust13Driver.TryParseTokenTypeElement(innerElement, out dummyStringOutParam) &&
+                    !trust13Driver.IsSignWithElement(innerElement, out dummyStringOutParam) &&
+                    !trust13Driver.IsEncryptWithElement(innerElement, out dummyStringOutParam) &&
+                    !trust13Driver.IsKeyWrapAlgorithmElement(innerElement, out dummyStringOutParam));
+        }
+
+        internal void AddAlgorithmParameters(SecurityAlgorithmSuite algorithmSuite, SecurityStandardsManager standardsManager, SecurityKeyType issuedKeyType)
+        {
+            this.additionalRequestParameters.Insert(0, standardsManager.TrustDriver.CreateEncryptionAlgorithmElement(algorithmSuite.DefaultEncryptionAlgorithm));
+            this.additionalRequestParameters.Insert(0, standardsManager.TrustDriver.CreateCanonicalizationAlgorithmElement(algorithmSuite.DefaultCanonicalizationAlgorithm));
+
+            if (this.keyType == SecurityKeyType.BearerKey)
+            {
+                // As the client does not have a proof token in the Bearer case
+                // we don't have any specific algorithms to request for.
+                return;
+            }
+
+            string signWithAlgorithm = (this.keyType == SecurityKeyType.SymmetricKey) ? algorithmSuite.DefaultSymmetricSignatureAlgorithm : algorithmSuite.DefaultAsymmetricSignatureAlgorithm;
+            this.additionalRequestParameters.Insert(0, standardsManager.TrustDriver.CreateSignWithElement(signWithAlgorithm));
+            string encryptWithAlgorithm;
+            if (issuedKeyType == SecurityKeyType.SymmetricKey)
+            {
+                encryptWithAlgorithm = algorithmSuite.DefaultEncryptionAlgorithm;
+            }
+            else
+            {
+                encryptWithAlgorithm = algorithmSuite.DefaultAsymmetricKeyWrapAlgorithm;
+            }
+            this.additionalRequestParameters.Insert(0, standardsManager.TrustDriver.CreateEncryptWithElement(encryptWithAlgorithm));
+
+            if (standardsManager.TrustVersion != TrustVersion.WSTrustFeb2005)
+            {
+                this.additionalRequestParameters.Insert(0, ((WSTrustDec2005.DriverDec2005)standardsManager.TrustDriver).CreateKeyWrapAlgorithmElement(algorithmSuite.DefaultAsymmetricKeyWrapAlgorithm));
+            }
+
+            return;
+        }
+
+        internal bool DoAlgorithmsMatch(SecurityAlgorithmSuite algorithmSuite, SecurityStandardsManager standardsManager, out Collection<XmlElement> otherRequestParameters)
+        {
+            bool doesSignWithAlgorithmMatch = false;
+            bool doesEncryptWithAlgorithmMatch = false;
+            bool doesEncryptionAlgorithmMatch = false;
+            bool doesCanonicalizationAlgorithmMatch = false;
+            bool doesKeyWrapAlgorithmMatch = false;
+            otherRequestParameters = new Collection<XmlElement>();
+            bool trustNormalizationPerformed = false;
+
+            Collection<XmlElement> trustVersionNormalizedParameterCollection;
+
+            // For Trust 1.3 we move all the additional parameters into the secondaryParameters
+            // element. So the list contains just one element called SecondaryParameters that 
+            // contains all the other elements as child elements.
+            if ((standardsManager.TrustVersion == TrustVersion.WSTrust13) &&
+                (this.AdditionalRequestParameters.Count == 1) &&
+                (((WSTrustDec2005.DriverDec2005)standardsManager.TrustDriver).IsSecondaryParametersElement(this.AdditionalRequestParameters[0])))
+            {
+                trustNormalizationPerformed = true;
+                trustVersionNormalizedParameterCollection = new Collection<XmlElement>();
+                foreach (XmlElement innerElement in this.AdditionalRequestParameters[0])
+                {
+                    trustVersionNormalizedParameterCollection.Add(innerElement);
+                }
+            }
+            else
+            {
+                trustVersionNormalizedParameterCollection = this.AdditionalRequestParameters;
+            }
+
+            for (int i = 0; i < trustVersionNormalizedParameterCollection.Count; i++)
+            {
+                string algorithm;
+                XmlElement element = trustVersionNormalizedParameterCollection[i];
+                if (standardsManager.TrustDriver.IsCanonicalizationAlgorithmElement(element, out algorithm))
+                {
+                    if (algorithmSuite.DefaultCanonicalizationAlgorithm != algorithm)
+                    {
+                        return false;
+                    }
+                    doesCanonicalizationAlgorithmMatch = true;
+                }
+                else if (standardsManager.TrustDriver.IsSignWithElement(element, out algorithm))
+                {
+                    if ((this.keyType == SecurityKeyType.SymmetricKey && algorithm != algorithmSuite.DefaultSymmetricSignatureAlgorithm)
+                        || (this.keyType == SecurityKeyType.AsymmetricKey && algorithm != algorithmSuite.DefaultAsymmetricSignatureAlgorithm))
+                    {
+                        return false;
+                    }
+                    doesSignWithAlgorithmMatch = true;
+                }
+                else if (standardsManager.TrustDriver.IsEncryptWithElement(element, out algorithm))
+                {
+                    if ((this.keyType == SecurityKeyType.SymmetricKey && algorithm != algorithmSuite.DefaultEncryptionAlgorithm)
+                        || (this.keyType == SecurityKeyType.AsymmetricKey && algorithm != algorithmSuite.DefaultAsymmetricKeyWrapAlgorithm))
+                    {
+                        return false;
+                    }
+                    doesEncryptWithAlgorithmMatch = true;
+                }
+                else if (standardsManager.TrustDriver.IsEncryptionAlgorithmElement(element, out algorithm))
+                {
+                    if (algorithm != algorithmSuite.DefaultEncryptionAlgorithm)
+                    {
+                        return false;
+                    }
+                    doesEncryptionAlgorithmMatch = true;
+                }
+                else if (standardsManager.TrustDriver.IsKeyWrapAlgorithmElement(element, out algorithm))
+                {
+                    if (algorithm != algorithmSuite.DefaultAsymmetricKeyWrapAlgorithm)
+                    {
+                        return false;
+                    }
+                    doesKeyWrapAlgorithmMatch = true;
+                }
+                else
+                {
+                    otherRequestParameters.Add(element);
+                }
+            }
+
+            // Undo normalization if performed
+            // move all back into secondaryParameters
+            if (trustNormalizationPerformed)
+            {
+                otherRequestParameters = this.AdditionalRequestParameters;
+            }
+
+            if (this.keyType == SecurityKeyType.BearerKey)
+            {
+                // As the client does not have a proof token in the Bearer case
+                // we don't have any specific algorithms to request for.
+                return true;
+            }
+            if (standardsManager.TrustVersion == TrustVersion.WSTrustFeb2005)
+            {
+                // For V1 compatibility check all algorithms
+                return (doesSignWithAlgorithmMatch && doesCanonicalizationAlgorithmMatch && doesEncryptionAlgorithmMatch && doesEncryptWithAlgorithmMatch);
+            }
+            else
+            {
+                return (doesSignWithAlgorithmMatch && doesCanonicalizationAlgorithmMatch && doesEncryptionAlgorithmMatch && doesEncryptWithAlgorithmMatch && doesKeyWrapAlgorithmMatch);
+            }
+        }
+
+        internal static IssuedSecurityTokenParameters CreateInfoCardParameters(SecurityStandardsManager standardsManager, SecurityAlgorithmSuite algorithm)
+        {
+            IssuedSecurityTokenParameters result = new IssuedSecurityTokenParameters(SecurityXXX2005Strings.SamlTokenType);
+            result.KeyType = SecurityKeyType.AsymmetricKey;
+            result.ClaimTypeRequirements.Add(new ClaimTypeRequirement(wsidPPIClaim));
+            result.IssuerAddress = null;
+            result.AddAlgorithmParameters(algorithm, standardsManager, result.KeyType);
+            return result;
+        }
+
+        internal static bool IsInfoCardParameters(IssuedSecurityTokenParameters parameters, SecurityStandardsManager standardsManager)
+        {
+            if (parameters == null)
+                return false;
+            if (parameters.TokenType != SecurityXXX2005Strings.SamlTokenType)
+                return false;
+            if (parameters.KeyType != SecurityKeyType.AsymmetricKey)
+                return false;
+
+            if (parameters.ClaimTypeRequirements.Count == 1)
+            {
+                ClaimTypeRequirement claimTypeRequirement = parameters.ClaimTypeRequirements[0] as ClaimTypeRequirement;
+                if (claimTypeRequirement == null)
+                    return false;
+                if (claimTypeRequirement.ClaimType != wsidPPIClaim)
+                    return false;
+            }
+            else if ((parameters.AdditionalRequestParameters != null) && (parameters.AdditionalRequestParameters.Count > 0))
+            {
+                // Check the AdditionalRequest Parameters to see if ClaimTypeRequirements got imported there.
+                bool claimTypeRequirementMatched = false;
+                XmlElement claimTypeRequirement = GetClaimTypeRequirement(parameters.AdditionalRequestParameters, standardsManager);
+                if (claimTypeRequirement != null && claimTypeRequirement.ChildNodes.Count == 1)
+                {
+                    XmlElement claimTypeElement = claimTypeRequirement.ChildNodes[0] as XmlElement;
+                    if (claimTypeElement != null)
+                    {
+                        XmlNode claimType = claimTypeElement.Attributes.GetNamedItem("Uri");
+                        if (claimType != null && claimType.Value == wsidPPIClaim)
+                        {
+                            claimTypeRequirementMatched = true;
+                        }
+                    }
+                }
+
+                if (!claimTypeRequirementMatched)
+                {
+                    return false;
+                }
+            }
+            else
+            {
+                return false;
+            }
+            if (parameters.IssuerAddress != null)
+                return false;
+            if (parameters.AlternativeIssuerEndpoints != null && parameters.AlternativeIssuerEndpoints.Count > 0)
+            {
+                return false;
+            }
+            return true;
+        }
+
+        // The method walks through the entire set of AdditionalRequestParameters and return the Claims Type requirement alone.
+        internal static XmlElement GetClaimTypeRequirement(Collection<XmlElement> additionalRequestParameters, SecurityStandardsManager standardsManager)
+        {
+            foreach (XmlElement requestParameter in additionalRequestParameters)
+            {
+                if ((requestParameter.LocalName == ((System.ServiceModel.Security.WSTrust.Driver)standardsManager.TrustDriver).DriverDictionary.Claims.Value) &&
+                    (requestParameter.NamespaceURI == ((System.ServiceModel.Security.WSTrust.Driver)standardsManager.TrustDriver).DriverDictionary.Namespace.Value))
+                {
+                    return requestParameter;
+                }
+
+                if ((requestParameter.LocalName == DXD.TrustDec2005Dictionary.SecondaryParameters.Value) &&
+                    (requestParameter.NamespaceURI == DXD.TrustDec2005Dictionary.Namespace.Value))
+                {
+                    Collection<XmlElement> secondaryParameters = new Collection<XmlElement>();
+                    foreach (XmlNode node in requestParameter.ChildNodes)
+                    {
+                        XmlElement nodeAsElement = node as XmlElement;
+                        if (nodeAsElement != null)
+                        {
+                            secondaryParameters.Add(nodeAsElement);
+                        }
+                    }
+                    XmlElement claimTypeRequirement = GetClaimTypeRequirement(secondaryParameters, standardsManager);
+                    if (claimTypeRequirement != null)
+                    {
+                        return claimTypeRequirement;
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        public override string ToString()
+        {
+            StringBuilder sb = new StringBuilder();
+            sb.AppendLine(base.ToString());
+
+            sb.AppendLine(String.Format(CultureInfo.InvariantCulture, "TokenType: {0}", this.tokenType == null ? "null" : this.tokenType));
+            sb.AppendLine(String.Format(CultureInfo.InvariantCulture, "KeyType: {0}", this.keyType.ToString()));
+            sb.AppendLine(String.Format(CultureInfo.InvariantCulture, "KeySize: {0}", this.keySize.ToString(CultureInfo.InvariantCulture)));
+            sb.AppendLine(String.Format(CultureInfo.InvariantCulture, "IssuerAddress: {0}", this.issuerAddress == null ? "null" : this.issuerAddress.ToString()));
+            sb.AppendLine(String.Format(CultureInfo.InvariantCulture, "IssuerMetadataAddress: {0}", this.issuerMetadataAddress == null ? "null" : this.issuerMetadataAddress.ToString()));
+            sb.AppendLine(String.Format(CultureInfo.InvariantCulture, "DefaultMessgeSecurityVersion: {0}", this.defaultMessageSecurityVersion == null ? "null" : this.defaultMessageSecurityVersion.ToString()));
+            sb.AppendLine(String.Format(CultureInfo.InvariantCulture, "UseStrTransform: {0}", this.useStrTransform.ToString()));
+
+            if (this.issuerBinding == null)
+            {
+                sb.AppendLine(String.Format(CultureInfo.InvariantCulture, "IssuerBinding: null"));
+            }
+            else
+            {
+                sb.AppendLine(String.Format(CultureInfo.InvariantCulture, "IssuerBinding:"));
+                BindingElementCollection bindingElements = this.issuerBinding.CreateBindingElements();
+                for (int i = 0; i < bindingElements.Count; i++)
+                {
+                    sb.AppendLine(String.Format(CultureInfo.InvariantCulture, "  BindingElement[{0}]:", i.ToString(CultureInfo.InvariantCulture)));
+                    sb.AppendLine("    " + bindingElements[i].ToString().Trim().Replace("\n", "\n    "));
+                }
+            }
+
+            if (this.claimTypeRequirements.Count == 0)
+            {
+                sb.AppendLine(String.Format(CultureInfo.InvariantCulture, "ClaimTypeRequirements: none"));
+            }
+            else
+            {
+                sb.AppendLine(String.Format(CultureInfo.InvariantCulture, "ClaimTypeRequirements:"));
+                for (int i = 0; i < this.claimTypeRequirements.Count; i++)
+                {
+                    sb.AppendLine(String.Format(CultureInfo.InvariantCulture, "  {0}, optional={1}", this.claimTypeRequirements[i].ClaimType, this.claimTypeRequirements[i].IsOptional));
+                }
+            }
+
+            return sb.ToString().Trim();
+        }
+
+        protected internal override void InitializeSecurityTokenRequirement(SecurityTokenRequirement requirement)
+        {
+            requirement.TokenType = this.TokenType;
+            requirement.RequireCryptographicToken = true;
+            requirement.KeyType = this.KeyType;
+
+            ServiceModelSecurityTokenRequirement serviceModelSecurityTokenRequirement = requirement as ServiceModelSecurityTokenRequirement;
+            if (serviceModelSecurityTokenRequirement != null)
+            {
+                serviceModelSecurityTokenRequirement.DefaultMessageSecurityVersion = this.DefaultMessageSecurityVersion;
+            }
+            else
+            {
+                requirement.Properties[ServiceModelSecurityTokenRequirement.DefaultMessageSecurityVersionProperty] = this.DefaultMessageSecurityVersion;
+            }
+
+            if (this.KeySize > 0)
+            {
+                requirement.KeySize = this.KeySize;
+            }
+            requirement.Properties[ServiceModelSecurityTokenRequirement.IssuerAddressProperty] = this.IssuerAddress;
+            if (this.IssuerBinding != null)
+            {
+                requirement.Properties[ServiceModelSecurityTokenRequirement.IssuerBindingProperty] = this.IssuerBinding;
+            }
+            requirement.Properties[ServiceModelSecurityTokenRequirement.IssuedSecurityTokenParametersProperty] = this.Clone();
+        }
+    }
+}

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/Tokens/IssuedSecurityTokenParameters.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/Tokens/IssuedSecurityTokenParameters.cs
@@ -1,26 +1,28 @@
-//-----------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation.  All rights reserved.
-//-----------------------------------------------------------------------------
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
+
+using System.Collections.ObjectModel;
+using System.Globalization;
+using System.IdentityModel.Selectors;
+using System.IdentityModel.Tokens;
+using System.Runtime;
+using System.ServiceModel;
+using System.ServiceModel.Channels;
+using System.ServiceModel.Security;
+using System.Text;
+using System.Xml;
 
 namespace System.ServiceModel.Security.Tokens
 {
-    using System.Collections.ObjectModel;
-    using System.Globalization;
-    using System.IdentityModel.Selectors;
-    using System.IdentityModel.Tokens;
-    using System.Runtime;
-    using System.ServiceModel;
-    using System.ServiceModel.Channels;
-    using System.ServiceModel.Security;
-    using System.Text;
-    using System.Xml;
+#pragma warning disable CS0219 // Issue #31 in progress -- remove this when fully implemented and all fields used
 
     public class IssuedSecurityTokenParameters : SecurityTokenParameters
     {
         const string wsidPrefix = "wsid";
         const string wsidNamespace = "http://schemas.xmlsoap.org/ws/2005/05/identity";
-        static readonly string wsidPPIClaim = String.Format(CultureInfo.InvariantCulture, "{0}/claims/privatepersonalidentifier", wsidNamespace);
+        static readonly string s_wsidPPIClaim = String.Format(CultureInfo.InvariantCulture, "{0}/claims/privatepersonalidentifier", wsidNamespace);
         internal const SecurityKeyType defaultKeyType = SecurityKeyType.SymmetricKey;
         internal const bool defaultUseStrTransform = false;
 
@@ -31,41 +33,42 @@ namespace System.ServiceModel.Security.Tokens
             public Binding IssuerBinding;
         }
 
-        Collection<XmlElement> additionalRequestParameters = new Collection<XmlElement>();
-        Collection<AlternativeIssuerEndpoint> alternativeIssuerEndpoints = new Collection<AlternativeIssuerEndpoint>();
-        MessageSecurityVersion defaultMessageSecurityVersion;
-        EndpointAddress issuerAddress;
-        EndpointAddress issuerMetadataAddress;
-        Binding issuerBinding;
-        int keySize;
-        SecurityKeyType keyType = defaultKeyType;
-        Collection<ClaimTypeRequirement> claimTypeRequirements = new Collection<ClaimTypeRequirement>();
-        bool useStrTransform = defaultUseStrTransform;
-        string tokenType;
+        private Collection<XmlElement> _additionalRequestParameters = new Collection<XmlElement>();
+        private Collection<AlternativeIssuerEndpoint> _alternativeIssuerEndpoints = new Collection<AlternativeIssuerEndpoint>();
+        private MessageSecurityVersion _defaultMessageSecurityVersion;
+        private EndpointAddress _issuerAddress;
+        private EndpointAddress _issuerMetadataAddress;
+        private Binding _issuerBinding;
+        private int _keySize;
+        private SecurityKeyType _keyType = defaultKeyType;
+        private Collection<ClaimTypeRequirement> _claimTypeRequirements = new Collection<ClaimTypeRequirement>();
+        private bool _useStrTransform = defaultUseStrTransform;
+        private string _tokenType;
 
         protected IssuedSecurityTokenParameters(IssuedSecurityTokenParameters other)
             : base(other)
         {
-            this.defaultMessageSecurityVersion = other.defaultMessageSecurityVersion;
-            this.issuerAddress = other.issuerAddress;
-            this.keyType = other.keyType;
-            this.tokenType = other.tokenType;
-            this.keySize = other.keySize;
-            this.useStrTransform = other.useStrTransform;
+            _defaultMessageSecurityVersion = other._defaultMessageSecurityVersion;
+            _issuerAddress = other._issuerAddress;
+            _keyType = other._keyType;
+            _tokenType = other._tokenType;
+            _keySize = other._keySize;
+            _useStrTransform = other._useStrTransform;
 
-            foreach (XmlElement parameter in other.additionalRequestParameters)
+            foreach (XmlElement parameter in other._additionalRequestParameters)
             {
-                this.additionalRequestParameters.Add((XmlElement)parameter.Clone());
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress (missing XmlElement.Clone)
+                //_additionalRequestParameters.Add((XmlElement)parameter.Clone());
             }
-            foreach (ClaimTypeRequirement c in other.claimTypeRequirements)
+            foreach (ClaimTypeRequirement c in other._claimTypeRequirements)
             {
-                this.claimTypeRequirements.Add(c);
+                _claimTypeRequirements.Add(c);
             }
-            if (other.issuerBinding != null)
+            if (other._issuerBinding != null)
             {
-                this.issuerBinding = new CustomBinding(other.issuerBinding);
+                _issuerBinding = new CustomBinding(other._issuerBinding);
             }
-            this.issuerMetadataAddress = other.issuerMetadataAddress;
+            _issuerMetadataAddress = other._issuerMetadataAddress;
         }
 
         public IssuedSecurityTokenParameters()
@@ -89,9 +92,9 @@ namespace System.ServiceModel.Security.Tokens
         public IssuedSecurityTokenParameters(string tokenType, EndpointAddress issuerAddress, Binding issuerBinding)
             : base()
         {
-            this.tokenType = tokenType;
-            this.issuerAddress = issuerAddress;
-            this.issuerBinding = issuerBinding;
+            _tokenType = tokenType;
+            _issuerAddress = issuerAddress;
+            _issuerBinding = issuerBinding;
         }
 
         internal protected override bool HasAsymmetricKey { get { return this.KeyType == SecurityKeyType.AsymmetricKey; } }
@@ -100,7 +103,7 @@ namespace System.ServiceModel.Security.Tokens
         {
             get
             {
-                return this.additionalRequestParameters;
+                return _additionalRequestParameters;
             }
         }
 
@@ -108,12 +111,12 @@ namespace System.ServiceModel.Security.Tokens
         {
             get
             {
-                return this.defaultMessageSecurityVersion;
+                return _defaultMessageSecurityVersion;
             }
 
             set
             {
-                defaultMessageSecurityVersion = value;
+                _defaultMessageSecurityVersion = value;
             }
         }
 
@@ -121,7 +124,7 @@ namespace System.ServiceModel.Security.Tokens
         {
             get
             {
-                return this.alternativeIssuerEndpoints;
+                return _alternativeIssuerEndpoints;
             }
         }
 
@@ -129,11 +132,11 @@ namespace System.ServiceModel.Security.Tokens
         {
             get
             {
-                return this.issuerAddress;
+                return _issuerAddress;
             }
             set
             {
-                this.issuerAddress = value;
+                _issuerAddress = value;
             }
         }
 
@@ -141,11 +144,11 @@ namespace System.ServiceModel.Security.Tokens
         {
             get
             {
-                return this.issuerMetadataAddress;
+                return _issuerMetadataAddress;
             }
             set
             {
-                this.issuerMetadataAddress = value;
+                _issuerMetadataAddress = value;
             }
         }
 
@@ -153,11 +156,11 @@ namespace System.ServiceModel.Security.Tokens
         {
             get
             {
-                return this.issuerBinding;
+                return _issuerBinding;
             }
             set
             {
-                this.issuerBinding = value;
+                _issuerBinding = value;
             }
         }
 
@@ -165,12 +168,12 @@ namespace System.ServiceModel.Security.Tokens
         {
             get
             {
-                return this.keyType;
+                return _keyType;
             }
             set
             {
                 SecurityKeyTypeHelper.Validate(value);
-                this.keyType = value;
+                _keyType = value;
             }
         }
 
@@ -178,13 +181,13 @@ namespace System.ServiceModel.Security.Tokens
         {
             get
             {
-                return this.keySize;
+                return _keySize;
             }
             set
             {
                 if (value < 0)
-                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("value", SR.GetString(SR.ValueMustBeNonNegative)));
-                this.keySize = value;
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("value", SR.Format(SR.ValueMustBeNonNegative)));
+                _keySize = value;
             }
         }
 
@@ -192,11 +195,11 @@ namespace System.ServiceModel.Security.Tokens
         {
             get
             {
-                return this.useStrTransform;
+                return _useStrTransform;
             }
             set
             {
-                this.useStrTransform = value;
+                _useStrTransform = value;
             }
         }
 
@@ -204,7 +207,7 @@ namespace System.ServiceModel.Security.Tokens
         {
             get
             {
-                return this.claimTypeRequirements;
+                return _claimTypeRequirements;
             }
         }
 
@@ -212,11 +215,11 @@ namespace System.ServiceModel.Security.Tokens
         {
             get
             {
-                return this.tokenType;
+                return _tokenType;
             }
             set
             {
-                this.tokenType = value;
+                _tokenType = value;
             }
         }
 
@@ -234,79 +237,84 @@ namespace System.ServiceModel.Security.Tokens
             if (token is GenericXmlSecurityToken)
                 return base.CreateGenericXmlTokenKeyIdentifierClause(token, referenceStyle);
             else
-                return this.CreateKeyIdentifierClause<SamlAssertionKeyIdentifierClause, SamlAssertionKeyIdentifierClause>(token, referenceStyle);
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+                //return this.CreateKeyIdentifierClause<SamlAssertionKeyIdentifierClause, SamlAssertionKeyIdentifierClause>(token, referenceStyle);
+            }
         }
 
         internal void SetRequestParameters(Collection<XmlElement> requestParameters, TrustDriver trustDriver)
         {
-            if (requestParameters == null)
-                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("requestParameters");
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
 
-            if (trustDriver == null)
-                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("trustDriver");
+            //if (requestParameters == null)
+            //    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("requestParameters");
 
-            Collection<XmlElement> unknownRequestParameters = new Collection<XmlElement>();
+            //if (trustDriver == null)
+            //    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("trustDriver");
 
-            foreach (XmlElement element in requestParameters)
-            {
-                int keySize;
-                string tokenType;
-                SecurityKeyType keyType;
-                Collection<XmlElement> requiredClaims;
-                if (trustDriver.TryParseKeySizeElement(element, out keySize))
-                    this.keySize = keySize;
-                else if (trustDriver.TryParseKeyTypeElement(element, out keyType))
-                    this.KeyType = keyType;
-                else if (trustDriver.TryParseTokenTypeElement(element, out tokenType))
-                    this.TokenType = tokenType;
-                // Only copy RP policy to client policy for TrustFeb2005
-                else if (trustDriver.StandardsManager.TrustVersion == TrustVersion.WSTrustFeb2005)
-                {
-                    if (trustDriver.TryParseRequiredClaimsElement(element, out requiredClaims))
-                    {
-                        Collection<XmlElement> unrecognizedRequiredClaims = new Collection<XmlElement>();
-                        foreach (XmlElement claimRequirement in requiredClaims)
-                        {
-                            if (claimRequirement.LocalName == "ClaimType" && claimRequirement.NamespaceURI == wsidNamespace)
-                            {
-                                string claimValue = claimRequirement.GetAttribute("Uri", string.Empty);
-                                if (!string.IsNullOrEmpty(claimValue))
-                                {
-                                    ClaimTypeRequirement claimTypeRequirement;
-                                    string optional = claimRequirement.GetAttribute("Optional", string.Empty);
-                                    if (String.IsNullOrEmpty(optional))
-                                    {
-                                        claimTypeRequirement = new ClaimTypeRequirement(claimValue);
-                                    }
-                                    else
-                                    {
-                                        claimTypeRequirement = new ClaimTypeRequirement(claimValue, XmlConvert.ToBoolean(optional));
-                                    }
+            //Collection<XmlElement> unknownRequestParameters = new Collection<XmlElement>();
 
-                                    this.claimTypeRequirements.Add(claimTypeRequirement);
-                                }
-                            }
-                            else
-                            {
-                                unrecognizedRequiredClaims.Add(claimRequirement);
-                            }
-                        }
-                        if (unrecognizedRequiredClaims.Count > 0)
-                            unknownRequestParameters.Add(trustDriver.CreateRequiredClaimsElement(unrecognizedRequiredClaims));
-                    }
-                    else
-                    {
-                        unknownRequestParameters.Add(element);
-                    }
-                }
-            }
+            //foreach (XmlElement element in requestParameters)
+            //{
+            //    int keySize;
+            //    string tokenType;
+            //    SecurityKeyType keyType;
+            //    Collection<XmlElement> requiredClaims;
+            //    if (trustDriver.TryParseKeySizeElement(element, out keySize))
+            //        _keySize = keySize;
+            //    else if (trustDriver.TryParseKeyTypeElement(element, out keyType))
+            //        this.KeyType = keyType;
+            //    else if (trustDriver.TryParseTokenTypeElement(element, out tokenType))
+            //        this.TokenType = tokenType;
+            //    // Only copy RP policy to client policy for TrustFeb2005
+            //    else if (trustDriver.StandardsManager.TrustVersion == TrustVersion.WSTrustFeb2005)
+            //    {
+            //        if (trustDriver.TryParseRequiredClaimsElement(element, out requiredClaims))
+            //        {
+            //            Collection<XmlElement> unrecognizedRequiredClaims = new Collection<XmlElement>();
+            //            foreach (XmlElement claimRequirement in requiredClaims)
+            //            {
+            //                if (claimRequirement.LocalName == "ClaimType" && claimRequirement.NamespaceURI == wsidNamespace)
+            //                {
+            //                    string claimValue = claimRequirement.GetAttribute("Uri", string.Empty);
+            //                    if (!string.IsNullOrEmpty(claimValue))
+            //                    {
+            //                        ClaimTypeRequirement claimTypeRequirement;
+            //                        string optional = claimRequirement.GetAttribute("Optional", string.Empty);
+            //                        if (String.IsNullOrEmpty(optional))
+            //                        {
+            //                            claimTypeRequirement = new ClaimTypeRequirement(claimValue);
+            //                        }
+            //                        else
+            //                        {
+            //                            claimTypeRequirement = new ClaimTypeRequirement(claimValue, XmlConvert.ToBoolean(optional));
+            //                        }
 
-            unknownRequestParameters = trustDriver.ProcessUnknownRequestParameters(unknownRequestParameters, requestParameters);
-            if (unknownRequestParameters.Count > 0)
-            {
-                for (int i = 0; i < unknownRequestParameters.Count; ++i)
-                    this.AdditionalRequestParameters.Add(unknownRequestParameters[i]);
-            }
+            //                        _claimTypeRequirements.Add(claimTypeRequirement);
+            //                    }
+            //                }
+            //                else
+            //                {
+            //                    unrecognizedRequiredClaims.Add(claimRequirement);
+            //                }
+            //            }
+            //            if (unrecognizedRequiredClaims.Count > 0)
+            //                unknownRequestParameters.Add(trustDriver.CreateRequiredClaimsElement(unrecognizedRequiredClaims));
+            //        }
+            //        else
+            //        {
+            //            unknownRequestParameters.Add(element);
+            //        }
+            //    }
+            //}
+
+            //unknownRequestParameters = trustDriver.ProcessUnknownRequestParameters(unknownRequestParameters, requestParameters);
+            //if (unknownRequestParameters.Count > 0)
+            //{
+            //    for (int i = 0; i < unknownRequestParameters.Count; ++i)
+            //        this.AdditionalRequestParameters.Add(unknownRequestParameters[i]);
+            //}
         }
 
         public Collection<XmlElement> CreateRequestParameters(MessageSecurityVersion messageSecurityVersion, SecurityTokenSerializer securityTokenSerializer)
@@ -316,56 +324,58 @@ namespace System.ServiceModel.Security.Tokens
 
         internal Collection<XmlElement> CreateRequestParameters(TrustDriver driver)
         {
-            if (driver == null)
-                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("driver");
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
 
-            Collection<XmlElement> result = new Collection<XmlElement>();
+            //if (driver == null)
+            //    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("driver");
 
-            if (this.tokenType != null)
-            {
-                result.Add(driver.CreateTokenTypeElement(tokenType));
-            }
+            //Collection<XmlElement> result = new Collection<XmlElement>();
 
-            result.Add(driver.CreateKeyTypeElement(this.keyType));
+            //if (_tokenType != null)
+            //{
+            //    result.Add(driver.CreateTokenTypeElement(_tokenType));
+            //}
 
-            if (this.keySize != 0)
-            {
-                result.Add(driver.CreateKeySizeElement(keySize));
-            }
-            if (this.claimTypeRequirements.Count > 0)
-            {
-                Collection<XmlElement> claimsElements = new Collection<XmlElement>();
-                XmlDocument doc = new XmlDocument();
-                foreach (ClaimTypeRequirement claimType in this.claimTypeRequirements)
-                {
-                    XmlElement element = doc.CreateElement(wsidPrefix, "ClaimType", wsidNamespace);
-                    XmlAttribute attr = doc.CreateAttribute("Uri");
-                    attr.Value = claimType.ClaimType;
-                    element.Attributes.Append(attr);
-                    if (claimType.IsOptional != ClaimTypeRequirement.DefaultIsOptional)
-                    {
-                        attr = doc.CreateAttribute("Optional");
-                        attr.Value = XmlConvert.ToString(claimType.IsOptional);
-                        element.Attributes.Append(attr);
-                    }
-                    claimsElements.Add(element);
-                }
-                result.Add(driver.CreateRequiredClaimsElement(claimsElements));
-            }
+            //result.Add(driver.CreateKeyTypeElement(_keyType));
 
-            if (this.additionalRequestParameters.Count > 0)
-            {
-                Collection<XmlElement> trustNormalizedParameters = NormalizeAdditionalParameters(this.additionalRequestParameters,
-                                                                                                 driver,
-                                                                                                 (this.claimTypeRequirements.Count > 0));
+            //if (_keySize != 0)
+            //{
+            //    result.Add(driver.CreateKeySizeElement(_keySize));
+            //}
+            //if (_claimTypeRequirements.Count > 0)
+            //{
+            //    Collection<XmlElement> claimsElements = new Collection<XmlElement>();
+            //    XmlDocument doc = new XmlDocument();
+            //    foreach (ClaimTypeRequirement claimType in _claimTypeRequirements)
+            //    {
+            //        XmlElement element = doc.CreateElement(wsidPrefix, "ClaimType", wsidNamespace);
+            //        XmlAttribute attr = doc.CreateAttribute("Uri");
+            //        attr.Value = claimType.ClaimType;
+            //        element.Attributes.Append(attr);
+            //        if (claimType.IsOptional != ClaimTypeRequirement.DefaultIsOptional)
+            //        {
+            //            attr = doc.CreateAttribute("Optional");
+            //            attr.Value = XmlConvert.ToString(claimType.IsOptional);
+            //            element.Attributes.Append(attr);
+            //        }
+            //        claimsElements.Add(element);
+            //    }
+            //    result.Add(driver.CreateRequiredClaimsElement(claimsElements));
+            //}
 
-                foreach (XmlElement parameter in trustNormalizedParameters)
-                {
-                    result.Add(parameter);
-                }
-            }
+            //if (_additionalRequestParameters.Count > 0)
+            //{
+            //    Collection<XmlElement> trustNormalizedParameters = NormalizeAdditionalParameters(_additionalRequestParameters,
+            //                                                                                     driver,
+            //                                                                                     (_claimTypeRequirements.Count > 0));
 
-            return result;
+            //    foreach (XmlElement parameter in trustNormalizedParameters)
+            //    {
+            //        result.Add(parameter);
+            //    }
+            //}
+
+            //return result;
         }
 
         private Collection<XmlElement> NormalizeAdditionalParameters(Collection<XmlElement> additionalParameters,
@@ -390,59 +400,61 @@ namespace System.ServiceModel.Security.Tokens
             //    specified as top-level element if "SecondaryParameters" element already specifies this.
             if (driver.StandardsManager.TrustVersion == TrustVersion.WSTrust13)
             {
-                Fx.Assert(driver.GetType() == typeof(WSTrustDec2005.DriverDec2005), "Invalid Trust Driver specified for Trust 1.3.");
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
 
-                XmlElement encryptionAlgorithmElement = null;
-                XmlElement canonicalizationAlgorithmElement = null;
-                XmlElement keyWrapAlgorithmElement = null;
-                XmlElement secondaryParameter = null;
+                //Fx.Assert(driver.GetType() == typeof(WSTrustDec2005.DriverDec2005), "Invalid Trust Driver specified for Trust 1.3.");
 
-                for (int i = 0; i < tmpCollection.Count; ++i)
-                {
-                    string algorithm;
+                //XmlElement encryptionAlgorithmElement = null;
+                //XmlElement canonicalizationAlgorithmElement = null;
+                //XmlElement keyWrapAlgorithmElement = null;
+                //XmlElement secondaryParameter = null;
 
-                    if (driver.IsEncryptionAlgorithmElement(tmpCollection[i], out algorithm))
-                    {
-                        encryptionAlgorithmElement = tmpCollection[i];
-                    }
-                    else if (driver.IsCanonicalizationAlgorithmElement(tmpCollection[i], out algorithm))
-                    {
-                        canonicalizationAlgorithmElement = tmpCollection[i];
-                    }
-                    else if (driver.IsKeyWrapAlgorithmElement(tmpCollection[i], out algorithm))
-                    {
-                        keyWrapAlgorithmElement = tmpCollection[i];
-                    }
-                    else if (((WSTrustDec2005.DriverDec2005)driver).IsSecondaryParametersElement(tmpCollection[i]))
-                    {
-                        secondaryParameter = tmpCollection[i];
-                    }
-                }
+                //for (int i = 0; i < tmpCollection.Count; ++i)
+                //{
+                //    string algorithm;
 
-                if (secondaryParameter != null)
-                {
-                    foreach (XmlNode node in secondaryParameter.ChildNodes)
-                    {
-                        XmlElement child = node as XmlElement;
-                        if (child != null)
-                        {
-                            string algorithm = null;
+                //    if (driver.IsEncryptionAlgorithmElement(tmpCollection[i], out algorithm))
+                //    {
+                //        encryptionAlgorithmElement = tmpCollection[i];
+                //    }
+                //    else if (driver.IsCanonicalizationAlgorithmElement(tmpCollection[i], out algorithm))
+                //    {
+                //        canonicalizationAlgorithmElement = tmpCollection[i];
+                //    }
+                //    else if (driver.IsKeyWrapAlgorithmElement(tmpCollection[i], out algorithm))
+                //    {
+                //        keyWrapAlgorithmElement = tmpCollection[i];
+                //    }
+                //    else if (((WSTrustDec2005.DriverDec2005)driver).IsSecondaryParametersElement(tmpCollection[i]))
+                //    {
+                //        secondaryParameter = tmpCollection[i];
+                //    }
+                //}
 
-                            if (driver.IsEncryptionAlgorithmElement(child, out algorithm) && (encryptionAlgorithmElement != null))
-                            {
-                                tmpCollection.Remove(encryptionAlgorithmElement);
-                            }
-                            else if (driver.IsCanonicalizationAlgorithmElement(child, out algorithm) && (canonicalizationAlgorithmElement != null))
-                            {
-                                tmpCollection.Remove(canonicalizationAlgorithmElement);
-                            }
-                            else if (driver.IsKeyWrapAlgorithmElement(child, out algorithm) && (keyWrapAlgorithmElement != null))
-                            {
-                                tmpCollection.Remove(keyWrapAlgorithmElement);
-                            }
-                        }
-                    }
-                }
+                //if (secondaryParameter != null)
+                //{
+                //    foreach (XmlNode node in secondaryParameter.ChildNodes)
+                //    {
+                //        XmlElement child = node as XmlElement;
+                //        if (child != null)
+                //        {
+                //            string algorithm = null;
+
+                //            if (driver.IsEncryptionAlgorithmElement(child, out algorithm) && (encryptionAlgorithmElement != null))
+                //            {
+                //                tmpCollection.Remove(encryptionAlgorithmElement);
+                //            }
+                //            else if (driver.IsCanonicalizationAlgorithmElement(child, out algorithm) && (canonicalizationAlgorithmElement != null))
+                //            {
+                //                tmpCollection.Remove(canonicalizationAlgorithmElement);
+                //            }
+                //            else if (driver.IsKeyWrapAlgorithmElement(child, out algorithm) && (keyWrapAlgorithmElement != null))
+                //            {
+                //                tmpCollection.Remove(keyWrapAlgorithmElement);
+                //            }
+                //        }
+                //    }
+                //}
             }
 
             // 2. Check for Mismatch.
@@ -472,31 +484,33 @@ namespace System.ServiceModel.Security.Tokens
             // If we are talking to a Trust 1.3 STS, replace any Feb '05 algorithm parameters with their Trust 1.3 counterparts
             if (driver.StandardsManager.TrustVersion == TrustVersion.WSTrust13)
             {
-                SecurityStandardsManager trustFeb2005StandardsManager = SecurityStandardsManager.DefaultInstance;
-                // the following cast is guaranteed to succeed
-                WSTrustFeb2005.DriverFeb2005 trustFeb2005Driver = (WSTrustFeb2005.DriverFeb2005)trustFeb2005StandardsManager.TrustDriver;
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
 
-                for (int i = 0; i < tmpCollection.Count; i++)
-                {
-                    string algorithmParameter = string.Empty;
+                //SecurityStandardsManager trustFeb2005StandardsManager = SecurityStandardsManager.DefaultInstance;
+                //// the following cast is guaranteed to succeed
+                //WSTrustFeb2005.DriverFeb2005 trustFeb2005Driver = (WSTrustFeb2005.DriverFeb2005)trustFeb2005StandardsManager.TrustDriver;
 
-                    if (trustFeb2005Driver.IsSignWithElement(tmpCollection[i], out algorithmParameter))
-                    {
-                        tmpCollection[i] = driver.CreateSignWithElement(algorithmParameter);
-                    }
-                    else if (trustFeb2005Driver.IsEncryptWithElement(tmpCollection[i], out algorithmParameter))
-                    {
-                        tmpCollection[i] = driver.CreateEncryptWithElement(algorithmParameter);
-                    }
-                    else if (trustFeb2005Driver.IsEncryptionAlgorithmElement(tmpCollection[i], out algorithmParameter))
-                    {
-                        tmpCollection[i] = driver.CreateEncryptionAlgorithmElement(algorithmParameter);
-                    }
-                    else if (trustFeb2005Driver.IsCanonicalizationAlgorithmElement(tmpCollection[i], out algorithmParameter))
-                    {
-                        tmpCollection[i] = driver.CreateCanonicalizationAlgorithmElement(algorithmParameter);
-                    }
-                }
+                //for (int i = 0; i < tmpCollection.Count; i++)
+                //{
+                //    string algorithmParameter = string.Empty;
+
+                //    if (trustFeb2005Driver.IsSignWithElement(tmpCollection[i], out algorithmParameter))
+                //    {
+                //        tmpCollection[i] = driver.CreateSignWithElement(algorithmParameter);
+                //    }
+                //    else if (trustFeb2005Driver.IsEncryptWithElement(tmpCollection[i], out algorithmParameter))
+                //    {
+                //        tmpCollection[i] = driver.CreateEncryptWithElement(algorithmParameter);
+                //    }
+                //    else if (trustFeb2005Driver.IsEncryptionAlgorithmElement(tmpCollection[i], out algorithmParameter))
+                //    {
+                //        tmpCollection[i] = driver.CreateEncryptionAlgorithmElement(algorithmParameter);
+                //    }
+                //    else if (trustFeb2005Driver.IsCanonicalizationAlgorithmElement(tmpCollection[i], out algorithmParameter))
+                //    {
+                //        tmpCollection[i] = driver.CreateCanonicalizationAlgorithmElement(algorithmParameter);
+                //    }
+                //}
             }
             else
             {
@@ -538,97 +552,99 @@ namespace System.ServiceModel.Security.Tokens
                 // Probe of standard Trust elements and remember them.
                 if ((childrenToPromote != null) && (childrenToPromote.Count > 0))
                 {
-                    XmlElement encryptionElement = null;
-                    string encryptionAlgorithm = String.Empty;
+                    throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
 
-                    XmlElement canonicalizationElement = null;
-                    string canonicalizationAlgoritm = String.Empty;
+                    //XmlElement encryptionElement = null;
+                    //string encryptionAlgorithm = String.Empty;
 
-                    XmlElement requiredClaimsElement = null;
-                    Collection<XmlElement> requiredClaims = null;
+                    //XmlElement canonicalizationElement = null;
+                    //string canonicalizationAlgoritm = String.Empty;
 
-                    Collection<XmlElement> processedElements = new Collection<XmlElement>();
+                    //XmlElement requiredClaimsElement = null;
+                    //Collection<XmlElement> requiredClaims = null;
 
-                    foreach (XmlElement e in childrenToPromote)
-                    {
-                        if ((encryptionElement == null) && trust13Driver.IsEncryptionAlgorithmElement(e, out encryptionAlgorithm))
-                        {
-                            encryptionElement = driver.CreateEncryptionAlgorithmElement(encryptionAlgorithm);
-                            processedElements.Add(e);
-                        }
-                        else if ((canonicalizationElement == null) && trust13Driver.IsCanonicalizationAlgorithmElement(e, out canonicalizationAlgoritm))
-                        {
-                            canonicalizationElement = driver.CreateCanonicalizationAlgorithmElement(canonicalizationAlgoritm);
-                            processedElements.Add(e);
-                        }
-                        else if ((requiredClaimsElement == null) && trust13Driver.TryParseRequiredClaimsElement(e, out requiredClaims))
-                        {
-                            requiredClaimsElement = driver.CreateRequiredClaimsElement(requiredClaims);
-                            processedElements.Add(e);
-                        }
-                    }
+                    //Collection<XmlElement> processedElements = new Collection<XmlElement>();
 
-                    for (int i = 0; i < processedElements.Count; ++i)
-                    {
-                        childrenToPromote.Remove(processedElements[i]);
-                    }
+                    //foreach (XmlElement e in childrenToPromote)
+                    //{
+                    //    if ((encryptionElement == null) && trust13Driver.IsEncryptionAlgorithmElement(e, out encryptionAlgorithm))
+                    //    {
+                    //        encryptionElement = driver.CreateEncryptionAlgorithmElement(encryptionAlgorithm);
+                    //        processedElements.Add(e);
+                    //    }
+                    //    else if ((canonicalizationElement == null) && trust13Driver.IsCanonicalizationAlgorithmElement(e, out canonicalizationAlgoritm))
+                    //    {
+                    //        canonicalizationElement = driver.CreateCanonicalizationAlgorithmElement(canonicalizationAlgoritm);
+                    //        processedElements.Add(e);
+                    //    }
+                    //    else if ((requiredClaimsElement == null) && trust13Driver.TryParseRequiredClaimsElement(e, out requiredClaims))
+                    //    {
+                    //        requiredClaimsElement = driver.CreateRequiredClaimsElement(requiredClaims);
+                    //        processedElements.Add(e);
+                    //    }
+                    //}
 
-                    XmlElement keyWrapAlgorithmElement = null;
+                    //for (int i = 0; i < processedElements.Count; ++i)
+                    //{
+                    //    childrenToPromote.Remove(processedElements[i]);
+                    //}
 
-                    // Replace the appropriate elements.
-                    for (int i = 0; i < tmpCollection.Count; ++i)
-                    {
-                        string algorithmParameter;
-                        Collection<XmlElement> reqClaims;
+                    //XmlElement keyWrapAlgorithmElement = null;
 
-                        if (trust13Driver.IsSignWithElement(tmpCollection[i], out algorithmParameter))
-                        {
-                            tmpCollection[i] = driver.CreateSignWithElement(algorithmParameter);
-                        }
-                        else if (trust13Driver.IsEncryptWithElement(tmpCollection[i], out algorithmParameter))
-                        {
-                            tmpCollection[i] = driver.CreateEncryptWithElement(algorithmParameter);
-                        }
-                        else if (trust13Driver.IsEncryptionAlgorithmElement(tmpCollection[i], out algorithmParameter) && (encryptionElement != null))
-                        {
-                            tmpCollection[i] = encryptionElement;
-                            encryptionElement = null;
-                        }
-                        else if (trust13Driver.IsCanonicalizationAlgorithmElement(tmpCollection[i], out algorithmParameter) && (canonicalizationElement != null))
-                        {
-                            tmpCollection[i] = canonicalizationElement;
-                            canonicalizationElement = null;
-                        }
-                        else if (trust13Driver.IsKeyWrapAlgorithmElement(tmpCollection[i], out algorithmParameter) && (keyWrapAlgorithmElement == null))
-                        {
-                            keyWrapAlgorithmElement = tmpCollection[i];
-                        }
-                        else if (trust13Driver.TryParseRequiredClaimsElement(tmpCollection[i], out reqClaims) && (requiredClaimsElement != null))
-                        {
-                            tmpCollection[i] = requiredClaimsElement;
-                            requiredClaimsElement = null;
-                        }
-                    }
+                    //// Replace the appropriate elements.
+                    //for (int i = 0; i < tmpCollection.Count; ++i)
+                    //{
+                    //    string algorithmParameter;
+                    //    Collection<XmlElement> reqClaims;
 
-                    if (keyWrapAlgorithmElement != null)
-                    {
-                        // Remove KeyWrapAlgorithmElement as this is not define in Trust Feb 2005.
-                        tmpCollection.Remove(keyWrapAlgorithmElement);
-                    }
+                    //    if (trust13Driver.IsSignWithElement(tmpCollection[i], out algorithmParameter))
+                    //    {
+                    //        tmpCollection[i] = driver.CreateSignWithElement(algorithmParameter);
+                    //    }
+                    //    else if (trust13Driver.IsEncryptWithElement(tmpCollection[i], out algorithmParameter))
+                    //    {
+                    //        tmpCollection[i] = driver.CreateEncryptWithElement(algorithmParameter);
+                    //    }
+                    //    else if (trust13Driver.IsEncryptionAlgorithmElement(tmpCollection[i], out algorithmParameter) && (encryptionElement != null))
+                    //    {
+                    //        tmpCollection[i] = encryptionElement;
+                    //        encryptionElement = null;
+                    //    }
+                    //    else if (trust13Driver.IsCanonicalizationAlgorithmElement(tmpCollection[i], out algorithmParameter) && (canonicalizationElement != null))
+                    //    {
+                    //        tmpCollection[i] = canonicalizationElement;
+                    //        canonicalizationElement = null;
+                    //    }
+                    //    else if (trust13Driver.IsKeyWrapAlgorithmElement(tmpCollection[i], out algorithmParameter) && (keyWrapAlgorithmElement == null))
+                    //    {
+                    //        keyWrapAlgorithmElement = tmpCollection[i];
+                    //    }
+                    //    else if (trust13Driver.TryParseRequiredClaimsElement(tmpCollection[i], out reqClaims) && (requiredClaimsElement != null))
+                    //    {
+                    //        tmpCollection[i] = requiredClaimsElement;
+                    //        requiredClaimsElement = null;
+                    //    }
+                    //}
 
-                    // Add the remaining elements to the additionaParameters list to the end.
-                    if (encryptionElement != null) tmpCollection.Add(encryptionElement);
-                    if (canonicalizationElement != null) tmpCollection.Add(canonicalizationElement);
-                    if (requiredClaimsElement != null) tmpCollection.Add(requiredClaimsElement);
+                    //if (keyWrapAlgorithmElement != null)
+                    //{
+                    //    // Remove KeyWrapAlgorithmElement as this is not define in Trust Feb 2005.
+                    //    tmpCollection.Remove(keyWrapAlgorithmElement);
+                    //}
 
-                    if (childrenToPromote.Count > 0)
-                    {
-                        // There are some non-standard elements. Just bump them to the top-level element.
-                        for (int i = 0; i < childrenToPromote.Count; ++i)
-                        {
-                            tmpCollection.Add(childrenToPromote[i]);
-                        }
-                    }
+                    //// Add the remaining elements to the additionaParameters list to the end.
+                    //if (encryptionElement != null) tmpCollection.Add(encryptionElement);
+                    //if (canonicalizationElement != null) tmpCollection.Add(canonicalizationElement);
+                    //if (requiredClaimsElement != null) tmpCollection.Add(requiredClaimsElement);
+
+                    //if (childrenToPromote.Count > 0)
+                    //{
+                    //    // There are some non-standard elements. Just bump them to the top-level element.
+                    //    for (int i = 0; i < childrenToPromote.Count; ++i)
+                    //    {
+                    //        tmpCollection.Add(childrenToPromote[i]);
+                    //    }
+                    //}
                 }
 
             }
@@ -650,73 +666,77 @@ namespace System.ServiceModel.Security.Tokens
 
         private bool CanPromoteToRoot(XmlElement innerElement, WSTrustDec2005.DriverDec2005 trust13Driver, bool clientSideClaimTypeRequirementsSpecified)
         {
-            SecurityKeyType dummyOutParamForKeyType;
-            int dummyOutParamForKeySize;
-            string dummyStringOutParam;
-            Collection<XmlElement> dummyOutParamForRequiredClaims = null;
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
 
-            // check if SecondaryParameters has claim requirements specified
-            if (trust13Driver.TryParseRequiredClaimsElement(innerElement, out dummyOutParamForRequiredClaims))
-            {
-                // if client has not specified any claim requirements, promote claim requirements 
-                // in SecondaryParameters to root level (and subsequently fix up the trust namespace)
-                return !clientSideClaimTypeRequirementsSpecified;
-            }
+            //SecurityKeyType dummyOutParamForKeyType;
+            //int dummyOutParamForKeySize;
+            //string dummyStringOutParam;
+            //Collection<XmlElement> dummyOutParamForRequiredClaims = null;
 
-            // KeySize, KeyType and TokenType were converted to top-level property values when the WSDL was
-            // imported, so drop it here. We check for EncryptWith and SignWith as these are Client specific algorithm values and we
-            // don't have to promote the service specified values. KeyWrapAlgorithm was never sent in the RST
-            // in V1 and hence we are dropping it here as well.
-            return (!trust13Driver.TryParseKeyTypeElement(innerElement, out dummyOutParamForKeyType) &&
-                    !trust13Driver.TryParseKeySizeElement(innerElement, out dummyOutParamForKeySize) &&
-                    !trust13Driver.TryParseTokenTypeElement(innerElement, out dummyStringOutParam) &&
-                    !trust13Driver.IsSignWithElement(innerElement, out dummyStringOutParam) &&
-                    !trust13Driver.IsEncryptWithElement(innerElement, out dummyStringOutParam) &&
-                    !trust13Driver.IsKeyWrapAlgorithmElement(innerElement, out dummyStringOutParam));
+            //// check if SecondaryParameters has claim requirements specified
+            //if (trust13Driver.TryParseRequiredClaimsElement(innerElement, out dummyOutParamForRequiredClaims))
+            //{
+            //    // if client has not specified any claim requirements, promote claim requirements 
+            //    // in SecondaryParameters to root level (and subsequently fix up the trust namespace)
+            //    return !clientSideClaimTypeRequirementsSpecified;
+            //}
+
+            //// KeySize, KeyType and TokenType were converted to top-level property values when the WSDL was
+            //// imported, so drop it here. We check for EncryptWith and SignWith as these are Client specific algorithm values and we
+            //// don't have to promote the service specified values. KeyWrapAlgorithm was never sent in the RST
+            //// in V1 and hence we are dropping it here as well.
+            //return (!trust13Driver.TryParseKeyTypeElement(innerElement, out dummyOutParamForKeyType) &&
+            //        !trust13Driver.TryParseKeySizeElement(innerElement, out dummyOutParamForKeySize) &&
+            //        !trust13Driver.TryParseTokenTypeElement(innerElement, out dummyStringOutParam) &&
+            //        !trust13Driver.IsSignWithElement(innerElement, out dummyStringOutParam) &&
+            //        !trust13Driver.IsEncryptWithElement(innerElement, out dummyStringOutParam) &&
+            //        !trust13Driver.IsKeyWrapAlgorithmElement(innerElement, out dummyStringOutParam));
         }
 
         internal void AddAlgorithmParameters(SecurityAlgorithmSuite algorithmSuite, SecurityStandardsManager standardsManager, SecurityKeyType issuedKeyType)
         {
-            this.additionalRequestParameters.Insert(0, standardsManager.TrustDriver.CreateEncryptionAlgorithmElement(algorithmSuite.DefaultEncryptionAlgorithm));
-            this.additionalRequestParameters.Insert(0, standardsManager.TrustDriver.CreateCanonicalizationAlgorithmElement(algorithmSuite.DefaultCanonicalizationAlgorithm));
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+            //_additionalRequestParameters.Insert(0, standardsManager.TrustDriver.CreateEncryptionAlgorithmElement(algorithmSuite.DefaultEncryptionAlgorithm));
+            //_additionalRequestParameters.Insert(0, standardsManager.TrustDriver.CreateCanonicalizationAlgorithmElement(algorithmSuite.DefaultCanonicalizationAlgorithm));
 
-            if (this.keyType == SecurityKeyType.BearerKey)
-            {
-                // As the client does not have a proof token in the Bearer case
-                // we don't have any specific algorithms to request for.
-                return;
-            }
+            //if (_keyType == SecurityKeyType.BearerKey)
+            //{
+            //    // As the client does not have a proof token in the Bearer case
+            //    // we don't have any specific algorithms to request for.
+            //    return;
+            //}
 
-            string signWithAlgorithm = (this.keyType == SecurityKeyType.SymmetricKey) ? algorithmSuite.DefaultSymmetricSignatureAlgorithm : algorithmSuite.DefaultAsymmetricSignatureAlgorithm;
-            this.additionalRequestParameters.Insert(0, standardsManager.TrustDriver.CreateSignWithElement(signWithAlgorithm));
-            string encryptWithAlgorithm;
-            if (issuedKeyType == SecurityKeyType.SymmetricKey)
-            {
-                encryptWithAlgorithm = algorithmSuite.DefaultEncryptionAlgorithm;
-            }
-            else
-            {
-                encryptWithAlgorithm = algorithmSuite.DefaultAsymmetricKeyWrapAlgorithm;
-            }
-            this.additionalRequestParameters.Insert(0, standardsManager.TrustDriver.CreateEncryptWithElement(encryptWithAlgorithm));
+            //string signWithAlgorithm = (_keyType == SecurityKeyType.SymmetricKey) ? algorithmSuite.DefaultSymmetricSignatureAlgorithm : algorithmSuite.DefaultAsymmetricSignatureAlgorithm;
+            //_additionalRequestParameters.Insert(0, standardsManager.TrustDriver.CreateSignWithElement(signWithAlgorithm));
+            //string encryptWithAlgorithm;
+            //if (issuedKeyType == SecurityKeyType.SymmetricKey)
+            //{
+            //    encryptWithAlgorithm = algorithmSuite.DefaultEncryptionAlgorithm;
+            //}
+            //else
+            //{
+            //    encryptWithAlgorithm = algorithmSuite.DefaultAsymmetricKeyWrapAlgorithm;
+            //}
+            //_additionalRequestParameters.Insert(0, standardsManager.TrustDriver.CreateEncryptWithElement(encryptWithAlgorithm));
 
-            if (standardsManager.TrustVersion != TrustVersion.WSTrustFeb2005)
-            {
-                this.additionalRequestParameters.Insert(0, ((WSTrustDec2005.DriverDec2005)standardsManager.TrustDriver).CreateKeyWrapAlgorithmElement(algorithmSuite.DefaultAsymmetricKeyWrapAlgorithm));
-            }
+            //if (standardsManager.TrustVersion != TrustVersion.WSTrustFeb2005)
+            //{
+            //    _additionalRequestParameters.Insert(0, ((WSTrustDec2005.DriverDec2005)standardsManager.TrustDriver).CreateKeyWrapAlgorithmElement(algorithmSuite.DefaultAsymmetricKeyWrapAlgorithm));
+            //}
 
-            return;
+            //return;
         }
 
         internal bool DoAlgorithmsMatch(SecurityAlgorithmSuite algorithmSuite, SecurityStandardsManager standardsManager, out Collection<XmlElement> otherRequestParameters)
         {
+            // Issue #31 in progress
             bool doesSignWithAlgorithmMatch = false;
             bool doesEncryptWithAlgorithmMatch = false;
             bool doesEncryptionAlgorithmMatch = false;
             bool doesCanonicalizationAlgorithmMatch = false;
             bool doesKeyWrapAlgorithmMatch = false;
-            otherRequestParameters = new Collection<XmlElement>();
             bool trustNormalizationPerformed = false;
+            otherRequestParameters = new Collection<XmlElement>();
 
             Collection<XmlElement> trustVersionNormalizedParameterCollection;
 
@@ -739,87 +759,88 @@ namespace System.ServiceModel.Security.Tokens
                 trustVersionNormalizedParameterCollection = this.AdditionalRequestParameters;
             }
 
-            for (int i = 0; i < trustVersionNormalizedParameterCollection.Count; i++)
-            {
-                string algorithm;
-                XmlElement element = trustVersionNormalizedParameterCollection[i];
-                if (standardsManager.TrustDriver.IsCanonicalizationAlgorithmElement(element, out algorithm))
-                {
-                    if (algorithmSuite.DefaultCanonicalizationAlgorithm != algorithm)
-                    {
-                        return false;
-                    }
-                    doesCanonicalizationAlgorithmMatch = true;
-                }
-                else if (standardsManager.TrustDriver.IsSignWithElement(element, out algorithm))
-                {
-                    if ((this.keyType == SecurityKeyType.SymmetricKey && algorithm != algorithmSuite.DefaultSymmetricSignatureAlgorithm)
-                        || (this.keyType == SecurityKeyType.AsymmetricKey && algorithm != algorithmSuite.DefaultAsymmetricSignatureAlgorithm))
-                    {
-                        return false;
-                    }
-                    doesSignWithAlgorithmMatch = true;
-                }
-                else if (standardsManager.TrustDriver.IsEncryptWithElement(element, out algorithm))
-                {
-                    if ((this.keyType == SecurityKeyType.SymmetricKey && algorithm != algorithmSuite.DefaultEncryptionAlgorithm)
-                        || (this.keyType == SecurityKeyType.AsymmetricKey && algorithm != algorithmSuite.DefaultAsymmetricKeyWrapAlgorithm))
-                    {
-                        return false;
-                    }
-                    doesEncryptWithAlgorithmMatch = true;
-                }
-                else if (standardsManager.TrustDriver.IsEncryptionAlgorithmElement(element, out algorithm))
-                {
-                    if (algorithm != algorithmSuite.DefaultEncryptionAlgorithm)
-                    {
-                        return false;
-                    }
-                    doesEncryptionAlgorithmMatch = true;
-                }
-                else if (standardsManager.TrustDriver.IsKeyWrapAlgorithmElement(element, out algorithm))
-                {
-                    if (algorithm != algorithmSuite.DefaultAsymmetricKeyWrapAlgorithm)
-                    {
-                        return false;
-                    }
-                    doesKeyWrapAlgorithmMatch = true;
-                }
-                else
-                {
-                    otherRequestParameters.Add(element);
-                }
-            }
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+            //for (int i = 0; i < trustVersionNormalizedParameterCollection.Count; i++)
+            //{
+            //    string algorithm;
+            //    XmlElement element = trustVersionNormalizedParameterCollection[i];
+            //    if (standardsManager.TrustDriver.IsCanonicalizationAlgorithmElement(element, out algorithm))
+            //    {
+            //        if (algorithmSuite.DefaultCanonicalizationAlgorithm != algorithm)
+            //        {
+            //            return false;
+            //        }
+            //        doesCanonicalizationAlgorithmMatch = true;
+            //    }
+            //    else if (standardsManager.TrustDriver.IsSignWithElement(element, out algorithm))
+            //    {
+            //        if ((_keyType == SecurityKeyType.SymmetricKey && algorithm != algorithmSuite.DefaultSymmetricSignatureAlgorithm)
+            //            || (_keyType == SecurityKeyType.AsymmetricKey && algorithm != algorithmSuite.DefaultAsymmetricSignatureAlgorithm))
+            //        {
+            //            return false;
+            //        }
+            //        doesSignWithAlgorithmMatch = true;
+            //    }
+            //    else if (standardsManager.TrustDriver.IsEncryptWithElement(element, out algorithm))
+            //    {
+            //        if ((_keyType == SecurityKeyType.SymmetricKey && algorithm != algorithmSuite.DefaultEncryptionAlgorithm)
+            //            || (_keyType == SecurityKeyType.AsymmetricKey && algorithm != algorithmSuite.DefaultAsymmetricKeyWrapAlgorithm))
+            //        {
+            //            return false;
+            //        }
+            //        doesEncryptWithAlgorithmMatch = true;
+            //    }
+            //    else if (standardsManager.TrustDriver.IsEncryptionAlgorithmElement(element, out algorithm))
+            //    {
+            //        if (algorithm != algorithmSuite.DefaultEncryptionAlgorithm)
+            //        {
+            //            return false;
+            //        }
+            //        doesEncryptionAlgorithmMatch = true;
+            //    }
+            //    else if (standardsManager.TrustDriver.IsKeyWrapAlgorithmElement(element, out algorithm))
+            //    {
+            //        if (algorithm != algorithmSuite.DefaultAsymmetricKeyWrapAlgorithm)
+            //        {
+            //            return false;
+            //        }
+            //        doesKeyWrapAlgorithmMatch = true;
+            //    }
+            //    else
+            //    {
+            //        otherRequestParameters.Add(element);
+            //    }
+            //}
 
-            // Undo normalization if performed
-            // move all back into secondaryParameters
-            if (trustNormalizationPerformed)
-            {
-                otherRequestParameters = this.AdditionalRequestParameters;
-            }
+            //// Undo normalization if performed
+            //// move all back into secondaryParameters
+            //if (trustNormalizationPerformed)
+            //{
+            //    otherRequestParameters = this.AdditionalRequestParameters;
+            //}
 
-            if (this.keyType == SecurityKeyType.BearerKey)
-            {
-                // As the client does not have a proof token in the Bearer case
-                // we don't have any specific algorithms to request for.
-                return true;
-            }
-            if (standardsManager.TrustVersion == TrustVersion.WSTrustFeb2005)
-            {
-                // For V1 compatibility check all algorithms
-                return (doesSignWithAlgorithmMatch && doesCanonicalizationAlgorithmMatch && doesEncryptionAlgorithmMatch && doesEncryptWithAlgorithmMatch);
-            }
-            else
-            {
-                return (doesSignWithAlgorithmMatch && doesCanonicalizationAlgorithmMatch && doesEncryptionAlgorithmMatch && doesEncryptWithAlgorithmMatch && doesKeyWrapAlgorithmMatch);
-            }
+            //if (_keyType == SecurityKeyType.BearerKey)
+            //{
+            //    // As the client does not have a proof token in the Bearer case
+            //    // we don't have any specific algorithms to request for.
+            //    return true;
+            //}
+            //if (standardsManager.TrustVersion == TrustVersion.WSTrustFeb2005)
+            //{
+            //    // For V1 compatibility check all algorithms
+            //    return (doesSignWithAlgorithmMatch && doesCanonicalizationAlgorithmMatch && doesEncryptionAlgorithmMatch && doesEncryptWithAlgorithmMatch);
+            //}
+            //else
+            //{
+            //    return (doesSignWithAlgorithmMatch && doesCanonicalizationAlgorithmMatch && doesEncryptionAlgorithmMatch && doesEncryptWithAlgorithmMatch && doesKeyWrapAlgorithmMatch);
+            //}
         }
 
         internal static IssuedSecurityTokenParameters CreateInfoCardParameters(SecurityStandardsManager standardsManager, SecurityAlgorithmSuite algorithm)
         {
             IssuedSecurityTokenParameters result = new IssuedSecurityTokenParameters(SecurityXXX2005Strings.SamlTokenType);
             result.KeyType = SecurityKeyType.AsymmetricKey;
-            result.ClaimTypeRequirements.Add(new ClaimTypeRequirement(wsidPPIClaim));
+            result.ClaimTypeRequirements.Add(new ClaimTypeRequirement(s_wsidPPIClaim));
             result.IssuerAddress = null;
             result.AddAlgorithmParameters(algorithm, standardsManager, result.KeyType);
             return result;
@@ -839,7 +860,7 @@ namespace System.ServiceModel.Security.Tokens
                 ClaimTypeRequirement claimTypeRequirement = parameters.ClaimTypeRequirements[0] as ClaimTypeRequirement;
                 if (claimTypeRequirement == null)
                     return false;
-                if (claimTypeRequirement.ClaimType != wsidPPIClaim)
+                if (claimTypeRequirement.ClaimType != s_wsidPPIClaim)
                     return false;
             }
             else if ((parameters.AdditionalRequestParameters != null) && (parameters.AdditionalRequestParameters.Count > 0))
@@ -853,7 +874,7 @@ namespace System.ServiceModel.Security.Tokens
                     if (claimTypeElement != null)
                     {
                         XmlNode claimType = claimTypeElement.Attributes.GetNamedItem("Uri");
-                        if (claimType != null && claimType.Value == wsidPPIClaim)
+                        if (claimType != null && claimType.Value == s_wsidPPIClaim)
                         {
                             claimTypeRequirementMatched = true;
                         }
@@ -917,22 +938,22 @@ namespace System.ServiceModel.Security.Tokens
             StringBuilder sb = new StringBuilder();
             sb.AppendLine(base.ToString());
 
-            sb.AppendLine(String.Format(CultureInfo.InvariantCulture, "TokenType: {0}", this.tokenType == null ? "null" : this.tokenType));
-            sb.AppendLine(String.Format(CultureInfo.InvariantCulture, "KeyType: {0}", this.keyType.ToString()));
-            sb.AppendLine(String.Format(CultureInfo.InvariantCulture, "KeySize: {0}", this.keySize.ToString(CultureInfo.InvariantCulture)));
-            sb.AppendLine(String.Format(CultureInfo.InvariantCulture, "IssuerAddress: {0}", this.issuerAddress == null ? "null" : this.issuerAddress.ToString()));
-            sb.AppendLine(String.Format(CultureInfo.InvariantCulture, "IssuerMetadataAddress: {0}", this.issuerMetadataAddress == null ? "null" : this.issuerMetadataAddress.ToString()));
-            sb.AppendLine(String.Format(CultureInfo.InvariantCulture, "DefaultMessgeSecurityVersion: {0}", this.defaultMessageSecurityVersion == null ? "null" : this.defaultMessageSecurityVersion.ToString()));
-            sb.AppendLine(String.Format(CultureInfo.InvariantCulture, "UseStrTransform: {0}", this.useStrTransform.ToString()));
+            sb.AppendLine(String.Format(CultureInfo.InvariantCulture, "TokenType: {0}", _tokenType == null ? "null" : _tokenType));
+            sb.AppendLine(String.Format(CultureInfo.InvariantCulture, "KeyType: {0}", _keyType.ToString()));
+            sb.AppendLine(String.Format(CultureInfo.InvariantCulture, "KeySize: {0}", _keySize.ToString(CultureInfo.InvariantCulture)));
+            sb.AppendLine(String.Format(CultureInfo.InvariantCulture, "IssuerAddress: {0}", _issuerAddress == null ? "null" : _issuerAddress.ToString()));
+            sb.AppendLine(String.Format(CultureInfo.InvariantCulture, "IssuerMetadataAddress: {0}", _issuerMetadataAddress == null ? "null" : _issuerMetadataAddress.ToString()));
+            sb.AppendLine(String.Format(CultureInfo.InvariantCulture, "DefaultMessgeSecurityVersion: {0}", _defaultMessageSecurityVersion == null ? "null" : _defaultMessageSecurityVersion.ToString()));
+            sb.AppendLine(String.Format(CultureInfo.InvariantCulture, "UseStrTransform: {0}", _useStrTransform.ToString()));
 
-            if (this.issuerBinding == null)
+            if (_issuerBinding == null)
             {
                 sb.AppendLine(String.Format(CultureInfo.InvariantCulture, "IssuerBinding: null"));
             }
             else
             {
                 sb.AppendLine(String.Format(CultureInfo.InvariantCulture, "IssuerBinding:"));
-                BindingElementCollection bindingElements = this.issuerBinding.CreateBindingElements();
+                BindingElementCollection bindingElements = _issuerBinding.CreateBindingElements();
                 for (int i = 0; i < bindingElements.Count; i++)
                 {
                     sb.AppendLine(String.Format(CultureInfo.InvariantCulture, "  BindingElement[{0}]:", i.ToString(CultureInfo.InvariantCulture)));
@@ -940,16 +961,16 @@ namespace System.ServiceModel.Security.Tokens
                 }
             }
 
-            if (this.claimTypeRequirements.Count == 0)
+            if (_claimTypeRequirements.Count == 0)
             {
                 sb.AppendLine(String.Format(CultureInfo.InvariantCulture, "ClaimTypeRequirements: none"));
             }
             else
             {
                 sb.AppendLine(String.Format(CultureInfo.InvariantCulture, "ClaimTypeRequirements:"));
-                for (int i = 0; i < this.claimTypeRequirements.Count; i++)
+                for (int i = 0; i < _claimTypeRequirements.Count; i++)
                 {
-                    sb.AppendLine(String.Format(CultureInfo.InvariantCulture, "  {0}, optional={1}", this.claimTypeRequirements[i].ClaimType, this.claimTypeRequirements[i].IsOptional));
+                    sb.AppendLine(String.Format(CultureInfo.InvariantCulture, "  {0}, optional={1}", _claimTypeRequirements[i].ClaimType, _claimTypeRequirements[i].IsOptional));
                 }
             }
 

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/Tokens/IssuedSecurityTokenParameters.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/Tokens/IssuedSecurityTokenParameters.cs
@@ -8,9 +8,7 @@ using System.Globalization;
 using System.IdentityModel.Selectors;
 using System.IdentityModel.Tokens;
 using System.Runtime;
-using System.ServiceModel;
 using System.ServiceModel.Channels;
-using System.ServiceModel.Security;
 using System.Text;
 using System.Xml;
 
@@ -20,9 +18,9 @@ namespace System.ServiceModel.Security.Tokens
 
     public class IssuedSecurityTokenParameters : SecurityTokenParameters
     {
-        const string wsidPrefix = "wsid";
-        const string wsidNamespace = "http://schemas.xmlsoap.org/ws/2005/05/identity";
-        static readonly string s_wsidPPIClaim = String.Format(CultureInfo.InvariantCulture, "{0}/claims/privatepersonalidentifier", wsidNamespace);
+        private const string wsidPrefix = "wsid";
+        private const string wsidNamespace = "http://schemas.xmlsoap.org/ws/2005/05/identity";
+        private static readonly string s_wsidPPIClaim = String.Format(CultureInfo.InvariantCulture, "{0}/claims/privatepersonalidentifier", wsidNamespace);
         internal const SecurityKeyType defaultKeyType = SecurityKeyType.SymmetricKey;
         internal const bool defaultUseStrTransform = false;
 

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/Tokens/KerberosSecurityTokenParameters.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/Tokens/KerberosSecurityTokenParameters.cs
@@ -1,15 +1,14 @@
-//-----------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation.  All rights reserved.
-//-----------------------------------------------------------------------------
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
+using System.ServiceModel.Security;
+using System.ServiceModel;
+using System.IdentityModel.Selectors;
+using System.IdentityModel.Tokens;
 
 namespace System.ServiceModel.Security.Tokens
 {
-    using System.ServiceModel.Security;
-    using System.ServiceModel;
-    using System.IdentityModel.Selectors;
-    using System.IdentityModel.Tokens;
-
     public class KerberosSecurityTokenParameters : SecurityTokenParameters
     {
         protected KerberosSecurityTokenParameters(KerberosSecurityTokenParameters other)

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/Tokens/KerberosSecurityTokenParameters.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/Tokens/KerberosSecurityTokenParameters.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.ServiceModel.Security;
-using System.ServiceModel;
 using System.IdentityModel.Selectors;
 using System.IdentityModel.Tokens;
 

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/Tokens/KerberosSecurityTokenParameters.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/Tokens/KerberosSecurityTokenParameters.cs
@@ -1,0 +1,50 @@
+//-----------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//-----------------------------------------------------------------------------
+
+
+namespace System.ServiceModel.Security.Tokens
+{
+    using System.ServiceModel.Security;
+    using System.ServiceModel;
+    using System.IdentityModel.Selectors;
+    using System.IdentityModel.Tokens;
+
+    public class KerberosSecurityTokenParameters : SecurityTokenParameters
+    {
+        protected KerberosSecurityTokenParameters(KerberosSecurityTokenParameters other)
+            : base(other)
+        {
+            // empty
+        }
+
+        public KerberosSecurityTokenParameters()
+            : base()
+        {
+            this.InclusionMode = SecurityTokenInclusionMode.Once;
+        }
+
+        internal protected override bool HasAsymmetricKey { get { return false; } }
+        internal protected override bool SupportsClientAuthentication { get { return true; } }
+        internal protected override bool SupportsServerAuthentication { get { return true; } }
+        internal protected override bool SupportsClientWindowsIdentity { get { return true; } }
+
+        protected override SecurityTokenParameters CloneCore()
+        {
+            return new KerberosSecurityTokenParameters(this);
+        }
+
+        internal protected override SecurityKeyIdentifierClause CreateKeyIdentifierClause(SecurityToken token, SecurityTokenReferenceStyle referenceStyle)
+        {
+            return base.CreateKeyIdentifierClause<KerberosTicketHashKeyIdentifierClause, LocalIdKeyIdentifierClause>(token, referenceStyle);
+        }
+
+        protected internal override void InitializeSecurityTokenRequirement(SecurityTokenRequirement requirement)
+        {
+            requirement.TokenType = SecurityTokenTypes.Kerberos;
+            requirement.KeyType = SecurityKeyType.SymmetricKey;
+            requirement.RequireCryptographicToken = true;
+        }
+    }
+}
+

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/Tokens/ProviderBackedSecurityToken.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/Tokens/ProviderBackedSecurityToken.cs
@@ -1,0 +1,156 @@
+//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.IdentityModel.Selectors;
+using System.IdentityModel.Tokens;
+using System.Runtime;
+using System.Security.Cryptography;
+using System.Security.Authentication.ExtendedProtection;
+using System.ServiceModel.Diagnostics;
+
+namespace System.ServiceModel.Security.Tokens
+{
+    /// <summary>
+    /// The ProviderBackedSecurityToken was added for the ChannelBindingToken work for Win7.  
+    /// It is used to delay the resolution of a token until it is needed.  
+    /// For the CBT, this delay is necessary as the CBT is not available until SecurityAppliedMessage.OnWriteMessage is called.
+    /// The CBT binds a token to the 
+    /// </summary>
+    internal class ProviderBackedSecurityToken : SecurityToken
+    {
+        SecurityTokenProvider _tokenProvider;
+
+        // Double-checked locking pattern requires volatile for read/write synchronization
+        volatile SecurityToken _securityToken;
+        TimeSpan _timeout;
+        ChannelBinding _channelBinding;
+
+        object _lock;
+
+        /// <summary>
+        /// Constructor to create an instance of this class.
+        /// </summary>
+        /// <param name="securityToken">SecurityToken that represents the SecurityTokenElement element.</param>
+        public ProviderBackedSecurityToken( SecurityTokenProvider tokenProvider, TimeSpan timeout )
+        {
+            _lock = new object();
+
+            if ( tokenProvider == null )
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentNullException("tokenProvider"));
+            }
+
+            _tokenProvider = tokenProvider;
+            _timeout = timeout;
+        }
+
+        public SecurityTokenProvider TokenProvider
+        {
+            get { return _tokenProvider; }
+        }
+
+        public ChannelBinding ChannelBinding
+        {
+            set { _channelBinding = value; }
+        }
+
+        void ResolveSecurityToken()
+        {
+            if ( _securityToken == null )
+            {
+                lock ( _lock )
+                {
+                    if ( _securityToken == null )
+                    {
+                        ClientCredentialsSecurityTokenManager.KerberosSecurityTokenProviderWrapper kerbTokenProvider = _tokenProvider 
+                                                        as ClientCredentialsSecurityTokenManager.KerberosSecurityTokenProviderWrapper;
+                        if (kerbTokenProvider != null)
+                        {
+                            _securityToken = kerbTokenProvider.GetToken((new TimeoutHelper(_timeout)).RemainingTime(), _channelBinding);
+                        }
+                        else
+                        {
+                            _securityToken = _tokenProvider.GetToken((new TimeoutHelper(_timeout)).RemainingTime());
+                        }
+                    }
+                }
+            }
+
+            if ( _securityToken == null )
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError( new SecurityTokenException( SR.GetString( SR.SecurityTokenNotResolved, _tokenProvider.GetType().ToString() ) ) );
+            }
+
+            return;
+        }
+
+        public SecurityToken Token
+        {
+            get
+            {
+                if ( _securityToken == null )
+                {
+                    ResolveSecurityToken();
+                }
+
+                return _securityToken;
+            }
+        }
+
+        public override string Id
+        {
+            get
+            {
+                if ( _securityToken == null )
+                {
+                    ResolveSecurityToken();
+                }
+
+                return _securityToken.Id;
+            }
+        }
+
+        public override System.Collections.ObjectModel.ReadOnlyCollection<SecurityKey> SecurityKeys
+        {
+            get
+            {
+                if ( _securityToken == null )
+                {
+                    ResolveSecurityToken();
+                }
+
+                return _securityToken.SecurityKeys;
+            }   
+        }
+
+        public override DateTime ValidFrom
+        {
+            get
+            {
+                if ( _securityToken == null )
+                {
+                    ResolveSecurityToken();
+                }
+
+                return _securityToken.ValidFrom;
+            }
+        }
+
+        public override DateTime ValidTo
+        {
+            get
+            {
+                if ( _securityToken == null )
+                {
+                    ResolveSecurityToken();
+                }
+
+                return _securityToken.ValidTo;
+            }   
+        }
+    }
+}
+

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/Tokens/ProviderBackedSecurityToken.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/Tokens/ProviderBackedSecurityToken.cs
@@ -1,6 +1,6 @@
-//------------------------------------------------------------
-// Copyright (c) Microsoft Corporation.  All rights reserved.
-//------------------------------------------------------------
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;
@@ -21,14 +21,14 @@ namespace System.ServiceModel.Security.Tokens
     /// </summary>
     internal class ProviderBackedSecurityToken : SecurityToken
     {
-        SecurityTokenProvider _tokenProvider;
+        private SecurityTokenProvider _tokenProvider;
 
         // Double-checked locking pattern requires volatile for read/write synchronization
-        volatile SecurityToken _securityToken;
-        TimeSpan _timeout;
-        ChannelBinding _channelBinding;
+        private volatile SecurityToken _securityToken;
+        private TimeSpan _timeout;
+        private ChannelBinding _channelBinding;
 
-        object _lock;
+        private object _lock;
 
         /// <summary>
         /// Constructor to create an instance of this class.
@@ -69,7 +69,7 @@ namespace System.ServiceModel.Security.Tokens
                                                         as ClientCredentialsSecurityTokenManager.KerberosSecurityTokenProviderWrapper;
                         if (kerbTokenProvider != null)
                         {
-                            _securityToken = kerbTokenProvider.GetToken((new TimeoutHelper(_timeout)).RemainingTime(), _channelBinding);
+                            _securityToken = kerbTokenProvider.GetToken((new TimeoutHelper(_timeout)).RemainingTime());
                         }
                         else
                         {
@@ -81,7 +81,7 @@ namespace System.ServiceModel.Security.Tokens
 
             if ( _securityToken == null )
             {
-                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError( new SecurityTokenException( SR.GetString( SR.SecurityTokenNotResolved, _tokenProvider.GetType().ToString() ) ) );
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError( new SecurityTokenException( SR.Format( SR.SecurityTokenNotResolved, _tokenProvider.GetType().ToString() ) ) );
             }
 
             return;

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/Tokens/ProviderBackedSecurityToken.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/Tokens/ProviderBackedSecurityToken.cs
@@ -3,13 +3,10 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
 using System.IdentityModel.Selectors;
 using System.IdentityModel.Tokens;
 using System.Runtime;
-using System.Security.Cryptography;
 using System.Security.Authentication.ExtendedProtection;
-using System.ServiceModel.Diagnostics;
 
 namespace System.ServiceModel.Security.Tokens
 {

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/Tokens/SecurityContextCookieSerializer.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/Tokens/SecurityContextCookieSerializer.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IdentityModel.Claims;
@@ -14,8 +13,6 @@ using System.Security.Principal;
 using System.ServiceModel;
 using System.ServiceModel.Dispatcher;
 using System.Xml;
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace System.ServiceModel.Security.Tokens
 {

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/Tokens/SecurityContextCookieSerializer.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/Tokens/SecurityContextCookieSerializer.cs
@@ -4,14 +4,7 @@
 
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.IdentityModel.Claims;
 using System.IdentityModel.Policy;
-using System.IO;
-using System.Runtime;
-using System.Runtime.Serialization;
-using System.Security.Principal;
-using System.ServiceModel;
-using System.ServiceModel.Dispatcher;
 using System.Xml;
 
 namespace System.ServiceModel.Security.Tokens
@@ -37,7 +30,7 @@ namespace System.ServiceModel.Security.Tokens
             DateTime tokenExpirationTime, UniqueId keyGeneration, DateTime keyEffectiveTime, DateTime keyExpirationTime,
             ReadOnlyCollection<IAuthorizationPolicy> authorizationPolicies)
         {
-            throw ExceptionHelper.PlatformNotSupported();
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
         }
     }
 }

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/Tokens/SecurityTokenParameters.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/Tokens/SecurityTokenParameters.cs
@@ -80,8 +80,8 @@ namespace System.ServiceModel.Security.Tokens
         internal protected abstract void InitializeSecurityTokenRequirement(SecurityTokenRequirement requirement);
 
         internal SecurityKeyIdentifierClause CreateKeyIdentifierClause<TExternalClause, TInternalClause>(SecurityToken token, SecurityTokenReferenceStyle referenceStyle)
-    where TExternalClause : SecurityKeyIdentifierClause
-    where TInternalClause : SecurityKeyIdentifierClause
+                    where TExternalClause : SecurityKeyIdentifierClause
+                    where TInternalClause : SecurityKeyIdentifierClause
         {
             if (token == null)
                 throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("token");

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/Tokens/SecurityTokenParameters.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/Tokens/SecurityTokenParameters.cs
@@ -4,14 +4,18 @@
 
 
 using System.Globalization;
+using System.IdentityModel.Selectors;
+using System.IdentityModel.Tokens;
 using System.Text;
 
 namespace System.ServiceModel.Security.Tokens
 {
     public abstract class SecurityTokenParameters
     {
+        internal const SecurityTokenInclusionMode defaultInclusionMode = SecurityTokenInclusionMode.AlwaysToRecipient;
         internal const bool defaultRequireDerivedKeys = true;
 
+        private SecurityTokenInclusionMode _inclusionMode = defaultInclusionMode;
         private bool _requireDerivedKeys = defaultRequireDerivedKeys;
 
         protected SecurityTokenParameters(SecurityTokenParameters other)
@@ -19,6 +23,7 @@ namespace System.ServiceModel.Security.Tokens
             if (other == null)
                 throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("other");
 
+            _inclusionMode = other._inclusionMode;
             _requireDerivedKeys = other._requireDerivedKeys;
         }
 
@@ -28,6 +33,19 @@ namespace System.ServiceModel.Security.Tokens
         }
 
         internal protected abstract bool HasAsymmetricKey { get; }
+
+        public SecurityTokenInclusionMode InclusionMode
+        {
+            get
+            {
+                return _inclusionMode;
+            }
+            set
+            {
+                SecurityTokenInclusionModeHelper.Validate(value);
+                _inclusionMode = value;
+            }
+        }
 
         public bool RequireDerivedKeys
         {
@@ -57,11 +75,56 @@ namespace System.ServiceModel.Security.Tokens
 
         protected abstract SecurityTokenParameters CloneCore();
 
+        internal protected abstract SecurityKeyIdentifierClause CreateKeyIdentifierClause(SecurityToken token, SecurityTokenReferenceStyle referenceStyle);
+
+        internal protected abstract void InitializeSecurityTokenRequirement(SecurityTokenRequirement requirement);
+
+        internal SecurityKeyIdentifierClause CreateKeyIdentifierClause<TExternalClause, TInternalClause>(SecurityToken token, SecurityTokenReferenceStyle referenceStyle)
+    where TExternalClause : SecurityKeyIdentifierClause
+    where TInternalClause : SecurityKeyIdentifierClause
+        {
+            if (token == null)
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("token");
+
+            SecurityKeyIdentifierClause result;
+
+            switch (referenceStyle)
+            {
+                default:
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new NotSupportedException(
+                        SR.Format(SR.TokenDoesNotSupportKeyIdentifierClauseCreation, token.GetType().Name, referenceStyle)));
+                case SecurityTokenReferenceStyle.External:
+                    result = token.CreateKeyIdentifierClause<TExternalClause>();
+                    break;
+                case SecurityTokenReferenceStyle.Internal:
+                    result = token.CreateKeyIdentifierClause<TInternalClause>();
+                    break;
+            }
+
+            return result;
+        }
+
+        internal SecurityKeyIdentifierClause CreateGenericXmlTokenKeyIdentifierClause(SecurityToken token, SecurityTokenReferenceStyle referenceStyle)
+        {
+            GenericXmlSecurityToken xmlToken = token as GenericXmlSecurityToken;
+            if (xmlToken != null)
+            {
+                if (referenceStyle == SecurityTokenReferenceStyle.Internal && xmlToken.InternalTokenReference != null)
+                    return xmlToken.InternalTokenReference;
+
+                if (referenceStyle == SecurityTokenReferenceStyle.External && xmlToken.ExternalTokenReference != null)
+                    return xmlToken.ExternalTokenReference;
+            }
+
+            throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new MessageSecurityException(SR.Format(SR.UnableToCreateTokenReference)));
+        }
+
         public override string ToString()
         {
             StringBuilder sb = new StringBuilder();
 
             sb.AppendLine(String.Format(CultureInfo.InvariantCulture, "{0}:", this.GetType().ToString()));
+            sb.AppendLine(String.Format(CultureInfo.InvariantCulture, "InclusionMode: {0}", _inclusionMode.ToString()));
             sb.Append(String.Format(CultureInfo.InvariantCulture, "RequireDerivedKeys: {0}", _requireDerivedKeys.ToString()));
 
             return sb.ToString();

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/Tokens/SslSecurityTokenParameters.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/Tokens/SslSecurityTokenParameters.cs
@@ -3,10 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using System.IdentityModel.Selectors;
-using System.ServiceModel.Channels;
-using System.ServiceModel;
 using System.IdentityModel.Tokens;
-using System.ServiceModel.Security;
+using System.ServiceModel.Channels;
 using System.Text;
 using System.Globalization;
 

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/Tokens/SslSecurityTokenParameters.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/Tokens/SslSecurityTokenParameters.cs
@@ -1,0 +1,139 @@
+//-----------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//-----------------------------------------------------------------------------
+
+
+namespace System.ServiceModel.Security.Tokens
+{
+    using System.IdentityModel.Selectors;
+    using System.ServiceModel.Channels;
+    using System.ServiceModel;
+    using System.IdentityModel.Tokens;
+    using System.ServiceModel.Security;
+    using System.Text;
+    using System.Globalization;
+
+    public class SslSecurityTokenParameters : SecurityTokenParameters
+    {
+        internal const bool defaultRequireClientCertificate = false;
+        internal const bool defaultRequireCancellation = false;
+
+        bool requireCancellation = defaultRequireCancellation;
+        bool requireClientCertificate;
+        BindingContext issuerBindingContext;
+
+        protected SslSecurityTokenParameters(SslSecurityTokenParameters other)
+            : base(other)
+        {
+            this.requireClientCertificate = other.requireClientCertificate;
+            this.requireCancellation = other.requireCancellation;
+            if (other.issuerBindingContext != null)
+            {
+                this.issuerBindingContext = other.issuerBindingContext.Clone();
+            }
+        }
+
+        public SslSecurityTokenParameters()
+            : this(defaultRequireClientCertificate)
+        {
+            // empty
+        }
+
+        public SslSecurityTokenParameters(bool requireClientCertificate)
+            : this(requireClientCertificate, defaultRequireCancellation)
+        {
+            // empty
+        }
+
+        public SslSecurityTokenParameters(bool requireClientCertificate, bool requireCancellation)
+            : base()
+        {
+            this.requireClientCertificate = requireClientCertificate;
+            this.requireCancellation = requireCancellation;
+        }
+
+        internal protected override bool HasAsymmetricKey { get { return false; } }
+
+        public bool RequireCancellation
+        {
+            get
+            {
+                return this.requireCancellation;
+            }
+            set
+            {
+                this.requireCancellation = value;
+            }
+        }
+
+        public bool RequireClientCertificate
+        {
+            get
+            {
+                return this.requireClientCertificate;
+            }
+            set
+            {
+                this.requireClientCertificate = value;
+            }
+        }
+
+        internal BindingContext IssuerBindingContext
+        {
+            get
+            {
+                return this.issuerBindingContext;
+            }
+            set
+            {
+                if (value != null)
+                {
+                    value = value.Clone();
+                }
+                this.issuerBindingContext = value;
+            }
+        }
+
+        internal protected override bool SupportsClientAuthentication { get { return this.requireClientCertificate; } }
+        internal protected override bool SupportsServerAuthentication { get { return true; } }
+        internal protected override bool SupportsClientWindowsIdentity { get { return this.requireClientCertificate; } }
+
+        protected override SecurityTokenParameters CloneCore()
+        {
+            return new SslSecurityTokenParameters(this);
+        }
+
+        internal protected override SecurityKeyIdentifierClause CreateKeyIdentifierClause(SecurityToken token, SecurityTokenReferenceStyle referenceStyle)
+        {
+            if (token is GenericXmlSecurityToken)
+                return base.CreateGenericXmlTokenKeyIdentifierClause(token, referenceStyle);
+            else
+                return this.CreateKeyIdentifierClause<SecurityContextKeyIdentifierClause, LocalIdKeyIdentifierClause>(token, referenceStyle);
+        }
+
+        protected internal override void InitializeSecurityTokenRequirement(SecurityTokenRequirement requirement)
+        {
+            requirement.TokenType = (this.RequireClientCertificate) ? ServiceModelSecurityTokenTypes.MutualSslnego : ServiceModelSecurityTokenTypes.AnonymousSslnego;
+            requirement.RequireCryptographicToken = true;
+            requirement.KeyType = SecurityKeyType.SymmetricKey;
+            requirement.Properties[ServiceModelSecurityTokenRequirement.SupportSecurityContextCancellationProperty] = this.RequireCancellation;
+            if (this.IssuerBindingContext != null)
+            {
+                requirement.Properties[ServiceModelSecurityTokenRequirement.IssuerBindingContextProperty] = this.IssuerBindingContext.Clone();
+            }
+            requirement.Properties[ServiceModelSecurityTokenRequirement.IssuedSecurityTokenParametersProperty] = this.Clone();
+        }
+
+        public override string ToString()
+        {
+            StringBuilder sb = new StringBuilder();
+            sb.AppendLine(base.ToString());
+
+            sb.AppendLine(String.Format(CultureInfo.InvariantCulture, "RequireCancellation: {0}", this.RequireCancellation.ToString()));
+            sb.Append(String.Format(CultureInfo.InvariantCulture, "RequireClientCertificate: {0}", this.RequireClientCertificate.ToString()));
+
+            return sb.ToString();
+        }
+    }
+}
+

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/Tokens/SslSecurityTokenParameters.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/Tokens/SslSecurityTokenParameters.cs
@@ -1,35 +1,34 @@
-//-----------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation.  All rights reserved.
-//-----------------------------------------------------------------------------
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
+using System.IdentityModel.Selectors;
+using System.ServiceModel.Channels;
+using System.ServiceModel;
+using System.IdentityModel.Tokens;
+using System.ServiceModel.Security;
+using System.Text;
+using System.Globalization;
 
 namespace System.ServiceModel.Security.Tokens
 {
-    using System.IdentityModel.Selectors;
-    using System.ServiceModel.Channels;
-    using System.ServiceModel;
-    using System.IdentityModel.Tokens;
-    using System.ServiceModel.Security;
-    using System.Text;
-    using System.Globalization;
-
     public class SslSecurityTokenParameters : SecurityTokenParameters
     {
         internal const bool defaultRequireClientCertificate = false;
         internal const bool defaultRequireCancellation = false;
 
-        bool requireCancellation = defaultRequireCancellation;
-        bool requireClientCertificate;
-        BindingContext issuerBindingContext;
+        private bool _requireCancellation = defaultRequireCancellation;
+        private bool _requireClientCertificate;
+        private BindingContext _issuerBindingContext;
 
         protected SslSecurityTokenParameters(SslSecurityTokenParameters other)
             : base(other)
         {
-            this.requireClientCertificate = other.requireClientCertificate;
-            this.requireCancellation = other.requireCancellation;
-            if (other.issuerBindingContext != null)
+            _requireClientCertificate = other._requireClientCertificate;
+            _requireCancellation = other._requireCancellation;
+            if (other._issuerBindingContext != null)
             {
-                this.issuerBindingContext = other.issuerBindingContext.Clone();
+                _issuerBindingContext = other._issuerBindingContext.Clone();
             }
         }
 
@@ -48,8 +47,8 @@ namespace System.ServiceModel.Security.Tokens
         public SslSecurityTokenParameters(bool requireClientCertificate, bool requireCancellation)
             : base()
         {
-            this.requireClientCertificate = requireClientCertificate;
-            this.requireCancellation = requireCancellation;
+            _requireClientCertificate = requireClientCertificate;
+            _requireCancellation = requireCancellation;
         }
 
         internal protected override bool HasAsymmetricKey { get { return false; } }
@@ -58,11 +57,11 @@ namespace System.ServiceModel.Security.Tokens
         {
             get
             {
-                return this.requireCancellation;
+                return _requireCancellation;
             }
             set
             {
-                this.requireCancellation = value;
+                _requireCancellation = value;
             }
         }
 
@@ -70,11 +69,11 @@ namespace System.ServiceModel.Security.Tokens
         {
             get
             {
-                return this.requireClientCertificate;
+                return _requireClientCertificate;
             }
             set
             {
-                this.requireClientCertificate = value;
+                _requireClientCertificate = value;
             }
         }
 
@@ -82,7 +81,7 @@ namespace System.ServiceModel.Security.Tokens
         {
             get
             {
-                return this.issuerBindingContext;
+                return _issuerBindingContext;
             }
             set
             {
@@ -90,13 +89,13 @@ namespace System.ServiceModel.Security.Tokens
                 {
                     value = value.Clone();
                 }
-                this.issuerBindingContext = value;
+                _issuerBindingContext = value;
             }
         }
 
-        internal protected override bool SupportsClientAuthentication { get { return this.requireClientCertificate; } }
+        internal protected override bool SupportsClientAuthentication { get { return _requireClientCertificate; } }
         internal protected override bool SupportsServerAuthentication { get { return true; } }
-        internal protected override bool SupportsClientWindowsIdentity { get { return this.requireClientCertificate; } }
+        internal protected override bool SupportsClientWindowsIdentity { get { return _requireClientCertificate; } }
 
         protected override SecurityTokenParameters CloneCore()
         {

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/Tokens/SspiSecurityToken.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/Tokens/SspiSecurityToken.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-
 using System.Collections.ObjectModel;
 using System.IdentityModel.Tokens;
 using System.Net;

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/Tokens/SspiSecurityTokenParameters.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/Tokens/SspiSecurityTokenParameters.cs
@@ -1,0 +1,118 @@
+//-----------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//-----------------------------------------------------------------------------
+
+
+namespace System.ServiceModel.Security.Tokens
+{
+    using System.IdentityModel.Selectors;
+    using System.ServiceModel.Channels;
+    using System.ServiceModel;
+    using System.IdentityModel.Tokens;
+    using System.ServiceModel.Security;
+    using System.Text;
+    using System.Globalization;
+
+    public class SspiSecurityTokenParameters : SecurityTokenParameters
+    {
+        internal const bool defaultRequireCancellation = false;
+
+        bool requireCancellation = defaultRequireCancellation;
+        BindingContext issuerBindingContext;
+
+
+        protected SspiSecurityTokenParameters(SspiSecurityTokenParameters other)
+            : base(other)
+        {
+            this.requireCancellation = other.requireCancellation;
+            if (other.issuerBindingContext != null)
+            {
+                this.issuerBindingContext = other.issuerBindingContext.Clone();
+            }
+        }
+
+
+        public SspiSecurityTokenParameters()
+            : this(defaultRequireCancellation)
+        {
+            // empty
+        }
+
+        public SspiSecurityTokenParameters(bool requireCancellation)
+            : base()
+        {
+            this.requireCancellation = requireCancellation;
+        }
+
+        internal protected override bool HasAsymmetricKey { get { return false; } }
+
+        public bool RequireCancellation
+        {
+            get
+            {
+                return this.requireCancellation;
+            }
+            set
+            {
+                this.requireCancellation = value;
+            }
+        }
+
+        internal BindingContext IssuerBindingContext
+        {
+            get
+            {
+                return this.issuerBindingContext;
+            }
+            set
+            {
+                if (value != null)
+                {
+                    value = value.Clone();
+                }
+                this.issuerBindingContext = value;
+            }
+        }
+
+        internal protected override bool SupportsClientAuthentication { get { return true; } }
+        internal protected override bool SupportsServerAuthentication { get { return true; } }
+        internal protected override bool SupportsClientWindowsIdentity { get { return true; } }
+
+        protected override SecurityTokenParameters CloneCore()
+        {
+            return new SspiSecurityTokenParameters(this);
+        }
+
+        internal protected override SecurityKeyIdentifierClause CreateKeyIdentifierClause(SecurityToken token, SecurityTokenReferenceStyle referenceStyle)
+        {
+            if (token is GenericXmlSecurityToken)
+                return base.CreateGenericXmlTokenKeyIdentifierClause(token, referenceStyle);
+            else
+                return this.CreateKeyIdentifierClause<SecurityContextKeyIdentifierClause, LocalIdKeyIdentifierClause>(token, referenceStyle);
+        }
+
+        protected internal override void InitializeSecurityTokenRequirement(SecurityTokenRequirement requirement)
+        {
+            requirement.TokenType = ServiceModelSecurityTokenTypes.Spnego;
+            requirement.RequireCryptographicToken = true;
+            requirement.KeyType = SecurityKeyType.SymmetricKey;
+            requirement.Properties[ServiceModelSecurityTokenRequirement.SupportSecurityContextCancellationProperty] = this.RequireCancellation;
+            if (this.IssuerBindingContext != null)
+            {
+                requirement.Properties[ServiceModelSecurityTokenRequirement.IssuerBindingContextProperty] = this.IssuerBindingContext.Clone();
+            }
+            requirement.Properties[ServiceModelSecurityTokenRequirement.IssuedSecurityTokenParametersProperty] = this.Clone();
+        }
+
+        public override string ToString()
+        {
+            StringBuilder sb = new StringBuilder();
+            sb.AppendLine(base.ToString());
+
+            sb.Append(String.Format(CultureInfo.InvariantCulture, "RequireCancellation: {0}", this.RequireCancellation.ToString()));
+
+            return sb.ToString();
+        }
+    }
+}
+

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/Tokens/SspiSecurityTokenParameters.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/Tokens/SspiSecurityTokenParameters.cs
@@ -3,10 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using System.IdentityModel.Selectors;
-using System.ServiceModel.Channels;
-using System.ServiceModel;
 using System.IdentityModel.Tokens;
-using System.ServiceModel.Security;
+using System.ServiceModel.Channels;
 using System.Text;
 using System.Globalization;
 
@@ -19,7 +17,6 @@ namespace System.ServiceModel.Security.Tokens
         private bool _requireCancellation = defaultRequireCancellation;
         private BindingContext _issuerBindingContext;
 
-
         protected SspiSecurityTokenParameters(SspiSecurityTokenParameters other)
             : base(other)
         {
@@ -29,7 +26,6 @@ namespace System.ServiceModel.Security.Tokens
                 _issuerBindingContext = other._issuerBindingContext.Clone();
             }
         }
-
 
         public SspiSecurityTokenParameters()
             : this(defaultRequireCancellation)

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/Tokens/SspiSecurityTokenParameters.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/Tokens/SspiSecurityTokenParameters.cs
@@ -1,33 +1,32 @@
-//-----------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation.  All rights reserved.
-//-----------------------------------------------------------------------------
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
+using System.IdentityModel.Selectors;
+using System.ServiceModel.Channels;
+using System.ServiceModel;
+using System.IdentityModel.Tokens;
+using System.ServiceModel.Security;
+using System.Text;
+using System.Globalization;
 
 namespace System.ServiceModel.Security.Tokens
 {
-    using System.IdentityModel.Selectors;
-    using System.ServiceModel.Channels;
-    using System.ServiceModel;
-    using System.IdentityModel.Tokens;
-    using System.ServiceModel.Security;
-    using System.Text;
-    using System.Globalization;
-
     public class SspiSecurityTokenParameters : SecurityTokenParameters
     {
         internal const bool defaultRequireCancellation = false;
 
-        bool requireCancellation = defaultRequireCancellation;
-        BindingContext issuerBindingContext;
+        private bool _requireCancellation = defaultRequireCancellation;
+        private BindingContext _issuerBindingContext;
 
 
         protected SspiSecurityTokenParameters(SspiSecurityTokenParameters other)
             : base(other)
         {
-            this.requireCancellation = other.requireCancellation;
-            if (other.issuerBindingContext != null)
+            _requireCancellation = other._requireCancellation;
+            if (other._issuerBindingContext != null)
             {
-                this.issuerBindingContext = other.issuerBindingContext.Clone();
+                _issuerBindingContext = other._issuerBindingContext.Clone();
             }
         }
 
@@ -41,7 +40,7 @@ namespace System.ServiceModel.Security.Tokens
         public SspiSecurityTokenParameters(bool requireCancellation)
             : base()
         {
-            this.requireCancellation = requireCancellation;
+            _requireCancellation = requireCancellation;
         }
 
         internal protected override bool HasAsymmetricKey { get { return false; } }
@@ -50,11 +49,11 @@ namespace System.ServiceModel.Security.Tokens
         {
             get
             {
-                return this.requireCancellation;
+                return _requireCancellation;
             }
             set
             {
-                this.requireCancellation = value;
+                _requireCancellation = value;
             }
         }
 
@@ -62,7 +61,7 @@ namespace System.ServiceModel.Security.Tokens
         {
             get
             {
-                return this.issuerBindingContext;
+                return _issuerBindingContext;
             }
             set
             {
@@ -70,7 +69,7 @@ namespace System.ServiceModel.Security.Tokens
                 {
                     value = value.Clone();
                 }
-                this.issuerBindingContext = value;
+                _issuerBindingContext = value;
             }
         }
 

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/Tokens/UserNameSecurityTokenParameters.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/Tokens/UserNameSecurityTokenParameters.cs
@@ -3,6 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 
+using System.IdentityModel.Selectors;
+using System.IdentityModel.Tokens;
+
 namespace System.ServiceModel.Security.Tokens
 {
     public class UserNameSecurityTokenParameters : SecurityTokenParameters
@@ -27,6 +30,17 @@ namespace System.ServiceModel.Security.Tokens
         protected override SecurityTokenParameters CloneCore()
         {
             return new UserNameSecurityTokenParameters(this);
+        }
+
+        internal protected override SecurityKeyIdentifierClause CreateKeyIdentifierClause(SecurityToken token, SecurityTokenReferenceStyle referenceStyle)
+        {
+            return this.CreateKeyIdentifierClause<SecurityKeyIdentifierClause, LocalIdKeyIdentifierClause>(token, referenceStyle);
+        }
+
+        protected internal override void InitializeSecurityTokenRequirement(SecurityTokenRequirement requirement)
+        {
+            requirement.TokenType = SecurityTokenTypes.UserName;
+            requirement.RequireCryptographicToken = false;
         }
     }
 }

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/Tokens/WrappedKeySecurityToken.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/Tokens/WrappedKeySecurityToken.cs
@@ -16,7 +16,6 @@ namespace System.ServiceModel.Security.Tokens
     {
         private string _id;
         private DateTime _effectiveTime;
-
         private EncryptedKey _encryptedKey;
         private ReadOnlyCollection<SecurityKey> _securityKey;
         private byte[] _wrappedKey;
@@ -26,7 +25,7 @@ namespace System.ServiceModel.Security.Tokens
         private SecurityKey _wrappingSecurityKey;
         private SecurityKeyIdentifier _wrappingTokenReference;
         private bool _serializeCarriedKeyName;
-        // byte[] wrappedKeyHash;
+        // private byte[] _wrappedKeyHash;
         private XmlDictionaryString _wrappingAlgorithmDictionaryString;
 
         // sender use

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/Tokens/WrappedKeySecurityToken.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/Tokens/WrappedKeySecurityToken.cs
@@ -1,0 +1,242 @@
+//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace System.ServiceModel.Security.Tokens
+{
+    using System.Collections.ObjectModel;
+    using System.IdentityModel;
+    using System.IdentityModel.Tokens;
+    using System.Runtime.CompilerServices;
+    using System.Security.Cryptography;
+    using System.ServiceModel.Security;
+    using System.Xml;
+
+    [TypeForwardedFrom("System.ServiceModel, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
+    public class WrappedKeySecurityToken : SecurityToken
+    {
+        string id;
+        DateTime effectiveTime;
+
+        EncryptedKey encryptedKey;
+        ReadOnlyCollection<SecurityKey> securityKey;
+        byte[] wrappedKey;
+        string wrappingAlgorithm;
+        ISspiNegotiation wrappingSspiContext;
+        SecurityToken wrappingToken;
+        SecurityKey wrappingSecurityKey;
+        SecurityKeyIdentifier wrappingTokenReference;
+        bool serializeCarriedKeyName;
+        byte[] wrappedKeyHash;
+        XmlDictionaryString wrappingAlgorithmDictionaryString;
+
+        // sender use
+        internal WrappedKeySecurityToken(string id, byte[] keyToWrap, ISspiNegotiation wrappingSspiContext)
+            : this(id, keyToWrap, (wrappingSspiContext != null) ? (wrappingSspiContext.KeyEncryptionAlgorithm) : null, wrappingSspiContext, null)
+        {
+        }
+
+        // sender use
+        public WrappedKeySecurityToken(string id, byte[] keyToWrap, string wrappingAlgorithm, SecurityToken wrappingToken, SecurityKeyIdentifier wrappingTokenReference)
+            : this(id, keyToWrap, wrappingAlgorithm, null, wrappingToken, wrappingTokenReference)
+        {
+        }
+
+        internal WrappedKeySecurityToken(string id, byte[] keyToWrap, string wrappingAlgorithm, XmlDictionaryString wrappingAlgorithmDictionaryString, SecurityToken wrappingToken, SecurityKeyIdentifier wrappingTokenReference)
+            : this(id, keyToWrap, wrappingAlgorithm, wrappingAlgorithmDictionaryString, wrappingToken, wrappingTokenReference, null, null)
+        {
+        }
+
+        // direct receiver use, chained sender use
+        internal WrappedKeySecurityToken(string id, byte[] keyToWrap, string wrappingAlgorithm, ISspiNegotiation wrappingSspiContext, byte[] wrappedKey)
+            : this(id, keyToWrap, wrappingAlgorithm, null)
+        {
+            if (wrappingSspiContext == null)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("wrappingSspiContext");
+            }
+            this.wrappingSspiContext = wrappingSspiContext;
+            if (wrappedKey == null)
+            {
+                this.wrappedKey = wrappingSspiContext.Encrypt(keyToWrap);
+            }
+            else
+            {
+                this.wrappedKey = wrappedKey;
+            }
+            this.serializeCarriedKeyName = false;
+        }
+
+        // receiver use
+        internal WrappedKeySecurityToken(string id, byte[] keyToWrap, string wrappingAlgorithm, SecurityToken wrappingToken, SecurityKeyIdentifier wrappingTokenReference, byte[] wrappedKey, SecurityKey wrappingSecurityKey)
+            : this(id, keyToWrap, wrappingAlgorithm, null, wrappingToken, wrappingTokenReference, wrappedKey, wrappingSecurityKey)
+        {
+        }
+
+        WrappedKeySecurityToken(string id, byte[] keyToWrap, string wrappingAlgorithm, XmlDictionaryString wrappingAlgorithmDictionaryString, SecurityToken wrappingToken, SecurityKeyIdentifier wrappingTokenReference, byte[] wrappedKey, SecurityKey wrappingSecurityKey)
+            : this(id, keyToWrap, wrappingAlgorithm, wrappingAlgorithmDictionaryString)
+        {
+            if (wrappingToken == null)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("wrappingToken");
+            }
+            this.wrappingToken = wrappingToken;
+            this.wrappingTokenReference = wrappingTokenReference;
+            if (wrappedKey == null)
+            {
+                this.wrappedKey = SecurityUtils.EncryptKey(wrappingToken, wrappingAlgorithm, keyToWrap);
+            }
+            else
+            {
+                this.wrappedKey = wrappedKey;
+            }
+            this.wrappingSecurityKey = wrappingSecurityKey;
+            this.serializeCarriedKeyName = true;
+        }
+
+        WrappedKeySecurityToken(string id, byte[] keyToWrap, string wrappingAlgorithm, XmlDictionaryString wrappingAlgorithmDictionaryString)
+        {
+            if (id == null)
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("id");
+            if (wrappingAlgorithm == null)
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("wrappingAlgorithm");
+            if (keyToWrap == null)
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("securityKeyToWrap");
+
+            this.id = id;
+            this.effectiveTime = DateTime.UtcNow;
+            this.securityKey = SecurityUtils.CreateSymmetricSecurityKeys(keyToWrap);
+            this.wrappingAlgorithm = wrappingAlgorithm;
+            this.wrappingAlgorithmDictionaryString = wrappingAlgorithmDictionaryString;
+        }
+
+        public override string Id
+        {
+            get { return this.id; }
+        }
+
+        public override DateTime ValidFrom
+        {
+            get { return this.effectiveTime; }
+        }
+
+        public override DateTime ValidTo
+        {
+            // Never expire
+            get { return DateTime.MaxValue; }
+        }
+
+        internal EncryptedKey EncryptedKey
+        {
+            get { return this.encryptedKey; }
+            set { this.encryptedKey = value; }
+        }
+
+        internal ReferenceList ReferenceList
+        {
+            get
+            {
+                return this.encryptedKey == null ? null : this.encryptedKey.ReferenceList;
+            }
+        }
+
+        public string WrappingAlgorithm
+        {
+            get { return this.wrappingAlgorithm; }
+        }
+
+        internal SecurityKey WrappingSecurityKey
+        {
+            get { return this.wrappingSecurityKey; }
+        }
+
+        public SecurityToken WrappingToken
+        {
+            get { return this.wrappingToken; }
+        }
+
+        public SecurityKeyIdentifier WrappingTokenReference
+        {
+            get { return this.wrappingTokenReference; }
+        }
+
+        internal string CarriedKeyName
+        {
+            get { return null; }
+        }
+
+        public override ReadOnlyCollection<SecurityKey> SecurityKeys
+        {
+            get { return this.securityKey; }
+        }
+
+        internal byte[] GetHash()
+        {
+            if (this.wrappedKeyHash == null)
+            {
+                EnsureEncryptedKeySetUp();
+                using (HashAlgorithm hash = CryptoHelper.NewSha1HashAlgorithm())
+                {
+                    this.wrappedKeyHash = hash.ComputeHash(this.encryptedKey.GetWrappedKey());
+                }
+            }
+            return wrappedKeyHash;
+        }
+
+        public byte[] GetWrappedKey()
+        {
+            return SecurityUtils.CloneBuffer(this.wrappedKey);
+        }
+
+        internal void EnsureEncryptedKeySetUp()
+        {
+            if (this.encryptedKey == null)
+            {
+                EncryptedKey ek = new EncryptedKey();
+                ek.Id = this.Id;
+                if (this.serializeCarriedKeyName)
+                {
+                    ek.CarriedKeyName = this.CarriedKeyName;
+                }
+                else
+                {
+                    ek.CarriedKeyName = null;
+                }
+                ek.EncryptionMethod = this.WrappingAlgorithm;
+                ek.EncryptionMethodDictionaryString = this.wrappingAlgorithmDictionaryString;
+                ek.SetUpKeyWrap(this.wrappedKey);
+                if (this.WrappingTokenReference != null)
+                {
+                    ek.KeyIdentifier = this.WrappingTokenReference;
+                }
+                this.encryptedKey = ek;
+            }
+        }
+
+        public override bool CanCreateKeyIdentifierClause<T>()
+        {
+            if (typeof(T) == typeof(EncryptedKeyHashIdentifierClause))
+                return true;
+
+            return base.CanCreateKeyIdentifierClause<T>();
+        }
+
+        public override T CreateKeyIdentifierClause<T>()
+        {
+            if (typeof(T) == typeof(EncryptedKeyHashIdentifierClause))
+                return new EncryptedKeyHashIdentifierClause(GetHash()) as T;
+
+            return base.CreateKeyIdentifierClause<T>();
+        }
+
+        public override bool MatchesKeyIdentifierClause(SecurityKeyIdentifierClause keyIdentifierClause)
+        {
+            EncryptedKeyHashIdentifierClause encKeyIdentifierClause = keyIdentifierClause as EncryptedKeyHashIdentifierClause;
+            if (encKeyIdentifierClause != null)
+                return encKeyIdentifierClause.Matches(GetHash());
+
+            return base.MatchesKeyIdentifierClause(keyIdentifierClause);
+        }
+    }
+}
+

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/Tokens/WrappedKeySecurityToken.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/Tokens/WrappedKeySecurityToken.cs
@@ -1,34 +1,33 @@
-//------------------------------------------------------------
-// Copyright (c) Microsoft Corporation.  All rights reserved.
-//------------------------------------------------------------
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.ObjectModel;
+using System.IdentityModel;
+using System.IdentityModel.Tokens;
+using System.Runtime.CompilerServices;
+using System.Security.Cryptography;
+using System.ServiceModel.Security;
+using System.Xml;
 
 namespace System.ServiceModel.Security.Tokens
 {
-    using System.Collections.ObjectModel;
-    using System.IdentityModel;
-    using System.IdentityModel.Tokens;
-    using System.Runtime.CompilerServices;
-    using System.Security.Cryptography;
-    using System.ServiceModel.Security;
-    using System.Xml;
-
-    [TypeForwardedFrom("System.ServiceModel, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public class WrappedKeySecurityToken : SecurityToken
     {
-        string id;
-        DateTime effectiveTime;
+        private string _id;
+        private DateTime _effectiveTime;
 
-        EncryptedKey encryptedKey;
-        ReadOnlyCollection<SecurityKey> securityKey;
-        byte[] wrappedKey;
-        string wrappingAlgorithm;
-        ISspiNegotiation wrappingSspiContext;
-        SecurityToken wrappingToken;
-        SecurityKey wrappingSecurityKey;
-        SecurityKeyIdentifier wrappingTokenReference;
-        bool serializeCarriedKeyName;
-        byte[] wrappedKeyHash;
-        XmlDictionaryString wrappingAlgorithmDictionaryString;
+        private EncryptedKey _encryptedKey;
+        private ReadOnlyCollection<SecurityKey> _securityKey;
+        private byte[] _wrappedKey;
+        private string _wrappingAlgorithm;
+        private ISspiNegotiation _wrappingSspiContext;
+        private SecurityToken _wrappingToken;
+        private SecurityKey _wrappingSecurityKey;
+        private SecurityKeyIdentifier _wrappingTokenReference;
+        private bool _serializeCarriedKeyName;
+        // byte[] wrappedKeyHash;
+        private XmlDictionaryString _wrappingAlgorithmDictionaryString;
 
         // sender use
         internal WrappedKeySecurityToken(string id, byte[] keyToWrap, ISspiNegotiation wrappingSspiContext)
@@ -55,16 +54,16 @@ namespace System.ServiceModel.Security.Tokens
             {
                 throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("wrappingSspiContext");
             }
-            this.wrappingSspiContext = wrappingSspiContext;
+            _wrappingSspiContext = wrappingSspiContext;
             if (wrappedKey == null)
             {
-                this.wrappedKey = wrappingSspiContext.Encrypt(keyToWrap);
+                _wrappedKey = wrappingSspiContext.Encrypt(keyToWrap);
             }
             else
             {
-                this.wrappedKey = wrappedKey;
+                _wrappedKey = wrappedKey;
             }
-            this.serializeCarriedKeyName = false;
+            _serializeCarriedKeyName = false;
         }
 
         // receiver use
@@ -76,48 +75,52 @@ namespace System.ServiceModel.Security.Tokens
         WrappedKeySecurityToken(string id, byte[] keyToWrap, string wrappingAlgorithm, XmlDictionaryString wrappingAlgorithmDictionaryString, SecurityToken wrappingToken, SecurityKeyIdentifier wrappingTokenReference, byte[] wrappedKey, SecurityKey wrappingSecurityKey)
             : this(id, keyToWrap, wrappingAlgorithm, wrappingAlgorithmDictionaryString)
         {
-            if (wrappingToken == null)
-            {
-                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("wrappingToken");
-            }
-            this.wrappingToken = wrappingToken;
-            this.wrappingTokenReference = wrappingTokenReference;
-            if (wrappedKey == null)
-            {
-                this.wrappedKey = SecurityUtils.EncryptKey(wrappingToken, wrappingAlgorithm, keyToWrap);
-            }
-            else
-            {
-                this.wrappedKey = wrappedKey;
-            }
-            this.wrappingSecurityKey = wrappingSecurityKey;
-            this.serializeCarriedKeyName = true;
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+
+            //if (wrappingToken == null)
+            //{
+            //    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("wrappingToken");
+            //}
+            //this.wrappingToken = wrappingToken;
+            //this.wrappingTokenReference = wrappingTokenReference;
+            //if (wrappedKey == null)
+            //{
+            //    this.wrappedKey = SecurityUtils.EncryptKey(wrappingToken, wrappingAlgorithm, keyToWrap);
+            //}
+            //else
+            //{
+            //    this.wrappedKey = wrappedKey;
+            //}
+            //this.wrappingSecurityKey = wrappingSecurityKey;
+            //this.serializeCarriedKeyName = true;
         }
 
         WrappedKeySecurityToken(string id, byte[] keyToWrap, string wrappingAlgorithm, XmlDictionaryString wrappingAlgorithmDictionaryString)
         {
-            if (id == null)
-                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("id");
-            if (wrappingAlgorithm == null)
-                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("wrappingAlgorithm");
-            if (keyToWrap == null)
-                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("securityKeyToWrap");
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
 
-            this.id = id;
-            this.effectiveTime = DateTime.UtcNow;
-            this.securityKey = SecurityUtils.CreateSymmetricSecurityKeys(keyToWrap);
-            this.wrappingAlgorithm = wrappingAlgorithm;
-            this.wrappingAlgorithmDictionaryString = wrappingAlgorithmDictionaryString;
+            //if (id == null)
+            //    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("id");
+            //if (wrappingAlgorithm == null)
+            //    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("wrappingAlgorithm");
+            //if (keyToWrap == null)
+            //    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("securityKeyToWrap");
+
+            //this.id = id;
+            //this.effectiveTime = DateTime.UtcNow;
+            //this.securityKey = SecurityUtils.CreateSymmetricSecurityKeys(keyToWrap);
+            //this.wrappingAlgorithm = wrappingAlgorithm;
+            //this.wrappingAlgorithmDictionaryString = wrappingAlgorithmDictionaryString;
         }
 
         public override string Id
         {
-            get { return this.id; }
+            get { return _id; }
         }
 
         public override DateTime ValidFrom
         {
-            get { return this.effectiveTime; }
+            get { return _effectiveTime; }
         }
 
         public override DateTime ValidTo
@@ -128,36 +131,36 @@ namespace System.ServiceModel.Security.Tokens
 
         internal EncryptedKey EncryptedKey
         {
-            get { return this.encryptedKey; }
-            set { this.encryptedKey = value; }
+            get { return _encryptedKey; }
+            set { _encryptedKey = value; }
         }
 
         internal ReferenceList ReferenceList
         {
             get
             {
-                return this.encryptedKey == null ? null : this.encryptedKey.ReferenceList;
+                return _encryptedKey == null ? null : _encryptedKey.ReferenceList;
             }
         }
 
         public string WrappingAlgorithm
         {
-            get { return this.wrappingAlgorithm; }
+            get { return _wrappingAlgorithm; }
         }
 
         internal SecurityKey WrappingSecurityKey
         {
-            get { return this.wrappingSecurityKey; }
+            get { return _wrappingSecurityKey; }
         }
 
         public SecurityToken WrappingToken
         {
-            get { return this.wrappingToken; }
+            get { return _wrappingToken; }
         }
 
         public SecurityKeyIdentifier WrappingTokenReference
         {
-            get { return this.wrappingTokenReference; }
+            get { return _wrappingTokenReference; }
         }
 
         internal string CarriedKeyName
@@ -167,34 +170,36 @@ namespace System.ServiceModel.Security.Tokens
 
         public override ReadOnlyCollection<SecurityKey> SecurityKeys
         {
-            get { return this.securityKey; }
+            get { return _securityKey; }
         }
 
         internal byte[] GetHash()
         {
-            if (this.wrappedKeyHash == null)
-            {
-                EnsureEncryptedKeySetUp();
-                using (HashAlgorithm hash = CryptoHelper.NewSha1HashAlgorithm())
-                {
-                    this.wrappedKeyHash = hash.ComputeHash(this.encryptedKey.GetWrappedKey());
-                }
-            }
-            return wrappedKeyHash;
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+            //if (this.wrappedKeyHash == null)
+            //{
+            //    EnsureEncryptedKeySetUp();
+            //    using (HashAlgorithm hash = CryptoHelper.NewSha1HashAlgorithm())
+            //    {
+            //        this.wrappedKeyHash = hash.ComputeHash(this.encryptedKey.GetWrappedKey());
+            //    }
+            //}
+            //return wrappedKeyHash;
         }
 
         public byte[] GetWrappedKey()
         {
-            return SecurityUtils.CloneBuffer(this.wrappedKey);
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+            //return SecurityUtils.CloneBuffer(this.wrappedKey);
         }
 
         internal void EnsureEncryptedKeySetUp()
         {
-            if (this.encryptedKey == null)
+            if (_encryptedKey == null)
             {
                 EncryptedKey ek = new EncryptedKey();
                 ek.Id = this.Id;
-                if (this.serializeCarriedKeyName)
+                if (_serializeCarriedKeyName)
                 {
                     ek.CarriedKeyName = this.CarriedKeyName;
                 }
@@ -203,39 +208,45 @@ namespace System.ServiceModel.Security.Tokens
                     ek.CarriedKeyName = null;
                 }
                 ek.EncryptionMethod = this.WrappingAlgorithm;
-                ek.EncryptionMethodDictionaryString = this.wrappingAlgorithmDictionaryString;
-                ek.SetUpKeyWrap(this.wrappedKey);
+                ek.EncryptionMethodDictionaryString = _wrappingAlgorithmDictionaryString;
+                ek.SetUpKeyWrap(_wrappedKey);
                 if (this.WrappingTokenReference != null)
                 {
                     ek.KeyIdentifier = this.WrappingTokenReference;
                 }
-                this.encryptedKey = ek;
+                _encryptedKey = ek;
             }
         }
 
         public override bool CanCreateKeyIdentifierClause<T>()
         {
-            if (typeof(T) == typeof(EncryptedKeyHashIdentifierClause))
-                return true;
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
 
-            return base.CanCreateKeyIdentifierClause<T>();
+            //if (typeof(T) == typeof(EncryptedKeyHashIdentifierClause))
+            //    return true;
+
+            //return base.CanCreateKeyIdentifierClause<T>();
         }
 
         public override T CreateKeyIdentifierClause<T>()
         {
-            if (typeof(T) == typeof(EncryptedKeyHashIdentifierClause))
-                return new EncryptedKeyHashIdentifierClause(GetHash()) as T;
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
 
-            return base.CreateKeyIdentifierClause<T>();
+            //if (typeof(T) == typeof(EncryptedKeyHashIdentifierClause))
+            //    return new EncryptedKeyHashIdentifierClause(GetHash()) as T;
+
+            //return base.CreateKeyIdentifierClause<T>();
         }
 
         public override bool MatchesKeyIdentifierClause(SecurityKeyIdentifierClause keyIdentifierClause)
         {
-            EncryptedKeyHashIdentifierClause encKeyIdentifierClause = keyIdentifierClause as EncryptedKeyHashIdentifierClause;
-            if (encKeyIdentifierClause != null)
-                return encKeyIdentifierClause.Matches(GetHash());
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
 
-            return base.MatchesKeyIdentifierClause(keyIdentifierClause);
+            //EncryptedKeyHashIdentifierClause encKeyIdentifierClause = keyIdentifierClause as EncryptedKeyHashIdentifierClause;
+            //if (encKeyIdentifierClause != null)
+            //    return encKeyIdentifierClause.Matches(GetHash());
+
+            //return base.MatchesKeyIdentifierClause(keyIdentifierClause);
         }
     }
 }

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/TransportSecurityProtocol.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/TransportSecurityProtocol.cs
@@ -205,8 +205,6 @@ namespace System.ServiceModel.Security
 
         protected virtual void VerifyIncomingMessageCore(ref Message message, TimeSpan timeout)
         {
-            // $$$ throw ExceptionHelper.PlatformNotSupported();   // #31 in progress
-
             TransportSecurityProtocolFactory factory = (TransportSecurityProtocolFactory)this.SecurityProtocolFactory;
             string actor = string.Empty; // message.Version.Envelope.UltimateDestinationActor;
 

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/TransportSecurityProtocol.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/TransportSecurityProtocol.cs
@@ -1,19 +1,19 @@
-//----------------------------------------------------------
-// Copyright (c) Microsoft Corporation.  All rights reserved.
-//------------------------------------------------------------
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.IdentityModel.Policy;
+using System.IdentityModel.Selectors;
+using System.IdentityModel.Tokens;
+using System.Runtime;
+using System.ServiceModel;
+using System.ServiceModel.Channels;
+using System.ServiceModel.Description;
 
 namespace System.ServiceModel.Security
 {
-    using System.Collections.Generic;
-    using System.Collections.ObjectModel;
-    using System.IdentityModel.Policy;
-    using System.IdentityModel.Selectors;
-    using System.IdentityModel.Tokens;
-    using System.Runtime;
-    using System.ServiceModel;
-    using System.ServiceModel.Channels;
-    using System.ServiceModel.Description;
-
     class TransportSecurityProtocol : SecurityProtocol
     {
         public TransportSecurityProtocol(TransportSecurityProtocolFactory factory, EndpointAddress target, Uri via)
@@ -191,7 +191,7 @@ namespace System.ServiceModel.Security
                 if (Fx.IsFatal(e)) throw;
 
                 base.OnVerifyIncomingMessageFailure(message, e);
-                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new MessageSecurityException(SR.GetString(SR.MessageSecurityVerificationFailed), e));
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new MessageSecurityException(SR.Format(SR.MessageSecurityVerificationFailed), e));
             }
         }
 
@@ -205,6 +205,8 @@ namespace System.ServiceModel.Security
 
         protected virtual void VerifyIncomingMessageCore(ref Message message, TimeSpan timeout)
         {
+            // $$$ throw ExceptionHelper.PlatformNotSupported();   // #31 in progress
+
             TransportSecurityProtocolFactory factory = (TransportSecurityProtocolFactory)this.SecurityProtocolFactory;
             string actor = string.Empty; // message.Version.Envelope.UltimateDestinationActor;
 
@@ -227,10 +229,10 @@ namespace System.ServiceModel.Security
                 {
                     if (String.IsNullOrEmpty(actor))
                         throw System.ServiceModel.Diagnostics.TraceUtility.ThrowHelperError(new MessageSecurityException(
-                            SR.GetString(SR.UnableToFindSecurityHeaderInMessageNoActor)), message);
+                            SR.Format(SR.UnableToFindSecurityHeaderInMessageNoActor)), message);
                     else
                         throw System.ServiceModel.Diagnostics.TraceUtility.ThrowHelperError(new MessageSecurityException(
-                            SR.GetString(SR.UnableToFindSecurityHeaderInMessage, actor)), message);
+                            SR.Format(SR.UnableToFindSecurityHeaderInMessage, actor)), message);
                 }
             }
 
@@ -242,10 +244,11 @@ namespace System.ServiceModel.Security
             securityHeader.ReaderQuotas = factory.SecurityBindingElement.ReaderQuotas;
 
             // Due to compatibility, only honor this setting if this app setting is enabled
-            if (ServiceModelAppSettings.UseConfiguredTransportSecurityHeaderLayout)
-            {
+            // Issue #31 in progress
+            //if (ServiceModelAppSettings.UseConfiguredTransportSecurityHeaderLayout)
+            //{
                 securityHeader.Layout = factory.SecurityHeaderLayout;
-            }
+            //}
 
             TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
             if (!factory.ActAsInitiator)

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/TransportSecurityProtocol.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/TransportSecurityProtocol.cs
@@ -8,7 +8,6 @@ using System.IdentityModel.Policy;
 using System.IdentityModel.Selectors;
 using System.IdentityModel.Tokens;
 using System.Runtime;
-using System.ServiceModel;
 using System.ServiceModel.Channels;
 using System.ServiceModel.Description;
 

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/TransportSecurityProtocol.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/TransportSecurityProtocol.cs
@@ -1,0 +1,302 @@
+//----------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace System.ServiceModel.Security
+{
+    using System.Collections.Generic;
+    using System.Collections.ObjectModel;
+    using System.IdentityModel.Policy;
+    using System.IdentityModel.Selectors;
+    using System.IdentityModel.Tokens;
+    using System.Runtime;
+    using System.ServiceModel;
+    using System.ServiceModel.Channels;
+    using System.ServiceModel.Description;
+
+    class TransportSecurityProtocol : SecurityProtocol
+    {
+        public TransportSecurityProtocol(TransportSecurityProtocolFactory factory, EndpointAddress target, Uri via)
+            : base(factory, target, via)
+        {
+        }
+
+        public override void SecureOutgoingMessage(ref Message message, TimeSpan timeout)
+        {
+            if (message == null)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("message");
+            }
+            this.CommunicationObject.ThrowIfClosedOrNotOpen();
+            string actor = string.Empty; // message.Version.Envelope.UltimateDestinationActor;
+            try
+            {
+                if (this.SecurityProtocolFactory.ActAsInitiator)
+                {
+                    SecureOutgoingMessageAtInitiator(ref message, actor, timeout);
+                }
+                else
+                {
+                    SecureOutgoingMessageAtResponder(ref message, actor);
+                }
+                base.OnOutgoingMessageSecured(message);
+            }
+            catch
+            {
+                base.OnSecureOutgoingMessageFailure(message);
+                throw;
+            }
+        }
+
+        protected virtual void SecureOutgoingMessageAtInitiator(ref Message message, string actor, TimeSpan timeout)
+        {
+            IList<SupportingTokenSpecification> supportingTokens;
+            TryGetSupportingTokens(this.SecurityProtocolFactory, this.Target, this.Via, message, timeout, true, out supportingTokens);
+            SetUpDelayedSecurityExecution(ref message, actor, supportingTokens);
+        }
+
+        protected void SecureOutgoingMessageAtResponder(ref Message message, string actor)
+        {
+            if (this.SecurityProtocolFactory.AddTimestamp && !this.SecurityProtocolFactory.SecurityBindingElement.EnableUnsecuredResponse)
+            {
+                SendSecurityHeader securityHeader = CreateSendSecurityHeaderForTransportProtocol(message, actor, this.SecurityProtocolFactory);
+                message = securityHeader.SetupExecution();
+            }
+        }
+
+        internal void SetUpDelayedSecurityExecution(ref Message message, string actor,
+            IList<SupportingTokenSpecification> supportingTokens)
+        {
+            SendSecurityHeader securityHeader = CreateSendSecurityHeaderForTransportProtocol(message, actor, this.SecurityProtocolFactory);
+            AddSupportingTokens(securityHeader, supportingTokens);
+            message = securityHeader.SetupExecution();
+        }
+
+        public override IAsyncResult BeginSecureOutgoingMessage(Message message, TimeSpan timeout, SecurityProtocolCorrelationState correlationState, AsyncCallback callback, object state)
+        {
+            if (message == null)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("message");
+            }
+            this.CommunicationObject.ThrowIfClosedOrNotOpen();
+            string actor = string.Empty; // message.Version.Envelope.UltimateDestinationActor;
+            try
+            {
+                if (this.SecurityProtocolFactory.ActAsInitiator)
+                {
+                    return this.BeginSecureOutgoingMessageAtInitiatorCore(message, actor, timeout, callback, state);
+                }
+                else
+                {
+                    SecureOutgoingMessageAtResponder(ref message, actor);
+                    return new CompletedAsyncResult<Message>(message, callback, state);
+                }
+            }
+            catch (Exception exception)
+            {
+                // Always immediately rethrow fatal exceptions.
+                if (Fx.IsFatal(exception)) throw;
+
+                base.OnSecureOutgoingMessageFailure(message);
+                throw;
+            }
+        }
+
+        public override IAsyncResult BeginSecureOutgoingMessage(Message message, TimeSpan timeout, AsyncCallback callback, object state)
+        {
+            return BeginSecureOutgoingMessage(message, timeout, null, callback, state);
+        }
+
+        protected virtual IAsyncResult BeginSecureOutgoingMessageAtInitiatorCore(Message message, string actor, TimeSpan timeout, AsyncCallback callback, object state)
+        {
+            IList<SupportingTokenSpecification> supportingTokens;
+            TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
+            if (TryGetSupportingTokens(this.SecurityProtocolFactory, this.Target, this.Via, message, timeoutHelper.RemainingTime(), false, out supportingTokens))
+            {
+                SetUpDelayedSecurityExecution(ref message, actor, supportingTokens);
+                return new CompletedAsyncResult<Message>(message, callback, state);
+            }
+            else
+            {
+                return new SecureOutgoingMessageAsyncResult(actor, message, this, timeout, callback, state);
+            }
+        }
+
+        protected virtual Message EndSecureOutgoingMessageAtInitiatorCore(IAsyncResult result)
+        {
+            if (result is CompletedAsyncResult<Message>)
+            {
+                return CompletedAsyncResult<Message>.End(result);
+            }
+            else
+            {
+                return SecureOutgoingMessageAsyncResult.End(result);
+            }
+        }
+
+        public override void EndSecureOutgoingMessage(IAsyncResult result, out Message message)
+        {
+            SecurityProtocolCorrelationState dummyState;
+            this.EndSecureOutgoingMessage(result, out message, out dummyState);
+        }
+
+        public override void EndSecureOutgoingMessage(IAsyncResult result, out Message message, out SecurityProtocolCorrelationState newCorrelationState)
+        {
+            if (result == null)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("result");
+            }
+            newCorrelationState = null;
+            try
+            {
+                if (result is CompletedAsyncResult<Message>)
+                {
+                    message = CompletedAsyncResult<Message>.End(result);
+                }
+                else
+                {
+                    message = this.EndSecureOutgoingMessageAtInitiatorCore(result);
+                }
+                base.OnOutgoingMessageSecured(message);
+            }
+            catch (Exception exception)
+            {
+                // Always immediately rethrow fatal exceptions.
+                if (Fx.IsFatal(exception)) throw;
+
+                base.OnSecureOutgoingMessageFailure(null);
+                throw;
+            }
+        }
+
+        public sealed override void VerifyIncomingMessage(ref Message message, TimeSpan timeout)
+        {
+            if (message == null)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("message");
+            }
+            this.CommunicationObject.ThrowIfClosedOrNotOpen();
+            try
+            {
+                VerifyIncomingMessageCore(ref message, timeout);
+            }
+            catch (MessageSecurityException e)
+            {
+                base.OnVerifyIncomingMessageFailure(message, e);
+                throw;
+            }
+            catch (Exception e)
+            {
+                // Always immediately rethrow fatal exceptions.
+                if (Fx.IsFatal(e)) throw;
+
+                base.OnVerifyIncomingMessageFailure(message, e);
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new MessageSecurityException(SR.GetString(SR.MessageSecurityVerificationFailed), e));
+            }
+        }
+
+        protected void AttachRecipientSecurityProperty(Message message, IList<SecurityToken> basicTokens, IList<SecurityToken> endorsingTokens,
+           IList<SecurityToken> signedEndorsingTokens, IList<SecurityToken> signedTokens, Dictionary<SecurityToken, ReadOnlyCollection<IAuthorizationPolicy>> tokenPoliciesMapping)
+        {
+            SecurityMessageProperty security = SecurityMessageProperty.GetOrCreate(message);
+            AddSupportingTokenSpecification(security, basicTokens, endorsingTokens, signedEndorsingTokens, signedTokens, tokenPoliciesMapping);
+            security.ServiceSecurityContext = new ServiceSecurityContext(security.GetInitiatorTokenAuthorizationPolicies());
+        }
+
+        protected virtual void VerifyIncomingMessageCore(ref Message message, TimeSpan timeout)
+        {
+            TransportSecurityProtocolFactory factory = (TransportSecurityProtocolFactory)this.SecurityProtocolFactory;
+            string actor = string.Empty; // message.Version.Envelope.UltimateDestinationActor;
+
+            ReceiveSecurityHeader securityHeader = factory.StandardsManager.TryCreateReceiveSecurityHeader(message, actor,
+                factory.IncomingAlgorithmSuite, (factory.ActAsInitiator) ? MessageDirection.Output : MessageDirection.Input);
+            bool expectBasicTokens;
+            bool expectEndorsingTokens;
+            bool expectSignedTokens;
+            IList<SupportingTokenAuthenticatorSpecification> supportingAuthenticators = factory.GetSupportingTokenAuthenticators(message.Headers.Action,
+                out expectSignedTokens, out expectBasicTokens, out expectEndorsingTokens);
+            if (securityHeader == null)
+            {
+                bool expectSupportingTokens = expectEndorsingTokens || expectSignedTokens || expectBasicTokens;
+                if ((factory.ActAsInitiator && (!factory.AddTimestamp || factory.SecurityBindingElement.EnableUnsecuredResponse))
+                    || (!factory.ActAsInitiator && !factory.AddTimestamp && !expectSupportingTokens))
+                {
+                    return;
+                }
+                else
+                {
+                    if (String.IsNullOrEmpty(actor))
+                        throw System.ServiceModel.Diagnostics.TraceUtility.ThrowHelperError(new MessageSecurityException(
+                            SR.GetString(SR.UnableToFindSecurityHeaderInMessageNoActor)), message);
+                    else
+                        throw System.ServiceModel.Diagnostics.TraceUtility.ThrowHelperError(new MessageSecurityException(
+                            SR.GetString(SR.UnableToFindSecurityHeaderInMessage, actor)), message);
+                }
+            }
+
+            securityHeader.RequireMessageProtection = false;
+            securityHeader.ExpectBasicTokens = expectBasicTokens;
+            securityHeader.ExpectSignedTokens = expectSignedTokens;
+            securityHeader.ExpectEndorsingTokens = expectEndorsingTokens;
+            securityHeader.MaxReceivedMessageSize = factory.SecurityBindingElement.MaxReceivedMessageSize;
+            securityHeader.ReaderQuotas = factory.SecurityBindingElement.ReaderQuotas;
+
+            // Due to compatibility, only honor this setting if this app setting is enabled
+            if (ServiceModelAppSettings.UseConfiguredTransportSecurityHeaderLayout)
+            {
+                securityHeader.Layout = factory.SecurityHeaderLayout;
+            }
+
+            TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
+            if (!factory.ActAsInitiator)
+            {
+                securityHeader.ConfigureTransportBindingServerReceiveHeader(supportingAuthenticators);
+                securityHeader.ConfigureOutOfBandTokenResolver(MergeOutOfBandResolvers(supportingAuthenticators, EmptyReadOnlyCollection<SecurityTokenResolver>.Instance));
+                if (factory.ExpectKeyDerivation)
+                {
+                    securityHeader.DerivedTokenAuthenticator = factory.DerivedKeyTokenAuthenticator;
+                }
+            }
+            securityHeader.ReplayDetectionEnabled = factory.DetectReplays;
+            securityHeader.SetTimeParameters(factory.NonceCache, factory.ReplayWindow, factory.MaxClockSkew);
+            securityHeader.Process(timeoutHelper.RemainingTime(), SecurityUtils.GetChannelBindingFromMessage(message), factory.ExtendedProtectionPolicy);
+            message = securityHeader.ProcessedMessage;
+            if (!factory.ActAsInitiator)
+            {
+                AttachRecipientSecurityProperty(message, securityHeader.BasicSupportingTokens, securityHeader.EndorsingSupportingTokens, securityHeader.SignedEndorsingSupportingTokens,
+                    securityHeader.SignedSupportingTokens, securityHeader.SecurityTokenAuthorizationPoliciesMapping);
+            }
+
+            base.OnIncomingMessageVerified(message);
+        }
+
+        sealed class SecureOutgoingMessageAsyncResult : GetSupportingTokensAsyncResult
+        {
+            Message message;
+            string actor;
+            TransportSecurityProtocol binding;
+
+            public SecureOutgoingMessageAsyncResult(string actor, Message message, TransportSecurityProtocol binding, TimeSpan timeout, AsyncCallback callback, object state)
+                : base(message, binding, timeout, callback, state)
+            {
+                this.actor = actor;
+                this.message = message;
+                this.binding = binding;
+                this.Start();
+            }
+
+            protected override bool OnGetSupportingTokensDone(TimeSpan timeout)
+            {
+                this.binding.SetUpDelayedSecurityExecution(ref this.message, this.actor, this.SupportingTokens);
+                return true;
+            }
+
+            internal static Message End(IAsyncResult result)
+            {
+                SecureOutgoingMessageAsyncResult self = AsyncResult.End<SecureOutgoingMessageAsyncResult>(result);
+                return self.message;
+            }
+        }
+    }
+}
+

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/TransportSecurityProtocolFactory.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/TransportSecurityProtocolFactory.cs
@@ -1,0 +1,48 @@
+//----------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace System.ServiceModel.Security
+{
+    // Note that this protocol and other protocls represented by its
+    // subclasses rely on transport security to provide message
+    // integrity, confidentiality and request-reply correlation.  SOAP
+    // level security features are add-ons to support custom tokens,
+    // and do not have the responsibility to protect specific exchange
+    // patterns.  So, thie protocol return true to both requst-reply
+    // support as well as duplex support.
+    class TransportSecurityProtocolFactory : SecurityProtocolFactory
+    {
+        public TransportSecurityProtocolFactory()
+            : base()
+        {
+        }
+
+        internal TransportSecurityProtocolFactory(TransportSecurityProtocolFactory factory)
+            : base(factory)
+        {
+        }
+
+        public override bool SupportsDuplex
+        {
+            get
+            {
+                return true;
+            }
+        }
+
+        public override bool SupportsReplayDetection
+        {
+            get
+            {
+                return false;
+            }
+        }
+
+        protected override SecurityProtocol OnCreateSecurityProtocol(EndpointAddress target, Uri via, object listenerSecurityState, TimeSpan timeout)
+        {
+            return new TransportSecurityProtocol(this, target, via);
+        }
+    }
+}
+

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/TransportSecurityProtocolFactory.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/TransportSecurityProtocolFactory.cs
@@ -1,6 +1,6 @@
-//----------------------------------------------------------
-// Copyright (c) Microsoft Corporation.  All rights reserved.
-//------------------------------------------------------------
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace System.ServiceModel.Security
 {

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/WSKeyInfoSerializer.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/WSKeyInfoSerializer.cs
@@ -2,12 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-
 using System.Collections.Generic;
 using System.IdentityModel;
 using System.IdentityModel.Selectors;
 using System.IdentityModel.Tokens;
-using System.ServiceModel.Security;
 using System.ServiceModel.Security.Tokens;
 using System.Xml;
 using TokenEntry = System.ServiceModel.Security.WSSecurityTokenSerializer.TokenEntry;

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/WSKeyInfoSerializer.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/WSKeyInfoSerializer.cs
@@ -1,0 +1,353 @@
+//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+using System.Collections.Generic;
+using System.IdentityModel;
+using System.IdentityModel.Selectors;
+using System.IdentityModel.Tokens;
+using System.ServiceModel.Security.Tokens;
+using System.Xml;
+
+namespace System.ServiceModel.Security
+{
+
+    class WSKeyInfoSerializer : KeyInfoSerializer
+    {
+        static Func<KeyInfoSerializer, IEnumerable<SecurityTokenSerializer.SerializerEntries>> CreateAdditionalEntries(SecurityVersion securityVersion, SecureConversationVersion secureConversationVersion)
+        {
+            return (KeyInfoSerializer keyInfoSerializer) =>
+                {
+                    List<SecurityTokenSerializer.SerializerEntries> serializerEntries = new List<SecurityTokenSerializer.SerializerEntries>();
+
+                    if (securityVersion == SecurityVersion.WSSecurity10)
+                    {
+                        serializerEntries.Add(new System.IdentityModel.Tokens.WSSecurityJan2004(keyInfoSerializer));
+                    }
+                    else if (securityVersion == SecurityVersion.WSSecurity11)
+                    {
+                        serializerEntries.Add(new System.IdentityModel.Tokens.WSSecurityXXX2005(keyInfoSerializer));
+                    }
+                    else
+                    {
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("securityVersion", SR.GetString(SR.MessageSecurityVersionOutOfRange)));
+                    }
+
+                    if (secureConversationVersion == SecureConversationVersion.WSSecureConversationFeb2005)
+                    {
+                        serializerEntries.Add(new WSSecureConversationFeb2005(keyInfoSerializer));
+                    }
+                    else if (secureConversationVersion == SecureConversationVersion.WSSecureConversation13)
+                    {
+                        serializerEntries.Add(new WSSecureConversationDec2005(keyInfoSerializer));
+                    }
+                    else
+                    {
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new NotSupportedException());
+                    }
+
+                    return serializerEntries;
+                };
+        }
+
+        public WSKeyInfoSerializer(bool emitBspRequiredAttributes, DictionaryManager dictionaryManager, System.IdentityModel.TrustDictionary trustDictionary, SecurityTokenSerializer innerSecurityTokenSerializer, SecurityVersion securityVersion, SecureConversationVersion secureConversationVersion)
+            : base(emitBspRequiredAttributes, dictionaryManager, trustDictionary, innerSecurityTokenSerializer, CreateAdditionalEntries(securityVersion, secureConversationVersion))
+        {
+        }
+
+        #region WSSecureConversation classes
+
+        abstract class WSSecureConversation : SecurityTokenSerializer.SerializerEntries
+        {
+            KeyInfoSerializer securityTokenSerializer;
+
+            protected WSSecureConversation( KeyInfoSerializer securityTokenSerializer )
+            {
+                this.securityTokenSerializer = securityTokenSerializer;
+            }
+
+            public KeyInfoSerializer SecurityTokenSerializer
+            {
+                get { return this.securityTokenSerializer; }
+            }
+
+            public abstract System.IdentityModel.SecureConversationDictionary SerializerDictionary
+            {
+                get;
+            }
+
+            public virtual string DerivationAlgorithm
+            {
+                get { return SecurityAlgorithms.Psha1KeyDerivation; }
+            }
+
+            public override void PopulateTokenEntries( IList<TokenEntry> tokenEntryList )
+            {
+                if ( tokenEntryList == null )
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull( "tokenEntryList" );
+                }
+                tokenEntryList.Add( new DerivedKeyTokenEntry( this ) );
+                tokenEntryList.Add( new SecurityContextTokenEntry( this ) );
+            }
+
+            protected abstract class SctStrEntry : StrEntry
+            {
+                WSSecureConversation parent;
+
+                public SctStrEntry( WSSecureConversation parent )
+                {
+                    this.parent = parent;
+                }
+
+                protected WSSecureConversation Parent
+                {
+                    get { return this.parent; }
+                }
+
+                public override Type GetTokenType( SecurityKeyIdentifierClause clause )
+                {
+                    return null;
+                }
+
+                public override string GetTokenTypeUri()
+                {
+                    return null;
+                }
+
+                public override bool CanReadClause( XmlDictionaryReader reader, string tokenType )
+                {
+                    if ( tokenType != null && tokenType != parent.SerializerDictionary.SecurityContextTokenType.Value )
+                    {
+                        return false;
+                    }
+                    if ( reader.IsStartElement(
+                        parent.SecurityTokenSerializer.DictionaryManager.SecurityJan2004Dictionary.Reference,
+                        parent.SecurityTokenSerializer.DictionaryManager.SecurityJan2004Dictionary.Namespace ) )
+                    {
+                        string valueType = reader.GetAttribute( parent.SecurityTokenSerializer.DictionaryManager.SecurityJan2004Dictionary.ValueType, null );
+                        if ( valueType != null && valueType != parent.SerializerDictionary.SecurityContextTokenReferenceValueType.Value )
+                        {
+                            return false;
+                        }
+                        string uri = reader.GetAttribute( parent.SecurityTokenSerializer.DictionaryManager.SecurityJan2004Dictionary.URI, null );
+                        if ( uri != null )
+                        {
+                            if ( uri.Length > 0 && uri[0] != '#' )
+                            {
+                                return true;
+                            }
+                        }
+                    }
+                    return false;
+                }
+
+                public override SecurityKeyIdentifierClause ReadClause( XmlDictionaryReader reader, byte[] derivationNonce, int derivationLength, string tokenType )
+                {
+                    System.Xml.UniqueId uri = XmlHelper.GetAttributeAsUniqueId( reader, XD.SecurityJan2004Dictionary.URI, null );
+                    System.Xml.UniqueId generation = ReadGeneration( reader );
+
+                    if ( reader.IsEmptyElement )
+                    {
+                        reader.Read();
+                    }
+                    else
+                    {
+                        reader.ReadStartElement();
+                        while ( reader.IsStartElement() )
+                        {
+                            reader.Skip();
+                        }
+                        reader.ReadEndElement();
+                    }
+
+                    return new SecurityContextKeyIdentifierClause( uri, generation, derivationNonce, derivationLength );
+                }
+
+                protected abstract System.Xml.UniqueId ReadGeneration( XmlDictionaryReader reader );
+
+                public override bool SupportsCore( SecurityKeyIdentifierClause clause )
+                {
+                    return clause is SecurityContextKeyIdentifierClause;
+                }
+
+                public override void WriteContent( XmlDictionaryWriter writer, SecurityKeyIdentifierClause clause )
+                {
+                    SecurityContextKeyIdentifierClause sctClause = clause as SecurityContextKeyIdentifierClause;
+                    writer.WriteStartElement( XD.SecurityJan2004Dictionary.Prefix.Value, XD.SecurityJan2004Dictionary.Reference, XD.SecurityJan2004Dictionary.Namespace );
+                    XmlHelper.WriteAttributeStringAsUniqueId( writer, null, XD.SecurityJan2004Dictionary.URI, null, sctClause.ContextId );
+                    WriteGeneration( writer, sctClause );
+                    writer.WriteAttributeString( XD.SecurityJan2004Dictionary.ValueType, null, parent.SerializerDictionary.SecurityContextTokenReferenceValueType.Value );
+                    writer.WriteEndElement();
+                }
+
+                protected abstract void WriteGeneration( XmlDictionaryWriter writer, SecurityContextKeyIdentifierClause clause );
+            }
+
+            protected class SecurityContextTokenEntry : SecurityTokenSerializer.TokenEntry
+            {
+                WSSecureConversation parent;
+                Type[] tokenTypes;
+
+                public SecurityContextTokenEntry( WSSecureConversation parent )
+                {
+                    this.parent = parent;
+                }
+
+                protected WSSecureConversation Parent
+                {
+                    get { return this.parent; }
+                }
+
+                protected override XmlDictionaryString LocalName { get { return parent.SerializerDictionary.SecurityContextToken; } }
+                protected override XmlDictionaryString NamespaceUri { get { return parent.SerializerDictionary.Namespace; } }
+                protected override Type[] GetTokenTypesCore()
+                {
+                    if ( tokenTypes == null )
+                        this.tokenTypes = new Type[] { typeof( SecurityContextSecurityToken ) };
+
+                    return this.tokenTypes;
+                }
+                public override string TokenTypeUri { get { return parent.SerializerDictionary.SecurityContextTokenType.Value; } }
+                protected override string ValueTypeUri { get { return null; } }
+
+            }
+
+            protected class DerivedKeyTokenEntry : SecurityTokenSerializer.TokenEntry
+            {
+                public const string DefaultLabel = "WS-SecureConversation";
+
+                WSSecureConversation parent;
+                Type[] tokenTypes;
+
+                public DerivedKeyTokenEntry( WSSecureConversation parent )
+                {
+                    if ( parent == null )
+                    {
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull( "parent" );
+                    }
+                    this.parent = parent;
+                }
+
+                protected override XmlDictionaryString LocalName { get { return parent.SerializerDictionary.DerivedKeyToken; } }
+                protected override XmlDictionaryString NamespaceUri { get { return parent.SerializerDictionary.Namespace; } }
+                protected override Type[] GetTokenTypesCore()
+                {
+                    if ( tokenTypes == null )
+                        this.tokenTypes = new Type[] { typeof( DerivedKeySecurityToken ) };
+
+                    return this.tokenTypes;
+                }
+
+                public override string TokenTypeUri { get { return parent.SerializerDictionary.DerivedKeyTokenType.Value; } }
+                protected override string ValueTypeUri { get { return null; } }
+            }
+        }
+
+        class WSSecureConversationFeb2005 : WSSecureConversation
+        {
+            public WSSecureConversationFeb2005( KeyInfoSerializer securityTokenSerializer )
+                : base( securityTokenSerializer )
+            {
+            }
+
+            public override System.IdentityModel.SecureConversationDictionary SerializerDictionary
+            {
+                get { return this.SecurityTokenSerializer.DictionaryManager.SecureConversationFeb2005Dictionary; }
+            }
+
+            public override void PopulateStrEntries( IList<StrEntry> strEntries )
+            {
+                strEntries.Add( new SctStrEntryFeb2005( this ) );
+            }
+
+            class SctStrEntryFeb2005 : SctStrEntry
+            {
+                public SctStrEntryFeb2005( WSSecureConversationFeb2005 parent )
+                    : base( parent )
+                {
+                }
+
+                protected override System.Xml.UniqueId ReadGeneration( XmlDictionaryReader reader )
+                {
+                    return XmlHelper.GetAttributeAsUniqueId(
+                        reader,
+                        this.Parent.SecurityTokenSerializer.DictionaryManager.SecureConversationDec2005Dictionary.Instance,
+                        this.Parent.SecurityTokenSerializer.DictionaryManager.SecureConversationFeb2005Dictionary.Namespace );
+                }
+
+                protected override void WriteGeneration( XmlDictionaryWriter writer, SecurityContextKeyIdentifierClause clause )
+                {
+                    // serialize the generation
+                    if ( clause.Generation != null )
+                    {
+                        XmlHelper.WriteAttributeStringAsUniqueId(
+                            writer,
+                            this.Parent.SecurityTokenSerializer.DictionaryManager.SecureConversationFeb2005Dictionary.Prefix.Value,
+                            this.Parent.SecurityTokenSerializer.DictionaryManager.SecureConversationDec2005Dictionary.Instance,
+                            this.Parent.SecurityTokenSerializer.DictionaryManager.SecureConversationFeb2005Dictionary.Namespace,
+                            clause.Generation );
+                    }
+                }
+            }
+        }
+
+        class WSSecureConversationDec2005 : WSSecureConversation
+        {
+            public WSSecureConversationDec2005( KeyInfoSerializer securityTokenSerializer )
+                : base( securityTokenSerializer )
+            {
+            }
+
+            public override System.IdentityModel.SecureConversationDictionary SerializerDictionary
+            {
+                get { return this.SecurityTokenSerializer.DictionaryManager.SecureConversationDec2005Dictionary; }
+            }
+
+            public override void PopulateStrEntries( IList<StrEntry> strEntries )
+            {
+                strEntries.Add( new SctStrEntryDec2005( this ) );
+            }
+
+            public override string DerivationAlgorithm
+            {
+                get
+                {
+                    return SecurityAlgorithms.Psha1KeyDerivationDec2005;
+                }
+            }
+
+            class SctStrEntryDec2005 : SctStrEntry
+            {
+                public SctStrEntryDec2005( WSSecureConversationDec2005 parent )
+                    : base( parent )
+                {
+                }
+
+                protected override System.Xml.UniqueId ReadGeneration( XmlDictionaryReader reader )
+                {
+                    return XmlHelper.GetAttributeAsUniqueId( reader, this.Parent.SecurityTokenSerializer.DictionaryManager.SecureConversationDec2005Dictionary.Instance,
+                        this.Parent.SecurityTokenSerializer.DictionaryManager.SecureConversationDec2005Dictionary.Namespace );
+                }
+
+                protected override void WriteGeneration( XmlDictionaryWriter writer, SecurityContextKeyIdentifierClause clause )
+                {
+                    // serialize the generation
+                    if ( clause.Generation != null )
+                    {
+                        XmlHelper.WriteAttributeStringAsUniqueId(
+                            writer,
+                            this.Parent.SecurityTokenSerializer.DictionaryManager.SecureConversationDec2005Dictionary.Prefix.Value,
+                            this.Parent.SecurityTokenSerializer.DictionaryManager.SecureConversationDec2005Dictionary.Instance,
+                            this.Parent.SecurityTokenSerializer.DictionaryManager.SecureConversationDec2005Dictionary.Namespace,
+                            clause.Generation );
+                    }
+                }
+            }
+
+        }
+
+        #endregion
+    }
+}
+

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/WSSecureConversation.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/WSSecureConversation.cs
@@ -11,7 +11,7 @@ using System.Runtime;
 using System.ServiceModel;
 using System.ServiceModel.Security.Tokens;
 using System.Xml;
-//using StrEntry = WSSecurityTokenSerializer.StrEntry;
+
 using TokenEntry = System.ServiceModel.Security.WSSecurityTokenSerializer.TokenEntry;
 
 

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/WSSecureConversation.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/WSSecureConversation.cs
@@ -1,0 +1,587 @@
+//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace System.ServiceModel.Security
+{
+    using System;
+    using System.Collections.Generic;
+    using System.IdentityModel.Selectors;
+    using System.IdentityModel.Tokens;
+    using System.Runtime;
+    using System.ServiceModel;
+    using System.ServiceModel.Security.Tokens;
+    using System.Xml;
+    using StrEntry = WSSecurityTokenSerializer.StrEntry;
+    using TokenEntry = WSSecurityTokenSerializer.TokenEntry;
+
+    abstract class WSSecureConversation : WSSecurityTokenSerializer.SerializerEntries
+    {
+        WSSecurityTokenSerializer tokenSerializer;
+        DerivedKeyTokenEntry derivedKeyEntry;
+
+        protected WSSecureConversation(WSSecurityTokenSerializer tokenSerializer, int maxKeyDerivationOffset, int maxKeyDerivationLabelLength, int maxKeyDerivationNonceLength)
+        {
+            if (tokenSerializer == null)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("tokenSerializer");
+            }
+            this.tokenSerializer = tokenSerializer;
+            this.derivedKeyEntry = new DerivedKeyTokenEntry(this, maxKeyDerivationOffset, maxKeyDerivationLabelLength, maxKeyDerivationNonceLength);
+        }
+
+        public abstract SecureConversationDictionary SerializerDictionary
+        {
+            get;
+        }
+
+        public WSSecurityTokenSerializer WSSecurityTokenSerializer
+        {
+            get { return this.tokenSerializer; }
+        }
+
+        public override void PopulateTokenEntries(IList<TokenEntry> tokenEntryList)
+        {
+            if (tokenEntryList == null)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("tokenEntryList");
+            }
+            tokenEntryList.Add(this.derivedKeyEntry);
+        }
+
+        public virtual bool IsAtDerivedKeyToken(XmlDictionaryReader reader)
+        {
+            return this.derivedKeyEntry.CanReadTokenCore(reader);
+        }
+
+        public virtual void ReadDerivedKeyTokenParameters(XmlDictionaryReader reader, SecurityTokenResolver tokenResolver, out string id, out string derivationAlgorithm, out string label, out int length, out byte[] nonce, out int offset, out int generation, out SecurityKeyIdentifierClause tokenToDeriveIdentifier, out SecurityToken tokenToDerive)
+        {
+            this.derivedKeyEntry.ReadDerivedKeyTokenParameters(reader, tokenResolver, out id, out derivationAlgorithm, out label,
+                out length, out nonce, out offset, out generation, out tokenToDeriveIdentifier, out tokenToDerive);
+        }
+
+        public virtual SecurityToken CreateDerivedKeyToken(string id, string derivationAlgorithm, string label, int length, byte[] nonce, int offset, int generation, SecurityKeyIdentifierClause tokenToDeriveIdentifier, SecurityToken tokenToDerive)
+        {
+            return this.derivedKeyEntry.CreateDerivedKeyToken(id, derivationAlgorithm, label, length, nonce, offset, generation,
+                tokenToDeriveIdentifier, tokenToDerive);
+        }
+
+        public virtual string DerivationAlgorithm
+        {
+            get { return SecurityAlgorithms.Psha1KeyDerivation; }
+        }
+
+        protected class DerivedKeyTokenEntry : WSSecurityTokenSerializer.TokenEntry
+        {
+            public const string DefaultLabel = "WS-SecureConversation";
+
+            WSSecureConversation parent;
+            int maxKeyDerivationOffset;
+            int maxKeyDerivationLabelLength;
+            int maxKeyDerivationNonceLength;
+
+            public DerivedKeyTokenEntry(WSSecureConversation parent, int maxKeyDerivationOffset, int maxKeyDerivationLabelLength, int maxKeyDerivationNonceLength)
+            {
+                if (parent == null)
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("parent");
+                }
+                this.parent = parent;
+                this.maxKeyDerivationOffset = maxKeyDerivationOffset;
+                this.maxKeyDerivationLabelLength = maxKeyDerivationLabelLength;
+                this.maxKeyDerivationNonceLength = maxKeyDerivationNonceLength;
+            }
+
+            protected override XmlDictionaryString LocalName { get { return parent.SerializerDictionary.DerivedKeyToken; } }
+            protected override XmlDictionaryString NamespaceUri { get { return parent.SerializerDictionary.Namespace; } }
+            protected override Type[] GetTokenTypesCore() { return new Type[] { typeof(DerivedKeySecurityToken) }; }
+            public override string TokenTypeUri { get { return parent.SerializerDictionary.DerivedKeyTokenType.Value; } }
+            protected override string ValueTypeUri { get { return null; } }
+
+            public override SecurityKeyIdentifierClause CreateKeyIdentifierClauseFromTokenXmlCore(XmlElement issuedTokenXml,
+                SecurityTokenReferenceStyle tokenReferenceStyle)
+            {
+                TokenReferenceStyleHelper.Validate(tokenReferenceStyle);
+
+                switch (tokenReferenceStyle)
+                {
+                    case SecurityTokenReferenceStyle.Internal:
+                        return CreateDirectReference(issuedTokenXml, UtilityStrings.IdAttribute, UtilityStrings.Namespace, typeof(DerivedKeySecurityToken));
+                    case SecurityTokenReferenceStyle.External:
+                        // DerivedKeys aren't referred to externally
+                        return null;
+                    default:
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("tokenReferenceStyle"));
+                }
+
+            }
+
+            // xml format
+            //<DerivedKeyToken wsu:Id="..." wsse:Algorithm="..."> id required, alg optional (curr disallowed)
+            //  <SecurityTokenReference>...</SecurityTokenReference> - required
+            //  <Properties>...</Properties> - disallowed (optional in spec, but we disallow it)
+            // choice begin - (schema requires a choice - we allow neither on read - we always write one)
+            //  <Generation>...</Generation> - optional
+            //  <Offset>...</Offset> - optional
+            // choice end
+            //  <Length>...</Length> - optional - default 32 on read (default specified in spec, not in schema - we always write it)
+            //  <Label>...</Label> - optional
+            //  <Nonce>...</Nonce> - required (optional in spec, but we require it)
+            //</DerivedKeyToken>
+            public virtual void ReadDerivedKeyTokenParameters(XmlDictionaryReader reader, SecurityTokenResolver tokenResolver, out string id, out string derivationAlgorithm, out string label, out int length, out byte[] nonce, out int offset, out int generation, out SecurityKeyIdentifierClause tokenToDeriveIdentifier, out SecurityToken tokenToDerive)
+            {
+                if (tokenResolver == null)
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("tokenResolver");
+                }
+
+                id = reader.GetAttribute(XD.UtilityDictionary.IdAttribute, XD.UtilityDictionary.Namespace);
+
+                derivationAlgorithm = reader.GetAttribute(XD.XmlSignatureDictionary.Algorithm, null);
+                if (derivationAlgorithm == null)
+                {
+                    derivationAlgorithm = parent.DerivationAlgorithm;
+                }
+
+                reader.ReadStartElement();
+
+                tokenToDeriveIdentifier = null;
+                tokenToDerive = null;
+
+                if (reader.IsStartElement(XD.SecurityJan2004Dictionary.SecurityTokenReference, XD.SecurityJan2004Dictionary.Namespace))
+                {
+                    tokenToDeriveIdentifier = parent.WSSecurityTokenSerializer.ReadKeyIdentifierClause(reader);
+                    tokenResolver.TryResolveToken(tokenToDeriveIdentifier, out tokenToDerive);
+                }
+                else
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new XmlException(SR.GetString(SR.DerivedKeyTokenRequiresTokenReference)));
+                }
+
+                // no support for properties
+
+                generation = -1;
+                if (reader.IsStartElement(parent.SerializerDictionary.Generation, parent.SerializerDictionary.Namespace))
+                {
+                    reader.ReadStartElement();
+                    generation = reader.ReadContentAsInt();
+                    reader.ReadEndElement();
+                    if (generation < 0)
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new XmlException(SR.GetString(SR.DerivedKeyInvalidGenerationSpecified, generation)));
+                }
+
+                offset = -1;
+                if (reader.IsStartElement(parent.SerializerDictionary.Offset, parent.SerializerDictionary.Namespace))
+                {
+                    reader.ReadStartElement();
+                    offset = reader.ReadContentAsInt();
+                    reader.ReadEndElement();
+                    if (offset < 0)
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new XmlException(SR.GetString(SR.DerivedKeyInvalidOffsetSpecified, offset)));
+                }
+
+                length = DerivedKeySecurityToken.DefaultDerivedKeyLength;
+                if (reader.IsStartElement(parent.SerializerDictionary.Length, parent.SerializerDictionary.Namespace))
+                {
+                    reader.ReadStartElement();
+                    length = reader.ReadContentAsInt();
+                    reader.ReadEndElement();
+                }
+
+                if ((offset == -1) && (generation == -1))
+                    offset = 0;
+
+                // verify that the offset is not larger than the max allowed
+                DerivedKeySecurityToken.EnsureAcceptableOffset(offset, generation, length, this.maxKeyDerivationOffset);
+
+                label = null;
+                if (reader.IsStartElement(parent.SerializerDictionary.Label, parent.SerializerDictionary.Namespace))
+                {
+                    reader.ReadStartElement();
+                    label = reader.ReadString();
+                    reader.ReadEndElement();
+                }
+                if (label != null && label.Length > this.maxKeyDerivationLabelLength)
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new MessageSecurityException(SR.GetString(SR.DerivedKeyTokenLabelTooLong, label.Length, this.maxKeyDerivationLabelLength)));
+                }
+
+                nonce = null;
+                reader.ReadStartElement(parent.SerializerDictionary.Nonce, parent.SerializerDictionary.Namespace);
+                nonce = reader.ReadContentAsBase64();
+                reader.ReadEndElement();
+
+                if (nonce != null && nonce.Length > this.maxKeyDerivationNonceLength)
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new MessageSecurityException(SR.GetString(SR.DerivedKeyTokenNonceTooLong, nonce.Length, this.maxKeyDerivationNonceLength)));
+                }
+
+                reader.ReadEndElement();
+            }
+
+            public virtual SecurityToken CreateDerivedKeyToken(string id, string derivationAlgorithm, string label, int length, byte[] nonce, int offset, int generation, SecurityKeyIdentifierClause tokenToDeriveIdentifier, SecurityToken tokenToDerive)
+            {
+                if (tokenToDerive == null)
+                {
+                    return new DerivedKeySecurityTokenStub(generation, offset, length,
+                        label, nonce, tokenToDeriveIdentifier, derivationAlgorithm, id);
+                }
+                else
+                {
+                    return new DerivedKeySecurityToken(generation, offset, length,
+                        label, nonce, tokenToDerive, tokenToDeriveIdentifier, derivationAlgorithm, id);
+                }
+            }
+
+            public override SecurityToken ReadTokenCore(XmlDictionaryReader reader, SecurityTokenResolver tokenResolver)
+            {
+                string id;
+                string derivationAlgorithm;
+                string label;
+                int length;
+                byte[] nonce;
+                int offset;
+                int generation;
+                SecurityKeyIdentifierClause tokenToDeriveIdentifier;
+                SecurityToken tokenToDerive;
+                this.ReadDerivedKeyTokenParameters(reader, tokenResolver, out id, out derivationAlgorithm, out label, out length,
+                    out nonce, out offset, out generation, out tokenToDeriveIdentifier, out tokenToDerive);
+
+                return CreateDerivedKeyToken(id, derivationAlgorithm, label, length, nonce, offset, generation,
+                    tokenToDeriveIdentifier, tokenToDerive);
+            }
+
+            public override void WriteTokenCore(XmlDictionaryWriter writer, SecurityToken token)
+            {
+                DerivedKeySecurityToken derivedKeyToken = token as DerivedKeySecurityToken;
+                string serializerPrefix = parent.SerializerDictionary.Prefix.Value;
+
+                writer.WriteStartElement(serializerPrefix, parent.SerializerDictionary.DerivedKeyToken, parent.SerializerDictionary.Namespace);
+                if (derivedKeyToken.Id != null)
+                {
+                    writer.WriteAttributeString(XD.UtilityDictionary.Prefix.Value, XD.UtilityDictionary.IdAttribute, XD.UtilityDictionary.Namespace, derivedKeyToken.Id);
+                }
+                if (derivedKeyToken.KeyDerivationAlgorithm != parent.DerivationAlgorithm)
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new MessageSecurityException(SR.GetString(SR.UnsupportedKeyDerivationAlgorithm, derivedKeyToken.KeyDerivationAlgorithm)));
+                }
+                parent.WSSecurityTokenSerializer.WriteKeyIdentifierClause(writer, derivedKeyToken.TokenToDeriveIdentifier);
+
+                // Don't support Properties element
+                if (derivedKeyToken.Generation > 0 || derivedKeyToken.Offset > 0 || derivedKeyToken.Length != 32)
+                {
+                    // this means they're both specified (offset must be gen * length) - we'll write generation
+                    if (derivedKeyToken.Generation >= 0 && derivedKeyToken.Offset >= 0)
+                    {
+                        writer.WriteStartElement(serializerPrefix, parent.SerializerDictionary.Generation, parent.SerializerDictionary.Namespace);
+                        writer.WriteValue(derivedKeyToken.Generation);
+                        writer.WriteEndElement();
+                    }
+                    else if (derivedKeyToken.Generation != -1)
+                    {
+                        writer.WriteStartElement(serializerPrefix, parent.SerializerDictionary.Generation, parent.SerializerDictionary.Namespace);
+                        writer.WriteValue(derivedKeyToken.Generation);
+                        writer.WriteEndElement();
+                    }
+                    else if (derivedKeyToken.Offset != -1)
+                    {
+                        writer.WriteStartElement(serializerPrefix, parent.SerializerDictionary.Offset, parent.SerializerDictionary.Namespace);
+                        writer.WriteValue(derivedKeyToken.Offset);
+                        writer.WriteEndElement();
+                    }
+
+                    if (derivedKeyToken.Length != 32)
+                    {
+                        writer.WriteStartElement(serializerPrefix, parent.SerializerDictionary.Length, parent.SerializerDictionary.Namespace);
+                        writer.WriteValue(derivedKeyToken.Length);
+                        writer.WriteEndElement();
+                    }
+                }
+
+                if (derivedKeyToken.Label != null)
+                {
+                    writer.WriteStartElement(serializerPrefix, parent.SerializerDictionary.Generation, parent.SerializerDictionary.Namespace);
+                    writer.WriteString(derivedKeyToken.Label);
+                    writer.WriteEndElement();
+                }
+                writer.WriteStartElement(serializerPrefix, parent.SerializerDictionary.Nonce, parent.SerializerDictionary.Namespace);
+                writer.WriteBase64(derivedKeyToken.Nonce, 0, derivedKeyToken.Nonce.Length);
+                writer.WriteEndElement();
+                writer.WriteEndElement();
+            }
+        }
+
+        protected abstract class SecurityContextTokenEntry : WSSecurityTokenSerializer.TokenEntry
+        {
+            WSSecureConversation parent;
+            SecurityContextCookieSerializer cookieSerializer;
+
+            public SecurityContextTokenEntry(WSSecureConversation parent, SecurityStateEncoder securityStateEncoder, IList<Type> knownClaimTypes)
+            {
+                this.parent = parent;
+                this.cookieSerializer = new SecurityContextCookieSerializer(securityStateEncoder, knownClaimTypes);
+            }
+
+            protected WSSecureConversation Parent
+            {
+                get { return this.parent; }
+            }
+
+            protected override XmlDictionaryString LocalName { get { return parent.SerializerDictionary.SecurityContextToken; } }
+            protected override XmlDictionaryString NamespaceUri { get { return parent.SerializerDictionary.Namespace; } }
+            protected override Type[] GetTokenTypesCore() { return new Type[] { typeof(SecurityContextSecurityToken) }; }
+            public override string TokenTypeUri { get { return parent.SerializerDictionary.SecurityContextTokenType.Value; } }
+            protected override string ValueTypeUri { get { return null; } }
+
+            public override SecurityKeyIdentifierClause CreateKeyIdentifierClauseFromTokenXmlCore(XmlElement issuedTokenXml,
+                SecurityTokenReferenceStyle tokenReferenceStyle)
+            {
+
+                TokenReferenceStyleHelper.Validate(tokenReferenceStyle);
+
+                switch (tokenReferenceStyle)
+                {
+                    case SecurityTokenReferenceStyle.Internal:
+                        return CreateDirectReference(issuedTokenXml, UtilityStrings.IdAttribute, UtilityStrings.Namespace, typeof(SecurityContextSecurityToken));
+                    case SecurityTokenReferenceStyle.External:
+                        UniqueId contextId = null;
+                        UniqueId generation = null;
+                        foreach (XmlNode node in issuedTokenXml.ChildNodes)
+                        {
+                            XmlElement element = node as XmlElement;
+                            if (element != null)
+                            {
+                                if (element.LocalName == parent.SerializerDictionary.Identifier.Value && element.NamespaceURI == parent.SerializerDictionary.Namespace.Value)
+                                {
+                                    contextId = XmlHelper.ReadTextElementAsUniqueId(element);
+                                }
+                                else if (CanReadGeneration(element))
+                                {
+                                    generation = ReadGeneration(element);
+                                }
+                            }
+                        }
+                        return new SecurityContextKeyIdentifierClause(contextId, generation);
+                    default:
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("tokenReferenceStyle"));
+                }
+            }
+
+            protected abstract bool CanReadGeneration(XmlDictionaryReader reader);
+            protected abstract bool CanReadGeneration(XmlElement element);
+            protected abstract UniqueId ReadGeneration(XmlDictionaryReader reader);
+            protected abstract UniqueId ReadGeneration(XmlElement element);
+
+            SecurityContextSecurityToken TryResolveSecurityContextToken(UniqueId contextId, UniqueId generation, string id, SecurityTokenResolver tokenResolver, out ISecurityContextSecurityTokenCache sctCache)
+            {
+                SecurityContextSecurityToken cachedSct = null;
+                sctCache = null;
+                if (tokenResolver is ISecurityContextSecurityTokenCache)
+                {
+                    sctCache = ((ISecurityContextSecurityTokenCache)tokenResolver);
+                    cachedSct = sctCache.GetContext(contextId, generation);
+                }
+                else if (tokenResolver is AggregateSecurityHeaderTokenResolver)
+                {
+                    // We will see if we have a ISecurityContextSecurityTokenCache in the 
+                    // AggregateTokenResolver. We will hold the reference to the first sctCache
+                    // we find.
+                    AggregateSecurityHeaderTokenResolver aggregateTokenResolve = tokenResolver as AggregateSecurityHeaderTokenResolver;
+                    for (int i = 0; i < aggregateTokenResolve.TokenResolvers.Count; ++i)
+                    {
+                        ISecurityContextSecurityTokenCache oobTokenResolver = aggregateTokenResolve.TokenResolvers[i] as ISecurityContextSecurityTokenCache;
+                        if (oobTokenResolver == null)
+                        {
+                            continue;
+                        }
+                        if (sctCache == null)
+                        {
+                            sctCache = oobTokenResolver;
+                        }
+                        cachedSct = oobTokenResolver.GetContext(contextId, generation);
+                        if (cachedSct != null)
+                        {
+                            break;
+                        }
+                    }
+                }
+                if (cachedSct == null)
+                {
+                    return null;
+                }
+                else if (cachedSct.Id == id)
+                {
+                    return cachedSct;
+                }
+                else
+                {
+                    return new SecurityContextSecurityToken(cachedSct, id);
+                }
+            }
+
+            public override SecurityToken ReadTokenCore(XmlDictionaryReader reader, SecurityTokenResolver tokenResolver)
+            {
+                UniqueId contextId = null;
+                byte[] encodedCookie = null;
+                UniqueId generation = null;
+                bool isCookieMode = false;
+
+                Fx.Assert(reader.NodeType == XmlNodeType.Element, "");
+
+                // check if there is an id
+                string id = reader.GetAttribute(XD.UtilityDictionary.IdAttribute, XD.UtilityDictionary.Namespace);
+
+                SecurityContextSecurityToken sct = null;
+
+                // There needs to be at least a contextId in here.
+                reader.ReadFullStartElement();
+                reader.MoveToStartElement(parent.SerializerDictionary.Identifier, parent.SerializerDictionary.Namespace);
+                contextId = reader.ReadElementContentAsUniqueId();
+                if (CanReadGeneration(reader))
+                {
+                    generation = ReadGeneration(reader);
+                }
+                if (reader.IsStartElement(parent.SerializerDictionary.Cookie, XD.DotNetSecurityDictionary.Namespace))
+                {
+                    isCookieMode = true;
+                    ISecurityContextSecurityTokenCache sctCache;
+                    sct = TryResolveSecurityContextToken(contextId, generation, id, tokenResolver, out sctCache);
+                    if (sct == null)
+                    {
+                        encodedCookie = reader.ReadElementContentAsBase64();
+                        if (encodedCookie != null)
+                        {
+                            sct = cookieSerializer.CreateSecurityContextFromCookie(encodedCookie, contextId, generation, id, reader.Quotas);
+                            if (sctCache != null)
+                            {
+                                sctCache.AddContext(sct);
+                            }
+                        }
+                    }
+                    else
+                    {
+                        reader.Skip();
+                    }
+                }
+                reader.ReadEndElement();
+
+                if (contextId == null)
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new MessageSecurityException(SR.GetString(SR.NoSecurityContextIdentifier)));
+                }
+
+                if (sct == null && !isCookieMode)
+                {
+                    ISecurityContextSecurityTokenCache sctCache;
+                    sct = TryResolveSecurityContextToken(contextId, generation, id, tokenResolver, out sctCache);
+                }
+                if (sct == null)
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new SecurityContextTokenValidationException(SR.GetString(SR.SecurityContextNotRegistered, contextId, generation)));
+                }
+                return sct;
+            }
+
+            protected virtual void WriteGeneration(XmlDictionaryWriter writer, SecurityContextSecurityToken sct)
+            {
+            }
+
+            public override void WriteTokenCore(XmlDictionaryWriter writer, SecurityToken token)
+            {
+                SecurityContextSecurityToken sct = (token as SecurityContextSecurityToken);
+
+                // serialize the name and any wsu:Id attribute
+                writer.WriteStartElement(parent.SerializerDictionary.Prefix.Value, parent.SerializerDictionary.SecurityContextToken, parent.SerializerDictionary.Namespace);
+                if (sct.Id != null)
+                {
+                    writer.WriteAttributeString(XD.UtilityDictionary.Prefix.Value, XD.UtilityDictionary.IdAttribute, XD.UtilityDictionary.Namespace, sct.Id);
+                }
+
+                // serialize the context id
+                writer.WriteStartElement(parent.SerializerDictionary.Prefix.Value, parent.SerializerDictionary.Identifier, parent.SerializerDictionary.Namespace);
+                XmlHelper.WriteStringAsUniqueId(writer, sct.ContextId);
+                writer.WriteEndElement();
+
+                WriteGeneration(writer, sct);
+
+                // if cookie-mode, then it must have a cookie
+                if (sct.IsCookieMode)
+                {
+                    if (sct.CookieBlob == null)
+                    {
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new MessageSecurityException(SR.GetString(SR.NoCookieInSct)));
+                    }
+
+                    // if the token has a cookie, write it out
+                    writer.WriteStartElement(XD.DotNetSecurityDictionary.Prefix.Value, parent.SerializerDictionary.Cookie, XD.DotNetSecurityDictionary.Namespace);
+                    writer.WriteBase64(sct.CookieBlob, 0, sct.CookieBlob.Length);
+                    writer.WriteEndElement();
+                }
+
+                writer.WriteEndElement();
+            }
+        }
+
+        public abstract class Driver : SecureConversationDriver
+        {
+            public Driver()
+            {
+            }
+
+            protected abstract SecureConversationDictionary DriverDictionary
+            {
+                get;
+            }
+
+            public override XmlDictionaryString IssueAction
+            {
+                get
+                {
+                    return DriverDictionary.RequestSecurityContextIssuance;
+                }
+            }
+
+            public override XmlDictionaryString IssueResponseAction
+            {
+                get
+                {
+                    return DriverDictionary.RequestSecurityContextIssuanceResponse;
+                }
+            }
+
+            public override XmlDictionaryString RenewNeededFaultCode
+            {
+                get { return DriverDictionary.RenewNeededFaultCode; }
+            }
+
+            public override XmlDictionaryString BadContextTokenFaultCode
+            {
+                get { return DriverDictionary.BadContextTokenFaultCode; }
+            }
+
+            public override UniqueId GetSecurityContextTokenId(XmlDictionaryReader reader)
+            {
+                if (reader == null)
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("reader");
+
+                reader.ReadStartElement(DriverDictionary.SecurityContextToken, DriverDictionary.Namespace);
+                UniqueId contextId = XmlHelper.ReadElementStringAsUniqueId(reader, DriverDictionary.Identifier, DriverDictionary.Namespace);
+                while (reader.IsStartElement())
+                {
+                    reader.Skip();
+                }
+                reader.ReadEndElement();
+                return contextId;
+            }
+
+            public override bool IsAtSecurityContextToken(XmlDictionaryReader reader)
+            {
+                if (reader == null)
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("reader");
+
+                return reader.IsStartElement(DriverDictionary.SecurityContextToken, DriverDictionary.Namespace);
+            }
+        }
+    }
+}
+

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/WSSecureConversation.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/WSSecureConversation.cs
@@ -2,18 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-
 using System;
 using System.Collections.Generic;
 using System.IdentityModel.Selectors;
 using System.IdentityModel.Tokens;
-using System.Runtime;
-using System.ServiceModel;
 using System.ServiceModel.Security.Tokens;
 using System.Xml;
 
 using TokenEntry = System.ServiceModel.Security.WSSecurityTokenSerializer.TokenEntry;
-
 
 namespace System.ServiceModel.Security
 {

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/WSSecureConversationDec2005.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/WSSecureConversationDec2005.cs
@@ -3,28 +3,12 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.ServiceModel;
-using System.Collections;
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.Globalization;
-using System.IO;
-using System.Text;
-using System.Threading;
-using System.Xml;
-using System.IdentityModel.Claims;
-using System.IdentityModel.Policy;
 using System.IdentityModel.Tokens;
-using System.Security.Cryptography.X509Certificates;
+using System.ServiceModel.Security.Tokens;
+using System.Xml;
 // Issue #31 in progress
 // using HexBinary = System.Runtime.Remoting.Metadata.W3cXsd2001.SoapHexBinary;
-using System.ServiceModel.Channels;
-using System.ServiceModel.Security;
-using System.ServiceModel.Security.Tokens;
-using System.Runtime.Serialization;
-using KeyIdentifierEntry = System.ServiceModel.Security.WSSecurityTokenSerializer.KeyIdentifierEntry;
-using KeyIdentifierClauseEntry = System.ServiceModel.Security.WSSecurityTokenSerializer.KeyIdentifierClauseEntry;
-using StrEntry = System.ServiceModel.Security.WSSecurityTokenSerializer.StrEntry;
 using TokenEntry = System.ServiceModel.Security.WSSecurityTokenSerializer.TokenEntry;
 
 namespace System.ServiceModel.Security

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/WSSecureConversationDec2005.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/WSSecureConversationDec2005.cs
@@ -1,0 +1,170 @@
+//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace System.ServiceModel.Security
+{
+    using System;
+    using System.ServiceModel;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.Globalization;
+    using System.IO;
+    using System.Text;
+    using System.Threading;
+    using System.Xml;
+    using System.IdentityModel.Claims;
+    using System.IdentityModel.Policy;
+    using System.IdentityModel.Tokens;
+    using System.Security.Cryptography.X509Certificates;
+    using HexBinary = System.Runtime.Remoting.Metadata.W3cXsd2001.SoapHexBinary;
+    using System.ServiceModel.Channels;
+    using System.ServiceModel.Security;
+    using System.ServiceModel.Security.Tokens;
+    using System.Runtime.Serialization;
+    using KeyIdentifierEntry = WSSecurityTokenSerializer.KeyIdentifierEntry;
+    using KeyIdentifierClauseEntry = WSSecurityTokenSerializer.KeyIdentifierClauseEntry;
+    using StrEntry = WSSecurityTokenSerializer.StrEntry;
+    using TokenEntry = WSSecurityTokenSerializer.TokenEntry;
+
+    class WSSecureConversationDec2005 : WSSecureConversation
+    {
+        SecurityStateEncoder securityStateEncoder;
+        IList<Type> knownClaimTypes;
+
+        public WSSecureConversationDec2005(WSSecurityTokenSerializer tokenSerializer, SecurityStateEncoder securityStateEncoder, IEnumerable<Type> knownTypes,
+            int maxKeyDerivationOffset, int maxKeyDerivationLabelLength, int maxKeyDerivationNonceLength)
+            : base(tokenSerializer, maxKeyDerivationOffset, maxKeyDerivationLabelLength, maxKeyDerivationNonceLength)
+        {
+            if (securityStateEncoder != null)
+            {
+                this.securityStateEncoder = securityStateEncoder;
+            }
+            else
+            {
+                this.securityStateEncoder = new DataProtectionSecurityStateEncoder();
+            }
+
+            this.knownClaimTypes = new List<Type>();
+            if (knownTypes != null)
+            {
+                // Clone this collection.
+                foreach (Type knownType in knownTypes)
+                {
+                    this.knownClaimTypes.Add(knownType);
+                }
+            }
+        }
+
+        public override SecureConversationDictionary SerializerDictionary
+        {
+            get { return DXD.SecureConversationDec2005Dictionary; }
+        }
+
+        public override void PopulateTokenEntries(IList<TokenEntry> tokenEntryList)
+        {
+            base.PopulateTokenEntries(tokenEntryList);
+            tokenEntryList.Add(new SecurityContextTokenEntryDec2005(this, this.securityStateEncoder, this.knownClaimTypes));
+        }
+
+        public override string DerivationAlgorithm
+        {
+            get
+            {
+                return SecurityAlgorithms.Psha1KeyDerivationDec2005;
+            }
+        }
+
+        class SecurityContextTokenEntryDec2005 : SecurityContextTokenEntry
+        {
+            public SecurityContextTokenEntryDec2005(WSSecureConversationDec2005 parent, SecurityStateEncoder securityStateEncoder, IList<Type> knownClaimTypes)
+                : base(parent, securityStateEncoder, knownClaimTypes)
+            {
+            }
+
+            protected override bool CanReadGeneration(XmlDictionaryReader reader)
+            {
+                return reader.IsStartElement(DXD.SecureConversationDec2005Dictionary.Instance, DXD.SecureConversationDec2005Dictionary.Namespace);
+            }
+
+            protected override bool CanReadGeneration(XmlElement element)
+            {
+                return (element.LocalName == DXD.SecureConversationDec2005Dictionary.Instance.Value &&
+                    element.NamespaceURI == DXD.SecureConversationDec2005Dictionary.Namespace.Value);
+            }
+
+            protected override UniqueId ReadGeneration(XmlDictionaryReader reader)
+            {
+                return reader.ReadElementContentAsUniqueId();
+            }
+
+            protected override UniqueId ReadGeneration(XmlElement element)
+            {
+                return XmlHelper.ReadTextElementAsUniqueId(element);
+            }
+
+            protected override void WriteGeneration(XmlDictionaryWriter writer, SecurityContextSecurityToken sct)
+            {
+                // serialize the generation
+                if (sct.KeyGeneration != null)
+                {
+                    writer.WriteStartElement(DXD.SecureConversationDec2005Dictionary.Prefix.Value,
+                        DXD.SecureConversationDec2005Dictionary.Instance,
+                        DXD.SecureConversationDec2005Dictionary.Namespace);
+                    XmlHelper.WriteStringAsUniqueId(writer, sct.KeyGeneration);
+                    writer.WriteEndElement();
+                }
+            }
+        }
+
+        public class DriverDec2005 : Driver
+        {
+            public DriverDec2005()
+            {
+            }
+
+            protected override SecureConversationDictionary DriverDictionary
+            {
+                get { return DXD.SecureConversationDec2005Dictionary; }
+            }
+
+            public override XmlDictionaryString CloseAction
+            {
+                get { return DXD.SecureConversationDec2005Dictionary.RequestSecurityContextClose; }
+            }
+
+            public override XmlDictionaryString CloseResponseAction
+            {
+                get { return DXD.SecureConversationDec2005Dictionary.RequestSecurityContextCloseResponse; }
+            }
+
+            public override bool IsSessionSupported
+            {
+                get { return true; }
+            }
+
+            public override XmlDictionaryString RenewAction
+            {
+                get { return DXD.SecureConversationDec2005Dictionary.RequestSecurityContextRenew; }
+            }
+
+            public override XmlDictionaryString RenewResponseAction
+            {
+                get { return DXD.SecureConversationDec2005Dictionary.RequestSecurityContextRenewResponse; }
+            }
+
+            public override XmlDictionaryString Namespace
+            {
+                get { return DXD.SecureConversationDec2005Dictionary.Namespace; }
+            }
+
+            public override string TokenTypeUri
+            {
+                get { return DXD.SecureConversationDec2005Dictionary.SecurityContextTokenType.Value; }
+            }
+        }
+    }
+}
+
+

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/WSSecureConversationDec2005.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/WSSecureConversationDec2005.cs
@@ -1,37 +1,38 @@
-//------------------------------------------------------------
-// Copyright (c) Microsoft Corporation.  All rights reserved.
-//------------------------------------------------------------
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.ServiceModel;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Xml;
+using System.IdentityModel.Claims;
+using System.IdentityModel.Policy;
+using System.IdentityModel.Tokens;
+using System.Security.Cryptography.X509Certificates;
+// Issue #31 in progress
+// using HexBinary = System.Runtime.Remoting.Metadata.W3cXsd2001.SoapHexBinary;
+using System.ServiceModel.Channels;
+using System.ServiceModel.Security;
+using System.ServiceModel.Security.Tokens;
+using System.Runtime.Serialization;
+using KeyIdentifierEntry = System.ServiceModel.Security.WSSecurityTokenSerializer.KeyIdentifierEntry;
+using KeyIdentifierClauseEntry = System.ServiceModel.Security.WSSecurityTokenSerializer.KeyIdentifierClauseEntry;
+using StrEntry = System.ServiceModel.Security.WSSecurityTokenSerializer.StrEntry;
+using TokenEntry = System.ServiceModel.Security.WSSecurityTokenSerializer.TokenEntry;
 
 namespace System.ServiceModel.Security
 {
-    using System;
-    using System.ServiceModel;
-    using System.Collections;
-    using System.Collections.Generic;
-    using System.Diagnostics;
-    using System.Globalization;
-    using System.IO;
-    using System.Text;
-    using System.Threading;
-    using System.Xml;
-    using System.IdentityModel.Claims;
-    using System.IdentityModel.Policy;
-    using System.IdentityModel.Tokens;
-    using System.Security.Cryptography.X509Certificates;
-    using HexBinary = System.Runtime.Remoting.Metadata.W3cXsd2001.SoapHexBinary;
-    using System.ServiceModel.Channels;
-    using System.ServiceModel.Security;
-    using System.ServiceModel.Security.Tokens;
-    using System.Runtime.Serialization;
-    using KeyIdentifierEntry = WSSecurityTokenSerializer.KeyIdentifierEntry;
-    using KeyIdentifierClauseEntry = WSSecurityTokenSerializer.KeyIdentifierClauseEntry;
-    using StrEntry = WSSecurityTokenSerializer.StrEntry;
-    using TokenEntry = WSSecurityTokenSerializer.TokenEntry;
-
     class WSSecureConversationDec2005 : WSSecureConversation
     {
-        SecurityStateEncoder securityStateEncoder;
-        IList<Type> knownClaimTypes;
+        private SecurityStateEncoder _securityStateEncoder;
+        private IList<Type> _knownClaimTypes;
 
         public WSSecureConversationDec2005(WSSecurityTokenSerializer tokenSerializer, SecurityStateEncoder securityStateEncoder, IEnumerable<Type> knownTypes,
             int maxKeyDerivationOffset, int maxKeyDerivationLabelLength, int maxKeyDerivationNonceLength)
@@ -39,20 +40,21 @@ namespace System.ServiceModel.Security
         {
             if (securityStateEncoder != null)
             {
-                this.securityStateEncoder = securityStateEncoder;
+                _securityStateEncoder = securityStateEncoder;
             }
             else
             {
-                this.securityStateEncoder = new DataProtectionSecurityStateEncoder();
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+                //this.securityStateEncoder = new DataProtectionSecurityStateEncoder();
             }
 
-            this.knownClaimTypes = new List<Type>();
+            _knownClaimTypes = new List<Type>();
             if (knownTypes != null)
             {
                 // Clone this collection.
                 foreach (Type knownType in knownTypes)
                 {
-                    this.knownClaimTypes.Add(knownType);
+                    _knownClaimTypes.Add(knownType);
                 }
             }
         }
@@ -65,7 +67,7 @@ namespace System.ServiceModel.Security
         public override void PopulateTokenEntries(IList<TokenEntry> tokenEntryList)
         {
             base.PopulateTokenEntries(tokenEntryList);
-            tokenEntryList.Add(new SecurityContextTokenEntryDec2005(this, this.securityStateEncoder, this.knownClaimTypes));
+            tokenEntryList.Add(new SecurityContextTokenEntryDec2005(this, _securityStateEncoder, _knownClaimTypes));
         }
 
         public override string DerivationAlgorithm
@@ -101,7 +103,8 @@ namespace System.ServiceModel.Security
 
             protected override UniqueId ReadGeneration(XmlElement element)
             {
-                return XmlHelper.ReadTextElementAsUniqueId(element);
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+                // return XmlHelper.ReadTextElementAsUniqueId(element);
             }
 
             protected override void WriteGeneration(XmlDictionaryWriter writer, SecurityContextSecurityToken sct)
@@ -166,5 +169,3 @@ namespace System.ServiceModel.Security
         }
     }
 }
-
-

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/WSSecureConversationFeb2005.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/WSSecureConversationFeb2005.cs
@@ -3,28 +3,11 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.ServiceModel;
-using System.Collections;
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.Globalization;
-using System.IO;
-using System.Text;
-using System.Threading;
+using System.ServiceModel.Security.Tokens;
 using System.Xml;
-using System.IdentityModel.Claims;
-using System.IdentityModel.Policy;
-using System.IdentityModel.Tokens;
-using System.Security.Cryptography.X509Certificates;
 // Issue #31 in progress
 // using HexBinary = System.Runtime.Remoting.Metadata.W3cXsd2001.SoapHexBinary;
-using System.ServiceModel.Channels;
-using System.ServiceModel.Security;
-using System.ServiceModel.Security.Tokens;
-using System.Runtime.Serialization;
-using KeyIdentifierEntry = System.ServiceModel.Security.WSSecurityTokenSerializer.KeyIdentifierEntry;
-using KeyIdentifierClauseEntry = System.ServiceModel.Security.WSSecurityTokenSerializer.KeyIdentifierClauseEntry;
-using StrEntry = System.ServiceModel.Security.WSSecurityTokenSerializer.StrEntry;
 using TokenEntry = System.ServiceModel.Security.WSSecurityTokenSerializer.TokenEntry;
 
 namespace System.ServiceModel.Security

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/WSSecureConversationFeb2005.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/WSSecureConversationFeb2005.cs
@@ -1,0 +1,160 @@
+//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace System.ServiceModel.Security
+{
+    using System;
+    using System.ServiceModel;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.Globalization;
+    using System.IO;
+    using System.Text;
+    using System.Threading;
+    using System.Xml;
+    using System.IdentityModel.Claims;
+    using System.IdentityModel.Policy;
+    using System.IdentityModel.Tokens;
+    using System.Security.Cryptography.X509Certificates;
+    using HexBinary = System.Runtime.Remoting.Metadata.W3cXsd2001.SoapHexBinary;
+    using System.ServiceModel.Channels;
+    using System.ServiceModel.Security;
+    using System.ServiceModel.Security.Tokens;
+    using System.Runtime.Serialization;
+    using KeyIdentifierEntry = WSSecurityTokenSerializer.KeyIdentifierEntry;
+    using KeyIdentifierClauseEntry = WSSecurityTokenSerializer.KeyIdentifierClauseEntry;
+    using StrEntry = WSSecurityTokenSerializer.StrEntry;
+    using TokenEntry = WSSecurityTokenSerializer.TokenEntry;
+    
+    class WSSecureConversationFeb2005 : WSSecureConversation
+    {
+        SecurityStateEncoder securityStateEncoder;
+        IList<Type> knownClaimTypes;
+
+        public WSSecureConversationFeb2005(WSSecurityTokenSerializer tokenSerializer, SecurityStateEncoder securityStateEncoder, IEnumerable<Type> knownTypes,
+            int maxKeyDerivationOffset, int maxKeyDerivationLabelLength, int maxKeyDerivationNonceLength)
+            : base(tokenSerializer, maxKeyDerivationOffset, maxKeyDerivationLabelLength, maxKeyDerivationNonceLength)
+        {
+            if (securityStateEncoder != null)
+            {
+                this.securityStateEncoder = securityStateEncoder;
+            }
+            else
+            {
+                this.securityStateEncoder = new DataProtectionSecurityStateEncoder();
+            }
+
+            this.knownClaimTypes = new List<Type>();
+            if (knownTypes != null)
+            {
+                // Clone this collection.
+                foreach (Type knownType in knownTypes)
+                {
+                    this.knownClaimTypes.Add(knownType);
+                }
+            }
+        }
+
+        public override SecureConversationDictionary SerializerDictionary
+        {
+            get { return XD.SecureConversationFeb2005Dictionary; }
+        }
+        
+        public override void PopulateTokenEntries(IList<TokenEntry> tokenEntryList)
+        {
+            base.PopulateTokenEntries(tokenEntryList);
+            tokenEntryList.Add(new SecurityContextTokenEntryFeb2005(this, this.securityStateEncoder, this.knownClaimTypes));
+        }
+
+        class SecurityContextTokenEntryFeb2005 : SecurityContextTokenEntry
+        {
+            public SecurityContextTokenEntryFeb2005(WSSecureConversationFeb2005 parent, SecurityStateEncoder securityStateEncoder, IList<Type> knownClaimTypes)
+                : base(parent, securityStateEncoder, knownClaimTypes)
+            {
+            }
+            
+            protected override bool CanReadGeneration(XmlDictionaryReader reader)
+            {
+                return reader.IsStartElement(DXD.SecureConversationDec2005Dictionary.Instance, XD.SecureConversationFeb2005Dictionary.Namespace);
+            }
+            
+            protected override bool CanReadGeneration(XmlElement element)
+            {
+                return (element.LocalName == DXD.SecureConversationDec2005Dictionary.Instance.Value &&
+                    element.NamespaceURI == XD.SecureConversationFeb2005Dictionary.Namespace.Value);
+            }
+            
+            protected override UniqueId ReadGeneration(XmlDictionaryReader reader)
+            {
+                return reader.ReadElementContentAsUniqueId();
+            }
+
+            protected override UniqueId ReadGeneration(XmlElement element)
+            {
+                return XmlHelper.ReadTextElementAsUniqueId(element);
+            }
+            
+            protected override void WriteGeneration(XmlDictionaryWriter writer, SecurityContextSecurityToken sct)
+            {
+                // serialize the generation
+                if (sct.KeyGeneration != null)
+                {
+                    writer.WriteStartElement(XD.SecureConversationFeb2005Dictionary.Prefix.Value, DXD.SecureConversationDec2005Dictionary.Instance,
+                        XD.SecureConversationFeb2005Dictionary.Namespace);
+                    XmlHelper.WriteStringAsUniqueId(writer, sct.KeyGeneration);
+                    writer.WriteEndElement();
+                }
+            }
+        }
+
+        public class DriverFeb2005 : Driver
+        {
+            public DriverFeb2005()
+            {
+            }
+
+            protected override SecureConversationDictionary DriverDictionary
+            {
+                get { return XD.SecureConversationFeb2005Dictionary; }
+            }
+
+            public override XmlDictionaryString CloseAction
+            {
+                get { return XD.SecureConversationFeb2005Dictionary.RequestSecurityContextClose; }
+            }
+
+            public override XmlDictionaryString CloseResponseAction
+            {
+                get { return XD.SecureConversationFeb2005Dictionary.RequestSecurityContextCloseResponse; }
+            }
+
+            public override bool IsSessionSupported
+            {
+                get { return true; }
+            }
+
+            public override XmlDictionaryString RenewAction
+            {
+                get { return XD.SecureConversationFeb2005Dictionary.RequestSecurityContextRenew; }
+            }
+
+            public override XmlDictionaryString RenewResponseAction
+            {
+                get { return XD.SecureConversationFeb2005Dictionary.RequestSecurityContextRenewResponse; }
+            }
+
+            public override XmlDictionaryString Namespace
+            {
+                get { return XD.SecureConversationFeb2005Dictionary.Namespace; }
+            }
+
+            public override string TokenTypeUri
+            {
+                get { return XD.SecureConversationFeb2005Dictionary.SecurityContextTokenType.Value; }
+            }
+        }
+    }
+}
+

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/WSSecureConversationFeb2005.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/WSSecureConversationFeb2005.cs
@@ -1,37 +1,38 @@
-//------------------------------------------------------------
-// Copyright (c) Microsoft Corporation.  All rights reserved.
-//------------------------------------------------------------
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.ServiceModel;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Xml;
+using System.IdentityModel.Claims;
+using System.IdentityModel.Policy;
+using System.IdentityModel.Tokens;
+using System.Security.Cryptography.X509Certificates;
+// Issue #31 in progress
+// using HexBinary = System.Runtime.Remoting.Metadata.W3cXsd2001.SoapHexBinary;
+using System.ServiceModel.Channels;
+using System.ServiceModel.Security;
+using System.ServiceModel.Security.Tokens;
+using System.Runtime.Serialization;
+using KeyIdentifierEntry = System.ServiceModel.Security.WSSecurityTokenSerializer.KeyIdentifierEntry;
+using KeyIdentifierClauseEntry = System.ServiceModel.Security.WSSecurityTokenSerializer.KeyIdentifierClauseEntry;
+using StrEntry = System.ServiceModel.Security.WSSecurityTokenSerializer.StrEntry;
+using TokenEntry = System.ServiceModel.Security.WSSecurityTokenSerializer.TokenEntry;
 
 namespace System.ServiceModel.Security
 {
-    using System;
-    using System.ServiceModel;
-    using System.Collections;
-    using System.Collections.Generic;
-    using System.Diagnostics;
-    using System.Globalization;
-    using System.IO;
-    using System.Text;
-    using System.Threading;
-    using System.Xml;
-    using System.IdentityModel.Claims;
-    using System.IdentityModel.Policy;
-    using System.IdentityModel.Tokens;
-    using System.Security.Cryptography.X509Certificates;
-    using HexBinary = System.Runtime.Remoting.Metadata.W3cXsd2001.SoapHexBinary;
-    using System.ServiceModel.Channels;
-    using System.ServiceModel.Security;
-    using System.ServiceModel.Security.Tokens;
-    using System.Runtime.Serialization;
-    using KeyIdentifierEntry = WSSecurityTokenSerializer.KeyIdentifierEntry;
-    using KeyIdentifierClauseEntry = WSSecurityTokenSerializer.KeyIdentifierClauseEntry;
-    using StrEntry = WSSecurityTokenSerializer.StrEntry;
-    using TokenEntry = WSSecurityTokenSerializer.TokenEntry;
-    
     class WSSecureConversationFeb2005 : WSSecureConversation
     {
-        SecurityStateEncoder securityStateEncoder;
-        IList<Type> knownClaimTypes;
+        private SecurityStateEncoder _securityStateEncoder;
+        private IList<Type> _knownClaimTypes;
 
         public WSSecureConversationFeb2005(WSSecurityTokenSerializer tokenSerializer, SecurityStateEncoder securityStateEncoder, IEnumerable<Type> knownTypes,
             int maxKeyDerivationOffset, int maxKeyDerivationLabelLength, int maxKeyDerivationNonceLength)
@@ -39,20 +40,20 @@ namespace System.ServiceModel.Security
         {
             if (securityStateEncoder != null)
             {
-                this.securityStateEncoder = securityStateEncoder;
+                _securityStateEncoder = securityStateEncoder;
             }
             else
             {
-                this.securityStateEncoder = new DataProtectionSecurityStateEncoder();
+                _securityStateEncoder = new DataProtectionSecurityStateEncoder();
             }
 
-            this.knownClaimTypes = new List<Type>();
+            _knownClaimTypes = new List<Type>();
             if (knownTypes != null)
             {
                 // Clone this collection.
                 foreach (Type knownType in knownTypes)
                 {
-                    this.knownClaimTypes.Add(knownType);
+                    _knownClaimTypes.Add(knownType);
                 }
             }
         }
@@ -65,7 +66,7 @@ namespace System.ServiceModel.Security
         public override void PopulateTokenEntries(IList<TokenEntry> tokenEntryList)
         {
             base.PopulateTokenEntries(tokenEntryList);
-            tokenEntryList.Add(new SecurityContextTokenEntryFeb2005(this, this.securityStateEncoder, this.knownClaimTypes));
+            tokenEntryList.Add(new SecurityContextTokenEntryFeb2005(this, _securityStateEncoder, _knownClaimTypes));
         }
 
         class SecurityContextTokenEntryFeb2005 : SecurityContextTokenEntry
@@ -93,7 +94,8 @@ namespace System.ServiceModel.Security
 
             protected override UniqueId ReadGeneration(XmlElement element)
             {
-                return XmlHelper.ReadTextElementAsUniqueId(element);
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+                //return XmlHelper.ReadTextElementAsUniqueId(element);
             }
             
             protected override void WriteGeneration(XmlDictionaryWriter writer, SecurityContextSecurityToken sct)
@@ -157,4 +159,3 @@ namespace System.ServiceModel.Security
         }
     }
 }
-

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/WSSecurityJan2004.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/WSSecurityJan2004.cs
@@ -1,0 +1,692 @@
+//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace System.ServiceModel.Security
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Globalization;
+    using System.IdentityModel.Selectors;
+    using System.IdentityModel.Tokens;
+    using System.Runtime;
+    using System.Security.Cryptography;
+    using System.Security.Cryptography.X509Certificates;
+    using System.ServiceModel;
+    using System.ServiceModel.Channels;
+    using System.ServiceModel.Security.Tokens;
+    using System.Text;
+    using System.Xml;
+    using HexBinary = System.Runtime.Remoting.Metadata.W3cXsd2001.SoapHexBinary;
+    using KeyIdentifierClauseEntry = WSSecurityTokenSerializer.KeyIdentifierClauseEntry;
+    using StrEntry = WSSecurityTokenSerializer.StrEntry;
+    using TokenEntry = WSSecurityTokenSerializer.TokenEntry;
+
+    class WSSecurityJan2004 : WSSecurityTokenSerializer.SerializerEntries
+    {
+        WSSecurityTokenSerializer tokenSerializer;
+        SamlSerializer samlSerializer;
+
+        public WSSecurityJan2004(WSSecurityTokenSerializer tokenSerializer, SamlSerializer samlSerializer)
+        {
+            this.tokenSerializer = tokenSerializer;
+            this.samlSerializer = samlSerializer;
+        }
+
+        public WSSecurityTokenSerializer WSSecurityTokenSerializer
+        {
+            get { return this.tokenSerializer; }
+        }
+
+        public SamlSerializer SamlSerializer
+        {
+            get { return this.samlSerializer; }
+        }
+
+        protected void PopulateJan2004TokenEntries(IList<TokenEntry> tokenEntryList)
+        {
+            tokenEntryList.Add(new GenericXmlTokenEntry());
+            tokenEntryList.Add(new UserNamePasswordTokenEntry(this.tokenSerializer));
+            tokenEntryList.Add(new KerberosTokenEntry(this.tokenSerializer));
+            tokenEntryList.Add(new X509TokenEntry(this.tokenSerializer));
+        }
+
+        public override void PopulateTokenEntries(IList<TokenEntry> tokenEntryList)
+        {
+            PopulateJan2004TokenEntries(tokenEntryList);
+            tokenEntryList.Add(new SamlTokenEntry(this.tokenSerializer, this.samlSerializer));
+            tokenEntryList.Add(new WrappedKeyTokenEntry(this.tokenSerializer));
+        }
+
+        internal abstract class BinaryTokenEntry : TokenEntry
+        {
+            internal static readonly XmlDictionaryString ElementName = XD.SecurityJan2004Dictionary.BinarySecurityToken;
+            internal static readonly XmlDictionaryString EncodingTypeAttribute = XD.SecurityJan2004Dictionary.EncodingType;
+            internal const string EncodingTypeAttributeString = SecurityJan2004Strings.EncodingType;
+            internal const string EncodingTypeValueBase64Binary = SecurityJan2004Strings.EncodingTypeValueBase64Binary;
+            internal const string EncodingTypeValueHexBinary = SecurityJan2004Strings.EncodingTypeValueHexBinary;
+            internal static readonly XmlDictionaryString ValueTypeAttribute = XD.SecurityJan2004Dictionary.ValueType;
+
+            WSSecurityTokenSerializer tokenSerializer;
+            string[] valueTypeUris = null;
+
+            protected BinaryTokenEntry(WSSecurityTokenSerializer tokenSerializer, string valueTypeUri)
+            {
+                this.tokenSerializer = tokenSerializer;
+                this.valueTypeUris = new string[1];
+                this.valueTypeUris[0] = valueTypeUri;
+            }
+
+            protected BinaryTokenEntry(WSSecurityTokenSerializer tokenSerializer, string[] valueTypeUris)
+            {
+                if (valueTypeUris == null)
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("valueTypeUris");
+
+                this.tokenSerializer = tokenSerializer;
+                this.valueTypeUris = new string[valueTypeUris.GetLength(0)];
+                for (int i = 0; i < this.valueTypeUris.GetLength(0); ++i)
+                    this.valueTypeUris[i] = valueTypeUris[i];
+            }
+
+            protected override XmlDictionaryString LocalName { get { return ElementName; } }
+            protected override XmlDictionaryString NamespaceUri { get { return XD.SecurityJan2004Dictionary.Namespace; } }
+            public override string TokenTypeUri { get { return this.valueTypeUris[0]; } }
+            protected override string ValueTypeUri { get { return this.valueTypeUris[0]; } }
+            public override bool SupportsTokenTypeUri(string tokenTypeUri)
+            {
+                for (int i = 0; i < this.valueTypeUris.GetLength(0); ++i)
+                {
+                    if (this.valueTypeUris[i] == tokenTypeUri)
+                        return true;
+                }
+
+                return false;
+            }
+
+            public abstract SecurityKeyIdentifierClause CreateKeyIdentifierClauseFromBinaryCore(byte[] rawData);
+
+            public override SecurityKeyIdentifierClause CreateKeyIdentifierClauseFromTokenXmlCore(XmlElement issuedTokenXml,
+                SecurityTokenReferenceStyle tokenReferenceStyle)
+            {
+                TokenReferenceStyleHelper.Validate(tokenReferenceStyle);
+
+                switch (tokenReferenceStyle)
+                {
+                    case SecurityTokenReferenceStyle.Internal:
+                        return CreateDirectReference(issuedTokenXml, UtilityStrings.IdAttribute, UtilityStrings.Namespace, this.TokenType);
+                    case SecurityTokenReferenceStyle.External:
+                        string encoding = issuedTokenXml.GetAttribute(EncodingTypeAttributeString, null);
+                        string encodedData = issuedTokenXml.InnerText;
+
+                        byte[] binaryData;
+                        if (encoding == null || encoding == EncodingTypeValueBase64Binary)
+                        {
+                            binaryData = Convert.FromBase64String(encodedData);
+                        }
+                        else if (encoding == EncodingTypeValueHexBinary)
+                        {
+                            binaryData = HexBinary.Parse(encodedData).Value;
+                        }
+                        else
+                        {
+                            throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new MessageSecurityException(SR.GetString(SR.UnknownEncodingInBinarySecurityToken)));
+                        }
+
+                        return CreateKeyIdentifierClauseFromBinaryCore(binaryData);
+                    default:
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("tokenReferenceStyle"));
+                }
+            }
+
+            public abstract SecurityToken ReadBinaryCore(string id, string valueTypeUri, byte[] rawData);
+
+            public override SecurityToken ReadTokenCore(XmlDictionaryReader reader, SecurityTokenResolver tokenResolver)
+            {
+                string wsuId = reader.GetAttribute(XD.UtilityDictionary.IdAttribute, XD.UtilityDictionary.Namespace);
+                string valueTypeUri = reader.GetAttribute(ValueTypeAttribute, null);
+                string encoding = reader.GetAttribute(EncodingTypeAttribute, null);
+
+                byte[] binaryData;
+                if (encoding == null || encoding == EncodingTypeValueBase64Binary)
+                {
+                    binaryData = reader.ReadElementContentAsBase64();
+                }
+                else if (encoding == EncodingTypeValueHexBinary)
+                {
+                    binaryData = HexBinary.Parse(reader.ReadElementContentAsString()).Value;
+                }
+                else
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new MessageSecurityException(SR.GetString(SR.UnknownEncodingInBinarySecurityToken)));
+                }
+
+                return ReadBinaryCore(wsuId, valueTypeUri, binaryData);
+            }
+
+            public abstract void WriteBinaryCore(SecurityToken token, out string id, out byte[] rawData);
+
+            public override void WriteTokenCore(XmlDictionaryWriter writer, SecurityToken token)
+            {
+                string id;
+                byte[] rawData;
+
+                WriteBinaryCore(token, out id, out rawData);
+
+                if (rawData == null)
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("rawData");
+                }
+
+                writer.WriteStartElement(XD.SecurityJan2004Dictionary.Prefix.Value, ElementName, XD.SecurityJan2004Dictionary.Namespace);
+                if (id != null)
+                {
+                    writer.WriteAttributeString(XD.UtilityDictionary.Prefix.Value, XD.UtilityDictionary.IdAttribute, XD.UtilityDictionary.Namespace, id);
+                }
+                if (valueTypeUris != null)
+                {
+                    writer.WriteAttributeString(ValueTypeAttribute, null, this.valueTypeUris[0]);
+                }
+                if (this.tokenSerializer.EmitBspRequiredAttributes)
+                {
+                    writer.WriteAttributeString(EncodingTypeAttribute, null, EncodingTypeValueBase64Binary);
+                }
+                writer.WriteBase64(rawData, 0, rawData.Length);
+                writer.WriteEndElement(); // BinarySecurityToken
+            }
+        }
+
+        class GenericXmlTokenEntry : TokenEntry
+        {
+            protected override XmlDictionaryString LocalName { get { return null; } }
+            protected override XmlDictionaryString NamespaceUri { get { return null; } }
+            protected override Type[] GetTokenTypesCore() { return new Type[] { typeof(GenericXmlSecurityToken) }; }
+            public override string TokenTypeUri { get { return null; } }
+            protected override string ValueTypeUri { get { return null; } }
+
+            public GenericXmlTokenEntry()
+            {
+            }
+
+
+            public override bool CanReadTokenCore(XmlElement element)
+            {
+                return false;
+            }
+
+            public override bool CanReadTokenCore(XmlDictionaryReader reader)
+            {
+                return false;
+            }
+
+            public override SecurityKeyIdentifierClause CreateKeyIdentifierClauseFromTokenXmlCore(XmlElement issuedTokenXml,
+                SecurityTokenReferenceStyle tokenReferenceStyle)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new NotSupportedException());
+            }
+
+            public override SecurityToken ReadTokenCore(XmlDictionaryReader reader, SecurityTokenResolver tokenResolver)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new NotSupportedException());
+            }
+
+            public override void WriteTokenCore(XmlDictionaryWriter writer, SecurityToken token)
+            {
+                BufferedGenericXmlSecurityToken bufferedXmlToken = token as BufferedGenericXmlSecurityToken;
+                if (bufferedXmlToken != null && bufferedXmlToken.TokenXmlBuffer != null)
+                {
+                    using (XmlDictionaryReader reader = bufferedXmlToken.TokenXmlBuffer.GetReader(0))
+                    {
+                        writer.WriteNode(reader, false);
+                    }
+                }
+                else
+                {
+                    GenericXmlSecurityToken xmlToken = (GenericXmlSecurityToken)token;
+                    xmlToken.TokenXml.WriteTo(writer);
+                }
+            }
+        }
+
+        class KerberosTokenEntry : BinaryTokenEntry
+        {
+            public KerberosTokenEntry(WSSecurityTokenSerializer tokenSerializer)
+                : base(tokenSerializer, new string[] { SecurityJan2004Strings.KerberosTokenTypeGSS, SecurityJan2004Strings.KerberosTokenType1510 })
+            {
+            }
+
+            protected override Type[] GetTokenTypesCore() { return new Type[] { typeof(KerberosReceiverSecurityToken), typeof(KerberosRequestorSecurityToken) }; }
+
+            public override SecurityKeyIdentifierClause CreateKeyIdentifierClauseFromBinaryCore(byte[] rawData)
+            {
+                byte[] tokenHash;
+                using (HashAlgorithm hasher = CryptoHelper.NewSha1HashAlgorithm())
+                {
+                    tokenHash = hasher.ComputeHash(rawData, 0, rawData.Length);
+                }
+                return new KerberosTicketHashKeyIdentifierClause(tokenHash);
+            }
+
+            public override SecurityToken ReadBinaryCore(string id, string valueTypeUri, byte[] rawData)
+            {
+                return new KerberosReceiverSecurityToken(rawData, id, false, valueTypeUri);
+            }
+
+            public override void WriteBinaryCore(SecurityToken token, out string id, out byte[] rawData)
+            {
+                KerberosRequestorSecurityToken kerbToken = (KerberosRequestorSecurityToken)token;
+                id = token.Id;
+                rawData = kerbToken.GetRequest();
+            }
+        }
+
+        protected class SamlTokenEntry : TokenEntry
+        {
+            const string samlAssertionId = "AssertionID";
+            SamlSerializer samlSerializer;
+            SecurityTokenSerializer tokenSerializer;
+
+            public SamlTokenEntry(SecurityTokenSerializer tokenSerializer, SamlSerializer samlSerializer)
+            {
+                this.tokenSerializer = tokenSerializer;
+                if (samlSerializer != null)
+                {
+                    this.samlSerializer = samlSerializer;
+                }
+                else
+                {
+                    this.samlSerializer = new SamlSerializer();
+                }
+                this.samlSerializer.PopulateDictionary(BinaryMessageEncoderFactory.XmlDictionary);
+            }
+
+            protected override XmlDictionaryString LocalName { get { return XD.SecurityJan2004Dictionary.SamlAssertion; } }
+            protected override XmlDictionaryString NamespaceUri { get { return XD.SecurityJan2004Dictionary.SamlUri; } }
+            protected override Type[] GetTokenTypesCore() { return new Type[] { typeof(SamlSecurityToken) }; }
+            public override string TokenTypeUri { get { return null; } }
+            protected override string ValueTypeUri { get { return null; } }
+
+            public override SecurityKeyIdentifierClause CreateKeyIdentifierClauseFromTokenXmlCore(XmlElement issuedTokenXml,
+                SecurityTokenReferenceStyle tokenReferenceStyle)
+            {
+                TokenReferenceStyleHelper.Validate(tokenReferenceStyle);
+
+                switch (tokenReferenceStyle)
+                {
+                    // SAML uses same reference for internal and external
+                    case SecurityTokenReferenceStyle.Internal:
+                    case SecurityTokenReferenceStyle.External:
+                        string assertionId = issuedTokenXml.GetAttribute(samlAssertionId);
+                        return new SamlAssertionKeyIdentifierClause(assertionId);
+                    default:
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("tokenReferenceStyle"));
+                }
+            }
+
+            public override SecurityToken ReadTokenCore(XmlDictionaryReader reader, SecurityTokenResolver tokenResolver)
+            {
+                SamlSecurityToken samlToken = this.samlSerializer.ReadToken(reader, this.tokenSerializer, tokenResolver);
+                return samlToken;
+            }
+
+            public override void WriteTokenCore(XmlDictionaryWriter writer, SecurityToken token)
+            {
+                SamlSecurityToken samlToken = token as SamlSecurityToken;
+                this.samlSerializer.WriteToken(samlToken, writer, this.tokenSerializer);
+            }
+        }
+
+        class UserNamePasswordTokenEntry : TokenEntry
+        {
+            WSSecurityTokenSerializer tokenSerializer;
+
+            public UserNamePasswordTokenEntry(WSSecurityTokenSerializer tokenSerializer)
+            {
+                this.tokenSerializer = tokenSerializer;
+            }
+
+            protected override XmlDictionaryString LocalName { get { return XD.SecurityJan2004Dictionary.UserNameTokenElement; } }
+            protected override XmlDictionaryString NamespaceUri { get { return XD.SecurityJan2004Dictionary.Namespace; } }
+            protected override Type[] GetTokenTypesCore() { return new Type[] { typeof(UserNameSecurityToken) }; }
+            public override string TokenTypeUri { get { return SecurityJan2004Strings.UPTokenType; } }
+            protected override string ValueTypeUri { get { return null; } }
+
+            public override IAsyncResult BeginReadTokenCore(XmlDictionaryReader reader, SecurityTokenResolver tokenResolver, AsyncCallback callback, object state)
+            {
+                string id;
+                string userName;
+                string password;
+
+                ParseToken(reader, out id, out userName, out password);
+
+                SecurityToken token = new UserNameSecurityToken(userName, password, id);
+                return new CompletedAsyncResult<SecurityToken>(token, callback, state);
+            }
+
+            public override SecurityKeyIdentifierClause CreateKeyIdentifierClauseFromTokenXmlCore(XmlElement issuedTokenXml,
+                SecurityTokenReferenceStyle tokenReferenceStyle)
+            {
+                TokenReferenceStyleHelper.Validate(tokenReferenceStyle);
+
+                switch (tokenReferenceStyle)
+                {
+                    case SecurityTokenReferenceStyle.Internal:
+                        return CreateDirectReference(issuedTokenXml, UtilityStrings.IdAttribute, UtilityStrings.Namespace, typeof(UserNameSecurityToken));
+                    case SecurityTokenReferenceStyle.External:
+                        // UP tokens aren't referred to externally
+                        return null;
+                    default:
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("tokenReferenceStyle"));
+                }
+            }
+
+            public override SecurityToken EndReadTokenCore(IAsyncResult result)
+            {
+                return CompletedAsyncResult<SecurityToken>.End(result);
+            }
+
+            public override SecurityToken ReadTokenCore(XmlDictionaryReader reader, SecurityTokenResolver tokenResolver)
+            {
+                string id;
+                string userName;
+                string password;
+
+                ParseToken(reader, out id, out userName, out password);
+
+                if (id == null)
+                    id = SecurityUniqueId.Create().Value;
+
+                return new UserNameSecurityToken(userName, password, id);
+            }
+
+            public override void WriteTokenCore(XmlDictionaryWriter writer, SecurityToken token)
+            {
+                UserNameSecurityToken upToken = (UserNameSecurityToken)token;
+                WriteUserNamePassword(writer, upToken.Id, upToken.UserName, upToken.Password);
+            }
+
+            void WriteUserNamePassword(XmlDictionaryWriter writer, string id, string userName, string password)
+            {
+                writer.WriteStartElement(XD.SecurityJan2004Dictionary.Prefix.Value, XD.SecurityJan2004Dictionary.UserNameTokenElement,
+                    XD.SecurityJan2004Dictionary.Namespace); // <wsse:UsernameToken
+                writer.WriteAttributeString(XD.UtilityDictionary.Prefix.Value, XD.UtilityDictionary.IdAttribute,
+                    XD.UtilityDictionary.Namespace, id); // wsu:Id="..."
+                writer.WriteElementString(XD.SecurityJan2004Dictionary.Prefix.Value, XD.SecurityJan2004Dictionary.UserNameElement,
+                    XD.SecurityJan2004Dictionary.Namespace, userName); // ><wsse:Username>...</wsse:Username>
+                if (password != null)
+                {
+                    writer.WriteStartElement(XD.SecurityJan2004Dictionary.Prefix.Value, XD.SecurityJan2004Dictionary.PasswordElement,
+                        XD.SecurityJan2004Dictionary.Namespace);
+                    if (this.tokenSerializer.EmitBspRequiredAttributes)
+                    {
+                        writer.WriteAttributeString(XD.SecurityJan2004Dictionary.TypeAttribute, null, SecurityJan2004Strings.UPTokenPasswordTextValue);
+                    }
+                    writer.WriteString(password); // <wsse:Password>...</wsse:Password>
+                    writer.WriteEndElement();
+                }
+                writer.WriteEndElement(); // </wsse:UsernameToken>
+            }
+
+            static string ParsePassword(XmlDictionaryReader reader)
+            {
+                string type = reader.GetAttribute(XD.SecurityJan2004Dictionary.TypeAttribute, null);
+                if (type != null && type.Length > 0 && type != SecurityJan2004Strings.UPTokenPasswordTextValue)
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new NotSupportedException(SR.GetString(SR.UnsupportedPasswordType, type)));
+                }
+
+                return reader.ReadElementString();
+            }
+
+            static void ParseToken(XmlDictionaryReader reader, out string id, out string userName, out string password)
+            {
+                id = null;
+                userName = null;
+                password = null;
+
+                reader.MoveToContent();
+                id = reader.GetAttribute(XD.UtilityDictionary.IdAttribute, XD.UtilityDictionary.Namespace);
+
+                reader.ReadStartElement(XD.SecurityJan2004Dictionary.UserNameTokenElement, XD.SecurityJan2004Dictionary.Namespace);
+                while (reader.IsStartElement())
+                {
+                    if (reader.IsStartElement(XD.SecurityJan2004Dictionary.UserNameElement, XD.SecurityJan2004Dictionary.Namespace))
+                    {
+                        userName = reader.ReadElementString();
+                    }
+                    else if (reader.IsStartElement(XD.SecurityJan2004Dictionary.PasswordElement, XD.SecurityJan2004Dictionary.Namespace))
+                    {
+                        password = ParsePassword(reader);
+                    }
+                    else if (reader.IsStartElement(XD.SecurityJan2004Dictionary.NonceElement, XD.SecurityJan2004Dictionary.Namespace))
+                    {
+                        // Nonce can be safely ignored
+                        reader.Skip();
+                    }
+                    else if (reader.IsStartElement(XD.UtilityDictionary.CreatedElement, XD.UtilityDictionary.Namespace))
+                    {
+                        // wsu:Created can be safely ignored
+                        reader.Skip();
+                    }
+                    else
+                    {
+                        XmlHelper.OnUnexpectedChildNodeError(SecurityJan2004Strings.UserNameTokenElement, reader);
+                    }
+                }
+                reader.ReadEndElement();
+
+                if (userName == null)
+                    XmlHelper.OnRequiredElementMissing(SecurityJan2004Strings.UserNameElement, SecurityJan2004Strings.Namespace);
+            }
+        }
+
+        protected class WrappedKeyTokenEntry : TokenEntry
+        {
+            WSSecurityTokenSerializer tokenSerializer;
+
+            public WrappedKeyTokenEntry(WSSecurityTokenSerializer tokenSerializer)
+            {
+                this.tokenSerializer = tokenSerializer;
+            }
+
+            protected override XmlDictionaryString LocalName { get { return EncryptedKey.ElementName; } }
+            protected override XmlDictionaryString NamespaceUri { get { return XD.XmlEncryptionDictionary.Namespace; } }
+            protected override Type[] GetTokenTypesCore() { return new Type[] { typeof(WrappedKeySecurityToken) }; }
+            public override string TokenTypeUri { get { return null; } }
+            protected override string ValueTypeUri { get { return null; } }
+
+            public override SecurityKeyIdentifierClause CreateKeyIdentifierClauseFromTokenXmlCore(XmlElement issuedTokenXml,
+                SecurityTokenReferenceStyle tokenReferenceStyle)
+            {
+
+                TokenReferenceStyleHelper.Validate(tokenReferenceStyle);
+
+                switch (tokenReferenceStyle)
+                {
+                    case SecurityTokenReferenceStyle.Internal:
+                        return CreateDirectReference(issuedTokenXml, XmlEncryptionStrings.Id, null, null);
+                    case SecurityTokenReferenceStyle.External:
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new XmlException(SR.GetString(SR.CantInferReferenceForToken, EncryptedKey.ElementName.Value)));
+                    default:
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("tokenReferenceStyle"));
+                }
+            }
+
+            public override SecurityToken ReadTokenCore(XmlDictionaryReader reader, SecurityTokenResolver tokenResolver)
+            {
+                EncryptedKey encryptedKey = new EncryptedKey();
+                encryptedKey.SecurityTokenSerializer = this.tokenSerializer;
+                encryptedKey.ReadFrom(reader);
+                SecurityKeyIdentifier unwrappingTokenIdentifier = encryptedKey.KeyIdentifier;
+                byte[] wrappedKey = encryptedKey.GetWrappedKey();
+                WrappedKeySecurityToken wrappedKeyToken = CreateWrappedKeyToken(encryptedKey.Id, encryptedKey.EncryptionMethod,
+                    encryptedKey.CarriedKeyName, unwrappingTokenIdentifier, wrappedKey, tokenResolver);
+                wrappedKeyToken.EncryptedKey = encryptedKey;
+
+                return wrappedKeyToken;
+            }
+
+            WrappedKeySecurityToken CreateWrappedKeyToken(string id, string encryptionMethod, string carriedKeyName,
+                SecurityKeyIdentifier unwrappingTokenIdentifier, byte[] wrappedKey, SecurityTokenResolver tokenResolver)
+            {
+                ISspiNegotiationInfo sspiResolver = tokenResolver as ISspiNegotiationInfo;
+                if (sspiResolver != null)
+                {
+                    ISspiNegotiation unwrappingSspiContext = sspiResolver.SspiNegotiation;
+                    // ensure that the encryption algorithm is compatible
+                    if (encryptionMethod != unwrappingSspiContext.KeyEncryptionAlgorithm)
+                    {
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new MessageSecurityException(SR.GetString(SR.BadKeyEncryptionAlgorithm, encryptionMethod)));
+                    }
+                    byte[] unwrappedKey = unwrappingSspiContext.Decrypt(wrappedKey);
+                    return new WrappedKeySecurityToken(id, unwrappedKey, encryptionMethod, unwrappingSspiContext, unwrappedKey);
+                }
+                else
+                {
+                    if (tokenResolver == null)
+                    {
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentNullException("tokenResolver"));
+                    }
+                    if (unwrappingTokenIdentifier == null || unwrappingTokenIdentifier.Count == 0)
+                    {
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new MessageSecurityException(SR.GetString(SR.MissingKeyInfoInEncryptedKey)));
+                    }
+
+                    SecurityToken unwrappingToken;
+                    SecurityHeaderTokenResolver resolver = tokenResolver as SecurityHeaderTokenResolver;
+                    if (resolver != null)
+                    {
+                        unwrappingToken = resolver.ExpectedWrapper;
+                        if (unwrappingToken != null)
+                        {
+                            if (!resolver.CheckExternalWrapperMatch(unwrappingTokenIdentifier))
+                            {
+                                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new MessageSecurityException(
+                                    SR.GetString(SR.EncryptedKeyWasNotEncryptedWithTheRequiredEncryptingToken, unwrappingToken)));
+                            }
+                        }
+                        else
+                        {
+                            throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new MessageSecurityException(
+                                SR.GetString(SR.UnableToResolveKeyInfoForUnwrappingToken, unwrappingTokenIdentifier, resolver)));
+                        }
+                    }
+                    else
+                    {
+                        try
+                        {
+                            unwrappingToken = tokenResolver.ResolveToken(unwrappingTokenIdentifier);
+                        }
+                        catch (Exception exception)
+                        {
+                            if (exception is MessageSecurityException)
+                                throw;
+
+                            throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new MessageSecurityException(
+                                SR.GetString(SR.UnableToResolveKeyInfoForUnwrappingToken, unwrappingTokenIdentifier, tokenResolver), exception));
+                        }
+                    }
+                    SecurityKey unwrappingSecurityKey;
+                    byte[] unwrappedKey = SecurityUtils.DecryptKey(unwrappingToken, encryptionMethod, wrappedKey, out unwrappingSecurityKey);
+                    return new WrappedKeySecurityToken(id, unwrappedKey, encryptionMethod, unwrappingToken, unwrappingTokenIdentifier, wrappedKey, unwrappingSecurityKey);
+                }
+            }
+
+            public override void WriteTokenCore(XmlDictionaryWriter writer, SecurityToken token)
+            {
+                WrappedKeySecurityToken wrappedKeyToken = token as WrappedKeySecurityToken;
+                wrappedKeyToken.EnsureEncryptedKeySetUp();
+                wrappedKeyToken.EncryptedKey.SecurityTokenSerializer = this.tokenSerializer;
+                wrappedKeyToken.EncryptedKey.WriteTo(writer, ServiceModelDictionaryManager.Instance);
+            }
+        }
+
+        protected class X509TokenEntry : BinaryTokenEntry
+        {
+            internal const string ValueTypeAbsoluteUri = SecurityJan2004Strings.X509TokenType;
+
+            public X509TokenEntry(WSSecurityTokenSerializer tokenSerializer)
+                : base(tokenSerializer, ValueTypeAbsoluteUri)
+            {
+            }
+
+            protected override Type[] GetTokenTypesCore() { return new Type[] { typeof(X509SecurityToken), typeof(X509WindowsSecurityToken) }; }
+
+            public override SecurityKeyIdentifierClause CreateKeyIdentifierClauseFromBinaryCore(byte[] rawData)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new XmlException(SR.GetString(SR.CantInferReferenceForToken, ValueTypeAbsoluteUri)));
+            }
+
+            public override SecurityToken ReadBinaryCore(string id, string valueTypeUri, byte[] rawData)
+            {
+                X509Certificate2 certificate;
+                if (!SecurityUtils.TryCreateX509CertificateFromRawData(rawData, out certificate))
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new MessageSecurityException(SR.GetString(SR.InvalidX509RawData)));
+                }
+                return new X509SecurityToken(certificate, id, false);
+            }
+
+            public override void WriteBinaryCore(SecurityToken token, out string id, out byte[] rawData)
+            {
+                id = token.Id;
+                X509SecurityToken x509Token = token as X509SecurityToken;
+                if (x509Token != null)
+                {
+                    rawData = x509Token.Certificate.GetRawCertData();
+                }
+                else
+                {
+                    rawData = ((X509WindowsSecurityToken)token).Certificate.GetRawCertData();
+                }
+            }
+        }
+
+        public class IdManager : SignatureTargetIdManager
+        {
+            static readonly IdManager instance = new IdManager();
+
+            IdManager()
+            {
+            }
+
+            public override string DefaultIdNamespacePrefix
+            {
+                get { return UtilityStrings.Prefix; }
+            }
+
+            public override string DefaultIdNamespaceUri
+            {
+                get { return UtilityStrings.Namespace; }
+            }
+
+            internal static IdManager Instance
+            {
+                get { return instance; }
+            }
+
+            public override string ExtractId(XmlDictionaryReader reader)
+            {
+                if (reader == null)
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("reader");
+
+                if (reader.IsStartElement(EncryptedData.ElementName, XD.XmlEncryptionDictionary.Namespace))
+                {
+                    return reader.GetAttribute(XD.XmlEncryptionDictionary.Id, null);
+                }
+                else
+                {
+                    return reader.GetAttribute(XD.UtilityDictionary.IdAttribute, XD.UtilityDictionary.Namespace);
+                }
+            }
+
+            public override void WriteIdAttribute(XmlDictionaryWriter writer, string id)
+            {
+                if (writer == null)
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("writer");
+
+                writer.WriteAttributeString(XD.UtilityDictionary.Prefix.Value, XD.UtilityDictionary.IdAttribute, XD.UtilityDictionary.Namespace, id);
+            }
+        }
+    }
+}
+

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/WSSecurityJan2004.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/WSSecurityJan2004.cs
@@ -4,21 +4,14 @@
 
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.IdentityModel.Selectors;
 using System.IdentityModel.Tokens;
 using System.Runtime;
-using System.Security.Cryptography;
-using System.Security.Cryptography.X509Certificates;
-using System.ServiceModel;
 using System.ServiceModel.Channels;
 using System.ServiceModel.Security.Tokens;
-using System.Text;
 using System.Xml;
 // Issue #31 in progress
 // using HexBinary = System.Runtime.Remoting.Metadata.W3cXsd2001.SoapHexBinary;
-using KeyIdentifierClauseEntry = System.ServiceModel.Security.WSSecurityTokenSerializer.KeyIdentifierClauseEntry;
-using StrEntry = System.ServiceModel.Security.WSSecurityTokenSerializer.StrEntry;
 using TokenEntry = System.ServiceModel.Security.WSSecurityTokenSerializer.TokenEntry;
 
 namespace System.ServiceModel.Security

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/WSSecurityJan2004.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/WSSecurityJan2004.cs
@@ -1,80 +1,85 @@
-//------------------------------------------------------------
-// Copyright (c) Microsoft Corporation.  All rights reserved.
-//------------------------------------------------------------
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IdentityModel.Selectors;
+using System.IdentityModel.Tokens;
+using System.Runtime;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using System.ServiceModel;
+using System.ServiceModel.Channels;
+using System.ServiceModel.Security.Tokens;
+using System.Text;
+using System.Xml;
+// Issue #31 in progress
+// using HexBinary = System.Runtime.Remoting.Metadata.W3cXsd2001.SoapHexBinary;
+using KeyIdentifierClauseEntry = System.ServiceModel.Security.WSSecurityTokenSerializer.KeyIdentifierClauseEntry;
+using StrEntry = System.ServiceModel.Security.WSSecurityTokenSerializer.StrEntry;
+using TokenEntry = System.ServiceModel.Security.WSSecurityTokenSerializer.TokenEntry;
 
 namespace System.ServiceModel.Security
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Globalization;
-    using System.IdentityModel.Selectors;
-    using System.IdentityModel.Tokens;
-    using System.Runtime;
-    using System.Security.Cryptography;
-    using System.Security.Cryptography.X509Certificates;
-    using System.ServiceModel;
-    using System.ServiceModel.Channels;
-    using System.ServiceModel.Security.Tokens;
-    using System.Text;
-    using System.Xml;
-    using HexBinary = System.Runtime.Remoting.Metadata.W3cXsd2001.SoapHexBinary;
-    using KeyIdentifierClauseEntry = WSSecurityTokenSerializer.KeyIdentifierClauseEntry;
-    using StrEntry = WSSecurityTokenSerializer.StrEntry;
-    using TokenEntry = WSSecurityTokenSerializer.TokenEntry;
-
     class WSSecurityJan2004 : WSSecurityTokenSerializer.SerializerEntries
     {
-        WSSecurityTokenSerializer tokenSerializer;
-        SamlSerializer samlSerializer;
+        private WSSecurityTokenSerializer _tokenSerializer;
+        private SamlSerializer _samlSerializer;
+
+        public WSSecurityJan2004(WSSecurityTokenSerializer tokenSerializer) : this(tokenSerializer, new SamlSerializer())
+        {
+        }
 
         public WSSecurityJan2004(WSSecurityTokenSerializer tokenSerializer, SamlSerializer samlSerializer)
         {
-            this.tokenSerializer = tokenSerializer;
-            this.samlSerializer = samlSerializer;
+            _tokenSerializer = tokenSerializer;
+            _samlSerializer = samlSerializer;
         }
 
         public WSSecurityTokenSerializer WSSecurityTokenSerializer
         {
-            get { return this.tokenSerializer; }
+            get { return _tokenSerializer; }
         }
 
         public SamlSerializer SamlSerializer
         {
-            get { return this.samlSerializer; }
+            get { return _samlSerializer; }
         }
 
         protected void PopulateJan2004TokenEntries(IList<TokenEntry> tokenEntryList)
         {
             tokenEntryList.Add(new GenericXmlTokenEntry());
-            tokenEntryList.Add(new UserNamePasswordTokenEntry(this.tokenSerializer));
-            tokenEntryList.Add(new KerberosTokenEntry(this.tokenSerializer));
-            tokenEntryList.Add(new X509TokenEntry(this.tokenSerializer));
+            tokenEntryList.Add(new UserNamePasswordTokenEntry(_tokenSerializer));
+            tokenEntryList.Add(new KerberosTokenEntry(_tokenSerializer));
+            tokenEntryList.Add(new X509TokenEntry(_tokenSerializer));
         }
 
         public override void PopulateTokenEntries(IList<TokenEntry> tokenEntryList)
         {
             PopulateJan2004TokenEntries(tokenEntryList);
-            tokenEntryList.Add(new SamlTokenEntry(this.tokenSerializer, this.samlSerializer));
-            tokenEntryList.Add(new WrappedKeyTokenEntry(this.tokenSerializer));
+            tokenEntryList.Add(new SamlTokenEntry(_tokenSerializer, _samlSerializer));
+            tokenEntryList.Add(new WrappedKeyTokenEntry(_tokenSerializer));
         }
 
         internal abstract class BinaryTokenEntry : TokenEntry
         {
-            internal static readonly XmlDictionaryString ElementName = XD.SecurityJan2004Dictionary.BinarySecurityToken;
-            internal static readonly XmlDictionaryString EncodingTypeAttribute = XD.SecurityJan2004Dictionary.EncodingType;
+            internal static readonly XmlDictionaryString s_ElementName = XD.SecurityJan2004Dictionary.BinarySecurityToken;
+            internal static readonly XmlDictionaryString s_EncodingTypeAttribute = XD.SecurityJan2004Dictionary.EncodingType;
             internal const string EncodingTypeAttributeString = SecurityJan2004Strings.EncodingType;
             internal const string EncodingTypeValueBase64Binary = SecurityJan2004Strings.EncodingTypeValueBase64Binary;
             internal const string EncodingTypeValueHexBinary = SecurityJan2004Strings.EncodingTypeValueHexBinary;
-            internal static readonly XmlDictionaryString ValueTypeAttribute = XD.SecurityJan2004Dictionary.ValueType;
+            internal static readonly XmlDictionaryString s_ValueTypeAttribute = XD.SecurityJan2004Dictionary.ValueType;
 
-            WSSecurityTokenSerializer tokenSerializer;
-            string[] valueTypeUris = null;
+            private WSSecurityTokenSerializer _tokenSerializer;
+            private string[] _valueTypeUris = null;
 
             protected BinaryTokenEntry(WSSecurityTokenSerializer tokenSerializer, string valueTypeUri)
             {
-                this.tokenSerializer = tokenSerializer;
-                this.valueTypeUris = new string[1];
-                this.valueTypeUris[0] = valueTypeUri;
+                _tokenSerializer = tokenSerializer;
+                _valueTypeUris = new string[1];
+                _valueTypeUris[0] = valueTypeUri;
             }
 
             protected BinaryTokenEntry(WSSecurityTokenSerializer tokenSerializer, string[] valueTypeUris)
@@ -82,21 +87,21 @@ namespace System.ServiceModel.Security
                 if (valueTypeUris == null)
                     throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("valueTypeUris");
 
-                this.tokenSerializer = tokenSerializer;
-                this.valueTypeUris = new string[valueTypeUris.GetLength(0)];
-                for (int i = 0; i < this.valueTypeUris.GetLength(0); ++i)
-                    this.valueTypeUris[i] = valueTypeUris[i];
+                _tokenSerializer = tokenSerializer;
+                _valueTypeUris = new string[valueTypeUris.GetLength(0)];
+                for (int i = 0; i < _valueTypeUris.GetLength(0); ++i)
+                    _valueTypeUris[i] = valueTypeUris[i];
             }
 
-            protected override XmlDictionaryString LocalName { get { return ElementName; } }
+            protected override XmlDictionaryString LocalName { get { return s_ElementName; } }
             protected override XmlDictionaryString NamespaceUri { get { return XD.SecurityJan2004Dictionary.Namespace; } }
-            public override string TokenTypeUri { get { return this.valueTypeUris[0]; } }
-            protected override string ValueTypeUri { get { return this.valueTypeUris[0]; } }
+            public override string TokenTypeUri { get { return _valueTypeUris[0]; } }
+            protected override string ValueTypeUri { get { return _valueTypeUris[0]; } }
             public override bool SupportsTokenTypeUri(string tokenTypeUri)
             {
-                for (int i = 0; i < this.valueTypeUris.GetLength(0); ++i)
+                for (int i = 0; i < _valueTypeUris.GetLength(0); ++i)
                 {
-                    if (this.valueTypeUris[i] == tokenTypeUri)
+                    if (_valueTypeUris[i] == tokenTypeUri)
                         return true;
                 }
 
@@ -125,11 +130,12 @@ namespace System.ServiceModel.Security
                         }
                         else if (encoding == EncodingTypeValueHexBinary)
                         {
-                            binaryData = HexBinary.Parse(encodedData).Value;
+                            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+                            ///binaryData = HexBinary.Parse(encodedData).Value;
                         }
                         else
                         {
-                            throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new MessageSecurityException(SR.GetString(SR.UnknownEncodingInBinarySecurityToken)));
+                            throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new MessageSecurityException(SR.Format(SR.UnknownEncodingInBinarySecurityToken)));
                         }
 
                         return CreateKeyIdentifierClauseFromBinaryCore(binaryData);
@@ -143,8 +149,8 @@ namespace System.ServiceModel.Security
             public override SecurityToken ReadTokenCore(XmlDictionaryReader reader, SecurityTokenResolver tokenResolver)
             {
                 string wsuId = reader.GetAttribute(XD.UtilityDictionary.IdAttribute, XD.UtilityDictionary.Namespace);
-                string valueTypeUri = reader.GetAttribute(ValueTypeAttribute, null);
-                string encoding = reader.GetAttribute(EncodingTypeAttribute, null);
+                string valueTypeUri = reader.GetAttribute(s_ValueTypeAttribute, null);
+                string encoding = reader.GetAttribute(s_EncodingTypeAttribute, null);
 
                 byte[] binaryData;
                 if (encoding == null || encoding == EncodingTypeValueBase64Binary)
@@ -153,11 +159,12 @@ namespace System.ServiceModel.Security
                 }
                 else if (encoding == EncodingTypeValueHexBinary)
                 {
-                    binaryData = HexBinary.Parse(reader.ReadElementContentAsString()).Value;
+                    throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+                    //binaryData = HexBinary.Parse(reader.ReadElementContentAsString()).Value;
                 }
                 else
                 {
-                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new MessageSecurityException(SR.GetString(SR.UnknownEncodingInBinarySecurityToken)));
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new MessageSecurityException(SR.Format(SR.UnknownEncodingInBinarySecurityToken)));
                 }
 
                 return ReadBinaryCore(wsuId, valueTypeUri, binaryData);
@@ -177,18 +184,18 @@ namespace System.ServiceModel.Security
                     throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("rawData");
                 }
 
-                writer.WriteStartElement(XD.SecurityJan2004Dictionary.Prefix.Value, ElementName, XD.SecurityJan2004Dictionary.Namespace);
+                writer.WriteStartElement(XD.SecurityJan2004Dictionary.Prefix.Value, s_ElementName, XD.SecurityJan2004Dictionary.Namespace);
                 if (id != null)
                 {
                     writer.WriteAttributeString(XD.UtilityDictionary.Prefix.Value, XD.UtilityDictionary.IdAttribute, XD.UtilityDictionary.Namespace, id);
                 }
-                if (valueTypeUris != null)
+                if (_valueTypeUris != null)
                 {
-                    writer.WriteAttributeString(ValueTypeAttribute, null, this.valueTypeUris[0]);
+                    writer.WriteAttributeString(s_ValueTypeAttribute, null, _valueTypeUris[0]);
                 }
-                if (this.tokenSerializer.EmitBspRequiredAttributes)
+                if (_tokenSerializer.EmitBspRequiredAttributes)
                 {
-                    writer.WriteAttributeString(EncodingTypeAttribute, null, EncodingTypeValueBase64Binary);
+                    writer.WriteAttributeString(s_EncodingTypeAttribute, null, EncodingTypeValueBase64Binary);
                 }
                 writer.WriteBase64(rawData, 0, rawData.Length);
                 writer.WriteEndElement(); // BinarySecurityToken
@@ -231,19 +238,20 @@ namespace System.ServiceModel.Security
 
             public override void WriteTokenCore(XmlDictionaryWriter writer, SecurityToken token)
             {
-                BufferedGenericXmlSecurityToken bufferedXmlToken = token as BufferedGenericXmlSecurityToken;
-                if (bufferedXmlToken != null && bufferedXmlToken.TokenXmlBuffer != null)
-                {
-                    using (XmlDictionaryReader reader = bufferedXmlToken.TokenXmlBuffer.GetReader(0))
-                    {
-                        writer.WriteNode(reader, false);
-                    }
-                }
-                else
-                {
-                    GenericXmlSecurityToken xmlToken = (GenericXmlSecurityToken)token;
-                    xmlToken.TokenXml.WriteTo(writer);
-                }
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+                //BufferedGenericXmlSecurityToken bufferedXmlToken = token as BufferedGenericXmlSecurityToken;
+                //if (bufferedXmlToken != null && bufferedXmlToken.TokenXmlBuffer != null)
+                //{
+                //    using (XmlDictionaryReader reader = bufferedXmlToken.TokenXmlBuffer.GetReader(0))
+                //    {
+                //        writer.WriteNode(reader, false);
+                //    }
+                //}
+                //else
+                //{
+                //    GenericXmlSecurityToken xmlToken = (GenericXmlSecurityToken)token;
+                //    xmlToken.TokenXml.WriteTo(writer);
+                //}
             }
         }
 
@@ -254,49 +262,56 @@ namespace System.ServiceModel.Security
             {
             }
 
-            protected override Type[] GetTokenTypesCore() { return new Type[] { typeof(KerberosReceiverSecurityToken), typeof(KerberosRequestorSecurityToken) }; }
+            protected override Type[] GetTokenTypesCore()
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+                //return new Type[] { typeof(KerberosReceiverSecurityToken), typeof(KerberosRequestorSecurityToken) };
+            }
 
             public override SecurityKeyIdentifierClause CreateKeyIdentifierClauseFromBinaryCore(byte[] rawData)
             {
-                byte[] tokenHash;
-                using (HashAlgorithm hasher = CryptoHelper.NewSha1HashAlgorithm())
-                {
-                    tokenHash = hasher.ComputeHash(rawData, 0, rawData.Length);
-                }
-                return new KerberosTicketHashKeyIdentifierClause(tokenHash);
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+                //byte[] tokenHash;
+                //using (HashAlgorithm hasher = CryptoHelper.NewSha1HashAlgorithm())
+                //{
+                //    tokenHash = hasher.ComputeHash(rawData, 0, rawData.Length);
+                //}
+                //return new KerberosTicketHashKeyIdentifierClause(tokenHash);
             }
 
             public override SecurityToken ReadBinaryCore(string id, string valueTypeUri, byte[] rawData)
             {
-                return new KerberosReceiverSecurityToken(rawData, id, false, valueTypeUri);
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+                //return new KerberosReceiverSecurityToken(rawData, id, false, valueTypeUri);
             }
 
             public override void WriteBinaryCore(SecurityToken token, out string id, out byte[] rawData)
             {
-                KerberosRequestorSecurityToken kerbToken = (KerberosRequestorSecurityToken)token;
-                id = token.Id;
-                rawData = kerbToken.GetRequest();
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+                //KerberosRequestorSecurityToken kerbToken = (KerberosRequestorSecurityToken)token;
+                //id = token.Id;
+                //rawData = kerbToken.GetRequest();
             }
         }
 
         protected class SamlTokenEntry : TokenEntry
         {
             const string samlAssertionId = "AssertionID";
-            SamlSerializer samlSerializer;
-            SecurityTokenSerializer tokenSerializer;
+            private SamlSerializer _samlSerializer;
+            private SecurityTokenSerializer _tokenSerializer;
 
             public SamlTokenEntry(SecurityTokenSerializer tokenSerializer, SamlSerializer samlSerializer)
             {
-                this.tokenSerializer = tokenSerializer;
+                _tokenSerializer = tokenSerializer;
                 if (samlSerializer != null)
                 {
-                    this.samlSerializer = samlSerializer;
+                    _samlSerializer = samlSerializer;
                 }
                 else
                 {
-                    this.samlSerializer = new SamlSerializer();
+                    _samlSerializer = new SamlSerializer();
                 }
-                this.samlSerializer.PopulateDictionary(BinaryMessageEncoderFactory.XmlDictionary);
+                _samlSerializer.PopulateDictionary(BinaryMessageEncoderFactory.XmlDictionary);
             }
 
             protected override XmlDictionaryString LocalName { get { return XD.SecurityJan2004Dictionary.SamlAssertion; } }
@@ -315,8 +330,9 @@ namespace System.ServiceModel.Security
                     // SAML uses same reference for internal and external
                     case SecurityTokenReferenceStyle.Internal:
                     case SecurityTokenReferenceStyle.External:
-                        string assertionId = issuedTokenXml.GetAttribute(samlAssertionId);
-                        return new SamlAssertionKeyIdentifierClause(assertionId);
+                        throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+                        //string assertionId = issuedTokenXml.GetAttribute(samlAssertionId);
+                        //return new SamlAssertionKeyIdentifierClause(assertionId);
                     default:
                         throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("tokenReferenceStyle"));
                 }
@@ -324,24 +340,26 @@ namespace System.ServiceModel.Security
 
             public override SecurityToken ReadTokenCore(XmlDictionaryReader reader, SecurityTokenResolver tokenResolver)
             {
-                SamlSecurityToken samlToken = this.samlSerializer.ReadToken(reader, this.tokenSerializer, tokenResolver);
-                return samlToken;
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+                //SamlSecurityToken samlToken = this.samlSerializer.ReadToken(reader, this.tokenSerializer, tokenResolver);
+                //return samlToken;
             }
 
             public override void WriteTokenCore(XmlDictionaryWriter writer, SecurityToken token)
             {
-                SamlSecurityToken samlToken = token as SamlSecurityToken;
-                this.samlSerializer.WriteToken(samlToken, writer, this.tokenSerializer);
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+                //SamlSecurityToken samlToken = token as SamlSecurityToken;
+                //this.samlSerializer.WriteToken(samlToken, writer, this.tokenSerializer);
             }
         }
 
         class UserNamePasswordTokenEntry : TokenEntry
         {
-            WSSecurityTokenSerializer tokenSerializer;
+            private WSSecurityTokenSerializer _tokenSerializer;
 
             public UserNamePasswordTokenEntry(WSSecurityTokenSerializer tokenSerializer)
             {
-                this.tokenSerializer = tokenSerializer;
+                _tokenSerializer = tokenSerializer;
             }
 
             protected override XmlDictionaryString LocalName { get { return XD.SecurityJan2004Dictionary.UserNameTokenElement; } }
@@ -416,7 +434,7 @@ namespace System.ServiceModel.Security
                 {
                     writer.WriteStartElement(XD.SecurityJan2004Dictionary.Prefix.Value, XD.SecurityJan2004Dictionary.PasswordElement,
                         XD.SecurityJan2004Dictionary.Namespace);
-                    if (this.tokenSerializer.EmitBspRequiredAttributes)
+                    if (_tokenSerializer.EmitBspRequiredAttributes)
                     {
                         writer.WriteAttributeString(XD.SecurityJan2004Dictionary.TypeAttribute, null, SecurityJan2004Strings.UPTokenPasswordTextValue);
                     }
@@ -431,7 +449,7 @@ namespace System.ServiceModel.Security
                 string type = reader.GetAttribute(XD.SecurityJan2004Dictionary.TypeAttribute, null);
                 if (type != null && type.Length > 0 && type != SecurityJan2004Strings.UPTokenPasswordTextValue)
                 {
-                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new NotSupportedException(SR.GetString(SR.UnsupportedPasswordType, type)));
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new NotSupportedException(SR.Format(SR.UnsupportedPasswordType, type)));
                 }
 
                 return reader.ReadElementString();
@@ -488,9 +506,26 @@ namespace System.ServiceModel.Security
                 this.tokenSerializer = tokenSerializer;
             }
 
-            protected override XmlDictionaryString LocalName { get { return EncryptedKey.ElementName; } }
-            protected override XmlDictionaryString NamespaceUri { get { return XD.XmlEncryptionDictionary.Namespace; } }
-            protected override Type[] GetTokenTypesCore() { return new Type[] { typeof(WrappedKeySecurityToken) }; }
+            protected override XmlDictionaryString LocalName {
+                get
+                {
+                    throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+                    // return EncryptedKey.ElementName; 
+                }
+            }
+            protected override XmlDictionaryString NamespaceUri
+            {
+                get
+                {
+                    throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+                    //return XD.XmlEncryptionDictionary.Namespace;
+                }
+            }
+            protected override Type[] GetTokenTypesCore()
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+                //return new Type[] { typeof(WrappedKeySecurityToken) };
+            }
             public override string TokenTypeUri { get { return null; } }
             protected override string ValueTypeUri { get { return null; } }
 
@@ -505,7 +540,8 @@ namespace System.ServiceModel.Security
                     case SecurityTokenReferenceStyle.Internal:
                         return CreateDirectReference(issuedTokenXml, XmlEncryptionStrings.Id, null, null);
                     case SecurityTokenReferenceStyle.External:
-                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new XmlException(SR.GetString(SR.CantInferReferenceForToken, EncryptedKey.ElementName.Value)));
+                        throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+                        //throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new XmlException(SR.Format(SR.CantInferReferenceForToken, EncryptedKey.ElementName.Value)));
                     default:
                         throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("tokenReferenceStyle"));
                 }
@@ -513,90 +549,94 @@ namespace System.ServiceModel.Security
 
             public override SecurityToken ReadTokenCore(XmlDictionaryReader reader, SecurityTokenResolver tokenResolver)
             {
-                EncryptedKey encryptedKey = new EncryptedKey();
-                encryptedKey.SecurityTokenSerializer = this.tokenSerializer;
-                encryptedKey.ReadFrom(reader);
-                SecurityKeyIdentifier unwrappingTokenIdentifier = encryptedKey.KeyIdentifier;
-                byte[] wrappedKey = encryptedKey.GetWrappedKey();
-                WrappedKeySecurityToken wrappedKeyToken = CreateWrappedKeyToken(encryptedKey.Id, encryptedKey.EncryptionMethod,
-                    encryptedKey.CarriedKeyName, unwrappingTokenIdentifier, wrappedKey, tokenResolver);
-                wrappedKeyToken.EncryptedKey = encryptedKey;
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
 
-                return wrappedKeyToken;
+                //EncryptedKey encryptedKey = new EncryptedKey();
+                //encryptedKey.SecurityTokenSerializer = this.tokenSerializer;
+                //encryptedKey.ReadFrom(reader);
+                //SecurityKeyIdentifier unwrappingTokenIdentifier = encryptedKey.KeyIdentifier;
+                //byte[] wrappedKey = encryptedKey.GetWrappedKey();
+                //WrappedKeySecurityToken wrappedKeyToken = CreateWrappedKeyToken(encryptedKey.Id, encryptedKey.EncryptionMethod,
+                //    encryptedKey.CarriedKeyName, unwrappingTokenIdentifier, wrappedKey, tokenResolver);
+                //wrappedKeyToken.EncryptedKey = encryptedKey;
+
+                //return wrappedKeyToken;
             }
 
-            WrappedKeySecurityToken CreateWrappedKeyToken(string id, string encryptionMethod, string carriedKeyName,
-                SecurityKeyIdentifier unwrappingTokenIdentifier, byte[] wrappedKey, SecurityTokenResolver tokenResolver)
-            {
-                ISspiNegotiationInfo sspiResolver = tokenResolver as ISspiNegotiationInfo;
-                if (sspiResolver != null)
-                {
-                    ISspiNegotiation unwrappingSspiContext = sspiResolver.SspiNegotiation;
-                    // ensure that the encryption algorithm is compatible
-                    if (encryptionMethod != unwrappingSspiContext.KeyEncryptionAlgorithm)
-                    {
-                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new MessageSecurityException(SR.GetString(SR.BadKeyEncryptionAlgorithm, encryptionMethod)));
-                    }
-                    byte[] unwrappedKey = unwrappingSspiContext.Decrypt(wrappedKey);
-                    return new WrappedKeySecurityToken(id, unwrappedKey, encryptionMethod, unwrappingSspiContext, unwrappedKey);
-                }
-                else
-                {
-                    if (tokenResolver == null)
-                    {
-                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentNullException("tokenResolver"));
-                    }
-                    if (unwrappingTokenIdentifier == null || unwrappingTokenIdentifier.Count == 0)
-                    {
-                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new MessageSecurityException(SR.GetString(SR.MissingKeyInfoInEncryptedKey)));
-                    }
+            // Issue #31 in progress
+            //WrappedKeySecurityToken CreateWrappedKeyToken(string id, string encryptionMethod, string carriedKeyName,
+            //    SecurityKeyIdentifier unwrappingTokenIdentifier, byte[] wrappedKey, SecurityTokenResolver tokenResolver)
+            //{
+            //    ISspiNegotiationInfo sspiResolver = tokenResolver as ISspiNegotiationInfo;
+            //    if (sspiResolver != null)
+            //    {
+            //        ISspiNegotiation unwrappingSspiContext = sspiResolver.SspiNegotiation;
+            //        // ensure that the encryption algorithm is compatible
+            //        if (encryptionMethod != unwrappingSspiContext.KeyEncryptionAlgorithm)
+            //        {
+            //            throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new MessageSecurityException(SR.Format(SR.BadKeyEncryptionAlgorithm, encryptionMethod)));
+            //        }
+            //        byte[] unwrappedKey = unwrappingSspiContext.Decrypt(wrappedKey);
+            //        return new WrappedKeySecurityToken(id, unwrappedKey, encryptionMethod, unwrappingSspiContext, unwrappedKey);
+            //    }
+            //    else
+            //    {
+            //        if (tokenResolver == null)
+            //        {
+            //            throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentNullException("tokenResolver"));
+            //        }
+            //        if (unwrappingTokenIdentifier == null || unwrappingTokenIdentifier.Count == 0)
+            //        {
+            //            throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new MessageSecurityException(SR.Format(SR.MissingKeyInfoInEncryptedKey)));
+            //        }
 
-                    SecurityToken unwrappingToken;
-                    SecurityHeaderTokenResolver resolver = tokenResolver as SecurityHeaderTokenResolver;
-                    if (resolver != null)
-                    {
-                        unwrappingToken = resolver.ExpectedWrapper;
-                        if (unwrappingToken != null)
-                        {
-                            if (!resolver.CheckExternalWrapperMatch(unwrappingTokenIdentifier))
-                            {
-                                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new MessageSecurityException(
-                                    SR.GetString(SR.EncryptedKeyWasNotEncryptedWithTheRequiredEncryptingToken, unwrappingToken)));
-                            }
-                        }
-                        else
-                        {
-                            throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new MessageSecurityException(
-                                SR.GetString(SR.UnableToResolveKeyInfoForUnwrappingToken, unwrappingTokenIdentifier, resolver)));
-                        }
-                    }
-                    else
-                    {
-                        try
-                        {
-                            unwrappingToken = tokenResolver.ResolveToken(unwrappingTokenIdentifier);
-                        }
-                        catch (Exception exception)
-                        {
-                            if (exception is MessageSecurityException)
-                                throw;
+            //        SecurityToken unwrappingToken;
+            //        SecurityHeaderTokenResolver resolver = tokenResolver as SecurityHeaderTokenResolver;
+            //        if (resolver != null)
+            //        {
+            //            unwrappingToken = resolver.ExpectedWrapper;
+            //            if (unwrappingToken != null)
+            //            {
+            //                if (!resolver.CheckExternalWrapperMatch(unwrappingTokenIdentifier))
+            //                {
+            //                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new MessageSecurityException(
+            //                        SR.Format(SR.EncryptedKeyWasNotEncryptedWithTheRequiredEncryptingToken, unwrappingToken)));
+            //                }
+            //            }
+            //            else
+            //            {
+            //                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new MessageSecurityException(
+            //                    SR.Format(SR.UnableToResolveKeyInfoForUnwrappingToken, unwrappingTokenIdentifier, resolver)));
+            //            }
+            //        }
+            //        else
+            //        {
+            //            try
+            //            {
+            //                unwrappingToken = tokenResolver.ResolveToken(unwrappingTokenIdentifier);
+            //            }
+            //            catch (Exception exception)
+            //            {
+            //                if (exception is MessageSecurityException)
+            //                    throw;
 
-                            throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new MessageSecurityException(
-                                SR.GetString(SR.UnableToResolveKeyInfoForUnwrappingToken, unwrappingTokenIdentifier, tokenResolver), exception));
-                        }
-                    }
-                    SecurityKey unwrappingSecurityKey;
-                    byte[] unwrappedKey = SecurityUtils.DecryptKey(unwrappingToken, encryptionMethod, wrappedKey, out unwrappingSecurityKey);
-                    return new WrappedKeySecurityToken(id, unwrappedKey, encryptionMethod, unwrappingToken, unwrappingTokenIdentifier, wrappedKey, unwrappingSecurityKey);
-                }
-            }
+            //                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new MessageSecurityException(
+            //                    SR.Format(SR.UnableToResolveKeyInfoForUnwrappingToken, unwrappingTokenIdentifier, tokenResolver), exception));
+            //            }
+            //        }
+            //        SecurityKey unwrappingSecurityKey;
+            //        byte[] unwrappedKey = SecurityUtils.DecryptKey(unwrappingToken, encryptionMethod, wrappedKey, out unwrappingSecurityKey);
+            //        return new WrappedKeySecurityToken(id, unwrappedKey, encryptionMethod, unwrappingToken, unwrappingTokenIdentifier, wrappedKey, unwrappingSecurityKey);
+            //    }
+            //}
 
             public override void WriteTokenCore(XmlDictionaryWriter writer, SecurityToken token)
             {
-                WrappedKeySecurityToken wrappedKeyToken = token as WrappedKeySecurityToken;
-                wrappedKeyToken.EnsureEncryptedKeySetUp();
-                wrappedKeyToken.EncryptedKey.SecurityTokenSerializer = this.tokenSerializer;
-                wrappedKeyToken.EncryptedKey.WriteTo(writer, ServiceModelDictionaryManager.Instance);
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+                //WrappedKeySecurityToken wrappedKeyToken = token as WrappedKeySecurityToken;
+                //wrappedKeyToken.EnsureEncryptedKeySetUp();
+                //wrappedKeyToken.EncryptedKey.SecurityTokenSerializer = this.tokenSerializer;
+                //wrappedKeyToken.EncryptedKey.WriteTo(writer, ServiceModelDictionaryManager.Instance);
             }
         }
 
@@ -609,35 +649,41 @@ namespace System.ServiceModel.Security
             {
             }
 
-            protected override Type[] GetTokenTypesCore() { return new Type[] { typeof(X509SecurityToken), typeof(X509WindowsSecurityToken) }; }
+            protected override Type[] GetTokenTypesCore()
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+                //return new Type[] { typeof(X509SecurityToken), typeof(X509WindowsSecurityToken)};
+            }
 
             public override SecurityKeyIdentifierClause CreateKeyIdentifierClauseFromBinaryCore(byte[] rawData)
             {
-                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new XmlException(SR.GetString(SR.CantInferReferenceForToken, ValueTypeAbsoluteUri)));
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new XmlException(SR.Format(SR.CantInferReferenceForToken, ValueTypeAbsoluteUri)));
             }
 
             public override SecurityToken ReadBinaryCore(string id, string valueTypeUri, byte[] rawData)
             {
-                X509Certificate2 certificate;
-                if (!SecurityUtils.TryCreateX509CertificateFromRawData(rawData, out certificate))
-                {
-                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new MessageSecurityException(SR.GetString(SR.InvalidX509RawData)));
-                }
-                return new X509SecurityToken(certificate, id, false);
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+                //X509Certificate2 certificate;
+                //if (!SecurityUtils.TryCreateX509CertificateFromRawData(rawData, out certificate))
+                //{
+                //    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new MessageSecurityException(SR.Format(SR.InvalidX509RawData)));
+                //}
+                //return new X509SecurityToken(certificate, id, false);
             }
 
             public override void WriteBinaryCore(SecurityToken token, out string id, out byte[] rawData)
             {
-                id = token.Id;
-                X509SecurityToken x509Token = token as X509SecurityToken;
-                if (x509Token != null)
-                {
-                    rawData = x509Token.Certificate.GetRawCertData();
-                }
-                else
-                {
-                    rawData = ((X509WindowsSecurityToken)token).Certificate.GetRawCertData();
-                }
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+                //id = token.Id;
+                //X509SecurityToken x509Token = token as X509SecurityToken;
+                //if (x509Token != null)
+                //{
+                //    rawData = x509Token.Certificate.GetRawCertData();
+                //}
+                //else
+                //{
+                //    rawData = ((X509WindowsSecurityToken)token).Certificate.GetRawCertData();
+                //}
             }
         }
 
@@ -666,17 +712,18 @@ namespace System.ServiceModel.Security
 
             public override string ExtractId(XmlDictionaryReader reader)
             {
-                if (reader == null)
-                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("reader");
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+                //if (reader == null)
+                //    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("reader");
 
-                if (reader.IsStartElement(EncryptedData.ElementName, XD.XmlEncryptionDictionary.Namespace))
-                {
-                    return reader.GetAttribute(XD.XmlEncryptionDictionary.Id, null);
-                }
-                else
-                {
-                    return reader.GetAttribute(XD.UtilityDictionary.IdAttribute, XD.UtilityDictionary.Namespace);
-                }
+                //if (reader.IsStartElement(EncryptedData.ElementName, XD.XmlEncryptionDictionary.Namespace))
+                //{
+                //    return reader.GetAttribute(XD.XmlEncryptionDictionary.Id, null);
+                //}
+                //else
+                //{
+                //    return reader.GetAttribute(XD.UtilityDictionary.IdAttribute, XD.UtilityDictionary.Namespace);
+                //}
             }
 
             public override void WriteIdAttribute(XmlDictionaryWriter writer, string id)

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/WSSecurityOneDotOneSendSecurityHeader.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/WSSecurityOneDotOneSendSecurityHeader.cs
@@ -3,19 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 
-using System.Collections.Generic;
 using System.ServiceModel.Channels;
-using System.ServiceModel;
 using System.ServiceModel.Description;
-using System.Diagnostics;
-using System.IO;
-using System.IdentityModel.Tokens;
-using System.Security.Cryptography;
-using System.ServiceModel.Security.Tokens;
-using System.Xml;
-using System.ServiceModel.Diagnostics;
-
-using ISignatureValueSecurityElement = System.IdentityModel.ISignatureValueSecurityElement;
 
 namespace System.ServiceModel.Security
 {

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/WSSecurityOneDotZeroSendSecurityHeader.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/WSSecurityOneDotZeroSendSecurityHeader.cs
@@ -2,14 +2,51 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-
-using System.ServiceModel.Channels;
-using System.ServiceModel.Description;
-
 namespace System.ServiceModel.Security
 {
-    internal class WSSecurityOneDotZeroSendSecurityHeader : SendSecurityHeader
+    using System.IdentityModel.Tokens;
+    using System.IO;
+    using System.Runtime;
+    using System.Security.Cryptography;
+    using System.ServiceModel;
+    using System.ServiceModel.Channels;
+    using System.ServiceModel.Description;
+    using System.ServiceModel.Diagnostics;
+    using System.Xml;
+    //using ExclusiveCanonicalizationTransform = System.IdentityModel.ExclusiveCanonicalizationTransform;
+    using HashStream = System.IdentityModel.HashStream;
+    using IPrefixGenerator = System.IdentityModel.IPrefixGenerator;
+    using ISecurityElement = System.IdentityModel.ISecurityElement;
+    using ISignatureValueSecurityElement = System.IdentityModel.ISignatureValueSecurityElement;
+    //using PreDigestedSignedInfo = System.IdentityModel.PreDigestedSignedInfo;
+    //using Reference = System.IdentityModel.Reference;
+    //using SignedInfo = System.IdentityModel.SignedInfo;
+    using SignedXml = System.IdentityModel.SignedXml;
+    //using StandardSignedInfo = System.IdentityModel.StandardSignedInfo;
+    using System.ServiceModel.Security.Tokens;
+
+    class WSSecurityOneDotZeroSendSecurityHeader : SendSecurityHeader
     {
+        private HashStream _hashStream;
+
+        // Issue #31 in progress
+        //PreDigestedSignedInfo _signedInfo;
+        private SignedXml _signedXml;
+        //private SecurityKey _signatureKey;
+        //private MessagePartSpecification _effectiveSignatureParts;
+
+        private SymmetricAlgorithm _encryptingSymmetricAlgorithm;
+        private ReferenceList _referenceList;
+        private SecurityKeyIdentifier _encryptionKeyIdentifier;
+
+        private bool _hasSignedEncryptedMessagePart;
+
+        // For Transport Secrity we have to sign the 'To' header with the 
+        // supporting tokens.
+        //Issue #31 in progress
+        //private byte[] _toHeaderHash = null;
+        //private string _toHeaderId = null;
+
         public WSSecurityOneDotZeroSendSecurityHeader(Message message, string actor, bool mustUnderstand, bool relay,
             SecurityStandardsManager standardsManager,
             SecurityAlgorithmSuite algorithmSuite,
@@ -17,5 +54,899 @@ namespace System.ServiceModel.Security
             : base(message, actor, mustUnderstand, relay, standardsManager, algorithmSuite, direction)
         {
         }
+
+        protected string EncryptionAlgorithm
+        {
+            get { return this.AlgorithmSuite.DefaultEncryptionAlgorithm; }
+        }
+
+        protected XmlDictionaryString EncryptionAlgorithmDictionaryString
+        {
+            get { return this.AlgorithmSuite.DefaultEncryptionAlgorithmDictionaryString; }
+        }
+
+        protected override bool HasSignedEncryptedMessagePart
+        {
+            get
+            {
+                return _hasSignedEncryptedMessagePart;
+            }
+        }
+
+        void AddEncryptionReference(MessageHeader header, string headerId, IPrefixGenerator prefixGenerator, bool sign,
+            out MemoryStream plainTextStream, out string encryptedDataId)
+        {
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+
+            //plainTextStream = new MemoryStream();
+            //XmlDictionaryWriter encryptingWriter = XmlDictionaryWriter.CreateTextWriter(plainTextStream);
+            //if (sign)
+            //{
+            //    AddSignatureReference(header, headerId, prefixGenerator, encryptingWriter);
+            //}
+            //else
+            //{
+            //    header.WriteHeader(encryptingWriter, this.Version);
+            //    encryptingWriter.Flush();
+            //}
+            //encryptedDataId = this.GenerateId();
+            //_referenceList.AddReferredId(encryptedDataId);
+        }
+
+        void AddSignatureReference(SecurityToken token, int position, SecurityTokenAttachmentMode mode)
+        {
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+            //SecurityKeyIdentifierClause keyIdentifierClause = null;
+            //bool strTransformEnabled = this.ShouldUseStrTransformForToken(token, position, mode, out keyIdentifierClause);
+            //AddTokenSignatureReference(token, keyIdentifierClause, strTransformEnabled);
+        }
+
+        void AddPrimaryTokenSignatureReference(SecurityToken token, SecurityTokenParameters securityTokenParameters)
+        {
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+            //// Currently we only support signing the primary token if the primary token is an issued token and protectTokens knob is set to true.
+            //// We will get rid of the below check when we support all token types.
+            //IssuedSecurityTokenParameters istp = securityTokenParameters as IssuedSecurityTokenParameters;
+            //if (istp == null)
+            //{
+            //    return;
+            //}
+
+            //bool strTransformEnabled = istp != null && istp.UseStrTransform;
+            //SecurityKeyIdentifierClause keyIdentifierClause = null;
+            //// Only if the primary token is included in the message that we sign it because WCF at present does not resolve externally referenced tokens. 
+            //// This means in the server's response 
+            //if (ShouldSerializeToken(securityTokenParameters, this.MessageDirection))
+            //{
+            //    if (strTransformEnabled)
+            //    {
+            //        keyIdentifierClause = securityTokenParameters.CreateKeyIdentifierClause(token, GetTokenReferenceStyle(securityTokenParameters));
+            //    }
+            //    AddTokenSignatureReference(token, keyIdentifierClause, strTransformEnabled);
+            //}
+        }
+
+        // Given a token and useStarTransform value this method adds apporopriate reference accordingly.
+        // 1. If strTransform is disabled, it adds a reference to the token's id. 
+        // 2. Else if strtransform is enabled it adds a reference the security token's keyIdentifier's id.
+        void AddTokenSignatureReference(SecurityToken token, SecurityKeyIdentifierClause keyIdentifierClause, bool strTransformEnabled)
+        {
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+
+            //if (!strTransformEnabled && token.Id == null)
+            //{
+            //    throw TraceUtility.ThrowHelperError(new MessageSecurityException(SR.Format(SR.ElementToSignMustHaveId)), this.Message);
+            //}
+
+            //HashStream hashStream = TakeHashStream();
+            //XmlDictionaryWriter utf8Writer = TakeUtf8Writer();
+            //utf8Writer.StartCanonicalization(hashStream, false, null);
+            //this.StandardsManager.SecurityTokenSerializer.WriteToken(utf8Writer, token);
+            //utf8Writer.EndCanonicalization();
+
+            //if (strTransformEnabled)
+            //{
+            //    if (keyIdentifierClause != null)
+            //    {
+            //        if (String.IsNullOrEmpty(keyIdentifierClause.Id))
+            //            keyIdentifierClause.Id = SecurityUniqueId.Create().Value;
+            //        this.ElementContainer.MapSecurityTokenToStrClause(token, keyIdentifierClause);
+            //        _signedInfo.AddReference(keyIdentifierClause.Id, hashStream.FlushHashAndGetValue(), true);
+            //    }
+            //    else
+            //        throw TraceUtility.ThrowHelperError(new MessageSecurityException(SR.GetString(SR.TokenManagerCannotCreateTokenReference)), this.Message);
+            //}
+            //else
+            //    _signedInfo.AddReference(token.Id, hashStream.FlushHashAndGetValue());
+        }
+
+        void AddSignatureReference(SendSecurityHeaderElement[] elements)
+        {
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+            //if (elements != null)
+            //{
+            //    for (int i = 0; i < elements.Length; ++i)
+            //    {
+            //        SecurityKeyIdentifierClause keyIdentifierClause = null;
+            //        TokenElement signedEncryptedTokenElement = elements[i].Item as TokenElement;
+
+            //        // signedEncryptedTokenElement can either be a TokenElement ( in SignThenEncrypt case) or EncryptedData ( in !SignThenEncryptCase)
+            //        // STR-Transform does not make sense in !SignThenEncrypt case .
+            //        // note: signedEncryptedTokenElement can also be SignatureConfirmation but we do not care about it here.
+            //        bool useStrTransform = signedEncryptedTokenElement != null
+            //                               && SignThenEncrypt
+            //                               && this.ShouldUseStrTransformForToken(signedEncryptedTokenElement.Token,
+            //                                                                     i,
+            //                                                                     SecurityTokenAttachmentMode.SignedEncrypted,
+            //                                                                     out keyIdentifierClause);
+
+            //        if (!useStrTransform && elements[i].Id == null)
+            //        {
+            //            throw TraceUtility.ThrowHelperError(new MessageSecurityException(SR.GetString(SR.ElementToSignMustHaveId)), this.Message);
+            //        }
+
+            //        HashStream hashStream = TakeHashStream();
+            //        XmlDictionaryWriter utf8Writer = TakeUtf8Writer();
+            //        utf8Writer.StartCanonicalization(hashStream, false, null);
+            //        elements[i].Item.WriteTo(utf8Writer, ServiceModelDictionaryManager.Instance);
+            //        utf8Writer.EndCanonicalization();
+
+            //        if (useStrTransform)
+            //        {
+            //            if (keyIdentifierClause != null)
+            //            {
+            //                if (String.IsNullOrEmpty(keyIdentifierClause.Id))
+            //                    keyIdentifierClause.Id = SecurityUniqueId.Create().Value;
+
+            //                this.ElementContainer.MapSecurityTokenToStrClause(signedEncryptedTokenElement.Token, keyIdentifierClause);
+            //                this.signedInfo.AddReference(keyIdentifierClause.Id, hashStream.FlushHashAndGetValue(), true);
+            //            }
+            //            else
+            //                throw TraceUtility.ThrowHelperError(new MessageSecurityException(SR.GetString(SR.TokenManagerCannotCreateTokenReference)), this.Message);
+            //        }
+            //        else
+            //            this.signedInfo.AddReference(elements[i].Id, hashStream.FlushHashAndGetValue());
+            //    }
+            //}
+        }
+
+        void AddSignatureReference(SecurityToken[] tokens, SecurityTokenAttachmentMode mode)
+        {
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+            //if (tokens != null)
+            //{
+            //    for (int i = 0; i < tokens.Length; ++i)
+            //    {
+            //        AddSignatureReference(tokens[i], i, mode);
+            //    }
+            //}
+        }
+
+        string GetSignatureHash(MessageHeader header, string headerId, IPrefixGenerator prefixGenerator, XmlDictionaryWriter writer, out byte[] hash)
+        {
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+
+            //HashStream hashStream = TakeHashStream();
+            //XmlDictionaryWriter effectiveWriter;
+            //XmlBuffer canonicalBuffer = null;
+
+            //if (writer.CanCanonicalize)
+            //{
+            //    effectiveWriter = writer;
+            //}
+            //else
+            //{
+            //    canonicalBuffer = new XmlBuffer(int.MaxValue);
+            //    effectiveWriter = canonicalBuffer.OpenSection(XmlDictionaryReaderQuotas.Max);
+            //}
+
+            //effectiveWriter.StartCanonicalization(hashStream, false, null);
+
+            //header.WriteStartHeader(effectiveWriter, this.Version);
+            //if (headerId == null)
+            //{
+            //    headerId = GenerateId();
+            //    this.StandardsManager.IdManager.WriteIdAttribute(effectiveWriter, headerId);
+            //}
+            //header.WriteHeaderContents(effectiveWriter, this.Version);
+            //effectiveWriter.WriteEndElement();
+            //effectiveWriter.EndCanonicalization();
+            //effectiveWriter.Flush();
+
+            //if (!ReferenceEquals(effectiveWriter, writer))
+            //{
+            //    Fx.Assert(canonicalBuffer != null, "Canonical buffer cannot be null.");
+            //    canonicalBuffer.CloseSection();
+            //    canonicalBuffer.Close();
+            //    XmlDictionaryReader dicReader = canonicalBuffer.GetReader(0);
+            //    writer.WriteNode(dicReader, false);
+            //    dicReader.Dispose();
+            //}
+
+            //hash = hashStream.FlushHashAndGetValue();
+
+            //return headerId;
+        }
+
+        void AddSignatureReference(MessageHeader header, string headerId, IPrefixGenerator prefixGenerator, XmlDictionaryWriter writer)
+        {
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+            //byte[] hashValue;
+            //headerId = GetSignatureHash(header, headerId, prefixGenerator, writer, out hashValue);
+            //_signedInfo.AddReference(headerId, hashValue);
+        }
+
+        void ApplySecurityAndWriteHeader(MessageHeader header, string headerId, XmlDictionaryWriter writer, IPrefixGenerator prefixGenerator)
+        {
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+
+            //if (!this.RequireMessageProtection && this.ShouldSignToHeader)
+            //{
+            //    if ((header.Name == XD.AddressingDictionary.To.Value) &&
+            //        (header.Namespace == this.Message.Version.Addressing.Namespace))
+            //    {
+            //        if (this.toHeaderHash == null)
+            //        {
+            //            byte[] headerHash;
+            //            headerId = GetSignatureHash(header, headerId, prefixGenerator, writer, out headerHash);
+            //            this.toHeaderHash = headerHash;
+            //            this.toHeaderId = headerId;
+            //        }
+            //        else
+            //            // More than one 'To' header is specified in the message.
+            //            throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new MessageSecurityException(SR.GetString(SR.TransportSecuredMessageHasMoreThanOneToHeader)));
+
+            //        return;
+            //    }
+            //}
+
+            //MessagePartProtectionMode protectionMode = GetProtectionMode(header);
+            //MemoryStream plainTextStream;
+            //string encryptedDataId;
+            //switch (protectionMode)
+            //{
+            //    case MessagePartProtectionMode.None:
+            //        header.WriteHeader(writer, this.Version);
+            //        return;
+            //    case MessagePartProtectionMode.Sign:
+            //        AddSignatureReference(header, headerId, prefixGenerator, writer);
+            //        return;
+            //    case MessagePartProtectionMode.SignThenEncrypt:
+            //        AddEncryptionReference(header, headerId, prefixGenerator, true, out plainTextStream, out encryptedDataId);
+            //        EncryptAndWriteHeader(header, encryptedDataId, plainTextStream, writer);
+            //        this.hasSignedEncryptedMessagePart = true;
+            //        return;
+            //    case MessagePartProtectionMode.Encrypt:
+            //        AddEncryptionReference(header, headerId, prefixGenerator, false, out plainTextStream, out encryptedDataId);
+            //        EncryptAndWriteHeader(header, encryptedDataId, plainTextStream, writer);
+            //        return;
+            //    case MessagePartProtectionMode.EncryptThenSign:
+            //        AddEncryptionReference(header, headerId, prefixGenerator, false, out plainTextStream, out encryptedDataId);
+            //        EncryptedHeader encryptedHeader = EncryptHeader(
+            //            header, this.encryptingSymmetricAlgorithm, this.encryptionKeyIdentifier, this.Version, encryptedDataId, plainTextStream);
+            //        AddSignatureReference(encryptedHeader, encryptedDataId, prefixGenerator, writer);
+            //        return;
+            //    default:
+            //        Fx.Assert("Invalid MessagePartProtectionMode");
+            //        return;
+            //}
+        }
+
+        public override void ApplySecurityAndWriteHeaders(MessageHeaders headers, XmlDictionaryWriter writer, IPrefixGenerator prefixGenerator)
+        {
+            string[] headerIds;
+            if (this.RequireMessageProtection || this.ShouldSignToHeader)
+            {
+                headerIds = headers.GetHeaderAttributes(UtilityStrings.IdAttribute,
+                    this.StandardsManager.IdManager.DefaultIdNamespaceUri);
+            }
+            else
+            {
+                headerIds = null;
+            }
+            for (int i = 0; i < headers.Count; i++)
+            {
+                MessageHeader header = headers.GetMessageHeader(i);
+                if (this.Version.Addressing == AddressingVersion.None && header.Namespace == AddressingVersion.None.Namespace)
+                {
+                    continue;
+                }
+
+                if (header != this)
+                {
+                    ApplySecurityAndWriteHeader(header, headerIds == null ? null : headerIds[i], writer, prefixGenerator);
+                }
+            }
+        }
+
+        static bool CanCanonicalizeAndFragment(XmlDictionaryWriter writer)
+        {
+            throw ExceptionHelper.PlatformNotSupported();   // #31: Required API: IFragmentCapableXmlDictionaryWriter 
+
+            //if (!writer.CanCanonicalize)
+            //{
+            //    return false;
+            //}
+            //IFragmentCapableXmlDictionaryWriter fragmentingWriter = writer as IFragmentCapableXmlDictionaryWriter;
+            //return fragmentingWriter != null && fragmentingWriter.CanFragment;
+        }
+
+        public override void ApplyBodySecurity(XmlDictionaryWriter writer, IPrefixGenerator prefixGenerator)
+        {
+            SecurityAppliedMessage message = this.SecurityAppliedMessage;
+            EncryptedData encryptedData;
+            HashStream hashStream;
+            switch (message.BodyProtectionMode)
+            {
+                case MessagePartProtectionMode.None:
+                    return;
+                case MessagePartProtectionMode.Sign:
+                    hashStream = TakeHashStream();
+                    if (CanCanonicalizeAndFragment(writer))
+                    {
+                        message.WriteBodyToSignWithFragments(hashStream, false, null, writer);
+                    }
+                    else
+                    {
+                        message.WriteBodyToSign(hashStream);
+                    }
+                    throw ExceptionHelper.PlatformNotSupported();   // #31: Required
+                    //_signedInfo.AddReference(message.BodyId, hashStream.FlushHashAndGetValue());
+                    //return;
+                case MessagePartProtectionMode.SignThenEncrypt:
+                    hashStream = TakeHashStream();
+                    encryptedData = CreateEncryptedDataForBody();
+                    if (CanCanonicalizeAndFragment(writer))
+                    {
+                        message.WriteBodyToSignThenEncryptWithFragments(hashStream, false, null, encryptedData, this._encryptingSymmetricAlgorithm, writer);
+                    }
+                    else
+                    {
+                        message.WriteBodyToSignThenEncrypt(hashStream, encryptedData, _encryptingSymmetricAlgorithm);
+                    }
+                    throw ExceptionHelper.PlatformNotSupported();   // #31: Required
+                    //_signedInfo.AddReference(message.BodyId, hashStream.FlushHashAndGetValue());
+                    //_referenceList.AddReferredId(encryptedData.Id);
+                    //_hasSignedEncryptedMessagePart = true;
+                    //return;
+                case MessagePartProtectionMode.Encrypt:
+                    encryptedData = CreateEncryptedDataForBody();
+                    message.WriteBodyToEncrypt(encryptedData, _encryptingSymmetricAlgorithm);
+                    _referenceList.AddReferredId(encryptedData.Id);
+                    return;
+                case MessagePartProtectionMode.EncryptThenSign:
+                    hashStream = TakeHashStream();
+                    encryptedData = CreateEncryptedDataForBody();
+                    message.WriteBodyToEncryptThenSign(hashStream, encryptedData, _encryptingSymmetricAlgorithm);
+                    throw ExceptionHelper.PlatformNotSupported();   // #31: Required
+                    //_signedInfo.AddReference(message.BodyId, hashStream.FlushHashAndGetValue());
+                    //_referenceList.AddReferredId(encryptedData.Id);
+                    //return;
+                default:
+                    Fx.Assert("Invalid MessagePartProtectionMode");
+                    return;
+            }
+        }
+
+        protected static MemoryStream CaptureToken(SecurityToken token, SecurityStandardsManager serializer)
+        {
+            MemoryStream stream = new MemoryStream();
+            XmlDictionaryWriter writer = XmlDictionaryWriter.CreateTextWriter(stream);
+            serializer.SecurityTokenSerializer.WriteToken(writer, token);
+            writer.Flush();
+            stream.Seek(0, SeekOrigin.Begin);
+            return stream;
+        }
+
+        protected static MemoryStream CaptureSecurityElement(ISecurityElement element)
+        {
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+
+            //MemoryStream stream = new MemoryStream();
+            //XmlDictionaryWriter writer = XmlDictionaryWriter.CreateTextWriter(stream);
+            //element.WriteTo(writer, ServiceModelDictionaryManager.Instance);
+            //writer.Flush();
+            //stream.Seek(0, SeekOrigin.Begin);
+            //return stream;
+        }
+
+        protected override ISecurityElement CompleteEncryptionCore(
+            SendSecurityHeaderElement primarySignature,
+            SendSecurityHeaderElement[] basicTokens,
+            SendSecurityHeaderElement[] signatureConfirmations,
+            SendSecurityHeaderElement[] endorsingSignatures)
+        {
+            if (_referenceList == null)
+            {
+                return null;
+            }
+
+            if (primarySignature != null && primarySignature.Item != null && primarySignature.MarkedForEncryption)
+            {
+                EncryptElement(primarySignature);
+            }
+
+            if (basicTokens != null)
+            {
+                for (int i = 0; i < basicTokens.Length; ++i)
+                {
+                    if (basicTokens[i].MarkedForEncryption)
+                        EncryptElement(basicTokens[i]);
+                }
+            }
+
+            if (signatureConfirmations != null)
+            {
+                for (int i = 0; i < signatureConfirmations.Length; ++i)
+                {
+                    if (signatureConfirmations[i].MarkedForEncryption)
+                        EncryptElement(signatureConfirmations[i]);
+                }
+            }
+
+            if (endorsingSignatures != null)
+            {
+                for (int i = 0; i < endorsingSignatures.Length; ++i)
+                {
+                    if (endorsingSignatures[i].MarkedForEncryption)
+                        EncryptElement(endorsingSignatures[i]);
+                }
+            }
+
+            try
+            {
+                return _referenceList.DataReferenceCount > 0 ? _referenceList : null;
+            }
+            finally
+            {
+                _referenceList = null;
+                _encryptingSymmetricAlgorithm = null;
+                _encryptionKeyIdentifier = null;
+            }
+        }
+
+        protected override ISignatureValueSecurityElement CompletePrimarySignatureCore(
+            SendSecurityHeaderElement[] signatureConfirmations,
+            SecurityToken[] signedEndorsingTokens,
+            SecurityToken[] signedTokens,
+            SendSecurityHeaderElement[] basicTokens, bool isPrimarySignature)
+        {
+            if (_signedXml == null)
+            {
+                return null;
+            }
+
+            SecurityTimestamp timestamp = this.Timestamp;
+            if (timestamp != null)
+            {
+                if (timestamp.Id == null)
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.TimestampToSignHasNoId)));
+                }
+                HashStream hashStream = TakeHashStream();
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+                //this.StandardsManager.WSUtilitySpecificationVersion.WriteTimestampCanonicalForm(
+                //    hashStream, timestamp, _signedInfo.ResourcePool.TakeEncodingBuffer());
+                //_signedInfo.AddReference(timestamp.Id, hashStream.FlushHashAndGetValue());
+            }
+
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+
+            //if ((this.ShouldSignToHeader) && (this.signatureKey is AsymmetricSecurityKey) && (this.Version.Addressing != AddressingVersion.None))
+            //{
+            //    if (this.toHeaderHash != null)
+            //        signedInfo.AddReference(this.toHeaderId, this.toHeaderHash);
+            //    else
+            //        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.GetString(SR.TransportSecurityRequireToHeader)));
+            //}
+
+            //AddSignatureReference(signatureConfirmations);
+            //if (isPrimarySignature && this.ShouldProtectTokens)
+            //{
+            //    AddPrimaryTokenSignatureReference(this.ElementContainer.SourceSigningToken, this.SigningTokenParameters);
+            //}
+
+            //if (this.RequireMessageProtection)
+            //{
+            //    AddSignatureReference(signedEndorsingTokens, SecurityTokenAttachmentMode.SignedEndorsing);
+            //    AddSignatureReference(signedTokens, SecurityTokenAttachmentMode.Signed);
+            //    AddSignatureReference(basicTokens);
+            //}
+
+            //if (this.signedInfo.ReferenceCount == 0)
+            //{
+            //    throw TraceUtility.ThrowHelperError(new MessageSecurityException(SR.GetString(SR.NoPartsOfMessageMatchedPartsToSign)), this.Message);
+            //}
+            //try
+            //{
+            //    this.signedXml.ComputeSignature(this.signatureKey);
+            //    return this.signedXml;
+            //}
+            //finally
+            //{
+            //    this.hashStream = null;
+            //    this.signedInfo = null;
+            //    this.signedXml = null;
+            //    this.signatureKey = null;
+            //    this.effectiveSignatureParts = null;
+            //}
+        }
+
+        EncryptedData CreateEncryptedData()
+        {
+            EncryptedData encryptedData = new EncryptedData();
+            encryptedData.SecurityTokenSerializer = this.StandardsManager.SecurityTokenSerializer;
+            encryptedData.KeyIdentifier = _encryptionKeyIdentifier;
+            encryptedData.EncryptionMethod = this.EncryptionAlgorithm;
+            encryptedData.EncryptionMethodDictionaryString = EncryptionAlgorithmDictionaryString;
+            return encryptedData;
+        }
+
+        EncryptedData CreateEncryptedData(MemoryStream stream, string id, bool typeElement)
+        {
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+            //EncryptedData encryptedData = CreateEncryptedData();
+            //encryptedData.Id = id;
+            //encryptedData.SetUpEncryption(_encryptingSymmetricAlgorithm, new ArraySegment<byte>(stream.GetBuffer(), 0, (int)stream.Length));
+            //if (typeElement)
+            //{
+            //    encryptedData.Type = EncryptedData.ElementType;
+            //}
+            //return encryptedData;
+        }
+
+        EncryptedData CreateEncryptedDataForBody()
+        {
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+
+            //EncryptedData encryptedData = CreateEncryptedData();
+            //encryptedData.Type = EncryptedData.ContentType;
+            //return encryptedData;
+        }
+
+        void EncryptAndWriteHeader(MessageHeader plainTextHeader, string id, MemoryStream stream, XmlDictionaryWriter writer)
+        {
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+            //EncryptedHeader encryptedHeader = EncryptHeader(
+            //    plainTextHeader,
+            //    this.encryptingSymmetricAlgorithm, this.encryptionKeyIdentifier, this.Version,
+            //    id, stream);
+            //encryptedHeader.WriteHeader(writer, this.Version);
+        }
+
+        void EncryptElement(SendSecurityHeaderElement element)
+        {
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+            //string id = GenerateId();
+            //ISecurityElement encryptedElement = CreateEncryptedData(CaptureSecurityElement(element.Item), id, true);
+            //this.referenceList.AddReferredId(id);
+            //element.Replace(id, encryptedElement);
+        }
+
+        protected virtual EncryptedHeader EncryptHeader(MessageHeader plainTextHeader, SymmetricAlgorithm algorithm,
+                SecurityKeyIdentifier keyIdentifier, MessageVersion version, string id, MemoryStream stream)
+        {
+            throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(
+                SR.Format(SR.HeaderEncryptionNotSupportedInWsSecurityJan2004, plainTextHeader.Name, plainTextHeader.Namespace)));
+        }
+
+        HashStream TakeHashStream()
+        {
+            HashStream hashStream = null;
+            if (_hashStream == null)
+            {
+                _hashStream = hashStream = new HashStream(CryptoHelper.CreateHashAlgorithm(this.AlgorithmSuite.DefaultDigestAlgorithm));
+            }
+            else
+            {
+                hashStream = _hashStream; ;
+                hashStream.Reset();
+            }
+            return hashStream;
+        }
+
+        XmlDictionaryWriter TakeUtf8Writer()
+        {
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+            //return this.signedInfo.ResourcePool.TakeUtf8Writer();
+        }
+
+        MessagePartProtectionMode GetProtectionMode(MessageHeader header)
+        {
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+
+            //if (!this.RequireMessageProtection)
+            //{
+            //    return MessagePartProtectionMode.None;
+            //}
+            //bool sign = _signedInfo != null && _effectiveSignatureParts.IsHeaderIncluded(header);
+            //bool encrypt = _referenceList != null && this.EncryptionParts.IsHeaderIncluded(header);
+            //return MessagePartProtectionModeHelper.GetProtectionMode(sign, encrypt, this.SignThenEncrypt);
+        }
+
+        protected override void StartEncryptionCore(SecurityToken token, SecurityKeyIdentifier keyIdentifier)
+        {
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+
+            //this.encryptingSymmetricAlgorithm = SecurityUtils.GetSymmetricAlgorithm(this.EncryptionAlgorithm, token);
+            //if (this.encryptingSymmetricAlgorithm == null)
+            //{
+            //    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new MessageSecurityException(
+            //        SR.GetString(SR.UnableToCreateSymmetricAlgorithmFromToken, this.EncryptionAlgorithm)));
+            //}
+            //this.encryptionKeyIdentifier = keyIdentifier;
+            //this.referenceList = new ReferenceList();
+        }
+
+        protected override void StartPrimarySignatureCore(SecurityToken token,
+            SecurityKeyIdentifier keyIdentifier,
+            MessagePartSpecification signatureParts,
+            bool generateTargettableSignature)
+        {
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+
+            //SecurityAlgorithmSuite suite = this.AlgorithmSuite;
+            //string canonicalizationAlgorithm = suite.DefaultCanonicalizationAlgorithm;
+            //XmlDictionaryString canonicalizationAlgorithmDictionaryString = suite.DefaultCanonicalizationAlgorithmDictionaryString;
+            //if (canonicalizationAlgorithm != SecurityAlgorithms.ExclusiveC14n)
+            //{
+            //    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(
+            //        new MessageSecurityException(SR.Format(SR.UnsupportedCanonicalizationAlgorithm, suite.DefaultCanonicalizationAlgorithm)));
+            //}
+            //string signatureAlgorithm;
+            //XmlDictionaryString signatureAlgorithmDictionaryString;
+            //suite.GetSignatureAlgorithmAndKey(token, out signatureAlgorithm, out this.signatureKey, out signatureAlgorithmDictionaryString);
+            //string digestAlgorithm = suite.DefaultDigestAlgorithm;
+            //XmlDictionaryString digestAlgorithmDictionaryString = suite.DefaultDigestAlgorithmDictionaryString;
+            //this.signedInfo = new PreDigestedSignedInfo(ServiceModelDictionaryManager.Instance, canonicalizationAlgorithm, canonicalizationAlgorithmDictionaryString, digestAlgorithm, digestAlgorithmDictionaryString, signatureAlgorithm, signatureAlgorithmDictionaryString);
+            //this.signedXml = new SignedXml(this.signedInfo, ServiceModelDictionaryManager.Instance, this.StandardsManager.SecurityTokenSerializer);
+            //if (keyIdentifier != null)
+            //{
+            //    this.signedXml.Signature.KeyIdentifier = keyIdentifier;
+            //}
+            //if (generateTargettableSignature)
+            //{
+            //    this.signedXml.Id = GenerateId();
+            //}
+            //this.effectiveSignatureParts = signatureParts;
+            //this.hashStream = this.signedInfo.ResourcePool.TakeHashStream(digestAlgorithm);
+        }
+
+        protected override ISignatureValueSecurityElement CreateSupportingSignature(SecurityToken token, SecurityKeyIdentifier identifier)
+        {
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+
+            //StartPrimarySignatureCore(token, identifier, MessagePartSpecification.NoParts, false);
+            //return CompletePrimarySignatureCore(null, null, null, null, false);
+        }
+
+        protected override ISignatureValueSecurityElement CreateSupportingSignature(SecurityToken token, SecurityKeyIdentifier identifier, ISecurityElement elementToSign)
+        {
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+
+            //SecurityAlgorithmSuite algorithmSuite = this.AlgorithmSuite;
+            //string signatureAlgorithm;
+            //XmlDictionaryString signatureAlgorithmDictionaryString;
+            //SecurityKey signatureKey;
+            //algorithmSuite.GetSignatureAlgorithmAndKey(token, out signatureAlgorithm, out signatureKey, out signatureAlgorithmDictionaryString);
+            //SignedXml signedXml = new SignedXml(ServiceModelDictionaryManager.Instance, this.StandardsManager.SecurityTokenSerializer);
+            //SignedInfo signedInfo = signedXml.Signature.SignedInfo;
+            //signedInfo.CanonicalizationMethod = algorithmSuite.DefaultCanonicalizationAlgorithm;
+            //signedInfo.CanonicalizationMethodDictionaryString = algorithmSuite.DefaultCanonicalizationAlgorithmDictionaryString;
+            //signedInfo.SignatureMethod = signatureAlgorithm;
+            //signedInfo.SignatureMethodDictionaryString = signatureAlgorithmDictionaryString;
+
+            //if (elementToSign.Id == null)
+            //{
+            //    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.GetString(SR.ElementToSignMustHaveId)));
+            //}
+            //Reference reference = new Reference(ServiceModelDictionaryManager.Instance, "#" + elementToSign.Id, elementToSign);
+            //reference.DigestMethod = algorithmSuite.DefaultDigestAlgorithm;
+            //reference.DigestMethodDictionaryString = algorithmSuite.DefaultDigestAlgorithmDictionaryString;
+            //reference.AddTransform(new ExclusiveCanonicalizationTransform());
+            //((StandardSignedInfo)signedInfo).AddReference(reference);
+
+            //signedXml.ComputeSignature(signatureKey);
+            //if (identifier != null)
+            //{
+            //    signedXml.Signature.KeyIdentifier = identifier;
+            //}
+            //return signedXml;
+        }
+
+        protected override void WriteSecurityTokenReferencyEntry(XmlDictionaryWriter writer, SecurityToken securityToken, SecurityTokenParameters securityTokenParameters)
+        {
+            SecurityKeyIdentifierClause keyIdentifierClause = null;
+
+            // Given a token this method writes its corresponding security token reference entry in the security header 
+            // 1. If the token parameters is an issuedSecurityTokenParamter 
+            // 2. If UseStrTransform is enabled on it.
+
+            IssuedSecurityTokenParameters issuedSecurityTokenParameters = securityTokenParameters as IssuedSecurityTokenParameters;
+            if (issuedSecurityTokenParameters == null || !issuedSecurityTokenParameters.UseStrTransform)
+                return;
+
+            if (this.ElementContainer.TryGetIdentifierClauseFromSecurityToken(securityToken, out keyIdentifierClause))
+            {
+                if (keyIdentifierClause != null && !String.IsNullOrEmpty(keyIdentifierClause.Id))
+                {
+                    WrappedXmlDictionaryWriter wrappedLocalWriter = new WrappedXmlDictionaryWriter(writer, keyIdentifierClause.Id);
+                    this.StandardsManager.SecurityTokenSerializer.WriteKeyIdentifierClause(wrappedLocalWriter, keyIdentifierClause);
+                }
+                else
+                    throw TraceUtility.ThrowHelperError(new MessageSecurityException(SR.Format(SR.TokenManagerCannotCreateTokenReference)), this.Message);
+            }
+        }
+    }
+
+    class WrappedXmlDictionaryWriter : XmlDictionaryWriter
+    {
+        XmlDictionaryWriter innerWriter;
+        int index;
+        bool insertId;
+        bool isStrReferenceElement;
+        string id;
+
+        public WrappedXmlDictionaryWriter(XmlDictionaryWriter writer, string id)
+        {
+            this.innerWriter = writer;
+            this.index = 0;
+            this.insertId = false;
+            this.isStrReferenceElement = false;
+            this.id = id;
+        }
+
+        public override void WriteStartAttribute(string prefix, string localName, string namespaceUri)
+        {
+            if (isStrReferenceElement && this.insertId && localName == XD.UtilityDictionary.IdAttribute.Value)
+            {
+                // This means the serializer is already writing the Id out, so we don't write it again.
+                this.insertId = false;
+            }
+            this.innerWriter.WriteStartAttribute(prefix, localName, namespaceUri);
+        }
+
+        public override void WriteStartElement(string prefix, string localName, string namespaceUri)
+        {
+            if (isStrReferenceElement && this.insertId)
+            {
+                if (id != null)
+                {
+                    this.innerWriter.WriteAttributeString(XD.UtilityDictionary.Prefix.Value, XD.UtilityDictionary.IdAttribute, XD.UtilityDictionary.Namespace, id);
+                }
+
+                isStrReferenceElement = false;
+                this.insertId = false;
+            }
+
+            index++;
+
+            if (index == 1 && localName == XD.SecurityJan2004Dictionary.SecurityTokenReference.Value)
+            {
+                this.insertId = true;
+                isStrReferenceElement = true;
+            }
+
+            this.innerWriter.WriteStartElement(prefix, localName, namespaceUri);
+        }
+
+        // Below methods simply call into innerWritter
+        // Issue #31 in progress
+        // Close is not part of API
+        public /*override*/ void Close()
+        {
+            this.innerWriter.Dispose();
+        }
+
+        public override void Flush()
+        {
+            this.innerWriter.Flush();
+        }
+
+        public override string LookupPrefix(string ns)
+        {
+            return this.innerWriter.LookupPrefix(ns);
+        }
+
+        public override void WriteBase64(byte[] buffer, int index, int count)
+        {
+            this.innerWriter.WriteBase64(buffer, index, count);
+        }
+
+        public override void WriteCData(string text)
+        {
+            this.innerWriter.WriteCData(text);
+        }
+
+        public override void WriteCharEntity(char ch)
+        {
+            this.innerWriter.WriteCharEntity(ch);
+        }
+
+        public override void WriteChars(char[] buffer, int index, int count)
+        {
+            this.innerWriter.WriteChars(buffer, index, count);
+        }
+
+        public override void WriteComment(string text)
+        {
+            this.innerWriter.WriteComment(text);
+        }
+
+        public override void WriteDocType(string name, string pubid, string sysid, string subset)
+        {
+            this.innerWriter.WriteDocType(name, pubid, sysid, subset);
+        }
+
+        public override void WriteEndAttribute()
+        {
+            this.innerWriter.WriteEndAttribute();
+        }
+
+        public override void WriteEndDocument()
+        {
+            this.innerWriter.WriteEndDocument();
+        }
+
+        public override void WriteEndElement()
+        {
+            this.innerWriter.WriteEndElement();
+        }
+
+        public override void WriteEntityRef(string name)
+        {
+            this.innerWriter.WriteEntityRef(name);
+        }
+
+        public override void WriteFullEndElement()
+        {
+            this.innerWriter.WriteFullEndElement();
+        }
+
+        public override void WriteProcessingInstruction(string name, string text)
+        {
+            this.innerWriter.WriteProcessingInstruction(name, text);
+        }
+
+        public override void WriteRaw(string data)
+        {
+            this.innerWriter.WriteRaw(data);
+        }
+
+        public override void WriteRaw(char[] buffer, int index, int count)
+        {
+            this.innerWriter.WriteRaw(buffer, index, count);
+        }
+
+        public override void WriteStartDocument(bool standalone)
+        {
+            this.innerWriter.WriteStartDocument(standalone);
+        }
+
+        public override void WriteStartDocument()
+        {
+            this.innerWriter.WriteStartDocument();
+        }
+
+        public override WriteState WriteState
+        {
+            get { return this.innerWriter.WriteState; }
+        }
+
+        public override void WriteString(string text)
+        {
+            this.innerWriter.WriteString(text);
+        }
+
+        public override void WriteSurrogateCharEntity(char lowChar, char highChar)
+        {
+            this.innerWriter.WriteSurrogateCharEntity(lowChar, highChar);
+        }
+
+        public override void WriteWhitespace(string ws)
+        {
+            this.innerWriter.WriteWhitespace(ws);
+        }
     }
 }
+

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/WSSecurityOneDotZeroSendSecurityHeader.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/WSSecurityOneDotZeroSendSecurityHeader.cs
@@ -2,29 +2,31 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+using System.IdentityModel.Tokens;
+using System.IO;
+using System.Runtime;
+using System.Security.Cryptography;
+using System.ServiceModel.Channels;
+using System.ServiceModel.Description;
+using System.ServiceModel.Diagnostics;
+using System.ServiceModel.Security.Tokens;
+using System.Xml;
+// Issue #31 in progress
+//using ExclusiveCanonicalizationTransform = System.IdentityModel.ExclusiveCanonicalizationTransform;
+using HashStream = System.IdentityModel.HashStream;
+using IPrefixGenerator = System.IdentityModel.IPrefixGenerator;
+using ISecurityElement = System.IdentityModel.ISecurityElement;
+using ISignatureValueSecurityElement = System.IdentityModel.ISignatureValueSecurityElement;
+//using PreDigestedSignedInfo = System.IdentityModel.PreDigestedSignedInfo;
+//using Reference = System.IdentityModel.Reference;
+//using SignedInfo = System.IdentityModel.SignedInfo;
+using SignedXml = System.IdentityModel.SignedXml;
+//using StandardSignedInfo = System.IdentityModel.StandardSignedInfo;
+
+
 namespace System.ServiceModel.Security
 {
-    using System.IdentityModel.Tokens;
-    using System.IO;
-    using System.Runtime;
-    using System.Security.Cryptography;
-    using System.ServiceModel;
-    using System.ServiceModel.Channels;
-    using System.ServiceModel.Description;
-    using System.ServiceModel.Diagnostics;
-    using System.Xml;
-    //using ExclusiveCanonicalizationTransform = System.IdentityModel.ExclusiveCanonicalizationTransform;
-    using HashStream = System.IdentityModel.HashStream;
-    using IPrefixGenerator = System.IdentityModel.IPrefixGenerator;
-    using ISecurityElement = System.IdentityModel.ISecurityElement;
-    using ISignatureValueSecurityElement = System.IdentityModel.ISignatureValueSecurityElement;
-    //using PreDigestedSignedInfo = System.IdentityModel.PreDigestedSignedInfo;
-    //using Reference = System.IdentityModel.Reference;
-    //using SignedInfo = System.IdentityModel.SignedInfo;
-    using SignedXml = System.IdentityModel.SignedXml;
-    //using StandardSignedInfo = System.IdentityModel.StandardSignedInfo;
-    using System.ServiceModel.Security.Tokens;
-
     class WSSecurityOneDotZeroSendSecurityHeader : SendSecurityHeader
     {
         private HashStream _hashStream;

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/WSSecurityTokenSerializer.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/WSSecurityTokenSerializer.cs
@@ -22,7 +22,16 @@ namespace System.ServiceModel.Security
         private const int DefaultMaximumKeyDerivationNonceLength = 128; // bytes
 
         private static WSSecurityTokenSerializer s_instance;
+        private readonly bool _emitBspRequiredAttributes;
+        private readonly SecurityVersion _securityVersion;
+        private readonly List<SerializerEntries> _serializerEntries;
+        private WSSecureConversation _secureConversation;
         private readonly List<TokenEntry> _tokenEntries = new List<TokenEntry>();
+        private int _maximumKeyDerivationOffset;
+        private int _maximumKeyDerivationLabelLength;
+        private int _maximumKeyDerivationNonceLength;
+
+        private KeyInfoSerializer _keyInfoSerializer;
 
         public WSSecurityTokenSerializer()
             : this(SecurityVersion.WSSecurity11)
@@ -68,7 +77,87 @@ namespace System.ServiceModel.Security
         public WSSecurityTokenSerializer(SecurityVersion securityVersion, TrustVersion trustVersion, SecureConversationVersion secureConversationVersion, bool emitBspRequiredAttributes, SamlSerializer samlSerializer, SecurityStateEncoder securityStateEncoder, IEnumerable<Type> knownTypes,
             int maximumKeyDerivationOffset, int maximumKeyDerivationLabelLength, int maximumKeyDerivationNonceLength)
         {
-            throw ExceptionHelper.PlatformNotSupported();
+            if (securityVersion == null)
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentNullException("securityVersion"));
+
+            if (maximumKeyDerivationOffset < 0)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("maximumKeyDerivationOffset", SR.Format(SR.ValueMustBeNonNegative)));
+            }
+            if (maximumKeyDerivationLabelLength < 0)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("maximumKeyDerivationLabelLength", SR.Format(SR.ValueMustBeNonNegative)));
+            }
+            if (maximumKeyDerivationNonceLength <= 0)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("maximumKeyDerivationNonceLength", SR.Format(SR.ValueMustBeGreaterThanZero)));
+            }
+
+            _securityVersion = securityVersion;
+            _emitBspRequiredAttributes = emitBspRequiredAttributes;
+            _maximumKeyDerivationOffset = maximumKeyDerivationOffset;
+            _maximumKeyDerivationNonceLength = maximumKeyDerivationNonceLength;
+            _maximumKeyDerivationLabelLength = maximumKeyDerivationLabelLength;
+
+            _serializerEntries = new List<SerializerEntries>();
+
+            if (secureConversationVersion == SecureConversationVersion.WSSecureConversationFeb2005)
+            {
+                _secureConversation = new WSSecureConversationFeb2005(this, securityStateEncoder, knownTypes, maximumKeyDerivationOffset, maximumKeyDerivationLabelLength, maximumKeyDerivationNonceLength);
+            }
+            else if (secureConversationVersion == SecureConversationVersion.WSSecureConversation13)
+            {
+                _secureConversation = new WSSecureConversationDec2005(this, securityStateEncoder, knownTypes, maximumKeyDerivationOffset, maximumKeyDerivationLabelLength, maximumKeyDerivationNonceLength);
+            }
+            else
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new NotSupportedException());
+            }
+
+            if (securityVersion == SecurityVersion.WSSecurity10)
+            {
+                _serializerEntries.Add(new WSSecurityJan2004(this, samlSerializer));
+            }
+            else if (securityVersion == SecurityVersion.WSSecurity11)
+            {
+                _serializerEntries.Add(new WSSecurityXXX2005(this, samlSerializer));
+            }
+            else
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("securityVersion", SR.Format(SR.MessageSecurityVersionOutOfRange)));
+            }
+            _serializerEntries.Add(_secureConversation);
+
+            IdentityModel.TrustDictionary trustDictionary = null;
+            if (trustVersion == TrustVersion.WSTrustFeb2005)
+            {
+                _serializerEntries.Add(new WSTrustFeb2005(this));
+                trustDictionary = new IdentityModel.TrustFeb2005Dictionary(new CollectionDictionary(DXD.TrustDec2005Dictionary.Feb2005DictionaryStrings));
+            }
+            else if (trustVersion == TrustVersion.WSTrust13)
+            {
+                _serializerEntries.Add(new WSTrustDec2005(this));
+                trustDictionary = new IdentityModel.TrustDec2005Dictionary(new CollectionDictionary(DXD.TrustDec2005Dictionary.Dec2005DictionaryString));
+            }
+            else
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new NotSupportedException());
+            }
+
+            _tokenEntries = new List<TokenEntry>();
+
+            for (int i = 0; i < _serializerEntries.Count; ++i)
+            {
+                SerializerEntries serializerEntry = _serializerEntries[i];
+                serializerEntry.PopulateTokenEntries(_tokenEntries);
+            }
+
+            IdentityModel.DictionaryManager dictionaryManager = new IdentityModel.DictionaryManager(ServiceModelDictionary.CurrentVersion);
+            dictionaryManager.SecureConversationDec2005Dictionary = new IdentityModel.SecureConversationDec2005Dictionary(new CollectionDictionary(DXD.SecureConversationDec2005Dictionary.SecureConversationDictionaryStrings));
+            dictionaryManager.SecurityAlgorithmDec2005Dictionary = new IdentityModel.SecurityAlgorithmDec2005Dictionary(new CollectionDictionary(DXD.SecurityAlgorithmDec2005Dictionary.SecurityAlgorithmDictionaryStrings));
+
+            _keyInfoSerializer = new WSKeyInfoSerializer(_emitBspRequiredAttributes, dictionaryManager, trustDictionary, this, securityVersion, secureConversationVersion);
+
         }
 
         public static WSSecurityTokenSerializer DefaultInstance
@@ -81,29 +170,37 @@ namespace System.ServiceModel.Security
             }
         }
 
+        internal KeyInfoSerializer KeyInfoSerializer
+        {
+            get
+            {
+                return _keyInfoSerializer;
+            }
+        }
+
         public bool EmitBspRequiredAttributes
         {
-            get { return false; }
+            get { return _emitBspRequiredAttributes; }
         }
 
         public SecurityVersion SecurityVersion
         {
-            get { return null; }
+            get { return _securityVersion; }
         }
 
         public int MaximumKeyDerivationOffset
         {
-            get { return 0; }
+            get { return _maximumKeyDerivationOffset; }
         }
 
         public int MaximumKeyDerivationLabelLength
         {
-            get { return 0; }
+            get { return _maximumKeyDerivationLabelLength; }
         }
 
         public int MaximumKeyDerivationNonceLength
         {
-            get { return 0; }
+            get { return _maximumKeyDerivationNonceLength; }
         }
 
 
@@ -167,47 +264,135 @@ namespace System.ServiceModel.Security
 
         protected override void WriteTokenCore(XmlWriter writer, SecurityToken token)
         {
-            throw ExceptionHelper.PlatformNotSupported();
+            bool wroteToken = false;
+            XmlDictionaryWriter localWriter = XmlDictionaryWriter.CreateDictionaryWriter(writer);
+            if (token.GetType() == typeof(ProviderBackedSecurityToken))
+            {
+                token = (token as ProviderBackedSecurityToken).Token;
+            }
+            for (int i = 0; i < _tokenEntries.Count; i++)
+            {
+                TokenEntry tokenEntry = _tokenEntries[i];
+                if (tokenEntry.SupportsCore(token.GetType()))
+                {
+                    try
+                    {
+                        tokenEntry.WriteTokenCore(localWriter, token);
+                    }
+#pragma warning suppress 56500 // covered by FxCOP
+                    catch (Exception e)
+                    {
+                        if (!ShouldWrapException(e))
+                        {
+                            throw;
+                        }
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new XmlException(SR.Format(SR.ErrorSerializingSecurityToken), e));
+                    }
+                    wroteToken = true;
+                    break;
+                }
+            }
+
+            if (!wroteToken)
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.StandardsManagerCannotWriteObject, token.GetType())));
+
+            localWriter.Flush();
         }
 
         protected override bool CanReadKeyIdentifierCore(XmlReader reader)
         {
-            throw ExceptionHelper.PlatformNotSupported();
+            try
+            {
+                return _keyInfoSerializer.CanReadKeyIdentifier(reader);
+            }
+            catch (System.IdentityModel.SecurityMessageSerializationException ex)
+            {
+                throw FxTrace.Exception.AsError(new MessageSecurityException(ex.Message));
+            }
         }
 
         protected override SecurityKeyIdentifier ReadKeyIdentifierCore(XmlReader reader)
         {
-            throw ExceptionHelper.PlatformNotSupported();
+            try
+            {
+                return _keyInfoSerializer.ReadKeyIdentifier(reader);
+            }
+            catch (System.IdentityModel.SecurityMessageSerializationException ex)
+            {
+                throw FxTrace.Exception.AsError(new MessageSecurityException(ex.Message));
+            }
         }
 
         protected override bool CanWriteKeyIdentifierCore(SecurityKeyIdentifier keyIdentifier)
         {
-            throw ExceptionHelper.PlatformNotSupported();
+            try
+            {
+                return _keyInfoSerializer.CanWriteKeyIdentifier(keyIdentifier);
+            }
+            catch (System.IdentityModel.SecurityMessageSerializationException ex)
+            {
+                throw FxTrace.Exception.AsError(new MessageSecurityException(ex.Message));
+            }
         }
 
         protected override void WriteKeyIdentifierCore(XmlWriter writer, SecurityKeyIdentifier keyIdentifier)
         {
-            throw ExceptionHelper.PlatformNotSupported();
+            try
+            {
+                _keyInfoSerializer.WriteKeyIdentifier(writer, keyIdentifier);
+            }
+            catch (System.IdentityModel.SecurityMessageSerializationException ex)
+            {
+                throw FxTrace.Exception.AsError(new MessageSecurityException(ex.Message));
+            }
         }
 
         protected override bool CanReadKeyIdentifierClauseCore(XmlReader reader)
         {
-            throw ExceptionHelper.PlatformNotSupported();
+            try
+            {
+                return _keyInfoSerializer.CanReadKeyIdentifierClause(reader);
+            }
+            catch (System.IdentityModel.SecurityMessageSerializationException ex)
+            {
+                throw FxTrace.Exception.AsError(new MessageSecurityException(ex.Message));
+            }
         }
 
         protected override SecurityKeyIdentifierClause ReadKeyIdentifierClauseCore(XmlReader reader)
         {
-            throw ExceptionHelper.PlatformNotSupported();
+            try
+            {
+                return _keyInfoSerializer.ReadKeyIdentifierClause(reader);
+            }
+            catch (System.IdentityModel.SecurityMessageSerializationException ex)
+            {
+                throw FxTrace.Exception.AsError(new MessageSecurityException(ex.Message));
+            }
         }
 
         protected override bool CanWriteKeyIdentifierClauseCore(SecurityKeyIdentifierClause keyIdentifierClause)
         {
-            throw ExceptionHelper.PlatformNotSupported();
+            try
+            {
+                return _keyInfoSerializer.CanWriteKeyIdentifierClause(keyIdentifierClause);
+            }
+            catch (System.IdentityModel.SecurityMessageSerializationException ex)
+            {
+                throw FxTrace.Exception.AsError(new MessageSecurityException(ex.Message));
+            }
         }
 
         protected override void WriteKeyIdentifierClauseCore(XmlWriter writer, SecurityKeyIdentifierClause keyIdentifierClause)
         {
-            throw ExceptionHelper.PlatformNotSupported();
+            try
+            {
+                _keyInfoSerializer.WriteKeyIdentifierClause(writer, keyIdentifierClause);
+            }
+            catch (System.IdentityModel.SecurityMessageSerializationException ex)
+            {
+                throw FxTrace.Exception.AsError(new MessageSecurityException(ex.Message));
+            }
         }
 
         internal Type[] GetTokenTypes(string tokenTypeUri)
@@ -292,7 +477,7 @@ namespace System.ServiceModel.Security
             throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new XmlException(SR.Format(SR.CannotReadToken, element.LocalName, element.NamespaceURI, element.GetAttribute(SecurityJan2004Strings.ValueType, null))));
         }
 
-        internal abstract new class TokenEntry
+        internal abstract class TokenEntry
         {
             private Type[] _tokenTypes = null;
             public virtual IAsyncResult BeginReadTokenCore(XmlDictionaryReader reader,
@@ -371,11 +556,6 @@ namespace System.ServiceModel.Security
             public abstract SecurityToken ReadTokenCore(XmlDictionaryReader reader, SecurityTokenResolver tokenResolver);
 
             public abstract void WriteTokenCore(XmlDictionaryWriter writer, SecurityToken token);
-        }
-
-        internal abstract new class SerializerEntries
-        {
-            public virtual void PopulateTokenEntries(IList<TokenEntry> tokenEntries) { }
         }
 
         internal class CollectionDictionary : IXmlDictionary

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/WSSecurityTokenSerializer.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/WSSecurityTokenSerializer.cs
@@ -2,16 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-
 using System.Collections.Generic;
 using System.IdentityModel.Selectors;
 using System.IdentityModel.Tokens;
 using System.Runtime;
-using System.ServiceModel;
 using System.ServiceModel.Security.Tokens;
 using System.Xml;
-using System.ServiceModel.Diagnostics;
-using System.Diagnostics;
 
 namespace System.ServiceModel.Security
 {

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/WSSecurityTokenSerializer.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/WSSecurityTokenSerializer.cs
@@ -237,7 +237,6 @@ namespace System.ServiceModel.Security
                     {
                         return tokenEntry.ReadTokenCore(localReader, tokenResolver);
                     }
-#pragma warning suppress 56500 // covered by FxCOP
                     catch (Exception e)
                     {
                         if (!ShouldWrapException(e))
@@ -279,7 +278,6 @@ namespace System.ServiceModel.Security
                     {
                         tokenEntry.WriteTokenCore(localWriter, token);
                     }
-#pragma warning suppress 56500 // covered by FxCOP
                     catch (Exception e)
                     {
                         if (!ShouldWrapException(e))
@@ -462,7 +460,6 @@ namespace System.ServiceModel.Security
                     {
                         return tokenEntry.CreateKeyIdentifierClauseFromTokenXmlCore(element, tokenReferenceStyle);
                     }
-#pragma warning suppress 56500 // covered by FxCOP
                     catch (Exception e)
                     {
                         if (!ShouldWrapException(e))

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/WSSecurityXXX2005.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/WSSecurityXXX2005.cs
@@ -1,0 +1,68 @@
+//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace System.ServiceModel.Security
+{
+    using System;
+    using System.ServiceModel;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.Globalization;
+    using System.IO;
+    using System.Text;
+    using System.Threading;
+    using System.Xml;
+    using System.IdentityModel.Claims;
+    using System.IdentityModel.Policy;
+    using System.IdentityModel.Tokens;
+    using System.Security.Cryptography.X509Certificates;
+    using System.ServiceModel.Security.Tokens;
+    using HexBinary = System.Runtime.Remoting.Metadata.W3cXsd2001.SoapHexBinary;
+    using System.ServiceModel.Channels;
+    using System.ServiceModel.Security;
+    using System.Runtime.Serialization;
+
+    using KeyIdentifierEntry = WSSecurityTokenSerializer.KeyIdentifierEntry;
+    using KeyIdentifierClauseEntry = WSSecurityTokenSerializer.KeyIdentifierClauseEntry;
+    using TokenEntry = WSSecurityTokenSerializer.TokenEntry;
+    using StrEntry = WSSecurityTokenSerializer.StrEntry;
+
+    class WSSecurityXXX2005 : WSSecurityJan2004
+    {
+        public WSSecurityXXX2005(WSSecurityTokenSerializer tokenSerializer, SamlSerializer samlSerializer)
+            : base(tokenSerializer, samlSerializer)
+        {
+        }
+
+        public override void PopulateTokenEntries(IList<TokenEntry> tokenEntryList)
+        {
+            PopulateJan2004TokenEntries(tokenEntryList);
+            tokenEntryList.Add(new WSSecurityXXX2005.WrappedKeyTokenEntry(this.WSSecurityTokenSerializer));
+            tokenEntryList.Add(new WSSecurityXXX2005.SamlTokenEntry(this.WSSecurityTokenSerializer, this.SamlSerializer));
+        }
+
+        new class SamlTokenEntry : WSSecurityJan2004.SamlTokenEntry
+        {
+            public SamlTokenEntry(WSSecurityTokenSerializer tokenSerializer, SamlSerializer samlSerializer)
+                : base(tokenSerializer, samlSerializer)
+            {
+            }
+
+            public override string TokenTypeUri { get { return SecurityXXX2005Strings.SamlTokenType; } }
+        }
+
+        new class WrappedKeyTokenEntry : WSSecurityJan2004.WrappedKeyTokenEntry
+        {
+            public WrappedKeyTokenEntry(WSSecurityTokenSerializer tokenSerializer)
+                : base(tokenSerializer)
+            {
+            }
+
+            public override string TokenTypeUri { get { return SecurityXXX2005Strings.EncryptedKeyTokenType; } }
+        }
+
+    }
+}
+

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/WSSecurityXXX2005.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/WSSecurityXXX2005.cs
@@ -3,30 +3,13 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.ServiceModel;
-using System.Collections;
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.Globalization;
-using System.IO;
-using System.Text;
-using System.Threading;
-using System.Xml;
-using System.IdentityModel.Claims;
-using System.IdentityModel.Policy;
 using System.IdentityModel.Tokens;
-using System.Security.Cryptography.X509Certificates;
-using System.ServiceModel.Security.Tokens;
+
 //Issue #31 in progress
 //using HexBinary = System.Runtime.Remoting.Metadata.W3cXsd2001.SoapHexBinary;
-using System.ServiceModel.Channels;
-using System.ServiceModel.Security;
-using System.Runtime.Serialization;
 
-using KeyIdentifierEntry = System.ServiceModel.Security.WSSecurityTokenSerializer.KeyIdentifierEntry;
-using KeyIdentifierClauseEntry = System.ServiceModel.Security.WSSecurityTokenSerializer.KeyIdentifierClauseEntry;
 using TokenEntry = System.ServiceModel.Security.WSSecurityTokenSerializer.TokenEntry;
-using StrEntry = System.ServiceModel.Security.WSSecurityTokenSerializer.StrEntry;
 
 namespace System.ServiceModel.Security
 {

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/WSSecurityXXX2005.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/WSSecurityXXX2005.cs
@@ -1,36 +1,42 @@
-//------------------------------------------------------------
-// Copyright (c) Microsoft Corporation.  All rights reserved.
-//------------------------------------------------------------
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.ServiceModel;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Xml;
+using System.IdentityModel.Claims;
+using System.IdentityModel.Policy;
+using System.IdentityModel.Tokens;
+using System.Security.Cryptography.X509Certificates;
+using System.ServiceModel.Security.Tokens;
+//Issue #31 in progress
+//using HexBinary = System.Runtime.Remoting.Metadata.W3cXsd2001.SoapHexBinary;
+using System.ServiceModel.Channels;
+using System.ServiceModel.Security;
+using System.Runtime.Serialization;
+
+using KeyIdentifierEntry = System.ServiceModel.Security.WSSecurityTokenSerializer.KeyIdentifierEntry;
+using KeyIdentifierClauseEntry = System.ServiceModel.Security.WSSecurityTokenSerializer.KeyIdentifierClauseEntry;
+using TokenEntry = System.ServiceModel.Security.WSSecurityTokenSerializer.TokenEntry;
+using StrEntry = System.ServiceModel.Security.WSSecurityTokenSerializer.StrEntry;
 
 namespace System.ServiceModel.Security
 {
-    using System;
-    using System.ServiceModel;
-    using System.Collections;
-    using System.Collections.Generic;
-    using System.Diagnostics;
-    using System.Globalization;
-    using System.IO;
-    using System.Text;
-    using System.Threading;
-    using System.Xml;
-    using System.IdentityModel.Claims;
-    using System.IdentityModel.Policy;
-    using System.IdentityModel.Tokens;
-    using System.Security.Cryptography.X509Certificates;
-    using System.ServiceModel.Security.Tokens;
-    using HexBinary = System.Runtime.Remoting.Metadata.W3cXsd2001.SoapHexBinary;
-    using System.ServiceModel.Channels;
-    using System.ServiceModel.Security;
-    using System.Runtime.Serialization;
-
-    using KeyIdentifierEntry = WSSecurityTokenSerializer.KeyIdentifierEntry;
-    using KeyIdentifierClauseEntry = WSSecurityTokenSerializer.KeyIdentifierClauseEntry;
-    using TokenEntry = WSSecurityTokenSerializer.TokenEntry;
-    using StrEntry = WSSecurityTokenSerializer.StrEntry;
-
     class WSSecurityXXX2005 : WSSecurityJan2004
     {
+        public WSSecurityXXX2005(WSSecurityTokenSerializer tokenSerializer)
+            : this(tokenSerializer, new SamlSerializer())
+        {
+        }
+
         public WSSecurityXXX2005(WSSecurityTokenSerializer tokenSerializer, SamlSerializer samlSerializer)
             : base(tokenSerializer, samlSerializer)
         {
@@ -62,7 +68,6 @@ namespace System.ServiceModel.Security
 
             public override string TokenTypeUri { get { return SecurityXXX2005Strings.EncryptedKeyTokenType; } }
         }
-
     }
 }
 

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/WSTrust.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/WSTrust.cs
@@ -1,0 +1,1665 @@
+//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace System.ServiceModel.Security
+{
+    using System;
+    using System.ServiceModel;
+    using System.ServiceModel.Description;
+    using System.ServiceModel.Dispatcher;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Collections.ObjectModel;
+    using System.Diagnostics;
+    using System.Globalization;
+    using System.IO;
+    using System.Text;
+    using System.Threading;
+    using System.Xml;
+    using System.Runtime;
+    using System.Security.Cryptography;
+    using System.IdentityModel.Claims;
+    using System.IdentityModel.Policy;
+    using System.IdentityModel.Selectors;
+    using System.IdentityModel.Tokens;
+    using System.Security.Cryptography.X509Certificates;
+    using System.ServiceModel.Security.Tokens;
+    using HexBinary = System.Runtime.Remoting.Metadata.W3cXsd2001.SoapHexBinary;
+    using System.ServiceModel.Channels;
+    using System.ServiceModel.Security;
+    using System.Runtime.Serialization;
+
+    using KeyIdentifierEntry = WSSecurityTokenSerializer.KeyIdentifierEntry;
+    using KeyIdentifierClauseEntry = WSSecurityTokenSerializer.KeyIdentifierClauseEntry;
+    using TokenEntry = WSSecurityTokenSerializer.TokenEntry;
+    using StrEntry = WSSecurityTokenSerializer.StrEntry;
+    using Psha1DerivedKeyGenerator = System.IdentityModel.Psha1DerivedKeyGenerator;
+
+    abstract class WSTrust : WSSecurityTokenSerializer.SerializerEntries
+    {
+        WSSecurityTokenSerializer tokenSerializer;
+
+        public WSTrust(WSSecurityTokenSerializer tokenSerializer)
+        {
+            this.tokenSerializer = tokenSerializer;
+        }
+
+        public WSSecurityTokenSerializer WSSecurityTokenSerializer
+        {
+            get { return this.tokenSerializer; }
+        }
+
+        public abstract TrustDictionary SerializerDictionary
+        {
+            get;
+        }
+
+        public override void PopulateTokenEntries(IList<TokenEntry> tokenEntryList)
+        {
+            tokenEntryList.Add(new BinarySecretTokenEntry(this));
+        }
+
+        class BinarySecretTokenEntry : TokenEntry
+        {
+            WSTrust parent;
+            TrustDictionary otherDictionary;
+
+            public BinarySecretTokenEntry(WSTrust parent)
+            {
+                this.parent = parent;
+                this.otherDictionary = null;
+
+                if (parent.SerializerDictionary is TrustDec2005Dictionary)
+                {
+                    this.otherDictionary = XD.TrustFeb2005Dictionary;
+                }
+
+                if (parent.SerializerDictionary is TrustFeb2005Dictionary)
+                {
+                    this.otherDictionary = DXD.TrustDec2005Dictionary;
+                }
+
+                // always set it, so we don't have to worry about null
+                if (this.otherDictionary == null)
+                    this.otherDictionary = this.parent.SerializerDictionary;
+            }
+
+            protected override XmlDictionaryString LocalName { get { return parent.SerializerDictionary.BinarySecret; } }
+            protected override XmlDictionaryString NamespaceUri { get { return parent.SerializerDictionary.Namespace; } }
+            protected override Type[] GetTokenTypesCore() { return new Type[] { typeof(BinarySecretSecurityToken) }; }
+            public override string TokenTypeUri { get { return null; } }
+            protected override string ValueTypeUri { get { return null; } }
+
+            public override bool CanReadTokenCore(XmlElement element)
+            {
+                string valueTypeUri = null;
+
+                if (element.HasAttribute(SecurityJan2004Strings.ValueType, null))
+                {
+                    valueTypeUri = element.GetAttribute(SecurityJan2004Strings.ValueType, null);
+                }
+
+                return element.LocalName == LocalName.Value && (element.NamespaceURI == NamespaceUri.Value || element.NamespaceURI == this.otherDictionary.Namespace.Value) && valueTypeUri == this.ValueTypeUri;
+            }
+
+            public override bool CanReadTokenCore(XmlDictionaryReader reader)
+            {
+                return (reader.IsStartElement(this.LocalName, this.NamespaceUri) || reader.IsStartElement(this.LocalName, this.otherDictionary.Namespace)) &&
+                       reader.GetAttribute(XD.SecurityJan2004Dictionary.ValueType, null) == this.ValueTypeUri;
+            }
+
+
+            public override SecurityKeyIdentifierClause CreateKeyIdentifierClauseFromTokenXmlCore(XmlElement issuedTokenXml,
+                SecurityTokenReferenceStyle tokenReferenceStyle)
+            {
+                TokenReferenceStyleHelper.Validate(tokenReferenceStyle);
+
+                switch (tokenReferenceStyle)
+                {
+                    case SecurityTokenReferenceStyle.Internal:
+                        return CreateDirectReference(issuedTokenXml, UtilityStrings.IdAttribute, UtilityStrings.Namespace, typeof(GenericXmlSecurityToken));
+                    case SecurityTokenReferenceStyle.External:
+                        // Binary Secret tokens aren't referred to externally
+                        return null;
+                    default:
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("tokenReferenceStyle"));
+                }
+            }
+
+            public override SecurityToken ReadTokenCore(XmlDictionaryReader reader, SecurityTokenResolver tokenResolver)
+            {
+                string secretType = reader.GetAttribute(XD.SecurityJan2004Dictionary.TypeAttribute, null);
+                string id = reader.GetAttribute(XD.UtilityDictionary.IdAttribute, XD.UtilityDictionary.Namespace);
+                bool isNonce = false;
+
+                if (secretType != null && secretType.Length > 0)
+                {
+                    if (secretType == parent.SerializerDictionary.NonceBinarySecret.Value || secretType == otherDictionary.NonceBinarySecret.Value)
+                    {
+                        isNonce = true;
+                    }
+                    else if (secretType != parent.SerializerDictionary.SymmetricKeyBinarySecret.Value && secretType != otherDictionary.SymmetricKeyBinarySecret.Value)
+                    {
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new MessageSecurityException(SR.GetString(SR.UnexpectedBinarySecretType, parent.SerializerDictionary.SymmetricKeyBinarySecret.Value, secretType)));
+                    }
+                }
+
+                byte[] secret = reader.ReadElementContentAsBase64();
+                if (isNonce)
+                {
+                    return new NonceToken(id, secret);
+                }
+                else
+                {
+                    return new BinarySecretSecurityToken(id, secret);
+                }
+            }
+
+            public override void WriteTokenCore(XmlDictionaryWriter writer, SecurityToken token)
+            {
+                BinarySecretSecurityToken simpleToken = token as BinarySecretSecurityToken;
+                byte[] secret = simpleToken.GetKeyBytes();
+                writer.WriteStartElement(parent.SerializerDictionary.Prefix.Value, parent.SerializerDictionary.BinarySecret, parent.SerializerDictionary.Namespace);
+                if (simpleToken.Id != null)
+                {
+                    writer.WriteAttributeString(XD.UtilityDictionary.Prefix.Value, XD.UtilityDictionary.IdAttribute, XD.UtilityDictionary.Namespace, simpleToken.Id);
+                }
+                if (token is NonceToken)
+                {
+                    writer.WriteAttributeString(XD.SecurityJan2004Dictionary.TypeAttribute, null, parent.SerializerDictionary.NonceBinarySecret.Value);
+                }
+                writer.WriteBase64(secret, 0, secret.Length);
+                writer.WriteEndElement();
+            }
+
+        }
+
+        public abstract class Driver : TrustDriver
+        {
+            static readonly string base64Uri = SecurityJan2004Strings.EncodingTypeValueBase64Binary;
+            static readonly string hexBinaryUri = SecurityJan2004Strings.EncodingTypeValueHexBinary;
+
+
+            SecurityStandardsManager standardsManager;
+            List<SecurityTokenAuthenticator> entropyAuthenticators;
+
+            public Driver(SecurityStandardsManager standardsManager)
+            {
+                this.standardsManager = standardsManager;
+                this.entropyAuthenticators = new List<SecurityTokenAuthenticator>(2);
+            }
+
+            public abstract TrustDictionary DriverDictionary
+            {
+                get;
+            }
+
+            public override XmlDictionaryString RequestSecurityTokenAction
+            {
+                get
+                {
+                    return DriverDictionary.RequestSecurityTokenIssuance;
+                }
+            }
+
+            public override XmlDictionaryString RequestSecurityTokenResponseAction
+            {
+                get
+                {
+                    return DriverDictionary.RequestSecurityTokenIssuanceResponse;
+                }
+            }
+
+            public override string RequestTypeIssue
+            {
+                get
+                {
+                    return DriverDictionary.RequestTypeIssue.Value;
+                }
+            }
+
+            public override string ComputedKeyAlgorithm
+            {
+                get { return DriverDictionary.Psha1ComputedKeyUri.Value; }
+            }
+
+            public override SecurityStandardsManager StandardsManager
+            {
+                get
+                {
+                    return this.standardsManager;
+                }
+            }
+
+            public override XmlDictionaryString Namespace
+            {
+                get { return DriverDictionary.Namespace; }
+            }
+
+            public override RequestSecurityToken CreateRequestSecurityToken(XmlReader xmlReader)
+            {
+                XmlDictionaryReader reader = XmlDictionaryReader.CreateDictionaryReader(xmlReader);
+                reader.MoveToStartElement(DriverDictionary.RequestSecurityToken, DriverDictionary.Namespace);
+                string context = null;
+                string tokenTypeUri = null;
+                string requestType = null;
+                int keySize = 0;
+                XmlDocument doc = new XmlDocument();
+                XmlElement rstXml = (doc.ReadNode(reader) as XmlElement);
+                SecurityKeyIdentifierClause renewTarget = null;
+                SecurityKeyIdentifierClause closeTarget = null;
+                for (int i = 0; i < rstXml.Attributes.Count; ++i)
+                {
+                    XmlAttribute attr = rstXml.Attributes[i];
+                    if (attr.LocalName == DriverDictionary.Context.Value)
+                    {
+                        context = attr.Value;
+                    }
+                }
+                for (int i = 0; i < rstXml.ChildNodes.Count; ++i)
+                {
+                    XmlElement child = (rstXml.ChildNodes[i] as XmlElement);
+                    if (child != null)
+                    {
+                        if (child.LocalName == DriverDictionary.TokenType.Value && child.NamespaceURI == DriverDictionary.Namespace.Value)
+                            tokenTypeUri = XmlHelper.ReadTextElementAsTrimmedString(child);
+                        else if (child.LocalName == DriverDictionary.RequestType.Value && child.NamespaceURI == DriverDictionary.Namespace.Value)
+                            requestType = XmlHelper.ReadTextElementAsTrimmedString(child);
+                        else if (child.LocalName == DriverDictionary.KeySize.Value && child.NamespaceURI == DriverDictionary.Namespace.Value)
+                            keySize = Int32.Parse(XmlHelper.ReadTextElementAsTrimmedString(child), NumberFormatInfo.InvariantInfo);
+                    }
+                }
+
+                ReadTargets(rstXml, out renewTarget, out closeTarget);
+
+                RequestSecurityToken rst = new RequestSecurityToken(standardsManager, rstXml, context, tokenTypeUri, requestType, keySize, renewTarget, closeTarget);
+                return rst;
+            }
+
+            System.IdentityModel.XmlBuffer GetIssuedTokenBuffer(System.IdentityModel.XmlBuffer rstrBuffer)
+            {
+                System.IdentityModel.XmlBuffer issuedTokenBuffer = null;
+                using (XmlDictionaryReader reader = rstrBuffer.GetReader(0))
+                {
+                    reader.ReadFullStartElement();
+                    while (reader.IsStartElement())
+                    {
+                        if (reader.IsStartElement(this.DriverDictionary.RequestedSecurityToken, this.DriverDictionary.Namespace))
+                        {
+                            reader.ReadStartElement();
+                            reader.MoveToContent();
+                            issuedTokenBuffer = new System.IdentityModel.XmlBuffer(Int32.MaxValue);
+                            using (XmlDictionaryWriter writer = issuedTokenBuffer.OpenSection(reader.Quotas))
+                            {
+                                writer.WriteNode(reader, false);
+                                issuedTokenBuffer.CloseSection();
+                                issuedTokenBuffer.Close();
+                            }
+                            reader.ReadEndElement();
+                            break;
+                        }
+                        else
+                        {
+                            reader.Skip();
+                        }
+                    }
+                }
+                return issuedTokenBuffer;
+            }
+
+            public override RequestSecurityTokenResponse CreateRequestSecurityTokenResponse(XmlReader xmlReader)
+            {
+                if (xmlReader == null)
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("xmlReader");
+                }
+                XmlDictionaryReader reader = XmlDictionaryReader.CreateDictionaryReader(xmlReader);
+                if (reader.IsStartElement(DriverDictionary.RequestSecurityTokenResponse, DriverDictionary.Namespace) == false)
+                {
+                    XmlHelper.OnRequiredElementMissing(DriverDictionary.RequestSecurityTokenResponse.Value, DriverDictionary.Namespace.Value);
+                }
+
+                System.IdentityModel.XmlBuffer rstrBuffer = new System.IdentityModel.XmlBuffer(Int32.MaxValue);
+                using (XmlDictionaryWriter writer = rstrBuffer.OpenSection(reader.Quotas))
+                {
+                    writer.WriteNode(reader, false);
+                    rstrBuffer.CloseSection();
+                    rstrBuffer.Close();
+                }
+                XmlDocument doc = new XmlDocument();
+                XmlElement rstrXml;
+                using (XmlReader reader2 = rstrBuffer.GetReader(0))
+                {
+                    rstrXml = (doc.ReadNode(reader2) as XmlElement);
+                }
+
+                System.IdentityModel.XmlBuffer issuedTokenBuffer = GetIssuedTokenBuffer(rstrBuffer);
+                string context = null;
+                string tokenTypeUri = null;
+                int keySize = 0;
+                SecurityKeyIdentifierClause requestedAttachedReference = null;
+                SecurityKeyIdentifierClause requestedUnattachedReference = null;
+                bool computeKey = false;
+                DateTime created = DateTime.UtcNow;
+                DateTime expires = SecurityUtils.MaxUtcDateTime;
+                bool isRequestedTokenClosed = false;
+                for (int i = 0; i < rstrXml.Attributes.Count; ++i)
+                {
+                    XmlAttribute attr = rstrXml.Attributes[i];
+                    if (attr.LocalName == DriverDictionary.Context.Value)
+                    {
+                        context = attr.Value;
+                    }
+                }
+
+                for (int i = 0; i < rstrXml.ChildNodes.Count; ++i)
+                {
+                    XmlElement child = (rstrXml.ChildNodes[i] as XmlElement);
+                    if (child != null)
+                    {
+                        if (child.LocalName == DriverDictionary.TokenType.Value && child.NamespaceURI == DriverDictionary.Namespace.Value)
+                            tokenTypeUri = XmlHelper.ReadTextElementAsTrimmedString(child);
+                        else if (child.LocalName == DriverDictionary.KeySize.Value && child.NamespaceURI == DriverDictionary.Namespace.Value)
+                            keySize = Int32.Parse(XmlHelper.ReadTextElementAsTrimmedString(child), NumberFormatInfo.InvariantInfo);
+                        else if (child.LocalName == DriverDictionary.RequestedProofToken.Value && child.NamespaceURI == DriverDictionary.Namespace.Value)
+                        {
+                            XmlElement proofXml = XmlHelper.GetChildElement(child);
+                            if (proofXml.LocalName == DriverDictionary.ComputedKey.Value && proofXml.NamespaceURI == DriverDictionary.Namespace.Value)
+                            {
+                                string computedKeyAlgorithm = XmlHelper.ReadTextElementAsTrimmedString(proofXml);
+                                if (computedKeyAlgorithm != this.DriverDictionary.Psha1ComputedKeyUri.Value)
+                                {
+                                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new SecurityNegotiationException(SR.GetString(SR.UnknownComputedKeyAlgorithm, computedKeyAlgorithm)));
+                                }
+                                computeKey = true;
+                            }
+                        }
+                        else if (child.LocalName == DriverDictionary.Lifetime.Value && child.NamespaceURI == DriverDictionary.Namespace.Value)
+                        {
+                            XmlElement createdXml = XmlHelper.GetChildElement(child, UtilityStrings.CreatedElement, UtilityStrings.Namespace);
+                            if (createdXml != null)
+                            {
+                                created = DateTime.ParseExact(XmlHelper.ReadTextElementAsTrimmedString(createdXml),
+                                    WSUtilitySpecificationVersion.AcceptedDateTimeFormats, DateTimeFormatInfo.InvariantInfo, DateTimeStyles.None).ToUniversalTime();
+                            }
+                            XmlElement expiresXml = XmlHelper.GetChildElement(child, UtilityStrings.ExpiresElement, UtilityStrings.Namespace);
+                            if (expiresXml != null)
+                            {
+                                expires = DateTime.ParseExact(XmlHelper.ReadTextElementAsTrimmedString(expiresXml),
+                                    WSUtilitySpecificationVersion.AcceptedDateTimeFormats, DateTimeFormatInfo.InvariantInfo, DateTimeStyles.None).ToUniversalTime();
+                            }
+                        }
+                    }
+                }
+
+                isRequestedTokenClosed = ReadRequestedTokenClosed(rstrXml);
+                ReadReferences(rstrXml, out requestedAttachedReference, out requestedUnattachedReference);
+
+                return new RequestSecurityTokenResponse(standardsManager, rstrXml, context, tokenTypeUri, keySize, requestedAttachedReference, requestedUnattachedReference,
+                                                        computeKey, created, expires, isRequestedTokenClosed, issuedTokenBuffer);
+            }
+
+            public override RequestSecurityTokenResponseCollection CreateRequestSecurityTokenResponseCollection(XmlReader xmlReader)
+            {
+                XmlDictionaryReader reader = XmlDictionaryReader.CreateDictionaryReader(xmlReader);
+                List<RequestSecurityTokenResponse> rstrCollection = new List<RequestSecurityTokenResponse>(2);
+                string rootName = reader.Name;
+                reader.ReadStartElement(DriverDictionary.RequestSecurityTokenResponseCollection, DriverDictionary.Namespace);
+                while (reader.IsStartElement(DriverDictionary.RequestSecurityTokenResponse.Value, DriverDictionary.Namespace.Value))
+                {
+                    RequestSecurityTokenResponse rstr = this.CreateRequestSecurityTokenResponse(reader);
+                    rstrCollection.Add(rstr);
+                }
+                reader.ReadEndElement();
+                if (rstrCollection.Count == 0)
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new XmlException(SR.GetString(SR.NoRequestSecurityTokenResponseElements)));
+                return new RequestSecurityTokenResponseCollection(rstrCollection.AsReadOnly(), this.StandardsManager);
+            }
+
+            XmlElement GetAppliesToElement(XmlElement rootElement)
+            {
+                if (rootElement == null)
+                {
+                    return null;
+                }
+                for (int i = 0; i < rootElement.ChildNodes.Count; ++i)
+                {
+                    XmlElement elem = (rootElement.ChildNodes[i] as XmlElement);
+                    if (elem != null)
+                    {
+                        if (elem.LocalName == DriverDictionary.AppliesTo.Value && elem.NamespaceURI == Namespaces.WSPolicy)
+                        {
+                            return elem;
+                        }
+                    }
+                }
+                return null;
+            }
+
+            T GetAppliesTo<T>(XmlElement rootXml, XmlObjectSerializer serializer)
+            {
+                XmlElement appliesToElement = GetAppliesToElement(rootXml);
+                if (appliesToElement != null)
+                {
+                    using (XmlReader reader = new XmlNodeReader(appliesToElement))
+                    {
+                        reader.ReadStartElement();
+                        lock (serializer)
+                        {
+                            return (T)serializer.ReadObject(reader);
+                        }
+                    }
+                }
+                else
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.GetString(SR.NoAppliesToPresent)));
+                }
+            }
+
+            public override T GetAppliesTo<T>(RequestSecurityToken rst, XmlObjectSerializer serializer)
+            {
+                if (rst == null)
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("rst");
+
+                return GetAppliesTo<T>(rst.RequestSecurityTokenXml, serializer);
+            }
+
+            public override T GetAppliesTo<T>(RequestSecurityTokenResponse rstr, XmlObjectSerializer serializer)
+            {
+                if (rstr == null)
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("rstr");
+
+                return GetAppliesTo<T>(rstr.RequestSecurityTokenResponseXml, serializer);
+            }
+
+            public override bool IsAppliesTo(string localName, string namespaceUri)
+            {
+                return (localName == DriverDictionary.AppliesTo.Value && namespaceUri == Namespaces.WSPolicy);
+            }
+
+            void GetAppliesToQName(XmlElement rootElement, out string localName, out string namespaceUri)
+            {
+                localName = namespaceUri = null;
+                XmlElement appliesToElement = GetAppliesToElement(rootElement);
+                if (appliesToElement != null)
+                {
+                    using (XmlReader reader = new XmlNodeReader(appliesToElement))
+                    {
+                        reader.ReadStartElement();
+                        reader.MoveToContent();
+                        localName = reader.LocalName;
+                        namespaceUri = reader.NamespaceURI;
+                    }
+                }
+            }
+
+            public override void GetAppliesToQName(RequestSecurityToken rst, out string localName, out string namespaceUri)
+            {
+                if (rst == null)
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("rst");
+
+                GetAppliesToQName(rst.RequestSecurityTokenXml, out localName, out namespaceUri);
+            }
+
+            public override void GetAppliesToQName(RequestSecurityTokenResponse rstr, out string localName, out string namespaceUri)
+            {
+                if (rstr == null)
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("rstr");
+
+                GetAppliesToQName(rstr.RequestSecurityTokenResponseXml, out localName, out namespaceUri);
+            }
+
+            public override byte[] GetAuthenticator(RequestSecurityTokenResponse rstr)
+            {
+                if (rstr != null && rstr.RequestSecurityTokenResponseXml != null && rstr.RequestSecurityTokenResponseXml.ChildNodes != null)
+                {
+                    for (int i = 0; i < rstr.RequestSecurityTokenResponseXml.ChildNodes.Count; ++i)
+                    {
+                        XmlElement element = rstr.RequestSecurityTokenResponseXml.ChildNodes[i] as XmlElement;
+                        if (element != null)
+                        {
+                            if (element.LocalName == DriverDictionary.Authenticator.Value && element.NamespaceURI == DriverDictionary.Namespace.Value)
+                            {
+                                XmlElement combinedHashElement = XmlHelper.GetChildElement(element);
+                                if (combinedHashElement.LocalName == DriverDictionary.CombinedHash.Value && combinedHashElement.NamespaceURI == DriverDictionary.Namespace.Value)
+                                {
+                                    string authenticatorString = XmlHelper.ReadTextElementAsTrimmedString(combinedHashElement);
+                                    return Convert.FromBase64String(authenticatorString);
+                                }
+                            }
+                        }
+                    }
+                }
+                return null;
+            }
+
+            public override BinaryNegotiation GetBinaryNegotiation(RequestSecurityTokenResponse rstr)
+            {
+                if (rstr == null)
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("rstr");
+
+                return GetBinaryNegotiation(rstr.RequestSecurityTokenResponseXml);
+            }
+
+            public override BinaryNegotiation GetBinaryNegotiation(RequestSecurityToken rst)
+            {
+                if (rst == null)
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("rst");
+
+                return GetBinaryNegotiation(rst.RequestSecurityTokenXml);
+            }
+
+            BinaryNegotiation GetBinaryNegotiation(XmlElement rootElement)
+            {
+                if (rootElement == null)
+                {
+                    return null;
+                }
+                for (int i = 0; i < rootElement.ChildNodes.Count; ++i)
+                {
+                    XmlElement elem = rootElement.ChildNodes[i] as XmlElement;
+                    if (elem != null)
+                    {
+                        if (elem.LocalName == DriverDictionary.BinaryExchange.Value && elem.NamespaceURI == DriverDictionary.Namespace.Value)
+                        {
+                            return ReadBinaryNegotiation(elem);
+                        }
+                    }
+                }
+                return null;
+            }
+
+            public override SecurityToken GetEntropy(RequestSecurityToken rst, SecurityTokenResolver resolver)
+            {
+                if (rst == null)
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("rst");
+
+                return GetEntropy(rst.RequestSecurityTokenXml, resolver);
+            }
+
+            public override SecurityToken GetEntropy(RequestSecurityTokenResponse rstr, SecurityTokenResolver resolver)
+            {
+                if (rstr == null)
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("rstr");
+
+                return GetEntropy(rstr.RequestSecurityTokenResponseXml, resolver);
+            }
+
+            SecurityToken GetEntropy(XmlElement rootElement, SecurityTokenResolver resolver)
+            {
+                if (rootElement == null || rootElement.ChildNodes == null)
+                {
+                    return null;
+                }
+                for (int i = 0; i < rootElement.ChildNodes.Count; ++i)
+                {
+                    XmlElement element = rootElement.ChildNodes[i] as XmlElement;
+                    if (element != null)
+                    {
+                        if (element.LocalName == DriverDictionary.Entropy.Value && element.NamespaceURI == DriverDictionary.Namespace.Value)
+                        {
+                            XmlElement tokenXml = XmlHelper.GetChildElement(element);
+                            string valueTypeUri = element.GetAttribute(SecurityJan2004Strings.ValueType);
+                            if (valueTypeUri.Length == 0)
+                                valueTypeUri = null;
+                            return standardsManager.SecurityTokenSerializer.ReadToken(new XmlNodeReader(tokenXml), resolver);
+                        }
+                    }
+                }
+                return null;
+            }
+
+            void GetIssuedAndProofXml(RequestSecurityTokenResponse rstr, out XmlElement issuedTokenXml, out XmlElement proofTokenXml)
+            {
+                issuedTokenXml = null;
+                proofTokenXml = null;
+                if ((rstr.RequestSecurityTokenResponseXml != null) && (rstr.RequestSecurityTokenResponseXml.ChildNodes != null))
+                {
+                    for (int i = 0; i < rstr.RequestSecurityTokenResponseXml.ChildNodes.Count; ++i)
+                    {
+                        XmlElement elem = rstr.RequestSecurityTokenResponseXml.ChildNodes[i] as XmlElement;
+                        if (elem != null)
+                        {
+                            if (elem.LocalName == DriverDictionary.RequestedSecurityToken.Value && elem.NamespaceURI == DriverDictionary.Namespace.Value)
+                            {
+                                if (issuedTokenXml != null)
+                                {
+                                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.GetString(SR.RstrHasMultipleIssuedTokens)));
+                                }
+                                issuedTokenXml = XmlHelper.GetChildElement(elem);
+                            }
+                            else if (elem.LocalName == DriverDictionary.RequestedProofToken.Value && elem.NamespaceURI == DriverDictionary.Namespace.Value)
+                            {
+                                if (proofTokenXml != null)
+                                {
+                                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.GetString(SR.RstrHasMultipleProofTokens)));
+                                }
+                                proofTokenXml = XmlHelper.GetChildElement(elem);
+                            }
+                        }
+                    }
+                }
+            }
+
+            /// <summary>
+            /// The algorithm for computing the key is:
+            /// 1. If there is requestorEntropy:
+            ///    a. If there is no <RequestedProofToken> use the requestorEntropy as the key
+            ///    b. If there is a <RequestedProofToken> with a ComputedKeyUri, combine the client and server entropies
+            ///    c. Anything else, throw
+            /// 2. If there is no requestorEntropy:
+            ///    a. THere has to be a <RequestedProofToken> that contains the proof key
+            /// </summary>
+            public override GenericXmlSecurityToken GetIssuedToken(RequestSecurityTokenResponse rstr, SecurityTokenResolver resolver, IList<SecurityTokenAuthenticator> allowedAuthenticators, SecurityKeyEntropyMode keyEntropyMode, byte[] requestorEntropy, string expectedTokenType,
+                ReadOnlyCollection<IAuthorizationPolicy> authorizationPolicies, int defaultKeySize, bool isBearerKeyType)
+            {
+
+                SecurityKeyEntropyModeHelper.Validate(keyEntropyMode);
+
+                if (defaultKeySize < 0)
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("defaultKeySize", SR.GetString(SR.ValueMustBeNonNegative)));
+                }
+
+                if (rstr == null)
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("rstr");
+
+                string tokenType;
+                if (rstr.TokenType != null)
+                {
+                    if (expectedTokenType != null && expectedTokenType != rstr.TokenType)
+                    {
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.GetString(SR.BadIssuedTokenType, rstr.TokenType, expectedTokenType)));
+                    }
+                    tokenType = rstr.TokenType;
+                }
+                else
+                {
+                    tokenType = expectedTokenType;
+                }
+
+                // search the response elements for licenseXml, proofXml, and lifetime
+                DateTime created = rstr.ValidFrom;
+                DateTime expires = rstr.ValidTo;
+                XmlElement proofXml;
+                XmlElement issuedTokenXml;
+                GetIssuedAndProofXml(rstr, out issuedTokenXml, out proofXml);
+
+                if (issuedTokenXml == null)
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.GetString(SR.NoLicenseXml)));
+
+                if (isBearerKeyType)
+                {
+                    if (proofXml != null)
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.GetString(SR.BearerKeyTypeCannotHaveProofKey)));
+
+                    return new GenericXmlSecurityToken(issuedTokenXml, null, created, expires, rstr.RequestedAttachedReference, rstr.RequestedUnattachedReference, authorizationPolicies);
+                }
+
+                SecurityToken proofToken;
+                SecurityToken entropyToken = GetEntropy(rstr, resolver);
+                if (keyEntropyMode == SecurityKeyEntropyMode.ClientEntropy)
+                {
+                    if (requestorEntropy == null)
+                    {
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.GetString(SR.EntropyModeRequiresRequestorEntropy, keyEntropyMode)));
+                    }
+                    // enforce that there is no entropy or proof token in the RSTR
+                    if (proofXml != null || entropyToken != null)
+                    {
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.GetString(SR.EntropyModeCannotHaveProofTokenOrIssuerEntropy, keyEntropyMode)));
+                    }
+                    proofToken = new BinarySecretSecurityToken(requestorEntropy);
+                }
+                else if (keyEntropyMode == SecurityKeyEntropyMode.ServerEntropy)
+                {
+                    if (requestorEntropy != null)
+                    {
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.GetString(SR.EntropyModeCannotHaveRequestorEntropy, keyEntropyMode)));
+                    }
+                    if (rstr.ComputeKey || entropyToken != null)
+                    {
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.GetString(SR.EntropyModeCannotHaveComputedKey, keyEntropyMode)));
+                    }
+                    if (proofXml == null)
+                    {
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.GetString(SR.EntropyModeRequiresProofToken, keyEntropyMode)));
+                    }
+                    string valueTypeUri = proofXml.GetAttribute(SecurityJan2004Strings.ValueType);
+                    if (valueTypeUri.Length == 0)
+                        valueTypeUri = null;
+                    proofToken = standardsManager.SecurityTokenSerializer.ReadToken(new XmlNodeReader(proofXml), resolver);
+                }
+                else
+                {
+                    if (!rstr.ComputeKey)
+                    {
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.GetString(SR.EntropyModeRequiresComputedKey, keyEntropyMode)));
+                    }
+                    if (entropyToken == null)
+                    {
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.GetString(SR.EntropyModeRequiresIssuerEntropy, keyEntropyMode)));
+                    }
+                    if (requestorEntropy == null)
+                    {
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.GetString(SR.EntropyModeRequiresRequestorEntropy, keyEntropyMode)));
+                    }
+                    if (rstr.KeySize == 0 && defaultKeySize == 0)
+                    {
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.GetString(SR.RstrKeySizeNotProvided)));
+                    }
+                    int issuedKeySize = (rstr.KeySize != 0) ? rstr.KeySize : defaultKeySize;
+                    byte[] issuerEntropy;
+                    if (entropyToken is BinarySecretSecurityToken)
+                        issuerEntropy = ((BinarySecretSecurityToken)entropyToken).GetKeyBytes();
+                    else if (entropyToken is WrappedKeySecurityToken)
+                        issuerEntropy = ((WrappedKeySecurityToken)entropyToken).GetWrappedKey();
+                    else
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new NotSupportedException(SR.GetString(SR.UnsupportedIssuerEntropyType)));
+                    // compute the PSHA1 derived key
+                    byte[] issuedKey = RequestSecurityTokenResponse.ComputeCombinedKey(requestorEntropy, issuerEntropy, issuedKeySize);
+                    proofToken = new BinarySecretSecurityToken(issuedKey);
+                }
+
+                SecurityKeyIdentifierClause internalReference = rstr.RequestedAttachedReference;
+                SecurityKeyIdentifierClause externalReference = rstr.RequestedUnattachedReference;
+
+                return new BufferedGenericXmlSecurityToken(issuedTokenXml, proofToken, created, expires, internalReference, externalReference, authorizationPolicies, rstr.IssuedTokenBuffer);
+            }
+
+            public override GenericXmlSecurityToken GetIssuedToken(RequestSecurityTokenResponse rstr, string expectedTokenType,
+                ReadOnlyCollection<IAuthorizationPolicy> authorizationPolicies, RSA clientKey)
+            {
+                if (rstr == null)
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentNullException("rstr"));
+
+                string tokenType;
+                if (rstr.TokenType != null)
+                {
+                    if (expectedTokenType != null && expectedTokenType != rstr.TokenType)
+                    {
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.GetString(SR.BadIssuedTokenType, rstr.TokenType, expectedTokenType)));
+                    }
+                    tokenType = rstr.TokenType;
+                }
+                else
+                {
+                    tokenType = expectedTokenType;
+                }
+
+                // search the response elements for licenseXml, proofXml, and lifetime
+                DateTime created = rstr.ValidFrom;
+                DateTime expires = rstr.ValidTo;
+                XmlElement proofXml;
+                XmlElement issuedTokenXml;
+                GetIssuedAndProofXml(rstr, out issuedTokenXml, out proofXml);
+
+                if (issuedTokenXml == null)
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.GetString(SR.NoLicenseXml)));
+
+                // enforce that there is no proof token in the RSTR
+                if (proofXml != null)
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.GetString(SR.ProofTokenXmlUnexpectedInRstr)));
+                }
+                SecurityKeyIdentifierClause internalReference = rstr.RequestedAttachedReference;
+                SecurityKeyIdentifierClause externalReference = rstr.RequestedUnattachedReference;
+
+                SecurityToken proofToken = new RsaSecurityToken(clientKey);
+                return new BufferedGenericXmlSecurityToken(issuedTokenXml, proofToken, created, expires, internalReference, externalReference, authorizationPolicies, rstr.IssuedTokenBuffer);
+            }
+
+            public override bool IsAtRequestSecurityTokenResponse(XmlReader reader)
+            {
+                if (reader == null)
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("reader");
+
+                return reader.IsStartElement(DriverDictionary.RequestSecurityTokenResponse.Value, DriverDictionary.Namespace.Value);
+            }
+
+            public override bool IsAtRequestSecurityTokenResponseCollection(XmlReader reader)
+            {
+                if (reader == null)
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("reader");
+
+                return reader.IsStartElement(DriverDictionary.RequestSecurityTokenResponseCollection.Value, DriverDictionary.Namespace.Value);
+            }
+
+            public override bool IsRequestedSecurityTokenElement(string name, string nameSpace)
+            {
+                return (name == DriverDictionary.RequestedSecurityToken.Value && nameSpace == DriverDictionary.Namespace.Value);
+            }
+
+            public override bool IsRequestedProofTokenElement(string name, string nameSpace)
+            {
+                return (name == DriverDictionary.RequestedProofToken.Value && nameSpace == DriverDictionary.Namespace.Value);
+            }
+
+            public static BinaryNegotiation ReadBinaryNegotiation(XmlElement elem)
+            {
+                if (elem == null)
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("elem");
+
+                // get the encoding and valueType attributes
+                string encodingUri = null;
+                string valueTypeUri = null;
+                byte[] negotiationData = null;
+                if (elem.Attributes != null)
+                {
+                    for (int i = 0; i < elem.Attributes.Count; ++i)
+                    {
+                        XmlAttribute attr = elem.Attributes[i];
+                        if (attr.LocalName == SecurityJan2004Strings.EncodingType && attr.NamespaceURI.Length == 0)
+                        {
+                            encodingUri = attr.Value;
+                            if (encodingUri != base64Uri && encodingUri != hexBinaryUri)
+                            {
+                                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new XmlException(SR.GetString(SR.UnsupportedBinaryEncoding, encodingUri)));
+                            }
+                        }
+                        else if (attr.LocalName == SecurityJan2004Strings.ValueType && attr.NamespaceURI.Length == 0)
+                        {
+                            valueTypeUri = attr.Value;
+                        }
+                        // ignore all other attributes
+                    }
+                }
+                if (encodingUri == null)
+                {
+                    XmlHelper.OnRequiredAttributeMissing("EncodingType", elem.Name);
+                }
+                if (valueTypeUri == null)
+                {
+                    XmlHelper.OnRequiredAttributeMissing("ValueType", elem.Name);
+                }
+                string encodedBlob = XmlHelper.ReadTextElementAsTrimmedString(elem);
+                if (encodingUri == base64Uri)
+                {
+                    negotiationData = Convert.FromBase64String(encodedBlob);
+                }
+                else
+                {
+                    negotiationData = HexBinary.Parse(encodedBlob).Value;
+                }
+                return new BinaryNegotiation(valueTypeUri, negotiationData);
+            }
+
+            // Note in Apr2004, internal & external references aren't supported - 
+            // our strategy is to see if there's a token reference (and use it for external ref) and backup is to scan the token xml to compute reference
+            protected virtual void ReadReferences(XmlElement rstrXml, out SecurityKeyIdentifierClause requestedAttachedReference,
+                    out SecurityKeyIdentifierClause requestedUnattachedReference)
+            {
+                XmlElement issuedTokenXml = null;
+                requestedAttachedReference = null;
+                requestedUnattachedReference = null;
+                for (int i = 0; i < rstrXml.ChildNodes.Count; ++i)
+                {
+                    XmlElement child = rstrXml.ChildNodes[i] as XmlElement;
+                    if (child != null)
+                    {
+                        if (child.LocalName == DriverDictionary.RequestedSecurityToken.Value && child.NamespaceURI == DriverDictionary.Namespace.Value)
+                        {
+                            issuedTokenXml = XmlHelper.GetChildElement(child);
+                        }
+                        else if (child.LocalName == DriverDictionary.RequestedTokenReference.Value && child.NamespaceURI == DriverDictionary.Namespace.Value)
+                        {
+                            requestedUnattachedReference = GetKeyIdentifierXmlReferenceClause(XmlHelper.GetChildElement(child));
+                        }
+                    }
+                }
+
+                if (issuedTokenXml != null)
+                {
+                    requestedAttachedReference = standardsManager.CreateKeyIdentifierClauseFromTokenXml(issuedTokenXml, SecurityTokenReferenceStyle.Internal);
+                    if (requestedUnattachedReference == null)
+                    {
+                        try
+                        {
+                            requestedUnattachedReference = standardsManager.CreateKeyIdentifierClauseFromTokenXml(issuedTokenXml, SecurityTokenReferenceStyle.External);
+                        }
+                        catch (XmlException)
+                        {
+                            throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new XmlException(SR.GetString(SR.TrustDriverIsUnableToCreatedNecessaryAttachedOrUnattachedReferences, issuedTokenXml.ToString())));
+                        }
+                    }
+                }
+            }
+
+            internal bool TryReadKeyIdentifierClause(XmlNodeReader reader, out SecurityKeyIdentifierClause keyIdentifierClause)
+            {
+                keyIdentifierClause = null;
+
+                try
+                {
+                    keyIdentifierClause = standardsManager.SecurityTokenSerializer.ReadKeyIdentifierClause(reader);
+                }
+                catch (XmlException e)
+                {
+                    if (Fx.IsFatal(e))
+                    {
+                        throw;
+                    }
+
+                    keyIdentifierClause = null;
+                    return false;
+                }
+                catch (Exception e)
+                {
+                    if (Fx.IsFatal(e))
+                    {
+                        throw;
+                    }
+
+                    keyIdentifierClause = null;
+                    return false;
+                }
+
+                return true;
+            }
+
+            internal SecurityKeyIdentifierClause CreateGenericXmlSecurityKeyIdentifierClause(XmlNodeReader reader, XmlElement keyIdentifierReferenceXmlElement)
+            {
+                SecurityKeyIdentifierClause keyIdentifierClause = null;
+                XmlDictionaryReader localReader = XmlDictionaryReader.CreateDictionaryReader(reader);
+                string strId = localReader.GetAttribute(XD.UtilityDictionary.IdAttribute, XD.UtilityDictionary.Namespace);
+                keyIdentifierClause = new GenericXmlSecurityKeyIdentifierClause(keyIdentifierReferenceXmlElement);
+                if (!String.IsNullOrEmpty(strId))
+                {
+                    keyIdentifierClause.Id = strId;
+                }
+                return keyIdentifierClause;
+            }
+
+            internal SecurityKeyIdentifierClause GetKeyIdentifierXmlReferenceClause(XmlElement keyIdentifierReferenceXmlElement)
+            {
+                SecurityKeyIdentifierClause keyIdentifierClause = null;
+                XmlNodeReader reader = new XmlNodeReader(keyIdentifierReferenceXmlElement);
+                if (!this.TryReadKeyIdentifierClause(reader, out keyIdentifierClause))
+                {
+                    keyIdentifierClause = CreateGenericXmlSecurityKeyIdentifierClause(new XmlNodeReader(keyIdentifierReferenceXmlElement), keyIdentifierReferenceXmlElement);
+                }
+
+                return keyIdentifierClause;
+            }
+
+            protected virtual bool ReadRequestedTokenClosed(XmlElement rstrXml)
+            {
+                return false;
+            }
+
+            protected virtual void ReadTargets(XmlElement rstXml, out SecurityKeyIdentifierClause renewTarget, out SecurityKeyIdentifierClause closeTarget)
+            {
+                renewTarget = null;
+                closeTarget = null;
+            }
+
+            public override void OnRSTRorRSTRCMissingException()
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new XmlException(SR.GetString(SR.ExpectedOneOfTwoElementsFromNamespace,
+                    DriverDictionary.RequestSecurityTokenResponse, DriverDictionary.RequestSecurityTokenResponseCollection,
+                    DriverDictionary.Namespace)));
+            }
+
+            void WriteAppliesTo(object appliesTo, Type appliesToType, XmlObjectSerializer serializer, XmlWriter xmlWriter)
+            {
+                XmlDictionaryWriter writer = XmlDictionaryWriter.CreateDictionaryWriter(xmlWriter);
+                writer.WriteStartElement(Namespaces.WSPolicyPrefix, DriverDictionary.AppliesTo.Value, Namespaces.WSPolicy);
+                lock (serializer)
+                {
+                    serializer.WriteObject(writer, appliesTo);
+                }
+                writer.WriteEndElement();
+            }
+
+            public void WriteBinaryNegotiation(BinaryNegotiation negotiation, XmlWriter xmlWriter)
+            {
+                if (negotiation == null)
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("negotiation");
+
+                XmlDictionaryWriter writer = XmlDictionaryWriter.CreateDictionaryWriter(xmlWriter);
+                negotiation.WriteTo(writer, this.DriverDictionary.Prefix.Value,
+                                            this.DriverDictionary.BinaryExchange, this.DriverDictionary.Namespace,
+                                            XD.SecurityJan2004Dictionary.ValueType, null);
+            }
+
+            public override void WriteRequestSecurityToken(RequestSecurityToken rst, XmlWriter xmlWriter)
+            {
+                if (rst == null)
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("rst");
+                }
+                if (xmlWriter == null)
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("xmlWriter");
+                }
+                XmlDictionaryWriter writer = XmlDictionaryWriter.CreateDictionaryWriter(xmlWriter);
+                if (rst.IsReceiver)
+                {
+                    rst.WriteTo(writer);
+                    return;
+                }
+                writer.WriteStartElement(DriverDictionary.Prefix.Value, DriverDictionary.RequestSecurityToken, DriverDictionary.Namespace);
+                XmlHelper.AddNamespaceDeclaration(writer, DriverDictionary.Prefix.Value, DriverDictionary.Namespace);
+                if (rst.Context != null)
+                    writer.WriteAttributeString(DriverDictionary.Context, null, rst.Context);
+
+                rst.OnWriteCustomAttributes(writer);
+                if (rst.TokenType != null)
+                {
+                    writer.WriteStartElement(DriverDictionary.Prefix.Value, DriverDictionary.TokenType, DriverDictionary.Namespace);
+                    writer.WriteString(rst.TokenType);
+                    writer.WriteEndElement();
+                }
+                if (rst.RequestType != null)
+                {
+                    writer.WriteStartElement(DriverDictionary.Prefix.Value, DriverDictionary.RequestType, DriverDictionary.Namespace);
+                    writer.WriteString(rst.RequestType);
+                    writer.WriteEndElement();
+                }
+
+                if (rst.AppliesTo != null)
+                {
+                    WriteAppliesTo(rst.AppliesTo, rst.AppliesToType, rst.AppliesToSerializer, writer);
+                }
+
+                SecurityToken entropyToken = rst.GetRequestorEntropy();
+                if (entropyToken != null)
+                {
+                    writer.WriteStartElement(DriverDictionary.Prefix.Value, DriverDictionary.Entropy, DriverDictionary.Namespace);
+                    standardsManager.SecurityTokenSerializer.WriteToken(writer, entropyToken);
+                    writer.WriteEndElement();
+                }
+
+                if (rst.KeySize != 0)
+                {
+                    writer.WriteStartElement(DriverDictionary.Prefix.Value, DriverDictionary.KeySize, DriverDictionary.Namespace);
+                    writer.WriteValue(rst.KeySize);
+                    writer.WriteEndElement();
+                }
+
+                BinaryNegotiation negotiationData = rst.GetBinaryNegotiation();
+                if (negotiationData != null)
+                    WriteBinaryNegotiation(negotiationData, writer);
+
+                WriteTargets(rst, writer);
+
+                if (rst.RequestProperties != null)
+                {
+                    foreach (XmlElement property in rst.RequestProperties)
+                    {
+                        property.WriteTo(writer);
+                    }
+                }
+
+                rst.OnWriteCustomElements(writer);
+                writer.WriteEndElement();
+            }
+
+            protected virtual void WriteTargets(RequestSecurityToken rst, XmlDictionaryWriter writer)
+            {
+            }
+
+            // Note in Apr2004, internal & external references aren't supported - our strategy is to generate the external ref as the TokenReference.
+            protected virtual void WriteReferences(RequestSecurityTokenResponse rstr, XmlDictionaryWriter writer)
+            {
+                if (rstr.RequestedUnattachedReference != null)
+                {
+                    writer.WriteStartElement(DriverDictionary.Prefix.Value, DriverDictionary.RequestedTokenReference, DriverDictionary.Namespace);
+                    standardsManager.SecurityTokenSerializer.WriteKeyIdentifierClause(writer, rstr.RequestedUnattachedReference);
+                    writer.WriteEndElement();
+                }
+            }
+
+            protected virtual void WriteRequestedTokenClosed(RequestSecurityTokenResponse rstr, XmlDictionaryWriter writer)
+            {
+            }
+
+            public override void WriteRequestSecurityTokenResponse(RequestSecurityTokenResponse rstr, XmlWriter xmlWriter)
+            {
+                if (rstr == null)
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("rstr");
+                if (xmlWriter == null)
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("xmlWriter");
+                XmlDictionaryWriter writer = XmlDictionaryWriter.CreateDictionaryWriter(xmlWriter);
+                if (rstr.IsReceiver)
+                {
+                    rstr.WriteTo(writer);
+                    return;
+                }
+                writer.WriteStartElement(DriverDictionary.Prefix.Value, DriverDictionary.RequestSecurityTokenResponse, DriverDictionary.Namespace);
+                if (rstr.Context != null)
+                {
+                    writer.WriteAttributeString(DriverDictionary.Context, null, rstr.Context);
+                }
+                // define WSUtility at the top level to avoid multiple definitions below
+                XmlHelper.AddNamespaceDeclaration(writer, UtilityStrings.Prefix, XD.UtilityDictionary.Namespace);
+                rstr.OnWriteCustomAttributes(writer);
+
+                if (rstr.TokenType != null)
+                    writer.WriteElementString(DriverDictionary.Prefix.Value, DriverDictionary.TokenType, DriverDictionary.Namespace, rstr.TokenType);
+
+                if (rstr.RequestedSecurityToken != null)
+                {
+                    writer.WriteStartElement(DriverDictionary.Prefix.Value, DriverDictionary.RequestedSecurityToken, DriverDictionary.Namespace);
+                    standardsManager.SecurityTokenSerializer.WriteToken(writer, rstr.RequestedSecurityToken);
+                    writer.WriteEndElement();
+                }
+
+                if (rstr.AppliesTo != null)
+                {
+                    WriteAppliesTo(rstr.AppliesTo, rstr.AppliesToType, rstr.AppliesToSerializer, writer);
+                }
+
+                WriteReferences(rstr, writer);
+
+                if (rstr.ComputeKey || rstr.RequestedProofToken != null)
+                {
+                    writer.WriteStartElement(DriverDictionary.Prefix.Value, DriverDictionary.RequestedProofToken, DriverDictionary.Namespace);
+                    if (rstr.ComputeKey)
+                    {
+                        writer.WriteElementString(DriverDictionary.Prefix.Value, DriverDictionary.ComputedKey, DriverDictionary.Namespace, DriverDictionary.Psha1ComputedKeyUri.Value);
+                    }
+                    else
+                    {
+                        standardsManager.SecurityTokenSerializer.WriteToken(writer, rstr.RequestedProofToken);
+                    }
+                    writer.WriteEndElement();
+                }
+
+                SecurityToken entropyToken = rstr.GetIssuerEntropy();
+                if (entropyToken != null)
+                {
+                    writer.WriteStartElement(DriverDictionary.Prefix.Value, DriverDictionary.Entropy, DriverDictionary.Namespace);
+                    standardsManager.SecurityTokenSerializer.WriteToken(writer, entropyToken);
+                    writer.WriteEndElement();
+                }
+
+                // To write out the lifetime, the following algorithm is used
+                //   1. If the lifetime is explicitly set, write it out.
+                //   2. Else, if a token/tokenbuilder has been set, use the lifetime in that.
+                //   3. Else do not serialize lifetime
+                if (rstr.IsLifetimeSet || rstr.RequestedSecurityToken != null)
+                {
+                    DateTime effectiveTime = SecurityUtils.MinUtcDateTime;
+                    DateTime expirationTime = SecurityUtils.MaxUtcDateTime;
+
+                    if (rstr.IsLifetimeSet)
+                    {
+                        effectiveTime = rstr.ValidFrom.ToUniversalTime();
+                        expirationTime = rstr.ValidTo.ToUniversalTime();
+                    }
+                    else if (rstr.RequestedSecurityToken != null)
+                    {
+                        effectiveTime = rstr.RequestedSecurityToken.ValidFrom.ToUniversalTime();
+                        expirationTime = rstr.RequestedSecurityToken.ValidTo.ToUniversalTime();
+                    }
+
+                    // write out the lifetime
+                    writer.WriteStartElement(DriverDictionary.Prefix.Value, DriverDictionary.Lifetime, DriverDictionary.Namespace);
+                    // write out Created
+                    writer.WriteStartElement(XD.UtilityDictionary.Prefix.Value, XD.UtilityDictionary.CreatedElement, XD.UtilityDictionary.Namespace);
+                    writer.WriteString(effectiveTime.ToString("yyyy-MM-ddTHH:mm:ss.fffZ", CultureInfo.InvariantCulture.DateTimeFormat));
+                    writer.WriteEndElement(); // wsu:Created
+                    // write out Expires
+                    writer.WriteStartElement(XD.UtilityDictionary.Prefix.Value, XD.UtilityDictionary.ExpiresElement, XD.UtilityDictionary.Namespace);
+                    writer.WriteString(expirationTime.ToString("yyyy-MM-ddTHH:mm:ss.fffZ", CultureInfo.InvariantCulture.DateTimeFormat));
+                    writer.WriteEndElement(); // wsu:Expires
+                    writer.WriteEndElement(); // wsse:Lifetime
+                }
+
+                byte[] authenticator = rstr.GetAuthenticator();
+                if (authenticator != null)
+                {
+                    writer.WriteStartElement(DriverDictionary.Prefix.Value, DriverDictionary.Authenticator, DriverDictionary.Namespace);
+                    writer.WriteStartElement(DriverDictionary.Prefix.Value, DriverDictionary.CombinedHash, DriverDictionary.Namespace);
+                    writer.WriteBase64(authenticator, 0, authenticator.Length);
+                    writer.WriteEndElement();
+                    writer.WriteEndElement();
+                }
+
+                if (rstr.KeySize > 0)
+                {
+                    writer.WriteStartElement(DriverDictionary.Prefix.Value, DriverDictionary.KeySize, DriverDictionary.Namespace);
+                    writer.WriteValue(rstr.KeySize);
+                    writer.WriteEndElement();
+                }
+
+                WriteRequestedTokenClosed(rstr, writer);
+
+                BinaryNegotiation negotiationData = rstr.GetBinaryNegotiation();
+                if (negotiationData != null)
+                    WriteBinaryNegotiation(negotiationData, writer);
+
+                rstr.OnWriteCustomElements(writer);
+                writer.WriteEndElement();
+            }
+
+            public override void WriteRequestSecurityTokenResponseCollection(RequestSecurityTokenResponseCollection rstrCollection, XmlWriter xmlWriter)
+            {
+                if (rstrCollection == null)
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("rstrCollection");
+
+                XmlDictionaryWriter writer = XmlDictionaryWriter.CreateDictionaryWriter(xmlWriter);
+                writer.WriteStartElement(DriverDictionary.Prefix.Value, DriverDictionary.RequestSecurityTokenResponseCollection, DriverDictionary.Namespace);
+                foreach (RequestSecurityTokenResponse rstr in rstrCollection.RstrCollection)
+                {
+                    rstr.WriteTo(writer);
+                }
+                writer.WriteEndElement();
+            }
+
+            protected void SetProtectionLevelForFederation(OperationDescriptionCollection operations)
+            {
+                foreach (OperationDescription operation in operations)
+                {
+                    foreach (MessageDescription message in operation.Messages)
+                    {
+                        if (message.Body.Parts.Count > 0)
+                        {
+                            foreach (MessagePartDescription part in message.Body.Parts)
+                            {
+                                part.ProtectionLevel = System.Net.Security.ProtectionLevel.EncryptAndSign;
+                            }
+                        }
+                        if (OperationFormatter.IsValidReturnValue(message.Body.ReturnValue))
+                        {
+                            message.Body.ReturnValue.ProtectionLevel = System.Net.Security.ProtectionLevel.EncryptAndSign;
+                        }
+                    }
+                }
+            }
+
+            public override bool TryParseKeySizeElement(XmlElement element, out int keySize)
+            {
+                if (element == null)
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("element");
+
+                if (element.LocalName == this.DriverDictionary.KeySize.Value
+                    && element.NamespaceURI == this.DriverDictionary.Namespace.Value)
+                {
+                    keySize = Int32.Parse(XmlHelper.ReadTextElementAsTrimmedString(element), NumberFormatInfo.InvariantInfo);
+                    return true;
+                }
+
+                keySize = 0;
+                return false;
+            }
+
+            public override XmlElement CreateKeySizeElement(int keySize)
+            {
+                if (keySize < 0)
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("keySize", SR.GetString(SR.ValueMustBeNonNegative)));
+                }
+                XmlDocument doc = new XmlDocument();
+                XmlElement result = doc.CreateElement(this.DriverDictionary.Prefix.Value, this.DriverDictionary.KeySize.Value,
+                    this.DriverDictionary.Namespace.Value);
+                result.AppendChild(doc.CreateTextNode(keySize.ToString(System.Globalization.CultureInfo.InvariantCulture.NumberFormat)));
+                return result;
+            }
+
+            public override XmlElement CreateKeyTypeElement(SecurityKeyType keyType)
+            {
+                if (keyType == SecurityKeyType.SymmetricKey)
+                    return CreateSymmetricKeyTypeElement();
+                else if (keyType == SecurityKeyType.AsymmetricKey)
+                    return CreatePublicKeyTypeElement();
+                else
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.GetString(SR.UnableToCreateKeyTypeElementForUnknownKeyType, keyType.ToString())));
+            }
+
+            public override bool TryParseKeyTypeElement(XmlElement element, out SecurityKeyType keyType)
+            {
+                if (element == null)
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("element");
+
+                if (TryParseSymmetricKeyElement(element))
+                {
+                    keyType = SecurityKeyType.SymmetricKey;
+                    return true;
+                }
+                else if (TryParsePublicKeyElement(element))
+                {
+                    keyType = SecurityKeyType.AsymmetricKey;
+                    return true;
+                }
+
+                keyType = SecurityKeyType.SymmetricKey;
+                return false;
+
+            }
+
+            public bool TryParseSymmetricKeyElement(XmlElement element)
+            {
+                if (element == null)
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("element");
+
+                return element.LocalName == this.DriverDictionary.KeyType.Value
+                    && element.NamespaceURI == this.DriverDictionary.Namespace.Value
+                    && element.InnerText == this.DriverDictionary.SymmetricKeyType.Value;
+            }
+
+            XmlElement CreateSymmetricKeyTypeElement()
+            {
+                XmlDocument doc = new XmlDocument();
+                XmlElement result = doc.CreateElement(this.DriverDictionary.Prefix.Value, this.DriverDictionary.KeyType.Value,
+                    this.DriverDictionary.Namespace.Value);
+                result.AppendChild(doc.CreateTextNode(this.DriverDictionary.SymmetricKeyType.Value));
+                return result;
+            }
+
+            bool TryParsePublicKeyElement(XmlElement element)
+            {
+                if (element == null)
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("element");
+
+                return element.LocalName == this.DriverDictionary.KeyType.Value
+                    && element.NamespaceURI == this.DriverDictionary.Namespace.Value
+                    && element.InnerText == this.DriverDictionary.PublicKeyType.Value;
+            }
+
+            XmlElement CreatePublicKeyTypeElement()
+            {
+                XmlDocument doc = new XmlDocument();
+                XmlElement result = doc.CreateElement(this.DriverDictionary.Prefix.Value, this.DriverDictionary.KeyType.Value,
+                    this.DriverDictionary.Namespace.Value);
+                result.AppendChild(doc.CreateTextNode(this.DriverDictionary.PublicKeyType.Value));
+                return result;
+            }
+
+            public override bool TryParseTokenTypeElement(XmlElement element, out string tokenType)
+            {
+                if (element == null)
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("element");
+
+                if (element.LocalName == this.DriverDictionary.TokenType.Value
+                    && element.NamespaceURI == this.DriverDictionary.Namespace.Value)
+                {
+                    tokenType = element.InnerText;
+                    return true;
+                }
+
+                tokenType = null;
+                return false;
+            }
+
+            public override XmlElement CreateTokenTypeElement(string tokenTypeUri)
+            {
+                if (tokenTypeUri == null)
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("tokenTypeUri");
+                }
+                XmlDocument doc = new XmlDocument();
+                XmlElement result = doc.CreateElement(this.DriverDictionary.Prefix.Value, this.DriverDictionary.TokenType.Value,
+                    this.DriverDictionary.Namespace.Value);
+                result.AppendChild(doc.CreateTextNode(tokenTypeUri));
+                return result;
+            }
+
+            public override XmlElement CreateUseKeyElement(SecurityKeyIdentifier keyIdentifier, SecurityStandardsManager standardsManager)
+            {
+                if (keyIdentifier == null)
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("keyIdentifier");
+                }
+                if (standardsManager == null)
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("standardsManager");
+                }
+                XmlDocument doc = new XmlDocument();
+                XmlElement result = doc.CreateElement(this.DriverDictionary.UseKey.Value, this.DriverDictionary.Namespace.Value);
+                MemoryStream stream = new MemoryStream();
+                using (XmlDictionaryWriter writer = XmlDictionaryWriter.CreateDictionaryWriter(new XmlTextWriter(stream, Encoding.UTF8)))
+                {
+#pragma warning suppress 56506 // standardsManager.SecurityTokenSerializer can never be null.
+                    standardsManager.SecurityTokenSerializer.WriteKeyIdentifier(writer, keyIdentifier);
+                    writer.Flush();
+                    stream.Seek(0, SeekOrigin.Begin);
+                    XmlNode skiNode;
+                    using (XmlDictionaryReader reader = XmlDictionaryReader.CreateDictionaryReader(new XmlTextReader(stream) { DtdProcessing = DtdProcessing.Prohibit }))
+                    {
+                        reader.MoveToContent();
+                        skiNode = doc.ReadNode(reader);
+                    }
+                    result.AppendChild(skiNode);
+                }
+                return result;
+            }
+
+            public override XmlElement CreateSignWithElement(string signatureAlgorithm)
+            {
+                if (signatureAlgorithm == null)
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("signatureAlgorithm");
+                }
+                XmlDocument doc = new XmlDocument();
+                XmlElement result = doc.CreateElement(this.DriverDictionary.Prefix.Value, this.DriverDictionary.SignWith.Value,
+                    this.DriverDictionary.Namespace.Value);
+                result.AppendChild(doc.CreateTextNode(signatureAlgorithm));
+                return result;
+            }
+
+            internal override bool IsSignWithElement(XmlElement element, out string signatureAlgorithm)
+            {
+                return CheckElement(element, this.DriverDictionary.SignWith.Value, this.DriverDictionary.Namespace.Value, out signatureAlgorithm);
+            }
+
+            public override XmlElement CreateEncryptWithElement(string encryptionAlgorithm)
+            {
+                if (encryptionAlgorithm == null)
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("encryptionAlgorithm");
+                }
+                XmlDocument doc = new XmlDocument();
+                XmlElement result = doc.CreateElement(this.DriverDictionary.Prefix.Value, this.DriverDictionary.EncryptWith.Value,
+                    this.DriverDictionary.Namespace.Value);
+                result.AppendChild(doc.CreateTextNode(encryptionAlgorithm));
+                return result;
+            }
+
+            public override XmlElement CreateEncryptionAlgorithmElement(string encryptionAlgorithm)
+            {
+                if (encryptionAlgorithm == null)
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("encryptionAlgorithm");
+                }
+                XmlDocument doc = new XmlDocument();
+                XmlElement result = doc.CreateElement(this.DriverDictionary.Prefix.Value, this.DriverDictionary.EncryptionAlgorithm.Value,
+                    this.DriverDictionary.Namespace.Value);
+                result.AppendChild(doc.CreateTextNode(encryptionAlgorithm));
+                return result;
+            }
+
+            internal override bool IsEncryptWithElement(XmlElement element, out string encryptWithAlgorithm)
+            {
+                return CheckElement(element, this.DriverDictionary.EncryptWith.Value, this.DriverDictionary.Namespace.Value, out encryptWithAlgorithm);
+            }
+
+            internal override bool IsEncryptionAlgorithmElement(XmlElement element, out string encryptionAlgorithm)
+            {
+                return CheckElement(element, this.DriverDictionary.EncryptionAlgorithm.Value, this.DriverDictionary.Namespace.Value, out encryptionAlgorithm);
+            }
+
+            public override XmlElement CreateComputedKeyAlgorithmElement(string algorithm)
+            {
+                if (algorithm == null)
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("algorithm");
+                }
+                XmlDocument doc = new XmlDocument();
+                XmlElement result = doc.CreateElement(this.DriverDictionary.Prefix.Value, this.DriverDictionary.ComputedKeyAlgorithm.Value,
+                    this.DriverDictionary.Namespace.Value);
+                result.AppendChild(doc.CreateTextNode(algorithm));
+                return result;
+            }
+
+            public override XmlElement CreateCanonicalizationAlgorithmElement(string algorithm)
+            {
+                if (algorithm == null)
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("algorithm");
+                }
+                XmlDocument doc = new XmlDocument();
+                XmlElement result = doc.CreateElement(this.DriverDictionary.Prefix.Value, this.DriverDictionary.CanonicalizationAlgorithm.Value,
+                    this.DriverDictionary.Namespace.Value);
+                result.AppendChild(doc.CreateTextNode(algorithm));
+                return result;
+            }
+
+            internal override bool IsCanonicalizationAlgorithmElement(XmlElement element, out string canonicalizationAlgorithm)
+            {
+                return CheckElement(element, this.DriverDictionary.CanonicalizationAlgorithm.Value, this.DriverDictionary.Namespace.Value, out canonicalizationAlgorithm);
+            }
+
+            public override bool TryParseRequiredClaimsElement(XmlElement element, out System.Collections.ObjectModel.Collection<XmlElement> requiredClaims)
+            {
+                if (element == null)
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("element");
+
+                if (element.LocalName == this.DriverDictionary.Claims.Value
+                    && element.NamespaceURI == this.DriverDictionary.Namespace.Value)
+                {
+                    requiredClaims = new System.Collections.ObjectModel.Collection<XmlElement>();
+                    foreach (XmlNode node in element.ChildNodes)
+                        if (node is XmlElement)
+                        {
+                            // PreSharp Bug: Parameter 'requiredClaims' to this public method must be validated: A null-dereference can occur here.
+#pragma warning suppress 56506
+                            requiredClaims.Add((XmlElement)node);
+                        }
+                    return true;
+                }
+
+                requiredClaims = null;
+                return false;
+            }
+
+            public override XmlElement CreateRequiredClaimsElement(IEnumerable<XmlElement> claimsList)
+            {
+                if (claimsList == null)
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("claimsList");
+                }
+                XmlDocument doc = new XmlDocument();
+                XmlElement result = doc.CreateElement(this.DriverDictionary.Prefix.Value, this.DriverDictionary.Claims.Value,
+                    this.DriverDictionary.Namespace.Value);
+                foreach (XmlElement claimElement in claimsList)
+                {
+                    XmlElement element = (XmlElement)doc.ImportNode(claimElement, true);
+                    result.AppendChild(element);
+                }
+                return result;
+            }
+
+            internal static void ValidateRequestedKeySize(int keySize, SecurityAlgorithmSuite algorithmSuite)
+            {
+                if ((keySize % 8 == 0) && algorithmSuite.IsSymmetricKeyLengthSupported(keySize))
+                {
+                    return;
+                }
+                else
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new SecurityNegotiationException(SR.GetString(SR.InvalidKeyLengthRequested, keySize)));
+                }
+            }
+
+            static void ValidateRequestorEntropy(SecurityToken entropy, SecurityKeyEntropyMode mode)
+            {
+                if ((mode == SecurityKeyEntropyMode.ClientEntropy || mode == SecurityKeyEntropyMode.CombinedEntropy)
+                    && (entropy == null))
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new InvalidOperationException(SR.GetString(SR.EntropyModeRequiresRequestorEntropy, mode)));
+                }
+                if (mode == SecurityKeyEntropyMode.ServerEntropy && entropy != null)
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new InvalidOperationException(SR.GetString(SR.EntropyModeCannotHaveRequestorEntropy, mode)));
+                }
+            }
+
+            internal static void ProcessRstAndIssueKey(RequestSecurityToken requestSecurityToken, SecurityTokenResolver resolver, SecurityKeyEntropyMode keyEntropyMode, SecurityAlgorithmSuite algorithmSuite, out int issuedKeySize, out byte[] issuerEntropy, out byte[] proofKey,
+                out SecurityToken proofToken)
+            {
+                SecurityToken requestorEntropyToken = requestSecurityToken.GetRequestorEntropy(resolver);
+                ValidateRequestorEntropy(requestorEntropyToken, keyEntropyMode);
+                byte[] requestorEntropy;
+                if (requestorEntropyToken != null)
+                {
+                    if (requestorEntropyToken is BinarySecretSecurityToken)
+                    {
+                        BinarySecretSecurityToken skToken = (BinarySecretSecurityToken)requestorEntropyToken;
+                        requestorEntropy = skToken.GetKeyBytes();
+                    }
+                    else if (requestorEntropyToken is WrappedKeySecurityToken)
+                    {
+                        requestorEntropy = ((WrappedKeySecurityToken)requestorEntropyToken).GetWrappedKey();
+                    }
+                    else
+                    {
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new InvalidOperationException(SR.GetString(SR.TokenCannotCreateSymmetricCrypto, requestorEntropyToken)));
+                    }
+                }
+                else
+                {
+                    requestorEntropy = null;
+                }
+
+                if (keyEntropyMode == SecurityKeyEntropyMode.ClientEntropy)
+                {
+                    if (requestorEntropy != null)
+                    {
+                        // validate that the entropy length matches the algorithm suite
+                        ValidateRequestedKeySize(requestorEntropy.Length * 8, algorithmSuite);
+                    }
+                    proofKey = requestorEntropy;
+                    issuerEntropy = null;
+                    issuedKeySize = 0;
+                    proofToken = null;
+                }
+                else
+                {
+                    if (requestSecurityToken.KeySize != 0)
+                    {
+                        ValidateRequestedKeySize(requestSecurityToken.KeySize, algorithmSuite);
+                        issuedKeySize = requestSecurityToken.KeySize;
+                    }
+                    else
+                    {
+                        issuedKeySize = algorithmSuite.DefaultSymmetricKeyLength;
+                    }
+                    RNGCryptoServiceProvider random = new RNGCryptoServiceProvider();
+                    if (keyEntropyMode == SecurityKeyEntropyMode.ServerEntropy)
+                    {
+                        proofKey = new byte[issuedKeySize / 8];
+                        // proof key is completely issued by the server
+                        random.GetNonZeroBytes(proofKey);
+                        issuerEntropy = null;
+                        proofToken = new BinarySecretSecurityToken(proofKey);
+                    }
+                    else
+                    {
+                        issuerEntropy = new byte[issuedKeySize / 8];
+                        random.GetNonZeroBytes(issuerEntropy);
+                        proofKey = RequestSecurityTokenResponse.ComputeCombinedKey(requestorEntropy, issuerEntropy, issuedKeySize);
+                        proofToken = null;
+                    }
+                }
+            }
+
+        }
+
+        protected static bool CheckElement(XmlElement element, string name, string ns, out string value)
+        {
+            value = null;
+            if (element.LocalName != name || element.NamespaceURI != ns)
+                return false;
+            if (element.FirstChild is XmlText)
+            {
+                value = ((XmlText)element.FirstChild).Value;
+                return true;
+            }
+            return false;
+        }
+    }
+}
+

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/WSTrust.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/WSTrust.cs
@@ -3,37 +3,21 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.ServiceModel;
-using System.ServiceModel.Description;
-using System.ServiceModel.Dispatcher;
-using System.Collections;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
-using System.Diagnostics;
-using System.Globalization;
-using System.IO;
-using System.Text;
-using System.Threading;
-using System.Xml;
-using System.Runtime;
-using System.Security.Cryptography;
-using System.IdentityModel.Claims;
-using System.IdentityModel.Policy;
 using System.IdentityModel.Selectors;
 using System.IdentityModel.Tokens;
-using System.Security.Cryptography.X509Certificates;
+using System.Runtime.Serialization;
+using System.ServiceModel.Description;
+using System.ServiceModel.Dispatcher;
 using System.ServiceModel.Security.Tokens;
+using System.Xml;
+
 // Issue #31 in progress
 //using HexBinary = System.Runtime.Remoting.Metadata.W3cXsd2001.SoapHexBinary;
 //using Psha1DerivedKeyGenerator = System.IdentityModel.Psha1DerivedKeyGenerator;
-using System.ServiceModel.Channels;
-using System.ServiceModel.Security;
-using System.Runtime.Serialization;
 
-using KeyIdentifierEntry = System.ServiceModel.Security.WSSecurityTokenSerializer.KeyIdentifierEntry;
-using KeyIdentifierClauseEntry = System.ServiceModel.Security.WSSecurityTokenSerializer.KeyIdentifierClauseEntry;
 using TokenEntry = System.ServiceModel.Security.WSSecurityTokenSerializer.TokenEntry;
-using StrEntry = System.ServiceModel.Security.WSSecurityTokenSerializer.StrEntry;
+
 
 namespace System.ServiceModel.Security
 {
@@ -45,7 +29,6 @@ namespace System.ServiceModel.Security
         {
             _tokenSerializer = tokenSerializer;
         }
-
 
         public WSSecurityTokenSerializer WSSecurityTokenSerializer
         {

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/WSTrust.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/WSTrust.cs
@@ -1,58 +1,60 @@
-//------------------------------------------------------------
-// Copyright (c) Microsoft Corporation.  All rights reserved.
-//------------------------------------------------------------
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.ServiceModel;
+using System.ServiceModel.Description;
+using System.ServiceModel.Dispatcher;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Diagnostics;
+using System.Globalization;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Xml;
+using System.Runtime;
+using System.Security.Cryptography;
+using System.IdentityModel.Claims;
+using System.IdentityModel.Policy;
+using System.IdentityModel.Selectors;
+using System.IdentityModel.Tokens;
+using System.Security.Cryptography.X509Certificates;
+using System.ServiceModel.Security.Tokens;
+// Issue #31 in progress
+//using HexBinary = System.Runtime.Remoting.Metadata.W3cXsd2001.SoapHexBinary;
+//using Psha1DerivedKeyGenerator = System.IdentityModel.Psha1DerivedKeyGenerator;
+using System.ServiceModel.Channels;
+using System.ServiceModel.Security;
+using System.Runtime.Serialization;
+
+using KeyIdentifierEntry = System.ServiceModel.Security.WSSecurityTokenSerializer.KeyIdentifierEntry;
+using KeyIdentifierClauseEntry = System.ServiceModel.Security.WSSecurityTokenSerializer.KeyIdentifierClauseEntry;
+using TokenEntry = System.ServiceModel.Security.WSSecurityTokenSerializer.TokenEntry;
+using StrEntry = System.ServiceModel.Security.WSSecurityTokenSerializer.StrEntry;
 
 namespace System.ServiceModel.Security
 {
-    using System;
-    using System.ServiceModel;
-    using System.ServiceModel.Description;
-    using System.ServiceModel.Dispatcher;
-    using System.Collections;
-    using System.Collections.Generic;
-    using System.Collections.ObjectModel;
-    using System.Diagnostics;
-    using System.Globalization;
-    using System.IO;
-    using System.Text;
-    using System.Threading;
-    using System.Xml;
-    using System.Runtime;
-    using System.Security.Cryptography;
-    using System.IdentityModel.Claims;
-    using System.IdentityModel.Policy;
-    using System.IdentityModel.Selectors;
-    using System.IdentityModel.Tokens;
-    using System.Security.Cryptography.X509Certificates;
-    using System.ServiceModel.Security.Tokens;
-    using HexBinary = System.Runtime.Remoting.Metadata.W3cXsd2001.SoapHexBinary;
-    using System.ServiceModel.Channels;
-    using System.ServiceModel.Security;
-    using System.Runtime.Serialization;
-
-    using KeyIdentifierEntry = WSSecurityTokenSerializer.KeyIdentifierEntry;
-    using KeyIdentifierClauseEntry = WSSecurityTokenSerializer.KeyIdentifierClauseEntry;
-    using TokenEntry = WSSecurityTokenSerializer.TokenEntry;
-    using StrEntry = WSSecurityTokenSerializer.StrEntry;
-    using Psha1DerivedKeyGenerator = System.IdentityModel.Psha1DerivedKeyGenerator;
-
-    abstract class WSTrust : WSSecurityTokenSerializer.SerializerEntries
+    internal abstract class WSTrust : WSSecurityTokenSerializer.SerializerEntries
     {
-        WSSecurityTokenSerializer tokenSerializer;
+        private WSSecurityTokenSerializer _tokenSerializer;
 
         public WSTrust(WSSecurityTokenSerializer tokenSerializer)
         {
-            this.tokenSerializer = tokenSerializer;
+            _tokenSerializer = tokenSerializer;
         }
+
 
         public WSSecurityTokenSerializer WSSecurityTokenSerializer
         {
-            get { return this.tokenSerializer; }
+            get { return _tokenSerializer; }
         }
 
         public abstract TrustDictionary SerializerDictionary
         {
-            get;
+            get; 
         }
 
         public override void PopulateTokenEntries(IList<TokenEntry> tokenEntryList)
@@ -62,32 +64,36 @@ namespace System.ServiceModel.Security
 
         class BinarySecretTokenEntry : TokenEntry
         {
-            WSTrust parent;
-            TrustDictionary otherDictionary;
+            private WSTrust _parent;
+            private TrustDictionary _otherDictionary;
 
             public BinarySecretTokenEntry(WSTrust parent)
             {
-                this.parent = parent;
-                this.otherDictionary = null;
+                _parent = parent;
+                _otherDictionary = null;
 
                 if (parent.SerializerDictionary is TrustDec2005Dictionary)
                 {
-                    this.otherDictionary = XD.TrustFeb2005Dictionary;
+                    _otherDictionary = XD.TrustFeb2005Dictionary;
                 }
 
                 if (parent.SerializerDictionary is TrustFeb2005Dictionary)
                 {
-                    this.otherDictionary = DXD.TrustDec2005Dictionary;
+                    _otherDictionary = DXD.TrustDec2005Dictionary;
                 }
 
                 // always set it, so we don't have to worry about null
-                if (this.otherDictionary == null)
-                    this.otherDictionary = this.parent.SerializerDictionary;
+                if (_otherDictionary == null)
+                    _otherDictionary = _parent.SerializerDictionary;
             }
 
-            protected override XmlDictionaryString LocalName { get { return parent.SerializerDictionary.BinarySecret; } }
-            protected override XmlDictionaryString NamespaceUri { get { return parent.SerializerDictionary.Namespace; } }
-            protected override Type[] GetTokenTypesCore() { return new Type[] { typeof(BinarySecretSecurityToken) }; }
+            protected override XmlDictionaryString LocalName { get { return _parent.SerializerDictionary.BinarySecret; } }
+            protected override XmlDictionaryString NamespaceUri { get { return _parent.SerializerDictionary.Namespace; } }
+            protected override Type[] GetTokenTypesCore()
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+                //return new Type[] { typeof(BinarySecretSecurityToken) };
+            }
             public override string TokenTypeUri { get { return null; } }
             protected override string ValueTypeUri { get { return null; } }
 
@@ -100,12 +106,12 @@ namespace System.ServiceModel.Security
                     valueTypeUri = element.GetAttribute(SecurityJan2004Strings.ValueType, null);
                 }
 
-                return element.LocalName == LocalName.Value && (element.NamespaceURI == NamespaceUri.Value || element.NamespaceURI == this.otherDictionary.Namespace.Value) && valueTypeUri == this.ValueTypeUri;
+                return element.LocalName == LocalName.Value && (element.NamespaceURI == NamespaceUri.Value || element.NamespaceURI == _otherDictionary.Namespace.Value) && valueTypeUri == this.ValueTypeUri;
             }
 
             public override bool CanReadTokenCore(XmlDictionaryReader reader)
             {
-                return (reader.IsStartElement(this.LocalName, this.NamespaceUri) || reader.IsStartElement(this.LocalName, this.otherDictionary.Namespace)) &&
+                return (reader.IsStartElement(this.LocalName, this.NamespaceUri) || reader.IsStartElement(this.LocalName, _otherDictionary.Namespace)) &&
                        reader.GetAttribute(XD.SecurityJan2004Dictionary.ValueType, null) == this.ValueTypeUri;
             }
 
@@ -129,65 +135,68 @@ namespace System.ServiceModel.Security
 
             public override SecurityToken ReadTokenCore(XmlDictionaryReader reader, SecurityTokenResolver tokenResolver)
             {
-                string secretType = reader.GetAttribute(XD.SecurityJan2004Dictionary.TypeAttribute, null);
-                string id = reader.GetAttribute(XD.UtilityDictionary.IdAttribute, XD.UtilityDictionary.Namespace);
-                bool isNonce = false;
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
 
-                if (secretType != null && secretType.Length > 0)
-                {
-                    if (secretType == parent.SerializerDictionary.NonceBinarySecret.Value || secretType == otherDictionary.NonceBinarySecret.Value)
-                    {
-                        isNonce = true;
-                    }
-                    else if (secretType != parent.SerializerDictionary.SymmetricKeyBinarySecret.Value && secretType != otherDictionary.SymmetricKeyBinarySecret.Value)
-                    {
-                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new MessageSecurityException(SR.GetString(SR.UnexpectedBinarySecretType, parent.SerializerDictionary.SymmetricKeyBinarySecret.Value, secretType)));
-                    }
-                }
+                //string secretType = reader.GetAttribute(XD.SecurityJan2004Dictionary.TypeAttribute, null);
+                //string id = reader.GetAttribute(XD.UtilityDictionary.IdAttribute, XD.UtilityDictionary.Namespace);
+                //bool isNonce = false;
 
-                byte[] secret = reader.ReadElementContentAsBase64();
-                if (isNonce)
-                {
-                    return new NonceToken(id, secret);
-                }
-                else
-                {
-                    return new BinarySecretSecurityToken(id, secret);
-                }
+                //if (secretType != null && secretType.Length > 0)
+                //{
+                //    if (secretType == parent.SerializerDictionary.NonceBinarySecret.Value || secretType == otherDictionary.NonceBinarySecret.Value)
+                //    {
+                //        isNonce = true;
+                //    }
+                //    else if (secretType != parent.SerializerDictionary.SymmetricKeyBinarySecret.Value && secretType != otherDictionary.SymmetricKeyBinarySecret.Value)
+                //    {
+                //        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new MessageSecurityException(SR.Format(SR.UnexpectedBinarySecretType, parent.SerializerDictionary.SymmetricKeyBinarySecret.Value, secretType)));
+                //    }
+                //}
+
+                //byte[] secret = reader.ReadElementContentAsBase64();
+                //if (isNonce)
+                //{
+                //    return new NonceToken(id, secret);
+                //}
+                //else
+                //{
+                //    return new BinarySecretSecurityToken(id, secret);
+                //}
             }
 
             public override void WriteTokenCore(XmlDictionaryWriter writer, SecurityToken token)
             {
-                BinarySecretSecurityToken simpleToken = token as BinarySecretSecurityToken;
-                byte[] secret = simpleToken.GetKeyBytes();
-                writer.WriteStartElement(parent.SerializerDictionary.Prefix.Value, parent.SerializerDictionary.BinarySecret, parent.SerializerDictionary.Namespace);
-                if (simpleToken.Id != null)
-                {
-                    writer.WriteAttributeString(XD.UtilityDictionary.Prefix.Value, XD.UtilityDictionary.IdAttribute, XD.UtilityDictionary.Namespace, simpleToken.Id);
-                }
-                if (token is NonceToken)
-                {
-                    writer.WriteAttributeString(XD.SecurityJan2004Dictionary.TypeAttribute, null, parent.SerializerDictionary.NonceBinarySecret.Value);
-                }
-                writer.WriteBase64(secret, 0, secret.Length);
-                writer.WriteEndElement();
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+
+                //BinarySecretSecurityToken simpleToken = token as BinarySecretSecurityToken;
+                //byte[] secret = simpleToken.GetKeyBytes();
+                //writer.WriteStartElement(parent.SerializerDictionary.Prefix.Value, parent.SerializerDictionary.BinarySecret, parent.SerializerDictionary.Namespace);
+                //if (simpleToken.Id != null)
+                //{
+                //    writer.WriteAttributeString(XD.UtilityDictionary.Prefix.Value, XD.UtilityDictionary.IdAttribute, XD.UtilityDictionary.Namespace, simpleToken.Id);
+                //}
+                //if (token is NonceToken)
+                //{
+                //    writer.WriteAttributeString(XD.SecurityJan2004Dictionary.TypeAttribute, null, parent.SerializerDictionary.NonceBinarySecret.Value);
+                //}
+                //writer.WriteBase64(secret, 0, secret.Length);
+                //writer.WriteEndElement();
             }
 
         }
 
         public abstract class Driver : TrustDriver
         {
-            static readonly string base64Uri = SecurityJan2004Strings.EncodingTypeValueBase64Binary;
-            static readonly string hexBinaryUri = SecurityJan2004Strings.EncodingTypeValueHexBinary;
+            private static readonly string _base64Uri = SecurityJan2004Strings.EncodingTypeValueBase64Binary;
+            private static readonly string _hexBinaryUri = SecurityJan2004Strings.EncodingTypeValueHexBinary;
 
-
-            SecurityStandardsManager standardsManager;
-            List<SecurityTokenAuthenticator> entropyAuthenticators;
+            private SecurityStandardsManager _standardsManager;
+            private List<SecurityTokenAuthenticator> _entropyAuthenticators;
 
             public Driver(SecurityStandardsManager standardsManager)
             {
-                this.standardsManager = standardsManager;
-                this.entropyAuthenticators = new List<SecurityTokenAuthenticator>(2);
+                _standardsManager = standardsManager;
+                _entropyAuthenticators = new List<SecurityTokenAuthenticator>(2);
             }
 
             public abstract TrustDictionary DriverDictionary
@@ -228,7 +237,7 @@ namespace System.ServiceModel.Security
             {
                 get
                 {
-                    return this.standardsManager;
+                    return _standardsManager;
                 }
             }
 
@@ -239,165 +248,171 @@ namespace System.ServiceModel.Security
 
             public override RequestSecurityToken CreateRequestSecurityToken(XmlReader xmlReader)
             {
-                XmlDictionaryReader reader = XmlDictionaryReader.CreateDictionaryReader(xmlReader);
-                reader.MoveToStartElement(DriverDictionary.RequestSecurityToken, DriverDictionary.Namespace);
-                string context = null;
-                string tokenTypeUri = null;
-                string requestType = null;
-                int keySize = 0;
-                XmlDocument doc = new XmlDocument();
-                XmlElement rstXml = (doc.ReadNode(reader) as XmlElement);
-                SecurityKeyIdentifierClause renewTarget = null;
-                SecurityKeyIdentifierClause closeTarget = null;
-                for (int i = 0; i < rstXml.Attributes.Count; ++i)
-                {
-                    XmlAttribute attr = rstXml.Attributes[i];
-                    if (attr.LocalName == DriverDictionary.Context.Value)
-                    {
-                        context = attr.Value;
-                    }
-                }
-                for (int i = 0; i < rstXml.ChildNodes.Count; ++i)
-                {
-                    XmlElement child = (rstXml.ChildNodes[i] as XmlElement);
-                    if (child != null)
-                    {
-                        if (child.LocalName == DriverDictionary.TokenType.Value && child.NamespaceURI == DriverDictionary.Namespace.Value)
-                            tokenTypeUri = XmlHelper.ReadTextElementAsTrimmedString(child);
-                        else if (child.LocalName == DriverDictionary.RequestType.Value && child.NamespaceURI == DriverDictionary.Namespace.Value)
-                            requestType = XmlHelper.ReadTextElementAsTrimmedString(child);
-                        else if (child.LocalName == DriverDictionary.KeySize.Value && child.NamespaceURI == DriverDictionary.Namespace.Value)
-                            keySize = Int32.Parse(XmlHelper.ReadTextElementAsTrimmedString(child), NumberFormatInfo.InvariantInfo);
-                    }
-                }
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
 
-                ReadTargets(rstXml, out renewTarget, out closeTarget);
+                //XmlDictionaryReader reader = XmlDictionaryReader.CreateDictionaryReader(xmlReader);
+                //reader.MoveToStartElement(DriverDictionary.RequestSecurityToken, DriverDictionary.Namespace);
+                //string context = null;
+                //string tokenTypeUri = null;
+                //string requestType = null;
+                //int keySize = 0;
+                //XmlDocument doc = new XmlDocument();
+                //XmlElement rstXml = (doc.ReadNode(reader) as XmlElement);
+                //SecurityKeyIdentifierClause renewTarget = null;
+                //SecurityKeyIdentifierClause closeTarget = null;
+                //for (int i = 0; i < rstXml.Attributes.Count; ++i)
+                //{
+                //    XmlAttribute attr = rstXml.Attributes[i];
+                //    if (attr.LocalName == DriverDictionary.Context.Value)
+                //    {
+                //        context = attr.Value;
+                //    }
+                //}
+                //for (int i = 0; i < rstXml.ChildNodes.Count; ++i)
+                //{
+                //    XmlElement child = (rstXml.ChildNodes[i] as XmlElement);
+                //    if (child != null)
+                //    {
+                //        if (child.LocalName == DriverDictionary.TokenType.Value && child.NamespaceURI == DriverDictionary.Namespace.Value)
+                //            tokenTypeUri = XmlHelper.ReadTextElementAsTrimmedString(child);
+                //        else if (child.LocalName == DriverDictionary.RequestType.Value && child.NamespaceURI == DriverDictionary.Namespace.Value)
+                //            requestType = XmlHelper.ReadTextElementAsTrimmedString(child);
+                //        else if (child.LocalName == DriverDictionary.KeySize.Value && child.NamespaceURI == DriverDictionary.Namespace.Value)
+                //            keySize = Int32.Parse(XmlHelper.ReadTextElementAsTrimmedString(child), NumberFormatInfo.InvariantInfo);
+                //    }
+                //}
 
-                RequestSecurityToken rst = new RequestSecurityToken(standardsManager, rstXml, context, tokenTypeUri, requestType, keySize, renewTarget, closeTarget);
-                return rst;
+                //ReadTargets(rstXml, out renewTarget, out closeTarget);
+
+                //RequestSecurityToken rst = new RequestSecurityToken(standardsManager, rstXml, context, tokenTypeUri, requestType, keySize, renewTarget, closeTarget);
+                //return rst;
             }
 
             System.IdentityModel.XmlBuffer GetIssuedTokenBuffer(System.IdentityModel.XmlBuffer rstrBuffer)
             {
-                System.IdentityModel.XmlBuffer issuedTokenBuffer = null;
-                using (XmlDictionaryReader reader = rstrBuffer.GetReader(0))
-                {
-                    reader.ReadFullStartElement();
-                    while (reader.IsStartElement())
-                    {
-                        if (reader.IsStartElement(this.DriverDictionary.RequestedSecurityToken, this.DriverDictionary.Namespace))
-                        {
-                            reader.ReadStartElement();
-                            reader.MoveToContent();
-                            issuedTokenBuffer = new System.IdentityModel.XmlBuffer(Int32.MaxValue);
-                            using (XmlDictionaryWriter writer = issuedTokenBuffer.OpenSection(reader.Quotas))
-                            {
-                                writer.WriteNode(reader, false);
-                                issuedTokenBuffer.CloseSection();
-                                issuedTokenBuffer.Close();
-                            }
-                            reader.ReadEndElement();
-                            break;
-                        }
-                        else
-                        {
-                            reader.Skip();
-                        }
-                    }
-                }
-                return issuedTokenBuffer;
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+
+                //System.IdentityModel.XmlBuffer issuedTokenBuffer = null;
+                //using (XmlDictionaryReader reader = rstrBuffer.GetReader(0))
+                //{
+                //    reader.ReadFullStartElement();
+                //    while (reader.IsStartElement())
+                //    {
+                //        if (reader.IsStartElement(this.DriverDictionary.RequestedSecurityToken, this.DriverDictionary.Namespace))
+                //        {
+                //            reader.ReadStartElement();
+                //            reader.MoveToContent();
+                //            issuedTokenBuffer = new System.IdentityModel.XmlBuffer(Int32.MaxValue);
+                //            using (XmlDictionaryWriter writer = issuedTokenBuffer.OpenSection(reader.Quotas))
+                //            {
+                //                writer.WriteNode(reader, false);
+                //                issuedTokenBuffer.CloseSection();
+                //                issuedTokenBuffer.Close();
+                //            }
+                //            reader.ReadEndElement();
+                //            break;
+                //        }
+                //        else
+                //        {
+                //            reader.Skip();
+                //        }
+                //    }
+                //}
+                //return issuedTokenBuffer;
             }
 
             public override RequestSecurityTokenResponse CreateRequestSecurityTokenResponse(XmlReader xmlReader)
             {
-                if (xmlReader == null)
-                {
-                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("xmlReader");
-                }
-                XmlDictionaryReader reader = XmlDictionaryReader.CreateDictionaryReader(xmlReader);
-                if (reader.IsStartElement(DriverDictionary.RequestSecurityTokenResponse, DriverDictionary.Namespace) == false)
-                {
-                    XmlHelper.OnRequiredElementMissing(DriverDictionary.RequestSecurityTokenResponse.Value, DriverDictionary.Namespace.Value);
-                }
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
 
-                System.IdentityModel.XmlBuffer rstrBuffer = new System.IdentityModel.XmlBuffer(Int32.MaxValue);
-                using (XmlDictionaryWriter writer = rstrBuffer.OpenSection(reader.Quotas))
-                {
-                    writer.WriteNode(reader, false);
-                    rstrBuffer.CloseSection();
-                    rstrBuffer.Close();
-                }
-                XmlDocument doc = new XmlDocument();
-                XmlElement rstrXml;
-                using (XmlReader reader2 = rstrBuffer.GetReader(0))
-                {
-                    rstrXml = (doc.ReadNode(reader2) as XmlElement);
-                }
+                //if (xmlReader == null)
+                //{
+                //    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("xmlReader");
+                //}
+                //XmlDictionaryReader reader = XmlDictionaryReader.CreateDictionaryReader(xmlReader);
+                //if (reader.IsStartElement(DriverDictionary.RequestSecurityTokenResponse, DriverDictionary.Namespace) == false)
+                //{
+                //    XmlHelper.OnRequiredElementMissing(DriverDictionary.RequestSecurityTokenResponse.Value, DriverDictionary.Namespace.Value);
+                //}
 
-                System.IdentityModel.XmlBuffer issuedTokenBuffer = GetIssuedTokenBuffer(rstrBuffer);
-                string context = null;
-                string tokenTypeUri = null;
-                int keySize = 0;
-                SecurityKeyIdentifierClause requestedAttachedReference = null;
-                SecurityKeyIdentifierClause requestedUnattachedReference = null;
-                bool computeKey = false;
-                DateTime created = DateTime.UtcNow;
-                DateTime expires = SecurityUtils.MaxUtcDateTime;
-                bool isRequestedTokenClosed = false;
-                for (int i = 0; i < rstrXml.Attributes.Count; ++i)
-                {
-                    XmlAttribute attr = rstrXml.Attributes[i];
-                    if (attr.LocalName == DriverDictionary.Context.Value)
-                    {
-                        context = attr.Value;
-                    }
-                }
+                //System.IdentityModel.XmlBuffer rstrBuffer = new System.IdentityModel.XmlBuffer(Int32.MaxValue);
+                //using (XmlDictionaryWriter writer = rstrBuffer.OpenSection(reader.Quotas))
+                //{
+                //    writer.WriteNode(reader, false);
+                //    rstrBuffer.CloseSection();
+                //    rstrBuffer.Close();
+                //}
+                //XmlDocument doc = new XmlDocument();
+                //XmlElement rstrXml;
+                //using (XmlReader reader2 = rstrBuffer.GetReader(0))
+                //{
+                //    rstrXml = (doc.ReadNode(reader2) as XmlElement);
+                //}
 
-                for (int i = 0; i < rstrXml.ChildNodes.Count; ++i)
-                {
-                    XmlElement child = (rstrXml.ChildNodes[i] as XmlElement);
-                    if (child != null)
-                    {
-                        if (child.LocalName == DriverDictionary.TokenType.Value && child.NamespaceURI == DriverDictionary.Namespace.Value)
-                            tokenTypeUri = XmlHelper.ReadTextElementAsTrimmedString(child);
-                        else if (child.LocalName == DriverDictionary.KeySize.Value && child.NamespaceURI == DriverDictionary.Namespace.Value)
-                            keySize = Int32.Parse(XmlHelper.ReadTextElementAsTrimmedString(child), NumberFormatInfo.InvariantInfo);
-                        else if (child.LocalName == DriverDictionary.RequestedProofToken.Value && child.NamespaceURI == DriverDictionary.Namespace.Value)
-                        {
-                            XmlElement proofXml = XmlHelper.GetChildElement(child);
-                            if (proofXml.LocalName == DriverDictionary.ComputedKey.Value && proofXml.NamespaceURI == DriverDictionary.Namespace.Value)
-                            {
-                                string computedKeyAlgorithm = XmlHelper.ReadTextElementAsTrimmedString(proofXml);
-                                if (computedKeyAlgorithm != this.DriverDictionary.Psha1ComputedKeyUri.Value)
-                                {
-                                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new SecurityNegotiationException(SR.GetString(SR.UnknownComputedKeyAlgorithm, computedKeyAlgorithm)));
-                                }
-                                computeKey = true;
-                            }
-                        }
-                        else if (child.LocalName == DriverDictionary.Lifetime.Value && child.NamespaceURI == DriverDictionary.Namespace.Value)
-                        {
-                            XmlElement createdXml = XmlHelper.GetChildElement(child, UtilityStrings.CreatedElement, UtilityStrings.Namespace);
-                            if (createdXml != null)
-                            {
-                                created = DateTime.ParseExact(XmlHelper.ReadTextElementAsTrimmedString(createdXml),
-                                    WSUtilitySpecificationVersion.AcceptedDateTimeFormats, DateTimeFormatInfo.InvariantInfo, DateTimeStyles.None).ToUniversalTime();
-                            }
-                            XmlElement expiresXml = XmlHelper.GetChildElement(child, UtilityStrings.ExpiresElement, UtilityStrings.Namespace);
-                            if (expiresXml != null)
-                            {
-                                expires = DateTime.ParseExact(XmlHelper.ReadTextElementAsTrimmedString(expiresXml),
-                                    WSUtilitySpecificationVersion.AcceptedDateTimeFormats, DateTimeFormatInfo.InvariantInfo, DateTimeStyles.None).ToUniversalTime();
-                            }
-                        }
-                    }
-                }
+                //System.IdentityModel.XmlBuffer issuedTokenBuffer = GetIssuedTokenBuffer(rstrBuffer);
+                //string context = null;
+                //string tokenTypeUri = null;
+                //int keySize = 0;
+                //SecurityKeyIdentifierClause requestedAttachedReference = null;
+                //SecurityKeyIdentifierClause requestedUnattachedReference = null;
+                //bool computeKey = false;
+                //DateTime created = DateTime.UtcNow;
+                //DateTime expires = SecurityUtils.MaxUtcDateTime;
+                //bool isRequestedTokenClosed = false;
+                //for (int i = 0; i < rstrXml.Attributes.Count; ++i)
+                //{
+                //    XmlAttribute attr = rstrXml.Attributes[i];
+                //    if (attr.LocalName == DriverDictionary.Context.Value)
+                //    {
+                //        context = attr.Value;
+                //    }
+                //}
 
-                isRequestedTokenClosed = ReadRequestedTokenClosed(rstrXml);
-                ReadReferences(rstrXml, out requestedAttachedReference, out requestedUnattachedReference);
+                //for (int i = 0; i < rstrXml.ChildNodes.Count; ++i)
+                //{
+                //    XmlElement child = (rstrXml.ChildNodes[i] as XmlElement);
+                //    if (child != null)
+                //    {
+                //        if (child.LocalName == DriverDictionary.TokenType.Value && child.NamespaceURI == DriverDictionary.Namespace.Value)
+                //            tokenTypeUri = XmlHelper.ReadTextElementAsTrimmedString(child);
+                //        else if (child.LocalName == DriverDictionary.KeySize.Value && child.NamespaceURI == DriverDictionary.Namespace.Value)
+                //            keySize = Int32.Parse(XmlHelper.ReadTextElementAsTrimmedString(child), NumberFormatInfo.InvariantInfo);
+                //        else if (child.LocalName == DriverDictionary.RequestedProofToken.Value && child.NamespaceURI == DriverDictionary.Namespace.Value)
+                //        {
+                //            XmlElement proofXml = XmlHelper.GetChildElement(child);
+                //            if (proofXml.LocalName == DriverDictionary.ComputedKey.Value && proofXml.NamespaceURI == DriverDictionary.Namespace.Value)
+                //            {
+                //                string computedKeyAlgorithm = XmlHelper.ReadTextElementAsTrimmedString(proofXml);
+                //                if (computedKeyAlgorithm != this.DriverDictionary.Psha1ComputedKeyUri.Value)
+                //                {
+                //                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new SecurityNegotiationException(SR.Format(SR.UnknownComputedKeyAlgorithm, computedKeyAlgorithm)));
+                //                }
+                //                computeKey = true;
+                //            }
+                //        }
+                //        else if (child.LocalName == DriverDictionary.Lifetime.Value && child.NamespaceURI == DriverDictionary.Namespace.Value)
+                //        {
+                //            XmlElement createdXml = XmlHelper.GetChildElement(child, UtilityStrings.CreatedElement, UtilityStrings.Namespace);
+                //            if (createdXml != null)
+                //            {
+                //                created = DateTime.ParseExact(XmlHelper.ReadTextElementAsTrimmedString(createdXml),
+                //                    WSUtilitySpecificationVersion.AcceptedDateTimeFormats, DateTimeFormatInfo.InvariantInfo, DateTimeStyles.None).ToUniversalTime();
+                //            }
+                //            XmlElement expiresXml = XmlHelper.GetChildElement(child, UtilityStrings.ExpiresElement, UtilityStrings.Namespace);
+                //            if (expiresXml != null)
+                //            {
+                //                expires = DateTime.ParseExact(XmlHelper.ReadTextElementAsTrimmedString(expiresXml),
+                //                    WSUtilitySpecificationVersion.AcceptedDateTimeFormats, DateTimeFormatInfo.InvariantInfo, DateTimeStyles.None).ToUniversalTime();
+                //            }
+                //        }
+                //    }
+                //}
 
-                return new RequestSecurityTokenResponse(standardsManager, rstrXml, context, tokenTypeUri, keySize, requestedAttachedReference, requestedUnattachedReference,
-                                                        computeKey, created, expires, isRequestedTokenClosed, issuedTokenBuffer);
+                //isRequestedTokenClosed = ReadRequestedTokenClosed(rstrXml);
+                //ReadReferences(rstrXml, out requestedAttachedReference, out requestedUnattachedReference);
+
+                //return new RequestSecurityTokenResponse(standardsManager, rstrXml, context, tokenTypeUri, keySize, requestedAttachedReference, requestedUnattachedReference,
+                //                                        computeKey, created, expires, isRequestedTokenClosed, issuedTokenBuffer);
             }
 
             public override RequestSecurityTokenResponseCollection CreateRequestSecurityTokenResponseCollection(XmlReader xmlReader)
@@ -413,7 +428,7 @@ namespace System.ServiceModel.Security
                 }
                 reader.ReadEndElement();
                 if (rstrCollection.Count == 0)
-                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new XmlException(SR.GetString(SR.NoRequestSecurityTokenResponseElements)));
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new XmlException(SR.Format(SR.NoRequestSecurityTokenResponseElements)));
                 return new RequestSecurityTokenResponseCollection(rstrCollection.AsReadOnly(), this.StandardsManager);
             }
 
@@ -428,10 +443,11 @@ namespace System.ServiceModel.Security
                     XmlElement elem = (rootElement.ChildNodes[i] as XmlElement);
                     if (elem != null)
                     {
-                        if (elem.LocalName == DriverDictionary.AppliesTo.Value && elem.NamespaceURI == Namespaces.WSPolicy)
-                        {
-                            return elem;
-                        }
+                        throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+                        //if (elem.LocalName == DriverDictionary.AppliesTo.Value && elem.NamespaceURI == Namespaces.WSPolicy)
+                        //{
+                        //    return elem;
+                        //}
                     }
                 }
                 return null;
@@ -442,18 +458,19 @@ namespace System.ServiceModel.Security
                 XmlElement appliesToElement = GetAppliesToElement(rootXml);
                 if (appliesToElement != null)
                 {
-                    using (XmlReader reader = new XmlNodeReader(appliesToElement))
-                    {
-                        reader.ReadStartElement();
-                        lock (serializer)
-                        {
-                            return (T)serializer.ReadObject(reader);
-                        }
-                    }
+                    throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+                    //using (XmlReader reader = new XmlNodeReader(appliesToElement))
+                    //{
+                    //    reader.ReadStartElement();
+                    //    lock (serializer)
+                    //    {
+                    //        return (T)serializer.ReadObject(reader);
+                    //    }
+                    //}
                 }
                 else
                 {
-                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.GetString(SR.NoAppliesToPresent)));
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.NoAppliesToPresent)));
                 }
             }
 
@@ -475,7 +492,8 @@ namespace System.ServiceModel.Security
 
             public override bool IsAppliesTo(string localName, string namespaceUri)
             {
-                return (localName == DriverDictionary.AppliesTo.Value && namespaceUri == Namespaces.WSPolicy);
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+                //return (localName == DriverDictionary.AppliesTo.Value && namespaceUri == Namespaces.WSPolicy);
             }
 
             void GetAppliesToQName(XmlElement rootElement, out string localName, out string namespaceUri)
@@ -484,13 +502,14 @@ namespace System.ServiceModel.Security
                 XmlElement appliesToElement = GetAppliesToElement(rootElement);
                 if (appliesToElement != null)
                 {
-                    using (XmlReader reader = new XmlNodeReader(appliesToElement))
-                    {
-                        reader.ReadStartElement();
-                        reader.MoveToContent();
-                        localName = reader.LocalName;
-                        namespaceUri = reader.NamespaceURI;
-                    }
+                    throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+                    //using (XmlReader reader = new XmlNodeReader(appliesToElement))
+                    //{
+                    //    reader.ReadStartElement();
+                    //    reader.MoveToContent();
+                    //    localName = reader.LocalName;
+                    //    namespaceUri = reader.NamespaceURI;
+                    //}
                 }
             }
 
@@ -524,8 +543,9 @@ namespace System.ServiceModel.Security
                                 XmlElement combinedHashElement = XmlHelper.GetChildElement(element);
                                 if (combinedHashElement.LocalName == DriverDictionary.CombinedHash.Value && combinedHashElement.NamespaceURI == DriverDictionary.Namespace.Value)
                                 {
-                                    string authenticatorString = XmlHelper.ReadTextElementAsTrimmedString(combinedHashElement);
-                                    return Convert.FromBase64String(authenticatorString);
+                                    throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+                                    //string authenticatorString = XmlHelper.ReadTextElementAsTrimmedString(combinedHashElement);
+                                    //return Convert.FromBase64String(authenticatorString);
                                 }
                             }
                         }
@@ -597,14 +617,16 @@ namespace System.ServiceModel.Security
                     XmlElement element = rootElement.ChildNodes[i] as XmlElement;
                     if (element != null)
                     {
-                        if (element.LocalName == DriverDictionary.Entropy.Value && element.NamespaceURI == DriverDictionary.Namespace.Value)
-                        {
-                            XmlElement tokenXml = XmlHelper.GetChildElement(element);
-                            string valueTypeUri = element.GetAttribute(SecurityJan2004Strings.ValueType);
-                            if (valueTypeUri.Length == 0)
-                                valueTypeUri = null;
-                            return standardsManager.SecurityTokenSerializer.ReadToken(new XmlNodeReader(tokenXml), resolver);
-                        }
+                        throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+
+                        //if (element.LocalName == DriverDictionary.Entropy.Value && element.NamespaceURI == DriverDictionary.Namespace.Value)
+                        //{
+                        //    XmlElement tokenXml = XmlHelper.GetChildElement(element);
+                        //    string valueTypeUri = element.GetAttribute(SecurityJan2004Strings.ValueType);
+                        //    if (valueTypeUri.Length == 0)
+                        //        valueTypeUri = null;
+                        //    return standardsManager.SecurityTokenSerializer.ReadToken(new XmlNodeReader(tokenXml), resolver);
+                        //}
                     }
                 }
                 return null;
@@ -625,7 +647,7 @@ namespace System.ServiceModel.Security
                             {
                                 if (issuedTokenXml != null)
                                 {
-                                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.GetString(SR.RstrHasMultipleIssuedTokens)));
+                                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.RstrHasMultipleIssuedTokens)));
                                 }
                                 issuedTokenXml = XmlHelper.GetChildElement(elem);
                             }
@@ -633,7 +655,7 @@ namespace System.ServiceModel.Security
                             {
                                 if (proofTokenXml != null)
                                 {
-                                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.GetString(SR.RstrHasMultipleProofTokens)));
+                                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.RstrHasMultipleProofTokens)));
                                 }
                                 proofTokenXml = XmlHelper.GetChildElement(elem);
                             }
@@ -651,164 +673,167 @@ namespace System.ServiceModel.Security
             /// 2. If there is no requestorEntropy:
             ///    a. THere has to be a <RequestedProofToken> that contains the proof key
             /// </summary>
-            public override GenericXmlSecurityToken GetIssuedToken(RequestSecurityTokenResponse rstr, SecurityTokenResolver resolver, IList<SecurityTokenAuthenticator> allowedAuthenticators, SecurityKeyEntropyMode keyEntropyMode, byte[] requestorEntropy, string expectedTokenType,
-                ReadOnlyCollection<IAuthorizationPolicy> authorizationPolicies, int defaultKeySize, bool isBearerKeyType)
-            {
+            /// 
 
-                SecurityKeyEntropyModeHelper.Validate(keyEntropyMode);
+            ////// Issue #31 in progress
+            ////public override GenericXmlSecurityToken GetIssuedToken(RequestSecurityTokenResponse rstr, SecurityTokenResolver resolver, IList<SecurityTokenAuthenticator> allowedAuthenticators, SecurityKeyEntropyMode keyEntropyMode, byte[] requestorEntropy, string expectedTokenType,
+            ////    ReadOnlyCollection<IAuthorizationPolicy> authorizationPolicies, int defaultKeySize, bool isBearerKeyType)
+            ////{
 
-                if (defaultKeySize < 0)
-                {
-                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("defaultKeySize", SR.GetString(SR.ValueMustBeNonNegative)));
-                }
+            ////    SecurityKeyEntropyModeHelper.Validate(keyEntropyMode);
 
-                if (rstr == null)
-                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("rstr");
+            ////    if (defaultKeySize < 0)
+            ////    {
+            ////        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("defaultKeySize", SR.Format(SR.ValueMustBeNonNegative)));
+            ////    }
 
-                string tokenType;
-                if (rstr.TokenType != null)
-                {
-                    if (expectedTokenType != null && expectedTokenType != rstr.TokenType)
-                    {
-                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.GetString(SR.BadIssuedTokenType, rstr.TokenType, expectedTokenType)));
-                    }
-                    tokenType = rstr.TokenType;
-                }
-                else
-                {
-                    tokenType = expectedTokenType;
-                }
+            ////    if (rstr == null)
+            ////        throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("rstr");
 
-                // search the response elements for licenseXml, proofXml, and lifetime
-                DateTime created = rstr.ValidFrom;
-                DateTime expires = rstr.ValidTo;
-                XmlElement proofXml;
-                XmlElement issuedTokenXml;
-                GetIssuedAndProofXml(rstr, out issuedTokenXml, out proofXml);
+            ////    string tokenType;
+            ////    if (rstr.TokenType != null)
+            ////    {
+            ////        if (expectedTokenType != null && expectedTokenType != rstr.TokenType)
+            ////        {
+            ////            throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.BadIssuedTokenType, rstr.TokenType, expectedTokenType)));
+            ////        }
+            ////        tokenType = rstr.TokenType;
+            ////    }
+            ////    else
+            ////    {
+            ////        tokenType = expectedTokenType;
+            ////    }
 
-                if (issuedTokenXml == null)
-                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.GetString(SR.NoLicenseXml)));
+            ////    // search the response elements for licenseXml, proofXml, and lifetime
+            ////    DateTime created = rstr.ValidFrom;
+            ////    DateTime expires = rstr.ValidTo;
+            ////    XmlElement proofXml;
+            ////    XmlElement issuedTokenXml;
+            ////    GetIssuedAndProofXml(rstr, out issuedTokenXml, out proofXml);
 
-                if (isBearerKeyType)
-                {
-                    if (proofXml != null)
-                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.GetString(SR.BearerKeyTypeCannotHaveProofKey)));
+            ////    if (issuedTokenXml == null)
+            ////        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.NoLicenseXml)));
 
-                    return new GenericXmlSecurityToken(issuedTokenXml, null, created, expires, rstr.RequestedAttachedReference, rstr.RequestedUnattachedReference, authorizationPolicies);
-                }
+            ////    if (isBearerKeyType)
+            ////    {
+            ////        if (proofXml != null)
+            ////            throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.BearerKeyTypeCannotHaveProofKey)));
 
-                SecurityToken proofToken;
-                SecurityToken entropyToken = GetEntropy(rstr, resolver);
-                if (keyEntropyMode == SecurityKeyEntropyMode.ClientEntropy)
-                {
-                    if (requestorEntropy == null)
-                    {
-                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.GetString(SR.EntropyModeRequiresRequestorEntropy, keyEntropyMode)));
-                    }
-                    // enforce that there is no entropy or proof token in the RSTR
-                    if (proofXml != null || entropyToken != null)
-                    {
-                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.GetString(SR.EntropyModeCannotHaveProofTokenOrIssuerEntropy, keyEntropyMode)));
-                    }
-                    proofToken = new BinarySecretSecurityToken(requestorEntropy);
-                }
-                else if (keyEntropyMode == SecurityKeyEntropyMode.ServerEntropy)
-                {
-                    if (requestorEntropy != null)
-                    {
-                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.GetString(SR.EntropyModeCannotHaveRequestorEntropy, keyEntropyMode)));
-                    }
-                    if (rstr.ComputeKey || entropyToken != null)
-                    {
-                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.GetString(SR.EntropyModeCannotHaveComputedKey, keyEntropyMode)));
-                    }
-                    if (proofXml == null)
-                    {
-                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.GetString(SR.EntropyModeRequiresProofToken, keyEntropyMode)));
-                    }
-                    string valueTypeUri = proofXml.GetAttribute(SecurityJan2004Strings.ValueType);
-                    if (valueTypeUri.Length == 0)
-                        valueTypeUri = null;
-                    proofToken = standardsManager.SecurityTokenSerializer.ReadToken(new XmlNodeReader(proofXml), resolver);
-                }
-                else
-                {
-                    if (!rstr.ComputeKey)
-                    {
-                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.GetString(SR.EntropyModeRequiresComputedKey, keyEntropyMode)));
-                    }
-                    if (entropyToken == null)
-                    {
-                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.GetString(SR.EntropyModeRequiresIssuerEntropy, keyEntropyMode)));
-                    }
-                    if (requestorEntropy == null)
-                    {
-                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.GetString(SR.EntropyModeRequiresRequestorEntropy, keyEntropyMode)));
-                    }
-                    if (rstr.KeySize == 0 && defaultKeySize == 0)
-                    {
-                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.GetString(SR.RstrKeySizeNotProvided)));
-                    }
-                    int issuedKeySize = (rstr.KeySize != 0) ? rstr.KeySize : defaultKeySize;
-                    byte[] issuerEntropy;
-                    if (entropyToken is BinarySecretSecurityToken)
-                        issuerEntropy = ((BinarySecretSecurityToken)entropyToken).GetKeyBytes();
-                    else if (entropyToken is WrappedKeySecurityToken)
-                        issuerEntropy = ((WrappedKeySecurityToken)entropyToken).GetWrappedKey();
-                    else
-                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new NotSupportedException(SR.GetString(SR.UnsupportedIssuerEntropyType)));
-                    // compute the PSHA1 derived key
-                    byte[] issuedKey = RequestSecurityTokenResponse.ComputeCombinedKey(requestorEntropy, issuerEntropy, issuedKeySize);
-                    proofToken = new BinarySecretSecurityToken(issuedKey);
-                }
+            ////        return new GenericXmlSecurityToken(issuedTokenXml, null, created, expires, rstr.RequestedAttachedReference, rstr.RequestedUnattachedReference, authorizationPolicies);
+            ////    }
 
-                SecurityKeyIdentifierClause internalReference = rstr.RequestedAttachedReference;
-                SecurityKeyIdentifierClause externalReference = rstr.RequestedUnattachedReference;
+            ////    SecurityToken proofToken;
+            ////    SecurityToken entropyToken = GetEntropy(rstr, resolver);
+            ////    if (keyEntropyMode == SecurityKeyEntropyMode.ClientEntropy)
+            ////    {
+            ////        if (requestorEntropy == null)
+            ////        {
+            ////            throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.EntropyModeRequiresRequestorEntropy, keyEntropyMode)));
+            ////        }
+            ////        // enforce that there is no entropy or proof token in the RSTR
+            ////        if (proofXml != null || entropyToken != null)
+            ////        {
+            ////            throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.EntropyModeCannotHaveProofTokenOrIssuerEntropy, keyEntropyMode)));
+            ////        }
+            ////        proofToken = new BinarySecretSecurityToken(requestorEntropy);
+            ////    }
+            ////    else if (keyEntropyMode == SecurityKeyEntropyMode.ServerEntropy)
+            ////    {
+            ////        if (requestorEntropy != null)
+            ////        {
+            ////            throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.EntropyModeCannotHaveRequestorEntropy, keyEntropyMode)));
+            ////        }
+            ////        if (rstr.ComputeKey || entropyToken != null)
+            ////        {
+            ////            throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.EntropyModeCannotHaveComputedKey, keyEntropyMode)));
+            ////        }
+            ////        if (proofXml == null)
+            ////        {
+            ////            throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.EntropyModeRequiresProofToken, keyEntropyMode)));
+            ////        }
+            ////        string valueTypeUri = proofXml.GetAttribute(SecurityJan2004Strings.ValueType);
+            ////        if (valueTypeUri.Length == 0)
+            ////            valueTypeUri = null;
+            ////        proofToken = standardsManager.SecurityTokenSerializer.ReadToken(new XmlNodeReader(proofXml), resolver);
+            ////    }
+            ////    else
+            ////    {
+            ////        if (!rstr.ComputeKey)
+            ////        {
+            ////            throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.EntropyModeRequiresComputedKey, keyEntropyMode)));
+            ////        }
+            ////        if (entropyToken == null)
+            ////        {
+            ////            throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.EntropyModeRequiresIssuerEntropy, keyEntropyMode)));
+            ////        }
+            ////        if (requestorEntropy == null)
+            ////        {
+            ////            throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.EntropyModeRequiresRequestorEntropy, keyEntropyMode)));
+            ////        }
+            ////        if (rstr.KeySize == 0 && defaultKeySize == 0)
+            ////        {
+            ////            throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.RstrKeySizeNotProvided)));
+            ////        }
+            ////        int issuedKeySize = (rstr.KeySize != 0) ? rstr.KeySize : defaultKeySize;
+            ////        byte[] issuerEntropy;
+            ////        if (entropyToken is BinarySecretSecurityToken)
+            ////            issuerEntropy = ((BinarySecretSecurityToken)entropyToken).GetKeyBytes();
+            ////        else if (entropyToken is WrappedKeySecurityToken)
+            ////            issuerEntropy = ((WrappedKeySecurityToken)entropyToken).GetWrappedKey();
+            ////        else
+            ////            throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new NotSupportedException(SR.Format(SR.UnsupportedIssuerEntropyType)));
+            ////        // compute the PSHA1 derived key
+            ////        byte[] issuedKey = RequestSecurityTokenResponse.ComputeCombinedKey(requestorEntropy, issuerEntropy, issuedKeySize);
+            ////        proofToken = new BinarySecretSecurityToken(issuedKey);
+            ////    }
 
-                return new BufferedGenericXmlSecurityToken(issuedTokenXml, proofToken, created, expires, internalReference, externalReference, authorizationPolicies, rstr.IssuedTokenBuffer);
-            }
+            ////    SecurityKeyIdentifierClause internalReference = rstr.RequestedAttachedReference;
+            ////    SecurityKeyIdentifierClause externalReference = rstr.RequestedUnattachedReference;
 
-            public override GenericXmlSecurityToken GetIssuedToken(RequestSecurityTokenResponse rstr, string expectedTokenType,
-                ReadOnlyCollection<IAuthorizationPolicy> authorizationPolicies, RSA clientKey)
-            {
-                if (rstr == null)
-                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentNullException("rstr"));
+            ////    return new BufferedGenericXmlSecurityToken(issuedTokenXml, proofToken, created, expires, internalReference, externalReference, authorizationPolicies, rstr.IssuedTokenBuffer);
+            ////}
 
-                string tokenType;
-                if (rstr.TokenType != null)
-                {
-                    if (expectedTokenType != null && expectedTokenType != rstr.TokenType)
-                    {
-                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.GetString(SR.BadIssuedTokenType, rstr.TokenType, expectedTokenType)));
-                    }
-                    tokenType = rstr.TokenType;
-                }
-                else
-                {
-                    tokenType = expectedTokenType;
-                }
+            //public override GenericXmlSecurityToken GetIssuedToken(RequestSecurityTokenResponse rstr, string expectedTokenType,
+            //    ReadOnlyCollection<IAuthorizationPolicy> authorizationPolicies, RSA clientKey)
+            //{
+            //    if (rstr == null)
+            //        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentNullException("rstr"));
 
-                // search the response elements for licenseXml, proofXml, and lifetime
-                DateTime created = rstr.ValidFrom;
-                DateTime expires = rstr.ValidTo;
-                XmlElement proofXml;
-                XmlElement issuedTokenXml;
-                GetIssuedAndProofXml(rstr, out issuedTokenXml, out proofXml);
+            //    string tokenType;
+            //    if (rstr.TokenType != null)
+            //    {
+            //        if (expectedTokenType != null && expectedTokenType != rstr.TokenType)
+            //        {
+            //            throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.BadIssuedTokenType, rstr.TokenType, expectedTokenType)));
+            //        }
+            //        tokenType = rstr.TokenType;
+            //    }
+            //    else
+            //    {
+            //        tokenType = expectedTokenType;
+            //    }
 
-                if (issuedTokenXml == null)
-                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.GetString(SR.NoLicenseXml)));
+            //    // search the response elements for licenseXml, proofXml, and lifetime
+            //    DateTime created = rstr.ValidFrom;
+            //    DateTime expires = rstr.ValidTo;
+            //    XmlElement proofXml;
+            //    XmlElement issuedTokenXml;
+            //    GetIssuedAndProofXml(rstr, out issuedTokenXml, out proofXml);
 
-                // enforce that there is no proof token in the RSTR
-                if (proofXml != null)
-                {
-                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.GetString(SR.ProofTokenXmlUnexpectedInRstr)));
-                }
-                SecurityKeyIdentifierClause internalReference = rstr.RequestedAttachedReference;
-                SecurityKeyIdentifierClause externalReference = rstr.RequestedUnattachedReference;
+            //    if (issuedTokenXml == null)
+            //        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.NoLicenseXml)));
 
-                SecurityToken proofToken = new RsaSecurityToken(clientKey);
-                return new BufferedGenericXmlSecurityToken(issuedTokenXml, proofToken, created, expires, internalReference, externalReference, authorizationPolicies, rstr.IssuedTokenBuffer);
-            }
+            //    // enforce that there is no proof token in the RSTR
+            //    if (proofXml != null)
+            //    {
+            //        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.ProofTokenXmlUnexpectedInRstr)));
+            //    }
+            //    SecurityKeyIdentifierClause internalReference = rstr.RequestedAttachedReference;
+            //    SecurityKeyIdentifierClause externalReference = rstr.RequestedUnattachedReference;
+
+            //    SecurityToken proofToken = new RsaSecurityToken(clientKey);
+            //    return new BufferedGenericXmlSecurityToken(issuedTokenXml, proofToken, created, expires, internalReference, externalReference, authorizationPolicies, rstr.IssuedTokenBuffer);
+            //}
 
             public override bool IsAtRequestSecurityTokenResponse(XmlReader reader)
             {
@@ -838,51 +863,53 @@ namespace System.ServiceModel.Security
 
             public static BinaryNegotiation ReadBinaryNegotiation(XmlElement elem)
             {
-                if (elem == null)
-                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("elem");
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
 
-                // get the encoding and valueType attributes
-                string encodingUri = null;
-                string valueTypeUri = null;
-                byte[] negotiationData = null;
-                if (elem.Attributes != null)
-                {
-                    for (int i = 0; i < elem.Attributes.Count; ++i)
-                    {
-                        XmlAttribute attr = elem.Attributes[i];
-                        if (attr.LocalName == SecurityJan2004Strings.EncodingType && attr.NamespaceURI.Length == 0)
-                        {
-                            encodingUri = attr.Value;
-                            if (encodingUri != base64Uri && encodingUri != hexBinaryUri)
-                            {
-                                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new XmlException(SR.GetString(SR.UnsupportedBinaryEncoding, encodingUri)));
-                            }
-                        }
-                        else if (attr.LocalName == SecurityJan2004Strings.ValueType && attr.NamespaceURI.Length == 0)
-                        {
-                            valueTypeUri = attr.Value;
-                        }
-                        // ignore all other attributes
-                    }
-                }
-                if (encodingUri == null)
-                {
-                    XmlHelper.OnRequiredAttributeMissing("EncodingType", elem.Name);
-                }
-                if (valueTypeUri == null)
-                {
-                    XmlHelper.OnRequiredAttributeMissing("ValueType", elem.Name);
-                }
-                string encodedBlob = XmlHelper.ReadTextElementAsTrimmedString(elem);
-                if (encodingUri == base64Uri)
-                {
-                    negotiationData = Convert.FromBase64String(encodedBlob);
-                }
-                else
-                {
-                    negotiationData = HexBinary.Parse(encodedBlob).Value;
-                }
-                return new BinaryNegotiation(valueTypeUri, negotiationData);
+                //if (elem == null)
+                //    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("elem");
+
+                //// get the encoding and valueType attributes
+                //string encodingUri = null;
+                //string valueTypeUri = null;
+                //byte[] negotiationData = null;
+                //if (elem.Attributes != null)
+                //{
+                //    for (int i = 0; i < elem.Attributes.Count; ++i)
+                //    {
+                //        XmlAttribute attr = elem.Attributes[i];
+                //        if (attr.LocalName == SecurityJan2004Strings.EncodingType && attr.NamespaceURI.Length == 0)
+                //        {
+                //            encodingUri = attr.Value;
+                //            if (encodingUri != base64Uri && encodingUri != hexBinaryUri)
+                //            {
+                //                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new XmlException(SR.Format(SR.UnsupportedBinaryEncoding, encodingUri)));
+                //            }
+                //        }
+                //        else if (attr.LocalName == SecurityJan2004Strings.ValueType && attr.NamespaceURI.Length == 0)
+                //        {
+                //            valueTypeUri = attr.Value;
+                //        }
+                //        // ignore all other attributes
+                //    }
+                //}
+                //if (encodingUri == null)
+                //{
+                //    XmlHelper.OnRequiredAttributeMissing("EncodingType", elem.Name);
+                //}
+                //if (valueTypeUri == null)
+                //{
+                //    XmlHelper.OnRequiredAttributeMissing("ValueType", elem.Name);
+                //}
+                //string encodedBlob = XmlHelper.ReadTextElementAsTrimmedString(elem);
+                //if (encodingUri == base64Uri)
+                //{
+                //    negotiationData = Convert.FromBase64String(encodedBlob);
+                //}
+                //else
+                //{
+                //    negotiationData = HexBinary.Parse(encodedBlob).Value;
+                //}
+                //return new BinaryNegotiation(valueTypeUri, negotiationData);
             }
 
             // Note in Apr2004, internal & external references aren't supported - 
@@ -911,76 +938,81 @@ namespace System.ServiceModel.Security
 
                 if (issuedTokenXml != null)
                 {
-                    requestedAttachedReference = standardsManager.CreateKeyIdentifierClauseFromTokenXml(issuedTokenXml, SecurityTokenReferenceStyle.Internal);
-                    if (requestedUnattachedReference == null)
-                    {
-                        try
-                        {
-                            requestedUnattachedReference = standardsManager.CreateKeyIdentifierClauseFromTokenXml(issuedTokenXml, SecurityTokenReferenceStyle.External);
-                        }
-                        catch (XmlException)
-                        {
-                            throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new XmlException(SR.GetString(SR.TrustDriverIsUnableToCreatedNecessaryAttachedOrUnattachedReferences, issuedTokenXml.ToString())));
-                        }
-                    }
+                    throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+
+                    //requestedAttachedReference = standardsManager.CreateKeyIdentifierClauseFromTokenXml(issuedTokenXml, SecurityTokenReferenceStyle.Internal);
+                    //if (requestedUnattachedReference == null)
+                    //{
+                    //    try
+                    //    {
+                    //        requestedUnattachedReference = standardsManager.CreateKeyIdentifierClauseFromTokenXml(issuedTokenXml, SecurityTokenReferenceStyle.External);
+                    //    }
+                    //    catch (XmlException)
+                    //    {
+                    //        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new XmlException(SR.Format(SR.TrustDriverIsUnableToCreatedNecessaryAttachedOrUnattachedReferences, issuedTokenXml.ToString())));
+                    //    }
+                    //}
                 }
             }
 
-            internal bool TryReadKeyIdentifierClause(XmlNodeReader reader, out SecurityKeyIdentifierClause keyIdentifierClause)
-            {
-                keyIdentifierClause = null;
+            // Issue #31 in progress
+            //internal bool TryReadKeyIdentifierClause(XmlNodeReader reader, out SecurityKeyIdentifierClause keyIdentifierClause)
+            //{
+            //    keyIdentifierClause = null;
 
-                try
-                {
-                    keyIdentifierClause = standardsManager.SecurityTokenSerializer.ReadKeyIdentifierClause(reader);
-                }
-                catch (XmlException e)
-                {
-                    if (Fx.IsFatal(e))
-                    {
-                        throw;
-                    }
+            //    try
+            //    {
+            //        keyIdentifierClause = standardsManager.SecurityTokenSerializer.ReadKeyIdentifierClause(reader);
+            //    }
+            //    catch (XmlException e)
+            //    {
+            //        if (Fx.IsFatal(e))
+            //        {
+            //            throw;
+            //        }
 
-                    keyIdentifierClause = null;
-                    return false;
-                }
-                catch (Exception e)
-                {
-                    if (Fx.IsFatal(e))
-                    {
-                        throw;
-                    }
+            //        keyIdentifierClause = null;
+            //        return false;
+            //    }
+            //    catch (Exception e)
+            //    {
+            //        if (Fx.IsFatal(e))
+            //        {
+            //            throw;
+            //        }
 
-                    keyIdentifierClause = null;
-                    return false;
-                }
+            //        keyIdentifierClause = null;
+            //        return false;
+            //    }
 
-                return true;
-            }
+            //    return true;
+            //}
 
-            internal SecurityKeyIdentifierClause CreateGenericXmlSecurityKeyIdentifierClause(XmlNodeReader reader, XmlElement keyIdentifierReferenceXmlElement)
-            {
-                SecurityKeyIdentifierClause keyIdentifierClause = null;
-                XmlDictionaryReader localReader = XmlDictionaryReader.CreateDictionaryReader(reader);
-                string strId = localReader.GetAttribute(XD.UtilityDictionary.IdAttribute, XD.UtilityDictionary.Namespace);
-                keyIdentifierClause = new GenericXmlSecurityKeyIdentifierClause(keyIdentifierReferenceXmlElement);
-                if (!String.IsNullOrEmpty(strId))
-                {
-                    keyIdentifierClause.Id = strId;
-                }
-                return keyIdentifierClause;
-            }
+            //internal SecurityKeyIdentifierClause CreateGenericXmlSecurityKeyIdentifierClause(XmlNodeReader reader, XmlElement keyIdentifierReferenceXmlElement)
+            //{
+            //    SecurityKeyIdentifierClause keyIdentifierClause = null;
+            //    XmlDictionaryReader localReader = XmlDictionaryReader.CreateDictionaryReader(reader);
+            //    string strId = localReader.GetAttribute(XD.UtilityDictionary.IdAttribute, XD.UtilityDictionary.Namespace);
+            //    keyIdentifierClause = new GenericXmlSecurityKeyIdentifierClause(keyIdentifierReferenceXmlElement);
+            //    if (!String.IsNullOrEmpty(strId))
+            //    {
+            //        keyIdentifierClause.Id = strId;
+            //    }
+            //    return keyIdentifierClause;
+            //}
 
             internal SecurityKeyIdentifierClause GetKeyIdentifierXmlReferenceClause(XmlElement keyIdentifierReferenceXmlElement)
             {
-                SecurityKeyIdentifierClause keyIdentifierClause = null;
-                XmlNodeReader reader = new XmlNodeReader(keyIdentifierReferenceXmlElement);
-                if (!this.TryReadKeyIdentifierClause(reader, out keyIdentifierClause))
-                {
-                    keyIdentifierClause = CreateGenericXmlSecurityKeyIdentifierClause(new XmlNodeReader(keyIdentifierReferenceXmlElement), keyIdentifierReferenceXmlElement);
-                }
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
 
-                return keyIdentifierClause;
+                //SecurityKeyIdentifierClause keyIdentifierClause = null;
+                //XmlNodeReader reader = new XmlNodeReader(keyIdentifierReferenceXmlElement);
+                //if (!this.TryReadKeyIdentifierClause(reader, out keyIdentifierClause))
+                //{
+                //    keyIdentifierClause = CreateGenericXmlSecurityKeyIdentifierClause(new XmlNodeReader(keyIdentifierReferenceXmlElement), keyIdentifierReferenceXmlElement);
+                //}
+
+                //return keyIdentifierClause;
             }
 
             protected virtual bool ReadRequestedTokenClosed(XmlElement rstrXml)
@@ -996,20 +1028,22 @@ namespace System.ServiceModel.Security
 
             public override void OnRSTRorRSTRCMissingException()
             {
-                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new XmlException(SR.GetString(SR.ExpectedOneOfTwoElementsFromNamespace,
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new XmlException(SR.Format(SR.ExpectedOneOfTwoElementsFromNamespace,
                     DriverDictionary.RequestSecurityTokenResponse, DriverDictionary.RequestSecurityTokenResponseCollection,
                     DriverDictionary.Namespace)));
             }
 
             void WriteAppliesTo(object appliesTo, Type appliesToType, XmlObjectSerializer serializer, XmlWriter xmlWriter)
             {
-                XmlDictionaryWriter writer = XmlDictionaryWriter.CreateDictionaryWriter(xmlWriter);
-                writer.WriteStartElement(Namespaces.WSPolicyPrefix, DriverDictionary.AppliesTo.Value, Namespaces.WSPolicy);
-                lock (serializer)
-                {
-                    serializer.WriteObject(writer, appliesTo);
-                }
-                writer.WriteEndElement();
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+
+                //XmlDictionaryWriter writer = XmlDictionaryWriter.CreateDictionaryWriter(xmlWriter);
+                //writer.WriteStartElement(Namespaces.WSPolicyPrefix, DriverDictionary.AppliesTo.Value, Namespaces.WSPolicy);
+                //lock (serializer)
+                //{
+                //    serializer.WriteObject(writer, appliesTo);
+                //}
+                //writer.WriteEndElement();
             }
 
             public void WriteBinaryNegotiation(BinaryNegotiation negotiation, XmlWriter xmlWriter)
@@ -1066,9 +1100,10 @@ namespace System.ServiceModel.Security
                 SecurityToken entropyToken = rst.GetRequestorEntropy();
                 if (entropyToken != null)
                 {
-                    writer.WriteStartElement(DriverDictionary.Prefix.Value, DriverDictionary.Entropy, DriverDictionary.Namespace);
-                    standardsManager.SecurityTokenSerializer.WriteToken(writer, entropyToken);
-                    writer.WriteEndElement();
+                    throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+                    //writer.WriteStartElement(DriverDictionary.Prefix.Value, DriverDictionary.Entropy, DriverDictionary.Namespace);
+                    //standardsManager.SecurityTokenSerializer.WriteToken(writer, entropyToken);
+                    //writer.WriteEndElement();
                 }
 
                 if (rst.KeySize != 0)
@@ -1105,9 +1140,11 @@ namespace System.ServiceModel.Security
             {
                 if (rstr.RequestedUnattachedReference != null)
                 {
-                    writer.WriteStartElement(DriverDictionary.Prefix.Value, DriverDictionary.RequestedTokenReference, DriverDictionary.Namespace);
-                    standardsManager.SecurityTokenSerializer.WriteKeyIdentifierClause(writer, rstr.RequestedUnattachedReference);
-                    writer.WriteEndElement();
+                    throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+
+                    //writer.WriteStartElement(DriverDictionary.Prefix.Value, DriverDictionary.RequestedTokenReference, DriverDictionary.Namespace);
+                    //standardsManager.SecurityTokenSerializer.WriteKeyIdentifierClause(writer, rstr.RequestedUnattachedReference);
+                    //writer.WriteEndElement();
                 }
             }
 
@@ -1117,122 +1154,124 @@ namespace System.ServiceModel.Security
 
             public override void WriteRequestSecurityTokenResponse(RequestSecurityTokenResponse rstr, XmlWriter xmlWriter)
             {
-                if (rstr == null)
-                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("rstr");
-                if (xmlWriter == null)
-                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("xmlWriter");
-                XmlDictionaryWriter writer = XmlDictionaryWriter.CreateDictionaryWriter(xmlWriter);
-                if (rstr.IsReceiver)
-                {
-                    rstr.WriteTo(writer);
-                    return;
-                }
-                writer.WriteStartElement(DriverDictionary.Prefix.Value, DriverDictionary.RequestSecurityTokenResponse, DriverDictionary.Namespace);
-                if (rstr.Context != null)
-                {
-                    writer.WriteAttributeString(DriverDictionary.Context, null, rstr.Context);
-                }
-                // define WSUtility at the top level to avoid multiple definitions below
-                XmlHelper.AddNamespaceDeclaration(writer, UtilityStrings.Prefix, XD.UtilityDictionary.Namespace);
-                rstr.OnWriteCustomAttributes(writer);
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
 
-                if (rstr.TokenType != null)
-                    writer.WriteElementString(DriverDictionary.Prefix.Value, DriverDictionary.TokenType, DriverDictionary.Namespace, rstr.TokenType);
+                //if (rstr == null)
+                //    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("rstr");
+                //if (xmlWriter == null)
+                //    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("xmlWriter");
+                //XmlDictionaryWriter writer = XmlDictionaryWriter.CreateDictionaryWriter(xmlWriter);
+                //if (rstr.IsReceiver)
+                //{
+                //    rstr.WriteTo(writer);
+                //    return;
+                //}
+                //writer.WriteStartElement(DriverDictionary.Prefix.Value, DriverDictionary.RequestSecurityTokenResponse, DriverDictionary.Namespace);
+                //if (rstr.Context != null)
+                //{
+                //    writer.WriteAttributeString(DriverDictionary.Context, null, rstr.Context);
+                //}
+                //// define WSUtility at the top level to avoid multiple definitions below
+                //XmlHelper.AddNamespaceDeclaration(writer, UtilityStrings.Prefix, XD.UtilityDictionary.Namespace);
+                //rstr.OnWriteCustomAttributes(writer);
 
-                if (rstr.RequestedSecurityToken != null)
-                {
-                    writer.WriteStartElement(DriverDictionary.Prefix.Value, DriverDictionary.RequestedSecurityToken, DriverDictionary.Namespace);
-                    standardsManager.SecurityTokenSerializer.WriteToken(writer, rstr.RequestedSecurityToken);
-                    writer.WriteEndElement();
-                }
+                //if (rstr.TokenType != null)
+                //    writer.WriteElementString(DriverDictionary.Prefix.Value, DriverDictionary.TokenType, DriverDictionary.Namespace, rstr.TokenType);
 
-                if (rstr.AppliesTo != null)
-                {
-                    WriteAppliesTo(rstr.AppliesTo, rstr.AppliesToType, rstr.AppliesToSerializer, writer);
-                }
+                //if (rstr.RequestedSecurityToken != null)
+                //{
+                //    writer.WriteStartElement(DriverDictionary.Prefix.Value, DriverDictionary.RequestedSecurityToken, DriverDictionary.Namespace);
+                //    standardsManager.SecurityTokenSerializer.WriteToken(writer, rstr.RequestedSecurityToken);
+                //    writer.WriteEndElement();
+                //}
 
-                WriteReferences(rstr, writer);
+                //if (rstr.AppliesTo != null)
+                //{
+                //    WriteAppliesTo(rstr.AppliesTo, rstr.AppliesToType, rstr.AppliesToSerializer, writer);
+                //}
 
-                if (rstr.ComputeKey || rstr.RequestedProofToken != null)
-                {
-                    writer.WriteStartElement(DriverDictionary.Prefix.Value, DriverDictionary.RequestedProofToken, DriverDictionary.Namespace);
-                    if (rstr.ComputeKey)
-                    {
-                        writer.WriteElementString(DriverDictionary.Prefix.Value, DriverDictionary.ComputedKey, DriverDictionary.Namespace, DriverDictionary.Psha1ComputedKeyUri.Value);
-                    }
-                    else
-                    {
-                        standardsManager.SecurityTokenSerializer.WriteToken(writer, rstr.RequestedProofToken);
-                    }
-                    writer.WriteEndElement();
-                }
+                //WriteReferences(rstr, writer);
 
-                SecurityToken entropyToken = rstr.GetIssuerEntropy();
-                if (entropyToken != null)
-                {
-                    writer.WriteStartElement(DriverDictionary.Prefix.Value, DriverDictionary.Entropy, DriverDictionary.Namespace);
-                    standardsManager.SecurityTokenSerializer.WriteToken(writer, entropyToken);
-                    writer.WriteEndElement();
-                }
+                //if (rstr.ComputeKey || rstr.RequestedProofToken != null)
+                //{
+                //    writer.WriteStartElement(DriverDictionary.Prefix.Value, DriverDictionary.RequestedProofToken, DriverDictionary.Namespace);
+                //    if (rstr.ComputeKey)
+                //    {
+                //        writer.WriteElementString(DriverDictionary.Prefix.Value, DriverDictionary.ComputedKey, DriverDictionary.Namespace, DriverDictionary.Psha1ComputedKeyUri.Value);
+                //    }
+                //    else
+                //    {
+                //        standardsManager.SecurityTokenSerializer.WriteToken(writer, rstr.RequestedProofToken);
+                //    }
+                //    writer.WriteEndElement();
+                //}
 
-                // To write out the lifetime, the following algorithm is used
-                //   1. If the lifetime is explicitly set, write it out.
-                //   2. Else, if a token/tokenbuilder has been set, use the lifetime in that.
-                //   3. Else do not serialize lifetime
-                if (rstr.IsLifetimeSet || rstr.RequestedSecurityToken != null)
-                {
-                    DateTime effectiveTime = SecurityUtils.MinUtcDateTime;
-                    DateTime expirationTime = SecurityUtils.MaxUtcDateTime;
+                //SecurityToken entropyToken = rstr.GetIssuerEntropy();
+                //if (entropyToken != null)
+                //{
+                //    writer.WriteStartElement(DriverDictionary.Prefix.Value, DriverDictionary.Entropy, DriverDictionary.Namespace);
+                //    standardsManager.SecurityTokenSerializer.WriteToken(writer, entropyToken);
+                //    writer.WriteEndElement();
+                //}
 
-                    if (rstr.IsLifetimeSet)
-                    {
-                        effectiveTime = rstr.ValidFrom.ToUniversalTime();
-                        expirationTime = rstr.ValidTo.ToUniversalTime();
-                    }
-                    else if (rstr.RequestedSecurityToken != null)
-                    {
-                        effectiveTime = rstr.RequestedSecurityToken.ValidFrom.ToUniversalTime();
-                        expirationTime = rstr.RequestedSecurityToken.ValidTo.ToUniversalTime();
-                    }
+                //// To write out the lifetime, the following algorithm is used
+                ////   1. If the lifetime is explicitly set, write it out.
+                ////   2. Else, if a token/tokenbuilder has been set, use the lifetime in that.
+                ////   3. Else do not serialize lifetime
+                //if (rstr.IsLifetimeSet || rstr.RequestedSecurityToken != null)
+                //{
+                //    DateTime effectiveTime = SecurityUtils.MinUtcDateTime;
+                //    DateTime expirationTime = SecurityUtils.MaxUtcDateTime;
 
-                    // write out the lifetime
-                    writer.WriteStartElement(DriverDictionary.Prefix.Value, DriverDictionary.Lifetime, DriverDictionary.Namespace);
-                    // write out Created
-                    writer.WriteStartElement(XD.UtilityDictionary.Prefix.Value, XD.UtilityDictionary.CreatedElement, XD.UtilityDictionary.Namespace);
-                    writer.WriteString(effectiveTime.ToString("yyyy-MM-ddTHH:mm:ss.fffZ", CultureInfo.InvariantCulture.DateTimeFormat));
-                    writer.WriteEndElement(); // wsu:Created
-                    // write out Expires
-                    writer.WriteStartElement(XD.UtilityDictionary.Prefix.Value, XD.UtilityDictionary.ExpiresElement, XD.UtilityDictionary.Namespace);
-                    writer.WriteString(expirationTime.ToString("yyyy-MM-ddTHH:mm:ss.fffZ", CultureInfo.InvariantCulture.DateTimeFormat));
-                    writer.WriteEndElement(); // wsu:Expires
-                    writer.WriteEndElement(); // wsse:Lifetime
-                }
+                //    if (rstr.IsLifetimeSet)
+                //    {
+                //        effectiveTime = rstr.ValidFrom.ToUniversalTime();
+                //        expirationTime = rstr.ValidTo.ToUniversalTime();
+                //    }
+                //    else if (rstr.RequestedSecurityToken != null)
+                //    {
+                //        effectiveTime = rstr.RequestedSecurityToken.ValidFrom.ToUniversalTime();
+                //        expirationTime = rstr.RequestedSecurityToken.ValidTo.ToUniversalTime();
+                //    }
 
-                byte[] authenticator = rstr.GetAuthenticator();
-                if (authenticator != null)
-                {
-                    writer.WriteStartElement(DriverDictionary.Prefix.Value, DriverDictionary.Authenticator, DriverDictionary.Namespace);
-                    writer.WriteStartElement(DriverDictionary.Prefix.Value, DriverDictionary.CombinedHash, DriverDictionary.Namespace);
-                    writer.WriteBase64(authenticator, 0, authenticator.Length);
-                    writer.WriteEndElement();
-                    writer.WriteEndElement();
-                }
+                //    // write out the lifetime
+                //    writer.WriteStartElement(DriverDictionary.Prefix.Value, DriverDictionary.Lifetime, DriverDictionary.Namespace);
+                //    // write out Created
+                //    writer.WriteStartElement(XD.UtilityDictionary.Prefix.Value, XD.UtilityDictionary.CreatedElement, XD.UtilityDictionary.Namespace);
+                //    writer.WriteString(effectiveTime.ToString("yyyy-MM-ddTHH:mm:ss.fffZ", CultureInfo.InvariantCulture.DateTimeFormat));
+                //    writer.WriteEndElement(); // wsu:Created
+                //    // write out Expires
+                //    writer.WriteStartElement(XD.UtilityDictionary.Prefix.Value, XD.UtilityDictionary.ExpiresElement, XD.UtilityDictionary.Namespace);
+                //    writer.WriteString(expirationTime.ToString("yyyy-MM-ddTHH:mm:ss.fffZ", CultureInfo.InvariantCulture.DateTimeFormat));
+                //    writer.WriteEndElement(); // wsu:Expires
+                //    writer.WriteEndElement(); // wsse:Lifetime
+                //}
 
-                if (rstr.KeySize > 0)
-                {
-                    writer.WriteStartElement(DriverDictionary.Prefix.Value, DriverDictionary.KeySize, DriverDictionary.Namespace);
-                    writer.WriteValue(rstr.KeySize);
-                    writer.WriteEndElement();
-                }
+                //byte[] authenticator = rstr.GetAuthenticator();
+                //if (authenticator != null)
+                //{
+                //    writer.WriteStartElement(DriverDictionary.Prefix.Value, DriverDictionary.Authenticator, DriverDictionary.Namespace);
+                //    writer.WriteStartElement(DriverDictionary.Prefix.Value, DriverDictionary.CombinedHash, DriverDictionary.Namespace);
+                //    writer.WriteBase64(authenticator, 0, authenticator.Length);
+                //    writer.WriteEndElement();
+                //    writer.WriteEndElement();
+                //}
 
-                WriteRequestedTokenClosed(rstr, writer);
+                //if (rstr.KeySize > 0)
+                //{
+                //    writer.WriteStartElement(DriverDictionary.Prefix.Value, DriverDictionary.KeySize, DriverDictionary.Namespace);
+                //    writer.WriteValue(rstr.KeySize);
+                //    writer.WriteEndElement();
+                //}
 
-                BinaryNegotiation negotiationData = rstr.GetBinaryNegotiation();
-                if (negotiationData != null)
-                    WriteBinaryNegotiation(negotiationData, writer);
+                //WriteRequestedTokenClosed(rstr, writer);
 
-                rstr.OnWriteCustomElements(writer);
-                writer.WriteEndElement();
+                //BinaryNegotiation negotiationData = rstr.GetBinaryNegotiation();
+                //if (negotiationData != null)
+                //    WriteBinaryNegotiation(negotiationData, writer);
+
+                //rstr.OnWriteCustomElements(writer);
+                //writer.WriteEndElement();
             }
 
             public override void WriteRequestSecurityTokenResponseCollection(RequestSecurityTokenResponseCollection rstrCollection, XmlWriter xmlWriter)
@@ -1270,65 +1309,66 @@ namespace System.ServiceModel.Security
                 }
             }
 
-            public override bool TryParseKeySizeElement(XmlElement element, out int keySize)
-            {
-                if (element == null)
-                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("element");
+            // Issue #31 in progress
+            //public override bool TryParseKeySizeElement(XmlElement element, out int keySize)
+            //{
+            //    if (element == null)
+            //        throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("element");
 
-                if (element.LocalName == this.DriverDictionary.KeySize.Value
-                    && element.NamespaceURI == this.DriverDictionary.Namespace.Value)
-                {
-                    keySize = Int32.Parse(XmlHelper.ReadTextElementAsTrimmedString(element), NumberFormatInfo.InvariantInfo);
-                    return true;
-                }
+            //    if (element.LocalName == this.DriverDictionary.KeySize.Value
+            //        && element.NamespaceURI == this.DriverDictionary.Namespace.Value)
+            //    {
+            //        keySize = Int32.Parse(XmlHelper.ReadTextElementAsTrimmedString(element), NumberFormatInfo.InvariantInfo);
+            //        return true;
+            //    }
 
-                keySize = 0;
-                return false;
-            }
+            //    keySize = 0;
+            //    return false;
+            //}
 
-            public override XmlElement CreateKeySizeElement(int keySize)
-            {
-                if (keySize < 0)
-                {
-                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("keySize", SR.GetString(SR.ValueMustBeNonNegative)));
-                }
-                XmlDocument doc = new XmlDocument();
-                XmlElement result = doc.CreateElement(this.DriverDictionary.Prefix.Value, this.DriverDictionary.KeySize.Value,
-                    this.DriverDictionary.Namespace.Value);
-                result.AppendChild(doc.CreateTextNode(keySize.ToString(System.Globalization.CultureInfo.InvariantCulture.NumberFormat)));
-                return result;
-            }
+            //public override XmlElement CreateKeySizeElement(int keySize)
+            //{
+            //    if (keySize < 0)
+            //    {
+            //        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("keySize", SR.Format(SR.ValueMustBeNonNegative)));
+            //    }
+            //    XmlDocument doc = new XmlDocument();
+            //    XmlElement result = doc.CreateElement(this.DriverDictionary.Prefix.Value, this.DriverDictionary.KeySize.Value,
+            //        this.DriverDictionary.Namespace.Value);
+            //    result.AppendChild(doc.CreateTextNode(keySize.ToString(System.Globalization.CultureInfo.InvariantCulture.NumberFormat)));
+            //    return result;
+            //}
 
-            public override XmlElement CreateKeyTypeElement(SecurityKeyType keyType)
-            {
-                if (keyType == SecurityKeyType.SymmetricKey)
-                    return CreateSymmetricKeyTypeElement();
-                else if (keyType == SecurityKeyType.AsymmetricKey)
-                    return CreatePublicKeyTypeElement();
-                else
-                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.GetString(SR.UnableToCreateKeyTypeElementForUnknownKeyType, keyType.ToString())));
-            }
+            //public override XmlElement CreateKeyTypeElement(SecurityKeyType keyType)
+            //{
+            //    if (keyType == SecurityKeyType.SymmetricKey)
+            //        return CreateSymmetricKeyTypeElement();
+            //    else if (keyType == SecurityKeyType.AsymmetricKey)
+            //        return CreatePublicKeyTypeElement();
+            //    else
+            //        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.UnableToCreateKeyTypeElementForUnknownKeyType, keyType.ToString())));
+            //}
 
-            public override bool TryParseKeyTypeElement(XmlElement element, out SecurityKeyType keyType)
-            {
-                if (element == null)
-                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("element");
+            //public override bool TryParseKeyTypeElement(XmlElement element, out SecurityKeyType keyType)
+            //{
+            //    if (element == null)
+            //        throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("element");
 
-                if (TryParseSymmetricKeyElement(element))
-                {
-                    keyType = SecurityKeyType.SymmetricKey;
-                    return true;
-                }
-                else if (TryParsePublicKeyElement(element))
-                {
-                    keyType = SecurityKeyType.AsymmetricKey;
-                    return true;
-                }
+            //    if (TryParseSymmetricKeyElement(element))
+            //    {
+            //        keyType = SecurityKeyType.SymmetricKey;
+            //        return true;
+            //    }
+            //    else if (TryParsePublicKeyElement(element))
+            //    {
+            //        keyType = SecurityKeyType.AsymmetricKey;
+            //        return true;
+            //    }
 
-                keyType = SecurityKeyType.SymmetricKey;
-                return false;
+            //    keyType = SecurityKeyType.SymmetricKey;
+            //    return false;
 
-            }
+            //}
 
             public bool TryParseSymmetricKeyElement(XmlElement element)
             {
@@ -1368,189 +1408,190 @@ namespace System.ServiceModel.Security
                 return result;
             }
 
-            public override bool TryParseTokenTypeElement(XmlElement element, out string tokenType)
-            {
-                if (element == null)
-                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("element");
+            // Issue #31 in progress
+            //public override bool TryParseTokenTypeElement(XmlElement element, out string tokenType)
+            //{
+            //    if (element == null)
+            //        throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("element");
 
-                if (element.LocalName == this.DriverDictionary.TokenType.Value
-                    && element.NamespaceURI == this.DriverDictionary.Namespace.Value)
-                {
-                    tokenType = element.InnerText;
-                    return true;
-                }
+            //    if (element.LocalName == this.DriverDictionary.TokenType.Value
+            //        && element.NamespaceURI == this.DriverDictionary.Namespace.Value)
+            //    {
+            //        tokenType = element.InnerText;
+            //        return true;
+            //    }
 
-                tokenType = null;
-                return false;
-            }
+            //    tokenType = null;
+            //    return false;
+            //}
 
-            public override XmlElement CreateTokenTypeElement(string tokenTypeUri)
-            {
-                if (tokenTypeUri == null)
-                {
-                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("tokenTypeUri");
-                }
-                XmlDocument doc = new XmlDocument();
-                XmlElement result = doc.CreateElement(this.DriverDictionary.Prefix.Value, this.DriverDictionary.TokenType.Value,
-                    this.DriverDictionary.Namespace.Value);
-                result.AppendChild(doc.CreateTextNode(tokenTypeUri));
-                return result;
-            }
+//            public override XmlElement CreateTokenTypeElement(string tokenTypeUri)
+//            {
+//                if (tokenTypeUri == null)
+//                {
+//                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("tokenTypeUri");
+//                }
+//                XmlDocument doc = new XmlDocument();
+//                XmlElement result = doc.CreateElement(this.DriverDictionary.Prefix.Value, this.DriverDictionary.TokenType.Value,
+//                    this.DriverDictionary.Namespace.Value);
+//                result.AppendChild(doc.CreateTextNode(tokenTypeUri));
+//                return result;
+//            }
 
-            public override XmlElement CreateUseKeyElement(SecurityKeyIdentifier keyIdentifier, SecurityStandardsManager standardsManager)
-            {
-                if (keyIdentifier == null)
-                {
-                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("keyIdentifier");
-                }
-                if (standardsManager == null)
-                {
-                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("standardsManager");
-                }
-                XmlDocument doc = new XmlDocument();
-                XmlElement result = doc.CreateElement(this.DriverDictionary.UseKey.Value, this.DriverDictionary.Namespace.Value);
-                MemoryStream stream = new MemoryStream();
-                using (XmlDictionaryWriter writer = XmlDictionaryWriter.CreateDictionaryWriter(new XmlTextWriter(stream, Encoding.UTF8)))
-                {
-#pragma warning suppress 56506 // standardsManager.SecurityTokenSerializer can never be null.
-                    standardsManager.SecurityTokenSerializer.WriteKeyIdentifier(writer, keyIdentifier);
-                    writer.Flush();
-                    stream.Seek(0, SeekOrigin.Begin);
-                    XmlNode skiNode;
-                    using (XmlDictionaryReader reader = XmlDictionaryReader.CreateDictionaryReader(new XmlTextReader(stream) { DtdProcessing = DtdProcessing.Prohibit }))
-                    {
-                        reader.MoveToContent();
-                        skiNode = doc.ReadNode(reader);
-                    }
-                    result.AppendChild(skiNode);
-                }
-                return result;
-            }
+//            public override XmlElement CreateUseKeyElement(SecurityKeyIdentifier keyIdentifier, SecurityStandardsManager standardsManager)
+//            {
+//                if (keyIdentifier == null)
+//                {
+//                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("keyIdentifier");
+//                }
+//                if (standardsManager == null)
+//                {
+//                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("standardsManager");
+//                }
+//                XmlDocument doc = new XmlDocument();
+//                XmlElement result = doc.CreateElement(this.DriverDictionary.UseKey.Value, this.DriverDictionary.Namespace.Value);
+//                MemoryStream stream = new MemoryStream();
+//                using (XmlDictionaryWriter writer = XmlDictionaryWriter.CreateDictionaryWriter(new XmlTextWriter(stream, Encoding.UTF8)))
+//                {
+//#pragma warning suppress 56506 // standardsManager.SecurityTokenSerializer can never be null.
+//                    standardsManager.SecurityTokenSerializer.WriteKeyIdentifier(writer, keyIdentifier);
+//                    writer.Flush();
+//                    stream.Seek(0, SeekOrigin.Begin);
+//                    XmlNode skiNode;
+//                    using (XmlDictionaryReader reader = XmlDictionaryReader.CreateDictionaryReader(new XmlTextReader(stream) { DtdProcessing = DtdProcessing.Prohibit }))
+//                    {
+//                        reader.MoveToContent();
+//                        skiNode = doc.ReadNode(reader);
+//                    }
+//                    result.AppendChild(skiNode);
+//                }
+//                return result;
+//            }
 
-            public override XmlElement CreateSignWithElement(string signatureAlgorithm)
-            {
-                if (signatureAlgorithm == null)
-                {
-                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("signatureAlgorithm");
-                }
-                XmlDocument doc = new XmlDocument();
-                XmlElement result = doc.CreateElement(this.DriverDictionary.Prefix.Value, this.DriverDictionary.SignWith.Value,
-                    this.DriverDictionary.Namespace.Value);
-                result.AppendChild(doc.CreateTextNode(signatureAlgorithm));
-                return result;
-            }
+//            public override XmlElement CreateSignWithElement(string signatureAlgorithm)
+//            {
+//                if (signatureAlgorithm == null)
+//                {
+//                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("signatureAlgorithm");
+//                }
+//                XmlDocument doc = new XmlDocument();
+//                XmlElement result = doc.CreateElement(this.DriverDictionary.Prefix.Value, this.DriverDictionary.SignWith.Value,
+//                    this.DriverDictionary.Namespace.Value);
+//                result.AppendChild(doc.CreateTextNode(signatureAlgorithm));
+//                return result;
+//            }
 
-            internal override bool IsSignWithElement(XmlElement element, out string signatureAlgorithm)
-            {
-                return CheckElement(element, this.DriverDictionary.SignWith.Value, this.DriverDictionary.Namespace.Value, out signatureAlgorithm);
-            }
+//            internal override bool IsSignWithElement(XmlElement element, out string signatureAlgorithm)
+//            {
+//                return CheckElement(element, this.DriverDictionary.SignWith.Value, this.DriverDictionary.Namespace.Value, out signatureAlgorithm);
+//            }
 
-            public override XmlElement CreateEncryptWithElement(string encryptionAlgorithm)
-            {
-                if (encryptionAlgorithm == null)
-                {
-                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("encryptionAlgorithm");
-                }
-                XmlDocument doc = new XmlDocument();
-                XmlElement result = doc.CreateElement(this.DriverDictionary.Prefix.Value, this.DriverDictionary.EncryptWith.Value,
-                    this.DriverDictionary.Namespace.Value);
-                result.AppendChild(doc.CreateTextNode(encryptionAlgorithm));
-                return result;
-            }
+//            public override XmlElement CreateEncryptWithElement(string encryptionAlgorithm)
+//            {
+//                if (encryptionAlgorithm == null)
+//                {
+//                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("encryptionAlgorithm");
+//                }
+//                XmlDocument doc = new XmlDocument();
+//                XmlElement result = doc.CreateElement(this.DriverDictionary.Prefix.Value, this.DriverDictionary.EncryptWith.Value,
+//                    this.DriverDictionary.Namespace.Value);
+//                result.AppendChild(doc.CreateTextNode(encryptionAlgorithm));
+//                return result;
+//            }
 
-            public override XmlElement CreateEncryptionAlgorithmElement(string encryptionAlgorithm)
-            {
-                if (encryptionAlgorithm == null)
-                {
-                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("encryptionAlgorithm");
-                }
-                XmlDocument doc = new XmlDocument();
-                XmlElement result = doc.CreateElement(this.DriverDictionary.Prefix.Value, this.DriverDictionary.EncryptionAlgorithm.Value,
-                    this.DriverDictionary.Namespace.Value);
-                result.AppendChild(doc.CreateTextNode(encryptionAlgorithm));
-                return result;
-            }
+//            public override XmlElement CreateEncryptionAlgorithmElement(string encryptionAlgorithm)
+//            {
+//                if (encryptionAlgorithm == null)
+//                {
+//                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("encryptionAlgorithm");
+//                }
+//                XmlDocument doc = new XmlDocument();
+//                XmlElement result = doc.CreateElement(this.DriverDictionary.Prefix.Value, this.DriverDictionary.EncryptionAlgorithm.Value,
+//                    this.DriverDictionary.Namespace.Value);
+//                result.AppendChild(doc.CreateTextNode(encryptionAlgorithm));
+//                return result;
+//            }
 
-            internal override bool IsEncryptWithElement(XmlElement element, out string encryptWithAlgorithm)
-            {
-                return CheckElement(element, this.DriverDictionary.EncryptWith.Value, this.DriverDictionary.Namespace.Value, out encryptWithAlgorithm);
-            }
+//            internal override bool IsEncryptWithElement(XmlElement element, out string encryptWithAlgorithm)
+//            {
+//                return CheckElement(element, this.DriverDictionary.EncryptWith.Value, this.DriverDictionary.Namespace.Value, out encryptWithAlgorithm);
+//            }
 
-            internal override bool IsEncryptionAlgorithmElement(XmlElement element, out string encryptionAlgorithm)
-            {
-                return CheckElement(element, this.DriverDictionary.EncryptionAlgorithm.Value, this.DriverDictionary.Namespace.Value, out encryptionAlgorithm);
-            }
+//            internal override bool IsEncryptionAlgorithmElement(XmlElement element, out string encryptionAlgorithm)
+//            {
+//                return CheckElement(element, this.DriverDictionary.EncryptionAlgorithm.Value, this.DriverDictionary.Namespace.Value, out encryptionAlgorithm);
+//            }
 
-            public override XmlElement CreateComputedKeyAlgorithmElement(string algorithm)
-            {
-                if (algorithm == null)
-                {
-                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("algorithm");
-                }
-                XmlDocument doc = new XmlDocument();
-                XmlElement result = doc.CreateElement(this.DriverDictionary.Prefix.Value, this.DriverDictionary.ComputedKeyAlgorithm.Value,
-                    this.DriverDictionary.Namespace.Value);
-                result.AppendChild(doc.CreateTextNode(algorithm));
-                return result;
-            }
+//            public override XmlElement CreateComputedKeyAlgorithmElement(string algorithm)
+//            {
+//                if (algorithm == null)
+//                {
+//                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("algorithm");
+//                }
+//                XmlDocument doc = new XmlDocument();
+//                XmlElement result = doc.CreateElement(this.DriverDictionary.Prefix.Value, this.DriverDictionary.ComputedKeyAlgorithm.Value,
+//                    this.DriverDictionary.Namespace.Value);
+//                result.AppendChild(doc.CreateTextNode(algorithm));
+//                return result;
+//            }
 
-            public override XmlElement CreateCanonicalizationAlgorithmElement(string algorithm)
-            {
-                if (algorithm == null)
-                {
-                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("algorithm");
-                }
-                XmlDocument doc = new XmlDocument();
-                XmlElement result = doc.CreateElement(this.DriverDictionary.Prefix.Value, this.DriverDictionary.CanonicalizationAlgorithm.Value,
-                    this.DriverDictionary.Namespace.Value);
-                result.AppendChild(doc.CreateTextNode(algorithm));
-                return result;
-            }
+//            public override XmlElement CreateCanonicalizationAlgorithmElement(string algorithm)
+//            {
+//                if (algorithm == null)
+//                {
+//                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("algorithm");
+//                }
+//                XmlDocument doc = new XmlDocument();
+//                XmlElement result = doc.CreateElement(this.DriverDictionary.Prefix.Value, this.DriverDictionary.CanonicalizationAlgorithm.Value,
+//                    this.DriverDictionary.Namespace.Value);
+//                result.AppendChild(doc.CreateTextNode(algorithm));
+//                return result;
+//            }
 
-            internal override bool IsCanonicalizationAlgorithmElement(XmlElement element, out string canonicalizationAlgorithm)
-            {
-                return CheckElement(element, this.DriverDictionary.CanonicalizationAlgorithm.Value, this.DriverDictionary.Namespace.Value, out canonicalizationAlgorithm);
-            }
+//            internal override bool IsCanonicalizationAlgorithmElement(XmlElement element, out string canonicalizationAlgorithm)
+//            {
+//                return CheckElement(element, this.DriverDictionary.CanonicalizationAlgorithm.Value, this.DriverDictionary.Namespace.Value, out canonicalizationAlgorithm);
+//            }
 
-            public override bool TryParseRequiredClaimsElement(XmlElement element, out System.Collections.ObjectModel.Collection<XmlElement> requiredClaims)
-            {
-                if (element == null)
-                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("element");
+//            public override bool TryParseRequiredClaimsElement(XmlElement element, out System.Collections.ObjectModel.Collection<XmlElement> requiredClaims)
+//            {
+//                if (element == null)
+//                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("element");
 
-                if (element.LocalName == this.DriverDictionary.Claims.Value
-                    && element.NamespaceURI == this.DriverDictionary.Namespace.Value)
-                {
-                    requiredClaims = new System.Collections.ObjectModel.Collection<XmlElement>();
-                    foreach (XmlNode node in element.ChildNodes)
-                        if (node is XmlElement)
-                        {
-                            // PreSharp Bug: Parameter 'requiredClaims' to this public method must be validated: A null-dereference can occur here.
-#pragma warning suppress 56506
-                            requiredClaims.Add((XmlElement)node);
-                        }
-                    return true;
-                }
+//                if (element.LocalName == this.DriverDictionary.Claims.Value
+//                    && element.NamespaceURI == this.DriverDictionary.Namespace.Value)
+//                {
+//                    requiredClaims = new System.Collections.ObjectModel.Collection<XmlElement>();
+//                    foreach (XmlNode node in element.ChildNodes)
+//                        if (node is XmlElement)
+//                        {
+//                            // PreSharp Bug: Parameter 'requiredClaims' to this public method must be validated: A null-dereference can occur here.
+//#pragma warning suppress 56506
+//                            requiredClaims.Add((XmlElement)node);
+//                        }
+//                    return true;
+//                }
 
-                requiredClaims = null;
-                return false;
-            }
+//                requiredClaims = null;
+//                return false;
+//            }
 
-            public override XmlElement CreateRequiredClaimsElement(IEnumerable<XmlElement> claimsList)
-            {
-                if (claimsList == null)
-                {
-                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("claimsList");
-                }
-                XmlDocument doc = new XmlDocument();
-                XmlElement result = doc.CreateElement(this.DriverDictionary.Prefix.Value, this.DriverDictionary.Claims.Value,
-                    this.DriverDictionary.Namespace.Value);
-                foreach (XmlElement claimElement in claimsList)
-                {
-                    XmlElement element = (XmlElement)doc.ImportNode(claimElement, true);
-                    result.AppendChild(element);
-                }
-                return result;
-            }
+//            public override XmlElement CreateRequiredClaimsElement(IEnumerable<XmlElement> claimsList)
+//            {
+//                if (claimsList == null)
+//                {
+//                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("claimsList");
+//                }
+//                XmlDocument doc = new XmlDocument();
+//                XmlElement result = doc.CreateElement(this.DriverDictionary.Prefix.Value, this.DriverDictionary.Claims.Value,
+//                    this.DriverDictionary.Namespace.Value);
+//                foreach (XmlElement claimElement in claimsList)
+//                {
+//                    XmlElement element = (XmlElement)doc.ImportNode(claimElement, true);
+//                    result.AppendChild(element);
+//                }
+//                return result;
+//            }
 
             internal static void ValidateRequestedKeySize(int keySize, SecurityAlgorithmSuite algorithmSuite)
             {
@@ -1560,7 +1601,7 @@ namespace System.ServiceModel.Security
                 }
                 else
                 {
-                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new SecurityNegotiationException(SR.GetString(SR.InvalidKeyLengthRequested, keySize)));
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new SecurityNegotiationException(SR.Format(SR.InvalidKeyLengthRequested, keySize)));
                 }
             }
 
@@ -1569,81 +1610,83 @@ namespace System.ServiceModel.Security
                 if ((mode == SecurityKeyEntropyMode.ClientEntropy || mode == SecurityKeyEntropyMode.CombinedEntropy)
                     && (entropy == null))
                 {
-                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new InvalidOperationException(SR.GetString(SR.EntropyModeRequiresRequestorEntropy, mode)));
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new InvalidOperationException(SR.Format(SR.EntropyModeRequiresRequestorEntropy, mode)));
                 }
                 if (mode == SecurityKeyEntropyMode.ServerEntropy && entropy != null)
                 {
-                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new InvalidOperationException(SR.GetString(SR.EntropyModeCannotHaveRequestorEntropy, mode)));
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new InvalidOperationException(SR.Format(SR.EntropyModeCannotHaveRequestorEntropy, mode)));
                 }
             }
 
             internal static void ProcessRstAndIssueKey(RequestSecurityToken requestSecurityToken, SecurityTokenResolver resolver, SecurityKeyEntropyMode keyEntropyMode, SecurityAlgorithmSuite algorithmSuite, out int issuedKeySize, out byte[] issuerEntropy, out byte[] proofKey,
                 out SecurityToken proofToken)
             {
-                SecurityToken requestorEntropyToken = requestSecurityToken.GetRequestorEntropy(resolver);
-                ValidateRequestorEntropy(requestorEntropyToken, keyEntropyMode);
-                byte[] requestorEntropy;
-                if (requestorEntropyToken != null)
-                {
-                    if (requestorEntropyToken is BinarySecretSecurityToken)
-                    {
-                        BinarySecretSecurityToken skToken = (BinarySecretSecurityToken)requestorEntropyToken;
-                        requestorEntropy = skToken.GetKeyBytes();
-                    }
-                    else if (requestorEntropyToken is WrappedKeySecurityToken)
-                    {
-                        requestorEntropy = ((WrappedKeySecurityToken)requestorEntropyToken).GetWrappedKey();
-                    }
-                    else
-                    {
-                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new InvalidOperationException(SR.GetString(SR.TokenCannotCreateSymmetricCrypto, requestorEntropyToken)));
-                    }
-                }
-                else
-                {
-                    requestorEntropy = null;
-                }
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
 
-                if (keyEntropyMode == SecurityKeyEntropyMode.ClientEntropy)
-                {
-                    if (requestorEntropy != null)
-                    {
-                        // validate that the entropy length matches the algorithm suite
-                        ValidateRequestedKeySize(requestorEntropy.Length * 8, algorithmSuite);
-                    }
-                    proofKey = requestorEntropy;
-                    issuerEntropy = null;
-                    issuedKeySize = 0;
-                    proofToken = null;
-                }
-                else
-                {
-                    if (requestSecurityToken.KeySize != 0)
-                    {
-                        ValidateRequestedKeySize(requestSecurityToken.KeySize, algorithmSuite);
-                        issuedKeySize = requestSecurityToken.KeySize;
-                    }
-                    else
-                    {
-                        issuedKeySize = algorithmSuite.DefaultSymmetricKeyLength;
-                    }
-                    RNGCryptoServiceProvider random = new RNGCryptoServiceProvider();
-                    if (keyEntropyMode == SecurityKeyEntropyMode.ServerEntropy)
-                    {
-                        proofKey = new byte[issuedKeySize / 8];
-                        // proof key is completely issued by the server
-                        random.GetNonZeroBytes(proofKey);
-                        issuerEntropy = null;
-                        proofToken = new BinarySecretSecurityToken(proofKey);
-                    }
-                    else
-                    {
-                        issuerEntropy = new byte[issuedKeySize / 8];
-                        random.GetNonZeroBytes(issuerEntropy);
-                        proofKey = RequestSecurityTokenResponse.ComputeCombinedKey(requestorEntropy, issuerEntropy, issuedKeySize);
-                        proofToken = null;
-                    }
-                }
+                //SecurityToken requestorEntropyToken = requestSecurityToken.GetRequestorEntropy(resolver);
+                //ValidateRequestorEntropy(requestorEntropyToken, keyEntropyMode);
+                //byte[] requestorEntropy;
+                //if (requestorEntropyToken != null)
+                //{
+                //    if (requestorEntropyToken is BinarySecretSecurityToken)
+                //    {
+                //        BinarySecretSecurityToken skToken = (BinarySecretSecurityToken)requestorEntropyToken;
+                //        requestorEntropy = skToken.GetKeyBytes();
+                //    }
+                //    else if (requestorEntropyToken is WrappedKeySecurityToken)
+                //    {
+                //        requestorEntropy = ((WrappedKeySecurityToken)requestorEntropyToken).GetWrappedKey();
+                //    }
+                //    else
+                //    {
+                //        throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new InvalidOperationException(SR.Format(SR.TokenCannotCreateSymmetricCrypto, requestorEntropyToken)));
+                //    }
+                //}
+                //else
+                //{
+                //    requestorEntropy = null;
+                //}
+
+                //if (keyEntropyMode == SecurityKeyEntropyMode.ClientEntropy)
+                //{
+                //    if (requestorEntropy != null)
+                //    {
+                //        // validate that the entropy length matches the algorithm suite
+                //        ValidateRequestedKeySize(requestorEntropy.Length * 8, algorithmSuite);
+                //    }
+                //    proofKey = requestorEntropy;
+                //    issuerEntropy = null;
+                //    issuedKeySize = 0;
+                //    proofToken = null;
+                //}
+                //else
+                //{
+                //    if (requestSecurityToken.KeySize != 0)
+                //    {
+                //        ValidateRequestedKeySize(requestSecurityToken.KeySize, algorithmSuite);
+                //        issuedKeySize = requestSecurityToken.KeySize;
+                //    }
+                //    else
+                //    {
+                //        issuedKeySize = algorithmSuite.DefaultSymmetricKeyLength;
+                //    }
+                //    RNGCryptoServiceProvider random = new RNGCryptoServiceProvider();
+                //    if (keyEntropyMode == SecurityKeyEntropyMode.ServerEntropy)
+                //    {
+                //        proofKey = new byte[issuedKeySize / 8];
+                //        // proof key is completely issued by the server
+                //        random.GetNonZeroBytes(proofKey);
+                //        issuerEntropy = null;
+                //        proofToken = new BinarySecretSecurityToken(proofKey);
+                //    }
+                //    else
+                //    {
+                //        issuerEntropy = new byte[issuedKeySize / 8];
+                //        random.GetNonZeroBytes(issuerEntropy);
+                //        proofKey = RequestSecurityTokenResponse.ComputeCombinedKey(requestorEntropy, issuerEntropy, issuedKeySize);
+                //        proofToken = null;
+                //    }
+                //}
             }
 
         }

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/WSTrust.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/WSTrust.cs
@@ -1453,7 +1453,6 @@ namespace System.ServiceModel.Security
 //                MemoryStream stream = new MemoryStream();
 //                using (XmlDictionaryWriter writer = XmlDictionaryWriter.CreateDictionaryWriter(new XmlTextWriter(stream, Encoding.UTF8)))
 //                {
-//#pragma warning suppress 56506 // standardsManager.SecurityTokenSerializer can never be null.
 //                    standardsManager.SecurityTokenSerializer.WriteKeyIdentifier(writer, keyIdentifier);
 //                    writer.Flush();
 //                    stream.Seek(0, SeekOrigin.Begin);
@@ -1565,8 +1564,6 @@ namespace System.ServiceModel.Security
 //                    foreach (XmlNode node in element.ChildNodes)
 //                        if (node is XmlElement)
 //                        {
-//                            // PreSharp Bug: Parameter 'requiredClaims' to this public method must be validated: A null-dereference can occur here.
-//#pragma warning suppress 56506
 //                            requiredClaims.Add((XmlElement)node);
 //                        }
 //                    return true;

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/WSTrustDec2005.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/WSTrustDec2005.cs
@@ -1,0 +1,189 @@
+//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace System.ServiceModel.Security
+{
+    using System;
+    using System.ServiceModel;
+    using System.ServiceModel.Description;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Collections.ObjectModel;
+    using System.Diagnostics;
+    using System.Globalization;
+    using System.IO;
+    using System.Text;
+    using System.Threading;
+    using System.Xml;
+    using System.IdentityModel.Claims;
+    using System.IdentityModel.Policy;
+    using System.IdentityModel.Tokens;
+    using System.Security.Cryptography.X509Certificates;
+    using System.ServiceModel.Security.Tokens;
+    using HexBinary = System.Runtime.Remoting.Metadata.W3cXsd2001.SoapHexBinary;
+    using System.ServiceModel.Channels;
+    using System.ServiceModel.Security;
+    using System.Runtime.Serialization;
+    using System.ServiceModel.Dispatcher;
+
+    using KeyIdentifierEntry = WSSecurityTokenSerializer.KeyIdentifierEntry;
+    using KeyIdentifierClauseEntry = WSSecurityTokenSerializer.KeyIdentifierClauseEntry;
+    using TokenEntry = WSSecurityTokenSerializer.TokenEntry;
+    using StrEntry = WSSecurityTokenSerializer.StrEntry;
+
+    class WSTrustDec2005 : WSTrustFeb2005
+    {
+        public WSTrustDec2005(WSSecurityTokenSerializer tokenSerializer)
+            : base(tokenSerializer)
+        {
+        }
+
+        public override TrustDictionary SerializerDictionary
+        {
+            get { return DXD.TrustDec2005Dictionary; }
+        }
+
+        public class DriverDec2005 : WSTrustFeb2005.DriverFeb2005
+        {
+            public DriverDec2005(SecurityStandardsManager standardsManager)
+                : base(standardsManager)
+            {
+            }
+
+            public override TrustDictionary DriverDictionary
+            {
+                get
+                {
+                    return DXD.TrustDec2005Dictionary;
+                }
+            }
+
+            public override XmlDictionaryString RequestSecurityTokenResponseFinalAction
+            {
+                get
+                {
+                    return DXD.TrustDec2005Dictionary.RequestSecurityTokenCollectionIssuanceFinalResponse;
+                }
+            }
+
+            public override XmlElement CreateKeyTypeElement(SecurityKeyType keyType)
+            {
+                if (keyType == SecurityKeyType.BearerKey)
+                {
+                    XmlDocument doc = new XmlDocument();
+                    XmlElement result = doc.CreateElement(this.DriverDictionary.Prefix.Value, this.DriverDictionary.KeyType.Value,
+                        this.DriverDictionary.Namespace.Value);
+                    result.AppendChild(doc.CreateTextNode(DXD.TrustDec2005Dictionary.BearerKeyType.Value));
+                    return result;
+                }
+
+                return base.CreateKeyTypeElement(keyType);
+            }
+
+            public override bool TryParseKeyTypeElement(XmlElement element, out SecurityKeyType keyType)
+            {
+                if (element == null)
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("element");
+
+                if (element.LocalName == this.DriverDictionary.KeyType.Value
+                    && element.NamespaceURI == this.DriverDictionary.Namespace.Value
+                    && element.InnerText == DXD.TrustDec2005Dictionary.BearerKeyType.Value)
+                {
+                    keyType = SecurityKeyType.BearerKey;
+                    return true;
+                }
+
+                return base.TryParseKeyTypeElement(element, out keyType);
+            }
+
+            public override XmlElement CreateRequiredClaimsElement(IEnumerable<XmlElement> claimsList)
+            {
+                XmlElement result = base.CreateRequiredClaimsElement(claimsList);
+                XmlAttribute dialectAttribute = result.OwnerDocument.CreateAttribute(DXD.TrustDec2005Dictionary.Dialect.Value);
+                dialectAttribute.Value = DXD.TrustDec2005Dictionary.DialectType.Value;
+                result.Attributes.Append(dialectAttribute);
+
+                return result;
+            }
+
+            public override IChannelFactory<IRequestChannel> CreateFederationProxy(EndpointAddress address, Binding binding, KeyedByTypeCollection<IEndpointBehavior> channelBehaviors)
+            {
+                if (channelBehaviors == null)
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("channelBehaviors");
+
+                ChannelFactory<IWsTrustDec2005SecurityTokenService> result = new ChannelFactory<IWsTrustDec2005SecurityTokenService>(binding, address);
+                SetProtectionLevelForFederation(result.Endpoint.Contract.Operations);
+                // remove the default client credentials that gets added to channel factories
+                result.Endpoint.Behaviors.Remove<ClientCredentials>();
+                for (int i = 0; i < channelBehaviors.Count; ++i)
+                {
+                    result.Endpoint.Behaviors.Add(channelBehaviors[i]);
+                }
+                // add a behavior that removes the UI channel initializer added by the client credentials since there should be no UI
+                // initializer popped up as part of obtaining the federation token (the UI should already have been popped up for the main channel)
+                result.Endpoint.Behaviors.Add(new WSTrustFeb2005.DriverFeb2005.InteractiveInitializersRemovingBehavior());
+
+                return new WSTrustFeb2005.DriverFeb2005.RequestChannelFactory<IWsTrustDec2005SecurityTokenService>(result);
+            }
+
+            public override Collection<XmlElement> ProcessUnknownRequestParameters(Collection<XmlElement> unknownRequestParameters, Collection<XmlElement> originalRequestParameters)
+            {
+                // For WS-Trust 1.3 we want everything in the requestSecurityTokenTemplate parameters to endup as Addtional parameters.
+                // The parameters will appear as a child element under a XmlElement named secondaryParameters.
+                if (originalRequestParameters == null)
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("originalRequestParameters");
+
+                if (originalRequestParameters.Count > 0 && originalRequestParameters[0] != null && originalRequestParameters[0].OwnerDocument != null)
+                {
+                    XmlElement secondaryParamElement = originalRequestParameters[0].OwnerDocument.CreateElement(DXD.TrustDec2005Dictionary.Prefix.Value, DXD.TrustDec2005Dictionary.SecondaryParameters.Value, DXD.TrustDec2005Dictionary.Namespace.Value);
+                    for (int i = 0; i < originalRequestParameters.Count; ++i)
+                    {
+                        secondaryParamElement.AppendChild(originalRequestParameters[i]);
+                    }
+
+                    Collection<XmlElement> tempCollection = new Collection<XmlElement>();
+                    tempCollection.Add(secondaryParamElement);
+                    return tempCollection;
+                }
+
+                return originalRequestParameters;
+            }
+
+            internal virtual bool IsSecondaryParametersElement(XmlElement element)
+            {
+                return ((element.LocalName == DXD.TrustDec2005Dictionary.SecondaryParameters.Value) &&
+                        (element.NamespaceURI == DXD.TrustDec2005Dictionary.Namespace.Value));
+            }
+
+            public virtual XmlElement CreateKeyWrapAlgorithmElement(string keyWrapAlgorithm)
+            {
+                if (keyWrapAlgorithm == null)
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("keyWrapAlgorithm");
+                }
+                XmlDocument doc = new XmlDocument();
+                XmlElement result = doc.CreateElement(DXD.TrustDec2005Dictionary.Prefix.Value, DXD.TrustDec2005Dictionary.KeyWrapAlgorithm.Value,
+                    DXD.TrustDec2005Dictionary.Namespace.Value);
+                result.AppendChild(doc.CreateTextNode(keyWrapAlgorithm));
+                return result;
+            }
+
+            internal override bool IsKeyWrapAlgorithmElement(XmlElement element, out string keyWrapAlgorithm)
+            {
+                return CheckElement(element, DXD.TrustDec2005Dictionary.KeyWrapAlgorithm.Value, DXD.TrustDec2005Dictionary.Namespace.Value, out keyWrapAlgorithm);
+            }
+
+            [ServiceContract]
+            internal interface IWsTrustDec2005SecurityTokenService
+            {
+                [OperationContract(IsOneWay = false,
+                                   Action = TrustDec2005Strings.RequestSecurityTokenIssuance,
+                                   ReplyAction = TrustDec2005Strings.RequestSecurityTokenCollectionIssuanceFinalResponse)]
+                [FaultContract(typeof(string), Action = "*", ProtectionLevel = System.Net.Security.ProtectionLevel.Sign)]
+                Message RequestToken(Message message);
+            }
+        }
+    }
+}
+

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/WSTrustDec2005.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/WSTrustDec2005.cs
@@ -1,37 +1,38 @@
-//------------------------------------------------------------
-// Copyright (c) Microsoft Corporation.  All rights reserved.
-//------------------------------------------------------------
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.ServiceModel;
+using System.ServiceModel.Description;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Diagnostics;
+using System.Globalization;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Xml;
+using System.IdentityModel.Claims;
+using System.IdentityModel.Policy;
+using System.IdentityModel.Tokens;
+using System.Security.Cryptography.X509Certificates;
+using System.ServiceModel.Security.Tokens;
+// Issue #31 in progress
+//using HexBinary = System.Runtime.Remoting.Metadata.W3cXsd2001.SoapHexBinary;
+using System.ServiceModel.Channels;
+using System.ServiceModel.Security;
+using System.Runtime.Serialization;
+using System.ServiceModel.Dispatcher;
+
+using KeyIdentifierEntry = System.ServiceModel.Security.WSSecurityTokenSerializer.KeyIdentifierEntry;
+using KeyIdentifierClauseEntry = System.ServiceModel.Security.WSSecurityTokenSerializer.KeyIdentifierClauseEntry;
+using TokenEntry = System.ServiceModel.Security.WSSecurityTokenSerializer.TokenEntry;
+using StrEntry = System.ServiceModel.Security.WSSecurityTokenSerializer.StrEntry;
 
 namespace System.ServiceModel.Security
 {
-    using System;
-    using System.ServiceModel;
-    using System.ServiceModel.Description;
-    using System.Collections;
-    using System.Collections.Generic;
-    using System.Collections.ObjectModel;
-    using System.Diagnostics;
-    using System.Globalization;
-    using System.IO;
-    using System.Text;
-    using System.Threading;
-    using System.Xml;
-    using System.IdentityModel.Claims;
-    using System.IdentityModel.Policy;
-    using System.IdentityModel.Tokens;
-    using System.Security.Cryptography.X509Certificates;
-    using System.ServiceModel.Security.Tokens;
-    using HexBinary = System.Runtime.Remoting.Metadata.W3cXsd2001.SoapHexBinary;
-    using System.ServiceModel.Channels;
-    using System.ServiceModel.Security;
-    using System.Runtime.Serialization;
-    using System.ServiceModel.Dispatcher;
-
-    using KeyIdentifierEntry = WSSecurityTokenSerializer.KeyIdentifierEntry;
-    using KeyIdentifierClauseEntry = WSSecurityTokenSerializer.KeyIdentifierClauseEntry;
-    using TokenEntry = WSSecurityTokenSerializer.TokenEntry;
-    using StrEntry = WSSecurityTokenSerializer.StrEntry;
-
     class WSTrustDec2005 : WSTrustFeb2005
     {
         public WSTrustDec2005(WSSecurityTokenSerializer tokenSerializer)
@@ -67,45 +68,46 @@ namespace System.ServiceModel.Security
                 }
             }
 
-            public override XmlElement CreateKeyTypeElement(SecurityKeyType keyType)
-            {
-                if (keyType == SecurityKeyType.BearerKey)
-                {
-                    XmlDocument doc = new XmlDocument();
-                    XmlElement result = doc.CreateElement(this.DriverDictionary.Prefix.Value, this.DriverDictionary.KeyType.Value,
-                        this.DriverDictionary.Namespace.Value);
-                    result.AppendChild(doc.CreateTextNode(DXD.TrustDec2005Dictionary.BearerKeyType.Value));
-                    return result;
-                }
+            // Issue #31 in progress
+            //public override XmlElement CreateKeyTypeElement(SecurityKeyType keyType)
+            //{
+            //    if (keyType == SecurityKeyType.BearerKey)
+            //    {
+            //        XmlDocument doc = new XmlDocument();
+            //        XmlElement result = doc.CreateElement(this.DriverDictionary.Prefix.Value, this.DriverDictionary.KeyType.Value,
+            //            this.DriverDictionary.Namespace.Value);
+            //        result.AppendChild(doc.CreateTextNode(DXD.TrustDec2005Dictionary.BearerKeyType.Value));
+            //        return result;
+            //    }
 
-                return base.CreateKeyTypeElement(keyType);
-            }
+            //    return base.CreateKeyTypeElement(keyType);
+            //}
 
-            public override bool TryParseKeyTypeElement(XmlElement element, out SecurityKeyType keyType)
-            {
-                if (element == null)
-                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("element");
+            //public override bool TryParseKeyTypeElement(XmlElement element, out SecurityKeyType keyType)
+            //{
+            //    if (element == null)
+            //        throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("element");
 
-                if (element.LocalName == this.DriverDictionary.KeyType.Value
-                    && element.NamespaceURI == this.DriverDictionary.Namespace.Value
-                    && element.InnerText == DXD.TrustDec2005Dictionary.BearerKeyType.Value)
-                {
-                    keyType = SecurityKeyType.BearerKey;
-                    return true;
-                }
+            //    if (element.LocalName == this.DriverDictionary.KeyType.Value
+            //        && element.NamespaceURI == this.DriverDictionary.Namespace.Value
+            //        && element.InnerText == DXD.TrustDec2005Dictionary.BearerKeyType.Value)
+            //    {
+            //        keyType = SecurityKeyType.BearerKey;
+            //        return true;
+            //    }
 
-                return base.TryParseKeyTypeElement(element, out keyType);
-            }
+            //    return base.TryParseKeyTypeElement(element, out keyType);
+            //}
 
-            public override XmlElement CreateRequiredClaimsElement(IEnumerable<XmlElement> claimsList)
-            {
-                XmlElement result = base.CreateRequiredClaimsElement(claimsList);
-                XmlAttribute dialectAttribute = result.OwnerDocument.CreateAttribute(DXD.TrustDec2005Dictionary.Dialect.Value);
-                dialectAttribute.Value = DXD.TrustDec2005Dictionary.DialectType.Value;
-                result.Attributes.Append(dialectAttribute);
+            //public override XmlElement CreateRequiredClaimsElement(IEnumerable<XmlElement> claimsList)
+            //{
+            //    XmlElement result = base.CreateRequiredClaimsElement(claimsList);
+            //    XmlAttribute dialectAttribute = result.OwnerDocument.CreateAttribute(DXD.TrustDec2005Dictionary.Dialect.Value);
+            //    dialectAttribute.Value = DXD.TrustDec2005Dictionary.DialectType.Value;
+            //    result.Attributes.Append(dialectAttribute);
 
-                return result;
-            }
+            //    return result;
+            //}
 
             public override IChannelFactory<IRequestChannel> CreateFederationProxy(EndpointAddress address, Binding binding, KeyedByTypeCollection<IEndpointBehavior> channelBehaviors)
             {
@@ -127,29 +129,6 @@ namespace System.ServiceModel.Security
                 return new WSTrustFeb2005.DriverFeb2005.RequestChannelFactory<IWsTrustDec2005SecurityTokenService>(result);
             }
 
-            public override Collection<XmlElement> ProcessUnknownRequestParameters(Collection<XmlElement> unknownRequestParameters, Collection<XmlElement> originalRequestParameters)
-            {
-                // For WS-Trust 1.3 we want everything in the requestSecurityTokenTemplate parameters to endup as Addtional parameters.
-                // The parameters will appear as a child element under a XmlElement named secondaryParameters.
-                if (originalRequestParameters == null)
-                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("originalRequestParameters");
-
-                if (originalRequestParameters.Count > 0 && originalRequestParameters[0] != null && originalRequestParameters[0].OwnerDocument != null)
-                {
-                    XmlElement secondaryParamElement = originalRequestParameters[0].OwnerDocument.CreateElement(DXD.TrustDec2005Dictionary.Prefix.Value, DXD.TrustDec2005Dictionary.SecondaryParameters.Value, DXD.TrustDec2005Dictionary.Namespace.Value);
-                    for (int i = 0; i < originalRequestParameters.Count; ++i)
-                    {
-                        secondaryParamElement.AppendChild(originalRequestParameters[i]);
-                    }
-
-                    Collection<XmlElement> tempCollection = new Collection<XmlElement>();
-                    tempCollection.Add(secondaryParamElement);
-                    return tempCollection;
-                }
-
-                return originalRequestParameters;
-            }
-
             internal virtual bool IsSecondaryParametersElement(XmlElement element)
             {
                 return ((element.LocalName == DXD.TrustDec2005Dictionary.SecondaryParameters.Value) &&
@@ -169,10 +148,11 @@ namespace System.ServiceModel.Security
                 return result;
             }
 
-            internal override bool IsKeyWrapAlgorithmElement(XmlElement element, out string keyWrapAlgorithm)
-            {
-                return CheckElement(element, DXD.TrustDec2005Dictionary.KeyWrapAlgorithm.Value, DXD.TrustDec2005Dictionary.Namespace.Value, out keyWrapAlgorithm);
-            }
+            // Issue #31 in progress
+            //internal override bool IsKeyWrapAlgorithmElement(XmlElement element, out string keyWrapAlgorithm)
+            //{
+            //    return CheckElement(element, DXD.TrustDec2005Dictionary.KeyWrapAlgorithm.Value, DXD.TrustDec2005Dictionary.Namespace.Value, out keyWrapAlgorithm);
+            //}
 
             [ServiceContract]
             internal interface IWsTrustDec2005SecurityTokenService

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/WSTrustDec2005.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/WSTrustDec2005.cs
@@ -3,33 +3,11 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.ServiceModel;
-using System.ServiceModel.Description;
-using System.Collections;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
-using System.Diagnostics;
-using System.Globalization;
-using System.IO;
-using System.Text;
-using System.Threading;
-using System.Xml;
-using System.IdentityModel.Claims;
-using System.IdentityModel.Policy;
-using System.IdentityModel.Tokens;
-using System.Security.Cryptography.X509Certificates;
-using System.ServiceModel.Security.Tokens;
-// Issue #31 in progress
-//using HexBinary = System.Runtime.Remoting.Metadata.W3cXsd2001.SoapHexBinary;
 using System.ServiceModel.Channels;
-using System.ServiceModel.Security;
-using System.Runtime.Serialization;
-using System.ServiceModel.Dispatcher;
-
-using KeyIdentifierEntry = System.ServiceModel.Security.WSSecurityTokenSerializer.KeyIdentifierEntry;
-using KeyIdentifierClauseEntry = System.ServiceModel.Security.WSSecurityTokenSerializer.KeyIdentifierClauseEntry;
-using TokenEntry = System.ServiceModel.Security.WSSecurityTokenSerializer.TokenEntry;
-using StrEntry = System.ServiceModel.Security.WSSecurityTokenSerializer.StrEntry;
+using System.ServiceModel.Description;
+using System.Xml;
+//using HexBinary = System.Runtime.Remoting.Metadata.W3cXsd2001.SoapHexBinary;  // Issue #31 in progress
 
 namespace System.ServiceModel.Security
 {

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/WSTrustFeb2005.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/WSTrustFeb2005.cs
@@ -1,37 +1,38 @@
-//------------------------------------------------------------
-// Copyright (c) Microsoft Corporation.  All rights reserved.
-//------------------------------------------------------------
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.ServiceModel;
+using System.ServiceModel.Description;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Diagnostics;
+using System.Globalization;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Xml;
+using System.IdentityModel.Claims;
+using System.IdentityModel.Policy;
+using System.IdentityModel.Tokens;
+using System.Security.Cryptography.X509Certificates;
+using System.ServiceModel.Security.Tokens;
+//using HexBinary = System.Runtime.Remoting.Metadata.W3cXsd2001.SoapHexBinary;
+using System.ServiceModel.Channels;
+using System.ServiceModel.Security;
+using System.Runtime.Serialization;
+using System.ServiceModel.Dispatcher;
+
+using KeyIdentifierEntry = System.ServiceModel.Security.WSSecurityTokenSerializer.KeyIdentifierEntry;
+using KeyIdentifierClauseEntry = System.ServiceModel.Security.WSSecurityTokenSerializer.KeyIdentifierClauseEntry;
+using TokenEntry = System.ServiceModel.Security.WSSecurityTokenSerializer.TokenEntry;
+using StrEntry = System.ServiceModel.Security.WSSecurityTokenSerializer.StrEntry;
+
 
 namespace System.ServiceModel.Security
 {
-    using System;
-    using System.ServiceModel;
-    using System.ServiceModel.Description;
-    using System.Collections;
-    using System.Collections.Generic;
-    using System.Collections.ObjectModel;
-    using System.Diagnostics;
-    using System.Globalization;
-    using System.IO;
-    using System.Text;
-    using System.Threading;
-    using System.Xml;
-    using System.IdentityModel.Claims;
-    using System.IdentityModel.Policy;
-    using System.IdentityModel.Tokens;
-    using System.Security.Cryptography.X509Certificates;
-    using System.ServiceModel.Security.Tokens;
-    using HexBinary = System.Runtime.Remoting.Metadata.W3cXsd2001.SoapHexBinary;
-    using System.ServiceModel.Channels;
-    using System.ServiceModel.Security;
-    using System.Runtime.Serialization;
-    using System.ServiceModel.Dispatcher;
-
-    using KeyIdentifierEntry = WSSecurityTokenSerializer.KeyIdentifierEntry;
-    using KeyIdentifierClauseEntry = WSSecurityTokenSerializer.KeyIdentifierClauseEntry;
-    using TokenEntry = WSSecurityTokenSerializer.TokenEntry;
-    using StrEntry = WSSecurityTokenSerializer.StrEntry;
-
     class WSTrustFeb2005 : WSTrust
     {
         public WSTrustFeb2005(WSSecurityTokenSerializer tokenSerializer)
@@ -115,11 +116,6 @@ namespace System.ServiceModel.Security
                 }
             }
 
-            public override Collection<XmlElement> ProcessUnknownRequestParameters(Collection<XmlElement> unknownRequestParameters, Collection<XmlElement> originalRequestParameters)
-            {
-                return unknownRequestParameters;
-            }
-
             protected override void ReadReferences(XmlElement rstrXml, out SecurityKeyIdentifierClause requestedAttachedReference,
                     out SecurityKeyIdentifierClause requestedUnattachedReference)
             {
@@ -150,19 +146,20 @@ namespace System.ServiceModel.Security
                 {
                     if (issuedTokenXml != null)
                     {
-                        if (requestedAttachedReference == null)
-                        {
-                            this.StandardsManager.TryCreateKeyIdentifierClauseFromTokenXml(issuedTokenXml, SecurityTokenReferenceStyle.Internal, out requestedAttachedReference);
-                        }
-                        if (requestedUnattachedReference == null)
-                        {
-                            this.StandardsManager.TryCreateKeyIdentifierClauseFromTokenXml(issuedTokenXml, SecurityTokenReferenceStyle.External, out requestedUnattachedReference);
-                        }
+                        throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+                        //if (requestedAttachedReference == null)
+                        //{
+                        //    this.StandardsManager.TryCreateKeyIdentifierClauseFromTokenXml(issuedTokenXml, SecurityTokenReferenceStyle.Internal, out requestedAttachedReference);
+                        //}
+                        //if (requestedUnattachedReference == null)
+                        //{
+                        //    this.StandardsManager.TryCreateKeyIdentifierClauseFromTokenXml(issuedTokenXml, SecurityTokenReferenceStyle.External, out requestedUnattachedReference);
+                        //}
                     }
                 }
                 catch (XmlException)
                 {
-                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new XmlException(SR.GetString(SR.TrustDriverIsUnableToCreatedNecessaryAttachedOrUnattachedReferences, issuedTokenXml.ToString())));
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new XmlException(SR.Format(SR.TrustDriverIsUnableToCreatedNecessaryAttachedOrUnattachedReferences, issuedTokenXml.ToString())));
                 }
 
             }
@@ -193,29 +190,32 @@ namespace System.ServiceModel.Security
                     XmlElement child = (rstXml.ChildNodes[i] as XmlElement);
                     if (child != null)
                     {
-                        if (child.LocalName == this.DriverDictionary.RenewTarget.Value && child.NamespaceURI == this.DriverDictionary.Namespace.Value)
-                            renewTarget = this.StandardsManager.SecurityTokenSerializer.ReadKeyIdentifierClause(new XmlNodeReader(child.FirstChild));
-                        else if (child.LocalName == this.DriverDictionary.CloseTarget.Value && child.NamespaceURI == this.DriverDictionary.Namespace.Value)
-                            closeTarget = this.StandardsManager.SecurityTokenSerializer.ReadKeyIdentifierClause(new XmlNodeReader(child.FirstChild));
+                        throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+                        //if (child.LocalName == this.DriverDictionary.RenewTarget.Value && child.NamespaceURI == this.DriverDictionary.Namespace.Value)
+                        //    renewTarget = this.StandardsManager.SecurityTokenSerializer.ReadKeyIdentifierClause(new XmlNodeReader(child.FirstChild));
+                        //else if (child.LocalName == this.DriverDictionary.CloseTarget.Value && child.NamespaceURI == this.DriverDictionary.Namespace.Value)
+                        //    closeTarget = this.StandardsManager.SecurityTokenSerializer.ReadKeyIdentifierClause(new XmlNodeReader(child.FirstChild));
                     }
                 }
             }
 
             protected override void WriteReferences(RequestSecurityTokenResponse rstr, XmlDictionaryWriter writer)
             {
-                if (rstr.RequestedAttachedReference != null)
-                {
-                    writer.WriteStartElement(this.DriverDictionary.Prefix.Value, this.DriverDictionary.RequestedAttachedReference, this.DriverDictionary.Namespace);
-                    this.StandardsManager.SecurityTokenSerializer.WriteKeyIdentifierClause(writer, rstr.RequestedAttachedReference);
-                    writer.WriteEndElement();
-                }
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
 
-                if (rstr.RequestedUnattachedReference != null)
-                {
-                    writer.WriteStartElement(this.DriverDictionary.Prefix.Value, this.DriverDictionary.RequestedUnattachedReference, this.DriverDictionary.Namespace);
-                    this.StandardsManager.SecurityTokenSerializer.WriteKeyIdentifierClause(writer, rstr.RequestedUnattachedReference);
-                    writer.WriteEndElement();
-                }
+                //if (rstr.RequestedAttachedReference != null)
+                //{
+                //    writer.WriteStartElement(this.DriverDictionary.Prefix.Value, this.DriverDictionary.RequestedAttachedReference, this.DriverDictionary.Namespace);
+                //    this.StandardsManager.SecurityTokenSerializer.WriteKeyIdentifierClause(writer, rstr.RequestedAttachedReference);
+                //    writer.WriteEndElement();
+                //}
+
+                //if (rstr.RequestedUnattachedReference != null)
+                //{
+                //    writer.WriteStartElement(this.DriverDictionary.Prefix.Value, this.DriverDictionary.RequestedUnattachedReference, this.DriverDictionary.Namespace);
+                //    this.StandardsManager.SecurityTokenSerializer.WriteKeyIdentifierClause(writer, rstr.RequestedUnattachedReference);
+                //    writer.WriteEndElement();
+                //}
             }
 
             protected override void WriteRequestedTokenClosed(RequestSecurityTokenResponse rstr, XmlDictionaryWriter writer)
@@ -228,19 +228,21 @@ namespace System.ServiceModel.Security
 
             protected override void WriteTargets(RequestSecurityToken rst, XmlDictionaryWriter writer)
             {
-                if (rst.RenewTarget != null)
-                {
-                    writer.WriteStartElement(this.DriverDictionary.Prefix.Value, this.DriverDictionary.RenewTarget, this.DriverDictionary.Namespace);
-                    this.StandardsManager.SecurityTokenSerializer.WriteKeyIdentifierClause(writer, rst.RenewTarget);
-                    writer.WriteEndElement();
-                }
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
 
-                if (rst.CloseTarget != null)
-                {
-                    writer.WriteStartElement(this.DriverDictionary.Prefix.Value, this.DriverDictionary.CloseTarget, this.DriverDictionary.Namespace);
-                    this.StandardsManager.SecurityTokenSerializer.WriteKeyIdentifierClause(writer, rst.CloseTarget);
-                    writer.WriteEndElement();
-                }
+                //if (rst.RenewTarget != null)
+                //{
+                //    writer.WriteStartElement(this.DriverDictionary.Prefix.Value, this.DriverDictionary.RenewTarget, this.DriverDictionary.Namespace);
+                //    this.StandardsManager.SecurityTokenSerializer.WriteKeyIdentifierClause(writer, rst.RenewTarget);
+                //    writer.WriteEndElement();
+                //}
+
+                //if (rst.CloseTarget != null)
+                //{
+                //    writer.WriteStartElement(this.DriverDictionary.Prefix.Value, this.DriverDictionary.CloseTarget, this.DriverDictionary.Namespace);
+                //    this.StandardsManager.SecurityTokenSerializer.WriteKeyIdentifierClause(writer, rst.CloseTarget);
+                //    writer.WriteEndElement();
+                //}
             }
 
             // this is now the abstract in WSTrust
@@ -293,65 +295,66 @@ namespace System.ServiceModel.Security
 
             public class RequestChannelFactory<TokenService> : ChannelFactoryBase, IChannelFactory<IRequestChannel>
             {
-                ChannelFactory<TokenService> innerChannelFactory;
+                ChannelFactory<TokenService> _innerChannelFactory;
 
                 public RequestChannelFactory(ChannelFactory<TokenService> innerChannelFactory)
                 {
-                    this.innerChannelFactory = innerChannelFactory;
+                    _innerChannelFactory = innerChannelFactory;
                 }
 
                 public IRequestChannel CreateChannel(EndpointAddress address)
                 {
-                    return this.innerChannelFactory.CreateChannel<IRequestChannel>(address);
+                    throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+                    //return this.innerChannelFactory.CreateChannel<IRequestChannel>(address);
                 }
 
                 public IRequestChannel CreateChannel(EndpointAddress address, Uri via)
                 {
-                    return this.innerChannelFactory.CreateChannel<IRequestChannel>(address, via);
+                    throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+                    //return this.innerChannelFactory.CreateChannel<IRequestChannel>(address, via);
                 }
 
                 protected override void OnAbort()
                 {
-                    this.innerChannelFactory.Abort();
+                    _innerChannelFactory.Abort();
                 }
 
                 protected override IAsyncResult OnBeginOpen(TimeSpan timeout, AsyncCallback callback, object state)
                 {
-                    return this.innerChannelFactory.BeginOpen(timeout, callback, state);
+                    return _innerChannelFactory.BeginOpen(timeout, callback, state);
                 }
 
                 protected override void OnEndOpen(IAsyncResult result)
                 {
-                    this.innerChannelFactory.EndOpen(result);
+                    _innerChannelFactory.EndOpen(result);
                 }
 
                 protected override IAsyncResult OnBeginClose(TimeSpan timeout, AsyncCallback callback, object state)
                 {
-                    return this.innerChannelFactory.BeginClose(timeout, callback, state);
+                    return _innerChannelFactory.BeginClose(timeout, callback, state);
                 }
 
                 protected override void OnEndClose(IAsyncResult result)
                 {
-                    this.innerChannelFactory.EndClose(result);
+                    _innerChannelFactory.EndClose(result);
                 }
 
                 protected override void OnClose(TimeSpan timeout)
                 {
-                    this.innerChannelFactory.Close(timeout);
+                    _innerChannelFactory.Close(timeout);
                 }
 
                 protected override void OnOpen(TimeSpan timeout)
                 {
-                    this.innerChannelFactory.Open(timeout);
+                    _innerChannelFactory.Open(timeout);
                 }
 
                 public override T GetProperty<T>()
                 {
-                    return this.innerChannelFactory.GetProperty<T>();
+                    return _innerChannelFactory.GetProperty<T>();
                 }
             }
         }
-
     }
 }
 

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/WSTrustFeb2005.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/WSTrustFeb2005.cs
@@ -3,33 +3,13 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.ServiceModel;
-using System.ServiceModel.Description;
-using System.Collections;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
-using System.Diagnostics;
-using System.Globalization;
-using System.IO;
-using System.Text;
-using System.Threading;
-using System.Xml;
-using System.IdentityModel.Claims;
-using System.IdentityModel.Policy;
 using System.IdentityModel.Tokens;
-using System.Security.Cryptography.X509Certificates;
-using System.ServiceModel.Security.Tokens;
-//using HexBinary = System.Runtime.Remoting.Metadata.W3cXsd2001.SoapHexBinary;
+//using HexBinary = System.Runtime.Remoting.Metadata.W3cXsd2001.SoapHexBinary;  // Issue #31 in progress
 using System.ServiceModel.Channels;
-using System.ServiceModel.Security;
-using System.Runtime.Serialization;
+using System.ServiceModel.Description;
 using System.ServiceModel.Dispatcher;
-
-using KeyIdentifierEntry = System.ServiceModel.Security.WSSecurityTokenSerializer.KeyIdentifierEntry;
-using KeyIdentifierClauseEntry = System.ServiceModel.Security.WSSecurityTokenSerializer.KeyIdentifierClauseEntry;
-using TokenEntry = System.ServiceModel.Security.WSSecurityTokenSerializer.TokenEntry;
-using StrEntry = System.ServiceModel.Security.WSSecurityTokenSerializer.StrEntry;
-
+using System.Xml;
 
 namespace System.ServiceModel.Security
 {

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/WSTrustFeb2005.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/WSTrustFeb2005.cs
@@ -1,0 +1,357 @@
+//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace System.ServiceModel.Security
+{
+    using System;
+    using System.ServiceModel;
+    using System.ServiceModel.Description;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Collections.ObjectModel;
+    using System.Diagnostics;
+    using System.Globalization;
+    using System.IO;
+    using System.Text;
+    using System.Threading;
+    using System.Xml;
+    using System.IdentityModel.Claims;
+    using System.IdentityModel.Policy;
+    using System.IdentityModel.Tokens;
+    using System.Security.Cryptography.X509Certificates;
+    using System.ServiceModel.Security.Tokens;
+    using HexBinary = System.Runtime.Remoting.Metadata.W3cXsd2001.SoapHexBinary;
+    using System.ServiceModel.Channels;
+    using System.ServiceModel.Security;
+    using System.Runtime.Serialization;
+    using System.ServiceModel.Dispatcher;
+
+    using KeyIdentifierEntry = WSSecurityTokenSerializer.KeyIdentifierEntry;
+    using KeyIdentifierClauseEntry = WSSecurityTokenSerializer.KeyIdentifierClauseEntry;
+    using TokenEntry = WSSecurityTokenSerializer.TokenEntry;
+    using StrEntry = WSSecurityTokenSerializer.StrEntry;
+
+    class WSTrustFeb2005 : WSTrust
+    {
+        public WSTrustFeb2005(WSSecurityTokenSerializer tokenSerializer)
+            : base(tokenSerializer)
+        {
+        }
+
+        public override TrustDictionary SerializerDictionary
+        {
+            get { return XD.TrustFeb2005Dictionary; }
+        }
+
+        public class DriverFeb2005 : Driver
+        {
+            public DriverFeb2005(SecurityStandardsManager standardsManager)
+                : base(standardsManager)
+            {
+            }
+
+            public override TrustDictionary DriverDictionary
+            {
+                get
+                {
+                    return XD.TrustFeb2005Dictionary;
+                }
+            }
+
+            public override XmlDictionaryString RequestSecurityTokenResponseFinalAction
+            {
+                get
+                {
+                    return XD.TrustFeb2005Dictionary.RequestSecurityTokenIssuanceResponse;
+                }
+            }
+
+            public override bool IsSessionSupported
+            {
+                get
+                {
+                    return true;
+                }
+            }
+
+            public override bool IsIssuedTokensSupported
+            {
+                get
+                {
+                    return true;
+                }
+            }
+
+            public override string IssuedTokensHeaderName
+            {
+                get
+                {
+                    return this.DriverDictionary.IssuedTokensHeader.Value;
+                }
+            }
+
+            public override string IssuedTokensHeaderNamespace
+            {
+                get
+                {
+                    return this.DriverDictionary.Namespace.Value;
+                }
+            }
+
+            public override string RequestTypeRenew
+            {
+                get
+                {
+                    return this.DriverDictionary.RequestTypeRenew.Value;
+                }
+            }
+
+            public override string RequestTypeClose
+            {
+                get
+                {
+                    return this.DriverDictionary.RequestTypeClose.Value;
+                }
+            }
+
+            public override Collection<XmlElement> ProcessUnknownRequestParameters(Collection<XmlElement> unknownRequestParameters, Collection<XmlElement> originalRequestParameters)
+            {
+                return unknownRequestParameters;
+            }
+
+            protected override void ReadReferences(XmlElement rstrXml, out SecurityKeyIdentifierClause requestedAttachedReference,
+                    out SecurityKeyIdentifierClause requestedUnattachedReference)
+            {
+                XmlElement issuedTokenXml = null;
+                requestedAttachedReference = null;
+                requestedUnattachedReference = null;
+                for (int i = 0; i < rstrXml.ChildNodes.Count; ++i)
+                {
+                    XmlElement child = rstrXml.ChildNodes[i] as XmlElement;
+                    if (child != null)
+                    {
+                        if (child.LocalName == this.DriverDictionary.RequestedSecurityToken.Value && child.NamespaceURI == this.DriverDictionary.Namespace.Value)
+                        {
+                            issuedTokenXml = XmlHelper.GetChildElement(child);
+                        }
+                        else if (child.LocalName == this.DriverDictionary.RequestedAttachedReference.Value && child.NamespaceURI == this.DriverDictionary.Namespace.Value)
+                        {
+                            requestedAttachedReference = GetKeyIdentifierXmlReferenceClause(XmlHelper.GetChildElement(child));
+                        }
+                        else if (child.LocalName == this.DriverDictionary.RequestedUnattachedReference.Value && child.NamespaceURI == this.DriverDictionary.Namespace.Value)
+                        {
+                            requestedUnattachedReference = GetKeyIdentifierXmlReferenceClause(XmlHelper.GetChildElement(child));
+                        }
+                    }
+                }
+
+                try
+                {
+                    if (issuedTokenXml != null)
+                    {
+                        if (requestedAttachedReference == null)
+                        {
+                            this.StandardsManager.TryCreateKeyIdentifierClauseFromTokenXml(issuedTokenXml, SecurityTokenReferenceStyle.Internal, out requestedAttachedReference);
+                        }
+                        if (requestedUnattachedReference == null)
+                        {
+                            this.StandardsManager.TryCreateKeyIdentifierClauseFromTokenXml(issuedTokenXml, SecurityTokenReferenceStyle.External, out requestedUnattachedReference);
+                        }
+                    }
+                }
+                catch (XmlException)
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new XmlException(SR.GetString(SR.TrustDriverIsUnableToCreatedNecessaryAttachedOrUnattachedReferences, issuedTokenXml.ToString())));
+                }
+
+            }
+
+            protected override bool ReadRequestedTokenClosed(XmlElement rstrXml)
+            {
+                for (int i = 0; i < rstrXml.ChildNodes.Count; ++i)
+                {
+                    XmlElement child = (rstrXml.ChildNodes[i] as XmlElement);
+                    if (child != null)
+                    {
+                        if (child.LocalName == this.DriverDictionary.RequestedTokenClosed.Value && child.NamespaceURI == this.DriverDictionary.Namespace.Value)
+                        {
+                            return true;
+                        }
+                    }
+                }
+                return false;
+            }
+
+            protected override void ReadTargets(XmlElement rstXml, out SecurityKeyIdentifierClause renewTarget, out SecurityKeyIdentifierClause closeTarget)
+            {
+                renewTarget = null;
+                closeTarget = null;
+
+                for (int i = 0; i < rstXml.ChildNodes.Count; ++i)
+                {
+                    XmlElement child = (rstXml.ChildNodes[i] as XmlElement);
+                    if (child != null)
+                    {
+                        if (child.LocalName == this.DriverDictionary.RenewTarget.Value && child.NamespaceURI == this.DriverDictionary.Namespace.Value)
+                            renewTarget = this.StandardsManager.SecurityTokenSerializer.ReadKeyIdentifierClause(new XmlNodeReader(child.FirstChild));
+                        else if (child.LocalName == this.DriverDictionary.CloseTarget.Value && child.NamespaceURI == this.DriverDictionary.Namespace.Value)
+                            closeTarget = this.StandardsManager.SecurityTokenSerializer.ReadKeyIdentifierClause(new XmlNodeReader(child.FirstChild));
+                    }
+                }
+            }
+
+            protected override void WriteReferences(RequestSecurityTokenResponse rstr, XmlDictionaryWriter writer)
+            {
+                if (rstr.RequestedAttachedReference != null)
+                {
+                    writer.WriteStartElement(this.DriverDictionary.Prefix.Value, this.DriverDictionary.RequestedAttachedReference, this.DriverDictionary.Namespace);
+                    this.StandardsManager.SecurityTokenSerializer.WriteKeyIdentifierClause(writer, rstr.RequestedAttachedReference);
+                    writer.WriteEndElement();
+                }
+
+                if (rstr.RequestedUnattachedReference != null)
+                {
+                    writer.WriteStartElement(this.DriverDictionary.Prefix.Value, this.DriverDictionary.RequestedUnattachedReference, this.DriverDictionary.Namespace);
+                    this.StandardsManager.SecurityTokenSerializer.WriteKeyIdentifierClause(writer, rstr.RequestedUnattachedReference);
+                    writer.WriteEndElement();
+                }
+            }
+
+            protected override void WriteRequestedTokenClosed(RequestSecurityTokenResponse rstr, XmlDictionaryWriter writer)
+            {
+                if (rstr.IsRequestedTokenClosed)
+                {
+                    writer.WriteElementString(this.DriverDictionary.RequestedTokenClosed, this.DriverDictionary.Namespace, String.Empty);
+                }
+            }
+
+            protected override void WriteTargets(RequestSecurityToken rst, XmlDictionaryWriter writer)
+            {
+                if (rst.RenewTarget != null)
+                {
+                    writer.WriteStartElement(this.DriverDictionary.Prefix.Value, this.DriverDictionary.RenewTarget, this.DriverDictionary.Namespace);
+                    this.StandardsManager.SecurityTokenSerializer.WriteKeyIdentifierClause(writer, rst.RenewTarget);
+                    writer.WriteEndElement();
+                }
+
+                if (rst.CloseTarget != null)
+                {
+                    writer.WriteStartElement(this.DriverDictionary.Prefix.Value, this.DriverDictionary.CloseTarget, this.DriverDictionary.Namespace);
+                    this.StandardsManager.SecurityTokenSerializer.WriteKeyIdentifierClause(writer, rst.CloseTarget);
+                    writer.WriteEndElement();
+                }
+            }
+
+            // this is now the abstract in WSTrust
+            public override IChannelFactory<IRequestChannel> CreateFederationProxy(EndpointAddress address, Binding binding, KeyedByTypeCollection<IEndpointBehavior> channelBehaviors)
+            {
+                if (channelBehaviors == null)
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("channelBehaviors");
+
+                ChannelFactory<IWsTrustFeb2005SecurityTokenService> result = new ChannelFactory<IWsTrustFeb2005SecurityTokenService>(binding, address);
+                SetProtectionLevelForFederation(result.Endpoint.Contract.Operations);
+                // remove the default client credentials that gets added to channel factories
+                result.Endpoint.Behaviors.Remove<ClientCredentials>();
+                for (int i = 0; i < channelBehaviors.Count; ++i)
+                {
+                    result.Endpoint.Behaviors.Add(channelBehaviors[i]);
+                }
+                // add a behavior that removes the UI channel initializer added by the client credentials since there should be no UI
+                // initializer popped up as part of obtaining the federation token (the UI should already have been popped up for the main channel)
+                result.Endpoint.Behaviors.Add(new InteractiveInitializersRemovingBehavior());
+
+                return new RequestChannelFactory<IWsTrustFeb2005SecurityTokenService>(result);
+            }
+
+            [ServiceContract]
+            internal interface IWsTrustFeb2005SecurityTokenService
+            {
+                [OperationContract(IsOneWay = false,
+                                   Action = TrustFeb2005Strings.RequestSecurityTokenIssuance,
+                                   ReplyAction = TrustFeb2005Strings.RequestSecurityTokenIssuanceResponse)]
+                [FaultContract(typeof(string), Action = "*", ProtectionLevel = System.Net.Security.ProtectionLevel.Sign)]
+                Message RequestToken(Message message);
+            }
+
+            public class InteractiveInitializersRemovingBehavior : IEndpointBehavior
+            {
+                public void Validate(ServiceEndpoint serviceEndpoint) { }
+                public void AddBindingParameters(ServiceEndpoint serviceEndpoint, BindingParameterCollection bindingParameters) { }
+                public void ApplyDispatchBehavior(ServiceEndpoint serviceEndpoint, EndpointDispatcher endpointDispatcher) { }
+                public void ApplyClientBehavior(ServiceEndpoint serviceEndpoint, ClientRuntime behavior)
+                {
+                    // it is very unlikely that InteractiveChannelInitializers will be null, this is defensive in case ClientRuntime every has a 
+                    // bug.  I am OK with this as ApplyingClientBehavior is a one-time channel setup.
+                    if (behavior != null && behavior.InteractiveChannelInitializers != null)
+                    {
+                        // clear away any interactive initializer
+                        behavior.InteractiveChannelInitializers.Clear();
+                    }
+                }
+            }
+
+            public class RequestChannelFactory<TokenService> : ChannelFactoryBase, IChannelFactory<IRequestChannel>
+            {
+                ChannelFactory<TokenService> innerChannelFactory;
+
+                public RequestChannelFactory(ChannelFactory<TokenService> innerChannelFactory)
+                {
+                    this.innerChannelFactory = innerChannelFactory;
+                }
+
+                public IRequestChannel CreateChannel(EndpointAddress address)
+                {
+                    return this.innerChannelFactory.CreateChannel<IRequestChannel>(address);
+                }
+
+                public IRequestChannel CreateChannel(EndpointAddress address, Uri via)
+                {
+                    return this.innerChannelFactory.CreateChannel<IRequestChannel>(address, via);
+                }
+
+                protected override void OnAbort()
+                {
+                    this.innerChannelFactory.Abort();
+                }
+
+                protected override IAsyncResult OnBeginOpen(TimeSpan timeout, AsyncCallback callback, object state)
+                {
+                    return this.innerChannelFactory.BeginOpen(timeout, callback, state);
+                }
+
+                protected override void OnEndOpen(IAsyncResult result)
+                {
+                    this.innerChannelFactory.EndOpen(result);
+                }
+
+                protected override IAsyncResult OnBeginClose(TimeSpan timeout, AsyncCallback callback, object state)
+                {
+                    return this.innerChannelFactory.BeginClose(timeout, callback, state);
+                }
+
+                protected override void OnEndClose(IAsyncResult result)
+                {
+                    this.innerChannelFactory.EndClose(result);
+                }
+
+                protected override void OnClose(TimeSpan timeout)
+                {
+                    this.innerChannelFactory.Close(timeout);
+                }
+
+                protected override void OnOpen(TimeSpan timeout)
+                {
+                    this.innerChannelFactory.Open(timeout);
+                }
+
+                public override T GetProperty<T>()
+                {
+                    return this.innerChannelFactory.GetProperty<T>();
+                }
+            }
+        }
+
+    }
+}
+

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/WrapperSecurityCommunicationObject.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/WrapperSecurityCommunicationObject.cs
@@ -2,9 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-
 using System.ServiceModel.Channels;
-using System.ServiceModel.Diagnostics;
 using System.IdentityModel.Selectors;
 using System.Runtime.Diagnostics;
 using System.Threading.Tasks;
@@ -45,7 +43,6 @@ namespace System.ServiceModel.Security
         {
             _innerCommunicationObject.OnAbort();
         }
-
 
         protected override IAsyncResult OnBeginClose(TimeSpan timeout, AsyncCallback callback, object state)
         {

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/WrapperSecurityCommunicationObject.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/WrapperSecurityCommunicationObject.cs
@@ -8,6 +8,7 @@ using System.ServiceModel.Diagnostics;
 using System.IdentityModel.Selectors;
 using System.Runtime.Diagnostics;
 using System.Threading.Tasks;
+using System.Runtime;
 
 namespace System.ServiceModel.Security
 {
@@ -45,14 +46,17 @@ namespace System.ServiceModel.Security
             _innerCommunicationObject.OnAbort();
         }
 
+
         protected override IAsyncResult OnBeginClose(TimeSpan timeout, AsyncCallback callback, object state)
         {
-            return _innerCommunicationObject.OnBeginClose(timeout, callback, state);
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+            //return _innerCommunicationObject.OnBeginClose(timeout, callback, state);
         }
 
         protected override IAsyncResult OnBeginOpen(TimeSpan timeout, AsyncCallback callback, object state)
         {
-            return _innerCommunicationObject.OnBeginOpen(timeout, callback, state);
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+            //return _innerCommunicationObject.OnBeginOpen(timeout, callback, state);
         }
 
         protected override void OnClose(TimeSpan timeout)
@@ -74,12 +78,14 @@ namespace System.ServiceModel.Security
 
         protected override void OnEndClose(IAsyncResult result)
         {
-            _innerCommunicationObject.OnEndClose(result);
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+            //_innerCommunicationObject.OnEndClose(result);
         }
 
         protected override void OnEndOpen(IAsyncResult result)
         {
-            _innerCommunicationObject.OnEndOpen(result);
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+            //_innerCommunicationObject.OnEndOpen(result);
         }
 
         protected override void OnFaulted()
@@ -110,30 +116,14 @@ namespace System.ServiceModel.Security
             base.ThrowIfDisposedOrImmutable();
         }
 
-        protected internal override async Task OnCloseAsync(TimeSpan timeout)
+        protected internal override Task OnCloseAsync(TimeSpan timeout)
         {
-            var asyncInnerCommunicationObject = _innerCommunicationObject as IAsyncCommunicationObject;
-            if (asyncInnerCommunicationObject != null)
-            {
-                await asyncInnerCommunicationObject.CloseAsync(timeout);
-            }
-            else
-            {
-                this.OnClose(timeout);
-            }
+            return _innerCommunicationObject.OnCloseAsync(timeout);
         }
 
-        protected internal override async Task OnOpenAsync(TimeSpan timeout)
+        protected internal override Task OnOpenAsync(TimeSpan timeout)
         {
-            var asyncInnerCommunicationObject = _innerCommunicationObject as IAsyncCommunicationObject;
-            if (asyncInnerCommunicationObject != null)
-            {
-                await asyncInnerCommunicationObject.OpenAsync(timeout);
-            }
-            else
-            {
-                this.OnOpen(timeout);
-            }
+            return _innerCommunicationObject.OnOpenAsync(timeout);
         }
     }
 
@@ -220,6 +210,11 @@ namespace System.ServiceModel.Security
             _communicationObject.Close();
         }
 
+        public Task CloseAsync(TimeSpan timeout)
+        {
+            return ((IAsyncCommunicationObject)_communicationObject).CloseAsync(timeout);
+        }
+
         public void Close(TimeSpan timeout)
         {
             _communicationObject.Close(timeout);
@@ -227,17 +222,20 @@ namespace System.ServiceModel.Security
 
         public IAsyncResult BeginClose(AsyncCallback callback, object state)
         {
-            return _communicationObject.BeginClose(callback, state);
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+            //return _communicationObject.BeginClose(callback, state);
         }
 
         public IAsyncResult BeginClose(TimeSpan timeout, AsyncCallback callback, object state)
         {
-            return _communicationObject.BeginClose(timeout, callback, state);
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+            //return _communicationObject.BeginClose(timeout, callback, state);
         }
 
         public void EndClose(IAsyncResult result)
         {
-            _communicationObject.EndClose(result);
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+           // _communicationObject.EndClose(result);
         }
 
         public void Open()
@@ -250,19 +248,27 @@ namespace System.ServiceModel.Security
             _communicationObject.Open(timeout);
         }
 
+        public Task OpenAsync(TimeSpan timeout)
+        {
+            return ((IAsyncCommunicationObject)_communicationObject).OpenAsync(timeout);
+        }
+
         public IAsyncResult BeginOpen(AsyncCallback callback, object state)
         {
-            return _communicationObject.BeginOpen(callback, state);
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+            //return _communicationObject.BeginOpen(callback, state);
         }
 
         public IAsyncResult BeginOpen(TimeSpan timeout, AsyncCallback callback, object state)
         {
-            return _communicationObject.BeginOpen(timeout, callback, state);
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+            //return _communicationObject.BeginOpen(timeout, callback, state);
         }
 
         public void EndOpen(IAsyncResult result)
         {
-            _communicationObject.EndOpen(result);
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+            //_communicationObject.EndOpen(result);
         }
 
         public void Dispose()
@@ -277,16 +283,23 @@ namespace System.ServiceModel.Security
 
         public IAsyncResult OnBeginClose(TimeSpan timeout, AsyncCallback callback, object state)
         {
-            return new OperationWithTimeoutAsyncResult(this.OnClose, timeout, callback, state);
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+            //return new OperationWithTimeoutAsyncResult(this.OnClose, timeout, callback, state);
         }
 
         public IAsyncResult OnBeginOpen(TimeSpan timeout, AsyncCallback callback, object state)
         {
-            return new OperationWithTimeoutAsyncResult(this.OnOpen, timeout, callback, state);
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+            //return new OperationWithTimeoutAsyncResult(this.OnOpen, timeout, callback, state);
         }
 
         public virtual void OnClose(TimeSpan timeout)
         {
+        }
+
+        public virtual Task OnCloseAsync(TimeSpan timeout)
+        {
+            return TaskHelpers.CompletedTask();
         }
 
         public virtual void OnClosed()
@@ -299,12 +312,14 @@ namespace System.ServiceModel.Security
 
         public void OnEndClose(IAsyncResult result)
         {
-            OperationWithTimeoutAsyncResult.End(result);
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+            //OperationWithTimeoutAsyncResult.End(result);
         }
 
         public void OnEndOpen(IAsyncResult result)
         {
-            OperationWithTimeoutAsyncResult.End(result);
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+            //OperationWithTimeoutAsyncResult.End(result);
         }
 
         public virtual void OnFaulted()
@@ -314,6 +329,11 @@ namespace System.ServiceModel.Security
 
         public virtual void OnOpen(TimeSpan timeout)
         {
+        }
+
+        public virtual Task OnOpenAsync(TimeSpan timeout)
+        {
+            return TaskHelpers.CompletedTask();
         }
 
         public virtual void OnOpened()
@@ -400,19 +420,27 @@ namespace System.ServiceModel.Security
             _communicationObject.Close(timeout);
         }
 
+        public Task CloseAsync(TimeSpan timeout)
+        {
+            return ((IAsyncCommunicationObject)_communicationObject).CloseAsync(timeout);
+        }
+
         public IAsyncResult BeginClose(AsyncCallback callback, object state)
         {
-            return _communicationObject.BeginClose(callback, state);
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+           // return _communicationObject.BeginClose(callback, state);
         }
 
         public IAsyncResult BeginClose(TimeSpan timeout, AsyncCallback callback, object state)
         {
-            return _communicationObject.BeginClose(timeout, callback, state);
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+            //return _communicationObject.BeginClose(timeout, callback, state);
         }
 
         public void EndClose(IAsyncResult result)
         {
-            _communicationObject.EndClose(result);
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+            //_communicationObject.EndClose(result);
         }
 
         public void Open()
@@ -425,19 +453,27 @@ namespace System.ServiceModel.Security
             _communicationObject.Open(timeout);
         }
 
+        public Task OpenAsync(TimeSpan timeout)
+        {
+            return ((IAsyncCommunicationObject)_communicationObject).OpenAsync(timeout);
+        }
+
         public IAsyncResult BeginOpen(AsyncCallback callback, object state)
         {
-            return _communicationObject.BeginOpen(callback, state);
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+            //return _communicationObject.BeginOpen(callback, state);
         }
 
         public IAsyncResult BeginOpen(TimeSpan timeout, AsyncCallback callback, object state)
         {
-            return _communicationObject.BeginOpen(timeout, callback, state);
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+            //return _communicationObject.BeginOpen(timeout, callback, state);
         }
 
         public void EndOpen(IAsyncResult result)
         {
-            _communicationObject.EndOpen(result);
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+            //_communicationObject.EndOpen(result);
         }
 
         public void Dispose()
@@ -462,6 +498,11 @@ namespace System.ServiceModel.Security
 
         public virtual void OnClose(TimeSpan timeout)
         {
+        }
+
+        public virtual Task OnCloseAsync(TimeSpan timeout)
+        {
+            return TaskHelpers.CompletedTask();
         }
 
         public virtual void OnClosed()
@@ -489,6 +530,11 @@ namespace System.ServiceModel.Security
 
         public virtual void OnOpen(TimeSpan timeout)
         {
+        }
+
+        public virtual Task OnOpenAsync(TimeSpan timeout)
+        {
+            return TaskHelpers.CompletedTask();
         }
 
         public virtual void OnOpened()

--- a/src/System.Private.ServiceModel/tests/Common/Scenarios/Endpoints.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Scenarios/Endpoints.cs
@@ -268,6 +268,14 @@ public static partial class Endpoints
         }
     }
 
+    public static string WsHttpTransSecUserName_Address
+    {
+        get
+        {
+            return GetEndpointAddress("WsHttpTranSecUserName.svc//wshttp-transec-username", protocol: "https");
+        }
+    }
+
     #region Secure WebSocket Addresses
     public static string WebSocketHttpsDuplexBinaryStreamed_Address
     {

--- a/src/System.Private.ServiceModel/tests/Common/Scenarios/ScenarioTestTypes.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Scenarios/ScenarioTestTypes.cs
@@ -1321,7 +1321,7 @@ public partial class XmlMessageContractTestResponse
 
     public XmlMessageContractTestResponse(string message)
     {
-        this._message = message;
+        _message = message;
     }
 
     [MessageHeader(Name = "OutOfBandData", Namespace = "http://www.contoso.com", MustUnderstand = false)]

--- a/src/System.Private.ServiceModel/tests/Common/Scenarios/ServiceInterfaces.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Scenarios/ServiceInterfaces.cs
@@ -259,6 +259,9 @@ public interface IWcfCustomUserNameService
 {
     [OperationContract(Action = "http://tempuri.org/IWcfCustomUserNameService/Echo")]
     String Echo(String message);
+
+    [OperationContract(Action = "http://tempuri.org/IWcfCustomUserNameService/Echo")]
+    Task<String> EchoAsync(String message);
 }
 
 [ServiceContract(
@@ -534,4 +537,14 @@ public interface IVerifyWebSockets
 {
     [OperationContract()]
     bool ValidateWebSocketsUsed();
+}
+
+[ServiceContract]
+public interface IWsTrustService
+{
+    [OperationContract]
+    String EchoWithTimeout(String message, TimeSpan serviceOperationTimeout);
+
+    [OperationContract(Action = "http://tempuri.org/IWsTrustService/EchoWithTimeout")]
+    Task<String> EchoWithTimeoutAsync(String message, TimeSpan serviceOperationTimeout);
 }

--- a/src/System.Private.ServiceModel/tests/Common/Scenarios/ServiceInterfaces.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Scenarios/ServiceInterfaces.cs
@@ -539,12 +539,3 @@ public interface IVerifyWebSockets
     bool ValidateWebSocketsUsed();
 }
 
-[ServiceContract]
-public interface IWsTrustService
-{
-    [OperationContract]
-    String EchoWithTimeout(String message, TimeSpan serviceOperationTimeout);
-
-    [OperationContract(Action = "http://tempuri.org/IWsTrustService/EchoWithTimeout")]
-    Task<String> EchoWithTimeoutAsync(String message, TimeSpan serviceOperationTimeout);
-}

--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Https/WsHttpsTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Https/WsHttpsTests.cs
@@ -4,15 +4,14 @@
 
 
 using System;
-using System.Net;
 using System.ServiceModel;
 using System.ServiceModel.Channels;
-using System.ServiceModel.Security;
 using System.Text;
+using System.Threading.Tasks;
 using Infrastructure.Common;
 
 using Xunit;
-using System.Threading.Tasks;
+
 
 public static partial class WsHttpsTests
 {

--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Https/WsHttpsTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Https/WsHttpsTests.cs
@@ -1,0 +1,187 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+
+using System;
+using System.Net;
+using System.ServiceModel;
+using System.ServiceModel.Channels;
+using System.ServiceModel.Security;
+using System.Text;
+using Infrastructure.Common;
+
+using Xunit;
+using System.Threading.Tasks;
+
+public static partial class WsHttpsTests
+{
+#if FULLXUNIT_NOTSUPPORTED
+    [Fact]
+#endif
+    [WcfFact]
+    [OuterLoop]
+    public static void CreateUserNameOverTransportBindingElement_Round_Trips()
+    {
+        ChannelFactory<IWcfCustomUserNameService> factory = null;
+        IWcfCustomUserNameService serviceProxy = null;
+        string testString = "Hello";
+        CustomBinding binding;
+        EndpointAddress endpointAddress = null;
+
+        try
+        {
+            // *** SETUP *** \\
+            var securityBindingElement = SecurityBindingElement.CreateUserNameOverTransportBindingElement();
+            securityBindingElement.IncludeTimestamp = false;
+            securityBindingElement.SecurityHeaderLayout = SecurityHeaderLayout.Lax;
+
+            binding = new CustomBinding(
+                            new TextMessageEncodingBindingElement(MessageVersion.Soap11, Encoding.UTF8), 
+                            securityBindingElement,
+                            new HttpsTransportBindingElement());
+
+            endpointAddress = new EndpointAddress(Endpoints.WsHttpTransSecUserName_Address);
+            factory = new ChannelFactory<IWcfCustomUserNameService>(binding, endpointAddress);
+            factory.Credentials.UserName.UserName = "test1";
+            factory.Credentials.UserName.Password = "Mytestpwd1";
+
+            serviceProxy = factory.CreateChannel();
+
+            // *** EXECUTE *** \\
+            string result = serviceProxy.Echo(testString);
+
+            // *** VALIDATE *** \\
+            Assert.True(result == testString, string.Format("Error: expected response from service: '{0}' Actual was: '{1}'", testString, result));
+
+            // *** CLEANUP *** \\
+            factory.Close();
+            ((ICommunicationObject)serviceProxy).Close();
+        }
+        finally
+        {
+            // *** ENSURE CLEANUP *** \\
+            ScenarioTestHelpers.CloseCommunicationObjects((ICommunicationObject)serviceProxy, factory);
+        }
+    }
+
+#if FULLXUNIT_NOTSUPPORTED
+    [Fact]
+#endif
+    [WcfFact]
+    [OuterLoop]
+    public static void CreateUserNameOverTransportBindingElement_Throws_Wrong_Credentials()
+    {
+        ChannelFactory<IWcfCustomUserNameService> factory = null;
+        IWcfCustomUserNameService serviceProxy = null;
+        string testString = "Hello";
+        CustomBinding binding;
+        EndpointAddress endpointAddress = null;
+        FaultException faultException = null;
+
+        try
+        {
+            // *** SETUP *** \\
+            var securityBindingElement = SecurityBindingElement.CreateUserNameOverTransportBindingElement();
+            securityBindingElement.IncludeTimestamp = false;
+            securityBindingElement.SecurityHeaderLayout = SecurityHeaderLayout.Lax;
+
+            binding = new CustomBinding(
+                            new TextMessageEncodingBindingElement(MessageVersion.Soap11, Encoding.UTF8),
+                            securityBindingElement,
+                            new HttpsTransportBindingElement());
+
+            endpointAddress = new EndpointAddress(Endpoints.WsHttpTransSecUserName_Address);
+            factory = new ChannelFactory<IWcfCustomUserNameService>(binding, endpointAddress);
+            factory.Credentials.UserName.UserName = "nottest1";
+            factory.Credentials.UserName.Password = "notMytestpwd1";
+
+            serviceProxy = factory.CreateChannel();
+
+            // *** EXECUTE *** \\
+            faultException = Assert.Throws<FaultException>(() =>
+            {
+                serviceProxy.Echo(testString);
+            });
+
+            // *** VALIDATE *** \\
+            string expectedFaultCode = "InvalidSecurityToken";
+            Assert.True(String.Equals(faultException.Code.Name, expectedFaultCode, StringComparison.OrdinalIgnoreCase),
+                        String.Format("Expected FaultCode '{0}' but actual was '{1}'", expectedFaultCode, faultException.Code.Name));
+
+            // *** CLEANUP *** \\
+            factory.Close();
+            ((ICommunicationObject)serviceProxy).Close();
+        }
+        finally
+        {
+            // *** ENSURE CLEANUP *** \\
+            ScenarioTestHelpers.CloseCommunicationObjects((ICommunicationObject)serviceProxy, factory);
+        }
+    }
+
+
+#if FULLXUNIT_NOTSUPPORTED
+    [Fact]
+#endif
+    [WcfFact]
+    [OuterLoop]
+    [Issue(1494)]
+    public static void CreateUserNameOverTransportBindingElement_Round_Trips_Async()
+    {
+        ChannelFactory<IWcfCustomUserNameService> factory = null;
+        IWcfCustomUserNameService serviceProxy = null;
+        string testString = "Hello";
+        CustomBinding binding;
+        EndpointAddress endpointAddress = null;
+
+        try
+        {
+            // *** SETUP *** \\
+            var securityBindingElement = SecurityBindingElement.CreateUserNameOverTransportBindingElement();
+            securityBindingElement.IncludeTimestamp = false;
+            securityBindingElement.SecurityHeaderLayout = SecurityHeaderLayout.Lax;
+
+            binding = new CustomBinding(
+                            new TextMessageEncodingBindingElement(MessageVersion.Soap11, Encoding.UTF8),
+                            securityBindingElement,
+                            new HttpsTransportBindingElement());
+
+            endpointAddress = new EndpointAddress(Endpoints.WsHttpTransSecUserName_Address);
+            factory = new ChannelFactory<IWcfCustomUserNameService>(binding, endpointAddress);
+            factory.Credentials.UserName.UserName = "test1";
+            factory.Credentials.UserName.Password = "Mytestpwd1";
+
+            // *** EXECUTE *** \\
+            // Async factory open is part of the code under test
+            Task t = Task.Factory.FromAsync(factory.BeginOpen, factory.EndOpen, TaskCreationOptions.None);
+            t.GetAwaiter().GetResult();
+
+            serviceProxy = factory.CreateChannel();
+
+            Task<string> echoTask = serviceProxy.EchoAsync(testString);
+            string result = echoTask.GetAwaiter().GetResult();
+
+            // *** VALIDATE *** \\
+
+            Assert.True(result == testString, string.Format("Error: expected response from service: '{0}' Actual was: '{1}'", testString, result));
+
+            // Async factory close is also code under test
+            t = Task.Factory.FromAsync(factory.BeginClose, factory.EndClose, TaskCreationOptions.None);
+            t.GetAwaiter().GetResult();
+
+            // Async proxy close is also code under test
+            t = Task.Factory.FromAsync(((ICommunicationObject)serviceProxy).BeginClose, ((ICommunicationObject)serviceProxy).EndClose, TaskCreationOptions.None);
+            t.GetAwaiter().GetResult();
+
+            // *** CLEANUP *** \\
+            // cleanup was all part of code under test
+        }
+        finally
+        {
+            // *** ENSURE CLEANUP *** \\
+            ScenarioTestHelpers.CloseCommunicationObjects((ICommunicationObject)serviceProxy, factory);
+        }
+    }
+
+}

--- a/src/System.Private.ServiceModel/tools/IISHostedWcfService/App_code/testhosts/WsHttpTranSecUserNameTestServiceHost.cs
+++ b/src/System.Private.ServiceModel/tools/IISHostedWcfService/App_code/testhosts/WsHttpTranSecUserNameTestServiceHost.cs
@@ -1,0 +1,83 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.ObjectModel;
+using System.IdentityModel.Selectors;
+using System.ServiceModel;
+using System.ServiceModel.Activation;
+using System.ServiceModel.Channels;
+using System.ServiceModel.Configuration;
+using System.ServiceModel.Description;
+using System.ServiceModel.Dispatcher;
+using System.ServiceModel.Security;
+using System.Text;
+
+namespace WcfService
+{
+    public class WsHttpTransSecUserNameTestServiceHostFactory : ServiceHostFactory
+    {
+        protected override ServiceHost CreateServiceHost(Type serviceType, Uri[] baseAddresses)
+        {
+            WsHttpTranSecUserNameTestServiceHost serviceHost = new WsHttpTranSecUserNameTestServiceHost(serviceType, baseAddresses);
+            return serviceHost;
+        }
+    }
+    public class WsHttpTranSecUserNameTestServiceHost : TestServiceHostBase<IWcfCustomUserNameService>
+    {
+        protected override string Address { get { return "wshttp-transec-username"; } }
+
+        protected override Binding GetBinding()
+        {
+            var securityBindingElement = SecurityBindingElement.CreateUserNameOverTransportBindingElement();
+            securityBindingElement.IncludeTimestamp = false;
+            securityBindingElement.SecurityHeaderLayout = SecurityHeaderLayout.Lax;
+
+            CustomBinding binding = new CustomBinding(
+                            new TextMessageEncodingBindingElement(MessageVersion.Soap11, Encoding.UTF8),
+                            securityBindingElement,
+                            new HttpsTransportBindingElement());
+            return binding;
+        }
+
+        public WsHttpTranSecUserNameTestServiceHost(Type serviceType, params Uri[] baseAddresses)
+            : base(serviceType, baseAddresses)
+        {
+        }
+
+        protected override void ApplyConfiguration()
+        {
+            base.ApplyConfiguration();
+
+            ServiceCredentials serviceCredentials = new ServiceCredentials();
+            serviceCredentials.UserNameAuthentication.UserNamePasswordValidationMode = UserNamePasswordValidationMode.Custom;
+            serviceCredentials.UserNameAuthentication.CustomUserNamePasswordValidator = new CustomUserNameValidator();
+            this.Description.Behaviors.Add(serviceCredentials);
+        }
+
+        //private class CustomUserNameValidator : UserNamePasswordValidator
+        //{
+        //    // This method validates users. It allows in two users, test1 and test2 
+        //    // with passwords 1tset and 2tset respectively.
+        //    // This code is for illustration purposes only and 
+        //    // must not be used in a production environment because it is not secure.	
+        //    public override void Validate(string userName, string password)
+        //    {
+        //        if (null == userName || null == password)
+        //        {
+        //            throw new ArgumentNullException();
+        //        }
+
+        //        if (!(userName == "someUser" && password == "somePassword"))
+        //        {
+        //            // This throws an informative fault to the client.
+        //            throw new FaultException("Unknown Username or Incorrect Password");
+        //            // When you do not want to throw an infomative fault to the client,
+        //            // throw the following exception.
+        //            // throw new SecurityTokenException("Unknown Username or Incorrect Password");
+        //        }
+        //    }
+        //}
+    }
+}

--- a/src/System.Private.ServiceModel/tools/IISHostedWcfService/Web.config
+++ b/src/System.Private.ServiceModel/tools/IISHostedWcfService/Web.config
@@ -89,6 +89,7 @@
         <add factory="WcfService.WebSocketHttpsDuplexBinaryBufferedTestServiceHostFactory" service="WcfService.WSDuplexService" relativeAddress="~\WebSocketHttpsDuplexBinaryBuffered.svc" />
         <add factory="WcfService.WebSocketHttpsDuplexTextBufferedTestServiceHostFactory" service="WcfService.WSDuplexService" relativeAddress="~\WebSocketHttpsDuplexTextBuffered.svc" />
         <add factory="WcfService.WebSocketHttpVerifyWebSocketsUsedTestServiceHostFactory" service="WcfService.VerifyWebSockets" relativeAddress="~\WebSocketHttpVerifyWebSocketsUsed.svc" />
+        <add factory="WcfService.WsHttpTranSecUserNameTestServiceHostFactory" service="WcfService.WcfUserNameService" relativeAddress="~\WsHttpTranSecUserName.svc" />
       </serviceActivations>
     </serviceHostingEnvironment>
   </system.serviceModel>

--- a/src/System.Private.ServiceModel/tools/IISHostedWcfService/Web.config
+++ b/src/System.Private.ServiceModel/tools/IISHostedWcfService/Web.config
@@ -89,7 +89,7 @@
         <add factory="WcfService.WebSocketHttpsDuplexBinaryBufferedTestServiceHostFactory" service="WcfService.WSDuplexService" relativeAddress="~\WebSocketHttpsDuplexBinaryBuffered.svc" />
         <add factory="WcfService.WebSocketHttpsDuplexTextBufferedTestServiceHostFactory" service="WcfService.WSDuplexService" relativeAddress="~\WebSocketHttpsDuplexTextBuffered.svc" />
         <add factory="WcfService.WebSocketHttpVerifyWebSocketsUsedTestServiceHostFactory" service="WcfService.VerifyWebSockets" relativeAddress="~\WebSocketHttpVerifyWebSocketsUsed.svc" />
-        <add factory="WcfService.WsHttpTranSecUserNameTestServiceHostFactory" service="WcfService.WcfUserNameService" relativeAddress="~\WsHttpTranSecUserName.svc" />
+        <add factory="WcfService.WsHttpTransSecUserNameTestServiceHostFactory" service="WcfService.WcfUserNameService" relativeAddress="~\WsHttpTranSecUserName.svc" />
       </serviceActivations>
     </serviceHostingEnvironment>
   </system.serviceModel>

--- a/src/System.Private.ServiceModel/tools/SelfHostedWcfService/Program.cs
+++ b/src/System.Private.ServiceModel/tools/SelfHostedWcfService/Program.cs
@@ -106,6 +106,7 @@ namespace SelfHostedWCFService
             CreateHost<WebSocketHttpsDuplexTextBufferedTestServiceHost, WSDuplexService>("WebSocketHttpsDuplexTextBuffered.svc", websocketsBaseAddress);
             CreateHost<ChannelExtensibilityServiceHost, WcfChannelExtensiblityService>("ChannelExtensibility.svc", httpBaseAddress);
             CreateHost<WebSocketHttpVerifyWebSocketsUsedTestServiceHost, VerifyWebSockets>("WebSocketHttpVerifyWebSocketsUsed.svc", websocketBaseAddress);
+            CreateHost<WsHttpTranSecUserNameTestServiceHost, WcfUserNameService>("WsHttpTranSecUserName.svc", httpsBaseAddress);
 
             //Start the crlUrl service last as the client use it to ensure all services have been started
             Uri testHostUrl = new Uri(string.Format("http://localhost/TestHost.svc", s_httpPort));


### PR DESCRIPTION
Add initial support for the simple-case use of SecurityBindingElement.CreateUserNameOverTransportBindingElement.  This entails bringing in a significant number of files from the full framework and new tests to ensure the simple default case works for synchronous operations.  It is the first step to handle issue #1257, but not enough to consider that issue fixed.

Other PR's will enable the async paths and expand testing of these new layers.

**UPDATE: this PR has been replaced by PR #1530 and will be discarded once that one is merged.**
