### PR TITLE
Re-enable tests disabled in UWP for issue #10

### DIFF
--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Negotiate/NegotiateStream_Http_Tests.4.1.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Negotiate/NegotiateStream_Http_Tests.4.1.0.cs
@@ -260,7 +260,6 @@ public class NegotiateStream_Http_Tests : ConditionalWcfTest
     [Condition(nameof(Windows_Authentication_Available),
                nameof(Root_Certificate_Installed),
                nameof(UPN_Available))]
-    [Issue(10, Framework = FrameworkID.NetNative)]
     [OuterLoop]
     public static void NegotiateStream_Http_With_Upn()
     {
@@ -406,7 +405,6 @@ public class NegotiateStream_Http_Tests : ConditionalWcfTest
                nameof(Explicit_Credentials_Available),
                nameof(Domain_Available),
                nameof(UPN_Available))]
-    [Issue(10, Framework = FrameworkID.NetNative)]
     [OuterLoop]
     public static void NegotiateStream_Http_With_ExplicitUserNameAndPassword_With_Upn()
     {


### PR DESCRIPTION
Testing with latest dependencies showed these 2 tests pass in UWP now.