### PR TITLE
Miscellaneous test property fixes

### DIFF
--- a/src/System.Private.ServiceModel/tests/Common/Infrastructure/ConditionalWcfTest.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Infrastructure/ConditionalWcfTest.cs
@@ -41,6 +41,11 @@ namespace Infrastructure.Common
 
                 // Highest precedence: environment variable if set and can be parsed
                 string value = Environment.GetEnvironmentVariable(conditionName);
+                if (value != null)
+                {
+                    value = value.Trim();
+                }
+
                 bool parsedValue = false;
                 if (!String.IsNullOrWhiteSpace(value) && bool.TryParse(value, out parsedValue))
                 {
@@ -51,7 +56,9 @@ namespace Infrastructure.Common
                 // Next precedence: TestProperties if present and can be parsed
                 else if (TestProperties.PropertyNames.Contains(conditionName))
                 {
+                    // GetProperty trims the string
                     value = TestProperties.GetProperty(conditionName);
+
                     if (!String.IsNullOrWhiteSpace(value) && bool.TryParse(value, out parsedValue))
                     {
                         result = parsedValue;

--- a/src/System.Private.ServiceModel/tests/Common/Infrastructure/TestProperties.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Infrastructure/TestProperties.cs
@@ -61,6 +61,11 @@ namespace Infrastructure.Common
                 result = s_properties.Value[propertyName];
             }
 
+            if (result != null)
+            {
+                result = result.Trim();
+            }
+
             return result;
         }
     }

--- a/src/System.Private.ServiceModel/tests/Common/Infrastructure/testproperties.targets
+++ b/src/System.Private.ServiceModel/tests/Common/Infrastructure/testproperties.targets
@@ -82,6 +82,7 @@ namespace Infrastructure.Common
             properties["Client_Certificate_Installed"] = "$(Client_Certificate_Installed)"%3B
             properties["Peer_Certificate_Installed"] = "$(Peer_Certificate_Installed)"%3B
             properties["SPN_Available"] = "$(SPN_Available)"%3B
+            properties["UPN_Available"] = "$(UPN_Available)"%3B
             properties["Server_Accepts_Certificates"] = "$(Server_Accepts_Certificates)"%3B
             properties["Ambient_Credentials_Available"] = "$(Ambient_Credentials_Available)"%3B
             properties["Explicit_Credentials_Available"] = "$(Explicit_Credentials_Available)"%3B

--- a/src/System.Private.ServiceModel/tests/Common/Infrastructure/xunit/IssueAttribute.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Infrastructure/xunit/IssueAttribute.cs
@@ -111,9 +111,9 @@ namespace Infrastructure.Common
                 return propertyAsBool ? new HashSet<int>() : null;
             }
 
-            // Anything else is interpreted as a semicolon-separate list of
+            // Anything else is interpreted as a semicolon or comma separated list of
             // issue numbers to include (i.e. not skip).
-            string[] issues = includeTestsWithIssues.Split(new char[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
+            string[] issues = includeTestsWithIssues.Split(new char[] { ';', ',' }, StringSplitOptions.RemoveEmptyEntries);
             HashSet<int> hashSet = new HashSet<int>();
             foreach (string issue in issues)
             {


### PR DESCRIPTION
Trim test property and environment variable values to avoid
issues we found with accidental whitespace.

UPN_Available was not properly being passed into TestProperties,
so this Condition was always false unless an environment variable
was set for it on the machine where the tests were run.

IssueAttribute parses the IncludeTestsWithIssues TestProperty to
allow multiple issues to be specified.  But if semicolon separated,
it causes a code-gen error in TestProperties.  So change it to allow
a comma separated list.