### PR TITLE
Enable WS* layers of WCF

### DIFF
--- a/src/System.Private.ServiceModel/src/Internals/System/Runtime/Serialization/XmlMappingTypes.cs
+++ b/src/System.Private.ServiceModel/src/Internals/System/Runtime/Serialization/XmlMappingTypes.cs
@@ -103,7 +103,7 @@ namespace System.Xml.Serialization
 
         public XmlMapping(object thisObject)
         {
-            this._wrapperObject = XmlMappingTypeWrapperFactory.GetWrapper(thisObject);
+            _wrapperObject = XmlMappingTypeWrapperFactory.GetWrapper(thisObject);
         }
 
         public IXmlMappingTypeWrapperObject Object

--- a/src/System.Private.ServiceModel/src/Resources/Strings.resx
+++ b/src/System.Private.ServiceModel/src/Resources/Strings.resx
@@ -6771,4 +6771,16 @@
   <data name="Xml_InvalidNodeType" xml:space="preserve">
     <value>'{0}' is an invalid XmlNodeType.</value>
   </data>
+  <data name="ErrorDeserializingKeyIdentifierClause" xml:space="preserve">
+    <value>'There was an error deserializing the security key identifier clause XML. Please see the inner exception for more details.</value>
+  </data>
+  <data name="ErrorSerializingKeyIdentifier" xml:space="preserve">
+    <value>There was an error serializing the security key identifier. Please see the inner exception for more details.</value>
+  </data>
+  <data name="ErrorSerializingKeyIdentifierClause" xml:space="preserve">
+    <value>There was an error serializing the security key identifier clause. Please see the inner exception for more details.</value>
+  </data>
+  <data name="CannotReadKeyIdentifierClause" xml:space="preserve">
+    <value>Cannot read KeyIdentifierClause from element '{0}' with namespace '{1}'.  Custom KeyIdentifierClauses require custom SecurityTokenSerializers.</value>
+  </data>
 </root>

--- a/src/System.Private.ServiceModel/src/System/IdentityModel/IPrefixGenerator.cs
+++ b/src/System.Private.ServiceModel/src/System/IdentityModel/IPrefixGenerator.cs
@@ -1,0 +1,11 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.IdentityModel
+{
+    interface IPrefixGenerator
+    {
+        string GetPrefix(string namespaceUri, int depth, bool isForAttribute);
+    }
+}

--- a/src/System.Private.ServiceModel/src/System/IdentityModel/Selectors/KerberosSecurityTokenProvider.cs
+++ b/src/System.Private.ServiceModel/src/System/IdentityModel/Selectors/KerberosSecurityTokenProvider.cs
@@ -70,5 +70,10 @@ namespace System.IdentityModel.Selectors
         {
             return Task.FromResult(GetToken(cancellationToken, null));
         }
+
+        protected override SecurityToken GetTokenCore(TimeSpan timeout)
+        {
+            return GetToken(CancellationToken.None, null);
+        }
     }
 }

--- a/src/System.Private.ServiceModel/src/System/IdentityModel/Selectors/SecurityTokenProvider.cs
+++ b/src/System.Private.ServiceModel/src/System/IdentityModel/Selectors/SecurityTokenProvider.cs
@@ -5,6 +5,7 @@
 
 using System.IdentityModel.Tokens;
 using System.Runtime;
+using System.ServiceModel;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -22,6 +23,16 @@ namespace System.IdentityModel.Selectors
         public virtual bool SupportsTokenCancellation
         {
             get { return false; }
+        }
+
+        public SecurityToken GetToken(TimeSpan timeout)
+        {
+            SecurityToken token = this.GetTokenCore(timeout);
+            if (token == null)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new SecurityTokenException(SR.Format(SR.TokenProviderUnableToGetToken, this)));
+            }
+            return token;
         }
 
         public async Task<SecurityToken> GetTokenAsync(CancellationToken cancellationToken)
@@ -58,6 +69,8 @@ namespace System.IdentityModel.Selectors
         }
 
         // protected methods
+        protected abstract SecurityToken GetTokenCore(TimeSpan timeout);
+
         protected abstract Task<SecurityToken> GetTokenCoreAsync(CancellationToken cancellationToken);
 
         protected virtual Task<SecurityToken> RenewTokenCoreAsync(CancellationToken cancellationToken, SecurityToken tokenToBeRenewed)

--- a/src/System.Private.ServiceModel/src/System/IdentityModel/Selectors/SecurityTokenSerializer.cs
+++ b/src/System.Private.ServiceModel/src/System/IdentityModel/Selectors/SecurityTokenSerializer.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.IdentityModel.Tokens;
 using System.ServiceModel;
 using System.Xml;
+using TokenEntry = System.ServiceModel.Security.WSSecurityTokenSerializer.TokenEntry;
 
 namespace System.IdentityModel.Selectors
 {
@@ -206,42 +207,6 @@ namespace System.IdentityModel.Selectors
             public abstract bool SupportsCore(SecurityKeyIdentifier keyIdentifier);
 
             public abstract void WriteKeyIdentifierCore(XmlDictionaryWriter writer, SecurityKeyIdentifier keyIdentifier);
-        }
-
-        internal abstract class TokenEntry
-        {
-            private Type[] _tokenTypes = null;
-
-            protected abstract XmlDictionaryString LocalName { get; }
-            protected abstract XmlDictionaryString NamespaceUri { get; }
-            public Type TokenType { get { return GetTokenTypes()[0]; } }
-            public abstract string TokenTypeUri { get; }
-            protected abstract string ValueTypeUri { get; }
-
-            public bool SupportsCore(Type tokenType)
-            {
-                Type[] tokenTypes = GetTokenTypes();
-                for (int i = 0; i < tokenTypes.Length; ++i)
-                {
-                    if (tokenTypes[i].IsAssignableFrom(tokenType))
-                        return true;
-                }
-                return false;
-            }
-
-            protected abstract Type[] GetTokenTypesCore();
-
-            public Type[] GetTokenTypes()
-            {
-                if (_tokenTypes == null)
-                    _tokenTypes = GetTokenTypesCore();
-                return _tokenTypes;
-            }
-
-            public virtual bool SupportsTokenTypeUri(string tokenTypeUri)
-            {
-                return (this.TokenTypeUri == tokenTypeUri);
-            }
         }
     }
 }

--- a/src/System.Private.ServiceModel/src/System/IdentityModel/Selectors/UserNameSecurityTokenProvider.cs
+++ b/src/System.Private.ServiceModel/src/System/IdentityModel/Selectors/UserNameSecurityTokenProvider.cs
@@ -28,5 +28,10 @@ namespace System.IdentityModel.Selectors
         {
             return Task.FromResult((SecurityToken)_userNameToken);
         }
+
+        protected override SecurityToken GetTokenCore(TimeSpan timeout)
+        {
+            return _userNameToken;
+        }
     }
 }

--- a/src/System.Private.ServiceModel/src/System/IdentityModel/Selectors/X509SecurityTokenProvider.cs
+++ b/src/System.Private.ServiceModel/src/System/IdentityModel/Selectors/X509SecurityTokenProvider.cs
@@ -41,6 +41,11 @@ namespace System.IdentityModel.Selectors
             return Task.FromResult<SecurityToken>(new X509SecurityToken(certificate: _certificate, clone: _clone, disposable: _clone));
         }
 
+        protected override SecurityToken GetTokenCore(TimeSpan timeout)
+        {
+            return new X509SecurityToken(certificate: _certificate, clone: _clone, disposable: _clone);
+        }
+
         public void Dispose()
         {
             if (_clone)

--- a/src/System.Private.ServiceModel/src/System/IdentityModel/Tokens/GenericXmlSecurityKeyIdentifierClause.cs
+++ b/src/System.Private.ServiceModel/src/System/IdentityModel/Tokens/GenericXmlSecurityKeyIdentifierClause.cs
@@ -1,0 +1,79 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.ServiceModel;
+using System.Xml;
+
+namespace System.IdentityModel.Tokens
+{
+    public class GenericXmlSecurityKeyIdentifierClause : SecurityKeyIdentifierClause
+    {
+        XmlElement referenceXml;
+
+        public GenericXmlSecurityKeyIdentifierClause(XmlElement referenceXml)
+            : this(referenceXml, null, 0)
+        {
+        }
+
+        public GenericXmlSecurityKeyIdentifierClause(XmlElement referenceXml, byte[] derivationNonce, int derivationLength)
+            : base(null, derivationNonce, derivationLength)
+        {
+            if (referenceXml == null)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("referenceXml");
+            }
+            this.referenceXml = referenceXml;
+        }
+
+        public XmlElement ReferenceXml
+        {
+            get { return this.referenceXml; }
+        }
+
+        public override bool Matches(SecurityKeyIdentifierClause keyIdentifierClause)
+        {
+            GenericXmlSecurityKeyIdentifierClause that = keyIdentifierClause as GenericXmlSecurityKeyIdentifierClause;
+            return ReferenceEquals(this, that) || (that != null && that.Matches(this.ReferenceXml));
+        }
+
+        private bool Matches(XmlElement xmlElement)
+        {
+            if (xmlElement == null)
+                return false;
+
+            return CompareNodes(this.referenceXml, xmlElement);
+        }
+
+        private bool CompareNodes(XmlNode originalNode, XmlNode newNode)
+        {
+            if (originalNode.OuterXml == newNode.OuterXml)
+                return true;
+
+            if (originalNode.LocalName != newNode.LocalName || originalNode.InnerText != newNode.InnerText)
+                return false;
+
+            if (originalNode.InnerXml == newNode.InnerXml)
+                return true;
+
+            if (originalNode.HasChildNodes)
+            {
+                if (!newNode.HasChildNodes || originalNode.ChildNodes.Count != newNode.ChildNodes.Count)
+                    return false;
+
+                bool childrenStatus = true;
+                for (int i = 0; i < originalNode.ChildNodes.Count; i++)
+                {
+                    childrenStatus = childrenStatus & CompareNodes(originalNode.ChildNodes[i], newNode.ChildNodes[i]);
+                }
+
+                return childrenStatus;
+            }
+            else if (newNode.HasChildNodes)
+                return false;
+
+            return true;
+        }
+    }
+}
+

--- a/src/System.Private.ServiceModel/src/System/IdentityModel/Tokens/GenericXmlSecurityToken.cs
+++ b/src/System.Private.ServiceModel/src/System/IdentityModel/Tokens/GenericXmlSecurityToken.cs
@@ -1,0 +1,188 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.ObjectModel;
+using System.Globalization;
+using System.IdentityModel.Policy;
+using System.IO;
+using System.Xml;
+using DiagnosticUtility = System.ServiceModel.DiagnosticUtility;
+
+namespace System.IdentityModel.Tokens
+{
+    public class GenericXmlSecurityToken : SecurityToken
+    {
+        const int SupportedPersistanceVersion = 1;
+        private string _id;
+        private SecurityToken _proofToken;
+        private SecurityKeyIdentifierClause _internalTokenReference;
+        private SecurityKeyIdentifierClause _externalTokenReference;
+        private XmlElement _tokenXml;
+        private ReadOnlyCollection<IAuthorizationPolicy> _authorizationPolicies;
+        private DateTime _effectiveTime;
+        private DateTime _expirationTime;
+
+        public GenericXmlSecurityToken(
+            XmlElement tokenXml,
+            SecurityToken proofToken,
+            DateTime effectiveTime,
+            DateTime expirationTime,
+            SecurityKeyIdentifierClause internalTokenReference,
+            SecurityKeyIdentifierClause externalTokenReference,
+            ReadOnlyCollection<IAuthorizationPolicy> authorizationPolicies
+            )
+        {
+            if (tokenXml == null)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("tokenXml");
+            }
+
+            _id = GetId(tokenXml);
+            _tokenXml = tokenXml;
+            _proofToken = proofToken;
+            _effectiveTime = effectiveTime.ToUniversalTime();
+            _expirationTime = expirationTime.ToUniversalTime();
+
+            _internalTokenReference = internalTokenReference;
+            _externalTokenReference = externalTokenReference;
+            _authorizationPolicies = authorizationPolicies ?? EmptyReadOnlyCollection<IAuthorizationPolicy>.Instance;
+        }
+
+        public override string Id
+        {
+            get { return _id; }
+        }
+
+        public override DateTime ValidFrom
+        {
+            get { return _effectiveTime; }
+        }
+
+        public override DateTime ValidTo
+        {
+            get { return _expirationTime; }
+        }
+
+        public SecurityKeyIdentifierClause InternalTokenReference
+        {
+            get { return _internalTokenReference; }
+        }
+
+        public SecurityKeyIdentifierClause ExternalTokenReference
+        {
+            get { return _externalTokenReference; }
+        }
+
+        public XmlElement TokenXml
+        {
+            get { return _tokenXml;  }
+        }
+
+        public SecurityToken ProofToken
+        {
+            get { return _proofToken; }
+        }
+
+        public ReadOnlyCollection<IAuthorizationPolicy> AuthorizationPolicies
+        {
+            get { return _authorizationPolicies; }
+        }
+
+        public override ReadOnlyCollection<SecurityKey> SecurityKeys
+        {
+            get 
+            {
+                if (_proofToken != null)
+                    return _proofToken.SecurityKeys;
+                else
+                    return EmptyReadOnlyCollection<SecurityKey>.Instance;
+            }
+        }
+ 
+        public override string ToString()
+        {
+            StringWriter writer = new StringWriter(CultureInfo.InvariantCulture);
+            writer.WriteLine("Generic XML token:");
+            writer.WriteLine("   validFrom: {0}", this.ValidFrom);
+            writer.WriteLine("   validTo: {0}", this.ValidTo);
+            if (_internalTokenReference != null)
+                writer.WriteLine("   InternalTokenReference: {0}", _internalTokenReference);
+            if (_externalTokenReference != null)
+                writer.WriteLine("   ExternalTokenReference: {0}", _externalTokenReference);
+            writer.WriteLine("   Token Element: ({0}, {1})", _tokenXml.LocalName, _tokenXml.NamespaceURI);
+            return writer.ToString();
+        }
+
+        static string GetId(XmlElement tokenXml)
+        {
+            if (tokenXml != null)
+            {
+                string id = tokenXml.GetAttribute(UtilityStrings.IdAttribute, UtilityStrings.Namespace);
+                if ( string.IsNullOrEmpty( id ) )
+                {
+                    // special case SAML 1.1 as this is the only possible ID as
+                    // spec is closed.  SAML 2.0 is xs:ID
+                    id = tokenXml.GetAttribute("AssertionID");
+
+                    // if we are still null, "Id"
+                    if ( string.IsNullOrEmpty( id ) )
+                    {
+                        id = tokenXml.GetAttribute("Id");
+                    }
+
+                    //This fixes the unecnrypted SAML 2.0 case. Eg: <Assertion ID="_05955298-214f-41e7-b4c3-84dbff7f01b9" 
+                    if (string.IsNullOrEmpty(id))
+                    {
+                        id = tokenXml.GetAttribute("ID");
+                    }
+                }
+
+                if ( !string.IsNullOrEmpty(id) )
+                {
+                    return id;
+                }
+            }
+
+            return null;
+        }
+
+        public override bool CanCreateKeyIdentifierClause<T>()
+        {
+            if (_internalTokenReference != null && typeof(T) == _internalTokenReference.GetType())
+                return true;
+
+            if (_externalTokenReference != null && typeof(T) == _externalTokenReference.GetType())
+                return true;
+
+            return false;
+        }
+
+        public override T CreateKeyIdentifierClause<T>()
+        {
+            if (_internalTokenReference != null && typeof(T) == _internalTokenReference.GetType())
+                return (T)_internalTokenReference;
+
+            if (_externalTokenReference != null && typeof(T) == _externalTokenReference.GetType())
+                return (T)_externalTokenReference;
+
+            throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new SecurityTokenException(SR.Format(SR.UnableToCreateTokenReference)));
+        }
+
+        public override bool MatchesKeyIdentifierClause(SecurityKeyIdentifierClause keyIdentifierClause)
+        {
+            if (_internalTokenReference != null && _internalTokenReference.Matches(keyIdentifierClause))
+            {
+                return true;
+            }
+            else if (_externalTokenReference != null && _externalTokenReference.Matches(keyIdentifierClause))
+            {
+                return true;
+            }
+            
+            return false;
+        }
+    }
+}
+

--- a/src/System.Private.ServiceModel/src/System/IdentityModel/Tokens/KerberosTicketHashKeyIdentifierClause.cs
+++ b/src/System.Private.ServiceModel/src/System/IdentityModel/Tokens/KerberosTicketHashKeyIdentifierClause.cs
@@ -1,0 +1,37 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Globalization;
+
+namespace System.IdentityModel.Tokens
+{
+    public sealed class KerberosTicketHashKeyIdentifierClause : BinaryKeyIdentifierClause
+    {
+        public KerberosTicketHashKeyIdentifierClause(byte[] ticketHash)
+            : this(ticketHash, null, 0)
+        {
+        }
+
+        public KerberosTicketHashKeyIdentifierClause(byte[] ticketHash, byte[] derivationNonce, int derivationLength)
+            : this(ticketHash, true, derivationNonce, derivationLength)
+        {
+        }
+        
+        internal KerberosTicketHashKeyIdentifierClause(byte[] ticketHash, bool cloneBuffer, byte[] derivationNonce, int derivationLength)
+            : base(null, ticketHash, cloneBuffer, derivationNonce, derivationLength)
+        {           
+        }
+
+        public byte[] GetKerberosTicketHash()
+        {
+            return GetBuffer();
+        }
+
+        public override string ToString()
+        {
+            return string.Format(CultureInfo.InvariantCulture, "KerberosTicketHashKeyIdentifierClause(Hash = {0})", ToBase64String());
+        }        
+    }
+}
+

--- a/src/System.Private.ServiceModel/src/System/IdentityModel/Tokens/KeyInfoSerializer.cs
+++ b/src/System.Private.ServiceModel/src/System/IdentityModel/Tokens/KeyInfoSerializer.cs
@@ -1,0 +1,371 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.IdentityModel.Selectors;
+using System.Runtime;
+using System.ServiceModel.Security;
+using System.Xml;
+using TokenEntry = System.ServiceModel.Security.WSSecurityTokenSerializer.TokenEntry;
+using DiagnosticUtility = System.ServiceModel.DiagnosticUtility;
+
+namespace System.IdentityModel.Tokens
+{
+    /// <summary>
+    /// Abstract class for SecurityKeyIdentifierClause Serializer.
+    /// </summary>
+    internal class KeyInfoSerializer : SecurityTokenSerializer
+    {
+        private readonly List<SecurityTokenSerializer.KeyIdentifierEntry> _keyIdentifierEntries;
+        private readonly List<SecurityTokenSerializer.KeyIdentifierClauseEntry> _keyIdentifierClauseEntries;
+        private readonly List<SecurityTokenSerializer.SerializerEntries> _serializerEntries;
+        private readonly List<TokenEntry> _tokenEntries;
+
+        private DictionaryManager _dictionaryManager;
+        private bool _emitBspRequiredAttributes;
+        private SecurityTokenSerializer _innerSecurityTokenSerializer;
+
+        /// <summary>
+        /// Creates an instance of <see cref="SecurityKeyIdentifierClauseSerializer"/>
+        /// </summary>
+        public KeyInfoSerializer(bool emitBspRequiredAttributes)
+            : this(emitBspRequiredAttributes, new DictionaryManager(), XD.TrustDec2005Dictionary, null)
+        {
+        }
+
+        public KeyInfoSerializer(
+            bool emitBspRequiredAttributes,
+            DictionaryManager dictionaryManager,
+            TrustDictionary trustDictionary,
+            SecurityTokenSerializer innerSecurityTokenSerializer ) :
+            this( emitBspRequiredAttributes, dictionaryManager, trustDictionary, innerSecurityTokenSerializer, null )
+        {
+        }
+
+        public KeyInfoSerializer(
+            bool emitBspRequiredAttributes,
+            DictionaryManager dictionaryManager,
+            TrustDictionary trustDictionary,
+            SecurityTokenSerializer innerSecurityTokenSerializer,
+            Func<KeyInfoSerializer, IEnumerable<SerializerEntries>> additionalEntries)
+        {
+            _dictionaryManager = dictionaryManager;
+            _emitBspRequiredAttributes = emitBspRequiredAttributes;
+            _innerSecurityTokenSerializer = innerSecurityTokenSerializer;
+
+            _serializerEntries = new List<SecurityTokenSerializer.SerializerEntries>();
+
+            _serializerEntries.Add(new XmlDsigSep2000(this));
+            _serializerEntries.Add(new XmlEncApr2001(this));
+
+            // Issue #31 in progress (WSTrust is abstract in ServiceModel)
+            //_serializerEntries.Add(new WSTrust(this, trustDictionary));
+
+            if (additionalEntries != null)
+            {
+                foreach (SerializerEntries entries in additionalEntries(this))
+                {
+                    _serializerEntries.Add(entries);
+                }
+            }
+
+            bool wsSecuritySerializerFound = false;
+            foreach (SerializerEntries entry in _serializerEntries)
+            {
+                if ((entry is WSSecurityXXX2005) || (entry is WSSecurityJan2004))
+                {
+                    wsSecuritySerializerFound = true;
+                    break;
+                }
+            }
+
+            if (!wsSecuritySerializerFound)
+            {
+                _serializerEntries.Add(new WSSecurityXXX2005((WSSecurityTokenSerializer) innerSecurityTokenSerializer));
+            }
+
+            _tokenEntries = new List<TokenEntry>();
+            _keyIdentifierEntries = new List<SecurityTokenSerializer.KeyIdentifierEntry>();
+            _keyIdentifierClauseEntries = new List<SecurityTokenSerializer.KeyIdentifierClauseEntry>();
+
+            for (int i = 0; i < _serializerEntries.Count; ++i)
+            {
+                SecurityTokenSerializer.SerializerEntries serializerEntry = _serializerEntries[i];
+                serializerEntry.PopulateTokenEntries(_tokenEntries);
+                serializerEntry.PopulateKeyIdentifierEntries(_keyIdentifierEntries);
+                serializerEntry.PopulateKeyIdentifierClauseEntries(_keyIdentifierClauseEntries);
+            }
+        }
+
+        public DictionaryManager DictionaryManager
+        {
+            get { return _dictionaryManager; }
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating if BSP required attributes should be written out.
+        /// </summary>
+        public bool EmitBspRequiredAttributes
+        {
+            get
+            {
+                return _emitBspRequiredAttributes;
+            }
+        }
+
+        public SecurityTokenSerializer InnerSecurityTokenSerializer
+        {
+            get
+            {
+                return _innerSecurityTokenSerializer == null ? this : _innerSecurityTokenSerializer;
+            }
+           set
+            {
+                _innerSecurityTokenSerializer = value;
+            }
+        }
+
+        protected override bool CanReadTokenCore(XmlReader reader)
+        {
+            return false;
+        }
+
+        protected override SecurityToken ReadTokenCore(XmlReader reader, SecurityTokenResolver tokenResolver)
+        {
+            XmlDictionaryReader localReader = XmlDictionaryReader.CreateDictionaryReader( reader ); 
+            throw DiagnosticUtility.ExceptionUtility.ThrowHelperError( new XmlException( SR.Format( SR.CannotReadToken, reader.LocalName, reader.NamespaceURI, localReader.GetAttribute( XD.SecurityJan2004Dictionary.ValueType, null ) ) ) );
+        }
+
+        protected override bool CanWriteTokenCore(SecurityToken token)
+        {
+            return false;
+        }
+
+        protected override void WriteTokenCore(XmlWriter writer, SecurityToken token)
+        {
+            throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.StandardsManagerCannotWriteObject, token.GetType())));
+        }
+
+        protected override bool CanReadKeyIdentifierCore(XmlReader reader)
+        {
+            XmlDictionaryReader localReader = XmlDictionaryReader.CreateDictionaryReader(reader);
+            for (int i = 0; i < _keyIdentifierEntries.Count; i++)
+            {
+                KeyIdentifierEntry keyIdentifierEntry = _keyIdentifierEntries[i];
+                if (keyIdentifierEntry.CanReadKeyIdentifierCore(localReader))
+                    return true;
+            }
+            return false;
+        }
+
+        protected override SecurityKeyIdentifier ReadKeyIdentifierCore(XmlReader reader)
+        {
+            XmlDictionaryReader localReader = XmlDictionaryReader.CreateDictionaryReader(reader);
+            localReader.ReadStartElement(XD.XmlSignatureDictionary.KeyInfo, XD.XmlSignatureDictionary.Namespace);
+            SecurityKeyIdentifier keyIdentifier = new SecurityKeyIdentifier();
+            while (localReader.IsStartElement())
+            {
+                SecurityKeyIdentifierClause clause = InnerSecurityTokenSerializer.ReadKeyIdentifierClause(localReader);
+                if (clause == null)
+                {
+                    localReader.Skip();
+                }
+                else
+                {
+                    keyIdentifier.Add(clause);
+                }
+            }
+            if (keyIdentifier.Count == 0)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new XmlException(SR.Format(SR.ErrorDeserializingKeyIdentifierClause)));
+            }
+            localReader.ReadEndElement();
+
+            return keyIdentifier;
+        }
+
+        protected override bool CanWriteKeyIdentifierCore(SecurityKeyIdentifier keyIdentifier)
+        {
+            for (int i = 0; i < _keyIdentifierEntries.Count; ++i)
+            {
+                KeyIdentifierEntry keyIdentifierEntry = _keyIdentifierEntries[i];
+                if (keyIdentifierEntry.SupportsCore(keyIdentifier))
+                    return true;
+            }
+            return false;
+        }
+
+        protected override void WriteKeyIdentifierCore(XmlWriter writer, SecurityKeyIdentifier keyIdentifier)
+        {
+            bool wroteKeyIdentifier = false;
+            XmlDictionaryWriter localWriter = XmlDictionaryWriter.CreateDictionaryWriter(writer);
+            for (int i = 0; i < _keyIdentifierEntries.Count; ++i)
+            {
+                KeyIdentifierEntry keyIdentifierEntry = _keyIdentifierEntries[i];
+                if (keyIdentifierEntry.SupportsCore(keyIdentifier))
+                {
+                    try
+                    {
+                        keyIdentifierEntry.WriteKeyIdentifierCore(localWriter, keyIdentifier);
+                    }
+                    catch (Exception e)
+                    {
+                        if (Fx.IsFatal(e))
+                            throw;
+                        
+                        if (!ShouldWrapException(e))
+                        {
+                            throw;
+                        }
+
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new XmlException(SR.Format(SR.ErrorSerializingKeyIdentifier), e));
+                    }
+                    wroteKeyIdentifier = true;
+                    break;
+                }
+            }
+
+            if (!wroteKeyIdentifier)
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.StandardsManagerCannotWriteObject, keyIdentifier.GetType())));
+
+            localWriter.Flush();
+        }
+
+        protected override bool CanReadKeyIdentifierClauseCore(XmlReader reader)
+        {
+            XmlDictionaryReader localReader = XmlDictionaryReader.CreateDictionaryReader(reader);
+            for (int i = 0; i < _keyIdentifierClauseEntries.Count; i++)
+            {
+                KeyIdentifierClauseEntry keyIdentifierClauseEntry = _keyIdentifierClauseEntries[i];
+                if (keyIdentifierClauseEntry.CanReadKeyIdentifierClauseCore(localReader))
+                    return true;
+            }
+            return false;
+        }
+
+        protected override SecurityKeyIdentifierClause ReadKeyIdentifierClauseCore(XmlReader reader)
+        {
+            XmlDictionaryReader localReader = XmlDictionaryReader.CreateDictionaryReader(reader);
+            for (int i = 0; i < _keyIdentifierClauseEntries.Count; i++)
+            {
+                KeyIdentifierClauseEntry keyIdentifierClauseEntry = _keyIdentifierClauseEntries[i];
+                if (keyIdentifierClauseEntry.CanReadKeyIdentifierClauseCore(localReader))
+                {
+                    try
+                    {
+                        return keyIdentifierClauseEntry.ReadKeyIdentifierClauseCore(localReader);
+                    }
+                    catch (Exception e)
+                    {
+                        if (Fx.IsFatal(e))
+                            throw;
+
+                        if (!ShouldWrapException(e))
+                        {
+                            throw;
+                        }
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new XmlException(SR.Format(SR.ErrorDeserializingKeyIdentifierClause), e));
+                    }
+                }
+            }
+            throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new XmlException(SR.Format(SR.CannotReadKeyIdentifierClause, reader.LocalName, reader.NamespaceURI)));
+        }
+
+        protected override bool CanWriteKeyIdentifierClauseCore(SecurityKeyIdentifierClause keyIdentifierClause)
+        {
+            for (int i = 0; i < _keyIdentifierClauseEntries.Count; ++i)
+            {
+                KeyIdentifierClauseEntry keyIdentifierClauseEntry = _keyIdentifierClauseEntries[i];
+                if (keyIdentifierClauseEntry.SupportsCore(keyIdentifierClause))
+                    return true;
+            }
+            return false;
+        }
+
+        protected override void WriteKeyIdentifierClauseCore(XmlWriter writer, SecurityKeyIdentifierClause keyIdentifierClause)
+        {
+            bool wroteKeyIdentifierClause = false;
+            XmlDictionaryWriter localWriter = XmlDictionaryWriter.CreateDictionaryWriter(writer);
+            for (int i = 0; i < _keyIdentifierClauseEntries.Count; ++i)
+            {
+                KeyIdentifierClauseEntry keyIdentifierClauseEntry = _keyIdentifierClauseEntries[i];
+                if (keyIdentifierClauseEntry.SupportsCore(keyIdentifierClause))
+                {
+                    try
+                    {
+                        keyIdentifierClauseEntry.WriteKeyIdentifierClauseCore(localWriter, keyIdentifierClause);
+                    }
+                    catch (Exception e)
+                    {
+                        if (Fx.IsFatal(e))
+                            throw;
+
+                        if (!ShouldWrapException(e))
+                        {
+                            throw;
+                        }
+                        
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new XmlException(SR.Format(SR.ErrorSerializingKeyIdentifierClause), e));
+                    }
+                    wroteKeyIdentifierClause = true;
+                    break;
+                }
+            }
+
+            if (!wroteKeyIdentifierClause)
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.StandardsManagerCannotWriteObject, keyIdentifierClause.GetType())));
+
+            localWriter.Flush();
+        }
+
+        internal void PopulateStrEntries(IList<StrEntry> strEntries)
+        {
+            foreach (SerializerEntries serializerEntry in _serializerEntries)
+            {
+                serializerEntry.PopulateStrEntries(strEntries);
+            }
+        }
+
+        bool ShouldWrapException(Exception e)
+        {
+            return ((e is ArgumentException) || (e is FormatException) || (e is InvalidOperationException));
+        }
+
+        internal Type[] GetTokenTypes(string tokenTypeUri)
+        {
+            if (tokenTypeUri != null)
+            {
+                for (int i = 0; i < _tokenEntries.Count; i++)
+                {
+                    TokenEntry tokenEntry = _tokenEntries[i];
+
+                    if (tokenEntry.SupportsTokenTypeUri(tokenTypeUri))
+                    {
+                        return tokenEntry.GetTokenTypes();
+                    }
+                }
+            }
+            return null;
+        }
+
+        protected internal virtual string GetTokenTypeUri(Type tokenType)
+        {
+            if (tokenType != null)
+            {
+                for (int i = 0; i < _tokenEntries.Count; i++)
+                {
+                    TokenEntry tokenEntry = _tokenEntries[i];
+
+                    if (tokenEntry.SupportsCore(tokenType))
+                    {
+                        return tokenEntry.TokenTypeUri;
+                    }
+                }
+            }
+            return null;
+        }
+
+    }
+
+}

--- a/src/System.Private.ServiceModel/src/System/IdentityModel/Tokens/SamlAssertion.cs
+++ b/src/System.Private.ServiceModel/src/System/IdentityModel/Tokens/SamlAssertion.cs
@@ -1,0 +1,654 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.IdentityModel.Tokens
+{
+    public class SamlAssertion // : ICanonicalWriterEndRootElementCallback  // Issue #31 in progress
+    {
+       string assertionId = SamlConstants.AssertionIdPrefix + Guid.NewGuid().ToString();
+
+        // Issue #31 in progress
+        //string issuer;
+        //DateTime issueInstant = DateTime.UtcNow.ToUniversalTime();
+        //SamlConditions conditions;
+        //SamlAdvice advice;
+        //readonly ImmutableCollection<SamlStatement> statements = new ImmutableCollection<SamlStatement>();
+        //ReadOnlyCollection<SecurityKey> cryptoList;
+
+        //SignedXml signature;
+        //SigningCredentials signingCredentials;
+        //SecurityKey verificationKey;
+        //SecurityToken signingToken;
+
+        //HashStream hashStream;
+        //XmlTokenStream tokenStream;
+        //SecurityTokenSerializer keyInfoSerializer;
+        //DictionaryManager dictionaryManager;
+        //XmlTokenStream sourceData;
+
+        //bool isReadOnly = false;
+
+        public SamlAssertion()
+        {
+        }
+
+        // Issue #31 in progress
+        //        public SamlAssertion(
+        //            string assertionId,
+        //            string issuer,
+        //            DateTime issueInstant,
+        //            SamlConditions samlConditions,
+        //            SamlAdvice samlAdvice,
+        //            IEnumerable<SamlStatement> samlStatements
+        //            )
+        //        {
+        //            if (string.IsNullOrEmpty(assertionId))
+        //                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgument(SR.Format(SR.SAMLAssertionIdRequired));
+
+        //            if (!IsAssertionIdValid(assertionId))
+        //                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgument(SR.Format(SR.SAMLAssertionIDIsInvalid, assertionId));
+
+        //            if (string.IsNullOrEmpty(issuer))
+        //                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgument(SR.Format(SR.SAMLAssertionIssuerRequired));
+
+        //            if (samlStatements == null)
+        //            {
+        //                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("samlStatements");
+        //            }
+
+        //            this.assertionId = assertionId;
+        //            this.issuer = issuer;
+        //            this.issueInstant = issueInstant.ToUniversalTime();
+        //            this.conditions = samlConditions;
+        //            this.advice = samlAdvice;
+
+        //            foreach (SamlStatement samlStatement in samlStatements)
+        //            {
+        //                if (samlStatement == null)
+        //                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgument(SR.Format(SR.SAMLEntityCannotBeNullOrEmpty, XD.SamlDictionary.Statement.Value));
+
+        //                this.statements.Add(samlStatement);
+        //            }
+
+        //            if (this.statements.Count == 0)
+        //                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgument(SR.Format(SR.SAMLAssertionRequireOneStatement));
+        //        }
+
+        //        public int MinorVersion
+        //        {
+        //            get { return SamlConstants.MinorVersionValue; }
+        //        }
+
+        //        public int MajorVersion
+        //        {
+        //            get { return SamlConstants.MajorVersionValue; }
+        //        }
+
+        public string AssertionId
+        {
+            get { return this.assertionId; }
+            set
+            {
+                throw ServiceModel.ExceptionHelper.PlatformNotSupported();  // Issue #31 in progress
+                //if (isReadOnly)
+                //    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.ObjectIsReadOnly)));
+
+                //if (string.IsNullOrEmpty(value))
+                //    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgument(SR.Format(SR.SAMLAssertionIdRequired));
+
+                //this.assertionId = value;
+            }
+        }
+
+        // Issue #31 in progress
+        //        /// <summary>
+        //        /// Indicates whether this assertion was deserialized from XML source
+        //        /// and can re-emit the XML data unchanged.
+        //        /// </summary>
+        //        /// <remarks>
+        //        /// <para>
+        //        /// The default implementation preserves the source data when read using
+        //        /// Saml2AssertionSerializer.ReadAssertion and is willing to re-emit the
+        //        /// original data as long as the Id has not changed from the time that 
+        //        /// assertion was read.
+        //        /// </para>
+        //        /// <para>
+        //        /// Note that it is vitally important that SAML assertions with different
+        //        /// data have different IDs. If implementing a scheme whereby an assertion
+        //        /// "template" is loaded and certain bits of data are filled in, the Id 
+        //        /// must be changed.
+        //        /// </para>
+        //        /// </remarks>
+        //        /// <returns></returns>
+        //        public virtual bool CanWriteSourceData
+        //        {
+        //            get { return null != this.sourceData; }
+        //        }
+
+        //        public string Issuer
+        //        {
+        //            get { return this.issuer; }
+        //            set
+        //            {
+        //                if (isReadOnly)
+        //                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.ObjectIsReadOnly)));
+
+        //                if (string.IsNullOrEmpty(value))
+        //                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgument(SR.Format(SR.SAMLAssertionIssuerRequired));
+
+        //                this.issuer = value;
+        //            }
+        //        }
+
+        //        public DateTime IssueInstant
+        //        {
+        //            get { return this.issueInstant; }
+        //            set
+        //            {
+        //                if (isReadOnly)
+        //                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.ObjectIsReadOnly)));
+
+        //                this.issueInstant = value;
+        //            }
+        //        }
+
+        //        public SamlConditions Conditions
+        //        {
+        //            get { return this.conditions; }
+        //            set
+        //            {
+        //                if (isReadOnly)
+        //                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.ObjectIsReadOnly)));
+
+        //                this.conditions = value;
+        //            }
+        //        }
+
+        //        public SamlAdvice Advice
+        //        {
+        //            get { return this.advice; }
+        //            set
+        //            {
+        //                if (isReadOnly)
+        //                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.ObjectIsReadOnly)));
+
+        //                this.advice = value;
+        //            }
+        //        }
+
+        //        public IList<SamlStatement> Statements
+        //        {
+        //            get
+        //            {
+        //                return this.statements;
+        //            }
+        //        }
+
+        //        public SigningCredentials SigningCredentials
+        //        {
+        //            get { return this.signingCredentials; }
+        //            set
+        //            {
+        //                if (isReadOnly)
+        //                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.ObjectIsReadOnly)));
+
+        //                this.signingCredentials = value;
+        //            }
+        //        }
+
+        //        internal SignedXml Signature
+        //        {
+        //            get { return this.signature; }
+        //        }
+
+        //        internal SecurityKey SignatureVerificationKey
+        //        {
+        //            get { return this.verificationKey; }
+        //        }
+
+        //        public SecurityToken SigningToken
+        //        {
+        //            get { return this.signingToken; }
+        //            set
+        //            {
+        //                if (isReadOnly)
+        //                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.ObjectIsReadOnly)));
+
+        //                this.signingToken = value;
+        //            }
+        //        }
+
+        //        public bool IsReadOnly
+        //        {
+        //            get { return this.isReadOnly; }
+        //        }
+
+        //        internal ReadOnlyCollection<SecurityKey> SecurityKeys
+        //        {
+        //            get
+        //            {
+        //                return this.cryptoList;
+        //            }
+        //        }
+
+        public void MakeReadOnly()
+        {
+            throw ServiceModel.ExceptionHelper.PlatformNotSupported();  // Issue #31 in progress
+            //if (!this.isReadOnly)
+            //{
+            //    if (this.conditions != null)
+            //        this.conditions.MakeReadOnly();
+
+            //    if (this.advice != null)
+            //        this.advice.MakeReadOnly();
+
+            //    foreach (SamlStatement statement in this.statements)
+            //    {
+            //        statement.MakeReadOnly();
+            //    }
+
+            //    this.statements.MakeReadOnly();
+
+            //    if (this.cryptoList == null)
+            //    {
+            //        this.cryptoList = BuildCryptoList();
+            //    }
+
+            //    this.isReadOnly = true;
+            //}
+        }
+
+        // Issue #31 in progress
+        //        /// <summary>
+        //        /// Captures the XML source data from an EnvelopedSignatureReader. 
+        //        /// </summary>
+        //        /// <remarks>
+        //        /// The EnvelopedSignatureReader that was used to read the data for this
+        //        /// assertion should be passed to this method after the &lt;/Assertion>
+        //        /// element has been read. This method will preserve the raw XML data
+        //        /// that was read, including the signature, so that it may be re-emitted
+        //        /// without changes and without the need to re-sign the data. See 
+        //        /// CanWriteSourceData and WriteSourceData.
+        //        /// </remarks>
+        //        /// <param name="reader"></param>
+        //        internal virtual void CaptureSourceData(EnvelopedSignatureReader reader)
+        //        {
+        //            if (null == reader)
+        //            {
+        //                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("reader");
+        //            }
+
+        //            this.sourceData = reader.XmlTokens;
+        //        }
+
+        //        protected void ReadSignature(XmlDictionaryReader reader, SecurityTokenSerializer keyInfoSerializer, SecurityTokenResolver outOfBandTokenResolver, SamlSerializer samlSerializer)
+        //        {
+        //            if (reader == null)
+        //                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("reader");
+
+        //            if (samlSerializer == null)
+        //                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("samlSerializer");
+
+        //            if (this.signature != null)
+        //                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.SAMLSignatureAlreadyRead)));
+
+        //            // If the reader cannot canonicalize then buffer the signature element to a canonicalizing reader.
+        //            XmlDictionaryReader effectiveReader = reader;
+        //            if (!effectiveReader.CanCanonicalize)
+        //            {
+        //                MemoryStream stream = new MemoryStream();
+        //                XmlDictionaryWriter writer = XmlDictionaryWriter.CreateBinaryWriter(stream, samlSerializer.DictionaryManager.ParentDictionary);
+        //                writer.WriteNode(effectiveReader, false);
+        //                writer.Flush();
+        //                stream.Position = 0;
+        //                effectiveReader = XmlDictionaryReader.CreateBinaryReader(stream.GetBuffer(), 0, (int)stream.Length, samlSerializer.DictionaryManager.ParentDictionary, reader.Quotas);
+        //                effectiveReader.MoveToContent();
+        //                writer.Close();
+        //            }
+        //            SignedXml signedXml = new SignedXml(new StandardSignedInfo(samlSerializer.DictionaryManager), samlSerializer.DictionaryManager, keyInfoSerializer);
+        //            signedXml.TransformFactory = ExtendedTransformFactory.Instance;
+        //            signedXml.ReadFrom(effectiveReader);
+        //            SecurityKeyIdentifier securityKeyIdentifier = signedXml.Signature.KeyIdentifier;
+        //            this.verificationKey = SamlSerializer.ResolveSecurityKey(securityKeyIdentifier, outOfBandTokenResolver);
+        //            if (this.verificationKey == null)
+        //                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new SecurityTokenException(SR.Format(SR.SAMLUnableToResolveSignatureKey, this.issuer)));
+
+        //            this.signature = signedXml;
+        //            this.signingToken = SamlSerializer.ResolveSecurityToken(securityKeyIdentifier, outOfBandTokenResolver);
+        //            if (this.signingToken == null)
+        //                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new SecurityTokenException(SR.Format(SR.SamlSigningTokenNotFound)));
+
+        //            if (!ReferenceEquals(reader, effectiveReader))
+        //                effectiveReader.Close();
+        //        }
+
+        //        void CheckObjectValidity()
+        //        {
+        //            if (string.IsNullOrEmpty(this.assertionId))
+        //                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new SecurityTokenException(SR.Format(SR.SAMLAssertionIdRequired)));
+
+        //            if (!IsAssertionIdValid(this.assertionId))
+        //                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new SecurityTokenException(SR.Format(SR.SAMLAssertionIDIsInvalid, this.assertionId)));
+
+        //            if (string.IsNullOrEmpty(this.issuer))
+        //                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new SecurityTokenException(SR.Format(SR.SAMLAssertionIssuerRequired)));
+
+        //            if (this.statements.Count == 0)
+        //                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new SecurityTokenException(SR.Format(SR.SAMLAssertionRequireOneStatement)));
+        //        }
+
+        //        bool IsAssertionIdValid(string assertionId)
+        //        {
+        //            if (string.IsNullOrEmpty(assertionId))
+        //                return false;
+
+        //            // The first character of the Assertion ID should be a letter or a '_'
+        //            return (((assertionId[0] >= 'A') && (assertionId[0] <= 'Z')) ||
+        //                ((assertionId[0] >= 'a') && (assertionId[0] <= 'z')) ||
+        //                (assertionId[0] == '_'));
+        //        }
+
+        //        ReadOnlyCollection<SecurityKey> BuildCryptoList()
+        //        {
+        //            List<SecurityKey> cryptoList = new List<SecurityKey>();
+
+        //            for (int i = 0; i < this.statements.Count; ++i)
+        //            {
+        //                SamlSubjectStatement statement = this.statements[i] as SamlSubjectStatement;
+        //                if (statement != null)
+        //                {
+        //                    bool skipCrypto = false;
+        //                    SecurityKey crypto = null;
+        //                    if (statement.SamlSubject != null)
+        //                        crypto = statement.SamlSubject.Crypto;
+        //                    InMemorySymmetricSecurityKey inMemorySymmetricSecurityKey = crypto as InMemorySymmetricSecurityKey;
+        //                    if (inMemorySymmetricSecurityKey != null)
+        //                    {
+
+        //                        // Verify that you have not already added this to crypto list.
+        //                        for (int j = 0; j < cryptoList.Count; ++j)
+        //                        {
+        //                            if ((cryptoList[j] is InMemorySymmetricSecurityKey) && (cryptoList[j].KeySize == inMemorySymmetricSecurityKey.KeySize))
+        //                            {
+        //                                byte[] key1 = ((InMemorySymmetricSecurityKey)cryptoList[j]).GetSymmetricKey();
+        //                                byte[] key2 = inMemorySymmetricSecurityKey.GetSymmetricKey();
+        //                                int k = 0;
+        //                                for (k = 0; k < key1.Length; ++k)
+        //                                {
+        //                                    if (key1[k] != key2[k])
+        //                                    {
+        //                                        break;
+        //                                    }
+        //                                }
+        //                                skipCrypto = (k == key1.Length);
+        //                            }
+
+        //                            if (skipCrypto)
+        //                                break;
+        //                        }
+        //                    }
+        //                    if (!skipCrypto && (crypto != null))
+        //                    {
+        //                        cryptoList.Add(crypto);
+        //                    }
+        //                }
+        //            }
+
+        //            return cryptoList.AsReadOnly();
+
+        //        }
+
+        //        void VerifySignature(SignedXml signature, SecurityKey signatureVerificationKey)
+        //        {
+        //            if (signature == null)
+        //                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("signature");
+
+        //            if (signatureVerificationKey == null)
+        //                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("signatureVerificatonKey");
+
+        //            signature.StartSignatureVerification(signatureVerificationKey);
+        //            signature.EnsureDigestValidity(this.assertionId, tokenStream);
+        //            signature.CompleteSignatureVerification();
+        //        }
+
+        //        void ICanonicalWriterEndRootElementCallback.OnEndOfRootElement(XmlDictionaryWriter dictionaryWriter)
+        //        {
+        //            byte[] hashValue = this.hashStream.FlushHashAndGetValue();
+
+        //            PreDigestedSignedInfo signedInfo = new PreDigestedSignedInfo(this.dictionaryManager);
+        //            signedInfo.AddEnvelopedSignatureTransform = true;
+        //            signedInfo.CanonicalizationMethod = SecurityAlgorithms.ExclusiveC14n;
+        //            signedInfo.SignatureMethod = this.signingCredentials.SignatureAlgorithm;
+        //            signedInfo.DigestMethod = this.signingCredentials.DigestAlgorithm;
+        //            signedInfo.AddReference(this.assertionId, hashValue);
+
+        //            SignedXml signedXml = new SignedXml(signedInfo, this.dictionaryManager, this.keyInfoSerializer);
+        //            signedXml.ComputeSignature(this.signingCredentials.SigningKey);
+        //            signedXml.Signature.KeyIdentifier = this.signingCredentials.SigningKeyIdentifier;
+        //            signedXml.WriteTo(dictionaryWriter);
+        //        }
+
+        //        public virtual void ReadXml(XmlDictionaryReader reader, SamlSerializer samlSerializer, SecurityTokenSerializer keyInfoSerializer, SecurityTokenResolver outOfBandTokenResolver)
+        //        {
+        //            if (reader == null)
+        //                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentNullException("ReadXml"));
+
+        //            if (samlSerializer == null)
+        //                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentNullException("samlSerializer"));
+
+        //            XmlDictionaryReader dictionaryReader = XmlDictionaryReader.CreateDictionaryReader(reader);
+        //            WrappedReader wrappedReader = new WrappedReader(dictionaryReader);
+        //            SamlDictionary dictionary = samlSerializer.DictionaryManager.SamlDictionary;
+
+        //            if (!wrappedReader.IsStartElement(dictionary.Assertion, dictionary.Namespace))
+        //                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new SecurityTokenException(SR.Format(SR.SAMLElementNotRecognized, wrappedReader.LocalName)));
+
+        //            string attributeValue = wrappedReader.GetAttribute(dictionary.MajorVersion, null);
+        //            if (string.IsNullOrEmpty(attributeValue))
+        //                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new SecurityTokenException(SR.Format(SR.SAMLAssertionMissingMajorVersionAttributeOnRead)));
+        //            int majorVersion = Int32.Parse(attributeValue, CultureInfo.InvariantCulture);
+
+        //            attributeValue = wrappedReader.GetAttribute(dictionary.MinorVersion, null);
+        //            if (string.IsNullOrEmpty(attributeValue))
+        //                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new SecurityTokenException(SR.Format(SR.SAMLAssertionMissingMinorVersionAttributeOnRead)));
+
+        //            int minorVersion = Int32.Parse(attributeValue, CultureInfo.InvariantCulture);
+
+        //            if ((majorVersion != SamlConstants.MajorVersionValue) || (minorVersion != SamlConstants.MinorVersionValue))
+        //            {
+        //                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new SecurityTokenException(SR.Format(SR.SAMLTokenVersionNotSupported, majorVersion, minorVersion, SamlConstants.MajorVersionValue, SamlConstants.MinorVersionValue)));
+        //            }
+
+        //            attributeValue = wrappedReader.GetAttribute(dictionary.AssertionId, null);
+        //            if (string.IsNullOrEmpty(attributeValue))
+        //                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new SecurityTokenException(SR.Format(SR.SAMLAssertionIdRequired)));
+
+        //            if (!IsAssertionIdValid(attributeValue))
+        //                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new SecurityTokenException(SR.Format(SR.SAMLAssertionIDIsInvalid, attributeValue)));
+
+        //            this.assertionId = attributeValue;
+
+        //            attributeValue = wrappedReader.GetAttribute(dictionary.Issuer, null);
+        //            if (string.IsNullOrEmpty(attributeValue))
+        //                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new SecurityTokenException(SR.Format(SR.SAMLAssertionMissingIssuerAttributeOnRead)));
+        //            this.issuer = attributeValue;
+
+        //            attributeValue = wrappedReader.GetAttribute(dictionary.IssueInstant, null);
+        //            if (!string.IsNullOrEmpty(attributeValue))
+        //                this.issueInstant = DateTime.ParseExact(
+        //                    attributeValue, SamlConstants.AcceptedDateTimeFormats, DateTimeFormatInfo.InvariantInfo, DateTimeStyles.None).ToUniversalTime();
+
+        //            wrappedReader.MoveToContent();
+        //            wrappedReader.Read();
+
+        //            if (wrappedReader.IsStartElement(dictionary.Conditions, dictionary.Namespace))
+        //            {
+        //                this.conditions = samlSerializer.LoadConditions(wrappedReader, keyInfoSerializer, outOfBandTokenResolver);
+        //                if (this.conditions == null)
+        //                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new SecurityTokenException(SR.Format(SR.SAMLUnableToLoadCondtions)));
+        //            }
+
+        //            if (wrappedReader.IsStartElement(dictionary.Advice, dictionary.Namespace))
+        //            {
+        //                this.advice = samlSerializer.LoadAdvice(wrappedReader, keyInfoSerializer, outOfBandTokenResolver);
+        //                if (this.advice == null)
+        //                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new SecurityTokenException(SR.Format(SR.SAMLUnableToLoadAdvice)));
+        //            }
+
+        //            while (wrappedReader.IsStartElement())
+        //            {
+        //                if (wrappedReader.IsStartElement(samlSerializer.DictionaryManager.XmlSignatureDictionary.Signature, samlSerializer.DictionaryManager.XmlSignatureDictionary.Namespace))
+        //                {
+        //                    break;
+        //                }
+        //                else
+        //                {
+        //                    SamlStatement statement = samlSerializer.LoadStatement(wrappedReader, keyInfoSerializer, outOfBandTokenResolver);
+        //                    if (statement == null)
+        //                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new SecurityTokenException(SR.Format(SR.SAMLUnableToLoadStatement)));
+        //                    this.statements.Add(statement);
+        //                }
+        //            }
+
+        //            if (this.statements.Count == 0)
+        //                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new SecurityTokenException(SR.Format(SR.SAMLAssertionRequireOneStatementOnRead)));
+
+        //            if (wrappedReader.IsStartElement(samlSerializer.DictionaryManager.XmlSignatureDictionary.Signature, samlSerializer.DictionaryManager.XmlSignatureDictionary.Namespace))
+        //                this.ReadSignature(wrappedReader, keyInfoSerializer, outOfBandTokenResolver, samlSerializer);
+
+        //            wrappedReader.MoveToContent();
+        //            wrappedReader.ReadEndElement();
+
+        //            this.tokenStream = wrappedReader.XmlTokens;
+
+        //            if (this.signature != null)
+        //            {
+        //                VerifySignature(this.signature, this.verificationKey);
+        //            }
+
+        //            BuildCryptoList();
+        //        }
+
+        //        internal void WriteTo(XmlWriter writer, SamlSerializer samlSerializer, SecurityTokenSerializer keyInfoSerializer)
+        //        {
+        //            if (writer == null)
+        //                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("writer");
+
+        //            if ((this.signingCredentials == null) && (this.signature == null))
+        //                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.SamlAssertionMissingSigningCredentials)));
+
+        //            XmlDictionaryWriter dictionaryWriter = XmlDictionaryWriter.CreateDictionaryWriter(writer);
+
+        //            if (this.signingCredentials != null)
+        //            {
+        //                using (HashAlgorithm hash = CryptoHelper.CreateHashAlgorithm(this.signingCredentials.DigestAlgorithm))
+        //                {
+        //                    this.hashStream = new HashStream(hash);
+        //                    this.keyInfoSerializer = keyInfoSerializer;
+        //                    this.dictionaryManager = samlSerializer.DictionaryManager;
+        //                    SamlDelegatingWriter delegatingWriter = new SamlDelegatingWriter(dictionaryWriter, this.hashStream, this, samlSerializer.DictionaryManager.ParentDictionary);
+        //                    this.WriteXml(delegatingWriter, samlSerializer, keyInfoSerializer);
+        //                }
+        //            }
+        //            else
+        //            {
+        //                this.tokenStream.SetElementExclusion(null, null);
+        //                this.tokenStream.WriteTo(dictionaryWriter, samlSerializer.DictionaryManager);
+        //            }
+        //        }
+
+        //        public virtual void WriteXml(XmlDictionaryWriter writer, SamlSerializer samlSerializer, SecurityTokenSerializer keyInfoSerializer)
+        //        {
+        //            CheckObjectValidity();
+
+        //            if (writer == null)
+        //                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("writer");
+
+        //            if (samlSerializer == null)
+        //                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentNullException("samlSerializer"));
+
+        //            SamlDictionary dictionary = samlSerializer.DictionaryManager.SamlDictionary;
+
+        //            try
+        //            {
+        //                writer.WriteStartElement(dictionary.PreferredPrefix.Value, dictionary.Assertion, dictionary.Namespace);
+
+        //                writer.WriteStartAttribute(dictionary.MajorVersion, null);
+        //                writer.WriteValue(SamlConstants.MajorVersionValue);
+        //                writer.WriteEndAttribute();
+        //                writer.WriteStartAttribute(dictionary.MinorVersion, null);
+        //                writer.WriteValue(SamlConstants.MinorVersionValue);
+        //                writer.WriteEndAttribute();
+        //                writer.WriteStartAttribute(dictionary.AssertionId, null);
+        //                writer.WriteString(this.assertionId);
+        //                writer.WriteEndAttribute();
+        //                writer.WriteStartAttribute(dictionary.Issuer, null);
+        //                writer.WriteString(this.issuer);
+        //                writer.WriteEndAttribute();
+        //                writer.WriteStartAttribute(dictionary.IssueInstant, null);
+        //                writer.WriteString(this.issueInstant.ToString(SamlConstants.GeneratedDateTimeFormat, CultureInfo.InvariantCulture));
+        //                writer.WriteEndAttribute();
+
+        //                // Write out conditions
+        //                if (this.conditions != null)
+        //                {
+        //                    this.conditions.WriteXml(writer, samlSerializer, keyInfoSerializer);
+        //                }
+
+        //                // Write out advice if there is one
+        //                if (this.advice != null)
+        //                {
+        //                    this.advice.WriteXml(writer, samlSerializer, keyInfoSerializer);
+        //                }
+
+        //                for (int i = 0; i < this.statements.Count; i++)
+        //                {
+        //                    this.statements[i].WriteXml(writer, samlSerializer, keyInfoSerializer);
+        //                }
+
+        //                writer.WriteEndElement();
+        //            }
+        //            catch (Exception e)
+        //            {
+        //                // Always immediately rethrow fatal exceptions.
+        //                if (Fx.IsFatal(e)) throw;
+
+        //                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.SAMLTokenNotSerialized), e));
+        //            }
+        //        }
+
+        //        /// <summary>
+        //        /// Writes the source data, if available.
+        //        /// </summary>
+        //        /// <exception cref="InvalidOperationException">When no source data is available</exception>
+        //        /// <param name="writer"></param>
+        //        public virtual void WriteSourceData(XmlWriter writer)
+        //        {
+        //            if (!this.CanWriteSourceData)
+        //            {
+        //                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(
+        //                    new InvalidOperationException(SR.Format(SR.ID4140)));
+        //            }
+
+        //            // This call will properly just reuse the existing writer if it already qualifies
+        //            XmlDictionaryWriter dictionaryWriter = XmlDictionaryWriter.CreateDictionaryWriter(writer);
+        //            this.sourceData.SetElementExclusion(null, null);
+        //            this.sourceData.GetWriter().WriteTo(dictionaryWriter, null );
+        //        }
+
+        //        static internal void AddSamlClaimTypes(ICollection<Type> knownClaimTypes)
+        //        {
+        //            if (knownClaimTypes == null)
+        //            {
+        //                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("knownClaimTypes");
+        //            }
+        //            knownClaimTypes.Add(typeof(SamlAuthorizationDecisionClaimResource));
+        //            knownClaimTypes.Add(typeof(SamlAuthenticationClaimResource));
+        //            knownClaimTypes.Add(typeof(SamlAccessDecision));
+        //            knownClaimTypes.Add(typeof(SamlAuthorityBinding));
+        //            knownClaimTypes.Add(typeof(SamlNameIdentifierClaimResource));
+        //        }
+    }
+}
+

--- a/src/System.Private.ServiceModel/src/System/IdentityModel/Tokens/SamlConstants.cs
+++ b/src/System.Private.ServiceModel/src/System/IdentityModel/Tokens/SamlConstants.cs
@@ -1,0 +1,117 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace System.IdentityModel.Tokens
+{
+    public static class SamlConstants
+    {
+        static public int MajorVersionValue { get { return 1; } }
+        static public int MinorVersionValue { get { return 1; } }
+        static public string Namespace { get { return SamlStrings.Namespace; } }
+        static public string HolderOfKey { get { return SamlStrings.HolderOfKey; } }
+        static public string SenderVouches { get { return SamlStrings.SenderVouches; } }
+        static public string UserName { get { return SamlStrings.UserName; } }
+        static public string UserNameNamespace { get { return SamlStrings.UserNameNamespace; } }
+        static public string EmailName { get { return SamlStrings.EmailName; } }
+        static public string EmailNamespace { get { return SamlStrings.EmailNamespace; } }
+
+        public const string Prefix = "saml";
+
+        internal static string[] s_AcceptedDateTimeFormats = new string[] {
+                "yyyy-MM-ddTHH:mm:ss.fffffffZ",
+                "yyyy-MM-ddTHH:mm:ss.ffffffZ",
+                "yyyy-MM-ddTHH:mm:ss.fffffZ",
+                "yyyy-MM-ddTHH:mm:ss.ffffZ",
+                "yyyy-MM-ddTHH:mm:ss.fffZ",
+                "yyyy-MM-ddTHH:mm:ss.ffZ",
+                "yyyy-MM-ddTHH:mm:ss.fZ",
+                "yyyy-MM-ddTHH:mm:ssZ",
+                "yyyy-MM-ddTHH:mm:ss.fffffffzzz",
+                "yyyy-MM-ddTHH:mm:ss.ffffffzzz",
+                "yyyy-MM-ddTHH:mm:ss.fffffzzz",
+                "yyyy-MM-ddTHH:mm:ss.ffffzzz",
+                "yyyy-MM-ddTHH:mm:ss.fffzzz",
+                "yyyy-MM-ddTHH:mm:ss.ffzzz",
+                "yyyy-MM-ddTHH:mm:ss.fzzz",
+                "yyyy-MM-ddTHH:mm:sszzz" };
+        internal const string AssertionIdPrefix = "SamlSecurityToken-";
+        internal const string GeneratedDateTimeFormat = "yyyy-MM-ddTHH:mm:ss.fffZ";
+
+
+        /// <summary>
+        /// Known values for <see cref="System.IdentityModel.Tokens.SamlAuthenticationStatement"/>
+        /// </summary>
+        internal static class AuthenticationMethods
+        {
+            public const string HardwareTokenString = "URI:urn:oasis:names:tc:SAML:1.0:am:HardwareToken";
+            public const string KerberosString = "urn:ietf:rfc:1510";
+            public const string PasswordString = "urn:oasis:names:tc:SAML:1.0:am:password";
+            public const string PgpString = "urn:oasis:names:tc:SAML:1.0:am:PGP";
+            public const string SecureRemotePasswordString = "urn:ietf:rfc:2945";
+            public const string SignatureString = "urn:ietf:rfc:3075";
+            public const string SpkiString = "urn:oasis:names:tc:SAML:1.0:am:SPKI";
+            public const string TlsClientString = "urn:ietf:rfc:2246";
+            public const string UnspecifiedString = "urn:oasis:names:tc:SAML:1.0:am:unspecified";
+            public const string WindowsString = "urn:federation:authentication:windows";
+            public const string X509String = "urn:oasis:names:tc:SAML:1.0:am:X509-PKI";
+            public const string XkmsString = "urn:oasis:names:tc:SAML:1.0:am:XKMS";
+        }
+
+        internal static class ElementNames
+        {
+            public const string Action = "Action";
+            public const string Advice = "Advice";
+            public const string Assertion = "Assertion";
+            public const string AssertionIdReference = "AssertionIDReference";
+            public const string Attribute = "Attribute";
+            public const string AttributeStatement = "AttributeStatement";
+            public const string AttributeValue = "AttributeValue";
+            public const string Audience = "Audience";
+            public const string AudienceRestrictionCondition = "AudienceRestrictionCondition";
+            public const string AuthenticationStatement = "AuthenticationStatement";
+            public const string AuthorityBinding = "AuthorityBinding";
+            public const string AuthorizationDecisionStatement = "AuthorizationDecisionStatement";
+            public const string Conditions = "Conditions";
+            public const string DoNotCacheCondition = "DoNotCacheCondition";
+            public const string Evidence = "Evidence";
+            public const string NameIdentifier = "NameIdentifier";
+            public const string SubjectConfirmation = "SubjectConfirmation";
+            public const string Subject = "Subject";
+            public const string SubjectConfirmationData = "SubjectConfirmationData";
+            public const string SubjectConfirmationMethod = "ConfirmationMethod";
+            public const string SubjectLocality = "SubjectLocality";
+        }
+
+        internal static class AttributeNames
+        {
+            public const string AssertionId = "AssertionID";
+            public const string AttributeName = "AttributeName";
+            public const string AttributeNamespace = "AttributeNamespace";
+            public const string AuthenticationInstant = "AuthenticationInstant";
+            public const string AuthenticationMethod = "AuthenticationMethod";
+            public const string AuthorityBinding = "AuthorityBinding";
+            public const string AuthorityKind = "AuthorityKind";
+            public const string Binding = "Binding";
+            public const string Decision = "Decision";
+            public const string Issuer = "Issuer";
+            public const string IssueInstant = "IssueInstant";
+            public const string Location = "Location";
+            public const string MajorVersion = "MajorVersion";
+            public const string MinorVersion = "MinorVersion";
+            public const string OriginalIssuer = "OriginalIssuer";
+            public const string NamespaceAttributePrefix = "xmlns";
+            public const string NameIdentifierFormat = "Format";
+            public const string NameIdentifierNameQualifier = "NameQualifier";
+            public const string Namespace = "Namespace";
+            public const string NotBefore = "NotBefore";
+            public const string NotOnOrAfter = "NotOnOrAfter";
+            public const string Resource = "Resource";
+            public const string SubjectLocalityDNSAddress = "DNSAddress";
+            public const string SubjectLocalityIPAddress = "IPAddress";
+        }
+    }
+}
+

--- a/src/System.Private.ServiceModel/src/System/IdentityModel/Tokens/SamlSecurityToken.cs
+++ b/src/System.Private.ServiceModel/src/System/IdentityModel/Tokens/SamlSecurityToken.cs
@@ -1,0 +1,109 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.ObjectModel;
+using DiagnosticUtility = System.ServiceModel.DiagnosticUtility;
+
+namespace System.IdentityModel.Tokens
+{
+    public class SamlSecurityToken : SecurityToken
+    {
+        SamlAssertion assertion;
+
+        protected SamlSecurityToken()
+        {
+        }
+
+        public SamlSecurityToken(SamlAssertion assertion)
+        {
+            Initialize(assertion);
+        }
+
+        protected void Initialize(SamlAssertion assertion)
+        {
+            if (assertion == null)
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("assertion");
+
+            this.assertion = assertion;
+            this.assertion.MakeReadOnly();
+        }
+
+        public override string Id
+        {
+            get { return this.assertion.AssertionId; }
+        }
+
+        public override ReadOnlyCollection<SecurityKey> SecurityKeys
+        {
+            get
+            {
+                throw ServiceModel.ExceptionHelper.PlatformNotSupported();  // Issue #31 in progress
+                //return this.assertion.SecurityKeys;
+            }
+        }
+
+        public SamlAssertion Assertion
+        {
+            get { return this.assertion; }
+        }
+
+        public override DateTime ValidFrom
+        {
+            get
+            {
+                throw ServiceModel.ExceptionHelper.PlatformNotSupported();  // Issue #31 in progress
+                //if (this.assertion.Conditions != null)
+                //{
+                //    return this.assertion.Conditions.NotBefore;
+                //}
+
+                //return SecurityUtils.MinUtcDateTime;
+            }
+        }
+
+        public override DateTime ValidTo
+        {
+            get
+            {
+                throw ServiceModel.ExceptionHelper.PlatformNotSupported();  // Issue #31 in progress
+                //if (this.assertion.Conditions != null)
+                //{
+                //    return this.assertion.Conditions.NotOnOrAfter;
+                //}
+
+                //return SecurityUtils.MaxUtcDateTime;
+            }
+        }
+
+        public override bool CanCreateKeyIdentifierClause<T>()
+        {
+            throw ServiceModel.ExceptionHelper.PlatformNotSupported();  // Issue #31 in progress
+            //if (typeof(T) == typeof(SamlAssertionKeyIdentifierClause))
+            //    return true;
+
+            //return false;
+        }
+
+        public override T CreateKeyIdentifierClause<T>()
+        {
+            throw ServiceModel.ExceptionHelper.PlatformNotSupported();  // Issue #31 in progress
+
+            //if (typeof(T) == typeof(SamlAssertionKeyIdentifierClause))
+            //    return new SamlAssertionKeyIdentifierClause(this.Id) as T;
+
+            //throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.UnableToCreateTokenReference)));
+        }
+
+        public override bool MatchesKeyIdentifierClause(SecurityKeyIdentifierClause keyIdentifierClause)
+        {
+            throw ServiceModel.ExceptionHelper.PlatformNotSupported();  // Issue #31 in progress
+            //SamlAssertionKeyIdentifierClause samlKeyIdentifierClause = keyIdentifierClause as SamlAssertionKeyIdentifierClause;
+            //if (samlKeyIdentifierClause != null)
+            //    return samlKeyIdentifierClause.Matches(this.Id);
+
+            //return false;
+        }
+    }
+}
+

--- a/src/System.Private.ServiceModel/src/System/IdentityModel/Tokens/SamlSerializer.cs
+++ b/src/System.Private.ServiceModel/src/System/IdentityModel/Tokens/SamlSerializer.cs
@@ -2,15 +2,238 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-
-using System.IdentityModel;
+using System;
+using System.Xml;
 
 namespace System.IdentityModel.Tokens
 {
     public class SamlSerializer
     {
+        private DictionaryManager _dictionaryManager;
+
         public SamlSerializer()
         {
         }
+
+        // Interface to plug in external Dictionaries. The external
+        // dictionary should already be populated with all strings 
+        // required by this assembly.
+        public void PopulateDictionary(IXmlDictionary dictionary)
+        {
+            if (dictionary == null)
+                throw ServiceModel.DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("dictionary");
+
+            _dictionaryManager = new DictionaryManager(dictionary);
+        }
+
+        internal DictionaryManager DictionaryManager
+        {
+            get
+            {
+                if (_dictionaryManager == null)
+                    _dictionaryManager = new DictionaryManager();
+
+                return _dictionaryManager;
+            }
+        }
+
+        // Issue #31 in progress
+        //        public virtual SamlSecurityToken ReadToken(XmlReader reader, SecurityTokenSerializer keyInfoSerializer, SecurityTokenResolver outOfBandTokenResolver)
+        //        {
+        //            if (reader == null)
+        //                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("reader");
+
+        //            XmlDictionaryReader dictionaryReader = XmlDictionaryReader.CreateDictionaryReader(reader);
+        //            WrappedReader wrappedReader = new WrappedReader(dictionaryReader);
+
+        //            SamlAssertion assertion = LoadAssertion(wrappedReader, keyInfoSerializer, outOfBandTokenResolver);
+        //            if (assertion == null)
+        //                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new SecurityTokenException(SR.Format(SR.SAMLUnableToLoadAssertion)));
+
+        //            //if (assertion.Signature == null)
+        //            //    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new SecurityTokenException(SR.Format(SR.SamlTokenMissingSignature)));
+
+        //            return new SamlSecurityToken(assertion);
+        //        }
+
+        //        public virtual void WriteToken(SamlSecurityToken token, XmlWriter writer, SecurityTokenSerializer keyInfoSerializer)
+        //        {
+        //            if (token == null)
+        //                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("token");
+
+        //            token.Assertion.WriteTo(writer, this, keyInfoSerializer);
+        //        }
+
+        //        public virtual SamlAssertion LoadAssertion(XmlDictionaryReader reader, SecurityTokenSerializer keyInfoSerializer, SecurityTokenResolver outOfBandTokenResolver)
+        //        {
+        //            if (reader == null)
+        //                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("reader");
+
+        //            SamlAssertion assertion = new SamlAssertion();
+        //            assertion.ReadXml(reader, this, keyInfoSerializer, outOfBandTokenResolver);
+
+        //            return assertion;
+        //        }
+
+        //        public virtual SamlCondition LoadCondition(XmlDictionaryReader reader, SecurityTokenSerializer keyInfoSerializer, SecurityTokenResolver outOfBandTokenResolver)
+        //        {
+        //            if (reader == null)
+        //                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("reader");
+
+        //            if (reader.IsStartElement(DictionaryManager.SamlDictionary.AudienceRestrictionCondition, DictionaryManager.SamlDictionary.Namespace))
+        //            {
+        //                SamlAudienceRestrictionCondition audienceRestriction = new SamlAudienceRestrictionCondition();
+        //                audienceRestriction.ReadXml(reader, this, keyInfoSerializer, outOfBandTokenResolver);
+        //                return audienceRestriction;
+        //            }
+        //            else if (reader.IsStartElement(DictionaryManager.SamlDictionary.DoNotCacheCondition, DictionaryManager.SamlDictionary.Namespace))
+        //            {
+        //                SamlDoNotCacheCondition doNotCacheCondition = new SamlDoNotCacheCondition();
+        //                doNotCacheCondition.ReadXml(reader, this, keyInfoSerializer, outOfBandTokenResolver);
+        //                return doNotCacheCondition;
+        //            }
+        //            else
+        //                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new XmlException(SR.Format(SR.SAMLUnableToLoadUnknownElement, reader.LocalName)));
+        //        }
+
+        //        public virtual SamlConditions LoadConditions(XmlDictionaryReader reader, SecurityTokenSerializer keyInfoSerializer, SecurityTokenResolver outOfBandTokenResolver)
+        //        {
+        //            if (reader == null)
+        //                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("reader");
+
+        //            SamlConditions conditions = new SamlConditions();
+        //            conditions.ReadXml(reader, this, keyInfoSerializer, outOfBandTokenResolver);
+
+        //            return conditions;
+        //        }
+
+        //        public virtual SamlAdvice LoadAdvice(XmlDictionaryReader reader, SecurityTokenSerializer keyInfoSerializer, SecurityTokenResolver outOfBandTokenResolver)
+        //        {
+        //            if (reader == null)
+        //                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("reader");
+
+        //            SamlAdvice advice = new SamlAdvice();
+        //            advice.ReadXml(reader, this, keyInfoSerializer, outOfBandTokenResolver);
+
+        //            return advice;
+        //        }
+
+        //        public virtual SamlStatement LoadStatement(XmlDictionaryReader reader, SecurityTokenSerializer keyInfoSerializer, SecurityTokenResolver outOfBandTokenResolver)
+        //        {
+        //            if (reader == null)
+        //                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("reader");
+
+        //            if (reader.IsStartElement(DictionaryManager.SamlDictionary.AuthenticationStatement, DictionaryManager.SamlDictionary.Namespace))
+        //            {
+        //                SamlAuthenticationStatement authStatement = new SamlAuthenticationStatement();
+        //                authStatement.ReadXml(reader, this, keyInfoSerializer, outOfBandTokenResolver);
+        //                return authStatement;
+        //            }
+        //            else if (reader.IsStartElement(DictionaryManager.SamlDictionary.AttributeStatement, DictionaryManager.SamlDictionary.Namespace))
+        //            {
+        //                SamlAttributeStatement attrStatement = new SamlAttributeStatement();
+        //                attrStatement.ReadXml(reader, this, keyInfoSerializer, outOfBandTokenResolver);
+        //                return attrStatement;
+        //            }
+        //            else if (reader.IsStartElement(DictionaryManager.SamlDictionary.AuthorizationDecisionStatement, DictionaryManager.SamlDictionary.Namespace))
+        //            {
+        //                SamlAuthorizationDecisionStatement authDecisionStatement = new SamlAuthorizationDecisionStatement();
+        //                authDecisionStatement.ReadXml(reader, this, keyInfoSerializer, outOfBandTokenResolver);
+        //                return authDecisionStatement;
+        //            }
+        //            else
+        //                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new XmlException(SR.Format(SR.SAMLUnableToLoadUnknownElement, reader.LocalName)));
+        //        }
+
+        //        public virtual SamlAttribute LoadAttribute(XmlDictionaryReader reader, SecurityTokenSerializer keyInfoSerializer, SecurityTokenResolver outOfBandTokenResolver)
+        //        {
+        //            // We will load all attributes as string values.
+        //            SamlAttribute attribute = new SamlAttribute();
+        //            attribute.ReadXml(reader, this, keyInfoSerializer, outOfBandTokenResolver);
+
+        //            return attribute;
+        //        }
+
+
+        //        // Helper metods to read and write SecurityKeyIdentifiers.
+        //        internal static SecurityKeyIdentifier ReadSecurityKeyIdentifier(XmlReader reader, SecurityTokenSerializer tokenSerializer)
+        //        {
+        //            if (tokenSerializer == null)
+        //                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("tokenSerializer", SR.Format(SR.SamlSerializerRequiresExternalSerializers));
+
+        //            if (tokenSerializer.CanReadKeyIdentifier(reader))
+        //            {
+        //                return tokenSerializer.ReadKeyIdentifier(reader);
+        //            }
+
+        //            throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.SamlSerializerUnableToReadSecurityKeyIdentifier)));
+        //        }
+
+        //        internal static void WriteSecurityKeyIdentifier(XmlWriter writer, SecurityKeyIdentifier ski, SecurityTokenSerializer tokenSerializer)
+        //        {
+        //            if (tokenSerializer == null)
+        //                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("tokenSerializer", SR.Format(SR.SamlSerializerRequiresExternalSerializers));
+
+        //            bool keyWritten = false;
+        //            if (tokenSerializer.CanWriteKeyIdentifier(ski))
+        //            {
+        //                tokenSerializer.WriteKeyIdentifier(writer, ski);
+        //                keyWritten = true;
+        //            }
+
+        //            if (!keyWritten)
+        //                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.SamlSerializerUnableToWriteSecurityKeyIdentifier, ski.ToString())));
+        //        }
+
+        //        internal static SecurityKey ResolveSecurityKey(SecurityKeyIdentifier ski, SecurityTokenResolver tokenResolver)
+        //        {
+        //            if (ski == null)
+        //                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("ski");
+
+        //            if (tokenResolver != null)
+        //            {
+        //                for (int i = 0; i < ski.Count; ++i)
+        //                {
+        //                    SecurityKey key = null;
+        //                    if (tokenResolver.TryResolveSecurityKey(ski[i], out key))
+        //                        return key;
+        //                }
+        //            }
+
+        //            if (ski.CanCreateKey)
+        //                return ski.CreateKey();
+
+        //            return null;
+        //        }
+
+        //        internal static SecurityToken ResolveSecurityToken(SecurityKeyIdentifier ski, SecurityTokenResolver tokenResolver)
+        //        {
+        //            SecurityToken token = null;
+
+        //            if (tokenResolver != null)
+        //            {
+        //                tokenResolver.TryResolveToken(ski, out token);
+        //            }
+
+        //            if (token == null)
+        //            {
+        //                // Check if this is a RSA key.
+        //                RsaKeyIdentifierClause rsaClause;
+        //                if (ski.TryFind<RsaKeyIdentifierClause>(out rsaClause))
+        //                    token = new RsaSecurityToken(rsaClause.Rsa);
+        //            }
+
+        //            if (token == null)
+        //            {
+        //                // Check if this is a X509RawDataKeyIdentifier Clause.
+        //                X509RawDataKeyIdentifierClause rawDataKeyIdentifierClause;
+        //                if (ski.TryFind<X509RawDataKeyIdentifierClause>(out rawDataKeyIdentifierClause))
+        //                    token = new X509SecurityToken(new X509Certificate2(rawDataKeyIdentifierClause.GetX509RawData()));
+        //            }
+
+        //            return token;
+        //        }
+
     }
+
 }

--- a/src/System.Private.ServiceModel/src/System/IdentityModel/Tokens/SecurityToken.cs
+++ b/src/System.Private.ServiceModel/src/System/IdentityModel/Tokens/SecurityToken.cs
@@ -2,9 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-
 using System.Collections.ObjectModel;
-using System.Runtime;
+using System.ServiceModel;
 
 namespace System.IdentityModel.Tokens
 {
@@ -14,5 +13,42 @@ namespace System.IdentityModel.Tokens
         public abstract ReadOnlyCollection<SecurityKey> SecurityKeys { get; }
         public abstract DateTime ValidFrom { get; }
         public abstract DateTime ValidTo { get; }
+
+        public virtual bool CanCreateKeyIdentifierClause<T>() where T : SecurityKeyIdentifierClause
+        {
+            return ((typeof(T) == typeof(LocalIdKeyIdentifierClause)) && CanCreateLocalKeyIdentifierClause());
+        }
+
+        public virtual T CreateKeyIdentifierClause<T>() where T : SecurityKeyIdentifierClause
+        {
+            if ((typeof(T) == typeof(LocalIdKeyIdentifierClause)) && CanCreateLocalKeyIdentifierClause())
+                return new LocalIdKeyIdentifierClause(Id, GetType()) as T;
+
+            throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new NotSupportedException(
+                SR.Format(SR.TokenDoesNotSupportKeyIdentifierClauseCreation, GetType().Name, typeof(T).Name)));
+        }
+
+        public virtual bool MatchesKeyIdentifierClause(SecurityKeyIdentifierClause keyIdentifierClause)
+        {
+            LocalIdKeyIdentifierClause localKeyIdentifierClause = keyIdentifierClause as LocalIdKeyIdentifierClause;
+            if (localKeyIdentifierClause != null)
+                return localKeyIdentifierClause.Matches(Id, GetType());
+
+            return false;
+        }
+
+        public virtual SecurityKey ResolveKeyIdentifierClause(SecurityKeyIdentifierClause keyIdentifierClause)
+        {
+            if (SecurityKeys.Count != 0 && MatchesKeyIdentifierClause(keyIdentifierClause))
+                return SecurityKeys[0];
+
+            return null;
+        }
+
+        bool CanCreateLocalKeyIdentifierClause()
+        {
+            return (Id != null);
+        }
     }
 }
+

--- a/src/System.Private.ServiceModel/src/System/IdentityModel/Tokens/XmlDsigSep2000.cs
+++ b/src/System.Private.ServiceModel/src/System/IdentityModel/Tokens/XmlDsigSep2000.cs
@@ -1,0 +1,350 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.IdentityModel.Selectors;
+using System.ServiceModel;
+using System.ServiceModel.Security;
+using System.Xml;
+using KeyIdentifierEntry = System.IdentityModel.Selectors.SecurityTokenSerializer.KeyIdentifierEntry;
+using DiagnosticUtility = System.ServiceModel.DiagnosticUtility;
+
+namespace System.IdentityModel.Tokens
+{
+    class XmlDsigSep2000 : SecurityTokenSerializer.SerializerEntries
+    {
+        private KeyInfoSerializer _securityTokenSerializer;
+
+        public XmlDsigSep2000( KeyInfoSerializer securityTokenSerializer )
+        {
+            _securityTokenSerializer = securityTokenSerializer;
+        }
+
+        public override void PopulateKeyIdentifierEntries( IList<KeyIdentifierEntry> keyIdentifierEntries )
+        {
+            keyIdentifierEntries.Add( new KeyInfoEntry( _securityTokenSerializer ) );
+        }
+
+        public override void PopulateKeyIdentifierClauseEntries( IList<SecurityTokenSerializer.KeyIdentifierClauseEntry> keyIdentifierClauseEntries )
+        {
+            keyIdentifierClauseEntries.Add( new KeyNameClauseEntry() );
+            keyIdentifierClauseEntries.Add( new KeyValueClauseEntry() );
+            keyIdentifierClauseEntries.Add( new X509CertificateClauseEntry() );
+        }
+
+        internal class KeyInfoEntry : KeyIdentifierEntry
+        {
+            KeyInfoSerializer securityTokenSerializer;
+
+            public KeyInfoEntry( KeyInfoSerializer securityTokenSerializer )
+            {
+                this.securityTokenSerializer = securityTokenSerializer;
+            }
+
+            protected override XmlDictionaryString LocalName
+            {
+                get
+                {
+                    return XD.XmlSignatureDictionary.KeyInfo;
+                }
+            }
+
+            protected override XmlDictionaryString NamespaceUri
+            {
+                get
+                {
+                    return XD.XmlSignatureDictionary.Namespace;
+                }
+            }
+
+            public override SecurityKeyIdentifier ReadKeyIdentifierCore( XmlDictionaryReader reader )
+            {
+                reader.ReadStartElement( LocalName, NamespaceUri );
+                SecurityKeyIdentifier keyIdentifier = new SecurityKeyIdentifier();
+                while ( reader.IsStartElement() )
+                {
+                    SecurityKeyIdentifierClause clause = this.securityTokenSerializer.ReadKeyIdentifierClause( reader );
+                    if ( clause == null )
+                    {
+                        reader.Skip();
+                    }
+                    else
+                    {
+                        keyIdentifier.Add( clause );
+                    }
+                }
+                if ( keyIdentifier.Count == 0 )
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError( new XmlException( SR.Format( SR.ErrorDeserializingKeyIdentifierClause ) ) );
+                }
+                reader.ReadEndElement();
+                return keyIdentifier;
+            }
+
+            public override bool SupportsCore( SecurityKeyIdentifier keyIdentifier )
+            {
+                return true;
+            }
+
+            public override void WriteKeyIdentifierCore( XmlDictionaryWriter writer, SecurityKeyIdentifier keyIdentifier )
+            {
+                writer.WriteStartElement( XD.XmlSignatureDictionary.Prefix.Value, LocalName, NamespaceUri );
+                bool clauseWritten = false;
+                foreach ( SecurityKeyIdentifierClause clause in keyIdentifier )
+                {
+                    this.securityTokenSerializer.InnerSecurityTokenSerializer.WriteKeyIdentifierClause( writer, clause );
+                    clauseWritten = true;
+                }
+                writer.WriteEndElement(); // KeyInfo
+                if ( !clauseWritten )
+                {
+                    throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+                    //throw DiagnosticUtility.ExceptionUtility.ThrowHelperError( new SecurityMessageSerializationException( SR.GetString( SR.NoKeyInfoClausesToWrite ) ) );
+                }
+            }
+        }
+
+        // <ds:KeyName>name</ds:KeyName>
+        internal class KeyNameClauseEntry : SecurityTokenSerializer.KeyIdentifierClauseEntry
+        {
+            protected override XmlDictionaryString LocalName
+            {
+                get
+                {
+                    return XD.XmlSignatureDictionary.KeyName;
+                }
+            }
+
+            protected override XmlDictionaryString NamespaceUri
+            {
+                get
+                {
+                    return XD.XmlSignatureDictionary.Namespace;
+                }
+            }
+
+            public override SecurityKeyIdentifierClause ReadKeyIdentifierClauseCore( XmlDictionaryReader reader )
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+
+                //reader.ReadStartElement( XD.XmlSignatureDictionary.KeyName, NamespaceUri );
+                //string name = reader.ReadString();
+                //reader.ReadEndElement();
+
+                //return new KeyNameIdentifierClause( name );
+            }
+
+            public override bool SupportsCore( SecurityKeyIdentifierClause keyIdentifierClause )
+            {
+                return keyIdentifierClause is KeyNameIdentifierClause;
+            }
+
+            public override void WriteKeyIdentifierClauseCore( XmlDictionaryWriter writer, SecurityKeyIdentifierClause keyIdentifierClause )
+            {
+                KeyNameIdentifierClause nameClause = keyIdentifierClause as KeyNameIdentifierClause;
+
+                writer.WriteElementString( XD.XmlSignatureDictionary.Prefix.Value, XD.XmlSignatureDictionary.KeyName, NamespaceUri, nameClause.KeyName );
+            }
+        }
+        // so far, we only support one type of KeyValue - RSAKeyValue
+        //   <ds:KeyValue>
+        //     <ds:RSAKeyValue>
+        //       <ds:Modulus>xA7SEU+...</ds:Modulus>
+        //         <ds:Exponent>AQAB</Exponent>
+        //     </ds:RSAKeyValue>
+        //   </ds:KeyValue>
+        internal class KeyValueClauseEntry : SecurityTokenSerializer.KeyIdentifierClauseEntry
+        {
+            protected override XmlDictionaryString LocalName
+            {
+                get
+                {
+                    return XD.XmlSignatureDictionary.KeyValue;
+                }
+            }
+
+            protected override XmlDictionaryString NamespaceUri
+            {
+                get
+                {
+                    return XD.XmlSignatureDictionary.Namespace;
+                }
+            }
+
+
+            public override SecurityKeyIdentifierClause ReadKeyIdentifierClauseCore( XmlDictionaryReader reader )
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+
+                //reader.ReadStartElement( XD.XmlSignatureDictionary.KeyValue, NamespaceUri );
+                //reader.ReadStartElement( XD.XmlSignatureDictionary.RsaKeyValue, NamespaceUri );
+                //reader.ReadStartElement( XD.XmlSignatureDictionary.Modulus, NamespaceUri );
+
+                //byte[] modulus = Convert.FromBase64String( reader.ReadString() );
+
+                //reader.ReadEndElement();
+                //reader.ReadStartElement( XD.XmlSignatureDictionary.Exponent, NamespaceUri );
+                //byte[] exponent = Convert.FromBase64String( reader.ReadString() );
+                //reader.ReadEndElement();
+                //reader.ReadEndElement();
+                //reader.ReadEndElement();
+
+                //RSA rsa = new RSACryptoServiceProvider();
+                //RSAParameters rsaParameters = new RSAParameters();
+                //rsaParameters.Modulus = modulus;
+                //rsaParameters.Exponent = exponent;
+                //rsa.ImportParameters( rsaParameters );
+
+                //return new RsaKeyIdentifierClause( rsa );
+            }
+
+            public override bool SupportsCore( SecurityKeyIdentifierClause keyIdentifierClause )
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+                //return keyIdentifierClause is RsaKeyIdentifierClause;
+            }
+
+            public override void WriteKeyIdentifierClauseCore( XmlDictionaryWriter writer, SecurityKeyIdentifierClause keyIdentifierClause )
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+                //RsaKeyIdentifierClause rsaClause = keyIdentifierClause as RsaKeyIdentifierClause;
+
+                //writer.WriteStartElement( XD.XmlSignatureDictionary.Prefix.Value, XD.XmlSignatureDictionary.KeyValue, NamespaceUri );
+                //writer.WriteStartElement( XD.XmlSignatureDictionary.Prefix.Value, XD.XmlSignatureDictionary.RsaKeyValue, NamespaceUri );
+                //writer.WriteStartElement( XD.XmlSignatureDictionary.Prefix.Value, XD.XmlSignatureDictionary.Modulus, NamespaceUri );
+                //rsaClause.WriteModulusAsBase64( writer );
+                //writer.WriteEndElement();
+                //writer.WriteStartElement( XD.XmlSignatureDictionary.Prefix.Value, XD.XmlSignatureDictionary.Exponent, NamespaceUri );
+                //rsaClause.WriteExponentAsBase64( writer );
+                //writer.WriteEndElement();
+                //writer.WriteEndElement();
+                //writer.WriteEndElement();
+            }
+        }
+
+        // so far, we only support two types of X509Data directly under KeyInfo  - X509Certificate and X509SKI
+        //   <ds:X509Data>
+        //     <ds:X509Certificate>...</ds:X509Certificate>
+        //      or
+        //     <X509SKI>... </X509SKI>
+        //   </ds:X509Data>
+        // only support 1 certificate right now
+        internal class X509CertificateClauseEntry : SecurityTokenSerializer.KeyIdentifierClauseEntry
+        {
+            protected override XmlDictionaryString LocalName
+            {
+                get
+                {
+                    return XD.XmlSignatureDictionary.X509Data;
+                }
+            }
+
+            protected override XmlDictionaryString NamespaceUri
+            {
+                get
+                {
+                    return XD.XmlSignatureDictionary.Namespace;
+                }
+            }
+
+            public override SecurityKeyIdentifierClause ReadKeyIdentifierClauseCore( XmlDictionaryReader reader )
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+
+                //SecurityKeyIdentifierClause ski = null;
+                //reader.ReadStartElement( XD.XmlSignatureDictionary.X509Data, NamespaceUri );
+                //while ( reader.IsStartElement() )
+                //{
+                //    if ( ski == null && reader.IsStartElement( XD.XmlSignatureDictionary.X509Certificate, NamespaceUri ) )
+                //    {
+                //        X509Certificate2 certificate = null;
+                //        if ( !SecurityUtils.TryCreateX509CertificateFromRawData( reader.ReadElementContentAsBase64(), out certificate ) )
+                //        {
+                //            throw DiagnosticUtility.ExceptionUtility.ThrowHelperError( new SecurityMessageSerializationException( SR.GetString( SR.InvalidX509RawData ) ) );
+                //        }
+                //        ski = new X509RawDataKeyIdentifierClause( certificate );
+                //    }
+                //    else if ( ski == null && reader.IsStartElement( XmlSignatureStrings.X509Ski, NamespaceUri.ToString() ) )
+                //    {
+                //        ski = new X509SubjectKeyIdentifierClause( reader.ReadElementContentAsBase64() );
+                //    }
+                //    else if ( ( ski == null ) && reader.IsStartElement( XD.XmlSignatureDictionary.X509IssuerSerial, XD.XmlSignatureDictionary.Namespace ) )
+                //    {
+                //        reader.ReadStartElement( XD.XmlSignatureDictionary.X509IssuerSerial, XD.XmlSignatureDictionary.Namespace );
+                //        reader.ReadStartElement( XD.XmlSignatureDictionary.X509IssuerName, XD.XmlSignatureDictionary.Namespace );
+                //        string issuerName = reader.ReadContentAsString();
+                //        reader.ReadEndElement();
+                //        reader.ReadStartElement( XD.XmlSignatureDictionary.X509SerialNumber, XD.XmlSignatureDictionary.Namespace );
+                //        string serialNumber = reader.ReadContentAsString();
+                //        reader.ReadEndElement();
+                //        reader.ReadEndElement();
+
+                //        ski = new X509IssuerSerialKeyIdentifierClause( issuerName, serialNumber );
+                //    }
+                //    else
+                //    {
+                //        reader.Skip();
+                //    }
+                //}
+                //reader.ReadEndElement();
+                //return ski;
+            }
+
+            public override bool SupportsCore( SecurityKeyIdentifierClause keyIdentifierClause )
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+
+                //return (keyIdentifierClause is X509RawDataKeyIdentifierClause);
+                //// This method should not write X509IssuerSerialKeyIdentifierClause or X509SubjectKeyIdentifierClause as that should be written by the WSSecurityXXX classes with SecurityTokenReference tag. 
+                //// The XmlDsig entries are written by the X509SecurityTokenHandler.
+            }
+
+            public override void WriteKeyIdentifierClauseCore( XmlDictionaryWriter writer, SecurityKeyIdentifierClause keyIdentifierClause )
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+
+                //X509RawDataKeyIdentifierClause x509Clause = keyIdentifierClause as X509RawDataKeyIdentifierClause;
+
+                //if ( x509Clause != null )
+                //{
+                //    writer.WriteStartElement( XD.XmlSignatureDictionary.Prefix.Value, XD.XmlSignatureDictionary.X509Data, NamespaceUri );
+
+                //    writer.WriteStartElement( XD.XmlSignatureDictionary.Prefix.Value, XD.XmlSignatureDictionary.X509Certificate, NamespaceUri );
+                //    byte[] certBytes = x509Clause.GetX509RawData();
+                //    writer.WriteBase64( certBytes, 0, certBytes.Length );
+                //    writer.WriteEndElement();
+
+                //    writer.WriteEndElement();
+                //}
+
+                //X509IssuerSerialKeyIdentifierClause issuerSerialClause = keyIdentifierClause as X509IssuerSerialKeyIdentifierClause;
+                //if ( issuerSerialClause != null )
+                //{                    
+                //    writer.WriteStartElement( XD.XmlSignatureDictionary.Prefix.Value, XD.XmlSignatureDictionary.X509Data, XD.XmlSignatureDictionary.Namespace );
+                //    writer.WriteStartElement( XD.XmlSignatureDictionary.Prefix.Value, XD.XmlSignatureDictionary.X509IssuerSerial, XD.XmlSignatureDictionary.Namespace );
+                //    writer.WriteElementString( XD.XmlSignatureDictionary.Prefix.Value, XD.XmlSignatureDictionary.X509IssuerName, XD.XmlSignatureDictionary.Namespace, issuerSerialClause.IssuerName );
+                //    writer.WriteElementString( XD.XmlSignatureDictionary.Prefix.Value, XD.XmlSignatureDictionary.X509SerialNumber, XD.XmlSignatureDictionary.Namespace, issuerSerialClause.IssuerSerialNumber );
+                //    writer.WriteEndElement();
+                //    writer.WriteEndElement();
+                //    return;
+                //}
+
+                //X509SubjectKeyIdentifierClause skiClause = keyIdentifierClause as X509SubjectKeyIdentifierClause;
+                //if ( skiClause != null )
+                //{
+                //    writer.WriteStartElement( XmlSignatureConstants.Prefix, XmlSignatureConstants.Elements.X509Data, XmlSignatureConstants.Namespace );
+                //    writer.WriteStartElement( XmlSignatureConstants.Prefix, XmlSignatureConstants.Elements.X509SKI, XmlSignatureConstants.Namespace );
+                //    byte[] ski = skiClause.GetX509SubjectKeyIdentifier();
+                //    writer.WriteBase64( ski, 0, ski.Length );
+                //    writer.WriteEndElement();
+                //    writer.WriteEndElement();
+                //    return;
+                //}
+            }
+        }
+
+    }
+}
+

--- a/src/System.Private.ServiceModel/src/System/IdentityModel/Tokens/XmlEncApr2001.cs
+++ b/src/System.Private.ServiceModel/src/System/IdentityModel/Tokens/XmlEncApr2001.cs
@@ -1,0 +1,146 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.IdentityModel.Selectors;
+using System.ServiceModel;
+using System.Xml;
+using KeyIdentifierClauseEntry = System.IdentityModel.Selectors.SecurityTokenSerializer.KeyIdentifierClauseEntry;
+
+namespace System.IdentityModel.Tokens
+{
+    class XmlEncApr2001 : SecurityTokenSerializer.SerializerEntries
+    {
+        KeyInfoSerializer _securityTokenSerializer;
+
+        public XmlEncApr2001(KeyInfoSerializer securityTokenSerializer)
+        {
+            _securityTokenSerializer = securityTokenSerializer;
+        }
+        
+        public override void PopulateKeyIdentifierClauseEntries(IList<KeyIdentifierClauseEntry> keyIdentifierClauseEntries)
+        {
+            keyIdentifierClauseEntries.Add(new EncryptedKeyClauseEntry(_securityTokenSerializer));
+        }
+
+        internal class EncryptedKeyClauseEntry : SecurityTokenSerializer.KeyIdentifierClauseEntry
+        {
+            private KeyInfoSerializer _securityTokenSerializer;
+
+            public EncryptedKeyClauseEntry(KeyInfoSerializer securityTokenSerializer)
+            {
+                _securityTokenSerializer = securityTokenSerializer;
+            }
+                        
+            protected override XmlDictionaryString LocalName
+            { 
+                get
+                {
+                    return XD.XmlEncryptionDictionary.EncryptedKey;
+                }
+            }
+            
+            protected override XmlDictionaryString NamespaceUri
+            { 
+                get
+                {
+                    return XD.XmlEncryptionDictionary.Namespace;
+                }
+            }
+            
+            public override SecurityKeyIdentifierClause ReadKeyIdentifierClauseCore(XmlDictionaryReader reader)
+            {
+                string encryptionMethod = null;
+                string carriedKeyName = null;
+                SecurityKeyIdentifier encryptingKeyIdentifier = null;
+                byte[] encryptedKey = null;
+
+                reader.ReadStartElement(XD.XmlEncryptionDictionary.EncryptedKey, NamespaceUri);
+                
+                if (reader.IsStartElement(XD.XmlEncryptionDictionary.EncryptionMethod, NamespaceUri))
+                {
+                    encryptionMethod = reader.GetAttribute(XD.XmlEncryptionDictionary.AlgorithmAttribute, null);
+                    bool isEmptyElement = reader.IsEmptyElement;
+                    reader.ReadStartElement();
+                    if (!isEmptyElement)
+                    {
+                        while (reader.IsStartElement())
+                        {
+                            reader.Skip();
+                        }
+                        reader.ReadEndElement();
+                    }
+                }
+
+                if (this._securityTokenSerializer.CanReadKeyIdentifier(reader))
+                {
+                    encryptingKeyIdentifier = this._securityTokenSerializer.ReadKeyIdentifier(reader);
+                }
+                
+                reader.ReadStartElement(XD.XmlEncryptionDictionary.CipherData, NamespaceUri);
+                reader.ReadStartElement(XD.XmlEncryptionDictionary.CipherValue, NamespaceUri);
+                encryptedKey = reader.ReadContentAsBase64();
+                reader.ReadEndElement();
+                reader.ReadEndElement();
+
+                if (reader.IsStartElement(XD.XmlEncryptionDictionary.CarriedKeyName, NamespaceUri))
+                {
+                    reader.ReadStartElement();
+                    throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+                    //carriedKeyName = reader.ReadString();                    
+                    //reader.ReadEndElement();
+                }
+                
+                reader.ReadEndElement();
+
+                return new EncryptedKeyIdentifierClause(encryptedKey, encryptionMethod, encryptingKeyIdentifier, carriedKeyName);
+            }
+
+            public override bool SupportsCore(SecurityKeyIdentifierClause keyIdentifierClause)
+            {
+                return keyIdentifierClause is EncryptedKeyIdentifierClause;
+            }
+
+            public override void WriteKeyIdentifierClauseCore(XmlDictionaryWriter writer, SecurityKeyIdentifierClause keyIdentifierClause)
+            {
+                EncryptedKeyIdentifierClause encryptedKeyClause = keyIdentifierClause as EncryptedKeyIdentifierClause;
+
+                writer.WriteStartElement(XD.XmlEncryptionDictionary.Prefix.Value, XD.XmlEncryptionDictionary.EncryptedKey, NamespaceUri);
+
+                if (encryptedKeyClause.EncryptionMethod != null)
+                {
+                    writer.WriteStartElement(XD.XmlEncryptionDictionary.Prefix.Value, XD.XmlEncryptionDictionary.EncryptionMethod, NamespaceUri);
+                    writer.WriteAttributeString(XD.XmlEncryptionDictionary.AlgorithmAttribute, null, encryptedKeyClause.EncryptionMethod);
+                    if (encryptedKeyClause.EncryptionMethod == XD.SecurityAlgorithmDictionary.RsaOaepKeyWrap.Value)
+                    {
+                        writer.WriteStartElement(XmlSignatureStrings.Prefix, XD.XmlSignatureDictionary.DigestMethod, XD.XmlSignatureDictionary.Namespace);
+                        writer.WriteAttributeString(XD.XmlSignatureDictionary.Algorithm, null, SecurityAlgorithms.Sha1Digest);
+                        writer.WriteEndElement();
+                    }
+                    writer.WriteEndElement();
+                }
+
+                if (encryptedKeyClause.EncryptingKeyIdentifier != null)
+                {
+                    this._securityTokenSerializer.WriteKeyIdentifier(writer, encryptedKeyClause.EncryptingKeyIdentifier);
+                }
+
+                writer.WriteStartElement(XD.XmlEncryptionDictionary.Prefix.Value, XD.XmlEncryptionDictionary.CipherData, NamespaceUri);
+                writer.WriteStartElement(XD.XmlEncryptionDictionary.Prefix.Value, XD.XmlEncryptionDictionary.CipherValue, NamespaceUri);
+                byte[] encryptedKey = encryptedKeyClause.GetEncryptedKey();
+                writer.WriteBase64(encryptedKey, 0, encryptedKey.Length);
+                writer.WriteEndElement();
+                writer.WriteEndElement();
+
+                if (encryptedKeyClause.CarriedKeyName != null)
+                {
+                    writer.WriteElementString(XD.XmlEncryptionDictionary.Prefix.Value, XD.XmlEncryptionDictionary.CarriedKeyName, NamespaceUri, encryptedKeyClause.CarriedKeyName);
+                }
+
+                writer.WriteEndElement();
+            }
+        }
+    }
+}
+

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/ChannelFactoryBase.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/ChannelFactoryBase.cs
@@ -198,7 +198,7 @@ namespace System.ServiceModel.Channels
             TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
             foreach (IChannel channel in currentChannels)
             {
-                IAsyncCommunicationObject iAsyncChannel = channel as IAsyncCommunicationObject;
+                var iAsyncChannel = channel as IAsyncCommunicationObject;
                 if (iAsyncChannel != null)
                 {
                     await iAsyncChannel.CloseAsync(timeoutHelper.RemainingTime());

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/DelegatingMessage.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/DelegatingMessage.cs
@@ -1,0 +1,92 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Xml;
+
+namespace System.ServiceModel.Channels
+{
+    abstract class DelegatingMessage : Message
+    {
+        private Message _innerMessage;
+
+        protected DelegatingMessage(Message innerMessage)
+        {
+            if (innerMessage == null)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("innerMessage");
+            }
+            _innerMessage = innerMessage;
+        }
+
+        public override bool IsEmpty
+        {
+            get
+            {
+                return _innerMessage.IsEmpty;
+            }
+        }
+
+        public override bool IsFault
+        {
+            get { return _innerMessage.IsFault; }
+        }
+
+        public override MessageHeaders Headers
+        {
+            get { return _innerMessage.Headers; }
+        }
+
+        public override MessageProperties Properties
+        {
+            get { return _innerMessage.Properties; }
+        }
+
+        public override MessageVersion Version
+        {
+            get { return _innerMessage.Version; }
+        }
+
+        protected Message InnerMessage
+        {
+            get { return _innerMessage; }
+        }
+
+        protected override void OnClose()
+        {
+            base.OnClose();
+            _innerMessage.Close();
+        }
+
+        protected override void OnWriteStartEnvelope(XmlDictionaryWriter writer)
+        {
+            _innerMessage.WriteStartEnvelope(writer);
+        }
+
+        protected override void OnWriteStartHeaders(XmlDictionaryWriter writer)
+        {
+            _innerMessage.WriteStartHeaders(writer);
+        }
+
+        protected override void OnWriteStartBody(XmlDictionaryWriter writer)
+        {
+            _innerMessage.WriteStartBody(writer);
+        }
+
+        protected override void OnWriteBodyContents(XmlDictionaryWriter writer)
+        {
+            _innerMessage.WriteBodyContents(writer);
+        }
+
+        protected override string OnGetBodyAttribute(string localName, string ns)
+        {
+            return _innerMessage.GetBodyAttribute(localName, ns);
+        }
+
+        protected override void OnBodyToString(XmlDictionaryWriter writer)
+        {
+            _innerMessage.BodyToString(writer);
+        }
+    }
+}
+

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/IReliableChannelBinder.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/IReliableChannelBinder.cs
@@ -1,0 +1,68 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.ServiceModel.Channels
+{
+    delegate void BinderExceptionHandler(IReliableChannelBinder sender, Exception exception);
+
+    interface IReliableChannelBinder
+    {
+        bool CanSendAsynchronously { get; }
+        IChannel Channel { get; }
+        bool Connected { get; }
+        TimeSpan DefaultSendTimeout { get; }
+        bool HasSession { get; }
+        EndpointAddress LocalAddress { get; }
+        EndpointAddress RemoteAddress { get; }
+        CommunicationState State { get; }
+
+        event BinderExceptionHandler Faulted;
+        event BinderExceptionHandler OnException;
+
+        void Abort();
+
+        void Close(TimeSpan timeout);
+        void Close(TimeSpan timeout, MaskingMode maskingMode);
+        IAsyncResult BeginClose(TimeSpan timeout, AsyncCallback callback, object state);
+        IAsyncResult BeginClose(TimeSpan timeout, MaskingMode maskingMode, AsyncCallback callback, object state);
+        void EndClose(IAsyncResult result);
+
+        void Open(TimeSpan timeout);
+        IAsyncResult BeginOpen(TimeSpan timeout, AsyncCallback callback, object state);
+        void EndOpen(IAsyncResult result);
+
+        IAsyncResult BeginSend(Message message, TimeSpan timeout, MaskingMode maskingMode, AsyncCallback callback, object state);
+        IAsyncResult BeginSend(Message message, TimeSpan timeout, AsyncCallback callback, object state);
+        void EndSend(IAsyncResult result);
+        void Send(Message message, TimeSpan timeout);
+        void Send(Message message, TimeSpan timeout, MaskingMode maskingMode);
+
+        bool TryReceive(TimeSpan timeout, out RequestContext requestContext);
+        bool TryReceive(TimeSpan timeout, out RequestContext requestContext, MaskingMode maskingMode);
+        IAsyncResult BeginTryReceive(TimeSpan timeout, AsyncCallback callback, object state);
+        IAsyncResult BeginTryReceive(TimeSpan timeout, MaskingMode maskingMode, AsyncCallback callback, object state);
+        bool EndTryReceive(IAsyncResult result, out RequestContext requestContext);
+
+        ISession GetInnerSession();
+        void HandleException(Exception e);
+        bool IsHandleable(Exception e);
+        void SetMaskingMode(RequestContext context, MaskingMode maskingMode);
+        RequestContext WrapRequestContext(RequestContext context);
+    }
+
+    interface IClientReliableChannelBinder : IReliableChannelBinder
+    {
+        Uri Via { get; }
+        event EventHandler ConnectionLost;
+
+        bool EnsureChannelForRequest();
+
+        IAsyncResult BeginRequest(Message message, TimeSpan timeout, AsyncCallback callback, object state);
+        IAsyncResult BeginRequest(Message message, TimeSpan timeout, MaskingMode maskingMode, AsyncCallback callback, object state);
+        Message EndRequest(IAsyncResult result);
+        Message Request(Message message, TimeSpan timeout);
+        Message Request(Message message, TimeSpan timeout, MaskingMode maskingMode);
+
+    }
+}

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/LayeredChannel.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/LayeredChannel.cs
@@ -4,6 +4,7 @@
 
 
 using System.Runtime;
+using System.Threading.Tasks;
 
 namespace System.ServiceModel.Channels
 {
@@ -57,12 +58,12 @@ namespace System.ServiceModel.Channels
 
         protected override IAsyncResult OnBeginClose(TimeSpan timeout, AsyncCallback callback, object state)
         {
-            return _innerChannel.BeginClose(timeout, callback, state);
+            throw ExceptionHelper.PlatformNotSupported();
         }
 
         protected override void OnEndClose(IAsyncResult result)
         {
-            _innerChannel.EndClose(result);
+            throw ExceptionHelper.PlatformNotSupported();
         }
 
         protected override void OnOpen(TimeSpan timeout)
@@ -72,12 +73,22 @@ namespace System.ServiceModel.Channels
 
         protected override IAsyncResult OnBeginOpen(TimeSpan timeout, AsyncCallback callback, object state)
         {
-            return _innerChannel.BeginOpen(timeout, callback, state);
+            throw ExceptionHelper.PlatformNotSupported();
         }
 
         protected override void OnEndOpen(IAsyncResult result)
         {
-            _innerChannel.EndOpen(result);
+            throw ExceptionHelper.PlatformNotSupported();
+        }
+
+        protected internal override Task OnOpenAsync(TimeSpan timeout)
+        {
+            return ((IAsyncCommunicationObject)_innerChannel).OpenAsync(timeout);
+        }
+
+        protected internal override Task OnCloseAsync(TimeSpan timeout)
+        {
+            return ((IAsyncCommunicationObject)_innerChannel).CloseAsync(timeout);
         }
 
         private void OnInnerChannelFaulted(object sender, EventArgs e)

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/ReliableChannelBinder.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/ReliableChannelBinder.cs
@@ -1,0 +1,4270 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.ServiceModel.Channels
+{
+    enum TolerateFaultsMode
+    {
+        Never,
+        IfNotSecuritySession,
+        Always
+    }
+
+    [Flags]
+    enum MaskingMode
+    {
+        None = 0x0,
+        Handled = 0x1,
+        Unhandled = 0x2,
+        All = Handled | Unhandled
+    }
+
+    // Issue #31 in progress
+//    abstract class ReliableChannelBinder<TChannel> : IReliableChannelBinder
+//        where TChannel : class, IChannel
+//    {
+//        bool aborted = false;
+//        TimeSpan defaultCloseTimeout;
+//        MaskingMode defaultMaskingMode;
+//        TimeSpan defaultSendTimeout;
+//        AsyncCallback onCloseChannelComplete;
+//        CommunicationState state = CommunicationState.Created;
+//        ChannelSynchronizer synchronizer;
+//        object thisLock = new object();
+
+//        protected ReliableChannelBinder(TChannel channel, MaskingMode maskingMode,
+//            TolerateFaultsMode faultMode, TimeSpan defaultCloseTimeout,
+//            TimeSpan defaultSendTimeout)
+//        {
+//            if ((maskingMode != MaskingMode.None) && (maskingMode != MaskingMode.All))
+//            {
+//                throw Fx.AssertAndThrow("ReliableChannelBinder was implemented with only 2 default masking modes, None and All.");
+//            }
+
+//            defaultMaskingMode = maskingMode;
+//            defaultCloseTimeout = defaultCloseTimeout;
+//            defaultSendTimeout = defaultSendTimeout;
+
+//            synchronizer = new ChannelSynchronizer(this, channel, faultMode);
+//        }
+
+//        protected abstract bool CanGetChannelForReceive
+//        {
+//            get;
+//        }
+
+//        public abstract bool CanSendAsynchronously
+//        {
+//            get;
+//        }
+
+//        public virtual ChannelParameterCollection ChannelParameters
+//        {
+//            get { return null; }
+//        }
+
+//        public IChannel Channel
+//        {
+//            get
+//            {
+//                return synchronizer.CurrentChannel;
+//            }
+//        }
+
+//        public bool Connected
+//        {
+//            get
+//            {
+//                return synchronizer.Connected;
+//            }
+//        }
+
+//        public MaskingMode DefaultMaskingMode
+//        {
+//            get
+//            {
+//                return defaultMaskingMode;
+//            }
+//        }
+
+//        public TimeSpan DefaultSendTimeout
+//        {
+//            get
+//            {
+//                return defaultSendTimeout;
+//            }
+//        }
+
+//        public abstract bool HasSession
+//        {
+//            get;
+//        }
+
+//        public abstract EndpointAddress LocalAddress
+//        {
+//            get;
+//        }
+
+//        protected abstract bool MustCloseChannel
+//        {
+//            get;
+//        }
+
+//        protected abstract bool MustOpenChannel
+//        {
+//            get;
+//        }
+
+//        public abstract EndpointAddress RemoteAddress
+//        {
+//            get;
+//        }
+
+//        public CommunicationState State
+//        {
+//            get
+//            {
+//                return state;
+//            }
+//        }
+
+//        protected ChannelSynchronizer Synchronizer
+//        {
+//            get
+//            {
+//                return synchronizer;
+//            }
+//        }
+
+//        protected object ThisLock
+//        {
+//            get
+//            {
+//                return thisLock;
+//            }
+//        }
+
+//        bool TolerateFaults
+//        {
+//            get
+//            {
+//                return synchronizer.TolerateFaults;
+//            }
+//        }
+
+//        public event EventHandler ConnectionLost;
+//        public event BinderExceptionHandler Faulted;
+//        public event BinderExceptionHandler OnException;
+
+
+//        public void Abort()
+//        {
+//            TChannel channel;
+//            lock (ThisLock)
+//            {
+//                aborted = true;
+
+//                if (state == CommunicationState.Closed)
+//                {
+//                    return;
+//                }
+
+//                state = CommunicationState.Closing;
+//                channel = synchronizer.StopSynchronizing(true);
+
+//                if (!MustCloseChannel)
+//                {
+//                    channel = null;
+//                }
+//            }
+
+//            synchronizer.UnblockWaiters();
+//            OnShutdown();
+//            OnAbort();
+
+//            if (channel != null)
+//            {
+//                channel.Abort();
+//            }
+
+//            TransitionToClosed();
+//        }
+
+//        protected virtual void AddOutputHeaders(Message message)
+//        {
+//        }
+
+//        public IAsyncResult BeginClose(TimeSpan timeout, AsyncCallback callback,
+//            object state)
+//        {
+//            return BeginClose(timeout, defaultMaskingMode, callback, state);
+//        }
+
+//        public IAsyncResult BeginClose(TimeSpan timeout, MaskingMode maskingMode,
+//            AsyncCallback callback, object state)
+//        {
+//            ThrowIfTimeoutNegative(timeout);
+//            TChannel channel;
+
+//            if (CloseCore(out channel))
+//            {
+//                return new CompletedAsyncResult(callback, state);
+//            }
+//            else
+//            {
+//                return new CloseAsyncResult(this, channel, timeout, maskingMode, callback, state);
+//            }
+//        }
+
+//        protected virtual IAsyncResult BeginCloseChannel(TChannel channel, TimeSpan timeout,
+//            AsyncCallback callback, object state)
+//        {
+//            return channel.BeginClose(timeout, callback, state);
+//        }
+
+//        public IAsyncResult BeginOpen(TimeSpan timeout, AsyncCallback callback, object state)
+//        {
+//            ThrowIfTimeoutNegative(timeout);
+
+//            if (OnOpening(defaultMaskingMode))
+//            {
+//                try
+//                {
+//                    return OnBeginOpen(timeout, callback, state);
+//                }
+//                catch (Exception e)
+//                {
+//                    if (Fx.IsFatal(e))
+//                    {
+//                        throw;
+//                    }
+
+//                    Fault(null);
+
+//                    if (defaultMaskingMode == MaskingMode.None)
+//                    {
+//                        throw;
+//                    }
+//                    else
+//                    {
+//                        RaiseOnException(e);
+//                    }
+//                }
+//            }
+
+//            return new BinderCompletedAsyncResult(callback, state);
+//        }
+
+//        public IAsyncResult BeginSend(Message message, TimeSpan timeout, AsyncCallback callback,
+//            object state)
+//        {
+//            return BeginSend(message, timeout, defaultMaskingMode, callback, state);
+//        }
+
+//        public IAsyncResult BeginSend(Message message, TimeSpan timeout, MaskingMode maskingMode,
+//            AsyncCallback callback, object state)
+//        {
+//            SendAsyncResult result = new SendAsyncResult(this, callback, state);
+//            result.Start(message, timeout, maskingMode);
+//            return result;
+//        }
+
+//        // ChannelSynchronizer helper, cannot take a lock.
+//        protected abstract IAsyncResult BeginTryGetChannel(TimeSpan timeout,
+//            AsyncCallback callback, object state);
+
+//        public virtual IAsyncResult BeginTryReceive(TimeSpan timeout, AsyncCallback callback,
+//            object state)
+//        {
+//            return BeginTryReceive(timeout, defaultMaskingMode, callback, state);
+//        }
+
+//        public virtual IAsyncResult BeginTryReceive(TimeSpan timeout, MaskingMode maskingMode,
+//            AsyncCallback callback, object state)
+//        {
+//            if (ValidateInputOperation(timeout))
+//                return new TryReceiveAsyncResult(this, timeout, maskingMode, callback, state);
+//            else
+//                return new CompletedAsyncResult(callback, state);
+//        }
+
+//        internal IAsyncResult BeginWaitForPendingOperations(TimeSpan timeout,
+//            AsyncCallback callback, object state)
+//        {
+//            return synchronizer.BeginWaitForPendingOperations(timeout, callback, state);
+//        }
+
+//        bool CloseCore(out TChannel channel)
+//        {
+//            channel = null;
+//            bool abort = true;
+//            bool abortChannel = false;
+
+//            lock (ThisLock)
+//            {
+//                if ((state == CommunicationState.Closing)
+//                    || (state == CommunicationState.Closed))
+//                {
+//                    return true;
+//                }
+
+//                if (state == CommunicationState.Opened)
+//                {
+//                    state = CommunicationState.Closing;
+//                    channel = synchronizer.StopSynchronizing(true);
+//                    abort = false;
+
+//                    if (!MustCloseChannel)
+//                    {
+//                        channel = null;
+//                    }
+
+//                    if (channel != null)
+//                    {
+//                        CommunicationState channelState = channel.State;
+
+//                        if ((channelState == CommunicationState.Created)
+//                            || (channelState == CommunicationState.Opening)
+//                            || (channelState == CommunicationState.Faulted))
+//                        {
+//                            abortChannel = true;
+//                        }
+//                        else if ((channelState == CommunicationState.Closing)
+//                            || (channelState == CommunicationState.Closed))
+//                        {
+//                            channel = null;
+//                        }
+//                    }
+//                }
+//            }
+
+//            synchronizer.UnblockWaiters();
+
+//            if (abort)
+//            {
+//                Abort();
+//                return true;
+//            }
+//            else
+//            {
+//                if (abortChannel)
+//                {
+//                    channel.Abort();
+//                    channel = null;
+//                }
+
+//                return false;
+//            }
+//        }
+
+//        public void Close(TimeSpan timeout)
+//        {
+//            Close(timeout, defaultMaskingMode);
+//        }
+
+//        public void Close(TimeSpan timeout, MaskingMode maskingMode)
+//        {
+//            ThrowIfTimeoutNegative(timeout);
+//            TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
+//            TChannel channel;
+
+//            if (CloseCore(out channel))
+//            {
+//                return;
+//            }
+
+//            try
+//            {
+//                OnShutdown();
+//                OnClose(timeoutHelper.RemainingTime());
+
+//                if (channel != null)
+//                {
+//                    CloseChannel(channel, timeoutHelper.RemainingTime());
+//                }
+
+//                TransitionToClosed();
+//            }
+//            catch (Exception e)
+//            {
+//                if (Fx.IsFatal(e))
+//                {
+//                    throw;
+//                }
+
+//                Abort();
+
+//                if (!HandleException(e, maskingMode))
+//                {
+//                    throw;
+//                }
+//            }
+//        }
+
+//        // The ChannelSynchronizer calls this from an operation thread so this method must not
+//        // block.
+//        void CloseChannel(TChannel channel)
+//        {
+//            if (!MustCloseChannel)
+//            {
+//                throw Fx.AssertAndThrow("MustCloseChannel is false when there is no receive loop and this method is called when there is a receive loop.");
+//            }
+
+//            if (onCloseChannelComplete == null)
+//            {
+//                onCloseChannelComplete = Fx.ThunkCallback(new AsyncCallback(OnCloseChannelComplete));
+//            }
+
+//            try
+//            {
+//                IAsyncResult result = channel.BeginClose(onCloseChannelComplete, channel);
+
+//                if (result.CompletedSynchronously)
+//                {
+//                    channel.EndClose(result);
+//                }
+//            }
+//            catch (Exception e)
+//            {
+//                if (Fx.IsFatal(e))
+//                {
+//                    throw;
+//                }
+
+//                HandleException(e, MaskingMode.All);
+//            }
+//        }
+
+//        protected virtual void CloseChannel(TChannel channel, TimeSpan timeout)
+//        {
+//            channel.Close(timeout);
+//        }
+
+//        public void EndClose(IAsyncResult result)
+//        {
+//            CloseAsyncResult closeResult = result as CloseAsyncResult;
+
+//            if (closeResult != null)
+//            {
+//                closeResult.End();
+//            }
+//            else
+//            {
+//                CompletedAsyncResult.End(result);
+//            }
+//        }
+
+//        protected virtual void EndCloseChannel(TChannel channel, IAsyncResult result)
+//        {
+//            channel.EndClose(result);
+//        }
+
+//        public void EndOpen(IAsyncResult result)
+//        {
+//            BinderCompletedAsyncResult completedResult = result as BinderCompletedAsyncResult;
+
+//            if (completedResult != null)
+//            {
+//                completedResult.End();
+//            }
+//            else
+//            {
+//                try
+//                {
+//                    OnEndOpen(result);
+//                }
+//                catch (Exception e)
+//                {
+//                    if (Fx.IsFatal(e))
+//                    {
+//                        throw;
+//                    }
+
+//                    Fault(null);
+
+//                    if (defaultMaskingMode == MaskingMode.None)
+//                    {
+//                        throw;
+//                    }
+//                    else
+//                    {
+//                        RaiseOnException(e);
+//                        return;
+//                    }
+//                }
+
+//                synchronizer.StartSynchronizing();
+//                OnOpened();
+//            }
+//        }
+
+//        public void EndSend(IAsyncResult result)
+//        {
+//            SendAsyncResult.End(result);
+//        }
+
+//        // ChannelSynchronizer helper, cannot take a lock.
+//        protected abstract bool EndTryGetChannel(IAsyncResult result);
+
+//        public virtual bool EndTryReceive(IAsyncResult result, out RequestContext requestContext)
+//        {
+//            TryReceiveAsyncResult tryReceiveResult = result as TryReceiveAsyncResult;
+
+//            if (tryReceiveResult != null)
+//            {
+//                return tryReceiveResult.End(out requestContext);
+//            }
+//            else
+//            {
+//                CompletedAsyncResult.End(result);
+//                requestContext = null;
+//                return true;
+//            }
+//        }
+
+//        public void EndWaitForPendingOperations(IAsyncResult result)
+//        {
+//            synchronizer.EndWaitForPendingOperations(result);
+//        }
+
+//        protected void Fault(Exception e)
+//        {
+//            lock (ThisLock)
+//            {
+//                if (state == CommunicationState.Created)
+//                {
+//                    throw Fx.AssertAndThrow("The binder should not detect the inner channel's faults until after the binder is opened.");
+//                }
+
+//                if ((state == CommunicationState.Faulted)
+//                    || (state == CommunicationState.Closed))
+//                {
+//                    return;
+//                }
+
+//                state = CommunicationState.Faulted;
+//                synchronizer.StopSynchronizing(false);
+//            }
+
+//            synchronizer.UnblockWaiters();
+
+//            BinderExceptionHandler handler = Faulted;
+
+//            if (handler != null)
+//            {
+//                handler(this, e);
+//            }
+//        }
+
+//        // ChannelSynchronizer helper, cannot take a lock.
+//        Exception GetClosedException(MaskingMode maskingMode)
+//        {
+//            if (ReliableChannelBinderHelper.MaskHandled(maskingMode))
+//            {
+//                return null;
+//            }
+//            else if (aborted)
+//            {
+//                return new CommunicationObjectAbortedException(SR.GetString(
+//                    SR.CommunicationObjectAborted1, GetType().ToString()));
+//            }
+//            else
+//            {
+//                return new ObjectDisposedException(GetType().ToString());
+//            }
+//        }
+
+//        // Must be called within lock (ThisLock)
+//        Exception GetClosedOrFaultedException(MaskingMode maskingMode)
+//        {
+//            if (state == CommunicationState.Faulted)
+//            {
+//                return GetFaultedException(maskingMode);
+//            }
+//            else if ((state == CommunicationState.Closing)
+//               || (state == CommunicationState.Closed))
+//            {
+//                return GetClosedException(maskingMode);
+//            }
+//            else
+//            {
+//                throw Fx.AssertAndThrow("Caller is attempting to get a terminal exception in a non-terminal state.");
+//            }
+//        }
+
+//        // ChannelSynchronizer helper, cannot take a lock.
+//        Exception GetFaultedException(MaskingMode maskingMode)
+//        {
+//            if (ReliableChannelBinderHelper.MaskHandled(maskingMode))
+//            {
+//                return null;
+//            }
+//            else
+//            {
+//                return new CommunicationObjectFaultedException(SR.GetString(
+//                    SR.CommunicationObjectFaulted1, GetType().ToString()));
+//            }
+//        }
+
+//        public abstract ISession GetInnerSession();
+
+//        public void HandleException(Exception e)
+//        {
+//            HandleException(e, MaskingMode.All);
+//        }
+
+//        protected bool HandleException(Exception e, MaskingMode maskingMode)
+//        {
+//            if (TolerateFaults && (e is CommunicationObjectFaultedException))
+//            {
+//                return true;
+//            }
+
+//            if (IsHandleable(e))
+//            {
+//                return ReliableChannelBinderHelper.MaskHandled(maskingMode);
+//            }
+
+//            bool maskUnhandled = ReliableChannelBinderHelper.MaskUnhandled(maskingMode);
+
+//            if (maskUnhandled)
+//            {
+//                RaiseOnException(e);
+//            }
+
+//            return maskUnhandled;
+//        }
+
+//        protected bool HandleException(Exception e, MaskingMode maskingMode, bool autoAborted)
+//        {
+//            if (TolerateFaults && autoAborted && e is CommunicationObjectAbortedException)
+//            {
+//                return true;
+//            }
+
+//            return HandleException(e, maskingMode);
+//        }
+
+//        // ChannelSynchronizer helper, cannot take a lock.
+//        protected abstract bool HasSecuritySession(TChannel channel);
+
+//        public bool IsHandleable(Exception e)
+//        {
+//            if (e is ProtocolException)
+//            {
+//                return false;
+//            }
+
+//            return (e is CommunicationException)
+//                || (e is TimeoutException);
+//        }
+
+//        protected abstract void OnAbort();
+//        protected abstract IAsyncResult OnBeginClose(TimeSpan timeout, AsyncCallback callback,
+//            object state);
+//        protected abstract IAsyncResult OnBeginOpen(TimeSpan timeout, AsyncCallback callback,
+//            object state);
+
+//        protected virtual IAsyncResult OnBeginSend(TChannel channel, Message message,
+//            TimeSpan timeout, AsyncCallback callback, object state)
+//        {
+//            throw Fx.AssertAndThrow("The derived class does not support the BeginSend operation.");
+//        }
+
+//        protected virtual IAsyncResult OnBeginTryReceive(TChannel channel, TimeSpan timeout,
+//            AsyncCallback callback, object state)
+//        {
+//            throw Fx.AssertAndThrow("The derived class does not support the BeginTryReceive operation.");
+//        }
+
+//        protected abstract void OnClose(TimeSpan timeout);
+
+//        void OnCloseChannelComplete(IAsyncResult result)
+//        {
+//            if (result.CompletedSynchronously)
+//            {
+//                return;
+//            }
+
+//            TChannel channel = (TChannel)result.AsyncState;
+
+//            try
+//            {
+//                channel.EndClose(result);
+//            }
+//            catch (Exception e)
+//            {
+//                if (Fx.IsFatal(e))
+//                {
+//                    throw;
+//                }
+
+//                HandleException(e, MaskingMode.All);
+//            }
+//        }
+
+//        protected abstract void OnEndClose(IAsyncResult result);
+//        protected abstract void OnEndOpen(IAsyncResult result);
+
+//        protected virtual void OnEndSend(TChannel channel, IAsyncResult result)
+//        {
+//            throw Fx.AssertAndThrow("The derived class does not support the EndSend operation.");
+//        }
+
+//        protected virtual bool OnEndTryReceive(TChannel channel, IAsyncResult result,
+//            out RequestContext requestContext)
+//        {
+//            throw Fx.AssertAndThrow("The derived class does not support the EndTryReceive operation.");
+//        }
+
+//        void OnInnerChannelFaulted()
+//        {
+//            if (!TolerateFaults)
+//                return;
+
+//            EventHandler handler = ConnectionLost;
+
+//            if (handler != null)
+//                handler(this, EventArgs.Empty);
+//        }
+
+//        protected abstract void OnOpen(TimeSpan timeout);
+
+//        void OnOpened()
+//        {
+//            lock (ThisLock)
+//            {
+//                if (state == CommunicationState.Opening)
+//                {
+//                    state = CommunicationState.Opened;
+//                }
+//            }
+//        }
+
+//        bool OnOpening(MaskingMode maskingMode)
+//        {
+//            lock (ThisLock)
+//            {
+//                if (state != CommunicationState.Created)
+//                {
+//                    Exception e = null;
+
+//                    if ((state == CommunicationState.Opening)
+//                        || (state == CommunicationState.Opened))
+//                    {
+//                        if (!ReliableChannelBinderHelper.MaskUnhandled(maskingMode))
+//                        {
+//                            e = new InvalidOperationException(SR.GetString(
+//                                SR.CommunicationObjectCannotBeModifiedInState,
+//                                GetType().ToString(), state.ToString()));
+//                        }
+//                    }
+//                    else
+//                    {
+//                        e = GetClosedOrFaultedException(maskingMode);
+//                    }
+
+//                    if (e != null)
+//                    {
+//                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(e);
+//                    }
+
+//                    return false;
+//                }
+//                else
+//                {
+//                    state = CommunicationState.Opening;
+//                    return true;
+//                }
+//            }
+//        }
+
+//        protected virtual void OnShutdown()
+//        {
+//        }
+
+//        protected virtual void OnSend(TChannel channel, Message message, TimeSpan timeout)
+//        {
+//            throw Fx.AssertAndThrow("The derived class does not support the Send operation.");
+//        }
+
+//        protected virtual bool OnTryReceive(TChannel channel, TimeSpan timeout,
+//            out RequestContext requestContext)
+//        {
+//            throw Fx.AssertAndThrow("The derived class does not support the TryReceive operation.");
+//        }
+
+//        public void Open(TimeSpan timeout)
+//        {
+//            ThrowIfTimeoutNegative(timeout);
+
+//            if (!OnOpening(defaultMaskingMode))
+//            {
+//                return;
+//            }
+
+//            try
+//            {
+//                OnOpen(timeout);
+//            }
+//            catch (Exception e)
+//            {
+//                if (Fx.IsFatal(e))
+//                {
+//                    throw;
+//                }
+
+//                Fault(null);
+
+//                if (defaultMaskingMode == MaskingMode.None)
+//                {
+//                    throw;
+//                }
+//                else
+//                {
+//                    RaiseOnException(e);
+//                    return;
+//                }
+//            }
+
+//            synchronizer.StartSynchronizing();
+//            OnOpened();
+//        }
+
+//        void RaiseOnException(Exception e)
+//        {
+//            BinderExceptionHandler handler = OnException;
+
+//            if (handler != null)
+//            {
+//                handler(this, e);
+//            }
+//        }
+
+//        public void Send(Message message, TimeSpan timeout)
+//        {
+//            Send(message, timeout, defaultMaskingMode);
+//        }
+
+//        public void Send(Message message, TimeSpan timeout, MaskingMode maskingMode)
+//        {
+//            if (!ValidateOutputOperation(message, timeout, maskingMode))
+//            {
+//                return;
+//            }
+
+//            bool autoAborted = false;
+
+//            try
+//            {
+//                TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
+//                TChannel channel;
+
+//                if (!synchronizer.TryGetChannelForOutput(timeoutHelper.RemainingTime(), maskingMode,
+//                    out channel))
+//                {
+//                    if (!ReliableChannelBinderHelper.MaskHandled(maskingMode))
+//                    {
+//                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(
+//                            new TimeoutException(SR.GetString(SR.TimeoutOnSend, timeout)));
+//                    }
+
+//                    return;
+//                }
+
+//                if (channel == null)
+//                {
+//                    return;
+//                }
+
+//                AddOutputHeaders(message);
+
+//                try
+//                {
+//                    OnSend(channel, message, timeoutHelper.RemainingTime());
+//                }
+//                finally
+//                {
+//                    autoAborted = Synchronizer.Aborting;
+//                    synchronizer.ReturnChannel();
+//                }
+//            }
+//            catch (Exception e)
+//            {
+//                if (Fx.IsFatal(e))
+//                {
+//                    throw;
+//                }
+
+//                if (!HandleException(e, maskingMode, autoAborted))
+//                {
+//                    throw;
+//                }
+//            }
+//        }
+
+//        public void SetMaskingMode(RequestContext context, MaskingMode maskingMode)
+//        {
+//            BinderRequestContext binderContext = (BinderRequestContext)context;
+//            binderContext.SetMaskingMode(maskingMode);
+//        }
+
+//        // throwDisposed indicates whether to throw in the Faulted, Closing, and Closed states.
+//        // returns true if in Opened state
+//        bool ThrowIfNotOpenedAndNotMasking(MaskingMode maskingMode, bool throwDisposed)
+//        {
+//            lock (ThisLock)
+//            {
+//                if (State == CommunicationState.Created)
+//                {
+//                    throw Fx.AssertAndThrow("Messaging operations cannot be called when the binder is in the Created state.");
+//                }
+
+//                if (State == CommunicationState.Opening)
+//                {
+//                    throw Fx.AssertAndThrow("Messaging operations cannot be called when the binder is in the Opening state.");
+//                }
+
+//                if (State == CommunicationState.Opened)
+//                {
+//                    return true;
+//                }
+
+//                // state is Faulted, Closing, or Closed
+//                if (throwDisposed)
+//                {
+//                    Exception e = GetClosedOrFaultedException(maskingMode);
+
+//                    if (e != null)
+//                    {
+//                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(e);
+//                    }
+//                }
+
+//                return false;
+//            }
+//        }
+
+//        void ThrowIfTimeoutNegative(TimeSpan timeout)
+//        {
+//            if (timeout < TimeSpan.Zero)
+//            {
+//                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(
+//                    new ArgumentOutOfRangeException("timeout", timeout, SR.SFxTimeoutOutOfRange0));
+//            }
+//        }
+
+//        void TransitionToClosed()
+//        {
+//            lock (ThisLock)
+//            {
+//                if ((state != CommunicationState.Closing)
+//                    && (state != CommunicationState.Closed)
+//                    && (state != CommunicationState.Faulted))
+//                {
+//                    throw Fx.AssertAndThrow("Caller cannot transition to the Closed state from a non-terminal state.");
+//                }
+
+//                state = CommunicationState.Closed;
+//            }
+//        }
+
+//        // ChannelSynchronizer helper, cannot take a lock.
+//        protected abstract bool TryGetChannel(TimeSpan timeout);
+
+//        public virtual bool TryReceive(TimeSpan timeout, out RequestContext requestContext)
+//        {
+//            return TryReceive(timeout, out requestContext, defaultMaskingMode);
+//        }
+
+//        public virtual bool TryReceive(TimeSpan timeout, out RequestContext requestContext, MaskingMode maskingMode)
+//        {
+//            if (maskingMode != MaskingMode.None)
+//            {
+//                throw Fx.AssertAndThrow("This method was implemented only for the case where we do not mask exceptions.");
+//            }
+
+//            if (!ValidateInputOperation(timeout))
+//            {
+//                requestContext = null;
+//                return true;
+//            }
+
+//            TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
+
+//            while (true)
+//            {
+//                bool autoAborted = false;
+
+//                try
+//                {
+//                    TChannel channel;
+//                    bool success = !synchronizer.TryGetChannelForInput(
+//                        CanGetChannelForReceive, timeoutHelper.RemainingTime(), out channel);
+
+//                    if (channel == null)
+//                    {
+//                        requestContext = null;
+//                        return success;
+//                    }
+
+//                    try
+//                    {
+//                        success = OnTryReceive(channel, timeoutHelper.RemainingTime(),
+//                            out requestContext);
+
+//                        // timed out || got message, return immediately
+//                        if (!success || (requestContext != null))
+//                        {
+//                            return success;
+//                        }
+
+//                        // the underlying channel closed or faulted, retry
+//                        synchronizer.OnReadEof();
+//                    }
+//                    finally
+//                    {
+//                        autoAborted = Synchronizer.Aborting;
+//                        synchronizer.ReturnChannel();
+//                    }
+//                }
+//                catch (Exception e)
+//                {
+//                    if (Fx.IsFatal(e))
+//                    {
+//                        throw;
+//                    }
+
+//                    if (!HandleException(e, maskingMode, autoAborted))
+//                    {
+//                        throw;
+//                    }
+//                }
+//            }
+//        }
+
+//        protected bool ValidateInputOperation(TimeSpan timeout)
+//        {
+//            if (timeout < TimeSpan.Zero)
+//            {
+//                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("timeout", timeout,
+//                    SR.SFxTimeoutOutOfRange0));
+//            }
+
+//            return ThrowIfNotOpenedAndNotMasking(MaskingMode.All, false);
+//        }
+
+//        protected bool ValidateOutputOperation(Message message, TimeSpan timeout, MaskingMode maskingMode)
+//        {
+//            if (message == null)
+//            {
+//                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("message");
+//            }
+
+//            if (timeout < TimeSpan.Zero)
+//            {
+//                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("timeout", timeout,
+//                    SR.SFxTimeoutOutOfRange0));
+//            }
+
+//            return ThrowIfNotOpenedAndNotMasking(maskingMode, true);
+//        }
+
+//        internal void WaitForPendingOperations(TimeSpan timeout)
+//        {
+//            synchronizer.WaitForPendingOperations(timeout);
+//        }
+
+//        protected RequestContext WrapMessage(Message message)
+//        {
+//            if (message == null)
+//            {
+//                return null;
+//            }
+
+//            return new MessageRequestContext(this, message);
+//        }
+
+//        public RequestContext WrapRequestContext(RequestContext context)
+//        {
+//            if (context == null)
+//            {
+//                return null;
+//            }
+
+//            if (!TolerateFaults && defaultMaskingMode == MaskingMode.None)
+//            {
+//                return context;
+//            }
+
+//            return new RequestRequestContext(this, context, context.RequestMessage);
+//        }
+
+//        sealed class BinderCompletedAsyncResult : CompletedAsyncResult
+//        {
+//            public BinderCompletedAsyncResult(AsyncCallback callback, object state)
+//                : base(callback, state)
+//            {
+//            }
+
+//            public void End()
+//            {
+//                CompletedAsyncResult.End(this);
+//            }
+//        }
+
+//        abstract class BinderRequestContext : RequestContextBase
+//        {
+//            ReliableChannelBinder<TChannel> binder;
+//            MaskingMode maskingMode;
+
+//            public BinderRequestContext(ReliableChannelBinder<TChannel> binder, Message message)
+//                : base(message, binder.defaultCloseTimeout, binder.defaultSendTimeout)
+//            {
+//                if (binder == null)
+//                {
+//                    Fx.Assert("Argument binder cannot be null.");
+//                }
+
+//                binder = binder;
+//                maskingMode = binder.defaultMaskingMode;
+//            }
+
+//            protected ReliableChannelBinder<TChannel> Binder
+//            {
+//                get
+//                {
+//                    return binder;
+//                }
+//            }
+
+//            protected MaskingMode MaskingMode
+//            {
+//                get
+//                {
+//                    return maskingMode;
+//                }
+//            }
+
+//            public void SetMaskingMode(MaskingMode maskingMode)
+//            {
+//                if (binder.defaultMaskingMode != MaskingMode.All)
+//                {
+//                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new NotSupportedException());
+//                }
+
+//                maskingMode = maskingMode;
+//            }
+//        }
+
+//        protected class ChannelSynchronizer
+//        {
+//            bool aborting; // Indicates the current channel is being aborted, not the synchronizer.
+//            ReliableChannelBinder<TChannel> binder;
+//            int count = 0;
+//            TChannel currentChannel;
+//            InterruptibleWaitObject drainEvent;
+//            static Action<object> asyncGetChannelCallback = new Action<object>(AsyncGetChannelCallback);
+//            TolerateFaultsMode faultMode;
+//            Queue<IWaiter> getChannelQueue;
+//            bool innerChannelFaulted;
+//            EventHandler onChannelFaulted;
+//            State state = State.Created;
+//            bool tolerateFaults = true;
+//            object thisLock = new object();
+//            Queue<IWaiter> waitQueue;
+
+//            public ChannelSynchronizer(ReliableChannelBinder<TChannel> binder, TChannel channel,
+//                TolerateFaultsMode faultMode)
+//            {
+//                binder = binder;
+//                currentChannel = channel;
+//                faultMode = faultMode;
+//            }
+
+//            public bool Aborting
+//            {
+//                get
+//                {
+//                    return aborting;
+//                }
+//            }
+
+//            public bool Connected
+//            {
+//                get
+//                {
+//                    return (state == State.ChannelOpened ||
+//                        state == State.ChannelOpening);
+//                }
+//            }
+
+//            public TChannel CurrentChannel
+//            {
+//                get
+//                {
+//                    return currentChannel;
+//                }
+//            }
+
+//            object ThisLock
+//            {
+//                get
+//                {
+//                    return thisLock;
+//                }
+//            }
+
+//            public bool TolerateFaults
+//            {
+//                get
+//                {
+//                    return tolerateFaults;
+//                }
+//            }
+
+//            // Server only API.
+//            public TChannel AbortCurentChannel()
+//            {
+//                lock (ThisLock)
+//                {
+//                    if (!tolerateFaults)
+//                    {
+//                        throw Fx.AssertAndThrow("It is only valid to abort the current channel when masking faults");
+//                    }
+
+//                    if (state == State.ChannelOpening)
+//                    {
+//                        aborting = true;
+//                    }
+//                    else if (state == State.ChannelOpened)
+//                    {
+//                        if (count == 0)
+//                        {
+//                            state = State.NoChannel;
+//                        }
+//                        else
+//                        {
+//                            aborting = true;
+//                            state = State.ChannelClosing;
+//                        }
+//                    }
+//                    else
+//                    {
+//                        return null;
+//                    }
+
+//                    return currentChannel;
+//                }
+//            }
+
+//            static void AsyncGetChannelCallback(object state)
+//            {
+//                AsyncWaiter waiter = (AsyncWaiter)state;
+//                waiter.GetChannel(false);
+//            }
+
+//            public IAsyncResult BeginTryGetChannelForInput(bool canGetChannel, TimeSpan timeout,
+//                AsyncCallback callback, object state)
+//            {
+//                return BeginTryGetChannel(canGetChannel, false, timeout, MaskingMode.All,
+//                    callback, state);
+//            }
+
+//            public IAsyncResult BeginTryGetChannelForOutput(TimeSpan timeout,
+//                MaskingMode maskingMode, AsyncCallback callback, object state)
+//            {
+//                return BeginTryGetChannel(true, true, timeout, maskingMode,
+//                    callback, state);
+//            }
+
+//            IAsyncResult BeginTryGetChannel(bool canGetChannel, bool canCauseFault,
+//                TimeSpan timeout, MaskingMode maskingMode, AsyncCallback callback, object state)
+//            {
+//                TChannel channel = null;
+//                AsyncWaiter waiter = null;
+//                bool getChannel = false;
+//                bool faulted = false;
+
+//                lock (ThisLock)
+//                {
+//                    if (!ThrowIfNecessary(maskingMode))
+//                    {
+//                        channel = null;
+//                    }
+//                    else if (state == State.ChannelOpened)
+//                    {
+//                        if (currentChannel == null)
+//                        {
+//                            throw Fx.AssertAndThrow("Field currentChannel cannot be null in the ChannelOpened state.");
+//                        }
+
+//                        count++;
+//                        channel = currentChannel;
+//                    }
+//                    else if (!tolerateFaults
+//                        && ((state == State.NoChannel)
+//                        || (state == State.ChannelClosing)))
+//                    {
+//                        if (canCauseFault)
+//                        {
+//                            faulted = true;
+//                        }
+
+//                        channel = null;
+//                    }
+//                    else if (!canGetChannel
+//                        || (state == State.ChannelOpening)
+//                        || (state == State.ChannelClosing))
+//                    {
+//                        waiter = new AsyncWaiter(this, canGetChannel, null, timeout, maskingMode,
+//                            binder.ChannelParameters,
+//                            callback, state);
+//                        GetQueue(canGetChannel).Enqueue(waiter);
+//                    }
+//                    else
+//                    {
+//                        if (state != State.NoChannel)
+//                        {
+//                            throw Fx.AssertAndThrow("The state must be NoChannel.");
+//                        }
+
+//                        waiter = new AsyncWaiter(this, canGetChannel,
+//                            GetCurrentChannelIfCreated(), timeout, maskingMode,
+//                            binder.ChannelParameters,
+//                            callback, state);
+
+//                        state = State.ChannelOpening;
+//                        getChannel = true;
+//                    }
+//                }
+
+//                if (faulted)
+//                {
+//                    binder.Fault(null);
+//                }
+
+//                if (waiter == null)
+//                {
+//                    return new CompletedAsyncResult<TChannel>(channel, callback, state);
+//                }
+
+//                if (getChannel)
+//                {
+//                    waiter.GetChannel(true);
+//                }
+//                else
+//                {
+//                    waiter.Wait();
+//                }
+
+//                return waiter;
+//            }
+
+//            public IAsyncResult BeginWaitForPendingOperations(TimeSpan timeout,
+//                AsyncCallback callback, object state)
+//            {
+//                lock (ThisLock)
+//                {
+//                    if (drainEvent != null)
+//                    {
+//                        throw Fx.AssertAndThrow("The WaitForPendingOperations operation may only be invoked once.");
+//                    }
+
+//                    if (count > 0)
+//                    {
+//                        drainEvent = new InterruptibleWaitObject(false, false);
+//                    }
+//                }
+
+//                if (drainEvent != null)
+//                {
+//                    return drainEvent.BeginWait(timeout, callback, state);
+//                }
+//                else
+//                {
+//                    return new SynchronizerCompletedAsyncResult(callback, state);
+//                }
+//            }
+
+//            bool CompleteSetChannel(IWaiter waiter, out TChannel channel)
+//            {
+//                if (waiter == null)
+//                {
+//                    throw Fx.AssertAndThrow("Argument waiter cannot be null.");
+//                }
+
+//                bool close = false;
+
+//                lock (ThisLock)
+//                {
+//                    if (ValidateOpened())
+//                    {
+//                        channel = currentChannel;
+//                        return true;
+//                    }
+//                    else
+//                    {
+//                        channel = null;
+//                        close = state == State.Closed;
+//                    }
+//                }
+
+//                if (close)
+//                {
+//                    waiter.Close();
+//                }
+//                else
+//                {
+//                    waiter.Fault();
+//                }
+
+//                return false;
+//            }
+
+//            public bool EndTryGetChannel(IAsyncResult result, out TChannel channel)
+//            {
+//                AsyncWaiter waiter = result as AsyncWaiter;
+
+//                if (waiter != null)
+//                {
+//                    return waiter.End(out channel);
+//                }
+//                else
+//                {
+//                    channel = CompletedAsyncResult<TChannel>.End(result);
+//                    return true;
+//                }
+//            }
+
+//            public void EndWaitForPendingOperations(IAsyncResult result)
+//            {
+//                SynchronizerCompletedAsyncResult completedResult =
+//                    result as SynchronizerCompletedAsyncResult;
+
+//                if (completedResult != null)
+//                {
+//                    completedResult.End();
+//                }
+//                else
+//                {
+//                    drainEvent.EndWait(result);
+//                }
+//            }
+
+//            // Client API only.
+//            public bool EnsureChannel()
+//            {
+//                bool fault = false;
+
+//                lock (ThisLock)
+//                {
+//                    if (ValidateOpened())
+//                    {
+//                        // This is called only during the RM CS phase. In this phase, there are 2
+//                        // valid states between Request calls, ChannelOpened and NoChannel.
+//                        if (state == State.ChannelOpened)
+//                        {
+//                            return true;
+//                        }
+
+//                        if (state != State.NoChannel)
+//                        {
+//                            throw Fx.AssertAndThrow("The caller may only invoke this EnsureChannel during the CreateSequence negotiation. ChannelOpening and ChannelClosing are invalid states during this phase of the negotiation.");
+//                        }
+
+//                        if (!tolerateFaults)
+//                        {
+//                            fault = true;
+//                        }
+//                        else
+//                        {
+//                            if (GetCurrentChannelIfCreated() != null)
+//                            {
+//                                return true;
+//                            }
+
+//                            if (binder.TryGetChannel(TimeSpan.Zero))
+//                            {
+//                                if (currentChannel == null)
+//                                {
+//                                    return false;
+//                                }
+
+//                                return true;
+//                            }
+//                        }
+//                    }
+//                }
+
+//                if (fault)
+//                {
+//                    binder.Fault(null);
+//                }
+
+//                return false;
+//            }
+
+//            IWaiter GetChannelWaiter()
+//            {
+//                if ((getChannelQueue == null) || (getChannelQueue.Count == 0))
+//                {
+//                    return null;
+//                }
+
+//                return getChannelQueue.Dequeue();
+//            }
+
+//            // Must be called within lock (ThisLock)
+//            TChannel GetCurrentChannelIfCreated()
+//            {
+//                if (state != State.NoChannel)
+//                {
+//                    throw Fx.AssertAndThrow("This method may only be called in the NoChannel state.");
+//                }
+
+//                if ((currentChannel != null)
+//                    && (currentChannel.State == CommunicationState.Created))
+//                {
+//                    return currentChannel;
+//                }
+//                else
+//                {
+//                    return null;
+//                }
+//            }
+
+//            Queue<IWaiter> GetQueue(bool canGetChannel)
+//            {
+//                if (canGetChannel)
+//                {
+//                    if (getChannelQueue == null)
+//                    {
+//                        getChannelQueue = new Queue<IWaiter>();
+//                    }
+
+//                    return getChannelQueue;
+//                }
+//                else
+//                {
+//                    if (waitQueue == null)
+//                    {
+//                        waitQueue = new Queue<IWaiter>();
+//                    }
+
+//                    return waitQueue;
+//                }
+//            }
+
+//            void OnChannelFaulted(object sender, EventArgs e)
+//            {
+//                TChannel faultedChannel = (TChannel)sender;
+//                bool faultBinder = false;
+//                bool raiseInnerChannelFaulted = false;
+
+//                lock (ThisLock)
+//                {
+//                    if (currentChannel != faultedChannel)
+//                    {
+//                        return;
+//                    }
+
+//                    // The synchronizer is already closed or aborted.
+//                    if (!ValidateOpened())
+//                    {
+//                        return;
+//                    }
+
+//                    if (state == State.ChannelOpened)
+//                    {
+//                        if (count == 0)
+//                        {
+//                            faultedChannel.Faulted -= onChannelFaulted;
+//                        }
+
+//                        faultBinder = !tolerateFaults;
+//                        state = State.ChannelClosing;
+//                        innerChannelFaulted = true;
+
+//                        if (!faultBinder && count == 0)
+//                        {
+//                            state = State.NoChannel;
+//                            aborting = false;
+//                            raiseInnerChannelFaulted = true;
+//                            innerChannelFaulted = false;
+//                        }
+//                    }
+//                }
+
+//                if (faultBinder)
+//                {
+//                    binder.Fault(null);
+//                }
+
+//                faultedChannel.Abort();
+
+//                if (raiseInnerChannelFaulted)
+//                {
+//                    binder.OnInnerChannelFaulted();
+//                }
+//            }
+
+//            bool OnChannelOpened(IWaiter waiter)
+//            {
+//                if (waiter == null)
+//                {
+//                    throw Fx.AssertAndThrow("Argument waiter cannot be null.");
+//                }
+
+//                bool close = false;
+//                bool fault = false;
+
+//                Queue<IWaiter> temp1 = null;
+//                Queue<IWaiter> temp2 = null;
+//                TChannel channel = null;
+
+//                lock (ThisLock)
+//                {
+//                    if (currentChannel == null)
+//                    {
+//                        throw Fx.AssertAndThrow("Caller must ensure that field currentChannel is set before opening the channel.");
+//                    }
+
+//                    if (ValidateOpened())
+//                    {
+//                        if (state != State.ChannelOpening)
+//                        {
+//                            throw Fx.AssertAndThrow("This method may only be called in the ChannelOpening state.");
+//                        }
+
+//                        state = State.ChannelOpened;
+//                        SetTolerateFaults();
+
+//                        count += 1;
+//                        count += (getChannelQueue == null) ? 0 : getChannelQueue.Count;
+//                        count += (waitQueue == null) ? 0 : waitQueue.Count;
+
+//                        temp1 = getChannelQueue;
+//                        temp2 = waitQueue;
+//                        channel = currentChannel;
+
+//                        getChannelQueue = null;
+//                        waitQueue = null;
+//                    }
+//                    else
+//                    {
+//                        close = state == State.Closed;
+//                        fault = state == State.Faulted;
+//                    }
+//                }
+
+//                if (close)
+//                {
+//                    waiter.Close();
+//                    return false;
+//                }
+//                else if (fault)
+//                {
+//                    waiter.Fault();
+//                    return false;
+//                }
+
+//                SetWaiters(temp1, channel);
+//                SetWaiters(temp2, channel);
+//                return true;
+//            }
+
+//            void OnGetChannelFailed()
+//            {
+//                IWaiter waiter = null;
+
+//                lock (ThisLock)
+//                {
+//                    if (!ValidateOpened())
+//                    {
+//                        return;
+//                    }
+
+//                    if (state != State.ChannelOpening)
+//                    {
+//                        throw Fx.AssertAndThrow("The state must be set to ChannelOpening before the caller attempts to open the channel.");
+//                    }
+
+//                    waiter = GetChannelWaiter();
+
+//                    if (waiter == null)
+//                    {
+//                        state = State.NoChannel;
+//                        return;
+//                    }
+//                }
+
+//                if (waiter is SyncWaiter)
+//                {
+//                    waiter.GetChannel(false);
+//                }
+//                else
+//                {
+//                    ActionItem.Schedule(asyncGetChannelCallback, waiter);
+//                }
+//            }
+
+//            public void OnReadEof()
+//            {
+//                lock (ThisLock)
+//                {
+//                    if (count <= 0)
+//                    {
+//                        throw Fx.AssertAndThrow("Caller must ensure that OnReadEof is called before ReturnChannel.");
+//                    }
+
+//                    if (ValidateOpened())
+//                    {
+//                        if ((state != State.ChannelOpened) && (state != State.ChannelClosing))
+//                        {
+//                            throw Fx.AssertAndThrow("Since count is positive, the only valid states are ChannelOpened and ChannelClosing.");
+//                        }
+
+//                        if (currentChannel.State != CommunicationState.Faulted)
+//                        {
+//                            state = State.ChannelClosing;
+//                        }
+//                    }
+//                }
+//            }
+
+//            bool RemoveWaiter(IWaiter waiter)
+//            {
+//                Queue<IWaiter> waiters = waiter.CanGetChannel ? getChannelQueue : waitQueue;
+//                bool removed = false;
+
+//                lock (ThisLock)
+//                {
+//                    if (!ValidateOpened())
+//                    {
+//                        return false;
+//                    }
+
+//                    for (int i = waiters.Count; i > 0; i--)
+//                    {
+//                        IWaiter temp = waiters.Dequeue();
+
+//                        if (object.ReferenceEquals(waiter, temp))
+//                        {
+//                            removed = true;
+//                        }
+//                        else
+//                        {
+//                            waiters.Enqueue(temp);
+//                        }
+//                    }
+//                }
+
+//                return removed;
+//            }
+
+//            public void ReturnChannel()
+//            {
+//                TChannel channel = null;
+//                IWaiter waiter = null;
+//                bool faultBinder = false;
+//                bool drained;
+//                bool raiseInnerChannelFaulted = false;
+
+//                lock (ThisLock)
+//                {
+//                    if (count <= 0)
+//                    {
+//                        throw Fx.AssertAndThrow("Method ReturnChannel() can only be called after TryGetChannel or EndTryGetChannel returns a channel.");
+//                    }
+
+//                    count--;
+//                    drained = (count == 0) && (drainEvent != null);
+
+//                    if (ValidateOpened())
+//                    {
+//                        if ((state != State.ChannelOpened) && (state != State.ChannelClosing))
+//                        {
+//                            throw Fx.AssertAndThrow("ChannelOpened and ChannelClosing are the only 2 valid states when count is positive.");
+//                        }
+
+//                        if (currentChannel.State == CommunicationState.Faulted)
+//                        {
+//                            faultBinder = !tolerateFaults;
+//                            innerChannelFaulted = true;
+//                            state = State.ChannelClosing;
+//                        }
+
+//                        if (!faultBinder && (state == State.ChannelClosing) && (count == 0))
+//                        {
+//                            channel = currentChannel;
+//                            raiseInnerChannelFaulted = innerChannelFaulted;
+//                            innerChannelFaulted = false;
+
+//                            state = State.NoChannel;
+//                            aborting = false;
+
+//                            waiter = GetChannelWaiter();
+
+//                            if (waiter != null)
+//                            {
+//                                state = State.ChannelOpening;
+//                            }
+//                        }
+//                    }
+//                }
+
+//                if (faultBinder)
+//                {
+//                    binder.Fault(null);
+//                }
+
+//                if (drained)
+//                {
+//                    drainEvent.Set();
+//                }
+
+//                if (channel != null)
+//                {
+//                    channel.Faulted -= onChannelFaulted;
+
+//                    if (channel.State == CommunicationState.Opened)
+//                    {
+//                        binder.CloseChannel(channel);
+//                    }
+//                    else
+//                    {
+//                        channel.Abort();
+//                    }
+
+//                    if (waiter != null)
+//                    {
+//                        waiter.GetChannel(false);
+//                    }
+//                }
+
+//                if (raiseInnerChannelFaulted)
+//                {
+//                    binder.OnInnerChannelFaulted();
+//                }
+//            }
+
+//            public bool SetChannel(TChannel channel)
+//            {
+//                lock (ThisLock)
+//                {
+//                    if (state != State.ChannelOpening && state != State.NoChannel)
+//                    {
+//                        throw Fx.AssertAndThrow("SetChannel is only valid in the NoChannel and ChannelOpening states");
+//                    }
+
+//                    if (!tolerateFaults)
+//                    {
+//                        throw Fx.AssertAndThrow("SetChannel is only valid when masking faults");
+//                    }
+
+//                    if (ValidateOpened())
+//                    {
+//                        currentChannel = channel;
+//                        return true;
+//                    }
+//                    else
+//                    {
+//                        return false;
+//                    }
+//                }
+//            }
+
+//            void SetTolerateFaults()
+//            {
+//                if (faultMode == TolerateFaultsMode.Never)
+//                {
+//                    tolerateFaults = false;
+//                }
+//                else if (faultMode == TolerateFaultsMode.IfNotSecuritySession)
+//                {
+//                    tolerateFaults = !binder.HasSecuritySession(currentChannel);
+//                }
+
+//                if (onChannelFaulted == null)
+//                {
+//                    onChannelFaulted = new EventHandler(OnChannelFaulted);
+//                }
+
+//                currentChannel.Faulted += onChannelFaulted;
+//            }
+
+//            void SetWaiters(Queue<IWaiter> waiters, TChannel channel)
+//            {
+//                if ((waiters != null) && (waiters.Count > 0))
+//                {
+//                    foreach (IWaiter waiter in waiters)
+//                    {
+//                        waiter.Set(channel);
+//                    }
+//                }
+//            }
+
+//            public void StartSynchronizing()
+//            {
+//                lock (ThisLock)
+//                {
+//                    if (state == State.Created)
+//                    {
+//                        state = State.NoChannel;
+//                    }
+//                    else
+//                    {
+//                        if (state != State.Closed)
+//                        {
+//                            throw Fx.AssertAndThrow("Abort is the only operation that can race with Open.");
+//                        }
+
+//                        return;
+//                    }
+
+//                    if (currentChannel == null)
+//                    {
+//                        if (!binder.TryGetChannel(TimeSpan.Zero))
+//                        {
+//                            return;
+//                        }
+//                    }
+
+//                    if (currentChannel == null)
+//                    {
+//                        return;
+//                    }
+
+//                    if (!binder.MustOpenChannel)
+//                    {
+//                        // Channel is already opened.
+//                        state = State.ChannelOpened;
+//                        SetTolerateFaults();
+//                    }
+//                }
+//            }
+
+//            public TChannel StopSynchronizing(bool close)
+//            {
+//                lock (ThisLock)
+//                {
+//                    if ((state != State.Faulted) && (state != State.Closed))
+//                    {
+//                        state = close ? State.Closed : State.Faulted;
+
+//                        if ((currentChannel != null) && (onChannelFaulted != null))
+//                        {
+//                            currentChannel.Faulted -= onChannelFaulted;
+//                        }
+//                    }
+
+//                    return currentChannel;
+//                }
+//            }
+
+//            // Must be called under a lock.
+//            bool ThrowIfNecessary(MaskingMode maskingMode)
+//            {
+//                if (ValidateOpened())
+//                {
+//                    return true;
+//                }
+
+//                // state is Closed or Faulted.
+//                Exception e;
+
+//                if (state == State.Closed)
+//                {
+//                    e = binder.GetClosedException(maskingMode);
+//                }
+//                else
+//                {
+//                    e = binder.GetFaultedException(maskingMode);
+//                }
+
+//                if (e != null)
+//                {
+//                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(e);
+//                }
+
+//                return false;
+//            }
+
+//            public bool TryGetChannelForInput(bool canGetChannel, TimeSpan timeout,
+//                out TChannel channel)
+//            {
+//                return TryGetChannel(canGetChannel, false, timeout, MaskingMode.All,
+//                    out channel);
+//            }
+
+//            public bool TryGetChannelForOutput(TimeSpan timeout, MaskingMode maskingMode,
+//                out TChannel channel)
+//            {
+//                return TryGetChannel(true, true, timeout, maskingMode, out channel);
+//            }
+
+//            bool TryGetChannel(bool canGetChannel, bool canCauseFault, TimeSpan timeout,
+//                MaskingMode maskingMode, out TChannel channel)
+//            {
+//                SyncWaiter waiter = null;
+//                bool faulted = false;
+//                bool getChannel = false;
+
+//                lock (ThisLock)
+//                {
+//                    if (!ThrowIfNecessary(maskingMode))
+//                    {
+//                        channel = null;
+//                        return true;
+//                    }
+
+//                    if (state == State.ChannelOpened)
+//                    {
+//                        if (currentChannel == null)
+//                        {
+//                            throw Fx.AssertAndThrow("Field currentChannel cannot be null in the ChannelOpened state.");
+//                        }
+
+//                        count++;
+//                        channel = currentChannel;
+//                        return true;
+//                    }
+
+//                    if (!tolerateFaults
+//                        && ((state == State.ChannelClosing)
+//                        || (state == State.NoChannel)))
+//                    {
+//                        if (!canCauseFault)
+//                        {
+//                            channel = null;
+//                            return true;
+//                        }
+
+//                        faulted = true;
+//                    }
+//                    else if (!canGetChannel
+//                        || (state == State.ChannelOpening)
+//                        || (state == State.ChannelClosing))
+//                    {
+//                        waiter = new SyncWaiter(this, canGetChannel, null, timeout, maskingMode, binder.ChannelParameters);
+//                        GetQueue(canGetChannel).Enqueue(waiter);
+//                    }
+//                    else
+//                    {
+//                        if (state != State.NoChannel)
+//                        {
+//                            throw Fx.AssertAndThrow("The state must be NoChannel.");
+//                        }
+
+//                        waiter = new SyncWaiter(this, canGetChannel,
+//                            GetCurrentChannelIfCreated(), timeout, maskingMode,
+//                            binder.ChannelParameters);
+
+//                        state = State.ChannelOpening;
+//                        getChannel = true;
+//                    }
+//                }
+
+//                if (faulted)
+//                {
+//                    binder.Fault(null);
+//                    channel = null;
+//                    return true;
+//                }
+
+//                if (getChannel)
+//                {
+//                    waiter.GetChannel(true);
+//                }
+
+//                return waiter.TryWait(out channel);
+//            }
+
+//            public void UnblockWaiters()
+//            {
+//                Queue<IWaiter> temp1;
+//                Queue<IWaiter> temp2;
+
+//                lock (ThisLock)
+//                {
+//                    temp1 = getChannelQueue;
+//                    temp2 = waitQueue;
+
+//                    getChannelQueue = null;
+//                    waitQueue = null;
+//                }
+
+//                bool close = state == State.Closed;
+//                UnblockWaiters(temp1, close);
+//                UnblockWaiters(temp2, close);
+//            }
+
+//            void UnblockWaiters(Queue<IWaiter> waiters, bool close)
+//            {
+//                if ((waiters != null) && (waiters.Count > 0))
+//                {
+//                    foreach (IWaiter waiter in waiters)
+//                    {
+//                        if (close)
+//                        {
+//                            waiter.Close();
+//                        }
+//                        else
+//                        {
+//                            waiter.Fault();
+//                        }
+//                    }
+//                }
+//            }
+
+//            bool ValidateOpened()
+//            {
+//                if (state == State.Created)
+//                {
+//                    throw Fx.AssertAndThrow("This operation expects that the synchronizer has been opened.");
+//                }
+
+//                return (state != State.Closed) && (state != State.Faulted);
+//            }
+
+//            public void WaitForPendingOperations(TimeSpan timeout)
+//            {
+//                lock (ThisLock)
+//                {
+//                    if (drainEvent != null)
+//                    {
+//                        throw Fx.AssertAndThrow("The WaitForPendingOperations operation may only be invoked once.");
+//                    }
+
+//                    if (count > 0)
+//                    {
+//                        drainEvent = new InterruptibleWaitObject(false, false);
+//                    }
+//                }
+
+//                if (drainEvent != null)
+//                {
+//                    drainEvent.Wait(timeout);
+//                }
+//            }
+
+//            enum State
+//            {
+//                Created,
+//                NoChannel,
+//                ChannelOpening,
+//                ChannelOpened,
+//                ChannelClosing,
+//                Faulted,
+//                Closed
+//            }
+
+//            public interface IWaiter
+//            {
+//                bool CanGetChannel { get; }
+
+//                void Close();
+//                void Fault();
+//                void GetChannel(bool onUserThread);
+//                void Set(TChannel channel);
+//            }
+
+//            public sealed class AsyncWaiter : AsyncResult, IWaiter
+//            {
+//                bool canGetChannel;
+//                TChannel channel;
+//                ChannelParameterCollection channelParameters;
+//                bool isSynchronous = true;
+//                MaskingMode maskingMode;
+//                static AsyncCallback onOpenComplete = Fx.ThunkCallback(new AsyncCallback(OnOpenComplete));
+//                static Action<object> onTimeoutElapsed = new Action<object>(OnTimeoutElapsed);
+//                static AsyncCallback onTryGetChannelComplete = Fx.ThunkCallback(new AsyncCallback(OnTryGetChannelComplete));
+//                bool timedOut = false;
+//                ChannelSynchronizer synchronizer;
+//                TimeoutHelper timeoutHelper;
+//                IOThreadTimer timer;
+//                bool timerCancelled = false;
+
+//                public AsyncWaiter(ChannelSynchronizer synchronizer, bool canGetChannel,
+//                    TChannel channel, TimeSpan timeout, MaskingMode maskingMode,
+//                    ChannelParameterCollection channelParameters,
+//                    AsyncCallback callback, object state)
+//                    : base(callback, state)
+//                {
+//                    if (!canGetChannel)
+//                    {
+//                        if (channel != null)
+//                        {
+//                            throw Fx.AssertAndThrow("This waiter must wait for a channel thus argument channel must be null.");
+//                        }
+//                    }
+
+//                    synchronizer = synchronizer;
+//                    canGetChannel = canGetChannel;
+//                    channel = channel;
+//                    timeoutHelper = new TimeoutHelper(timeout);
+//                    maskingMode = maskingMode;
+//                    channelParameters = channelParameters;
+//                }
+
+//                public bool CanGetChannel
+//                {
+//                    get
+//                    {
+//                        return canGetChannel;
+//                    }
+//                }
+
+//                object ThisLock
+//                {
+//                    get
+//                    {
+//                        return this;
+//                    }
+//                }
+
+//                void CancelTimer()
+//                {
+//                    lock (ThisLock)
+//                    {
+//                        if (!timerCancelled)
+//                        {
+//                            if (timer != null)
+//                            {
+//                                timer.Cancel();
+//                            }
+
+//                            timerCancelled = true;
+//                        }
+//                    }
+//                }
+
+//                public void Close()
+//                {
+//                    CancelTimer();
+//                    channel = null;
+//                    Complete(false,
+//                        synchronizer.binder.GetClosedException(maskingMode));
+//                }
+
+//                bool CompleteOpen(IAsyncResult result)
+//                {
+//                    channel.EndOpen(result);
+//                    return OnChannelOpened();
+//                }
+
+//                bool CompleteTryGetChannel(IAsyncResult result)
+//                {
+//                    if (!synchronizer.binder.EndTryGetChannel(result))
+//                    {
+//                        timedOut = true;
+//                        OnGetChannelFailed();
+//                        return true;
+//                    }
+
+//                    if (!synchronizer.CompleteSetChannel(this, out channel))
+//                    {
+//                        if (!IsCompleted)
+//                        {
+//                            throw Fx.AssertAndThrow("CompleteSetChannel must complete the IWaiter if it returns false.");
+//                        }
+
+//                        return false;
+//                    }
+
+//                    return OpenChannel();
+//                }
+
+//                public bool End(out TChannel channel)
+//                {
+//                    AsyncResult.End<AsyncWaiter>(this);
+//                    channel = channel;
+//                    return !timedOut;
+//                }
+
+//                public void Fault()
+//                {
+//                    CancelTimer();
+//                    channel = null;
+//                    Complete(false,
+//                        synchronizer.binder.GetFaultedException(maskingMode));
+//                }
+
+//                bool GetChannel()
+//                {
+//                    if (channel != null)
+//                    {
+//                        return OpenChannel();
+//                    }
+//                    else
+//                    {
+//                        IAsyncResult result = synchronizer.binder.BeginTryGetChannel(
+//                            timeoutHelper.RemainingTime(), onTryGetChannelComplete, this);
+
+//                        if (result.CompletedSynchronously)
+//                        {
+//                            return CompleteTryGetChannel(result);
+//                        }
+//                    }
+
+//                    return false;
+//                }
+
+//                public void GetChannel(bool onUserThread)
+//                {
+//                    if (!CanGetChannel)
+//                    {
+//                        throw Fx.AssertAndThrow("This waiter must wait for a channel thus the caller cannot attempt to get a channel.");
+//                    }
+
+//                    isSynchronous = onUserThread;
+
+//                    if (onUserThread)
+//                    {
+//                        bool throwing = true;
+
+//                        try
+//                        {
+//                            if (GetChannel())
+//                            {
+//                                Complete(true);
+//                            }
+
+//                            throwing = false;
+//                        }
+//                        finally
+//                        {
+//                            if (throwing)
+//                            {
+//                                OnGetChannelFailed();
+//                            }
+//                        }
+//                    }
+//                    else
+//                    {
+//                        bool complete = false;
+//                        Exception completeException = null;
+
+//                        try
+//                        {
+//                            CancelTimer();
+//                            complete = GetChannel();
+//                        }
+//                        catch (Exception e)
+//                        {
+//                            if (Fx.IsFatal(e))
+//                            {
+//                                throw;
+//                            }
+
+//                            OnGetChannelFailed();
+//                            completeException = e;
+//                        }
+
+//                        if (complete || completeException != null)
+//                        {
+//                            Complete(false, completeException);
+//                        }
+//                    }
+//                }
+
+//                bool OnChannelOpened()
+//                {
+//                    if (synchronizer.OnChannelOpened(this))
+//                    {
+//                        return true;
+//                    }
+//                    else
+//                    {
+//                        if (!IsCompleted)
+//                        {
+//                            throw Fx.AssertAndThrow("OnChannelOpened must complete the IWaiter if it returns false.");
+//                        }
+
+//                        return false;
+//                    }
+//                }
+
+//                void OnGetChannelFailed()
+//                {
+//                    if (channel != null)
+//                    {
+//                        channel.Abort();
+//                    }
+
+//                    synchronizer.OnGetChannelFailed();
+//                }
+
+//                static void OnOpenComplete(IAsyncResult result)
+//                {
+//                    if (!result.CompletedSynchronously)
+//                    {
+//                        AsyncWaiter waiter = (AsyncWaiter)result.AsyncState;
+//                        bool complete = false;
+//                        Exception completeException = null;
+
+//                        waiter.isSynchronous = false;
+
+//                        try
+//                        {
+//                            complete = waiter.CompleteOpen(result);
+//                        }
+//                        catch (Exception e)
+//                        {
+//                            if (Fx.IsFatal(e))
+//                            {
+//                                throw;
+//                            }
+
+//                            completeException = e;
+//                        }
+
+//                        if (complete)
+//                        {
+//                            waiter.Complete(false);
+//                        }
+//                        else if (completeException != null)
+//                        {
+//                            waiter.OnGetChannelFailed();
+//                            waiter.Complete(false, completeException);
+//                        }
+//                    }
+//                }
+
+//                void OnTimeoutElapsed()
+//                {
+//                    if (synchronizer.RemoveWaiter(this))
+//                    {
+//                        timedOut = true;
+//                        Complete(isSynchronous, null);
+//                    }
+//                }
+
+//                static void OnTimeoutElapsed(object state)
+//                {
+//                    AsyncWaiter waiter = (AsyncWaiter)state;
+//                    waiter.isSynchronous = false;
+//                    waiter.OnTimeoutElapsed();
+//                }
+
+//                static void OnTryGetChannelComplete(IAsyncResult result)
+//                {
+//                    if (!result.CompletedSynchronously)
+//                    {
+//                        AsyncWaiter waiter = (AsyncWaiter)result.AsyncState;
+//                        waiter.isSynchronous = false;
+//                        bool complete = false;
+//                        Exception completeException = null;
+
+//                        try
+//                        {
+//                            complete = waiter.CompleteTryGetChannel(result);
+//                        }
+//                        catch (Exception e)
+//                        {
+//                            if (Fx.IsFatal(e))
+//                            {
+//                                throw;
+//                            }
+
+//                            completeException = e;
+//                        }
+
+//                        if (complete || completeException != null)
+//                        {
+//                            if (completeException != null)
+//                                waiter.OnGetChannelFailed();
+//                            waiter.Complete(waiter.isSynchronous, completeException);
+//                        }
+//                    }
+//                }
+
+//                bool OpenChannel()
+//                {
+//                    if (synchronizer.binder.MustOpenChannel)
+//                    {
+//                        if (channelParameters != null)
+//                        {
+//                            channelParameters.PropagateChannelParameters(channel);
+//                        }
+
+//                        IAsyncResult result = channel.BeginOpen(
+//                            timeoutHelper.RemainingTime(), onOpenComplete, this);
+
+//                        if (result.CompletedSynchronously)
+//                        {
+//                            return CompleteOpen(result);
+//                        }
+
+//                        return false;
+//                    }
+//                    else
+//                    {
+//                        return OnChannelOpened();
+//                    }
+//                }
+
+//                public void Set(TChannel channel)
+//                {
+//                    CancelTimer();
+//                    channel = channel;
+//                    Complete(false);
+//                }
+
+//                // Always called from the user's thread.
+//                public void Wait()
+//                {
+//                    lock (ThisLock)
+//                    {
+//                        if (timerCancelled)
+//                        {
+//                            return;
+//                        }
+
+//                        TimeSpan timeout = timeoutHelper.RemainingTime();
+
+//                        if (timeout > TimeSpan.Zero)
+//                        {
+//                            timer = new IOThreadTimer(onTimeoutElapsed, this, true);
+//                            timer.Set(timeoutHelper.RemainingTime());
+//                            return;
+//                        }
+//                    }
+
+//                    OnTimeoutElapsed();
+//                }
+//            }
+
+//            sealed class SynchronizerCompletedAsyncResult : CompletedAsyncResult
+//            {
+//                public SynchronizerCompletedAsyncResult(AsyncCallback callback, object state)
+//                    : base(callback, state)
+//                {
+//                }
+
+//                public void End()
+//                {
+//                    CompletedAsyncResult.End(this);
+//                }
+//            }
+
+//            sealed class SyncWaiter : IWaiter
+//            {
+//                bool canGetChannel;
+//                TChannel channel;
+//                ChannelParameterCollection channelParameters;
+//                AutoResetEvent completeEvent = new AutoResetEvent(false);
+//                Exception exception;
+//                bool getChannel = false;
+//                MaskingMode maskingMode;
+//                ChannelSynchronizer synchronizer;
+//                TimeoutHelper timeoutHelper;
+
+//                public SyncWaiter(ChannelSynchronizer synchronizer, bool canGetChannel,
+//                    TChannel channel, TimeSpan timeout, MaskingMode maskingMode,
+//                    ChannelParameterCollection channelParameters)
+//                {
+//                    if (!canGetChannel)
+//                    {
+//                        if (channel != null)
+//                        {
+//                            throw Fx.AssertAndThrow("This waiter must wait for a channel thus argument channel must be null.");
+//                        }
+//                    }
+
+//                    synchronizer = synchronizer;
+//                    canGetChannel = canGetChannel;
+//                    channel = channel;
+//                    timeoutHelper = new TimeoutHelper(timeout);
+//                    maskingMode = maskingMode;
+//                    channelParameters = channelParameters;
+//                }
+
+//                public bool CanGetChannel
+//                {
+//                    get
+//                    {
+//                        return canGetChannel;
+//                    }
+//                }
+
+//                public void Close()
+//                {
+//                    exception = synchronizer.binder.GetClosedException(maskingMode);
+//                    completeEvent.Set();
+//                }
+
+//                public void Fault()
+//                {
+//                    exception = synchronizer.binder.GetFaultedException(maskingMode);
+//                    completeEvent.Set();
+//                }
+
+//                public void GetChannel(bool onUserThread)
+//                {
+//                    if (!CanGetChannel)
+//                    {
+//                        throw Fx.AssertAndThrow("This waiter must wait for a channel thus the caller cannot attempt to get a channel.");
+//                    }
+
+//                    getChannel = true;
+//                    completeEvent.Set();
+//                }
+
+//                public void Set(TChannel channel)
+//                {
+//                    if (channel == null)
+//                    {
+//                        throw Fx.AssertAndThrow("Argument channel cannot be null. Caller must call Fault or Close instead.");
+//                    }
+
+//                    channel = channel;
+//                    completeEvent.Set();
+//                }
+
+//                bool TryGetChannel()
+//                {
+//                    TChannel channel;
+
+//                    if (channel != null)
+//                    {
+//                        channel = channel;
+//                    }
+//                    else if (synchronizer.binder.TryGetChannel(
+//                        timeoutHelper.RemainingTime()))
+//                    {
+//                        if (!synchronizer.CompleteSetChannel(this, out channel))
+//                        {
+//                            return true;
+//                        }
+//                    }
+//                    else
+//                    {
+//                        synchronizer.OnGetChannelFailed();
+//                        return false;
+//                    }
+
+//                    if (synchronizer.binder.MustOpenChannel)
+//                    {
+//                        bool throwing = true;
+
+//                        if (channelParameters != null)
+//                        {
+//                            channelParameters.PropagateChannelParameters(channel);
+//                        }
+
+//                        try
+//                        {
+//                            channel.Open(timeoutHelper.RemainingTime());
+//                            throwing = false;
+//                        }
+//                        finally
+//                        {
+//                            if (throwing)
+//                            {
+//                                channel.Abort();
+//                                synchronizer.OnGetChannelFailed();
+//                            }
+//                        }
+//                    }
+
+//                    if (synchronizer.OnChannelOpened(this))
+//                    {
+//                        Set(channel);
+//                    }
+
+//                    return true;
+//                }
+
+//                public bool TryWait(out TChannel channel)
+//                {
+//                    if (!Wait())
+//                    {
+//                        channel = null;
+//                        return false;
+//                    }
+//                    else if (getChannel && !TryGetChannel())
+//                    {
+//                        channel = null;
+//                        return false;
+//                    }
+
+//                    completeEvent.Close();
+
+//                    if (exception != null)
+//                    {
+//                        if (channel != null)
+//                        {
+//                            throw Fx.AssertAndThrow("User of IWaiter called both Set and Fault or Close.");
+//                        }
+
+//                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(exception);
+//                    }
+
+//                    channel = channel;
+//                    return true;
+//                }
+
+//                bool Wait()
+//                {
+//                    if (!TimeoutHelper.WaitOne(completeEvent, timeoutHelper.RemainingTime()))
+//                    {
+//                        if (synchronizer.RemoveWaiter(this))
+//                        {
+//                            return false;
+//                        }
+//                        else
+//                        {
+//                            TimeoutHelper.WaitOne(completeEvent, TimeSpan.MaxValue);
+//                        }
+//                    }
+
+//                    return true;
+//                }
+//            }
+//        }
+
+//        sealed class CloseAsyncResult : AsyncResult
+//        {
+//            ReliableChannelBinder<TChannel> binder;
+//            TChannel channel;
+//            MaskingMode maskingMode;
+//            static AsyncCallback onBinderCloseComplete = Fx.ThunkCallback(new AsyncCallback(OnBinderCloseComplete));
+//            static AsyncCallback onChannelCloseComplete = Fx.ThunkCallback(new AsyncCallback(OnChannelCloseComplete));
+//            TimeoutHelper timeoutHelper;
+
+//            public CloseAsyncResult(ReliableChannelBinder<TChannel> binder, TChannel channel,
+//                TimeSpan timeout, MaskingMode maskingMode, AsyncCallback callback, object state)
+//                : base(callback, state)
+//            {
+//                binder = binder;
+//                channel = channel;
+//                timeoutHelper = new TimeoutHelper(timeout);
+//                maskingMode = maskingMode;
+//                bool complete = false;
+
+//                try
+//                {
+//                    binder.OnShutdown();
+//                    IAsyncResult result = binder.OnBeginClose(timeout, onBinderCloseComplete, this);
+
+//                    if (result.CompletedSynchronously)
+//                    {
+//                        complete = CompleteBinderClose(true, result);
+//                    }
+//                }
+//                catch (Exception e)
+//                {
+//                    if (Fx.IsFatal(e))
+//                    {
+//                        throw;
+//                    }
+
+//                    binder.Abort();
+
+//                    if (!binder.HandleException(e, maskingMode))
+//                    {
+//                        throw;
+//                    }
+//                    else
+//                    {
+//                        complete = true;
+//                    }
+//                }
+
+//                if (complete)
+//                {
+//                    Complete(true);
+//                }
+//            }
+
+//            bool CompleteBinderClose(bool synchronous, IAsyncResult result)
+//            {
+//                binder.OnEndClose(result);
+
+//                if (channel != null)
+//                {
+//                    result = binder.BeginCloseChannel(channel,
+//                        timeoutHelper.RemainingTime(), onChannelCloseComplete, this);
+
+//                    if (result.CompletedSynchronously)
+//                    {
+//                        return CompleteChannelClose(synchronous, result);
+//                    }
+//                    else
+//                    {
+//                        return false;
+//                    }
+//                }
+//                else
+//                {
+//                    binder.TransitionToClosed();
+//                    return true;
+//                }
+//            }
+
+//            bool CompleteChannelClose(bool synchronous, IAsyncResult result)
+//            {
+//                binder.EndCloseChannel(channel, result);
+//                binder.TransitionToClosed();
+//                return true;
+//            }
+
+//            public void End()
+//            {
+//                AsyncResult.End<CloseAsyncResult>(this);
+//            }
+
+//            Exception HandleAsyncException(Exception e)
+//            {
+//                binder.Abort();
+
+//                if (binder.HandleException(e, maskingMode))
+//                {
+//                    return null;
+//                }
+//                else
+//                {
+//                    return e;
+//                }
+//            }
+
+//            static void OnBinderCloseComplete(IAsyncResult result)
+//            {
+//                if (!result.CompletedSynchronously)
+//                {
+//                    CloseAsyncResult closeResult = (CloseAsyncResult)result.AsyncState;
+//                    bool complete;
+//                    Exception completeException;
+
+//                    try
+//                    {
+//                        complete = closeResult.CompleteBinderClose(false, result);
+//                        completeException = null;
+//                    }
+//                    catch (Exception e)
+//                    {
+//                        if (Fx.IsFatal(e))
+//                        {
+//                            throw;
+//                        }
+
+//                        complete = true;
+//                        completeException = e;
+//                    }
+
+//                    if (complete)
+//                    {
+//                        if (completeException != null)
+//                        {
+//                            completeException = closeResult.HandleAsyncException(completeException);
+//                        }
+
+//                        closeResult.Complete(false, completeException);
+//                    }
+//                }
+//            }
+
+//            static void OnChannelCloseComplete(IAsyncResult result)
+//            {
+//                if (!result.CompletedSynchronously)
+//                {
+//                    CloseAsyncResult closeResult = (CloseAsyncResult)result.AsyncState;
+//                    bool complete;
+//                    Exception completeException;
+
+//                    try
+//                    {
+//                        complete = closeResult.CompleteChannelClose(false, result);
+//                        completeException = null;
+//                    }
+//                    catch (Exception e)
+//                    {
+//                        if (Fx.IsFatal(e))
+//                        {
+//                            throw;
+//                        }
+
+//                        complete = true;
+//                        completeException = e;
+//                    }
+
+//                    if (complete)
+//                    {
+//                        if (completeException != null)
+//                        {
+//                            completeException = closeResult.HandleAsyncException(completeException);
+//                        }
+
+//                        closeResult.Complete(false, completeException);
+//                    }
+//                }
+//            }
+//        }
+
+//        protected abstract class InputAsyncResult<TBinder> : AsyncResult
+//            where TBinder : ReliableChannelBinder<TChannel>
+//        {
+//            bool autoAborted;
+//            TBinder binder;
+//            bool canGetChannel;
+//            TChannel channel;
+//            bool isSynchronous = true;
+//            MaskingMode maskingMode;
+//            static AsyncCallback onInputComplete = Fx.ThunkCallback(new AsyncCallback(OnInputCompleteStatic));
+//            static AsyncCallback onTryGetChannelComplete = Fx.ThunkCallback(new AsyncCallback(OnTryGetChannelCompleteStatic));
+//            bool success;
+//            TimeoutHelper timeoutHelper;
+
+//            public InputAsyncResult(TBinder binder, bool canGetChannel, TimeSpan timeout,
+//                MaskingMode maskingMode, AsyncCallback callback, object state)
+//                : base(callback, state)
+//            {
+//                binder = binder;
+//                canGetChannel = canGetChannel;
+//                timeoutHelper = new TimeoutHelper(timeout);
+//                maskingMode = maskingMode;
+//            }
+
+//            protected abstract IAsyncResult BeginInput(TBinder binder, TChannel channel,
+//                TimeSpan timeout, AsyncCallback callback, object state);
+
+//            // returns true if the caller should retry
+//            bool CompleteInput(IAsyncResult result)
+//            {
+//                bool complete;
+
+//                try
+//                {
+//                    success = EndInput(binder, channel, result, out complete);
+//                }
+//                finally
+//                {
+//                    autoAborted = binder.Synchronizer.Aborting;
+//                    binder.synchronizer.ReturnChannel();
+//                }
+
+//                return !complete;
+//            }
+
+//            // returns true if the caller should retry
+//            bool CompleteTryGetChannel(IAsyncResult result, out bool complete)
+//            {
+//                complete = false;
+//                success = binder.synchronizer.EndTryGetChannel(result, out channel);
+
+//                // the synchronizer is faulted and not reestablishing or closed, or the call timed
+//                // out, complete and don't retry.
+//                if (channel == null)
+//                {
+//                    complete = true;
+//                    return false;
+//                }
+
+//                bool throwing = true;
+//                IAsyncResult inputResult = null;
+
+//                try
+//                {
+//                    inputResult = BeginInput(binder, channel,
+//                        timeoutHelper.RemainingTime(), onInputComplete, this);
+//                    throwing = false;
+//                }
+//                finally
+//                {
+//                    if (throwing)
+//                    {
+//                        autoAborted = binder.Synchronizer.Aborting;
+//                        binder.synchronizer.ReturnChannel();
+//                    }
+//                }
+
+//                if (inputResult.CompletedSynchronously)
+//                {
+//                    if (CompleteInput(inputResult))
+//                    {
+//                        complete = false;
+//                        return true;
+//                    }
+//                    else
+//                    {
+//                        complete = true;
+//                        return false;
+//                    }
+//                }
+//                else
+//                {
+//                    complete = false;
+//                    return false;
+//                }
+//            }
+
+//            public bool End()
+//            {
+//                AsyncResult.End<InputAsyncResult<TBinder>>(this);
+//                return success;
+//            }
+
+//            protected abstract bool EndInput(TBinder binder, TChannel channel,
+//                IAsyncResult result, out bool complete);
+
+//            void OnInputComplete(IAsyncResult result)
+//            {
+//                isSynchronous = false;
+//                bool retry;
+//                Exception completeException = null;
+
+//                try
+//                {
+//                    retry = CompleteInput(result);
+//                }
+//                catch (Exception e)
+//                {
+//                    if (Fx.IsFatal(e))
+//                    {
+//                        throw;
+//                    }
+
+//                    if (!binder.HandleException(e, maskingMode, autoAborted))
+//                    {
+//                        completeException = e;
+//                        retry = false;
+//                    }
+//                    else
+//                    {
+//                        retry = true;
+//                    }
+//                }
+
+//                if (retry)
+//                {
+//                    StartOnNonUserThread();
+//                }
+//                else
+//                {
+//                    Complete(isSynchronous, completeException);
+//                }
+//            }
+
+//            static void OnInputCompleteStatic(IAsyncResult result)
+//            {
+//                if (!result.CompletedSynchronously)
+//                {
+//                    InputAsyncResult<TBinder> inputResult =
+//                        (InputAsyncResult<TBinder>)result.AsyncState;
+//                    inputResult.OnInputComplete(result);
+//                }
+//            }
+
+//            void OnTryGetChannelComplete(IAsyncResult result)
+//            {
+//                isSynchronous = false;
+//                bool retry = false;
+//                bool complete = false;
+//                Exception completeException = null;
+
+//                try
+//                {
+//                    retry = CompleteTryGetChannel(result, out complete);
+//                }
+//                catch (Exception e)
+//                {
+//                    if (Fx.IsFatal(e))
+//                    {
+//                        throw;
+//                    }
+
+//                    if (!binder.HandleException(e, maskingMode, autoAborted))
+//                    {
+//                        completeException = e;
+//                        retry = false;
+//                    }
+//                    else
+//                    {
+//                        retry = true;
+//                    }
+//                }
+
+//                // Can't complete AND retry.
+//                if (complete && retry)
+//                {
+//                    throw Fx.AssertAndThrow("The derived class' implementation of CompleteTryGetChannel() cannot indicate that the asynchronous operation should complete and retry.");
+//                }
+
+//                if (retry)
+//                {
+//                    StartOnNonUserThread();
+//                }
+//                else if (complete || completeException != null)
+//                {
+//                    Complete(isSynchronous, completeException);
+//                }
+//            }
+
+//            static void OnTryGetChannelCompleteStatic(IAsyncResult result)
+//            {
+//                if (!result.CompletedSynchronously)
+//                {
+//                    InputAsyncResult<TBinder> inputResult =
+//                        (InputAsyncResult<TBinder>)result.AsyncState;
+//                    inputResult.OnTryGetChannelComplete(result);
+//                }
+//            }
+
+//            protected bool Start()
+//            {
+//                while (true)
+//                {
+//                    bool retry = false;
+//                    bool complete = false;
+
+//                    autoAborted = false;
+
+//                    try
+//                    {
+//                        IAsyncResult result = binder.synchronizer.BeginTryGetChannelForInput(
+//                            canGetChannel, timeoutHelper.RemainingTime(),
+//                            onTryGetChannelComplete, this);
+
+//                        if (result.CompletedSynchronously)
+//                        {
+//                            retry = CompleteTryGetChannel(result, out complete);
+//                        }
+//                    }
+//                    catch (Exception e)
+//                    {
+//                        if (Fx.IsFatal(e))
+//                        {
+//                            throw;
+//                        }
+
+//                        if (!binder.HandleException(e, maskingMode, autoAborted))
+//                        {
+//                            throw;
+//                        }
+//                        else
+//                        {
+//                            retry = true;
+//                        }
+//                    }
+
+//                    // Can't complete AND retry.
+//                    if (complete && retry)
+//                    {
+//                        throw Fx.AssertAndThrow("The derived class' implementation of CompleteTryGetChannel() cannot indicate that the asynchronous operation should complete and retry.");
+//                    }
+
+//                    if (!retry)
+//                    {
+//                        return complete;
+//                    }
+//                }
+//            }
+
+//            void StartOnNonUserThread()
+//            {
+//                bool complete = false;
+//                Exception completeException = null;
+
+//                try
+//                {
+//                    complete = Start();
+//                }
+//                catch (Exception e)
+//                {
+//                    if (Fx.IsFatal(e))
+//                        throw;
+
+//                    completeException = e;
+//                }
+
+//                if (complete || completeException != null)
+//                    Complete(false, completeException);
+//            }
+//        }
+
+//        sealed class MessageRequestContext : BinderRequestContext
+//        {
+//            public MessageRequestContext(ReliableChannelBinder<TChannel> binder, Message message)
+//                : base(binder, message)
+//            {
+//            }
+
+//            protected override void OnAbort()
+//            {
+//            }
+
+//            protected override void OnClose(TimeSpan timeout)
+//            {
+//            }
+
+//            protected override IAsyncResult OnBeginReply(Message message, TimeSpan timeout, AsyncCallback callback, object state)
+//            {
+//                return new ReplyAsyncResult(this, message, timeout, callback, state);
+//            }
+
+//            protected override void OnEndReply(IAsyncResult result)
+//            {
+//                ReplyAsyncResult.End(result);
+//            }
+
+//            protected override void OnReply(Message message, TimeSpan timeout)
+//            {
+//                if (message != null)
+//                {
+//                    Binder.Send(message, timeout, MaskingMode);
+//                }
+//            }
+
+//            class ReplyAsyncResult : AsyncResult
+//            {
+//                static AsyncCallback onSend;
+//                MessageRequestContext context;
+
+//                public ReplyAsyncResult(MessageRequestContext context, Message message, TimeSpan timeout, AsyncCallback callback, object state)
+//                    : base(callback, state)
+//                {
+//                    if (message != null)
+//                    {
+//                        if (onSend == null)
+//                        {
+//                            onSend = Fx.ThunkCallback(new AsyncCallback(OnSend));
+//                        }
+//                        context = context;
+//                        IAsyncResult result = context.Binder.BeginSend(message, timeout, context.MaskingMode, onSend, this);
+//                        if (!result.CompletedSynchronously)
+//                        {
+//                            return;
+//                        }
+//                        context.Binder.EndSend(result);
+//                    }
+
+//                    base.Complete(true);
+//                }
+
+//                public static void End(IAsyncResult result)
+//                {
+//                    AsyncResult.End<ReplyAsyncResult>(result);
+//                }
+
+//                static void OnSend(IAsyncResult result)
+//                {
+//                    if (result.CompletedSynchronously)
+//                    {
+//                        return;
+//                    }
+
+//                    Exception completionException = null;
+//                    ReplyAsyncResult thisPtr = (ReplyAsyncResult)result.AsyncState;
+//                    try
+//                    {
+//                        thisPtr.context.Binder.EndSend(result);
+//                    }
+//                    catch (Exception exception)
+//                    {
+//                        if (Fx.IsFatal(exception))
+//                        {
+//                            throw;
+//                        }
+//                        completionException = exception;
+//                    }
+
+//                    thisPtr.Complete(false, completionException);
+//                }
+//            }
+//        }
+
+//        protected abstract class OutputAsyncResult<TBinder> : AsyncResult
+//            where TBinder : ReliableChannelBinder<TChannel>
+//        {
+//            bool autoAborted;
+//            TBinder binder;
+//            TChannel channel;
+//            bool hasChannel = false;
+//            MaskingMode maskingMode;
+//            Message message;
+//            static AsyncCallback onTryGetChannelComplete = Fx.ThunkCallback(new AsyncCallback(OnTryGetChannelCompleteStatic));
+//            static AsyncCallback onOutputComplete = Fx.ThunkCallback(new AsyncCallback(OnOutputCompleteStatic));
+//            TimeSpan timeout;
+//            TimeoutHelper timeoutHelper;
+
+//            public OutputAsyncResult(TBinder binder, AsyncCallback callback, object state)
+//                : base(callback, state)
+//            {
+//                binder = binder;
+//            }
+
+//            public MaskingMode MaskingMode
+//            {
+//                get
+//                {
+//                    return maskingMode;
+//                }
+//            }
+
+//            protected abstract IAsyncResult BeginOutput(TBinder binder, TChannel channel,
+//                Message message, TimeSpan timeout, MaskingMode maskingMode, AsyncCallback callback,
+//                object state);
+
+//            void Cleanup()
+//            {
+//                if (hasChannel)
+//                {
+//                    autoAborted = binder.Synchronizer.Aborting;
+//                    binder.synchronizer.ReturnChannel();
+//                }
+//            }
+
+//            bool CompleteOutput(IAsyncResult result)
+//            {
+//                EndOutput(binder, channel, maskingMode, result);
+//                Cleanup();
+//                return true;
+//            }
+
+//            bool CompleteTryGetChannel(IAsyncResult result)
+//            {
+//                bool timedOut = !binder.synchronizer.EndTryGetChannel(result,
+//                    out channel);
+
+//                if (timedOut || (channel == null))
+//                {
+//                    Cleanup();
+
+//                    if (timedOut && !ReliableChannelBinderHelper.MaskHandled(maskingMode))
+//                    {
+//                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new TimeoutException(GetTimeoutString(timeout)));
+//                    }
+
+//                    return true;
+//                }
+
+//                hasChannel = true;
+
+//                result = BeginOutput(binder, channel, message,
+//                    timeoutHelper.RemainingTime(), maskingMode, onOutputComplete,
+//                    this);
+
+//                if (result.CompletedSynchronously)
+//                {
+//                    return CompleteOutput(result);
+//                }
+//                else
+//                {
+//                    return false;
+//                }
+//            }
+
+//            protected abstract void EndOutput(TBinder binder, TChannel channel,
+//                MaskingMode maskingMode, IAsyncResult result);
+
+//            protected abstract string GetTimeoutString(TimeSpan timeout);
+
+//            void OnOutputComplete(IAsyncResult result)
+//            {
+//                if (!result.CompletedSynchronously)
+//                {
+//                    bool complete = false;
+//                    Exception completeException = null;
+
+//                    try
+//                    {
+//                        complete = CompleteOutput(result);
+//                    }
+//                    catch (Exception e)
+//                    {
+//                        if (Fx.IsFatal(e))
+//                        {
+//                            throw;
+//                        }
+
+//                        Cleanup();
+//                        complete = true;
+//                        if (!binder.HandleException(e, maskingMode, autoAborted))
+//                        {
+//                            completeException = e;
+//                        }
+//                    }
+
+//                    if (complete)
+//                    {
+//                        Complete(false, completeException);
+//                    }
+//                }
+//            }
+
+//            static void OnOutputCompleteStatic(IAsyncResult result)
+//            {
+//                OutputAsyncResult<TBinder> outputResult =
+//                    (OutputAsyncResult<TBinder>)result.AsyncState;
+
+//                outputResult.OnOutputComplete(result);
+//            }
+
+//            void OnTryGetChannelComplete(IAsyncResult result)
+//            {
+//                if (!result.CompletedSynchronously)
+//                {
+//                    bool complete = false;
+//                    Exception completeException = null;
+
+//                    try
+//                    {
+//                        complete = CompleteTryGetChannel(result);
+//                    }
+//                    catch (Exception e)
+//                    {
+//                        if (Fx.IsFatal(e))
+//                        {
+//                            throw;
+//                        }
+
+//                        Cleanup();
+//                        complete = true;
+//                        if (!binder.HandleException(e, maskingMode, autoAborted))
+//                        {
+//                            completeException = e;
+//                        }
+//                    }
+
+//                    if (complete)
+//                    {
+//                        Complete(false, completeException);
+//                    }
+//                }
+//            }
+
+//            static void OnTryGetChannelCompleteStatic(IAsyncResult result)
+//            {
+//                OutputAsyncResult<TBinder> outputResult =
+//                    (OutputAsyncResult<TBinder>)result.AsyncState;
+
+//                outputResult.OnTryGetChannelComplete(result);
+//            }
+
+//            public void Start(Message message, TimeSpan timeout, MaskingMode maskingMode)
+//            {
+//                if (!binder.ValidateOutputOperation(message, timeout, maskingMode))
+//                {
+//                    Complete(true);
+//                    return;
+//                }
+
+//                message = message;
+//                timeout = timeout;
+//                timeoutHelper = new TimeoutHelper(timeout);
+//                maskingMode = maskingMode;
+
+//                bool complete = false;
+
+//                try
+//                {
+//                    IAsyncResult result = binder.synchronizer.BeginTryGetChannelForOutput(
+//                        timeoutHelper.RemainingTime(), maskingMode, onTryGetChannelComplete, this);
+
+//                    if (result.CompletedSynchronously)
+//                    {
+//                        complete = CompleteTryGetChannel(result);
+//                    }
+//                }
+//                catch (Exception e)
+//                {
+//                    if (Fx.IsFatal(e))
+//                    {
+//                        throw;
+//                    }
+
+//                    Cleanup();
+//                    if (binder.HandleException(e, maskingMode, autoAborted))
+//                    {
+//                        complete = true;
+//                    }
+//                    else
+//                    {
+//                        throw;
+//                    }
+//                }
+
+//                if (complete)
+//                {
+//                    Complete(true);
+//                }
+//            }
+//        }
+
+//        sealed class RequestRequestContext : BinderRequestContext
+//        {
+//            RequestContext innerContext;
+
+//            public RequestRequestContext(ReliableChannelBinder<TChannel> binder,
+//                RequestContext innerContext, Message message)
+//                : base(binder, message)
+//            {
+//                if ((binder.defaultMaskingMode != MaskingMode.All) && !binder.TolerateFaults)
+//                {
+//                    throw Fx.AssertAndThrow("This request context is designed to catch exceptions. Thus it cannot be used if the caller expects no exception handling.");
+//                }
+
+//                if (innerContext == null)
+//                {
+//                    throw Fx.AssertAndThrow("Argument innerContext cannot be null.");
+//                }
+
+//                innerContext = innerContext;
+//            }
+
+//            protected override void OnAbort()
+//            {
+//                innerContext.Abort();
+//            }
+
+//            protected override IAsyncResult OnBeginReply(Message message, TimeSpan timeout,
+//                AsyncCallback callback, object state)
+//            {
+//                try
+//                {
+//                    if (message != null)
+//                        Binder.AddOutputHeaders(message);
+//                    return innerContext.BeginReply(message, timeout, callback, state);
+//                }
+//                catch (ObjectDisposedException) { }
+//                catch (Exception e)
+//                {
+//                    if (Fx.IsFatal(e))
+//                    {
+//                        throw;
+//                    }
+
+//                    if (!Binder.HandleException(e, MaskingMode))
+//                    {
+//                        throw;
+//                    }
+
+//                    innerContext.Abort();
+//                }
+
+//                return new BinderCompletedAsyncResult(callback, state);
+//            }
+
+//            protected override void OnClose(TimeSpan timeout)
+//            {
+//                try
+//                {
+//                    innerContext.Close(timeout);
+//                }
+//                catch (ObjectDisposedException) { }
+//                catch (Exception e)
+//                {
+//                    if (Fx.IsFatal(e))
+//                    {
+//                        throw;
+//                    }
+
+//                    if (!Binder.HandleException(e, MaskingMode))
+//                    {
+//                        throw;
+//                    }
+
+//                    innerContext.Abort();
+//                }
+//            }
+
+//            protected override void OnEndReply(IAsyncResult result)
+//            {
+//                BinderCompletedAsyncResult completedResult = result as BinderCompletedAsyncResult;
+//                if (completedResult != null)
+//                {
+//                    completedResult.End();
+//                    return;
+//                }
+
+//                try
+//                {
+//                    innerContext.EndReply(result);
+//                }
+//                catch (ObjectDisposedException) { }
+//                catch (Exception e)
+//                {
+//                    if (Fx.IsFatal(e))
+//                    {
+//                        throw;
+//                    }
+
+//                    if (!Binder.HandleException(e, MaskingMode))
+//                    {
+//                        throw;
+//                    }
+
+//                    innerContext.Abort();
+//                }
+//            }
+
+//            protected override void OnReply(Message message, TimeSpan timeout)
+//            {
+//                try
+//                {
+//                    if (message != null)
+//                        Binder.AddOutputHeaders(message);
+//                    innerContext.Reply(message, timeout);
+//                }
+//                catch (ObjectDisposedException) { }
+//                catch (Exception e)
+//                {
+//                    if (Fx.IsFatal(e))
+//                    {
+//                        throw;
+//                    }
+
+//                    if (!Binder.HandleException(e, MaskingMode))
+//                    {
+//                        throw;
+//                    }
+
+//                    innerContext.Abort();
+//                }
+//            }
+//        }
+
+//        sealed class SendAsyncResult : OutputAsyncResult<ReliableChannelBinder<TChannel>>
+//        {
+//            public SendAsyncResult(ReliableChannelBinder<TChannel> binder, AsyncCallback callback,
+//                object state)
+//                : base(binder, callback, state)
+//            {
+//            }
+
+//            protected override IAsyncResult BeginOutput(ReliableChannelBinder<TChannel> binder,
+//                TChannel channel, Message message, TimeSpan timeout, MaskingMode maskingMode,
+//                AsyncCallback callback, object state)
+//            {
+//                binder.AddOutputHeaders(message);
+//                return binder.OnBeginSend(channel, message, timeout, callback, state);
+//            }
+
+//            public static void End(IAsyncResult result)
+//            {
+//                AsyncResult.End<SendAsyncResult>(result);
+//            }
+
+//            protected override void EndOutput(ReliableChannelBinder<TChannel> binder,
+//                TChannel channel, MaskingMode maskingMode, IAsyncResult result)
+//            {
+//                binder.OnEndSend(channel, result);
+//            }
+
+//            protected override string GetTimeoutString(TimeSpan timeout)
+//            {
+//                return SR.GetString(SR.TimeoutOnSend, timeout);
+//            }
+//        }
+
+//        sealed class TryReceiveAsyncResult : InputAsyncResult<ReliableChannelBinder<TChannel>>
+//        {
+//            RequestContext requestContext;
+
+//            public TryReceiveAsyncResult(ReliableChannelBinder<TChannel> binder, TimeSpan timeout,
+//                MaskingMode maskingMode, AsyncCallback callback, object state)
+//                : base(binder, binder.CanGetChannelForReceive, timeout, maskingMode, callback, state)
+//            {
+//                if (Start())
+//                    Complete(true);
+//            }
+
+//            protected override IAsyncResult BeginInput(ReliableChannelBinder<TChannel> binder,
+//                TChannel channel, TimeSpan timeout, AsyncCallback callback, object state)
+//            {
+//                return binder.OnBeginTryReceive(channel, timeout, callback, state);
+//            }
+
+//            public bool End(out RequestContext requestContext)
+//            {
+//                requestContext = requestContext;
+//                return End();
+//            }
+
+//            protected override bool EndInput(ReliableChannelBinder<TChannel> binder,
+//                TChannel channel, IAsyncResult result, out bool complete)
+//            {
+//                bool success = binder.OnEndTryReceive(channel, result, out requestContext);
+
+//                // timed out || got message, complete immediately
+//                complete = !success || (requestContext != null);
+
+//                if (!complete)
+//                {
+//                    // the underlying channel closed or faulted
+//                    binder.synchronizer.OnReadEof();
+//                }
+
+//                return success;
+//            }
+//        }
+//    }
+
+//    static class ReliableChannelBinderHelper
+//    {
+//        internal static IAsyncResult BeginCloseDuplexSessionChannel(
+//            ReliableChannelBinder<IDuplexSessionChannel> binder, IDuplexSessionChannel channel,
+//            TimeSpan timeout, AsyncCallback callback, object state)
+//        {
+//            return new CloseDuplexSessionChannelAsyncResult(binder, channel, timeout, callback,
+//                state);
+//        }
+
+//        internal static IAsyncResult BeginCloseReplySessionChannel(
+//            ReliableChannelBinder<IReplySessionChannel> binder, IReplySessionChannel channel,
+//            TimeSpan timeout, AsyncCallback callback, object state)
+//        {
+//            return new CloseReplySessionChannelAsyncResult(binder, channel, timeout, callback,
+//                state);
+//        }
+
+//        internal static void CloseDuplexSessionChannel(
+//            ReliableChannelBinder<IDuplexSessionChannel> binder, IDuplexSessionChannel channel,
+//            TimeSpan timeout)
+//        {
+//            TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
+
+//            channel.Session.CloseOutputSession(timeoutHelper.RemainingTime());
+//            binder.WaitForPendingOperations(timeoutHelper.RemainingTime());
+
+//            TimeSpan iterationTimeout = timeoutHelper.RemainingTime();
+//            bool lastIteration = (iterationTimeout == TimeSpan.Zero);
+
+//            while (true)
+//            {
+//                Message message = null;
+//                bool receiveThrowing = true;
+
+//                try
+//                {
+//                    bool success = channel.TryReceive(iterationTimeout, out message);
+
+//                    receiveThrowing = false;
+//                    if (success && message == null)
+//                    {
+//                        channel.Close(timeoutHelper.RemainingTime());
+//                        return;
+//                    }
+//                }
+//                catch (Exception e)
+//                {
+//                    if (Fx.IsFatal(e))
+//                        throw;
+
+//                    if (receiveThrowing)
+//                    {
+//                        if (!MaskHandled(binder.DefaultMaskingMode) || !binder.IsHandleable(e))
+//                            throw;
+
+//                        receiveThrowing = false;
+//                    }
+//                    else
+//                    {
+//                        throw;
+//                    }
+//                }
+//                finally
+//                {
+//                    if (message != null)
+//                        message.Close();
+
+//                    if (receiveThrowing)
+//                        channel.Abort();
+//                }
+
+//                if (lastIteration || channel.State != CommunicationState.Opened)
+//                    break;
+
+//                iterationTimeout = timeoutHelper.RemainingTime();
+//                lastIteration = (iterationTimeout == TimeSpan.Zero);
+//            }
+
+//            channel.Abort();
+//        }
+
+//        internal static void CloseReplySessionChannel(
+//            ReliableChannelBinder<IReplySessionChannel> binder, IReplySessionChannel channel,
+//            TimeSpan timeout)
+//        {
+//            TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
+
+//            binder.WaitForPendingOperations(timeoutHelper.RemainingTime());
+
+//            TimeSpan iterationTimeout = timeoutHelper.RemainingTime();
+//            bool lastIteration = (iterationTimeout == TimeSpan.Zero);
+
+//            while (true)
+//            {
+//                RequestContext context = null;
+//                bool receiveThrowing = true;
+
+//                try
+//                {
+//                    bool success = channel.TryReceiveRequest(iterationTimeout, out context);
+
+//                    receiveThrowing = false;
+//                    if (success && context == null)
+//                    {
+//                        channel.Close(timeoutHelper.RemainingTime());
+//                        return;
+//                    }
+//                }
+//                catch (Exception e)
+//                {
+//                    if (Fx.IsFatal(e))
+//                        throw;
+
+//                    if (receiveThrowing)
+//                    {
+//                        if (!MaskHandled(binder.DefaultMaskingMode) || !binder.IsHandleable(e))
+//                            throw;
+
+//                        receiveThrowing = false;
+//                    }
+//                    else
+//                    {
+//                        throw;
+//                    }
+//                }
+//                finally
+//                {
+//                    if (context != null)
+//                    {
+//                        context.RequestMessage.Close();
+//                        context.Close();
+//                    }
+
+//                    if (receiveThrowing)
+//                        channel.Abort();
+//                }
+
+//                if (lastIteration || channel.State != CommunicationState.Opened)
+//                    break;
+
+//                iterationTimeout = timeoutHelper.RemainingTime();
+//                lastIteration = (iterationTimeout == TimeSpan.Zero);
+//            }
+
+//            channel.Abort();
+//        }
+
+//        internal static void EndCloseDuplexSessionChannel(IDuplexSessionChannel channel,
+//                IAsyncResult result)
+//        {
+//            CloseDuplexSessionChannelAsyncResult.End(result);
+//        }
+
+//        internal static void EndCloseReplySessionChannel(IReplySessionChannel channel,
+//                IAsyncResult result)
+//        {
+//            CloseReplySessionChannelAsyncResult.End(result);
+//        }
+
+//        internal static bool MaskHandled(MaskingMode maskingMode)
+//        {
+//            return (maskingMode & MaskingMode.Handled) == MaskingMode.Handled;
+//        }
+
+//        internal static bool MaskUnhandled(MaskingMode maskingMode)
+//        {
+//            return (maskingMode & MaskingMode.Unhandled) == MaskingMode.Unhandled;
+//        }
+
+//        abstract class CloseInputSessionChannelAsyncResult<TChannel, TItem> : AsyncResult
+//            where TChannel : class, IChannel
+//            where TItem : class
+//        {
+//            static AsyncCallback onChannelCloseCompleteStatic =
+//                Fx.ThunkCallback(
+//                new AsyncCallback(OnChannelCloseCompleteStatic));
+//            static AsyncCallback onInputCompleteStatic =
+//                Fx.ThunkCallback(new AsyncCallback(OnInputCompleteStatic));
+//            static AsyncCallback onWaitForPendingOperationsCompleteStatic =
+//                Fx.ThunkCallback(
+//                new AsyncCallback(OnWaitForPendingOperationsCompleteStatic));
+//            ReliableChannelBinder<TChannel> binder;
+//            TChannel channel;
+//            bool lastReceive;
+//            TimeoutHelper timeoutHelper;
+
+//            protected CloseInputSessionChannelAsyncResult(
+//                ReliableChannelBinder<TChannel> binder, TChannel channel,
+//                TimeSpan timeout, AsyncCallback callback, object state)
+//                : base(callback, state)
+//            {
+//                binder = binder;
+//                channel = channel;
+//                timeoutHelper = new TimeoutHelper(timeout);
+//            }
+
+//            protected TChannel Channel
+//            {
+//                get
+//                {
+//                    return channel;
+//                }
+//            }
+
+//            protected TimeSpan RemainingTime
+//            {
+//                get
+//                {
+//                    return timeoutHelper.RemainingTime();
+//                }
+//            }
+
+//            protected bool Begin()
+//            {
+//                bool complete = false;
+//                IAsyncResult result = binder.BeginWaitForPendingOperations(
+//                    RemainingTime, onWaitForPendingOperationsCompleteStatic,
+//                    this);
+
+//                if (result.CompletedSynchronously)
+//                    complete = HandleWaitForPendingOperationsComplete(result);
+
+//                return complete;
+//            }
+
+//            protected abstract IAsyncResult BeginTryInput(TimeSpan timeout, AsyncCallback callback,
+//                object state);
+
+//            protected abstract void DisposeItem(TItem item);
+
+//            protected abstract bool EndTryInput(IAsyncResult result, out TItem item);
+
+//            void HandleChannelCloseComplete(IAsyncResult result)
+//            {
+//                channel.EndClose(result);
+//            }
+
+//            bool HandleInputComplete(IAsyncResult result, out bool gotEof)
+//            {
+//                TItem item = null;
+//                bool endThrowing = true;
+
+//                gotEof = false;
+
+//                try
+//                {
+//                    bool success = false;
+
+//                    success = EndTryInput(result, out item);
+//                    endThrowing = false;
+
+//                    if (!success || item != null)
+//                    {
+//                        if (lastReceive || channel.State != CommunicationState.Opened)
+//                        {
+//                            channel.Abort();
+//                            return true;
+//                        }
+//                        else
+//                        {
+//                            return false;
+//                        }
+//                    }
+
+//                    gotEof = true;
+
+//                    result = channel.BeginClose(RemainingTime,
+//                        onChannelCloseCompleteStatic, this);
+//                    if (result.CompletedSynchronously)
+//                    {
+//                        HandleChannelCloseComplete(result);
+//                        return true;
+//                    }
+//                    else
+//                    {
+//                        return false;
+//                    }
+//                }
+//                catch (Exception e)
+//                {
+//                    if (Fx.IsFatal(e))
+//                        throw;
+
+//                    if (endThrowing)
+//                    {
+//                        if (!MaskHandled(binder.DefaultMaskingMode) || !binder.IsHandleable(e))
+//                            throw;
+
+//                        if (lastReceive || channel.State != CommunicationState.Opened)
+//                        {
+//                            channel.Abort();
+//                            return true;
+//                        }
+//                        else
+//                        {
+//                            return false;
+//                        }
+//                    }
+
+//                    throw;
+//                }
+//                finally
+//                {
+//                    if (item != null)
+//                        DisposeItem(item);
+
+//                    if (endThrowing)
+//                        channel.Abort();
+//                }
+//            }
+
+//            bool HandleWaitForPendingOperationsComplete(IAsyncResult result)
+//            {
+//                binder.EndWaitForPendingOperations(result);
+//                return WaitForEof();
+//            }
+
+//            static void OnChannelCloseCompleteStatic(IAsyncResult result)
+//            {
+//                if (result.CompletedSynchronously)
+//                    return;
+
+//                CloseInputSessionChannelAsyncResult<TChannel, TItem> closeResult =
+//                    (CloseInputSessionChannelAsyncResult<TChannel, TItem>)result.AsyncState;
+
+//                Exception completeException = null;
+
+//                try
+//                {
+//                    closeResult.HandleChannelCloseComplete(result);
+//                }
+//                catch (Exception e)
+//                {
+//                    if (Fx.IsFatal(e))
+//                        throw;
+
+//                    completeException = e;
+//                }
+
+//                closeResult.Complete(false, completeException);
+//            }
+
+//            static void OnInputCompleteStatic(IAsyncResult result)
+//            {
+//                if (result.CompletedSynchronously)
+//                    return;
+
+//                CloseInputSessionChannelAsyncResult<TChannel, TItem> closeResult =
+//                    (CloseInputSessionChannelAsyncResult<TChannel, TItem>)result.AsyncState;
+
+//                bool complete = false;
+//                Exception completeException = null;
+
+//                try
+//                {
+//                    bool gotEof;
+
+//                    complete = closeResult.HandleInputComplete(result, out gotEof);
+//                    if (!complete && !gotEof)
+//                        complete = closeResult.WaitForEof();
+//                }
+//                catch (Exception e)
+//                {
+//                    if (Fx.IsFatal(e))
+//                        throw;
+
+//                    completeException = e;
+//                }
+
+//                if (complete || completeException != null)
+//                    closeResult.Complete(false, completeException);
+//            }
+
+//            static void OnWaitForPendingOperationsCompleteStatic(IAsyncResult result)
+//            {
+//                if (result.CompletedSynchronously)
+//                    return;
+
+//                CloseInputSessionChannelAsyncResult<TChannel, TItem> closeResult =
+//                    (CloseInputSessionChannelAsyncResult<TChannel, TItem>)result.AsyncState;
+
+//                bool complete = false;
+//                Exception completeException = null;
+
+//                try
+//                {
+//                    complete = closeResult.HandleWaitForPendingOperationsComplete(result);
+//                }
+//                catch (Exception e)
+//                {
+//                    if (Fx.IsFatal(e))
+//                        throw;
+
+//                    completeException = e;
+//                }
+
+//                if (complete || completeException != null)
+//                    closeResult.Complete(false, completeException);
+//            }
+
+//            bool WaitForEof()
+//            {
+//                TimeSpan iterationTimeout = RemainingTime;
+//                lastReceive = (iterationTimeout == TimeSpan.Zero);
+
+//                while (true)
+//                {
+//                    IAsyncResult result = null;
+
+//                    try
+//                    {
+//                        result = BeginTryInput(iterationTimeout, onInputCompleteStatic, this);
+//                    }
+//                    catch (Exception e)
+//                    {
+//                        if (Fx.IsFatal(e))
+//                            throw;
+
+//                        if (!MaskHandled(binder.DefaultMaskingMode) || !binder.IsHandleable(e))
+//                            throw;
+//                    }
+
+//                    if (result != null)
+//                    {
+//                        if (result.CompletedSynchronously)
+//                        {
+//                            bool gotEof;
+//                            bool complete = HandleInputComplete(result, out gotEof);
+
+//                            if (complete || gotEof)
+//                                return complete;
+//                        }
+//                        else
+//                            return false;
+//                    }
+
+//                    if (lastReceive || channel.State != CommunicationState.Opened)
+//                    {
+//                        channel.Abort();
+//                        break;
+//                    }
+
+//                    iterationTimeout = RemainingTime;
+//                    lastReceive = (iterationTimeout == TimeSpan.Zero);
+//                }
+
+//                return true;
+//            }
+//        }
+
+//        sealed class CloseDuplexSessionChannelAsyncResult :
+//            CloseInputSessionChannelAsyncResult<IDuplexSessionChannel, Message>
+//        {
+//            static AsyncCallback onCloseOutputSessionCompleteStatic =
+//                Fx.ThunkCallback(
+//                new AsyncCallback(OnCloseOutputSessionCompleteStatic));
+
+//            public CloseDuplexSessionChannelAsyncResult(
+//                ReliableChannelBinder<IDuplexSessionChannel> binder, IDuplexSessionChannel channel,
+//                TimeSpan timeout, AsyncCallback callback, object state)
+//                : base(binder, channel, timeout, callback, state)
+//            {
+//                bool complete = false;
+
+//                IAsyncResult result = Channel.Session.BeginCloseOutputSession(
+//                    RemainingTime, onCloseOutputSessionCompleteStatic, this);
+
+//                if (result.CompletedSynchronously)
+//                    complete = HandleCloseOutputSessionComplete(result);
+
+//                if (complete)
+//                    Complete(true);
+//            }
+
+//            protected override IAsyncResult BeginTryInput(TimeSpan timeout, AsyncCallback callback, object state)
+//            {
+//                return Channel.BeginTryReceive(timeout, callback, state);
+//            }
+
+//            protected override void DisposeItem(Message item)
+//            {
+//                item.Close();
+//            }
+
+//            public static void End(IAsyncResult result)
+//            {
+//                AsyncResult.End<CloseDuplexSessionChannelAsyncResult>(result);
+//            }
+
+//            protected override bool EndTryInput(IAsyncResult result, out Message item)
+//            {
+//                return Channel.EndTryReceive(result, out item);
+//            }
+
+//            bool HandleCloseOutputSessionComplete(IAsyncResult result)
+//            {
+//                Channel.Session.EndCloseOutputSession(result);
+//                return Begin();
+//            }
+
+//            static void OnCloseOutputSessionCompleteStatic(IAsyncResult result)
+//            {
+//                if (result.CompletedSynchronously)
+//                    return;
+
+//                CloseDuplexSessionChannelAsyncResult closeResult =
+//                    (CloseDuplexSessionChannelAsyncResult)result.AsyncState;
+
+//                bool complete = false;
+//                Exception completeException = null;
+
+//                try
+//                {
+//                    complete = closeResult.HandleCloseOutputSessionComplete(result);
+//                }
+//                catch (Exception e)
+//                {
+//                    if (Fx.IsFatal(e))
+//                        throw;
+
+//                    completeException = e;
+//                }
+
+//                if (complete || completeException != null)
+//                    closeResult.Complete(false, completeException);
+//            }
+//        }
+
+//        sealed class CloseReplySessionChannelAsyncResult :
+//            CloseInputSessionChannelAsyncResult<IReplySessionChannel, RequestContext>
+//        {
+//            public CloseReplySessionChannelAsyncResult(
+//                ReliableChannelBinder<IReplySessionChannel> binder, IReplySessionChannel channel,
+//                TimeSpan timeout, AsyncCallback callback, object state)
+//                : base(binder, channel, timeout, callback, state)
+//            {
+//                if (Begin())
+//                    Complete(true);
+//            }
+
+//            protected override IAsyncResult BeginTryInput(TimeSpan timeout, AsyncCallback callback, object state)
+//            {
+//                return Channel.BeginTryReceiveRequest(timeout, callback, state);
+//            }
+
+//            protected override void DisposeItem(RequestContext item)
+//            {
+//                item.RequestMessage.Close();
+//                item.Close();
+//            }
+
+//            public static void End(IAsyncResult result)
+//            {
+//                AsyncResult.End<CloseReplySessionChannelAsyncResult>(result);
+//            }
+
+//            protected override bool EndTryInput(IAsyncResult result, out RequestContext item)
+//            {
+//                return Channel.EndTryReceiveRequest(result, out item);
+//            }
+//        }
+//    }
+}
+

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/SecurityBindingElement.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/SecurityBindingElement.cs
@@ -5,6 +5,7 @@
 
 using System.Collections.Generic;
 using System.Globalization;
+using System.IdentityModel.Selectors;
 using System.Net.Security;
 using System.ServiceModel.Security;
 using System.ServiceModel.Security.Tokens;
@@ -21,15 +22,19 @@ namespace System.ServiceModel.Channels
         internal const bool defaultEnableUnsecuredResponse = false;
         internal const bool defaultProtectTokens = false;
 
+        private SecurityAlgorithmSuite _defaultAlgorithmSuite;
         private SupportingTokenParameters _endpointSupportingTokenParameters;
+        private SupportingTokenParameters _optionalEndpointSupportingTokenParameters;
         private bool _includeTimestamp;
-
+        private Dictionary<string, SupportingTokenParameters> _operationSupportingTokenParameters;
+        private Dictionary<string, SupportingTokenParameters> _optionalOperationSupportingTokenParameters;
         private LocalClientSecuritySettings _localClientSettings;
 
         private MessageSecurityVersion _messageSecurityVersion;
         private SecurityHeaderLayout _securityHeaderLayout;
         private long _maxReceivedMessageSize = TransportDefaults.MaxReceivedMessageSize;
         private XmlDictionaryReaderQuotas _readerQuotas;
+        private bool _enableUnsecuredResponse;
         private bool _protectTokens = defaultProtectTokens;
 
         internal SecurityBindingElement()
@@ -37,9 +42,14 @@ namespace System.ServiceModel.Channels
         {
             _messageSecurityVersion = MessageSecurityVersion.Default;
             _includeTimestamp = defaultIncludeTimestamp;
+            _defaultAlgorithmSuite = SecurityAlgorithmSuite.Default;
             _localClientSettings = new LocalClientSecuritySettings();
             _endpointSupportingTokenParameters = new SupportingTokenParameters();
+            _optionalEndpointSupportingTokenParameters = new SupportingTokenParameters();
+            _operationSupportingTokenParameters = new Dictionary<string, SupportingTokenParameters>();
+            _optionalOperationSupportingTokenParameters = new Dictionary<string, SupportingTokenParameters>();
             _securityHeaderLayout = SecurityProtocolFactory.defaultSecurityHeaderLayout;
+            _enableUnsecuredResponse = defaultEnableUnsecuredResponse;
         }
 
         internal SecurityBindingElement(SecurityBindingElement elementToBeCloned)
@@ -49,12 +59,25 @@ namespace System.ServiceModel.Channels
                 throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("elementToBeCloned");
 
             _includeTimestamp = elementToBeCloned._includeTimestamp;
+            _defaultAlgorithmSuite = elementToBeCloned._defaultAlgorithmSuite;
             _messageSecurityVersion = elementToBeCloned._messageSecurityVersion;
             _securityHeaderLayout = elementToBeCloned._securityHeaderLayout;
             _endpointSupportingTokenParameters = elementToBeCloned._endpointSupportingTokenParameters.Clone();
+            _optionalEndpointSupportingTokenParameters = (SupportingTokenParameters)elementToBeCloned._optionalEndpointSupportingTokenParameters.Clone();
+            _operationSupportingTokenParameters = new Dictionary<string, SupportingTokenParameters>();
+            foreach (string key in elementToBeCloned._operationSupportingTokenParameters.Keys)
+            {
+                _operationSupportingTokenParameters[key] = (SupportingTokenParameters)elementToBeCloned._operationSupportingTokenParameters[key].Clone();
+            }
+            _optionalOperationSupportingTokenParameters = new Dictionary<string, SupportingTokenParameters>();
+            foreach (string key in elementToBeCloned._optionalOperationSupportingTokenParameters.Keys)
+            {
+                _optionalOperationSupportingTokenParameters[key] = (SupportingTokenParameters)elementToBeCloned._optionalOperationSupportingTokenParameters[key].Clone();
+            }
             _localClientSettings = elementToBeCloned._localClientSettings.Clone();
             _maxReceivedMessageSize = elementToBeCloned._maxReceivedMessageSize;
             _readerQuotas = elementToBeCloned._readerQuotas;
+            _enableUnsecuredResponse = elementToBeCloned._enableUnsecuredResponse;
         }
 
         public SupportingTokenParameters EndpointSupportingTokenParameters
@@ -62,6 +85,30 @@ namespace System.ServiceModel.Channels
             get
             {
                 return _endpointSupportingTokenParameters;
+            }
+        }
+
+        public SupportingTokenParameters OptionalEndpointSupportingTokenParameters
+        {
+            get
+            {
+                return _optionalEndpointSupportingTokenParameters;
+            }
+        }
+
+        public IDictionary<string, SupportingTokenParameters> OperationSupportingTokenParameters
+        {
+            get
+            {
+                return _operationSupportingTokenParameters;
+            }
+        }
+
+        public IDictionary<string, SupportingTokenParameters> OptionalOperationSupportingTokenParameters
+        {
+            get
+            {
+                return _optionalOperationSupportingTokenParameters;
             }
         }
 
@@ -94,6 +141,18 @@ namespace System.ServiceModel.Channels
             }
         }
 
+        public bool EnableUnsecuredResponse
+        {
+            get
+            {
+                return _enableUnsecuredResponse;
+            }
+            set
+            {
+                _enableUnsecuredResponse = value;
+            }
+        }
+
         public bool IncludeTimestamp
         {
             get
@@ -103,6 +162,20 @@ namespace System.ServiceModel.Channels
             set
             {
                 _includeTimestamp = value;
+            }
+        }
+
+        public SecurityAlgorithmSuite DefaultAlgorithmSuite
+        {
+            get
+            {
+                return _defaultAlgorithmSuite;
+            }
+            set
+            {
+                if (value == null)
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentNullException("value"));
+                _defaultAlgorithmSuite = value;
             }
         }
 
@@ -160,27 +233,108 @@ namespace System.ServiceModel.Channels
             supportsWindowsIdentity = false;
             bool tmpSupportsClientAuth;
             bool tmpSupportsWindowsIdentity;
-            this.GetSupportingTokensCapabilities(requirements.Endorsing, out tmpSupportsClientAuth, out tmpSupportsWindowsIdentity);
+            GetSupportingTokensCapabilities(requirements.Endorsing, out tmpSupportsClientAuth, out tmpSupportsWindowsIdentity);
             supportsClientAuth = supportsClientAuth || tmpSupportsClientAuth;
             supportsWindowsIdentity = supportsWindowsIdentity || tmpSupportsWindowsIdentity;
 
-            this.GetSupportingTokensCapabilities(requirements.SignedEndorsing, out tmpSupportsClientAuth, out tmpSupportsWindowsIdentity);
+            GetSupportingTokensCapabilities(requirements.SignedEndorsing, out tmpSupportsClientAuth, out tmpSupportsWindowsIdentity);
             supportsClientAuth = supportsClientAuth || tmpSupportsClientAuth;
             supportsWindowsIdentity = supportsWindowsIdentity || tmpSupportsWindowsIdentity;
 
-            this.GetSupportingTokensCapabilities(requirements.SignedEncrypted, out tmpSupportsClientAuth, out tmpSupportsWindowsIdentity);
+            GetSupportingTokensCapabilities(requirements.SignedEncrypted, out tmpSupportsClientAuth, out tmpSupportsWindowsIdentity);
             supportsClientAuth = supportsClientAuth || tmpSupportsClientAuth;
             supportsWindowsIdentity = supportsWindowsIdentity || tmpSupportsWindowsIdentity;
         }
 
         internal void GetSupportingTokensCapabilities(out bool supportsClientAuth, out bool supportsWindowsIdentity)
         {
-            this.GetSupportingTokensCapabilities(this.EndpointSupportingTokenParameters, out supportsClientAuth, out supportsWindowsIdentity);
+            GetSupportingTokensCapabilities(EndpointSupportingTokenParameters, out supportsClientAuth, out supportsWindowsIdentity);
+        }
+
+        static BindingContext CreateIssuerBindingContextForNegotiation(BindingContext issuerBindingContext)
+        {
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+            //TransportBindingElement transport = issuerBindingContext.RemainingBindingElements.Find<TransportBindingElement>();
+            //if (transport == null)
+            //{
+            //    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.TransportBindingElementNotFound)));
+            //}
+            //ChannelDemuxerBindingElement demuxer = null;
+            //// pick the demuxer above transport (i.e. the last demuxer in the array)
+            //for (int i = 0; i < issuerBindingContext.RemainingBindingElements.Count; ++i)
+            //{
+            //    if (issuerBindingContext.RemainingBindingElements[i] is ChannelDemuxerBindingElement)
+            //    {
+            //        demuxer = (ChannelDemuxerBindingElement)issuerBindingContext.RemainingBindingElements[i];
+            //    }
+            //}
+            //if (demuxer == null)
+            //{
+            //    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.ChannelDemuxerBindingElementNotFound)));
+            //}
+            //BindingElementCollection negotiationBindingElements = new BindingElementCollection();
+            //negotiationBindingElements.Add(demuxer.Clone());
+            //negotiationBindingElements.Add(transport.Clone());
+            //CustomBinding binding = new CustomBinding(negotiationBindingElements);
+            //binding.OpenTimeout = issuerBindingContext.Binding.OpenTimeout;
+            //binding.CloseTimeout = issuerBindingContext.Binding.CloseTimeout;
+            //binding.SendTimeout = issuerBindingContext.Binding.SendTimeout;
+            //binding.ReceiveTimeout = issuerBindingContext.Binding.ReceiveTimeout;
+            //if (issuerBindingContext.ListenUriBaseAddress != null)
+            //{
+            //    return new BindingContext(binding, new BindingParameterCollection(issuerBindingContext.BindingParameters), issuerBindingContext.ListenUriBaseAddress,
+            //        issuerBindingContext.ListenUriRelativeAddress, issuerBindingContext.ListenUriMode);
+            //}
+            //else
+            //{
+            //    return new BindingContext(binding, new BindingParameterCollection(issuerBindingContext.BindingParameters));
+            //}
         }
 
         protected static void SetIssuerBindingContextIfRequired(SecurityTokenParameters parameters, BindingContext issuerBindingContext)
         {
-            throw ExceptionHelper.PlatformNotSupported("SetIssuerBindingContextIfRequired is not supported.");
+            if (parameters is SslSecurityTokenParameters)
+            {
+                ((SslSecurityTokenParameters)parameters).IssuerBindingContext = CreateIssuerBindingContextForNegotiation(issuerBindingContext);
+            }
+            else if (parameters is SspiSecurityTokenParameters)
+            {
+                ((SspiSecurityTokenParameters)parameters).IssuerBindingContext = CreateIssuerBindingContextForNegotiation(issuerBindingContext);
+            }
+        }
+
+        static void SetIssuerBindingContextIfRequired(SupportingTokenParameters supportingParameters, BindingContext issuerBindingContext)
+        {
+            for (int i = 0; i < supportingParameters.Endorsing.Count; ++i)
+            {
+                SetIssuerBindingContextIfRequired(supportingParameters.Endorsing[i], issuerBindingContext);
+            }
+            for (int i = 0; i < supportingParameters.SignedEndorsing.Count; ++i)
+            {
+                SetIssuerBindingContextIfRequired(supportingParameters.SignedEndorsing[i], issuerBindingContext);
+            }
+            for (int i = 0; i < supportingParameters.Signed.Count; ++i)
+            {
+                SetIssuerBindingContextIfRequired(supportingParameters.Signed[i], issuerBindingContext);
+            }
+            for (int i = 0; i < supportingParameters.SignedEncrypted.Count; ++i)
+            {
+                SetIssuerBindingContextIfRequired(supportingParameters.SignedEncrypted[i], issuerBindingContext);
+            }
+        }
+
+        void SetIssuerBindingContextIfRequired(BindingContext issuerBindingContext)
+        {
+            SetIssuerBindingContextIfRequired(EndpointSupportingTokenParameters, issuerBindingContext);
+            SetIssuerBindingContextIfRequired(OptionalEndpointSupportingTokenParameters, issuerBindingContext);
+            foreach (SupportingTokenParameters parameters in OperationSupportingTokenParameters.Values)
+            {
+                SetIssuerBindingContextIfRequired(parameters, issuerBindingContext);
+            }
+            foreach (SupportingTokenParameters parameters in OptionalOperationSupportingTokenParameters.Values)
+            {
+                SetIssuerBindingContextIfRequired(parameters, issuerBindingContext);
+            }
         }
 
         internal bool RequiresChannelDemuxer(SecurityTokenParameters parameters)
@@ -208,12 +362,15 @@ namespace System.ServiceModel.Channels
             return false;
         }
 
+        internal abstract SecurityProtocolFactory CreateSecurityProtocolFactory<TChannel>(BindingContext context, SecurityCredentialsManager credentialsManager,
+                                                                                          bool isForService, BindingContext issuanceBindingContext);
+
         public override IChannelFactory<TChannel> BuildChannelFactory<TChannel>(BindingContext context)
         {
             if (context == null)
                 throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("context");
 
-            if (!this.CanBuildChannelFactory<TChannel>(context))
+            if (!CanBuildChannelFactory<TChannel>(context))
             {
                 throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentException(SR.Format(SR.ChannelTypeNotSupported, typeof(TChannel)), "TChannel"));
             }
@@ -232,7 +389,7 @@ namespace System.ServiceModel.Channels
             if (transportBindingElement != null)
                 _maxReceivedMessageSize = transportBindingElement.MaxReceivedMessageSize;
 
-            IChannelFactory<TChannel> result = this.BuildChannelFactoryCore<TChannel>(context);
+            IChannelFactory<TChannel> result = BuildChannelFactoryCore<TChannel>(context);
 
             return result;
         }
@@ -244,9 +401,9 @@ namespace System.ServiceModel.Channels
             if (context == null)
                 throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("context");
 
-            if (this.SessionMode)
+            if (SessionMode)
             {
-                return this.CanBuildSessionChannelFactory<TChannel>(context);
+                return CanBuildSessionChannelFactory<TChannel>(context);
             }
 
             if (!context.CanBuildInnerChannelFactory<TChannel>())
@@ -255,8 +412,8 @@ namespace System.ServiceModel.Channels
             }
 
             return typeof(TChannel) == typeof(IOutputChannel) || typeof(TChannel) == typeof(IOutputSessionChannel) ||
-                (this.SupportsDuplex && (typeof(TChannel) == typeof(IDuplexChannel) || typeof(TChannel) == typeof(IDuplexSessionChannel))) ||
-                (this.SupportsRequestReply && (typeof(TChannel) == typeof(IRequestChannel) || typeof(TChannel) == typeof(IRequestSessionChannel)));
+                (SupportsDuplex && (typeof(TChannel) == typeof(IDuplexChannel) || typeof(TChannel) == typeof(IDuplexSessionChannel))) ||
+                (SupportsRequestReply && (typeof(TChannel) == typeof(IRequestChannel) || typeof(TChannel) == typeof(IRequestSessionChannel)));
         }
 
         private bool CanBuildSessionChannelFactory<TChannel>(BindingContext context)
@@ -320,7 +477,7 @@ namespace System.ServiceModel.Channels
 
         private ISecurityCapabilities GetSecurityCapabilities(BindingContext context)
         {
-            ISecurityCapabilities thisSecurityCapability = this.GetIndividualISecurityCapabilities();
+            ISecurityCapabilities thisSecurityCapability = GetIndividualISecurityCapabilities();
             ISecurityCapabilities lowerSecurityCapability = context.GetInnerProperty<ISecurityCapabilities>();
             if (lowerSecurityCapability == null)
             {
@@ -445,19 +602,102 @@ namespace System.ServiceModel.Channels
             throw ExceptionHelper.PlatformNotSupported("SecurityBindingElement.CreateSecureConversatationBindingElement is not supported.");
         }
 
+        void SetPrivacyNoticeUriIfRequired(SecurityProtocolFactory factory, Binding binding)
+        {
+            // Issue #31 in progress (don't throw here to allow further processing)
+            //PrivacyNoticeBindingElement privacyElement = binding.CreateBindingElements().Find<PrivacyNoticeBindingElement>();
+            //if (privacyElement != null)
+            //{
+            //    factory.PrivacyNoticeUri = privacyElement.Url;
+            //    factory.PrivacyNoticeVersion = privacyElement.Version;
+            //}
+        }
+
+        internal void ConfigureProtocolFactory(SecurityProtocolFactory factory, SecurityCredentialsManager credentialsManager, bool isForService, BindingContext issuerBindingContext, Binding binding)
+        {
+            if (factory == null)
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentNullException("factory"));
+            if (credentialsManager == null)
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentNullException("credentialsManager"));
+
+            factory.AddTimestamp = IncludeTimestamp;
+            factory.IncomingAlgorithmSuite = DefaultAlgorithmSuite;
+            factory.OutgoingAlgorithmSuite = DefaultAlgorithmSuite;
+            factory.SecurityHeaderLayout = SecurityHeaderLayout;
+
+            if (!isForService)
+            {
+                factory.TimestampValidityDuration = LocalClientSettings.TimestampValidityDuration;
+                factory.DetectReplays = LocalClientSettings.DetectReplays;
+                factory.MaxCachedNonces = LocalClientSettings.ReplayCacheSize;
+                factory.MaxClockSkew = LocalClientSettings.MaxClockSkew;
+                factory.ReplayWindow = LocalClientSettings.ReplayWindow;
+
+                if (LocalClientSettings.DetectReplays)
+                {
+                    factory.NonceCache = LocalClientSettings.NonceCache;
+                }
+            }
+            else
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+
+                //factory.TimestampValidityDuration = LocalServiceSettings.TimestampValidityDuration;
+                //factory.DetectReplays = LocalServiceSettings.DetectReplays;
+                //factory.MaxCachedNonces = LocalServiceSettings.ReplayCacheSize;
+                //factory.MaxClockSkew = LocalServiceSettings.MaxClockSkew;
+                //factory.ReplayWindow = LocalServiceSettings.ReplayWindow;
+
+                //if (LocalServiceSettings.DetectReplays)
+                //{
+                //    factory.NonceCache = LocalServiceSettings.NonceCache;
+                //}
+            }
+
+            factory.SecurityBindingElement = (SecurityBindingElement)Clone();
+            factory.SecurityBindingElement.SetIssuerBindingContextIfRequired(issuerBindingContext);
+            factory.SecurityTokenManager = credentialsManager.CreateSecurityTokenManager();
+            SecurityTokenSerializer tokenSerializer = factory.SecurityTokenManager.CreateSecurityTokenSerializer(_messageSecurityVersion.SecurityTokenVersion);
+            factory.StandardsManager = new SecurityStandardsManager(_messageSecurityVersion, tokenSerializer);
+            if (!isForService)
+            {
+                SetPrivacyNoticeUriIfRequired(factory, binding);
+            }
+        }
+
         public override string ToString()
         {
             StringBuilder sb = new StringBuilder();
 
-            sb.AppendLine(String.Format(CultureInfo.InvariantCulture, "{0}:", this.GetType().ToString()));
+            sb.AppendLine(String.Format(CultureInfo.InvariantCulture, "{0}:", GetType().ToString()));
             sb.AppendLine(String.Format(CultureInfo.InvariantCulture, "IncludeTimestamp: {0}", _includeTimestamp.ToString()));
-            sb.AppendLine(String.Format(CultureInfo.InvariantCulture, "MessageSecurityVersion: {0}", this.MessageSecurityVersion.ToString()));
+            sb.AppendLine(String.Format(CultureInfo.InvariantCulture, "MessageSecurityVersion: {0}", MessageSecurityVersion.ToString()));
             sb.AppendLine(String.Format(CultureInfo.InvariantCulture, "SecurityHeaderLayout: {0}", _securityHeaderLayout.ToString()));
             sb.AppendLine(String.Format(CultureInfo.InvariantCulture, "ProtectTokens: {0}", _protectTokens.ToString()));
             sb.AppendLine("EndpointSupportingTokenParameters:");
-            sb.AppendLine("  " + this.EndpointSupportingTokenParameters.ToString().Trim().Replace("\n", "\n  "));
+            sb.AppendLine("  " + EndpointSupportingTokenParameters.ToString().Trim().Replace("\n", "\n  "));
 
             return sb.ToString().Trim();
+        }
+
+        internal void ApplyAuditBehaviorSettings(BindingContext context, SecurityProtocolFactory factory)
+        {
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+            //ServiceSecurityAuditBehavior auditBehavior = context.BindingParameters.Find<ServiceSecurityAuditBehavior>();
+            //if (auditBehavior != null)
+            //{
+            //    factory.AuditLogLocation = auditBehavior.AuditLogLocation;
+            //    factory.SuppressAuditFailure = auditBehavior.SuppressAuditFailure;
+            //    factory.ServiceAuthorizationAuditLevel = auditBehavior.ServiceAuthorizationAuditLevel;
+            //    factory.MessageAuthenticationAuditLevel = auditBehavior.MessageAuthenticationAuditLevel;
+            //}
+            //else
+            //{
+            //    factory.AuditLogLocation = ServiceSecurityAuditBehavior.defaultAuditLogLocation;
+            //    factory.SuppressAuditFailure = ServiceSecurityAuditBehavior.defaultSuppressAuditFailure;
+            //    factory.ServiceAuthorizationAuditLevel = ServiceSecurityAuditBehavior.defaultServiceAuthorizationAuditLevel;
+            //    factory.MessageAuthenticationAuditLevel = ServiceSecurityAuditBehavior.defaultMessageAuthenticationAuditLevel;
+            //}
         }
     }
 }

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/SecurityCapabilities.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/SecurityCapabilities.cs
@@ -9,27 +9,27 @@ namespace System.ServiceModel.Channels
 {
     public class SecurityCapabilities : ISecurityCapabilities
     {
-        internal bool supportsServerAuth;
-        internal bool supportsClientAuth;
-        internal bool supportsClientWindowsIdentity;
-        internal ProtectionLevel requestProtectionLevel;
-        internal ProtectionLevel responseProtectionLevel;
+        internal bool _supportsServerAuth;
+        internal bool _supportsClientAuth;
+        internal bool _supportsClientWindowsIdentity;
+        internal ProtectionLevel _requestProtectionLevel;
+        internal ProtectionLevel _responseProtectionLevel;
 
         public SecurityCapabilities(bool supportsClientAuth, bool supportsServerAuth, bool supportsClientWindowsIdentity,
             ProtectionLevel requestProtectionLevel, ProtectionLevel responseProtectionLevel)
         {
-            this.supportsClientAuth = supportsClientAuth;
-            this.supportsServerAuth = supportsServerAuth;
-            this.supportsClientWindowsIdentity = supportsClientWindowsIdentity;
-            this.requestProtectionLevel = requestProtectionLevel;
-            this.responseProtectionLevel = responseProtectionLevel;
+            _supportsClientAuth = supportsClientAuth;
+            _supportsServerAuth = supportsServerAuth;
+            _supportsClientWindowsIdentity = supportsClientWindowsIdentity;
+            _requestProtectionLevel = requestProtectionLevel;
+            _responseProtectionLevel = responseProtectionLevel;
         }
 
-        public ProtectionLevel SupportedRequestProtectionLevel { get { return requestProtectionLevel; } }
-        public ProtectionLevel SupportedResponseProtectionLevel { get { return responseProtectionLevel; } }
-        public bool SupportsClientAuthentication { get { return supportsClientAuth; } }
-        public bool SupportsClientWindowsIdentity { get { return supportsClientWindowsIdentity; } }
-        public bool SupportsServerAuthentication { get { return supportsServerAuth; } }
+        public ProtectionLevel SupportedRequestProtectionLevel { get { return _requestProtectionLevel; } }
+        public ProtectionLevel SupportedResponseProtectionLevel { get { return _responseProtectionLevel; } }
+        public bool SupportsClientAuthentication { get { return _supportsClientAuth; } }
+        public bool SupportsClientWindowsIdentity { get { return _supportsClientWindowsIdentity; } }
+        public bool SupportsServerAuthentication { get { return _supportsServerAuth; } }
 
         public static SecurityCapabilities None
         {

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/SecurityChannelFactory.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/SecurityChannelFactory.cs
@@ -1,0 +1,853 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Runtime;
+using System.Runtime.InteropServices;
+using System.Security.Authentication.ExtendedProtection;
+using System.ServiceModel;
+using System.ServiceModel.Diagnostics;
+using System.ServiceModel.Dispatcher;
+using System.ServiceModel.Security;
+using System.Threading.Tasks;
+
+namespace System.ServiceModel.Channels
+{
+    sealed class SecurityChannelFactory<TChannel>
+        : LayeredChannelFactory<TChannel>
+    {
+        private ChannelBuilder _channelBuilder;
+        private SecurityProtocolFactory _securityProtocolFactory;
+        private SecuritySessionClientSettings<TChannel> _sessionClientSettings;
+        private bool _sessionMode;
+        private MessageVersion _messageVersion;
+        private ISecurityCapabilities _securityCapabilities;
+
+        public SecurityChannelFactory(ISecurityCapabilities securityCapabilities, BindingContext context,
+            SecuritySessionClientSettings<TChannel> sessionClientSettings)
+            : this(securityCapabilities, context, sessionClientSettings.ChannelBuilder, sessionClientSettings.CreateInnerChannelFactory())
+        {
+            _sessionMode = true;
+            _sessionClientSettings = sessionClientSettings;
+        }
+
+        public SecurityChannelFactory(ISecurityCapabilities securityCapabilities, BindingContext context, ChannelBuilder channelBuilder, SecurityProtocolFactory protocolFactory)
+            : this(securityCapabilities, context, channelBuilder, protocolFactory, channelBuilder.BuildChannelFactory<TChannel>())
+        {
+        }
+
+        public SecurityChannelFactory(ISecurityCapabilities securityCapabilities, BindingContext context, ChannelBuilder channelBuilder, SecurityProtocolFactory protocolFactory, IChannelFactory innerChannelFactory)
+            : this(securityCapabilities, context, channelBuilder, innerChannelFactory)
+        {
+            _securityProtocolFactory = protocolFactory;
+        }
+
+        SecurityChannelFactory(ISecurityCapabilities securityCapabilities, BindingContext context, ChannelBuilder channelBuilder, IChannelFactory innerChannelFactory)
+            : base(context.Binding, innerChannelFactory)
+        {
+            _channelBuilder = channelBuilder;
+            _messageVersion = context.Binding.MessageVersion;
+            _securityCapabilities = securityCapabilities;
+        }
+
+        // used by internal test code
+        internal SecurityChannelFactory(Binding binding, SecurityProtocolFactory protocolFactory, IChannelFactory innerChannelFactory)
+            : base(binding, innerChannelFactory)
+        {
+            _securityProtocolFactory = protocolFactory;
+        }
+
+        public ChannelBuilder ChannelBuilder
+        {
+            get
+            {
+                return _channelBuilder;
+            }
+        }
+
+        public SecurityProtocolFactory SecurityProtocolFactory
+        {
+            get
+            {
+                return _securityProtocolFactory;
+            }
+        }
+
+        public SecuritySessionClientSettings<TChannel> SessionClientSettings
+        {
+            get
+            {
+                Fx.Assert(SessionMode == true, "SessionClientSettings can only be used if SessionMode == true");
+                return _sessionClientSettings;
+            }
+        }
+
+        public bool SessionMode
+        {
+            get
+            {
+                return _sessionMode;
+            }
+        }
+
+        bool SupportsDuplex
+        {
+            get
+            {
+                ThrowIfProtocolFactoryNotSet();
+                return _securityProtocolFactory.SupportsDuplex;
+            }
+        }
+
+        bool SupportsRequestReply
+        {
+            get
+            {
+                ThrowIfProtocolFactoryNotSet();
+                return _securityProtocolFactory.SupportsRequestReply;
+            }
+        }
+
+        public MessageVersion MessageVersion
+        {
+            get
+            {
+                return _messageVersion;
+            }
+        }
+
+        void CloseProtocolFactory(bool aborted, TimeSpan timeout)
+        {
+            SecurityProtocolFactory factory = _securityProtocolFactory;
+            if (factory != null && !SessionMode)
+            {
+                factory.Close(aborted, timeout);
+                _securityProtocolFactory = null;
+            }
+        }
+
+        async Task CloseProtocolFactoryAsync(TimeSpan timeout)
+        {
+            SecurityProtocolFactory factory = _securityProtocolFactory;
+            if (factory != null && !SessionMode)
+            {
+                await factory.CloseAsync(timeout);
+                _securityProtocolFactory = null;
+            }
+        }
+
+        public override T GetProperty<T>()
+        {
+            if (SessionMode && (typeof(T) == typeof(IChannelSecureConversationSessionSettings)))
+            {
+                return (T)(object)SessionClientSettings;
+            }
+            else if (typeof(T) == typeof(ISecurityCapabilities))
+            {
+                return (T)(object)_securityCapabilities;
+            }
+
+            return base.GetProperty<T>();
+        }
+
+        protected override void OnAbort()
+        {
+            base.OnAbort();
+            CloseProtocolFactory(true, TimeSpan.Zero);
+            if (_sessionClientSettings != null)
+            {
+                _sessionClientSettings.Abort();
+            }
+        }
+
+        protected override IAsyncResult OnBeginClose(TimeSpan timeout, AsyncCallback callback, object state)
+        {
+            throw ExceptionHelper.PlatformNotSupported("SecurityChannelFactory OnBeginClose not supported.");
+
+            //List<OperationWithTimeoutBeginCallback> begins = new List<OperationWithTimeoutBeginCallback>();
+            //List<OperationEndCallback> ends = new List<OperationEndCallback>();
+            //begins.Add(new OperationWithTimeoutBeginCallback(base.OnBeginClose));
+            //ends.Add(new OperationEndCallback(base.OnEndClose));
+
+            //if (securityProtocolFactory != null && !SessionMode)
+            //{
+            //    begins.Add(new OperationWithTimeoutBeginCallback(securityProtocolFactory.BeginClose));
+            //    ends.Add(new OperationEndCallback(securityProtocolFactory.EndClose));
+            //}
+
+            //if (sessionClientSettings != null)
+            //{
+            //    begins.Add(new OperationWithTimeoutBeginCallback(sessionClientSettings.BeginClose));
+            //    ends.Add(new OperationEndCallback(sessionClientSettings.EndClose));
+            //}
+
+            //return OperationWithTimeoutComposer.BeginComposeAsyncOperations(timeout, begins.ToArray(), ends.ToArray(), callback, state);
+        }
+
+        protected override void OnEndClose(IAsyncResult result)
+        {
+            throw ExceptionHelper.PlatformNotSupported("SecurityChannelFactory OnEndClose not supported.");
+
+            // OperationWithTimeoutComposer.EndComposeAsyncOperations(result);
+        }
+
+        protected override void OnClose(TimeSpan timeout)
+        {
+            TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
+            base.OnClose(timeout);
+            CloseProtocolFactory(false, timeoutHelper.RemainingTime());
+            if (_sessionClientSettings != null)
+            {
+                _sessionClientSettings.Close(timeoutHelper.RemainingTime());
+            }
+        }
+
+        protected internal override Task OnCloseAsync(TimeSpan timeout)
+        {
+            return OnCloseAsyncInternal(timeout);
+        }
+
+        private async Task OnCloseAsyncInternal(TimeSpan timeout)
+        {
+            TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
+            await base.OnCloseAsync(timeoutHelper.RemainingTime());
+            await CloseProtocolFactoryAsync(timeoutHelper.RemainingTime());
+            if (_sessionClientSettings != null)
+            {
+                await _sessionClientSettings.CloseAsync(timeoutHelper.RemainingTime());
+            }
+        }
+
+        protected override TChannel OnCreateChannel(EndpointAddress address, Uri via)
+        {
+            ThrowIfDisposed();
+            if (SessionMode)
+            {
+                return _sessionClientSettings.OnCreateChannel(address, via);
+            }
+
+            if (typeof(TChannel) == typeof(IOutputChannel))
+            {
+                return (TChannel)(object)new SecurityOutputChannel(this, _securityProtocolFactory, ((IChannelFactory<IOutputChannel>)InnerChannelFactory).CreateChannel(address, via), address, via);
+            }
+            else if (typeof(TChannel) == typeof(IOutputSessionChannel))
+            {
+                return (TChannel)(object)new SecurityOutputSessionChannel(this, _securityProtocolFactory, ((IChannelFactory<IOutputSessionChannel>)InnerChannelFactory).CreateChannel(address, via), address, via);
+            }
+            else if (typeof(TChannel) == typeof(IDuplexChannel))
+            {
+                return (TChannel)(object)new SecurityDuplexChannel(this, _securityProtocolFactory, ((IChannelFactory<IDuplexChannel>)InnerChannelFactory).CreateChannel(address, via), address, via);
+            }
+            else if (typeof(TChannel) == typeof(IDuplexSessionChannel))
+            {
+                return (TChannel)(object)new SecurityDuplexSessionChannel(this, _securityProtocolFactory, ((IChannelFactory<IDuplexSessionChannel>)InnerChannelFactory).CreateChannel(address, via), address, via);
+            }
+            else if (typeof(TChannel) == typeof(IRequestChannel))
+            {
+                return (TChannel)(object)new SecurityRequestChannel(this, _securityProtocolFactory, ((IChannelFactory<IRequestChannel>)InnerChannelFactory).CreateChannel(address, via), address, via);
+            }
+
+            //typeof(TChannel) == typeof(IRequestSessionChannel)
+            return (TChannel)(object)new SecurityRequestSessionChannel(this, _securityProtocolFactory, ((IChannelFactory<IRequestSessionChannel>)InnerChannelFactory).CreateChannel(address, via), address, via);
+        }
+
+        protected override void OnOpen(TimeSpan timeout)
+        {
+            TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
+            OnOpenCore(timeoutHelper.RemainingTime());
+            base.OnOpen(timeoutHelper.RemainingTime());
+            SetBufferManager();
+        }
+
+        protected internal override Task OnOpenAsync(TimeSpan timeout)
+        {
+            return OnOpenAsyncInternal(timeout);
+        }
+
+        private async Task OnOpenAsyncInternal(TimeSpan timeout)
+        {
+            TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
+            await OnOpenCoreAsync(timeoutHelper.RemainingTime());
+            await base.OnOpenAsync(timeoutHelper.RemainingTime());
+            SetBufferManager();
+        }
+
+        void SetBufferManager()
+        {
+            ITransportFactorySettings transportSettings = GetProperty<ITransportFactorySettings>();
+
+            if (transportSettings == null)
+                return;
+
+            BufferManager bufferManager = transportSettings.BufferManager;
+
+            if (bufferManager == null)
+                return;
+
+            if (SessionMode && SessionClientSettings != null && SessionClientSettings.SessionProtocolFactory != null)
+            {
+                SessionClientSettings.SessionProtocolFactory.StreamBufferManager = bufferManager;
+            }
+            else
+            {
+                ThrowIfProtocolFactoryNotSet();
+                _securityProtocolFactory.StreamBufferManager = bufferManager;
+            }
+        }
+
+
+        protected override IAsyncResult OnBeginOpen(TimeSpan timeout, AsyncCallback callback, object state)
+        {
+            throw ExceptionHelper.PlatformNotSupported(); // Issue #31 in progress
+            //return new OperationWithTimeoutAsyncResult(new OperationWithTimeoutCallback(OnOpen), timeout, callback, state);
+        }
+
+        protected override void OnEndOpen(IAsyncResult result)
+        {
+            throw ExceptionHelper.PlatformNotSupported(); // Issue #31 in progress
+            //OperationWithTimeoutAsyncResult.End(result);
+        }
+
+        void OnOpenCore(TimeSpan timeout)
+        {
+            TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
+            if (SessionMode)
+            {
+                SessionClientSettings.Open(this, InnerChannelFactory, ChannelBuilder, timeoutHelper.RemainingTime());
+            }
+            else
+            {
+                ThrowIfProtocolFactoryNotSet();
+                _securityProtocolFactory.Open(true, timeoutHelper.RemainingTime());
+            }
+        }
+
+        private async Task OnOpenCoreAsync(TimeSpan timeout)
+        {
+            TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
+            if (SessionMode)
+            {
+                await SessionClientSettings.OpenAsync(this, InnerChannelFactory, ChannelBuilder, timeoutHelper.RemainingTime());
+            }
+            else
+            {
+                ThrowIfProtocolFactoryNotSet();
+                await _securityProtocolFactory.OpenAsync(true, timeoutHelper.RemainingTime());
+            }
+        }
+
+        void ThrowIfDuplexNotSupported()
+        {
+            if (!SupportsDuplex)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(
+                    SR.Format(SR.SecurityProtocolFactoryDoesNotSupportDuplex, _securityProtocolFactory)));
+            }
+        }
+
+        void ThrowIfProtocolFactoryNotSet()
+        {
+            if (_securityProtocolFactory == null)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(
+                    SR.Format(SR.SecurityProtocolFactoryShouldBeSetBeforeThisOperation)));
+            }
+        }
+
+        void ThrowIfRequestReplyNotSupported()
+        {
+            if (!SupportsRequestReply)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(
+                    SR.Format(SR.SecurityProtocolFactoryDoesNotSupportRequestReply, _securityProtocolFactory)));
+            }
+        }
+
+
+        abstract class ClientSecurityChannel<UChannel> : SecurityChannel<UChannel>
+            where UChannel : class, IChannel
+        {
+            private EndpointAddress _to;
+            private Uri _via;
+            private SecurityProtocolFactory _securityProtocolFactory;
+            private ChannelParameterCollection _channelParameters;
+
+            protected ClientSecurityChannel(ChannelManagerBase factory, SecurityProtocolFactory securityProtocolFactory,
+                UChannel innerChannel, EndpointAddress to, Uri via)
+                : base(factory, innerChannel)
+            {
+                _to = to;
+                _via = via;
+                _securityProtocolFactory = securityProtocolFactory;
+                _channelParameters = new ChannelParameterCollection(this);
+            }
+
+            protected SecurityProtocolFactory SecurityProtocolFactory
+            {
+                get { return _securityProtocolFactory; }
+            }
+
+            public EndpointAddress RemoteAddress
+            {
+                get { return _to; }
+            }
+
+            public Uri Via
+            {
+                get { return _via; }
+            }
+
+            protected bool TryGetSecurityFaultException(Message faultMessage, out Exception faultException)
+            {
+                faultException = null;
+                if (!faultMessage.IsFault)
+                {
+                    return false;
+                }
+                MessageFault fault = MessageFault.CreateFault(faultMessage, TransportDefaults.MaxSecurityFaultSize);
+                faultException = SecurityUtils.CreateSecurityFaultException(fault);
+                return true;
+            }
+
+            protected override IAsyncResult OnBeginOpen(TimeSpan timeout, AsyncCallback callback, object state)
+            {
+                throw ExceptionHelper.PlatformNotSupported(); // Issue #31 in progress
+
+                //EnableChannelBindingSupport();
+
+                //return new OpenAsyncResult(this, timeout, callback, state);
+            }
+
+            protected override void OnEndOpen(IAsyncResult result)
+            {
+                throw ExceptionHelper.PlatformNotSupported(); // Issue #31 in progress
+                //OpenAsyncResult.End(result);
+            }
+
+            protected override void OnOpen(TimeSpan timeout)
+            {
+                TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
+                EnableChannelBindingSupport();
+
+                SecurityProtocol securityProtocol = SecurityProtocolFactory.CreateSecurityProtocol(
+                    _to,
+                    Via,
+                    null,
+                    typeof(TChannel) == typeof(IRequestChannel),
+                    timeoutHelper.RemainingTime());
+                OnProtocolCreationComplete(securityProtocol);
+                SecurityProtocol.Open(timeoutHelper.RemainingTime());
+                base.OnOpen(timeoutHelper.RemainingTime());
+            }
+
+            protected internal override Task OnOpenAsync(TimeSpan timeout)
+            {
+                return OnOpenAsyncInternal(timeout);
+            }
+
+            private async Task OnOpenAsyncInternal(TimeSpan timeout)
+            {
+                TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
+
+                EnableChannelBindingSupport();
+
+                SecurityProtocol securityProtocol = SecurityProtocolFactory.CreateSecurityProtocol(
+                    _to,
+                    Via,
+                    null,
+                    typeof(TChannel) == typeof(IRequestChannel),
+                    timeoutHelper.RemainingTime());
+                OnProtocolCreationComplete(securityProtocol);
+                await SecurityProtocol.OpenAsync(timeoutHelper.RemainingTime());
+                await base.OnOpenAsync(timeoutHelper.RemainingTime());
+            }
+
+            void EnableChannelBindingSupport()
+            {
+                if (_securityProtocolFactory != null && _securityProtocolFactory.ExtendedProtectionPolicy != null && _securityProtocolFactory.ExtendedProtectionPolicy.CustomChannelBinding != null)
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new NotSupportedException(SR.Format(SR.ExtendedProtectionPolicyCustomChannelBindingNotSupported)));
+                }
+
+                // Do not enable channel binding if there is no reason as it sets up chunking mode.
+                if (!SecurityUtils.IsSecurityBindingSuitableForChannelBinding(SecurityProtocolFactory.SecurityBindingElement as TransportSecurityBindingElement))
+                    return;
+
+                if (InnerChannel != null)
+                {
+                    IChannelBindingProvider cbp = InnerChannel.GetProperty<IChannelBindingProvider>();
+                    if (cbp != null)
+                    {
+                        cbp.EnableChannelBindingSupport();
+                    }
+                }
+            }
+
+            void OnProtocolCreationComplete(SecurityProtocol securityProtocol)
+            {
+                SecurityProtocol = securityProtocol;
+                SecurityProtocol.ChannelParameters = _channelParameters;
+            }
+
+            public override T GetProperty<T>()
+            {
+                if (typeof(T) == typeof(ChannelParameterCollection))
+                {
+                    return (T)(object)_channelParameters;
+                }
+
+                return base.GetProperty<T>();
+            }
+        }
+
+        class SecurityOutputChannel : ClientSecurityChannel<IOutputChannel>, IOutputChannel
+        {
+            public SecurityOutputChannel(ChannelManagerBase factory, SecurityProtocolFactory securityProtocolFactory, IOutputChannel innerChannel, EndpointAddress to, Uri via)
+                : base(factory, securityProtocolFactory, innerChannel, to, via)
+            {
+            }
+
+            public IAsyncResult BeginSend(Message message, AsyncCallback callback, object state)
+            {
+                return BeginSend(message, DefaultSendTimeout, callback, state);
+            }
+
+            public IAsyncResult BeginSend(Message message, TimeSpan timeout, AsyncCallback callback, object state)
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+                //ThrowIfFaulted();
+                //ThrowIfDisposedOrNotOpen(message);
+                //return new OutputChannelSendAsyncResult(message, SecurityProtocol, InnerChannel, timeout, callback, state);
+            }
+
+            public void EndSend(IAsyncResult result)
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+                // OutputChannelSendAsyncResult.End(result);
+            }
+
+            public void Send(Message message)
+            {
+                Send(message, DefaultSendTimeout);
+            }
+
+            public void Send(Message message, TimeSpan timeout)
+            {
+                ThrowIfFaulted();
+                ThrowIfDisposedOrNotOpen(message);
+                TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
+                SecurityProtocol.SecureOutgoingMessage(ref message, timeoutHelper.RemainingTime());
+                InnerChannel.Send(message, timeoutHelper.RemainingTime());
+            }
+        }
+
+        sealed class SecurityOutputSessionChannel : SecurityOutputChannel, IOutputSessionChannel
+        {
+            public SecurityOutputSessionChannel(ChannelManagerBase factory, SecurityProtocolFactory securityProtocolFactory, IOutputSessionChannel innerChannel, EndpointAddress to, Uri via)
+                : base(factory, securityProtocolFactory, innerChannel, to, via)
+            {
+            }
+
+            public IOutputSession Session
+            {
+                get
+                {
+                    return ((IOutputSessionChannel)InnerChannel).Session;
+                }
+            }
+        }
+
+        class SecurityRequestChannel : ClientSecurityChannel<IRequestChannel>, IAsyncRequestChannel
+        {
+            public SecurityRequestChannel(ChannelManagerBase factory, SecurityProtocolFactory securityProtocolFactory, IRequestChannel innerChannel, EndpointAddress to, Uri via)
+                : base(factory, securityProtocolFactory, innerChannel, to, via)
+            {
+            }
+
+            public IAsyncResult BeginRequest(Message message, AsyncCallback callback, object state)
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // Issues #31 and #1494 in progress
+                //return BeginRequest(message, DefaultSendTimeout, callback, state);
+            }
+
+            public IAsyncResult BeginRequest(Message message, TimeSpan timeout, AsyncCallback callback, object state)
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // Issues #31 and #1494 in progress
+                //ThrowIfFaulted();
+                //ThrowIfDisposedOrNotOpen(message);
+                //return new RequestChannelSendAsyncResult(message, SecurityProtocol, InnerChannel, this, timeout, callback, state);
+            }
+
+            public Message EndRequest(IAsyncResult result)
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // Issues #31 and #1494 in progress
+                //return RequestChannelSendAsyncResult.End(result);
+            }
+
+            public Message Request(Message message)
+            {
+                return Request(message, DefaultSendTimeout);
+            }
+
+            internal Message ProcessReply(Message reply, SecurityProtocolCorrelationState correlationState, TimeSpan timeout)
+            {
+                if (reply != null)
+                {
+                    if (DiagnosticUtility.ShouldUseActivity)
+                    {
+                        ServiceModelActivity replyActivity = TraceUtility.ExtractActivity(reply);
+                        if (replyActivity != null &&
+                            correlationState != null &&
+                            correlationState.Activity != null &&
+                            replyActivity.Id != correlationState.Activity.Id)
+                        {
+                            using (ServiceModelActivity.BoundOperation(replyActivity))
+                            {
+                                if (null != FxTrace.Trace)
+                                {
+                                    FxTrace.Trace.TraceTransfer(correlationState.Activity.Id);
+                                }
+                                replyActivity.Stop();
+                            }
+                        }
+                    }
+                    ServiceModelActivity activity = correlationState == null ? null : correlationState.Activity;
+                    using (ServiceModelActivity.BoundOperation(activity))
+                    {
+                        if (DiagnosticUtility.ShouldUseActivity)
+                        {
+                            TraceUtility.SetActivity(reply, activity);
+                        }
+                        Message unverifiedMessage = reply;
+                        Exception faultException = null;
+                        try
+                        {
+                            SecurityProtocol.VerifyIncomingMessage(ref reply, timeout, correlationState);
+                        }
+                        catch (MessageSecurityException)
+                        {
+                            TryGetSecurityFaultException(unverifiedMessage, out faultException);
+                            if (faultException == null)
+                            {
+                                throw;
+                            }
+                        }
+                        if (faultException != null)
+                        {
+                            Fault(faultException);
+                            throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(faultException);
+                        }
+                    }
+                }
+                return reply;
+            }
+
+            public Message Request(Message message, TimeSpan timeout)
+            {
+                ThrowIfFaulted();
+                ThrowIfDisposedOrNotOpen(message);
+                TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
+                SecurityProtocolCorrelationState correlationState = SecurityProtocol.SecureOutgoingMessage(ref message, timeoutHelper.RemainingTime(), null);
+                Message reply = InnerChannel.Request(message, timeoutHelper.RemainingTime());
+                return ProcessReply(reply, correlationState, timeoutHelper.RemainingTime());
+            }
+
+            public Task<Message> RequestAsync(Message message)
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+            }
+
+            public Task<Message> RequestAsync(Message message, TimeSpan timeout)
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+            }
+        }
+
+        sealed class SecurityRequestSessionChannel : SecurityRequestChannel, IRequestSessionChannel
+        {
+            public SecurityRequestSessionChannel(ChannelManagerBase factory, SecurityProtocolFactory securityProtocolFactory, IRequestSessionChannel innerChannel, EndpointAddress to, Uri via)
+                : base(factory, securityProtocolFactory, innerChannel, to, via)
+            {
+            }
+
+            public IOutputSession Session
+            {
+                get
+                {
+                    return ((IRequestSessionChannel)InnerChannel).Session;
+                }
+            }
+        }
+
+        class SecurityDuplexChannel : SecurityOutputChannel, IDuplexChannel
+        {
+            public SecurityDuplexChannel(ChannelManagerBase factory, SecurityProtocolFactory securityProtocolFactory, IDuplexChannel innerChannel, EndpointAddress to, Uri via)
+                : base(factory, securityProtocolFactory, innerChannel, to, via)
+            {
+            }
+
+            internal IDuplexChannel InnerDuplexChannel
+            {
+                get { return (IDuplexChannel)InnerChannel; }
+            }
+
+            public EndpointAddress LocalAddress
+            {
+                get
+                {
+                    return InnerDuplexChannel.LocalAddress;
+                }
+            }
+
+            internal virtual bool AcceptUnsecuredFaults
+            {
+                get { return false; }
+            }
+
+            public Message Receive()
+            {
+                return Receive(DefaultReceiveTimeout);
+            }
+
+            public Message Receive(TimeSpan timeout)
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+                //return InputChannel.HelpReceive(this, timeout);
+            }
+
+            public IAsyncResult BeginReceive(AsyncCallback callback, object state)
+            {
+                return BeginReceive(DefaultReceiveTimeout, callback, state);
+            }
+
+            public IAsyncResult BeginReceive(TimeSpan timeout, AsyncCallback callback, object state)
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+                //return InputChannel.HelpBeginReceive(this, timeout, callback, state);
+            }
+
+            public Message EndReceive(IAsyncResult result)
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+                //return InputChannel.HelpEndReceive(result);
+            }
+
+            public virtual IAsyncResult BeginTryReceive(TimeSpan timeout, AsyncCallback callback, object state)
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+                //if (DoneReceivingInCurrentState())
+                //{
+                //    throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+                //    //return new DoneReceivingAsyncResult(callback, state);
+                //}
+
+                //ClientDuplexReceiveMessageAndVerifySecurityAsyncResult result =
+                //    new ClientDuplexReceiveMessageAndVerifySecurityAsyncResult(this, InnerDuplexChannel, timeout, callback, state);
+                //result.Start();
+                //return result;
+            }
+
+            public virtual bool EndTryReceive(IAsyncResult result, out Message message)
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+                //DoneReceivingAsyncResult doneRecevingResult = result as DoneReceivingAsyncResult;
+                //if (doneRecevingResult != null)
+                //{
+                //    return DoneReceivingAsyncResult.End(doneRecevingResult, out message);
+                //}
+
+                //return ClientDuplexReceiveMessageAndVerifySecurityAsyncResult.End(result, out message);
+            }
+
+            internal Message ProcessMessage(Message message, TimeSpan timeout)
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+
+                //if (message == null)
+                //{
+                //    return null;
+                //}
+                //Message unverifiedMessage = message;
+                //Exception faultException = null;
+                //try
+                //{
+                //    SecurityProtocol.VerifyIncomingMessage(ref message, timeout);
+                //}
+                //catch (MessageSecurityException)
+                //{
+                //    TryGetSecurityFaultException(unverifiedMessage, out faultException);
+                //    if (faultException == null)
+                //    {
+                //        throw;
+                //    }
+                //}
+                //if (faultException != null)
+                //{
+                //    if (AcceptUnsecuredFaults)
+                //    {
+                //        Fault(faultException);
+                //    }
+                //    throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(faultException);
+                //}
+                //return message;
+            }
+
+
+            public bool TryReceive(TimeSpan timeout, out Message message)
+            {
+                if (DoneReceivingInCurrentState())
+                {
+                    message = null;
+                    return true;
+                }
+
+                TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
+                if (!InnerDuplexChannel.TryReceive(timeoutHelper.RemainingTime(), out message))
+                {
+                    return false;
+                }
+                message = ProcessMessage(message, timeoutHelper.RemainingTime());
+                return true;
+            }
+
+            public bool WaitForMessage(TimeSpan timeout)
+            {
+                return InnerDuplexChannel.WaitForMessage(timeout);
+            }
+
+            public IAsyncResult BeginWaitForMessage(TimeSpan timeout, AsyncCallback callback, object state)
+            {
+                return InnerDuplexChannel.BeginWaitForMessage(timeout, callback, state);
+            }
+
+            public bool EndWaitForMessage(IAsyncResult result)
+            {
+                return InnerDuplexChannel.EndWaitForMessage(result);
+            }
+        }
+
+        sealed class SecurityDuplexSessionChannel : SecurityDuplexChannel, IDuplexSessionChannel
+        {
+            public SecurityDuplexSessionChannel(ChannelManagerBase factory, SecurityProtocolFactory securityProtocolFactory, IDuplexSessionChannel innerChannel, EndpointAddress to, Uri via)
+                : base(factory, securityProtocolFactory, innerChannel, to, via)
+            {
+            }
+
+            public IDuplexSession Session
+            {
+                get
+                {
+                    return ((IDuplexSessionChannel)InnerChannel).Session;
+                }
+            }
+
+            internal override bool AcceptUnsecuredFaults
+            {
+                get { return true; }
+            }
+        }
+    }
+}
+

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/ServiceChannel.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/ServiceChannel.cs
@@ -17,8 +17,9 @@ using System.Threading.Tasks;
 
 namespace System.ServiceModel.Channels
 {
-    // This class is sealed because the constructor could call Abort, which is virtual
-    internal sealed class ServiceChannel : CommunicationObject, IChannel, IClientChannel, IDuplexContextChannel, IOutputChannel, IRequestChannel, IServiceChannel
+    // This class should be sealed because the constructor could call Abort, which is virtual.
+    // But .NET Core is adding some new virtual methods.
+    internal class ServiceChannel : CommunicationObject, IChannel, IClientChannel, IDuplexContextChannel, IOutputChannel, IAsyncRequestChannel, IServiceChannel
     {
         private int _activityCount = 0;
         private bool _allowInitializationUI = true;
@@ -1219,6 +1220,16 @@ namespace System.ServiceModel.Channels
         {
             ProxyOperationRuntime operation = UnhandledProxyOperation;
             return (Message)Call(message.Headers.Action, false, operation, new object[] { message }, Array.Empty<object>(), timeout);
+        }
+
+        public Task<Message> RequestAsync(Message message)
+        {
+            return RequestAsync(message, OperationTimeout);
+        }
+
+        public Task<Message> RequestAsync(Message message, TimeSpan timeout)
+        {
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #1494
         }
 
         public IAsyncResult BeginRequest(Message message, AsyncCallback callback, object state)

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/ServiceChannelFactory.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/ServiceChannelFactory.cs
@@ -412,7 +412,7 @@ namespace System.ServiceModel.Channels
                     channel = _channelsList[0];
                 }
 
-                IAsyncCommunicationObject asyncChannel = channel as IAsyncCommunicationObject;
+                var asyncChannel = channel as IAsyncCommunicationObject;
                 if (asyncChannel != null)
                 {
                     await asyncChannel.CloseAsync(timeoutHelper.RemainingTime());
@@ -454,14 +454,21 @@ namespace System.ServiceModel.Channels
                 _innerChannelFactory.Open(timeout);
             }
 
+            protected internal override Task OnOpenAsync(TimeSpan timeout)
+            {
+                return ((IAsyncCommunicationObject)_innerChannelFactory).OpenAsync(timeout);
+            }
+
             protected override IAsyncResult OnBeginOpen(TimeSpan timeout, AsyncCallback callback, object state)
             {
-                return _innerChannelFactory.BeginOpen(timeout, callback, state);
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+                //return _innerChannelFactory.BeginOpen(timeout, callback, state);
             }
 
             protected override void OnEndOpen(IAsyncResult result)
             {
-                _innerChannelFactory.EndOpen(result);
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+                //_innerChannelFactory.EndOpen(result);
             }
 
             protected override void OnClose(TimeSpan timeout)
@@ -471,26 +478,23 @@ namespace System.ServiceModel.Channels
                 _innerChannelFactory.Close(timeoutHelper.RemainingTime());
             }
 
+
             protected override IAsyncResult OnBeginClose(TimeSpan timeout, AsyncCallback callback, object state)
             {
-                return new ChainedAsyncResult(timeout, callback, state, base.OnBeginClose, base.OnEndClose,
-                    _innerChannelFactory.BeginClose, _innerChannelFactory.EndClose);
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+                //return new ChainedAsyncResult(timeout, callback, state, base.OnBeginClose, base.OnEndClose,
+                //    _innerChannelFactory.BeginClose, _innerChannelFactory.EndClose);
             }
 
             protected override void OnEndClose(IAsyncResult result)
             {
-                ChainedAsyncResult.End(result);
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+                //ChainedAsyncResult.End(result);
             }
 
             protected internal override Task OnCloseAsync(TimeSpan timeout)
             {
                 return OnCloseAsyncInternal(timeout);
-            }
-
-            protected internal override Task OnOpenAsync(TimeSpan timeout)
-            {
-                this.OnOpen(timeout);
-                return TaskHelpers.CompletedTask();
             }
 
             public override T GetProperty<T>()

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/TransportSecurityBindingElement.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/TransportSecurityBindingElement.cs
@@ -5,7 +5,9 @@
 
 
 using System.Net.Security;
+using System.ServiceModel.Description;
 using System.ServiceModel.Security;
+using System.ServiceModel.Security.Tokens;
 
 namespace System.ServiceModel.Channels
 {
@@ -49,10 +51,113 @@ namespace System.ServiceModel.Channels
             get { return true; }
         }
 
+        internal override SecurityProtocolFactory CreateSecurityProtocolFactory<TChannel>(BindingContext context, SecurityCredentialsManager credentialsManager, bool isForService, BindingContext issuerBindingContext)
+        {
+            if (context == null)
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("context");
+            if (credentialsManager == null)
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("credentialsManager");
+
+            TransportSecurityProtocolFactory protocolFactory = new TransportSecurityProtocolFactory();
+            if (isForService)
+                base.ApplyAuditBehaviorSettings(context, protocolFactory);
+            base.ConfigureProtocolFactory(protocolFactory, credentialsManager, isForService, issuerBindingContext, context.Binding);
+            protocolFactory.DetectReplays = false;
+
+            return protocolFactory;
+        }
 
         protected override IChannelFactory<TChannel> BuildChannelFactoryCore<TChannel>(BindingContext context)
         {
-            throw ExceptionHelper.PlatformNotSupported("TransportSecurityBindingElement.BuildChannelFactoryCore is not supported.");
+            ISecurityCapabilities securityCapabilities = this.GetProperty<ISecurityCapabilities>(context);
+            SecurityCredentialsManager credentialsManager = context.BindingParameters.Find<SecurityCredentialsManager>();
+            if (credentialsManager == null)
+            {
+                credentialsManager = ClientCredentials.CreateDefaultCredentials();
+            }
+
+            SecureConversationSecurityTokenParameters scParameters = null;
+            if (this.EndpointSupportingTokenParameters.Endorsing.Count > 0)
+            {
+                scParameters = this.EndpointSupportingTokenParameters.Endorsing[0] as SecureConversationSecurityTokenParameters;
+            }
+
+            // This adds the demuxer element to the context
+
+            bool requireDemuxer = RequiresChannelDemuxer();
+            ChannelBuilder channelBuilder = new ChannelBuilder(context, requireDemuxer);
+
+            if (requireDemuxer)
+            {
+                throw ExceptionHelper.PlatformNotSupported("TransportSecurityBindingElement demuxing is not supported"); // Issue #31 in progress
+                // ApplyPropertiesOnDemuxer(channelBuilder, context);
+            }
+            BindingContext issuerBindingContext = context.Clone();
+
+            SecurityChannelFactory<TChannel> channelFactory;
+            if (scParameters != null)
+            {
+                if (scParameters.BootstrapSecurityBindingElement == null)
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.SecureConversationSecurityTokenParametersRequireBootstrapBinding)));
+
+                scParameters.IssuerBindingContext = issuerBindingContext;
+                if (scParameters.RequireCancellation)
+                {
+                    throw ExceptionHelper.PlatformNotSupported("TransportSecurityBindingElement RequireCancellation is not supported"); // Issue #31 in progress
+
+                    //SessionSymmetricTransportSecurityProtocolFactory sessionFactory = new SessionSymmetricTransportSecurityProtocolFactory();
+                    //sessionFactory.SecurityTokenParameters = scParameters.Clone();
+                    //((SecureConversationSecurityTokenParameters)sessionFactory.SecurityTokenParameters).IssuerBindingContext = issuerBindingContext;
+                    //this.EndpointSupportingTokenParameters.Endorsing.RemoveAt(0);
+                    //try
+                    //{
+                    //    base.ConfigureProtocolFactory(sessionFactory, credentialsManager, false, issuerBindingContext, context.Binding);
+                    //}
+                    //finally
+                    //{
+                    //    this.EndpointSupportingTokenParameters.Endorsing.Insert(0, scParameters);
+                    //}
+
+                    //SecuritySessionClientSettings<TChannel> sessionClientSettings = new SecuritySessionClientSettings<TChannel>();
+                    //sessionClientSettings.ChannelBuilder = channelBuilder;
+                    //sessionClientSettings.KeyRenewalInterval = this.LocalClientSettings.SessionKeyRenewalInterval;
+                    //sessionClientSettings.KeyRolloverInterval = this.LocalClientSettings.SessionKeyRolloverInterval;
+                    //sessionClientSettings.TolerateTransportFailures = this.LocalClientSettings.ReconnectTransportOnFailure;
+                    //sessionClientSettings.CanRenewSession = scParameters.CanRenewSession;
+                    //sessionClientSettings.IssuedSecurityTokenParameters = scParameters.Clone();
+                    //((SecureConversationSecurityTokenParameters)sessionClientSettings.IssuedSecurityTokenParameters).IssuerBindingContext = issuerBindingContext;
+                    //sessionClientSettings.SecurityStandardsManager = sessionFactory.StandardsManager;
+                    //sessionClientSettings.SessionProtocolFactory = sessionFactory;
+                    //channelFactory = new SecurityChannelFactory<TChannel>(securityCapabilities, context, sessionClientSettings);
+                }
+                else
+                {
+                    TransportSecurityProtocolFactory protocolFactory = new TransportSecurityProtocolFactory();
+                    this.EndpointSupportingTokenParameters.Endorsing.RemoveAt(0);
+                    try
+                    {
+                        base.ConfigureProtocolFactory(protocolFactory, credentialsManager, false, issuerBindingContext, context.Binding);
+                        SecureConversationSecurityTokenParameters acceleratedTokenParameters = (SecureConversationSecurityTokenParameters)scParameters.Clone();
+                        acceleratedTokenParameters.IssuerBindingContext = issuerBindingContext;
+                        protocolFactory.SecurityBindingElement.EndpointSupportingTokenParameters.Endorsing.Insert(0, acceleratedTokenParameters);
+                    }
+                    finally
+                    {
+                        this.EndpointSupportingTokenParameters.Endorsing.Insert(0, scParameters);
+                    }
+
+                    channelFactory = new SecurityChannelFactory<TChannel>(securityCapabilities, context, channelBuilder, protocolFactory);
+                }
+            }
+            else
+            {
+                SecurityProtocolFactory protocolFactory = this.CreateSecurityProtocolFactory<TChannel>(
+                    context, credentialsManager, false, issuerBindingContext);
+                channelFactory = new SecurityChannelFactory<TChannel>(securityCapabilities, context, channelBuilder, protocolFactory);
+            }
+
+            return channelFactory;
+
         }
 
         public override T GetProperty<T>(BindingContext context)

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Description/ClientCredentials.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Description/ClientCredentials.cs
@@ -37,7 +37,6 @@ namespace System.ServiceModel.Description
                 _windows = new WindowsClientCredential(other._windows);
             if (other._httpDigest != null)
                 _httpDigest = new HttpDigestClientCredential(other._httpDigest);
-
             _isReadOnly = other._isReadOnly;
         }
 
@@ -111,6 +110,25 @@ namespace System.ServiceModel.Description
             }
         }
 
+        public bool UseIdentityConfiguration
+        {
+            get
+            {
+                return false;
+            }
+            set
+            {
+                if (_isReadOnly)
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.ObjectIsReadOnly)));
+                }
+                
+                if (value)
+                {
+                    throw ExceptionHelper.PlatformNotSupported();
+                }
+            }
+        }
 
         internal static ClientCredentials CreateDefaultCredentials()
         {

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Diagnostics/SecurityTraceRecordHelper.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Diagnostics/SecurityTraceRecordHelper.cs
@@ -5,7 +5,10 @@
 
 using System.IdentityModel.Claims;
 using System.IdentityModel.Policy;
+using System.IdentityModel.Tokens;
 using System.Runtime.Diagnostics;
+using System.ServiceModel.Channels;
+using System.ServiceModel.Security;
 
 namespace System.ServiceModel.Diagnostics
 {
@@ -38,6 +41,30 @@ namespace System.ServiceModel.Diagnostics
         }
 
         internal static void TraceIdentityDeterminationFailure(EndpointAddress epr, Type identityVerifier)
+        {
+        }
+
+        internal static void TraceOutgoingMessageSecured(SecurityProtocol binding, Message message)
+        {
+        }
+
+        internal static void TraceVerifyIncomingMessageFailure(SecurityProtocol binding, Message message)
+        {
+        }
+
+        internal static void TraceSecureOutgoingMessageFailure(SecurityProtocol binding, Message message)
+        {
+        }
+
+        internal static void TraceIncomingMessageVerified(SecurityProtocol binding, Message message)
+        {
+        }
+
+        internal static void TraceCloseMessageSent(SecurityToken sessionToken, EndpointAddress remoteTarget)
+        {
+        }
+
+        internal static void TraceCloseResponseMessageSent(SecurityToken sessionToken, EndpointAddress remoteTarget)
         {
         }
     }

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/ClientCredentialsSecurityTokenManager.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/ClientCredentialsSecurityTokenManager.cs
@@ -176,8 +176,26 @@ namespace System.ServiceModel
 
         public override SecurityTokenSerializer CreateSecurityTokenSerializer(SecurityTokenVersion version)
         {
-            // not referenced anywhere in current code, but must implement abstract. 
-            throw ExceptionHelper.PlatformNotSupported("CreateSecurityTokenSerializer(SecurityTokenVersion version) not supported");
+            if (version == null)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("version");
+            }
+
+            if (_parent != null && _parent.UseIdentityConfiguration)
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+                // this.WrapTokenHandlersAsSecurityTokenSerializer(version);
+            }
+
+            MessageSecurityTokenVersion wsVersion = version as MessageSecurityTokenVersion;
+            if (wsVersion != null)
+            {
+                return new WSSecurityTokenSerializer(wsVersion.SecurityVersion, wsVersion.TrustVersion, wsVersion.SecureConversationVersion, wsVersion.EmitBspRequiredAttributes, null, null, null);
+            }
+            else
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new NotSupportedException(SR.Format(SR.SecurityTokenManagerCannotCreateSerializerForVersion, version)));
+            }
         }
 
         private X509SecurityTokenAuthenticator CreateServerX509TokenAuthenticator()
@@ -259,26 +277,33 @@ namespace System.ServiceModel
 
             return result;
         }
-    }
 
-    internal class KerberosSecurityTokenProviderWrapper : CommunicationObjectSecurityTokenProvider
-    {
-        private KerberosSecurityTokenProvider _innerProvider;
+        internal class KerberosSecurityTokenProviderWrapper : CommunicationObjectSecurityTokenProvider
+        {
+            private KerberosSecurityTokenProvider _innerProvider;
 
-        public KerberosSecurityTokenProviderWrapper(KerberosSecurityTokenProvider innerProvider)
-        {
-            _innerProvider = innerProvider;
-        }
+            public KerberosSecurityTokenProviderWrapper(KerberosSecurityTokenProvider innerProvider)
+            {
+                _innerProvider = innerProvider;
+            }
 
-        internal Task<SecurityToken> GetTokenAsync(CancellationToken cancellationToken, ChannelBinding channelbinding)
-        {
-            return Task.FromResult((SecurityToken)new KerberosRequestorSecurityToken(_innerProvider.ServicePrincipalName,
-                _innerProvider.TokenImpersonationLevel, _innerProvider.NetworkCredential,
-                SecurityUniqueId.Create().Value));
-        }
-        protected override Task<SecurityToken> GetTokenCoreAsync(CancellationToken cancellationToken)
-        {
-            return GetTokenAsync(cancellationToken, null);
+            internal Task<SecurityToken> GetTokenAsync(CancellationToken cancellationToken, ChannelBinding channelbinding)
+            {
+                return Task.FromResult((SecurityToken)new KerberosRequestorSecurityToken(_innerProvider.ServicePrincipalName,
+                    _innerProvider.TokenImpersonationLevel, _innerProvider.NetworkCredential,
+                    SecurityUniqueId.Create().Value));
+            }
+            protected override Task<SecurityToken> GetTokenCoreAsync(CancellationToken cancellationToken)
+            {
+                return GetTokenAsync(cancellationToken, null);
+            }
+
+            protected override SecurityToken GetTokenCore(TimeSpan timeout)
+            {
+                return new KerberosRequestorSecurityToken(_innerProvider.ServicePrincipalName,
+                    _innerProvider.TokenImpersonationLevel, _innerProvider.NetworkCredential,
+                    SecurityUniqueId.Create().Value);
+            }
         }
     }
 }

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/CryptoHelper.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/CryptoHelper.cs
@@ -1,0 +1,364 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+
+using System.IdentityModel.Tokens;
+using System.Diagnostics.CodeAnalysis;
+using System.Security.Cryptography;
+
+// Issue #31 in progress
+// using Psha1DerivedKeyGenerator = System.IdentityModel.Psha1DerivedKeyGenerator;
+using CryptoAlgorithms = System.IdentityModel.CryptoHelper;
+using System.Runtime;
+
+namespace System.ServiceModel.Security
+{
+    static class CryptoHelper
+    {
+        private static byte[] s_emptyBuffer;
+
+        // Issue #31 in progress
+        // static readonly RandomNumberGenerator random = new RNGCryptoServiceProvider();
+
+        enum CryptoAlgorithmType
+        {
+            Unknown,
+            Symmetric,
+            Asymmetric
+        }
+
+        internal static byte[] EmptyBuffer
+        {
+            get
+            {
+                if (s_emptyBuffer == null)
+                {
+                    byte[] tmp = new byte[0];
+                    s_emptyBuffer = tmp;
+                }
+                return s_emptyBuffer;
+            }
+        }
+
+        internal static HashAlgorithm NewSha1HashAlgorithm()
+        {
+            return CryptoHelper.CreateHashAlgorithm(SecurityAlgorithms.Sha1Digest);
+        }
+
+        internal static HashAlgorithm NewSha256HashAlgorithm()
+        {
+            return CryptoHelper.CreateHashAlgorithm(SecurityAlgorithms.Sha256Digest);
+        }
+
+        [SuppressMessage("Microsoft.Security.Cryptography", "CA5354:DoNotUseSHA1", Justification = "Cannot change. Required as SOAP spec requires supporting SHA1.")]
+        internal static HashAlgorithm CreateHashAlgorithm(string digestMethod)
+        {
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+
+            //object algorithmObject = CryptoAlgorithms.GetAlgorithmFromConfig(digestMethod);
+            //if (algorithmObject != null)
+            //{
+            //    HashAlgorithm hashAlgorithm = algorithmObject as HashAlgorithm;
+            //    if (hashAlgorithm != null)
+            //        return hashAlgorithm;
+            //    throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new MessageSecurityException(SR.GetString(SR.CustomCryptoAlgorithmIsNotValidHashAlgorithm, digestMethod)));
+            //}
+
+            //switch (digestMethod)
+            //{
+            //    case SecurityAlgorithms.Sha1Digest:
+            //        if (SecurityUtilsEx.RequiresFipsCompliance)
+            //            return new SHA1CryptoServiceProvider();
+            //        else
+            //            return new SHA1Managed();
+            //    case SecurityAlgorithms.Sha256Digest:
+            //        if (SecurityUtilsEx.RequiresFipsCompliance)
+            //            return new SHA256CryptoServiceProvider();
+            //        else
+            //            return new SHA256Managed();
+            //    default:
+            //        throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new MessageSecurityException(SR.GetString(SR.UnsupportedCryptoAlgorithm, digestMethod)));
+
+            //}
+        }
+
+        [SuppressMessage("Microsoft.Security.Cryptography", "CA5354:DoNotUseSHA1", Justification = "Cannot change. Required as SOAP spec requires supporting SHA1.")]
+        internal static HashAlgorithm CreateHashForAsymmetricSignature(string signatureMethod)
+        {
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+
+            //object algorithmObject = CryptoAlgorithms.GetAlgorithmFromConfig(signatureMethod);
+            //if (algorithmObject != null)
+            //{
+            //    HashAlgorithm hashAlgorithm;
+            //    SignatureDescription signatureDescription = algorithmObject as SignatureDescription;
+
+            //    if (signatureDescription != null)
+            //    {
+            //        hashAlgorithm = signatureDescription.CreateDigest();
+            //        if (hashAlgorithm != null)
+            //            return hashAlgorithm;
+            //    }
+
+            //    hashAlgorithm = algorithmObject as HashAlgorithm;
+            //    if (hashAlgorithm != null)
+            //        return hashAlgorithm;
+
+            //    throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new MessageSecurityException(SR.GetString(SR.CustomCryptoAlgorithmIsNotValidAsymmetricSignature, signatureMethod)));
+            //}
+
+            //switch (signatureMethod)
+            //{
+            //    case SecurityAlgorithms.RsaSha1Signature:
+            //    case SecurityAlgorithms.DsaSha1Signature:
+            //        if (SecurityUtilsEx.RequiresFipsCompliance)
+            //            return new SHA1CryptoServiceProvider();
+            //        else
+            //            return new SHA1Managed();
+
+            //    case SecurityAlgorithms.RsaSha256Signature:
+            //        if (SecurityUtilsEx.RequiresFipsCompliance)
+            //            return new SHA256CryptoServiceProvider();
+            //        else
+            //            return new SHA256Managed();
+
+            //    default:
+            //        throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new MessageSecurityException(SR.GetString(SR.UnsupportedCryptoAlgorithm, signatureMethod)));
+            //}
+        }
+
+        internal static byte[] ExtractIVAndDecrypt(SymmetricAlgorithm algorithm, byte[] cipherText, int offset, int count)
+        {
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+
+            //if (cipherText == null)
+            //{
+            //    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("cipherText");
+            //}
+            //if (count < 0 || count > cipherText.Length)
+            //{
+            //    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("count", SR.GetString(SR.ValueMustBeInRange, 0, cipherText.Length)));
+
+            //}
+            //if (offset < 0 || offset > cipherText.Length - count)
+            //{
+            //    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("offset", SR.GetString(SR.ValueMustBeInRange, 0, cipherText.Length - count)));
+            //}
+
+            //int ivSize = algorithm.BlockSize / 8;
+            //byte[] iv = new byte[ivSize];
+            //Buffer.BlockCopy(cipherText, offset, iv, 0, iv.Length);
+            //algorithm.Padding = PaddingMode.ISO10126;
+            //algorithm.Mode = CipherMode.CBC;
+            //try
+            //{
+            //    using (ICryptoTransform decrTransform = algorithm.CreateDecryptor(algorithm.Key, iv))
+            //    {
+            //        return decrTransform.TransformFinalBlock(cipherText, offset + iv.Length, count - iv.Length);
+            //    }
+            //}
+            //catch (CryptographicException ex)
+            //{
+            //    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new MessageSecurityException(SR.GetString(SR.DecryptionFailed), ex));
+            //}
+        }
+
+        internal static void FillRandomBytes(byte[] buffer)
+        {
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+            //random.GetBytes(buffer);
+        }
+
+        static CryptoAlgorithmType GetAlgorithmType(string algorithm)
+        {
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+
+            //object algorithmObject = null;
+
+            //try
+            //{
+            //    algorithmObject = CryptoAlgorithms.GetAlgorithmFromConfig(algorithm);
+            //}
+            //catch (InvalidOperationException)
+            //{
+            //    algorithmObject = null;
+            //    // We swallow the exception and continue.
+            //}
+            //if (algorithmObject != null)
+            //{
+            //    SymmetricAlgorithm symmetricAlgorithm = algorithmObject as SymmetricAlgorithm;
+            //    KeyedHashAlgorithm keyedHashAlgorithm = algorithmObject as KeyedHashAlgorithm;
+            //    if (symmetricAlgorithm != null || keyedHashAlgorithm != null)
+            //        return CryptoAlgorithmType.Symmetric;
+
+            //    // NOTE: A KeyedHashAlgorithm is symmetric in nature.
+
+            //    AsymmetricAlgorithm asymmetricAlgorithm = algorithmObject as AsymmetricAlgorithm;
+            //    SignatureDescription signatureDescription = algorithmObject as SignatureDescription;
+            //    if (asymmetricAlgorithm != null || signatureDescription != null)
+            //        return CryptoAlgorithmType.Asymmetric;
+
+            //    return CryptoAlgorithmType.Unknown;
+            //}
+
+            //switch (algorithm)
+            //{
+            //    case SecurityAlgorithms.DsaSha1Signature:
+            //    case SecurityAlgorithms.RsaSha1Signature:
+            //    case SecurityAlgorithms.RsaSha256Signature:
+            //    case SecurityAlgorithms.RsaOaepKeyWrap:
+            //    case SecurityAlgorithms.RsaV15KeyWrap:
+            //        return CryptoAlgorithmType.Asymmetric;
+            //    case SecurityAlgorithms.HmacSha1Signature:
+            //    case SecurityAlgorithms.HmacSha256Signature:
+            //    case SecurityAlgorithms.Aes128Encryption:
+            //    case SecurityAlgorithms.Aes192Encryption:
+            //    case SecurityAlgorithms.Aes256Encryption:
+            //    case SecurityAlgorithms.TripleDesEncryption:
+            //    case SecurityAlgorithms.Aes128KeyWrap:
+            //    case SecurityAlgorithms.Aes192KeyWrap:
+            //    case SecurityAlgorithms.Aes256KeyWrap:
+            //    case SecurityAlgorithms.TripleDesKeyWrap:
+            //    case SecurityAlgorithms.Psha1KeyDerivation:
+            //    case SecurityAlgorithms.Psha1KeyDerivationDec2005:
+            //        return CryptoAlgorithmType.Symmetric;
+            //    default:
+            //        return CryptoAlgorithmType.Unknown;
+            //}
+        }
+
+        internal static byte[] GenerateIVAndEncrypt(SymmetricAlgorithm algorithm, byte[] plainText, int offset, int count)
+        {
+            byte[] iv;
+            byte[] cipherText;
+            GenerateIVAndEncrypt(algorithm, new ArraySegment<byte>(plainText, offset, count), out iv, out cipherText);
+            byte[] output = Fx.AllocateByteArray(checked(iv.Length + cipherText.Length));
+            Buffer.BlockCopy(iv, 0, output, 0, iv.Length);
+            Buffer.BlockCopy(cipherText, 0, output, iv.Length, cipherText.Length);
+            return output;
+        }
+
+        internal static void GenerateIVAndEncrypt(SymmetricAlgorithm algorithm, ArraySegment<byte> plainText, out byte[] iv, out byte[] cipherText)
+        {
+            int ivSize = algorithm.BlockSize / 8;
+            iv = new byte[ivSize];
+            FillRandomBytes(iv);
+            algorithm.Padding = PaddingMode.PKCS7;
+            algorithm.Mode = CipherMode.CBC;
+            using (ICryptoTransform encrTransform = algorithm.CreateEncryptor(algorithm.Key, iv))
+            {
+                cipherText = encrTransform.TransformFinalBlock(plainText.Array, plainText.Offset, plainText.Count);
+            }
+        }
+
+        internal static bool IsEqual(byte[] a, byte[] b)
+        {
+            if (a == null || b == null || a.Length != b.Length)
+            {
+                return false;
+            }
+
+            for (int i = 0; i < a.Length; i++)
+            {
+                if (a[i] != b[i])
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        internal static bool IsSymmetricAlgorithm(string algorithm)
+        {
+            return GetAlgorithmType(algorithm) == CryptoAlgorithmType.Symmetric;
+        }
+
+        internal static bool IsSymmetricSupportedAlgorithm(string algorithm, int keySize)
+        {
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+
+            //bool found = false;
+            //object algorithmObject = null;
+
+            //try
+            //{
+            //    algorithmObject = CryptoAlgorithms.GetAlgorithmFromConfig(algorithm);
+            //}
+            //catch (InvalidOperationException)
+            //{
+            //    algorithmObject = null;
+            //    // We swallow the exception and continue.
+            //}
+            //if (algorithmObject != null)
+            //{
+            //    SymmetricAlgorithm symmetricAlgorithm = algorithmObject as SymmetricAlgorithm;
+            //    KeyedHashAlgorithm keyedHashAlgorithm = algorithmObject as KeyedHashAlgorithm;
+            //    if (symmetricAlgorithm != null || keyedHashAlgorithm != null)
+            //        found = true;
+            //}
+
+            //switch (algorithm)
+            //{
+            //    case SecurityAlgorithms.DsaSha1Signature:
+            //    case SecurityAlgorithms.RsaSha1Signature:
+            //    case SecurityAlgorithms.RsaSha256Signature:
+            //    case SecurityAlgorithms.RsaOaepKeyWrap:
+            //    case SecurityAlgorithms.RsaV15KeyWrap:
+            //        return false;
+            //    case SecurityAlgorithms.HmacSha1Signature:
+            //    case SecurityAlgorithms.HmacSha256Signature:
+            //    case SecurityAlgorithms.Psha1KeyDerivation:
+            //    case SecurityAlgorithms.Psha1KeyDerivationDec2005:
+            //        return true;
+            //    case SecurityAlgorithms.Aes128Encryption:
+            //    case SecurityAlgorithms.Aes128KeyWrap:
+            //        return keySize == 128;
+            //    case SecurityAlgorithms.Aes192Encryption:
+            //    case SecurityAlgorithms.Aes192KeyWrap:
+            //        return keySize == 192;
+            //    case SecurityAlgorithms.Aes256Encryption:
+            //    case SecurityAlgorithms.Aes256KeyWrap:
+            //        return keySize == 256;
+            //    case SecurityAlgorithms.TripleDesEncryption:
+            //    case SecurityAlgorithms.TripleDesKeyWrap:
+            //        return keySize == 128 || keySize == 192;
+            //    default:
+            //        if (found)
+            //            return true;
+            //        return false;
+            //}
+        }
+
+        internal static void ValidateBufferBounds(Array buffer, int offset, int count)
+        {
+            if (buffer == null)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentNullException("buffer"));
+            }
+            if (count < 0 || count > buffer.Length)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("count", SR.Format(SR.ValueMustBeInRange, 0, buffer.Length)));
+            }
+            if (offset < 0 || offset > buffer.Length - count)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("offset", SR.Format(SR.ValueMustBeInRange, 0, buffer.Length - count)));
+            }
+        }
+
+        internal static void ValidateSymmetricKeyLength(int keyLength, SecurityAlgorithmSuite algorithmSuite)
+        {
+            if (!algorithmSuite.IsSymmetricKeyLengthSupported(keyLength))
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new ArgumentOutOfRangeException("algorithmSuite",
+                   SR.Format(SR.UnsupportedKeyLength, keyLength, algorithmSuite.ToString())));
+            }
+            if (keyLength % 8 != 0)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new ArgumentOutOfRangeException("algorithmSuite",
+                   SR.Format(SR.KeyLengthMustBeMultipleOfEight, keyLength)));
+            }
+        }
+    }
+}
+

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/DataProtectionSecurityStateEncoder.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/DataProtectionSecurityStateEncoder.cs
@@ -1,0 +1,96 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace System.ServiceModel.Security
+{
+    public class DataProtectionSecurityStateEncoder : SecurityStateEncoder
+    {
+        private byte[] _entropy;
+        private bool _useCurrentUserProtectionScope;
+
+        public DataProtectionSecurityStateEncoder()
+            : this(true)
+        {
+            // empty
+        }
+
+        public DataProtectionSecurityStateEncoder(bool useCurrentUserProtectionScope)
+            : this(useCurrentUserProtectionScope, null)
+        { }
+
+        public DataProtectionSecurityStateEncoder(bool useCurrentUserProtectionScope, byte[] entropy)
+        {
+            _useCurrentUserProtectionScope = useCurrentUserProtectionScope;
+            if (entropy == null)
+            {
+                _entropy = null;
+            }
+            else
+            {
+                _entropy = Fx.AllocateByteArray(entropy.Length);
+                Buffer.BlockCopy(entropy, 0, _entropy, 0, entropy.Length);
+            }
+        }
+
+        public bool UseCurrentUserProtectionScope
+        {
+            get
+            {
+                return _useCurrentUserProtectionScope;
+            }
+        }
+
+        public byte[] GetEntropy()
+        {
+            byte[] result = null;
+            if (_entropy != null)
+            {
+                result = Fx.AllocateByteArray(_entropy.Length);
+                Buffer.BlockCopy(_entropy, 0, result, 0, _entropy.Length);
+            }
+            return result;
+        }
+
+        public override string ToString()
+        {
+            StringBuilder result = new StringBuilder();
+            result.Append(this.GetType().ToString());
+            result.AppendFormat("{0}  UseCurrentUserProtectionScope={1}", Environment.NewLine, _useCurrentUserProtectionScope);
+            result.AppendFormat("{0}  Entropy Length={1}", Environment.NewLine, (_entropy == null) ? 0 : _entropy.Length);
+            return result.ToString();
+        }
+
+        protected internal override byte[] DecodeSecurityState( byte[] data )
+        {
+            try
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+                //return ProtectedData.Unprotect(data, this.entropy, (this.useCurrentUserProtectionScope) ? DataProtectionScope.CurrentUser : DataProtectionScope.LocalMachine);
+            }
+            catch (CryptographicException exception)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new CryptographicException(SR.Format(SR.SecurityStateEncoderDecodingFailure), exception));
+            }
+
+        }
+
+        protected internal override byte[] EncodeSecurityState( byte[] data )
+        {
+            try
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+                //return ProtectedData.Protect(data, this.entropy, (this.useCurrentUserProtectionScope) ? DataProtectionScope.CurrentUser : DataProtectionScope.LocalMachine);
+            }
+            catch (CryptographicException exception)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new CryptographicException(SR.Format(SR.SecurityStateEncoderEncodingFailure), exception));
+            }
+        }
+    }
+}
+

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/DelegatingHeader.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/DelegatingHeader.cs
@@ -1,0 +1,83 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.ServiceModel;
+using System.ServiceModel.Channels;
+using System.Xml;
+
+namespace System.ServiceModel.Security
+{
+    abstract class DelegatingHeader : MessageHeader
+    {
+        MessageHeader _innerHeader;
+
+        protected DelegatingHeader(MessageHeader innerHeader)
+        {
+            if (innerHeader == null)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("innerHeader");
+            }
+            _innerHeader = innerHeader;
+        }
+
+        public override bool MustUnderstand
+        {
+            get
+            {
+                return _innerHeader.MustUnderstand;
+            }
+        }
+
+        public override string Name
+        {
+            get
+            {
+                return _innerHeader.Name;
+            }
+        }
+
+        public override string Namespace
+        {
+            get
+            {
+                return _innerHeader.Namespace;
+            }
+        }
+
+        public override bool Relay
+        {
+            get
+            {
+                return _innerHeader.Relay;
+            }
+        }
+
+        public override string Actor
+        {
+            get
+            {
+                return _innerHeader.Actor;
+            }
+        }
+
+        protected MessageHeader InnerHeader
+        {
+            get
+            {
+                return _innerHeader;
+            }
+        }
+
+        protected override void OnWriteStartHeader(XmlDictionaryWriter writer, MessageVersion messageVersion)
+        {
+            _innerHeader.WriteStartHeader(writer, messageVersion);
+        }
+
+        protected override void OnWriteHeaderContents(XmlDictionaryWriter writer, MessageVersion messageVersion)
+        {
+            _innerHeader.WriteHeaderContents(writer, messageVersion);
+        }
+    }
+}
+

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/EncryptedData.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/EncryptedData.cs
@@ -1,0 +1,107 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.IdentityModel;
+using System.ServiceModel.Channels;
+using System.Security.Cryptography;
+using System.Xml;
+
+namespace System.ServiceModel.Security
+{
+    class EncryptedData : EncryptedType
+    {
+        internal static readonly XmlDictionaryString s_ElementName = System.IdentityModel.XD.XmlEncryptionDictionary.EncryptedData;
+        internal static readonly string s_ElementType = XmlEncryptionStrings.ElementType;
+        internal static readonly string s_ContentType = XmlEncryptionStrings.ContentType;
+        private SymmetricAlgorithm _algorithm;
+        private byte[] _decryptedBuffer;
+        private ArraySegment<byte> _buffer;
+        private byte[] _iv;
+        private byte[] _cipherText;
+
+        protected override XmlDictionaryString OpeningElementName
+        {
+            get { return s_ElementName; }
+        }
+
+        void EnsureDecryptionSet()
+        {
+            if (this.State == EncryptionState.DecryptionSetup)
+            {
+                SetPlainText();
+            }
+            else if (this.State != EncryptionState.Decrypted)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new MessageSecurityException(SR.Format(SR.BadEncryptionState)));
+            }
+        }
+
+        protected override void ForceEncryption()
+        {
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+            //CryptoHelper.GenerateIVAndEncrypt(this.algorithm, this.buffer, out this.iv, out this.cipherText);
+            //this.State = EncryptionState.Encrypted;
+            //this.buffer = new ArraySegment<byte>(CryptoHelper.EmptyBuffer);
+        }
+
+        public byte[] GetDecryptedBuffer()
+        {
+            EnsureDecryptionSet();
+            return _decryptedBuffer;
+        }
+
+        protected override void ReadCipherData(XmlDictionaryReader reader)
+        {
+            _cipherText = reader.ReadContentAsBase64();
+        }
+
+        protected override void ReadCipherData(XmlDictionaryReader reader, long maxBufferSize)
+        {
+            _cipherText = SecurityUtils.ReadContentAsBase64(reader, maxBufferSize);
+        }
+
+        void SetPlainText()
+        {
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+            //this.decryptedBuffer = CryptoHelper.ExtractIVAndDecrypt(this.algorithm, this.cipherText, 0, this.cipherText.Length);
+            //this.State = EncryptionState.Decrypted;
+        }
+
+        public void SetUpDecryption(SymmetricAlgorithm algorithm)
+        {
+            if (this.State != EncryptionState.Read)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new MessageSecurityException(SR.Format(SR.BadEncryptionState)));
+            }
+            if (algorithm == null)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("algorithm");
+            }
+            _algorithm = algorithm;
+            this.State = EncryptionState.DecryptionSetup;
+        }
+
+        public void SetUpEncryption(SymmetricAlgorithm algorithm, ArraySegment<byte> buffer)
+        {
+            if (this.State != EncryptionState.New)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new MessageSecurityException(SR.Format(SR.BadEncryptionState)));
+            }
+            if (algorithm == null)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("algorithm");
+            }
+            _algorithm = algorithm;
+            _buffer = buffer;
+            this.State = EncryptionState.EncryptionSetup;
+        }
+
+        protected override void WriteCipherData(XmlDictionaryWriter writer)
+        {
+            writer.WriteBase64(_iv, 0, _iv.Length);
+            writer.WriteBase64(_cipherText, 0, _cipherText.Length);
+        }
+    }
+}
+

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/EncryptedHeader.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/EncryptedHeader.cs
@@ -1,0 +1,101 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+using System.Globalization;
+using System.ServiceModel;
+using System.ServiceModel.Channels;
+using System.Xml;
+using ISecurityElement = System.IdentityModel.ISecurityElement;
+
+namespace System.ServiceModel.Security
+{
+    sealed class EncryptedHeader : DelegatingHeader
+    {
+        private EncryptedHeaderXml _headerXml;
+        private string _name;
+        private string _namespaceUri;
+        private MessageVersion _version;
+
+        public EncryptedHeader(MessageHeader plainTextHeader, EncryptedHeaderXml headerXml, string name, string namespaceUri, MessageVersion version)
+            : base(plainTextHeader)
+        {
+            if (!headerXml.HasId || headerXml.Id == null)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new MessageSecurityException(SR.Format(SR.EncryptedHeaderXmlMustHaveId)));
+            }
+            _headerXml = headerXml;
+            _name = name;
+            _namespaceUri = namespaceUri;
+            _version = version;
+        }
+
+        public string Id
+        {
+            get { return _headerXml.Id; }
+        }
+
+        public override string Name
+        {
+            get { return _name; }
+        }
+
+        public override string Namespace
+        {
+            get { return _namespaceUri; }
+        }
+
+        public override string Actor
+        {
+            get
+            {
+                return _headerXml.Actor;
+            }
+        }
+
+        public override bool MustUnderstand
+        {
+            get
+            {
+                return _headerXml.MustUnderstand;
+            }
+        }
+
+        public override bool Relay
+        {
+            get
+            {
+                return _headerXml.Relay;
+            }
+        }
+
+        internal MessageHeader OriginalHeader
+        {
+            get { return this.InnerHeader; }
+        }
+
+        public override bool IsMessageVersionSupported(MessageVersion messageVersion)
+        {
+            return _version.Equals( messageVersion );
+        }
+
+        protected override void OnWriteStartHeader(XmlDictionaryWriter writer, MessageVersion messageVersion)
+        {
+            if (!IsMessageVersionSupported(messageVersion))
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentException(SR.Format(SR.MessageHeaderVersionNotSupported, String.Format(CultureInfo.InvariantCulture, "{0}:{1}", this.Namespace, this.Name), _version.ToString()), "version"));
+            }
+
+            _headerXml.WriteHeaderElement(writer);
+            WriteHeaderAttributes(writer, messageVersion);
+            _headerXml.WriteHeaderId(writer);
+        }
+
+        protected override void OnWriteHeaderContents(XmlDictionaryWriter writer, MessageVersion messageVersion)
+        {
+            _headerXml.WriteHeaderContents(writer);
+        }
+    }
+}
+

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/EncryptedHeaderXml.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/EncryptedHeaderXml.cs
@@ -1,0 +1,189 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.IdentityModel.Tokens;
+using System.IdentityModel.Selectors;
+using System.IO;
+using System.Security.Cryptography;
+using System.ServiceModel;
+using System.ServiceModel.Channels;
+using System.Xml;
+
+using DictionaryManager = System.IdentityModel.DictionaryManager;
+using ISecurityElement = System.IdentityModel.ISecurityElement;
+
+namespace System.ServiceModel.Security
+{
+    sealed class EncryptedHeaderXml
+    {
+        internal static readonly XmlDictionaryString s_ElementName = XD.SecurityXXX2005Dictionary.EncryptedHeader;
+        internal static readonly XmlDictionaryString s_NamespaceUri = XD.SecurityXXX2005Dictionary.Namespace;
+        const string Prefix = SecurityXXX2005Strings.Prefix;
+
+        private string _id;
+        private bool _mustUnderstand;
+        private bool _relay;
+        private string _actor;
+        private MessageVersion _version;
+        private EncryptedData _encryptedData;
+
+        public EncryptedHeaderXml(MessageVersion version, bool shouldReadXmlReferenceKeyInfoClause)
+        {
+            _version = version;
+            _encryptedData = new EncryptedData();
+            
+            // This is for the case when the service send an EncryptedHeader to the client where the KeyInfo clause contains referenceXml clause.
+            _encryptedData.ShouldReadXmlReferenceKeyInfoClause = shouldReadXmlReferenceKeyInfoClause;
+        }
+
+        public string Actor
+        {
+            get
+            {
+                return _actor;
+            }
+            set
+            {
+                _actor = value;
+            }
+        }
+
+        public string EncryptionMethod
+        {
+            get
+            {
+                return _encryptedData.EncryptionMethod;
+            }
+            set
+            {
+                _encryptedData.EncryptionMethod = value;
+            }
+        }
+
+        public XmlDictionaryString EncryptionMethodDictionaryString
+        {
+            get
+            {
+                return _encryptedData.EncryptionMethodDictionaryString;
+            }
+            set
+            {
+                _encryptedData.EncryptionMethodDictionaryString = value;
+            }
+        }
+
+        public bool HasId
+        {
+            get
+            {
+                return true;
+            }
+        }
+
+        public string Id
+        {
+            get
+            {
+                return _id;
+            }
+            set
+            {
+                _id = value;
+            }
+        }
+
+        public SecurityKeyIdentifier KeyIdentifier
+        {
+            get
+            {
+                return _encryptedData.KeyIdentifier;
+            }
+            set
+            {
+                _encryptedData.KeyIdentifier = value;
+            }
+        }
+
+        public bool MustUnderstand
+        {
+            get
+            {
+                return _mustUnderstand;
+            }
+            set
+            {
+                _mustUnderstand = value;
+            }
+        }
+
+        public bool Relay
+        {
+            get
+            {
+                return _relay;
+            }
+            set
+            {
+                _relay = value;
+            }
+        }
+
+        public SecurityTokenSerializer SecurityTokenSerializer
+        {
+            get
+            {
+                return _encryptedData.SecurityTokenSerializer;
+            }
+            set
+            {
+                _encryptedData.SecurityTokenSerializer = value;
+            }
+        }
+
+        public byte[] GetDecryptedBuffer()
+        {
+            return _encryptedData.GetDecryptedBuffer();
+        }
+
+        public void ReadFrom(XmlDictionaryReader reader, long maxBufferSize)
+        {
+            reader.MoveToStartElement(s_ElementName, s_NamespaceUri);
+            bool isReferenceParameter;
+            MessageHeader.GetHeaderAttributes(reader, _version, out _actor, out _mustUnderstand, out _relay, out isReferenceParameter);
+            _id = reader.GetAttribute(XD.UtilityDictionary.IdAttribute, XD.UtilityDictionary.Namespace);
+
+            reader.ReadStartElement();
+            _encryptedData.ReadFrom(reader, maxBufferSize);
+            reader.ReadEndElement();
+        }
+
+        public void SetUpDecryption(SymmetricAlgorithm algorithm)
+        {
+            _encryptedData.SetUpDecryption(algorithm);
+        }
+
+        public void SetUpEncryption(SymmetricAlgorithm algorithm, MemoryStream source)
+        {
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+            //encryptedData.SetUpEncryption(algorithm, new ArraySegment<byte>(source.GetBuffer(), 0, (int) source.Length));
+        }
+
+        public void WriteHeaderElement(XmlDictionaryWriter writer)
+        {
+            writer.WriteStartElement(Prefix, s_ElementName, s_NamespaceUri);
+        }
+
+        public void WriteHeaderId(XmlDictionaryWriter writer)
+        {
+            writer.WriteAttributeString(XD.UtilityDictionary.Prefix.Value, XD.UtilityDictionary.IdAttribute, XD.UtilityDictionary.Namespace, _id);
+        }
+
+        public void WriteHeaderContents(XmlDictionaryWriter writer)
+        {
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+            //this.encryptedData.WriteTo(writer, ServiceModelDictionaryManager.Instance);
+        }
+    }
+}
+

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/EncryptedKey.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/EncryptedKey.cs
@@ -1,0 +1,131 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.IdentityModel;
+using System.Runtime.CompilerServices;
+using System.Xml;
+
+namespace System.ServiceModel.Security
+{
+    sealed class EncryptedKey : EncryptedType
+    {
+        internal static readonly XmlDictionaryString s_CarriedKeyElementName = System.IdentityModel.XD.XmlEncryptionDictionary.CarriedKeyName;
+        internal static readonly XmlDictionaryString s_ElementName = System.IdentityModel.XD.XmlEncryptionDictionary.EncryptedKey;
+        internal static readonly XmlDictionaryString s_RecipientAttribute = System.IdentityModel.XD.XmlEncryptionDictionary.Recipient;
+
+        private string _carriedKeyName;
+        private string _recipient;
+        private ReferenceList _referenceList;
+        private byte[] _wrappedKey;
+
+        public string CarriedKeyName
+        {
+            get { return _carriedKeyName; }
+            set { _carriedKeyName = value; }
+        }
+
+        public string Recipient
+        {
+            get { return _recipient; }
+            set { _recipient = value; }
+        }
+
+        public ReferenceList ReferenceList
+        {
+            get { return _referenceList; }
+            set { _referenceList = value; }
+        }
+
+        protected override XmlDictionaryString OpeningElementName
+        {
+            get { return s_ElementName; }
+        }
+
+        protected override void ForceEncryption()
+        {
+            // no work to be done here since, unlike bulk encryption, key wrapping is done eagerly
+        }
+
+        public byte[] GetWrappedKey()
+        {
+            if (this.State == EncryptionState.New)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.BadEncryptionState)));
+            }
+            return _wrappedKey;
+        }
+
+        public void SetUpKeyWrap(byte[] wrappedKey)
+        {
+            if (this.State != EncryptionState.New)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.BadEncryptionState)));
+            }
+            if (wrappedKey == null)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("wrappedKey");
+            }
+            _wrappedKey = wrappedKey;
+            this.State = EncryptionState.Encrypted;
+        }
+
+        protected override void ReadAdditionalAttributes(XmlDictionaryReader reader)
+        {
+            _recipient = reader.GetAttribute(s_RecipientAttribute, null);
+        }
+
+        protected override void ReadAdditionalElements(XmlDictionaryReader reader)
+        {
+            if (reader.IsStartElement(ReferenceList.s_ElementName, EncryptedType.s_NamespaceUri))
+            {
+                _referenceList = new ReferenceList();
+                _referenceList.ReadFrom(reader);
+            }
+            if (reader.IsStartElement(s_CarriedKeyElementName, EncryptedType.s_NamespaceUri))
+            {
+                reader.ReadStartElement(s_CarriedKeyElementName, EncryptedType.s_NamespaceUri);
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress (NET Standard 2.0: needs ReadString() API)
+                //_carriedKeyName = reader.ReadString();
+                //reader.ReadEndElement();
+            }
+        }
+
+        protected override void ReadCipherData(XmlDictionaryReader reader)
+        {
+            _wrappedKey = reader.ReadContentAsBase64();
+        }
+
+        protected override void ReadCipherData(XmlDictionaryReader reader, long maxBufferSize)
+        {
+            _wrappedKey = SecurityUtils.ReadContentAsBase64(reader, maxBufferSize);
+        }
+
+        protected override void WriteAdditionalAttributes(XmlDictionaryWriter writer, DictionaryManager dictionaryManager)
+        {
+            if (_recipient != null)
+            {
+                writer.WriteAttributeString(s_RecipientAttribute, null, _recipient);
+            }
+        }
+
+        protected override void WriteAdditionalElements(XmlDictionaryWriter writer, DictionaryManager dictionaryManager)
+        {
+            if (_carriedKeyName != null)
+            {
+                writer.WriteStartElement(s_CarriedKeyElementName, EncryptedType.s_NamespaceUri);
+                writer.WriteString(_carriedKeyName);
+                writer.WriteEndElement(); // CarriedKeyName
+            }
+            if (_referenceList != null)
+            {
+                _referenceList.WriteTo(writer, dictionaryManager);
+            }
+        }
+
+        protected override void WriteCipherData(XmlDictionaryWriter writer)
+        {
+            writer.WriteBase64(_wrappedKey, 0, _wrappedKey.Length);
+        }
+    }
+}

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/EncryptedType.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/EncryptedType.cs
@@ -1,0 +1,459 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.IdentityModel;
+using System.IdentityModel.Selectors;
+using System.IdentityModel.Tokens;
+using System.Runtime;
+using System.Runtime.CompilerServices;
+using System.Xml;
+using DictionaryManager = System.IdentityModel.DictionaryManager;
+using ISecurityElement = System.IdentityModel.ISecurityElement;
+
+namespace System.ServiceModel.Security
+{
+    abstract class EncryptedType : ISecurityElement
+    {
+        internal static readonly XmlDictionaryString s_NamespaceUri = System.IdentityModel.XD.XmlEncryptionDictionary.Namespace;
+        internal static readonly XmlDictionaryString s_EncodingAttribute = System.IdentityModel.XD.XmlEncryptionDictionary.Encoding;
+        internal static readonly XmlDictionaryString s_MimeTypeAttribute = System.IdentityModel.XD.XmlEncryptionDictionary.MimeType;
+        internal static readonly XmlDictionaryString s_TypeAttribute = System.IdentityModel.XD.XmlEncryptionDictionary.Type;
+        internal static readonly XmlDictionaryString s_CipherDataElementName = System.IdentityModel.XD.XmlEncryptionDictionary.CipherData;
+        internal static readonly XmlDictionaryString s_CipherValueElementName = System.IdentityModel.XD.XmlEncryptionDictionary.CipherValue;
+
+        private string _encoding;
+        private EncryptionMethodElement _encryptionMethod;
+        private string _id;
+        private string _wsuId;
+        private SecurityKeyIdentifier _keyIdentifier;
+        private string _mimeType;
+        private EncryptionState _state;
+        private string _type;
+        private SecurityTokenSerializer _tokenSerializer;
+        private bool _shouldReadXmlReferenceKeyInfoClause;
+
+        protected EncryptedType()
+        {
+            _encryptionMethod.Init();
+            _state = EncryptionState.New;
+            _tokenSerializer = new KeyInfoSerializer(false);
+        }
+
+        public string Encoding
+        {
+            get
+            {
+                return _encoding;
+            }
+            set
+            {
+                _encoding = value;
+            }
+        }
+
+        public string EncryptionMethod
+        {
+            get
+            {
+                return _encryptionMethod.algorithm;
+            }
+            set
+            {
+                _encryptionMethod.algorithm = value;
+            }
+        }
+
+        public XmlDictionaryString EncryptionMethodDictionaryString
+        {
+            get
+            {
+                return _encryptionMethod.algorithmDictionaryString;
+            }
+            set
+            {
+                _encryptionMethod.algorithmDictionaryString = value;
+            }
+        }
+
+        public bool HasId
+        {
+            get
+            {
+                return true;
+            }
+        }
+
+        public string Id
+        {
+            get
+            {
+                return _id;
+            }
+            set
+            {
+                _id = value;
+            }
+        }
+
+        // This is set to true on the client side. And this means that when this knob is set to true and the default serializers on the client side fail 
+        // to read the KeyInfo clause from the incoming response message from a service; then the ckient should 
+        // try to read the keyInfo clause as GenericXmlSecurityKeyIdentifierClause before throwing.
+        public bool ShouldReadXmlReferenceKeyInfoClause
+        {
+            get
+            {
+                return _shouldReadXmlReferenceKeyInfoClause;
+            }
+            set
+            {
+                _shouldReadXmlReferenceKeyInfoClause = value;
+            }
+        }
+
+        public string WsuId
+        {
+            get
+            {
+                return _wsuId;
+            }
+            set
+            {
+                _wsuId = value;
+            }
+        }
+
+        public SecurityKeyIdentifier KeyIdentifier
+        {
+            get
+            {
+                return _keyIdentifier;
+            }
+            set
+            {
+                _keyIdentifier = value;
+            }
+        }
+
+        public string MimeType
+        {
+            get
+            {
+                return _mimeType;
+            }
+            set
+            {
+                _mimeType = value;
+            }
+        }
+
+        public string Type
+        {
+            get
+            {
+                return _type;
+            }
+            set
+            {
+                _type = value;
+            }
+        }
+
+        protected abstract XmlDictionaryString OpeningElementName
+        {
+            get;
+        }
+
+        protected EncryptionState State
+        {
+            get
+            {
+                return _state;
+            }
+            set
+            {
+                _state = value;
+            }
+        }
+
+        public SecurityTokenSerializer SecurityTokenSerializer
+        {
+            get
+            {
+                return _tokenSerializer;
+            }
+            set
+            {
+                _tokenSerializer = value ?? new KeyInfoSerializer(false);
+            }
+        }
+
+        protected abstract void ForceEncryption();
+
+        protected virtual void ReadAdditionalAttributes(XmlDictionaryReader reader)
+        {
+        }
+
+        protected virtual void ReadAdditionalElements(XmlDictionaryReader reader)
+        {
+        }
+
+        protected abstract void ReadCipherData(XmlDictionaryReader reader);
+        protected abstract void ReadCipherData(XmlDictionaryReader reader, long maxBufferSize);
+
+        public void ReadFrom(XmlReader reader)
+        {
+            ReadFrom(reader, 0);
+        }
+
+        public void ReadFrom(XmlDictionaryReader reader)
+        {
+            ReadFrom(reader, 0);
+        }
+
+        public void ReadFrom(XmlReader reader, long maxBufferSize)
+        {
+            ReadFrom(XmlDictionaryReader.CreateDictionaryReader(reader), maxBufferSize);
+        }
+
+        public void ReadFrom(XmlDictionaryReader reader, long maxBufferSize)
+        {
+            ValidateReadState();
+            reader.MoveToStartElement(OpeningElementName, s_NamespaceUri);
+            _encoding = reader.GetAttribute(s_EncodingAttribute, null);
+            _id = reader.GetAttribute(System.IdentityModel.XD.XmlEncryptionDictionary.Id, null) ?? SecurityUniqueId.Create().Value;
+            _wsuId = reader.GetAttribute(System.IdentityModel.XD.XmlEncryptionDictionary.Id, XD.UtilityDictionary.Namespace) ?? SecurityUniqueId.Create().Value;
+            _mimeType = reader.GetAttribute(s_MimeTypeAttribute, null);
+            _type = reader.GetAttribute(s_TypeAttribute, null);
+            ReadAdditionalAttributes(reader);
+            reader.Read();
+
+            if (reader.IsStartElement(EncryptionMethodElement.ElementName, s_NamespaceUri))
+            {
+                _encryptionMethod.ReadFrom(reader);
+            }
+
+            if (_tokenSerializer.CanReadKeyIdentifier(reader))
+            {
+                // XmlElement xml = null;
+                XmlDictionaryReader localReader;
+
+                if (this.ShouldReadXmlReferenceKeyInfoClause)
+                {
+                    // We create the dom only when needed to not affect perf.
+                    throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+                    //XmlDocument doc = new XmlDocument();
+                    //xml = (doc.ReadNode(reader) as XmlElement);
+                    //localReader = XmlDictionaryReader.CreateDictionaryReader(new XmlNodeReader(xml));
+                }
+                else
+                {
+                    localReader = reader;
+                }
+
+                try
+                {
+                    this.KeyIdentifier = _tokenSerializer.ReadKeyIdentifier(localReader);
+                }
+                catch (Exception e)
+                {
+                    // In case when the issued token ( custom token) is used as an initiator token; we will fail 
+                    // to read the keyIdentifierClause using the plugged in default serializer. So We need to try to read it as an XmlReferencekeyIdentifierClause 
+                    // if it is the client side.
+
+                    if (Fx.IsFatal(e) || !this.ShouldReadXmlReferenceKeyInfoClause)
+                    {
+                        throw;
+                    }
+
+                    throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+                    //this.keyIdentifier = ReadGenericXmlSecurityKeyIdentifier( XmlDictionaryReader.CreateDictionaryReader( new XmlNodeReader(xml)), e);
+                }
+            }
+
+            reader.ReadStartElement(s_CipherDataElementName, EncryptedType.s_NamespaceUri);
+            reader.ReadStartElement(s_CipherValueElementName, EncryptedType.s_NamespaceUri);
+            if (maxBufferSize == 0)
+                ReadCipherData(reader);
+            else
+                ReadCipherData(reader, maxBufferSize);
+            reader.ReadEndElement(); // CipherValue
+            reader.ReadEndElement(); // CipherData
+
+            ReadAdditionalElements(reader);
+            reader.ReadEndElement(); // OpeningElementName
+            this.State = EncryptionState.Read;
+        }
+
+        private SecurityKeyIdentifier ReadGenericXmlSecurityKeyIdentifier(XmlDictionaryReader localReader, Exception previousException)
+        {
+            if (!localReader.IsStartElement(XD.XmlSignatureDictionary.KeyInfo, XD.XmlSignatureDictionary.Namespace))
+            {
+                return null;
+            }
+
+            localReader.ReadStartElement(XD.XmlSignatureDictionary.KeyInfo, XD.XmlSignatureDictionary.Namespace);
+            SecurityKeyIdentifier keyIdentifier = new SecurityKeyIdentifier();
+          
+            if (localReader.IsStartElement())
+            {
+                SecurityKeyIdentifierClause clause = null;
+                string strId = localReader.GetAttribute(XD.UtilityDictionary.IdAttribute, XD.UtilityDictionary.Namespace);
+                XmlDocument doc = new XmlDocument();
+                XmlElement keyIdentifierReferenceXml = (doc.ReadNode(localReader) as XmlElement);
+                clause = new GenericXmlSecurityKeyIdentifierClause(keyIdentifierReferenceXml);
+                if (!string.IsNullOrEmpty(strId))
+                    clause.Id = strId;
+                keyIdentifier.Add(clause);
+            }
+
+            if (keyIdentifier.Count == 0)
+                throw previousException;
+
+            localReader.ReadEndElement();
+            return keyIdentifier;
+        }
+
+        protected virtual void WriteAdditionalAttributes(XmlDictionaryWriter writer, DictionaryManager dictionaryManager)
+        {
+        }
+
+        protected virtual void WriteAdditionalElements(XmlDictionaryWriter writer, DictionaryManager dictionaryManager)
+        {
+        }
+
+        protected abstract void WriteCipherData(XmlDictionaryWriter writer);
+
+        public void WriteTo(XmlDictionaryWriter writer, DictionaryManager dictionaryManager)
+        {
+            if (writer == null)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("writer");
+            }
+            ValidateWriteState();
+            writer.WriteStartElement(XmlEncryptionStrings.Prefix, this.OpeningElementName, s_NamespaceUri);
+            if (_id != null && _id.Length != 0)
+            {
+                writer.WriteAttributeString(System.IdentityModel.XD.XmlEncryptionDictionary.Id, null, this.Id);
+            }
+            if (_type != null)
+            {
+                writer.WriteAttributeString(s_TypeAttribute, null, this.Type);
+            }
+            if (_mimeType != null)
+            {
+                writer.WriteAttributeString(s_MimeTypeAttribute, null, this.MimeType);
+            }
+            if (_encoding != null)
+            {
+                writer.WriteAttributeString(s_EncodingAttribute, null, this.Encoding);
+            }
+            WriteAdditionalAttributes(writer, dictionaryManager);
+            if (_encryptionMethod.algorithm != null)
+            {
+                _encryptionMethod.WriteTo(writer);
+            }
+            if (this.KeyIdentifier != null)
+            {
+                _tokenSerializer.WriteKeyIdentifier(writer, this.KeyIdentifier);
+            }
+
+            writer.WriteStartElement(s_CipherDataElementName, s_NamespaceUri);
+            writer.WriteStartElement(s_CipherValueElementName, s_NamespaceUri);
+            WriteCipherData(writer);
+            writer.WriteEndElement(); // CipherValue
+            writer.WriteEndElement(); // CipherData
+
+            WriteAdditionalElements(writer, dictionaryManager);
+            writer.WriteEndElement(); // OpeningElementName
+        }
+
+        void ValidateReadState()
+        {
+            if (this.State != EncryptionState.New)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new SecurityMessageSerializationException(SR.Format(SR.BadEncryptionState)));
+            }
+        }
+
+        void ValidateWriteState()
+        {
+            if (this.State == EncryptionState.EncryptionSetup)
+            {
+                ForceEncryption();
+            }
+            else if (this.State == EncryptionState.New)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new SecurityMessageSerializationException(SR.Format(SR.BadEncryptionState)));
+            }
+        }
+
+        protected enum EncryptionState
+        {
+            New,
+            Read,
+            DecryptionSetup,
+            Decrypted,
+            EncryptionSetup,
+            Encrypted
+        }
+        
+        struct EncryptionMethodElement
+        {
+            internal string algorithm;
+            internal XmlDictionaryString algorithmDictionaryString;
+            internal static readonly XmlDictionaryString ElementName = System.IdentityModel.XD.XmlEncryptionDictionary.EncryptionMethod;
+
+            public void Init()
+            {
+                this.algorithm = null;
+            }
+
+            public void ReadFrom(XmlDictionaryReader reader)
+            {
+                reader.MoveToStartElement(ElementName, System.IdentityModel.XD.XmlEncryptionDictionary.Namespace);
+                bool isEmptyElement = reader.IsEmptyElement;
+                this.algorithm = reader.GetAttribute(XD.XmlSignatureDictionary.Algorithm, null);
+                if (this.algorithm == null)
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new SecurityMessageSerializationException(
+                        SR.Format(SR.RequiredAttributeMissing, XD.XmlSignatureDictionary.Algorithm.Value, ElementName.Value)));
+                }
+                reader.Read();
+                if (!isEmptyElement)
+                {
+                    while (reader.IsStartElement())
+                    {
+                        reader.Skip();
+                    }
+                    reader.ReadEndElement();
+                }
+            }
+
+            public void WriteTo(XmlDictionaryWriter writer)
+            {
+                writer.WriteStartElement(XmlEncryptionStrings.Prefix, ElementName, System.IdentityModel.XD.XmlEncryptionDictionary.Namespace);
+                if (this.algorithmDictionaryString != null)
+                {
+                    writer.WriteStartAttribute(XD.XmlSignatureDictionary.Algorithm, null);
+                    writer.WriteString(this.algorithmDictionaryString);
+                    writer.WriteEndAttribute();
+                }
+                else
+                {
+                    writer.WriteAttributeString(XD.XmlSignatureDictionary.Algorithm, null, this.algorithm);
+                }
+                if (this.algorithm == XD.SecurityAlgorithmDictionary.RsaOaepKeyWrap.Value)
+                {
+                    writer.WriteStartElement(XmlSignatureStrings.Prefix, XD.XmlSignatureDictionary.DigestMethod, XD.XmlSignatureDictionary.Namespace);
+                    writer.WriteStartAttribute(XD.XmlSignatureDictionary.Algorithm, null);
+                    writer.WriteString(XD.SecurityAlgorithmDictionary.Sha1Digest);
+                    writer.WriteEndAttribute();
+                    writer.WriteEndElement();
+                }
+                writer.WriteEndElement(); // EncryptionMethod
+            }
+        }
+    }
+}
+

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/IChannelSecureConversationSessionSettings.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/IChannelSecureConversationSessionSettings.cs
@@ -1,0 +1,27 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.ServiceModel.Security
+{
+    interface IChannelSecureConversationSessionSettings
+    {
+        TimeSpan KeyRenewalInterval
+        {
+            get;
+            set;
+        }
+
+        TimeSpan KeyRolloverInterval
+        {
+            get;
+            set;
+        }
+
+        bool TolerateTransportFailures
+        {
+            get;
+            set;
+        }
+    }
+}

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/ISecureConversationSession.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/ISecureConversationSession.cs
@@ -1,0 +1,15 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.ServiceModel;
+using System.Xml;
+
+namespace System.ServiceModel.Security
+{
+    public interface ISecureConversationSession : ISecuritySession
+    {
+        void WriteSessionTokenIdentifier(XmlDictionaryWriter writer);
+        bool TryReadSessionTokenIdentifier(XmlReader reader);
+    }
+}

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/ISecurityCommunicationObject.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/ISecurityCommunicationObject.cs
@@ -3,6 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 
+using System.Threading.Tasks;
+
 namespace System.ServiceModel.Security
 {
     internal interface ISecurityCommunicationObject
@@ -10,15 +12,18 @@ namespace System.ServiceModel.Security
         TimeSpan DefaultOpenTimeout { get; }
         TimeSpan DefaultCloseTimeout { get; }
         void OnAbort();
-        IAsyncResult OnBeginClose(TimeSpan timeout, AsyncCallback callback, object state);
-        IAsyncResult OnBeginOpen(TimeSpan timeout, AsyncCallback callback, object state);
+
+        Task CloseAsync(TimeSpan timeout);
+        Task OpenAsync(TimeSpan timeout);
+
         void OnClose(TimeSpan timeout);
         void OnClosed();
         void OnClosing();
-        void OnEndClose(IAsyncResult result);
-        void OnEndOpen(IAsyncResult result);
+
         void OnFaulted();
         void OnOpen(TimeSpan timeout);
+        Task OnOpenAsync(TimeSpan timeout);
+        Task OnCloseAsync(TimeSpan timeout);
         void OnOpened();
         void OnOpening();
     }

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/ISspiNegotiation.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/ISspiNegotiation.cs
@@ -1,0 +1,51 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Security.Authentication.ExtendedProtection;
+
+namespace System.ServiceModel.Security
+{
+    interface ISspiNegotiation : IDisposable
+    {
+
+        DateTime ExpirationTimeUtc
+        {
+            get;
+        }
+        /// <summary>
+        /// This indicates if the handshake is complete or not. 
+        /// Note that the IsValidContext flag indicates if the handshake ended in
+        /// success or failure
+        /// </summary>
+        bool IsCompleted
+        {
+            get;
+        }
+
+        bool IsValidContext
+        {
+            get;
+        }
+
+        string KeyEncryptionAlgorithm
+        {
+            get;
+        }
+
+        byte[] Decrypt(byte[] encryptedData);
+
+        byte[] Encrypt(byte[] data);
+
+        byte[] GetOutgoingBlob(byte[] incomingBlob, ChannelBinding channelbinding, ExtendedProtectionPolicy protectionPolicy);
+
+        string GetRemoteIdentityName();
+    }
+
+    interface ISspiNegotiationInfo
+    {
+        ISspiNegotiation SspiNegotiation { get; }
+    }
+}
+

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/KeyNameIdentifierClause.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/KeyNameIdentifierClause.cs
@@ -1,0 +1,46 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Globalization;
+using System.IdentityModel.Tokens;
+
+namespace System.ServiceModel.Security
+{
+    public class KeyNameIdentifierClause : SecurityKeyIdentifierClause
+    {
+        private string _keyName;
+
+        public KeyNameIdentifierClause(string keyName)
+            : base(null)
+        {
+            if (keyName == null)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("keyName");
+            }
+            _keyName = keyName;
+        }
+
+        public string KeyName
+        {
+            get { return _keyName; }
+        }
+
+        public override bool Matches(SecurityKeyIdentifierClause keyIdentifierClause)
+        {
+            KeyNameIdentifierClause that = keyIdentifierClause as KeyNameIdentifierClause;
+            return ReferenceEquals(this, that) || (that != null && that.Matches(_keyName));
+        }
+
+        public bool Matches(string keyName)
+        {
+            return _keyName == keyName;
+        }
+
+        public override string ToString()
+        {
+            return string.Format(CultureInfo.InvariantCulture, "KeyNameIdentifierClause(KeyName = '{0}')", this.KeyName);
+        }
+    }
+}
+

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/MessagePartProtectionMode.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/MessagePartProtectionMode.cs
@@ -1,0 +1,49 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.ServiceModel.Security
+{
+    enum MessagePartProtectionMode
+    {
+        None,
+        Sign,
+        Encrypt,
+        SignThenEncrypt,
+        EncryptThenSign,
+    }
+
+    static class MessagePartProtectionModeHelper
+    {
+        public static MessagePartProtectionMode GetProtectionMode(bool sign, bool encrypt, bool signThenEncrypt)
+        {
+            if (sign)
+            {
+                if (encrypt)
+                {
+                    if (signThenEncrypt)
+                    {
+                        return MessagePartProtectionMode.SignThenEncrypt;
+                    }
+                    else
+                    {
+                        return MessagePartProtectionMode.EncryptThenSign;
+                    }
+                }
+                else
+                {
+                    return MessagePartProtectionMode.Sign;
+                }
+            }
+            else if (encrypt)
+            {
+                return MessagePartProtectionMode.Encrypt;
+            }
+            else
+            {
+                return MessagePartProtectionMode.None;
+            }
+        }
+    }
+}
+

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/ReceiveSecurityHeader.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/ReceiveSecurityHeader.cs
@@ -2,7 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Diagnostics.Contracts;
+using System.IdentityModel.Policy;
+using System.IdentityModel.Selectors;
+using System.IdentityModel.Tokens;
+using System.Security.Authentication.ExtendedProtection;
 using System.ServiceModel.Channels;
 using System.ServiceModel.Description;
 using System.Xml;
@@ -11,6 +17,25 @@ namespace System.ServiceModel.Security
 {
     internal abstract class ReceiveSecurityHeader : SecurityHeader
     {
+        private bool _expectBasicTokens;
+        private bool _expectSignedTokens;
+        private bool _expectEndorsingTokens;
+        private long _maxReceivedMessageSize = TransportDefaults.MaxReceivedMessageSize;
+        private XmlDictionaryReaderQuotas _readerQuotas;
+        private IList<SupportingTokenAuthenticatorSpecification> _supportingTokenAuthenticators;
+        private ReadOnlyCollection<SecurityTokenResolver> _outOfBandTokenResolver;
+        private SecurityTokenAuthenticator _derivedTokenAuthenticator;
+        private bool _replayDetectionEnabled = false;
+        private NonceCache _nonceCache;
+        private TimeSpan _replayWindow;
+        private TimeSpan _clockSkew;
+        private Collection<SecurityToken> _basicTokens;
+        private Collection<SecurityToken> _signedTokens;
+        private Collection<SecurityToken> _endorsingTokens;
+        private Collection<SecurityToken> _signedEndorsingTokens;
+        private Dictionary<SecurityToken, ReadOnlyCollection<IAuthorizationPolicy>> _tokenPoliciesMapping;
+        private bool _enforceDerivedKeyRequirement = true;
+
         protected ReceiveSecurityHeader(Message message, string actor, bool mustUnderstand, bool relay,
             SecurityStandardsManager standardsManager,
             SecurityAlgorithmSuite algorithmSuite,
@@ -31,9 +56,610 @@ namespace System.ServiceModel.Security
             get { return this.StandardsManager.SecurityVersion.HeaderNamespace.Value; }
         }
 
+        public Collection<SecurityToken> BasicSupportingTokens
+        {
+            get
+            {
+                return _basicTokens;
+            }
+        }
+
+        public Collection<SecurityToken> SignedSupportingTokens
+        {
+            get
+            {
+                return _signedTokens;
+            }
+        }
+
+        public Collection<SecurityToken> EndorsingSupportingTokens
+        {
+            get
+            {
+                return _endorsingTokens;
+            }
+        }
+
+        public Collection<SecurityToken> SignedEndorsingSupportingTokens
+        {
+            get
+            {
+                return _signedEndorsingTokens;
+            }
+        }
+
+        public Message ProcessedMessage
+        {
+            get { return Message; }
+        }
+
+        public SecurityTokenAuthenticator DerivedTokenAuthenticator
+        {
+            get
+            {
+                return _derivedTokenAuthenticator;
+            }
+            set
+            {
+                ThrowIfProcessingStarted();
+                _derivedTokenAuthenticator = value;
+            }
+        }
+
+        public bool EnforceDerivedKeyRequirement
+        {
+            get
+            {
+                return _enforceDerivedKeyRequirement;
+            }
+            set
+            {
+                ThrowIfProcessingStarted();
+                _enforceDerivedKeyRequirement = value;
+            }
+        }
+
+        public bool ReplayDetectionEnabled
+        {
+            get { return _replayDetectionEnabled; }
+            set
+            {
+                ThrowIfProcessingStarted();
+                _replayDetectionEnabled = value;
+            }
+        }
+
         protected override void OnWriteHeaderContents(XmlDictionaryWriter writer, MessageVersion messageVersion)
         {
-            throw ExceptionHelper.PlatformNotSupported();
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+
+            //XmlDictionaryReader securityHeaderReader = GetReaderAtSecurityHeader();
+            //securityHeaderReader.ReadStartElement();
+            //for (int i = 0; i < this.ElementManager.Count; ++i)
+            //{
+            //    ReceiveSecurityHeaderEntry entry;
+            //    this.ElementManager.GetElementEntry(i, out entry);
+            //    XmlDictionaryReader reader = null;
+            //    if (entry.encrypted)
+            //    {
+            //        reader = this.ElementManager.GetReader(i, false);
+            //        writer.WriteNode(reader, false);
+            //        reader.Close();
+            //        securityHeaderReader.Skip();
+            //    }
+            //    else
+            //    {
+            //        writer.WriteNode(securityHeaderReader, false);
+            //    }
+            //}
+            //securityHeaderReader.Close();
+        }
+
+        public bool ExpectBasicTokens
+        {
+            get { return _expectBasicTokens; }
+            set
+            {
+                ThrowIfProcessingStarted();
+                _expectBasicTokens = value;
+            }
+        }
+
+        public bool ExpectSignedTokens
+        {
+            get { return _expectSignedTokens; }
+            set
+            {
+                ThrowIfProcessingStarted();
+                _expectSignedTokens = value;
+            }
+        }
+
+        public bool ExpectEndorsingTokens
+        {
+            get { return _expectEndorsingTokens; }
+            set
+            {
+                ThrowIfProcessingStarted();
+                _expectEndorsingTokens = value;
+            }
+        }
+
+        internal long MaxReceivedMessageSize
+        {
+            get
+            {
+                return _maxReceivedMessageSize;
+            }
+            set
+            {
+                ThrowIfProcessingStarted();
+                _maxReceivedMessageSize = value;
+            }
+        }
+
+        internal XmlDictionaryReaderQuotas ReaderQuotas
+        {
+            get { return _readerQuotas; }
+            set
+            {
+                ThrowIfProcessingStarted();
+
+                if (value == null)
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("value");
+
+                _readerQuotas = value;
+            }
+        }
+
+        public Dictionary<SecurityToken, ReadOnlyCollection<IAuthorizationPolicy>> SecurityTokenAuthorizationPoliciesMapping
+        {
+            get
+            {
+                if (_tokenPoliciesMapping == null)
+                {
+                    _tokenPoliciesMapping = new Dictionary<SecurityToken, ReadOnlyCollection<IAuthorizationPolicy>>();
+                }
+                return _tokenPoliciesMapping;
+            }
+        }
+
+        public void ConfigureTransportBindingServerReceiveHeader(IList<SupportingTokenAuthenticatorSpecification> supportingTokenAuthenticators)
+        {
+            _supportingTokenAuthenticators = supportingTokenAuthenticators;
+        }
+
+        public void ConfigureOutOfBandTokenResolver(ReadOnlyCollection<SecurityTokenResolver> outOfBandResolvers)
+        {
+            if (outOfBandResolvers == null)
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull(nameof(outOfBandResolvers));
+            if (outOfBandResolvers.Count == 0)
+            {
+                return;
+            }
+            _outOfBandTokenResolver = outOfBandResolvers;
+        }
+
+        Collection<SecurityToken> EnsureSupportingTokens(ref Collection<SecurityToken> list)
+        {
+            if (list == null)
+                list = new Collection<SecurityToken>();
+            return list;
+        }
+
+        void VerifySupportingToken(TokenTracker tracker)
+        {
+            if (tracker == null)
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("tracker");
+
+            Contract.Assert(tracker._spec != null, "Supporting token trackers cannot have null specification.");
+
+            SupportingTokenAuthenticatorSpecification spec = tracker._spec;
+
+            if (tracker._token == null)
+            {
+                if (spec.IsTokenOptional)
+                    return;
+                else
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new MessageSecurityException(SR.Format(SR.SupportingTokenNotProvided, spec.TokenParameters, spec.SecurityTokenAttachmentMode)));
+            }
+            switch (spec.SecurityTokenAttachmentMode)
+            {
+                case SecurityTokenAttachmentMode.Endorsing:
+                    if (!tracker._IsEndorsing)
+                    {
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new MessageSecurityException(SR.Format(SR.SupportingTokenIsNotEndorsing, spec.TokenParameters)));
+                    }
+                    if (this.EnforceDerivedKeyRequirement && spec.TokenParameters.RequireDerivedKeys && !spec.TokenParameters.HasAsymmetricKey && !tracker._IsDerivedFrom)
+                    {
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new MessageSecurityException(SR.Format(SR.SupportingSignatureIsNotDerivedFrom, spec.TokenParameters)));
+                    }
+                    EnsureSupportingTokens(ref _endorsingTokens).Add(tracker._token);
+                    break;
+                case SecurityTokenAttachmentMode.Signed:
+                    if (!tracker._IsSigned && this.RequireMessageProtection)
+                    {
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new MessageSecurityException(SR.Format(SR.SupportingTokenIsNotSigned, spec.TokenParameters)));
+                    }
+                    EnsureSupportingTokens(ref _signedTokens).Add(tracker._token);
+                    break;
+                case SecurityTokenAttachmentMode.SignedEncrypted:
+                    if (!tracker._IsSigned && this.RequireMessageProtection)
+                    {
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new MessageSecurityException(SR.Format(SR.SupportingTokenIsNotSigned, spec.TokenParameters)));
+                    }
+                    if (!tracker._IsEncrypted && this.RequireMessageProtection)
+                    {
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new MessageSecurityException(SR.Format(SR.SupportingTokenIsNotEncrypted, spec.TokenParameters)));
+                    }
+                    EnsureSupportingTokens(ref _basicTokens).Add(tracker._token);
+                    break;
+                case SecurityTokenAttachmentMode.SignedEndorsing:
+                    if (!tracker._IsSigned && this.RequireMessageProtection)
+                    {
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new MessageSecurityException(SR.Format(SR.SupportingTokenIsNotSigned, spec.TokenParameters)));
+                    }
+                    if (!tracker._IsEndorsing)
+                    {
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new MessageSecurityException(SR.Format(SR.SupportingTokenIsNotEndorsing, spec.TokenParameters)));
+                    }
+                    if (this.EnforceDerivedKeyRequirement && spec.TokenParameters.RequireDerivedKeys && !spec.TokenParameters.HasAsymmetricKey && !tracker._IsDerivedFrom)
+                    {
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new MessageSecurityException(SR.Format(SR.SupportingSignatureIsNotDerivedFrom, spec.TokenParameters)));
+                    }
+                    EnsureSupportingTokens(ref _signedEndorsingTokens).Add(tracker._token);
+                    break;
+
+                default:
+                    Contract.Assert(false, "Unknown token attachment mode " + spec.SecurityTokenAttachmentMode);
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new NotSupportedException(SR.Format(SR.UnknownTokenAttachmentMode, spec.SecurityTokenAttachmentMode)));
+            }
+        }
+
+        // replay detection done if enableReplayDetection is set to true.
+        public void SetTimeParameters(NonceCache nonceCache, TimeSpan replayWindow, TimeSpan clockSkew)
+        {
+            _nonceCache = nonceCache;
+            _replayWindow = replayWindow;
+            _clockSkew = clockSkew;
+        }
+
+        public void Process(TimeSpan timeout, ChannelBinding channelBinding, ExtendedProtectionPolicy extendedProtectionPolicy)
+        {
+            Contract.Assert(this.ReaderQuotas != null, "Reader quotas must be set before processing");
+
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+
+        //    MessageProtectionOrder actualProtectionOrder = this.protectionOrder;
+        //    bool wasProtectionOrderDowngraded = false;
+        //    if (this.protectionOrder == MessageProtectionOrder.SignBeforeEncryptAndEncryptSignature)
+        //    {
+        //        if (this.RequiredEncryptionParts == null || !this.RequiredEncryptionParts.IsBodyIncluded)
+        //        {
+        //            // Let's downgrade for now. If after signature verification we find a header that 
+        //            // is signed and encrypted, we will check for signature encryption too.
+        //            actualProtectionOrder = MessageProtectionOrder.SignBeforeEncrypt;
+        //            wasProtectionOrderDowngraded = true;
+        //        }
+        //    }
+
+        //    this.channelBinding = channelBinding;
+        //    this.extendedProtectionPolicy = extendedProtectionPolicy;
+        //    this.orderTracker.SetRequiredProtectionOrder(actualProtectionOrder);
+
+        //    SetProcessingStarted();
+        //    this.timeoutHelper = new TimeoutHelper(timeout);
+        //    this.Message = this.securityVerifiedMessage = new SecurityVerifiedMessage(this.Message, this);
+        //    XmlDictionaryReader reader = CreateSecurityHeaderReader();
+        //    reader.MoveToStartElement();
+        //    if (reader.IsEmptyElement)
+        //    {
+        //        throw TraceUtility.ThrowHelperError(new MessageSecurityException(SR.Format(SR.SecurityHeaderIsEmpty)), this.Message);
+        //    }
+        //    if (this.RequireMessageProtection)
+        //    {
+        //        this.securityElementAttributes = XmlAttributeHolder.ReadAttributes(reader);
+        //    }
+        //    else
+        //    {
+        //        this.securityElementAttributes = XmlAttributeHolder.emptyArray;
+        //    }
+        //    reader.ReadStartElement();
+
+        //    if (this.primaryTokenParameters != null)
+        //    {
+        //        this.primaryTokenTracker = new TokenTracker(null, this.outOfBandPrimaryToken, this.allowFirstTokenMismatch);
+        //    }
+        //    // universalTokenResolver is used for resolving tokens
+        //    universalTokenResolver = new SecurityHeaderTokenResolver(this);
+        //    // primary token resolver is used for resolving primary signature and decryption
+        //    primaryTokenResolver = new SecurityHeaderTokenResolver(this);
+        //    if (this.outOfBandPrimaryToken != null)
+        //    {
+        //        universalTokenResolver.Add(this.outOfBandPrimaryToken, SecurityTokenReferenceStyle.External, this.primaryTokenParameters);
+        //        primaryTokenResolver.Add(this.outOfBandPrimaryToken, SecurityTokenReferenceStyle.External, this.primaryTokenParameters);
+        //    }
+        //    else if (this.outOfBandPrimaryTokenCollection != null)
+        //    {
+        //        for (int i = 0; i < this.outOfBandPrimaryTokenCollection.Count; ++i)
+        //        {
+        //            universalTokenResolver.Add(this.outOfBandPrimaryTokenCollection[i], SecurityTokenReferenceStyle.External, this.primaryTokenParameters);
+        //            primaryTokenResolver.Add(this.outOfBandPrimaryTokenCollection[i], SecurityTokenReferenceStyle.External, this.primaryTokenParameters);
+        //        }
+        //    }
+        //    if (this.wrappingToken != null)
+        //    {
+        //        universalTokenResolver.ExpectedWrapper = this.wrappingToken;
+        //        universalTokenResolver.ExpectedWrapperTokenParameters = this.wrappingTokenParameters;
+        //        primaryTokenResolver.ExpectedWrapper = this.wrappingToken;
+        //        primaryTokenResolver.ExpectedWrapperTokenParameters = this.wrappingTokenParameters;
+        //    }
+        //    else if (expectedEncryptionToken != null)
+        //    {
+        //        universalTokenResolver.Add(expectedEncryptionToken, SecurityTokenReferenceStyle.External, expectedEncryptionTokenParameters);
+        //        primaryTokenResolver.Add(expectedEncryptionToken, SecurityTokenReferenceStyle.External, expectedEncryptionTokenParameters);
+        //    }
+
+        //    if (this.outOfBandTokenResolver == null)
+        //    {
+        //        this.combinedUniversalTokenResolver = this.universalTokenResolver;
+        //        this.combinedPrimaryTokenResolver = this.primaryTokenResolver;
+        //    }
+        //    else
+        //    {
+        //        this.combinedUniversalTokenResolver = new AggregateSecurityHeaderTokenResolver(this.universalTokenResolver, this.outOfBandTokenResolver);
+        //        this.combinedPrimaryTokenResolver = new AggregateSecurityHeaderTokenResolver(this.primaryTokenResolver, this.outOfBandTokenResolver);
+        //    }
+
+        //    allowedAuthenticators = new List<SecurityTokenAuthenticator>();
+        //    if (this.primaryTokenAuthenticator != null)
+        //    {
+        //        allowedAuthenticators.Add(this.primaryTokenAuthenticator);
+        //    }
+        //    if (this.DerivedTokenAuthenticator != null)
+        //    {
+        //        allowedAuthenticators.Add(this.DerivedTokenAuthenticator);
+        //    }
+        //    pendingSupportingTokenAuthenticator = null;
+        //    int numSupportingTokensRequiringDerivation = 0;
+        //    if (this.supportingTokenAuthenticators != null && this.supportingTokenAuthenticators.Count > 0)
+        //    {
+        //        this.supportingTokenTrackers = new List<TokenTracker>(this.supportingTokenAuthenticators.Count);
+        //        for (int i = 0; i < this.supportingTokenAuthenticators.Count; ++i)
+        //        {
+        //            SupportingTokenAuthenticatorSpecification spec = this.supportingTokenAuthenticators[i];
+        //            switch (spec.SecurityTokenAttachmentMode)
+        //            {
+        //                case SecurityTokenAttachmentMode.Endorsing:
+        //                    this.hasEndorsingOrSignedEndorsingSupportingTokens = true;
+        //                    break;
+        //                case SecurityTokenAttachmentMode.Signed:
+        //                    this.hasAtLeastOneSupportingTokenExpectedToBeSigned = true;
+        //                    break;
+        //                case SecurityTokenAttachmentMode.SignedEndorsing:
+        //                    this.hasEndorsingOrSignedEndorsingSupportingTokens = true;
+        //                    this.hasAtLeastOneSupportingTokenExpectedToBeSigned = true;
+        //                    break;
+        //                case SecurityTokenAttachmentMode.SignedEncrypted:
+        //                    this.hasAtLeastOneSupportingTokenExpectedToBeSigned = true;
+        //                    break;
+        //            }
+
+        //            if ((this.primaryTokenAuthenticator != null) && (this.primaryTokenAuthenticator.GetType().Equals(spec.TokenAuthenticator.GetType())))
+        //            {
+        //                pendingSupportingTokenAuthenticator = spec.TokenAuthenticator;
+        //            }
+        //            else
+        //            {
+        //                allowedAuthenticators.Add(spec.TokenAuthenticator);
+        //            }
+        //            if (spec.TokenParameters.RequireDerivedKeys && !spec.TokenParameters.HasAsymmetricKey &&
+        //                (spec.SecurityTokenAttachmentMode == SecurityTokenAttachmentMode.Endorsing || spec.SecurityTokenAttachmentMode == SecurityTokenAttachmentMode.SignedEndorsing))
+        //            {
+        //                ++numSupportingTokensRequiringDerivation;
+        //            }
+        //            this.supportingTokenTrackers.Add(new TokenTracker(spec));
+        //        }
+        //    }
+
+        //    if (this.DerivedTokenAuthenticator != null)
+        //    {
+        //        // we expect key derivation. Compute quotas for derived keys
+        //        int maxKeyDerivationLengthInBits = this.AlgorithmSuite.DefaultEncryptionKeyDerivationLength >= this.AlgorithmSuite.DefaultSignatureKeyDerivationLength ?
+        //            this.AlgorithmSuite.DefaultEncryptionKeyDerivationLength : this.AlgorithmSuite.DefaultSignatureKeyDerivationLength;
+        //        this.maxDerivedKeyLength = maxKeyDerivationLengthInBits / 8;
+        //        // the upper bound of derived keys is (1 for primary signature + 1 for encryption + supporting token signatures requiring derivation)*2
+        //        // the multiplication by 2 is to take care of interop scenarios that may arise that require more derived keys than the lower bound.
+        //        this.maxDerivedKeys = (1 + 1 + numSupportingTokensRequiringDerivation) * 2;
+        //    }
+
+        //    SecurityHeaderElementInferenceEngine engine = SecurityHeaderElementInferenceEngine.GetInferenceEngine(this.Layout);
+        //    engine.ExecuteProcessingPasses(this, reader);
+        //    if (this.RequireMessageProtection)
+        //    {
+        //        this.ElementManager.EnsureAllRequiredSecurityHeaderTargetsWereProtected();
+        //        ExecuteMessageProtectionPass(this.hasAtLeastOneSupportingTokenExpectedToBeSigned);
+        //        if (this.RequiredSignatureParts != null && this.SignatureToken == null)
+        //        {
+        //            throw TraceUtility.ThrowHelperError(new MessageSecurityException(SR.Format(SR.RequiredSignatureMissing)), this.Message);
+        //        }
+        //    }
+
+        //    EnsureDecryptionComplete();
+
+        //    this.signatureTracker.SetDerivationSourceIfRequired();
+        //    this.encryptionTracker.SetDerivationSourceIfRequired();
+        //    if (this.EncryptionToken != null)
+        //    {
+        //        if (wrappingToken != null)
+        //        {
+        //            if (!(this.EncryptionToken is WrappedKeySecurityToken) || ((WrappedKeySecurityToken)this.EncryptionToken).WrappingToken != this.wrappingToken)
+        //            {
+        //                throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new MessageSecurityException(SR.Format(SR.EncryptedKeyWasNotEncryptedWithTheRequiredEncryptingToken, this.wrappingToken)));
+        //            }
+        //        }
+        //        else if (expectedEncryptionToken != null)
+        //        {
+        //            if (this.EncryptionToken != expectedEncryptionToken)
+        //            {
+        //                throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new MessageSecurityException(SR.Format(SR.MessageWasNotEncryptedWithTheRequiredEncryptingToken)));
+        //            }
+        //        }
+        //        else if (this.SignatureToken != null && this.EncryptionToken != this.SignatureToken)
+        //        {
+        //            throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new MessageSecurityException(SR.Format(SR.SignatureAndEncryptionTokenMismatch, this.SignatureToken, this.EncryptionToken)));
+        //        }
+        //    }
+
+        //    // ensure that the primary signature was signed with derived keys if required
+        //    if (this.EnforceDerivedKeyRequirement)
+        //    {
+        //        if (this.SignatureToken != null)
+        //        {
+        //            if (this.primaryTokenParameters != null)
+        //            {
+        //                if (this.primaryTokenParameters.RequireDerivedKeys && !this.primaryTokenParameters.HasAsymmetricKey && !this.primaryTokenTracker.IsDerivedFrom)
+        //                {
+        //                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new MessageSecurityException(SR.Format(SR.PrimarySignatureWasNotSignedByDerivedKey, this.primaryTokenParameters)));
+        //                }
+        //            }
+        //            else if (this.wrappingTokenParameters != null && this.wrappingTokenParameters.RequireDerivedKeys)
+        //            {
+        //                if (!this.signatureTracker.IsDerivedToken)
+        //                {
+        //                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new MessageSecurityException(SR.Format(SR.PrimarySignatureWasNotSignedByDerivedWrappedKey, this.wrappingTokenParameters)));
+        //                }
+        //            }
+        //        }
+
+        //        // verify that the encryption is using key derivation
+        //        if (this.EncryptionToken != null)
+        //        {
+        //            if (wrappingTokenParameters != null)
+        //            {
+        //                if (wrappingTokenParameters.RequireDerivedKeys && !this.encryptionTracker.IsDerivedToken)
+        //                {
+        //                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new MessageSecurityException(SR.Format(SR.MessageWasNotEncryptedByDerivedWrappedKey, this.wrappingTokenParameters)));
+        //                }
+        //            }
+        //            else if (expectedEncryptionTokenParameters != null)
+        //            {
+        //                if (expectedEncryptionTokenParameters.RequireDerivedKeys && !this.encryptionTracker.IsDerivedToken)
+        //                {
+        //                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new MessageSecurityException(SR.Format(SR.MessageWasNotEncryptedByDerivedEncryptionToken, this.expectedEncryptionTokenParameters)));
+        //                }
+        //            }
+        //            else if (primaryTokenParameters != null && !primaryTokenParameters.HasAsymmetricKey && primaryTokenParameters.RequireDerivedKeys && !this.encryptionTracker.IsDerivedToken)
+        //            {
+        //                throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new MessageSecurityException(SR.Format(SR.MessageWasNotEncryptedByDerivedEncryptionToken, this.primaryTokenParameters)));
+        //            }
+        //        }
+        //    }
+
+        //    if (wasProtectionOrderDowngraded && (this.BasicSupportingTokens != null) && (this.BasicSupportingTokens.Count > 0))
+        //    {
+        //        // Basic tokens are always signed and encrypted. So check if Signatures 
+        //        // are encrypted as well.
+        //        this.VerifySignatureEncryption();
+        //    }
+
+        //    // verify all supporting token parameters have their requirements met
+        //    if (this.supportingTokenTrackers != null)
+        //    {
+        //        for (int i = 0; i < this.supportingTokenTrackers.Count; ++i)
+        //        {
+        //            VerifySupportingToken(this.supportingTokenTrackers[i]);
+        //        }
+        //    }
+
+        //    if (this.replayDetectionEnabled)
+        //    {
+        //        if (this.timestamp == null)
+        //        {
+        //            throw TraceUtility.ThrowHelperError(new MessageSecurityException(
+        //                SR.Format(SR.NoTimestampAvailableInSecurityHeaderToDoReplayDetection)), this.Message);
+        //        }
+        //        if (this.primarySignatureValue == null)
+        //        {
+        //            throw TraceUtility.ThrowHelperError(new MessageSecurityException(
+        //                SR.Format(SR.NoSignatureAvailableInSecurityHeaderToDoReplayDetection)), this.Message);
+        //        }
+
+        //        AddNonce(this.nonceCache, this.primarySignatureValue);
+
+        //        // if replay detection is on, redo creation range checks to ensure full coverage
+        //        this.timestamp.ValidateFreshness(this.replayWindow, this.clockSkew);
+        //    }
+
+        //    if (this.ExpectSignatureConfirmation)
+        //    {
+        //        this.ElementManager.VerifySignatureConfirmationWasFound();
+        //    }
+
+        //    MarkHeaderAsUnderstood();
+        }
+
+    }
+
+    class TokenTracker
+    {
+        public SecurityToken _token;
+        public bool _IsDerivedFrom;
+        public bool _IsSigned;
+        public bool _IsEncrypted;
+        public bool _IsEndorsing;
+        public bool _AlreadyReadEndorsingSignature;
+        private bool _allowFirstTokenMismatch;
+        public SupportingTokenAuthenticatorSpecification _spec;
+
+        public TokenTracker(SupportingTokenAuthenticatorSpecification spec)
+            : this(spec, null, false)
+        {
+        }
+
+        public TokenTracker(SupportingTokenAuthenticatorSpecification spec, SecurityToken token, bool allowFirstTokenMismatch)
+        {
+            _spec = spec;
+            _token = token;
+            _allowFirstTokenMismatch = allowFirstTokenMismatch;
+        }
+
+        public void RecordToken(SecurityToken token)
+        {
+            if (_token == null)
+            {
+                _token = token;
+            }
+            else if (_allowFirstTokenMismatch)
+            {
+                if (!AreTokensEqual(_token, token))
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new MessageSecurityException(SR.Format(SR.MismatchInSecurityOperationToken)));
+                }
+                _token = token;
+                _allowFirstTokenMismatch = false;
+            }
+            else if (!object.ReferenceEquals(_token, token))
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new MessageSecurityException(SR.Format(SR.MismatchInSecurityOperationToken)));
+            }
+        }
+
+        static bool AreTokensEqual(SecurityToken outOfBandToken, SecurityToken replyToken)
+        {
+            // we support the serialized reply token legacy feature only for X509 certificates.
+            // in this case the thumbprint of the reply certificate must match the outofband certificate's thumbprint
+            if ((outOfBandToken is X509SecurityToken) && (replyToken is X509SecurityToken))
+            {
+                byte[] outOfBandCertificateThumbprint = ((X509SecurityToken)outOfBandToken).Certificate.GetCertHash();
+                byte[] replyCertificateThumbprint = ((X509SecurityToken)replyToken).Certificate.GetCertHash();
+                return (CryptoHelper.IsEqual(outOfBandCertificateThumbprint, replyCertificateThumbprint));
+            }
+            else
+            {
+                return false;
+            }
         }
     }
+
 }

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/ReferenceList.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/ReferenceList.cs
@@ -1,0 +1,143 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Xml;
+using DictionaryManager = System.IdentityModel.DictionaryManager;
+using ISecurityElement = System.IdentityModel.ISecurityElement;
+
+namespace System.ServiceModel.Security
+{
+    sealed class ReferenceList : ISecurityElement
+    {
+        internal static readonly XmlDictionaryString s_ElementName = System.IdentityModel.XD.XmlEncryptionDictionary.ReferenceList;
+        const string NamespacePrefix = XmlEncryptionStrings.Prefix;
+        internal static readonly XmlDictionaryString s_NamespaceUri = EncryptedType.s_NamespaceUri;
+        internal static readonly XmlDictionaryString s_UriAttribute = System.IdentityModel.XD.XmlEncryptionDictionary.URI;
+        private List<string> _referredIds = new List<string>();
+
+        public ReferenceList()
+        {
+        }
+
+        public int DataReferenceCount
+        {
+            get { return _referredIds.Count; }
+        }
+
+        public bool HasId
+        {
+            get { return false; }
+        }
+
+        public string Id
+        {
+            get
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new NotSupportedException());
+            }
+        }
+
+        public void AddReferredId(string id)
+        {
+            if (id == null)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentNullException("id"));
+            }
+            _referredIds.Add(id);
+        }
+
+        public bool ContainsReferredId(string id)
+        {
+            if (id == null)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentNullException("id"));
+            }
+            return _referredIds.Contains(id);
+        }
+
+        public string GetReferredId(int index)
+        {
+            return _referredIds[index];
+        }
+
+        public void ReadFrom(XmlDictionaryReader reader)
+        {
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+
+            //reader.ReadStartElement(ElementName, NamespaceUri);
+            //while (reader.IsStartElement())
+            //{
+            //    string id = DataReference.ReadFrom(reader);
+            //    if (this.referredIds.Contains(id))
+            //    {
+            //        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(
+            //            new SecurityMessageSerializationException(SR.Format(SR.InvalidDataReferenceInReferenceList, "#" + id)));
+            //    }
+            //    this.referredIds.Add(id);
+            //}
+            //reader.ReadEndElement(); // ReferenceList
+            //if (this.DataReferenceCount == 0)
+            //{
+            //    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new SecurityMessageSerializationException(SR.Format(SR.ReferenceListCannotBeEmpty)));
+            //}
+        }
+
+        public bool TryRemoveReferredId(string id)
+        {
+            if (id == null)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentNullException("id"));
+            }
+            return _referredIds.Remove(id);
+        }
+
+        public void WriteTo(XmlDictionaryWriter writer, DictionaryManager dictionaryManager)
+        {
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+
+            //if (this.DataReferenceCount == 0)
+            //{
+            //    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.ReferenceListCannotBeEmpty)));
+            //}
+            //writer.WriteStartElement(NamespacePrefix, ElementName, NamespaceUri);
+            //for (int i = 0; i < this.DataReferenceCount; i++)
+            //{
+            //    DataReference.WriteTo(writer, this.referredIds[i]);
+            //}
+            //writer.WriteEndElement(); // ReferenceList
+        }
+
+        static class DataReference
+        {
+            internal static readonly XmlDictionaryString s_ElementName = System.IdentityModel.XD.XmlEncryptionDictionary.DataReference;
+            internal static readonly XmlDictionaryString s_NamespaceUri = EncryptedType.s_NamespaceUri;
+
+            public static string ReadFrom(XmlDictionaryReader reader)
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+
+                //string prefix;
+                //string uri = XmlHelper.ReadEmptyElementAndRequiredAttribute(reader, ElementName, NamespaceUri, ReferenceList.UriAttribute, out prefix);
+                //if (uri.Length < 2 || uri[0] != '#')
+                //{
+                //    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(
+                //        new SecurityMessageSerializationException(SR.Format(SR.InvalidDataReferenceInReferenceList, uri)));
+                //}
+                //return uri.Substring(1);
+            }
+
+            public static void WriteTo(XmlDictionaryWriter writer, string referredId)
+            {
+                writer.WriteStartElement(System.IdentityModel.XD.XmlEncryptionDictionary.Prefix.Value, s_ElementName, s_NamespaceUri);
+                writer.WriteStartAttribute(ReferenceList.s_UriAttribute, null);
+                writer.WriteString("#");
+                writer.WriteString(referredId);
+                writer.WriteEndAttribute();
+                writer.WriteEndElement();
+            }
+        }
+    }
+}
+

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SecurityAppliedMessage.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SecurityAppliedMessage.cs
@@ -1,0 +1,469 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.IdentityModel.Tokens;
+using System.IO;
+using System.Runtime;
+using System.Security.Cryptography;
+using System.ServiceModel.Channels;
+using System.ServiceModel.Security.Tokens;
+using System.Xml;
+using IPrefixGenerator = System.IdentityModel.IPrefixGenerator;
+using ISecurityElement = System.IdentityModel.ISecurityElement;
+
+namespace System.ServiceModel.Security
+{
+    sealed class SecurityAppliedMessage : DelegatingMessage
+    {
+        private string _bodyId;
+        private bool _bodyIdInserted;
+        private string _bodyPrefix = MessageStrings.Prefix;
+        private XmlBuffer _fullBodyBuffer;
+        private ISecurityElement _encryptedBodyContent;
+        private XmlAttributeHolder[] _bodyAttributes;
+        private bool _delayedApplicationHandled;
+        private readonly MessagePartProtectionMode _bodyProtectionMode;
+        private BodyState _state = BodyState.Created;
+        private readonly SendSecurityHeader _securityHeader;
+        private MemoryStream _startBodyFragment;
+        private MemoryStream _endBodyFragment;
+        private byte[] _fullBodyFragment;
+       // private int _fullBodyFragmentLength;
+
+        public SecurityAppliedMessage(Message messageToProcess, SendSecurityHeader securityHeader, bool signBody, bool encryptBody)
+            : base(messageToProcess)
+        {
+            Fx.Assert(!(messageToProcess is SecurityAppliedMessage), "SecurityAppliedMessage should not be wrapped");
+            _securityHeader = securityHeader;
+            _bodyProtectionMode = MessagePartProtectionModeHelper.GetProtectionMode(signBody, encryptBody, securityHeader.SignThenEncrypt);
+        }
+
+        public string BodyId
+        {
+            get { return _bodyId; }
+        }
+
+        public MessagePartProtectionMode BodyProtectionMode
+        {
+            get { return _bodyProtectionMode; }
+        }
+
+        internal byte[] PrimarySignatureValue
+        {
+            get { return _securityHeader.PrimarySignatureValue; }
+        }
+
+        Exception CreateBadStateException(string operation)
+        {
+            return new InvalidOperationException(SR.Format(SR.MessageBodyOperationNotValidInBodyState,
+                operation, _state));
+        }
+
+        void EnsureUniqueSecurityApplication()
+        {
+            if (_delayedApplicationHandled)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.DelayedSecurityApplicationAlreadyCompleted)));
+            }
+            _delayedApplicationHandled = true;
+        }
+
+        protected override void OnBodyToString(XmlDictionaryWriter writer)
+        {
+            if (_state == BodyState.Created || _fullBodyFragment != null)
+            {
+                base.OnBodyToString(writer);
+            }
+            else
+            {
+                OnWriteBodyContents(writer);
+            }
+        }
+
+        protected override void OnClose()
+        {
+            try
+            {
+                this.InnerMessage.Close();
+            }
+            finally
+            {
+                _fullBodyBuffer = null;
+                _bodyAttributes = null;
+                _encryptedBodyContent = null;
+                _state = BodyState.Disposed;
+            }
+        }
+
+        protected override void OnWriteStartBody(XmlDictionaryWriter writer)
+        {
+            if (_startBodyFragment != null || _fullBodyFragment != null)
+            {
+                WriteStartInnerMessageWithId(writer);
+                return;
+            }
+
+            switch (_state)
+            {
+                case BodyState.Created:
+                case BodyState.Encrypted:
+                    this.InnerMessage.WriteStartBody(writer);
+                    return;
+                case BodyState.Signed:
+                case BodyState.EncryptedThenSigned:
+                    XmlDictionaryReader reader = _fullBodyBuffer.GetReader(0);
+                    writer.WriteStartElement(reader.Prefix, reader.LocalName, reader.NamespaceURI);
+                    writer.WriteAttributes(reader, false);
+                    reader.Dispose();
+                    return;
+                case BodyState.SignedThenEncrypted:
+                    writer.WriteStartElement(_bodyPrefix, XD.MessageDictionary.Body, this.Version.Envelope.DictionaryNamespace);
+                    if (_bodyAttributes != null)
+                    {
+                        XmlAttributeHolder.WriteAttributes(_bodyAttributes, writer);
+                    }
+                    return;
+                default:
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(CreateBadStateException("OnWriteStartBody"));
+            }
+        }
+
+        protected override void OnWriteBodyContents(XmlDictionaryWriter writer)
+        {
+            switch (_state)
+            {
+                case BodyState.Created:
+                    this.InnerMessage.WriteBodyContents(writer);
+                    return;
+                case BodyState.Signed:
+                case BodyState.EncryptedThenSigned:
+                    using (XmlDictionaryReader reader = _fullBodyBuffer.GetReader(0))
+                    {
+                        reader.ReadStartElement();
+                        while (reader.NodeType != XmlNodeType.EndElement)
+                            writer.WriteNode(reader, false);
+                        reader.ReadEndElement();
+                    }
+                    return;
+                case BodyState.Encrypted:
+                case BodyState.SignedThenEncrypted:
+                    _encryptedBodyContent.WriteTo(writer, ServiceModelDictionaryManager.Instance);
+                    break;
+                default:
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(CreateBadStateException("OnWriteBodyContents"));
+            }
+        }
+
+        protected override void OnWriteMessage(XmlDictionaryWriter writer)
+        {
+            // For Kerb one shot, the channel binding will be need to be fished out of the message, cached and added to the
+            // token before calling ISC.
+
+            AttachChannelBindingTokenIfFound();
+
+            EnsureUniqueSecurityApplication();
+
+            MessagePrefixGenerator prefixGenerator = new MessagePrefixGenerator(writer);
+            _securityHeader.StartSecurityApplication();
+
+            this.Headers.Add(_securityHeader);
+
+            this.InnerMessage.WriteStartEnvelope(writer);
+
+            this.Headers.RemoveAt(this.Headers.Count - 1);
+
+            _securityHeader.ApplyBodySecurity(writer, prefixGenerator);
+
+            this.InnerMessage.WriteStartHeaders(writer);
+            _securityHeader.ApplySecurityAndWriteHeaders(this.Headers, writer, prefixGenerator);
+
+            _securityHeader.RemoveSignatureEncryptionIfAppropriate();
+
+            _securityHeader.CompleteSecurityApplication();
+            _securityHeader.WriteHeader(writer, this.Version);
+            writer.WriteEndElement();
+
+            if (_fullBodyFragment != null)
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+                //((IFragmentCapableXmlDictionaryWriter)writer).WriteFragment(this.fullBodyFragment, 0, _fullBodyFragmentLength);
+            }
+            else
+            {
+                if (_startBodyFragment != null)
+                {
+                    throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+                    //((IFragmentCapableXmlDictionaryWriter)writer).WriteFragment(this.startBodyFragment.GetBuffer(), 0, (int)this.startBodyFragment.Length);
+                }
+                else
+                {
+                    OnWriteStartBody(writer);
+                }
+
+                OnWriteBodyContents(writer);
+
+                if (_endBodyFragment != null)
+                {
+                    throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+                    //((IFragmentCapableXmlDictionaryWriter)writer).WriteFragment(_endBodyFragment.GetBuffer(), 0, (int)this.endBodyFragment.Length);
+                }
+                else
+                {
+                    writer.WriteEndElement();
+                }
+            }
+
+            writer.WriteEndElement();
+        }
+
+        void AttachChannelBindingTokenIfFound()
+        {
+            ChannelBindingMessageProperty cbmp = null;
+            ChannelBindingMessageProperty.TryGet(this.InnerMessage, out cbmp);
+
+            if (cbmp != null)
+            {
+                if (_securityHeader.ElementContainer != null && _securityHeader.ElementContainer.EndorsingSupportingTokens != null)
+                {
+                    foreach (SecurityToken token in _securityHeader.ElementContainer.EndorsingSupportingTokens)
+                    {
+                        ProviderBackedSecurityToken pbst = token as ProviderBackedSecurityToken;
+                        if (pbst != null)
+                        {
+                            pbst.ChannelBinding = cbmp.ChannelBinding;
+                        }
+                    }
+                }
+            }
+        }
+
+        void SetBodyId()
+        {
+            _bodyId = this.InnerMessage.GetBodyAttribute(
+                UtilityStrings.IdAttribute,
+                _securityHeader.StandardsManager.IdManager.DefaultIdNamespaceUri);
+            if (_bodyId == null)
+            {
+                _bodyId = _securityHeader.GenerateId();
+                _bodyIdInserted = true;
+            }
+        }
+
+        public void WriteBodyToEncrypt(EncryptedData encryptedData, SymmetricAlgorithm algorithm)
+        {
+            encryptedData.Id = _securityHeader.GenerateId();
+
+            BodyContentHelper helper = new BodyContentHelper();
+            XmlDictionaryWriter encryptingWriter = helper.CreateWriter();
+            this.InnerMessage.WriteBodyContents(encryptingWriter);
+            encryptedData.SetUpEncryption(algorithm, helper.ExtractResult());
+            _encryptedBodyContent = encryptedData;
+
+            _state = BodyState.Encrypted;
+        }
+
+        public void WriteBodyToEncryptThenSign(Stream canonicalStream, EncryptedData encryptedData, SymmetricAlgorithm algorithm)
+        {
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+
+            //encryptedData.Id = this.securityHeader.GenerateId();
+            //SetBodyId();
+
+            //XmlDictionaryWriter encryptingWriter = XmlDictionaryWriter.CreateTextWriter(Stream.Null);
+            //// The XmlSerializer body formatter would add a
+            //// document declaration to the body fragment when a fresh writer 
+            //// is provided. Hence, insert a dummy element here and capture 
+            //// the body contents as a fragment.
+            //encryptingWriter.WriteStartElement("a");
+            //MemoryStream ms = new MemoryStream();
+            //((IFragmentCapableXmlDictionaryWriter)encryptingWriter).StartFragment(ms, true);
+
+            //this.InnerMessage.WriteBodyContents(encryptingWriter);
+            //((IFragmentCapableXmlDictionaryWriter)encryptingWriter).EndFragment();
+            //encryptingWriter.WriteEndElement();
+            //ms.Flush();
+            //encryptedData.SetUpEncryption(algorithm, new ArraySegment<byte>(ms.GetBuffer(), 0, (int) ms.Length));
+
+            //this.fullBodyBuffer = new XmlBuffer(int.MaxValue);
+            //XmlDictionaryWriter canonicalWriter = this.fullBodyBuffer.OpenSection(XmlDictionaryReaderQuotas.Max);
+
+            //canonicalWriter.StartCanonicalization(canonicalStream, false, null);
+            //WriteStartInnerMessageWithId(canonicalWriter);
+            //encryptedData.WriteTo(canonicalWriter, ServiceModelDictionaryManager.Instance);
+            //canonicalWriter.WriteEndElement();
+            //canonicalWriter.EndCanonicalization();
+            //canonicalWriter.Flush();
+
+            //this.fullBodyBuffer.CloseSection();
+            //this.fullBodyBuffer.Close();
+
+            //this.state = BodyState.EncryptedThenSigned;
+        }
+
+        public void WriteBodyToSign(Stream canonicalStream)
+        {
+            SetBodyId();
+
+            _fullBodyBuffer = new XmlBuffer(int.MaxValue);
+            XmlDictionaryWriter canonicalWriter = _fullBodyBuffer.OpenSection(XmlDictionaryReaderQuotas.Max);
+            canonicalWriter.StartCanonicalization(canonicalStream, false, null);
+            WriteInnerMessageWithId(canonicalWriter);
+            canonicalWriter.EndCanonicalization();
+            canonicalWriter.Flush();
+            _fullBodyBuffer.CloseSection();
+            _fullBodyBuffer.Close();
+
+            _state = BodyState.Signed;
+        }
+
+        public void WriteBodyToSignThenEncrypt(Stream canonicalStream, EncryptedData encryptedData, SymmetricAlgorithm algorithm)
+        {
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+
+            //XmlBuffer buffer = new XmlBuffer(int.MaxValue);
+            //XmlDictionaryWriter fragmentingWriter = buffer.OpenSection(XmlDictionaryReaderQuotas.Max);
+            //WriteBodyToSignThenEncryptWithFragments(canonicalStream, false, null, encryptedData, algorithm, fragmentingWriter);
+            //((IFragmentCapableXmlDictionaryWriter)fragmentingWriter).WriteFragment(this.startBodyFragment.GetBuffer(), 0, (int)this.startBodyFragment.Length);
+            //((IFragmentCapableXmlDictionaryWriter)fragmentingWriter).WriteFragment(this.endBodyFragment.GetBuffer(), 0, (int)this.endBodyFragment.Length);
+            //buffer.CloseSection();
+            //buffer.Close();
+
+            //this.startBodyFragment = null;
+            //this.endBodyFragment = null;
+
+            //XmlDictionaryReader reader = buffer.GetReader(0);
+            //reader.MoveToContent();
+            //this.bodyPrefix = reader.Prefix;
+            //if (reader.HasAttributes)
+            //{
+            //    this.bodyAttributes = XmlAttributeHolder.ReadAttributes(reader);
+            //}
+            //reader.Close();
+        }
+
+        public void WriteBodyToSignThenEncryptWithFragments(
+            Stream stream, bool includeComments, string[] inclusivePrefixes,
+            EncryptedData encryptedData, SymmetricAlgorithm algorithm, XmlDictionaryWriter writer)
+        {
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+
+            //IFragmentCapableXmlDictionaryWriter fragmentingWriter = (IFragmentCapableXmlDictionaryWriter) writer;
+
+            //SetBodyId();
+            //encryptedData.Id = this.securityHeader.GenerateId();
+
+            //this.startBodyFragment = new MemoryStream();
+            //BufferedOutputStream bodyContentFragment = new BufferManagerOutputStream(SR.XmlBufferQuotaExceeded, 1024, int.MaxValue, this.securityHeader.StreamBufferManager);
+            //this.endBodyFragment = new MemoryStream();
+
+            //writer.StartCanonicalization(stream, includeComments, inclusivePrefixes);
+
+            //fragmentingWriter.StartFragment(this.startBodyFragment, false);
+            //WriteStartInnerMessageWithId(writer);
+            //fragmentingWriter.EndFragment();
+
+            //fragmentingWriter.StartFragment(bodyContentFragment, true);
+            //this.InnerMessage.WriteBodyContents(writer);
+            //fragmentingWriter.EndFragment();
+
+            //fragmentingWriter.StartFragment(this.endBodyFragment, false);
+            //writer.WriteEndElement();
+            //fragmentingWriter.EndFragment();
+
+            //writer.EndCanonicalization();
+
+            //int bodyLength;
+            //byte[] bodyBuffer = bodyContentFragment.ToArray(out bodyLength);
+
+            //encryptedData.SetUpEncryption(algorithm, new ArraySegment<byte>(bodyBuffer, 0, bodyLength));
+            //this.encryptedBodyContent = encryptedData;
+
+            //this.state = BodyState.SignedThenEncrypted;
+        }
+
+        public void WriteBodyToSignWithFragments(Stream stream, bool includeComments, string[] inclusivePrefixes, XmlDictionaryWriter writer)
+        {
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+
+            //IFragmentCapableXmlDictionaryWriter fragmentingWriter = (IFragmentCapableXmlDictionaryWriter) writer;
+
+            //SetBodyId();
+            //BufferedOutputStream fullBodyFragment = new BufferManagerOutputStream(SR.XmlBufferQuotaExceeded, 1024, int.MaxValue, this.securityHeader.StreamBufferManager);
+            //writer.StartCanonicalization(stream, includeComments, inclusivePrefixes);
+            //fragmentingWriter.StartFragment(fullBodyFragment, false);
+            //WriteStartInnerMessageWithId(writer);
+            //this.InnerMessage.WriteBodyContents(writer);
+            //writer.WriteEndElement();
+            //fragmentingWriter.EndFragment();
+            //writer.EndCanonicalization();
+
+            //this.fullBodyFragment = fullBodyFragment.ToArray(out this.fullBodyFragmentLength);
+
+            //this.state = BodyState.Signed;
+        }
+
+        void WriteInnerMessageWithId(XmlDictionaryWriter writer)
+        {
+            WriteStartInnerMessageWithId(writer);
+            this.InnerMessage.WriteBodyContents(writer);
+            writer.WriteEndElement();
+        }
+
+        void WriteStartInnerMessageWithId(XmlDictionaryWriter writer)
+        {
+            this.InnerMessage.WriteStartBody(writer);
+            if (_bodyIdInserted)
+            {
+                _securityHeader.StandardsManager.IdManager.WriteIdAttribute(writer, _bodyId);
+            }
+        }
+
+        enum BodyState
+        {
+            Created,
+            Signed,
+            SignedThenEncrypted,
+            EncryptedThenSigned,
+            Encrypted,
+            Disposed,
+        }
+
+        struct BodyContentHelper
+        {
+            MemoryStream stream;
+            XmlDictionaryWriter writer;
+
+            public XmlDictionaryWriter CreateWriter()
+            {
+                this.stream = new MemoryStream();
+                this.writer = XmlDictionaryWriter.CreateTextWriter(stream);
+                return this.writer;
+            }
+
+            public ArraySegment<byte> ExtractResult()
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+
+                //this.writer.Flush();
+                //return new ArraySegment<byte>(this.stream.GetBuffer(), 0, (int) this.stream.Length);
+            }
+        }
+
+        sealed class MessagePrefixGenerator : IPrefixGenerator
+        {
+            XmlWriter writer;
+
+            public MessagePrefixGenerator(XmlWriter writer)
+            {
+                this.writer = writer;
+            }
+
+            public string GetPrefix(string namespaceUri, int depth, bool isForAttribute)
+            {
+                return this.writer.LookupPrefix(namespaceUri);
+            }
+        }
+    }
+}
+

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SecurityAuditHelper.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SecurityAuditHelper.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.ServiceModel.Channels;
 
 namespace System.ServiceModel.Security
 {
@@ -14,5 +15,16 @@ namespace System.ServiceModel.Security
                 return false;
             }
         }
+
+        public static void WriteMessageAuthenticationSuccessEvent(AuditLogLocation auditLogLocation, bool suppressAuditFailure, Message message,
+                                                                  Uri serviceUri, string action, string clientIdentity)
+        {
+        }
+
+        public static void WriteMessageAuthenticationFailureEvent(AuditLogLocation auditLogLocation, bool suppressAuditFailure, Message message,
+                                                                  Uri serviceUri, string action, string clientIdentity, Exception exception)
+        {
+        }
     }
 }
+

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SecurityChannel.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SecurityChannel.cs
@@ -5,6 +5,7 @@
 
 using System.Runtime;
 using System.ServiceModel.Channels;
+using System.Threading.Tasks;
 
 namespace System.ServiceModel.Security
 {
@@ -90,6 +91,22 @@ namespace System.ServiceModel.Security
                 _securityProtocol.Close(false, timeoutHelper.RemainingTime());
             }
             base.OnClose(timeoutHelper.RemainingTime());
+        }
+
+        protected internal override Task OnCloseAsync(TimeSpan timeout)
+        {
+            return OnCloseAsyncInternal(timeout);
+        }
+
+        private async Task OnCloseAsyncInternal(TimeSpan timeout)
+        {
+            TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
+            if (_securityProtocol != null)
+            {
+                await _securityProtocol.CloseAsync(false, timeoutHelper.RemainingTime());
+            }
+
+            await base.OnCloseAsync(timeoutHelper.RemainingTime());
         }
 
         protected void ThrowIfDisposedOrNotOpen(Message message)

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SecurityContextKeyIdentifierClause.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SecurityContextKeyIdentifierClause.cs
@@ -2,16 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Globalization;
+using System.IdentityModel.Tokens;
+using System.Xml;
 
 namespace System.ServiceModel.Security
 {
-    using System.Globalization;
-    using System.IdentityModel.Tokens;
-    using System.Runtime.CompilerServices;
-    using System.Xml;
-    using DiagnosticUtility = System.ServiceModel.DiagnosticUtility;
-
-    [TypeForwardedFrom("System.ServiceModel, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public class SecurityContextKeyIdentifierClause : SecurityKeyIdentifierClause
     {
         private readonly UniqueId _contextId;

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SecurityProtocol.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SecurityProtocol.cs
@@ -2,19 +2,17 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Diagnostics;
 using System.IdentityModel.Policy;
 using System.IdentityModel.Selectors;
 using System.IdentityModel.Tokens;
 using System.Runtime;
-using System.ServiceModel;
 using System.ServiceModel.Channels;
 using System.ServiceModel.Description;
 using System.ServiceModel.Diagnostics;
 using System.ServiceModel.Security.Tokens;
+using System.Threading.Tasks;
 
 namespace System.ServiceModel.Security
 {
@@ -30,40 +28,1090 @@ namespace System.ServiceModel.Security
     // of simple return values.
     internal abstract class SecurityProtocol : ISecurityCommunicationObject
     {
-        private WrapperSecurityCommunicationObject _communicationObject;
+        static ReadOnlyCollection<SupportingTokenProviderSpecification> emptyTokenProviders;
+
+        ICollection<SupportingTokenProviderSpecification> channelSupportingTokenProviderSpecification;
+        Dictionary<string, ICollection<SupportingTokenProviderSpecification>> scopedSupportingTokenProviderSpecification;
+        Dictionary<string, Collection<SupportingTokenProviderSpecification>> mergedSupportingTokenProvidersMap;
+        SecurityProtocolFactory factory;
+        EndpointAddress target;
+        Uri via;
+        WrapperSecurityCommunicationObject communicationObject;
+        ChannelParameterCollection channelParameters;
+
+        protected SecurityProtocol(SecurityProtocolFactory factory, EndpointAddress target, Uri via)
+        {
+            this.factory = factory;
+            this.target = target;
+            this.via = via;
+            this.communicationObject = new WrapperSecurityCommunicationObject(this);
+        }
+
+        protected WrapperSecurityCommunicationObject CommunicationObject
+        {
+            get { return this.communicationObject; }
+        }
+
+        public SecurityProtocolFactory SecurityProtocolFactory
+        {
+            get { return this.factory; }
+        }
+
+        public EndpointAddress Target
+        {
+            get { return this.target; }
+        }
+
+        public Uri Via
+        {
+            get { return this.via; }
+        }
+
+        public ICollection<SupportingTokenProviderSpecification> ChannelSupportingTokenProviderSpecification
+        {
+            get
+            {
+                return this.channelSupportingTokenProviderSpecification;
+            }
+        }
+
+        public Dictionary<string, ICollection<SupportingTokenProviderSpecification>> ScopedSupportingTokenProviderSpecification
+        {
+            get
+            {
+                return this.scopedSupportingTokenProviderSpecification;
+            }
+        }
+
+        static ReadOnlyCollection<SupportingTokenProviderSpecification> EmptyTokenProviders
+        {
+            get
+            {
+                if (emptyTokenProviders == null)
+                {
+                    emptyTokenProviders = new ReadOnlyCollection<SupportingTokenProviderSpecification>(new List<SupportingTokenProviderSpecification>());
+                }
+                return emptyTokenProviders;
+            }
+        }
+
+        public ChannelParameterCollection ChannelParameters
+        {
+            get
+            {
+                return this.channelParameters;
+            }
+            set
+            {
+                this.communicationObject.ThrowIfDisposedOrImmutable();
+                this.channelParameters = value;
+            }
+        }
+
+        // ISecurityCommunicationObject members
+        public TimeSpan DefaultOpenTimeout
+        {
+            get { return ServiceDefaults.OpenTimeout; }
+        }
 
         public TimeSpan DefaultCloseTimeout
         {
-            get { throw ExceptionHelper.PlatformNotSupported(); }
+            get { return ServiceDefaults.CloseTimeout; }
         }
 
-        public TimeSpan DefaultOpenTimeout
+
+        public Task CloseAsync(TimeSpan timeout)
         {
-            get { throw ExceptionHelper.PlatformNotSupported(); }
+            return ((IAsyncCommunicationObject)this.communicationObject).CloseAsync(timeout);
         }
 
-        public void OnAbort() { throw ExceptionHelper.PlatformNotSupported(); }
-        public IAsyncResult OnBeginClose(TimeSpan timeout, AsyncCallback callback, object state) { throw ExceptionHelper.PlatformNotSupported(); }
-        public IAsyncResult OnBeginOpen(TimeSpan timeout, AsyncCallback callback, object state) { throw ExceptionHelper.PlatformNotSupported(); }
-        public void OnClose(TimeSpan timeout) { throw ExceptionHelper.PlatformNotSupported(); }
-        public void OnClosed() { throw ExceptionHelper.PlatformNotSupported(); }
-        public void OnClosing() { throw ExceptionHelper.PlatformNotSupported(); }
-        public void OnEndClose(IAsyncResult result) { throw ExceptionHelper.PlatformNotSupported(); }
-        public void OnEndOpen(IAsyncResult result) { throw ExceptionHelper.PlatformNotSupported(); }
-        public void OnFaulted() { throw ExceptionHelper.PlatformNotSupported(); }
-        public void OnOpen(TimeSpan timeout) { throw ExceptionHelper.PlatformNotSupported(); }
-        public void OnOpened() { throw ExceptionHelper.PlatformNotSupported(); }
-        public void OnOpening() { throw ExceptionHelper.PlatformNotSupported(); }
+        public Task OpenAsync(TimeSpan timeout)
+        {
+            return ((IAsyncCommunicationObject)this.communicationObject).OpenAsync(timeout);
+        }
+
+        public void OnClosed()
+        {
+        }
+
+        public void OnClosing()
+        {
+        }
+
+        public void OnEndClose(IAsyncResult result)
+        {
+            OperationWithTimeoutAsyncResult.End(result);
+        }
+
+        public void OnEndOpen(IAsyncResult result)
+        {
+            OperationWithTimeoutAsyncResult.End(result);
+        }
+
+        public void OnFaulted()
+        {
+        }
+
+        public void OnOpened()
+        {
+        }
+
+        public void OnOpening()
+        {
+        }
+
+        internal IList<SupportingTokenProviderSpecification> GetSupportingTokenProviders(string action)
+        {
+            if (this.mergedSupportingTokenProvidersMap != null && this.mergedSupportingTokenProvidersMap.Count > 0)
+            {
+                if (action != null && this.mergedSupportingTokenProvidersMap.ContainsKey(action))
+                {
+                    return this.mergedSupportingTokenProvidersMap[action];
+                }
+                else if (this.mergedSupportingTokenProvidersMap.ContainsKey(MessageHeaders.WildcardAction))
+                {
+                    return this.mergedSupportingTokenProvidersMap[MessageHeaders.WildcardAction];
+                }
+            }
+            // return null if the token providers list is empty - this gets a perf benefit since calling Count is expensive for an empty
+            // ReadOnlyCollection
+            return (this.channelSupportingTokenProviderSpecification == EmptyTokenProviders) ? null : (IList<SupportingTokenProviderSpecification>)this.channelSupportingTokenProviderSpecification;
+        }
+
+        protected InitiatorServiceModelSecurityTokenRequirement CreateInitiatorSecurityTokenRequirement()
+        {
+            InitiatorServiceModelSecurityTokenRequirement requirement = new InitiatorServiceModelSecurityTokenRequirement();
+            requirement.TargetAddress = this.Target;
+            requirement.Via = this.via;
+            requirement.SecurityBindingElement = this.factory.SecurityBindingElement;
+            requirement.SecurityAlgorithmSuite = this.factory.OutgoingAlgorithmSuite;
+            requirement.MessageSecurityVersion = this.factory.MessageSecurityVersion.SecurityTokenVersion;
+            if (this.factory.PrivacyNoticeUri != null)
+            {
+                requirement.Properties[ServiceModelSecurityTokenRequirement.PrivacyNoticeUriProperty] = this.factory.PrivacyNoticeUri;
+            }
+            if (this.channelParameters != null)
+            {
+                requirement.Properties[ServiceModelSecurityTokenRequirement.ChannelParametersCollectionProperty] = this.channelParameters;
+            }
+
+            requirement.Properties[ServiceModelSecurityTokenRequirement.PrivacyNoticeVersionProperty] = this.factory.PrivacyNoticeVersion;
+
+            return requirement;
+        }
+
+        InitiatorServiceModelSecurityTokenRequirement CreateInitiatorSecurityTokenRequirement(SecurityTokenParameters parameters, SecurityTokenAttachmentMode attachmentMode)
+        {
+            InitiatorServiceModelSecurityTokenRequirement requirement = CreateInitiatorSecurityTokenRequirement();
+            parameters.InitializeSecurityTokenRequirement(requirement);
+            requirement.KeyUsage = SecurityKeyUsage.Signature;
+            requirement.Properties[ServiceModelSecurityTokenRequirement.MessageDirectionProperty] = MessageDirection.Output;
+            requirement.Properties[ServiceModelSecurityTokenRequirement.SupportingTokenAttachmentModeProperty] = attachmentMode;
+            return requirement;
+        }
+
+        void AddSupportingTokenProviders(SupportingTokenParameters supportingTokenParameters, bool isOptional, IList<SupportingTokenProviderSpecification> providerSpecList)
+        {
+            for (int i = 0; i < supportingTokenParameters.Endorsing.Count; ++i)
+            {
+                SecurityTokenRequirement requirement = this.CreateInitiatorSecurityTokenRequirement(supportingTokenParameters.Endorsing[i], SecurityTokenAttachmentMode.Endorsing);
+                try
+                {
+                    if (isOptional)
+                    {
+                        requirement.IsOptionalToken = true;
+                    }
+                    System.IdentityModel.Selectors.SecurityTokenProvider provider = this.factory.SecurityTokenManager.CreateSecurityTokenProvider(requirement);
+                    if (provider == null)
+                    {
+                        continue;
+                    }
+                    SupportingTokenProviderSpecification providerSpec = new SupportingTokenProviderSpecification(provider, SecurityTokenAttachmentMode.Endorsing, supportingTokenParameters.Endorsing[i]);
+                    providerSpecList.Add(providerSpec);
+                }
+                catch (Exception e)
+                {
+                    if (!isOptional || Fx.IsFatal(e))
+                    {
+                        throw;
+                    }
+                }
+            }
+            for (int i = 0; i < supportingTokenParameters.SignedEndorsing.Count; ++i)
+            {
+                SecurityTokenRequirement requirement = this.CreateInitiatorSecurityTokenRequirement(supportingTokenParameters.SignedEndorsing[i], SecurityTokenAttachmentMode.SignedEndorsing);
+                try
+                {
+                    if (isOptional)
+                    {
+                        requirement.IsOptionalToken = true;
+                    }
+                    System.IdentityModel.Selectors.SecurityTokenProvider provider = this.factory.SecurityTokenManager.CreateSecurityTokenProvider(requirement);
+                    if (provider == null)
+                    {
+                        continue;
+                    }
+                    SupportingTokenProviderSpecification providerSpec = new SupportingTokenProviderSpecification(provider, SecurityTokenAttachmentMode.SignedEndorsing, supportingTokenParameters.SignedEndorsing[i]);
+                    providerSpecList.Add(providerSpec);
+                }
+                catch (Exception e)
+                {
+                    if (!isOptional || Fx.IsFatal(e))
+                    {
+                        throw;
+                    }
+                }
+            }
+            for (int i = 0; i < supportingTokenParameters.SignedEncrypted.Count; ++i)
+            {
+                SecurityTokenRequirement requirement = this.CreateInitiatorSecurityTokenRequirement(supportingTokenParameters.SignedEncrypted[i], SecurityTokenAttachmentMode.SignedEncrypted);
+                try
+                {
+                    if (isOptional)
+                    {
+                        requirement.IsOptionalToken = true;
+                    }
+                    System.IdentityModel.Selectors.SecurityTokenProvider provider = this.factory.SecurityTokenManager.CreateSecurityTokenProvider(requirement);
+                    if (provider == null)
+                    {
+                        continue;
+                    }
+                    SupportingTokenProviderSpecification providerSpec = new SupportingTokenProviderSpecification(provider, SecurityTokenAttachmentMode.SignedEncrypted, supportingTokenParameters.SignedEncrypted[i]);
+                    providerSpecList.Add(providerSpec);
+                }
+                catch (Exception e)
+                {
+                    if (!isOptional || Fx.IsFatal(e))
+                    {
+                        throw;
+                    }
+                }
+            }
+            for (int i = 0; i < supportingTokenParameters.Signed.Count; ++i)
+            {
+                SecurityTokenRequirement requirement = this.CreateInitiatorSecurityTokenRequirement(supportingTokenParameters.Signed[i], SecurityTokenAttachmentMode.Signed);
+                try
+                {
+                    if (isOptional)
+                    {
+                        requirement.IsOptionalToken = true;
+                    }
+                    System.IdentityModel.Selectors.SecurityTokenProvider provider = this.factory.SecurityTokenManager.CreateSecurityTokenProvider(requirement);
+                    if (provider == null)
+                    {
+                        continue;
+                    }
+                    SupportingTokenProviderSpecification providerSpec = new SupportingTokenProviderSpecification(provider, SecurityTokenAttachmentMode.Signed, supportingTokenParameters.Signed[i]);
+                    providerSpecList.Add(providerSpec);
+                }
+                catch (Exception e)
+                {
+                    if (!isOptional || Fx.IsFatal(e))
+                    {
+                        throw;
+                    }
+                }
+            }
+        }
+
+        void MergeSupportingTokenProviders(TimeSpan timeout)
+        {
+            if (this.ScopedSupportingTokenProviderSpecification.Count == 0)
+            {
+                this.mergedSupportingTokenProvidersMap = null;
+            }
+            else
+            {
+                TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
+                this.factory.ExpectSupportingTokens = true;
+                this.mergedSupportingTokenProvidersMap = new Dictionary<string, Collection<SupportingTokenProviderSpecification>>();
+                foreach (string action in this.ScopedSupportingTokenProviderSpecification.Keys)
+                {
+                    ICollection<SupportingTokenProviderSpecification> scopedProviders = this.ScopedSupportingTokenProviderSpecification[action];
+                    if (scopedProviders == null || scopedProviders.Count == 0)
+                    {
+                        continue;
+                    }
+                    Collection<SupportingTokenProviderSpecification> mergedProviders = new Collection<SupportingTokenProviderSpecification>();
+                    foreach (SupportingTokenProviderSpecification spec in this.channelSupportingTokenProviderSpecification)
+                    {
+                        mergedProviders.Add(spec);
+                    }
+                    foreach (SupportingTokenProviderSpecification spec in scopedProviders)
+                    {
+                        SecurityUtils.OpenTokenProviderIfRequired(spec.TokenProvider, timeoutHelper.RemainingTime());
+                        if (spec.SecurityTokenAttachmentMode == SecurityTokenAttachmentMode.Endorsing || spec.SecurityTokenAttachmentMode == SecurityTokenAttachmentMode.SignedEndorsing)
+                        {
+                            if (spec.TokenParameters.RequireDerivedKeys && !spec.TokenParameters.HasAsymmetricKey)
+                            {
+                                this.factory.ExpectKeyDerivation = true;
+                            }
+                        }
+                        mergedProviders.Add(spec);
+                    }
+                    this.mergedSupportingTokenProvidersMap.Add(action, mergedProviders);
+                }
+            }
+        }
+
+        private async Task MergeSupportingTokenProvidersAsync(TimeSpan timeout)
+        {
+            if (this.ScopedSupportingTokenProviderSpecification.Count == 0)
+            {
+                this.mergedSupportingTokenProvidersMap = null;
+            }
+            else
+            {
+                TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
+                this.factory.ExpectSupportingTokens = true;
+                this.mergedSupportingTokenProvidersMap = new Dictionary<string, Collection<SupportingTokenProviderSpecification>>();
+                foreach (string action in this.ScopedSupportingTokenProviderSpecification.Keys)
+                {
+                    ICollection<SupportingTokenProviderSpecification> scopedProviders = this.ScopedSupportingTokenProviderSpecification[action];
+                    if (scopedProviders == null || scopedProviders.Count == 0)
+                    {
+                        continue;
+                    }
+                    Collection<SupportingTokenProviderSpecification> mergedProviders = new Collection<SupportingTokenProviderSpecification>();
+                    foreach (SupportingTokenProviderSpecification spec in this.channelSupportingTokenProviderSpecification)
+                    {
+                        mergedProviders.Add(spec);
+                    }
+                    foreach (SupportingTokenProviderSpecification spec in scopedProviders)
+                    {
+                        await SecurityUtils.OpenTokenProviderIfRequiredAsync(spec.TokenProvider, timeoutHelper.RemainingTime());
+                        if (spec.SecurityTokenAttachmentMode == SecurityTokenAttachmentMode.Endorsing || spec.SecurityTokenAttachmentMode == SecurityTokenAttachmentMode.SignedEndorsing)
+                        {
+                            if (spec.TokenParameters.RequireDerivedKeys && !spec.TokenParameters.HasAsymmetricKey)
+                            {
+                                this.factory.ExpectKeyDerivation = true;
+                            }
+                        }
+                        mergedProviders.Add(spec);
+                    }
+                    this.mergedSupportingTokenProvidersMap.Add(action, mergedProviders);
+                }
+            }
+        }
+
+        public void Open(TimeSpan timeout)
+        {
+            this.communicationObject.Open(timeout);
+        }
+
+        public virtual void OnOpen(TimeSpan timeout)
+        {
+            TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
+            if (this.factory.ActAsInitiator)
+            {
+                throw ExceptionHelper.PlatformNotSupported("SecurityProtocol OnOpen ActAsInitiator not supported.");
+
+                //this.channelSupportingTokenProviderSpecification = new Collection<SupportingTokenProviderSpecification>();
+                //this.scopedSupportingTokenProviderSpecification = new Dictionary<string, ICollection<SupportingTokenProviderSpecification>>();
+
+                //AddSupportingTokenProviders(this.factory.SecurityBindingElement.EndpointSupportingTokenParameters, false, (IList<SupportingTokenProviderSpecification>)this.channelSupportingTokenProviderSpecification);
+                //AddSupportingTokenProviders(this.factory.SecurityBindingElement.OptionalEndpointSupportingTokenParameters, true, (IList<SupportingTokenProviderSpecification>)this.channelSupportingTokenProviderSpecification);
+                //foreach (string action in this.factory.SecurityBindingElement.OperationSupportingTokenParameters.Keys)
+                //{
+                //    Collection<SupportingTokenProviderSpecification> providerSpecList = new Collection<SupportingTokenProviderSpecification>();
+                //    AddSupportingTokenProviders(this.factory.SecurityBindingElement.OperationSupportingTokenParameters[action], false, providerSpecList);
+                //    this.scopedSupportingTokenProviderSpecification.Add(action, providerSpecList);
+                //}
+                //foreach (string action in this.factory.SecurityBindingElement.OptionalOperationSupportingTokenParameters.Keys)
+                //{
+                //    Collection<SupportingTokenProviderSpecification> providerSpecList;
+                //    ICollection<SupportingTokenProviderSpecification> existingList;
+                //    if (this.scopedSupportingTokenProviderSpecification.TryGetValue(action, out existingList))
+                //    {
+                //        providerSpecList = ((Collection<SupportingTokenProviderSpecification>)existingList);
+                //    }
+                //    else
+                //    {
+                //        providerSpecList = new Collection<SupportingTokenProviderSpecification>();
+                //        this.scopedSupportingTokenProviderSpecification.Add(action, providerSpecList);
+                //    }
+                //    this.AddSupportingTokenProviders(this.factory.SecurityBindingElement.OptionalOperationSupportingTokenParameters[action], true, providerSpecList);
+                //}
+
+                //if (!this.channelSupportingTokenProviderSpecification.IsReadOnly)
+                //{
+                //    if (this.channelSupportingTokenProviderSpecification.Count == 0)
+                //    {
+                //        this.channelSupportingTokenProviderSpecification = EmptyTokenProviders;
+                //    }
+                //    else
+                //    {
+                //        this.factory.ExpectSupportingTokens = true;
+                //        foreach (SupportingTokenProviderSpecification tokenProviderSpec in this.channelSupportingTokenProviderSpecification)
+                //        {
+                //            SecurityUtils.OpenTokenProviderIfRequired(tokenProviderSpec.TokenProvider, timeoutHelper.RemainingTime());
+                //            if (tokenProviderSpec.SecurityTokenAttachmentMode == SecurityTokenAttachmentMode.Endorsing || tokenProviderSpec.SecurityTokenAttachmentMode == SecurityTokenAttachmentMode.SignedEndorsing)
+                //            {
+                //                if (tokenProviderSpec.TokenParameters.RequireDerivedKeys && !tokenProviderSpec.TokenParameters.HasAsymmetricKey)
+                //                {
+                //                    this.factory.ExpectKeyDerivation = true;
+                //                }
+                //            }
+                //        }
+                //        this.channelSupportingTokenProviderSpecification =
+                //            new ReadOnlyCollection<SupportingTokenProviderSpecification>((Collection<SupportingTokenProviderSpecification>)this.channelSupportingTokenProviderSpecification);
+                //    }
+                //}
+                //// create a merged map of the per operation supporting tokens
+                //MergeSupportingTokenProviders(timeoutHelper.RemainingTime());
+            }
+        }
+
+        public virtual Task OnOpenAsync(TimeSpan timeout)
+        {
+            return OnOpenAsyncInternal(timeout);
+        }
+
+        private async Task OnOpenAsyncInternal(TimeSpan timeout)
+        {
+            TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
+            if (this.factory.ActAsInitiator)
+            {
+                this.channelSupportingTokenProviderSpecification = new Collection<SupportingTokenProviderSpecification>();
+                this.scopedSupportingTokenProviderSpecification = new Dictionary<string, ICollection<SupportingTokenProviderSpecification>>();
+
+                AddSupportingTokenProviders(this.factory.SecurityBindingElement.EndpointSupportingTokenParameters, false, (IList<SupportingTokenProviderSpecification>)this.channelSupportingTokenProviderSpecification);
+                AddSupportingTokenProviders(this.factory.SecurityBindingElement.OptionalEndpointSupportingTokenParameters, true, (IList<SupportingTokenProviderSpecification>)this.channelSupportingTokenProviderSpecification);
+                foreach (string action in this.factory.SecurityBindingElement.OperationSupportingTokenParameters.Keys)
+                {
+                    Collection<SupportingTokenProviderSpecification> providerSpecList = new Collection<SupportingTokenProviderSpecification>();
+                    AddSupportingTokenProviders(this.factory.SecurityBindingElement.OperationSupportingTokenParameters[action], false, providerSpecList);
+                    this.scopedSupportingTokenProviderSpecification.Add(action, providerSpecList);
+                }
+                foreach (string action in this.factory.SecurityBindingElement.OptionalOperationSupportingTokenParameters.Keys)
+                {
+                    Collection<SupportingTokenProviderSpecification> providerSpecList;
+                    ICollection<SupportingTokenProviderSpecification> existingList;
+                    if (this.scopedSupportingTokenProviderSpecification.TryGetValue(action, out existingList))
+                    {
+                        providerSpecList = ((Collection<SupportingTokenProviderSpecification>)existingList);
+                    }
+                    else
+                    {
+                        providerSpecList = new Collection<SupportingTokenProviderSpecification>();
+                        this.scopedSupportingTokenProviderSpecification.Add(action, providerSpecList);
+                    }
+                    this.AddSupportingTokenProviders(this.factory.SecurityBindingElement.OptionalOperationSupportingTokenParameters[action], true, providerSpecList);
+                }
+
+                if (!this.channelSupportingTokenProviderSpecification.IsReadOnly)
+                {
+                    if (this.channelSupportingTokenProviderSpecification.Count == 0)
+                    {
+                        this.channelSupportingTokenProviderSpecification = EmptyTokenProviders;
+                    }
+                    else
+                    {
+                        this.factory.ExpectSupportingTokens = true;
+                        foreach (SupportingTokenProviderSpecification tokenProviderSpec in this.channelSupportingTokenProviderSpecification)
+                        {
+                            await SecurityUtils.OpenTokenProviderIfRequiredAsync(tokenProviderSpec.TokenProvider, timeoutHelper.RemainingTime());
+                            if (tokenProviderSpec.SecurityTokenAttachmentMode == SecurityTokenAttachmentMode.Endorsing || tokenProviderSpec.SecurityTokenAttachmentMode == SecurityTokenAttachmentMode.SignedEndorsing)
+                            {
+                                if (tokenProviderSpec.TokenParameters.RequireDerivedKeys && !tokenProviderSpec.TokenParameters.HasAsymmetricKey)
+                                {
+                                    this.factory.ExpectKeyDerivation = true;
+                                }
+                            }
+                        }
+                        this.channelSupportingTokenProviderSpecification =
+                            new ReadOnlyCollection<SupportingTokenProviderSpecification>((Collection<SupportingTokenProviderSpecification>)this.channelSupportingTokenProviderSpecification);
+                    }
+                }
+                // create a merged map of the per operation supporting tokens
+                await MergeSupportingTokenProvidersAsync(timeoutHelper.RemainingTime());
+            }
+        }
 
         public void Close(bool aborted, TimeSpan timeout)
         {
             if (aborted)
             {
-                _communicationObject.Abort();
+                this.communicationObject.Abort();
             }
             else
             {
-                _communicationObject.Close(timeout);
+                this.communicationObject.Close(timeout);
+            }
+        }
+
+        public Task CloseAsync(bool aborted, TimeSpan timeout)
+        {
+            if (aborted)
+            {
+                this.communicationObject.Abort();
+                return TaskHelpers.CompletedTask();
+            }
+            else
+            {
+                return ((IAsyncCommunicationObject)this.communicationObject).CloseAsync(timeout);
+            }
+        }
+
+        public virtual void OnAbort()
+        {
+            if (this.factory.ActAsInitiator)
+            {
+                if (this.channelSupportingTokenProviderSpecification != null)
+                {
+                    foreach (SupportingTokenProviderSpecification spec in this.channelSupportingTokenProviderSpecification)
+                    {
+                        SecurityUtils.AbortTokenProviderIfRequired(spec.TokenProvider);
+                    }
+                }
+
+                if (this.scopedSupportingTokenProviderSpecification != null)
+                {
+                    foreach (string action in this.scopedSupportingTokenProviderSpecification.Keys)
+                    {
+                        ICollection<SupportingTokenProviderSpecification> supportingProviders = this.scopedSupportingTokenProviderSpecification[action];
+                        foreach (SupportingTokenProviderSpecification spec in supportingProviders)
+                        {
+                            SecurityUtils.AbortTokenProviderIfRequired(spec.TokenProvider);
+                        }
+                    }
+                }
+            }
+        }
+
+        public virtual void OnClose(TimeSpan timeout)
+        {
+            if (this.factory.ActAsInitiator)
+            {
+                TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
+                foreach (SupportingTokenProviderSpecification spec in this.channelSupportingTokenProviderSpecification)
+                {
+                    SecurityUtils.CloseTokenProviderIfRequired(spec.TokenProvider, timeoutHelper.RemainingTime());
+                }
+                foreach (string action in this.scopedSupportingTokenProviderSpecification.Keys)
+                {
+                    ICollection<SupportingTokenProviderSpecification> supportingProviders = this.scopedSupportingTokenProviderSpecification[action];
+                    foreach (SupportingTokenProviderSpecification spec in supportingProviders)
+                    {
+                        SecurityUtils.CloseTokenProviderIfRequired(spec.TokenProvider, timeoutHelper.RemainingTime());
+                    }
+                }
+            }
+        }
+
+        public virtual Task OnCloseAsync(TimeSpan timeout)
+        {
+            return OnCloseAsyncInternal(timeout);
+        }
+
+        private async Task OnCloseAsyncInternal(TimeSpan timeout)
+        {
+            if (this.factory.ActAsInitiator)
+            {
+                TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
+                foreach (SupportingTokenProviderSpecification spec in this.channelSupportingTokenProviderSpecification)
+                {
+                    await SecurityUtils.CloseTokenProviderIfRequiredAsync(spec.TokenProvider, timeoutHelper.RemainingTime());
+                }
+                foreach (string action in this.scopedSupportingTokenProviderSpecification.Keys)
+                {
+                    ICollection<SupportingTokenProviderSpecification> supportingProviders = this.scopedSupportingTokenProviderSpecification[action];
+                    foreach (SupportingTokenProviderSpecification spec in supportingProviders)
+                    {
+                        await SecurityUtils.CloseTokenProviderIfRequiredAsync(spec.TokenProvider, timeoutHelper.RemainingTime());
+                    }
+                }
+            }
+        }
+
+        public IAsyncResult BeginClose(TimeSpan timeout, AsyncCallback callback, object state)
+        {
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+            //return this.communicationObject.BeginClose(timeout, callback, state);
+        }
+
+        public void EndClose(IAsyncResult result)
+        {
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+            //this.communicationObject.EndClose(result);
+        }
+
+        static void SetSecurityHeaderId(SendSecurityHeader securityHeader, Message message)
+        {
+            SecurityMessageProperty messageProperty = message.Properties.Security;
+            if (messageProperty != null)
+            {
+                securityHeader.IdPrefix = messageProperty.SenderIdPrefix;
+            }
+        }
+
+        void AddSupportingTokenSpecification(SecurityMessageProperty security, IList<SecurityToken> tokens, SecurityTokenAttachmentMode attachmentMode, IDictionary<SecurityToken, ReadOnlyCollection<IAuthorizationPolicy>> tokenPoliciesMapping)
+        {
+            if (tokens == null || tokens.Count == 0)
+            {
+                return;
+            }
+            for (int i = 0; i < tokens.Count; ++i)
+            {
+                security.IncomingSupportingTokens.Add(new SupportingTokenSpecification(tokens[i], tokenPoliciesMapping[tokens[i]], attachmentMode));
+            }
+        }
+
+        protected void AddSupportingTokenSpecification(SecurityMessageProperty security, IList<SecurityToken> basicTokens, IList<SecurityToken> endorsingTokens, IList<SecurityToken> signedEndorsingTokens, IList<SecurityToken> signedTokens, IDictionary<SecurityToken, ReadOnlyCollection<IAuthorizationPolicy>> tokenPoliciesMapping)
+        {
+            AddSupportingTokenSpecification(security, basicTokens, SecurityTokenAttachmentMode.SignedEncrypted, tokenPoliciesMapping);
+            AddSupportingTokenSpecification(security, endorsingTokens, SecurityTokenAttachmentMode.Endorsing, tokenPoliciesMapping);
+            AddSupportingTokenSpecification(security, signedEndorsingTokens, SecurityTokenAttachmentMode.SignedEndorsing, tokenPoliciesMapping);
+            AddSupportingTokenSpecification(security, signedTokens, SecurityTokenAttachmentMode.Signed, tokenPoliciesMapping);
+        }
+
+        protected SendSecurityHeader CreateSendSecurityHeader(Message message, string actor, SecurityProtocolFactory factory)
+        {
+            return CreateSendSecurityHeader(message, actor, factory, true);
+        }
+
+        protected SendSecurityHeader CreateSendSecurityHeaderForTransportProtocol(Message message, string actor, SecurityProtocolFactory factory)
+        {
+            return CreateSendSecurityHeader(message, actor, factory, false);
+        }
+
+        SendSecurityHeader CreateSendSecurityHeader(Message message, string actor, SecurityProtocolFactory factory, bool requireMessageProtection)
+        {
+            // throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+
+            MessageDirection transferDirection = factory.ActAsInitiator ? MessageDirection.Input : MessageDirection.Output;
+            SendSecurityHeader sendSecurityHeader = factory.StandardsManager.CreateSendSecurityHeader(
+                message,
+                actor, true, false,
+                factory.OutgoingAlgorithmSuite, transferDirection);
+            sendSecurityHeader.Layout = factory.SecurityHeaderLayout;
+            sendSecurityHeader.RequireMessageProtection = requireMessageProtection;
+            SetSecurityHeaderId(sendSecurityHeader, message);
+            if (factory.AddTimestamp)
+            {
+                sendSecurityHeader.AddTimestamp(factory.TimestampValidityDuration);
+            }
+
+            sendSecurityHeader.StreamBufferManager = factory.StreamBufferManager;
+            return sendSecurityHeader;
+        }
+
+        internal void AddMessageSupportingTokens(Message message, ref IList<SupportingTokenSpecification> supportingTokens)
+        {
+            SecurityMessageProperty supportingTokensProperty = message.Properties.Security;
+            if (supportingTokensProperty != null && supportingTokensProperty.HasOutgoingSupportingTokens)
+            {
+                if (supportingTokens == null)
+                {
+                    supportingTokens = new Collection<SupportingTokenSpecification>();
+                }
+                for (int i = 0; i < supportingTokensProperty.OutgoingSupportingTokens.Count; ++i)
+                {
+                    SupportingTokenSpecification spec = supportingTokensProperty.OutgoingSupportingTokens[i];
+                    if (spec.SecurityTokenParameters == null)
+                    {
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new MessageSecurityException(SR.Format(SR.SenderSideSupportingTokensMustSpecifySecurityTokenParameters)));
+                    }
+                    supportingTokens.Add(spec);
+                }
+            }
+        }
+
+        internal bool TryGetSupportingTokens(SecurityProtocolFactory factory, EndpointAddress target, Uri via, Message message, TimeSpan timeout, bool isBlockingCall, out IList<SupportingTokenSpecification> supportingTokens)
+        {
+            if (!factory.ActAsInitiator)
+            {
+                supportingTokens = null;
+                return true;
+            }
+            if (message == null)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("message");
+            }
+            TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
+            supportingTokens = null;
+            IList<SupportingTokenProviderSpecification> supportingTokenProviders = this.GetSupportingTokenProviders(message.Headers.Action);
+            if (supportingTokenProviders != null && supportingTokenProviders.Count > 0)
+            {
+                // dont do anything if blocking is not allowed
+                if (!isBlockingCall)
+                {
+                    return false;
+                }
+
+                supportingTokens = new Collection<SupportingTokenSpecification>();
+                for (int i = 0; i < supportingTokenProviders.Count; ++i)
+                {
+                    SupportingTokenProviderSpecification spec = supportingTokenProviders[i];
+                    SecurityToken supportingToken;
+                    // The ProviderBackedSecurityToken was added in Win7 to allow KerberosRequestorSecurity 
+                    // to pass a channel binding to InitializeSecurityContext.
+                    if ((this is TransportSecurityProtocol) && (spec.TokenParameters is KerberosSecurityTokenParameters))
+                    {
+                        supportingToken = new ProviderBackedSecurityToken(spec.TokenProvider, timeoutHelper.RemainingTime());
+                    }
+                    else
+                    {
+                        supportingToken = spec.TokenProvider.GetToken(timeoutHelper.RemainingTime());
+                    }
+
+                    supportingTokens.Add(new SupportingTokenSpecification(supportingToken, EmptyReadOnlyCollection<IAuthorizationPolicy>.Instance, spec.SecurityTokenAttachmentMode, spec.TokenParameters));
+                }
+            }
+            // add any runtime supporting tokens
+            AddMessageSupportingTokens(message, ref supportingTokens);
+
+            return true;
+        }
+
+        protected IList<SupportingTokenAuthenticatorSpecification> GetSupportingTokenAuthenticatorsAndSetExpectationFlags(SecurityProtocolFactory factory, Message message,
+            ReceiveSecurityHeader securityHeader)
+        {
+            if (factory.ActAsInitiator)
+            {
+                return null;
+            }
+            if (message == null)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("message");
+            }
+            bool expectBasicTokens;
+            bool expectSignedTokens;
+            bool expectEndorsingTokens;
+            IList<SupportingTokenAuthenticatorSpecification> authenticators = factory.GetSupportingTokenAuthenticators(message.Headers.Action,
+                out expectSignedTokens, out expectBasicTokens, out expectEndorsingTokens);
+            securityHeader.ExpectBasicTokens = expectBasicTokens;
+            securityHeader.ExpectEndorsingTokens = expectEndorsingTokens;
+            securityHeader.ExpectSignedTokens = expectSignedTokens;
+            return authenticators;
+        }
+
+
+        protected ReadOnlyCollection<SecurityTokenResolver> MergeOutOfBandResolvers(IList<SupportingTokenAuthenticatorSpecification> supportingAuthenticators, ReadOnlyCollection<SecurityTokenResolver> primaryResolvers)
+        {
+            Collection<SecurityTokenResolver> outOfBandResolvers = null;
+            if (supportingAuthenticators != null && supportingAuthenticators.Count > 0)
+            {
+                for (int i = 0; i < supportingAuthenticators.Count; ++i)
+                {
+                    if (supportingAuthenticators[i].TokenResolver != null)
+                    {
+                        outOfBandResolvers = outOfBandResolvers ?? new Collection<SecurityTokenResolver>();
+                        outOfBandResolvers.Add(supportingAuthenticators[i].TokenResolver);
+                    }
+                }
+            }
+            if (outOfBandResolvers != null)
+            {
+                if (primaryResolvers != null)
+                {
+                    for (int i = 0; i < primaryResolvers.Count; ++i)
+                    {
+                        outOfBandResolvers.Insert(0, primaryResolvers[i]);
+                    }
+                }
+                return new ReadOnlyCollection<SecurityTokenResolver>(outOfBandResolvers);
+            }
+            else
+            {
+                return primaryResolvers ?? EmptyReadOnlyCollection<SecurityTokenResolver>.Instance;
+            }
+        }
+
+
+        protected void AddSupportingTokens(SendSecurityHeader securityHeader, IList<SupportingTokenSpecification> supportingTokens)
+        {
+            if (supportingTokens != null)
+            {
+                for (int i = 0; i < supportingTokens.Count; ++i)
+                {
+                    SecurityToken token = supportingTokens[i].SecurityToken;
+                    SecurityTokenParameters tokenParameters = supportingTokens[i].SecurityTokenParameters;
+                    switch (supportingTokens[i].SecurityTokenAttachmentMode)
+                    {
+                        case SecurityTokenAttachmentMode.Signed:
+                            securityHeader.AddSignedSupportingToken(token, tokenParameters);
+                            break;
+                        case SecurityTokenAttachmentMode.Endorsing:
+                            securityHeader.AddEndorsingSupportingToken(token, tokenParameters);
+                            break;
+                        case SecurityTokenAttachmentMode.SignedEncrypted:
+                            securityHeader.AddBasicSupportingToken(token, tokenParameters);
+                            break;
+                        case SecurityTokenAttachmentMode.SignedEndorsing:
+                            securityHeader.AddSignedEndorsingSupportingToken(token, tokenParameters);
+                            break;
+                        default:
+                            Fx.Assert("Unknown token attachment mode " + supportingTokens[i].SecurityTokenAttachmentMode.ToString());
+                            throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new NotSupportedException(SR.Format(SR.UnknownTokenAttachmentMode, supportingTokens[i].SecurityTokenAttachmentMode.ToString())));
+                    }
+                }
+            }
+        }
+
+        public virtual IAsyncResult BeginSecureOutgoingMessage(Message message, TimeSpan timeout, AsyncCallback callback, object state)
+        {
+            SecureOutgoingMessage(ref message, timeout);
+            return new CompletedAsyncResult<Message>(message, callback, state);
+        }
+
+        public virtual IAsyncResult BeginSecureOutgoingMessage(Message message, TimeSpan timeout, SecurityProtocolCorrelationState correlationState, AsyncCallback callback, object state)
+        {
+            SecurityProtocolCorrelationState newCorrelationState = SecureOutgoingMessage(ref message, timeout, correlationState);
+            return new CompletedAsyncResult<Message, SecurityProtocolCorrelationState>(message, newCorrelationState, callback, state);
+        }
+
+        public virtual IAsyncResult BeginVerifyIncomingMessage(Message message, TimeSpan timeout, AsyncCallback callback, object state)
+        {
+            VerifyIncomingMessage(ref message, timeout);
+            return new CompletedAsyncResult<Message>(message, callback, state);
+        }
+
+        public virtual IAsyncResult BeginVerifyIncomingMessage(Message message, TimeSpan timeout, SecurityProtocolCorrelationState[] correlationStates, AsyncCallback callback, object state)
+        {
+            SecurityProtocolCorrelationState newCorrelationState = VerifyIncomingMessage(ref message, timeout, correlationStates);
+            return new CompletedAsyncResult<Message, SecurityProtocolCorrelationState>(message, newCorrelationState, callback, state);
+        }
+
+        public virtual void EndSecureOutgoingMessage(IAsyncResult result, out Message message)
+        {
+            message = CompletedAsyncResult<Message>.End(result);
+        }
+
+        public virtual void EndSecureOutgoingMessage(IAsyncResult result, out Message message, out SecurityProtocolCorrelationState newCorrelationState)
+        {
+            message = CompletedAsyncResult<Message, SecurityProtocolCorrelationState>.End(result, out newCorrelationState);
+        }
+
+        public virtual void EndVerifyIncomingMessage(IAsyncResult result, out Message message)
+        {
+            message = CompletedAsyncResult<Message>.End(result);
+        }
+
+        public virtual void EndVerifyIncomingMessage(IAsyncResult result, out Message message, out SecurityProtocolCorrelationState newCorrelationState)
+        {
+            message = CompletedAsyncResult<Message, SecurityProtocolCorrelationState>.End(result, out newCorrelationState);
+        }
+
+        internal static SecurityToken GetToken(SecurityTokenProvider provider, EndpointAddress target, TimeSpan timeout)
+        {
+            if (provider == null)
+            {
+                // should this be an ArgumentNullException ?
+                // throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentNullException("provider"));
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new MessageSecurityException(SR.Format(SR.TokenProviderCannotGetTokensForTarget, target)));
+            }
+
+            SecurityToken token = null;
+
+            try
+            {
+                token = provider.GetToken(timeout);
+            }
+            catch (SecurityTokenException exception)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new MessageSecurityException(SR.Format(SR.TokenProviderCannotGetTokensForTarget, target), exception));
+            }
+            catch (SecurityNegotiationException sne)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new SecurityNegotiationException(SR.Format(SR.TokenProviderCannotGetTokensForTarget, target), sne));
+            }
+
+            return token;
+        }
+
+        public abstract void SecureOutgoingMessage(ref Message message, TimeSpan timeout);
+
+        // subclasses that offer correlation should override this version
+        public virtual SecurityProtocolCorrelationState SecureOutgoingMessage(ref Message message, TimeSpan timeout, SecurityProtocolCorrelationState correlationState)
+        {
+            SecureOutgoingMessage(ref message, timeout);
+            return null;
+        }
+
+        protected virtual void OnOutgoingMessageSecured(Message securedMessage)
+        {
+            SecurityTraceRecordHelper.TraceOutgoingMessageSecured(this, securedMessage);
+        }
+
+        protected virtual void OnSecureOutgoingMessageFailure(Message message)
+        {
+            SecurityTraceRecordHelper.TraceSecureOutgoingMessageFailure(this, message);
+        }
+
+        public abstract void VerifyIncomingMessage(ref Message message, TimeSpan timeout);
+
+        // subclasses that offer correlation should override this version
+        public virtual SecurityProtocolCorrelationState VerifyIncomingMessage(ref Message message, TimeSpan timeout, params SecurityProtocolCorrelationState[] correlationStates)
+        {
+            VerifyIncomingMessage(ref message, timeout);
+
+            return null;
+        }
+
+        protected virtual void OnIncomingMessageVerified(Message verifiedMessage)
+        {
+            SecurityTraceRecordHelper.TraceIncomingMessageVerified(this, verifiedMessage);
+
+            if (AuditLevel.Success == (this.factory.MessageAuthenticationAuditLevel & AuditLevel.Success))
+            {
+                SecurityAuditHelper.WriteMessageAuthenticationSuccessEvent(this.factory.AuditLogLocation,
+                    this.factory.SuppressAuditFailure, verifiedMessage, verifiedMessage.Headers.To, verifiedMessage.Headers.Action,
+                    SecurityUtils.GetIdentityNamesFromContext(verifiedMessage.Properties.Security.ServiceSecurityContext.AuthorizationContext));
+            }
+        }
+
+        protected virtual void OnVerifyIncomingMessageFailure(Message message, Exception exception)
+        {
+            SecurityTraceRecordHelper.TraceVerifyIncomingMessageFailure(this, message);
+
+            if (AuditLevel.Failure == (this.factory.MessageAuthenticationAuditLevel & AuditLevel.Failure))
+            {
+                try
+                {
+                    SecurityMessageProperty security = message.Properties.Security;
+                    string primaryIdentity;
+                    if (security != null && security.ServiceSecurityContext != null)
+                        primaryIdentity = SecurityUtils.GetIdentityNamesFromContext(security.ServiceSecurityContext.AuthorizationContext);
+                    else
+                        primaryIdentity = SecurityUtils.AnonymousIdentity.Name;
+
+                    SecurityAuditHelper.WriteMessageAuthenticationFailureEvent(this.factory.AuditLogLocation,
+                        this.factory.SuppressAuditFailure, message, message.Headers.To, message.Headers.Action, primaryIdentity, exception);
+                }
+                catch (Exception auditException)
+                {
+                    if (Fx.IsFatal(auditException))
+                        throw;
+
+                    // Issue #31 in progress
+                    //DiagnosticUtility.TraceHandledException(auditException, TraceEventType.Error);
+                }
+            }
+        }
+
+        protected abstract class GetSupportingTokensAsyncResult : AsyncResult
+        {
+            static AsyncCallback getSupportingTokensCallback = Fx.ThunkCallback(new AsyncCallback(GetSupportingTokenCallback));
+            SecurityProtocol binding;
+            Message message;
+            IList<SupportingTokenSpecification> supportingTokens;
+            int currentTokenProviderIndex = 0;
+            IList<SupportingTokenProviderSpecification> supportingTokenProviders;
+            TimeoutHelper timeoutHelper;
+
+            public GetSupportingTokensAsyncResult(Message m, SecurityProtocol binding, TimeSpan timeout, AsyncCallback callback, object state)
+                : base(callback, state)
+            {
+                this.message = m;
+                this.binding = binding;
+                this.timeoutHelper = new TimeoutHelper(timeout);
+            }
+
+            protected IList<SupportingTokenSpecification> SupportingTokens
+            {
+                get { return this.supportingTokens; }
+            }
+
+            protected abstract bool OnGetSupportingTokensDone(TimeSpan timeout);
+
+            static void GetSupportingTokenCallback(IAsyncResult result)
+            {
+                if (result.CompletedSynchronously)
+                {
+                    return;
+                }
+                GetSupportingTokensAsyncResult self = (GetSupportingTokensAsyncResult)result.AsyncState;
+                bool completeSelf;
+                Exception completionException = null;
+                try
+                {
+                    self.AddSupportingToken(result);
+                    completeSelf = self.AddSupportingTokens();
+                }
+                catch (Exception e)
+                {
+                    if (Fx.IsFatal(e))
+                    {
+                        throw;
+                    }
+
+                    completeSelf = true;
+                    completionException = e;
+                }
+                if (completeSelf)
+                {
+                    self.Complete(false, completionException);
+                }
+            }
+
+            void AddSupportingToken(IAsyncResult result)
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // #31 and #1494 in progress
+
+                //SupportingTokenProviderSpecification spec = supportingTokenProviders[this.currentTokenProviderIndex];
+                //SecurityTokenProvider.SecurityTokenAsyncResult securityTokenAsyncResult = result as SecurityTokenProvider.SecurityTokenAsyncResult;
+                //if (securityTokenAsyncResult != null)
+                //{
+                //    this.supportingTokens.Add(new SupportingTokenSpecification(SecurityTokenProvider.SecurityTokenAsyncResult.End(result), EmptyReadOnlyCollection<IAuthorizationPolicy>.Instance, spec.SecurityTokenAttachmentMode, spec.TokenParameters));
+                //}
+                //else
+                //{
+                //    this.supportingTokens.Add(new SupportingTokenSpecification(spec.TokenProvider.EndGetToken(result), EmptyReadOnlyCollection<IAuthorizationPolicy>.Instance, spec.SecurityTokenAttachmentMode, spec.TokenParameters));
+                //}
+
+                //++this.currentTokenProviderIndex;
+            }
+
+            bool AddSupportingTokens()
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // #31 and #1494 in progress
+
+                //while (this.currentTokenProviderIndex < supportingTokenProviders.Count)
+                //{
+                //    SupportingTokenProviderSpecification spec = supportingTokenProviders[this.currentTokenProviderIndex];
+                //    IAsyncResult result = null;
+                //    if ((this.binding is TransportSecurityProtocol) && (spec.TokenParameters is KerberosSecurityTokenParameters))
+                //    {
+                //        result = new SecurityTokenProvider.SecurityTokenAsyncResult(new ProviderBackedSecurityToken(spec.TokenProvider, timeoutHelper.RemainingTime()), null, this);
+                //    }
+                //    else
+                //    {
+                //        result = spec.TokenProvider.BeginGetToken(timeoutHelper.RemainingTime(), getSupportingTokensCallback, this);
+                //    }
+
+                //    if (!result.CompletedSynchronously)
+                //    {
+                //        return false;
+                //    }
+                //    this.AddSupportingToken(result);
+                //}
+                //this.binding.AddMessageSupportingTokens(message, ref this.supportingTokens);
+                //return this.OnGetSupportingTokensDone(timeoutHelper.RemainingTime());
+            }
+
+            protected void Start()
+            {
+                bool completeSelf;
+                if (this.binding.TryGetSupportingTokens(this.binding.SecurityProtocolFactory, this.binding.Target, this.binding.Via, this.message, timeoutHelper.RemainingTime(), false, out supportingTokens))
+                {
+                    completeSelf = this.OnGetSupportingTokensDone(timeoutHelper.RemainingTime());
+                }
+                else
+                {
+                    this.supportingTokens = new Collection<SupportingTokenSpecification>();
+                    this.supportingTokenProviders = this.binding.GetSupportingTokenProviders(message.Headers.Action);
+                    if (!(this.supportingTokenProviders != null && this.supportingTokenProviders.Count > 0))
+                    {
+                        Fx.Assert("There must be at least 1 supporting token provider");
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new NotSupportedException("There must be at least 1 supporting token provider"));
+                    }
+                    completeSelf = this.AddSupportingTokens();
+                }
+                if (completeSelf)
+                {
+                    base.Complete(true);
+                }
             }
         }
     }

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SecurityProtocolCorrelationState.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SecurityProtocolCorrelationState.cs
@@ -1,0 +1,38 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.IdentityModel.Tokens;
+using System.ServiceModel.Diagnostics;
+
+namespace System.ServiceModel.Security
+{
+    class SecurityProtocolCorrelationState
+    {
+        private SecurityToken _token;
+        private SignatureConfirmations _signatureConfirmations;
+        private ServiceModelActivity _activity;
+
+        public SecurityProtocolCorrelationState(SecurityToken token)
+        {
+            _token = token;
+            _activity = DiagnosticUtility.ShouldUseActivity ? ServiceModelActivity.Current : null;
+        }
+
+        public SecurityToken Token
+        {
+            get { return _token; }
+        }
+
+        internal SignatureConfirmations SignatureConfirmations
+        {
+            get { return _signatureConfirmations; }
+            set { _signatureConfirmations = value; }
+        }
+
+        internal ServiceModelActivity Activity
+        {
+            get { return _activity; }
+        }
+    }
+}

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SecurityProtocolFactory.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SecurityProtocolFactory.cs
@@ -2,9 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Globalization;
 using System.IdentityModel.Selectors;
 using System.IdentityModel.Tokens;
 using System.Runtime;
@@ -12,7 +12,7 @@ using System.Security.Authentication.ExtendedProtection;
 using System.ServiceModel.Channels;
 using System.ServiceModel.Description;
 using System.ServiceModel.Security.Tokens;
-using System.Globalization;
+using System.Threading.Tasks;
 
 namespace System.ServiceModel.Security
 {
@@ -194,6 +194,12 @@ namespace System.ServiceModel.Security
             {
                 _streamBufferManager = value;
             }
+        }
+
+        public ExtendedProtectionPolicy ExtendedProtectionPolicy
+        {
+            get { return _extendedProtectionPolicy; }
+            set { _extendedProtectionPolicy = value; }
         }
 
         internal bool IsDuplexReply
@@ -686,6 +692,31 @@ namespace System.ServiceModel.Security
             }
         }
 
+        public virtual Task OnCloseAsync(TimeSpan timeout)
+        {
+            return OnCloseAsyncInternal(timeout);
+        }
+
+        private async Task OnCloseAsyncInternal(TimeSpan timeout)
+        {
+            TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
+            if (!_actAsInitiator)
+            {
+                foreach (SupportingTokenAuthenticatorSpecification spec in _channelSupportingTokenAuthenticatorSpecification)
+                {
+                    await SecurityUtils.CloseTokenAuthenticatorIfRequiredAsync(spec.TokenAuthenticator, timeoutHelper.RemainingTime());
+                }
+                foreach (string action in _scopedSupportingTokenAuthenticatorSpecification.Keys)
+                {
+                    ICollection<SupportingTokenAuthenticatorSpecification> supportingAuthenticators = _scopedSupportingTokenAuthenticatorSpecification[action];
+                    foreach (SupportingTokenAuthenticatorSpecification spec in supportingAuthenticators)
+                    {
+                        await SecurityUtils.CloseTokenAuthenticatorIfRequiredAsync(spec.TokenAuthenticator, timeoutHelper.RemainingTime());
+                    }
+                }
+            }
+        }
+
         public virtual object CreateListenerSecurityState()
         {
             return null;
@@ -817,6 +848,71 @@ namespace System.ServiceModel.Security
                     foreach (SupportingTokenAuthenticatorSpecification spec in scopedAuthenticators)
                     {
                         SecurityUtils.OpenTokenAuthenticatorIfRequired(spec.TokenAuthenticator, timeoutHelper.RemainingTime());
+                        mergedAuthenticators.Add(spec);
+                        if (spec.SecurityTokenAttachmentMode == SecurityTokenAttachmentMode.Endorsing ||
+                            spec.SecurityTokenAttachmentMode == SecurityTokenAttachmentMode.SignedEndorsing)
+                        {
+                            if (spec.TokenParameters.RequireDerivedKeys && !spec.TokenParameters.HasAsymmetricKey)
+                            {
+                                _expectKeyDerivation = true;
+                            }
+                        }
+                        SecurityTokenAttachmentMode mode = spec.SecurityTokenAttachmentMode;
+                        if (mode == SecurityTokenAttachmentMode.SignedEncrypted
+                            || mode == SecurityTokenAttachmentMode.Signed
+                            || mode == SecurityTokenAttachmentMode.SignedEndorsing)
+                        {
+                            expectSignedTokens = true;
+                            if (mode == SecurityTokenAttachmentMode.SignedEncrypted)
+                            {
+                                expectBasicTokens = true;
+                            }
+                        }
+                        if (mode == SecurityTokenAttachmentMode.Endorsing || mode == SecurityTokenAttachmentMode.SignedEndorsing)
+                        {
+                            expectEndorsingTokens = true;
+                        }
+                    }
+                    VerifyTypeUniqueness(mergedAuthenticators);
+                    MergedSupportingTokenAuthenticatorSpecification mergedSpec = new MergedSupportingTokenAuthenticatorSpecification();
+                    mergedSpec.SupportingTokenAuthenticators = mergedAuthenticators;
+                    mergedSpec.ExpectBasicTokens = expectBasicTokens;
+                    mergedSpec.ExpectEndorsingTokens = expectEndorsingTokens;
+                    mergedSpec.ExpectSignedTokens = expectSignedTokens;
+                    _mergedSupportingTokenAuthenticatorsMap.Add(action, mergedSpec);
+                }
+            }
+        }
+
+        private async Task MergeSupportingTokenAuthenticatorsAsync(TimeSpan timeout)
+        {
+            if (_scopedSupportingTokenAuthenticatorSpecification.Count == 0)
+            {
+                _mergedSupportingTokenAuthenticatorsMap = null;
+            }
+            else
+            {
+                TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
+                _expectSupportingTokens = true;
+                _mergedSupportingTokenAuthenticatorsMap = new Dictionary<string, MergedSupportingTokenAuthenticatorSpecification>();
+                foreach (string action in _scopedSupportingTokenAuthenticatorSpecification.Keys)
+                {
+                    ICollection<SupportingTokenAuthenticatorSpecification> scopedAuthenticators = _scopedSupportingTokenAuthenticatorSpecification[action];
+                    if (scopedAuthenticators == null || scopedAuthenticators.Count == 0)
+                    {
+                        continue;
+                    }
+                    Collection<SupportingTokenAuthenticatorSpecification> mergedAuthenticators = new Collection<SupportingTokenAuthenticatorSpecification>();
+                    bool expectSignedTokens = _expectChannelSignedTokens;
+                    bool expectBasicTokens = _expectChannelBasicTokens;
+                    bool expectEndorsingTokens = _expectChannelEndorsingTokens;
+                    foreach (SupportingTokenAuthenticatorSpecification spec in _channelSupportingTokenAuthenticatorSpecification)
+                    {
+                        mergedAuthenticators.Add(spec);
+                    }
+                    foreach (SupportingTokenAuthenticatorSpecification spec in scopedAuthenticators)
+                    {
+                        await SecurityUtils.OpenTokenAuthenticatorIfRequiredAsync(spec.TokenAuthenticator, timeoutHelper.RemainingTime());
                         mergedAuthenticators.Add(spec);
                         if (spec.SecurityTokenAttachmentMode == SecurityTokenAttachmentMode.Endorsing ||
                             spec.SecurityTokenAttachmentMode == SecurityTokenAttachmentMode.SignedEndorsing)
@@ -1035,21 +1131,112 @@ namespace System.ServiceModel.Security
             _derivedKeyTokenAuthenticator = new NonValidatingSecurityTokenAuthenticator<DerivedKeySecurityToken>();
         }
 
+        public virtual Task OnOpenAsync(TimeSpan timeout)
+        {
+            return OnOpenAsyncInternal(timeout);
+        }
+
+        private async Task OnOpenAsyncInternal(TimeSpan timeout)
+        { 
+            if (this.SecurityBindingElement == null)
+            {
+                this.OnPropertySettingsError("SecurityBindingElement", true);
+            }
+            if (this.SecurityTokenManager == null)
+            {
+                this.OnPropertySettingsError("SecurityTokenManager", true);
+            }
+            _messageSecurityVersion = _standardsManager.MessageSecurityVersion;
+            TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
+            _expectOutgoingMessages = this.ActAsInitiator || this.SupportsRequestReply;
+            _expectIncomingMessages = !this.ActAsInitiator || this.SupportsRequestReply;
+            if (!_actAsInitiator)
+            {
+                AddSupportingTokenAuthenticators(_securityBindingElement.EndpointSupportingTokenParameters, false, (IList<SupportingTokenAuthenticatorSpecification>)_channelSupportingTokenAuthenticatorSpecification);
+                // validate the token authenticator types and create a merged map if needed.
+                if (!_channelSupportingTokenAuthenticatorSpecification.IsReadOnly)
+                {
+                    if (_channelSupportingTokenAuthenticatorSpecification.Count == 0)
+                    {
+                        _channelSupportingTokenAuthenticatorSpecification = EmptyTokenAuthenticators;
+                    }
+                    else
+                    {
+                        _expectSupportingTokens = true;
+                        foreach (SupportingTokenAuthenticatorSpecification tokenAuthenticatorSpec in _channelSupportingTokenAuthenticatorSpecification)
+                        {
+                            SecurityUtils.OpenTokenAuthenticatorIfRequired(tokenAuthenticatorSpec.TokenAuthenticator, timeoutHelper.RemainingTime());
+                            if (tokenAuthenticatorSpec.SecurityTokenAttachmentMode == SecurityTokenAttachmentMode.Endorsing
+                                || tokenAuthenticatorSpec.SecurityTokenAttachmentMode == SecurityTokenAttachmentMode.SignedEndorsing)
+                            {
+                                if (tokenAuthenticatorSpec.TokenParameters.RequireDerivedKeys && !tokenAuthenticatorSpec.TokenParameters.HasAsymmetricKey)
+                                {
+                                    _expectKeyDerivation = true;
+                                }
+                            }
+                            SecurityTokenAttachmentMode mode = tokenAuthenticatorSpec.SecurityTokenAttachmentMode;
+                            if (mode == SecurityTokenAttachmentMode.SignedEncrypted
+                                || mode == SecurityTokenAttachmentMode.Signed
+                                || mode == SecurityTokenAttachmentMode.SignedEndorsing)
+                            {
+                                _expectChannelSignedTokens = true;
+                                if (mode == SecurityTokenAttachmentMode.SignedEncrypted)
+                                {
+                                    _expectChannelBasicTokens = true;
+                                }
+                            }
+                            if (mode == SecurityTokenAttachmentMode.Endorsing || mode == SecurityTokenAttachmentMode.SignedEndorsing)
+                            {
+                                _expectChannelEndorsingTokens = true;
+                            }
+                        }
+                        _channelSupportingTokenAuthenticatorSpecification =
+                            new ReadOnlyCollection<SupportingTokenAuthenticatorSpecification>((Collection<SupportingTokenAuthenticatorSpecification>)_channelSupportingTokenAuthenticatorSpecification);
+                    }
+                }
+                VerifyTypeUniqueness(_channelSupportingTokenAuthenticatorSpecification);
+
+                await MergeSupportingTokenAuthenticatorsAsync(timeoutHelper.RemainingTime());
+            }
+
+            if (this.DetectReplays)
+            {
+                if (!this.SupportsReplayDetection)
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgument("DetectReplays", SR.Format(SR.SecurityProtocolCannotDoReplayDetection, this));
+                }
+                if (this.MaxClockSkew == TimeSpan.MaxValue || this.ReplayWindow == TimeSpan.MaxValue)
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.NoncesCachedInfinitely));
+                }
+
+                // If DetectReplays is true and nonceCache is null then use the default InMemoryNonceCache. 
+                if (_nonceCache == null)
+                {
+                    // The nonce needs to be cached for replayWindow + 2*clockSkew to eliminate replays
+                    _nonceCache = new InMemoryNonceCache(this.ReplayWindow + this.MaxClockSkew + this.MaxClockSkew, this.MaxCachedNonces);
+                }
+            }
+
+            _derivedKeyTokenAuthenticator = new NonValidatingSecurityTokenAuthenticator<DerivedKeySecurityToken>();
+        }
+
+
         public void Open(bool actAsInitiator, TimeSpan timeout)
         {
             _actAsInitiator = actAsInitiator;
             _communicationObject.Open(timeout);
         }
 
-        public IAsyncResult BeginOpen(bool actAsInitiator, TimeSpan timeout, AsyncCallback callback, object state)
+        public Task OpenAsync(TimeSpan timeout)
         {
-            _actAsInitiator = actAsInitiator;
-            return this.CommunicationObject.BeginOpen(timeout, callback, state);
+            return ((IAsyncCommunicationObject)_communicationObject).OpenAsync(timeout);
         }
 
-        public void EndOpen(IAsyncResult result)
+        public Task OpenAsync(bool actAsInitiator, TimeSpan timeout)
         {
-            this.CommunicationObject.EndOpen(result);
+            _actAsInitiator = actAsInitiator;
+            return OpenAsync(timeout);
         }
 
         public void Close(bool aborted, TimeSpan timeout)
@@ -1064,14 +1251,9 @@ namespace System.ServiceModel.Security
             }
         }
 
-        public IAsyncResult BeginClose(TimeSpan timeout, AsyncCallback callback, object state)
+        public Task CloseAsync(TimeSpan timeout)
         {
-            return this.CommunicationObject.BeginClose(timeout, callback, state);
-        }
-
-        public void EndClose(IAsyncResult result)
-        {
-            this.CommunicationObject.EndClose(result);
+            return ((IAsyncCommunicationObject)_communicationObject).CloseAsync(timeout);
         }
 
         internal void Open(string propertyName, bool requiredForForwardDirection, SecurityTokenAuthenticator authenticator, TimeSpan timeout)

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SecuritySessionClientSettings.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SecuritySessionClientSettings.cs
@@ -1,0 +1,3591 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Globalization;
+using System.IdentityModel.Selectors;
+using System.IdentityModel.Tokens;
+using System.Net;
+using System.Runtime;
+using System.ServiceModel.Channels;
+using System.ServiceModel.Diagnostics;
+using System.ServiceModel.Security.Tokens;
+using System.Threading.Tasks;
+using System.Xml;
+
+namespace System.ServiceModel.Security
+{
+    // This class is named Settings since the only public APIs are for
+    // settings; however, this class also manages all functionality
+    // for session channels through internal APIs
+
+    static class SecuritySessionClientSettings
+    {
+        internal const string defaultKeyRenewalIntervalString = "10:00:00";
+        internal const string defaultKeyRolloverIntervalString = "00:05:00";
+
+        internal static readonly TimeSpan s_defaultKeyRenewalInterval = TimeSpan.Parse(defaultKeyRenewalIntervalString, CultureInfo.InvariantCulture);
+        internal static readonly TimeSpan s_defaultKeyRolloverInterval = TimeSpan.Parse(defaultKeyRolloverIntervalString, CultureInfo.InvariantCulture);
+        internal const bool defaultTolerateTransportFailures = true;
+    }
+
+    sealed class SecuritySessionClientSettings<TChannel> : IChannelSecureConversationSessionSettings, ISecurityCommunicationObject
+    {
+        private SecurityProtocolFactory _sessionProtocolFactory;
+        private TimeSpan _keyRenewalInterval;
+        private TimeSpan _keyRolloverInterval;
+        private bool _tolerateTransportFailures;
+        private SecurityChannelFactory<TChannel> _securityChannelFactory;
+        private IChannelFactory _innerChannelFactory;
+        private ChannelBuilder _channelBuilder;
+        private WrapperSecurityCommunicationObject _communicationObject;
+        private SecurityStandardsManager _standardsManager;
+        private SecurityTokenParameters _issuedTokenParameters;
+        private int _issuedTokenRenewalThreshold;
+        private bool _canRenewSession = true;
+        private object _thisLock = new object();
+
+        public SecuritySessionClientSettings()
+        {
+            _keyRenewalInterval = SecuritySessionClientSettings.s_defaultKeyRenewalInterval;
+            _keyRolloverInterval = SecuritySessionClientSettings.s_defaultKeyRolloverInterval;
+            _tolerateTransportFailures = SecuritySessionClientSettings.defaultTolerateTransportFailures;
+            _communicationObject = new WrapperSecurityCommunicationObject(this);
+        }
+
+        IChannelFactory InnerChannelFactory
+        {
+            get
+            {
+                return _innerChannelFactory;
+            }
+        }
+
+        internal ChannelBuilder ChannelBuilder
+        {
+            get
+            {
+                return _channelBuilder;
+            }
+            set
+            {
+                _channelBuilder = value;
+            }
+        }
+
+        SecurityChannelFactory<TChannel> SecurityChannelFactory
+        {
+            get
+            {
+                return _securityChannelFactory;
+            }
+        }
+
+        public SecurityProtocolFactory SessionProtocolFactory
+        {
+            get
+            {
+                return _sessionProtocolFactory;
+            }
+            set
+            {
+                _communicationObject.ThrowIfDisposedOrImmutable();
+                _sessionProtocolFactory = value;
+            }
+        }
+
+        public TimeSpan KeyRenewalInterval
+        {
+            get
+            {
+                return _keyRenewalInterval;
+            }
+            set
+            {
+                if (value <= TimeSpan.Zero)
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("value", SR.Format(SR.TimeSpanMustbeGreaterThanTimeSpanZero)));
+                }
+                _communicationObject.ThrowIfDisposedOrImmutable();
+                _keyRenewalInterval = value;
+            }
+        }
+
+        public TimeSpan KeyRolloverInterval
+        {
+            get
+            {
+                return _keyRolloverInterval;
+            }
+            set
+            {
+                if (value <= TimeSpan.Zero)
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("value", SR.Format(SR.TimeSpanMustbeGreaterThanTimeSpanZero)));
+                }
+                _communicationObject.ThrowIfDisposedOrImmutable();
+                _keyRolloverInterval = value;
+            }
+        }
+
+        public bool TolerateTransportFailures
+        {
+            get
+            {
+                return _tolerateTransportFailures;
+            }
+            set
+            {
+                _communicationObject.ThrowIfDisposedOrImmutable();
+                _tolerateTransportFailures = value;
+            }
+        }
+
+        public bool CanRenewSession
+        {
+            get
+            {
+                return _canRenewSession;
+            }
+            set
+            {
+                _canRenewSession = value;
+            }
+        }
+
+        public SecurityTokenParameters IssuedSecurityTokenParameters
+        {
+            get
+            {
+                return _issuedTokenParameters;
+            }
+            set
+            {
+                _communicationObject.ThrowIfDisposedOrImmutable();
+                _issuedTokenParameters = value;
+            }
+        }
+
+        public SecurityStandardsManager SecurityStandardsManager
+        {
+            get
+            {
+                return _standardsManager;
+            }
+            set
+            {
+                _communicationObject.ThrowIfDisposedOrImmutable();
+                _standardsManager = value;
+            }
+        }
+
+        // ISecurityCommunicationObject members
+        public TimeSpan DefaultOpenTimeout
+        {
+            get { return ServiceDefaults.OpenTimeout; }
+        }
+
+        public TimeSpan DefaultCloseTimeout
+        {
+            get { return ServiceDefaults.CloseTimeout; }
+        }
+
+        internal IChannelFactory CreateInnerChannelFactory()
+        {
+            if (this.ChannelBuilder.CanBuildChannelFactory<IDuplexSessionChannel>())
+            {
+                return this.ChannelBuilder.BuildChannelFactory<IDuplexSessionChannel>();
+            }
+            else if (this.ChannelBuilder.CanBuildChannelFactory<IDuplexChannel>())
+            {
+                return this.ChannelBuilder.BuildChannelFactory<IDuplexChannel>();
+            }
+            else if (this.ChannelBuilder.CanBuildChannelFactory<IRequestChannel>())
+            {
+                return this.ChannelBuilder.BuildChannelFactory<IRequestChannel>();
+            }
+            else
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new NotSupportedException());
+            }
+        }
+
+        public Task CloseAsync(TimeSpan timeout)
+        {
+            return ((IAsyncCommunicationObject)_communicationObject).CloseAsync(timeout);
+        }
+
+        public Task OpenAsync(TimeSpan timeout)
+        {
+            TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
+            if (_sessionProtocolFactory == null)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.SecuritySessionProtocolFactoryShouldBeSetBeforeThisOperation)));
+            }
+            if (_standardsManager == null)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.SecurityStandardsManagerNotSet, this.GetType().ToString())));
+            }
+            if (_issuedTokenParameters == null)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.IssuedSecurityTokenParametersNotSet, this.GetType())));
+            }
+            if (_keyRenewalInterval < _keyRolloverInterval)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.KeyRolloverGreaterThanKeyRenewal)));
+            }
+            _issuedTokenRenewalThreshold = _sessionProtocolFactory.SecurityBindingElement.LocalClientSettings.CookieRenewalThresholdPercentage;
+            this.ConfigureSessionProtocolFactory();
+            return _sessionProtocolFactory.OpenAsync(true, timeoutHelper.RemainingTime());
+        }
+
+        public void OnClosed()
+        {
+        }
+
+        public void OnClosing()
+        {
+        }
+
+        public void OnFaulted()
+        {
+        }
+
+        public void OnOpened()
+        {
+        }
+
+        public void OnOpening()
+        {
+        }
+
+        public void OnClose(TimeSpan timeout)
+        {
+            if (_sessionProtocolFactory != null)
+            {
+                _sessionProtocolFactory.Close(false, timeout);
+            }
+        }
+
+        public Task OnCloseAsync(TimeSpan timeout)
+        {
+            return OnCloseAsyncInternal(timeout);
+        }
+
+        private async Task OnCloseAsyncInternal(TimeSpan timeout)
+        {
+            if (_sessionProtocolFactory != null)
+            {
+                await _sessionProtocolFactory.CloseAsync(timeout);
+            }
+        }
+
+        public void OnAbort()
+        {
+            if (_sessionProtocolFactory != null)
+            {
+                _sessionProtocolFactory.Close(true, TimeSpan.Zero);
+            }
+        }
+
+        public void OnOpen(TimeSpan timeout)
+        {
+            TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
+            if (_sessionProtocolFactory == null)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.SecuritySessionProtocolFactoryShouldBeSetBeforeThisOperation)));
+            }
+            if (_standardsManager == null)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.SecurityStandardsManagerNotSet, this.GetType().ToString())));
+            }
+            if (_issuedTokenParameters == null)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.IssuedSecurityTokenParametersNotSet, this.GetType())));
+            }
+            if (_keyRenewalInterval < _keyRolloverInterval)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.KeyRolloverGreaterThanKeyRenewal)));
+            }
+            _issuedTokenRenewalThreshold = _sessionProtocolFactory.SecurityBindingElement.LocalClientSettings.CookieRenewalThresholdPercentage;
+            this.ConfigureSessionProtocolFactory();
+            _sessionProtocolFactory.Open(true, timeoutHelper.RemainingTime());
+        }
+
+
+        public Task OnOpenAsync(TimeSpan timeout)
+        {
+            return OnOpenAsyncInternal(timeout);
+        }
+
+        private async Task OnOpenAsyncInternal(TimeSpan timeout)
+        {
+            TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
+            if (_sessionProtocolFactory == null)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.SecuritySessionProtocolFactoryShouldBeSetBeforeThisOperation)));
+            }
+            if (_standardsManager == null)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.SecurityStandardsManagerNotSet, this.GetType().ToString())));
+            }
+            if (_issuedTokenParameters == null)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.IssuedSecurityTokenParametersNotSet, this.GetType())));
+            }
+            if (_keyRenewalInterval < _keyRolloverInterval)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.KeyRolloverGreaterThanKeyRenewal)));
+            }
+            _issuedTokenRenewalThreshold = _sessionProtocolFactory.SecurityBindingElement.LocalClientSettings.CookieRenewalThresholdPercentage;
+            this.ConfigureSessionProtocolFactory();
+            await _sessionProtocolFactory.OpenAsync(true, timeoutHelper.RemainingTime());
+        }
+
+        internal void Close(TimeSpan timeout)
+        {
+            _communicationObject.Close(timeout);
+        }
+
+        internal void Abort()
+        {
+            _communicationObject.Abort();
+        }
+
+        internal void Open(SecurityChannelFactory<TChannel> securityChannelFactory,
+            IChannelFactory innerChannelFactory, ChannelBuilder channelBuilder, TimeSpan timeout)
+        {
+            _securityChannelFactory = securityChannelFactory;
+            _innerChannelFactory = innerChannelFactory;
+            _channelBuilder = channelBuilder;
+            _communicationObject.Open(timeout);
+        }
+
+        internal Task OpenAsync(SecurityChannelFactory<TChannel> securityChannelFactory,
+                                IChannelFactory innerChannelFactory, ChannelBuilder channelBuilder, TimeSpan timeout)
+        {
+            _securityChannelFactory = securityChannelFactory;
+            _innerChannelFactory = innerChannelFactory;
+            _channelBuilder = channelBuilder;
+            return ((IAsyncCommunicationObject)_communicationObject).OpenAsync(timeout);
+        }
+
+        internal TChannel OnCreateChannel(EndpointAddress remoteAddress, Uri via)
+        {
+            _communicationObject.ThrowIfClosed();
+
+            if (typeof(TChannel) == typeof(IRequestSessionChannel))
+            {
+                return (TChannel)((object)(new SecurityRequestSessionChannel(this, remoteAddress, via)));
+            }
+            else if (typeof(TChannel) == typeof(IDuplexSessionChannel))
+            {
+                // typeof(TChannel) == typeof(IDuplexSessionChannel)
+                return (TChannel)((object)(new ClientSecurityDuplexSessionChannel(this, remoteAddress, via)));
+            }
+            else
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentException(SR.Format(SR.ChannelTypeNotSupported, typeof(TChannel)), "TChannel"));
+            }
+        }
+
+        void ConfigureSessionProtocolFactory()
+        {
+            throw ExceptionHelper.PlatformNotSupported();   // #31 in progress
+
+            //if (this.sessionProtocolFactory is SessionSymmetricMessageSecurityProtocolFactory)
+            //{
+            //    AddressingVersion addressing = MessageVersion.Default.Addressing;
+            //    if (this.channelBuilder != null)
+            //    {
+            //        MessageEncodingBindingElement encoding = this.channelBuilder.Binding.Elements.Find<MessageEncodingBindingElement>();
+            //        if (encoding != null)
+            //        {
+            //            addressing = encoding.MessageVersion.Addressing;
+            //        }
+            //    }
+
+            //    if (addressing != AddressingVersion.WSAddressing10 && addressing != AddressingVersion.WSAddressingAugust2004)
+            //    {
+            //        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(
+            //            new ProtocolException(SR.Format(SR.AddressingVersionNotSupported, addressing)));
+            //    }
+
+            //    SessionSymmetricMessageSecurityProtocolFactory symmetric = (SessionSymmetricMessageSecurityProtocolFactory)this.sessionProtocolFactory;
+            //    if (!symmetric.ApplyIntegrity || !symmetric.RequireIntegrity)
+            //        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.SecuritySessionRequiresMessageIntegrity)));
+            //    MessagePartSpecification bodyPart = new MessagePartSpecification(true);
+            //    symmetric.ProtectionRequirements.OutgoingSignatureParts.AddParts(bodyPart, this.SecurityStandardsManager.SecureConversationDriver.CloseResponseAction);
+            //    symmetric.ProtectionRequirements.OutgoingSignatureParts.AddParts(bodyPart, this.SecurityStandardsManager.SecureConversationDriver.CloseAction);
+            //    symmetric.ProtectionRequirements.OutgoingSignatureParts.AddParts(bodyPart, addressing.FaultAction);
+            //    symmetric.ProtectionRequirements.OutgoingSignatureParts.AddParts(bodyPart, addressing.DefaultFaultAction);
+            //    symmetric.ProtectionRequirements.OutgoingSignatureParts.AddParts(bodyPart, DotNetSecurityStrings.SecuritySessionFaultAction);
+            //    symmetric.ProtectionRequirements.IncomingSignatureParts.AddParts(bodyPart, this.SecurityStandardsManager.SecureConversationDriver.CloseAction);
+            //    symmetric.ProtectionRequirements.IncomingSignatureParts.AddParts(bodyPart, this.SecurityStandardsManager.SecureConversationDriver.CloseResponseAction);
+            //    if (symmetric.ApplyConfidentiality)
+            //    {
+            //        symmetric.ProtectionRequirements.IncomingEncryptionParts.AddParts(MessagePartSpecification.NoParts, this.SecurityStandardsManager.SecureConversationDriver.CloseAction);
+            //        symmetric.ProtectionRequirements.IncomingEncryptionParts.AddParts(MessagePartSpecification.NoParts, this.SecurityStandardsManager.SecureConversationDriver.CloseResponseAction);
+            //    }
+            //    if (symmetric.RequireConfidentiality)
+            //    {
+            //        symmetric.ProtectionRequirements.OutgoingEncryptionParts.AddParts(MessagePartSpecification.NoParts, this.SecurityStandardsManager.SecureConversationDriver.CloseResponseAction);
+            //        symmetric.ProtectionRequirements.OutgoingEncryptionParts.AddParts(MessagePartSpecification.NoParts, this.SecurityStandardsManager.SecureConversationDriver.CloseAction);
+            //        symmetric.ProtectionRequirements.OutgoingEncryptionParts.AddParts(bodyPart, addressing.FaultAction);
+            //        symmetric.ProtectionRequirements.OutgoingEncryptionParts.AddParts(bodyPart, addressing.DefaultFaultAction);
+            //        symmetric.ProtectionRequirements.OutgoingEncryptionParts.AddParts(bodyPart, DotNetSecurityStrings.SecuritySessionFaultAction);
+            //    }
+            //}
+            //else if (this.sessionProtocolFactory is SessionSymmetricTransportSecurityProtocolFactory)
+            //{
+            //    SessionSymmetricTransportSecurityProtocolFactory transport = (SessionSymmetricTransportSecurityProtocolFactory)this.sessionProtocolFactory;
+            //    transport.AddTimestamp = true;
+            //    transport.SecurityTokenParameters.RequireDerivedKeys = false;
+            //}
+            //else
+            //{
+            //    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new NotSupportedException());
+            //}
+        }
+
+        abstract class ClientSecuritySessionChannel : ChannelBase
+        {
+            EndpointAddress to;
+            Uri via;
+            IClientReliableChannelBinder channelBinder;
+            ChannelParameterCollection channelParameters;
+            SecurityToken currentSessionToken;
+            SecurityToken previousSessionToken;
+            DateTime keyRenewalTime;
+            DateTime keyRolloverTime;
+            SecurityProtocol securityProtocol;
+            SecuritySessionClientSettings<TChannel> settings;
+            SecurityTokenProvider sessionTokenProvider;
+            bool isKeyRenewalOngoing = false;
+            // InterruptibleWaitObject keyRenewalCompletedEvent;    // #31 in progress
+            // InterruptibleWaitObject outputSessionCloseHandle = new InterruptibleWaitObject(true);
+            // InterruptibleWaitObject inputSessionClosedHandle = new InterruptibleWaitObject(false);
+            bool sentClose;
+            bool receivedClose;
+            volatile bool isOutputClosed;
+            volatile bool isInputClosed;
+
+            bool sendCloseHandshake = false;
+            MessageVersion messageVersion;
+            bool isCompositeDuplexConnection;
+            Message closeResponse;
+
+            WebHeaderCollection webHeaderCollection;
+
+            protected ClientSecuritySessionChannel(SecuritySessionClientSettings<TChannel> settings, EndpointAddress to, Uri via)
+                : base(settings.SecurityChannelFactory)
+            {
+                this.settings = settings;
+                this.to = to;
+                this.via = via;
+                // this.keyRenewalCompletedEvent = new InterruptibleWaitObject(false);
+                this.messageVersion = settings.SecurityChannelFactory.MessageVersion;
+                this.channelParameters = new ChannelParameterCollection(this);
+                this.InitializeChannelBinder();
+                this.webHeaderCollection = new WebHeaderCollection();
+            }
+
+            protected SecuritySessionClientSettings<TChannel> Settings
+            {
+                get
+                {
+                    return this.settings;
+                }
+            }
+
+            protected IClientReliableChannelBinder ChannelBinder
+            {
+                get
+                {
+                    return this.channelBinder;
+                }
+            }
+
+            public EndpointAddress RemoteAddress
+            {
+                get
+                {
+                    return this.to;
+                }
+            }
+
+            public Uri Via
+            {
+                get
+                {
+                    return this.via;
+                }
+            }
+
+            protected bool SendCloseHandshake
+            {
+                get
+                {
+                    return this.sendCloseHandshake;
+                }
+            }
+
+            protected EndpointAddress InternalLocalAddress
+            {
+                get
+                {
+                    if (this.channelBinder != null)
+                        return this.channelBinder.LocalAddress;
+                    return null;
+                }
+            }
+
+            protected virtual bool CanDoSecurityCorrelation
+            {
+                get
+                {
+                    return false;
+                }
+            }
+
+            public MessageVersion MessageVersion
+            {
+                get { return this.messageVersion; }
+            }
+
+            protected bool IsInputClosed
+            {
+                get { return isInputClosed; }
+            }
+
+            protected bool IsOutputClosed
+            {
+                get { return isOutputClosed; }
+            }
+
+            protected abstract bool ExpectClose
+            {
+                get;
+            }
+
+            protected abstract string SessionId
+            {
+                get;
+            }
+
+            public override T GetProperty<T>()
+            {
+                if (typeof(T) == typeof(ChannelParameterCollection))
+                {
+                    return this.channelParameters as T;
+                }
+
+                if (typeof(T) == typeof(FaultConverter) && (this.channelBinder != null))
+                {
+                    return new SecurityChannelFaultConverter(this.channelBinder.Channel) as T;
+                }
+                else if (typeof(T) == typeof(WebHeaderCollection))
+                {
+                    return (T)(object)this.webHeaderCollection;
+                }
+
+
+                T result = base.GetProperty<T>();
+                if ((result == null) && (channelBinder != null) && (channelBinder.Channel != null))
+                {
+                    result = channelBinder.Channel.GetProperty<T>();
+                }
+
+                return result;
+            }
+
+            protected abstract void InitializeSession(SecurityToken sessionToken);
+
+            void InitializeSecurityState(SecurityToken sessionToken)
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // #31 in progress
+
+                //InitializeSession(sessionToken);
+                //this.currentSessionToken = sessionToken;
+                //this.previousSessionToken = null;
+                //List<SecurityToken> incomingSessionTokens = new List<SecurityToken>(1);
+                //incomingSessionTokens.Add(sessionToken);
+                //((IInitiatorSecuritySessionProtocol)this.securityProtocol).SetIdentityCheckAuthenticator(new GenericXmlSecurityTokenAuthenticator());
+                //((IInitiatorSecuritySessionProtocol)this.securityProtocol).SetIncomingSessionTokens(incomingSessionTokens);
+                //((IInitiatorSecuritySessionProtocol)this.securityProtocol).SetOutgoingSessionToken(sessionToken);
+                //if (this.CanDoSecurityCorrelation)
+                //{
+                //    ((IInitiatorSecuritySessionProtocol)this.securityProtocol).ReturnCorrelationState = true;
+                //}
+                //this.keyRenewalTime = GetKeyRenewalTime(sessionToken);
+            }
+
+            void SetupSessionTokenProvider()
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // #31 in progress
+
+                //InitiatorServiceModelSecurityTokenRequirement requirement = new InitiatorServiceModelSecurityTokenRequirement();
+                //this.Settings.IssuedSecurityTokenParameters.InitializeSecurityTokenRequirement(requirement);
+                //requirement.KeyUsage = SecurityKeyUsage.Signature;
+                //requirement.SupportSecurityContextCancellation = true;
+                //requirement.SecurityAlgorithmSuite = this.Settings.SessionProtocolFactory.OutgoingAlgorithmSuite;
+                //requirement.SecurityBindingElement = this.Settings.SessionProtocolFactory.SecurityBindingElement;
+                //requirement.TargetAddress = this.to;
+                //requirement.Via = this.Via;
+                //requirement.MessageSecurityVersion = this.Settings.SessionProtocolFactory.MessageSecurityVersion.SecurityTokenVersion;
+                //requirement.Properties[ServiceModelSecurityTokenRequirement.PrivacyNoticeUriProperty] = this.Settings.SessionProtocolFactory.PrivacyNoticeUri;
+                //requirement.WebHeaders = this.webHeaderCollection;
+
+                //if (this.channelParameters != null)
+                //{
+                //    requirement.Properties[ServiceModelSecurityTokenRequirement.ChannelParametersCollectionProperty] = this.channelParameters;
+                //}
+                //requirement.Properties[ServiceModelSecurityTokenRequirement.PrivacyNoticeVersionProperty] = this.Settings.SessionProtocolFactory.PrivacyNoticeVersion;
+                //if (this.channelBinder.LocalAddress != null)
+                //{
+                //    requirement.DuplexClientLocalAddress = this.channelBinder.LocalAddress;
+                //}
+                //this.sessionTokenProvider = this.Settings.SessionProtocolFactory.SecurityTokenManager.CreateSecurityTokenProvider(requirement);
+            }
+
+            void OpenCore(SecurityToken sessionToken, TimeSpan timeout)
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // #31 in progress
+
+                //TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
+                //this.securityProtocol = this.Settings.SessionProtocolFactory.CreateSecurityProtocol(this.to, this.Via, null, true, timeoutHelper.RemainingTime());
+                //if (!(this.securityProtocol is IInitiatorSecuritySessionProtocol))
+                //{
+                //    Fx.Assert("Security protocol must be IInitiatorSecuritySessionProtocol.");
+                //    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.ProtocolMisMatch, "IInitiatorSecuritySessionProtocol", this.GetType().ToString())));
+                //}
+                //this.securityProtocol.Open(timeoutHelper.RemainingTime());
+                //this.channelBinder.Open(timeoutHelper.RemainingTime());
+                //this.InitializeSecurityState(sessionToken);
+            }
+
+            protected override void OnFaulted()
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // #31 in progress
+
+                //this.AbortCore();
+                //_inputSessionClosedHandle.Fault(this);
+                //_keyRenewalCompletedEvent.Fault(this);
+                //_outputSessionCloseHandle.Fault(this);
+                //base.OnFaulted();
+            }
+
+            protected override void OnOpen(TimeSpan timeout)
+            {
+                TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
+                SetupSessionTokenProvider();
+                SecurityUtils.OpenTokenProviderIfRequired(this.sessionTokenProvider, timeoutHelper.RemainingTime());
+                using (ServiceModelActivity activity = DiagnosticUtility.ShouldUseActivity ?
+                    ServiceModelActivity.CreateBoundedActivity() : null)
+                {
+                    if (DiagnosticUtility.ShouldUseActivity)
+                    {
+                        ServiceModelActivity.Start(activity, SR.Format(SR.ActivitySecuritySetup), ActivityType.SecuritySetup);
+                    }
+                    SecurityToken sessionToken = this.sessionTokenProvider.GetToken(timeoutHelper.RemainingTime());
+                    // Token was issued, do send cancel on close;
+                    this.sendCloseHandshake = true;
+                    this.OpenCore(sessionToken, timeoutHelper.RemainingTime());
+                }
+            }
+
+            protected override IAsyncResult OnBeginOpen(TimeSpan timeout, AsyncCallback callback, object state)
+            {
+                throw ExceptionHelper.PlatformNotSupported();
+            }
+
+            protected override void OnEndOpen(IAsyncResult result)
+            {
+                throw ExceptionHelper.PlatformNotSupported();
+            }
+
+            void InitializeChannelBinder()
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // #31 in progress
+
+                //ChannelBuilder channelBuilder = this.Settings.ChannelBuilder;
+                //TolerateFaultsMode faultMode = this.Settings.TolerateTransportFailures ? TolerateFaultsMode.Always : TolerateFaultsMode.Never;
+                //if (channelBuilder.CanBuildChannelFactory<IDuplexSessionChannel>())
+                //{
+                //    this.channelBinder = ClientReliableChannelBinder<IDuplexSessionChannel>.CreateBinder(this.RemoteAddress, this.Via, (IChannelFactory<IDuplexSessionChannel>)(object)this.Settings.InnerChannelFactory,
+                //        MaskingMode.None, faultMode, this.channelParameters, this.DefaultCloseTimeout, this.DefaultSendTimeout);
+                //}
+                //else if (channelBuilder.CanBuildChannelFactory<IDuplexChannel>())
+                //{
+                //    this.channelBinder = ClientReliableChannelBinder<IDuplexChannel>.CreateBinder(this.RemoteAddress, this.Via, (IChannelFactory<IDuplexChannel>)(object)this.Settings.InnerChannelFactory,
+                //        MaskingMode.None, faultMode, this.channelParameters, this.DefaultCloseTimeout, this.DefaultSendTimeout);
+                //    this.isCompositeDuplexConnection = true;
+                //}
+                //else if (channelBuilder.CanBuildChannelFactory<IRequestChannel>())
+                //{
+                //    this.channelBinder = ClientReliableChannelBinder<IRequestChannel>.CreateBinder(this.RemoteAddress, this.Via, (IChannelFactory<IRequestChannel>)(object)this.Settings.InnerChannelFactory,
+                //        MaskingMode.None, faultMode, this.channelParameters, this.DefaultCloseTimeout, this.DefaultSendTimeout);
+                //}
+                //else if (channelBuilder.CanBuildChannelFactory<IRequestSessionChannel>())
+                //{
+                //    this.channelBinder = ClientReliableChannelBinder<IRequestSessionChannel>.CreateBinder(this.RemoteAddress, this.Via, (IChannelFactory<IRequestSessionChannel>)(object)this.Settings.InnerChannelFactory,
+                //        MaskingMode.None, faultMode, this.channelParameters, this.DefaultCloseTimeout, this.DefaultSendTimeout);
+                //}
+                //this.channelBinder.Faulted += this.OnInnerFaulted;
+            }
+
+            //void OnInnerFaulted(IReliableChannelBinder sender, Exception exception)
+            //{
+            //    throw ExceptionHelper.PlatformNotSupported();   // #31 in progress
+            //    //this.Fault(exception);
+            //}
+
+            protected virtual bool OnCloseResponseReceived()
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // #31 in progress
+
+                //bool setInputSessionClosedHandle = false;
+                //bool isCloseResponseExpected = false;
+                //lock (ThisLock)
+                //{
+                //    isCloseResponseExpected = this.sentClose;
+                //    if (isCloseResponseExpected && !this.isInputClosed)
+                //    {
+                //        this.isInputClosed = true;
+                //        setInputSessionClosedHandle = true;
+                //    }
+                //}
+                //if (!isCloseResponseExpected)
+                //{
+                //    this.Fault(new ProtocolException(SR.Format(SR.UnexpectedSecuritySessionCloseResponse)));
+                //    return false;
+                //}
+                //if (setInputSessionClosedHandle)
+                //{
+                //    this.inputSessionClosedHandle.Set();
+                //}
+                //return true;
+            }
+
+            protected virtual bool OnCloseReceived()
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // #31 in progress
+
+                //if (!ExpectClose)
+                //{
+                //    this.Fault(new ProtocolException(SR.Format(SR.UnexpectedSecuritySessionClose)));
+                //    return false;
+                //}
+                //bool setInputSessionClosedHandle = false;
+                //lock (ThisLock)
+                //{
+                //    if (!this.isInputClosed)
+                //    {
+                //        this.isInputClosed = true;
+                //        this.receivedClose = true;
+                //        setInputSessionClosedHandle = true;
+                //    }
+                //}
+                //if (setInputSessionClosedHandle)
+                //{
+                //    this.inputSessionClosedHandle.Set();
+                //}
+                //return true;
+            }
+
+            Message PrepareCloseMessage()
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // #31 in progress
+
+                //SecurityToken tokenToClose;
+                //lock (ThisLock)
+                //{
+                //    tokenToClose = this.currentSessionToken;
+                //}
+                //RequestSecurityToken rst = new RequestSecurityToken(this.Settings.SecurityStandardsManager);
+                //rst.RequestType = this.Settings.SecurityStandardsManager.TrustDriver.RequestTypeClose;
+                //rst.CloseTarget = this.Settings.IssuedSecurityTokenParameters.CreateKeyIdentifierClause(tokenToClose, SecurityTokenReferenceStyle.External);
+                //rst.MakeReadOnly();
+                //Message closeMessage = Message.CreateMessage(this.MessageVersion, ActionHeader.Create(this.Settings.SecurityStandardsManager.SecureConversationDriver.CloseAction, this.MessageVersion.Addressing), rst);
+
+                //RequestReplyCorrelator.PrepareRequest(closeMessage);
+                //if (this.webHeaderCollection != null && this.webHeaderCollection.Count > 0)
+                //{
+                //    object prop = null;
+                //    HttpRequestMessageProperty rmp = null;
+                //    if (closeMessage.Properties.TryGetValue(HttpRequestMessageProperty.Name, out prop))
+                //    {
+                //        rmp = prop as HttpRequestMessageProperty;
+                //    }
+                //    else
+                //    {
+                //        rmp = new HttpRequestMessageProperty();
+                //        closeMessage.Properties.Add(HttpRequestMessageProperty.Name, rmp);
+                //    }
+
+                //    if (rmp != null && rmp.Headers != null)
+                //    {
+                //        rmp.Headers.Add(this.webHeaderCollection);
+                //    }
+                //}
+
+
+                //if (this.InternalLocalAddress != null)
+                //{
+                //    closeMessage.Headers.ReplyTo = this.InternalLocalAddress;
+                //}
+                //else
+                //{
+                //    if (closeMessage.Version.Addressing == AddressingVersion.WSAddressing10)
+                //    {
+                //        closeMessage.Headers.ReplyTo = null;
+                //    }
+                //    else if (closeMessage.Version.Addressing == AddressingVersion.WSAddressingAugust2004)
+                //    {
+                //        closeMessage.Headers.ReplyTo = EndpointAddress.AnonymousAddress;
+                //    }
+                //    else
+                //    {
+                //        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(
+                //            new ProtocolException(SR.Format(SR.AddressingVersionNotSupported, closeMessage.Version.Addressing)));
+                //    }
+                //}
+                //if (TraceUtility.PropagateUserActivity || TraceUtility.ShouldPropagateActivity)
+                //{
+                //    TraceUtility.AddAmbientActivityToMessage(closeMessage);
+                //}
+                //return closeMessage;
+            }
+
+            protected SecurityProtocolCorrelationState SendCloseMessage(TimeSpan timeout)
+            {
+                TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
+                SecurityProtocolCorrelationState closeCorrelationState;
+                Message closeMessage = PrepareCloseMessage();
+                try
+                {
+                    closeCorrelationState = this.securityProtocol.SecureOutgoingMessage(ref closeMessage, timeoutHelper.RemainingTime(), null);
+                    this.ChannelBinder.Send(closeMessage, timeoutHelper.RemainingTime());
+                }
+                finally
+                {
+                    closeMessage.Close();
+                }
+
+                SecurityTraceRecordHelper.TraceCloseMessageSent(this.currentSessionToken, this.RemoteAddress);
+                return closeCorrelationState;
+            }
+
+            protected void SendCloseResponseMessage(TimeSpan timeout)
+            {
+                TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
+
+                Message message = null;
+                try
+                {
+                    message = this.closeResponse;
+                    this.securityProtocol.SecureOutgoingMessage(ref message, timeoutHelper.RemainingTime(), null);
+                    this.ChannelBinder.Send(message, timeoutHelper.RemainingTime());
+                    SecurityTraceRecordHelper.TraceCloseResponseMessageSent(this.currentSessionToken, this.RemoteAddress);
+                }
+                finally
+                {
+                    message.Close();
+                }
+            }
+
+            IAsyncResult BeginSendCloseMessage(TimeSpan timeout, AsyncCallback callback, object state)
+            {
+                using (ServiceModelActivity activity = DiagnosticUtility.ShouldUseActivity ?
+                    ServiceModelActivity.CreateBoundedActivity() : null)
+                {
+                    if (DiagnosticUtility.ShouldUseActivity)
+                    {
+                        ServiceModelActivity.Start(activity, SR.Format(SR.ActivitySecurityClose), ActivityType.SecuritySetup);
+                    }
+                    Message closeMessage = PrepareCloseMessage();
+                    return new SecureSendAsyncResult(closeMessage, this, timeout, callback, state, true);
+                }
+            }
+
+            SecurityProtocolCorrelationState EndSendCloseMessage(IAsyncResult result)
+            {
+                SecurityProtocolCorrelationState correlationState = SecureSendAsyncResult.End(result);
+                SecurityTraceRecordHelper.TraceCloseMessageSent(this.currentSessionToken, this.RemoteAddress);
+                return correlationState;
+            }
+
+            IAsyncResult BeginSendCloseResponseMessage(TimeSpan timeout, AsyncCallback callback, object state)
+            {
+                return new SecureSendAsyncResult(this.closeResponse, this, timeout, callback, state, true);
+            }
+
+            void EndSendCloseResponseMessage(IAsyncResult result)
+            {
+                SecureSendAsyncResult.End(result);
+                SecurityTraceRecordHelper.TraceCloseResponseMessageSent(this.currentSessionToken, this.RemoteAddress);
+            }
+
+            MessageFault GetProtocolFault(ref Message message, out bool isKeyRenewalFault, out bool isSessionAbortedFault)
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // #31 in progress
+                //isKeyRenewalFault = false;
+                //isSessionAbortedFault = false;
+                //MessageFault result = null;
+                //using (MessageBuffer buffer = message.CreateBufferedCopy(int.MaxValue))
+                //{
+                //    message = buffer.CreateMessage();
+                //    Message copy = buffer.CreateMessage();
+                //    MessageFault fault = MessageFault.CreateFault(copy, TransportDefaults.MaxSecurityFaultSize);
+                //    if (fault.Code.IsSenderFault)
+                //    {
+                //        FaultCode subCode = fault.Code.SubCode;
+                //        if (subCode != null)
+                //        {
+                //            SecurityStandardsManager standardsManager = this.securityProtocol.SecurityProtocolFactory.StandardsManager;
+                //            SecureConversationDriver scDriver = standardsManager.SecureConversationDriver;
+                //            if (subCode.Namespace == scDriver.Namespace.Value && subCode.Name == scDriver.RenewNeededFaultCode.Value)
+                //            {
+                //                result = fault;
+                //                isKeyRenewalFault = true;
+                //            }
+                //            else if (subCode.Namespace == DotNetSecurityStrings.Namespace && subCode.Name == DotNetSecurityStrings.SecuritySessionAbortedFault)
+                //            {
+                //                result = fault;
+                //                isSessionAbortedFault = true;
+                //            }
+                //        }
+                //    }
+                //}
+                //return result;
+            }
+
+
+            void ProcessKeyRenewalFault()
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // #31 in progress
+
+                //SecurityTraceRecordHelper.TraceSessionKeyRenewalFault(this.currentSessionToken, this.RemoteAddress);
+                //lock (ThisLock)
+                //{
+                //    this.keyRenewalTime = DateTime.UtcNow;
+                //}
+            }
+
+            void ProcessSessionAbortedFault(MessageFault sessionAbortedFault)
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // #31 in progress
+
+                //SecurityTraceRecordHelper.TraceRemoteSessionAbortedFault(this.currentSessionToken, this.RemoteAddress);
+                //this.Fault(new FaultException(sessionAbortedFault));
+            }
+
+            void ProcessCloseResponse(Message response)
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // #31 in progress
+
+                //// the close message may have been received by the channel after the channel factory has been closed
+                //if (response.Headers.Action != this.Settings.SecurityStandardsManager.SecureConversationDriver.CloseResponseAction.Value)
+                //{
+                //    throw TraceUtility.ThrowHelperError(new MessageSecurityException(SR.Format(SR.InvalidCloseResponseAction, response.Headers.Action)), response);
+                //}
+                //RequestSecurityTokenResponse rstr = null;
+                //XmlDictionaryReader bodyReader = response.GetReaderAtBodyContents();
+                //using (bodyReader)
+                //{
+                //    if (this.Settings.SecurityStandardsManager.MessageSecurityVersion.TrustVersion == TrustVersion.WSTrustFeb2005)
+                //        rstr = this.Settings.SecurityStandardsManager.TrustDriver.CreateRequestSecurityTokenResponse(bodyReader);
+                //    else if (this.Settings.SecurityStandardsManager.MessageSecurityVersion.TrustVersion == TrustVersion.WSTrust13)
+                //    {
+                //        RequestSecurityTokenResponseCollection rstrc = this.Settings.SecurityStandardsManager.TrustDriver.CreateRequestSecurityTokenResponseCollection(bodyReader);
+                //        foreach (RequestSecurityTokenResponse rstrItem in rstrc.RstrCollection)
+                //        {
+                //            if (rstr != null)
+                //            {
+                //                // More than one RSTR is found. So throw an exception.
+                //                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new MessageSecurityException(SR.Format(SR.MoreThanOneRSTRInRSTRC)));
+                //            }
+                //            rstr = rstrItem;
+                //        }
+                //    }
+                //    else
+                //    {
+                //        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new NotSupportedException());
+                //    }
+
+                //    response.ReadFromBodyContentsToEnd(bodyReader);
+                //}
+                //if (!rstr.IsRequestedTokenClosed)
+                //{
+                //    throw TraceUtility.ThrowHelperError(new MessageSecurityException(SR.Format(SR.SessionTokenWasNotClosed)), response);
+                //}
+            }
+
+            void PrepareReply(Message request, Message reply)
+            {
+                if (request.Headers.ReplyTo != null)
+                {
+                    request.Headers.ReplyTo.ApplyTo(reply);
+                }
+                else if (request.Headers.From != null)
+                {
+                    request.Headers.From.ApplyTo(reply);
+                }
+                if (request.Headers.MessageId != null)
+                {
+                    reply.Headers.RelatesTo = request.Headers.MessageId;
+                }
+                TraceUtility.CopyActivity(request, reply);
+                if (TraceUtility.PropagateUserActivity || TraceUtility.ShouldPropagateActivity)
+                {
+                    TraceUtility.AddActivityHeader(reply);
+                }
+            }
+
+            bool DoesSkiClauseMatchSigningToken(SecurityContextKeyIdentifierClause skiClause, Message request)
+            {
+                if (this.SessionId == null)
+                {
+                    return false;
+                }
+                return (skiClause.ContextId.ToString() == this.SessionId);
+            }
+
+            void ProcessCloseMessage(Message message)
+            {
+                RequestSecurityToken rst;
+                XmlDictionaryReader bodyReader = message.GetReaderAtBodyContents();
+                using (bodyReader)
+                {
+                    rst = this.Settings.SecurityStandardsManager.TrustDriver.CreateRequestSecurityToken(bodyReader);
+                    message.ReadFromBodyContentsToEnd(bodyReader);
+                }
+                if (rst.RequestType != null && rst.RequestType != this.Settings.SecurityStandardsManager.TrustDriver.RequestTypeClose)
+                {
+                    throw TraceUtility.ThrowHelperWarning(new MessageSecurityException(SR.Format(SR.InvalidRstRequestType, rst.RequestType)), message);
+                }
+                if (rst.CloseTarget == null)
+                {
+                    throw TraceUtility.ThrowHelperWarning(new MessageSecurityException(SR.Format(SR.NoCloseTargetSpecified)), message);
+                }
+                SecurityContextKeyIdentifierClause sctSkiClause = rst.CloseTarget as SecurityContextKeyIdentifierClause;
+                if (sctSkiClause == null || !DoesSkiClauseMatchSigningToken(sctSkiClause, message))
+                {
+                    throw TraceUtility.ThrowHelperWarning(new MessageSecurityException(SR.Format(SR.BadCloseTarget, rst.CloseTarget)), message);
+                }
+                // prepare the close response
+                RequestSecurityTokenResponse rstr = new RequestSecurityTokenResponse(this.Settings.SecurityStandardsManager);
+                rstr.Context = rst.Context;
+                rstr.IsRequestedTokenClosed = true;
+                rstr.MakeReadOnly();
+                Message response = null;
+                if (this.Settings.SecurityStandardsManager.MessageSecurityVersion.TrustVersion == TrustVersion.WSTrustFeb2005)
+                {
+                    response = Message.CreateMessage(message.Version, ActionHeader.Create(this.Settings.SecurityStandardsManager.SecureConversationDriver.CloseResponseAction, message.Version.Addressing), rstr);
+                }
+                else if (this.Settings.SecurityStandardsManager.MessageSecurityVersion.TrustVersion == TrustVersion.WSTrust13)
+                {
+                    List<RequestSecurityTokenResponse> rstrList = new List<RequestSecurityTokenResponse>();
+                    rstrList.Add(rstr);
+                    RequestSecurityTokenResponseCollection rstrCollection = new RequestSecurityTokenResponseCollection(rstrList, this.Settings.SecurityStandardsManager);
+                    response = Message.CreateMessage(message.Version, ActionHeader.Create(this.Settings.SecurityStandardsManager.SecureConversationDriver.CloseResponseAction, message.Version.Addressing), rstrCollection);
+                }
+                else
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new NotSupportedException());
+                }
+
+                PrepareReply(message, response);
+                this.closeResponse = response;
+            }
+
+            bool ShouldWrapException(Exception e)
+            {
+                return ((e is FormatException) || (e is XmlException));
+            }
+
+            protected Message ProcessIncomingMessage(Message message, TimeSpan timeout, SecurityProtocolCorrelationState correlationState, out MessageFault protocolFault)
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // #31 in progress
+
+//                protocolFault = null;
+//                lock (ThisLock)
+//                {
+//                    DoKeyRolloverIfNeeded();
+//                }
+
+//                try
+//                {
+//                    VerifyIncomingMessage(ref message, timeout, correlationState);
+
+//                    string action = message.Headers.Action;
+
+//                    if (action == this.Settings.SecurityStandardsManager.SecureConversationDriver.CloseResponseAction.Value)
+//                    {
+//                        SecurityTraceRecordHelper.TraceCloseResponseReceived(this.currentSessionToken, this.RemoteAddress);
+//                        this.ProcessCloseResponse(message);
+//                        this.OnCloseResponseReceived();
+//                    }
+//                    else if (action == this.Settings.SecurityStandardsManager.SecureConversationDriver.CloseAction.Value)
+//                    {
+//                        SecurityTraceRecordHelper.TraceCloseMessageReceived(this.currentSessionToken, this.RemoteAddress);
+//                        this.ProcessCloseMessage(message);
+//                        this.OnCloseReceived();
+//                    }
+//                    else if (action == DotNetSecurityStrings.SecuritySessionFaultAction)
+//                    {
+//                        bool isKeyRenewalFault;
+//                        bool isSessionAbortedFault;
+//                        protocolFault = GetProtocolFault(ref message, out isKeyRenewalFault, out isSessionAbortedFault);
+//                        if (isKeyRenewalFault)
+//                        {
+//                            ProcessKeyRenewalFault();
+//                        }
+//                        else if (isSessionAbortedFault)
+//                        {
+//                            ProcessSessionAbortedFault(protocolFault);
+//                        }
+//                        else
+//                        {
+//                            return message;
+//                        }
+//                    }
+//                    else
+//                    {
+//                        return message;
+//                    }
+//                }
+//                catch (Exception e)
+//                {
+//                    if ((e is CommunicationException) || (e is TimeoutException) || (Fx.IsFatal(e)) || !ShouldWrapException(e))
+//                    {
+//                        throw;
+//                    }
+//                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new MessageSecurityException(SR.Format(SR.MessageSecurityVerificationFailed), e));
+//                }
+
+//                message.Close();
+//                return null;
+            }
+
+            protected Message ProcessRequestContext(RequestContext requestContext, TimeSpan timeout, SecurityProtocolCorrelationState correlationState)
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // #31 in progres
+
+                //if (requestContext == null)
+                //{
+                //    return null;
+                //}
+                //TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
+                //Message message = requestContext.RequestMessage;
+                //Message unverifiedMessage = message;
+                //try
+                //{
+                //    Exception faultException = null;
+                //    try
+                //    {
+                //        MessageFault dummyProtocolFault;
+                //        return ProcessIncomingMessage(message, timeoutHelper.RemainingTime(), correlationState, out dummyProtocolFault);
+                //    }
+                //    catch (MessageSecurityException e)
+                //    {
+                //        // if the message is an unsecured security fault from the other party over the same connection then fault the session
+                //        if (!isCompositeDuplexConnection)
+                //        {
+                //            if (unverifiedMessage.IsFault)
+                //            {
+                //                MessageFault fault = MessageFault.CreateFault(unverifiedMessage, TransportDefaults.MaxSecurityFaultSize);
+                //                if (SecurityUtils.IsSecurityFault(fault, this.settings.sessionProtocolFactory.StandardsManager))
+                //                {
+                //                    faultException = SecurityUtils.CreateSecurityFaultException(fault);
+                //                }
+                //            }
+                //            else
+                //            {
+                //                faultException = e;
+                //            }
+                //        }
+                //    }
+                //    if (faultException != null)
+                //    {
+                //        this.Fault(faultException);
+                //        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(faultException);
+                //    }
+                //    return null;
+                //}
+                //finally
+                //{
+                //    requestContext.Close(timeoutHelper.RemainingTime());
+                //}
+            }
+
+            /// <summary>
+            /// This method removes the previous session key when the key rollover time is past.
+            /// It must be called within a lock
+            /// </summary>
+            void DoKeyRolloverIfNeeded()
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // #31 in progres
+
+                //if (DateTime.UtcNow >= this.keyRolloverTime && this.previousSessionToken != null)
+                //{
+                //    SecurityTraceRecordHelper.TracePreviousSessionKeyDiscarded(this.previousSessionToken, this.currentSessionToken, this.RemoteAddress);
+                //    // forget the previous session token 
+                //    this.previousSessionToken = null;
+                //    List<SecurityToken> incomingTokens = new List<SecurityToken>(1);
+                //    incomingTokens.Add(this.currentSessionToken);
+                //    ((IInitiatorSecuritySessionProtocol)this.securityProtocol).SetIncomingSessionTokens(incomingTokens);
+                //}
+            }
+
+            DateTime GetKeyRenewalTime(SecurityToken token)
+            {
+                TimeSpan tokenValidityInterval = TimeSpan.FromTicks((long)(((token.ValidTo.Ticks - token.ValidFrom.Ticks) * this.settings._issuedTokenRenewalThreshold) / 100));
+                DateTime keyRenewalTime1 = TimeoutHelper.Add(token.ValidFrom, tokenValidityInterval);
+                DateTime keyRenewalTime2 = TimeoutHelper.Add(token.ValidFrom, this.settings._keyRenewalInterval);
+                if (keyRenewalTime1 < keyRenewalTime2)
+                {
+                    return keyRenewalTime1;
+                }
+                else
+                {
+                    return keyRenewalTime2;
+                }
+            }
+
+            /// <summary>
+            /// This method returns true if key renewal is needed.
+            /// It must be called within a lock
+            /// </summary>
+            bool IsKeyRenewalNeeded()
+            {
+                return DateTime.UtcNow >= this.keyRenewalTime;
+            }
+
+            /// <summary>
+            /// When the new session token is obtained, mark the current token as previous and remove it
+            /// after KeyRolloverTime. Mark the new current as pending and update the next key renewal time
+            /// </summary>
+            void UpdateSessionTokens(SecurityToken newToken)
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // #31 in progres
+
+                //lock (ThisLock)
+                //{
+                //    this.previousSessionToken = this.currentSessionToken;
+                //    this.keyRolloverTime = TimeoutHelper.Add(DateTime.UtcNow, this.Settings.KeyRolloverInterval);
+                //    this.currentSessionToken = newToken;
+                //    this.keyRenewalTime = GetKeyRenewalTime(newToken);
+                //    List<SecurityToken> incomingTokens = new List<SecurityToken>(2);
+                //    incomingTokens.Add(this.previousSessionToken);
+                //    incomingTokens.Add(this.currentSessionToken);
+                //    ((IInitiatorSecuritySessionProtocol)this.securityProtocol).SetIncomingSessionTokens(incomingTokens);
+                //    ((IInitiatorSecuritySessionProtocol)this.securityProtocol).SetOutgoingSessionToken(this.currentSessionToken);
+                //    SecurityTraceRecordHelper.TraceSessionKeyRenewed(this.currentSessionToken, this.previousSessionToken, this.RemoteAddress);
+                //}
+            }
+
+            void RenewKey(TimeSpan timeout)
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // #31 in progres
+
+                //if (!this.settings.CanRenewSession)
+                //{
+                //    throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new SessionKeyExpiredException(SR.Format(SR.SessionKeyRenewalNotSupported)));
+                //}
+
+                //bool startKeyRenewal;
+                //lock (ThisLock)
+                //{
+                //    if (!this.isKeyRenewalOngoing)
+                //    {
+                //        this.isKeyRenewalOngoing = true;
+                //        this.keyRenewalCompletedEvent.Reset();
+                //        startKeyRenewal = true;
+                //    }
+                //    else
+                //    {
+                //        startKeyRenewal = false;
+                //    }
+                //}
+                //if (startKeyRenewal == true)
+                //{
+                //    try
+                //    {
+                //        using (ServiceModelActivity activity = DiagnosticUtility.ShouldUseActivity ?
+                //            ServiceModelActivity.CreateBoundedActivity() : null)
+                //        {
+                //            if (DiagnosticUtility.ShouldUseActivity)
+                //            {
+                //                ServiceModelActivity.Start(activity, SR.Format(SR.ActivitySecurityRenew), ActivityType.SecuritySetup);
+                //            }
+                //            SecurityToken renewedToken = this.sessionTokenProvider.RenewToken(timeout, this.currentSessionToken);
+                //            UpdateSessionTokens(renewedToken);
+                //        }
+                //    }
+                //    finally
+                //    {
+                //        lock (ThisLock)
+                //        {
+                //            this.isKeyRenewalOngoing = false;
+                //            this.keyRenewalCompletedEvent.Set();
+                //        }
+                //    }
+                //}
+                //else
+                //{
+                //    this.keyRenewalCompletedEvent.Wait(timeout);
+                //    lock (ThisLock)
+                //    {
+                //        if (IsKeyRenewalNeeded())
+                //        {
+                //            // the key renewal attempt failed. Throw an exception to the user
+                //            throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new SessionKeyExpiredException(SR.Format(SR.UnableToRenewSessionKey)));
+                //        }
+                //    }
+                //}
+            }
+
+            bool CheckIfKeyRenewalNeeded()
+            {
+                bool doKeyRenewal = false;
+                lock (ThisLock)
+                {
+                    doKeyRenewal = IsKeyRenewalNeeded();
+                    DoKeyRolloverIfNeeded();
+                }
+                return doKeyRenewal;
+            }
+
+            protected IAsyncResult BeginSecureOutgoingMessage(Message message, TimeSpan timeout, AsyncCallback callback, object state)
+            {
+                bool doKeyRenewal = CheckIfKeyRenewalNeeded();
+                if (!doKeyRenewal)
+                {
+                    SecurityProtocolCorrelationState correlationState = this.securityProtocol.SecureOutgoingMessage(ref message, timeout, null);
+                    return new CompletedAsyncResult<Message, SecurityProtocolCorrelationState>(message, correlationState, callback, state);
+                }
+                else
+                {
+                    return new KeyRenewalAsyncResult(message, this, timeout, callback, state);
+                }
+            }
+
+            protected Message EndSecureOutgoingMessage(IAsyncResult result, out SecurityProtocolCorrelationState correlationState)
+            {
+                if (result is CompletedAsyncResult<Message, SecurityProtocolCorrelationState>)
+                {
+                    return CompletedAsyncResult<Message, SecurityProtocolCorrelationState>.End(result, out correlationState);
+                }
+                else
+                {
+                    TimeSpan remainingTime;
+                    Message message = KeyRenewalAsyncResult.End(result, out remainingTime);
+                    correlationState = this.securityProtocol.SecureOutgoingMessage(ref message, remainingTime, null);
+                    return message;
+                }
+            }
+
+            protected SecurityProtocolCorrelationState SecureOutgoingMessage(ref Message message, TimeSpan timeout)
+            {
+                bool doKeyRenewal = CheckIfKeyRenewalNeeded();
+                TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
+                if (doKeyRenewal)
+                {
+                    RenewKey(timeoutHelper.RemainingTime());
+                }
+                return this.securityProtocol.SecureOutgoingMessage(ref message, timeoutHelper.RemainingTime(), null);
+            }
+
+            protected void VerifyIncomingMessage(ref Message message, TimeSpan timeout, SecurityProtocolCorrelationState correlationState)
+            {
+                this.securityProtocol.VerifyIncomingMessage(ref message, timeout, correlationState);
+            }
+
+            protected virtual void AbortCore()
+            {
+                if (this.channelBinder != null)
+                {
+                    this.channelBinder.Abort();
+                }
+                if (this.sessionTokenProvider != null)
+                {
+                    SecurityUtils.AbortTokenProviderIfRequired(this.sessionTokenProvider);
+                }
+            }
+
+            protected virtual void CloseCore(TimeSpan timeout)
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // #31 in progres
+
+                //TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
+
+                //try
+                //{
+                //    if (this.channelBinder != null)
+                //    {
+                //        this.channelBinder.Close(timeoutHelper.RemainingTime());
+                //    }
+                //    if (this.sessionTokenProvider != null)
+                //    {
+                //        SecurityUtils.CloseTokenProviderIfRequired(this.sessionTokenProvider, timeoutHelper.RemainingTime());
+                //    }
+                //    this.keyRenewalCompletedEvent.Abort(this);
+                //    this.inputSessionClosedHandle.Abort(this);
+                //}
+                //catch (CommunicationObjectAbortedException)
+                //{
+                //    if (this.State != CommunicationState.Closed)
+                //    {
+                //        throw;
+                //    }
+                //}
+            }
+
+            protected virtual IAsyncResult BeginCloseCore(TimeSpan timeout, AsyncCallback callback, object state)
+            {
+                throw ExceptionHelper.PlatformNotSupported(); // Issue #31 in progress
+                //return new CloseCoreAsyncResult(this, timeout, callback, state);
+            }
+
+            protected virtual void EndCloseCore(IAsyncResult result)
+            {
+                throw ExceptionHelper.PlatformNotSupported(); // Issue #31 in progress
+                //CloseCoreAsyncResult.End(result);
+            }
+
+            protected IAsyncResult BeginReceiveInternal(TimeSpan timeout, SecurityProtocolCorrelationState correlationState, AsyncCallback callback, object state)
+            {
+                return new ReceiveAsyncResult(this, timeout, correlationState, callback, state);
+            }
+
+            protected Message EndReceiveInternal(IAsyncResult result)
+            {
+                return ReceiveAsyncResult.End(result);
+            }
+
+            protected Message ReceiveInternal(TimeSpan timeout, SecurityProtocolCorrelationState correlationState)
+            {
+                TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
+                while (!this.isInputClosed)
+                {
+                    RequestContext requestContext;
+
+                    if (this.ChannelBinder.TryReceive(timeoutHelper.RemainingTime(), out requestContext))
+                    {
+                        if (requestContext == null)
+                        {
+                            return null;
+                        }
+
+                        Message message = ProcessRequestContext(requestContext, timeoutHelper.RemainingTime(), correlationState);
+
+                        if (message != null)
+                        {
+                            return message;
+                        }
+                    }
+
+                    if (timeoutHelper.RemainingTime() == TimeSpan.Zero)
+                    {
+                        // we timed out
+                        break;
+                    }
+                }
+
+                return null;
+            }
+
+            protected bool CloseSession(TimeSpan timeout, out bool wasAborted)
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // #31 in progress
+
+                //using (ServiceModelActivity activity = DiagnosticUtility.ShouldUseActivity ?
+                //    ServiceModelActivity.CreateBoundedActivity() : null)
+                //{
+                //    if (DiagnosticUtility.ShouldUseActivity)
+                //    {
+                //        ServiceModelActivity.Start(activity, SR.Format(SR.ActivitySecurityClose), ActivityType.SecuritySetup);
+                //    }
+
+                //    TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
+                //    wasAborted = false;
+                //    try
+                //    {
+                //        this.CloseOutputSession(timeoutHelper.RemainingTime());
+                //        return this.inputSessionClosedHandle.Wait(timeoutHelper.RemainingTime(), false);
+                //    }
+                //    catch (CommunicationObjectAbortedException)
+                //    {
+                //        if (this.State != CommunicationState.Closed)
+                //        {
+                //            throw;
+                //        }
+                //        wasAborted = true;
+                //    }
+                //    return false;
+                //}
+            }
+
+            protected IAsyncResult BeginCloseSession(TimeSpan timeout, AsyncCallback callback, object state)
+            {
+                using (ServiceModelActivity activity = DiagnosticUtility.ShouldUseActivity ?
+                    ServiceModelActivity.CreateAsyncActivity() : null)
+                {
+                    if (DiagnosticUtility.ShouldUseActivity)
+                    {
+                        ServiceModelActivity.Start(activity, SR.Format(SR.ActivitySecurityClose), ActivityType.SecuritySetup);
+                    }
+                    return new CloseSessionAsyncResult(timeout, this, callback, state);
+                }
+            }
+
+            protected bool EndCloseSession(IAsyncResult result, out bool wasAborted)
+            {
+                return CloseSessionAsyncResult.End(result, out wasAborted);
+            }
+
+            void DetermineCloseMessageToSend(out bool sendClose, out bool sendCloseResponse)
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // #31 in progress
+
+                //sendClose = false;
+                //sendCloseResponse = false;
+                //lock (ThisLock)
+                //{
+                //    if (!this.isOutputClosed)
+                //    {
+                //        this.isOutputClosed = true;
+                //        if (this.receivedClose)
+                //        {
+                //            sendCloseResponse = true;
+                //        }
+                //        else
+                //        {
+                //            sendClose = true;
+                //            this.sentClose = true;
+                //        }
+                //        this.outputSessionCloseHandle.Reset();
+                //    }
+                //}
+            }
+
+            protected virtual SecurityProtocolCorrelationState CloseOutputSession(TimeSpan timeout)
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // #31 in progress
+
+                //ThrowIfFaulted();
+                //if (!this.SendCloseHandshake)
+                //{
+                //    return null;
+                //}
+                //bool sendClose;
+                //bool sendCloseResponse;
+                //DetermineCloseMessageToSend(out sendClose, out sendCloseResponse);
+                //if (sendClose || sendCloseResponse)
+                //{
+                //    try
+                //    {
+                //        if (sendClose)
+                //        {
+                //            return this.SendCloseMessage(timeout);
+                //        }
+                //        else
+                //        {
+                //            this.SendCloseResponseMessage(timeout);
+                //            return null;
+                //        }
+                //    }
+                //    finally
+                //    {
+                //        this.outputSessionCloseHandle.Set();
+                //    }
+                //}
+                //else
+                //{
+                //    return null;
+                //}
+            }
+
+            protected virtual IAsyncResult BeginCloseOutputSession(TimeSpan timeout, AsyncCallback callback, object state)
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // #31 in progress
+
+                //ThrowIfFaulted();
+                //if (!this.SendCloseHandshake)
+                //{
+                //    return new CompletedAsyncResult(callback, state);
+                //}
+                //bool sendClose;
+                //bool sendCloseResponse;
+                //DetermineCloseMessageToSend(out sendClose, out sendCloseResponse);
+                //if (sendClose || sendCloseResponse)
+                //{
+                //    bool setOutputSessionCloseHandle = true;
+                //    try
+                //    {
+                //        IAsyncResult result;
+                //        if (sendClose)
+                //        {
+                //            result = this.BeginSendCloseMessage(timeout, callback, state);
+                //        }
+                //        else
+                //        {
+                //            result = this.BeginSendCloseResponseMessage(timeout, callback, state);
+                //        }
+                //        setOutputSessionCloseHandle = false;
+                //        return result;
+                //    }
+                //    finally
+                //    {
+                //        if (setOutputSessionCloseHandle)
+                //        {
+                //            this.outputSessionCloseHandle.Set();
+                //        }
+                //    }
+                //}
+                //else
+                //{
+                //    return new CompletedAsyncResult(callback, state);
+                //}
+            }
+
+            protected virtual SecurityProtocolCorrelationState EndCloseOutputSession(IAsyncResult result)
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // #31 in progress
+
+                //if (result is CompletedAsyncResult)
+                //{
+                //    CompletedAsyncResult.End(result);
+                //    return null;
+                //}
+                //bool sentCloseLocal;
+                //lock (ThisLock)
+                //{
+                //    sentCloseLocal = this.sentClose;
+                //}
+                //try
+                //{
+                //    if (sentCloseLocal)
+                //    {
+                //        return this.EndSendCloseMessage(result);
+                //    }
+                //    else
+                //    {
+                //        this.EndSendCloseResponseMessage(result);
+                //        return null;
+                //    }
+                //}
+                //finally
+                //{
+                //    this.outputSessionCloseHandle.Set();
+                //}
+            }
+
+            protected void CheckOutputOpen()
+            {
+                ThrowIfClosedOrNotOpen();
+                lock (ThisLock)
+                {
+                    if (isOutputClosed)
+                    {
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new CommunicationException(SR.Format(SR.OutputNotExpected)));
+                    }
+                }
+            }
+
+            protected override void OnAbort()
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // #31 in progress
+
+                //this.AbortCore();
+                //this.inputSessionClosedHandle.Abort(this);
+                //this.keyRenewalCompletedEvent.Abort(this);
+                //this.outputSessionCloseHandle.Abort(this);
+            }
+
+            protected override void OnClose(TimeSpan timeout)
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // #31 in progress
+
+                //TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
+                //if (this.SendCloseHandshake)
+                //{
+                //    bool wasAborted;
+                //    bool wasSessionClosed = this.CloseSession(timeout, out wasAborted);
+                //    if (wasAborted)
+                //    {
+                //        return;
+                //    }
+                //    if (!wasSessionClosed)
+                //    {
+                //        throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new TimeoutException(SR.Format(SR.ClientSecurityCloseTimeout, timeout)));
+                //    }
+                //    // wait for any concurrent output session close to finish
+                //    try
+                //    {
+                //        if (!this.outputSessionCloseHandle.Wait(timeoutHelper.RemainingTime(), false))
+                //        {
+                //            throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new TimeoutException(SR.Format(SR.ClientSecurityOutputSessionCloseTimeout, timeoutHelper.OriginalTimeout)));
+                //        }
+                //    }
+                //    catch (CommunicationObjectAbortedException)
+                //    {
+                //        if (this.State == CommunicationState.Closed)
+                //        {
+                //            return;
+                //        }
+                //        else
+                //        {
+                //            throw;
+                //        }
+                //    }
+                //}
+
+                //this.CloseCore(timeoutHelper.RemainingTime());
+            }
+
+            protected override IAsyncResult OnBeginClose(TimeSpan timeout, AsyncCallback callback, object state)
+            {
+                throw ExceptionHelper.PlatformNotSupported();
+            }
+
+            protected override void OnEndClose(IAsyncResult result)
+            {
+                throw ExceptionHelper.PlatformNotSupported();
+            }
+
+            class CloseCoreAsyncResult : TraceAsyncResult
+            {
+                static AsyncCallback closeChannelBinderCallback = Fx.ThunkCallback(new AsyncCallback(ChannelBinderCloseCallback));
+                static AsyncCallback closeTokenProviderCallback = Fx.ThunkCallback(new AsyncCallback(CloseTokenProviderCallback));
+
+                TimeoutHelper timeoutHelper;
+                ClientSecuritySessionChannel channel;
+
+                public CloseCoreAsyncResult(ClientSecuritySessionChannel channel, TimeSpan timeout, AsyncCallback callback, object state)
+                    : base(callback, state)
+                {
+                    this.channel = channel;
+                    this.timeoutHelper = new TimeoutHelper(timeout);
+                    bool completeSelf = false;
+                    if (channel.channelBinder != null)
+                    {
+                        try
+                        {
+                            IAsyncResult result = this.channel.channelBinder.BeginClose(timeoutHelper.RemainingTime(), closeChannelBinderCallback, this);
+                            if (!result.CompletedSynchronously)
+                            {
+                                return;
+                            }
+                            this.channel.channelBinder.EndClose(result);
+                        }
+                        catch (CommunicationObjectAbortedException)
+                        {
+                            if (this.channel.State != CommunicationState.Closed)
+                            {
+                                throw;
+                            }
+                            completeSelf = true;
+                        }
+                    }
+                    if (!completeSelf)
+                    {
+                        completeSelf = this.OnChannelBinderClosed();
+                    }
+                    if (completeSelf)
+                    {
+                        Complete(true);
+                    }
+                }
+
+                static void ChannelBinderCloseCallback(IAsyncResult result)
+                {
+                    if (result.CompletedSynchronously)
+                    {
+                        return;
+                    }
+                    CloseCoreAsyncResult self = (CloseCoreAsyncResult)(result.AsyncState);
+                    Exception completionException = null;
+                    bool completeSelf = false;
+                    try
+                    {
+                        try
+                        {
+                            self.channel.channelBinder.EndClose(result);
+                        }
+                        catch (CommunicationObjectAbortedException)
+                        {
+                            if (self.channel.State != CommunicationState.Closed)
+                            {
+                                throw;
+                            }
+                            completeSelf = true;
+                        }
+                        if (!completeSelf)
+                        {
+                            completeSelf = self.OnChannelBinderClosed();
+                        }
+                    }
+                    catch (Exception e)
+                    {
+                        if (Fx.IsFatal(e))
+                        {
+                            throw;
+                        }
+                        completeSelf = true;
+                        completionException = e;
+                    }
+                    if (completeSelf)
+                    {
+                        self.Complete(false, completionException);
+                    }
+                }
+
+                bool OnChannelBinderClosed()
+                {
+                    throw ExceptionHelper.PlatformNotSupported();   // #31 in progress
+
+                    //if (channel.sessionTokenProvider != null)
+                    //{
+                    //    try
+                    //    {
+                    //        IAsyncResult result = SecurityUtils.BeginCloseTokenProviderIfRequired(this.channel.sessionTokenProvider, timeoutHelper.RemainingTime(), closeTokenProviderCallback, this);
+                    //        if (!result.CompletedSynchronously)
+                    //        {
+                    //            return false;
+                    //        }
+                    //        SecurityUtils.EndCloseTokenProviderIfRequired(result);
+                    //    }
+                    //    catch (CommunicationObjectAbortedException)
+                    //    {
+                    //        if (channel.State != CommunicationState.Closed)
+                    //        {
+                    //            throw;
+                    //        }
+                    //        return true;
+                    //    }
+                    //}
+                    //return this.OnTokenProviderClosed();
+                }
+
+                static void CloseTokenProviderCallback(IAsyncResult result)
+                {
+                    throw ExceptionHelper.PlatformNotSupported();   // #31 in progress
+
+//                    if (result.CompletedSynchronously)
+//                    {
+//                        return;
+//                    }
+//                    CloseCoreAsyncResult self = (CloseCoreAsyncResult)(result.AsyncState);
+//                    Exception completionException = null;
+//                    bool completeSelf = false;
+//                    try
+//                    {
+//                        try
+//                        {
+//                            SecurityUtils.EndCloseTokenProviderIfRequired(result);
+//                        }
+//                        catch (CommunicationObjectAbortedException)
+//                        {
+//                            if (self.channel.State != CommunicationState.Closed)
+//                            {
+//                                throw;
+//                            }
+//                            completeSelf = true;
+//                        }
+//                        if (!completeSelf)
+//                        {
+//                            completeSelf = self.OnTokenProviderClosed();
+//                        }
+//                    }
+//                    catch (Exception e)
+//                    {
+//                        if (Fx.IsFatal(e))
+//                        {
+//                            throw;
+//                        }
+//                        completeSelf = true;
+//                        completionException = e;
+//                    }
+//                    if (completeSelf)
+//                    {
+//                        self.Complete(false, completionException);
+//                    }
+                }
+
+                bool OnTokenProviderClosed()
+                {
+                    throw ExceptionHelper.PlatformNotSupported();   // #31 in progress
+
+                    //this.channel.keyRenewalCompletedEvent.Abort(this.channel);
+                    //this.channel.inputSessionClosedHandle.Abort(this.channel);
+                    //return true;
+                }
+
+                public static void End(IAsyncResult result)
+                {
+                    AsyncResult.End<CloseCoreAsyncResult>(result);
+                }
+            }
+
+            class ReceiveAsyncResult : TraceAsyncResult
+            {
+                static AsyncCallback onReceive = Fx.ThunkCallback(new AsyncCallback(OnReceive));
+                ClientSecuritySessionChannel channel;
+                Message message;
+                SecurityProtocolCorrelationState correlationState;
+                TimeoutHelper timeoutHelper;
+
+                public ReceiveAsyncResult(ClientSecuritySessionChannel channel, TimeSpan timeout, SecurityProtocolCorrelationState correlationState, AsyncCallback callback, object state)
+                    : base(callback, state)
+                {
+                    this.channel = channel;
+                    this.correlationState = correlationState;
+                    this.timeoutHelper = new TimeoutHelper(timeout);
+
+                    IAsyncResult result = channel.ChannelBinder.BeginTryReceive(timeoutHelper.RemainingTime(), onReceive, this);
+
+                    if (!result.CompletedSynchronously)
+                        return;
+
+                    bool completedSynchronously = CompleteReceive(result);
+                    if (completedSynchronously)
+                    {
+                        Complete(true);
+                    }
+                }
+
+                bool CompleteReceive(IAsyncResult result)
+                {
+                    while (!channel.isInputClosed)
+                    {
+                        RequestContext requestContext;
+                        if (channel.ChannelBinder.EndTryReceive(result, out requestContext))
+                        {
+                            if (requestContext == null)
+                                break;
+
+                            message = channel.ProcessRequestContext(requestContext, timeoutHelper.RemainingTime(), this.correlationState);
+
+                            if (message != null || channel.isInputClosed)
+                                break;
+                        }
+
+                        TimeSpan timeout = timeoutHelper.RemainingTime();
+                        if (timeout == TimeSpan.Zero)
+                        {
+                            // we timed out
+                            break;
+                        }
+
+                        result = channel.ChannelBinder.BeginTryReceive(timeoutHelper.RemainingTime(), onReceive, this);
+
+                        if (!result.CompletedSynchronously)
+                            return false;
+                    }
+
+                    return true;
+                }
+
+                public static Message End(IAsyncResult result)
+                {
+                    ReceiveAsyncResult receiveResult = AsyncResult.End<ReceiveAsyncResult>(result);
+                    return receiveResult.message;
+                }
+
+                static void OnReceive(IAsyncResult result)
+                {
+                    if (result.CompletedSynchronously)
+                        return;
+                    ReceiveAsyncResult self = (ReceiveAsyncResult)result.AsyncState;
+                    bool completeSelf = false;
+                    Exception completionException = null;
+                    try
+                    {
+                        completeSelf = self.CompleteReceive(result);
+                    }
+                    catch (Exception e)
+                    {
+                        if (Fx.IsFatal(e))
+                        {
+                            throw;
+                        }
+
+                        completeSelf = true;
+                        completionException = e;
+                    }
+                    if (completeSelf)
+                    {
+                        self.Complete(false, completionException);
+                    }
+                }
+            }
+
+            class CloseSessionAsyncResult : TraceAsyncResult
+            {
+                static readonly AsyncCallback closeOutputSessionCallback = Fx.ThunkCallback(new AsyncCallback(CloseOutputSessionCallback));
+                static readonly AsyncCallback shutdownWaitCallback = Fx.ThunkCallback(new AsyncCallback(ShutdownWaitCallback));
+
+                ClientSecuritySessionChannel sessionChannel;
+                bool closeCompleted;
+                bool wasAborted;
+                TimeoutHelper timeoutHelper;
+
+                public CloseSessionAsyncResult(TimeSpan timeout, ClientSecuritySessionChannel sessionChannel, AsyncCallback callback, object state)
+                    : base(callback, state)
+                {
+                    this.timeoutHelper = new TimeoutHelper(timeout);
+                    this.sessionChannel = sessionChannel;
+                    bool completeSelf = false;
+                    try
+                    {
+                        IAsyncResult result = this.sessionChannel.BeginCloseOutputSession(timeoutHelper.RemainingTime(), closeOutputSessionCallback, this);
+                        if (!result.CompletedSynchronously)
+                        {
+                            return;
+                        }
+                        this.sessionChannel.EndCloseOutputSession(result);
+                    }
+                    catch (CommunicationObjectAbortedException)
+                    {
+                        if (this.sessionChannel.State != CommunicationState.Closed)
+                        {
+                            throw;
+                        }
+                        completeSelf = true;
+                        wasAborted = true;
+                    }
+                    if (!wasAborted)
+                    {
+                        completeSelf = this.OnOutputSessionClosed();
+                    }
+                    if (completeSelf)
+                    {
+                        Complete(true);
+                    }
+                }
+
+                static void CloseOutputSessionCallback(IAsyncResult result)
+                {
+                    if (result.CompletedSynchronously)
+                    {
+                        return;
+                    }
+                    CloseSessionAsyncResult thisResult = (CloseSessionAsyncResult)result.AsyncState;
+                    bool completeSelf = false;
+                    Exception completionException = null;
+                    try
+                    {
+                        try
+                        {
+                            thisResult.sessionChannel.EndCloseOutputSession(result);
+                        }
+                        catch (CommunicationObjectAbortedException)
+                        {
+                            if (thisResult.sessionChannel.State != CommunicationState.Closed)
+                            {
+                                throw;
+                            }
+                            thisResult.wasAborted = true;
+                            completeSelf = true;
+                        }
+                        if (!thisResult.wasAborted)
+                        {
+                            completeSelf = thisResult.OnOutputSessionClosed();
+                        }
+                    }
+                    catch (Exception e)
+                    {
+                        if (Fx.IsFatal(e))
+                        {
+                            throw;
+                        }
+
+                        completeSelf = true;
+                        completionException = e;
+                    }
+                    if (completeSelf)
+                    {
+                        thisResult.Complete(false, completionException);
+                    }
+                }
+
+                bool OnOutputSessionClosed()
+                {
+                    throw ExceptionHelper.PlatformNotSupported();   // #31 in progress
+
+                    //try
+                    //{
+                    //    IAsyncResult result = this.sessionChannel.inputSessionClosedHandle.BeginWait(this.timeoutHelper.RemainingTime(), true, shutdownWaitCallback, this);
+                    //    if (!result.CompletedSynchronously)
+                    //    {
+                    //        return false;
+                    //    }
+                    //    this.sessionChannel.inputSessionClosedHandle.EndWait(result);
+                    //    this.closeCompleted = true;
+                    //}
+                    //catch (CommunicationObjectAbortedException)
+                    //{
+                    //    if (this.sessionChannel.State != CommunicationState.Closed)
+                    //    {
+                    //        throw;
+                    //    }
+                    //    // if the channel was aborted by a parallel thread, allow the Close to
+                    //    // complete cleanly
+                    //    this.wasAborted = true;
+                    //}
+                    //catch (TimeoutException)
+                    //{
+                    //    this.closeCompleted = false;
+                    //}
+                    //return true;
+                }
+
+                static void ShutdownWaitCallback(IAsyncResult result)
+                {
+                    throw ExceptionHelper.PlatformNotSupported();   // #31 in progress
+
+//                    if (result.CompletedSynchronously)
+//                    {
+//                        return;
+//                    }
+//                    CloseSessionAsyncResult thisResult = (CloseSessionAsyncResult)result.AsyncState;
+//                    Exception completionException = null;
+//                    try
+//                    {
+//                        thisResult.sessionChannel.inputSessionClosedHandle.EndWait(result);
+//                        thisResult.closeCompleted = true;
+//                    }
+//                    catch (CommunicationObjectAbortedException)
+//                    {
+//                        if (thisResult.sessionChannel.State != CommunicationState.Closed)
+//                        {
+//                            throw;
+//                        }
+//                        thisResult.wasAborted = true;
+//                    }
+//                    catch (TimeoutException)
+//                    {
+//                        thisResult.closeCompleted = false;
+//                    }
+//                    catch (Exception e)
+//                    {
+//                        if (Fx.IsFatal(e))
+//                        {
+//                            throw;
+//                        }
+//                        completionException = e;
+//                    }
+//                    thisResult.Complete(false, completionException);
+                }
+
+                public static bool End(IAsyncResult result, out bool wasAborted)
+                {
+                    CloseSessionAsyncResult thisResult = AsyncResult.End<CloseSessionAsyncResult>(result);
+                    wasAborted = thisResult.wasAborted;
+                    ServiceModelActivity.Stop(thisResult.CallbackActivity);
+                    return thisResult.closeCompleted;
+                }
+            }
+
+            class CloseAsyncResult : TraceAsyncResult
+            {
+                static readonly AsyncCallback closeSessionCallback = Fx.ThunkCallback(new AsyncCallback(CloseSessionCallback));
+                static readonly AsyncCallback outputSessionClosedCallback = Fx.ThunkCallback(new AsyncCallback(OutputSessionClosedCallback));
+                static readonly AsyncCallback closeCoreCallback = Fx.ThunkCallback(new AsyncCallback(CloseCoreCallback));
+
+                ClientSecuritySessionChannel sessionChannel;
+                TimeoutHelper timeoutHelper;
+
+                public CloseAsyncResult(ClientSecuritySessionChannel sessionChannel, TimeSpan timeout, AsyncCallback callback, object state)
+                    : base(callback, state)
+                {
+                    sessionChannel.ThrowIfFaulted();
+                    this.timeoutHelper = new TimeoutHelper(timeout);
+                    this.sessionChannel = sessionChannel;
+
+                    if (!sessionChannel.SendCloseHandshake)
+                    {
+                        if (this.CloseCore())
+                        {
+                            Complete(true);
+                        }
+                        return;
+                    }
+
+                    bool wasClosed;
+                    bool wasAborted = false;
+                    IAsyncResult result = this.sessionChannel.BeginCloseSession(this.timeoutHelper.RemainingTime(), closeSessionCallback, this);
+                    if (!result.CompletedSynchronously)
+                    {
+                        return;
+                    }
+                    wasClosed = this.sessionChannel.EndCloseSession(result, out wasAborted);
+                    if (wasAborted)
+                    {
+                        Complete(true);
+                        return;
+                    }
+                    if (!wasClosed)
+                    {
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new TimeoutException(SR.Format(SR.ClientSecurityCloseTimeout, timeout)));
+                    }
+                    bool completeSelf = this.OnWaitForOutputSessionClose(out wasAborted);
+                    if (wasAborted || completeSelf)
+                    {
+                        Complete(true);
+                    }
+                }
+
+                static void CloseSessionCallback(IAsyncResult result)
+                {
+                    if (result.CompletedSynchronously)
+                    {
+                        return;
+                    }
+                    CloseAsyncResult thisResult = (CloseAsyncResult)result.AsyncState;
+                    bool completeSelf = false;
+                    Exception completionException = null;
+                    try
+                    {
+                        bool wasAborted;
+                        bool wasClosed = thisResult.sessionChannel.EndCloseSession(result, out wasAborted);
+                        if (wasAborted)
+                        {
+                            completeSelf = true;
+                        }
+                        else
+                        {
+                            if (!wasClosed)
+                            {
+                                throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new TimeoutException(SR.Format(SR.ClientSecurityCloseTimeout, thisResult.timeoutHelper.OriginalTimeout)));
+                            }
+                            completeSelf = thisResult.OnWaitForOutputSessionClose(out wasAborted);
+                            if (wasAborted)
+                            {
+                                completeSelf = true;
+                            }
+                        }
+                    }
+                    catch (Exception e)
+                    {
+                        if (Fx.IsFatal(e))
+                        {
+                            throw;
+                        }
+
+                        completeSelf = true;
+                        completionException = e;
+                    }
+                    if (completeSelf)
+                    {
+                        thisResult.Complete(false, completionException);
+                    }
+                }
+
+                bool OnWaitForOutputSessionClose(out bool wasAborted)
+                {
+                    throw ExceptionHelper.PlatformNotSupported();   // #31 in progress
+
+                    //wasAborted = false;
+                    //bool wasOutputSessionClosed = false;
+                    //// wait for pending output sessions to finish
+                    //try
+                    //{
+                    //    IAsyncResult result = this.sessionChannel.outputSessionCloseHandle.BeginWait(timeoutHelper.RemainingTime(), true, outputSessionClosedCallback, this);
+                    //    if (!result.CompletedSynchronously)
+                    //    {
+                    //        return false;
+                    //    }
+                    //    this.sessionChannel.outputSessionCloseHandle.EndWait(result);
+                    //    wasOutputSessionClosed = true;
+                    //}
+                    //catch (TimeoutException)
+                    //{
+                    //    wasOutputSessionClosed = false;
+                    //}
+                    //catch (CommunicationObjectAbortedException)
+                    //{
+                    //    if (this.sessionChannel.State == CommunicationState.Closed)
+                    //    {
+                    //        wasAborted = true;
+                    //    }
+                    //    else
+                    //    {
+                    //        throw;
+                    //    }
+                    //}
+                    //if (wasAborted)
+                    //{
+                    //    return true;
+                    //}
+                    //if (!wasOutputSessionClosed)
+                    //{
+                    //    throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new TimeoutException(SR.Format(SR.ClientSecurityOutputSessionCloseTimeout, timeoutHelper.OriginalTimeout)));
+                    //}
+                    //else
+                    //{
+                    //    return this.CloseCore();
+                    //}
+                }
+
+                static void OutputSessionClosedCallback(IAsyncResult result)
+                {
+                    throw ExceptionHelper.PlatformNotSupported();   // #31 in progress
+
+//                    if (result.CompletedSynchronously)
+//                    {
+//                        return;
+//                    }
+//                    CloseAsyncResult self = (CloseAsyncResult)(result.AsyncState);
+//                    Exception completionException = null;
+//                    bool completeSelf = false;
+//                    try
+//                    {
+//                        bool wasOutputSessionClosed = false;
+//                        bool wasAborted = false;
+//                        try
+//                        {
+//                            self.sessionChannel.outputSessionCloseHandle.EndWait(result);
+//                            wasOutputSessionClosed = true;
+//                        }
+//                        catch (TimeoutException)
+//                        {
+//                            wasOutputSessionClosed = false;
+//                        }
+//                        catch (CommunicationObjectFaultedException)
+//                        {
+//                            if (self.sessionChannel.State == CommunicationState.Closed)
+//                            {
+//                                wasAborted = true;
+//                            }
+//                            else
+//                            {
+//                                throw;
+//                            }
+//                        }
+//                        if (!wasAborted)
+//                        {
+//                            if (!wasOutputSessionClosed)
+//                            {
+//                                throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new TimeoutException(SR.Format(SR.ClientSecurityOutputSessionCloseTimeout, self.timeoutHelper.OriginalTimeout)));
+//                            }
+//                            completeSelf = self.CloseCore();
+//                        }
+//                        else
+//                        {
+//                            completeSelf = true;
+//                        }
+//                    }
+//                    catch (Exception e)
+//                    {
+//                        if (Fx.IsFatal(e))
+//                        {
+//                            throw;
+//                        }
+//                        completionException = e;
+//                        completeSelf = true;
+//                    }
+//                    if (completeSelf)
+//                    {
+//                        self.Complete(false, completionException);
+//                    }
+                }
+
+                bool CloseCore()
+                {
+                    IAsyncResult result = this.sessionChannel.BeginCloseCore(timeoutHelper.RemainingTime(), closeCoreCallback, this);
+                    if (!result.CompletedSynchronously)
+                    {
+                        return false;
+                    }
+                    this.sessionChannel.EndCloseCore(result);
+                    return true;
+                }
+
+                static void CloseCoreCallback(IAsyncResult result)
+                {
+                    if (result.CompletedSynchronously)
+                    {
+                        return;
+                    }
+                    CloseAsyncResult self = (CloseAsyncResult)(result.AsyncState);
+                    Exception completionException = null;
+                    try
+                    {
+                        self.sessionChannel.EndCloseCore(result);
+                    }
+                    catch (Exception e)
+                    {
+                        if (Fx.IsFatal(e))
+                        {
+                            throw;
+                        }
+                        completionException = e;
+                    }
+                    self.Complete(false, completionException);
+                }
+
+                public static void End(IAsyncResult result)
+                {
+                    AsyncResult.End<CloseAsyncResult>(result);
+                }
+            }
+
+            class KeyRenewalAsyncResult : TraceAsyncResult
+            {
+                static readonly Action<object> renewKeyCallback = new Action<object>(RenewKeyCallback);
+                Message message;
+                ClientSecuritySessionChannel sessionChannel;
+                TimeoutHelper timeoutHelper;
+
+                public KeyRenewalAsyncResult(Message message, ClientSecuritySessionChannel sessionChannel, TimeSpan timeout, AsyncCallback callback, object state)
+                    : base(callback, state)
+                {
+                    timeoutHelper = new TimeoutHelper(timeout);
+                    this.message = message;
+                    this.sessionChannel = sessionChannel;
+                    // its ok to start up a separate thread for this since this is a very rare event.
+                    ActionItem.Schedule(renewKeyCallback, this);
+                }
+
+                static void RenewKeyCallback(object state)
+                {
+                    KeyRenewalAsyncResult thisResult = (KeyRenewalAsyncResult)state;
+                    Exception completionException = null;
+                    try
+                    {
+                        using (thisResult.CallbackActivity == null ? null : ServiceModelActivity.BoundOperation(thisResult.CallbackActivity))
+                        {
+                            thisResult.sessionChannel.RenewKey(thisResult.timeoutHelper.RemainingTime());
+                        }
+                    }
+                    catch (Exception e)
+                    {
+                        if (Fx.IsFatal(e))
+                        {
+                            throw;
+                        }
+
+                        completionException = e;
+                    }
+                    thisResult.Complete(false, completionException);
+                }
+
+                public static Message End(IAsyncResult result, out TimeSpan remainingTime)
+                {
+                    KeyRenewalAsyncResult thisResult = AsyncResult.End<KeyRenewalAsyncResult>(result);
+                    remainingTime = thisResult.timeoutHelper.RemainingTime();
+                    return thisResult.message;
+                }
+            }
+
+            internal abstract class SecureSendAsyncResultBase : TraceAsyncResult
+            {
+                static readonly AsyncCallback secureOutgoingMessageCallback = Fx.ThunkCallback(new AsyncCallback(SecureOutgoingMessageCallback));
+                Message message;
+                SecurityProtocolCorrelationState correlationState;
+                ClientSecuritySessionChannel sessionChannel;
+                bool didSecureOutgoingMessageCompleteSynchronously = false;
+                TimeoutHelper timeoutHelper;
+
+                protected SecureSendAsyncResultBase(Message message, ClientSecuritySessionChannel sessionChannel, TimeSpan timeout, AsyncCallback callback, object state)
+                    : base(callback, state)
+                {
+                    this.message = message;
+                    this.sessionChannel = sessionChannel;
+                    this.timeoutHelper = new TimeoutHelper(timeout);
+                    IAsyncResult result = this.sessionChannel.BeginSecureOutgoingMessage(message, timeoutHelper.RemainingTime(), secureOutgoingMessageCallback, this);
+                    if (!result.CompletedSynchronously)
+                    {
+                        return;
+                    }
+                    this.message = this.sessionChannel.EndSecureOutgoingMessage(result, out this.correlationState);
+                    this.didSecureOutgoingMessageCompleteSynchronously = true;
+                }
+
+                protected bool DidSecureOutgoingMessageCompleteSynchronously
+                {
+                    get
+                    {
+                        return this.didSecureOutgoingMessageCompleteSynchronously;
+                    }
+                }
+
+                protected TimeoutHelper TimeoutHelper
+                {
+                    get
+                    {
+                        return this.timeoutHelper;
+                    }
+                }
+
+                protected IClientReliableChannelBinder ChannelBinder
+                {
+                    get
+                    {
+                        return this.sessionChannel.ChannelBinder;
+                    }
+                }
+
+                protected Message Message
+                {
+                    get
+                    {
+                        return this.message;
+                    }
+                }
+
+                protected SecurityProtocolCorrelationState SecurityCorrelationState
+                {
+                    get
+                    {
+                        return this.correlationState;
+                    }
+                }
+
+                protected abstract bool OnMessageSecured();
+
+                static void SecureOutgoingMessageCallback(IAsyncResult result)
+                {
+                    if (result.CompletedSynchronously)
+                    {
+                        return;
+                    }
+                    SecureSendAsyncResultBase thisResult = (SecureSendAsyncResultBase)result.AsyncState;
+                    bool completeSelf = false;
+                    Exception completionException = null;
+                    try
+                    {
+                        thisResult.message = thisResult.sessionChannel.EndSecureOutgoingMessage(result, out thisResult.correlationState);
+                        completeSelf = thisResult.OnMessageSecured();
+                    }
+                    catch (Exception e)
+                    {
+                        if (Fx.IsFatal(e))
+                        {
+                            throw;
+                        }
+
+                        completeSelf = true;
+                        completionException = e;
+                    }
+                    if (completeSelf)
+                    {
+                        thisResult.Complete(false, completionException);
+                    }
+                }
+            }
+
+            internal sealed class SecureSendAsyncResult : SecureSendAsyncResultBase
+            {
+                static readonly AsyncCallback sendCallback = Fx.ThunkCallback(new AsyncCallback(SendCallback));
+
+                bool autoCloseMessage;
+
+                public SecureSendAsyncResult(Message message, ClientSecuritySessionChannel sessionChannel, TimeSpan timeout, AsyncCallback callback, object state, bool autoCloseMessage)
+                    : base(message, sessionChannel, timeout, callback, state)
+                {
+                    this.autoCloseMessage = autoCloseMessage;
+
+                    if (!this.DidSecureOutgoingMessageCompleteSynchronously)
+                    {
+                        return;
+                    }
+                    bool completeSelf = this.OnMessageSecured();
+                    if (completeSelf)
+                    {
+                        Complete(true);
+                    }
+                }
+
+                protected override bool OnMessageSecured()
+                {
+                    bool closeMessage = true;
+                    try
+                    {
+                        IAsyncResult result = this.ChannelBinder.BeginSend(this.Message, this.TimeoutHelper.RemainingTime(), sendCallback, this);
+                        if (!result.CompletedSynchronously)
+                        {
+                            closeMessage = false;
+                            return false;
+                        }
+                        this.ChannelBinder.EndSend(result);
+                        return true;
+                    }
+                    finally
+                    {
+                        if (closeMessage && this.autoCloseMessage && this.Message != null)
+                        {
+                            this.Message.Close();
+                        }
+                    }
+                }
+
+                static void SendCallback(IAsyncResult result)
+                {
+                    if (result.CompletedSynchronously)
+                    {
+                        return;
+                    }
+                    SecureSendAsyncResult thisResult = (SecureSendAsyncResult)result.AsyncState;
+                    Exception completionException = null;
+                    try
+                    {
+                        thisResult.ChannelBinder.EndSend(result);
+                    }
+                    catch (Exception e)
+                    {
+                        if (Fx.IsFatal(e))
+                        {
+                            throw;
+                        }
+
+                        completionException = e;
+                    }
+                    finally
+                    {
+                        if (thisResult.autoCloseMessage && thisResult.Message != null)
+                        {
+                            thisResult.Message.Close();
+                        }
+                        if (thisResult.CallbackActivity != null && DiagnosticUtility.ShouldUseActivity)
+                        {
+                            thisResult.CallbackActivity.Stop();
+                        }
+                    }
+
+                    thisResult.Complete(false, completionException);
+                }
+
+                public static SecurityProtocolCorrelationState End(IAsyncResult result)
+                {
+                    SecureSendAsyncResult thisResult = AsyncResult.End<SecureSendAsyncResult>(result);
+                    return thisResult.SecurityCorrelationState;
+                }
+            }
+
+            protected class SoapSecurityOutputSession : ISecureConversationSession, IOutputSession
+            {
+                private ClientSecuritySessionChannel _channel;
+                private EndpointIdentity _remoteIdentity;
+                private UniqueId _sessionId;
+                // #31 in progress
+                // private SecurityKeyIdentifierClause _sessionTokenIdentifier;
+                // private SecurityStandardsManager _standardsManager;
+
+                public SoapSecurityOutputSession(ClientSecuritySessionChannel channel)
+                {
+                    _channel = channel;
+                }
+
+                internal void Initialize(SecurityToken sessionToken, SecuritySessionClientSettings<TChannel> settings)
+                {
+                    throw ExceptionHelper.PlatformNotSupported();   // #31 in progress
+
+                    //if (sessionToken == null)
+                    //{
+                    //    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("sessionToken");
+                    //}
+                    //if (settings == null)
+                    //{
+                    //    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("settings");
+                    //}
+                    //Claim identityClaim = SecurityUtils.GetPrimaryIdentityClaim(((GenericXmlSecurityToken)sessionToken).AuthorizationPolicies);
+                    //if (identityClaim != null)
+                    //{
+                    //    this.remoteIdentity = EndpointIdentity.CreateIdentity(identityClaim);
+                    //}
+                    //this.standardsManager = settings.SessionProtocolFactory.StandardsManager;
+                    //this.sessionId = GetSessionId(sessionToken, this.standardsManager);
+                    //this.sessionTokenIdentifier = settings.IssuedSecurityTokenParameters.CreateKeyIdentifierClause(sessionToken,
+                    //    SecurityTokenReferenceStyle.External);
+                }
+
+                UniqueId GetSessionId(SecurityToken sessionToken, SecurityStandardsManager standardsManager)
+                {
+                    throw ExceptionHelper.PlatformNotSupported();   // #31 in progress
+
+                    //GenericXmlSecurityToken gxt = sessionToken as GenericXmlSecurityToken;
+                    //if (gxt == null)
+                    //{
+                    //    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new NotSupportedException(SR.Format(SR.SessionTokenIsNotGenericXmlToken, sessionToken, typeof(GenericXmlSecurityToken))));
+                    //}
+                    //return standardsManager.SecureConversationDriver.GetSecurityContextTokenId(XmlDictionaryReader.CreateDictionaryReader(new XmlNodeReader(gxt.TokenXml)));
+                }
+
+                public string Id
+                {
+                    get
+                    {
+                        if (_sessionId == null)
+                        {
+                            throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.ChannelMustBeOpenedToGetSessionId)));
+                        }
+                        return _sessionId.ToString();
+                    }
+                }
+
+                public EndpointIdentity RemoteIdentity
+                {
+                    get
+                    {
+                        return _remoteIdentity;
+                    }
+                }
+
+                public void WriteSessionTokenIdentifier(XmlDictionaryWriter writer)
+                {
+                    throw ExceptionHelper.PlatformNotSupported();   // #31 in progress
+
+                    //this.channel.ThrowIfDisposedOrNotOpen();
+                    //this.standardsManager.SecurityTokenSerializer.WriteKeyIdentifierClause(writer, this.sessionTokenIdentifier);
+                }
+
+                public bool TryReadSessionTokenIdentifier(XmlReader reader)
+                {
+                    throw ExceptionHelper.PlatformNotSupported();   // #31 in progress
+
+                    //this.channel.ThrowIfDisposedOrNotOpen();
+                    //if (!this.standardsManager.SecurityTokenSerializer.CanReadKeyIdentifierClause(reader))
+                    //{
+                    //    return false;
+                    //}
+                    //SecurityContextKeyIdentifierClause incomingTokenIdentifier =
+                    //    this.standardsManager.SecurityTokenSerializer.ReadKeyIdentifierClause(reader) as SecurityContextKeyIdentifierClause;
+                    //return incomingTokenIdentifier != null && incomingTokenIdentifier.Matches(sessionId, null);
+                }
+            }
+        }
+
+        abstract class ClientSecuritySimplexSessionChannel : ClientSecuritySessionChannel
+        {
+            SoapSecurityOutputSession outputSession;
+
+            protected ClientSecuritySimplexSessionChannel(SecuritySessionClientSettings<TChannel> settings, EndpointAddress to, Uri via)
+                : base(settings, to, via)
+            {
+                this.outputSession = new SoapSecurityOutputSession(this);
+            }
+
+            public IOutputSession Session
+            {
+                get
+                {
+                    return this.outputSession;
+                }
+            }
+
+            protected override bool ExpectClose
+            {
+                get { return false; }
+            }
+
+            protected override string SessionId
+            {
+                get { return this.Session.Id; }
+            }
+
+            protected override void InitializeSession(SecurityToken sessionToken)
+            {
+                this.outputSession.Initialize(sessionToken, this.Settings);
+            }
+        }
+
+        sealed class SecurityRequestSessionChannel : ClientSecuritySimplexSessionChannel, IRequestSessionChannel
+        {
+            public SecurityRequestSessionChannel(SecuritySessionClientSettings<TChannel> settings, EndpointAddress to, Uri via)
+                : base(settings, to, via)
+            {
+            }
+
+            protected override bool CanDoSecurityCorrelation
+            {
+                get
+                {
+                    return true;
+                }
+            }
+
+            protected override SecurityProtocolCorrelationState CloseOutputSession(TimeSpan timeout)
+            {
+                ThrowIfFaulted();
+                TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
+                SecurityProtocolCorrelationState correlationState = base.CloseOutputSession(timeoutHelper.RemainingTime());
+
+                Message message = ReceiveInternal(timeoutHelper.RemainingTime(), correlationState);
+
+                if (message != null)
+                {
+                    using (message)
+                    {
+                        ProtocolException error = ProtocolException.ReceiveShutdownReturnedNonNull(message);
+                        throw TraceUtility.ThrowHelperWarning(error, message);
+                    }
+                }
+                return null;
+            }
+
+            protected override IAsyncResult BeginCloseOutputSession(TimeSpan timeout, AsyncCallback callback, object state)
+            {
+                ThrowIfFaulted();
+                return new CloseOutputSessionAsyncResult(this, timeout, callback, state);
+            }
+
+            protected override SecurityProtocolCorrelationState EndCloseOutputSession(IAsyncResult result)
+            {
+                CloseOutputSessionAsyncResult.End(result);
+                return null;
+            }
+
+            IAsyncResult BeginBaseCloseOutputSession(TimeSpan timeout, AsyncCallback callback, object state)
+            {
+                return base.BeginCloseOutputSession(timeout, callback, state);
+            }
+
+            SecurityProtocolCorrelationState EndBaseCloseOutputSession(IAsyncResult result)
+            {
+                return base.EndCloseOutputSession(result);
+            }
+
+            public Message Request(Message message)
+            {
+                return this.Request(message, this.DefaultSendTimeout);
+            }
+
+            Message ProcessReply(Message reply, TimeSpan timeout, SecurityProtocolCorrelationState correlationState)
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // #31 in progress
+
+                //if (reply == null)
+                //{
+                //    return null;
+                //}
+                //Message unverifiedReply = reply;
+                //Message processedReply = null;
+                //MessageFault protocolFault = null;
+                //Exception faultException = null;
+                //try
+                //{
+                //    processedReply = this.ProcessIncomingMessage(reply, timeout, correlationState, out protocolFault);
+                //}
+                //catch (MessageSecurityException)
+                //{
+                //    if (unverifiedReply.IsFault)
+                //    {
+                //        MessageFault fault = MessageFault.CreateFault(unverifiedReply, TransportDefaults.MaxSecurityFaultSize);
+                //        if (SecurityUtils.IsSecurityFault(fault, this.Settings.standardsManager))
+                //        {
+                //            faultException = SecurityUtils.CreateSecurityFaultException(fault);
+                //        }
+                //    }
+                //    if (faultException == null)
+                //    {
+                //        throw;
+                //    }
+                //}
+                //if (faultException != null)
+                //{
+                //    Fault(faultException);
+                //    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(faultException);
+                //}
+                //if (processedReply == null && protocolFault != null)
+                //{
+                //    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new MessageSecurityException(SR.Format(SR.SecuritySessionFaultReplyWasSent), new FaultException(protocolFault)));
+                //}
+                //return processedReply;
+            }
+
+
+            public Message Request(Message message, TimeSpan timeout)
+            {
+                ThrowIfFaulted();
+                CheckOutputOpen();
+                TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
+                SecurityProtocolCorrelationState correlationState = this.SecureOutgoingMessage(ref message, timeoutHelper.RemainingTime());
+                Message reply = this.ChannelBinder.Request(message, timeoutHelper.RemainingTime());
+                return ProcessReply(reply, timeoutHelper.RemainingTime(), correlationState);
+            }
+
+            public IAsyncResult BeginRequest(Message message, AsyncCallback callback, object state)
+            {
+                return this.BeginRequest(message, this.DefaultSendTimeout, callback, state);
+            }
+
+            public IAsyncResult BeginRequest(Message message, TimeSpan timeout, AsyncCallback callback, object state)
+            {
+                ThrowIfFaulted();
+                CheckOutputOpen();
+                return new SecureRequestAsyncResult(message, this, timeout, callback, state);
+            }
+
+            public Message EndRequest(IAsyncResult result)
+            {
+                SecurityProtocolCorrelationState requestCorrelationState;
+                TimeSpan remainingTime;
+                Message reply = SecureRequestAsyncResult.EndAsReply(result, out requestCorrelationState, out remainingTime);
+                return ProcessReply(reply, remainingTime, requestCorrelationState);
+            }
+
+            sealed class SecureRequestAsyncResult : SecureSendAsyncResultBase
+            {
+                static readonly AsyncCallback requestCallback = Fx.ThunkCallback(new AsyncCallback(RequestCallback));
+                Message reply;
+
+                public SecureRequestAsyncResult(Message request, ClientSecuritySessionChannel sessionChannel, TimeSpan timeout, AsyncCallback callback, object state)
+                    : base(request, sessionChannel, timeout, callback, state)
+                {
+                    if (!this.DidSecureOutgoingMessageCompleteSynchronously)
+                    {
+                        return;
+                    }
+                    bool completeSelf = OnMessageSecured();
+                    if (completeSelf)
+                    {
+                        Complete(true);
+                    }
+                }
+
+                protected override bool OnMessageSecured()
+                {
+                    IAsyncResult result = this.ChannelBinder.BeginRequest(this.Message, this.TimeoutHelper.RemainingTime(), requestCallback, this);
+                    if (!result.CompletedSynchronously)
+                    {
+                        return false;
+                    }
+                    this.reply = this.ChannelBinder.EndRequest(result);
+                    return true;
+                }
+
+                static void RequestCallback(IAsyncResult result)
+                {
+                    if (result.CompletedSynchronously)
+                    {
+                        return;
+                    }
+                    SecureRequestAsyncResult thisAsyncResult = (SecureRequestAsyncResult)result.AsyncState;
+                    Exception completionException = null;
+                    try
+                    {
+                        thisAsyncResult.reply = thisAsyncResult.ChannelBinder.EndRequest(result);
+                    }
+                    catch (Exception e)
+                    {
+                        if (Fx.IsFatal(e))
+                        {
+                            throw;
+                        }
+
+                        completionException = e;
+                    }
+                    thisAsyncResult.Complete(false, completionException);
+                }
+
+                public static Message EndAsReply(IAsyncResult result, out SecurityProtocolCorrelationState correlationState, out TimeSpan remainingTime)
+                {
+                    SecureRequestAsyncResult thisResult = AsyncResult.End<SecureRequestAsyncResult>(result);
+                    correlationState = thisResult.SecurityCorrelationState;
+                    remainingTime = thisResult.TimeoutHelper.RemainingTime();
+                    return thisResult.reply;
+                }
+            }
+
+            class CloseOutputSessionAsyncResult : TraceAsyncResult
+            {
+                static readonly AsyncCallback baseCloseOutputSessionCallback = Fx.ThunkCallback(new AsyncCallback(BaseCloseOutputSessionCallback));
+                static readonly AsyncCallback receiveInternalCallback = Fx.ThunkCallback(new AsyncCallback(ReceiveInternalCallback));
+                SecurityRequestSessionChannel requestChannel;
+                SecurityProtocolCorrelationState correlationState;
+                TimeoutHelper timeoutHelper;
+
+                public CloseOutputSessionAsyncResult(SecurityRequestSessionChannel requestChannel, TimeSpan timeout, AsyncCallback callback, object state)
+                    : base(callback, state)
+                {
+                    this.timeoutHelper = new TimeoutHelper(timeout);
+                    this.requestChannel = requestChannel;
+                    IAsyncResult result = this.requestChannel.BeginBaseCloseOutputSession(timeoutHelper.RemainingTime(), baseCloseOutputSessionCallback, this);
+                    if (!result.CompletedSynchronously)
+                    {
+                        return;
+                    }
+                    this.correlationState = this.requestChannel.EndBaseCloseOutputSession(result);
+                    bool completeSelf = this.OnBaseOutputSessionClosed();
+                    if (completeSelf)
+                    {
+                        Complete(true);
+                    }
+                }
+
+                static void BaseCloseOutputSessionCallback(IAsyncResult result)
+                {
+                    if (result.CompletedSynchronously)
+                    {
+                        return;
+                    }
+                    CloseOutputSessionAsyncResult thisAsyncResult = (CloseOutputSessionAsyncResult)result.AsyncState;
+                    bool completeSelf = false;
+                    Exception completionException = null;
+                    try
+                    {
+                        thisAsyncResult.correlationState = thisAsyncResult.requestChannel.EndBaseCloseOutputSession(result);
+                        completeSelf = thisAsyncResult.OnBaseOutputSessionClosed();
+                    }
+                    catch (Exception e)
+                    {
+                        if (Fx.IsFatal(e))
+                        {
+                            throw;
+                        }
+
+                        completeSelf = true;
+                        completionException = e;
+                    }
+                    if (completeSelf)
+                    {
+                        thisAsyncResult.Complete(false, completionException);
+                    }
+                }
+
+                bool OnBaseOutputSessionClosed()
+                {
+                    IAsyncResult result = this.requestChannel.BeginReceiveInternal(this.timeoutHelper.RemainingTime(), this.correlationState, receiveInternalCallback, this);
+                    if (!result.CompletedSynchronously)
+                    {
+                        return false;
+                    }
+                    Message message = this.requestChannel.EndReceiveInternal(result);
+                    return this.OnMessageReceived(message);
+                }
+
+                static void ReceiveInternalCallback(IAsyncResult result)
+                {
+                    if (result.CompletedSynchronously)
+                    {
+                        return;
+                    }
+                    CloseOutputSessionAsyncResult thisAsyncResult = (CloseOutputSessionAsyncResult)result.AsyncState;
+                    bool completeSelf = false;
+                    Exception completionException = null;
+                    try
+                    {
+                        Message message = thisAsyncResult.requestChannel.EndReceiveInternal(result);
+                        completeSelf = thisAsyncResult.OnMessageReceived(message);
+                    }
+                    catch (Exception e)
+                    {
+                        if (Fx.IsFatal(e))
+                        {
+                            throw;
+                        }
+
+                        completeSelf = true;
+                        completionException = e;
+                    }
+                    if (completeSelf)
+                    {
+                        thisAsyncResult.Complete(false, completionException);
+                    }
+                }
+
+                bool OnMessageReceived(Message message)
+                {
+                    if (message != null)
+                    {
+                        using (message)
+                        {
+                            ProtocolException error = ProtocolException.ReceiveShutdownReturnedNonNull(message);
+                            throw TraceUtility.ThrowHelperWarning(error, message);
+                        }
+                    }
+                    return true;
+                }
+
+                public static void End(IAsyncResult result)
+                {
+                    AsyncResult.End<CloseOutputSessionAsyncResult>(result);
+                }
+            }
+        }
+
+        class ClientSecurityDuplexSessionChannel : ClientSecuritySessionChannel, IDuplexSessionChannel
+        {
+            private static AsyncCallback s_onReceive = Fx.ThunkCallback(new AsyncCallback(OnReceive));
+            private SoapSecurityClientDuplexSession _session;
+            private InputQueue<Message> _queue;
+            // #31 in progress
+            //private Action _startReceiving;
+            private Action<object> _completeLater;
+
+            public ClientSecurityDuplexSessionChannel(SecuritySessionClientSettings<TChannel> settings, EndpointAddress to, Uri via)
+                : base(settings, to, via)
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // #31 in progress
+
+                //this.session = new SoapSecurityClientDuplexSession(this);
+                //this.queue = TraceUtility.CreateInputQueue<Message>();
+                //this.startReceiving = new Action(StartReceiving);
+                //this.completeLater = new Action<object>(CompleteLater);
+            }
+
+            public EndpointAddress LocalAddress
+            {
+                get
+                {
+                    return base.InternalLocalAddress;
+                }
+            }
+
+            public IDuplexSession Session
+            {
+                get
+                {
+                    return _session;
+                }
+            }
+
+            protected override bool ExpectClose
+            {
+                get { return true; }
+            }
+
+            protected override string SessionId
+            {
+                get { return _session.Id; }
+            }
+
+            public Message Receive()
+            {
+                return this.Receive(this.DefaultReceiveTimeout);
+            }
+
+            public Message Receive(TimeSpan timeout)
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // #31 in progress
+                //return InputChannel.HelpReceive(this, timeout);
+            }
+
+            public IAsyncResult BeginReceive(AsyncCallback callback, object state)
+            {
+                return this.BeginReceive(this.DefaultReceiveTimeout, callback, state);
+            }
+
+            public IAsyncResult BeginReceive(TimeSpan timeout, AsyncCallback callback, object state)
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // #31 in progress
+                //return InputChannel.HelpBeginReceive(this, timeout, callback, state);
+            }
+
+            public Message EndReceive(IAsyncResult result)
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // #31 in progress
+                //return InputChannel.HelpEndReceive(result);
+            }
+
+            public IAsyncResult BeginTryReceive(TimeSpan timeout, AsyncCallback callback, object state)
+            {
+                ThrowIfFaulted();
+                return _queue.BeginDequeue(timeout, callback, state);
+            }
+
+            public bool EndTryReceive(IAsyncResult result, out Message message)
+            {
+                bool wasDequeued = _queue.EndDequeue(result, out message);
+                if (message == null)
+                {
+                    // the channel could have faulted, shutting down the input queue
+                    ThrowIfFaulted();
+                }
+                return wasDequeued;
+            }
+
+            protected override void OnOpened()
+            {
+                base.OnOpened();
+                StartReceiving();
+            }
+
+            public bool TryReceive(TimeSpan timeout, out Message message)
+            {
+                ThrowIfFaulted();
+                bool wasDequeued = _queue.Dequeue(timeout, out message);
+                if (message == null)
+                {
+                    // the channel could have faulted, shutting down the input queue
+                    ThrowIfFaulted();
+                }
+                return wasDequeued;
+            }
+
+            public void Send(Message message)
+            {
+                this.Send(message, this.DefaultSendTimeout);
+            }
+
+            public void Send(Message message, TimeSpan timeout)
+            {
+                ThrowIfFaulted();
+                CheckOutputOpen();
+                TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
+                this.SecureOutgoingMessage(ref message, timeoutHelper.RemainingTime());
+                this.ChannelBinder.Send(message, timeoutHelper.RemainingTime());
+            }
+
+            public IAsyncResult BeginSend(Message message, AsyncCallback callback, object state)
+            {
+                return this.BeginSend(message, this.DefaultSendTimeout, callback, state);
+            }
+
+            public IAsyncResult BeginSend(Message message, TimeSpan timeout, AsyncCallback callback, object state)
+            {
+                ThrowIfFaulted();
+                CheckOutputOpen();
+                return new SecureSendAsyncResult(message, this, timeout, callback, state, false);
+            }
+
+            public void EndSend(IAsyncResult result)
+            {
+                SecureSendAsyncResult.End(result);
+            }
+
+            protected override void InitializeSession(SecurityToken sessionToken)
+            {
+                _session.Initialize(sessionToken, this.Settings);
+            }
+
+            void StartReceiving()
+            {
+                IAsyncResult result = this.IssueReceive();
+                if (result != null && result.CompletedSynchronously)
+                {
+                    ActionItem.Schedule(_completeLater, result);
+                }
+            }
+
+            IAsyncResult IssueReceive()
+            {
+                while (true)
+                {
+                    // no need to receive anymore if in the closed state
+                    if (this.State == CommunicationState.Closed || this.State == CommunicationState.Faulted || this.IsInputClosed)
+                    {
+                        return null;
+                    }
+                    try
+                    {
+                        return this.BeginReceiveInternal(TimeSpan.MaxValue, null, s_onReceive, this);
+
+                    }
+                    catch (CommunicationException /* #31 in progress e */)
+                    {
+                        // BeginReceive failed. ignore the exception and start another receive
+                        // DiagnosticUtility.TraceHandledException(e, TraceEventType.Information);
+                    }
+                    catch (TimeoutException /* #31 in progress e */)
+                    {
+                        // BeginReceive failed. ignore the exception and start another receive
+                        //if (TD.ReceiveTimeoutIsEnabled())
+                        //{
+                        //    TD.ReceiveTimeout(e.Message);
+                        //}
+                        //DiagnosticUtility.TraceHandledException(e, TraceEventType.Information);
+                    }
+                }
+            }
+
+            void CompleteLater(object obj)
+            {
+                CompleteReceive((IAsyncResult)obj);
+            }
+
+            static void OnReceive(IAsyncResult result)
+            {
+                if (result.CompletedSynchronously)
+                    return;
+
+                ((ClientSecurityDuplexSessionChannel)result.AsyncState).CompleteReceive(result);
+            }
+
+            void CompleteReceive(IAsyncResult result)
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // #31 in progress
+//                Message message = null;
+//                bool issueAnotherReceive = false;
+//                try
+//                {
+//                    message = this.EndReceiveInternal(result);
+//                    issueAnotherReceive = true;
+//                }
+//                catch (MessageSecurityException)
+//                {
+//                    // a messagesecurityexception will only be thrown if the channel received a fault
+//                    // from the other side, in which case the channel would have faulted
+//                    issueAnotherReceive = false;
+//                }
+//                catch (CommunicationException e)
+//                {
+//                    issueAnotherReceive = true;
+//                    // EndReceive failed. ignore the exception and start another receive
+//                    DiagnosticUtility.TraceHandledException(e, TraceEventType.Information);
+//                }
+//                catch (TimeoutException e)
+//                {
+//                    issueAnotherReceive = true;
+//                    // EndReceive failed. ignore the exception and start another receive
+//                    if (TD.ReceiveTimeoutIsEnabled())
+//                    {
+//                        TD.ReceiveTimeout(e.Message);
+//                    }
+//                    DiagnosticUtility.TraceHandledException(e, TraceEventType.Information);
+//                }
+//                IAsyncResult nextReceiveResult = null;
+//                if (issueAnotherReceive)
+//                {
+//                    nextReceiveResult = this.IssueReceive();
+//                    if (nextReceiveResult != null && nextReceiveResult.CompletedSynchronously)
+//                    {
+//                        ActionItem.Schedule(completeLater, nextReceiveResult);
+//                    }
+//                }
+//                if (message != null)
+//                {
+//                    // since we may be dispatching to user code swallow non-fatal exceptions
+//                    try
+//                    {
+//                        this.queue.EnqueueAndDispatch(message);
+//                    }
+//                    catch (Exception e)
+//                    {
+//                        if (Fx.IsFatal(e)) throw;
+//                        DiagnosticUtility.TraceHandledException(e, TraceEventType.Warning);
+//                    }
+//                }
+            }
+
+            protected override void AbortCore()
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // #31 in progress
+                //try
+                //{
+                //    this.queue.Dispose();
+                //}
+                //catch (CommunicationException e)
+                //{
+                //    DiagnosticUtility.TraceHandledException(e, TraceEventType.Information);
+                //}
+                //catch (TimeoutException e)
+                //{
+                //    if (TD.CloseTimeoutIsEnabled())
+                //    {
+                //        TD.CloseTimeout(e.Message);
+                //    }
+                //    DiagnosticUtility.TraceHandledException(e, TraceEventType.Information);
+                //}
+                //base.AbortCore();
+            }
+
+            public bool WaitForMessage(TimeSpan timeout)
+            {
+                return _queue.WaitForItem(timeout);
+            }
+
+            public IAsyncResult BeginWaitForMessage(TimeSpan timeout, AsyncCallback callback, object state)
+            {
+                return _queue.BeginWaitForItem(timeout, callback, state);
+            }
+
+            public bool EndWaitForMessage(IAsyncResult result)
+            {
+                return _queue.EndWaitForItem(result);
+            }
+
+            protected override void OnFaulted()
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // #31 in progress
+                //_queue.Shutdown(() => this.GetPendingException());
+                //base.OnFaulted();
+            }
+
+            protected override bool OnCloseResponseReceived()
+            {
+                if (base.OnCloseResponseReceived())
+                {
+                    _queue.Shutdown();
+                    return true;
+                }
+                else
+                {
+                    return false;
+                }
+            }
+
+            protected override bool OnCloseReceived()
+            {
+                if (base.OnCloseReceived())
+                {
+                    _queue.Shutdown();
+                    return true;
+                }
+                else
+                {
+                    return false;
+                }
+            }
+
+            class SoapSecurityClientDuplexSession : SoapSecurityOutputSession, IDuplexSession
+            {
+                ClientSecurityDuplexSessionChannel channel;
+                bool initialized = false;
+
+                public SoapSecurityClientDuplexSession(ClientSecurityDuplexSessionChannel channel)
+                    : base(channel)
+                {
+                    this.channel = channel;
+                }
+
+                internal new void Initialize(SecurityToken sessionToken, SecuritySessionClientSettings<TChannel> settings)
+                {
+                    base.Initialize(sessionToken, settings);
+                    this.initialized = true;
+                }
+
+                void CheckInitialized()
+                {
+                    if (!this.initialized)
+                    {
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.ChannelNotOpen)));
+                    }
+                }
+
+                public void CloseOutputSession()
+                {
+                    this.CloseOutputSession(this.channel.DefaultCloseTimeout);
+                }
+
+                public void CloseOutputSession(TimeSpan timeout)
+                {
+                    throw ExceptionHelper.PlatformNotSupported();   // #31 in progress
+
+//                    CheckInitialized();
+//                    this.channel.ThrowIfFaulted();
+//                    this.channel.ThrowIfNotOpened();
+//                    Exception pendingException = null;
+//                    try
+//                    {
+//                        this.channel.CloseOutputSession(timeout);
+//                    }
+//                    catch (CommunicationObjectAbortedException)
+//                    {
+//                        if (this.channel.State != CommunicationState.Closed)
+//                        {
+//                            throw;
+//                        }
+//                    }
+//                    catch (Exception e)
+//                    {
+//                        if (Fx.IsFatal(e)) throw;
+//                        pendingException = e;
+//                    }
+//                    if (pendingException != null)
+//                    {
+//                        this.channel.Fault(pendingException);
+//                        throw pendingException;
+//                    }
+                }
+
+                public IAsyncResult BeginCloseOutputSession(AsyncCallback callback, object state)
+                {
+                    return this.BeginCloseOutputSession(this.channel.DefaultCloseTimeout, callback, state);
+                }
+
+                public IAsyncResult BeginCloseOutputSession(TimeSpan timeout, AsyncCallback callback, object state)
+                {
+                    throw ExceptionHelper.PlatformNotSupported();   // #31 in progress
+
+//                    CheckInitialized();
+//                    this.channel.ThrowIfFaulted();
+//                    this.channel.ThrowIfNotOpened();
+//                    Exception pendingException = null;
+//                    try
+//                    {
+//                        return this.channel.BeginCloseOutputSession(timeout, callback, state);
+//                    }
+//                    catch (CommunicationObjectAbortedException)
+//                    {
+//                        if (this.channel.State != CommunicationState.Closed)
+//                        {
+//                            throw;
+//                        }
+//                        // another thread must have aborted the channel. Allow the close to complete
+//                        // gracefully
+//                        return new CompletedAsyncResult(callback, state);
+//                    }
+//                    catch (Exception e)
+//                    {
+//                        if (Fx.IsFatal(e)) throw;
+//                        pendingException = e;
+//                    }
+//                    if (pendingException != null)
+//                    {
+//                        this.channel.Fault(pendingException);
+//                        if (pendingException is CommunicationException)
+//                        {
+//                            throw pendingException;
+//                        }
+//                        else
+//                        {
+//                            throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(pendingException);
+//                        }
+//                    }
+//                    // we should never reach here
+//                    Fx.Assert("Unexpected control flow");
+//                    return null;
+                }
+
+                public void EndCloseOutputSession(IAsyncResult result)
+                {
+                    throw ExceptionHelper.PlatformNotSupported();   // #31 in progress
+
+//                    if (result is CompletedAsyncResult)
+//                    {
+//                        CompletedAsyncResult.End(result);
+//                        return;
+//                    }
+//                    Exception pendingException = null;
+//                    try
+//                    {
+//                        this.channel.EndCloseOutputSession(result);
+//                    }
+//                    catch (CommunicationObjectAbortedException)
+//                    {
+//                        if (this.channel.State != CommunicationState.Closed)
+//                        {
+//                            throw;
+//                        }
+//                        // another thread must have aborted the channel. Allow the close to complete
+//                        // gracefully
+//                    }
+//                    catch (Exception e)
+//                    {
+//                        if (Fx.IsFatal(e)) throw;
+//                        pendingException = e;
+//                    }
+//                    if (pendingException != null)
+//                    {
+//                        this.channel.Fault(pendingException);
+//                        if (pendingException is CommunicationException)
+//                        {
+//                            throw pendingException;
+//                        }
+//                        else
+//                        {
+//                            throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(pendingException);
+//                        }
+//                    }
+                }
+            }
+        }
+    }
+}
+

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SecurityStandardsManager.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SecurityStandardsManager.cs
@@ -2,29 +2,27 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-
 using System.Collections.Generic;
-using System.ServiceModel.Channels;
-using System.ServiceModel;
-using System.ServiceModel.Description;
-using System.ServiceModel.Security.Tokens;
-using System.Collections.ObjectModel;
-using System.IdentityModel.Policy;
 using System.IdentityModel.Selectors;
 using System.IdentityModel.Tokens;
-using System.Xml;
 using System.Runtime.CompilerServices;
+using System.ServiceModel.Channels;
+using System.ServiceModel.Description;
+using System.ServiceModel.Security.Tokens;
+using System.Xml;
 
 namespace System.ServiceModel.Security
 {
     internal class SecurityStandardsManager
     {
-#pragma warning disable 0649 // Remove this once we do real implementation, this prevents "field is never assigned to" warning
         private static SecurityStandardsManager s_instance;
         private readonly MessageSecurityVersion _messageSecurityVersion;
+        private readonly WSUtilitySpecificationVersion _wsUtilitySpecificationVersion;
+        private readonly SecureConversationDriver _secureConversationDriver;
         private readonly TrustDriver _trustDriver;
-#pragma warning restore 0649
-
+        private readonly SignatureTargetIdManager _idManager;
+        private readonly SecurityTokenSerializer _tokenSerializer;
+        private WSSecurityTokenSerializer _wsSecurityTokenSerializer;
 
         [MethodImpl(MethodImplOptions.NoInlining)]
         public SecurityStandardsManager()
@@ -39,7 +37,32 @@ namespace System.ServiceModel.Security
 
         public SecurityStandardsManager(MessageSecurityVersion messageSecurityVersion, SecurityTokenSerializer tokenSerializer)
         {
-            throw ExceptionHelper.PlatformNotSupported();
+            if (messageSecurityVersion == null)
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentNullException("messageSecurityVersion"));
+            if (tokenSerializer == null)
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("tokenSerializer");
+
+            _messageSecurityVersion = messageSecurityVersion;
+            _tokenSerializer = tokenSerializer;
+            if (messageSecurityVersion.SecureConversationVersion == SecureConversationVersion.WSSecureConversation13)
+                _secureConversationDriver = new WSSecureConversationDec2005.DriverDec2005();
+            else
+                _secureConversationDriver = new WSSecureConversationFeb2005.DriverFeb2005();
+
+            if (this.SecurityVersion == SecurityVersion.WSSecurity10 || this.SecurityVersion == SecurityVersion.WSSecurity11)
+            {
+                _idManager = WSSecurityJan2004.IdManager.Instance;
+            }
+            else
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("messageSecurityVersion", SR.Format(SR.MessageSecurityVersionOutOfRange)));
+            }
+
+            _wsUtilitySpecificationVersion = WSUtilitySpecificationVersion.Default;
+            if (messageSecurityVersion.MessageSecurityTokenVersion.TrustVersion == TrustVersion.WSTrust13)
+                _trustDriver = new WSTrustDec2005.DriverDec2005(this);
+            else
+                _trustDriver = new WSTrustFeb2005.DriverFeb2005(this);
         }
 
         public static SecurityStandardsManager DefaultInstance
@@ -62,9 +85,147 @@ namespace System.ServiceModel.Security
             get { return _messageSecurityVersion; }
         }
 
+        public TrustVersion TrustVersion
+        {
+            get { return _messageSecurityVersion.TrustVersion; }
+        }
+
+        public SecureConversationVersion SecureConversationVersion
+        {
+            get { return _messageSecurityVersion.SecureConversationVersion; }
+        }
+
+        internal SecurityTokenSerializer SecurityTokenSerializer
+        {
+            get { return _tokenSerializer; }
+        }
+
+        internal WSUtilitySpecificationVersion WSUtilitySpecificationVersion
+        {
+            get { return _wsUtilitySpecificationVersion; }
+        }
+
+        internal SignatureTargetIdManager IdManager
+        {
+            get { return _idManager; }
+        }
+
+        internal SecureConversationDriver SecureConversationDriver
+        {
+            get { return _secureConversationDriver; }
+        }
+
         internal TrustDriver TrustDriver
         {
             get { return _trustDriver; }
         }
+
+        WSSecurityTokenSerializer WSSecurityTokenSerializer
+        {
+            get
+            {
+                if (_wsSecurityTokenSerializer == null)
+                {
+                    WSSecurityTokenSerializer wsSecurityTokenSerializer = _tokenSerializer as WSSecurityTokenSerializer;
+                    if (wsSecurityTokenSerializer == null)
+                    {
+                        wsSecurityTokenSerializer = new WSSecurityTokenSerializer(SecurityVersion);
+                    }
+                    _wsSecurityTokenSerializer = wsSecurityTokenSerializer;
+                }
+                return _wsSecurityTokenSerializer;
+            }
+        }
+
+        internal bool TryCreateKeyIdentifierClauseFromTokenXml(XmlElement element, SecurityTokenReferenceStyle tokenReferenceStyle, out SecurityKeyIdentifierClause securityKeyIdentifierClause)
+        {
+            return WSSecurityTokenSerializer.TryCreateKeyIdentifierClauseFromTokenXml(element, tokenReferenceStyle, out securityKeyIdentifierClause);
+        }
+
+        internal SecurityKeyIdentifierClause CreateKeyIdentifierClauseFromTokenXml(XmlElement element, SecurityTokenReferenceStyle tokenReferenceStyle)
+        {
+            return WSSecurityTokenSerializer.CreateKeyIdentifierClauseFromTokenXml(element, tokenReferenceStyle);
+        }
+
+        internal SendSecurityHeader CreateSendSecurityHeader(Message message,
+            string actor, bool mustUnderstand, bool relay,
+            SecurityAlgorithmSuite algorithmSuite, MessageDirection direction)
+        {
+            return SecurityVersion.CreateSendSecurityHeader(message, actor, mustUnderstand, relay, this, algorithmSuite, direction);
+        }
+
+        internal ReceiveSecurityHeader CreateReceiveSecurityHeader(Message message,
+            string actor,
+            SecurityAlgorithmSuite algorithmSuite, MessageDirection direction)
+        {
+            ReceiveSecurityHeader header = TryCreateReceiveSecurityHeader(message, actor, algorithmSuite, direction);
+            if (header == null)
+            {
+                if (String.IsNullOrEmpty(actor))
+                    throw System.ServiceModel.Diagnostics.TraceUtility.ThrowHelperError(new MessageSecurityException(
+                        SR.Format(SR.UnableToFindSecurityHeaderInMessageNoActor)), message);
+                else
+                    throw System.ServiceModel.Diagnostics.TraceUtility.ThrowHelperError(new MessageSecurityException(
+                        SR.Format(SR.UnableToFindSecurityHeaderInMessage, actor)), message);
+            }
+            return header;
+        }
+
+        internal ReceiveSecurityHeader TryCreateReceiveSecurityHeader(Message message,
+            string actor,
+            SecurityAlgorithmSuite algorithmSuite, MessageDirection direction)
+        {
+            return this.SecurityVersion.TryCreateReceiveSecurityHeader(message, actor, this, algorithmSuite, direction);
+        }
+
+        internal bool DoesMessageContainSecurityHeader(Message message)
+        {
+            return this.SecurityVersion.DoesMessageContainSecurityHeader(message);
+        }
+
+        internal bool TryGetSecurityContextIds(Message message, string[] actors, bool isStrictMode, ICollection<UniqueId> results)
+        {
+            if (results == null)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("results");
+            }
+            SecureConversationDriver driver = this.SecureConversationDriver;
+            int securityHeaderIndex = this.SecurityVersion.FindIndexOfSecurityHeader(message, actors);
+            if (securityHeaderIndex < 0)
+            {
+                return false;
+            }
+            bool addedContextIds = false;
+            using (XmlDictionaryReader reader = message.Headers.GetReaderAtHeader(securityHeaderIndex))
+            {
+                if (!reader.IsStartElement())
+                {
+                    return false;
+                }
+                if (reader.IsEmptyElement)
+                {
+                    return false;
+                }
+                reader.ReadStartElement();
+                while (reader.IsStartElement())
+                {
+                    if (driver.IsAtSecurityContextToken(reader))
+                    {
+                        results.Add(driver.GetSecurityContextTokenId(reader));
+                        addedContextIds = true;
+                        if (isStrictMode)
+                        {
+                            break;
+                        }
+                    }
+                    else
+                    {
+                        reader.Skip();
+                    }
+                }
+            }
+            return addedContextIds;
+        }
+
     }
 }

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SecurityUtils.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SecurityUtils.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Globalization;
+using System.IdentityModel;
 using System.IdentityModel.Claims;
 using System.IdentityModel.Policy;
 using System.IdentityModel.Selectors;
@@ -15,6 +16,7 @@ using System.Net;
 using System.Net.Security;
 using System.Runtime;
 using System.Security.Authentication;
+using System.Security.Authentication.ExtendedProtection;
 using System.Security.Cryptography.X509Certificates;
 using System.Security.Principal;
 using System.ServiceModel.Channels;
@@ -22,6 +24,8 @@ using System.ServiceModel.Diagnostics;
 using System.ServiceModel.Security.Tokens;
 using System.Text;
 using System.Threading;
+using System.Threading.Tasks;
+using System.Xml;
 
 namespace System.ServiceModel.Security
 {
@@ -219,12 +223,47 @@ namespace System.ServiceModel.Security
         }
     }
 
+    internal class ServiceModelDictionaryManager
+    {
+        static DictionaryManager dictionaryManager;
+
+        public static DictionaryManager Instance
+        {
+            get
+            {
+                if (dictionaryManager == null)
+                    dictionaryManager = new DictionaryManager(BinaryMessageEncoderFactory.XmlDictionary);
+
+                return dictionaryManager;
+            }
+        }
+    }
+
     internal static class SecurityUtils
     {
         public const string Principal = "Principal";
         public const string Identities = "Identities";
         private static IIdentity s_anonymousIdentity;
         private static X509SecurityTokenAuthenticator s_nonValidatingX509Authenticator;
+
+        public static ChannelBinding GetChannelBindingFromMessage(Message message)
+        {
+            if (message == null)
+            {
+                return null;
+            }
+
+            ChannelBindingMessageProperty channelBindingMessageProperty = null;
+            ChannelBindingMessageProperty.TryGet(message, out channelBindingMessageProperty);
+            ChannelBinding channelBinding = null;
+
+            if (channelBindingMessageProperty != null)
+            {
+                channelBinding = channelBindingMessageProperty.ChannelBinding;
+            }
+
+            return channelBinding;
+        }
 
         internal static X509SecurityTokenAuthenticator NonValidatingX509Authenticator
         {
@@ -416,6 +455,35 @@ namespace System.ServiceModel.Security
             return string.Format(CultureInfo.InvariantCulture, "host/{0}", target.Uri.DnsSafeHost);
         }
 
+        internal static T GetSecurityKey<T>(SecurityToken token) where T : SecurityKey
+        {
+            T result = null;
+            if (token.SecurityKeys != null)
+            {
+                for (int i = 0; i < token.SecurityKeys.Count; ++i)
+                {
+                    T temp = (token.SecurityKeys[i] as T);
+                    if (temp != null)
+                    {
+                        if (result != null)
+                        {
+                            throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new MessageSecurityException(SR.Format(SR.MultipleMatchingCryptosFound, typeof(T).ToString())));
+                        }
+                        else
+                        {
+                            result = temp;
+                        }
+                    }
+                }
+            }
+            return result;
+        }
+
+        internal static bool HasSymmetricSecurityKey(SecurityToken token)
+        {
+            return GetSecurityKey<SymmetricSecurityKey>(token) != null;
+        }
+
         internal static bool IsSupportedAlgorithm(string algorithm, SecurityToken token)
         {
             if (token.SecurityKeys == null)
@@ -584,7 +652,6 @@ namespace System.ServiceModel.Security
             {
                 name = identity.Name;
             }
-#pragma warning suppress 56500
             catch (Exception e)
             {
                 if (Fx.IsFatal(e))
@@ -619,15 +686,66 @@ namespace System.ServiceModel.Security
 #endif // SUPPORTS_WINDOWSIDENTITY
         }
 
+        internal static byte[] ReadContentAsBase64(XmlDictionaryReader reader, long maxBufferSize)
+        {
+            if (reader == null)
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("reader");
+
+            // Code cloned from System.Xml.XmlDictionaryReder.
+            byte[][] buffers = new byte[32][];
+            byte[] buffer;
+            // Its best to read in buffers that are a multiple of 3 so we don't break base64 boundaries when converting text
+            int count = 384;
+            int bufferCount = 0;
+            int totalRead = 0;
+            while (true)
+            {
+                buffer = new byte[count];
+                buffers[bufferCount++] = buffer;
+                int read = 0;
+                while (read < buffer.Length)
+                {
+                    int actual = reader.ReadContentAsBase64(buffer, read, buffer.Length - read);
+                    if (actual == 0)
+                        break;
+                    read += actual;
+                }
+                if (totalRead > maxBufferSize - read)
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new QuotaExceededException(SR.Format(SR.BufferQuotaExceededReadingBase64, maxBufferSize)));
+                totalRead += read;
+                if (read < buffer.Length)
+                    break;
+                count = count * 2;
+            }
+            buffer = new byte[totalRead];
+            int offset = 0;
+            for (int i = 0; i < bufferCount - 1; i++)
+            {
+                Buffer.BlockCopy(buffers[i], 0, buffer, offset, buffers[i].Length);
+                offset += buffers[i].Length;
+            }
+            Buffer.BlockCopy(buffers[bufferCount - 1], 0, buffer, offset, totalRead - offset);
+            return buffer;
+        }
 
         internal static void OpenTokenProviderIfRequired(SecurityTokenProvider tokenProvider, TimeSpan timeout)
         {
             OpenCommunicationObject(tokenProvider as ICommunicationObject, timeout);
         }
 
+        internal static Task OpenTokenProviderIfRequiredAsync(SecurityTokenProvider tokenProvider, TimeSpan timeout)
+        {
+            return OpenCommunicationObjectAsync(tokenProvider as ICommunicationObject, timeout);
+        }
+
         internal static void CloseTokenProviderIfRequired(SecurityTokenProvider tokenProvider, TimeSpan timeout)
         {
             CloseCommunicationObject(tokenProvider, false, timeout);
+        }
+
+        internal static Task CloseTokenProviderIfRequiredAsync(SecurityTokenProvider tokenProvider, TimeSpan timeout)
+        {
+            return CloseCommunicationObjectAsync(tokenProvider, false, timeout);
         }
 
         internal static void AbortTokenProviderIfRequired(SecurityTokenProvider tokenProvider)
@@ -640,14 +758,29 @@ namespace System.ServiceModel.Security
             OpenCommunicationObject(tokenAuthenticator as ICommunicationObject, timeout);
         }
 
+        internal static Task OpenTokenAuthenticatorIfRequiredAsync(SecurityTokenAuthenticator tokenAuthenticator, TimeSpan timeout)
+        {
+            return OpenCommunicationObjectAsync(tokenAuthenticator as ICommunicationObject, timeout);
+        }
+
         internal static void CloseTokenAuthenticatorIfRequired(SecurityTokenAuthenticator tokenAuthenticator, TimeSpan timeout)
         {
             CloseTokenAuthenticatorIfRequired(tokenAuthenticator, false, timeout);
         }
 
+        internal static Task CloseTokenAuthenticatorIfRequiredAsync(SecurityTokenAuthenticator tokenAuthenticator, TimeSpan timeout)
+        {
+            return CloseTokenAuthenticatorIfRequiredAsync(tokenAuthenticator, false, timeout);
+        }
+
         internal static void CloseTokenAuthenticatorIfRequired(SecurityTokenAuthenticator tokenAuthenticator, bool aborted, TimeSpan timeout)
         {
             CloseCommunicationObject(tokenAuthenticator, aborted, timeout);
+        }
+
+        internal static Task CloseTokenAuthenticatorIfRequiredAsync(SecurityTokenAuthenticator tokenAuthenticator, bool aborted, TimeSpan timeout)
+        {
+            return CloseCommunicationObjectAsync(tokenAuthenticator, aborted, timeout);
         }
 
         internal static void AbortTokenAuthenticatorIfRequired(SecurityTokenAuthenticator tokenAuthenticator)
@@ -659,6 +792,22 @@ namespace System.ServiceModel.Security
         {
             if (obj != null)
                 obj.Open(timeout);
+        }
+
+        private static async Task OpenCommunicationObjectAsync(ICommunicationObject obj, TimeSpan timeout)
+        {
+            if (obj != null)
+            {
+                var asyncCo = obj as IAsyncCommunicationObject;
+                if (asyncCo != null)
+                {
+                    await asyncCo.OpenAsync(timeout);
+                }
+                else
+                {
+                    obj.Open(timeout);
+                }
+            }
         }
 
         private static void CloseCommunicationObject(Object obj, bool aborted, TimeSpan timeout)
@@ -688,6 +837,55 @@ namespace System.ServiceModel.Security
                     ((IDisposable)obj).Dispose();
                 }
             }
+        }
+
+        private async static Task CloseCommunicationObjectAsync(Object obj, bool aborted, TimeSpan timeout)
+        {
+            if (obj != null)
+            {
+                ICommunicationObject co = obj as ICommunicationObject;
+                var asyncCo = obj as IAsyncCommunicationObject;
+                if (co != null)
+                {
+                    if (aborted)
+                    {
+                        try
+                        {
+                            co.Abort();
+                        }
+                        catch (CommunicationException)
+                        {
+                        }
+                    }
+                    else
+                    {
+                        if (asyncCo != null)
+                        {
+                            await asyncCo.CloseAsync(timeout);
+                        }
+                        else
+                        {
+                            co.Close(timeout);
+                        }
+                    }
+                }
+                else if (obj is IDisposable)
+                {
+                    ((IDisposable)obj).Dispose();
+                }
+            }
+        }
+
+        internal static Exception CreateSecurityFaultException(Message unverifiedMessage)
+        {
+            MessageFault fault = MessageFault.CreateFault(unverifiedMessage, TransportDefaults.MaxSecurityFaultSize);
+            return CreateSecurityFaultException(fault);
+        }
+
+        internal static Exception CreateSecurityFaultException(MessageFault fault)
+        {
+            FaultException faultException = FaultException.CreateFault(fault, typeof(string), typeof(object));
+            return new MessageSecurityException(SR.Format(SR.UnsecuredMessageFaultReceived), faultException);
         }
 
         internal static SecurityStandardsManager CreateSecurityStandardsManager(MessageSecurityVersion securityVersion, SecurityTokenManager tokenManager)
@@ -959,6 +1157,63 @@ namespace System.ServiceModel.Security
             // Check that Dispose() and Reset() do the same thing
             certificate.Dispose();
         }
+
+        internal static bool IsSecurityBindingSuitableForChannelBinding(TransportSecurityBindingElement securityBindingElement)
+        {
+            if (securityBindingElement == null)
+            {
+                return false;
+            }
+
+            // channel binding of OperationSupportingTokenParameters, OptionalEndpointSupportingTokenParameters, or OptionalOperationSupportingTokenParameters
+            // is not supported in Win7
+            if (AreSecurityTokenParametersSuitableForChannelBinding(securityBindingElement.EndpointSupportingTokenParameters.Endorsing))
+            {
+                return true;
+            }
+
+            if (AreSecurityTokenParametersSuitableForChannelBinding(securityBindingElement.EndpointSupportingTokenParameters.Signed))
+            {
+                return true;
+            }
+
+            if (AreSecurityTokenParametersSuitableForChannelBinding(securityBindingElement.EndpointSupportingTokenParameters.SignedEncrypted))
+            {
+                return true;
+            }
+
+            if (AreSecurityTokenParametersSuitableForChannelBinding(securityBindingElement.EndpointSupportingTokenParameters.SignedEndorsing))
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        internal static bool AreSecurityTokenParametersSuitableForChannelBinding(Collection<SecurityTokenParameters> tokenParameters)
+        {
+            if (tokenParameters == null)
+            {
+                return false;
+            }
+
+            foreach (SecurityTokenParameters stp in tokenParameters)
+            {
+                if (stp is SspiSecurityTokenParameters || stp is KerberosSecurityTokenParameters)
+                {
+                    return true;
+                }
+
+                SecureConversationSecurityTokenParameters scstp = stp as SecureConversationSecurityTokenParameters;
+                if (scstp != null)
+                {
+                    return IsSecurityBindingSuitableForChannelBinding(scstp.BootstrapSecurityBindingElement as TransportSecurityBindingElement);
+                }
+            }
+
+            return false;
+        }
+
     }
 
     internal struct SecurityUniqueId
@@ -1029,7 +1284,6 @@ namespace System.ServiceModel.Security
                     thisResult._operationWithTimeout(thisResult._timeoutHelper.RemainingTime());
                 }
             }
-#pragma warning suppress 56500 // covered by FxCOP
             catch (Exception e)
             {
                 if (Fx.IsFatal(e))

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SendSecurityHeader.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SendSecurityHeader.cs
@@ -2,22 +2,112 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-
+using System.Collections.Generic;
+using System.Diagnostics.Contracts;
+using System.IdentityModel;
+using System.IdentityModel.Tokens;
 using System.ServiceModel.Channels;
 using System.ServiceModel.Description;
+using System.ServiceModel.Diagnostics;
+using System.ServiceModel.Security.Tokens;
 using System.Xml;
 
 namespace System.ServiceModel.Security
 {
     internal abstract class SendSecurityHeader : SecurityHeader, IMessageHeaderWithSharedNamespace
     {
+        private bool _basicTokenEncrypted;
+        private SendSecurityHeaderElementContainer _elementContainer;
+        private bool _primarySignatureDone;
+        bool _encryptSignature;
+        private SignatureConfirmations _signatureValuesGenerated;
+        private SignatureConfirmations _signatureConfirmationsToSend;
+        private int _idCounter;
+        private string _idPrefix;
+        private bool _hasSignedTokens;
+        private bool _hasEncryptedTokens;
+        private MessagePartSpecification _signatureParts;
+        private MessagePartSpecification _encryptionParts;
+        private SecurityTokenParameters _signingTokenParameters;
+        private SecurityTokenParameters _encryptingTokenParameters;
+        private List<SecurityToken> _basicTokens = null;
+        private List<SecurityTokenParameters> _basicSupportingTokenParameters = null;
+        private List<SecurityTokenParameters> _endorsingTokenParameters = null;
+        private List<SecurityTokenParameters> _signedEndorsingTokenParameters = null;
+        private List<SecurityTokenParameters> _signedTokenParameters = null;
+        private SecurityToken _encryptingToken;
+        private bool _skipKeyInfoForEncryption;
+        private byte[] _primarySignatureValue = null;
+        private bool _shouldProtectTokens;
+        private BufferManager _bufferManager;
+        private bool _shouldSignToHeader = false;
+        private SecurityProtocolCorrelationState _correlationState;
+        private bool _signThenEncrypt = true;
+        private static readonly string[] s_ids = new string[] { "_0", "_1", "_2", "_3", "_4", "_5", "_6", "_7", "_8", "_9" };
+
         protected SendSecurityHeader(Message message, string actor, bool mustUnderstand, bool relay,
             SecurityStandardsManager standardsManager,
             SecurityAlgorithmSuite algorithmSuite,
             MessageDirection transferDirection)
             : base(message, actor, mustUnderstand, relay, standardsManager, algorithmSuite, transferDirection)
         {
-            throw ExceptionHelper.PlatformNotSupported();
+            _elementContainer = new SendSecurityHeaderElementContainer();
+        }
+
+        public SendSecurityHeaderElementContainer ElementContainer
+        {
+            get { return _elementContainer; }
+        }
+
+        public BufferManager StreamBufferManager
+        {
+            get
+            {
+                if (_bufferManager == null)
+                {
+                    _bufferManager = BufferManager.CreateBufferManager(0, int.MaxValue);
+                }
+
+                return _bufferManager;
+            }
+            set
+            {
+                _bufferManager = value;
+            }
+        }
+
+        public MessagePartSpecification EncryptionParts
+        {
+            get { return _encryptionParts; }
+            set
+            {
+                ThrowIfProcessingStarted();
+                if (value == null)
+                {
+                    throw TraceUtility.ThrowHelperError(new ArgumentNullException("value"), this.Message);
+                }
+                if (!value.IsReadOnly)
+                {
+                    throw TraceUtility.ThrowHelperError(new InvalidOperationException(
+                        SR.Format(SR.MessagePartSpecificationMustBeImmutable)), this.Message);
+                }
+                _encryptionParts = value;
+            }
+        }
+
+        public bool EncryptPrimarySignature
+        {
+            get { return _encryptSignature; }
+            set
+            {
+                ThrowIfProcessingStarted();
+                _encryptSignature = value;
+            }
+        }
+
+        internal byte[] PrimarySignatureValue
+        {
+            get { return _primarySignatureValue; }
         }
 
         XmlDictionaryString IMessageHeaderWithSharedNamespace.SharedNamespace
@@ -40,9 +130,856 @@ namespace System.ServiceModel.Security
             get { return this.StandardsManager.SecurityVersion.HeaderNamespace.Value; }
         }
 
+        protected SecurityAppliedMessage SecurityAppliedMessage
+        {
+            get { return (SecurityAppliedMessage)this.Message; }
+        }
+
+        public bool ShouldProtectTokens
+        {
+            get { return _shouldProtectTokens; }
+            set
+            {
+                ThrowIfProcessingStarted();
+                _shouldProtectTokens = value;
+            }
+        }
+
+        public bool SignThenEncrypt
+        {
+            get { return _signThenEncrypt; }
+            set
+            {
+                ThrowIfProcessingStarted();
+                _signThenEncrypt = value;
+            }
+        }
+
+        public MessagePartSpecification SignatureParts
+        {
+            get { return _signatureParts; }
+            set
+            {
+                ThrowIfProcessingStarted();
+                if (value == null)
+                {
+                    throw TraceUtility.ThrowHelperError(new ArgumentNullException("value"), this.Message);
+                }
+                if (!value.IsReadOnly)
+                {
+                    throw TraceUtility.ThrowHelperError(new InvalidOperationException(
+                        SR.Format(SR.MessagePartSpecificationMustBeImmutable)), this.Message);
+                }
+                _signatureParts = value;
+            }
+        }
+
+        public SecurityTimestamp Timestamp
+        {
+            get { return _elementContainer.Timestamp; }
+        }
+
+        public bool HasSignedTokens
+        {
+            get
+            {
+                return _hasSignedTokens;
+            }
+        }
+
+        public bool HasEncryptedTokens
+        {
+            get
+            {
+                return _hasEncryptedTokens;
+            }
+        }
+
+        void AddParameters(ref List<SecurityTokenParameters> list, SecurityTokenParameters item)
+        {
+            if (list == null)
+            {
+                list = new List<SecurityTokenParameters>();
+            }
+            list.Add(item);
+        }
+
+        public abstract void ApplyBodySecurity(XmlDictionaryWriter writer, IPrefixGenerator prefixGenerator);
+
+        public abstract void ApplySecurityAndWriteHeaders(MessageHeaders headers, XmlDictionaryWriter writer, IPrefixGenerator prefixGenerator);
+
+        protected virtual bool HasSignedEncryptedMessagePart
+        {
+            get { return false; }
+        }
+
         protected override void OnWriteHeaderContents(XmlDictionaryWriter writer, MessageVersion messageVersion)
         {
+            if (_basicSupportingTokenParameters != null && _basicSupportingTokenParameters.Count > 0
+                && this.RequireMessageProtection && !_basicTokenEncrypted)
+            {
+                throw TraceUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.BasicTokenCannotBeWrittenWithoutEncryption)), this.Message);
+            }
+
+            if (_elementContainer.Timestamp != null && this.Layout != SecurityHeaderLayout.LaxTimestampLast)
+            {
+                this.StandardsManager.WSUtilitySpecificationVersion.WriteTimestamp(writer, _elementContainer.Timestamp);
+            }
+            if (_elementContainer.PrerequisiteToken != null)
+            {
+                this.StandardsManager.SecurityTokenSerializer.WriteToken(writer, _elementContainer.PrerequisiteToken);
+            }
+            if (_elementContainer.SourceSigningToken != null)
+            {
+                if (ShouldSerializeToken(this._signingTokenParameters, this.MessageDirection))
+                {
+                    this.StandardsManager.SecurityTokenSerializer.WriteToken(writer, _elementContainer.SourceSigningToken);
+
+                    // Implement Protect token 
+                    // NOTE: The spec says sign the primary token if it is not included in the message. But we currently are not supporting it
+                    // as we do not support STR-Transform for external references. Hence we can not sign the token which is external ie not in the message.
+                    // This only affects the messages from service to client where 
+                    // 1. allowSerializedSigningTokenOnReply is false.
+                    // 2. SymmetricSecurityBindingElement with IssuedTokens binding where the issued token has a symmetric key.
+
+                    if (this.ShouldProtectTokens)
+                    {
+                        this.WriteSecurityTokenReferencyEntry(writer, _elementContainer.SourceSigningToken, _signingTokenParameters);
+                    }
+                }
+            }
+            if (_elementContainer.DerivedSigningToken != null)
+            {
+                this.StandardsManager.SecurityTokenSerializer.WriteToken(writer, _elementContainer.DerivedSigningToken);
+            }
+            if (_elementContainer.SourceEncryptionToken != null && _elementContainer.SourceEncryptionToken != _elementContainer.SourceSigningToken && ShouldSerializeToken(_encryptingTokenParameters, this.MessageDirection))
+            {
+                this.StandardsManager.SecurityTokenSerializer.WriteToken(writer, _elementContainer.SourceEncryptionToken);
+            }
+            if (_elementContainer.WrappedEncryptionToken != null)
+            {
+                this.StandardsManager.SecurityTokenSerializer.WriteToken(writer, _elementContainer.WrappedEncryptionToken);
+            }
+            if (_elementContainer.DerivedEncryptionToken != null)
+            {
+                this.StandardsManager.SecurityTokenSerializer.WriteToken(writer, _elementContainer.DerivedEncryptionToken);
+            }
+            if (this.SignThenEncrypt)
+            {
+                if (_elementContainer.ReferenceList != null)
+                {
+                    _elementContainer.ReferenceList.WriteTo(writer, ServiceModelDictionaryManager.Instance);
+                }
+            }
+
+            SecurityToken[] signedTokens = _elementContainer.GetSignedSupportingTokens();
+            if (signedTokens != null)
+            {
+                for (int i = 0; i < signedTokens.Length; ++i)
+                {
+                    this.StandardsManager.SecurityTokenSerializer.WriteToken(writer, signedTokens[i]);
+                    this.WriteSecurityTokenReferencyEntry(writer, signedTokens[i], _signedTokenParameters[i]);
+                }
+            }
+            SendSecurityHeaderElement[] basicTokensXml = _elementContainer.GetBasicSupportingTokens();
+            if (basicTokensXml != null)
+            {
+                for (int i = 0; i < basicTokensXml.Length; ++i)
+                {
+                    basicTokensXml[i].Item.WriteTo(writer, ServiceModelDictionaryManager.Instance);
+                    if (this.SignThenEncrypt)
+                    {
+                        this.WriteSecurityTokenReferencyEntry(writer, _basicTokens[i], _basicSupportingTokenParameters[i]);
+                    }
+                }
+            }
+            SecurityToken[] endorsingTokens = _elementContainer.GetEndorsingSupportingTokens();
+            if (endorsingTokens != null)
+            {
+                for (int i = 0; i < endorsingTokens.Length; ++i)
+                {
+                    if (ShouldSerializeToken(_endorsingTokenParameters[i], this.MessageDirection))
+                    {
+                        this.StandardsManager.SecurityTokenSerializer.WriteToken(writer, endorsingTokens[i]);
+                    }
+                }
+            }
+            SecurityToken[] endorsingDerivedTokens = _elementContainer.GetEndorsingDerivedSupportingTokens();
+            if (endorsingDerivedTokens != null)
+            {
+                for (int i = 0; i < endorsingDerivedTokens.Length; ++i)
+                {
+                    this.StandardsManager.SecurityTokenSerializer.WriteToken(writer, endorsingDerivedTokens[i]);
+                }
+            }
+            SecurityToken[] signedEndorsingTokens = _elementContainer.GetSignedEndorsingSupportingTokens();
+            if (signedEndorsingTokens != null)
+            {
+                for (int i = 0; i < signedEndorsingTokens.Length; ++i)
+                {
+                    this.StandardsManager.SecurityTokenSerializer.WriteToken(writer, signedEndorsingTokens[i]);
+                    this.WriteSecurityTokenReferencyEntry(writer, signedEndorsingTokens[i], _signedEndorsingTokenParameters[i]);
+                }
+            }
+            SecurityToken[] signedEndorsingDerivedTokens = _elementContainer.GetSignedEndorsingDerivedSupportingTokens();
+            if (signedEndorsingDerivedTokens != null)
+            {
+                for (int i = 0; i < signedEndorsingDerivedTokens.Length; ++i)
+                {
+                    this.StandardsManager.SecurityTokenSerializer.WriteToken(writer, signedEndorsingDerivedTokens[i]);
+                }
+            }
+            SendSecurityHeaderElement[] signatureConfirmations = _elementContainer.GetSignatureConfirmations();
+            if (signatureConfirmations != null)
+            {
+                for (int i = 0; i < signatureConfirmations.Length; ++i)
+                {
+                    signatureConfirmations[i].Item.WriteTo(writer, ServiceModelDictionaryManager.Instance);
+                }
+            }
+            if (_elementContainer.PrimarySignature != null && _elementContainer.PrimarySignature.Item != null)
+            {
+                _elementContainer.PrimarySignature.Item.WriteTo(writer, ServiceModelDictionaryManager.Instance);
+            }
+            SendSecurityHeaderElement[] endorsingSignatures = _elementContainer.GetEndorsingSignatures();
+            if (endorsingSignatures != null)
+            {
+                for (int i = 0; i < endorsingSignatures.Length; ++i)
+                {
+                    endorsingSignatures[i].Item.WriteTo(writer, ServiceModelDictionaryManager.Instance);
+                }
+            }
+            if (!this.SignThenEncrypt)
+            {
+                if (_elementContainer.ReferenceList != null)
+                {
+                    _elementContainer.ReferenceList.WriteTo(writer, ServiceModelDictionaryManager.Instance);
+                }
+            }
+            if (_elementContainer.Timestamp != null && this.Layout == SecurityHeaderLayout.LaxTimestampLast)
+            {
+                this.StandardsManager.WSUtilitySpecificationVersion.WriteTimestamp(writer, _elementContainer.Timestamp);
+            }
+        }
+
+        protected bool ShouldSignToHeader
+        {
+            get { return this._shouldSignToHeader; }
+        }
+
+        public string IdPrefix
+        {
+            get { return _idPrefix; }
+            set
+            {
+                ThrowIfProcessingStarted();
+                _idPrefix = string.IsNullOrEmpty(value) || value == "_" ? null : value;
+            }
+        }
+
+        public void AddTimestamp(TimeSpan timestampValidityDuration)
+        {
+            DateTime now = DateTime.UtcNow;
+            string id = this.RequireMessageProtection ? SecurityUtils.GenerateId() : GenerateId();
+            AddTimestamp(new SecurityTimestamp(now, now + timestampValidityDuration, id));
+        }
+
+        public void AddTimestamp(SecurityTimestamp timestamp)
+        {
+            ThrowIfProcessingStarted();
+            if (_elementContainer.Timestamp != null)
+            {
+                throw TraceUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.TimestampAlreadySetForSecurityHeader)), this.Message);
+            }
+            if (timestamp == null)
+            {
+                throw TraceUtility.ThrowHelperArgumentNull("timestamp", this.Message);
+            }
+
+            _elementContainer.Timestamp = timestamp;
+        }
+
+        public void AddBasicSupportingToken(SecurityToken token, SecurityTokenParameters parameters)
+        {
+            if (token == null)
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("token");
+            if (parameters == null)
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("parameters");
+            ThrowIfProcessingStarted();
+            SendSecurityHeaderElement tokenElement = new SendSecurityHeaderElement(token.Id, new TokenElement(token, this.StandardsManager));
+            tokenElement.MarkedForEncryption = true;
+            _elementContainer.AddBasicSupportingToken(tokenElement);
+            _hasEncryptedTokens = true;
+            _hasSignedTokens = true;
+            AddParameters(ref _basicSupportingTokenParameters, parameters);
+            if (_basicTokens == null)
+            {
+                _basicTokens = new List<SecurityToken>();
+            }
+
+            //  We maintain a list of the basic tokens for the SignThenEncrypt case as we will 
+            //  need this token to write STR entry on OnWriteHeaderContents. 
+            _basicTokens.Add(token);
+
+        }
+
+        public void AddEndorsingSupportingToken(SecurityToken token, SecurityTokenParameters parameters)
+        {
             throw ExceptionHelper.PlatformNotSupported();
+
+            // Issue #31 in progress
+
+            //if (token == null)
+            //    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("token");
+            //if (parameters == null)
+            //    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("parameters");
+            //ThrowIfProcessingStarted();
+            //this.elementContainer.AddEndorsingSupportingToken(token);
+            //// The ProviderBackedSecurityToken was added for the ChannelBindingToken (CBT) effort for win7.  
+            //// We can assume the key is of type symmetric key.
+            ////
+            //// Asking for the key type from the token will cause the ProviderBackedSecurityToken 
+            //// to attempt to resolve the token and the nego will start.  
+            ////
+            //// We don't want that.  
+            //// We want to defer the nego until after the CBT is available in SecurityAppliedMessage.OnWriteMessage.
+            //if (!(token is ProviderBackedSecurityToken))
+            //{
+            //    this.shouldSignToHeader |= (!this.RequireMessageProtection) && (SecurityUtils.GetSecurityKey<AsymmetricSecurityKey>(token) != null);
+            //}
+            //this.AddParameters(ref this.endorsingTokenParameters, parameters);
+        }
+
+        public void AddSignedEndorsingSupportingToken(SecurityToken token, SecurityTokenParameters parameters)
+        {
+            throw ExceptionHelper.PlatformNotSupported();    // Issue #31 in progress
+            //if (token == null)
+            //    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("token");
+            //if (parameters == null)
+            //    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("parameters");
+            //ThrowIfProcessingStarted();
+            //this.elementContainer.AddSignedEndorsingSupportingToken(token);
+            //hasSignedTokens = true;
+            //this.shouldSignToHeader |= (!this.RequireMessageProtection) && (SecurityUtils.GetSecurityKey<AsymmetricSecurityKey>(token) != null);
+            //this.AddParameters(ref this.signedEndorsingTokenParameters, parameters);
+        }
+
+        public void AddSignedSupportingToken(SecurityToken token, SecurityTokenParameters parameters)
+        {
+            throw ExceptionHelper.PlatformNotSupported();
+
+            // Issue #31 in progress
+            //if (token == null)
+            //    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("token");
+            //if (parameters == null)
+            //    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("parameters");
+            //ThrowIfProcessingStarted();
+            //this.elementContainer.AddSignedSupportingToken(token);
+            //hasSignedTokens = true;
+            //this.AddParameters(ref this.signedTokenParameters, parameters);
+        }
+
+        public void RemoveSignatureEncryptionIfAppropriate()
+        {
+            if (this.SignThenEncrypt &&
+                this.EncryptPrimarySignature &&
+                (this.SecurityAppliedMessage.BodyProtectionMode != MessagePartProtectionMode.SignThenEncrypt) &&
+                (_basicSupportingTokenParameters == null || _basicSupportingTokenParameters.Count == 0) &&
+                (_signatureConfirmationsToSend == null || _signatureConfirmationsToSend.Count == 0 || !_signatureConfirmationsToSend.IsMarkedForEncryption) &&
+                !this.HasSignedEncryptedMessagePart)
+            {
+                _encryptSignature = false;
+            }
+        }
+
+        public string GenerateId()
+        {
+            int id = _idCounter++;
+
+            if (_idPrefix != null)
+            {
+                return _idPrefix + id;
+            }
+
+            if (id < s_ids.Length)
+            {
+                return s_ids[id];
+            }
+            else
+            {
+                return "_" + id;
+            }
+        }
+
+        SignatureConfirmations GetSignatureValues()
+        {
+            return _signatureValuesGenerated;
+        }
+
+        internal static bool ShouldSerializeToken(SecurityTokenParameters parameters, MessageDirection transferDirection)
+        {
+            switch (parameters.InclusionMode)
+            {
+                case SecurityTokenInclusionMode.AlwaysToInitiator:
+                    return (transferDirection == MessageDirection.Output);
+                case SecurityTokenInclusionMode.Once:
+                case SecurityTokenInclusionMode.AlwaysToRecipient:
+                    return (transferDirection == MessageDirection.Input);
+                case SecurityTokenInclusionMode.Never:
+                    return false;
+                default:
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new NotSupportedException(SR.Format(SR.UnsupportedTokenInclusionMode, parameters.InclusionMode)));
+            }
+        }
+
+        protected abstract void WriteSecurityTokenReferencyEntry(XmlDictionaryWriter writer, SecurityToken securityToken, SecurityTokenParameters securityTokenParameters);
+
+        public Message SetupExecution()
+        {
+            ThrowIfProcessingStarted();
+            SetProcessingStarted();
+
+            bool signBody = false;
+            if (_elementContainer.SourceSigningToken != null)
+            {
+                if (_signatureParts == null)
+                {
+                    throw TraceUtility.ThrowHelperError(new ArgumentNullException("SignatureParts"), this.Message);
+                }
+                signBody = _signatureParts.IsBodyIncluded;
+            }
+
+            bool encryptBody = false;
+            if (_elementContainer.SourceEncryptionToken != null)
+            {
+                if (_encryptionParts == null)
+                {
+                    throw TraceUtility.ThrowHelperError(new ArgumentNullException("EncryptionParts"), this.Message);
+                }
+                encryptBody = _encryptionParts.IsBodyIncluded;
+            }
+
+            SecurityAppliedMessage message = new SecurityAppliedMessage(this.Message, this, signBody, encryptBody);
+            this.Message = message;
+            return message;
+        }
+
+        protected internal SecurityTokenReferenceStyle GetTokenReferenceStyle(SecurityTokenParameters parameters)
+        {
+            return (ShouldSerializeToken(parameters, this.MessageDirection)) ? SecurityTokenReferenceStyle.Internal : SecurityTokenReferenceStyle.External;
+        }
+
+        void StartSignature()
+        {
+            if (_elementContainer.SourceSigningToken == null)
+            {
+                return;
+            }
+
+            // determine the key identifier clause to use for the source
+            SecurityTokenReferenceStyle sourceSigningKeyReferenceStyle = GetTokenReferenceStyle(_signingTokenParameters);
+            SecurityKeyIdentifierClause sourceSigningKeyIdentifierClause = _signingTokenParameters.CreateKeyIdentifierClause(_elementContainer.SourceSigningToken, sourceSigningKeyReferenceStyle);
+            if (sourceSigningKeyIdentifierClause == null)
+            {
+                throw TraceUtility.ThrowHelperError(new MessageSecurityException(SR.Format(SR.TokenManagerCannotCreateTokenReference)), this.Message);
+            }
+
+            SecurityToken signingToken;
+            SecurityKeyIdentifierClause signingKeyIdentifierClause;
+
+            // determine if a token needs to be derived
+            if (_signingTokenParameters.RequireDerivedKeys && !_signingTokenParameters.HasAsymmetricKey)
+            {
+                string derivationAlgorithm = this.AlgorithmSuite.GetSignatureKeyDerivationAlgorithm(_elementContainer.SourceSigningToken, this.StandardsManager.MessageSecurityVersion.SecureConversationVersion);
+                string expectedDerivationAlgorithm = SecurityUtils.GetKeyDerivationAlgorithm(this.StandardsManager.MessageSecurityVersion.SecureConversationVersion);
+                if (derivationAlgorithm == expectedDerivationAlgorithm)
+                {
+                    DerivedKeySecurityToken derivedSigningToken = new DerivedKeySecurityToken(-1, 0, this.AlgorithmSuite.GetSignatureKeyDerivationLength(_elementContainer.SourceSigningToken, this.StandardsManager.MessageSecurityVersion.SecureConversationVersion), null, DerivedKeySecurityToken.DefaultNonceLength, _elementContainer.SourceSigningToken,
+                        sourceSigningKeyIdentifierClause, derivationAlgorithm, GenerateId());
+                    signingToken = _elementContainer.DerivedSigningToken = derivedSigningToken;
+                    signingKeyIdentifierClause = new LocalIdKeyIdentifierClause(signingToken.Id, signingToken.GetType());
+                }
+                else
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new NotSupportedException(SR.Format(SR.UnsupportedCryptoAlgorithm, derivationAlgorithm)));
+                }
+            }
+            else
+            {
+                signingToken = _elementContainer.SourceSigningToken;
+                signingKeyIdentifierClause = sourceSigningKeyIdentifierClause;
+            }
+
+            SecurityKeyIdentifier signingKeyIdentifier = new SecurityKeyIdentifier(signingKeyIdentifierClause);
+
+            if (_signatureConfirmationsToSend != null && _signatureConfirmationsToSend.Count > 0)
+            {
+                ISecurityElement[] signatureConfirmationElements;
+                signatureConfirmationElements = CreateSignatureConfirmationElements(_signatureConfirmationsToSend);
+                for (int i = 0; i < signatureConfirmationElements.Length; ++i)
+                {
+                    SendSecurityHeaderElement sigConfElement = new SendSecurityHeaderElement(signatureConfirmationElements[i].Id, signatureConfirmationElements[i]);
+                    sigConfElement.MarkedForEncryption = _signatureConfirmationsToSend.IsMarkedForEncryption;
+                    _elementContainer.AddSignatureConfirmation(sigConfElement);
+                }
+            }
+
+            bool generateTargettablePrimarySignature = ((_endorsingTokenParameters != null) || (_signedEndorsingTokenParameters != null));
+            this.StartPrimarySignatureCore(signingToken, signingKeyIdentifier, _signatureParts, generateTargettablePrimarySignature);
+        }
+
+        void CompleteSignature()
+        {
+            ISignatureValueSecurityElement signedXml = CompletePrimarySignatureCore(
+                _elementContainer.GetSignatureConfirmations(), _elementContainer.GetSignedEndorsingSupportingTokens(),
+                _elementContainer.GetSignedSupportingTokens(), _elementContainer.GetBasicSupportingTokens(), true);
+            if (signedXml == null)
+            {
+                return;
+            }
+            _elementContainer.PrimarySignature = new SendSecurityHeaderElement(signedXml.Id, signedXml);
+            _elementContainer.PrimarySignature.MarkedForEncryption = _encryptSignature;
+            AddGeneratedSignatureValue(signedXml.GetSignatureValue(), this.EncryptPrimarySignature);
+            _primarySignatureDone = true;
+            _primarySignatureValue = signedXml.GetSignatureValue();
+        }
+
+        protected abstract void StartPrimarySignatureCore(SecurityToken token, SecurityKeyIdentifier identifier, MessagePartSpecification signatureParts, bool generateTargettablePrimarySignature);
+
+        protected abstract ISignatureValueSecurityElement CompletePrimarySignatureCore(SendSecurityHeaderElement[] signatureConfirmations,
+           SecurityToken[] signedEndorsingTokens, SecurityToken[] signedTokens, SendSecurityHeaderElement[] basicTokens, bool isPrimarySignature);
+
+
+        protected abstract ISignatureValueSecurityElement CreateSupportingSignature(SecurityToken token, SecurityKeyIdentifier identifier);
+
+        protected abstract ISignatureValueSecurityElement CreateSupportingSignature(SecurityToken token, SecurityKeyIdentifier identifier, ISecurityElement primarySignature);
+
+        protected abstract void StartEncryptionCore(SecurityToken token, SecurityKeyIdentifier keyIdentifier);
+
+        protected abstract ISecurityElement CompleteEncryptionCore(SendSecurityHeaderElement primarySignature,
+            SendSecurityHeaderElement[] basicTokens, SendSecurityHeaderElement[] signatureConfirmations, SendSecurityHeaderElement[] endorsingSignatures);
+
+        void SignWithSupportingToken(SecurityToken token, SecurityKeyIdentifierClause identifierClause)
+        {
+            if (token == null)
+            {
+                throw TraceUtility.ThrowHelperArgumentNull("token", this.Message);
+            }
+            if (identifierClause == null)
+            {
+                throw TraceUtility.ThrowHelperError(new MessageSecurityException(SR.Format(SR.TokenManagerCannotCreateTokenReference)), this.Message);
+            }
+            if (!this.RequireMessageProtection)
+            {
+                if (_elementContainer.Timestamp == null)
+                {
+                    throw TraceUtility.ThrowHelperError(new InvalidOperationException(
+                        SR.Format(SR.SigningWithoutPrimarySignatureRequiresTimestamp)), this.Message);
+                }
+            }
+            else
+            {
+                if (!_primarySignatureDone)
+                {
+                    throw TraceUtility.ThrowHelperError(new InvalidOperationException(
+                        SR.Format(SR.PrimarySignatureMustBeComputedBeforeSupportingTokenSignatures)), this.Message);
+                }
+                if (_elementContainer.PrimarySignature.Item == null)
+                {
+                    throw TraceUtility.ThrowHelperError(new InvalidOperationException(
+                        SR.Format(SR.SupportingTokenSignaturesNotExpected)), this.Message);
+                }
+            }
+
+            SecurityKeyIdentifier identifier = new SecurityKeyIdentifier(identifierClause);
+            ISignatureValueSecurityElement supportingSignature;
+            if (!this.RequireMessageProtection)
+            {
+                supportingSignature = CreateSupportingSignature(token, identifier);
+            }
+            else
+            {
+                supportingSignature = CreateSupportingSignature(token, identifier, _elementContainer.PrimarySignature.Item);
+            }
+            AddGeneratedSignatureValue(supportingSignature.GetSignatureValue(), _encryptSignature);
+            SendSecurityHeaderElement supportingSignatureElement = new SendSecurityHeaderElement(supportingSignature.Id, supportingSignature);
+            supportingSignatureElement.MarkedForEncryption = _encryptSignature;
+            _elementContainer.AddEndorsingSignature(supportingSignatureElement);
+        }
+
+        void SignWithSupportingTokens()
+        {
+            SecurityToken[] endorsingTokens = _elementContainer.GetEndorsingSupportingTokens();
+            if (endorsingTokens != null)
+            {
+                for (int i = 0; i < endorsingTokens.Length; ++i)
+                {
+                    SecurityToken source = endorsingTokens[i];
+                    SecurityKeyIdentifierClause sourceKeyClause = _endorsingTokenParameters[i].CreateKeyIdentifierClause(source, GetTokenReferenceStyle(_endorsingTokenParameters[i]));
+                    if (sourceKeyClause == null)
+                    {
+                        throw TraceUtility.ThrowHelperError(new MessageSecurityException(SR.Format(SR.TokenManagerCannotCreateTokenReference)), this.Message);
+                    }
+                    SecurityToken signingToken;
+                    SecurityKeyIdentifierClause signingKeyClause;
+                    if (_endorsingTokenParameters[i].RequireDerivedKeys && !_endorsingTokenParameters[i].HasAsymmetricKey)
+                    {
+                        string derivationAlgorithm = SecurityUtils.GetKeyDerivationAlgorithm(this.StandardsManager.MessageSecurityVersion.SecureConversationVersion);
+                        DerivedKeySecurityToken dkt = new DerivedKeySecurityToken(-1, 0,
+                            this.AlgorithmSuite.GetSignatureKeyDerivationLength(source, this.StandardsManager.MessageSecurityVersion.SecureConversationVersion), null,
+                            DerivedKeySecurityToken.DefaultNonceLength, source, sourceKeyClause, derivationAlgorithm, GenerateId());
+                        signingToken = dkt;
+                        signingKeyClause = new LocalIdKeyIdentifierClause(dkt.Id, dkt.GetType());
+                        _elementContainer.AddEndorsingDerivedSupportingToken(dkt);
+                    }
+                    else
+                    {
+                        signingToken = source;
+                        signingKeyClause = sourceKeyClause;
+                    }
+                    SignWithSupportingToken(signingToken, signingKeyClause);
+                }
+            }
+            SecurityToken[] signedEndorsingSupportingTokens = _elementContainer.GetSignedEndorsingSupportingTokens();
+            if (signedEndorsingSupportingTokens != null)
+            {
+                for (int i = 0; i < signedEndorsingSupportingTokens.Length; ++i)
+                {
+                    SecurityToken source = signedEndorsingSupportingTokens[i];
+                    SecurityKeyIdentifierClause sourceKeyClause = _signedEndorsingTokenParameters[i].CreateKeyIdentifierClause(source, GetTokenReferenceStyle(_signedEndorsingTokenParameters[i]));
+                    if (sourceKeyClause == null)
+                    {
+                        throw TraceUtility.ThrowHelperError(new MessageSecurityException(SR.Format(SR.TokenManagerCannotCreateTokenReference)), this.Message);
+                    }
+                    SecurityToken signingToken;
+                    SecurityKeyIdentifierClause signingKeyClause;
+                    if (_signedEndorsingTokenParameters[i].RequireDerivedKeys && !_signedEndorsingTokenParameters[i].HasAsymmetricKey)
+                    {
+                        string derivationAlgorithm = SecurityUtils.GetKeyDerivationAlgorithm(this.StandardsManager.MessageSecurityVersion.SecureConversationVersion);
+                        DerivedKeySecurityToken dkt = new DerivedKeySecurityToken(-1, 0,
+                            this.AlgorithmSuite.GetSignatureKeyDerivationLength(source, this.StandardsManager.MessageSecurityVersion.SecureConversationVersion), null,
+                            DerivedKeySecurityToken.DefaultNonceLength, source, sourceKeyClause, derivationAlgorithm, GenerateId());
+                        signingToken = dkt;
+                        signingKeyClause = new LocalIdKeyIdentifierClause(dkt.Id, dkt.GetType());
+                        _elementContainer.AddSignedEndorsingDerivedSupportingToken(dkt);
+                    }
+                    else
+                    {
+                        signingToken = source;
+                        signingKeyClause = sourceKeyClause;
+                    }
+                    SignWithSupportingToken(signingToken, signingKeyClause);
+                }
+            }
+        }
+
+        protected virtual ISignatureValueSecurityElement[] CreateSignatureConfirmationElements(SignatureConfirmations signatureConfirmations)
+        {
+            throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(
+                SR.Format(SR.SignatureConfirmationNotSupported)));
+        }
+
+        void StartEncryption()
+        {
+            if (_elementContainer.SourceEncryptionToken == null)
+            {
+                return;
+            }
+            // determine the key identifier clause to use for the source
+            SecurityTokenReferenceStyle sourceEncryptingKeyReferenceStyle = GetTokenReferenceStyle(_encryptingTokenParameters);
+            bool encryptionTokenSerialized = sourceEncryptingKeyReferenceStyle == SecurityTokenReferenceStyle.Internal;
+            SecurityKeyIdentifierClause sourceEncryptingKeyIdentifierClause = _encryptingTokenParameters.CreateKeyIdentifierClause(_elementContainer.SourceEncryptionToken, sourceEncryptingKeyReferenceStyle);
+            if (sourceEncryptingKeyIdentifierClause == null)
+            {
+                throw TraceUtility.ThrowHelperError(new MessageSecurityException(SR.Format(SR.TokenManagerCannotCreateTokenReference)), this.Message);
+            }
+            SecurityToken sourceToken;
+            SecurityKeyIdentifierClause sourceTokenIdentifierClause;
+
+            // if the source token cannot do symmetric crypto, create a wrapped key
+            if (!SecurityUtils.HasSymmetricSecurityKey(_elementContainer.SourceEncryptionToken))
+            {
+                int keyLength = Math.Max(128, this.AlgorithmSuite.DefaultSymmetricKeyLength);
+                CryptoHelper.ValidateSymmetricKeyLength(keyLength, this.AlgorithmSuite);
+                byte[] key = new byte[keyLength / 8];
+                CryptoHelper.FillRandomBytes(key);
+                string keyWrapAlgorithm;
+                XmlDictionaryString keyWrapAlgorithmDictionaryString;
+                this.AlgorithmSuite.GetKeyWrapAlgorithm(_elementContainer.SourceEncryptionToken, out keyWrapAlgorithm, out keyWrapAlgorithmDictionaryString);
+                WrappedKeySecurityToken wrappedKey = new WrappedKeySecurityToken(GenerateId(), key, keyWrapAlgorithm, keyWrapAlgorithmDictionaryString,
+                    _elementContainer.SourceEncryptionToken, new SecurityKeyIdentifier(sourceEncryptingKeyIdentifierClause));
+                _elementContainer.WrappedEncryptionToken = wrappedKey;
+                sourceToken = wrappedKey;
+                sourceTokenIdentifierClause = new LocalIdKeyIdentifierClause(wrappedKey.Id, wrappedKey.GetType());
+                encryptionTokenSerialized = true;
+            }
+            else
+            {
+                sourceToken = _elementContainer.SourceEncryptionToken;
+                sourceTokenIdentifierClause = sourceEncryptingKeyIdentifierClause;
+            }
+
+            // determine if a key needs to be derived
+            SecurityKeyIdentifierClause encryptingKeyIdentifierClause;
+            // determine if a token needs to be derived
+            if (_encryptingTokenParameters.RequireDerivedKeys)
+            {
+                string derivationAlgorithm = this.AlgorithmSuite.GetEncryptionKeyDerivationAlgorithm(sourceToken, this.StandardsManager.MessageSecurityVersion.SecureConversationVersion);
+                string expectedDerivationAlgorithm = SecurityUtils.GetKeyDerivationAlgorithm(this.StandardsManager.MessageSecurityVersion.SecureConversationVersion);
+                if (derivationAlgorithm == expectedDerivationAlgorithm)
+                {
+                    DerivedKeySecurityToken derivedEncryptingToken = new DerivedKeySecurityToken(-1, 0,
+                        this.AlgorithmSuite.GetEncryptionKeyDerivationLength(sourceToken, this.StandardsManager.MessageSecurityVersion.SecureConversationVersion), null, DerivedKeySecurityToken.DefaultNonceLength, sourceToken, sourceTokenIdentifierClause, derivationAlgorithm, GenerateId());
+                    _encryptingToken = _elementContainer.DerivedEncryptionToken = derivedEncryptingToken;
+                    encryptingKeyIdentifierClause = new LocalIdKeyIdentifierClause(derivedEncryptingToken.Id, derivedEncryptingToken.GetType());
+                }
+                else
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new NotSupportedException(SR.Format(SR.UnsupportedCryptoAlgorithm, derivationAlgorithm)));
+                }
+            }
+            else
+            {
+                _encryptingToken = sourceToken;
+                encryptingKeyIdentifierClause = sourceTokenIdentifierClause;
+            }
+
+            _skipKeyInfoForEncryption = encryptionTokenSerialized && this.EncryptedKeyContainsReferenceList && (_encryptingToken is WrappedKeySecurityToken) && _signThenEncrypt;
+            SecurityKeyIdentifier identifier;
+            if (_skipKeyInfoForEncryption)
+            {
+                identifier = null;
+            }
+            else
+            {
+                identifier = new SecurityKeyIdentifier(encryptingKeyIdentifierClause);
+            }
+
+            StartEncryptionCore(_encryptingToken, identifier);
+        }
+
+        void CompleteEncryption()
+        {
+            ISecurityElement referenceList = CompleteEncryptionCore(
+                _elementContainer.PrimarySignature,
+                _elementContainer.GetBasicSupportingTokens(),
+                _elementContainer.GetSignatureConfirmations(),
+                _elementContainer.GetEndorsingSignatures());
+
+            if (referenceList == null)
+            {
+                // null out all the encryption fields since there is no encryption needed
+                _elementContainer.SourceEncryptionToken = null;
+                _elementContainer.WrappedEncryptionToken = null;
+                _elementContainer.DerivedEncryptionToken = null;
+                return;
+            }
+
+            if (_skipKeyInfoForEncryption)
+            {
+                WrappedKeySecurityToken wrappedKeyToken = _encryptingToken as WrappedKeySecurityToken;
+                wrappedKeyToken.EnsureEncryptedKeySetUp();
+                wrappedKeyToken.EncryptedKey.ReferenceList = (ReferenceList)referenceList;
+            }
+            else
+            {
+                _elementContainer.ReferenceList = referenceList;
+            }
+            _basicTokenEncrypted = true;
+        }
+
+        internal void StartSecurityApplication()
+        {
+            if (this.SignThenEncrypt)
+            {
+                StartSignature();
+                StartEncryption();
+            }
+            else
+            {
+                StartEncryption();
+                StartSignature();
+            }
+        }
+
+        internal void CompleteSecurityApplication()
+        {
+            if (this.SignThenEncrypt)
+            {
+                CompleteSignature();
+                SignWithSupportingTokens();
+                CompleteEncryption();
+            }
+            else
+            {
+                CompleteEncryption();
+                CompleteSignature();
+                SignWithSupportingTokens();
+            }
+
+            if (_correlationState != null)
+            {
+                _correlationState.SignatureConfirmations = GetSignatureValues();
+            }
+        }
+
+        void AddGeneratedSignatureValue(byte[] signatureValue, bool wasEncrypted)
+        {
+            // cache outgoing signatures only on the client side
+            if (this.MaintainSignatureConfirmationState && (_signatureConfirmationsToSend == null))
+            {
+                if (_signatureValuesGenerated == null)
+                {
+                    _signatureValuesGenerated = new SignatureConfirmations();
+                }
+                _signatureValuesGenerated.AddConfirmation(signatureValue, wasEncrypted);
+            }
+        }
+    }
+
+    class TokenElement : ISecurityElement
+    {
+        SecurityStandardsManager _standardsManager;
+        SecurityToken _token;
+
+        public TokenElement(SecurityToken token, SecurityStandardsManager standardsManager)
+        {
+            Contract.Assert(token != null);
+            Contract.Assert(standardsManager != null);
+
+            _token = token;
+            _standardsManager = standardsManager;
+        }
+
+        public override bool Equals(object item)
+        {
+            TokenElement element = item as TokenElement;
+            return (element != null && this._token == element._token && this._standardsManager == element._standardsManager);
+        }
+
+        public override int GetHashCode()
+        {
+            return _token.GetHashCode() ^ _standardsManager.GetHashCode();
+        }
+
+        public bool HasId
+        {
+            get { return true; }
+        }
+
+        public string Id
+        {
+            get { return _token.Id; }
+        }
+
+        public SecurityToken Token
+        {
+            get { return _token; }
+        }
+
+        public void WriteTo(XmlDictionaryWriter writer, DictionaryManager dictionaryManager)
+        {
+            _standardsManager.SecurityTokenSerializer.WriteToken(writer, _token);
         }
     }
 }

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SendSecurityHeaderElement.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SendSecurityHeaderElement.cs
@@ -1,0 +1,50 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using ISecurityElement = System.IdentityModel.ISecurityElement;
+
+namespace System.ServiceModel.Security
+{
+    class SendSecurityHeaderElement
+    {
+        private string _id;
+        private ISecurityElement _item;
+        private bool _markedForEncryption;
+
+        public SendSecurityHeaderElement(string id, ISecurityElement item)
+        {
+            _id = id;
+            _item = item;
+            _markedForEncryption = false;
+        }
+
+        public string Id
+        {
+            get { return _id; }
+        }
+
+        public ISecurityElement Item
+        {
+            get { return _item; }
+        }
+
+        public bool MarkedForEncryption
+        {
+            get { return _markedForEncryption; }
+            set { _markedForEncryption = value; }
+        }
+
+        public bool IsSameItem(ISecurityElement item)
+        {
+            return _item == item || _item.Equals(item);
+        }
+
+        public void Replace(string id, ISecurityElement item)
+        {
+            _item = item;
+            _id = id;
+        }
+    }
+}
+

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SendSecurityHeaderElementContainer.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SendSecurityHeaderElementContainer.cs
@@ -1,0 +1,153 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.IdentityModel.Tokens;
+using ISecurityElement = System.IdentityModel.ISecurityElement;
+
+namespace System.ServiceModel.Security
+{
+    class SendSecurityHeaderElementContainer
+    {
+        private List<SecurityToken> _signedSupportingTokens = null;
+        private List<SendSecurityHeaderElement> _basicSupportingTokens = null;
+        private List<SecurityToken> _endorsingSupportingTokens = null;
+        private List<SecurityToken> _endorsingDerivedSupportingTokens = null;
+        private List<SecurityToken> _signedEndorsingSupportingTokens = null;
+        private List<SecurityToken> _signedEndorsingDerivedSupportingTokens = null;
+        private List<SendSecurityHeaderElement> _signatureConfirmations = null;
+        private List<SendSecurityHeaderElement> _endorsingSignatures = null;
+        private Dictionary<SecurityToken, SecurityKeyIdentifierClause> _securityTokenMappedToIdentifierClause = null;
+
+        public SecurityTimestamp Timestamp;
+        public SecurityToken PrerequisiteToken;
+        public SecurityToken SourceSigningToken;
+        public SecurityToken DerivedSigningToken;
+        public SecurityToken SourceEncryptionToken;
+        public SecurityToken WrappedEncryptionToken;
+        public SecurityToken DerivedEncryptionToken;
+        public ISecurityElement ReferenceList;
+        public SendSecurityHeaderElement PrimarySignature;
+
+        void Add<T>(ref List<T> list, T item)
+        {
+            if (list == null)
+            {
+                list = new List<T>();
+            }
+            list.Add(item);
+        }
+
+        public SecurityToken[] GetSignedSupportingTokens()
+        {
+            return (_signedSupportingTokens != null) ? _signedSupportingTokens.ToArray() : null;
+        }
+
+        public void AddSignedSupportingToken(SecurityToken token)
+        {
+            Add<SecurityToken>(ref _signedSupportingTokens, token);
+        }
+
+        public List<SecurityToken> EndorsingSupportingTokens
+        {
+            get { return _endorsingSupportingTokens; }
+        }
+
+        public SendSecurityHeaderElement[] GetBasicSupportingTokens()
+        {
+            return (_basicSupportingTokens != null) ? _basicSupportingTokens.ToArray() : null;
+        }
+
+        public void AddBasicSupportingToken(SendSecurityHeaderElement tokenElement)
+        {
+            Add<SendSecurityHeaderElement>(ref _basicSupportingTokens, tokenElement);
+        }
+
+        public SecurityToken[] GetSignedEndorsingSupportingTokens()
+        {
+            return (_signedEndorsingSupportingTokens != null) ? _signedEndorsingSupportingTokens.ToArray() : null;
+        }
+
+        public void AddSignedEndorsingSupportingToken(SecurityToken token)
+        {
+            Add<SecurityToken>(ref _signedEndorsingSupportingTokens, token);
+        }
+
+        public SecurityToken[] GetSignedEndorsingDerivedSupportingTokens()
+        {
+            return (_signedEndorsingDerivedSupportingTokens != null) ? _signedEndorsingDerivedSupportingTokens.ToArray() : null;
+        }
+
+        public void AddSignedEndorsingDerivedSupportingToken(SecurityToken token)
+        {
+            Add<SecurityToken>(ref _signedEndorsingDerivedSupportingTokens, token);
+        }
+
+        public SecurityToken[] GetEndorsingSupportingTokens()
+        {
+            return (_endorsingSupportingTokens != null) ? _endorsingSupportingTokens.ToArray() : null;
+        }
+
+        public void AddEndorsingSupportingToken(SecurityToken token)
+        {
+            Add<SecurityToken>(ref _endorsingSupportingTokens, token);
+        }
+
+        public SecurityToken[] GetEndorsingDerivedSupportingTokens()
+        {
+            return (_endorsingDerivedSupportingTokens != null) ? _endorsingDerivedSupportingTokens.ToArray() : null;
+        }
+
+        public void AddEndorsingDerivedSupportingToken(SecurityToken token)
+        {
+            Add<SecurityToken>(ref _endorsingDerivedSupportingTokens, token);
+        }
+
+        public SendSecurityHeaderElement[] GetSignatureConfirmations()
+        {
+            return (_signatureConfirmations != null) ? _signatureConfirmations.ToArray() : null;
+        }
+
+        public void AddSignatureConfirmation(SendSecurityHeaderElement confirmation)
+        {
+            Add<SendSecurityHeaderElement>(ref _signatureConfirmations, confirmation);
+        }
+
+        public SendSecurityHeaderElement[] GetEndorsingSignatures()
+        {
+            return (_endorsingSignatures != null) ? _endorsingSignatures.ToArray() : null;
+        }
+
+        public void AddEndorsingSignature(SendSecurityHeaderElement signature)
+        {
+            Add<SendSecurityHeaderElement>(ref _endorsingSignatures, signature);
+        }
+
+        public void MapSecurityTokenToStrClause(SecurityToken securityToken, SecurityKeyIdentifierClause keyIdentifierClause)
+        {
+            if (_securityTokenMappedToIdentifierClause == null)
+            {
+                _securityTokenMappedToIdentifierClause = new Dictionary<SecurityToken, SecurityKeyIdentifierClause>();
+            }
+
+            if (!_securityTokenMappedToIdentifierClause.ContainsKey(securityToken))
+            {
+                _securityTokenMappedToIdentifierClause.Add(securityToken, keyIdentifierClause);
+            }
+        }
+
+        public bool TryGetIdentifierClauseFromSecurityToken(SecurityToken securityToken, out SecurityKeyIdentifierClause keyIdentifierClause)
+        {
+            keyIdentifierClause = null;
+            if (securityToken == null
+                || _securityTokenMappedToIdentifierClause == null
+                || !_securityTokenMappedToIdentifierClause.TryGetValue(securityToken, out keyIdentifierClause))
+            {
+                return false;
+            }
+            return true;
+        }       
+    }
+}
+

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SignatureConfirmations.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SignatureConfirmations.cs
@@ -1,0 +1,66 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace System.ServiceModel.Security
+{
+    class SignatureConfirmations
+    {
+        private SignatureConfirmation[] _confirmations;
+        private int _length;
+        private bool _encrypted;
+
+        struct SignatureConfirmation
+        {
+            public byte[] value;
+
+            public SignatureConfirmation(byte[] value)
+            {
+                this.value = value;
+            }
+        }
+
+        public SignatureConfirmations()
+        {
+            _confirmations = new SignatureConfirmation[1];
+            _length = 0;
+        }
+
+        public int Count
+        {
+            get { return _length; }
+        }
+
+        public void AddConfirmation(byte[] value, bool encrypted)
+        {
+            if (_confirmations.Length == _length)
+            {
+                SignatureConfirmation[] newConfirmations = new SignatureConfirmation[_length * 2];
+                Array.Copy(_confirmations, 0, newConfirmations, 0, _length);
+                _confirmations = newConfirmations;
+            }
+            _confirmations[_length] = new SignatureConfirmation(value);
+            ++_length;
+            _encrypted |= encrypted;
+        }
+
+        public void GetConfirmation(int index, out byte[] value, out bool encrypted)
+        {
+            if (index < 0 || index >= _length)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("index", SR.Format(SR.ValueMustBeInRange, 0, _length)));
+            }
+
+            value = _confirmations[index].value;
+            encrypted = _encrypted;
+        }
+
+        public bool IsMarkedForEncryption
+        {
+            get { return _encrypted; }
+        }
+    }
+}
+

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SspiSecurityTokenProvider.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SspiSecurityTokenProvider.cs
@@ -2,12 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-
 using System.IdentityModel.Selectors;
 using System.IdentityModel.Tokens;
-using System.ServiceModel.Security.Tokens;
 using System.Net;
 using System.Security.Principal;
+using System.ServiceModel.Security.Tokens;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -35,6 +34,11 @@ namespace System.ServiceModel.Security
         protected override Task<SecurityToken> GetTokenCoreAsync(CancellationToken cancellationToken)
         {
             return Task.FromResult<SecurityToken>(_token);
+        }
+
+        protected override SecurityToken GetTokenCore(TimeSpan timeout)
+        {
+            return _token;
         }
     }
 }

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/Tokens/DerivedKeySecurityToken.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/Tokens/DerivedKeySecurityToken.cs
@@ -1,21 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+// See the LICENSE file in the project root for more information
 
-
-using System.Collections;
-using System.ServiceModel;
-using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Globalization;
-using System.IO;
-using System.IdentityModel.Claims;
-using System.IdentityModel.Policy;
 using System.IdentityModel.Tokens;
-using System.IdentityModel.Selectors;
-using System.Security.Cryptography;
-using System.Text;
-using System.Xml;
 
 namespace System.ServiceModel.Security.Tokens
 {
@@ -33,7 +21,7 @@ namespace System.ServiceModel.Security.Tokens
         public const int DefaultNonceLength = 16;
         public const int DefaultDerivedKeyLength = 32;
 
-#pragma warning disable 0649 // Remove this once we do real implementation, this prevents "field is never assigned to" warning. 
+#pragma warning disable 0649 // Issue #31 in progress. Remove this once we do real implementation, this prevents "field is never assigned to" warning. 
         // fields are read from in this class, but lack of implemenation means we never assign them yet. 
         private string _id;
         private byte[] _key;
@@ -49,6 +37,48 @@ namespace System.ServiceModel.Security.Tokens
         private ReadOnlyCollection<SecurityKey> _securityKeys;
 #pragma warning restore 0649
 
+        // create from scratch
+        public DerivedKeySecurityToken(SecurityToken tokenToDerive, SecurityKeyIdentifierClause tokenToDeriveIdentifier, int length)
+            : this(tokenToDerive, tokenToDeriveIdentifier, length, SecurityUtils.GenerateId())
+        {
+        }
+
+        internal DerivedKeySecurityToken(SecurityToken tokenToDerive, SecurityKeyIdentifierClause tokenToDeriveIdentifier,
+            int length, string id)
+        {
+            if (length != 16 && length != 24 && length != 32)
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentException(SR.Format(SR.Psha1KeyLengthInvalid, length * 8)));
+
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+
+            //byte[] nonce = new byte[DefaultNonceLength];
+            //RNGCryptoServiceProvider rng = new RNGCryptoServiceProvider();
+            //rng.GetBytes(nonce);
+
+            //Initialize(id, -1, 0, length, null, nonce, tokenToDerive, tokenToDeriveIdentifier, SecurityAlgorithms.Psha1KeyDerivation);
+        }
+
+        internal DerivedKeySecurityToken(int generation, int offset, int length,
+            string label, int minNonceLength, SecurityToken tokenToDerive,
+            SecurityKeyIdentifierClause tokenToDeriveIdentifier,
+            string derivationAlgorithm, string id)
+        {
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+
+            //byte[] nonce = new byte[minNonceLength];
+            //RNGCryptoServiceProvider rng = new RNGCryptoServiceProvider();
+            //rng.GetBytes(nonce);
+
+            //Initialize(id, generation, offset, length, label, nonce, tokenToDerive, tokenToDeriveIdentifier, derivationAlgorithm);
+        }
+
+        // create from xml
+        internal DerivedKeySecurityToken(int generation, int offset, int length,
+            string label, byte[] nonce, SecurityToken tokenToDerive,
+            SecurityKeyIdentifierClause tokenToDeriveIdentifier, string derivationAlgorithm, string id)
+        {
+            Initialize(id, generation, offset, length, label, nonce, tokenToDerive, tokenToDeriveIdentifier, derivationAlgorithm, false);
+        }
 
         public override string Id
         {
@@ -133,6 +163,95 @@ namespace System.ServiceModel.Security.Tokens
             return (keys != null);
         }
 
+        void Initialize(string id, int generation, int offset, int length, string label, byte[] nonce,
+    SecurityToken tokenToDerive, SecurityKeyIdentifierClause tokenToDeriveIdentifier, string derivationAlgorithm)
+        {
+            Initialize(id, generation, offset, length, label, nonce, tokenToDerive, tokenToDeriveIdentifier, derivationAlgorithm, true);
+        }
+
+        void Initialize(string id, int generation, int offset, int length, string label, byte[] nonce,
+            SecurityToken tokenToDerive, SecurityKeyIdentifierClause tokenToDeriveIdentifier, string derivationAlgorithm,
+            bool initializeDerivedKey)
+        {
+            if (id == null)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("id");
+            }
+            if (tokenToDerive == null)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("tokenToDerive");
+            }
+            if (tokenToDeriveIdentifier == null)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("tokentoDeriveIdentifier");
+            }
+            if (!SecurityUtils.IsSupportedAlgorithm(derivationAlgorithm, tokenToDerive))
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentException(SR.Format(SR.DerivedKeyCannotDeriveFromSecret)));
+            }
+            if (nonce == null)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("nonce");
+            }
+            if (length == -1)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("length"));
+            }
+            if (offset == -1 && generation == -1)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgument(SR.Format(SR.DerivedKeyPosAndGenNotSpecified));
+            }
+            if (offset >= 0 && generation >= 0)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgument(SR.Format(SR.DerivedKeyPosAndGenBothSpecified));
+            }
+
+            _id = id;
+            _label = label;
+            _nonce = nonce;
+            _length = length;
+            _offset = offset;
+            _generation = generation;
+            _tokenToDerive = tokenToDerive;
+            _tokenToDeriveIdentifier = tokenToDeriveIdentifier;
+            _keyDerivationAlgorithm = derivationAlgorithm;
+
+            if (initializeDerivedKey)
+            {
+                InitializeDerivedKey(_length);
+            }
+        }
+
+        internal void InitializeDerivedKey(int maxKeyLength)
+        {
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+
+            //if (_key != null)
+            //{
+            //    return;
+            //}
+            //if (_length > maxKeyLength)
+            //{
+            //    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgument(SR.Format(SR.DerivedKeyLengthTooLong, _length, maxKeyLength));
+            //}
+
+            //_key = SecurityUtils.GenerateDerivedKey(_tokenToDerive, _keyDerivationAlgorithm,
+            //    (_label != null ? Encoding.UTF8.GetBytes(_label) : DefaultLabel), _nonce, _length * 8,
+            //    ((_offset >= 0) ? _offset : _generation * _length));
+            //if ((_key == null) || (_key.Length == 0))
+            //{
+            //    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgument(SR.Format(SR.DerivedKeyCannotDeriveFromSecret));
+            //}
+            //List<SecurityKey> temp = new List<SecurityKey>(1);
+            //temp.Add(new InMemorySymmetricSecurityKey(_key, false));
+            //_securityKeys = temp.AsReadOnly();
+        }
+
+        internal void InitializeDerivedKey(ReadOnlyCollection<SecurityKey> securityKeys)
+        {
+            _key = ((SymmetricSecurityKey)securityKeys[0]).GetSymmetricKey();
+            _securityKeys = securityKeys;
+        }
 
         internal static void EnsureAcceptableOffset(int offset, int generation, int length, int maxOffset)
         {

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/Tokens/IssuedSecurityTokenParameters.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/Tokens/IssuedSecurityTokenParameters.cs
@@ -1,0 +1,1006 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+
+using System.Collections.ObjectModel;
+using System.Globalization;
+using System.IdentityModel.Selectors;
+using System.IdentityModel.Tokens;
+using System.Runtime;
+using System.ServiceModel.Channels;
+using System.Text;
+using System.Xml;
+
+namespace System.ServiceModel.Security.Tokens
+{
+#pragma warning disable CS0219 // Issue #31 in progress -- remove this when fully implemented and all fields used
+
+    public class IssuedSecurityTokenParameters : SecurityTokenParameters
+    {
+        private const string wsidPrefix = "wsid";
+        private const string wsidNamespace = "http://schemas.xmlsoap.org/ws/2005/05/identity";
+        private static readonly string s_wsidPPIClaim = String.Format(CultureInfo.InvariantCulture, "{0}/claims/privatepersonalidentifier", wsidNamespace);
+        internal const SecurityKeyType defaultKeyType = SecurityKeyType.SymmetricKey;
+        internal const bool defaultUseStrTransform = false;
+
+        internal struct AlternativeIssuerEndpoint
+        {
+            public EndpointAddress IssuerAddress;
+            public EndpointAddress IssuerMetadataAddress;
+            public Binding IssuerBinding;
+        }
+
+        private Collection<XmlElement> _additionalRequestParameters = new Collection<XmlElement>();
+        private Collection<AlternativeIssuerEndpoint> _alternativeIssuerEndpoints = new Collection<AlternativeIssuerEndpoint>();
+        private MessageSecurityVersion _defaultMessageSecurityVersion;
+        private EndpointAddress _issuerAddress;
+        private EndpointAddress _issuerMetadataAddress;
+        private Binding _issuerBinding;
+        private int _keySize;
+        private SecurityKeyType _keyType = defaultKeyType;
+        private Collection<ClaimTypeRequirement> _claimTypeRequirements = new Collection<ClaimTypeRequirement>();
+        private bool _useStrTransform = defaultUseStrTransform;
+        private string _tokenType;
+
+        protected IssuedSecurityTokenParameters(IssuedSecurityTokenParameters other)
+            : base(other)
+        {
+            _defaultMessageSecurityVersion = other._defaultMessageSecurityVersion;
+            _issuerAddress = other._issuerAddress;
+            _keyType = other._keyType;
+            _tokenType = other._tokenType;
+            _keySize = other._keySize;
+            _useStrTransform = other._useStrTransform;
+
+            foreach (XmlElement parameter in other._additionalRequestParameters)
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress (missing XmlElement.Clone)
+                //_additionalRequestParameters.Add((XmlElement)parameter.Clone());
+            }
+            foreach (ClaimTypeRequirement c in other._claimTypeRequirements)
+            {
+                _claimTypeRequirements.Add(c);
+            }
+            if (other._issuerBinding != null)
+            {
+                _issuerBinding = new CustomBinding(other._issuerBinding);
+            }
+            _issuerMetadataAddress = other._issuerMetadataAddress;
+        }
+
+        public IssuedSecurityTokenParameters()
+            : this(null, null, null)
+        {
+            // empty
+        }
+
+        public IssuedSecurityTokenParameters(string tokenType)
+            : this(tokenType, null, null)
+        {
+            // empty
+        }
+
+        public IssuedSecurityTokenParameters(string tokenType, EndpointAddress issuerAddress)
+            : this(tokenType, issuerAddress, null)
+        {
+            // empty
+        }
+
+        public IssuedSecurityTokenParameters(string tokenType, EndpointAddress issuerAddress, Binding issuerBinding)
+            : base()
+        {
+            _tokenType = tokenType;
+            _issuerAddress = issuerAddress;
+            _issuerBinding = issuerBinding;
+        }
+
+        internal protected override bool HasAsymmetricKey { get { return this.KeyType == SecurityKeyType.AsymmetricKey; } }
+
+        public Collection<XmlElement> AdditionalRequestParameters
+        {
+            get
+            {
+                return _additionalRequestParameters;
+            }
+        }
+
+        public MessageSecurityVersion DefaultMessageSecurityVersion
+        {
+            get
+            {
+                return _defaultMessageSecurityVersion;
+            }
+
+            set
+            {
+                _defaultMessageSecurityVersion = value;
+            }
+        }
+
+        internal Collection<AlternativeIssuerEndpoint> AlternativeIssuerEndpoints
+        {
+            get
+            {
+                return _alternativeIssuerEndpoints;
+            }
+        }
+
+        public EndpointAddress IssuerAddress
+        {
+            get
+            {
+                return _issuerAddress;
+            }
+            set
+            {
+                _issuerAddress = value;
+            }
+        }
+
+        public EndpointAddress IssuerMetadataAddress
+        {
+            get
+            {
+                return _issuerMetadataAddress;
+            }
+            set
+            {
+                _issuerMetadataAddress = value;
+            }
+        }
+
+        public Binding IssuerBinding
+        {
+            get
+            {
+                return _issuerBinding;
+            }
+            set
+            {
+                _issuerBinding = value;
+            }
+        }
+
+        public SecurityKeyType KeyType
+        {
+            get
+            {
+                return _keyType;
+            }
+            set
+            {
+                SecurityKeyTypeHelper.Validate(value);
+                _keyType = value;
+            }
+        }
+
+        public int KeySize
+        {
+            get
+            {
+                return _keySize;
+            }
+            set
+            {
+                if (value < 0)
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("value", SR.Format(SR.ValueMustBeNonNegative)));
+                _keySize = value;
+            }
+        }
+
+        public bool UseStrTransform
+        {
+            get
+            {
+                return _useStrTransform;
+            }
+            set
+            {
+                _useStrTransform = value;
+            }
+        }
+
+        public Collection<ClaimTypeRequirement> ClaimTypeRequirements
+        {
+            get
+            {
+                return _claimTypeRequirements;
+            }
+        }
+
+        public string TokenType
+        {
+            get
+            {
+                return _tokenType;
+            }
+            set
+            {
+                _tokenType = value;
+            }
+        }
+
+        internal protected override bool SupportsClientAuthentication { get { return true; } }
+        internal protected override bool SupportsServerAuthentication { get { return true; } }
+        internal protected override bool SupportsClientWindowsIdentity { get { return false; } }
+
+        protected override SecurityTokenParameters CloneCore()
+        {
+            return new IssuedSecurityTokenParameters(this);
+        }
+
+        internal protected override SecurityKeyIdentifierClause CreateKeyIdentifierClause(SecurityToken token, SecurityTokenReferenceStyle referenceStyle)
+        {
+            if (token is GenericXmlSecurityToken)
+                return base.CreateGenericXmlTokenKeyIdentifierClause(token, referenceStyle);
+            else
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+                //return this.CreateKeyIdentifierClause<SamlAssertionKeyIdentifierClause, SamlAssertionKeyIdentifierClause>(token, referenceStyle);
+            }
+        }
+
+        internal void SetRequestParameters(Collection<XmlElement> requestParameters, TrustDriver trustDriver)
+        {
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+
+            //if (requestParameters == null)
+            //    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("requestParameters");
+
+            //if (trustDriver == null)
+            //    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("trustDriver");
+
+            //Collection<XmlElement> unknownRequestParameters = new Collection<XmlElement>();
+
+            //foreach (XmlElement element in requestParameters)
+            //{
+            //    int keySize;
+            //    string tokenType;
+            //    SecurityKeyType keyType;
+            //    Collection<XmlElement> requiredClaims;
+            //    if (trustDriver.TryParseKeySizeElement(element, out keySize))
+            //        _keySize = keySize;
+            //    else if (trustDriver.TryParseKeyTypeElement(element, out keyType))
+            //        this.KeyType = keyType;
+            //    else if (trustDriver.TryParseTokenTypeElement(element, out tokenType))
+            //        this.TokenType = tokenType;
+            //    // Only copy RP policy to client policy for TrustFeb2005
+            //    else if (trustDriver.StandardsManager.TrustVersion == TrustVersion.WSTrustFeb2005)
+            //    {
+            //        if (trustDriver.TryParseRequiredClaimsElement(element, out requiredClaims))
+            //        {
+            //            Collection<XmlElement> unrecognizedRequiredClaims = new Collection<XmlElement>();
+            //            foreach (XmlElement claimRequirement in requiredClaims)
+            //            {
+            //                if (claimRequirement.LocalName == "ClaimType" && claimRequirement.NamespaceURI == wsidNamespace)
+            //                {
+            //                    string claimValue = claimRequirement.GetAttribute("Uri", string.Empty);
+            //                    if (!string.IsNullOrEmpty(claimValue))
+            //                    {
+            //                        ClaimTypeRequirement claimTypeRequirement;
+            //                        string optional = claimRequirement.GetAttribute("Optional", string.Empty);
+            //                        if (String.IsNullOrEmpty(optional))
+            //                        {
+            //                            claimTypeRequirement = new ClaimTypeRequirement(claimValue);
+            //                        }
+            //                        else
+            //                        {
+            //                            claimTypeRequirement = new ClaimTypeRequirement(claimValue, XmlConvert.ToBoolean(optional));
+            //                        }
+
+            //                        _claimTypeRequirements.Add(claimTypeRequirement);
+            //                    }
+            //                }
+            //                else
+            //                {
+            //                    unrecognizedRequiredClaims.Add(claimRequirement);
+            //                }
+            //            }
+            //            if (unrecognizedRequiredClaims.Count > 0)
+            //                unknownRequestParameters.Add(trustDriver.CreateRequiredClaimsElement(unrecognizedRequiredClaims));
+            //        }
+            //        else
+            //        {
+            //            unknownRequestParameters.Add(element);
+            //        }
+            //    }
+            //}
+
+            //unknownRequestParameters = trustDriver.ProcessUnknownRequestParameters(unknownRequestParameters, requestParameters);
+            //if (unknownRequestParameters.Count > 0)
+            //{
+            //    for (int i = 0; i < unknownRequestParameters.Count; ++i)
+            //        this.AdditionalRequestParameters.Add(unknownRequestParameters[i]);
+            //}
+        }
+
+        public Collection<XmlElement> CreateRequestParameters(MessageSecurityVersion messageSecurityVersion, SecurityTokenSerializer securityTokenSerializer)
+        {
+            return CreateRequestParameters(SecurityUtils.CreateSecurityStandardsManager(messageSecurityVersion, securityTokenSerializer).TrustDriver);
+        }
+
+        internal Collection<XmlElement> CreateRequestParameters(TrustDriver driver)
+        {
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+
+            //if (driver == null)
+            //    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("driver");
+
+            //Collection<XmlElement> result = new Collection<XmlElement>();
+
+            //if (_tokenType != null)
+            //{
+            //    result.Add(driver.CreateTokenTypeElement(_tokenType));
+            //}
+
+            //result.Add(driver.CreateKeyTypeElement(_keyType));
+
+            //if (_keySize != 0)
+            //{
+            //    result.Add(driver.CreateKeySizeElement(_keySize));
+            //}
+            //if (_claimTypeRequirements.Count > 0)
+            //{
+            //    Collection<XmlElement> claimsElements = new Collection<XmlElement>();
+            //    XmlDocument doc = new XmlDocument();
+            //    foreach (ClaimTypeRequirement claimType in _claimTypeRequirements)
+            //    {
+            //        XmlElement element = doc.CreateElement(wsidPrefix, "ClaimType", wsidNamespace);
+            //        XmlAttribute attr = doc.CreateAttribute("Uri");
+            //        attr.Value = claimType.ClaimType;
+            //        element.Attributes.Append(attr);
+            //        if (claimType.IsOptional != ClaimTypeRequirement.DefaultIsOptional)
+            //        {
+            //            attr = doc.CreateAttribute("Optional");
+            //            attr.Value = XmlConvert.ToString(claimType.IsOptional);
+            //            element.Attributes.Append(attr);
+            //        }
+            //        claimsElements.Add(element);
+            //    }
+            //    result.Add(driver.CreateRequiredClaimsElement(claimsElements));
+            //}
+
+            //if (_additionalRequestParameters.Count > 0)
+            //{
+            //    Collection<XmlElement> trustNormalizedParameters = NormalizeAdditionalParameters(_additionalRequestParameters,
+            //                                                                                     driver,
+            //                                                                                     (_claimTypeRequirements.Count > 0));
+
+            //    foreach (XmlElement parameter in trustNormalizedParameters)
+            //    {
+            //        result.Add(parameter);
+            //    }
+            //}
+
+            //return result;
+        }
+
+        private Collection<XmlElement> NormalizeAdditionalParameters(Collection<XmlElement> additionalParameters,
+                                                                     TrustDriver driver,
+                                                                     bool clientSideClaimTypeRequirementsSpecified)
+        {
+            // Ensure STS trust version is one of the currently supported versions: Feb 05 / Trust 1.3
+            Fx.Assert(((driver.StandardsManager.TrustVersion == TrustVersion.WSTrustFeb2005) ||
+                                           (driver.StandardsManager.TrustVersion == TrustVersion.WSTrust13)),
+                                           "Unsupported trust version specified for the STS.");
+
+            // We have a mismatch. Make a local copy of additionalParameters for making any potential modifications 
+            // as part of normalization
+            Collection<XmlElement> tmpCollection = new Collection<XmlElement>();
+            foreach (XmlElement e in additionalParameters)
+            {
+                tmpCollection.Add(e);
+            }
+
+
+            // 1. For Trust 1.3 EncryptionAlgorithm, CanonicalizationAlgorithm and KeyWrapAlgorithm should not be
+            //    specified as top-level element if "SecondaryParameters" element already specifies this.
+            if (driver.StandardsManager.TrustVersion == TrustVersion.WSTrust13)
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+
+                //Fx.Assert(driver.GetType() == typeof(WSTrustDec2005.DriverDec2005), "Invalid Trust Driver specified for Trust 1.3.");
+
+                //XmlElement encryptionAlgorithmElement = null;
+                //XmlElement canonicalizationAlgorithmElement = null;
+                //XmlElement keyWrapAlgorithmElement = null;
+                //XmlElement secondaryParameter = null;
+
+                //for (int i = 0; i < tmpCollection.Count; ++i)
+                //{
+                //    string algorithm;
+
+                //    if (driver.IsEncryptionAlgorithmElement(tmpCollection[i], out algorithm))
+                //    {
+                //        encryptionAlgorithmElement = tmpCollection[i];
+                //    }
+                //    else if (driver.IsCanonicalizationAlgorithmElement(tmpCollection[i], out algorithm))
+                //    {
+                //        canonicalizationAlgorithmElement = tmpCollection[i];
+                //    }
+                //    else if (driver.IsKeyWrapAlgorithmElement(tmpCollection[i], out algorithm))
+                //    {
+                //        keyWrapAlgorithmElement = tmpCollection[i];
+                //    }
+                //    else if (((WSTrustDec2005.DriverDec2005)driver).IsSecondaryParametersElement(tmpCollection[i]))
+                //    {
+                //        secondaryParameter = tmpCollection[i];
+                //    }
+                //}
+
+                //if (secondaryParameter != null)
+                //{
+                //    foreach (XmlNode node in secondaryParameter.ChildNodes)
+                //    {
+                //        XmlElement child = node as XmlElement;
+                //        if (child != null)
+                //        {
+                //            string algorithm = null;
+
+                //            if (driver.IsEncryptionAlgorithmElement(child, out algorithm) && (encryptionAlgorithmElement != null))
+                //            {
+                //                tmpCollection.Remove(encryptionAlgorithmElement);
+                //            }
+                //            else if (driver.IsCanonicalizationAlgorithmElement(child, out algorithm) && (canonicalizationAlgorithmElement != null))
+                //            {
+                //                tmpCollection.Remove(canonicalizationAlgorithmElement);
+                //            }
+                //            else if (driver.IsKeyWrapAlgorithmElement(child, out algorithm) && (keyWrapAlgorithmElement != null))
+                //            {
+                //                tmpCollection.Remove(keyWrapAlgorithmElement);
+                //            }
+                //        }
+                //    }
+                //}
+            }
+
+            // 2. Check for Mismatch.
+            //      a. Trust Feb 2005 -> Trust 1.3. do the following,
+            //          (i) Copy EncryptionAlgorithm and CanonicalizationAlgorithm as the top-level elements.
+            //              Note, this is in contradiction to step 1. But we don't have a choice here as we cannot say from the 
+            //              Additional Parameters section in the config what came from the service and what came from the client.
+            //          (ii) Convert SignWith and EncryptWith elements to Trust 1.3 namespace.
+            //      b. For Trust 1.3 -> Trust Feb 2005, do the following,
+            //          (i) Find EncryptionAlgorithm, CanonicalizationAlgorithm from inside the "SecondaryParameters" element. 
+            //              If found, then promote these as the top-level elements replacing the existing values.
+            //          (ii) Convert the SignWith and EncryptWith elements to the Trust Feb 2005 namespace and drop the KeyWrapAlgorithm
+            //               element.
+
+            // make an optimistic check to detect mismatched trust-versions between STS and RP
+            bool mismatch = (((driver.StandardsManager.TrustVersion == TrustVersion.WSTrustFeb2005) &&
+                              !CollectionContainsElementsWithTrustNamespace(additionalParameters, TrustFeb2005Strings.Namespace)) ||
+                             ((driver.StandardsManager.TrustVersion == TrustVersion.WSTrust13) &&
+                              !CollectionContainsElementsWithTrustNamespace(additionalParameters, TrustDec2005Strings.Namespace)));
+            // if no mismatch, return unmodified collection
+            if (!mismatch)
+            {
+                return tmpCollection;
+            }
+
+            // 2.a
+            // If we are talking to a Trust 1.3 STS, replace any Feb '05 algorithm parameters with their Trust 1.3 counterparts
+            if (driver.StandardsManager.TrustVersion == TrustVersion.WSTrust13)
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+
+                //SecurityStandardsManager trustFeb2005StandardsManager = SecurityStandardsManager.DefaultInstance;
+                //// the following cast is guaranteed to succeed
+                //WSTrustFeb2005.DriverFeb2005 trustFeb2005Driver = (WSTrustFeb2005.DriverFeb2005)trustFeb2005StandardsManager.TrustDriver;
+
+                //for (int i = 0; i < tmpCollection.Count; i++)
+                //{
+                //    string algorithmParameter = string.Empty;
+
+                //    if (trustFeb2005Driver.IsSignWithElement(tmpCollection[i], out algorithmParameter))
+                //    {
+                //        tmpCollection[i] = driver.CreateSignWithElement(algorithmParameter);
+                //    }
+                //    else if (trustFeb2005Driver.IsEncryptWithElement(tmpCollection[i], out algorithmParameter))
+                //    {
+                //        tmpCollection[i] = driver.CreateEncryptWithElement(algorithmParameter);
+                //    }
+                //    else if (trustFeb2005Driver.IsEncryptionAlgorithmElement(tmpCollection[i], out algorithmParameter))
+                //    {
+                //        tmpCollection[i] = driver.CreateEncryptionAlgorithmElement(algorithmParameter);
+                //    }
+                //    else if (trustFeb2005Driver.IsCanonicalizationAlgorithmElement(tmpCollection[i], out algorithmParameter))
+                //    {
+                //        tmpCollection[i] = driver.CreateCanonicalizationAlgorithmElement(algorithmParameter);
+                //    }
+                //}
+            }
+            else
+            {
+                // 2.b
+                // We are talking to a Feb 05 STS. Filter out any SecondaryParameters element.
+                Collection<XmlElement> childrenToPromote = null;
+                WSSecurityTokenSerializer trust13Serializer = new WSSecurityTokenSerializer(SecurityVersion.WSSecurity11,
+                                                                                            TrustVersion.WSTrust13,
+                                                                                            SecureConversationVersion.WSSecureConversation13,
+                                                                                            true, null, null, null);
+                SecurityStandardsManager trust13StandardsManager = new SecurityStandardsManager(MessageSecurityVersion.WSSecurity11WSTrust13WSSecureConversation13WSSecurityPolicy12, trust13Serializer);
+                // the following cast is guaranteed to succeed
+                WSTrustDec2005.DriverDec2005 trust13Driver = (WSTrustDec2005.DriverDec2005)trust13StandardsManager.TrustDriver;
+
+                foreach (XmlElement parameter in tmpCollection)
+                {
+                    // check if SecondaryParameters is present
+                    if (trust13Driver.IsSecondaryParametersElement(parameter))
+                    {
+                        childrenToPromote = new Collection<XmlElement>();
+                        // walk SecondaryParameters and collect any 'non-standard' children
+                        foreach (XmlNode innerNode in parameter.ChildNodes)
+                        {
+                            XmlElement innerElement = innerNode as XmlElement;
+                            if ((innerElement != null) && CanPromoteToRoot(innerElement, trust13Driver, clientSideClaimTypeRequirementsSpecified))
+                            {
+                                childrenToPromote.Add(innerElement);
+                            }
+                        }
+
+                        // remove SecondaryParameters element
+                        tmpCollection.Remove(parameter);
+
+                        // we are done - break out of the loop
+                        break;
+                    }
+                }
+
+                // Probe of standard Trust elements and remember them.
+                if ((childrenToPromote != null) && (childrenToPromote.Count > 0))
+                {
+                    throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+
+                    //XmlElement encryptionElement = null;
+                    //string encryptionAlgorithm = String.Empty;
+
+                    //XmlElement canonicalizationElement = null;
+                    //string canonicalizationAlgoritm = String.Empty;
+
+                    //XmlElement requiredClaimsElement = null;
+                    //Collection<XmlElement> requiredClaims = null;
+
+                    //Collection<XmlElement> processedElements = new Collection<XmlElement>();
+
+                    //foreach (XmlElement e in childrenToPromote)
+                    //{
+                    //    if ((encryptionElement == null) && trust13Driver.IsEncryptionAlgorithmElement(e, out encryptionAlgorithm))
+                    //    {
+                    //        encryptionElement = driver.CreateEncryptionAlgorithmElement(encryptionAlgorithm);
+                    //        processedElements.Add(e);
+                    //    }
+                    //    else if ((canonicalizationElement == null) && trust13Driver.IsCanonicalizationAlgorithmElement(e, out canonicalizationAlgoritm))
+                    //    {
+                    //        canonicalizationElement = driver.CreateCanonicalizationAlgorithmElement(canonicalizationAlgoritm);
+                    //        processedElements.Add(e);
+                    //    }
+                    //    else if ((requiredClaimsElement == null) && trust13Driver.TryParseRequiredClaimsElement(e, out requiredClaims))
+                    //    {
+                    //        requiredClaimsElement = driver.CreateRequiredClaimsElement(requiredClaims);
+                    //        processedElements.Add(e);
+                    //    }
+                    //}
+
+                    //for (int i = 0; i < processedElements.Count; ++i)
+                    //{
+                    //    childrenToPromote.Remove(processedElements[i]);
+                    //}
+
+                    //XmlElement keyWrapAlgorithmElement = null;
+
+                    //// Replace the appropriate elements.
+                    //for (int i = 0; i < tmpCollection.Count; ++i)
+                    //{
+                    //    string algorithmParameter;
+                    //    Collection<XmlElement> reqClaims;
+
+                    //    if (trust13Driver.IsSignWithElement(tmpCollection[i], out algorithmParameter))
+                    //    {
+                    //        tmpCollection[i] = driver.CreateSignWithElement(algorithmParameter);
+                    //    }
+                    //    else if (trust13Driver.IsEncryptWithElement(tmpCollection[i], out algorithmParameter))
+                    //    {
+                    //        tmpCollection[i] = driver.CreateEncryptWithElement(algorithmParameter);
+                    //    }
+                    //    else if (trust13Driver.IsEncryptionAlgorithmElement(tmpCollection[i], out algorithmParameter) && (encryptionElement != null))
+                    //    {
+                    //        tmpCollection[i] = encryptionElement;
+                    //        encryptionElement = null;
+                    //    }
+                    //    else if (trust13Driver.IsCanonicalizationAlgorithmElement(tmpCollection[i], out algorithmParameter) && (canonicalizationElement != null))
+                    //    {
+                    //        tmpCollection[i] = canonicalizationElement;
+                    //        canonicalizationElement = null;
+                    //    }
+                    //    else if (trust13Driver.IsKeyWrapAlgorithmElement(tmpCollection[i], out algorithmParameter) && (keyWrapAlgorithmElement == null))
+                    //    {
+                    //        keyWrapAlgorithmElement = tmpCollection[i];
+                    //    }
+                    //    else if (trust13Driver.TryParseRequiredClaimsElement(tmpCollection[i], out reqClaims) && (requiredClaimsElement != null))
+                    //    {
+                    //        tmpCollection[i] = requiredClaimsElement;
+                    //        requiredClaimsElement = null;
+                    //    }
+                    //}
+
+                    //if (keyWrapAlgorithmElement != null)
+                    //{
+                    //    // Remove KeyWrapAlgorithmElement as this is not define in Trust Feb 2005.
+                    //    tmpCollection.Remove(keyWrapAlgorithmElement);
+                    //}
+
+                    //// Add the remaining elements to the additionaParameters list to the end.
+                    //if (encryptionElement != null) tmpCollection.Add(encryptionElement);
+                    //if (canonicalizationElement != null) tmpCollection.Add(canonicalizationElement);
+                    //if (requiredClaimsElement != null) tmpCollection.Add(requiredClaimsElement);
+
+                    //if (childrenToPromote.Count > 0)
+                    //{
+                    //    // There are some non-standard elements. Just bump them to the top-level element.
+                    //    for (int i = 0; i < childrenToPromote.Count; ++i)
+                    //    {
+                    //        tmpCollection.Add(childrenToPromote[i]);
+                    //    }
+                    //}
+                }
+
+            }
+
+            return tmpCollection;
+        }
+
+        private bool CollectionContainsElementsWithTrustNamespace(Collection<XmlElement> collection, string trustNamespace)
+        {
+            for (int i = 0; i < collection.Count; i++)
+            {
+                if ((collection[i] != null) && (collection[i].NamespaceURI == trustNamespace))
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        private bool CanPromoteToRoot(XmlElement innerElement, WSTrustDec2005.DriverDec2005 trust13Driver, bool clientSideClaimTypeRequirementsSpecified)
+        {
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+
+            //SecurityKeyType dummyOutParamForKeyType;
+            //int dummyOutParamForKeySize;
+            //string dummyStringOutParam;
+            //Collection<XmlElement> dummyOutParamForRequiredClaims = null;
+
+            //// check if SecondaryParameters has claim requirements specified
+            //if (trust13Driver.TryParseRequiredClaimsElement(innerElement, out dummyOutParamForRequiredClaims))
+            //{
+            //    // if client has not specified any claim requirements, promote claim requirements 
+            //    // in SecondaryParameters to root level (and subsequently fix up the trust namespace)
+            //    return !clientSideClaimTypeRequirementsSpecified;
+            //}
+
+            //// KeySize, KeyType and TokenType were converted to top-level property values when the WSDL was
+            //// imported, so drop it here. We check for EncryptWith and SignWith as these are Client specific algorithm values and we
+            //// don't have to promote the service specified values. KeyWrapAlgorithm was never sent in the RST
+            //// in V1 and hence we are dropping it here as well.
+            //return (!trust13Driver.TryParseKeyTypeElement(innerElement, out dummyOutParamForKeyType) &&
+            //        !trust13Driver.TryParseKeySizeElement(innerElement, out dummyOutParamForKeySize) &&
+            //        !trust13Driver.TryParseTokenTypeElement(innerElement, out dummyStringOutParam) &&
+            //        !trust13Driver.IsSignWithElement(innerElement, out dummyStringOutParam) &&
+            //        !trust13Driver.IsEncryptWithElement(innerElement, out dummyStringOutParam) &&
+            //        !trust13Driver.IsKeyWrapAlgorithmElement(innerElement, out dummyStringOutParam));
+        }
+
+        internal void AddAlgorithmParameters(SecurityAlgorithmSuite algorithmSuite, SecurityStandardsManager standardsManager, SecurityKeyType issuedKeyType)
+        {
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+            //_additionalRequestParameters.Insert(0, standardsManager.TrustDriver.CreateEncryptionAlgorithmElement(algorithmSuite.DefaultEncryptionAlgorithm));
+            //_additionalRequestParameters.Insert(0, standardsManager.TrustDriver.CreateCanonicalizationAlgorithmElement(algorithmSuite.DefaultCanonicalizationAlgorithm));
+
+            //if (_keyType == SecurityKeyType.BearerKey)
+            //{
+            //    // As the client does not have a proof token in the Bearer case
+            //    // we don't have any specific algorithms to request for.
+            //    return;
+            //}
+
+            //string signWithAlgorithm = (_keyType == SecurityKeyType.SymmetricKey) ? algorithmSuite.DefaultSymmetricSignatureAlgorithm : algorithmSuite.DefaultAsymmetricSignatureAlgorithm;
+            //_additionalRequestParameters.Insert(0, standardsManager.TrustDriver.CreateSignWithElement(signWithAlgorithm));
+            //string encryptWithAlgorithm;
+            //if (issuedKeyType == SecurityKeyType.SymmetricKey)
+            //{
+            //    encryptWithAlgorithm = algorithmSuite.DefaultEncryptionAlgorithm;
+            //}
+            //else
+            //{
+            //    encryptWithAlgorithm = algorithmSuite.DefaultAsymmetricKeyWrapAlgorithm;
+            //}
+            //_additionalRequestParameters.Insert(0, standardsManager.TrustDriver.CreateEncryptWithElement(encryptWithAlgorithm));
+
+            //if (standardsManager.TrustVersion != TrustVersion.WSTrustFeb2005)
+            //{
+            //    _additionalRequestParameters.Insert(0, ((WSTrustDec2005.DriverDec2005)standardsManager.TrustDriver).CreateKeyWrapAlgorithmElement(algorithmSuite.DefaultAsymmetricKeyWrapAlgorithm));
+            //}
+
+            //return;
+        }
+
+        internal bool DoAlgorithmsMatch(SecurityAlgorithmSuite algorithmSuite, SecurityStandardsManager standardsManager, out Collection<XmlElement> otherRequestParameters)
+        {
+            // Issue #31 in progress
+            bool doesSignWithAlgorithmMatch = false;
+            bool doesEncryptWithAlgorithmMatch = false;
+            bool doesEncryptionAlgorithmMatch = false;
+            bool doesCanonicalizationAlgorithmMatch = false;
+            bool doesKeyWrapAlgorithmMatch = false;
+            bool trustNormalizationPerformed = false;
+            otherRequestParameters = new Collection<XmlElement>();
+
+            Collection<XmlElement> trustVersionNormalizedParameterCollection;
+
+            // For Trust 1.3 we move all the additional parameters into the secondaryParameters
+            // element. So the list contains just one element called SecondaryParameters that 
+            // contains all the other elements as child elements.
+            if ((standardsManager.TrustVersion == TrustVersion.WSTrust13) &&
+                (this.AdditionalRequestParameters.Count == 1) &&
+                (((WSTrustDec2005.DriverDec2005)standardsManager.TrustDriver).IsSecondaryParametersElement(this.AdditionalRequestParameters[0])))
+            {
+                trustNormalizationPerformed = true;
+                trustVersionNormalizedParameterCollection = new Collection<XmlElement>();
+                foreach (XmlElement innerElement in this.AdditionalRequestParameters[0])
+                {
+                    trustVersionNormalizedParameterCollection.Add(innerElement);
+                }
+            }
+            else
+            {
+                trustVersionNormalizedParameterCollection = this.AdditionalRequestParameters;
+            }
+
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+            //for (int i = 0; i < trustVersionNormalizedParameterCollection.Count; i++)
+            //{
+            //    string algorithm;
+            //    XmlElement element = trustVersionNormalizedParameterCollection[i];
+            //    if (standardsManager.TrustDriver.IsCanonicalizationAlgorithmElement(element, out algorithm))
+            //    {
+            //        if (algorithmSuite.DefaultCanonicalizationAlgorithm != algorithm)
+            //        {
+            //            return false;
+            //        }
+            //        doesCanonicalizationAlgorithmMatch = true;
+            //    }
+            //    else if (standardsManager.TrustDriver.IsSignWithElement(element, out algorithm))
+            //    {
+            //        if ((_keyType == SecurityKeyType.SymmetricKey && algorithm != algorithmSuite.DefaultSymmetricSignatureAlgorithm)
+            //            || (_keyType == SecurityKeyType.AsymmetricKey && algorithm != algorithmSuite.DefaultAsymmetricSignatureAlgorithm))
+            //        {
+            //            return false;
+            //        }
+            //        doesSignWithAlgorithmMatch = true;
+            //    }
+            //    else if (standardsManager.TrustDriver.IsEncryptWithElement(element, out algorithm))
+            //    {
+            //        if ((_keyType == SecurityKeyType.SymmetricKey && algorithm != algorithmSuite.DefaultEncryptionAlgorithm)
+            //            || (_keyType == SecurityKeyType.AsymmetricKey && algorithm != algorithmSuite.DefaultAsymmetricKeyWrapAlgorithm))
+            //        {
+            //            return false;
+            //        }
+            //        doesEncryptWithAlgorithmMatch = true;
+            //    }
+            //    else if (standardsManager.TrustDriver.IsEncryptionAlgorithmElement(element, out algorithm))
+            //    {
+            //        if (algorithm != algorithmSuite.DefaultEncryptionAlgorithm)
+            //        {
+            //            return false;
+            //        }
+            //        doesEncryptionAlgorithmMatch = true;
+            //    }
+            //    else if (standardsManager.TrustDriver.IsKeyWrapAlgorithmElement(element, out algorithm))
+            //    {
+            //        if (algorithm != algorithmSuite.DefaultAsymmetricKeyWrapAlgorithm)
+            //        {
+            //            return false;
+            //        }
+            //        doesKeyWrapAlgorithmMatch = true;
+            //    }
+            //    else
+            //    {
+            //        otherRequestParameters.Add(element);
+            //    }
+            //}
+
+            //// Undo normalization if performed
+            //// move all back into secondaryParameters
+            //if (trustNormalizationPerformed)
+            //{
+            //    otherRequestParameters = this.AdditionalRequestParameters;
+            //}
+
+            //if (_keyType == SecurityKeyType.BearerKey)
+            //{
+            //    // As the client does not have a proof token in the Bearer case
+            //    // we don't have any specific algorithms to request for.
+            //    return true;
+            //}
+            //if (standardsManager.TrustVersion == TrustVersion.WSTrustFeb2005)
+            //{
+            //    // For V1 compatibility check all algorithms
+            //    return (doesSignWithAlgorithmMatch && doesCanonicalizationAlgorithmMatch && doesEncryptionAlgorithmMatch && doesEncryptWithAlgorithmMatch);
+            //}
+            //else
+            //{
+            //    return (doesSignWithAlgorithmMatch && doesCanonicalizationAlgorithmMatch && doesEncryptionAlgorithmMatch && doesEncryptWithAlgorithmMatch && doesKeyWrapAlgorithmMatch);
+            //}
+        }
+
+        internal static IssuedSecurityTokenParameters CreateInfoCardParameters(SecurityStandardsManager standardsManager, SecurityAlgorithmSuite algorithm)
+        {
+            IssuedSecurityTokenParameters result = new IssuedSecurityTokenParameters(SecurityXXX2005Strings.SamlTokenType);
+            result.KeyType = SecurityKeyType.AsymmetricKey;
+            result.ClaimTypeRequirements.Add(new ClaimTypeRequirement(s_wsidPPIClaim));
+            result.IssuerAddress = null;
+            result.AddAlgorithmParameters(algorithm, standardsManager, result.KeyType);
+            return result;
+        }
+
+        internal static bool IsInfoCardParameters(IssuedSecurityTokenParameters parameters, SecurityStandardsManager standardsManager)
+        {
+            if (parameters == null)
+                return false;
+            if (parameters.TokenType != SecurityXXX2005Strings.SamlTokenType)
+                return false;
+            if (parameters.KeyType != SecurityKeyType.AsymmetricKey)
+                return false;
+
+            if (parameters.ClaimTypeRequirements.Count == 1)
+            {
+                ClaimTypeRequirement claimTypeRequirement = parameters.ClaimTypeRequirements[0] as ClaimTypeRequirement;
+                if (claimTypeRequirement == null)
+                    return false;
+                if (claimTypeRequirement.ClaimType != s_wsidPPIClaim)
+                    return false;
+            }
+            else if ((parameters.AdditionalRequestParameters != null) && (parameters.AdditionalRequestParameters.Count > 0))
+            {
+                // Check the AdditionalRequest Parameters to see if ClaimTypeRequirements got imported there.
+                bool claimTypeRequirementMatched = false;
+                XmlElement claimTypeRequirement = GetClaimTypeRequirement(parameters.AdditionalRequestParameters, standardsManager);
+                if (claimTypeRequirement != null && claimTypeRequirement.ChildNodes.Count == 1)
+                {
+                    XmlElement claimTypeElement = claimTypeRequirement.ChildNodes[0] as XmlElement;
+                    if (claimTypeElement != null)
+                    {
+                        XmlNode claimType = claimTypeElement.Attributes.GetNamedItem("Uri");
+                        if (claimType != null && claimType.Value == s_wsidPPIClaim)
+                        {
+                            claimTypeRequirementMatched = true;
+                        }
+                    }
+                }
+
+                if (!claimTypeRequirementMatched)
+                {
+                    return false;
+                }
+            }
+            else
+            {
+                return false;
+            }
+            if (parameters.IssuerAddress != null)
+                return false;
+            if (parameters.AlternativeIssuerEndpoints != null && parameters.AlternativeIssuerEndpoints.Count > 0)
+            {
+                return false;
+            }
+            return true;
+        }
+
+        // The method walks through the entire set of AdditionalRequestParameters and return the Claims Type requirement alone.
+        internal static XmlElement GetClaimTypeRequirement(Collection<XmlElement> additionalRequestParameters, SecurityStandardsManager standardsManager)
+        {
+            foreach (XmlElement requestParameter in additionalRequestParameters)
+            {
+                if ((requestParameter.LocalName == ((System.ServiceModel.Security.WSTrust.Driver)standardsManager.TrustDriver).DriverDictionary.Claims.Value) &&
+                    (requestParameter.NamespaceURI == ((System.ServiceModel.Security.WSTrust.Driver)standardsManager.TrustDriver).DriverDictionary.Namespace.Value))
+                {
+                    return requestParameter;
+                }
+
+                if ((requestParameter.LocalName == DXD.TrustDec2005Dictionary.SecondaryParameters.Value) &&
+                    (requestParameter.NamespaceURI == DXD.TrustDec2005Dictionary.Namespace.Value))
+                {
+                    Collection<XmlElement> secondaryParameters = new Collection<XmlElement>();
+                    foreach (XmlNode node in requestParameter.ChildNodes)
+                    {
+                        XmlElement nodeAsElement = node as XmlElement;
+                        if (nodeAsElement != null)
+                        {
+                            secondaryParameters.Add(nodeAsElement);
+                        }
+                    }
+                    XmlElement claimTypeRequirement = GetClaimTypeRequirement(secondaryParameters, standardsManager);
+                    if (claimTypeRequirement != null)
+                    {
+                        return claimTypeRequirement;
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        public override string ToString()
+        {
+            StringBuilder sb = new StringBuilder();
+            sb.AppendLine(base.ToString());
+
+            sb.AppendLine(String.Format(CultureInfo.InvariantCulture, "TokenType: {0}", _tokenType == null ? "null" : _tokenType));
+            sb.AppendLine(String.Format(CultureInfo.InvariantCulture, "KeyType: {0}", _keyType.ToString()));
+            sb.AppendLine(String.Format(CultureInfo.InvariantCulture, "KeySize: {0}", _keySize.ToString(CultureInfo.InvariantCulture)));
+            sb.AppendLine(String.Format(CultureInfo.InvariantCulture, "IssuerAddress: {0}", _issuerAddress == null ? "null" : _issuerAddress.ToString()));
+            sb.AppendLine(String.Format(CultureInfo.InvariantCulture, "IssuerMetadataAddress: {0}", _issuerMetadataAddress == null ? "null" : _issuerMetadataAddress.ToString()));
+            sb.AppendLine(String.Format(CultureInfo.InvariantCulture, "DefaultMessgeSecurityVersion: {0}", _defaultMessageSecurityVersion == null ? "null" : _defaultMessageSecurityVersion.ToString()));
+            sb.AppendLine(String.Format(CultureInfo.InvariantCulture, "UseStrTransform: {0}", _useStrTransform.ToString()));
+
+            if (_issuerBinding == null)
+            {
+                sb.AppendLine(String.Format(CultureInfo.InvariantCulture, "IssuerBinding: null"));
+            }
+            else
+            {
+                sb.AppendLine(String.Format(CultureInfo.InvariantCulture, "IssuerBinding:"));
+                BindingElementCollection bindingElements = _issuerBinding.CreateBindingElements();
+                for (int i = 0; i < bindingElements.Count; i++)
+                {
+                    sb.AppendLine(String.Format(CultureInfo.InvariantCulture, "  BindingElement[{0}]:", i.ToString(CultureInfo.InvariantCulture)));
+                    sb.AppendLine("    " + bindingElements[i].ToString().Trim().Replace("\n", "\n    "));
+                }
+            }
+
+            if (_claimTypeRequirements.Count == 0)
+            {
+                sb.AppendLine(String.Format(CultureInfo.InvariantCulture, "ClaimTypeRequirements: none"));
+            }
+            else
+            {
+                sb.AppendLine(String.Format(CultureInfo.InvariantCulture, "ClaimTypeRequirements:"));
+                for (int i = 0; i < _claimTypeRequirements.Count; i++)
+                {
+                    sb.AppendLine(String.Format(CultureInfo.InvariantCulture, "  {0}, optional={1}", _claimTypeRequirements[i].ClaimType, _claimTypeRequirements[i].IsOptional));
+                }
+            }
+
+            return sb.ToString().Trim();
+        }
+
+        protected internal override void InitializeSecurityTokenRequirement(SecurityTokenRequirement requirement)
+        {
+            requirement.TokenType = this.TokenType;
+            requirement.RequireCryptographicToken = true;
+            requirement.KeyType = this.KeyType;
+
+            ServiceModelSecurityTokenRequirement serviceModelSecurityTokenRequirement = requirement as ServiceModelSecurityTokenRequirement;
+            if (serviceModelSecurityTokenRequirement != null)
+            {
+                serviceModelSecurityTokenRequirement.DefaultMessageSecurityVersion = this.DefaultMessageSecurityVersion;
+            }
+            else
+            {
+                requirement.Properties[ServiceModelSecurityTokenRequirement.DefaultMessageSecurityVersionProperty] = this.DefaultMessageSecurityVersion;
+            }
+
+            if (this.KeySize > 0)
+            {
+                requirement.KeySize = this.KeySize;
+            }
+            requirement.Properties[ServiceModelSecurityTokenRequirement.IssuerAddressProperty] = this.IssuerAddress;
+            if (this.IssuerBinding != null)
+            {
+                requirement.Properties[ServiceModelSecurityTokenRequirement.IssuerBindingProperty] = this.IssuerBinding;
+            }
+            requirement.Properties[ServiceModelSecurityTokenRequirement.IssuedSecurityTokenParametersProperty] = this.Clone();
+        }
+    }
+}

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/Tokens/KerberosSecurityTokenParameters.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/Tokens/KerberosSecurityTokenParameters.cs
@@ -1,0 +1,47 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.IdentityModel.Selectors;
+using System.IdentityModel.Tokens;
+
+namespace System.ServiceModel.Security.Tokens
+{
+    public class KerberosSecurityTokenParameters : SecurityTokenParameters
+    {
+        protected KerberosSecurityTokenParameters(KerberosSecurityTokenParameters other)
+            : base(other)
+        {
+            // empty
+        }
+
+        public KerberosSecurityTokenParameters()
+            : base()
+        {
+            this.InclusionMode = SecurityTokenInclusionMode.Once;
+        }
+
+        internal protected override bool HasAsymmetricKey { get { return false; } }
+        internal protected override bool SupportsClientAuthentication { get { return true; } }
+        internal protected override bool SupportsServerAuthentication { get { return true; } }
+        internal protected override bool SupportsClientWindowsIdentity { get { return true; } }
+
+        protected override SecurityTokenParameters CloneCore()
+        {
+            return new KerberosSecurityTokenParameters(this);
+        }
+
+        internal protected override SecurityKeyIdentifierClause CreateKeyIdentifierClause(SecurityToken token, SecurityTokenReferenceStyle referenceStyle)
+        {
+            return base.CreateKeyIdentifierClause<KerberosTicketHashKeyIdentifierClause, LocalIdKeyIdentifierClause>(token, referenceStyle);
+        }
+
+        protected internal override void InitializeSecurityTokenRequirement(SecurityTokenRequirement requirement)
+        {
+            requirement.TokenType = SecurityTokenTypes.Kerberos;
+            requirement.KeyType = SecurityKeyType.SymmetricKey;
+            requirement.RequireCryptographicToken = true;
+        }
+    }
+}
+

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/Tokens/ProviderBackedSecurityToken.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/Tokens/ProviderBackedSecurityToken.cs
@@ -1,0 +1,153 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IdentityModel.Selectors;
+using System.IdentityModel.Tokens;
+using System.Runtime;
+using System.Security.Authentication.ExtendedProtection;
+
+namespace System.ServiceModel.Security.Tokens
+{
+    /// <summary>
+    /// The ProviderBackedSecurityToken was added for the ChannelBindingToken work for Win7.  
+    /// It is used to delay the resolution of a token until it is needed.  
+    /// For the CBT, this delay is necessary as the CBT is not available until SecurityAppliedMessage.OnWriteMessage is called.
+    /// The CBT binds a token to the 
+    /// </summary>
+    internal class ProviderBackedSecurityToken : SecurityToken
+    {
+        private SecurityTokenProvider _tokenProvider;
+
+        // Double-checked locking pattern requires volatile for read/write synchronization
+        private volatile SecurityToken _securityToken;
+        private TimeSpan _timeout;
+        private ChannelBinding _channelBinding;
+
+        private object _lock;
+
+        /// <summary>
+        /// Constructor to create an instance of this class.
+        /// </summary>
+        /// <param name="securityToken">SecurityToken that represents the SecurityTokenElement element.</param>
+        public ProviderBackedSecurityToken( SecurityTokenProvider tokenProvider, TimeSpan timeout )
+        {
+            _lock = new object();
+
+            if ( tokenProvider == null )
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentNullException("tokenProvider"));
+            }
+
+            _tokenProvider = tokenProvider;
+            _timeout = timeout;
+        }
+
+        public SecurityTokenProvider TokenProvider
+        {
+            get { return _tokenProvider; }
+        }
+
+        public ChannelBinding ChannelBinding
+        {
+            set { _channelBinding = value; }
+        }
+
+        void ResolveSecurityToken()
+        {
+            if ( _securityToken == null )
+            {
+                lock ( _lock )
+                {
+                    if ( _securityToken == null )
+                    {
+                        ClientCredentialsSecurityTokenManager.KerberosSecurityTokenProviderWrapper kerbTokenProvider = _tokenProvider 
+                                                        as ClientCredentialsSecurityTokenManager.KerberosSecurityTokenProviderWrapper;
+                        if (kerbTokenProvider != null)
+                        {
+                            _securityToken = kerbTokenProvider.GetToken((new TimeoutHelper(_timeout)).RemainingTime());
+                        }
+                        else
+                        {
+                            _securityToken = _tokenProvider.GetToken((new TimeoutHelper(_timeout)).RemainingTime());
+                        }
+                    }
+                }
+            }
+
+            if ( _securityToken == null )
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError( new SecurityTokenException( SR.Format( SR.SecurityTokenNotResolved, _tokenProvider.GetType().ToString() ) ) );
+            }
+
+            return;
+        }
+
+        public SecurityToken Token
+        {
+            get
+            {
+                if ( _securityToken == null )
+                {
+                    ResolveSecurityToken();
+                }
+
+                return _securityToken;
+            }
+        }
+
+        public override string Id
+        {
+            get
+            {
+                if ( _securityToken == null )
+                {
+                    ResolveSecurityToken();
+                }
+
+                return _securityToken.Id;
+            }
+        }
+
+        public override System.Collections.ObjectModel.ReadOnlyCollection<SecurityKey> SecurityKeys
+        {
+            get
+            {
+                if ( _securityToken == null )
+                {
+                    ResolveSecurityToken();
+                }
+
+                return _securityToken.SecurityKeys;
+            }   
+        }
+
+        public override DateTime ValidFrom
+        {
+            get
+            {
+                if ( _securityToken == null )
+                {
+                    ResolveSecurityToken();
+                }
+
+                return _securityToken.ValidFrom;
+            }
+        }
+
+        public override DateTime ValidTo
+        {
+            get
+            {
+                if ( _securityToken == null )
+                {
+                    ResolveSecurityToken();
+                }
+
+                return _securityToken.ValidTo;
+            }   
+        }
+    }
+}
+

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/Tokens/SecurityContextCookieSerializer.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/Tokens/SecurityContextCookieSerializer.cs
@@ -2,20 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.IdentityModel.Claims;
 using System.IdentityModel.Policy;
-using System.IO;
-using System.Runtime;
-using System.Runtime.Serialization;
-using System.Security.Principal;
-using System.ServiceModel;
-using System.ServiceModel.Dispatcher;
 using System.Xml;
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace System.ServiceModel.Security.Tokens
 {
@@ -40,7 +30,7 @@ namespace System.ServiceModel.Security.Tokens
             DateTime tokenExpirationTime, UniqueId keyGeneration, DateTime keyEffectiveTime, DateTime keyExpirationTime,
             ReadOnlyCollection<IAuthorizationPolicy> authorizationPolicies)
         {
-            throw ExceptionHelper.PlatformNotSupported();
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
         }
     }
 }

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/Tokens/SecurityTokenParameters.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/Tokens/SecurityTokenParameters.cs
@@ -4,14 +4,18 @@
 
 
 using System.Globalization;
+using System.IdentityModel.Selectors;
+using System.IdentityModel.Tokens;
 using System.Text;
 
 namespace System.ServiceModel.Security.Tokens
 {
     public abstract class SecurityTokenParameters
     {
+        internal const SecurityTokenInclusionMode defaultInclusionMode = SecurityTokenInclusionMode.AlwaysToRecipient;
         internal const bool defaultRequireDerivedKeys = true;
 
+        private SecurityTokenInclusionMode _inclusionMode = defaultInclusionMode;
         private bool _requireDerivedKeys = defaultRequireDerivedKeys;
 
         protected SecurityTokenParameters(SecurityTokenParameters other)
@@ -19,6 +23,7 @@ namespace System.ServiceModel.Security.Tokens
             if (other == null)
                 throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("other");
 
+            _inclusionMode = other._inclusionMode;
             _requireDerivedKeys = other._requireDerivedKeys;
         }
 
@@ -28,6 +33,19 @@ namespace System.ServiceModel.Security.Tokens
         }
 
         internal protected abstract bool HasAsymmetricKey { get; }
+
+        public SecurityTokenInclusionMode InclusionMode
+        {
+            get
+            {
+                return _inclusionMode;
+            }
+            set
+            {
+                SecurityTokenInclusionModeHelper.Validate(value);
+                _inclusionMode = value;
+            }
+        }
 
         public bool RequireDerivedKeys
         {
@@ -57,11 +75,56 @@ namespace System.ServiceModel.Security.Tokens
 
         protected abstract SecurityTokenParameters CloneCore();
 
+        internal protected abstract SecurityKeyIdentifierClause CreateKeyIdentifierClause(SecurityToken token, SecurityTokenReferenceStyle referenceStyle);
+
+        internal protected abstract void InitializeSecurityTokenRequirement(SecurityTokenRequirement requirement);
+
+        internal SecurityKeyIdentifierClause CreateKeyIdentifierClause<TExternalClause, TInternalClause>(SecurityToken token, SecurityTokenReferenceStyle referenceStyle)
+                    where TExternalClause : SecurityKeyIdentifierClause
+                    where TInternalClause : SecurityKeyIdentifierClause
+        {
+            if (token == null)
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("token");
+
+            SecurityKeyIdentifierClause result;
+
+            switch (referenceStyle)
+            {
+                default:
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new NotSupportedException(
+                        SR.Format(SR.TokenDoesNotSupportKeyIdentifierClauseCreation, token.GetType().Name, referenceStyle)));
+                case SecurityTokenReferenceStyle.External:
+                    result = token.CreateKeyIdentifierClause<TExternalClause>();
+                    break;
+                case SecurityTokenReferenceStyle.Internal:
+                    result = token.CreateKeyIdentifierClause<TInternalClause>();
+                    break;
+            }
+
+            return result;
+        }
+
+        internal SecurityKeyIdentifierClause CreateGenericXmlTokenKeyIdentifierClause(SecurityToken token, SecurityTokenReferenceStyle referenceStyle)
+        {
+            GenericXmlSecurityToken xmlToken = token as GenericXmlSecurityToken;
+            if (xmlToken != null)
+            {
+                if (referenceStyle == SecurityTokenReferenceStyle.Internal && xmlToken.InternalTokenReference != null)
+                    return xmlToken.InternalTokenReference;
+
+                if (referenceStyle == SecurityTokenReferenceStyle.External && xmlToken.ExternalTokenReference != null)
+                    return xmlToken.ExternalTokenReference;
+            }
+
+            throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new MessageSecurityException(SR.Format(SR.UnableToCreateTokenReference)));
+        }
+
         public override string ToString()
         {
             StringBuilder sb = new StringBuilder();
 
             sb.AppendLine(String.Format(CultureInfo.InvariantCulture, "{0}:", this.GetType().ToString()));
+            sb.AppendLine(String.Format(CultureInfo.InvariantCulture, "InclusionMode: {0}", _inclusionMode.ToString()));
             sb.Append(String.Format(CultureInfo.InvariantCulture, "RequireDerivedKeys: {0}", _requireDerivedKeys.ToString()));
 
             return sb.ToString();

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/Tokens/SslSecurityTokenParameters.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/Tokens/SslSecurityTokenParameters.cs
@@ -1,0 +1,136 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.IdentityModel.Selectors;
+using System.IdentityModel.Tokens;
+using System.ServiceModel.Channels;
+using System.Text;
+using System.Globalization;
+
+namespace System.ServiceModel.Security.Tokens
+{
+    public class SslSecurityTokenParameters : SecurityTokenParameters
+    {
+        internal const bool defaultRequireClientCertificate = false;
+        internal const bool defaultRequireCancellation = false;
+
+        private bool _requireCancellation = defaultRequireCancellation;
+        private bool _requireClientCertificate;
+        private BindingContext _issuerBindingContext;
+
+        protected SslSecurityTokenParameters(SslSecurityTokenParameters other)
+            : base(other)
+        {
+            _requireClientCertificate = other._requireClientCertificate;
+            _requireCancellation = other._requireCancellation;
+            if (other._issuerBindingContext != null)
+            {
+                _issuerBindingContext = other._issuerBindingContext.Clone();
+            }
+        }
+
+        public SslSecurityTokenParameters()
+            : this(defaultRequireClientCertificate)
+        {
+            // empty
+        }
+
+        public SslSecurityTokenParameters(bool requireClientCertificate)
+            : this(requireClientCertificate, defaultRequireCancellation)
+        {
+            // empty
+        }
+
+        public SslSecurityTokenParameters(bool requireClientCertificate, bool requireCancellation)
+            : base()
+        {
+            _requireClientCertificate = requireClientCertificate;
+            _requireCancellation = requireCancellation;
+        }
+
+        internal protected override bool HasAsymmetricKey { get { return false; } }
+
+        public bool RequireCancellation
+        {
+            get
+            {
+                return _requireCancellation;
+            }
+            set
+            {
+                _requireCancellation = value;
+            }
+        }
+
+        public bool RequireClientCertificate
+        {
+            get
+            {
+                return _requireClientCertificate;
+            }
+            set
+            {
+                _requireClientCertificate = value;
+            }
+        }
+
+        internal BindingContext IssuerBindingContext
+        {
+            get
+            {
+                return _issuerBindingContext;
+            }
+            set
+            {
+                if (value != null)
+                {
+                    value = value.Clone();
+                }
+                _issuerBindingContext = value;
+            }
+        }
+
+        internal protected override bool SupportsClientAuthentication { get { return _requireClientCertificate; } }
+        internal protected override bool SupportsServerAuthentication { get { return true; } }
+        internal protected override bool SupportsClientWindowsIdentity { get { return _requireClientCertificate; } }
+
+        protected override SecurityTokenParameters CloneCore()
+        {
+            return new SslSecurityTokenParameters(this);
+        }
+
+        internal protected override SecurityKeyIdentifierClause CreateKeyIdentifierClause(SecurityToken token, SecurityTokenReferenceStyle referenceStyle)
+        {
+            if (token is GenericXmlSecurityToken)
+                return base.CreateGenericXmlTokenKeyIdentifierClause(token, referenceStyle);
+            else
+                return this.CreateKeyIdentifierClause<SecurityContextKeyIdentifierClause, LocalIdKeyIdentifierClause>(token, referenceStyle);
+        }
+
+        protected internal override void InitializeSecurityTokenRequirement(SecurityTokenRequirement requirement)
+        {
+            requirement.TokenType = (this.RequireClientCertificate) ? ServiceModelSecurityTokenTypes.MutualSslnego : ServiceModelSecurityTokenTypes.AnonymousSslnego;
+            requirement.RequireCryptographicToken = true;
+            requirement.KeyType = SecurityKeyType.SymmetricKey;
+            requirement.Properties[ServiceModelSecurityTokenRequirement.SupportSecurityContextCancellationProperty] = this.RequireCancellation;
+            if (this.IssuerBindingContext != null)
+            {
+                requirement.Properties[ServiceModelSecurityTokenRequirement.IssuerBindingContextProperty] = this.IssuerBindingContext.Clone();
+            }
+            requirement.Properties[ServiceModelSecurityTokenRequirement.IssuedSecurityTokenParametersProperty] = this.Clone();
+        }
+
+        public override string ToString()
+        {
+            StringBuilder sb = new StringBuilder();
+            sb.AppendLine(base.ToString());
+
+            sb.AppendLine(String.Format(CultureInfo.InvariantCulture, "RequireCancellation: {0}", this.RequireCancellation.ToString()));
+            sb.Append(String.Format(CultureInfo.InvariantCulture, "RequireClientCertificate: {0}", this.RequireClientCertificate.ToString()));
+
+            return sb.ToString();
+        }
+    }
+}
+

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/Tokens/SspiSecurityToken.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/Tokens/SspiSecurityToken.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-
 using System.Collections.ObjectModel;
 using System.IdentityModel.Tokens;
 using System.Net;

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/Tokens/SspiSecurityTokenParameters.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/Tokens/SspiSecurityTokenParameters.cs
@@ -1,0 +1,113 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.IdentityModel.Selectors;
+using System.IdentityModel.Tokens;
+using System.ServiceModel.Channels;
+using System.Text;
+using System.Globalization;
+
+namespace System.ServiceModel.Security.Tokens
+{
+    public class SspiSecurityTokenParameters : SecurityTokenParameters
+    {
+        internal const bool defaultRequireCancellation = false;
+
+        private bool _requireCancellation = defaultRequireCancellation;
+        private BindingContext _issuerBindingContext;
+
+        protected SspiSecurityTokenParameters(SspiSecurityTokenParameters other)
+            : base(other)
+        {
+            _requireCancellation = other._requireCancellation;
+            if (other._issuerBindingContext != null)
+            {
+                _issuerBindingContext = other._issuerBindingContext.Clone();
+            }
+        }
+
+        public SspiSecurityTokenParameters()
+            : this(defaultRequireCancellation)
+        {
+            // empty
+        }
+
+        public SspiSecurityTokenParameters(bool requireCancellation)
+            : base()
+        {
+            _requireCancellation = requireCancellation;
+        }
+
+        internal protected override bool HasAsymmetricKey { get { return false; } }
+
+        public bool RequireCancellation
+        {
+            get
+            {
+                return _requireCancellation;
+            }
+            set
+            {
+                _requireCancellation = value;
+            }
+        }
+
+        internal BindingContext IssuerBindingContext
+        {
+            get
+            {
+                return _issuerBindingContext;
+            }
+            set
+            {
+                if (value != null)
+                {
+                    value = value.Clone();
+                }
+                _issuerBindingContext = value;
+            }
+        }
+
+        internal protected override bool SupportsClientAuthentication { get { return true; } }
+        internal protected override bool SupportsServerAuthentication { get { return true; } }
+        internal protected override bool SupportsClientWindowsIdentity { get { return true; } }
+
+        protected override SecurityTokenParameters CloneCore()
+        {
+            return new SspiSecurityTokenParameters(this);
+        }
+
+        internal protected override SecurityKeyIdentifierClause CreateKeyIdentifierClause(SecurityToken token, SecurityTokenReferenceStyle referenceStyle)
+        {
+            if (token is GenericXmlSecurityToken)
+                return base.CreateGenericXmlTokenKeyIdentifierClause(token, referenceStyle);
+            else
+                return this.CreateKeyIdentifierClause<SecurityContextKeyIdentifierClause, LocalIdKeyIdentifierClause>(token, referenceStyle);
+        }
+
+        protected internal override void InitializeSecurityTokenRequirement(SecurityTokenRequirement requirement)
+        {
+            requirement.TokenType = ServiceModelSecurityTokenTypes.Spnego;
+            requirement.RequireCryptographicToken = true;
+            requirement.KeyType = SecurityKeyType.SymmetricKey;
+            requirement.Properties[ServiceModelSecurityTokenRequirement.SupportSecurityContextCancellationProperty] = this.RequireCancellation;
+            if (this.IssuerBindingContext != null)
+            {
+                requirement.Properties[ServiceModelSecurityTokenRequirement.IssuerBindingContextProperty] = this.IssuerBindingContext.Clone();
+            }
+            requirement.Properties[ServiceModelSecurityTokenRequirement.IssuedSecurityTokenParametersProperty] = this.Clone();
+        }
+
+        public override string ToString()
+        {
+            StringBuilder sb = new StringBuilder();
+            sb.AppendLine(base.ToString());
+
+            sb.Append(String.Format(CultureInfo.InvariantCulture, "RequireCancellation: {0}", this.RequireCancellation.ToString()));
+
+            return sb.ToString();
+        }
+    }
+}
+

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/Tokens/UserNameSecurityTokenParameters.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/Tokens/UserNameSecurityTokenParameters.cs
@@ -3,6 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 
+using System.IdentityModel.Selectors;
+using System.IdentityModel.Tokens;
+
 namespace System.ServiceModel.Security.Tokens
 {
     public class UserNameSecurityTokenParameters : SecurityTokenParameters
@@ -27,6 +30,17 @@ namespace System.ServiceModel.Security.Tokens
         protected override SecurityTokenParameters CloneCore()
         {
             return new UserNameSecurityTokenParameters(this);
+        }
+
+        internal protected override SecurityKeyIdentifierClause CreateKeyIdentifierClause(SecurityToken token, SecurityTokenReferenceStyle referenceStyle)
+        {
+            return this.CreateKeyIdentifierClause<SecurityKeyIdentifierClause, LocalIdKeyIdentifierClause>(token, referenceStyle);
+        }
+
+        protected internal override void InitializeSecurityTokenRequirement(SecurityTokenRequirement requirement)
+        {
+            requirement.TokenType = SecurityTokenTypes.UserName;
+            requirement.RequireCryptographicToken = false;
         }
     }
 }

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/Tokens/WrappedKeySecurityToken.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/Tokens/WrappedKeySecurityToken.cs
@@ -1,0 +1,252 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.ObjectModel;
+using System.IdentityModel;
+using System.IdentityModel.Tokens;
+using System.Runtime.CompilerServices;
+using System.Security.Cryptography;
+using System.ServiceModel.Security;
+using System.Xml;
+
+namespace System.ServiceModel.Security.Tokens
+{
+    public class WrappedKeySecurityToken : SecurityToken
+    {
+        private string _id;
+        private DateTime _effectiveTime;
+        private EncryptedKey _encryptedKey;
+        private ReadOnlyCollection<SecurityKey> _securityKey;
+        private byte[] _wrappedKey;
+        private string _wrappingAlgorithm;
+        private ISspiNegotiation _wrappingSspiContext;
+        private SecurityToken _wrappingToken;
+        private SecurityKey _wrappingSecurityKey;
+        private SecurityKeyIdentifier _wrappingTokenReference;
+        private bool _serializeCarriedKeyName;
+        // private byte[] _wrappedKeyHash;
+        private XmlDictionaryString _wrappingAlgorithmDictionaryString;
+
+        // sender use
+        internal WrappedKeySecurityToken(string id, byte[] keyToWrap, ISspiNegotiation wrappingSspiContext)
+            : this(id, keyToWrap, (wrappingSspiContext != null) ? (wrappingSspiContext.KeyEncryptionAlgorithm) : null, wrappingSspiContext, null)
+        {
+        }
+
+        // sender use
+        public WrappedKeySecurityToken(string id, byte[] keyToWrap, string wrappingAlgorithm, SecurityToken wrappingToken, SecurityKeyIdentifier wrappingTokenReference)
+            : this(id, keyToWrap, wrappingAlgorithm, null, wrappingToken, wrappingTokenReference)
+        {
+        }
+
+        internal WrappedKeySecurityToken(string id, byte[] keyToWrap, string wrappingAlgorithm, XmlDictionaryString wrappingAlgorithmDictionaryString, SecurityToken wrappingToken, SecurityKeyIdentifier wrappingTokenReference)
+            : this(id, keyToWrap, wrappingAlgorithm, wrappingAlgorithmDictionaryString, wrappingToken, wrappingTokenReference, null, null)
+        {
+        }
+
+        // direct receiver use, chained sender use
+        internal WrappedKeySecurityToken(string id, byte[] keyToWrap, string wrappingAlgorithm, ISspiNegotiation wrappingSspiContext, byte[] wrappedKey)
+            : this(id, keyToWrap, wrappingAlgorithm, null)
+        {
+            if (wrappingSspiContext == null)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("wrappingSspiContext");
+            }
+            _wrappingSspiContext = wrappingSspiContext;
+            if (wrappedKey == null)
+            {
+                _wrappedKey = wrappingSspiContext.Encrypt(keyToWrap);
+            }
+            else
+            {
+                _wrappedKey = wrappedKey;
+            }
+            _serializeCarriedKeyName = false;
+        }
+
+        // receiver use
+        internal WrappedKeySecurityToken(string id, byte[] keyToWrap, string wrappingAlgorithm, SecurityToken wrappingToken, SecurityKeyIdentifier wrappingTokenReference, byte[] wrappedKey, SecurityKey wrappingSecurityKey)
+            : this(id, keyToWrap, wrappingAlgorithm, null, wrappingToken, wrappingTokenReference, wrappedKey, wrappingSecurityKey)
+        {
+        }
+
+        WrappedKeySecurityToken(string id, byte[] keyToWrap, string wrappingAlgorithm, XmlDictionaryString wrappingAlgorithmDictionaryString, SecurityToken wrappingToken, SecurityKeyIdentifier wrappingTokenReference, byte[] wrappedKey, SecurityKey wrappingSecurityKey)
+            : this(id, keyToWrap, wrappingAlgorithm, wrappingAlgorithmDictionaryString)
+        {
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+
+            //if (wrappingToken == null)
+            //{
+            //    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("wrappingToken");
+            //}
+            //this.wrappingToken = wrappingToken;
+            //this.wrappingTokenReference = wrappingTokenReference;
+            //if (wrappedKey == null)
+            //{
+            //    this.wrappedKey = SecurityUtils.EncryptKey(wrappingToken, wrappingAlgorithm, keyToWrap);
+            //}
+            //else
+            //{
+            //    this.wrappedKey = wrappedKey;
+            //}
+            //this.wrappingSecurityKey = wrappingSecurityKey;
+            //this.serializeCarriedKeyName = true;
+        }
+
+        WrappedKeySecurityToken(string id, byte[] keyToWrap, string wrappingAlgorithm, XmlDictionaryString wrappingAlgorithmDictionaryString)
+        {
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+
+            //if (id == null)
+            //    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("id");
+            //if (wrappingAlgorithm == null)
+            //    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("wrappingAlgorithm");
+            //if (keyToWrap == null)
+            //    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("securityKeyToWrap");
+
+            //this.id = id;
+            //this.effectiveTime = DateTime.UtcNow;
+            //this.securityKey = SecurityUtils.CreateSymmetricSecurityKeys(keyToWrap);
+            //this.wrappingAlgorithm = wrappingAlgorithm;
+            //this.wrappingAlgorithmDictionaryString = wrappingAlgorithmDictionaryString;
+        }
+
+        public override string Id
+        {
+            get { return _id; }
+        }
+
+        public override DateTime ValidFrom
+        {
+            get { return _effectiveTime; }
+        }
+
+        public override DateTime ValidTo
+        {
+            // Never expire
+            get { return DateTime.MaxValue; }
+        }
+
+        internal EncryptedKey EncryptedKey
+        {
+            get { return _encryptedKey; }
+            set { _encryptedKey = value; }
+        }
+
+        internal ReferenceList ReferenceList
+        {
+            get
+            {
+                return _encryptedKey == null ? null : _encryptedKey.ReferenceList;
+            }
+        }
+
+        public string WrappingAlgorithm
+        {
+            get { return _wrappingAlgorithm; }
+        }
+
+        internal SecurityKey WrappingSecurityKey
+        {
+            get { return _wrappingSecurityKey; }
+        }
+
+        public SecurityToken WrappingToken
+        {
+            get { return _wrappingToken; }
+        }
+
+        public SecurityKeyIdentifier WrappingTokenReference
+        {
+            get { return _wrappingTokenReference; }
+        }
+
+        internal string CarriedKeyName
+        {
+            get { return null; }
+        }
+
+        public override ReadOnlyCollection<SecurityKey> SecurityKeys
+        {
+            get { return _securityKey; }
+        }
+
+        internal byte[] GetHash()
+        {
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+            //if (this.wrappedKeyHash == null)
+            //{
+            //    EnsureEncryptedKeySetUp();
+            //    using (HashAlgorithm hash = CryptoHelper.NewSha1HashAlgorithm())
+            //    {
+            //        this.wrappedKeyHash = hash.ComputeHash(this.encryptedKey.GetWrappedKey());
+            //    }
+            //}
+            //return wrappedKeyHash;
+        }
+
+        public byte[] GetWrappedKey()
+        {
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+            //return SecurityUtils.CloneBuffer(this.wrappedKey);
+        }
+
+        internal void EnsureEncryptedKeySetUp()
+        {
+            if (_encryptedKey == null)
+            {
+                EncryptedKey ek = new EncryptedKey();
+                ek.Id = this.Id;
+                if (_serializeCarriedKeyName)
+                {
+                    ek.CarriedKeyName = this.CarriedKeyName;
+                }
+                else
+                {
+                    ek.CarriedKeyName = null;
+                }
+                ek.EncryptionMethod = this.WrappingAlgorithm;
+                ek.EncryptionMethodDictionaryString = _wrappingAlgorithmDictionaryString;
+                ek.SetUpKeyWrap(_wrappedKey);
+                if (this.WrappingTokenReference != null)
+                {
+                    ek.KeyIdentifier = this.WrappingTokenReference;
+                }
+                _encryptedKey = ek;
+            }
+        }
+
+        public override bool CanCreateKeyIdentifierClause<T>()
+        {
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+
+            //if (typeof(T) == typeof(EncryptedKeyHashIdentifierClause))
+            //    return true;
+
+            //return base.CanCreateKeyIdentifierClause<T>();
+        }
+
+        public override T CreateKeyIdentifierClause<T>()
+        {
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+
+            //if (typeof(T) == typeof(EncryptedKeyHashIdentifierClause))
+            //    return new EncryptedKeyHashIdentifierClause(GetHash()) as T;
+
+            //return base.CreateKeyIdentifierClause<T>();
+        }
+
+        public override bool MatchesKeyIdentifierClause(SecurityKeyIdentifierClause keyIdentifierClause)
+        {
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+
+            //EncryptedKeyHashIdentifierClause encKeyIdentifierClause = keyIdentifierClause as EncryptedKeyHashIdentifierClause;
+            //if (encKeyIdentifierClause != null)
+            //    return encKeyIdentifierClause.Matches(GetHash());
+
+            //return base.MatchesKeyIdentifierClause(keyIdentifierClause);
+        }
+    }
+}
+

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/TransportSecurityProtocol.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/TransportSecurityProtocol.cs
@@ -1,0 +1,302 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.IdentityModel.Policy;
+using System.IdentityModel.Selectors;
+using System.IdentityModel.Tokens;
+using System.Runtime;
+using System.ServiceModel.Channels;
+using System.ServiceModel.Description;
+
+namespace System.ServiceModel.Security
+{
+    class TransportSecurityProtocol : SecurityProtocol
+    {
+        public TransportSecurityProtocol(TransportSecurityProtocolFactory factory, EndpointAddress target, Uri via)
+            : base(factory, target, via)
+        {
+        }
+
+        public override void SecureOutgoingMessage(ref Message message, TimeSpan timeout)
+        {
+            if (message == null)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("message");
+            }
+            this.CommunicationObject.ThrowIfClosedOrNotOpen();
+            string actor = string.Empty; // message.Version.Envelope.UltimateDestinationActor;
+            try
+            {
+                if (this.SecurityProtocolFactory.ActAsInitiator)
+                {
+                    SecureOutgoingMessageAtInitiator(ref message, actor, timeout);
+                }
+                else
+                {
+                    SecureOutgoingMessageAtResponder(ref message, actor);
+                }
+                base.OnOutgoingMessageSecured(message);
+            }
+            catch
+            {
+                base.OnSecureOutgoingMessageFailure(message);
+                throw;
+            }
+        }
+
+        protected virtual void SecureOutgoingMessageAtInitiator(ref Message message, string actor, TimeSpan timeout)
+        {
+            IList<SupportingTokenSpecification> supportingTokens;
+            TryGetSupportingTokens(this.SecurityProtocolFactory, this.Target, this.Via, message, timeout, true, out supportingTokens);
+            SetUpDelayedSecurityExecution(ref message, actor, supportingTokens);
+        }
+
+        protected void SecureOutgoingMessageAtResponder(ref Message message, string actor)
+        {
+            if (this.SecurityProtocolFactory.AddTimestamp && !this.SecurityProtocolFactory.SecurityBindingElement.EnableUnsecuredResponse)
+            {
+                SendSecurityHeader securityHeader = CreateSendSecurityHeaderForTransportProtocol(message, actor, this.SecurityProtocolFactory);
+                message = securityHeader.SetupExecution();
+            }
+        }
+
+        internal void SetUpDelayedSecurityExecution(ref Message message, string actor,
+            IList<SupportingTokenSpecification> supportingTokens)
+        {
+            SendSecurityHeader securityHeader = CreateSendSecurityHeaderForTransportProtocol(message, actor, this.SecurityProtocolFactory);
+            AddSupportingTokens(securityHeader, supportingTokens);
+            message = securityHeader.SetupExecution();
+        }
+
+        public override IAsyncResult BeginSecureOutgoingMessage(Message message, TimeSpan timeout, SecurityProtocolCorrelationState correlationState, AsyncCallback callback, object state)
+        {
+            if (message == null)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("message");
+            }
+            this.CommunicationObject.ThrowIfClosedOrNotOpen();
+            string actor = string.Empty; // message.Version.Envelope.UltimateDestinationActor;
+            try
+            {
+                if (this.SecurityProtocolFactory.ActAsInitiator)
+                {
+                    return this.BeginSecureOutgoingMessageAtInitiatorCore(message, actor, timeout, callback, state);
+                }
+                else
+                {
+                    SecureOutgoingMessageAtResponder(ref message, actor);
+                    return new CompletedAsyncResult<Message>(message, callback, state);
+                }
+            }
+            catch (Exception exception)
+            {
+                // Always immediately rethrow fatal exceptions.
+                if (Fx.IsFatal(exception)) throw;
+
+                base.OnSecureOutgoingMessageFailure(message);
+                throw;
+            }
+        }
+
+        public override IAsyncResult BeginSecureOutgoingMessage(Message message, TimeSpan timeout, AsyncCallback callback, object state)
+        {
+            return BeginSecureOutgoingMessage(message, timeout, null, callback, state);
+        }
+
+        protected virtual IAsyncResult BeginSecureOutgoingMessageAtInitiatorCore(Message message, string actor, TimeSpan timeout, AsyncCallback callback, object state)
+        {
+            IList<SupportingTokenSpecification> supportingTokens;
+            TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
+            if (TryGetSupportingTokens(this.SecurityProtocolFactory, this.Target, this.Via, message, timeoutHelper.RemainingTime(), false, out supportingTokens))
+            {
+                SetUpDelayedSecurityExecution(ref message, actor, supportingTokens);
+                return new CompletedAsyncResult<Message>(message, callback, state);
+            }
+            else
+            {
+                return new SecureOutgoingMessageAsyncResult(actor, message, this, timeout, callback, state);
+            }
+        }
+
+        protected virtual Message EndSecureOutgoingMessageAtInitiatorCore(IAsyncResult result)
+        {
+            if (result is CompletedAsyncResult<Message>)
+            {
+                return CompletedAsyncResult<Message>.End(result);
+            }
+            else
+            {
+                return SecureOutgoingMessageAsyncResult.End(result);
+            }
+        }
+
+        public override void EndSecureOutgoingMessage(IAsyncResult result, out Message message)
+        {
+            SecurityProtocolCorrelationState dummyState;
+            this.EndSecureOutgoingMessage(result, out message, out dummyState);
+        }
+
+        public override void EndSecureOutgoingMessage(IAsyncResult result, out Message message, out SecurityProtocolCorrelationState newCorrelationState)
+        {
+            if (result == null)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("result");
+            }
+            newCorrelationState = null;
+            try
+            {
+                if (result is CompletedAsyncResult<Message>)
+                {
+                    message = CompletedAsyncResult<Message>.End(result);
+                }
+                else
+                {
+                    message = this.EndSecureOutgoingMessageAtInitiatorCore(result);
+                }
+                base.OnOutgoingMessageSecured(message);
+            }
+            catch (Exception exception)
+            {
+                // Always immediately rethrow fatal exceptions.
+                if (Fx.IsFatal(exception)) throw;
+
+                base.OnSecureOutgoingMessageFailure(null);
+                throw;
+            }
+        }
+
+        public sealed override void VerifyIncomingMessage(ref Message message, TimeSpan timeout)
+        {
+            if (message == null)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("message");
+            }
+            this.CommunicationObject.ThrowIfClosedOrNotOpen();
+            try
+            {
+                VerifyIncomingMessageCore(ref message, timeout);
+            }
+            catch (MessageSecurityException e)
+            {
+                base.OnVerifyIncomingMessageFailure(message, e);
+                throw;
+            }
+            catch (Exception e)
+            {
+                // Always immediately rethrow fatal exceptions.
+                if (Fx.IsFatal(e)) throw;
+
+                base.OnVerifyIncomingMessageFailure(message, e);
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new MessageSecurityException(SR.Format(SR.MessageSecurityVerificationFailed), e));
+            }
+        }
+
+        protected void AttachRecipientSecurityProperty(Message message, IList<SecurityToken> basicTokens, IList<SecurityToken> endorsingTokens,
+           IList<SecurityToken> signedEndorsingTokens, IList<SecurityToken> signedTokens, Dictionary<SecurityToken, ReadOnlyCollection<IAuthorizationPolicy>> tokenPoliciesMapping)
+        {
+            SecurityMessageProperty security = SecurityMessageProperty.GetOrCreate(message);
+            AddSupportingTokenSpecification(security, basicTokens, endorsingTokens, signedEndorsingTokens, signedTokens, tokenPoliciesMapping);
+            security.ServiceSecurityContext = new ServiceSecurityContext(security.GetInitiatorTokenAuthorizationPolicies());
+        }
+
+        protected virtual void VerifyIncomingMessageCore(ref Message message, TimeSpan timeout)
+        {
+            TransportSecurityProtocolFactory factory = (TransportSecurityProtocolFactory)this.SecurityProtocolFactory;
+            string actor = string.Empty; // message.Version.Envelope.UltimateDestinationActor;
+
+            ReceiveSecurityHeader securityHeader = factory.StandardsManager.TryCreateReceiveSecurityHeader(message, actor,
+                factory.IncomingAlgorithmSuite, (factory.ActAsInitiator) ? MessageDirection.Output : MessageDirection.Input);
+            bool expectBasicTokens;
+            bool expectEndorsingTokens;
+            bool expectSignedTokens;
+            IList<SupportingTokenAuthenticatorSpecification> supportingAuthenticators = factory.GetSupportingTokenAuthenticators(message.Headers.Action,
+                out expectSignedTokens, out expectBasicTokens, out expectEndorsingTokens);
+            if (securityHeader == null)
+            {
+                bool expectSupportingTokens = expectEndorsingTokens || expectSignedTokens || expectBasicTokens;
+                if ((factory.ActAsInitiator && (!factory.AddTimestamp || factory.SecurityBindingElement.EnableUnsecuredResponse))
+                    || (!factory.ActAsInitiator && !factory.AddTimestamp && !expectSupportingTokens))
+                {
+                    return;
+                }
+                else
+                {
+                    if (String.IsNullOrEmpty(actor))
+                        throw System.ServiceModel.Diagnostics.TraceUtility.ThrowHelperError(new MessageSecurityException(
+                            SR.Format(SR.UnableToFindSecurityHeaderInMessageNoActor)), message);
+                    else
+                        throw System.ServiceModel.Diagnostics.TraceUtility.ThrowHelperError(new MessageSecurityException(
+                            SR.Format(SR.UnableToFindSecurityHeaderInMessage, actor)), message);
+                }
+            }
+
+            securityHeader.RequireMessageProtection = false;
+            securityHeader.ExpectBasicTokens = expectBasicTokens;
+            securityHeader.ExpectSignedTokens = expectSignedTokens;
+            securityHeader.ExpectEndorsingTokens = expectEndorsingTokens;
+            securityHeader.MaxReceivedMessageSize = factory.SecurityBindingElement.MaxReceivedMessageSize;
+            securityHeader.ReaderQuotas = factory.SecurityBindingElement.ReaderQuotas;
+
+            // Due to compatibility, only honor this setting if this app setting is enabled
+            // Issue #31 in progress
+            //if (ServiceModelAppSettings.UseConfiguredTransportSecurityHeaderLayout)
+            //{
+                securityHeader.Layout = factory.SecurityHeaderLayout;
+            //}
+
+            TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
+            if (!factory.ActAsInitiator)
+            {
+                securityHeader.ConfigureTransportBindingServerReceiveHeader(supportingAuthenticators);
+                securityHeader.ConfigureOutOfBandTokenResolver(MergeOutOfBandResolvers(supportingAuthenticators, EmptyReadOnlyCollection<SecurityTokenResolver>.Instance));
+                if (factory.ExpectKeyDerivation)
+                {
+                    securityHeader.DerivedTokenAuthenticator = factory.DerivedKeyTokenAuthenticator;
+                }
+            }
+            securityHeader.ReplayDetectionEnabled = factory.DetectReplays;
+            securityHeader.SetTimeParameters(factory.NonceCache, factory.ReplayWindow, factory.MaxClockSkew);
+            securityHeader.Process(timeoutHelper.RemainingTime(), SecurityUtils.GetChannelBindingFromMessage(message), factory.ExtendedProtectionPolicy);
+            message = securityHeader.ProcessedMessage;
+            if (!factory.ActAsInitiator)
+            {
+                AttachRecipientSecurityProperty(message, securityHeader.BasicSupportingTokens, securityHeader.EndorsingSupportingTokens, securityHeader.SignedEndorsingSupportingTokens,
+                    securityHeader.SignedSupportingTokens, securityHeader.SecurityTokenAuthorizationPoliciesMapping);
+            }
+
+            base.OnIncomingMessageVerified(message);
+        }
+
+        sealed class SecureOutgoingMessageAsyncResult : GetSupportingTokensAsyncResult
+        {
+            Message message;
+            string actor;
+            TransportSecurityProtocol binding;
+
+            public SecureOutgoingMessageAsyncResult(string actor, Message message, TransportSecurityProtocol binding, TimeSpan timeout, AsyncCallback callback, object state)
+                : base(message, binding, timeout, callback, state)
+            {
+                this.actor = actor;
+                this.message = message;
+                this.binding = binding;
+                this.Start();
+            }
+
+            protected override bool OnGetSupportingTokensDone(TimeSpan timeout)
+            {
+                this.binding.SetUpDelayedSecurityExecution(ref this.message, this.actor, this.SupportingTokens);
+                return true;
+            }
+
+            internal static Message End(IAsyncResult result)
+            {
+                SecureOutgoingMessageAsyncResult self = AsyncResult.End<SecureOutgoingMessageAsyncResult>(result);
+                return self.message;
+            }
+        }
+    }
+}
+

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/TransportSecurityProtocolFactory.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/TransportSecurityProtocolFactory.cs
@@ -1,0 +1,48 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.ServiceModel.Security
+{
+    // Note that this protocol and other protocls represented by its
+    // subclasses rely on transport security to provide message
+    // integrity, confidentiality and request-reply correlation.  SOAP
+    // level security features are add-ons to support custom tokens,
+    // and do not have the responsibility to protect specific exchange
+    // patterns.  So, thie protocol return true to both requst-reply
+    // support as well as duplex support.
+    class TransportSecurityProtocolFactory : SecurityProtocolFactory
+    {
+        public TransportSecurityProtocolFactory()
+            : base()
+        {
+        }
+
+        internal TransportSecurityProtocolFactory(TransportSecurityProtocolFactory factory)
+            : base(factory)
+        {
+        }
+
+        public override bool SupportsDuplex
+        {
+            get
+            {
+                return true;
+            }
+        }
+
+        public override bool SupportsReplayDetection
+        {
+            get
+            {
+                return false;
+            }
+        }
+
+        protected override SecurityProtocol OnCreateSecurityProtocol(EndpointAddress target, Uri via, object listenerSecurityState, TimeSpan timeout)
+        {
+            return new TransportSecurityProtocol(this, target, via);
+        }
+    }
+}
+

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/WSKeyInfoSerializer.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/WSKeyInfoSerializer.cs
@@ -1,0 +1,387 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.IdentityModel;
+using System.IdentityModel.Selectors;
+using System.IdentityModel.Tokens;
+using System.ServiceModel.Security.Tokens;
+using System.Xml;
+using TokenEntry = System.ServiceModel.Security.WSSecurityTokenSerializer.TokenEntry;
+
+namespace System.ServiceModel.Security
+{
+    class WSKeyInfoSerializer : KeyInfoSerializer
+    {
+        static Func<KeyInfoSerializer, IEnumerable<SecurityTokenSerializer.SerializerEntries>> CreateAdditionalEntries(SecurityTokenSerializer tokenSerializer, SecurityVersion securityVersion, SecureConversationVersion secureConversationVersion)
+        {
+            return (KeyInfoSerializer keyInfoSerializer) =>
+                {
+                    List<SecurityTokenSerializer.SerializerEntries> serializerEntries = new List<SecurityTokenSerializer.SerializerEntries>();
+
+                    if (securityVersion == SecurityVersion.WSSecurity10)
+                    {
+                        serializerEntries.Add(new WSSecurityJan2004((WSSecurityTokenSerializer) tokenSerializer));
+                    }
+                    else if (securityVersion == SecurityVersion.WSSecurity11)
+                    {
+                        serializerEntries.Add(new WSSecurityXXX2005((WSSecurityTokenSerializer)tokenSerializer));
+                    }
+                    else
+                    {
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("securityVersion", SR.Format(SR.MessageSecurityVersionOutOfRange)));
+                    }
+
+
+                    if (secureConversationVersion == SecureConversationVersion.WSSecureConversationFeb2005)
+                    {
+                        serializerEntries.Add(new WSSecureConversationFeb2005(keyInfoSerializer));
+                    }
+                    else if (secureConversationVersion == SecureConversationVersion.WSSecureConversation13)
+                    {
+                        serializerEntries.Add(new WSSecureConversationDec2005(keyInfoSerializer));
+                    }
+                    else
+                    {
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new NotSupportedException());
+                    }
+
+                    return serializerEntries;
+                };
+        }
+
+        public WSKeyInfoSerializer(bool emitBspRequiredAttributes, DictionaryManager dictionaryManager, System.IdentityModel.TrustDictionary trustDictionary, SecurityTokenSerializer innerSecurityTokenSerializer, SecurityVersion securityVersion, SecureConversationVersion secureConversationVersion)
+            : base(emitBspRequiredAttributes, dictionaryManager, trustDictionary, innerSecurityTokenSerializer, CreateAdditionalEntries(innerSecurityTokenSerializer, securityVersion, secureConversationVersion))
+        {
+        }
+
+        #region WSSecureConversation classes
+
+        abstract class WSSecureConversation : SecurityTokenSerializer.SerializerEntries
+        {
+            private KeyInfoSerializer _securityTokenSerializer;
+
+            protected WSSecureConversation( KeyInfoSerializer securityTokenSerializer )
+            {
+                _securityTokenSerializer = securityTokenSerializer;
+            }
+
+            public KeyInfoSerializer SecurityTokenSerializer
+            {
+                get { return _securityTokenSerializer; }
+            }
+
+            public abstract System.IdentityModel.SecureConversationDictionary SerializerDictionary
+            {
+                get;
+            }
+
+            public virtual string DerivationAlgorithm
+            {
+                get { return SecurityAlgorithms.Psha1KeyDerivation; }
+            }
+
+            public override void PopulateTokenEntries( IList<TokenEntry> tokenEntryList )
+            {
+                if ( tokenEntryList == null )
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull( "tokenEntryList" );
+                }
+                tokenEntryList.Add( new DerivedKeyTokenEntry( this ) );
+                tokenEntryList.Add( new SecurityContextTokenEntry( this ) );
+            }
+
+            protected abstract class SctStrEntry : StrEntry
+            {
+                private WSSecureConversation _parent;
+
+                public SctStrEntry( WSSecureConversation parent )
+                {
+                    _parent = parent;
+                }
+
+                protected WSSecureConversation Parent
+                {
+                    get { return _parent; }
+                }
+
+                public override Type GetTokenType( SecurityKeyIdentifierClause clause )
+                {
+                    return null;
+                }
+
+                public override string GetTokenTypeUri()
+                {
+                    return null;
+                }
+
+                public override bool CanReadClause( XmlDictionaryReader reader, string tokenType )
+                {
+                    if ( tokenType != null && tokenType != _parent.SerializerDictionary.SecurityContextTokenType.Value )
+                    {
+                        return false;
+                    }
+                    if ( reader.IsStartElement(
+                        _parent.SecurityTokenSerializer.DictionaryManager.SecurityJan2004Dictionary.Reference,
+                        _parent.SecurityTokenSerializer.DictionaryManager.SecurityJan2004Dictionary.Namespace ) )
+                    {
+                        string valueType = reader.GetAttribute( _parent.SecurityTokenSerializer.DictionaryManager.SecurityJan2004Dictionary.ValueType, null );
+                        if ( valueType != null && valueType != _parent.SerializerDictionary.SecurityContextTokenReferenceValueType.Value )
+                        {
+                            return false;
+                        }
+                        string uri = reader.GetAttribute( _parent.SecurityTokenSerializer.DictionaryManager.SecurityJan2004Dictionary.URI, null );
+                        if ( uri != null )
+                        {
+                            if ( uri.Length > 0 && uri[0] != '#' )
+                            {
+                                return true;
+                            }
+                        }
+                    }
+                    return false;
+                }
+
+                public override SecurityKeyIdentifierClause ReadClause( XmlDictionaryReader reader, byte[] derivationNonce, int derivationLength, string tokenType )
+                {
+                    System.Xml.UniqueId uri = XmlHelper.GetAttributeAsUniqueId( reader, XD.SecurityJan2004Dictionary.URI, null );
+                    System.Xml.UniqueId generation = ReadGeneration( reader );
+
+                    if ( reader.IsEmptyElement )
+                    {
+                        reader.Read();
+                    }
+                    else
+                    {
+                        reader.ReadStartElement();
+                        while ( reader.IsStartElement() )
+                        {
+                            reader.Skip();
+                        }
+                        reader.ReadEndElement();
+                    }
+
+                    return new SecurityContextKeyIdentifierClause( uri, generation, derivationNonce, derivationLength );
+                }
+
+                protected abstract System.Xml.UniqueId ReadGeneration( XmlDictionaryReader reader );
+
+                public override bool SupportsCore( SecurityKeyIdentifierClause clause )
+                {
+                    return clause is SecurityContextKeyIdentifierClause;
+                }
+
+                public override void WriteContent( XmlDictionaryWriter writer, SecurityKeyIdentifierClause clause )
+                {
+                    SecurityContextKeyIdentifierClause sctClause = clause as SecurityContextKeyIdentifierClause;
+                    writer.WriteStartElement( XD.SecurityJan2004Dictionary.Prefix.Value, XD.SecurityJan2004Dictionary.Reference, XD.SecurityJan2004Dictionary.Namespace );
+                    XmlHelper.WriteAttributeStringAsUniqueId( writer, null, XD.SecurityJan2004Dictionary.URI, null, sctClause.ContextId );
+                    WriteGeneration( writer, sctClause );
+                    writer.WriteAttributeString( XD.SecurityJan2004Dictionary.ValueType, null, _parent.SerializerDictionary.SecurityContextTokenReferenceValueType.Value );
+                    writer.WriteEndElement();
+                }
+
+                protected abstract void WriteGeneration( XmlDictionaryWriter writer, SecurityContextKeyIdentifierClause clause );
+            }
+
+            protected class SecurityContextTokenEntry : TokenEntry
+            {
+                private WSSecureConversation _parent;
+                private Type[] _tokenTypes;
+
+                public SecurityContextTokenEntry( WSSecureConversation parent )
+                {
+                    _parent = parent;
+                }
+
+                protected WSSecureConversation Parent
+                {
+                    get { return _parent; }
+                }
+
+                protected override XmlDictionaryString LocalName { get { return _parent.SerializerDictionary.SecurityContextToken; } }
+                protected override XmlDictionaryString NamespaceUri { get { return _parent.SerializerDictionary.Namespace; } }
+                protected override Type[] GetTokenTypesCore()
+                {
+                    if ( _tokenTypes == null )
+                        _tokenTypes = new Type[] { typeof( SecurityContextSecurityToken ) };
+
+                    return _tokenTypes;
+                }
+
+                public override SecurityKeyIdentifierClause CreateKeyIdentifierClauseFromTokenXmlCore(XmlElement issuedTokenXml, SecurityTokenReferenceStyle tokenReferenceStyle)
+                {
+                    throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+                }
+
+                public override SecurityToken ReadTokenCore(XmlDictionaryReader reader, SecurityTokenResolver tokenResolver)
+                {
+                    throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+                }
+
+                public override void WriteTokenCore(XmlDictionaryWriter writer, SecurityToken token)
+                {
+                    throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+                }
+
+                public override string TokenTypeUri { get { return _parent.SerializerDictionary.SecurityContextTokenType.Value; } }
+                protected override string ValueTypeUri { get { return null; } }
+
+            }
+
+            protected class DerivedKeyTokenEntry : TokenEntry
+            {
+                public const string DefaultLabel = "WS-SecureConversation";
+
+                private WSSecureConversation _parent;
+                private Type[] _tokenTypes;
+
+                public DerivedKeyTokenEntry( WSSecureConversation parent )
+                {
+                    if ( parent == null )
+                    {
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull( "parent" );
+                    }
+                    _parent = parent;
+                }
+
+                protected override XmlDictionaryString LocalName { get { return _parent.SerializerDictionary.DerivedKeyToken; } }
+                protected override XmlDictionaryString NamespaceUri { get { return _parent.SerializerDictionary.Namespace; } }
+                protected override Type[] GetTokenTypesCore()
+                {
+                    if ( _tokenTypes == null )
+                        _tokenTypes = new Type[] { typeof( DerivedKeySecurityToken ) };
+
+                    return _tokenTypes;
+                }
+
+                public override SecurityKeyIdentifierClause CreateKeyIdentifierClauseFromTokenXmlCore(XmlElement issuedTokenXml, SecurityTokenReferenceStyle tokenReferenceStyle)
+                {
+                    throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+                }
+
+                public override SecurityToken ReadTokenCore(XmlDictionaryReader reader, SecurityTokenResolver tokenResolver)
+                {
+                    throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+                }
+
+                public override void WriteTokenCore(XmlDictionaryWriter writer, SecurityToken token)
+                {
+                    throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+                }
+
+                public override string TokenTypeUri { get { return _parent.SerializerDictionary.DerivedKeyTokenType.Value; } }
+                protected override string ValueTypeUri { get { return null; } }
+
+
+            }
+        }
+
+        class WSSecureConversationFeb2005 : WSSecureConversation
+        {
+            public WSSecureConversationFeb2005( KeyInfoSerializer securityTokenSerializer )
+                : base( securityTokenSerializer )
+            {
+            }
+
+            public override System.IdentityModel.SecureConversationDictionary SerializerDictionary
+            {
+                get { return this.SecurityTokenSerializer.DictionaryManager.SecureConversationFeb2005Dictionary; }
+            }
+
+            public override void PopulateStrEntries( IList<StrEntry> strEntries )
+            {
+                strEntries.Add( new SctStrEntryFeb2005( this ) );
+            }
+
+            class SctStrEntryFeb2005 : SctStrEntry
+            {
+                public SctStrEntryFeb2005( WSSecureConversationFeb2005 parent )
+                    : base( parent )
+                {
+                }
+
+                protected override System.Xml.UniqueId ReadGeneration( XmlDictionaryReader reader )
+                {
+                    return XmlHelper.GetAttributeAsUniqueId(
+                        reader,
+                        this.Parent.SecurityTokenSerializer.DictionaryManager.SecureConversationDec2005Dictionary.Instance,
+                        this.Parent.SecurityTokenSerializer.DictionaryManager.SecureConversationFeb2005Dictionary.Namespace );
+                }
+
+                protected override void WriteGeneration( XmlDictionaryWriter writer, SecurityContextKeyIdentifierClause clause )
+                {
+                    // serialize the generation
+                    if ( clause.Generation != null )
+                    {
+                        XmlHelper.WriteAttributeStringAsUniqueId(
+                            writer,
+                            this.Parent.SecurityTokenSerializer.DictionaryManager.SecureConversationFeb2005Dictionary.Prefix.Value,
+                            this.Parent.SecurityTokenSerializer.DictionaryManager.SecureConversationDec2005Dictionary.Instance,
+                            this.Parent.SecurityTokenSerializer.DictionaryManager.SecureConversationFeb2005Dictionary.Namespace,
+                            clause.Generation );
+                    }
+                }
+            }
+        }
+
+        class WSSecureConversationDec2005 : WSSecureConversation
+        {
+            public WSSecureConversationDec2005( KeyInfoSerializer securityTokenSerializer )
+                : base( securityTokenSerializer )
+            {
+            }
+
+            public override System.IdentityModel.SecureConversationDictionary SerializerDictionary
+            {
+                get { return this.SecurityTokenSerializer.DictionaryManager.SecureConversationDec2005Dictionary; }
+            }
+
+            public override void PopulateStrEntries( IList<StrEntry> strEntries )
+            {
+                strEntries.Add( new SctStrEntryDec2005( this ) );
+            }
+
+            public override string DerivationAlgorithm
+            {
+                get
+                {
+                    return SecurityAlgorithms.Psha1KeyDerivationDec2005;
+                }
+            }
+
+            class SctStrEntryDec2005 : SctStrEntry
+            {
+                public SctStrEntryDec2005( WSSecureConversationDec2005 parent )
+                    : base( parent )
+                {
+                }
+
+                protected override System.Xml.UniqueId ReadGeneration( XmlDictionaryReader reader )
+                {
+                    return XmlHelper.GetAttributeAsUniqueId( reader, this.Parent.SecurityTokenSerializer.DictionaryManager.SecureConversationDec2005Dictionary.Instance,
+                        this.Parent.SecurityTokenSerializer.DictionaryManager.SecureConversationDec2005Dictionary.Namespace );
+                }
+
+                protected override void WriteGeneration( XmlDictionaryWriter writer, SecurityContextKeyIdentifierClause clause )
+                {
+                    // serialize the generation
+                    if ( clause.Generation != null )
+                    {
+                        XmlHelper.WriteAttributeStringAsUniqueId(
+                            writer,
+                            this.Parent.SecurityTokenSerializer.DictionaryManager.SecureConversationDec2005Dictionary.Prefix.Value,
+                            this.Parent.SecurityTokenSerializer.DictionaryManager.SecureConversationDec2005Dictionary.Instance,
+                            this.Parent.SecurityTokenSerializer.DictionaryManager.SecureConversationDec2005Dictionary.Namespace,
+                            clause.Generation );
+                    }
+                }
+            }
+
+        }
+
+        #endregion
+    }
+}
+

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/WSSecureConversation.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/WSSecureConversation.cs
@@ -1,0 +1,595 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.IdentityModel.Selectors;
+using System.IdentityModel.Tokens;
+using System.ServiceModel.Security.Tokens;
+using System.Xml;
+
+using TokenEntry = System.ServiceModel.Security.WSSecurityTokenSerializer.TokenEntry;
+
+namespace System.ServiceModel.Security
+{
+    abstract class WSSecureConversation : WSSecurityTokenSerializer.SerializerEntries
+    {
+        private WSSecurityTokenSerializer _tokenSerializer;
+        private DerivedKeyTokenEntry _derivedKeyEntry;
+
+        protected WSSecureConversation(WSSecurityTokenSerializer tokenSerializer, int maxKeyDerivationOffset, int maxKeyDerivationLabelLength, int maxKeyDerivationNonceLength)
+        {
+            if (tokenSerializer == null)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("tokenSerializer");
+            }
+            _tokenSerializer = tokenSerializer;
+            _derivedKeyEntry = new DerivedKeyTokenEntry(this, maxKeyDerivationOffset, maxKeyDerivationLabelLength, maxKeyDerivationNonceLength);
+        }
+
+        public abstract SecureConversationDictionary SerializerDictionary
+        {
+            get;
+        }
+
+        public WSSecurityTokenSerializer WSSecurityTokenSerializer
+        {
+            get { return _tokenSerializer; }
+        }
+
+        public override void PopulateTokenEntries(IList<TokenEntry> tokenEntryList)
+        {
+            if (tokenEntryList == null)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("tokenEntryList");
+            }
+            tokenEntryList.Add(_derivedKeyEntry);
+        }
+
+        public virtual bool IsAtDerivedKeyToken(XmlDictionaryReader reader)
+        {
+            return _derivedKeyEntry.CanReadTokenCore(reader);
+        }
+
+        public virtual void ReadDerivedKeyTokenParameters(XmlDictionaryReader reader, SecurityTokenResolver tokenResolver, out string id, out string derivationAlgorithm, out string label, out int length, out byte[] nonce, out int offset, out int generation, out SecurityKeyIdentifierClause tokenToDeriveIdentifier, out SecurityToken tokenToDerive)
+        {
+            _derivedKeyEntry.ReadDerivedKeyTokenParameters(reader, tokenResolver, out id, out derivationAlgorithm, out label,
+                out length, out nonce, out offset, out generation, out tokenToDeriveIdentifier, out tokenToDerive);
+        }
+
+        public virtual SecurityToken CreateDerivedKeyToken(string id, string derivationAlgorithm, string label, int length, byte[] nonce, int offset, int generation, SecurityKeyIdentifierClause tokenToDeriveIdentifier, SecurityToken tokenToDerive)
+        {
+            return _derivedKeyEntry.CreateDerivedKeyToken(id, derivationAlgorithm, label, length, nonce, offset, generation,
+                tokenToDeriveIdentifier, tokenToDerive);
+        }
+
+        public virtual string DerivationAlgorithm
+        {
+            get { return SecurityAlgorithms.Psha1KeyDerivation; }
+        }
+
+        protected class DerivedKeyTokenEntry : WSSecurityTokenSerializer.TokenEntry
+        {
+            public const string DefaultLabel = "WS-SecureConversation";
+
+            private WSSecureConversation _parent;
+            private int _maxKeyDerivationOffset;
+            private int _maxKeyDerivationLabelLength;
+            private int _maxKeyDerivationNonceLength;
+
+            public DerivedKeyTokenEntry(WSSecureConversation parent, int maxKeyDerivationOffset, int maxKeyDerivationLabelLength, int maxKeyDerivationNonceLength)
+            {
+                if (parent == null)
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("parent");
+                }
+                _parent = parent;
+                _maxKeyDerivationOffset = maxKeyDerivationOffset;
+                _maxKeyDerivationLabelLength = maxKeyDerivationLabelLength;
+                _maxKeyDerivationNonceLength = maxKeyDerivationNonceLength;
+            }
+
+            protected override XmlDictionaryString LocalName { get { return _parent.SerializerDictionary.DerivedKeyToken; } }
+            protected override XmlDictionaryString NamespaceUri { get { return _parent.SerializerDictionary.Namespace; } }
+            protected override Type[] GetTokenTypesCore() { return new Type[] { typeof(DerivedKeySecurityToken) }; }
+            public override string TokenTypeUri { get { return _parent.SerializerDictionary.DerivedKeyTokenType.Value; } }
+            protected override string ValueTypeUri { get { return null; } }
+
+            public override SecurityKeyIdentifierClause CreateKeyIdentifierClauseFromTokenXmlCore(XmlElement issuedTokenXml,
+                SecurityTokenReferenceStyle tokenReferenceStyle)
+            {
+                TokenReferenceStyleHelper.Validate(tokenReferenceStyle);
+
+                switch (tokenReferenceStyle)
+                {
+                    case SecurityTokenReferenceStyle.Internal:
+                        return CreateDirectReference(issuedTokenXml, UtilityStrings.IdAttribute, UtilityStrings.Namespace, typeof(DerivedKeySecurityToken));
+                    case SecurityTokenReferenceStyle.External:
+                        // DerivedKeys aren't referred to externally
+                        return null;
+                    default:
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("tokenReferenceStyle"));
+                }
+
+            }
+
+            // xml format
+            //<DerivedKeyToken wsu:Id="..." wsse:Algorithm="..."> id required, alg optional (curr disallowed)
+            //  <SecurityTokenReference>...</SecurityTokenReference> - required
+            //  <Properties>...</Properties> - disallowed (optional in spec, but we disallow it)
+            // choice begin - (schema requires a choice - we allow neither on read - we always write one)
+            //  <Generation>...</Generation> - optional
+            //  <Offset>...</Offset> - optional
+            // choice end
+            //  <Length>...</Length> - optional - default 32 on read (default specified in spec, not in schema - we always write it)
+            //  <Label>...</Label> - optional
+            //  <Nonce>...</Nonce> - required (optional in spec, but we require it)
+            //</DerivedKeyToken>
+            public virtual void ReadDerivedKeyTokenParameters(XmlDictionaryReader reader, SecurityTokenResolver tokenResolver, out string id, out string derivationAlgorithm, out string label, out int length, out byte[] nonce, out int offset, out int generation, out SecurityKeyIdentifierClause tokenToDeriveIdentifier, out SecurityToken tokenToDerive)
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+
+                //if (tokenResolver == null)
+                //{
+                //    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("tokenResolver");
+                //}
+
+                //id = reader.GetAttribute(XD.UtilityDictionary.IdAttribute, XD.UtilityDictionary.Namespace);
+
+                //derivationAlgorithm = reader.GetAttribute(XD.XmlSignatureDictionary.Algorithm, null);
+                //if (derivationAlgorithm == null)
+                //{
+                //    derivationAlgorithm = parent.DerivationAlgorithm;
+                //}
+
+                //reader.ReadStartElement();
+
+                //tokenToDeriveIdentifier = null;
+                //tokenToDerive = null;
+
+                //if (reader.IsStartElement(XD.SecurityJan2004Dictionary.SecurityTokenReference, XD.SecurityJan2004Dictionary.Namespace))
+                //{
+                //    tokenToDeriveIdentifier = parent.WSSecurityTokenSerializer.ReadKeyIdentifierClause(reader);
+                //    tokenResolver.TryResolveToken(tokenToDeriveIdentifier, out tokenToDerive);
+                //}
+                //else
+                //{
+                //    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new XmlException(SR.Format(SR.DerivedKeyTokenRequiresTokenReference)));
+                //}
+
+                //// no support for properties
+
+                //generation = -1;
+                //if (reader.IsStartElement(parent.SerializerDictionary.Generation, parent.SerializerDictionary.Namespace))
+                //{
+                //    reader.ReadStartElement();
+                //    generation = reader.ReadContentAsInt();
+                //    reader.ReadEndElement();
+                //    if (generation < 0)
+                //        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new XmlException(SR.Format(SR.DerivedKeyInvalidGenerationSpecified, generation)));
+                //}
+
+                //offset = -1;
+                //if (reader.IsStartElement(parent.SerializerDictionary.Offset, parent.SerializerDictionary.Namespace))
+                //{
+                //    reader.ReadStartElement();
+                //    offset = reader.ReadContentAsInt();
+                //    reader.ReadEndElement();
+                //    if (offset < 0)
+                //        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new XmlException(SR.Format(SR.DerivedKeyInvalidOffsetSpecified, offset)));
+                //}
+
+                //length = DerivedKeySecurityToken.DefaultDerivedKeyLength;
+                //if (reader.IsStartElement(parent.SerializerDictionary.Length, parent.SerializerDictionary.Namespace))
+                //{
+                //    reader.ReadStartElement();
+                //    length = reader.ReadContentAsInt();
+                //    reader.ReadEndElement();
+                //}
+
+                //if ((offset == -1) && (generation == -1))
+                //    offset = 0;
+
+                //// verify that the offset is not larger than the max allowed
+                //DerivedKeySecurityToken.EnsureAcceptableOffset(offset, generation, length, this.maxKeyDerivationOffset);
+
+                //label = null;
+                //if (reader.IsStartElement(parent.SerializerDictionary.Label, parent.SerializerDictionary.Namespace))
+                //{
+                //    reader.ReadStartElement();
+                //    label = reader.ReadString();
+                //    reader.ReadEndElement();
+                //}
+                //if (label != null && label.Length > this.maxKeyDerivationLabelLength)
+                //{
+                //    throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new MessageSecurityException(SR.Format(SR.DerivedKeyTokenLabelTooLong, label.Length, this.maxKeyDerivationLabelLength)));
+                //}
+
+                //nonce = null;
+                //reader.ReadStartElement(parent.SerializerDictionary.Nonce, parent.SerializerDictionary.Namespace);
+                //nonce = reader.ReadContentAsBase64();
+                //reader.ReadEndElement();
+
+                //if (nonce != null && nonce.Length > this.maxKeyDerivationNonceLength)
+                //{
+                //    throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new MessageSecurityException(SR.Format(SR.DerivedKeyTokenNonceTooLong, nonce.Length, this.maxKeyDerivationNonceLength)));
+                //}
+
+                //reader.ReadEndElement();
+            }
+
+            public virtual SecurityToken CreateDerivedKeyToken(string id, string derivationAlgorithm, string label, int length, byte[] nonce, int offset, int generation, SecurityKeyIdentifierClause tokenToDeriveIdentifier, SecurityToken tokenToDerive)
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+
+                //if (tokenToDerive == null)
+                //{
+                //    return new DerivedKeySecurityTokenStub(generation, offset, length,
+                //        label, nonce, tokenToDeriveIdentifier, derivationAlgorithm, id);
+                //}
+                //else
+                //{
+                //    return new DerivedKeySecurityToken(generation, offset, length,
+                //        label, nonce, tokenToDerive, tokenToDeriveIdentifier, derivationAlgorithm, id);
+                //}
+            }
+
+            public override SecurityToken ReadTokenCore(XmlDictionaryReader reader, SecurityTokenResolver tokenResolver)
+            {
+                string id;
+                string derivationAlgorithm;
+                string label;
+                int length;
+                byte[] nonce;
+                int offset;
+                int generation;
+                SecurityKeyIdentifierClause tokenToDeriveIdentifier;
+                SecurityToken tokenToDerive;
+                this.ReadDerivedKeyTokenParameters(reader, tokenResolver, out id, out derivationAlgorithm, out label, out length,
+                    out nonce, out offset, out generation, out tokenToDeriveIdentifier, out tokenToDerive);
+
+                return CreateDerivedKeyToken(id, derivationAlgorithm, label, length, nonce, offset, generation,
+                    tokenToDeriveIdentifier, tokenToDerive);
+            }
+
+            public override void WriteTokenCore(XmlDictionaryWriter writer, SecurityToken token)
+            {
+                DerivedKeySecurityToken derivedKeyToken = token as DerivedKeySecurityToken;
+                string serializerPrefix = _parent.SerializerDictionary.Prefix.Value;
+
+                writer.WriteStartElement(serializerPrefix, _parent.SerializerDictionary.DerivedKeyToken, _parent.SerializerDictionary.Namespace);
+                if (derivedKeyToken.Id != null)
+                {
+                    writer.WriteAttributeString(XD.UtilityDictionary.Prefix.Value, XD.UtilityDictionary.IdAttribute, XD.UtilityDictionary.Namespace, derivedKeyToken.Id);
+                }
+                if (derivedKeyToken.KeyDerivationAlgorithm != _parent.DerivationAlgorithm)
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new MessageSecurityException(SR.Format(SR.UnsupportedKeyDerivationAlgorithm, derivedKeyToken.KeyDerivationAlgorithm)));
+                }
+                _parent.WSSecurityTokenSerializer.WriteKeyIdentifierClause(writer, derivedKeyToken.TokenToDeriveIdentifier);
+
+                // Don't support Properties element
+                if (derivedKeyToken.Generation > 0 || derivedKeyToken.Offset > 0 || derivedKeyToken.Length != 32)
+                {
+                    // this means they're both specified (offset must be gen * length) - we'll write generation
+                    if (derivedKeyToken.Generation >= 0 && derivedKeyToken.Offset >= 0)
+                    {
+                        writer.WriteStartElement(serializerPrefix, _parent.SerializerDictionary.Generation, _parent.SerializerDictionary.Namespace);
+                        writer.WriteValue(derivedKeyToken.Generation);
+                        writer.WriteEndElement();
+                    }
+                    else if (derivedKeyToken.Generation != -1)
+                    {
+                        writer.WriteStartElement(serializerPrefix, _parent.SerializerDictionary.Generation, _parent.SerializerDictionary.Namespace);
+                        writer.WriteValue(derivedKeyToken.Generation);
+                        writer.WriteEndElement();
+                    }
+                    else if (derivedKeyToken.Offset != -1)
+                    {
+                        writer.WriteStartElement(serializerPrefix, _parent.SerializerDictionary.Offset, _parent.SerializerDictionary.Namespace);
+                        writer.WriteValue(derivedKeyToken.Offset);
+                        writer.WriteEndElement();
+                    }
+
+                    if (derivedKeyToken.Length != 32)
+                    {
+                        writer.WriteStartElement(serializerPrefix, _parent.SerializerDictionary.Length, _parent.SerializerDictionary.Namespace);
+                        writer.WriteValue(derivedKeyToken.Length);
+                        writer.WriteEndElement();
+                    }
+                }
+
+                if (derivedKeyToken.Label != null)
+                {
+                    writer.WriteStartElement(serializerPrefix, _parent.SerializerDictionary.Generation, _parent.SerializerDictionary.Namespace);
+                    writer.WriteString(derivedKeyToken.Label);
+                    writer.WriteEndElement();
+                }
+                writer.WriteStartElement(serializerPrefix, _parent.SerializerDictionary.Nonce, _parent.SerializerDictionary.Namespace);
+                writer.WriteBase64(derivedKeyToken.Nonce, 0, derivedKeyToken.Nonce.Length);
+                writer.WriteEndElement();
+                writer.WriteEndElement();
+            }
+        }
+
+        protected abstract class SecurityContextTokenEntry : WSSecurityTokenSerializer.TokenEntry
+        {
+            private WSSecureConversation _parent;
+            private SecurityContextCookieSerializer _cookieSerializer;
+
+            public SecurityContextTokenEntry(WSSecureConversation parent, SecurityStateEncoder securityStateEncoder, IList<Type> knownClaimTypes)
+            {
+                _parent = parent;
+                _cookieSerializer = new SecurityContextCookieSerializer(securityStateEncoder, knownClaimTypes);
+            }
+
+            protected WSSecureConversation Parent
+            {
+                get { return _parent; }
+            }
+
+            protected override XmlDictionaryString LocalName { get { return _parent.SerializerDictionary.SecurityContextToken; } }
+            protected override XmlDictionaryString NamespaceUri { get { return _parent.SerializerDictionary.Namespace; } }
+            protected override Type[] GetTokenTypesCore() { return new Type[] { typeof(SecurityContextSecurityToken) }; }
+            public override string TokenTypeUri { get { return _parent.SerializerDictionary.SecurityContextTokenType.Value; } }
+            protected override string ValueTypeUri { get { return null; } }
+
+            public override SecurityKeyIdentifierClause CreateKeyIdentifierClauseFromTokenXmlCore(XmlElement issuedTokenXml,
+                SecurityTokenReferenceStyle tokenReferenceStyle)
+            {
+
+                TokenReferenceStyleHelper.Validate(tokenReferenceStyle);
+
+                switch (tokenReferenceStyle)
+                {
+                    case SecurityTokenReferenceStyle.Internal:
+                        return CreateDirectReference(issuedTokenXml, UtilityStrings.IdAttribute, UtilityStrings.Namespace, typeof(SecurityContextSecurityToken));
+                    case SecurityTokenReferenceStyle.External:
+                        UniqueId contextId = null;
+                        UniqueId generation = null;
+                        foreach (XmlNode node in issuedTokenXml.ChildNodes)
+                        {
+                            XmlElement element = node as XmlElement;
+                            if (element != null)
+                            {
+                                if (element.LocalName == _parent.SerializerDictionary.Identifier.Value && element.NamespaceURI == _parent.SerializerDictionary.Namespace.Value)
+                                {
+                                    throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+                                    //contextId = XmlHelper.ReadTextElementAsUniqueId(element);
+                                }
+                                else if (CanReadGeneration(element))
+                                {
+                                    generation = ReadGeneration(element);
+                                }
+                            }
+                        }
+                        return new SecurityContextKeyIdentifierClause(contextId, generation);
+                    default:
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("tokenReferenceStyle"));
+                }
+            }
+
+            protected abstract bool CanReadGeneration(XmlDictionaryReader reader);
+            protected abstract bool CanReadGeneration(XmlElement element);
+            protected abstract UniqueId ReadGeneration(XmlDictionaryReader reader);
+            protected abstract UniqueId ReadGeneration(XmlElement element);
+
+            SecurityContextSecurityToken TryResolveSecurityContextToken(UniqueId contextId, UniqueId generation, string id, SecurityTokenResolver tokenResolver, out ISecurityContextSecurityTokenCache sctCache)
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+
+                //SecurityContextSecurityToken cachedSct = null;
+                //sctCache = null;
+                //if (tokenResolver is ISecurityContextSecurityTokenCache)
+                //{
+                //    sctCache = ((ISecurityContextSecurityTokenCache)tokenResolver);
+                //    cachedSct = sctCache.GetContext(contextId, generation);
+                //}
+                //else if (tokenResolver is AggregateSecurityHeaderTokenResolver)
+                //{
+                //    // We will see if we have a ISecurityContextSecurityTokenCache in the 
+                //    // AggregateTokenResolver. We will hold the reference to the first sctCache
+                //    // we find.
+                //    AggregateSecurityHeaderTokenResolver aggregateTokenResolve = tokenResolver as AggregateSecurityHeaderTokenResolver;
+                //    for (int i = 0; i < aggregateTokenResolve.TokenResolvers.Count; ++i)
+                //    {
+                //        ISecurityContextSecurityTokenCache oobTokenResolver = aggregateTokenResolve.TokenResolvers[i] as ISecurityContextSecurityTokenCache;
+                //        if (oobTokenResolver == null)
+                //        {
+                //            continue;
+                //        }
+                //        if (sctCache == null)
+                //        {
+                //            sctCache = oobTokenResolver;
+                //        }
+                //        cachedSct = oobTokenResolver.GetContext(contextId, generation);
+                //        if (cachedSct != null)
+                //        {
+                //            break;
+                //        }
+                //    }
+                //}
+                //if (cachedSct == null)
+                //{
+                //    return null;
+                //}
+                //else if (cachedSct.Id == id)
+                //{
+                //    return cachedSct;
+                //}
+                //else
+                //{
+                //    return new SecurityContextSecurityToken(cachedSct, id);
+                //}
+            }
+
+            public override SecurityToken ReadTokenCore(XmlDictionaryReader reader, SecurityTokenResolver tokenResolver)
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+
+                //UniqueId contextId = null;
+                //byte[] encodedCookie = null;
+                //UniqueId generation = null;
+                //bool isCookieMode = false;
+
+                //Fx.Assert(reader.NodeType == XmlNodeType.Element, "");
+
+                //// check if there is an id
+                //string id = reader.GetAttribute(XD.UtilityDictionary.IdAttribute, XD.UtilityDictionary.Namespace);
+
+                //SecurityContextSecurityToken sct = null;
+
+                //// There needs to be at least a contextId in here.
+                //reader.ReadFullStartElement();
+                //reader.MoveToStartElement(parent.SerializerDictionary.Identifier, parent.SerializerDictionary.Namespace);
+                //contextId = reader.ReadElementContentAsUniqueId();
+                //if (CanReadGeneration(reader))
+                //{
+                //    generation = ReadGeneration(reader);
+                //}
+                //if (reader.IsStartElement(parent.SerializerDictionary.Cookie, XD.DotNetSecurityDictionary.Namespace))
+                //{
+                //    isCookieMode = true;
+                //    ISecurityContextSecurityTokenCache sctCache;
+                //    sct = TryResolveSecurityContextToken(contextId, generation, id, tokenResolver, out sctCache);
+                //    if (sct == null)
+                //    {
+                //        encodedCookie = reader.ReadElementContentAsBase64();
+                //        if (encodedCookie != null)
+                //        {
+                //            sct = cookieSerializer.CreateSecurityContextFromCookie(encodedCookie, contextId, generation, id, reader.Quotas);
+                //            if (sctCache != null)
+                //            {
+                //                sctCache.AddContext(sct);
+                //            }
+                //        }
+                //    }
+                //    else
+                //    {
+                //        reader.Skip();
+                //    }
+                //}
+                //reader.ReadEndElement();
+
+                //if (contextId == null)
+                //{
+                //    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new MessageSecurityException(SR.Format(SR.NoSecurityContextIdentifier)));
+                //}
+
+                //if (sct == null && !isCookieMode)
+                //{
+                //    ISecurityContextSecurityTokenCache sctCache;
+                //    sct = TryResolveSecurityContextToken(contextId, generation, id, tokenResolver, out sctCache);
+                //}
+                //if (sct == null)
+                //{
+                //    throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new SecurityContextTokenValidationException(SR.Format(SR.SecurityContextNotRegistered, contextId, generation)));
+                //}
+                //return sct;
+            }
+
+            protected virtual void WriteGeneration(XmlDictionaryWriter writer, SecurityContextSecurityToken sct)
+            {
+            }
+
+            public override void WriteTokenCore(XmlDictionaryWriter writer, SecurityToken token)
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+
+                //SecurityContextSecurityToken sct = (token as SecurityContextSecurityToken);
+
+                //// serialize the name and any wsu:Id attribute
+                //writer.WriteStartElement(parent.SerializerDictionary.Prefix.Value, parent.SerializerDictionary.SecurityContextToken, parent.SerializerDictionary.Namespace);
+                //if (sct.Id != null)
+                //{
+                //    writer.WriteAttributeString(XD.UtilityDictionary.Prefix.Value, XD.UtilityDictionary.IdAttribute, XD.UtilityDictionary.Namespace, sct.Id);
+                //}
+
+                //// serialize the context id
+                //writer.WriteStartElement(parent.SerializerDictionary.Prefix.Value, parent.SerializerDictionary.Identifier, parent.SerializerDictionary.Namespace);
+                //XmlHelper.WriteStringAsUniqueId(writer, sct.ContextId);
+                //writer.WriteEndElement();
+
+                //WriteGeneration(writer, sct);
+
+                //// if cookie-mode, then it must have a cookie
+                //if (sct.IsCookieMode)
+                //{
+                //    if (sct.CookieBlob == null)
+                //    {
+                //        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new MessageSecurityException(SR.Format(SR.NoCookieInSct)));
+                //    }
+
+                //    // if the token has a cookie, write it out
+                //    writer.WriteStartElement(XD.DotNetSecurityDictionary.Prefix.Value, parent.SerializerDictionary.Cookie, XD.DotNetSecurityDictionary.Namespace);
+                //    writer.WriteBase64(sct.CookieBlob, 0, sct.CookieBlob.Length);
+                //    writer.WriteEndElement();
+                //}
+
+                //writer.WriteEndElement();
+            }
+        }
+
+        public abstract class Driver : SecureConversationDriver
+        {
+            public Driver()
+            {
+            }
+
+            protected abstract SecureConversationDictionary DriverDictionary
+            {
+                get;
+            }
+
+            public override XmlDictionaryString IssueAction
+            {
+                get
+                {
+                    return DriverDictionary.RequestSecurityContextIssuance;
+                }
+            }
+
+            public override XmlDictionaryString IssueResponseAction
+            {
+                get
+                {
+                    return DriverDictionary.RequestSecurityContextIssuanceResponse;
+                }
+            }
+
+            public override XmlDictionaryString RenewNeededFaultCode
+            {
+                get { return DriverDictionary.RenewNeededFaultCode; }
+            }
+
+            public override XmlDictionaryString BadContextTokenFaultCode
+            {
+                get { return DriverDictionary.BadContextTokenFaultCode; }
+            }
+
+            public override UniqueId GetSecurityContextTokenId(XmlDictionaryReader reader)
+            {
+                if (reader == null)
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("reader");
+
+                reader.ReadStartElement(DriverDictionary.SecurityContextToken, DriverDictionary.Namespace);
+                UniqueId contextId = XmlHelper.ReadElementStringAsUniqueId(reader, DriverDictionary.Identifier, DriverDictionary.Namespace);
+                while (reader.IsStartElement())
+                {
+                    reader.Skip();
+                }
+                reader.ReadEndElement();
+                return contextId;
+            }
+
+            public override bool IsAtSecurityContextToken(XmlDictionaryReader reader)
+            {
+                if (reader == null)
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("reader");
+
+                return reader.IsStartElement(DriverDictionary.SecurityContextToken, DriverDictionary.Namespace);
+            }
+        }
+    }
+}

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/WSSecureConversationDec2005.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/WSSecureConversationDec2005.cs
@@ -1,0 +1,155 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.IdentityModel.Tokens;
+using System.ServiceModel.Security.Tokens;
+using System.Xml;
+// Issue #31 in progress
+// using HexBinary = System.Runtime.Remoting.Metadata.W3cXsd2001.SoapHexBinary;
+using TokenEntry = System.ServiceModel.Security.WSSecurityTokenSerializer.TokenEntry;
+
+namespace System.ServiceModel.Security
+{
+    class WSSecureConversationDec2005 : WSSecureConversation
+    {
+        private SecurityStateEncoder _securityStateEncoder;
+        private IList<Type> _knownClaimTypes;
+
+        public WSSecureConversationDec2005(WSSecurityTokenSerializer tokenSerializer, SecurityStateEncoder securityStateEncoder, IEnumerable<Type> knownTypes,
+            int maxKeyDerivationOffset, int maxKeyDerivationLabelLength, int maxKeyDerivationNonceLength)
+            : base(tokenSerializer, maxKeyDerivationOffset, maxKeyDerivationLabelLength, maxKeyDerivationNonceLength)
+        {
+            if (securityStateEncoder != null)
+            {
+                _securityStateEncoder = securityStateEncoder;
+            }
+            else
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+                //this.securityStateEncoder = new DataProtectionSecurityStateEncoder();
+            }
+
+            _knownClaimTypes = new List<Type>();
+            if (knownTypes != null)
+            {
+                // Clone this collection.
+                foreach (Type knownType in knownTypes)
+                {
+                    _knownClaimTypes.Add(knownType);
+                }
+            }
+        }
+
+        public override SecureConversationDictionary SerializerDictionary
+        {
+            get { return DXD.SecureConversationDec2005Dictionary; }
+        }
+
+        public override void PopulateTokenEntries(IList<TokenEntry> tokenEntryList)
+        {
+            base.PopulateTokenEntries(tokenEntryList);
+            tokenEntryList.Add(new SecurityContextTokenEntryDec2005(this, _securityStateEncoder, _knownClaimTypes));
+        }
+
+        public override string DerivationAlgorithm
+        {
+            get
+            {
+                return SecurityAlgorithms.Psha1KeyDerivationDec2005;
+            }
+        }
+
+        class SecurityContextTokenEntryDec2005 : SecurityContextTokenEntry
+        {
+            public SecurityContextTokenEntryDec2005(WSSecureConversationDec2005 parent, SecurityStateEncoder securityStateEncoder, IList<Type> knownClaimTypes)
+                : base(parent, securityStateEncoder, knownClaimTypes)
+            {
+            }
+
+            protected override bool CanReadGeneration(XmlDictionaryReader reader)
+            {
+                return reader.IsStartElement(DXD.SecureConversationDec2005Dictionary.Instance, DXD.SecureConversationDec2005Dictionary.Namespace);
+            }
+
+            protected override bool CanReadGeneration(XmlElement element)
+            {
+                return (element.LocalName == DXD.SecureConversationDec2005Dictionary.Instance.Value &&
+                    element.NamespaceURI == DXD.SecureConversationDec2005Dictionary.Namespace.Value);
+            }
+
+            protected override UniqueId ReadGeneration(XmlDictionaryReader reader)
+            {
+                return reader.ReadElementContentAsUniqueId();
+            }
+
+            protected override UniqueId ReadGeneration(XmlElement element)
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+                // return XmlHelper.ReadTextElementAsUniqueId(element);
+            }
+
+            protected override void WriteGeneration(XmlDictionaryWriter writer, SecurityContextSecurityToken sct)
+            {
+                // serialize the generation
+                if (sct.KeyGeneration != null)
+                {
+                    writer.WriteStartElement(DXD.SecureConversationDec2005Dictionary.Prefix.Value,
+                        DXD.SecureConversationDec2005Dictionary.Instance,
+                        DXD.SecureConversationDec2005Dictionary.Namespace);
+                    XmlHelper.WriteStringAsUniqueId(writer, sct.KeyGeneration);
+                    writer.WriteEndElement();
+                }
+            }
+        }
+
+        public class DriverDec2005 : Driver
+        {
+            public DriverDec2005()
+            {
+            }
+
+            protected override SecureConversationDictionary DriverDictionary
+            {
+                get { return DXD.SecureConversationDec2005Dictionary; }
+            }
+
+            public override XmlDictionaryString CloseAction
+            {
+                get { return DXD.SecureConversationDec2005Dictionary.RequestSecurityContextClose; }
+            }
+
+            public override XmlDictionaryString CloseResponseAction
+            {
+                get { return DXD.SecureConversationDec2005Dictionary.RequestSecurityContextCloseResponse; }
+            }
+
+            public override bool IsSessionSupported
+            {
+                get { return true; }
+            }
+
+            public override XmlDictionaryString RenewAction
+            {
+                get { return DXD.SecureConversationDec2005Dictionary.RequestSecurityContextRenew; }
+            }
+
+            public override XmlDictionaryString RenewResponseAction
+            {
+                get { return DXD.SecureConversationDec2005Dictionary.RequestSecurityContextRenewResponse; }
+            }
+
+            public override XmlDictionaryString Namespace
+            {
+                get { return DXD.SecureConversationDec2005Dictionary.Namespace; }
+            }
+
+            public override string TokenTypeUri
+            {
+                get { return DXD.SecureConversationDec2005Dictionary.SecurityContextTokenType.Value; }
+            }
+        }
+    }
+}

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/WSSecureConversationFeb2005.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/WSSecureConversationFeb2005.cs
@@ -1,0 +1,144 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.ServiceModel.Security.Tokens;
+using System.Xml;
+// Issue #31 in progress
+// using HexBinary = System.Runtime.Remoting.Metadata.W3cXsd2001.SoapHexBinary;
+using TokenEntry = System.ServiceModel.Security.WSSecurityTokenSerializer.TokenEntry;
+
+namespace System.ServiceModel.Security
+{
+    class WSSecureConversationFeb2005 : WSSecureConversation
+    {
+        private SecurityStateEncoder _securityStateEncoder;
+        private IList<Type> _knownClaimTypes;
+
+        public WSSecureConversationFeb2005(WSSecurityTokenSerializer tokenSerializer, SecurityStateEncoder securityStateEncoder, IEnumerable<Type> knownTypes,
+            int maxKeyDerivationOffset, int maxKeyDerivationLabelLength, int maxKeyDerivationNonceLength)
+            : base(tokenSerializer, maxKeyDerivationOffset, maxKeyDerivationLabelLength, maxKeyDerivationNonceLength)
+        {
+            if (securityStateEncoder != null)
+            {
+                _securityStateEncoder = securityStateEncoder;
+            }
+            else
+            {
+                _securityStateEncoder = new DataProtectionSecurityStateEncoder();
+            }
+
+            _knownClaimTypes = new List<Type>();
+            if (knownTypes != null)
+            {
+                // Clone this collection.
+                foreach (Type knownType in knownTypes)
+                {
+                    _knownClaimTypes.Add(knownType);
+                }
+            }
+        }
+
+        public override SecureConversationDictionary SerializerDictionary
+        {
+            get { return XD.SecureConversationFeb2005Dictionary; }
+        }
+        
+        public override void PopulateTokenEntries(IList<TokenEntry> tokenEntryList)
+        {
+            base.PopulateTokenEntries(tokenEntryList);
+            tokenEntryList.Add(new SecurityContextTokenEntryFeb2005(this, _securityStateEncoder, _knownClaimTypes));
+        }
+
+        class SecurityContextTokenEntryFeb2005 : SecurityContextTokenEntry
+        {
+            public SecurityContextTokenEntryFeb2005(WSSecureConversationFeb2005 parent, SecurityStateEncoder securityStateEncoder, IList<Type> knownClaimTypes)
+                : base(parent, securityStateEncoder, knownClaimTypes)
+            {
+            }
+            
+            protected override bool CanReadGeneration(XmlDictionaryReader reader)
+            {
+                return reader.IsStartElement(DXD.SecureConversationDec2005Dictionary.Instance, XD.SecureConversationFeb2005Dictionary.Namespace);
+            }
+            
+            protected override bool CanReadGeneration(XmlElement element)
+            {
+                return (element.LocalName == DXD.SecureConversationDec2005Dictionary.Instance.Value &&
+                    element.NamespaceURI == XD.SecureConversationFeb2005Dictionary.Namespace.Value);
+            }
+            
+            protected override UniqueId ReadGeneration(XmlDictionaryReader reader)
+            {
+                return reader.ReadElementContentAsUniqueId();
+            }
+
+            protected override UniqueId ReadGeneration(XmlElement element)
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+                //return XmlHelper.ReadTextElementAsUniqueId(element);
+            }
+            
+            protected override void WriteGeneration(XmlDictionaryWriter writer, SecurityContextSecurityToken sct)
+            {
+                // serialize the generation
+                if (sct.KeyGeneration != null)
+                {
+                    writer.WriteStartElement(XD.SecureConversationFeb2005Dictionary.Prefix.Value, DXD.SecureConversationDec2005Dictionary.Instance,
+                        XD.SecureConversationFeb2005Dictionary.Namespace);
+                    XmlHelper.WriteStringAsUniqueId(writer, sct.KeyGeneration);
+                    writer.WriteEndElement();
+                }
+            }
+        }
+
+        public class DriverFeb2005 : Driver
+        {
+            public DriverFeb2005()
+            {
+            }
+
+            protected override SecureConversationDictionary DriverDictionary
+            {
+                get { return XD.SecureConversationFeb2005Dictionary; }
+            }
+
+            public override XmlDictionaryString CloseAction
+            {
+                get { return XD.SecureConversationFeb2005Dictionary.RequestSecurityContextClose; }
+            }
+
+            public override XmlDictionaryString CloseResponseAction
+            {
+                get { return XD.SecureConversationFeb2005Dictionary.RequestSecurityContextCloseResponse; }
+            }
+
+            public override bool IsSessionSupported
+            {
+                get { return true; }
+            }
+
+            public override XmlDictionaryString RenewAction
+            {
+                get { return XD.SecureConversationFeb2005Dictionary.RequestSecurityContextRenew; }
+            }
+
+            public override XmlDictionaryString RenewResponseAction
+            {
+                get { return XD.SecureConversationFeb2005Dictionary.RequestSecurityContextRenewResponse; }
+            }
+
+            public override XmlDictionaryString Namespace
+            {
+                get { return XD.SecureConversationFeb2005Dictionary.Namespace; }
+            }
+
+            public override string TokenTypeUri
+            {
+                get { return XD.SecureConversationFeb2005Dictionary.SecurityContextTokenType.Value; }
+            }
+        }
+    }
+}

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/WSSecurityJan2004.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/WSSecurityJan2004.cs
@@ -1,0 +1,732 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.IdentityModel.Selectors;
+using System.IdentityModel.Tokens;
+using System.Runtime;
+using System.ServiceModel.Channels;
+using System.ServiceModel.Security.Tokens;
+using System.Xml;
+// Issue #31 in progress
+// using HexBinary = System.Runtime.Remoting.Metadata.W3cXsd2001.SoapHexBinary;
+using TokenEntry = System.ServiceModel.Security.WSSecurityTokenSerializer.TokenEntry;
+
+namespace System.ServiceModel.Security
+{
+    class WSSecurityJan2004 : WSSecurityTokenSerializer.SerializerEntries
+    {
+        private WSSecurityTokenSerializer _tokenSerializer;
+        private SamlSerializer _samlSerializer;
+
+        public WSSecurityJan2004(WSSecurityTokenSerializer tokenSerializer) : this(tokenSerializer, new SamlSerializer())
+        {
+        }
+
+        public WSSecurityJan2004(WSSecurityTokenSerializer tokenSerializer, SamlSerializer samlSerializer)
+        {
+            _tokenSerializer = tokenSerializer;
+            _samlSerializer = samlSerializer;
+        }
+
+        public WSSecurityTokenSerializer WSSecurityTokenSerializer
+        {
+            get { return _tokenSerializer; }
+        }
+
+        public SamlSerializer SamlSerializer
+        {
+            get { return _samlSerializer; }
+        }
+
+        protected void PopulateJan2004TokenEntries(IList<TokenEntry> tokenEntryList)
+        {
+            tokenEntryList.Add(new GenericXmlTokenEntry());
+            tokenEntryList.Add(new UserNamePasswordTokenEntry(_tokenSerializer));
+            tokenEntryList.Add(new KerberosTokenEntry(_tokenSerializer));
+            tokenEntryList.Add(new X509TokenEntry(_tokenSerializer));
+        }
+
+        public override void PopulateTokenEntries(IList<TokenEntry> tokenEntryList)
+        {
+            PopulateJan2004TokenEntries(tokenEntryList);
+            tokenEntryList.Add(new SamlTokenEntry(_tokenSerializer, _samlSerializer));
+            tokenEntryList.Add(new WrappedKeyTokenEntry(_tokenSerializer));
+        }
+
+        internal abstract class BinaryTokenEntry : TokenEntry
+        {
+            internal static readonly XmlDictionaryString s_ElementName = XD.SecurityJan2004Dictionary.BinarySecurityToken;
+            internal static readonly XmlDictionaryString s_EncodingTypeAttribute = XD.SecurityJan2004Dictionary.EncodingType;
+            internal const string EncodingTypeAttributeString = SecurityJan2004Strings.EncodingType;
+            internal const string EncodingTypeValueBase64Binary = SecurityJan2004Strings.EncodingTypeValueBase64Binary;
+            internal const string EncodingTypeValueHexBinary = SecurityJan2004Strings.EncodingTypeValueHexBinary;
+            internal static readonly XmlDictionaryString s_ValueTypeAttribute = XD.SecurityJan2004Dictionary.ValueType;
+
+            private WSSecurityTokenSerializer _tokenSerializer;
+            private string[] _valueTypeUris = null;
+
+            protected BinaryTokenEntry(WSSecurityTokenSerializer tokenSerializer, string valueTypeUri)
+            {
+                _tokenSerializer = tokenSerializer;
+                _valueTypeUris = new string[1];
+                _valueTypeUris[0] = valueTypeUri;
+            }
+
+            protected BinaryTokenEntry(WSSecurityTokenSerializer tokenSerializer, string[] valueTypeUris)
+            {
+                if (valueTypeUris == null)
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("valueTypeUris");
+
+                _tokenSerializer = tokenSerializer;
+                _valueTypeUris = new string[valueTypeUris.GetLength(0)];
+                for (int i = 0; i < _valueTypeUris.GetLength(0); ++i)
+                    _valueTypeUris[i] = valueTypeUris[i];
+            }
+
+            protected override XmlDictionaryString LocalName { get { return s_ElementName; } }
+            protected override XmlDictionaryString NamespaceUri { get { return XD.SecurityJan2004Dictionary.Namespace; } }
+            public override string TokenTypeUri { get { return _valueTypeUris[0]; } }
+            protected override string ValueTypeUri { get { return _valueTypeUris[0]; } }
+            public override bool SupportsTokenTypeUri(string tokenTypeUri)
+            {
+                for (int i = 0; i < _valueTypeUris.GetLength(0); ++i)
+                {
+                    if (_valueTypeUris[i] == tokenTypeUri)
+                        return true;
+                }
+
+                return false;
+            }
+
+            public abstract SecurityKeyIdentifierClause CreateKeyIdentifierClauseFromBinaryCore(byte[] rawData);
+
+            public override SecurityKeyIdentifierClause CreateKeyIdentifierClauseFromTokenXmlCore(XmlElement issuedTokenXml,
+                SecurityTokenReferenceStyle tokenReferenceStyle)
+            {
+                TokenReferenceStyleHelper.Validate(tokenReferenceStyle);
+
+                switch (tokenReferenceStyle)
+                {
+                    case SecurityTokenReferenceStyle.Internal:
+                        return CreateDirectReference(issuedTokenXml, UtilityStrings.IdAttribute, UtilityStrings.Namespace, this.TokenType);
+                    case SecurityTokenReferenceStyle.External:
+                        string encoding = issuedTokenXml.GetAttribute(EncodingTypeAttributeString, null);
+                        string encodedData = issuedTokenXml.InnerText;
+
+                        byte[] binaryData;
+                        if (encoding == null || encoding == EncodingTypeValueBase64Binary)
+                        {
+                            binaryData = Convert.FromBase64String(encodedData);
+                        }
+                        else if (encoding == EncodingTypeValueHexBinary)
+                        {
+                            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+                            ///binaryData = HexBinary.Parse(encodedData).Value;
+                        }
+                        else
+                        {
+                            throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new MessageSecurityException(SR.Format(SR.UnknownEncodingInBinarySecurityToken)));
+                        }
+
+                        return CreateKeyIdentifierClauseFromBinaryCore(binaryData);
+                    default:
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("tokenReferenceStyle"));
+                }
+            }
+
+            public abstract SecurityToken ReadBinaryCore(string id, string valueTypeUri, byte[] rawData);
+
+            public override SecurityToken ReadTokenCore(XmlDictionaryReader reader, SecurityTokenResolver tokenResolver)
+            {
+                string wsuId = reader.GetAttribute(XD.UtilityDictionary.IdAttribute, XD.UtilityDictionary.Namespace);
+                string valueTypeUri = reader.GetAttribute(s_ValueTypeAttribute, null);
+                string encoding = reader.GetAttribute(s_EncodingTypeAttribute, null);
+
+                byte[] binaryData;
+                if (encoding == null || encoding == EncodingTypeValueBase64Binary)
+                {
+                    binaryData = reader.ReadElementContentAsBase64();
+                }
+                else if (encoding == EncodingTypeValueHexBinary)
+                {
+                    throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+                    //binaryData = HexBinary.Parse(reader.ReadElementContentAsString()).Value;
+                }
+                else
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new MessageSecurityException(SR.Format(SR.UnknownEncodingInBinarySecurityToken)));
+                }
+
+                return ReadBinaryCore(wsuId, valueTypeUri, binaryData);
+            }
+
+            public abstract void WriteBinaryCore(SecurityToken token, out string id, out byte[] rawData);
+
+            public override void WriteTokenCore(XmlDictionaryWriter writer, SecurityToken token)
+            {
+                string id;
+                byte[] rawData;
+
+                WriteBinaryCore(token, out id, out rawData);
+
+                if (rawData == null)
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("rawData");
+                }
+
+                writer.WriteStartElement(XD.SecurityJan2004Dictionary.Prefix.Value, s_ElementName, XD.SecurityJan2004Dictionary.Namespace);
+                if (id != null)
+                {
+                    writer.WriteAttributeString(XD.UtilityDictionary.Prefix.Value, XD.UtilityDictionary.IdAttribute, XD.UtilityDictionary.Namespace, id);
+                }
+                if (_valueTypeUris != null)
+                {
+                    writer.WriteAttributeString(s_ValueTypeAttribute, null, _valueTypeUris[0]);
+                }
+                if (_tokenSerializer.EmitBspRequiredAttributes)
+                {
+                    writer.WriteAttributeString(s_EncodingTypeAttribute, null, EncodingTypeValueBase64Binary);
+                }
+                writer.WriteBase64(rawData, 0, rawData.Length);
+                writer.WriteEndElement(); // BinarySecurityToken
+            }
+        }
+
+        class GenericXmlTokenEntry : TokenEntry
+        {
+            protected override XmlDictionaryString LocalName { get { return null; } }
+            protected override XmlDictionaryString NamespaceUri { get { return null; } }
+            protected override Type[] GetTokenTypesCore() { return new Type[] { typeof(GenericXmlSecurityToken) }; }
+            public override string TokenTypeUri { get { return null; } }
+            protected override string ValueTypeUri { get { return null; } }
+
+            public GenericXmlTokenEntry()
+            {
+            }
+
+
+            public override bool CanReadTokenCore(XmlElement element)
+            {
+                return false;
+            }
+
+            public override bool CanReadTokenCore(XmlDictionaryReader reader)
+            {
+                return false;
+            }
+
+            public override SecurityKeyIdentifierClause CreateKeyIdentifierClauseFromTokenXmlCore(XmlElement issuedTokenXml,
+                SecurityTokenReferenceStyle tokenReferenceStyle)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new NotSupportedException());
+            }
+
+            public override SecurityToken ReadTokenCore(XmlDictionaryReader reader, SecurityTokenResolver tokenResolver)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new NotSupportedException());
+            }
+
+            public override void WriteTokenCore(XmlDictionaryWriter writer, SecurityToken token)
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+                //BufferedGenericXmlSecurityToken bufferedXmlToken = token as BufferedGenericXmlSecurityToken;
+                //if (bufferedXmlToken != null && bufferedXmlToken.TokenXmlBuffer != null)
+                //{
+                //    using (XmlDictionaryReader reader = bufferedXmlToken.TokenXmlBuffer.GetReader(0))
+                //    {
+                //        writer.WriteNode(reader, false);
+                //    }
+                //}
+                //else
+                //{
+                //    GenericXmlSecurityToken xmlToken = (GenericXmlSecurityToken)token;
+                //    xmlToken.TokenXml.WriteTo(writer);
+                //}
+            }
+        }
+
+        class KerberosTokenEntry : BinaryTokenEntry
+        {
+            public KerberosTokenEntry(WSSecurityTokenSerializer tokenSerializer)
+                : base(tokenSerializer, new string[] { SecurityJan2004Strings.KerberosTokenTypeGSS, SecurityJan2004Strings.KerberosTokenType1510 })
+            {
+            }
+
+            protected override Type[] GetTokenTypesCore()
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+                //return new Type[] { typeof(KerberosReceiverSecurityToken), typeof(KerberosRequestorSecurityToken) };
+            }
+
+            public override SecurityKeyIdentifierClause CreateKeyIdentifierClauseFromBinaryCore(byte[] rawData)
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+                //byte[] tokenHash;
+                //using (HashAlgorithm hasher = CryptoHelper.NewSha1HashAlgorithm())
+                //{
+                //    tokenHash = hasher.ComputeHash(rawData, 0, rawData.Length);
+                //}
+                //return new KerberosTicketHashKeyIdentifierClause(tokenHash);
+            }
+
+            public override SecurityToken ReadBinaryCore(string id, string valueTypeUri, byte[] rawData)
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+                //return new KerberosReceiverSecurityToken(rawData, id, false, valueTypeUri);
+            }
+
+            public override void WriteBinaryCore(SecurityToken token, out string id, out byte[] rawData)
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+                //KerberosRequestorSecurityToken kerbToken = (KerberosRequestorSecurityToken)token;
+                //id = token.Id;
+                //rawData = kerbToken.GetRequest();
+            }
+        }
+
+        protected class SamlTokenEntry : TokenEntry
+        {
+            const string samlAssertionId = "AssertionID";
+            private SamlSerializer _samlSerializer;
+            private SecurityTokenSerializer _tokenSerializer;
+
+            public SamlTokenEntry(SecurityTokenSerializer tokenSerializer, SamlSerializer samlSerializer)
+            {
+                _tokenSerializer = tokenSerializer;
+                if (samlSerializer != null)
+                {
+                    _samlSerializer = samlSerializer;
+                }
+                else
+                {
+                    _samlSerializer = new SamlSerializer();
+                }
+                _samlSerializer.PopulateDictionary(BinaryMessageEncoderFactory.XmlDictionary);
+            }
+
+            protected override XmlDictionaryString LocalName { get { return XD.SecurityJan2004Dictionary.SamlAssertion; } }
+            protected override XmlDictionaryString NamespaceUri { get { return XD.SecurityJan2004Dictionary.SamlUri; } }
+            protected override Type[] GetTokenTypesCore() { return new Type[] { typeof(SamlSecurityToken) }; }
+            public override string TokenTypeUri { get { return null; } }
+            protected override string ValueTypeUri { get { return null; } }
+
+            public override SecurityKeyIdentifierClause CreateKeyIdentifierClauseFromTokenXmlCore(XmlElement issuedTokenXml,
+                SecurityTokenReferenceStyle tokenReferenceStyle)
+            {
+                TokenReferenceStyleHelper.Validate(tokenReferenceStyle);
+
+                switch (tokenReferenceStyle)
+                {
+                    // SAML uses same reference for internal and external
+                    case SecurityTokenReferenceStyle.Internal:
+                    case SecurityTokenReferenceStyle.External:
+                        throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+                        //string assertionId = issuedTokenXml.GetAttribute(samlAssertionId);
+                        //return new SamlAssertionKeyIdentifierClause(assertionId);
+                    default:
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("tokenReferenceStyle"));
+                }
+            }
+
+            public override SecurityToken ReadTokenCore(XmlDictionaryReader reader, SecurityTokenResolver tokenResolver)
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+                //SamlSecurityToken samlToken = this.samlSerializer.ReadToken(reader, this.tokenSerializer, tokenResolver);
+                //return samlToken;
+            }
+
+            public override void WriteTokenCore(XmlDictionaryWriter writer, SecurityToken token)
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+                //SamlSecurityToken samlToken = token as SamlSecurityToken;
+                //this.samlSerializer.WriteToken(samlToken, writer, this.tokenSerializer);
+            }
+        }
+
+        class UserNamePasswordTokenEntry : TokenEntry
+        {
+            private WSSecurityTokenSerializer _tokenSerializer;
+
+            public UserNamePasswordTokenEntry(WSSecurityTokenSerializer tokenSerializer)
+            {
+                _tokenSerializer = tokenSerializer;
+            }
+
+            protected override XmlDictionaryString LocalName { get { return XD.SecurityJan2004Dictionary.UserNameTokenElement; } }
+            protected override XmlDictionaryString NamespaceUri { get { return XD.SecurityJan2004Dictionary.Namespace; } }
+            protected override Type[] GetTokenTypesCore() { return new Type[] { typeof(UserNameSecurityToken) }; }
+            public override string TokenTypeUri { get { return SecurityJan2004Strings.UPTokenType; } }
+            protected override string ValueTypeUri { get { return null; } }
+
+            public override IAsyncResult BeginReadTokenCore(XmlDictionaryReader reader, SecurityTokenResolver tokenResolver, AsyncCallback callback, object state)
+            {
+                string id;
+                string userName;
+                string password;
+
+                ParseToken(reader, out id, out userName, out password);
+
+                SecurityToken token = new UserNameSecurityToken(userName, password, id);
+                return new CompletedAsyncResult<SecurityToken>(token, callback, state);
+            }
+
+            public override SecurityKeyIdentifierClause CreateKeyIdentifierClauseFromTokenXmlCore(XmlElement issuedTokenXml,
+                SecurityTokenReferenceStyle tokenReferenceStyle)
+            {
+                TokenReferenceStyleHelper.Validate(tokenReferenceStyle);
+
+                switch (tokenReferenceStyle)
+                {
+                    case SecurityTokenReferenceStyle.Internal:
+                        return CreateDirectReference(issuedTokenXml, UtilityStrings.IdAttribute, UtilityStrings.Namespace, typeof(UserNameSecurityToken));
+                    case SecurityTokenReferenceStyle.External:
+                        // UP tokens aren't referred to externally
+                        return null;
+                    default:
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("tokenReferenceStyle"));
+                }
+            }
+
+            public override SecurityToken EndReadTokenCore(IAsyncResult result)
+            {
+                return CompletedAsyncResult<SecurityToken>.End(result);
+            }
+
+            public override SecurityToken ReadTokenCore(XmlDictionaryReader reader, SecurityTokenResolver tokenResolver)
+            {
+                string id;
+                string userName;
+                string password;
+
+                ParseToken(reader, out id, out userName, out password);
+
+                if (id == null)
+                    id = SecurityUniqueId.Create().Value;
+
+                return new UserNameSecurityToken(userName, password, id);
+            }
+
+            public override void WriteTokenCore(XmlDictionaryWriter writer, SecurityToken token)
+            {
+                UserNameSecurityToken upToken = (UserNameSecurityToken)token;
+                WriteUserNamePassword(writer, upToken.Id, upToken.UserName, upToken.Password);
+            }
+
+            void WriteUserNamePassword(XmlDictionaryWriter writer, string id, string userName, string password)
+            {
+                writer.WriteStartElement(XD.SecurityJan2004Dictionary.Prefix.Value, XD.SecurityJan2004Dictionary.UserNameTokenElement,
+                    XD.SecurityJan2004Dictionary.Namespace); // <wsse:UsernameToken
+                writer.WriteAttributeString(XD.UtilityDictionary.Prefix.Value, XD.UtilityDictionary.IdAttribute,
+                    XD.UtilityDictionary.Namespace, id); // wsu:Id="..."
+                writer.WriteElementString(XD.SecurityJan2004Dictionary.Prefix.Value, XD.SecurityJan2004Dictionary.UserNameElement,
+                    XD.SecurityJan2004Dictionary.Namespace, userName); // ><wsse:Username>...</wsse:Username>
+                if (password != null)
+                {
+                    writer.WriteStartElement(XD.SecurityJan2004Dictionary.Prefix.Value, XD.SecurityJan2004Dictionary.PasswordElement,
+                        XD.SecurityJan2004Dictionary.Namespace);
+                    if (_tokenSerializer.EmitBspRequiredAttributes)
+                    {
+                        writer.WriteAttributeString(XD.SecurityJan2004Dictionary.TypeAttribute, null, SecurityJan2004Strings.UPTokenPasswordTextValue);
+                    }
+                    writer.WriteString(password); // <wsse:Password>...</wsse:Password>
+                    writer.WriteEndElement();
+                }
+                writer.WriteEndElement(); // </wsse:UsernameToken>
+            }
+
+            static string ParsePassword(XmlDictionaryReader reader)
+            {
+                string type = reader.GetAttribute(XD.SecurityJan2004Dictionary.TypeAttribute, null);
+                if (type != null && type.Length > 0 && type != SecurityJan2004Strings.UPTokenPasswordTextValue)
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new NotSupportedException(SR.Format(SR.UnsupportedPasswordType, type)));
+                }
+
+                return reader.ReadElementString();
+            }
+
+            static void ParseToken(XmlDictionaryReader reader, out string id, out string userName, out string password)
+            {
+                id = null;
+                userName = null;
+                password = null;
+
+                reader.MoveToContent();
+                id = reader.GetAttribute(XD.UtilityDictionary.IdAttribute, XD.UtilityDictionary.Namespace);
+
+                reader.ReadStartElement(XD.SecurityJan2004Dictionary.UserNameTokenElement, XD.SecurityJan2004Dictionary.Namespace);
+                while (reader.IsStartElement())
+                {
+                    if (reader.IsStartElement(XD.SecurityJan2004Dictionary.UserNameElement, XD.SecurityJan2004Dictionary.Namespace))
+                    {
+                        userName = reader.ReadElementString();
+                    }
+                    else if (reader.IsStartElement(XD.SecurityJan2004Dictionary.PasswordElement, XD.SecurityJan2004Dictionary.Namespace))
+                    {
+                        password = ParsePassword(reader);
+                    }
+                    else if (reader.IsStartElement(XD.SecurityJan2004Dictionary.NonceElement, XD.SecurityJan2004Dictionary.Namespace))
+                    {
+                        // Nonce can be safely ignored
+                        reader.Skip();
+                    }
+                    else if (reader.IsStartElement(XD.UtilityDictionary.CreatedElement, XD.UtilityDictionary.Namespace))
+                    {
+                        // wsu:Created can be safely ignored
+                        reader.Skip();
+                    }
+                    else
+                    {
+                        XmlHelper.OnUnexpectedChildNodeError(SecurityJan2004Strings.UserNameTokenElement, reader);
+                    }
+                }
+                reader.ReadEndElement();
+
+                if (userName == null)
+                    XmlHelper.OnRequiredElementMissing(SecurityJan2004Strings.UserNameElement, SecurityJan2004Strings.Namespace);
+            }
+        }
+
+        protected class WrappedKeyTokenEntry : TokenEntry
+        {
+            WSSecurityTokenSerializer tokenSerializer;
+
+            public WrappedKeyTokenEntry(WSSecurityTokenSerializer tokenSerializer)
+            {
+                this.tokenSerializer = tokenSerializer;
+            }
+
+            protected override XmlDictionaryString LocalName {
+                get
+                {
+                    throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+                    // return EncryptedKey.ElementName; 
+                }
+            }
+            protected override XmlDictionaryString NamespaceUri
+            {
+                get
+                {
+                    throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+                    //return XD.XmlEncryptionDictionary.Namespace;
+                }
+            }
+            protected override Type[] GetTokenTypesCore()
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+                //return new Type[] { typeof(WrappedKeySecurityToken) };
+            }
+            public override string TokenTypeUri { get { return null; } }
+            protected override string ValueTypeUri { get { return null; } }
+
+            public override SecurityKeyIdentifierClause CreateKeyIdentifierClauseFromTokenXmlCore(XmlElement issuedTokenXml,
+                SecurityTokenReferenceStyle tokenReferenceStyle)
+            {
+
+                TokenReferenceStyleHelper.Validate(tokenReferenceStyle);
+
+                switch (tokenReferenceStyle)
+                {
+                    case SecurityTokenReferenceStyle.Internal:
+                        return CreateDirectReference(issuedTokenXml, XmlEncryptionStrings.Id, null, null);
+                    case SecurityTokenReferenceStyle.External:
+                        throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+                        //throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new XmlException(SR.Format(SR.CantInferReferenceForToken, EncryptedKey.ElementName.Value)));
+                    default:
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("tokenReferenceStyle"));
+                }
+            }
+
+            public override SecurityToken ReadTokenCore(XmlDictionaryReader reader, SecurityTokenResolver tokenResolver)
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+
+                //EncryptedKey encryptedKey = new EncryptedKey();
+                //encryptedKey.SecurityTokenSerializer = this.tokenSerializer;
+                //encryptedKey.ReadFrom(reader);
+                //SecurityKeyIdentifier unwrappingTokenIdentifier = encryptedKey.KeyIdentifier;
+                //byte[] wrappedKey = encryptedKey.GetWrappedKey();
+                //WrappedKeySecurityToken wrappedKeyToken = CreateWrappedKeyToken(encryptedKey.Id, encryptedKey.EncryptionMethod,
+                //    encryptedKey.CarriedKeyName, unwrappingTokenIdentifier, wrappedKey, tokenResolver);
+                //wrappedKeyToken.EncryptedKey = encryptedKey;
+
+                //return wrappedKeyToken;
+            }
+
+            // Issue #31 in progress
+            //WrappedKeySecurityToken CreateWrappedKeyToken(string id, string encryptionMethod, string carriedKeyName,
+            //    SecurityKeyIdentifier unwrappingTokenIdentifier, byte[] wrappedKey, SecurityTokenResolver tokenResolver)
+            //{
+            //    ISspiNegotiationInfo sspiResolver = tokenResolver as ISspiNegotiationInfo;
+            //    if (sspiResolver != null)
+            //    {
+            //        ISspiNegotiation unwrappingSspiContext = sspiResolver.SspiNegotiation;
+            //        // ensure that the encryption algorithm is compatible
+            //        if (encryptionMethod != unwrappingSspiContext.KeyEncryptionAlgorithm)
+            //        {
+            //            throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new MessageSecurityException(SR.Format(SR.BadKeyEncryptionAlgorithm, encryptionMethod)));
+            //        }
+            //        byte[] unwrappedKey = unwrappingSspiContext.Decrypt(wrappedKey);
+            //        return new WrappedKeySecurityToken(id, unwrappedKey, encryptionMethod, unwrappingSspiContext, unwrappedKey);
+            //    }
+            //    else
+            //    {
+            //        if (tokenResolver == null)
+            //        {
+            //            throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentNullException("tokenResolver"));
+            //        }
+            //        if (unwrappingTokenIdentifier == null || unwrappingTokenIdentifier.Count == 0)
+            //        {
+            //            throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new MessageSecurityException(SR.Format(SR.MissingKeyInfoInEncryptedKey)));
+            //        }
+
+            //        SecurityToken unwrappingToken;
+            //        SecurityHeaderTokenResolver resolver = tokenResolver as SecurityHeaderTokenResolver;
+            //        if (resolver != null)
+            //        {
+            //            unwrappingToken = resolver.ExpectedWrapper;
+            //            if (unwrappingToken != null)
+            //            {
+            //                if (!resolver.CheckExternalWrapperMatch(unwrappingTokenIdentifier))
+            //                {
+            //                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new MessageSecurityException(
+            //                        SR.Format(SR.EncryptedKeyWasNotEncryptedWithTheRequiredEncryptingToken, unwrappingToken)));
+            //                }
+            //            }
+            //            else
+            //            {
+            //                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new MessageSecurityException(
+            //                    SR.Format(SR.UnableToResolveKeyInfoForUnwrappingToken, unwrappingTokenIdentifier, resolver)));
+            //            }
+            //        }
+            //        else
+            //        {
+            //            try
+            //            {
+            //                unwrappingToken = tokenResolver.ResolveToken(unwrappingTokenIdentifier);
+            //            }
+            //            catch (Exception exception)
+            //            {
+            //                if (exception is MessageSecurityException)
+            //                    throw;
+
+            //                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new MessageSecurityException(
+            //                    SR.Format(SR.UnableToResolveKeyInfoForUnwrappingToken, unwrappingTokenIdentifier, tokenResolver), exception));
+            //            }
+            //        }
+            //        SecurityKey unwrappingSecurityKey;
+            //        byte[] unwrappedKey = SecurityUtils.DecryptKey(unwrappingToken, encryptionMethod, wrappedKey, out unwrappingSecurityKey);
+            //        return new WrappedKeySecurityToken(id, unwrappedKey, encryptionMethod, unwrappingToken, unwrappingTokenIdentifier, wrappedKey, unwrappingSecurityKey);
+            //    }
+            //}
+
+            public override void WriteTokenCore(XmlDictionaryWriter writer, SecurityToken token)
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+                //WrappedKeySecurityToken wrappedKeyToken = token as WrappedKeySecurityToken;
+                //wrappedKeyToken.EnsureEncryptedKeySetUp();
+                //wrappedKeyToken.EncryptedKey.SecurityTokenSerializer = this.tokenSerializer;
+                //wrappedKeyToken.EncryptedKey.WriteTo(writer, ServiceModelDictionaryManager.Instance);
+            }
+        }
+
+        protected class X509TokenEntry : BinaryTokenEntry
+        {
+            internal const string ValueTypeAbsoluteUri = SecurityJan2004Strings.X509TokenType;
+
+            public X509TokenEntry(WSSecurityTokenSerializer tokenSerializer)
+                : base(tokenSerializer, ValueTypeAbsoluteUri)
+            {
+            }
+
+            protected override Type[] GetTokenTypesCore()
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+                //return new Type[] { typeof(X509SecurityToken), typeof(X509WindowsSecurityToken)};
+            }
+
+            public override SecurityKeyIdentifierClause CreateKeyIdentifierClauseFromBinaryCore(byte[] rawData)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new XmlException(SR.Format(SR.CantInferReferenceForToken, ValueTypeAbsoluteUri)));
+            }
+
+            public override SecurityToken ReadBinaryCore(string id, string valueTypeUri, byte[] rawData)
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+                //X509Certificate2 certificate;
+                //if (!SecurityUtils.TryCreateX509CertificateFromRawData(rawData, out certificate))
+                //{
+                //    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new MessageSecurityException(SR.Format(SR.InvalidX509RawData)));
+                //}
+                //return new X509SecurityToken(certificate, id, false);
+            }
+
+            public override void WriteBinaryCore(SecurityToken token, out string id, out byte[] rawData)
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+                //id = token.Id;
+                //X509SecurityToken x509Token = token as X509SecurityToken;
+                //if (x509Token != null)
+                //{
+                //    rawData = x509Token.Certificate.GetRawCertData();
+                //}
+                //else
+                //{
+                //    rawData = ((X509WindowsSecurityToken)token).Certificate.GetRawCertData();
+                //}
+            }
+        }
+
+        public class IdManager : SignatureTargetIdManager
+        {
+            static readonly IdManager instance = new IdManager();
+
+            IdManager()
+            {
+            }
+
+            public override string DefaultIdNamespacePrefix
+            {
+                get { return UtilityStrings.Prefix; }
+            }
+
+            public override string DefaultIdNamespaceUri
+            {
+                get { return UtilityStrings.Namespace; }
+            }
+
+            internal static IdManager Instance
+            {
+                get { return instance; }
+            }
+
+            public override string ExtractId(XmlDictionaryReader reader)
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+                //if (reader == null)
+                //    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("reader");
+
+                //if (reader.IsStartElement(EncryptedData.ElementName, XD.XmlEncryptionDictionary.Namespace))
+                //{
+                //    return reader.GetAttribute(XD.XmlEncryptionDictionary.Id, null);
+                //}
+                //else
+                //{
+                //    return reader.GetAttribute(XD.UtilityDictionary.IdAttribute, XD.UtilityDictionary.Namespace);
+                //}
+            }
+
+            public override void WriteIdAttribute(XmlDictionaryWriter writer, string id)
+            {
+                if (writer == null)
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("writer");
+
+                writer.WriteAttributeString(XD.UtilityDictionary.Prefix.Value, XD.UtilityDictionary.IdAttribute, XD.UtilityDictionary.Namespace, id);
+            }
+        }
+    }
+}
+

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/WSSecurityOneDotOneSendSecurityHeader.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/WSSecurityOneDotOneSendSecurityHeader.cs
@@ -3,19 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 
-using System.Collections.Generic;
 using System.ServiceModel.Channels;
-using System.ServiceModel;
 using System.ServiceModel.Description;
-using System.Diagnostics;
-using System.IO;
-using System.IdentityModel.Tokens;
-using System.Security.Cryptography;
-using System.ServiceModel.Security.Tokens;
-using System.Xml;
-using System.ServiceModel.Diagnostics;
-
-using ISignatureValueSecurityElement = System.IdentityModel.ISignatureValueSecurityElement;
 
 namespace System.ServiceModel.Security
 {

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/WSSecurityOneDotZeroSendSecurityHeader.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/WSSecurityOneDotZeroSendSecurityHeader.cs
@@ -2,14 +2,53 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-
+using System;
+using System.IdentityModel.Tokens;
+using System.IO;
+using System.Runtime;
+using System.Security.Cryptography;
 using System.ServiceModel.Channels;
 using System.ServiceModel.Description;
+using System.ServiceModel.Diagnostics;
+using System.ServiceModel.Security.Tokens;
+using System.Xml;
+// Issue #31 in progress
+//using ExclusiveCanonicalizationTransform = System.IdentityModel.ExclusiveCanonicalizationTransform;
+using HashStream = System.IdentityModel.HashStream;
+using IPrefixGenerator = System.IdentityModel.IPrefixGenerator;
+using ISecurityElement = System.IdentityModel.ISecurityElement;
+using ISignatureValueSecurityElement = System.IdentityModel.ISignatureValueSecurityElement;
+//using PreDigestedSignedInfo = System.IdentityModel.PreDigestedSignedInfo;
+//using Reference = System.IdentityModel.Reference;
+//using SignedInfo = System.IdentityModel.SignedInfo;
+using SignedXml = System.IdentityModel.SignedXml;
+//using StandardSignedInfo = System.IdentityModel.StandardSignedInfo;
+
 
 namespace System.ServiceModel.Security
 {
-    internal class WSSecurityOneDotZeroSendSecurityHeader : SendSecurityHeader
+    class WSSecurityOneDotZeroSendSecurityHeader : SendSecurityHeader
     {
+        private HashStream _hashStream;
+
+        // Issue #31 in progress
+        //PreDigestedSignedInfo _signedInfo;
+        private SignedXml _signedXml;
+        //private SecurityKey _signatureKey;
+        //private MessagePartSpecification _effectiveSignatureParts;
+
+        private SymmetricAlgorithm _encryptingSymmetricAlgorithm;
+        private ReferenceList _referenceList;
+        private SecurityKeyIdentifier _encryptionKeyIdentifier;
+
+        private bool _hasSignedEncryptedMessagePart;
+
+        // For Transport Secrity we have to sign the 'To' header with the 
+        // supporting tokens.
+        //Issue #31 in progress
+        //private byte[] _toHeaderHash = null;
+        //private string _toHeaderId = null;
+
         public WSSecurityOneDotZeroSendSecurityHeader(Message message, string actor, bool mustUnderstand, bool relay,
             SecurityStandardsManager standardsManager,
             SecurityAlgorithmSuite algorithmSuite,
@@ -17,5 +56,899 @@ namespace System.ServiceModel.Security
             : base(message, actor, mustUnderstand, relay, standardsManager, algorithmSuite, direction)
         {
         }
+
+        protected string EncryptionAlgorithm
+        {
+            get { return this.AlgorithmSuite.DefaultEncryptionAlgorithm; }
+        }
+
+        protected XmlDictionaryString EncryptionAlgorithmDictionaryString
+        {
+            get { return this.AlgorithmSuite.DefaultEncryptionAlgorithmDictionaryString; }
+        }
+
+        protected override bool HasSignedEncryptedMessagePart
+        {
+            get
+            {
+                return _hasSignedEncryptedMessagePart;
+            }
+        }
+
+        void AddEncryptionReference(MessageHeader header, string headerId, IPrefixGenerator prefixGenerator, bool sign,
+            out MemoryStream plainTextStream, out string encryptedDataId)
+        {
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+
+            //plainTextStream = new MemoryStream();
+            //XmlDictionaryWriter encryptingWriter = XmlDictionaryWriter.CreateTextWriter(plainTextStream);
+            //if (sign)
+            //{
+            //    AddSignatureReference(header, headerId, prefixGenerator, encryptingWriter);
+            //}
+            //else
+            //{
+            //    header.WriteHeader(encryptingWriter, this.Version);
+            //    encryptingWriter.Flush();
+            //}
+            //encryptedDataId = this.GenerateId();
+            //_referenceList.AddReferredId(encryptedDataId);
+        }
+
+        void AddSignatureReference(SecurityToken token, int position, SecurityTokenAttachmentMode mode)
+        {
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+            //SecurityKeyIdentifierClause keyIdentifierClause = null;
+            //bool strTransformEnabled = this.ShouldUseStrTransformForToken(token, position, mode, out keyIdentifierClause);
+            //AddTokenSignatureReference(token, keyIdentifierClause, strTransformEnabled);
+        }
+
+        void AddPrimaryTokenSignatureReference(SecurityToken token, SecurityTokenParameters securityTokenParameters)
+        {
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+            //// Currently we only support signing the primary token if the primary token is an issued token and protectTokens knob is set to true.
+            //// We will get rid of the below check when we support all token types.
+            //IssuedSecurityTokenParameters istp = securityTokenParameters as IssuedSecurityTokenParameters;
+            //if (istp == null)
+            //{
+            //    return;
+            //}
+
+            //bool strTransformEnabled = istp != null && istp.UseStrTransform;
+            //SecurityKeyIdentifierClause keyIdentifierClause = null;
+            //// Only if the primary token is included in the message that we sign it because WCF at present does not resolve externally referenced tokens. 
+            //// This means in the server's response 
+            //if (ShouldSerializeToken(securityTokenParameters, this.MessageDirection))
+            //{
+            //    if (strTransformEnabled)
+            //    {
+            //        keyIdentifierClause = securityTokenParameters.CreateKeyIdentifierClause(token, GetTokenReferenceStyle(securityTokenParameters));
+            //    }
+            //    AddTokenSignatureReference(token, keyIdentifierClause, strTransformEnabled);
+            //}
+        }
+
+        // Given a token and useStarTransform value this method adds apporopriate reference accordingly.
+        // 1. If strTransform is disabled, it adds a reference to the token's id. 
+        // 2. Else if strtransform is enabled it adds a reference the security token's keyIdentifier's id.
+        void AddTokenSignatureReference(SecurityToken token, SecurityKeyIdentifierClause keyIdentifierClause, bool strTransformEnabled)
+        {
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+
+            //if (!strTransformEnabled && token.Id == null)
+            //{
+            //    throw TraceUtility.ThrowHelperError(new MessageSecurityException(SR.Format(SR.ElementToSignMustHaveId)), this.Message);
+            //}
+
+            //HashStream hashStream = TakeHashStream();
+            //XmlDictionaryWriter utf8Writer = TakeUtf8Writer();
+            //utf8Writer.StartCanonicalization(hashStream, false, null);
+            //this.StandardsManager.SecurityTokenSerializer.WriteToken(utf8Writer, token);
+            //utf8Writer.EndCanonicalization();
+
+            //if (strTransformEnabled)
+            //{
+            //    if (keyIdentifierClause != null)
+            //    {
+            //        if (String.IsNullOrEmpty(keyIdentifierClause.Id))
+            //            keyIdentifierClause.Id = SecurityUniqueId.Create().Value;
+            //        this.ElementContainer.MapSecurityTokenToStrClause(token, keyIdentifierClause);
+            //        _signedInfo.AddReference(keyIdentifierClause.Id, hashStream.FlushHashAndGetValue(), true);
+            //    }
+            //    else
+            //        throw TraceUtility.ThrowHelperError(new MessageSecurityException(SR.GetString(SR.TokenManagerCannotCreateTokenReference)), this.Message);
+            //}
+            //else
+            //    _signedInfo.AddReference(token.Id, hashStream.FlushHashAndGetValue());
+        }
+
+        void AddSignatureReference(SendSecurityHeaderElement[] elements)
+        {
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+            //if (elements != null)
+            //{
+            //    for (int i = 0; i < elements.Length; ++i)
+            //    {
+            //        SecurityKeyIdentifierClause keyIdentifierClause = null;
+            //        TokenElement signedEncryptedTokenElement = elements[i].Item as TokenElement;
+
+            //        // signedEncryptedTokenElement can either be a TokenElement ( in SignThenEncrypt case) or EncryptedData ( in !SignThenEncryptCase)
+            //        // STR-Transform does not make sense in !SignThenEncrypt case .
+            //        // note: signedEncryptedTokenElement can also be SignatureConfirmation but we do not care about it here.
+            //        bool useStrTransform = signedEncryptedTokenElement != null
+            //                               && SignThenEncrypt
+            //                               && this.ShouldUseStrTransformForToken(signedEncryptedTokenElement.Token,
+            //                                                                     i,
+            //                                                                     SecurityTokenAttachmentMode.SignedEncrypted,
+            //                                                                     out keyIdentifierClause);
+
+            //        if (!useStrTransform && elements[i].Id == null)
+            //        {
+            //            throw TraceUtility.ThrowHelperError(new MessageSecurityException(SR.GetString(SR.ElementToSignMustHaveId)), this.Message);
+            //        }
+
+            //        HashStream hashStream = TakeHashStream();
+            //        XmlDictionaryWriter utf8Writer = TakeUtf8Writer();
+            //        utf8Writer.StartCanonicalization(hashStream, false, null);
+            //        elements[i].Item.WriteTo(utf8Writer, ServiceModelDictionaryManager.Instance);
+            //        utf8Writer.EndCanonicalization();
+
+            //        if (useStrTransform)
+            //        {
+            //            if (keyIdentifierClause != null)
+            //            {
+            //                if (String.IsNullOrEmpty(keyIdentifierClause.Id))
+            //                    keyIdentifierClause.Id = SecurityUniqueId.Create().Value;
+
+            //                this.ElementContainer.MapSecurityTokenToStrClause(signedEncryptedTokenElement.Token, keyIdentifierClause);
+            //                this.signedInfo.AddReference(keyIdentifierClause.Id, hashStream.FlushHashAndGetValue(), true);
+            //            }
+            //            else
+            //                throw TraceUtility.ThrowHelperError(new MessageSecurityException(SR.GetString(SR.TokenManagerCannotCreateTokenReference)), this.Message);
+            //        }
+            //        else
+            //            this.signedInfo.AddReference(elements[i].Id, hashStream.FlushHashAndGetValue());
+            //    }
+            //}
+        }
+
+        void AddSignatureReference(SecurityToken[] tokens, SecurityTokenAttachmentMode mode)
+        {
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+            //if (tokens != null)
+            //{
+            //    for (int i = 0; i < tokens.Length; ++i)
+            //    {
+            //        AddSignatureReference(tokens[i], i, mode);
+            //    }
+            //}
+        }
+
+        string GetSignatureHash(MessageHeader header, string headerId, IPrefixGenerator prefixGenerator, XmlDictionaryWriter writer, out byte[] hash)
+        {
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+
+            //HashStream hashStream = TakeHashStream();
+            //XmlDictionaryWriter effectiveWriter;
+            //XmlBuffer canonicalBuffer = null;
+
+            //if (writer.CanCanonicalize)
+            //{
+            //    effectiveWriter = writer;
+            //}
+            //else
+            //{
+            //    canonicalBuffer = new XmlBuffer(int.MaxValue);
+            //    effectiveWriter = canonicalBuffer.OpenSection(XmlDictionaryReaderQuotas.Max);
+            //}
+
+            //effectiveWriter.StartCanonicalization(hashStream, false, null);
+
+            //header.WriteStartHeader(effectiveWriter, this.Version);
+            //if (headerId == null)
+            //{
+            //    headerId = GenerateId();
+            //    this.StandardsManager.IdManager.WriteIdAttribute(effectiveWriter, headerId);
+            //}
+            //header.WriteHeaderContents(effectiveWriter, this.Version);
+            //effectiveWriter.WriteEndElement();
+            //effectiveWriter.EndCanonicalization();
+            //effectiveWriter.Flush();
+
+            //if (!ReferenceEquals(effectiveWriter, writer))
+            //{
+            //    Fx.Assert(canonicalBuffer != null, "Canonical buffer cannot be null.");
+            //    canonicalBuffer.CloseSection();
+            //    canonicalBuffer.Close();
+            //    XmlDictionaryReader dicReader = canonicalBuffer.GetReader(0);
+            //    writer.WriteNode(dicReader, false);
+            //    dicReader.Dispose();
+            //}
+
+            //hash = hashStream.FlushHashAndGetValue();
+
+            //return headerId;
+        }
+
+        void AddSignatureReference(MessageHeader header, string headerId, IPrefixGenerator prefixGenerator, XmlDictionaryWriter writer)
+        {
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+            //byte[] hashValue;
+            //headerId = GetSignatureHash(header, headerId, prefixGenerator, writer, out hashValue);
+            //_signedInfo.AddReference(headerId, hashValue);
+        }
+
+        void ApplySecurityAndWriteHeader(MessageHeader header, string headerId, XmlDictionaryWriter writer, IPrefixGenerator prefixGenerator)
+        {
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+
+            //if (!this.RequireMessageProtection && this.ShouldSignToHeader)
+            //{
+            //    if ((header.Name == XD.AddressingDictionary.To.Value) &&
+            //        (header.Namespace == this.Message.Version.Addressing.Namespace))
+            //    {
+            //        if (this.toHeaderHash == null)
+            //        {
+            //            byte[] headerHash;
+            //            headerId = GetSignatureHash(header, headerId, prefixGenerator, writer, out headerHash);
+            //            this.toHeaderHash = headerHash;
+            //            this.toHeaderId = headerId;
+            //        }
+            //        else
+            //            // More than one 'To' header is specified in the message.
+            //            throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new MessageSecurityException(SR.GetString(SR.TransportSecuredMessageHasMoreThanOneToHeader)));
+
+            //        return;
+            //    }
+            //}
+
+            //MessagePartProtectionMode protectionMode = GetProtectionMode(header);
+            //MemoryStream plainTextStream;
+            //string encryptedDataId;
+            //switch (protectionMode)
+            //{
+            //    case MessagePartProtectionMode.None:
+            //        header.WriteHeader(writer, this.Version);
+            //        return;
+            //    case MessagePartProtectionMode.Sign:
+            //        AddSignatureReference(header, headerId, prefixGenerator, writer);
+            //        return;
+            //    case MessagePartProtectionMode.SignThenEncrypt:
+            //        AddEncryptionReference(header, headerId, prefixGenerator, true, out plainTextStream, out encryptedDataId);
+            //        EncryptAndWriteHeader(header, encryptedDataId, plainTextStream, writer);
+            //        this.hasSignedEncryptedMessagePart = true;
+            //        return;
+            //    case MessagePartProtectionMode.Encrypt:
+            //        AddEncryptionReference(header, headerId, prefixGenerator, false, out plainTextStream, out encryptedDataId);
+            //        EncryptAndWriteHeader(header, encryptedDataId, plainTextStream, writer);
+            //        return;
+            //    case MessagePartProtectionMode.EncryptThenSign:
+            //        AddEncryptionReference(header, headerId, prefixGenerator, false, out plainTextStream, out encryptedDataId);
+            //        EncryptedHeader encryptedHeader = EncryptHeader(
+            //            header, this.encryptingSymmetricAlgorithm, this.encryptionKeyIdentifier, this.Version, encryptedDataId, plainTextStream);
+            //        AddSignatureReference(encryptedHeader, encryptedDataId, prefixGenerator, writer);
+            //        return;
+            //    default:
+            //        Fx.Assert("Invalid MessagePartProtectionMode");
+            //        return;
+            //}
+        }
+
+        public override void ApplySecurityAndWriteHeaders(MessageHeaders headers, XmlDictionaryWriter writer, IPrefixGenerator prefixGenerator)
+        {
+            string[] headerIds;
+            if (this.RequireMessageProtection || this.ShouldSignToHeader)
+            {
+                headerIds = headers.GetHeaderAttributes(UtilityStrings.IdAttribute,
+                    this.StandardsManager.IdManager.DefaultIdNamespaceUri);
+            }
+            else
+            {
+                headerIds = null;
+            }
+            for (int i = 0; i < headers.Count; i++)
+            {
+                MessageHeader header = headers.GetMessageHeader(i);
+                if (this.Version.Addressing == AddressingVersion.None && header.Namespace == AddressingVersion.None.Namespace)
+                {
+                    continue;
+                }
+
+                if (header != this)
+                {
+                    ApplySecurityAndWriteHeader(header, headerIds == null ? null : headerIds[i], writer, prefixGenerator);
+                }
+            }
+        }
+
+        static bool CanCanonicalizeAndFragment(XmlDictionaryWriter writer)
+        {
+            throw ExceptionHelper.PlatformNotSupported();   // #31: Required API: IFragmentCapableXmlDictionaryWriter 
+
+            //if (!writer.CanCanonicalize)
+            //{
+            //    return false;
+            //}
+            //IFragmentCapableXmlDictionaryWriter fragmentingWriter = writer as IFragmentCapableXmlDictionaryWriter;
+            //return fragmentingWriter != null && fragmentingWriter.CanFragment;
+        }
+
+        public override void ApplyBodySecurity(XmlDictionaryWriter writer, IPrefixGenerator prefixGenerator)
+        {
+            SecurityAppliedMessage message = this.SecurityAppliedMessage;
+            EncryptedData encryptedData;
+            HashStream hashStream;
+            switch (message.BodyProtectionMode)
+            {
+                case MessagePartProtectionMode.None:
+                    return;
+                case MessagePartProtectionMode.Sign:
+                    hashStream = TakeHashStream();
+                    if (CanCanonicalizeAndFragment(writer))
+                    {
+                        message.WriteBodyToSignWithFragments(hashStream, false, null, writer);
+                    }
+                    else
+                    {
+                        message.WriteBodyToSign(hashStream);
+                    }
+                    throw ExceptionHelper.PlatformNotSupported();   // #31: Required
+                    //_signedInfo.AddReference(message.BodyId, hashStream.FlushHashAndGetValue());
+                    //return;
+                case MessagePartProtectionMode.SignThenEncrypt:
+                    hashStream = TakeHashStream();
+                    encryptedData = CreateEncryptedDataForBody();
+                    if (CanCanonicalizeAndFragment(writer))
+                    {
+                        message.WriteBodyToSignThenEncryptWithFragments(hashStream, false, null, encryptedData, this._encryptingSymmetricAlgorithm, writer);
+                    }
+                    else
+                    {
+                        message.WriteBodyToSignThenEncrypt(hashStream, encryptedData, _encryptingSymmetricAlgorithm);
+                    }
+                    throw ExceptionHelper.PlatformNotSupported();   // #31: Required
+                    //_signedInfo.AddReference(message.BodyId, hashStream.FlushHashAndGetValue());
+                    //_referenceList.AddReferredId(encryptedData.Id);
+                    //_hasSignedEncryptedMessagePart = true;
+                    //return;
+                case MessagePartProtectionMode.Encrypt:
+                    encryptedData = CreateEncryptedDataForBody();
+                    message.WriteBodyToEncrypt(encryptedData, _encryptingSymmetricAlgorithm);
+                    _referenceList.AddReferredId(encryptedData.Id);
+                    return;
+                case MessagePartProtectionMode.EncryptThenSign:
+                    hashStream = TakeHashStream();
+                    encryptedData = CreateEncryptedDataForBody();
+                    message.WriteBodyToEncryptThenSign(hashStream, encryptedData, _encryptingSymmetricAlgorithm);
+                    throw ExceptionHelper.PlatformNotSupported();   // #31: Required
+                    //_signedInfo.AddReference(message.BodyId, hashStream.FlushHashAndGetValue());
+                    //_referenceList.AddReferredId(encryptedData.Id);
+                    //return;
+                default:
+                    Fx.Assert("Invalid MessagePartProtectionMode");
+                    return;
+            }
+        }
+
+        protected static MemoryStream CaptureToken(SecurityToken token, SecurityStandardsManager serializer)
+        {
+            MemoryStream stream = new MemoryStream();
+            XmlDictionaryWriter writer = XmlDictionaryWriter.CreateTextWriter(stream);
+            serializer.SecurityTokenSerializer.WriteToken(writer, token);
+            writer.Flush();
+            stream.Seek(0, SeekOrigin.Begin);
+            return stream;
+        }
+
+        protected static MemoryStream CaptureSecurityElement(ISecurityElement element)
+        {
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+
+            //MemoryStream stream = new MemoryStream();
+            //XmlDictionaryWriter writer = XmlDictionaryWriter.CreateTextWriter(stream);
+            //element.WriteTo(writer, ServiceModelDictionaryManager.Instance);
+            //writer.Flush();
+            //stream.Seek(0, SeekOrigin.Begin);
+            //return stream;
+        }
+
+        protected override ISecurityElement CompleteEncryptionCore(
+            SendSecurityHeaderElement primarySignature,
+            SendSecurityHeaderElement[] basicTokens,
+            SendSecurityHeaderElement[] signatureConfirmations,
+            SendSecurityHeaderElement[] endorsingSignatures)
+        {
+            if (_referenceList == null)
+            {
+                return null;
+            }
+
+            if (primarySignature != null && primarySignature.Item != null && primarySignature.MarkedForEncryption)
+            {
+                EncryptElement(primarySignature);
+            }
+
+            if (basicTokens != null)
+            {
+                for (int i = 0; i < basicTokens.Length; ++i)
+                {
+                    if (basicTokens[i].MarkedForEncryption)
+                        EncryptElement(basicTokens[i]);
+                }
+            }
+
+            if (signatureConfirmations != null)
+            {
+                for (int i = 0; i < signatureConfirmations.Length; ++i)
+                {
+                    if (signatureConfirmations[i].MarkedForEncryption)
+                        EncryptElement(signatureConfirmations[i]);
+                }
+            }
+
+            if (endorsingSignatures != null)
+            {
+                for (int i = 0; i < endorsingSignatures.Length; ++i)
+                {
+                    if (endorsingSignatures[i].MarkedForEncryption)
+                        EncryptElement(endorsingSignatures[i]);
+                }
+            }
+
+            try
+            {
+                return _referenceList.DataReferenceCount > 0 ? _referenceList : null;
+            }
+            finally
+            {
+                _referenceList = null;
+                _encryptingSymmetricAlgorithm = null;
+                _encryptionKeyIdentifier = null;
+            }
+        }
+
+        protected override ISignatureValueSecurityElement CompletePrimarySignatureCore(
+            SendSecurityHeaderElement[] signatureConfirmations,
+            SecurityToken[] signedEndorsingTokens,
+            SecurityToken[] signedTokens,
+            SendSecurityHeaderElement[] basicTokens, bool isPrimarySignature)
+        {
+            if (_signedXml == null)
+            {
+                return null;
+            }
+
+            SecurityTimestamp timestamp = this.Timestamp;
+            if (timestamp != null)
+            {
+                if (timestamp.Id == null)
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.TimestampToSignHasNoId)));
+                }
+                HashStream hashStream = TakeHashStream();
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+                //this.StandardsManager.WSUtilitySpecificationVersion.WriteTimestampCanonicalForm(
+                //    hashStream, timestamp, _signedInfo.ResourcePool.TakeEncodingBuffer());
+                //_signedInfo.AddReference(timestamp.Id, hashStream.FlushHashAndGetValue());
+            }
+
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+
+            //if ((this.ShouldSignToHeader) && (this.signatureKey is AsymmetricSecurityKey) && (this.Version.Addressing != AddressingVersion.None))
+            //{
+            //    if (this.toHeaderHash != null)
+            //        signedInfo.AddReference(this.toHeaderId, this.toHeaderHash);
+            //    else
+            //        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.GetString(SR.TransportSecurityRequireToHeader)));
+            //}
+
+            //AddSignatureReference(signatureConfirmations);
+            //if (isPrimarySignature && this.ShouldProtectTokens)
+            //{
+            //    AddPrimaryTokenSignatureReference(this.ElementContainer.SourceSigningToken, this.SigningTokenParameters);
+            //}
+
+            //if (this.RequireMessageProtection)
+            //{
+            //    AddSignatureReference(signedEndorsingTokens, SecurityTokenAttachmentMode.SignedEndorsing);
+            //    AddSignatureReference(signedTokens, SecurityTokenAttachmentMode.Signed);
+            //    AddSignatureReference(basicTokens);
+            //}
+
+            //if (this.signedInfo.ReferenceCount == 0)
+            //{
+            //    throw TraceUtility.ThrowHelperError(new MessageSecurityException(SR.GetString(SR.NoPartsOfMessageMatchedPartsToSign)), this.Message);
+            //}
+            //try
+            //{
+            //    this.signedXml.ComputeSignature(this.signatureKey);
+            //    return this.signedXml;
+            //}
+            //finally
+            //{
+            //    this.hashStream = null;
+            //    this.signedInfo = null;
+            //    this.signedXml = null;
+            //    this.signatureKey = null;
+            //    this.effectiveSignatureParts = null;
+            //}
+        }
+
+        EncryptedData CreateEncryptedData()
+        {
+            EncryptedData encryptedData = new EncryptedData();
+            encryptedData.SecurityTokenSerializer = this.StandardsManager.SecurityTokenSerializer;
+            encryptedData.KeyIdentifier = _encryptionKeyIdentifier;
+            encryptedData.EncryptionMethod = this.EncryptionAlgorithm;
+            encryptedData.EncryptionMethodDictionaryString = EncryptionAlgorithmDictionaryString;
+            return encryptedData;
+        }
+
+        EncryptedData CreateEncryptedData(MemoryStream stream, string id, bool typeElement)
+        {
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+            //EncryptedData encryptedData = CreateEncryptedData();
+            //encryptedData.Id = id;
+            //encryptedData.SetUpEncryption(_encryptingSymmetricAlgorithm, new ArraySegment<byte>(stream.GetBuffer(), 0, (int)stream.Length));
+            //if (typeElement)
+            //{
+            //    encryptedData.Type = EncryptedData.ElementType;
+            //}
+            //return encryptedData;
+        }
+
+        EncryptedData CreateEncryptedDataForBody()
+        {
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+
+            //EncryptedData encryptedData = CreateEncryptedData();
+            //encryptedData.Type = EncryptedData.ContentType;
+            //return encryptedData;
+        }
+
+        void EncryptAndWriteHeader(MessageHeader plainTextHeader, string id, MemoryStream stream, XmlDictionaryWriter writer)
+        {
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+            //EncryptedHeader encryptedHeader = EncryptHeader(
+            //    plainTextHeader,
+            //    this.encryptingSymmetricAlgorithm, this.encryptionKeyIdentifier, this.Version,
+            //    id, stream);
+            //encryptedHeader.WriteHeader(writer, this.Version);
+        }
+
+        void EncryptElement(SendSecurityHeaderElement element)
+        {
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+            //string id = GenerateId();
+            //ISecurityElement encryptedElement = CreateEncryptedData(CaptureSecurityElement(element.Item), id, true);
+            //this.referenceList.AddReferredId(id);
+            //element.Replace(id, encryptedElement);
+        }
+
+        protected virtual EncryptedHeader EncryptHeader(MessageHeader plainTextHeader, SymmetricAlgorithm algorithm,
+                SecurityKeyIdentifier keyIdentifier, MessageVersion version, string id, MemoryStream stream)
+        {
+            throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(
+                SR.Format(SR.HeaderEncryptionNotSupportedInWsSecurityJan2004, plainTextHeader.Name, plainTextHeader.Namespace)));
+        }
+
+        HashStream TakeHashStream()
+        {
+            HashStream hashStream = null;
+            if (_hashStream == null)
+            {
+                _hashStream = hashStream = new HashStream(CryptoHelper.CreateHashAlgorithm(this.AlgorithmSuite.DefaultDigestAlgorithm));
+            }
+            else
+            {
+                hashStream = _hashStream; ;
+                hashStream.Reset();
+            }
+            return hashStream;
+        }
+
+        XmlDictionaryWriter TakeUtf8Writer()
+        {
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+            //return this.signedInfo.ResourcePool.TakeUtf8Writer();
+        }
+
+        MessagePartProtectionMode GetProtectionMode(MessageHeader header)
+        {
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+
+            //if (!this.RequireMessageProtection)
+            //{
+            //    return MessagePartProtectionMode.None;
+            //}
+            //bool sign = _signedInfo != null && _effectiveSignatureParts.IsHeaderIncluded(header);
+            //bool encrypt = _referenceList != null && this.EncryptionParts.IsHeaderIncluded(header);
+            //return MessagePartProtectionModeHelper.GetProtectionMode(sign, encrypt, this.SignThenEncrypt);
+        }
+
+        protected override void StartEncryptionCore(SecurityToken token, SecurityKeyIdentifier keyIdentifier)
+        {
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+
+            //this.encryptingSymmetricAlgorithm = SecurityUtils.GetSymmetricAlgorithm(this.EncryptionAlgorithm, token);
+            //if (this.encryptingSymmetricAlgorithm == null)
+            //{
+            //    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new MessageSecurityException(
+            //        SR.GetString(SR.UnableToCreateSymmetricAlgorithmFromToken, this.EncryptionAlgorithm)));
+            //}
+            //this.encryptionKeyIdentifier = keyIdentifier;
+            //this.referenceList = new ReferenceList();
+        }
+
+        protected override void StartPrimarySignatureCore(SecurityToken token,
+            SecurityKeyIdentifier keyIdentifier,
+            MessagePartSpecification signatureParts,
+            bool generateTargettableSignature)
+        {
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+
+            //SecurityAlgorithmSuite suite = this.AlgorithmSuite;
+            //string canonicalizationAlgorithm = suite.DefaultCanonicalizationAlgorithm;
+            //XmlDictionaryString canonicalizationAlgorithmDictionaryString = suite.DefaultCanonicalizationAlgorithmDictionaryString;
+            //if (canonicalizationAlgorithm != SecurityAlgorithms.ExclusiveC14n)
+            //{
+            //    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(
+            //        new MessageSecurityException(SR.Format(SR.UnsupportedCanonicalizationAlgorithm, suite.DefaultCanonicalizationAlgorithm)));
+            //}
+            //string signatureAlgorithm;
+            //XmlDictionaryString signatureAlgorithmDictionaryString;
+            //suite.GetSignatureAlgorithmAndKey(token, out signatureAlgorithm, out this.signatureKey, out signatureAlgorithmDictionaryString);
+            //string digestAlgorithm = suite.DefaultDigestAlgorithm;
+            //XmlDictionaryString digestAlgorithmDictionaryString = suite.DefaultDigestAlgorithmDictionaryString;
+            //this.signedInfo = new PreDigestedSignedInfo(ServiceModelDictionaryManager.Instance, canonicalizationAlgorithm, canonicalizationAlgorithmDictionaryString, digestAlgorithm, digestAlgorithmDictionaryString, signatureAlgorithm, signatureAlgorithmDictionaryString);
+            //this.signedXml = new SignedXml(this.signedInfo, ServiceModelDictionaryManager.Instance, this.StandardsManager.SecurityTokenSerializer);
+            //if (keyIdentifier != null)
+            //{
+            //    this.signedXml.Signature.KeyIdentifier = keyIdentifier;
+            //}
+            //if (generateTargettableSignature)
+            //{
+            //    this.signedXml.Id = GenerateId();
+            //}
+            //this.effectiveSignatureParts = signatureParts;
+            //this.hashStream = this.signedInfo.ResourcePool.TakeHashStream(digestAlgorithm);
+        }
+
+        protected override ISignatureValueSecurityElement CreateSupportingSignature(SecurityToken token, SecurityKeyIdentifier identifier)
+        {
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+
+            //StartPrimarySignatureCore(token, identifier, MessagePartSpecification.NoParts, false);
+            //return CompletePrimarySignatureCore(null, null, null, null, false);
+        }
+
+        protected override ISignatureValueSecurityElement CreateSupportingSignature(SecurityToken token, SecurityKeyIdentifier identifier, ISecurityElement elementToSign)
+        {
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+
+            //SecurityAlgorithmSuite algorithmSuite = this.AlgorithmSuite;
+            //string signatureAlgorithm;
+            //XmlDictionaryString signatureAlgorithmDictionaryString;
+            //SecurityKey signatureKey;
+            //algorithmSuite.GetSignatureAlgorithmAndKey(token, out signatureAlgorithm, out signatureKey, out signatureAlgorithmDictionaryString);
+            //SignedXml signedXml = new SignedXml(ServiceModelDictionaryManager.Instance, this.StandardsManager.SecurityTokenSerializer);
+            //SignedInfo signedInfo = signedXml.Signature.SignedInfo;
+            //signedInfo.CanonicalizationMethod = algorithmSuite.DefaultCanonicalizationAlgorithm;
+            //signedInfo.CanonicalizationMethodDictionaryString = algorithmSuite.DefaultCanonicalizationAlgorithmDictionaryString;
+            //signedInfo.SignatureMethod = signatureAlgorithm;
+            //signedInfo.SignatureMethodDictionaryString = signatureAlgorithmDictionaryString;
+
+            //if (elementToSign.Id == null)
+            //{
+            //    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.GetString(SR.ElementToSignMustHaveId)));
+            //}
+            //Reference reference = new Reference(ServiceModelDictionaryManager.Instance, "#" + elementToSign.Id, elementToSign);
+            //reference.DigestMethod = algorithmSuite.DefaultDigestAlgorithm;
+            //reference.DigestMethodDictionaryString = algorithmSuite.DefaultDigestAlgorithmDictionaryString;
+            //reference.AddTransform(new ExclusiveCanonicalizationTransform());
+            //((StandardSignedInfo)signedInfo).AddReference(reference);
+
+            //signedXml.ComputeSignature(signatureKey);
+            //if (identifier != null)
+            //{
+            //    signedXml.Signature.KeyIdentifier = identifier;
+            //}
+            //return signedXml;
+        }
+
+        protected override void WriteSecurityTokenReferencyEntry(XmlDictionaryWriter writer, SecurityToken securityToken, SecurityTokenParameters securityTokenParameters)
+        {
+            SecurityKeyIdentifierClause keyIdentifierClause = null;
+
+            // Given a token this method writes its corresponding security token reference entry in the security header 
+            // 1. If the token parameters is an issuedSecurityTokenParamter 
+            // 2. If UseStrTransform is enabled on it.
+
+            IssuedSecurityTokenParameters issuedSecurityTokenParameters = securityTokenParameters as IssuedSecurityTokenParameters;
+            if (issuedSecurityTokenParameters == null || !issuedSecurityTokenParameters.UseStrTransform)
+                return;
+
+            if (this.ElementContainer.TryGetIdentifierClauseFromSecurityToken(securityToken, out keyIdentifierClause))
+            {
+                if (keyIdentifierClause != null && !String.IsNullOrEmpty(keyIdentifierClause.Id))
+                {
+                    WrappedXmlDictionaryWriter wrappedLocalWriter = new WrappedXmlDictionaryWriter(writer, keyIdentifierClause.Id);
+                    this.StandardsManager.SecurityTokenSerializer.WriteKeyIdentifierClause(wrappedLocalWriter, keyIdentifierClause);
+                }
+                else
+                    throw TraceUtility.ThrowHelperError(new MessageSecurityException(SR.Format(SR.TokenManagerCannotCreateTokenReference)), this.Message);
+            }
+        }
+    }
+
+    class WrappedXmlDictionaryWriter : XmlDictionaryWriter
+    {
+        XmlDictionaryWriter innerWriter;
+        int index;
+        bool insertId;
+        bool isStrReferenceElement;
+        string id;
+
+        public WrappedXmlDictionaryWriter(XmlDictionaryWriter writer, string id)
+        {
+            this.innerWriter = writer;
+            this.index = 0;
+            this.insertId = false;
+            this.isStrReferenceElement = false;
+            this.id = id;
+        }
+
+        public override void WriteStartAttribute(string prefix, string localName, string namespaceUri)
+        {
+            if (isStrReferenceElement && this.insertId && localName == XD.UtilityDictionary.IdAttribute.Value)
+            {
+                // This means the serializer is already writing the Id out, so we don't write it again.
+                this.insertId = false;
+            }
+            this.innerWriter.WriteStartAttribute(prefix, localName, namespaceUri);
+        }
+
+        public override void WriteStartElement(string prefix, string localName, string namespaceUri)
+        {
+            if (isStrReferenceElement && this.insertId)
+            {
+                if (id != null)
+                {
+                    this.innerWriter.WriteAttributeString(XD.UtilityDictionary.Prefix.Value, XD.UtilityDictionary.IdAttribute, XD.UtilityDictionary.Namespace, id);
+                }
+
+                isStrReferenceElement = false;
+                this.insertId = false;
+            }
+
+            index++;
+
+            if (index == 1 && localName == XD.SecurityJan2004Dictionary.SecurityTokenReference.Value)
+            {
+                this.insertId = true;
+                isStrReferenceElement = true;
+            }
+
+            this.innerWriter.WriteStartElement(prefix, localName, namespaceUri);
+        }
+
+        // Below methods simply call into innerWritter
+        // Issue #31 in progress
+        // Close is not part of API
+        public /*override*/ void Close()
+        {
+            this.innerWriter.Dispose();
+        }
+
+        public override void Flush()
+        {
+            this.innerWriter.Flush();
+        }
+
+        public override string LookupPrefix(string ns)
+        {
+            return this.innerWriter.LookupPrefix(ns);
+        }
+
+        public override void WriteBase64(byte[] buffer, int index, int count)
+        {
+            this.innerWriter.WriteBase64(buffer, index, count);
+        }
+
+        public override void WriteCData(string text)
+        {
+            this.innerWriter.WriteCData(text);
+        }
+
+        public override void WriteCharEntity(char ch)
+        {
+            this.innerWriter.WriteCharEntity(ch);
+        }
+
+        public override void WriteChars(char[] buffer, int index, int count)
+        {
+            this.innerWriter.WriteChars(buffer, index, count);
+        }
+
+        public override void WriteComment(string text)
+        {
+            this.innerWriter.WriteComment(text);
+        }
+
+        public override void WriteDocType(string name, string pubid, string sysid, string subset)
+        {
+            this.innerWriter.WriteDocType(name, pubid, sysid, subset);
+        }
+
+        public override void WriteEndAttribute()
+        {
+            this.innerWriter.WriteEndAttribute();
+        }
+
+        public override void WriteEndDocument()
+        {
+            this.innerWriter.WriteEndDocument();
+        }
+
+        public override void WriteEndElement()
+        {
+            this.innerWriter.WriteEndElement();
+        }
+
+        public override void WriteEntityRef(string name)
+        {
+            this.innerWriter.WriteEntityRef(name);
+        }
+
+        public override void WriteFullEndElement()
+        {
+            this.innerWriter.WriteFullEndElement();
+        }
+
+        public override void WriteProcessingInstruction(string name, string text)
+        {
+            this.innerWriter.WriteProcessingInstruction(name, text);
+        }
+
+        public override void WriteRaw(string data)
+        {
+            this.innerWriter.WriteRaw(data);
+        }
+
+        public override void WriteRaw(char[] buffer, int index, int count)
+        {
+            this.innerWriter.WriteRaw(buffer, index, count);
+        }
+
+        public override void WriteStartDocument(bool standalone)
+        {
+            this.innerWriter.WriteStartDocument(standalone);
+        }
+
+        public override void WriteStartDocument()
+        {
+            this.innerWriter.WriteStartDocument();
+        }
+
+        public override WriteState WriteState
+        {
+            get { return this.innerWriter.WriteState; }
+        }
+
+        public override void WriteString(string text)
+        {
+            this.innerWriter.WriteString(text);
+        }
+
+        public override void WriteSurrogateCharEntity(char lowChar, char highChar)
+        {
+            this.innerWriter.WriteSurrogateCharEntity(lowChar, highChar);
+        }
+
+        public override void WriteWhitespace(string ws)
+        {
+            this.innerWriter.WriteWhitespace(ws);
+        }
     }
 }
+

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/WSSecurityXXX2005.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/WSSecurityXXX2005.cs
@@ -1,0 +1,56 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.IdentityModel.Tokens;
+
+//Issue #31 in progress
+//using HexBinary = System.Runtime.Remoting.Metadata.W3cXsd2001.SoapHexBinary;
+
+using TokenEntry = System.ServiceModel.Security.WSSecurityTokenSerializer.TokenEntry;
+
+namespace System.ServiceModel.Security
+{
+    class WSSecurityXXX2005 : WSSecurityJan2004
+    {
+        public WSSecurityXXX2005(WSSecurityTokenSerializer tokenSerializer)
+            : this(tokenSerializer, new SamlSerializer())
+        {
+        }
+
+        public WSSecurityXXX2005(WSSecurityTokenSerializer tokenSerializer, SamlSerializer samlSerializer)
+            : base(tokenSerializer, samlSerializer)
+        {
+        }
+
+        public override void PopulateTokenEntries(IList<TokenEntry> tokenEntryList)
+        {
+            PopulateJan2004TokenEntries(tokenEntryList);
+            tokenEntryList.Add(new WSSecurityXXX2005.WrappedKeyTokenEntry(this.WSSecurityTokenSerializer));
+            tokenEntryList.Add(new WSSecurityXXX2005.SamlTokenEntry(this.WSSecurityTokenSerializer, this.SamlSerializer));
+        }
+
+        new class SamlTokenEntry : WSSecurityJan2004.SamlTokenEntry
+        {
+            public SamlTokenEntry(WSSecurityTokenSerializer tokenSerializer, SamlSerializer samlSerializer)
+                : base(tokenSerializer, samlSerializer)
+            {
+            }
+
+            public override string TokenTypeUri { get { return SecurityXXX2005Strings.SamlTokenType; } }
+        }
+
+        new class WrappedKeyTokenEntry : WSSecurityJan2004.WrappedKeyTokenEntry
+        {
+            public WrappedKeyTokenEntry(WSSecurityTokenSerializer tokenSerializer)
+                : base(tokenSerializer)
+            {
+            }
+
+            public override string TokenTypeUri { get { return SecurityXXX2005Strings.EncryptedKeyTokenType; } }
+        }
+    }
+}
+

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/WSTrust.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/WSTrust.cs
@@ -1,0 +1,1688 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.IdentityModel.Selectors;
+using System.IdentityModel.Tokens;
+using System.Runtime.Serialization;
+using System.ServiceModel.Description;
+using System.ServiceModel.Dispatcher;
+using System.ServiceModel.Security.Tokens;
+using System.Xml;
+
+// Issue #31 in progress
+//using HexBinary = System.Runtime.Remoting.Metadata.W3cXsd2001.SoapHexBinary;
+//using Psha1DerivedKeyGenerator = System.IdentityModel.Psha1DerivedKeyGenerator;
+
+using TokenEntry = System.ServiceModel.Security.WSSecurityTokenSerializer.TokenEntry;
+
+
+namespace System.ServiceModel.Security
+{
+    internal abstract class WSTrust : WSSecurityTokenSerializer.SerializerEntries
+    {
+        private WSSecurityTokenSerializer _tokenSerializer;
+
+        public WSTrust(WSSecurityTokenSerializer tokenSerializer)
+        {
+            _tokenSerializer = tokenSerializer;
+        }
+
+        public WSSecurityTokenSerializer WSSecurityTokenSerializer
+        {
+            get { return _tokenSerializer; }
+        }
+
+        public abstract TrustDictionary SerializerDictionary
+        {
+            get; 
+        }
+
+        public override void PopulateTokenEntries(IList<TokenEntry> tokenEntryList)
+        {
+            tokenEntryList.Add(new BinarySecretTokenEntry(this));
+        }
+
+        class BinarySecretTokenEntry : TokenEntry
+        {
+            private WSTrust _parent;
+            private TrustDictionary _otherDictionary;
+
+            public BinarySecretTokenEntry(WSTrust parent)
+            {
+                _parent = parent;
+                _otherDictionary = null;
+
+                if (parent.SerializerDictionary is TrustDec2005Dictionary)
+                {
+                    _otherDictionary = XD.TrustFeb2005Dictionary;
+                }
+
+                if (parent.SerializerDictionary is TrustFeb2005Dictionary)
+                {
+                    _otherDictionary = DXD.TrustDec2005Dictionary;
+                }
+
+                // always set it, so we don't have to worry about null
+                if (_otherDictionary == null)
+                    _otherDictionary = _parent.SerializerDictionary;
+            }
+
+            protected override XmlDictionaryString LocalName { get { return _parent.SerializerDictionary.BinarySecret; } }
+            protected override XmlDictionaryString NamespaceUri { get { return _parent.SerializerDictionary.Namespace; } }
+            protected override Type[] GetTokenTypesCore()
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+                //return new Type[] { typeof(BinarySecretSecurityToken) };
+            }
+            public override string TokenTypeUri { get { return null; } }
+            protected override string ValueTypeUri { get { return null; } }
+
+            public override bool CanReadTokenCore(XmlElement element)
+            {
+                string valueTypeUri = null;
+
+                if (element.HasAttribute(SecurityJan2004Strings.ValueType, null))
+                {
+                    valueTypeUri = element.GetAttribute(SecurityJan2004Strings.ValueType, null);
+                }
+
+                return element.LocalName == LocalName.Value && (element.NamespaceURI == NamespaceUri.Value || element.NamespaceURI == _otherDictionary.Namespace.Value) && valueTypeUri == this.ValueTypeUri;
+            }
+
+            public override bool CanReadTokenCore(XmlDictionaryReader reader)
+            {
+                return (reader.IsStartElement(this.LocalName, this.NamespaceUri) || reader.IsStartElement(this.LocalName, _otherDictionary.Namespace)) &&
+                       reader.GetAttribute(XD.SecurityJan2004Dictionary.ValueType, null) == this.ValueTypeUri;
+            }
+
+
+            public override SecurityKeyIdentifierClause CreateKeyIdentifierClauseFromTokenXmlCore(XmlElement issuedTokenXml,
+                SecurityTokenReferenceStyle tokenReferenceStyle)
+            {
+                TokenReferenceStyleHelper.Validate(tokenReferenceStyle);
+
+                switch (tokenReferenceStyle)
+                {
+                    case SecurityTokenReferenceStyle.Internal:
+                        return CreateDirectReference(issuedTokenXml, UtilityStrings.IdAttribute, UtilityStrings.Namespace, typeof(GenericXmlSecurityToken));
+                    case SecurityTokenReferenceStyle.External:
+                        // Binary Secret tokens aren't referred to externally
+                        return null;
+                    default:
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("tokenReferenceStyle"));
+                }
+            }
+
+            public override SecurityToken ReadTokenCore(XmlDictionaryReader reader, SecurityTokenResolver tokenResolver)
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+
+                //string secretType = reader.GetAttribute(XD.SecurityJan2004Dictionary.TypeAttribute, null);
+                //string id = reader.GetAttribute(XD.UtilityDictionary.IdAttribute, XD.UtilityDictionary.Namespace);
+                //bool isNonce = false;
+
+                //if (secretType != null && secretType.Length > 0)
+                //{
+                //    if (secretType == parent.SerializerDictionary.NonceBinarySecret.Value || secretType == otherDictionary.NonceBinarySecret.Value)
+                //    {
+                //        isNonce = true;
+                //    }
+                //    else if (secretType != parent.SerializerDictionary.SymmetricKeyBinarySecret.Value && secretType != otherDictionary.SymmetricKeyBinarySecret.Value)
+                //    {
+                //        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new MessageSecurityException(SR.Format(SR.UnexpectedBinarySecretType, parent.SerializerDictionary.SymmetricKeyBinarySecret.Value, secretType)));
+                //    }
+                //}
+
+                //byte[] secret = reader.ReadElementContentAsBase64();
+                //if (isNonce)
+                //{
+                //    return new NonceToken(id, secret);
+                //}
+                //else
+                //{
+                //    return new BinarySecretSecurityToken(id, secret);
+                //}
+            }
+
+            public override void WriteTokenCore(XmlDictionaryWriter writer, SecurityToken token)
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+
+                //BinarySecretSecurityToken simpleToken = token as BinarySecretSecurityToken;
+                //byte[] secret = simpleToken.GetKeyBytes();
+                //writer.WriteStartElement(parent.SerializerDictionary.Prefix.Value, parent.SerializerDictionary.BinarySecret, parent.SerializerDictionary.Namespace);
+                //if (simpleToken.Id != null)
+                //{
+                //    writer.WriteAttributeString(XD.UtilityDictionary.Prefix.Value, XD.UtilityDictionary.IdAttribute, XD.UtilityDictionary.Namespace, simpleToken.Id);
+                //}
+                //if (token is NonceToken)
+                //{
+                //    writer.WriteAttributeString(XD.SecurityJan2004Dictionary.TypeAttribute, null, parent.SerializerDictionary.NonceBinarySecret.Value);
+                //}
+                //writer.WriteBase64(secret, 0, secret.Length);
+                //writer.WriteEndElement();
+            }
+
+        }
+
+        public abstract class Driver : TrustDriver
+        {
+            private static readonly string _base64Uri = SecurityJan2004Strings.EncodingTypeValueBase64Binary;
+            private static readonly string _hexBinaryUri = SecurityJan2004Strings.EncodingTypeValueHexBinary;
+
+            private SecurityStandardsManager _standardsManager;
+            private List<SecurityTokenAuthenticator> _entropyAuthenticators;
+
+            public Driver(SecurityStandardsManager standardsManager)
+            {
+                _standardsManager = standardsManager;
+                _entropyAuthenticators = new List<SecurityTokenAuthenticator>(2);
+            }
+
+            public abstract TrustDictionary DriverDictionary
+            {
+                get;
+            }
+
+            public override XmlDictionaryString RequestSecurityTokenAction
+            {
+                get
+                {
+                    return DriverDictionary.RequestSecurityTokenIssuance;
+                }
+            }
+
+            public override XmlDictionaryString RequestSecurityTokenResponseAction
+            {
+                get
+                {
+                    return DriverDictionary.RequestSecurityTokenIssuanceResponse;
+                }
+            }
+
+            public override string RequestTypeIssue
+            {
+                get
+                {
+                    return DriverDictionary.RequestTypeIssue.Value;
+                }
+            }
+
+            public override string ComputedKeyAlgorithm
+            {
+                get { return DriverDictionary.Psha1ComputedKeyUri.Value; }
+            }
+
+            public override SecurityStandardsManager StandardsManager
+            {
+                get
+                {
+                    return _standardsManager;
+                }
+            }
+
+            public override XmlDictionaryString Namespace
+            {
+                get { return DriverDictionary.Namespace; }
+            }
+
+            public override RequestSecurityToken CreateRequestSecurityToken(XmlReader xmlReader)
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+
+                //XmlDictionaryReader reader = XmlDictionaryReader.CreateDictionaryReader(xmlReader);
+                //reader.MoveToStartElement(DriverDictionary.RequestSecurityToken, DriverDictionary.Namespace);
+                //string context = null;
+                //string tokenTypeUri = null;
+                //string requestType = null;
+                //int keySize = 0;
+                //XmlDocument doc = new XmlDocument();
+                //XmlElement rstXml = (doc.ReadNode(reader) as XmlElement);
+                //SecurityKeyIdentifierClause renewTarget = null;
+                //SecurityKeyIdentifierClause closeTarget = null;
+                //for (int i = 0; i < rstXml.Attributes.Count; ++i)
+                //{
+                //    XmlAttribute attr = rstXml.Attributes[i];
+                //    if (attr.LocalName == DriverDictionary.Context.Value)
+                //    {
+                //        context = attr.Value;
+                //    }
+                //}
+                //for (int i = 0; i < rstXml.ChildNodes.Count; ++i)
+                //{
+                //    XmlElement child = (rstXml.ChildNodes[i] as XmlElement);
+                //    if (child != null)
+                //    {
+                //        if (child.LocalName == DriverDictionary.TokenType.Value && child.NamespaceURI == DriverDictionary.Namespace.Value)
+                //            tokenTypeUri = XmlHelper.ReadTextElementAsTrimmedString(child);
+                //        else if (child.LocalName == DriverDictionary.RequestType.Value && child.NamespaceURI == DriverDictionary.Namespace.Value)
+                //            requestType = XmlHelper.ReadTextElementAsTrimmedString(child);
+                //        else if (child.LocalName == DriverDictionary.KeySize.Value && child.NamespaceURI == DriverDictionary.Namespace.Value)
+                //            keySize = Int32.Parse(XmlHelper.ReadTextElementAsTrimmedString(child), NumberFormatInfo.InvariantInfo);
+                //    }
+                //}
+
+                //ReadTargets(rstXml, out renewTarget, out closeTarget);
+
+                //RequestSecurityToken rst = new RequestSecurityToken(standardsManager, rstXml, context, tokenTypeUri, requestType, keySize, renewTarget, closeTarget);
+                //return rst;
+            }
+
+            System.IdentityModel.XmlBuffer GetIssuedTokenBuffer(System.IdentityModel.XmlBuffer rstrBuffer)
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+
+                //System.IdentityModel.XmlBuffer issuedTokenBuffer = null;
+                //using (XmlDictionaryReader reader = rstrBuffer.GetReader(0))
+                //{
+                //    reader.ReadFullStartElement();
+                //    while (reader.IsStartElement())
+                //    {
+                //        if (reader.IsStartElement(this.DriverDictionary.RequestedSecurityToken, this.DriverDictionary.Namespace))
+                //        {
+                //            reader.ReadStartElement();
+                //            reader.MoveToContent();
+                //            issuedTokenBuffer = new System.IdentityModel.XmlBuffer(Int32.MaxValue);
+                //            using (XmlDictionaryWriter writer = issuedTokenBuffer.OpenSection(reader.Quotas))
+                //            {
+                //                writer.WriteNode(reader, false);
+                //                issuedTokenBuffer.CloseSection();
+                //                issuedTokenBuffer.Close();
+                //            }
+                //            reader.ReadEndElement();
+                //            break;
+                //        }
+                //        else
+                //        {
+                //            reader.Skip();
+                //        }
+                //    }
+                //}
+                //return issuedTokenBuffer;
+            }
+
+            public override RequestSecurityTokenResponse CreateRequestSecurityTokenResponse(XmlReader xmlReader)
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+
+                //if (xmlReader == null)
+                //{
+                //    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("xmlReader");
+                //}
+                //XmlDictionaryReader reader = XmlDictionaryReader.CreateDictionaryReader(xmlReader);
+                //if (reader.IsStartElement(DriverDictionary.RequestSecurityTokenResponse, DriverDictionary.Namespace) == false)
+                //{
+                //    XmlHelper.OnRequiredElementMissing(DriverDictionary.RequestSecurityTokenResponse.Value, DriverDictionary.Namespace.Value);
+                //}
+
+                //System.IdentityModel.XmlBuffer rstrBuffer = new System.IdentityModel.XmlBuffer(Int32.MaxValue);
+                //using (XmlDictionaryWriter writer = rstrBuffer.OpenSection(reader.Quotas))
+                //{
+                //    writer.WriteNode(reader, false);
+                //    rstrBuffer.CloseSection();
+                //    rstrBuffer.Close();
+                //}
+                //XmlDocument doc = new XmlDocument();
+                //XmlElement rstrXml;
+                //using (XmlReader reader2 = rstrBuffer.GetReader(0))
+                //{
+                //    rstrXml = (doc.ReadNode(reader2) as XmlElement);
+                //}
+
+                //System.IdentityModel.XmlBuffer issuedTokenBuffer = GetIssuedTokenBuffer(rstrBuffer);
+                //string context = null;
+                //string tokenTypeUri = null;
+                //int keySize = 0;
+                //SecurityKeyIdentifierClause requestedAttachedReference = null;
+                //SecurityKeyIdentifierClause requestedUnattachedReference = null;
+                //bool computeKey = false;
+                //DateTime created = DateTime.UtcNow;
+                //DateTime expires = SecurityUtils.MaxUtcDateTime;
+                //bool isRequestedTokenClosed = false;
+                //for (int i = 0; i < rstrXml.Attributes.Count; ++i)
+                //{
+                //    XmlAttribute attr = rstrXml.Attributes[i];
+                //    if (attr.LocalName == DriverDictionary.Context.Value)
+                //    {
+                //        context = attr.Value;
+                //    }
+                //}
+
+                //for (int i = 0; i < rstrXml.ChildNodes.Count; ++i)
+                //{
+                //    XmlElement child = (rstrXml.ChildNodes[i] as XmlElement);
+                //    if (child != null)
+                //    {
+                //        if (child.LocalName == DriverDictionary.TokenType.Value && child.NamespaceURI == DriverDictionary.Namespace.Value)
+                //            tokenTypeUri = XmlHelper.ReadTextElementAsTrimmedString(child);
+                //        else if (child.LocalName == DriverDictionary.KeySize.Value && child.NamespaceURI == DriverDictionary.Namespace.Value)
+                //            keySize = Int32.Parse(XmlHelper.ReadTextElementAsTrimmedString(child), NumberFormatInfo.InvariantInfo);
+                //        else if (child.LocalName == DriverDictionary.RequestedProofToken.Value && child.NamespaceURI == DriverDictionary.Namespace.Value)
+                //        {
+                //            XmlElement proofXml = XmlHelper.GetChildElement(child);
+                //            if (proofXml.LocalName == DriverDictionary.ComputedKey.Value && proofXml.NamespaceURI == DriverDictionary.Namespace.Value)
+                //            {
+                //                string computedKeyAlgorithm = XmlHelper.ReadTextElementAsTrimmedString(proofXml);
+                //                if (computedKeyAlgorithm != this.DriverDictionary.Psha1ComputedKeyUri.Value)
+                //                {
+                //                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new SecurityNegotiationException(SR.Format(SR.UnknownComputedKeyAlgorithm, computedKeyAlgorithm)));
+                //                }
+                //                computeKey = true;
+                //            }
+                //        }
+                //        else if (child.LocalName == DriverDictionary.Lifetime.Value && child.NamespaceURI == DriverDictionary.Namespace.Value)
+                //        {
+                //            XmlElement createdXml = XmlHelper.GetChildElement(child, UtilityStrings.CreatedElement, UtilityStrings.Namespace);
+                //            if (createdXml != null)
+                //            {
+                //                created = DateTime.ParseExact(XmlHelper.ReadTextElementAsTrimmedString(createdXml),
+                //                    WSUtilitySpecificationVersion.AcceptedDateTimeFormats, DateTimeFormatInfo.InvariantInfo, DateTimeStyles.None).ToUniversalTime();
+                //            }
+                //            XmlElement expiresXml = XmlHelper.GetChildElement(child, UtilityStrings.ExpiresElement, UtilityStrings.Namespace);
+                //            if (expiresXml != null)
+                //            {
+                //                expires = DateTime.ParseExact(XmlHelper.ReadTextElementAsTrimmedString(expiresXml),
+                //                    WSUtilitySpecificationVersion.AcceptedDateTimeFormats, DateTimeFormatInfo.InvariantInfo, DateTimeStyles.None).ToUniversalTime();
+                //            }
+                //        }
+                //    }
+                //}
+
+                //isRequestedTokenClosed = ReadRequestedTokenClosed(rstrXml);
+                //ReadReferences(rstrXml, out requestedAttachedReference, out requestedUnattachedReference);
+
+                //return new RequestSecurityTokenResponse(standardsManager, rstrXml, context, tokenTypeUri, keySize, requestedAttachedReference, requestedUnattachedReference,
+                //                                        computeKey, created, expires, isRequestedTokenClosed, issuedTokenBuffer);
+            }
+
+            public override RequestSecurityTokenResponseCollection CreateRequestSecurityTokenResponseCollection(XmlReader xmlReader)
+            {
+                XmlDictionaryReader reader = XmlDictionaryReader.CreateDictionaryReader(xmlReader);
+                List<RequestSecurityTokenResponse> rstrCollection = new List<RequestSecurityTokenResponse>(2);
+                string rootName = reader.Name;
+                reader.ReadStartElement(DriverDictionary.RequestSecurityTokenResponseCollection, DriverDictionary.Namespace);
+                while (reader.IsStartElement(DriverDictionary.RequestSecurityTokenResponse.Value, DriverDictionary.Namespace.Value))
+                {
+                    RequestSecurityTokenResponse rstr = this.CreateRequestSecurityTokenResponse(reader);
+                    rstrCollection.Add(rstr);
+                }
+                reader.ReadEndElement();
+                if (rstrCollection.Count == 0)
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new XmlException(SR.Format(SR.NoRequestSecurityTokenResponseElements)));
+                return new RequestSecurityTokenResponseCollection(rstrCollection.AsReadOnly(), this.StandardsManager);
+            }
+
+            XmlElement GetAppliesToElement(XmlElement rootElement)
+            {
+                if (rootElement == null)
+                {
+                    return null;
+                }
+                for (int i = 0; i < rootElement.ChildNodes.Count; ++i)
+                {
+                    XmlElement elem = (rootElement.ChildNodes[i] as XmlElement);
+                    if (elem != null)
+                    {
+                        throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+                        //if (elem.LocalName == DriverDictionary.AppliesTo.Value && elem.NamespaceURI == Namespaces.WSPolicy)
+                        //{
+                        //    return elem;
+                        //}
+                    }
+                }
+                return null;
+            }
+
+            T GetAppliesTo<T>(XmlElement rootXml, XmlObjectSerializer serializer)
+            {
+                XmlElement appliesToElement = GetAppliesToElement(rootXml);
+                if (appliesToElement != null)
+                {
+                    throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+                    //using (XmlReader reader = new XmlNodeReader(appliesToElement))
+                    //{
+                    //    reader.ReadStartElement();
+                    //    lock (serializer)
+                    //    {
+                    //        return (T)serializer.ReadObject(reader);
+                    //    }
+                    //}
+                }
+                else
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.NoAppliesToPresent)));
+                }
+            }
+
+            public override T GetAppliesTo<T>(RequestSecurityToken rst, XmlObjectSerializer serializer)
+            {
+                if (rst == null)
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("rst");
+
+                return GetAppliesTo<T>(rst.RequestSecurityTokenXml, serializer);
+            }
+
+            public override T GetAppliesTo<T>(RequestSecurityTokenResponse rstr, XmlObjectSerializer serializer)
+            {
+                if (rstr == null)
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("rstr");
+
+                return GetAppliesTo<T>(rstr.RequestSecurityTokenResponseXml, serializer);
+            }
+
+            public override bool IsAppliesTo(string localName, string namespaceUri)
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+                //return (localName == DriverDictionary.AppliesTo.Value && namespaceUri == Namespaces.WSPolicy);
+            }
+
+            void GetAppliesToQName(XmlElement rootElement, out string localName, out string namespaceUri)
+            {
+                localName = namespaceUri = null;
+                XmlElement appliesToElement = GetAppliesToElement(rootElement);
+                if (appliesToElement != null)
+                {
+                    throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+                    //using (XmlReader reader = new XmlNodeReader(appliesToElement))
+                    //{
+                    //    reader.ReadStartElement();
+                    //    reader.MoveToContent();
+                    //    localName = reader.LocalName;
+                    //    namespaceUri = reader.NamespaceURI;
+                    //}
+                }
+            }
+
+            public override void GetAppliesToQName(RequestSecurityToken rst, out string localName, out string namespaceUri)
+            {
+                if (rst == null)
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("rst");
+
+                GetAppliesToQName(rst.RequestSecurityTokenXml, out localName, out namespaceUri);
+            }
+
+            public override void GetAppliesToQName(RequestSecurityTokenResponse rstr, out string localName, out string namespaceUri)
+            {
+                if (rstr == null)
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("rstr");
+
+                GetAppliesToQName(rstr.RequestSecurityTokenResponseXml, out localName, out namespaceUri);
+            }
+
+            public override byte[] GetAuthenticator(RequestSecurityTokenResponse rstr)
+            {
+                if (rstr != null && rstr.RequestSecurityTokenResponseXml != null && rstr.RequestSecurityTokenResponseXml.ChildNodes != null)
+                {
+                    for (int i = 0; i < rstr.RequestSecurityTokenResponseXml.ChildNodes.Count; ++i)
+                    {
+                        XmlElement element = rstr.RequestSecurityTokenResponseXml.ChildNodes[i] as XmlElement;
+                        if (element != null)
+                        {
+                            if (element.LocalName == DriverDictionary.Authenticator.Value && element.NamespaceURI == DriverDictionary.Namespace.Value)
+                            {
+                                XmlElement combinedHashElement = XmlHelper.GetChildElement(element);
+                                if (combinedHashElement.LocalName == DriverDictionary.CombinedHash.Value && combinedHashElement.NamespaceURI == DriverDictionary.Namespace.Value)
+                                {
+                                    throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+                                    //string authenticatorString = XmlHelper.ReadTextElementAsTrimmedString(combinedHashElement);
+                                    //return Convert.FromBase64String(authenticatorString);
+                                }
+                            }
+                        }
+                    }
+                }
+                return null;
+            }
+
+            public override BinaryNegotiation GetBinaryNegotiation(RequestSecurityTokenResponse rstr)
+            {
+                if (rstr == null)
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("rstr");
+
+                return GetBinaryNegotiation(rstr.RequestSecurityTokenResponseXml);
+            }
+
+            public override BinaryNegotiation GetBinaryNegotiation(RequestSecurityToken rst)
+            {
+                if (rst == null)
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("rst");
+
+                return GetBinaryNegotiation(rst.RequestSecurityTokenXml);
+            }
+
+            BinaryNegotiation GetBinaryNegotiation(XmlElement rootElement)
+            {
+                if (rootElement == null)
+                {
+                    return null;
+                }
+                for (int i = 0; i < rootElement.ChildNodes.Count; ++i)
+                {
+                    XmlElement elem = rootElement.ChildNodes[i] as XmlElement;
+                    if (elem != null)
+                    {
+                        if (elem.LocalName == DriverDictionary.BinaryExchange.Value && elem.NamespaceURI == DriverDictionary.Namespace.Value)
+                        {
+                            return ReadBinaryNegotiation(elem);
+                        }
+                    }
+                }
+                return null;
+            }
+
+            public override SecurityToken GetEntropy(RequestSecurityToken rst, SecurityTokenResolver resolver)
+            {
+                if (rst == null)
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("rst");
+
+                return GetEntropy(rst.RequestSecurityTokenXml, resolver);
+            }
+
+            public override SecurityToken GetEntropy(RequestSecurityTokenResponse rstr, SecurityTokenResolver resolver)
+            {
+                if (rstr == null)
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("rstr");
+
+                return GetEntropy(rstr.RequestSecurityTokenResponseXml, resolver);
+            }
+
+            SecurityToken GetEntropy(XmlElement rootElement, SecurityTokenResolver resolver)
+            {
+                if (rootElement == null || rootElement.ChildNodes == null)
+                {
+                    return null;
+                }
+                for (int i = 0; i < rootElement.ChildNodes.Count; ++i)
+                {
+                    XmlElement element = rootElement.ChildNodes[i] as XmlElement;
+                    if (element != null)
+                    {
+                        throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+
+                        //if (element.LocalName == DriverDictionary.Entropy.Value && element.NamespaceURI == DriverDictionary.Namespace.Value)
+                        //{
+                        //    XmlElement tokenXml = XmlHelper.GetChildElement(element);
+                        //    string valueTypeUri = element.GetAttribute(SecurityJan2004Strings.ValueType);
+                        //    if (valueTypeUri.Length == 0)
+                        //        valueTypeUri = null;
+                        //    return standardsManager.SecurityTokenSerializer.ReadToken(new XmlNodeReader(tokenXml), resolver);
+                        //}
+                    }
+                }
+                return null;
+            }
+
+            void GetIssuedAndProofXml(RequestSecurityTokenResponse rstr, out XmlElement issuedTokenXml, out XmlElement proofTokenXml)
+            {
+                issuedTokenXml = null;
+                proofTokenXml = null;
+                if ((rstr.RequestSecurityTokenResponseXml != null) && (rstr.RequestSecurityTokenResponseXml.ChildNodes != null))
+                {
+                    for (int i = 0; i < rstr.RequestSecurityTokenResponseXml.ChildNodes.Count; ++i)
+                    {
+                        XmlElement elem = rstr.RequestSecurityTokenResponseXml.ChildNodes[i] as XmlElement;
+                        if (elem != null)
+                        {
+                            if (elem.LocalName == DriverDictionary.RequestedSecurityToken.Value && elem.NamespaceURI == DriverDictionary.Namespace.Value)
+                            {
+                                if (issuedTokenXml != null)
+                                {
+                                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.RstrHasMultipleIssuedTokens)));
+                                }
+                                issuedTokenXml = XmlHelper.GetChildElement(elem);
+                            }
+                            else if (elem.LocalName == DriverDictionary.RequestedProofToken.Value && elem.NamespaceURI == DriverDictionary.Namespace.Value)
+                            {
+                                if (proofTokenXml != null)
+                                {
+                                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.RstrHasMultipleProofTokens)));
+                                }
+                                proofTokenXml = XmlHelper.GetChildElement(elem);
+                            }
+                        }
+                    }
+                }
+            }
+
+            /// <summary>
+            /// The algorithm for computing the key is:
+            /// 1. If there is requestorEntropy:
+            ///    a. If there is no <RequestedProofToken> use the requestorEntropy as the key
+            ///    b. If there is a <RequestedProofToken> with a ComputedKeyUri, combine the client and server entropies
+            ///    c. Anything else, throw
+            /// 2. If there is no requestorEntropy:
+            ///    a. THere has to be a <RequestedProofToken> that contains the proof key
+            /// </summary>
+            /// 
+
+            ////// Issue #31 in progress
+            ////public override GenericXmlSecurityToken GetIssuedToken(RequestSecurityTokenResponse rstr, SecurityTokenResolver resolver, IList<SecurityTokenAuthenticator> allowedAuthenticators, SecurityKeyEntropyMode keyEntropyMode, byte[] requestorEntropy, string expectedTokenType,
+            ////    ReadOnlyCollection<IAuthorizationPolicy> authorizationPolicies, int defaultKeySize, bool isBearerKeyType)
+            ////{
+
+            ////    SecurityKeyEntropyModeHelper.Validate(keyEntropyMode);
+
+            ////    if (defaultKeySize < 0)
+            ////    {
+            ////        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("defaultKeySize", SR.Format(SR.ValueMustBeNonNegative)));
+            ////    }
+
+            ////    if (rstr == null)
+            ////        throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("rstr");
+
+            ////    string tokenType;
+            ////    if (rstr.TokenType != null)
+            ////    {
+            ////        if (expectedTokenType != null && expectedTokenType != rstr.TokenType)
+            ////        {
+            ////            throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.BadIssuedTokenType, rstr.TokenType, expectedTokenType)));
+            ////        }
+            ////        tokenType = rstr.TokenType;
+            ////    }
+            ////    else
+            ////    {
+            ////        tokenType = expectedTokenType;
+            ////    }
+
+            ////    // search the response elements for licenseXml, proofXml, and lifetime
+            ////    DateTime created = rstr.ValidFrom;
+            ////    DateTime expires = rstr.ValidTo;
+            ////    XmlElement proofXml;
+            ////    XmlElement issuedTokenXml;
+            ////    GetIssuedAndProofXml(rstr, out issuedTokenXml, out proofXml);
+
+            ////    if (issuedTokenXml == null)
+            ////        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.NoLicenseXml)));
+
+            ////    if (isBearerKeyType)
+            ////    {
+            ////        if (proofXml != null)
+            ////            throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.BearerKeyTypeCannotHaveProofKey)));
+
+            ////        return new GenericXmlSecurityToken(issuedTokenXml, null, created, expires, rstr.RequestedAttachedReference, rstr.RequestedUnattachedReference, authorizationPolicies);
+            ////    }
+
+            ////    SecurityToken proofToken;
+            ////    SecurityToken entropyToken = GetEntropy(rstr, resolver);
+            ////    if (keyEntropyMode == SecurityKeyEntropyMode.ClientEntropy)
+            ////    {
+            ////        if (requestorEntropy == null)
+            ////        {
+            ////            throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.EntropyModeRequiresRequestorEntropy, keyEntropyMode)));
+            ////        }
+            ////        // enforce that there is no entropy or proof token in the RSTR
+            ////        if (proofXml != null || entropyToken != null)
+            ////        {
+            ////            throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.EntropyModeCannotHaveProofTokenOrIssuerEntropy, keyEntropyMode)));
+            ////        }
+            ////        proofToken = new BinarySecretSecurityToken(requestorEntropy);
+            ////    }
+            ////    else if (keyEntropyMode == SecurityKeyEntropyMode.ServerEntropy)
+            ////    {
+            ////        if (requestorEntropy != null)
+            ////        {
+            ////            throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.EntropyModeCannotHaveRequestorEntropy, keyEntropyMode)));
+            ////        }
+            ////        if (rstr.ComputeKey || entropyToken != null)
+            ////        {
+            ////            throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.EntropyModeCannotHaveComputedKey, keyEntropyMode)));
+            ////        }
+            ////        if (proofXml == null)
+            ////        {
+            ////            throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.EntropyModeRequiresProofToken, keyEntropyMode)));
+            ////        }
+            ////        string valueTypeUri = proofXml.GetAttribute(SecurityJan2004Strings.ValueType);
+            ////        if (valueTypeUri.Length == 0)
+            ////            valueTypeUri = null;
+            ////        proofToken = standardsManager.SecurityTokenSerializer.ReadToken(new XmlNodeReader(proofXml), resolver);
+            ////    }
+            ////    else
+            ////    {
+            ////        if (!rstr.ComputeKey)
+            ////        {
+            ////            throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.EntropyModeRequiresComputedKey, keyEntropyMode)));
+            ////        }
+            ////        if (entropyToken == null)
+            ////        {
+            ////            throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.EntropyModeRequiresIssuerEntropy, keyEntropyMode)));
+            ////        }
+            ////        if (requestorEntropy == null)
+            ////        {
+            ////            throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.EntropyModeRequiresRequestorEntropy, keyEntropyMode)));
+            ////        }
+            ////        if (rstr.KeySize == 0 && defaultKeySize == 0)
+            ////        {
+            ////            throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.RstrKeySizeNotProvided)));
+            ////        }
+            ////        int issuedKeySize = (rstr.KeySize != 0) ? rstr.KeySize : defaultKeySize;
+            ////        byte[] issuerEntropy;
+            ////        if (entropyToken is BinarySecretSecurityToken)
+            ////            issuerEntropy = ((BinarySecretSecurityToken)entropyToken).GetKeyBytes();
+            ////        else if (entropyToken is WrappedKeySecurityToken)
+            ////            issuerEntropy = ((WrappedKeySecurityToken)entropyToken).GetWrappedKey();
+            ////        else
+            ////            throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new NotSupportedException(SR.Format(SR.UnsupportedIssuerEntropyType)));
+            ////        // compute the PSHA1 derived key
+            ////        byte[] issuedKey = RequestSecurityTokenResponse.ComputeCombinedKey(requestorEntropy, issuerEntropy, issuedKeySize);
+            ////        proofToken = new BinarySecretSecurityToken(issuedKey);
+            ////    }
+
+            ////    SecurityKeyIdentifierClause internalReference = rstr.RequestedAttachedReference;
+            ////    SecurityKeyIdentifierClause externalReference = rstr.RequestedUnattachedReference;
+
+            ////    return new BufferedGenericXmlSecurityToken(issuedTokenXml, proofToken, created, expires, internalReference, externalReference, authorizationPolicies, rstr.IssuedTokenBuffer);
+            ////}
+
+            //public override GenericXmlSecurityToken GetIssuedToken(RequestSecurityTokenResponse rstr, string expectedTokenType,
+            //    ReadOnlyCollection<IAuthorizationPolicy> authorizationPolicies, RSA clientKey)
+            //{
+            //    if (rstr == null)
+            //        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentNullException("rstr"));
+
+            //    string tokenType;
+            //    if (rstr.TokenType != null)
+            //    {
+            //        if (expectedTokenType != null && expectedTokenType != rstr.TokenType)
+            //        {
+            //            throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.BadIssuedTokenType, rstr.TokenType, expectedTokenType)));
+            //        }
+            //        tokenType = rstr.TokenType;
+            //    }
+            //    else
+            //    {
+            //        tokenType = expectedTokenType;
+            //    }
+
+            //    // search the response elements for licenseXml, proofXml, and lifetime
+            //    DateTime created = rstr.ValidFrom;
+            //    DateTime expires = rstr.ValidTo;
+            //    XmlElement proofXml;
+            //    XmlElement issuedTokenXml;
+            //    GetIssuedAndProofXml(rstr, out issuedTokenXml, out proofXml);
+
+            //    if (issuedTokenXml == null)
+            //        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.NoLicenseXml)));
+
+            //    // enforce that there is no proof token in the RSTR
+            //    if (proofXml != null)
+            //    {
+            //        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.ProofTokenXmlUnexpectedInRstr)));
+            //    }
+            //    SecurityKeyIdentifierClause internalReference = rstr.RequestedAttachedReference;
+            //    SecurityKeyIdentifierClause externalReference = rstr.RequestedUnattachedReference;
+
+            //    SecurityToken proofToken = new RsaSecurityToken(clientKey);
+            //    return new BufferedGenericXmlSecurityToken(issuedTokenXml, proofToken, created, expires, internalReference, externalReference, authorizationPolicies, rstr.IssuedTokenBuffer);
+            //}
+
+            public override bool IsAtRequestSecurityTokenResponse(XmlReader reader)
+            {
+                if (reader == null)
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("reader");
+
+                return reader.IsStartElement(DriverDictionary.RequestSecurityTokenResponse.Value, DriverDictionary.Namespace.Value);
+            }
+
+            public override bool IsAtRequestSecurityTokenResponseCollection(XmlReader reader)
+            {
+                if (reader == null)
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("reader");
+
+                return reader.IsStartElement(DriverDictionary.RequestSecurityTokenResponseCollection.Value, DriverDictionary.Namespace.Value);
+            }
+
+            public override bool IsRequestedSecurityTokenElement(string name, string nameSpace)
+            {
+                return (name == DriverDictionary.RequestedSecurityToken.Value && nameSpace == DriverDictionary.Namespace.Value);
+            }
+
+            public override bool IsRequestedProofTokenElement(string name, string nameSpace)
+            {
+                return (name == DriverDictionary.RequestedProofToken.Value && nameSpace == DriverDictionary.Namespace.Value);
+            }
+
+            public static BinaryNegotiation ReadBinaryNegotiation(XmlElement elem)
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+
+                //if (elem == null)
+                //    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("elem");
+
+                //// get the encoding and valueType attributes
+                //string encodingUri = null;
+                //string valueTypeUri = null;
+                //byte[] negotiationData = null;
+                //if (elem.Attributes != null)
+                //{
+                //    for (int i = 0; i < elem.Attributes.Count; ++i)
+                //    {
+                //        XmlAttribute attr = elem.Attributes[i];
+                //        if (attr.LocalName == SecurityJan2004Strings.EncodingType && attr.NamespaceURI.Length == 0)
+                //        {
+                //            encodingUri = attr.Value;
+                //            if (encodingUri != base64Uri && encodingUri != hexBinaryUri)
+                //            {
+                //                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new XmlException(SR.Format(SR.UnsupportedBinaryEncoding, encodingUri)));
+                //            }
+                //        }
+                //        else if (attr.LocalName == SecurityJan2004Strings.ValueType && attr.NamespaceURI.Length == 0)
+                //        {
+                //            valueTypeUri = attr.Value;
+                //        }
+                //        // ignore all other attributes
+                //    }
+                //}
+                //if (encodingUri == null)
+                //{
+                //    XmlHelper.OnRequiredAttributeMissing("EncodingType", elem.Name);
+                //}
+                //if (valueTypeUri == null)
+                //{
+                //    XmlHelper.OnRequiredAttributeMissing("ValueType", elem.Name);
+                //}
+                //string encodedBlob = XmlHelper.ReadTextElementAsTrimmedString(elem);
+                //if (encodingUri == base64Uri)
+                //{
+                //    negotiationData = Convert.FromBase64String(encodedBlob);
+                //}
+                //else
+                //{
+                //    negotiationData = HexBinary.Parse(encodedBlob).Value;
+                //}
+                //return new BinaryNegotiation(valueTypeUri, negotiationData);
+            }
+
+            // Note in Apr2004, internal & external references aren't supported - 
+            // our strategy is to see if there's a token reference (and use it for external ref) and backup is to scan the token xml to compute reference
+            protected virtual void ReadReferences(XmlElement rstrXml, out SecurityKeyIdentifierClause requestedAttachedReference,
+                    out SecurityKeyIdentifierClause requestedUnattachedReference)
+            {
+                XmlElement issuedTokenXml = null;
+                requestedAttachedReference = null;
+                requestedUnattachedReference = null;
+                for (int i = 0; i < rstrXml.ChildNodes.Count; ++i)
+                {
+                    XmlElement child = rstrXml.ChildNodes[i] as XmlElement;
+                    if (child != null)
+                    {
+                        if (child.LocalName == DriverDictionary.RequestedSecurityToken.Value && child.NamespaceURI == DriverDictionary.Namespace.Value)
+                        {
+                            issuedTokenXml = XmlHelper.GetChildElement(child);
+                        }
+                        else if (child.LocalName == DriverDictionary.RequestedTokenReference.Value && child.NamespaceURI == DriverDictionary.Namespace.Value)
+                        {
+                            requestedUnattachedReference = GetKeyIdentifierXmlReferenceClause(XmlHelper.GetChildElement(child));
+                        }
+                    }
+                }
+
+                if (issuedTokenXml != null)
+                {
+                    throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+
+                    //requestedAttachedReference = standardsManager.CreateKeyIdentifierClauseFromTokenXml(issuedTokenXml, SecurityTokenReferenceStyle.Internal);
+                    //if (requestedUnattachedReference == null)
+                    //{
+                    //    try
+                    //    {
+                    //        requestedUnattachedReference = standardsManager.CreateKeyIdentifierClauseFromTokenXml(issuedTokenXml, SecurityTokenReferenceStyle.External);
+                    //    }
+                    //    catch (XmlException)
+                    //    {
+                    //        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new XmlException(SR.Format(SR.TrustDriverIsUnableToCreatedNecessaryAttachedOrUnattachedReferences, issuedTokenXml.ToString())));
+                    //    }
+                    //}
+                }
+            }
+
+            // Issue #31 in progress
+            //internal bool TryReadKeyIdentifierClause(XmlNodeReader reader, out SecurityKeyIdentifierClause keyIdentifierClause)
+            //{
+            //    keyIdentifierClause = null;
+
+            //    try
+            //    {
+            //        keyIdentifierClause = standardsManager.SecurityTokenSerializer.ReadKeyIdentifierClause(reader);
+            //    }
+            //    catch (XmlException e)
+            //    {
+            //        if (Fx.IsFatal(e))
+            //        {
+            //            throw;
+            //        }
+
+            //        keyIdentifierClause = null;
+            //        return false;
+            //    }
+            //    catch (Exception e)
+            //    {
+            //        if (Fx.IsFatal(e))
+            //        {
+            //            throw;
+            //        }
+
+            //        keyIdentifierClause = null;
+            //        return false;
+            //    }
+
+            //    return true;
+            //}
+
+            //internal SecurityKeyIdentifierClause CreateGenericXmlSecurityKeyIdentifierClause(XmlNodeReader reader, XmlElement keyIdentifierReferenceXmlElement)
+            //{
+            //    SecurityKeyIdentifierClause keyIdentifierClause = null;
+            //    XmlDictionaryReader localReader = XmlDictionaryReader.CreateDictionaryReader(reader);
+            //    string strId = localReader.GetAttribute(XD.UtilityDictionary.IdAttribute, XD.UtilityDictionary.Namespace);
+            //    keyIdentifierClause = new GenericXmlSecurityKeyIdentifierClause(keyIdentifierReferenceXmlElement);
+            //    if (!String.IsNullOrEmpty(strId))
+            //    {
+            //        keyIdentifierClause.Id = strId;
+            //    }
+            //    return keyIdentifierClause;
+            //}
+
+            internal SecurityKeyIdentifierClause GetKeyIdentifierXmlReferenceClause(XmlElement keyIdentifierReferenceXmlElement)
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+
+                //SecurityKeyIdentifierClause keyIdentifierClause = null;
+                //XmlNodeReader reader = new XmlNodeReader(keyIdentifierReferenceXmlElement);
+                //if (!this.TryReadKeyIdentifierClause(reader, out keyIdentifierClause))
+                //{
+                //    keyIdentifierClause = CreateGenericXmlSecurityKeyIdentifierClause(new XmlNodeReader(keyIdentifierReferenceXmlElement), keyIdentifierReferenceXmlElement);
+                //}
+
+                //return keyIdentifierClause;
+            }
+
+            protected virtual bool ReadRequestedTokenClosed(XmlElement rstrXml)
+            {
+                return false;
+            }
+
+            protected virtual void ReadTargets(XmlElement rstXml, out SecurityKeyIdentifierClause renewTarget, out SecurityKeyIdentifierClause closeTarget)
+            {
+                renewTarget = null;
+                closeTarget = null;
+            }
+
+            public override void OnRSTRorRSTRCMissingException()
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new XmlException(SR.Format(SR.ExpectedOneOfTwoElementsFromNamespace,
+                    DriverDictionary.RequestSecurityTokenResponse, DriverDictionary.RequestSecurityTokenResponseCollection,
+                    DriverDictionary.Namespace)));
+            }
+
+            void WriteAppliesTo(object appliesTo, Type appliesToType, XmlObjectSerializer serializer, XmlWriter xmlWriter)
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+
+                //XmlDictionaryWriter writer = XmlDictionaryWriter.CreateDictionaryWriter(xmlWriter);
+                //writer.WriteStartElement(Namespaces.WSPolicyPrefix, DriverDictionary.AppliesTo.Value, Namespaces.WSPolicy);
+                //lock (serializer)
+                //{
+                //    serializer.WriteObject(writer, appliesTo);
+                //}
+                //writer.WriteEndElement();
+            }
+
+            public void WriteBinaryNegotiation(BinaryNegotiation negotiation, XmlWriter xmlWriter)
+            {
+                if (negotiation == null)
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("negotiation");
+
+                XmlDictionaryWriter writer = XmlDictionaryWriter.CreateDictionaryWriter(xmlWriter);
+                negotiation.WriteTo(writer, this.DriverDictionary.Prefix.Value,
+                                            this.DriverDictionary.BinaryExchange, this.DriverDictionary.Namespace,
+                                            XD.SecurityJan2004Dictionary.ValueType, null);
+            }
+
+            public override void WriteRequestSecurityToken(RequestSecurityToken rst, XmlWriter xmlWriter)
+            {
+                if (rst == null)
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("rst");
+                }
+                if (xmlWriter == null)
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("xmlWriter");
+                }
+                XmlDictionaryWriter writer = XmlDictionaryWriter.CreateDictionaryWriter(xmlWriter);
+                if (rst.IsReceiver)
+                {
+                    rst.WriteTo(writer);
+                    return;
+                }
+                writer.WriteStartElement(DriverDictionary.Prefix.Value, DriverDictionary.RequestSecurityToken, DriverDictionary.Namespace);
+                XmlHelper.AddNamespaceDeclaration(writer, DriverDictionary.Prefix.Value, DriverDictionary.Namespace);
+                if (rst.Context != null)
+                    writer.WriteAttributeString(DriverDictionary.Context, null, rst.Context);
+
+                rst.OnWriteCustomAttributes(writer);
+                if (rst.TokenType != null)
+                {
+                    writer.WriteStartElement(DriverDictionary.Prefix.Value, DriverDictionary.TokenType, DriverDictionary.Namespace);
+                    writer.WriteString(rst.TokenType);
+                    writer.WriteEndElement();
+                }
+                if (rst.RequestType != null)
+                {
+                    writer.WriteStartElement(DriverDictionary.Prefix.Value, DriverDictionary.RequestType, DriverDictionary.Namespace);
+                    writer.WriteString(rst.RequestType);
+                    writer.WriteEndElement();
+                }
+
+                if (rst.AppliesTo != null)
+                {
+                    WriteAppliesTo(rst.AppliesTo, rst.AppliesToType, rst.AppliesToSerializer, writer);
+                }
+
+                SecurityToken entropyToken = rst.GetRequestorEntropy();
+                if (entropyToken != null)
+                {
+                    throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+                    //writer.WriteStartElement(DriverDictionary.Prefix.Value, DriverDictionary.Entropy, DriverDictionary.Namespace);
+                    //standardsManager.SecurityTokenSerializer.WriteToken(writer, entropyToken);
+                    //writer.WriteEndElement();
+                }
+
+                if (rst.KeySize != 0)
+                {
+                    writer.WriteStartElement(DriverDictionary.Prefix.Value, DriverDictionary.KeySize, DriverDictionary.Namespace);
+                    writer.WriteValue(rst.KeySize);
+                    writer.WriteEndElement();
+                }
+
+                BinaryNegotiation negotiationData = rst.GetBinaryNegotiation();
+                if (negotiationData != null)
+                    WriteBinaryNegotiation(negotiationData, writer);
+
+                WriteTargets(rst, writer);
+
+                if (rst.RequestProperties != null)
+                {
+                    foreach (XmlElement property in rst.RequestProperties)
+                    {
+                        property.WriteTo(writer);
+                    }
+                }
+
+                rst.OnWriteCustomElements(writer);
+                writer.WriteEndElement();
+            }
+
+            protected virtual void WriteTargets(RequestSecurityToken rst, XmlDictionaryWriter writer)
+            {
+            }
+
+            // Note in Apr2004, internal & external references aren't supported - our strategy is to generate the external ref as the TokenReference.
+            protected virtual void WriteReferences(RequestSecurityTokenResponse rstr, XmlDictionaryWriter writer)
+            {
+                if (rstr.RequestedUnattachedReference != null)
+                {
+                    throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+
+                    //writer.WriteStartElement(DriverDictionary.Prefix.Value, DriverDictionary.RequestedTokenReference, DriverDictionary.Namespace);
+                    //standardsManager.SecurityTokenSerializer.WriteKeyIdentifierClause(writer, rstr.RequestedUnattachedReference);
+                    //writer.WriteEndElement();
+                }
+            }
+
+            protected virtual void WriteRequestedTokenClosed(RequestSecurityTokenResponse rstr, XmlDictionaryWriter writer)
+            {
+            }
+
+            public override void WriteRequestSecurityTokenResponse(RequestSecurityTokenResponse rstr, XmlWriter xmlWriter)
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+
+                //if (rstr == null)
+                //    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("rstr");
+                //if (xmlWriter == null)
+                //    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("xmlWriter");
+                //XmlDictionaryWriter writer = XmlDictionaryWriter.CreateDictionaryWriter(xmlWriter);
+                //if (rstr.IsReceiver)
+                //{
+                //    rstr.WriteTo(writer);
+                //    return;
+                //}
+                //writer.WriteStartElement(DriverDictionary.Prefix.Value, DriverDictionary.RequestSecurityTokenResponse, DriverDictionary.Namespace);
+                //if (rstr.Context != null)
+                //{
+                //    writer.WriteAttributeString(DriverDictionary.Context, null, rstr.Context);
+                //}
+                //// define WSUtility at the top level to avoid multiple definitions below
+                //XmlHelper.AddNamespaceDeclaration(writer, UtilityStrings.Prefix, XD.UtilityDictionary.Namespace);
+                //rstr.OnWriteCustomAttributes(writer);
+
+                //if (rstr.TokenType != null)
+                //    writer.WriteElementString(DriverDictionary.Prefix.Value, DriverDictionary.TokenType, DriverDictionary.Namespace, rstr.TokenType);
+
+                //if (rstr.RequestedSecurityToken != null)
+                //{
+                //    writer.WriteStartElement(DriverDictionary.Prefix.Value, DriverDictionary.RequestedSecurityToken, DriverDictionary.Namespace);
+                //    standardsManager.SecurityTokenSerializer.WriteToken(writer, rstr.RequestedSecurityToken);
+                //    writer.WriteEndElement();
+                //}
+
+                //if (rstr.AppliesTo != null)
+                //{
+                //    WriteAppliesTo(rstr.AppliesTo, rstr.AppliesToType, rstr.AppliesToSerializer, writer);
+                //}
+
+                //WriteReferences(rstr, writer);
+
+                //if (rstr.ComputeKey || rstr.RequestedProofToken != null)
+                //{
+                //    writer.WriteStartElement(DriverDictionary.Prefix.Value, DriverDictionary.RequestedProofToken, DriverDictionary.Namespace);
+                //    if (rstr.ComputeKey)
+                //    {
+                //        writer.WriteElementString(DriverDictionary.Prefix.Value, DriverDictionary.ComputedKey, DriverDictionary.Namespace, DriverDictionary.Psha1ComputedKeyUri.Value);
+                //    }
+                //    else
+                //    {
+                //        standardsManager.SecurityTokenSerializer.WriteToken(writer, rstr.RequestedProofToken);
+                //    }
+                //    writer.WriteEndElement();
+                //}
+
+                //SecurityToken entropyToken = rstr.GetIssuerEntropy();
+                //if (entropyToken != null)
+                //{
+                //    writer.WriteStartElement(DriverDictionary.Prefix.Value, DriverDictionary.Entropy, DriverDictionary.Namespace);
+                //    standardsManager.SecurityTokenSerializer.WriteToken(writer, entropyToken);
+                //    writer.WriteEndElement();
+                //}
+
+                //// To write out the lifetime, the following algorithm is used
+                ////   1. If the lifetime is explicitly set, write it out.
+                ////   2. Else, if a token/tokenbuilder has been set, use the lifetime in that.
+                ////   3. Else do not serialize lifetime
+                //if (rstr.IsLifetimeSet || rstr.RequestedSecurityToken != null)
+                //{
+                //    DateTime effectiveTime = SecurityUtils.MinUtcDateTime;
+                //    DateTime expirationTime = SecurityUtils.MaxUtcDateTime;
+
+                //    if (rstr.IsLifetimeSet)
+                //    {
+                //        effectiveTime = rstr.ValidFrom.ToUniversalTime();
+                //        expirationTime = rstr.ValidTo.ToUniversalTime();
+                //    }
+                //    else if (rstr.RequestedSecurityToken != null)
+                //    {
+                //        effectiveTime = rstr.RequestedSecurityToken.ValidFrom.ToUniversalTime();
+                //        expirationTime = rstr.RequestedSecurityToken.ValidTo.ToUniversalTime();
+                //    }
+
+                //    // write out the lifetime
+                //    writer.WriteStartElement(DriverDictionary.Prefix.Value, DriverDictionary.Lifetime, DriverDictionary.Namespace);
+                //    // write out Created
+                //    writer.WriteStartElement(XD.UtilityDictionary.Prefix.Value, XD.UtilityDictionary.CreatedElement, XD.UtilityDictionary.Namespace);
+                //    writer.WriteString(effectiveTime.ToString("yyyy-MM-ddTHH:mm:ss.fffZ", CultureInfo.InvariantCulture.DateTimeFormat));
+                //    writer.WriteEndElement(); // wsu:Created
+                //    // write out Expires
+                //    writer.WriteStartElement(XD.UtilityDictionary.Prefix.Value, XD.UtilityDictionary.ExpiresElement, XD.UtilityDictionary.Namespace);
+                //    writer.WriteString(expirationTime.ToString("yyyy-MM-ddTHH:mm:ss.fffZ", CultureInfo.InvariantCulture.DateTimeFormat));
+                //    writer.WriteEndElement(); // wsu:Expires
+                //    writer.WriteEndElement(); // wsse:Lifetime
+                //}
+
+                //byte[] authenticator = rstr.GetAuthenticator();
+                //if (authenticator != null)
+                //{
+                //    writer.WriteStartElement(DriverDictionary.Prefix.Value, DriverDictionary.Authenticator, DriverDictionary.Namespace);
+                //    writer.WriteStartElement(DriverDictionary.Prefix.Value, DriverDictionary.CombinedHash, DriverDictionary.Namespace);
+                //    writer.WriteBase64(authenticator, 0, authenticator.Length);
+                //    writer.WriteEndElement();
+                //    writer.WriteEndElement();
+                //}
+
+                //if (rstr.KeySize > 0)
+                //{
+                //    writer.WriteStartElement(DriverDictionary.Prefix.Value, DriverDictionary.KeySize, DriverDictionary.Namespace);
+                //    writer.WriteValue(rstr.KeySize);
+                //    writer.WriteEndElement();
+                //}
+
+                //WriteRequestedTokenClosed(rstr, writer);
+
+                //BinaryNegotiation negotiationData = rstr.GetBinaryNegotiation();
+                //if (negotiationData != null)
+                //    WriteBinaryNegotiation(negotiationData, writer);
+
+                //rstr.OnWriteCustomElements(writer);
+                //writer.WriteEndElement();
+            }
+
+            public override void WriteRequestSecurityTokenResponseCollection(RequestSecurityTokenResponseCollection rstrCollection, XmlWriter xmlWriter)
+            {
+                if (rstrCollection == null)
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("rstrCollection");
+
+                XmlDictionaryWriter writer = XmlDictionaryWriter.CreateDictionaryWriter(xmlWriter);
+                writer.WriteStartElement(DriverDictionary.Prefix.Value, DriverDictionary.RequestSecurityTokenResponseCollection, DriverDictionary.Namespace);
+                foreach (RequestSecurityTokenResponse rstr in rstrCollection.RstrCollection)
+                {
+                    rstr.WriteTo(writer);
+                }
+                writer.WriteEndElement();
+            }
+
+            protected void SetProtectionLevelForFederation(OperationDescriptionCollection operations)
+            {
+                foreach (OperationDescription operation in operations)
+                {
+                    foreach (MessageDescription message in operation.Messages)
+                    {
+                        if (message.Body.Parts.Count > 0)
+                        {
+                            foreach (MessagePartDescription part in message.Body.Parts)
+                            {
+                                part.ProtectionLevel = System.Net.Security.ProtectionLevel.EncryptAndSign;
+                            }
+                        }
+                        if (OperationFormatter.IsValidReturnValue(message.Body.ReturnValue))
+                        {
+                            message.Body.ReturnValue.ProtectionLevel = System.Net.Security.ProtectionLevel.EncryptAndSign;
+                        }
+                    }
+                }
+            }
+
+            // Issue #31 in progress
+            //public override bool TryParseKeySizeElement(XmlElement element, out int keySize)
+            //{
+            //    if (element == null)
+            //        throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("element");
+
+            //    if (element.LocalName == this.DriverDictionary.KeySize.Value
+            //        && element.NamespaceURI == this.DriverDictionary.Namespace.Value)
+            //    {
+            //        keySize = Int32.Parse(XmlHelper.ReadTextElementAsTrimmedString(element), NumberFormatInfo.InvariantInfo);
+            //        return true;
+            //    }
+
+            //    keySize = 0;
+            //    return false;
+            //}
+
+            //public override XmlElement CreateKeySizeElement(int keySize)
+            //{
+            //    if (keySize < 0)
+            //    {
+            //        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("keySize", SR.Format(SR.ValueMustBeNonNegative)));
+            //    }
+            //    XmlDocument doc = new XmlDocument();
+            //    XmlElement result = doc.CreateElement(this.DriverDictionary.Prefix.Value, this.DriverDictionary.KeySize.Value,
+            //        this.DriverDictionary.Namespace.Value);
+            //    result.AppendChild(doc.CreateTextNode(keySize.ToString(System.Globalization.CultureInfo.InvariantCulture.NumberFormat)));
+            //    return result;
+            //}
+
+            //public override XmlElement CreateKeyTypeElement(SecurityKeyType keyType)
+            //{
+            //    if (keyType == SecurityKeyType.SymmetricKey)
+            //        return CreateSymmetricKeyTypeElement();
+            //    else if (keyType == SecurityKeyType.AsymmetricKey)
+            //        return CreatePublicKeyTypeElement();
+            //    else
+            //        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.UnableToCreateKeyTypeElementForUnknownKeyType, keyType.ToString())));
+            //}
+
+            //public override bool TryParseKeyTypeElement(XmlElement element, out SecurityKeyType keyType)
+            //{
+            //    if (element == null)
+            //        throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("element");
+
+            //    if (TryParseSymmetricKeyElement(element))
+            //    {
+            //        keyType = SecurityKeyType.SymmetricKey;
+            //        return true;
+            //    }
+            //    else if (TryParsePublicKeyElement(element))
+            //    {
+            //        keyType = SecurityKeyType.AsymmetricKey;
+            //        return true;
+            //    }
+
+            //    keyType = SecurityKeyType.SymmetricKey;
+            //    return false;
+
+            //}
+
+            public bool TryParseSymmetricKeyElement(XmlElement element)
+            {
+                if (element == null)
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("element");
+
+                return element.LocalName == this.DriverDictionary.KeyType.Value
+                    && element.NamespaceURI == this.DriverDictionary.Namespace.Value
+                    && element.InnerText == this.DriverDictionary.SymmetricKeyType.Value;
+            }
+
+            XmlElement CreateSymmetricKeyTypeElement()
+            {
+                XmlDocument doc = new XmlDocument();
+                XmlElement result = doc.CreateElement(this.DriverDictionary.Prefix.Value, this.DriverDictionary.KeyType.Value,
+                    this.DriverDictionary.Namespace.Value);
+                result.AppendChild(doc.CreateTextNode(this.DriverDictionary.SymmetricKeyType.Value));
+                return result;
+            }
+
+            bool TryParsePublicKeyElement(XmlElement element)
+            {
+                if (element == null)
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("element");
+
+                return element.LocalName == this.DriverDictionary.KeyType.Value
+                    && element.NamespaceURI == this.DriverDictionary.Namespace.Value
+                    && element.InnerText == this.DriverDictionary.PublicKeyType.Value;
+            }
+
+            XmlElement CreatePublicKeyTypeElement()
+            {
+                XmlDocument doc = new XmlDocument();
+                XmlElement result = doc.CreateElement(this.DriverDictionary.Prefix.Value, this.DriverDictionary.KeyType.Value,
+                    this.DriverDictionary.Namespace.Value);
+                result.AppendChild(doc.CreateTextNode(this.DriverDictionary.PublicKeyType.Value));
+                return result;
+            }
+
+            // Issue #31 in progress
+            //public override bool TryParseTokenTypeElement(XmlElement element, out string tokenType)
+            //{
+            //    if (element == null)
+            //        throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("element");
+
+            //    if (element.LocalName == this.DriverDictionary.TokenType.Value
+            //        && element.NamespaceURI == this.DriverDictionary.Namespace.Value)
+            //    {
+            //        tokenType = element.InnerText;
+            //        return true;
+            //    }
+
+            //    tokenType = null;
+            //    return false;
+            //}
+
+//            public override XmlElement CreateTokenTypeElement(string tokenTypeUri)
+//            {
+//                if (tokenTypeUri == null)
+//                {
+//                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("tokenTypeUri");
+//                }
+//                XmlDocument doc = new XmlDocument();
+//                XmlElement result = doc.CreateElement(this.DriverDictionary.Prefix.Value, this.DriverDictionary.TokenType.Value,
+//                    this.DriverDictionary.Namespace.Value);
+//                result.AppendChild(doc.CreateTextNode(tokenTypeUri));
+//                return result;
+//            }
+
+//            public override XmlElement CreateUseKeyElement(SecurityKeyIdentifier keyIdentifier, SecurityStandardsManager standardsManager)
+//            {
+//                if (keyIdentifier == null)
+//                {
+//                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("keyIdentifier");
+//                }
+//                if (standardsManager == null)
+//                {
+//                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("standardsManager");
+//                }
+//                XmlDocument doc = new XmlDocument();
+//                XmlElement result = doc.CreateElement(this.DriverDictionary.UseKey.Value, this.DriverDictionary.Namespace.Value);
+//                MemoryStream stream = new MemoryStream();
+//                using (XmlDictionaryWriter writer = XmlDictionaryWriter.CreateDictionaryWriter(new XmlTextWriter(stream, Encoding.UTF8)))
+//                {
+//                    standardsManager.SecurityTokenSerializer.WriteKeyIdentifier(writer, keyIdentifier);
+//                    writer.Flush();
+//                    stream.Seek(0, SeekOrigin.Begin);
+//                    XmlNode skiNode;
+//                    using (XmlDictionaryReader reader = XmlDictionaryReader.CreateDictionaryReader(new XmlTextReader(stream) { DtdProcessing = DtdProcessing.Prohibit }))
+//                    {
+//                        reader.MoveToContent();
+//                        skiNode = doc.ReadNode(reader);
+//                    }
+//                    result.AppendChild(skiNode);
+//                }
+//                return result;
+//            }
+
+//            public override XmlElement CreateSignWithElement(string signatureAlgorithm)
+//            {
+//                if (signatureAlgorithm == null)
+//                {
+//                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("signatureAlgorithm");
+//                }
+//                XmlDocument doc = new XmlDocument();
+//                XmlElement result = doc.CreateElement(this.DriverDictionary.Prefix.Value, this.DriverDictionary.SignWith.Value,
+//                    this.DriverDictionary.Namespace.Value);
+//                result.AppendChild(doc.CreateTextNode(signatureAlgorithm));
+//                return result;
+//            }
+
+//            internal override bool IsSignWithElement(XmlElement element, out string signatureAlgorithm)
+//            {
+//                return CheckElement(element, this.DriverDictionary.SignWith.Value, this.DriverDictionary.Namespace.Value, out signatureAlgorithm);
+//            }
+
+//            public override XmlElement CreateEncryptWithElement(string encryptionAlgorithm)
+//            {
+//                if (encryptionAlgorithm == null)
+//                {
+//                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("encryptionAlgorithm");
+//                }
+//                XmlDocument doc = new XmlDocument();
+//                XmlElement result = doc.CreateElement(this.DriverDictionary.Prefix.Value, this.DriverDictionary.EncryptWith.Value,
+//                    this.DriverDictionary.Namespace.Value);
+//                result.AppendChild(doc.CreateTextNode(encryptionAlgorithm));
+//                return result;
+//            }
+
+//            public override XmlElement CreateEncryptionAlgorithmElement(string encryptionAlgorithm)
+//            {
+//                if (encryptionAlgorithm == null)
+//                {
+//                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("encryptionAlgorithm");
+//                }
+//                XmlDocument doc = new XmlDocument();
+//                XmlElement result = doc.CreateElement(this.DriverDictionary.Prefix.Value, this.DriverDictionary.EncryptionAlgorithm.Value,
+//                    this.DriverDictionary.Namespace.Value);
+//                result.AppendChild(doc.CreateTextNode(encryptionAlgorithm));
+//                return result;
+//            }
+
+//            internal override bool IsEncryptWithElement(XmlElement element, out string encryptWithAlgorithm)
+//            {
+//                return CheckElement(element, this.DriverDictionary.EncryptWith.Value, this.DriverDictionary.Namespace.Value, out encryptWithAlgorithm);
+//            }
+
+//            internal override bool IsEncryptionAlgorithmElement(XmlElement element, out string encryptionAlgorithm)
+//            {
+//                return CheckElement(element, this.DriverDictionary.EncryptionAlgorithm.Value, this.DriverDictionary.Namespace.Value, out encryptionAlgorithm);
+//            }
+
+//            public override XmlElement CreateComputedKeyAlgorithmElement(string algorithm)
+//            {
+//                if (algorithm == null)
+//                {
+//                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("algorithm");
+//                }
+//                XmlDocument doc = new XmlDocument();
+//                XmlElement result = doc.CreateElement(this.DriverDictionary.Prefix.Value, this.DriverDictionary.ComputedKeyAlgorithm.Value,
+//                    this.DriverDictionary.Namespace.Value);
+//                result.AppendChild(doc.CreateTextNode(algorithm));
+//                return result;
+//            }
+
+//            public override XmlElement CreateCanonicalizationAlgorithmElement(string algorithm)
+//            {
+//                if (algorithm == null)
+//                {
+//                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("algorithm");
+//                }
+//                XmlDocument doc = new XmlDocument();
+//                XmlElement result = doc.CreateElement(this.DriverDictionary.Prefix.Value, this.DriverDictionary.CanonicalizationAlgorithm.Value,
+//                    this.DriverDictionary.Namespace.Value);
+//                result.AppendChild(doc.CreateTextNode(algorithm));
+//                return result;
+//            }
+
+//            internal override bool IsCanonicalizationAlgorithmElement(XmlElement element, out string canonicalizationAlgorithm)
+//            {
+//                return CheckElement(element, this.DriverDictionary.CanonicalizationAlgorithm.Value, this.DriverDictionary.Namespace.Value, out canonicalizationAlgorithm);
+//            }
+
+//            public override bool TryParseRequiredClaimsElement(XmlElement element, out System.Collections.ObjectModel.Collection<XmlElement> requiredClaims)
+//            {
+//                if (element == null)
+//                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("element");
+
+//                if (element.LocalName == this.DriverDictionary.Claims.Value
+//                    && element.NamespaceURI == this.DriverDictionary.Namespace.Value)
+//                {
+//                    requiredClaims = new System.Collections.ObjectModel.Collection<XmlElement>();
+//                    foreach (XmlNode node in element.ChildNodes)
+//                        if (node is XmlElement)
+//                        {
+//                            requiredClaims.Add((XmlElement)node);
+//                        }
+//                    return true;
+//                }
+
+//                requiredClaims = null;
+//                return false;
+//            }
+
+//            public override XmlElement CreateRequiredClaimsElement(IEnumerable<XmlElement> claimsList)
+//            {
+//                if (claimsList == null)
+//                {
+//                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("claimsList");
+//                }
+//                XmlDocument doc = new XmlDocument();
+//                XmlElement result = doc.CreateElement(this.DriverDictionary.Prefix.Value, this.DriverDictionary.Claims.Value,
+//                    this.DriverDictionary.Namespace.Value);
+//                foreach (XmlElement claimElement in claimsList)
+//                {
+//                    XmlElement element = (XmlElement)doc.ImportNode(claimElement, true);
+//                    result.AppendChild(element);
+//                }
+//                return result;
+//            }
+
+            internal static void ValidateRequestedKeySize(int keySize, SecurityAlgorithmSuite algorithmSuite)
+            {
+                if ((keySize % 8 == 0) && algorithmSuite.IsSymmetricKeyLengthSupported(keySize))
+                {
+                    return;
+                }
+                else
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new SecurityNegotiationException(SR.Format(SR.InvalidKeyLengthRequested, keySize)));
+                }
+            }
+
+            static void ValidateRequestorEntropy(SecurityToken entropy, SecurityKeyEntropyMode mode)
+            {
+                if ((mode == SecurityKeyEntropyMode.ClientEntropy || mode == SecurityKeyEntropyMode.CombinedEntropy)
+                    && (entropy == null))
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new InvalidOperationException(SR.Format(SR.EntropyModeRequiresRequestorEntropy, mode)));
+                }
+                if (mode == SecurityKeyEntropyMode.ServerEntropy && entropy != null)
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new InvalidOperationException(SR.Format(SR.EntropyModeCannotHaveRequestorEntropy, mode)));
+                }
+            }
+
+            internal static void ProcessRstAndIssueKey(RequestSecurityToken requestSecurityToken, SecurityTokenResolver resolver, SecurityKeyEntropyMode keyEntropyMode, SecurityAlgorithmSuite algorithmSuite, out int issuedKeySize, out byte[] issuerEntropy, out byte[] proofKey,
+                out SecurityToken proofToken)
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+
+                //SecurityToken requestorEntropyToken = requestSecurityToken.GetRequestorEntropy(resolver);
+                //ValidateRequestorEntropy(requestorEntropyToken, keyEntropyMode);
+                //byte[] requestorEntropy;
+                //if (requestorEntropyToken != null)
+                //{
+                //    if (requestorEntropyToken is BinarySecretSecurityToken)
+                //    {
+                //        BinarySecretSecurityToken skToken = (BinarySecretSecurityToken)requestorEntropyToken;
+                //        requestorEntropy = skToken.GetKeyBytes();
+                //    }
+                //    else if (requestorEntropyToken is WrappedKeySecurityToken)
+                //    {
+                //        requestorEntropy = ((WrappedKeySecurityToken)requestorEntropyToken).GetWrappedKey();
+                //    }
+                //    else
+                //    {
+                //        throw DiagnosticUtility.ExceptionUtility.ThrowHelperWarning(new InvalidOperationException(SR.Format(SR.TokenCannotCreateSymmetricCrypto, requestorEntropyToken)));
+                //    }
+                //}
+                //else
+                //{
+                //    requestorEntropy = null;
+                //}
+
+                //if (keyEntropyMode == SecurityKeyEntropyMode.ClientEntropy)
+                //{
+                //    if (requestorEntropy != null)
+                //    {
+                //        // validate that the entropy length matches the algorithm suite
+                //        ValidateRequestedKeySize(requestorEntropy.Length * 8, algorithmSuite);
+                //    }
+                //    proofKey = requestorEntropy;
+                //    issuerEntropy = null;
+                //    issuedKeySize = 0;
+                //    proofToken = null;
+                //}
+                //else
+                //{
+                //    if (requestSecurityToken.KeySize != 0)
+                //    {
+                //        ValidateRequestedKeySize(requestSecurityToken.KeySize, algorithmSuite);
+                //        issuedKeySize = requestSecurityToken.KeySize;
+                //    }
+                //    else
+                //    {
+                //        issuedKeySize = algorithmSuite.DefaultSymmetricKeyLength;
+                //    }
+                //    RNGCryptoServiceProvider random = new RNGCryptoServiceProvider();
+                //    if (keyEntropyMode == SecurityKeyEntropyMode.ServerEntropy)
+                //    {
+                //        proofKey = new byte[issuedKeySize / 8];
+                //        // proof key is completely issued by the server
+                //        random.GetNonZeroBytes(proofKey);
+                //        issuerEntropy = null;
+                //        proofToken = new BinarySecretSecurityToken(proofKey);
+                //    }
+                //    else
+                //    {
+                //        issuerEntropy = new byte[issuedKeySize / 8];
+                //        random.GetNonZeroBytes(issuerEntropy);
+                //        proofKey = RequestSecurityTokenResponse.ComputeCombinedKey(requestorEntropy, issuerEntropy, issuedKeySize);
+                //        proofToken = null;
+                //    }
+                //}
+            }
+
+        }
+
+        protected static bool CheckElement(XmlElement element, string name, string ns, out string value)
+        {
+            value = null;
+            if (element.LocalName != name || element.NamespaceURI != ns)
+                return false;
+            if (element.FirstChild is XmlText)
+            {
+                value = ((XmlText)element.FirstChild).Value;
+                return true;
+            }
+            return false;
+        }
+    }
+}
+

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/WSTrustDec2005.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/WSTrustDec2005.cs
@@ -1,0 +1,147 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.ServiceModel.Channels;
+using System.ServiceModel.Description;
+using System.Xml;
+//using HexBinary = System.Runtime.Remoting.Metadata.W3cXsd2001.SoapHexBinary;  // Issue #31 in progress
+
+namespace System.ServiceModel.Security
+{
+    class WSTrustDec2005 : WSTrustFeb2005
+    {
+        public WSTrustDec2005(WSSecurityTokenSerializer tokenSerializer)
+            : base(tokenSerializer)
+        {
+        }
+
+        public override TrustDictionary SerializerDictionary
+        {
+            get { return DXD.TrustDec2005Dictionary; }
+        }
+
+        public class DriverDec2005 : WSTrustFeb2005.DriverFeb2005
+        {
+            public DriverDec2005(SecurityStandardsManager standardsManager)
+                : base(standardsManager)
+            {
+            }
+
+            public override TrustDictionary DriverDictionary
+            {
+                get
+                {
+                    return DXD.TrustDec2005Dictionary;
+                }
+            }
+
+            public override XmlDictionaryString RequestSecurityTokenResponseFinalAction
+            {
+                get
+                {
+                    return DXD.TrustDec2005Dictionary.RequestSecurityTokenCollectionIssuanceFinalResponse;
+                }
+            }
+
+            // Issue #31 in progress
+            //public override XmlElement CreateKeyTypeElement(SecurityKeyType keyType)
+            //{
+            //    if (keyType == SecurityKeyType.BearerKey)
+            //    {
+            //        XmlDocument doc = new XmlDocument();
+            //        XmlElement result = doc.CreateElement(this.DriverDictionary.Prefix.Value, this.DriverDictionary.KeyType.Value,
+            //            this.DriverDictionary.Namespace.Value);
+            //        result.AppendChild(doc.CreateTextNode(DXD.TrustDec2005Dictionary.BearerKeyType.Value));
+            //        return result;
+            //    }
+
+            //    return base.CreateKeyTypeElement(keyType);
+            //}
+
+            //public override bool TryParseKeyTypeElement(XmlElement element, out SecurityKeyType keyType)
+            //{
+            //    if (element == null)
+            //        throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("element");
+
+            //    if (element.LocalName == this.DriverDictionary.KeyType.Value
+            //        && element.NamespaceURI == this.DriverDictionary.Namespace.Value
+            //        && element.InnerText == DXD.TrustDec2005Dictionary.BearerKeyType.Value)
+            //    {
+            //        keyType = SecurityKeyType.BearerKey;
+            //        return true;
+            //    }
+
+            //    return base.TryParseKeyTypeElement(element, out keyType);
+            //}
+
+            //public override XmlElement CreateRequiredClaimsElement(IEnumerable<XmlElement> claimsList)
+            //{
+            //    XmlElement result = base.CreateRequiredClaimsElement(claimsList);
+            //    XmlAttribute dialectAttribute = result.OwnerDocument.CreateAttribute(DXD.TrustDec2005Dictionary.Dialect.Value);
+            //    dialectAttribute.Value = DXD.TrustDec2005Dictionary.DialectType.Value;
+            //    result.Attributes.Append(dialectAttribute);
+
+            //    return result;
+            //}
+
+            public override IChannelFactory<IRequestChannel> CreateFederationProxy(EndpointAddress address, Binding binding, KeyedByTypeCollection<IEndpointBehavior> channelBehaviors)
+            {
+                if (channelBehaviors == null)
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("channelBehaviors");
+
+                ChannelFactory<IWsTrustDec2005SecurityTokenService> result = new ChannelFactory<IWsTrustDec2005SecurityTokenService>(binding, address);
+                SetProtectionLevelForFederation(result.Endpoint.Contract.Operations);
+                // remove the default client credentials that gets added to channel factories
+                result.Endpoint.Behaviors.Remove<ClientCredentials>();
+                for (int i = 0; i < channelBehaviors.Count; ++i)
+                {
+                    result.Endpoint.Behaviors.Add(channelBehaviors[i]);
+                }
+                // add a behavior that removes the UI channel initializer added by the client credentials since there should be no UI
+                // initializer popped up as part of obtaining the federation token (the UI should already have been popped up for the main channel)
+                result.Endpoint.Behaviors.Add(new WSTrustFeb2005.DriverFeb2005.InteractiveInitializersRemovingBehavior());
+
+                return new WSTrustFeb2005.DriverFeb2005.RequestChannelFactory<IWsTrustDec2005SecurityTokenService>(result);
+            }
+
+            internal virtual bool IsSecondaryParametersElement(XmlElement element)
+            {
+                return ((element.LocalName == DXD.TrustDec2005Dictionary.SecondaryParameters.Value) &&
+                        (element.NamespaceURI == DXD.TrustDec2005Dictionary.Namespace.Value));
+            }
+
+            public virtual XmlElement CreateKeyWrapAlgorithmElement(string keyWrapAlgorithm)
+            {
+                if (keyWrapAlgorithm == null)
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("keyWrapAlgorithm");
+                }
+                XmlDocument doc = new XmlDocument();
+                XmlElement result = doc.CreateElement(DXD.TrustDec2005Dictionary.Prefix.Value, DXD.TrustDec2005Dictionary.KeyWrapAlgorithm.Value,
+                    DXD.TrustDec2005Dictionary.Namespace.Value);
+                result.AppendChild(doc.CreateTextNode(keyWrapAlgorithm));
+                return result;
+            }
+
+            // Issue #31 in progress
+            //internal override bool IsKeyWrapAlgorithmElement(XmlElement element, out string keyWrapAlgorithm)
+            //{
+            //    return CheckElement(element, DXD.TrustDec2005Dictionary.KeyWrapAlgorithm.Value, DXD.TrustDec2005Dictionary.Namespace.Value, out keyWrapAlgorithm);
+            //}
+
+            [ServiceContract]
+            internal interface IWsTrustDec2005SecurityTokenService
+            {
+                [OperationContract(IsOneWay = false,
+                                   Action = TrustDec2005Strings.RequestSecurityTokenIssuance,
+                                   ReplyAction = TrustDec2005Strings.RequestSecurityTokenCollectionIssuanceFinalResponse)]
+                [FaultContract(typeof(string), Action = "*", ProtectionLevel = System.Net.Security.ProtectionLevel.Sign)]
+                Message RequestToken(Message message);
+            }
+        }
+    }
+}
+

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/WSTrustFeb2005.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/WSTrustFeb2005.cs
@@ -1,0 +1,340 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.IdentityModel.Tokens;
+//using HexBinary = System.Runtime.Remoting.Metadata.W3cXsd2001.SoapHexBinary;  // Issue #31 in progress
+using System.ServiceModel.Channels;
+using System.ServiceModel.Description;
+using System.ServiceModel.Dispatcher;
+using System.Xml;
+
+namespace System.ServiceModel.Security
+{
+    class WSTrustFeb2005 : WSTrust
+    {
+        public WSTrustFeb2005(WSSecurityTokenSerializer tokenSerializer)
+            : base(tokenSerializer)
+        {
+        }
+
+        public override TrustDictionary SerializerDictionary
+        {
+            get { return XD.TrustFeb2005Dictionary; }
+        }
+
+        public class DriverFeb2005 : Driver
+        {
+            public DriverFeb2005(SecurityStandardsManager standardsManager)
+                : base(standardsManager)
+            {
+            }
+
+            public override TrustDictionary DriverDictionary
+            {
+                get
+                {
+                    return XD.TrustFeb2005Dictionary;
+                }
+            }
+
+            public override XmlDictionaryString RequestSecurityTokenResponseFinalAction
+            {
+                get
+                {
+                    return XD.TrustFeb2005Dictionary.RequestSecurityTokenIssuanceResponse;
+                }
+            }
+
+            public override bool IsSessionSupported
+            {
+                get
+                {
+                    return true;
+                }
+            }
+
+            public override bool IsIssuedTokensSupported
+            {
+                get
+                {
+                    return true;
+                }
+            }
+
+            public override string IssuedTokensHeaderName
+            {
+                get
+                {
+                    return this.DriverDictionary.IssuedTokensHeader.Value;
+                }
+            }
+
+            public override string IssuedTokensHeaderNamespace
+            {
+                get
+                {
+                    return this.DriverDictionary.Namespace.Value;
+                }
+            }
+
+            public override string RequestTypeRenew
+            {
+                get
+                {
+                    return this.DriverDictionary.RequestTypeRenew.Value;
+                }
+            }
+
+            public override string RequestTypeClose
+            {
+                get
+                {
+                    return this.DriverDictionary.RequestTypeClose.Value;
+                }
+            }
+
+            protected override void ReadReferences(XmlElement rstrXml, out SecurityKeyIdentifierClause requestedAttachedReference,
+                    out SecurityKeyIdentifierClause requestedUnattachedReference)
+            {
+                XmlElement issuedTokenXml = null;
+                requestedAttachedReference = null;
+                requestedUnattachedReference = null;
+                for (int i = 0; i < rstrXml.ChildNodes.Count; ++i)
+                {
+                    XmlElement child = rstrXml.ChildNodes[i] as XmlElement;
+                    if (child != null)
+                    {
+                        if (child.LocalName == this.DriverDictionary.RequestedSecurityToken.Value && child.NamespaceURI == this.DriverDictionary.Namespace.Value)
+                        {
+                            issuedTokenXml = XmlHelper.GetChildElement(child);
+                        }
+                        else if (child.LocalName == this.DriverDictionary.RequestedAttachedReference.Value && child.NamespaceURI == this.DriverDictionary.Namespace.Value)
+                        {
+                            requestedAttachedReference = GetKeyIdentifierXmlReferenceClause(XmlHelper.GetChildElement(child));
+                        }
+                        else if (child.LocalName == this.DriverDictionary.RequestedUnattachedReference.Value && child.NamespaceURI == this.DriverDictionary.Namespace.Value)
+                        {
+                            requestedUnattachedReference = GetKeyIdentifierXmlReferenceClause(XmlHelper.GetChildElement(child));
+                        }
+                    }
+                }
+
+                try
+                {
+                    if (issuedTokenXml != null)
+                    {
+                        throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+                        //if (requestedAttachedReference == null)
+                        //{
+                        //    this.StandardsManager.TryCreateKeyIdentifierClauseFromTokenXml(issuedTokenXml, SecurityTokenReferenceStyle.Internal, out requestedAttachedReference);
+                        //}
+                        //if (requestedUnattachedReference == null)
+                        //{
+                        //    this.StandardsManager.TryCreateKeyIdentifierClauseFromTokenXml(issuedTokenXml, SecurityTokenReferenceStyle.External, out requestedUnattachedReference);
+                        //}
+                    }
+                }
+                catch (XmlException)
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new XmlException(SR.Format(SR.TrustDriverIsUnableToCreatedNecessaryAttachedOrUnattachedReferences, issuedTokenXml.ToString())));
+                }
+
+            }
+
+            protected override bool ReadRequestedTokenClosed(XmlElement rstrXml)
+            {
+                for (int i = 0; i < rstrXml.ChildNodes.Count; ++i)
+                {
+                    XmlElement child = (rstrXml.ChildNodes[i] as XmlElement);
+                    if (child != null)
+                    {
+                        if (child.LocalName == this.DriverDictionary.RequestedTokenClosed.Value && child.NamespaceURI == this.DriverDictionary.Namespace.Value)
+                        {
+                            return true;
+                        }
+                    }
+                }
+                return false;
+            }
+
+            protected override void ReadTargets(XmlElement rstXml, out SecurityKeyIdentifierClause renewTarget, out SecurityKeyIdentifierClause closeTarget)
+            {
+                renewTarget = null;
+                closeTarget = null;
+
+                for (int i = 0; i < rstXml.ChildNodes.Count; ++i)
+                {
+                    XmlElement child = (rstXml.ChildNodes[i] as XmlElement);
+                    if (child != null)
+                    {
+                        throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+                        //if (child.LocalName == this.DriverDictionary.RenewTarget.Value && child.NamespaceURI == this.DriverDictionary.Namespace.Value)
+                        //    renewTarget = this.StandardsManager.SecurityTokenSerializer.ReadKeyIdentifierClause(new XmlNodeReader(child.FirstChild));
+                        //else if (child.LocalName == this.DriverDictionary.CloseTarget.Value && child.NamespaceURI == this.DriverDictionary.Namespace.Value)
+                        //    closeTarget = this.StandardsManager.SecurityTokenSerializer.ReadKeyIdentifierClause(new XmlNodeReader(child.FirstChild));
+                    }
+                }
+            }
+
+            protected override void WriteReferences(RequestSecurityTokenResponse rstr, XmlDictionaryWriter writer)
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+
+                //if (rstr.RequestedAttachedReference != null)
+                //{
+                //    writer.WriteStartElement(this.DriverDictionary.Prefix.Value, this.DriverDictionary.RequestedAttachedReference, this.DriverDictionary.Namespace);
+                //    this.StandardsManager.SecurityTokenSerializer.WriteKeyIdentifierClause(writer, rstr.RequestedAttachedReference);
+                //    writer.WriteEndElement();
+                //}
+
+                //if (rstr.RequestedUnattachedReference != null)
+                //{
+                //    writer.WriteStartElement(this.DriverDictionary.Prefix.Value, this.DriverDictionary.RequestedUnattachedReference, this.DriverDictionary.Namespace);
+                //    this.StandardsManager.SecurityTokenSerializer.WriteKeyIdentifierClause(writer, rstr.RequestedUnattachedReference);
+                //    writer.WriteEndElement();
+                //}
+            }
+
+            protected override void WriteRequestedTokenClosed(RequestSecurityTokenResponse rstr, XmlDictionaryWriter writer)
+            {
+                if (rstr.IsRequestedTokenClosed)
+                {
+                    writer.WriteElementString(this.DriverDictionary.RequestedTokenClosed, this.DriverDictionary.Namespace, String.Empty);
+                }
+            }
+
+            protected override void WriteTargets(RequestSecurityToken rst, XmlDictionaryWriter writer)
+            {
+                throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+
+                //if (rst.RenewTarget != null)
+                //{
+                //    writer.WriteStartElement(this.DriverDictionary.Prefix.Value, this.DriverDictionary.RenewTarget, this.DriverDictionary.Namespace);
+                //    this.StandardsManager.SecurityTokenSerializer.WriteKeyIdentifierClause(writer, rst.RenewTarget);
+                //    writer.WriteEndElement();
+                //}
+
+                //if (rst.CloseTarget != null)
+                //{
+                //    writer.WriteStartElement(this.DriverDictionary.Prefix.Value, this.DriverDictionary.CloseTarget, this.DriverDictionary.Namespace);
+                //    this.StandardsManager.SecurityTokenSerializer.WriteKeyIdentifierClause(writer, rst.CloseTarget);
+                //    writer.WriteEndElement();
+                //}
+            }
+
+            // this is now the abstract in WSTrust
+            public override IChannelFactory<IRequestChannel> CreateFederationProxy(EndpointAddress address, Binding binding, KeyedByTypeCollection<IEndpointBehavior> channelBehaviors)
+            {
+                if (channelBehaviors == null)
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("channelBehaviors");
+
+                ChannelFactory<IWsTrustFeb2005SecurityTokenService> result = new ChannelFactory<IWsTrustFeb2005SecurityTokenService>(binding, address);
+                SetProtectionLevelForFederation(result.Endpoint.Contract.Operations);
+                // remove the default client credentials that gets added to channel factories
+                result.Endpoint.Behaviors.Remove<ClientCredentials>();
+                for (int i = 0; i < channelBehaviors.Count; ++i)
+                {
+                    result.Endpoint.Behaviors.Add(channelBehaviors[i]);
+                }
+                // add a behavior that removes the UI channel initializer added by the client credentials since there should be no UI
+                // initializer popped up as part of obtaining the federation token (the UI should already have been popped up for the main channel)
+                result.Endpoint.Behaviors.Add(new InteractiveInitializersRemovingBehavior());
+
+                return new RequestChannelFactory<IWsTrustFeb2005SecurityTokenService>(result);
+            }
+
+            [ServiceContract]
+            internal interface IWsTrustFeb2005SecurityTokenService
+            {
+                [OperationContract(IsOneWay = false,
+                                   Action = TrustFeb2005Strings.RequestSecurityTokenIssuance,
+                                   ReplyAction = TrustFeb2005Strings.RequestSecurityTokenIssuanceResponse)]
+                [FaultContract(typeof(string), Action = "*", ProtectionLevel = System.Net.Security.ProtectionLevel.Sign)]
+                Message RequestToken(Message message);
+            }
+
+            public class InteractiveInitializersRemovingBehavior : IEndpointBehavior
+            {
+                public void Validate(ServiceEndpoint serviceEndpoint) { }
+                public void AddBindingParameters(ServiceEndpoint serviceEndpoint, BindingParameterCollection bindingParameters) { }
+                public void ApplyDispatchBehavior(ServiceEndpoint serviceEndpoint, EndpointDispatcher endpointDispatcher) { }
+                public void ApplyClientBehavior(ServiceEndpoint serviceEndpoint, ClientRuntime behavior)
+                {
+                    // it is very unlikely that InteractiveChannelInitializers will be null, this is defensive in case ClientRuntime every has a 
+                    // bug.  I am OK with this as ApplyingClientBehavior is a one-time channel setup.
+                    if (behavior != null && behavior.InteractiveChannelInitializers != null)
+                    {
+                        // clear away any interactive initializer
+                        behavior.InteractiveChannelInitializers.Clear();
+                    }
+                }
+            }
+
+            public class RequestChannelFactory<TokenService> : ChannelFactoryBase, IChannelFactory<IRequestChannel>
+            {
+                ChannelFactory<TokenService> _innerChannelFactory;
+
+                public RequestChannelFactory(ChannelFactory<TokenService> innerChannelFactory)
+                {
+                    _innerChannelFactory = innerChannelFactory;
+                }
+
+                public IRequestChannel CreateChannel(EndpointAddress address)
+                {
+                    throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+                    //return this.innerChannelFactory.CreateChannel<IRequestChannel>(address);
+                }
+
+                public IRequestChannel CreateChannel(EndpointAddress address, Uri via)
+                {
+                    throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+                    //return this.innerChannelFactory.CreateChannel<IRequestChannel>(address, via);
+                }
+
+                protected override void OnAbort()
+                {
+                    _innerChannelFactory.Abort();
+                }
+
+                protected override IAsyncResult OnBeginOpen(TimeSpan timeout, AsyncCallback callback, object state)
+                {
+                    return _innerChannelFactory.BeginOpen(timeout, callback, state);
+                }
+
+                protected override void OnEndOpen(IAsyncResult result)
+                {
+                    _innerChannelFactory.EndOpen(result);
+                }
+
+                protected override IAsyncResult OnBeginClose(TimeSpan timeout, AsyncCallback callback, object state)
+                {
+                    return _innerChannelFactory.BeginClose(timeout, callback, state);
+                }
+
+                protected override void OnEndClose(IAsyncResult result)
+                {
+                    _innerChannelFactory.EndClose(result);
+                }
+
+                protected override void OnClose(TimeSpan timeout)
+                {
+                    _innerChannelFactory.Close(timeout);
+                }
+
+                protected override void OnOpen(TimeSpan timeout)
+                {
+                    _innerChannelFactory.Open(timeout);
+                }
+
+                public override T GetProperty<T>()
+                {
+                    return _innerChannelFactory.GetProperty<T>();
+                }
+            }
+        }
+    }
+}
+

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/WrapperSecurityCommunicationObject.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/WrapperSecurityCommunicationObject.cs
@@ -2,12 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-
 using System.ServiceModel.Channels;
-using System.ServiceModel.Diagnostics;
 using System.IdentityModel.Selectors;
 using System.Runtime.Diagnostics;
 using System.Threading.Tasks;
+using System.Runtime;
 
 namespace System.ServiceModel.Security
 {
@@ -47,12 +46,14 @@ namespace System.ServiceModel.Security
 
         protected override IAsyncResult OnBeginClose(TimeSpan timeout, AsyncCallback callback, object state)
         {
-            return _innerCommunicationObject.OnBeginClose(timeout, callback, state);
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+            //return _innerCommunicationObject.OnBeginClose(timeout, callback, state);
         }
 
         protected override IAsyncResult OnBeginOpen(TimeSpan timeout, AsyncCallback callback, object state)
         {
-            return _innerCommunicationObject.OnBeginOpen(timeout, callback, state);
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+            //return _innerCommunicationObject.OnBeginOpen(timeout, callback, state);
         }
 
         protected override void OnClose(TimeSpan timeout)
@@ -74,12 +75,14 @@ namespace System.ServiceModel.Security
 
         protected override void OnEndClose(IAsyncResult result)
         {
-            _innerCommunicationObject.OnEndClose(result);
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+            //_innerCommunicationObject.OnEndClose(result);
         }
 
         protected override void OnEndOpen(IAsyncResult result)
         {
-            _innerCommunicationObject.OnEndOpen(result);
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+            //_innerCommunicationObject.OnEndOpen(result);
         }
 
         protected override void OnFaulted()
@@ -110,30 +113,14 @@ namespace System.ServiceModel.Security
             base.ThrowIfDisposedOrImmutable();
         }
 
-        protected internal override async Task OnCloseAsync(TimeSpan timeout)
+        protected internal override Task OnCloseAsync(TimeSpan timeout)
         {
-            var asyncInnerCommunicationObject = _innerCommunicationObject as IAsyncCommunicationObject;
-            if (asyncInnerCommunicationObject != null)
-            {
-                await asyncInnerCommunicationObject.CloseAsync(timeout);
-            }
-            else
-            {
-                this.OnClose(timeout);
-            }
+            return _innerCommunicationObject.OnCloseAsync(timeout);
         }
 
-        protected internal override async Task OnOpenAsync(TimeSpan timeout)
+        protected internal override Task OnOpenAsync(TimeSpan timeout)
         {
-            var asyncInnerCommunicationObject = _innerCommunicationObject as IAsyncCommunicationObject;
-            if (asyncInnerCommunicationObject != null)
-            {
-                await asyncInnerCommunicationObject.OpenAsync(timeout);
-            }
-            else
-            {
-                this.OnOpen(timeout);
-            }
+            return _innerCommunicationObject.OnOpenAsync(timeout);
         }
     }
 
@@ -220,6 +207,11 @@ namespace System.ServiceModel.Security
             _communicationObject.Close();
         }
 
+        public Task CloseAsync(TimeSpan timeout)
+        {
+            return ((IAsyncCommunicationObject)_communicationObject).CloseAsync(timeout);
+        }
+
         public void Close(TimeSpan timeout)
         {
             _communicationObject.Close(timeout);
@@ -227,17 +219,20 @@ namespace System.ServiceModel.Security
 
         public IAsyncResult BeginClose(AsyncCallback callback, object state)
         {
-            return _communicationObject.BeginClose(callback, state);
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+            //return _communicationObject.BeginClose(callback, state);
         }
 
         public IAsyncResult BeginClose(TimeSpan timeout, AsyncCallback callback, object state)
         {
-            return _communicationObject.BeginClose(timeout, callback, state);
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+            //return _communicationObject.BeginClose(timeout, callback, state);
         }
 
         public void EndClose(IAsyncResult result)
         {
-            _communicationObject.EndClose(result);
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+           // _communicationObject.EndClose(result);
         }
 
         public void Open()
@@ -250,19 +245,27 @@ namespace System.ServiceModel.Security
             _communicationObject.Open(timeout);
         }
 
+        public Task OpenAsync(TimeSpan timeout)
+        {
+            return ((IAsyncCommunicationObject)_communicationObject).OpenAsync(timeout);
+        }
+
         public IAsyncResult BeginOpen(AsyncCallback callback, object state)
         {
-            return _communicationObject.BeginOpen(callback, state);
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+            //return _communicationObject.BeginOpen(callback, state);
         }
 
         public IAsyncResult BeginOpen(TimeSpan timeout, AsyncCallback callback, object state)
         {
-            return _communicationObject.BeginOpen(timeout, callback, state);
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+            //return _communicationObject.BeginOpen(timeout, callback, state);
         }
 
         public void EndOpen(IAsyncResult result)
         {
-            _communicationObject.EndOpen(result);
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+            //_communicationObject.EndOpen(result);
         }
 
         public void Dispose()
@@ -277,16 +280,23 @@ namespace System.ServiceModel.Security
 
         public IAsyncResult OnBeginClose(TimeSpan timeout, AsyncCallback callback, object state)
         {
-            return new OperationWithTimeoutAsyncResult(this.OnClose, timeout, callback, state);
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+            //return new OperationWithTimeoutAsyncResult(this.OnClose, timeout, callback, state);
         }
 
         public IAsyncResult OnBeginOpen(TimeSpan timeout, AsyncCallback callback, object state)
         {
-            return new OperationWithTimeoutAsyncResult(this.OnOpen, timeout, callback, state);
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+            //return new OperationWithTimeoutAsyncResult(this.OnOpen, timeout, callback, state);
         }
 
         public virtual void OnClose(TimeSpan timeout)
         {
+        }
+
+        public virtual Task OnCloseAsync(TimeSpan timeout)
+        {
+            return TaskHelpers.CompletedTask();
         }
 
         public virtual void OnClosed()
@@ -299,12 +309,14 @@ namespace System.ServiceModel.Security
 
         public void OnEndClose(IAsyncResult result)
         {
-            OperationWithTimeoutAsyncResult.End(result);
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+            //OperationWithTimeoutAsyncResult.End(result);
         }
 
         public void OnEndOpen(IAsyncResult result)
         {
-            OperationWithTimeoutAsyncResult.End(result);
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+            //OperationWithTimeoutAsyncResult.End(result);
         }
 
         public virtual void OnFaulted()
@@ -314,6 +326,11 @@ namespace System.ServiceModel.Security
 
         public virtual void OnOpen(TimeSpan timeout)
         {
+        }
+
+        public virtual Task OnOpenAsync(TimeSpan timeout)
+        {
+            return TaskHelpers.CompletedTask();
         }
 
         public virtual void OnOpened()
@@ -400,19 +417,27 @@ namespace System.ServiceModel.Security
             _communicationObject.Close(timeout);
         }
 
+        public Task CloseAsync(TimeSpan timeout)
+        {
+            return ((IAsyncCommunicationObject)_communicationObject).CloseAsync(timeout);
+        }
+
         public IAsyncResult BeginClose(AsyncCallback callback, object state)
         {
-            return _communicationObject.BeginClose(callback, state);
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+           // return _communicationObject.BeginClose(callback, state);
         }
 
         public IAsyncResult BeginClose(TimeSpan timeout, AsyncCallback callback, object state)
         {
-            return _communicationObject.BeginClose(timeout, callback, state);
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+            //return _communicationObject.BeginClose(timeout, callback, state);
         }
 
         public void EndClose(IAsyncResult result)
         {
-            _communicationObject.EndClose(result);
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+            //_communicationObject.EndClose(result);
         }
 
         public void Open()
@@ -425,19 +450,27 @@ namespace System.ServiceModel.Security
             _communicationObject.Open(timeout);
         }
 
+        public Task OpenAsync(TimeSpan timeout)
+        {
+            return ((IAsyncCommunicationObject)_communicationObject).OpenAsync(timeout);
+        }
+
         public IAsyncResult BeginOpen(AsyncCallback callback, object state)
         {
-            return _communicationObject.BeginOpen(callback, state);
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+            //return _communicationObject.BeginOpen(callback, state);
         }
 
         public IAsyncResult BeginOpen(TimeSpan timeout, AsyncCallback callback, object state)
         {
-            return _communicationObject.BeginOpen(timeout, callback, state);
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+            //return _communicationObject.BeginOpen(timeout, callback, state);
         }
 
         public void EndOpen(IAsyncResult result)
         {
-            _communicationObject.EndOpen(result);
+            throw ExceptionHelper.PlatformNotSupported();   // Issue #31 in progress
+            //_communicationObject.EndOpen(result);
         }
 
         public void Dispose()
@@ -462,6 +495,11 @@ namespace System.ServiceModel.Security
 
         public virtual void OnClose(TimeSpan timeout)
         {
+        }
+
+        public virtual Task OnCloseAsync(TimeSpan timeout)
+        {
+            return TaskHelpers.CompletedTask();
         }
 
         public virtual void OnClosed()
@@ -489,6 +527,11 @@ namespace System.ServiceModel.Security
 
         public virtual void OnOpen(TimeSpan timeout)
         {
+        }
+
+        public virtual Task OnOpenAsync(TimeSpan timeout)
+        {
+            return TaskHelpers.CompletedTask();
         }
 
         public virtual void OnOpened()

--- a/src/System.Private.ServiceModel/tests/Common/Scenarios/Endpoints.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Scenarios/Endpoints.cs
@@ -268,6 +268,14 @@ public static partial class Endpoints
         }
     }
 
+    public static string WsHttpTransSecUserName_Address
+    {
+        get
+        {
+            return GetEndpointAddress("WsHttpTranSecUserName.svc//wshttp-transec-username", protocol: "https");
+        }
+    }
+
     #region Secure WebSocket Addresses
     public static string WebSocketHttpsDuplexBinaryStreamed_Address
     {

--- a/src/System.Private.ServiceModel/tests/Common/Scenarios/ScenarioTestTypes.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Scenarios/ScenarioTestTypes.cs
@@ -1321,7 +1321,7 @@ public partial class XmlMessageContractTestResponse
 
     public XmlMessageContractTestResponse(string message)
     {
-        this._message = message;
+        _message = message;
     }
 
     [MessageHeader(Name = "OutOfBandData", Namespace = "http://www.contoso.com", MustUnderstand = false)]

--- a/src/System.Private.ServiceModel/tests/Common/Scenarios/ServiceInterfaces.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Scenarios/ServiceInterfaces.cs
@@ -259,6 +259,9 @@ public interface IWcfCustomUserNameService
 {
     [OperationContract(Action = "http://tempuri.org/IWcfCustomUserNameService/Echo")]
     String Echo(String message);
+
+    [OperationContract(Action = "http://tempuri.org/IWcfCustomUserNameService/Echo")]
+    Task<String> EchoAsync(String message);
 }
 
 [ServiceContract(
@@ -535,3 +538,4 @@ public interface IVerifyWebSockets
     [OperationContract()]
     bool ValidateWebSocketsUsed();
 }
+

--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Https/WsHttpsTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Https/WsHttpsTests.cs
@@ -1,0 +1,186 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+
+using System;
+using System.ServiceModel;
+using System.ServiceModel.Channels;
+using System.Text;
+using System.Threading.Tasks;
+using Infrastructure.Common;
+
+using Xunit;
+
+
+public static partial class WsHttpsTests
+{
+#if FULLXUNIT_NOTSUPPORTED
+    [Fact]
+#endif
+    [WcfFact]
+    [OuterLoop]
+    public static void CreateUserNameOverTransportBindingElement_Round_Trips()
+    {
+        ChannelFactory<IWcfCustomUserNameService> factory = null;
+        IWcfCustomUserNameService serviceProxy = null;
+        string testString = "Hello";
+        CustomBinding binding;
+        EndpointAddress endpointAddress = null;
+
+        try
+        {
+            // *** SETUP *** \\
+            var securityBindingElement = SecurityBindingElement.CreateUserNameOverTransportBindingElement();
+            securityBindingElement.IncludeTimestamp = false;
+            securityBindingElement.SecurityHeaderLayout = SecurityHeaderLayout.Lax;
+
+            binding = new CustomBinding(
+                            new TextMessageEncodingBindingElement(MessageVersion.Soap11, Encoding.UTF8), 
+                            securityBindingElement,
+                            new HttpsTransportBindingElement());
+
+            endpointAddress = new EndpointAddress(Endpoints.WsHttpTransSecUserName_Address);
+            factory = new ChannelFactory<IWcfCustomUserNameService>(binding, endpointAddress);
+            factory.Credentials.UserName.UserName = "test1";
+            factory.Credentials.UserName.Password = "Mytestpwd1";
+
+            serviceProxy = factory.CreateChannel();
+
+            // *** EXECUTE *** \\
+            string result = serviceProxy.Echo(testString);
+
+            // *** VALIDATE *** \\
+            Assert.True(result == testString, string.Format("Error: expected response from service: '{0}' Actual was: '{1}'", testString, result));
+
+            // *** CLEANUP *** \\
+            factory.Close();
+            ((ICommunicationObject)serviceProxy).Close();
+        }
+        finally
+        {
+            // *** ENSURE CLEANUP *** \\
+            ScenarioTestHelpers.CloseCommunicationObjects((ICommunicationObject)serviceProxy, factory);
+        }
+    }
+
+#if FULLXUNIT_NOTSUPPORTED
+    [Fact]
+#endif
+    [WcfFact]
+    [OuterLoop]
+    public static void CreateUserNameOverTransportBindingElement_Throws_Wrong_Credentials()
+    {
+        ChannelFactory<IWcfCustomUserNameService> factory = null;
+        IWcfCustomUserNameService serviceProxy = null;
+        string testString = "Hello";
+        CustomBinding binding;
+        EndpointAddress endpointAddress = null;
+        FaultException faultException = null;
+
+        try
+        {
+            // *** SETUP *** \\
+            var securityBindingElement = SecurityBindingElement.CreateUserNameOverTransportBindingElement();
+            securityBindingElement.IncludeTimestamp = false;
+            securityBindingElement.SecurityHeaderLayout = SecurityHeaderLayout.Lax;
+
+            binding = new CustomBinding(
+                            new TextMessageEncodingBindingElement(MessageVersion.Soap11, Encoding.UTF8),
+                            securityBindingElement,
+                            new HttpsTransportBindingElement());
+
+            endpointAddress = new EndpointAddress(Endpoints.WsHttpTransSecUserName_Address);
+            factory = new ChannelFactory<IWcfCustomUserNameService>(binding, endpointAddress);
+            factory.Credentials.UserName.UserName = "nottest1";
+            factory.Credentials.UserName.Password = "notMytestpwd1";
+
+            serviceProxy = factory.CreateChannel();
+
+            // *** EXECUTE *** \\
+            faultException = Assert.Throws<FaultException>(() =>
+            {
+                serviceProxy.Echo(testString);
+            });
+
+            // *** VALIDATE *** \\
+            string expectedFaultCode = "InvalidSecurityToken";
+            Assert.True(String.Equals(faultException.Code.Name, expectedFaultCode, StringComparison.OrdinalIgnoreCase),
+                        String.Format("Expected FaultCode '{0}' but actual was '{1}'", expectedFaultCode, faultException.Code.Name));
+
+            // *** CLEANUP *** \\
+            factory.Close();
+            ((ICommunicationObject)serviceProxy).Close();
+        }
+        finally
+        {
+            // *** ENSURE CLEANUP *** \\
+            ScenarioTestHelpers.CloseCommunicationObjects((ICommunicationObject)serviceProxy, factory);
+        }
+    }
+
+
+#if FULLXUNIT_NOTSUPPORTED
+    [Fact]
+#endif
+    [WcfFact]
+    [OuterLoop]
+    [Issue(1494)]
+    public static void CreateUserNameOverTransportBindingElement_Round_Trips_Async()
+    {
+        ChannelFactory<IWcfCustomUserNameService> factory = null;
+        IWcfCustomUserNameService serviceProxy = null;
+        string testString = "Hello";
+        CustomBinding binding;
+        EndpointAddress endpointAddress = null;
+
+        try
+        {
+            // *** SETUP *** \\
+            var securityBindingElement = SecurityBindingElement.CreateUserNameOverTransportBindingElement();
+            securityBindingElement.IncludeTimestamp = false;
+            securityBindingElement.SecurityHeaderLayout = SecurityHeaderLayout.Lax;
+
+            binding = new CustomBinding(
+                            new TextMessageEncodingBindingElement(MessageVersion.Soap11, Encoding.UTF8),
+                            securityBindingElement,
+                            new HttpsTransportBindingElement());
+
+            endpointAddress = new EndpointAddress(Endpoints.WsHttpTransSecUserName_Address);
+            factory = new ChannelFactory<IWcfCustomUserNameService>(binding, endpointAddress);
+            factory.Credentials.UserName.UserName = "test1";
+            factory.Credentials.UserName.Password = "Mytestpwd1";
+
+            // *** EXECUTE *** \\
+            // Async factory open is part of the code under test
+            Task t = Task.Factory.FromAsync(factory.BeginOpen, factory.EndOpen, TaskCreationOptions.None);
+            t.GetAwaiter().GetResult();
+
+            serviceProxy = factory.CreateChannel();
+
+            Task<string> echoTask = serviceProxy.EchoAsync(testString);
+            string result = echoTask.GetAwaiter().GetResult();
+
+            // *** VALIDATE *** \\
+
+            Assert.True(result == testString, string.Format("Error: expected response from service: '{0}' Actual was: '{1}'", testString, result));
+
+            // Async factory close is also code under test
+            t = Task.Factory.FromAsync(factory.BeginClose, factory.EndClose, TaskCreationOptions.None);
+            t.GetAwaiter().GetResult();
+
+            // Async proxy close is also code under test
+            t = Task.Factory.FromAsync(((ICommunicationObject)serviceProxy).BeginClose, ((ICommunicationObject)serviceProxy).EndClose, TaskCreationOptions.None);
+            t.GetAwaiter().GetResult();
+
+            // *** CLEANUP *** \\
+            // cleanup was all part of code under test
+        }
+        finally
+        {
+            // *** ENSURE CLEANUP *** \\
+            ScenarioTestHelpers.CloseCommunicationObjects((ICommunicationObject)serviceProxy, factory);
+        }
+    }
+
+}

--- a/src/System.Private.ServiceModel/tools/IISHostedWcfService/App_code/testhosts/WsHttpTranSecUserNameTestServiceHost.cs
+++ b/src/System.Private.ServiceModel/tools/IISHostedWcfService/App_code/testhosts/WsHttpTranSecUserNameTestServiceHost.cs
@@ -1,0 +1,83 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.ObjectModel;
+using System.IdentityModel.Selectors;
+using System.ServiceModel;
+using System.ServiceModel.Activation;
+using System.ServiceModel.Channels;
+using System.ServiceModel.Configuration;
+using System.ServiceModel.Description;
+using System.ServiceModel.Dispatcher;
+using System.ServiceModel.Security;
+using System.Text;
+
+namespace WcfService
+{
+    public class WsHttpTransSecUserNameTestServiceHostFactory : ServiceHostFactory
+    {
+        protected override ServiceHost CreateServiceHost(Type serviceType, Uri[] baseAddresses)
+        {
+            WsHttpTranSecUserNameTestServiceHost serviceHost = new WsHttpTranSecUserNameTestServiceHost(serviceType, baseAddresses);
+            return serviceHost;
+        }
+    }
+    public class WsHttpTranSecUserNameTestServiceHost : TestServiceHostBase<IWcfCustomUserNameService>
+    {
+        protected override string Address { get { return "wshttp-transec-username"; } }
+
+        protected override Binding GetBinding()
+        {
+            var securityBindingElement = SecurityBindingElement.CreateUserNameOverTransportBindingElement();
+            securityBindingElement.IncludeTimestamp = false;
+            securityBindingElement.SecurityHeaderLayout = SecurityHeaderLayout.Lax;
+
+            CustomBinding binding = new CustomBinding(
+                            new TextMessageEncodingBindingElement(MessageVersion.Soap11, Encoding.UTF8),
+                            securityBindingElement,
+                            new HttpsTransportBindingElement());
+            return binding;
+        }
+
+        public WsHttpTranSecUserNameTestServiceHost(Type serviceType, params Uri[] baseAddresses)
+            : base(serviceType, baseAddresses)
+        {
+        }
+
+        protected override void ApplyConfiguration()
+        {
+            base.ApplyConfiguration();
+
+            ServiceCredentials serviceCredentials = new ServiceCredentials();
+            serviceCredentials.UserNameAuthentication.UserNamePasswordValidationMode = UserNamePasswordValidationMode.Custom;
+            serviceCredentials.UserNameAuthentication.CustomUserNamePasswordValidator = new CustomUserNameValidator();
+            this.Description.Behaviors.Add(serviceCredentials);
+        }
+
+        //private class CustomUserNameValidator : UserNamePasswordValidator
+        //{
+        //    // This method validates users. It allows in two users, test1 and test2 
+        //    // with passwords 1tset and 2tset respectively.
+        //    // This code is for illustration purposes only and 
+        //    // must not be used in a production environment because it is not secure.	
+        //    public override void Validate(string userName, string password)
+        //    {
+        //        if (null == userName || null == password)
+        //        {
+        //            throw new ArgumentNullException();
+        //        }
+
+        //        if (!(userName == "someUser" && password == "somePassword"))
+        //        {
+        //            // This throws an informative fault to the client.
+        //            throw new FaultException("Unknown Username or Incorrect Password");
+        //            // When you do not want to throw an infomative fault to the client,
+        //            // throw the following exception.
+        //            // throw new SecurityTokenException("Unknown Username or Incorrect Password");
+        //        }
+        //    }
+        //}
+    }
+}

--- a/src/System.Private.ServiceModel/tools/IISHostedWcfService/Web.config
+++ b/src/System.Private.ServiceModel/tools/IISHostedWcfService/Web.config
@@ -89,6 +89,7 @@
         <add factory="WcfService.WebSocketHttpsDuplexBinaryBufferedTestServiceHostFactory" service="WcfService.WSDuplexService" relativeAddress="~\WebSocketHttpsDuplexBinaryBuffered.svc" />
         <add factory="WcfService.WebSocketHttpsDuplexTextBufferedTestServiceHostFactory" service="WcfService.WSDuplexService" relativeAddress="~\WebSocketHttpsDuplexTextBuffered.svc" />
         <add factory="WcfService.WebSocketHttpVerifyWebSocketsUsedTestServiceHostFactory" service="WcfService.VerifyWebSockets" relativeAddress="~\WebSocketHttpVerifyWebSocketsUsed.svc" />
+        <add factory="WcfService.WsHttpTransSecUserNameTestServiceHostFactory" service="WcfService.WcfUserNameService" relativeAddress="~\WsHttpTranSecUserName.svc" />
       </serviceActivations>
     </serviceHostingEnvironment>
   </system.serviceModel>

--- a/src/System.Private.ServiceModel/tools/SelfHostedWcfService/Program.cs
+++ b/src/System.Private.ServiceModel/tools/SelfHostedWcfService/Program.cs
@@ -106,6 +106,7 @@ namespace SelfHostedWCFService
             CreateHost<WebSocketHttpsDuplexTextBufferedTestServiceHost, WSDuplexService>("WebSocketHttpsDuplexTextBuffered.svc", websocketsBaseAddress);
             CreateHost<ChannelExtensibilityServiceHost, WcfChannelExtensiblityService>("ChannelExtensibility.svc", httpBaseAddress);
             CreateHost<WebSocketHttpVerifyWebSocketsUsedTestServiceHost, VerifyWebSockets>("WebSocketHttpVerifyWebSocketsUsed.svc", websocketBaseAddress);
+            CreateHost<WsHttpTranSecUserNameTestServiceHost, WcfUserNameService>("WsHttpTranSecUserName.svc", httpsBaseAddress);
 
             //Start the crlUrl service last as the client use it to ensure all services have been started
             Uri testHostUrl = new Uri(string.Format("http://localhost/TestHost.svc", s_httpPort));


### PR DESCRIPTION
This enabling will happening in several stages.
This first stage is porting the missing types into the GitHub
repo, code formatting, and commenting out code that is not needed to allow
SecurityBindingElement.CreateUserNameOverTransportBindingElement
to work.

Subsequent PR's will add additional tests and expand the WS*
functionality a piece at a time.