### PR TITLE
Port to 1.1:Fix UpnIdentity

### DIFF
--- a/src/System.Private.ServiceModel/src/System/IdentityModel/Claims/Claim.cs
+++ b/src/System.Private.ServiceModel/src/System/IdentityModel/Claims/Claim.cs
@@ -146,7 +146,6 @@ namespace System.IdentityModel.Claims
             return new Claim(ClaimTypes.Thumbprint, SecurityUtils.CloneBuffer(thumbprint), Rights.PossessProperty, ClaimComparer.Thumbprint);
         }
 
-#if SUPPORTS_WINDOWSIDENTITY
         public static Claim CreateUpnClaim(string upn)
         {
             if (upn == null)
@@ -154,7 +153,6 @@ namespace System.IdentityModel.Claims
 
             return new Claim(ClaimTypes.Upn, upn, Rights.PossessProperty, ClaimComparer.Upn);
         }
-#endif // SUPPORTS_WINDOWSIDENTITY
 
         public static Claim CreateUriClaim(Uri uri)
         {

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Diagnostics/SecurityTraceRecordHelper.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Diagnostics/SecurityTraceRecordHelper.cs
@@ -40,5 +40,9 @@ namespace System.ServiceModel.Diagnostics
         internal static void TraceIdentityDeterminationFailure(EndpointAddress epr, Type identityVerifier)
         {
         }
+
+        internal static void TraceSpnToSidMappingFailure(string spn, Exception e)
+        {
+        }
     }
 }

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/UpnEndpointIdentity.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/UpnEndpointIdentity.cs
@@ -3,8 +3,14 @@
 // See the LICENSE file in the project root for more information.
 
 
+using System.ComponentModel;
 using System.Security.Principal;
 using System.IdentityModel.Claims;
+using System.Runtime;
+using System.Runtime.InteropServices;
+using System.ServiceModel.Diagnostics;
+using System.Text;
+using System.Xml;
 
 namespace System.ServiceModel
 {
@@ -23,24 +29,22 @@ namespace System.ServiceModel
         public UpnEndpointIdentity(string upnName)
         {
             if (upnName == null)
-                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("upnName");
-#if SUPPORTS_WINDOWSIDENTITY
-            base.Initialize(Claim.CreateUpnClaim(upnName));
-#else 
-            throw ExceptionHelper.PlatformNotSupported("UpnEndpointIdentity is not supported on this platform");
-#endif // SUPPORTS_WINDOWSIDENTITY
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull(nameof(upnName));
+            }
+
+            Initialize(Claim.CreateUpnClaim(upnName));
         }
 
         public UpnEndpointIdentity(Claim identity)
         {
             if (identity == null)
-                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("identity");
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull(nameof(identity));
 
-            // PreSharp Bug: Parameter 'identity.ResourceType' to this public method must be validated: A null-dereference can occur here.
             if (!identity.ClaimType.Equals(ClaimTypes.Upn))
                 throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgument(SR.Format(SR.UnrecognizedClaimTypeForIdentity, identity.ClaimType, ClaimTypes.Upn));
 
-            base.Initialize(identity);
+            Initialize(identity);
         }
 
 #if SUPPORTS_WINDOWSIDENTITY
@@ -53,6 +57,110 @@ namespace System.ServiceModel
             _upnSid = windowsIdentity.User;
             _hasUpnSidBeenComputed = true;
         }
+
+        internal override void EnsureIdentityClaim()
+        {
+            if (_windowsIdentity != null)
+            {
+                lock (_thisLock)
+                {
+                    if (_windowsIdentity != null)
+                    {
+                        Initialize(Claim.CreateUpnClaim(GetUpnFromWindowsIdentity(_windowsIdentity)));
+                        _windowsIdentity.Dispose();
+                        _windowsIdentity = null;
+                    }
+                }
+            }
+        }
+
+        string GetUpnFromWindowsIdentity(WindowsIdentity windowsIdentity)
+        {
+            string downlevelName = null;
+            string upnName = null;
+ 
+            try
+            {
+                downlevelName = windowsIdentity.Name;
+ 
+                if (IsMachineJoinedToDomain())
+                {
+                    upnName = GetUpnFromDownlevelName(downlevelName);
+                }
+            }
+            catch (Exception e)
+            {
+                if (Fx.IsFatal(e))
+                {
+                    throw;
+                }
+             }
+ 
+            // if the AD cannot be queried for the fully qualified domain name,
+            // fall back to the downlevel UPN name
+            return upnName ?? downlevelName;
+        }
+
+        bool IsMachineJoinedToDomain()
+        {
+            throw ExceptionHelper.PlatformNotSupported();
+        }
+
+        string GetUpnFromDownlevelName(string downlevelName)
+        {
+            throw ExceptionHelper.PlatformNotSupported();
+        }
 #endif // SUPPORTS_WINDOWSIDENTITY
+
+        internal override void WriteContentsTo(XmlDictionaryWriter writer)
+        {
+            if (writer == null)
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull(nameof(writer));
+
+            writer.WriteElementString(XD.AddressingDictionary.Upn, XD.AddressingDictionary.IdentityExtensionNamespace, (string)this.IdentityClaim.Resource);
+        }
+
+#if SUPPORTS_WINDOWSIDENTITY
+        internal SecurityIdentifier GetUpnSid()
+        {
+            Fx.Assert(ClaimTypes.Upn.Equals(this.IdentityClaim.ClaimType), "");
+            if (!_hasUpnSidBeenComputed)
+            {
+                lock (_thisLock)
+                {
+                    string upn = (string)this.IdentityClaim.Resource;
+                    if (!_hasUpnSidBeenComputed)
+                    {
+                        try
+                        {
+                            NTAccount userAccount = new NTAccount(upn);
+                            _upnSid = userAccount.Translate(typeof(SecurityIdentifier)) as SecurityIdentifier;
+                        }
+#pragma warning suppress 56500 // covered by FxCOP
+                        catch (Exception e)
+                        {
+                            // Always immediately rethrow fatal exceptions.
+                            if (Fx.IsFatal(e))
+                            {
+                                throw;
+                            }
+
+                            if (e is NullReferenceException)
+                            {
+                                throw;
+                            }
+
+                            SecurityTraceRecordHelper.TraceSpnToSidMappingFailure(upn, e);
+                        }
+                        finally
+                        {
+                            _hasUpnSidBeenComputed = true;
+                        }
+                    }
+                }
+            }
+            return _upnSid;
+        }
+#endif
     }
 }

--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Negotiate/NegotiateStream_Http_Tests.4.1.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Negotiate/NegotiateStream_Http_Tests.4.1.0.cs
@@ -260,7 +260,7 @@ public class NegotiateStream_Http_Tests : ConditionalWcfTest
     [Condition(nameof(Windows_Authentication_Available),
                nameof(Root_Certificate_Installed),
                nameof(UPN_Available))]
-    [Issue(10)]
+    [Issue(10, Framework = FrameworkID.NetNative)]
     [OuterLoop]
     public static void NegotiateStream_Http_With_Upn()
     {
@@ -406,7 +406,7 @@ public class NegotiateStream_Http_Tests : ConditionalWcfTest
                nameof(Explicit_Credentials_Available),
                nameof(Domain_Available),
                nameof(UPN_Available))]
-    [Issue(10)]
+    [Issue(10, Framework = FrameworkID.NetNative)]
     [OuterLoop]
     public static void NegotiateStream_Http_With_ExplicitUserNameAndPassword_With_Upn()
     {

--- a/src/System.ServiceModel.Security/tests/ServiceModel/UpnEndpointIdentityTest.cs
+++ b/src/System.ServiceModel.Security/tests/ServiceModel/UpnEndpointIdentityTest.cs
@@ -16,7 +16,6 @@ public static class UpnEndpointIdentityTest
     [WcfTheory]
     [InlineData("")]
     [InlineData("test@wcf.example.com")]
-    [Issue(1454, Framework = FrameworkID.NetNative)]
     public static void Ctor_UpnName(string upn)
     {
         UpnEndpointIdentity upnEndpointEntity = new UpnEndpointIdentity(upn);


### PR DESCRIPTION
Fix UpnIdentity
Re-enable tests disabled by issue 10, except for NET Native.
2 tests are still disabled by issue 10, so re-enables those tests. 
 Both require manual setup to run, so
we will not see them pass or fail in CI or VSO.
These tests still fail in UWP and so remain disabled there.