### PR TITLE
Update code coverage job

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -109,7 +109,7 @@ wcfUtilities = new WcfUtilities()
     
     newJob.with {
         steps {
-            batchFile("build.cmd -coverage -outerloop -${configurationGroup} -- /p:ShouldGenerateNuSpec=false /p:OSGroup=${osGroupMap[os]} /p:WithCategories=\"InnerLoop;OuterLoop\" /p:ServiceUri=%WcfServiceUri%")
+            batchFile("build.cmd -coverage -outerloop -${configurationGroup} -- /p:ShouldGenerateNuSpec=false /p:OSGroup=${osGroupMap[os]} /p:ServiceUri=%WcfServiceUri%")
         }
     }
 


### PR DESCRIPTION
After change to dev workflow, code coverage jobs are failing because we pass in
a WithCategories=OuterLoop parameter. Remove this so we get code coverage again