### PR TITLE
Skip tests with known issue or should not get run on Linux

### DIFF
--- a/src/System.Private.ServiceModel/tests/Common/Infrastructure/ConditionalWcfTest.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Infrastructure/ConditionalWcfTest.cs
@@ -92,7 +92,7 @@ namespace Infrastructure.Common
         }
         
         // Returns 'true' if the client code is executing on a Windows OS
-        private static bool Is_Windows()
+        public static bool Is_Windows()
         {
             return GetConditionValue(nameof(Is_Windows),
                                      ConditionalTestDetectors.IsWindows);

--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Https/ClientCredentialTypeTests.4.1.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Https/ClientCredentialTypeTests.4.1.0.cs
@@ -215,7 +215,7 @@ public class Https_ClientCredentialTypeTests : ConditionalWcfTest
     }
 
     [WcfFact]
-    [Condition(nameof(Windows_Authentication_Available), nameof(Root_Certificate_Installed))]
+    [Condition(nameof(Windows_Authentication_Available), nameof(Is_Windows))]
     [OuterLoop]
     public static void WindowsAuthentication_RoundTrips_Echo()
     {

--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Negotiate/NegotiateStream_Http_Tests.4.1.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Negotiate/NegotiateStream_Http_Tests.4.1.0.cs
@@ -61,6 +61,7 @@ public class NegotiateStream_Http_Tests : ConditionalWcfTest
                nameof(Root_Certificate_Installed),
                nameof(Ambient_Credentials_Available))]
     [OuterLoop]
+    [Issue(1569, OS = OSID.AnyUnix)]
     public static void NegotiateStream_Http_AmbientCredentials()
     {
         string testString = "Hello";
@@ -157,6 +158,7 @@ public class NegotiateStream_Http_Tests : ConditionalWcfTest
     //          "NegotiateTestDomain"
     //          "NegotiateTestSpn" (host/<servername>)
     //          "ServiceUri" (server running as machine context)
+    [Issue(1569, OS = OSID.AnyUnix)]
     public static void NegotiateStream_Http_With_ExplicitSpn()
     {
         string testString = "Hello";


### PR DESCRIPTION
* Two tests are failing in Kerberos Manual tests due to known product issue.
* One test need to validate server window credential on the client side,
does not work on non window machines.

Fixes #1564 and issue#1563