### PR TITLE
Re-enable tests disabled by issue 10

### DIFF
--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Negotiate/NegotiateStream_Http_Tests.4.1.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Negotiate/NegotiateStream_Http_Tests.4.1.0.cs
@@ -260,7 +260,7 @@ public class NegotiateStream_Http_Tests : ConditionalWcfTest
     [Condition(nameof(Windows_Authentication_Available),
                nameof(Root_Certificate_Installed),
                nameof(UPN_Available))]
-    [Issue(10)]
+    [Issue(10, Framework = FrameworkID.NetNative)]
     [OuterLoop]
     public static void NegotiateStream_Http_With_Upn()
     {
@@ -406,7 +406,7 @@ public class NegotiateStream_Http_Tests : ConditionalWcfTest
                nameof(Explicit_Credentials_Available),
                nameof(Domain_Available),
                nameof(UPN_Available))]
-    [Issue(10)]
+    [Issue(10, Framework = FrameworkID.NetNative)]
     [OuterLoop]
     public static void NegotiateStream_Http_With_ExplicitUserNameAndPassword_With_Upn()
     {


### PR DESCRIPTION
PR #1502 fixed issue #10 by implementing UpnEndpointIdentity.
But 2 tests were still disabled by issue 10, so this PR just
re-enables those tests.  Both require manual setup to run, so
we will not see them pass or fail in CI or VSO.

Update: the tests still fail in UWP, so this PR only re-enables them for non-UWP frameworks.