### PR TITLE
Fix OnOpen/OnBeginOpen issues with custom channels

### DIFF
--- a/src/System.Private.ServiceModel/src/Internals/System/Runtime/TaskHelpers.cs
+++ b/src/System.Private.ServiceModel/src/Internals/System/Runtime/TaskHelpers.cs
@@ -299,6 +299,20 @@ namespace System.Runtime
             return new SyncContextScope();
         }
 
+        // Calls the given Action asynchronously.
+        public static async Task CallActionAsync<TArg>(Action<TArg> action, TArg argument)
+        {
+            using (var scope = TaskHelpers.RunTaskContinuationsOnOurThreads())
+            {
+                if (scope != null)  // No need to change threads if already off of thread pool
+                {
+                    await Task.Yield(); // Move synchronous method off of thread pool
+                }
+
+                action(argument);
+            }
+        }
+
         private class SyncContextScope : IDisposable
         {
             private readonly SynchronizationContext _prevContext;

--- a/src/System.Private.ServiceModel/src/Resources/System.Private.ServiceModel.rd.xml
+++ b/src/System.Private.ServiceModel/src/Resources/System.Private.ServiceModel.rd.xml
@@ -12,6 +12,10 @@
     
     <Assembly Name="System.Private.ServiceModel">
       <Namespace Name="System.ServiceModel">
+        <!-- All ICommunicationObject implementations require reflection -->
+        <Type Name="ICommunicationObject" Dynamic="Required All" >
+           <Subtypes Browse="All" />
+        </Type>
         <Type Name="BasicHttpBinding" Dynamic="Required All" />
         <!-- WCF attributes must be reflectable to instantiate Attribute from CustomAttributeData -->
         <Type Name="FaultContractAttribute" Dynamic="Required All" >

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/ChannelFactory.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/ChannelFactory.cs
@@ -319,15 +319,7 @@ namespace System.ServiceModel
         {
             if (_innerFactory != null)
             {
-                IAsyncChannelFactory asyncFactory = _innerFactory as IAsyncChannelFactory;
-                if (asyncFactory != null)
-                {
-                    await asyncFactory.CloseAsync(timeout);
-                }
-                else
-                {
-                    _innerFactory.Close(timeout);
-                }
+                await CloseOtherAsync(_innerFactory, timeout);
             }
         }
 
@@ -345,15 +337,7 @@ namespace System.ServiceModel
         {
             if (_innerFactory != null)
             {
-                IAsyncChannelFactory asyncFactory = _innerFactory as IAsyncChannelFactory;
-                if (asyncFactory != null)
-                {
-                    await asyncFactory.OpenAsync(timeout);
-                }
-                else
-                {
-                    _innerFactory.Open(timeout);
-                }
+                await OpenOtherAsync(_innerFactory, timeout);
             }
         }
 

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/ConnectionOrientedTransportChannelFactory.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/ConnectionOrientedTransportChannelFactory.cs
@@ -68,6 +68,13 @@ namespace System.ServiceModel.Channels
                 // there is the binding is configured with security
                 _flowIdentity = supportsImpersonationDuringAsyncOpen;
             }
+
+            // We explicitly declare this type and all derived types support
+            // async open/close.  We currently must do this because the NET Native
+            // toolchain does not recognize this type was granted Reflection degree.
+            // Is it safe to do this only because this is an internal type and no
+            // derived type is public or exposed in contract.
+            SupportsAsyncOpenClose = true;
         }
 
         public int ConnectionBufferSize

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/ServiceChannel.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/ServiceChannel.cs
@@ -1289,28 +1289,12 @@ namespace System.ServiceModel.Channels
 
             if (_closeBinder)
             {
-                var asyncInnerChannel = InnerChannel as IAsyncCommunicationObject;
-                if (asyncInnerChannel != null)
-                {
-                    await asyncInnerChannel.CloseAsync(timeoutHelper.RemainingTime());
-                }
-                else
-                {
-                    InnerChannel.Close(timeoutHelper.RemainingTime());
-                }
+                await CloseOtherAsync(InnerChannel, timeoutHelper.RemainingTime());
             }
 
             if (_closeFactory)
             {
-                var asyncFactory = _factory as IAsyncCommunicationObject;
-                if (asyncFactory != null)
-                {
-                    await asyncFactory.CloseAsync(timeoutHelper.RemainingTime());
-                }
-                else
-                {
-                    _factory.Close(timeoutHelper.RemainingTime());
-                }
+                await CloseOtherAsync(_factory, timeoutHelper.RemainingTime());
             }
 
             CleanupChannelCollections();
@@ -1345,15 +1329,7 @@ namespace System.ServiceModel.Channels
 
             if (_openBinder)
             {
-                var asyncInnerChannel = InnerChannel as IAsyncCommunicationObject;
-                if (asyncInnerChannel != null)
-                {
-                    await asyncInnerChannel.OpenAsync(timeout);
-                }
-                else
-                {
-                    InnerChannel.Open(timeout);
-                }
+                await OpenOtherAsync(InnerChannel, timeout);
             }
 
             BindDuplexCallbacks();

--- a/src/System.Private.ServiceModel/tests/Common/Unit/IMockCommunicationObject.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Unit/IMockCommunicationObject.cs
@@ -1,0 +1,45 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.ServiceModel;
+
+// IMockCommunicationObject allows caller to provide delegate to intercept
+// every abstract and virtual method.  Each has a corresponding Defaultxxx()
+// method that does what the default Communication object would do, allowing
+// the caller to do processing before and after the default behavior.
+public interface IMockCommunicationObject : ICommunicationObject
+{
+    // Delegates tests can override
+    Func<TimeSpan> DefaultCloseTimeoutOverride { get; set; }
+    Func<TimeSpan> DefaultOpenTimeoutOverride { get; set; }
+    Action OnAbortOverride { get; set; }
+    Func<TimeSpan, AsyncCallback, object, IAsyncResult> OnBeginCloseOverride { get; set; }
+    Func<TimeSpan, AsyncCallback, object, IAsyncResult> OnBeginOpenOverride { get; set; }
+    Action<TimeSpan> OnOpenOverride { get; set; }
+    Action<TimeSpan> OnCloseOverride { get; set; }
+    Action<IAsyncResult> OnEndCloseOverride { get; set; }
+    Action<IAsyncResult> OnEndOpenOverride { get; set; }
+
+    Action OnOpeningOverride { get; set; }
+    Action OnOpenedOverride { get; set; }
+    Action OnClosingOverride { get; set; }
+    Action OnClosedOverride { get; set; }
+    Action OnFaultedOverride { get; set; }
+
+    // Default bahaviors tests can call
+    void DefaultOnAbort();
+    void DefaultOnOpening();
+    void DefaultOnOpen(TimeSpan timeout);
+    void DefaultOnOpened();
+    void DefaultOnClosing();
+    void DefaultOnClose(TimeSpan timeout);
+    void DefaultOnClosed();
+
+    IAsyncResult DefaultOnBeginOpen(TimeSpan timeout, AsyncCallback callback, object state);
+    void DefaultOnEndOpen(IAsyncResult result);
+
+    IAsyncResult DefaultOnBeginClose(TimeSpan timeout, AsyncCallback callback, object state);
+    void DefaultOnEndClose(IAsyncResult result);
+}

--- a/src/System.Private.ServiceModel/tests/Common/Unit/MockAsyncResult.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Unit/MockAsyncResult.cs
@@ -6,42 +6,55 @@ using System;
 using System.Threading;
 
 public class MockAsyncResult : IAsyncResult
+{
+    public MockAsyncResult(TimeSpan timeout, AsyncCallback callback, object state)
     {
-        public MockAsyncResult(TimeSpan timeout, AsyncCallback callback, object state)
+        Timeout = timeout;
+        Callback = callback;
+        AsyncState = state;
+        AsyncWaitHandle = new ManualResetEvent(false);
+    }
+
+    public MockAsyncResult() : this(TimeSpan.FromSeconds(30), null, null)
+    {
+    }
+
+    public TimeSpan Timeout { get; set; }
+
+    public AsyncCallback Callback { get; set; }
+
+    public object AsyncState { get; set; }
+
+    public WaitHandle AsyncWaitHandle { get; set; }
+
+    public bool CompletedSynchronously { get; set; }
+
+    public bool IsCompleted { get; set; }
+
+    public bool IsCompleting { get; set; }
+
+    public object Result { get; set; }
+
+    public void Complete()
+    {
+        Complete(null);
+    }
+
+    public void Complete(object result)
+    {
+        if (!IsCompleting)
         {
-            Timeout = timeout;
-            Callback = callback;
-            AsyncState = state;
-            AsyncWaitHandle = new ManualResetEvent(false);
-        }
+            Result = result;
+            IsCompleting = true;
+            CompletedSynchronously = true;
+            IsCompleted = true;
+            ((ManualResetEvent)AsyncWaitHandle).Set();
 
-        public TimeSpan Timeout { get; set; }
-
-        public AsyncCallback Callback { get; set; }
-
-        public object AsyncState { get; set; }
-
-        public WaitHandle AsyncWaitHandle { get; set; }
-
-        public bool CompletedSynchronously { get; set; }
-
-        public bool IsCompleted { get; set; }
-
-        public bool IsCompleting { get; set; }
-
-        public void Complete()
-        {
-            if (!IsCompleting)
+            if (Callback != null)
             {
-                IsCompleting = true;
-                CompletedSynchronously = true;
-                IsCompleted = true;
-                ((ManualResetEvent)AsyncWaitHandle).Set();
-
-                if (Callback != null)
-                {
-                    Callback(this);
-                }
+                Callback(this);
             }
         }
     }
+}
+

--- a/src/System.Private.ServiceModel/tests/Common/Unit/MockChannelBase.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Unit/MockChannelBase.cs
@@ -1,0 +1,250 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.ServiceModel;
+using System.ServiceModel.Channels;
+
+public class MockChannelBase : ChannelBase, IMockCommunicationObject
+{
+    private readonly EndpointAddress _address;
+    private readonly MessageEncoder _encoder;
+    private readonly ChannelManagerBase _manager;
+
+    public MockChannelBase(ChannelManagerBase manager, MessageEncoderFactory encoderFactory, EndpointAddress address)
+    : base(manager)
+    {
+        _address = address;
+        _manager = manager;
+        _encoder = encoderFactory.CreateSessionEncoder();
+
+        OpenAsyncResult = new MockAsyncResult();
+        CloseAsyncResult = new MockAsyncResult();
+
+        GetEndpointPropertyOverride = DefaultGetEndpointProperty;
+
+        // CommunicationObject overrides
+        DefaultCloseTimeoutOverride = DefaultDefaultCloseTimeout;
+        DefaultOpenTimeoutOverride = DefaultDefaultOpenTimeout;
+
+        OnAbortOverride = DefaultOnAbort;
+        OnOpenOverride = DefaultOnOpen;
+        OnCloseOverride = DefaultOnClose;
+
+        OnBeginOpenOverride = DefaultOnBeginOpen;
+        OnEndOpenOverride = DefaultOnEndOpen;
+
+        OnBeginCloseOverride = DefaultOnBeginClose;
+        OnEndCloseOverride = DefaultOnEndClose;
+
+        // All the virtuals
+        OnOpeningOverride = DefaultOnOpening;
+        OnOpenedOverride = DefaultOnOpened;
+        OnClosingOverride = DefaultOnClosing;
+        OnClosedOverride = DefaultOnClosed;
+        OnFaultedOverride = DefaultOnFaulted;
+    }
+
+    public Func<EndpointAddress> GetEndpointPropertyOverride { get; set; }
+
+    public MockAsyncResult OpenAsyncResult { get; set; }
+    public MockAsyncResult CloseAsyncResult { get; set; }
+
+    // Abstract overrides
+    public Func<TimeSpan> DefaultCloseTimeoutOverride { get; set; }
+    public Func<TimeSpan> DefaultOpenTimeoutOverride { get; set; }
+    public Action OnAbortOverride { get; set; }
+    public Func<TimeSpan, AsyncCallback, object, IAsyncResult> OnBeginCloseOverride { get; set; }
+    public Func<TimeSpan, AsyncCallback, object, IAsyncResult> OnBeginOpenOverride { get; set; }
+    public Action<TimeSpan> OnOpenOverride { get; set; }
+    public Action<TimeSpan> OnCloseOverride { get; set; }
+    public Action<IAsyncResult> OnEndCloseOverride { get; set; }
+    public Action<IAsyncResult> OnEndOpenOverride { get; set; }
+
+    // Virtual overrides
+    public Action OnOpeningOverride { get; set; }
+    public Action OnOpenedOverride { get; set; }
+    public Action OnClosingOverride { get; set; }
+    public Action OnClosedOverride { get; set; }
+    public Action OnFaultedOverride { get; set; }
+
+    public EndpointAddress RemoteAddress
+    {
+        get { return DefaultGetEndpointProperty(); }
+    }
+
+    public EndpointAddress DefaultGetEndpointProperty()
+    {
+        return _address;
+    }
+
+    protected override TimeSpan DefaultCloseTimeout
+    {
+        get
+        {
+            return DefaultCloseTimeoutOverride();
+        }
+    }
+
+    public TimeSpan DefaultDefaultCloseTimeout()
+    {
+        return TimeSpan.FromSeconds(30);
+    }
+
+    protected override TimeSpan DefaultOpenTimeout
+    {
+        get
+        {
+            return DefaultOpenTimeoutOverride();
+        }
+    }
+
+    public TimeSpan DefaultDefaultOpenTimeout()
+    {
+        return TimeSpan.FromSeconds(30);
+    }
+
+    protected override void OnAbort()
+    {
+        OnAbortOverride();
+    }
+
+    public void DefaultOnAbort()
+    {
+        // abstract -- no base to call
+    }
+
+    protected override IAsyncResult OnBeginClose(TimeSpan timeout, AsyncCallback callback, object state)
+    {
+        return OnBeginCloseOverride(timeout, callback, state);
+    }
+
+    public IAsyncResult DefaultOnBeginClose(TimeSpan timeout, AsyncCallback callback, object state)
+    {
+        // Modify the placeholder async result we already instantiated.
+        CloseAsyncResult.Callback = callback;
+        CloseAsyncResult.AsyncState = state;
+
+        // The mock always Completes the IAsyncResult before handing it back.
+        // This is done because the sync path has no access to this IAsyncResult
+        // that happens behind the scenes.
+        CloseAsyncResult.Complete();
+
+        return CloseAsyncResult;
+        // abstract -- no base to call
+    }
+
+    protected override IAsyncResult OnBeginOpen(TimeSpan timeout, AsyncCallback callback, object state)
+    {
+        return OnBeginOpenOverride(timeout, callback, state);
+    }
+
+    public IAsyncResult DefaultOnBeginOpen(TimeSpan timeout, AsyncCallback callback, object state)
+    {
+        // Modify the placeholder async result we already instantiated.
+        OpenAsyncResult.Callback = callback;
+        OpenAsyncResult.AsyncState = state;
+
+        // The mock always Completes the IAsyncResult before handing it back.
+        // This is done because the sync path has no access to this IAsyncResult
+        // that happens behind the scenes.
+        OpenAsyncResult.Complete();
+
+        return OpenAsyncResult;
+        // abstract -- no base to call
+    }
+
+    protected override void OnClose(TimeSpan timeout)
+    {
+        OnCloseOverride(timeout);
+    }
+
+    public void DefaultOnClose(TimeSpan timeout)
+    {
+        // abstract -- no base to call
+    }
+
+    protected override void OnEndClose(IAsyncResult result)
+    {
+        OnEndCloseOverride(result);
+    }
+
+    public void DefaultOnEndClose(IAsyncResult result)
+    {
+        ((MockAsyncResult)result).Complete();
+        // abstract -- no base to call
+    }
+
+    protected override void OnEndOpen(IAsyncResult result)
+    {
+        OnEndOpenOverride(result);
+    }
+
+    public void DefaultOnEndOpen(IAsyncResult result)
+    {
+        ((MockAsyncResult)result).Complete();
+        // abstract -- no base to call
+    }
+
+    protected override void OnOpen(TimeSpan timeout)
+    {
+        OnOpenOverride(timeout);
+    }
+
+    public void DefaultOnOpen(TimeSpan timeout)
+    {
+        // abstract -- no base to call
+    }
+
+    // Virtuals
+    protected override void OnOpening()
+    {
+        OnOpeningOverride();
+    }
+
+    public void DefaultOnOpening()
+    {
+        base.OnOpening();
+    }
+
+    protected override void OnOpened()
+    {
+        OnOpenedOverride();
+    }
+
+    public void DefaultOnOpened()
+    {
+        base.OnOpened();
+    }
+
+    protected override void OnClosing()
+    {
+        OnClosingOverride();
+    }
+
+    public void DefaultOnClosing()
+    {
+        base.OnClosing();
+    }
+
+    protected override void OnClosed()
+    {
+        OnClosedOverride();
+    }
+
+    public void DefaultOnClosed()
+    {
+        base.OnClosed();
+    }
+
+    protected override void OnFaulted()
+    {
+        OnFaultedOverride();
+    }
+
+    public void DefaultOnFaulted()
+    {
+        base.OnFaulted();
+    }
+}

--- a/src/System.Private.ServiceModel/tests/Common/Unit/MockChannelFactory.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Unit/MockChannelFactory.cs
@@ -1,0 +1,249 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.ServiceModel;
+using System.ServiceModel.Channels;
+
+public class MockChannelFactory<TChannel> : ChannelFactoryBase<TChannel>, IMockCommunicationObject where TChannel : IChannel
+{
+    public MockChannelFactory(BindingContext context, MessageEncoderFactory encoderFactory)
+            : base(context.Binding)
+    {
+        MessageEncoderFactory = encoderFactory;
+
+        OnCreateChannelOverride = DefaultOnCreateChannel;
+
+        OpenAsyncResult = new MockAsyncResult();
+        CloseAsyncResult = new MockAsyncResult();
+
+        // Each overrideable method has a delegate property that
+        // can be set to override it, please a default handler.
+
+        // CommunicationObject overrides
+        DefaultCloseTimeoutOverride = DefaultDefaultCloseTimeout;
+        DefaultOpenTimeoutOverride = DefaultDefaultOpenTimeout;
+
+        OnAbortOverride = DefaultOnAbort;
+        OnOpenOverride = DefaultOnOpen;
+        OnCloseOverride = DefaultOnClose;
+
+        OnBeginOpenOverride = DefaultOnBeginOpen;
+        OnEndOpenOverride = DefaultOnEndOpen;
+
+        OnBeginCloseOverride = DefaultOnBeginClose;
+        OnEndCloseOverride = DefaultOnEndClose;
+
+        // All the virtuals
+        OnOpeningOverride = DefaultOnOpening;
+        OnOpenedOverride = DefaultOnOpened;
+        OnClosingOverride = DefaultOnClosing;
+        OnClosedOverride = DefaultOnClosed;
+        OnFaultedOverride = DefaultOnFaulted;
+    }
+
+    public Func<EndpointAddress, Uri, IChannel> OnCreateChannelOverride { get; set; }
+
+    public MessageEncoderFactory MessageEncoderFactory { get; set; }
+
+    public MockAsyncResult OpenAsyncResult { get; set; }
+    public MockAsyncResult CloseAsyncResult { get; set; }
+
+    // Abstract overrides
+    public Func<TimeSpan> DefaultCloseTimeoutOverride { get; set; }
+    public Func<TimeSpan> DefaultOpenTimeoutOverride { get; set; }
+    public Action OnAbortOverride { get; set; }
+    public Func<TimeSpan, AsyncCallback, object, IAsyncResult> OnBeginCloseOverride { get; set; }
+    public Func<TimeSpan, AsyncCallback, object, IAsyncResult> OnBeginOpenOverride { get; set; }
+    public Action<TimeSpan> OnOpenOverride { get; set; }
+    public Action<TimeSpan> OnCloseOverride { get; set; }
+    public Action<IAsyncResult> OnEndCloseOverride { get; set; }
+    public Action<IAsyncResult> OnEndOpenOverride { get; set; }
+
+    // Virtual overrides
+    public Action OnOpeningOverride { get; set; }
+    public Action OnOpenedOverride { get; set; }
+    public Action OnClosingOverride { get; set; }
+    public Action OnClosedOverride { get; set; }
+    public Action OnFaultedOverride { get; set; }
+
+    protected override TChannel OnCreateChannel(EndpointAddress address, Uri via)
+    {
+        return (TChannel) OnCreateChannelOverride(address, via);
+    }
+
+    public IChannel DefaultOnCreateChannel(EndpointAddress address, Uri via)
+    {
+        // Default is a mock IRequestChannel.
+        // If callers want something else, supply a delegate to OnCreateChannelOverride
+        // that creates the TChannel needed, and don't call this default.
+        return new MockRequestChannel(this, MessageEncoderFactory, address, via);
+    }
+
+    protected override TimeSpan DefaultCloseTimeout
+    {
+        get
+        {
+            return DefaultCloseTimeoutOverride();
+        }
+    }
+
+    public TimeSpan DefaultDefaultCloseTimeout()
+    {
+        return TimeSpan.FromSeconds(30);
+    }
+
+    protected override TimeSpan DefaultOpenTimeout
+    {
+        get
+        {
+            return DefaultOpenTimeoutOverride();
+        }
+    }
+
+    public TimeSpan DefaultDefaultOpenTimeout()
+    {
+        return TimeSpan.FromSeconds(30);
+    }
+
+    protected override void OnAbort()
+    {
+        OnAbortOverride();
+    }
+
+    public void DefaultOnAbort()
+    {
+        base.OnAbort();
+    }
+
+    protected override IAsyncResult OnBeginClose(TimeSpan timeout, AsyncCallback callback, object state)
+    {
+        return OnBeginCloseOverride(timeout, callback, state);
+    }
+
+    public IAsyncResult DefaultOnBeginClose(TimeSpan timeout, AsyncCallback callback, object state)
+    {
+        // Modify the placeholder async result we already instantiated.
+        CloseAsyncResult.Callback = callback;
+        CloseAsyncResult.AsyncState = state;
+
+        // The mock always Completes the IAsyncResult before handing it back.
+        // This is done because the sync path has no access to this IAsyncResult
+        // that happens behind the scenes.
+        CloseAsyncResult.Complete();
+
+        return CloseAsyncResult;
+    }
+
+    protected override IAsyncResult OnBeginOpen(TimeSpan timeout, AsyncCallback callback, object state)
+    {
+        return OnBeginOpenOverride(timeout, callback, state);
+    }
+
+    public IAsyncResult DefaultOnBeginOpen(TimeSpan timeout, AsyncCallback callback, object state)
+    {
+        // Modify the placeholder async result we already instantiated.
+        OpenAsyncResult.Callback = callback;
+        OpenAsyncResult.AsyncState = state;
+
+        // The mock always Completes the IAsyncResult before handing it back.
+        // This is done because the sync path has no access to this IAsyncResult
+        // that happens behind the scenes.
+        OpenAsyncResult.Complete();
+
+        return OpenAsyncResult;
+    }
+
+    protected override void OnClose(TimeSpan timeout)
+    {
+        OnCloseOverride(timeout);
+    }
+
+    public void DefaultOnClose(TimeSpan timeout)
+    {
+        base.OnClose(timeout);
+    }
+
+    protected override void OnEndClose(IAsyncResult result)
+    {
+        OnEndCloseOverride(result);
+    }
+
+    public void DefaultOnEndClose(IAsyncResult result)
+    {
+        ((MockAsyncResult)result).Complete();
+    }
+
+    protected override void OnEndOpen(IAsyncResult result)
+    {
+        OnEndOpenOverride(result);
+    }
+
+    public void DefaultOnEndOpen(IAsyncResult result)
+    {
+        ((MockAsyncResult)result).Complete();
+    }
+
+    protected override void OnOpen(TimeSpan timeout)
+    {
+        OnOpenOverride(timeout);
+    }
+
+    public void DefaultOnOpen(TimeSpan timeout)
+    {
+        // abstract -- no base to call
+    }
+
+    // Virtuals
+    protected override void OnOpening()
+    {
+        OnOpeningOverride();
+    }
+
+    public void DefaultOnOpening()
+    {
+        base.OnOpening();
+    }
+
+    protected override void OnOpened()
+    {
+        OnOpenedOverride();
+    }
+
+    public void DefaultOnOpened()
+    {
+        base.OnOpened();
+    }
+
+    protected override void OnClosing()
+    {
+        OnClosingOverride();
+    }
+
+    public void DefaultOnClosing()
+    {
+        base.OnClosing();
+    }
+
+    protected override void OnClosed()
+    {
+        OnClosedOverride();
+    }
+
+    public void DefaultOnClosed()
+    {
+        base.OnClosed();
+    }
+
+    protected override void OnFaulted()
+    {
+        OnFaultedOverride();
+    }
+
+    public void DefaultOnFaulted()
+    {
+        base.OnFaulted();
+    }
+
+}

--- a/src/System.Private.ServiceModel/tests/Common/Unit/MockRequestChannel.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Unit/MockRequestChannel.cs
@@ -1,0 +1,79 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.ServiceModel;
+using System.ServiceModel.Channels;
+
+public class MockRequestChannel : MockChannelBase, IRequestChannel
+{
+    private readonly Uri _via;
+
+    public Uri Via
+    {
+        get { return this._via; }
+    }
+
+    public Func<Message, TimeSpan, Message> RequestOverride { get; set; }
+    public Func<Message,TimeSpan,AsyncCallback,object, IAsyncResult> BeginRequestOverride { get; set; }
+    public Func<IAsyncResult, Message> EndRequestOverride { get; set; }
+
+    public MockRequestChannel(ChannelManagerBase manager, MessageEncoderFactory encoderFactory, EndpointAddress address, Uri via)
+            : base(manager, encoderFactory, address)
+    {
+        this._via = via;
+
+        RequestOverride = DefaultRequest;
+        BeginRequestOverride = DefaultBeginRequest;
+        EndRequestOverride = DefaultEndRequest;
+    }
+
+    public Message Request(Message message, TimeSpan timeout)
+    {
+        return RequestOverride(message, timeout);
+    }
+
+    public Message DefaultRequest(Message message, TimeSpan timeout)
+    {
+        // Default is just to loopback the request message.
+        // Set RequestOverride to a delegate to do anything else you need.
+        return message;
+    }
+
+    public Message Request(Message message)
+    {
+        return this.Request(message, DefaultReceiveTimeout);
+    }
+
+    public IAsyncResult BeginRequest(Message message, TimeSpan timeout, AsyncCallback callback, object state)
+    {
+        return BeginRequestOverride(message, timeout, callback, state);
+    }
+
+    public IAsyncResult BeginRequest(Message message, AsyncCallback callback, object state)
+    {
+        return BeginRequest(message, DefaultReceiveTimeout, callback, state);
+    }
+
+    public IAsyncResult DefaultBeginRequest(Message message, TimeSpan timeout, AsyncCallback callback, object state)
+    {
+        // Default is to create an already completed IAsyncResult containing
+        // the input message.
+        MockAsyncResult result = new MockAsyncResult(timeout, callback, state);
+        result.Complete(message);
+        return result;
+    }
+
+    public Message EndRequest(IAsyncResult result)
+    {
+        return EndRequestOverride(result);
+    }
+
+    public Message DefaultEndRequest(IAsyncResult result)
+    {
+        // Default is to just loopback the input message from BeginRequest
+        return (Message)((MockAsyncResult)result).Result;
+    }
+
+}

--- a/src/System.Private.ServiceModel/tests/Common/Unit/MockTransportBindingElement.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Unit/MockTransportBindingElement.cs
@@ -1,0 +1,59 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.ServiceModel.Channels;
+
+public class MockTransportBindingElement : TransportBindingElement
+{
+    public MockTransportBindingElement()
+    {
+        SchemePropertyOverride = DefaultGetSchemeProperty;
+        BuildChannelFactoryOverride = (Type t, BindingContext bc) => DefaultBuildChannelFactory(t, bc);
+    }
+
+    public Func<String> SchemePropertyOverride { get; set; }
+    public Func<Type,BindingContext,IChannelFactory> BuildChannelFactoryOverride { get; set; }
+
+    public override string Scheme
+    {
+        get
+        {
+            return SchemePropertyOverride();
+        }
+    }
+
+    public string DefaultGetSchemeProperty()
+    {
+        return "myprotocol";
+    }
+
+    public override BindingElement Clone()
+    {
+        MockTransportBindingElement element = new MockTransportBindingElement();
+
+        // Propagate the overrides
+        element.SchemePropertyOverride = this.SchemePropertyOverride;
+        element.BuildChannelFactoryOverride = this.BuildChannelFactoryOverride;
+        return element;
+    }
+
+    public override bool CanBuildChannelFactory<TChannel>(BindingContext context)
+    {
+        return true;
+    }
+
+    public override IChannelFactory<TChannel> BuildChannelFactory<TChannel>(BindingContext context)
+    {
+        return (IChannelFactory<TChannel>)BuildChannelFactoryOverride(typeof(TChannel), context);
+    }
+
+    public IChannelFactory DefaultBuildChannelFactory(Type tChannel, BindingContext context)
+    {
+        // Default is a MockChannelFactory<IRequestChannel>.
+        // If you need a different TChannel, supply a delegate to BuildChannelFactoryOverride
+        // and construct the kind you need.
+        return new MockChannelFactory<IRequestChannel>(context, new TextMessageEncodingBindingElement().CreateMessageEncoderFactory());
+    }
+}

--- a/src/System.ServiceModel.Primitives/tests/Channels/CommunicationObjectTest.cs
+++ b/src/System.ServiceModel.Primitives/tests/Channels/CommunicationObjectTest.cs
@@ -22,8 +22,8 @@ public static class CommunicationObjectTest
         TimeSpan timeout = TimeSpan.FromSeconds(30);
 
         // *** SETUP *** \\
-        InterceptAllOpenMethods(mco, openMethodsCalled);
-        InterceptAllCloseMethods(mco, closeMethodsCalled);
+        MockCommunicationObject.InterceptAllOpenMethods(mco, openMethodsCalled);
+        MockCommunicationObject.InterceptAllCloseMethods(mco, closeMethodsCalled);
 
         // *** EXECUTE *** \\
         mco.Open(timeout);
@@ -53,8 +53,8 @@ public static class CommunicationObjectTest
         TimeSpan timeout = TimeSpan.FromSeconds(30);
 
         // *** SETUP *** \\
-        InterceptAllOpenMethods(mco, openMethodsCalled);
-        InterceptAllCloseMethods(mco, closeMethodsCalled);
+        MockCommunicationObject.InterceptAllOpenMethods(mco, openMethodsCalled);
+        MockCommunicationObject.InterceptAllCloseMethods(mco, closeMethodsCalled);
 
         // *** EXECUTE *** \\
         IAsyncResult openAr = mco.BeginOpen(timeout, callback: null, state: null);
@@ -87,7 +87,7 @@ public static class CommunicationObjectTest
         TimeSpan timeout = TimeSpan.FromSeconds(30);
 
         // *** SETUP *** \\
-        InterceptAllCloseMethods(mco, closeMethodsCalled);
+        MockCommunicationObject.InterceptAllCloseMethods(mco, closeMethodsCalled);
 
         // *** EXECUTE *** \\
         mco.Open(timeout);
@@ -114,8 +114,8 @@ public static class CommunicationObjectTest
         TimeSpan timeout = TimeSpan.FromSeconds(30);
 
         // *** SETUP *** \\
-        InterceptAllOpenEvents(mco, openEventsFired);
-        InterceptAllCloseEvents(mco, closeEventsFired);
+        MockCommunicationObject.InterceptAllOpenEvents(mco, openEventsFired);
+        MockCommunicationObject.InterceptAllCloseEvents(mco, closeEventsFired);
 
         // *** EXECUTE *** \\
         mco.Open(timeout);
@@ -144,8 +144,8 @@ public static class CommunicationObjectTest
         TimeSpan timeout = TimeSpan.FromMinutes(30);
 
         // *** SETUP *** \\
-        InterceptAllOpenEvents(mco, openEventsFired);
-        InterceptAllCloseEvents(mco, closeEventsFired);
+        MockCommunicationObject.InterceptAllOpenEvents(mco, openEventsFired);
+        MockCommunicationObject.InterceptAllCloseEvents(mco, closeEventsFired);
 
         // *** EXECUTE *** \\
         IAsyncResult openAr = mco.BeginOpen(timeout, callback: null, state: null);
@@ -178,7 +178,7 @@ public static class CommunicationObjectTest
         CommunicationStateData data = new CommunicationStateData();
 
         // *** SETUP *** \\
-        InterceptAllStateChanges(mco, data);
+        MockCommunicationObject.InterceptAllStateChanges(mco, data);
 
         // *** EXECUTE *** \\
         mco.Open(timeout);
@@ -240,7 +240,7 @@ public static class CommunicationObjectTest
         CommunicationStateData data = new CommunicationStateData();
 
         // *** SETUP *** \\
-        InterceptAllStateChanges(mco, data);
+        MockCommunicationObject.InterceptAllStateChanges(mco, data);
 
         // *** EXECUTE *** \\
         IAsyncResult openAr = mco.BeginOpen(timeout, callback: null, state: null);
@@ -408,175 +408,4 @@ public static class CommunicationObjectTest
                     String.Format("Expected exception message '{0}' but actual was '{1}'",
                                   exceptionMessage, actualException.Message));
     }
-
-    #region Helpers
-    // This helper will override all the open methods of the MockCommunicationObject
-    // and record their names into the provided list in the order they are called.
-    private static void InterceptAllOpenMethods(MockCommunicationObject mco, List<string> methodsCalled)
-    {
-        mco.OnOpeningOverride = () =>
-        {
-            methodsCalled.Add("OnOpening");
-            mco.DefaultOnOpening();
-        };
-
-        mco.OnOpenOverride = (TimeSpan t) =>
-        {
-            methodsCalled.Add("OnOpen");
-            mco.DefaultOnOpen(t);
-        };
-
-        mco.OnBeginOpenOverride = (TimeSpan t, AsyncCallback c, object s) =>
-        {
-            methodsCalled.Add("OnBeginOpen");
-            return mco.DefaultOnBeginOpen(t, c, s);
-        };
-
-        mco.OnOpenedOverride = () =>
-        {
-            methodsCalled.Add("OnOpened");
-            mco.DefaultOnOpened();
-        };
-    }
-
-    // This helper will override all the open methods of the MockCommunicationObject
-    // and record their names into the provided list in the order they are called.
-    private static void InterceptAllCloseMethods(MockCommunicationObject mco, List<string> methodsCalled)
-    {
-        mco.OnClosingOverride = () =>
-        {
-            methodsCalled.Add("OnClosing");
-            mco.DefaultOnClosing();
-        };
-
-        mco.OnCloseOverride = (TimeSpan t) =>
-        {
-            methodsCalled.Add("OnClose");
-            mco.DefaultOnClose(t);
-        };
-
-        mco.OnBeginCloseOverride = (TimeSpan t, AsyncCallback c, object s) =>
-        {
-            methodsCalled.Add("OnBeginClose");
-            return mco.DefaultOnBeginClose(t, c, s);
-        };
-
-        mco.OnClosedOverride = () =>
-        {
-            methodsCalled.Add("OnClosed");
-            mco.DefaultOnClosed();
-        };
-
-        // The OnAbort is considered one of the methods associated with close.
-        mco.OnAbortOverride = () =>
-        {
-            methodsCalled.Add("OnAbort");
-            mco.DefaultOnAbort();
-        };
-    }
-
-    // Intercepts all the events expected to fire during an open
-    private static void InterceptAllOpenEvents(MockCommunicationObject mco, List<string> eventsFired)
-    {
-        mco.Opening += (s, ea) => eventsFired.Add("Opening");
-        mco.Opened += (s, ea) => eventsFired.Add("Opened");
-    }
-
-    // Intercepts all the events expected to fire during a close
-    private static void InterceptAllCloseEvents(MockCommunicationObject mco, List<string> eventsFired)
-    {
-        mco.Closing += (s, ea) => eventsFired.Add("Closing");
-        mco.Closed += (s, ea) => eventsFired.Add("Closed");
-    }
-
-    // Intercepts all the open and close methods in MockCommunicationObject
-    // and records the CommunicationState before and after the default code executes,
-    private static void InterceptAllStateChanges(MockCommunicationObject mco, CommunicationStateData data)
-    {
-        // Immediately capture the current state after initial creation
-        data.StateAfterCreate = mco.State;
-
-        mco.OnOpeningOverride = () =>
-        {
-            data.StateEnterOnOpening = mco.State;
-            mco.DefaultOnOpening();
-            data.StateLeaveOnOpening = mco.State;
-        };
-
-        mco.OnOpenOverride = (TimeSpan t) =>
-        {
-            data.StateEnterOnOpen = mco.State;
-            mco.DefaultOnOpen(t);
-            data.StateLeaveOnOpen = mco.State;
-        };
-
-        mco.OnBeginOpenOverride = (TimeSpan t, AsyncCallback c, object s) =>
-        {
-            data.StateEnterOnBeginOpen = mco.State;
-            IAsyncResult result = mco.DefaultOnBeginOpen(t, c, s);
-            data.StateLeaveOnBeginOpen = mco.State;
-            return result;
-        };
-
-        mco.OnOpenedOverride = () =>
-        {
-            data.StateEnterOnOpened = mco.State;
-            mco.DefaultOnOpened();
-            data.StateLeaveOnOpened = mco.State;
-        };
-
-        mco.OnClosingOverride = () =>
-        {
-            data.StateEnterOnClosing = mco.State;
-            mco.DefaultOnClosing();
-            data.StateLeaveOnClosing = mco.State;
-        };
-
-        mco.OnCloseOverride = (TimeSpan t) =>
-        {
-            data.StateEnterOnClose = mco.State;
-            mco.DefaultOnClose(t);
-            data.StateLeaveOnClose = mco.State;
-        };
-
-        mco.OnBeginCloseOverride = (TimeSpan t, AsyncCallback c, object s) =>
-        {
-            data.StateEnterOnBeginClose = mco.State;
-            IAsyncResult result = mco.DefaultOnBeginClose(t, c, s);
-            data.StateLeaveOnBeginClose = mco.State;
-            return result;
-        };
-
-        mco.OnClosedOverride = () =>
-        {
-            data.StateEnterOnClosed = mco.State;
-            mco.DefaultOnClosed();
-            data.StateLeaveOnClosed = mco.State;
-        };
-    }
-
-    // Helper data class to carry CommunicationState values as they
-    // transition through the open and close methods.
-    private class CommunicationStateData
-    {
-        public CommunicationState StateAfterCreate { get; set; }
-        public CommunicationState StateEnterOnOpening { get; set; }
-        public CommunicationState StateLeaveOnOpening { get; set; }
-        public CommunicationState StateEnterOnOpen { get; set; }
-        public CommunicationState StateLeaveOnOpen { get; set; }
-        public CommunicationState StateEnterOnBeginOpen { get; set; }
-        public CommunicationState StateLeaveOnBeginOpen { get; set; }
-        public CommunicationState StateEnterOnOpened { get; set; }
-        public CommunicationState StateLeaveOnOpened { get; set; }
-
-        public CommunicationState StateEnterOnClosing { get; set; }
-        public CommunicationState StateLeaveOnClosing { get; set; }
-        public CommunicationState StateEnterOnClose { get; set; }
-        public CommunicationState StateLeaveOnClose { get; set; }
-        public CommunicationState StateEnterOnBeginClose { get; set; }
-        public CommunicationState StateLeaveOnBeginClose { get; set; }
-        public CommunicationState StateEnterOnClosed { get; set; }
-        public CommunicationState StateLeaveOnClosed { get; set; }
-    }
-    #endregion Helpers
 }

--- a/src/System.ServiceModel.Primitives/tests/Channels/CustomChannelTest.cs
+++ b/src/System.ServiceModel.Primitives/tests/Channels/CustomChannelTest.cs
@@ -1,0 +1,409 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+
+using System;
+using System.Collections.Generic;
+using System.ServiceModel;
+using System.ServiceModel.Channels;
+using System.Threading;
+using Infrastructure.Common;
+using Xunit;
+using System.Threading.Tasks;
+
+public static class CustomChannelTest
+{
+    [WcfFact]
+    public static void CustomChannel_Sync_Open_Close_Methods_Called()
+    {
+        MockChannelFactory<IRequestChannel> mockChannelFactory = null;
+        MockRequestChannel mockRequestChannel = null;
+        List<string> channelOpenMethodsCalled = new List<string>();
+        List<string> channelCloseMethodsCalled = new List<string>();
+        List<string> factoryOpenMethodsCalled = new List<string>();
+        List<string> factoryCloseMethodsCalled = new List<string>();
+        string testMessageBody = "CustomChannelTest_Sync";
+        Message inputMessage = Message.CreateMessage(MessageVersion.Default, action: "Test", body: testMessageBody);
+
+        // *** SETUP *** \\
+        // Intercept the creation of the factory so we can intercept creation of the channel
+        Func<Type, BindingContext, IChannelFactory> buildFactoryAction = (Type type, BindingContext context) =>
+        {
+            // Create the channel factory and intercept all open and close method calls
+            mockChannelFactory = new MockChannelFactory<IRequestChannel>(context, new TextMessageEncodingBindingElement().CreateMessageEncoderFactory());
+            MockCommunicationObject.InterceptAllOpenMethods(mockChannelFactory, factoryOpenMethodsCalled);
+            MockCommunicationObject.InterceptAllCloseMethods(mockChannelFactory, factoryCloseMethodsCalled);
+
+            // Override the OnCreateChannel call so we get the mock channel created by the factory
+            mockChannelFactory.OnCreateChannelOverride = (EndpointAddress endpoint, Uri via) =>
+            {
+                // Create the mock channel and intercept all its open and close method calls
+                mockRequestChannel = (MockRequestChannel) mockChannelFactory.DefaultOnCreateChannel(endpoint, via);
+                MockCommunicationObject.InterceptAllOpenMethods(mockRequestChannel, channelOpenMethodsCalled);
+                MockCommunicationObject.InterceptAllCloseMethods(mockRequestChannel, channelCloseMethodsCalled);
+                return mockRequestChannel;
+            };
+            return mockChannelFactory;
+        };
+
+        MockTransportBindingElement mockBindingElement = new MockTransportBindingElement();
+        mockBindingElement.BuildChannelFactoryOverride = buildFactoryAction;
+
+        CustomBinding binding = new CustomBinding(mockBindingElement);
+        EndpointAddress address = new EndpointAddress("myprotocol://localhost:5000");
+        var factory = new ChannelFactory<ICustomChannelServiceInterface>(binding, address);
+
+        // We rely on the implicit open of the channel to be synchronous.
+        // This is true for both the full framework and this NET Core version.
+        ICustomChannelServiceInterface channel = factory.CreateChannel();
+
+        // *** EXECUTE *** \\
+        Message outputMessage = channel.Process(inputMessage);
+
+        // The mock's default behavior is just to loopback what we sent.
+        var result = outputMessage.GetBody<string>();
+
+        // Explicitly close the channel factory synchronously.
+        // One of the important aspects of this test is that a synchronous
+        // close of the factory also synchronously closes the channel.
+        factory.Close();
+
+        // *** VALIDATE *** \\
+        Assert.True(String.Equals(testMessageBody, result), 
+                    String.Format("Expected body to be '{0}' but actual was '{1}'", testMessageBody, result));
+
+        string expectedOpens = "OnOpening,OnOpen,OnOpened";
+        string expectedCloses = "OnClosing,OnClose,OnClosed";
+
+        string actualOpens = String.Join(",", channelOpenMethodsCalled);
+        Assert.True(String.Equals(expectedOpens, actualOpens, StringComparison.Ordinal),
+               String.Format("Expected channel open methods to be '{0}' but actual was '{1}'.",
+                             expectedOpens, actualOpens));
+
+        string actualCloses = String.Join(",", channelCloseMethodsCalled);
+        Assert.True(String.Equals(expectedCloses, actualCloses, StringComparison.Ordinal),
+               String.Format("Expected channel close methods to be '{0}' but actual was '{1}'.",
+                             expectedCloses, actualCloses));
+
+        actualOpens = String.Join(",", factoryOpenMethodsCalled);
+        Assert.True(String.Equals(expectedOpens, actualOpens, StringComparison.Ordinal),
+               String.Format("Expected factory open methods to be '{0}' but actual was '{1}'.",
+                             expectedOpens, actualOpens));
+
+        actualCloses = String.Join(",", factoryCloseMethodsCalled);
+        Assert.True(String.Equals(expectedCloses, actualCloses, StringComparison.Ordinal),
+               String.Format("Expected factory close methods to be '{0}' but actual was '{1}'.",
+                             expectedCloses, actualCloses));
+
+        Assert.True(factory.State == CommunicationState.Closed,
+            String.Format("Expected factory's final state to be Closed but was '{0}'", factory.State));
+
+        Assert.True(((ICommunicationObject)channel).State == CommunicationState.Closed,
+            String.Format("Expected channel's final state to be Closed but was '{0}'", ((ICommunicationObject)channel).State));
+
+    }
+
+    [WcfFact]
+    public static void CustomChannel_Async_Open_Close_Methods_Called()
+    {
+        MockChannelFactory<IRequestChannel> mockChannelFactory = null;
+        MockRequestChannel mockRequestChannel = null;
+        List<string> channelOpenMethodsCalled = new List<string>();
+        List<string> channelCloseMethodsCalled = new List<string>();
+        List<string> factoryOpenMethodsCalled = new List<string>();
+        List<string> factoryCloseMethodsCalled = new List<string>();
+        string testMessageBody = "CustomChannelTest_Async";
+        Message inputMessage = Message.CreateMessage(MessageVersion.Default, action: "Test", body: testMessageBody);
+
+        // *** SETUP *** \\
+        // Intercept the creation of the factory so we can intercept creation of the channel
+        Func<Type, BindingContext, IChannelFactory> buildFactoryAction = (Type type, BindingContext context) =>
+        {
+            // Create the channel factory and intercept all open and close method calls
+            mockChannelFactory = new MockChannelFactory<IRequestChannel>(context, new TextMessageEncodingBindingElement().CreateMessageEncoderFactory());
+            MockCommunicationObject.InterceptAllOpenMethods(mockChannelFactory, factoryOpenMethodsCalled);
+            MockCommunicationObject.InterceptAllCloseMethods(mockChannelFactory, factoryCloseMethodsCalled);
+
+                // Override the OnCreateChannel call so we get the mock channel created by the factory
+                mockChannelFactory.OnCreateChannelOverride = (EndpointAddress endpoint, Uri via) =>
+            {
+                // Create the default mock channel and intercept all its open and close method calls
+                mockRequestChannel = (MockRequestChannel)mockChannelFactory.DefaultOnCreateChannel(endpoint, via);
+                MockCommunicationObject.InterceptAllOpenMethods(mockRequestChannel, channelOpenMethodsCalled);
+                MockCommunicationObject.InterceptAllCloseMethods(mockRequestChannel, channelCloseMethodsCalled);
+
+                return mockRequestChannel;
+            };
+            return mockChannelFactory;
+        };
+
+        MockTransportBindingElement mockBindingElement = new MockTransportBindingElement();
+        mockBindingElement.BuildChannelFactoryOverride = buildFactoryAction;
+
+        CustomBinding binding = new CustomBinding(mockBindingElement);
+        EndpointAddress address = new EndpointAddress("myprotocol://localhost:5000");
+        var factory = new ChannelFactory<ICustomChannelServiceInterface>(binding, address);
+
+        // Explicitly open factory asynchronously because the implicit open is synchronous
+        IAsyncResult openResult = factory.BeginOpen(null, null);
+        Task openTask = Task.Factory.FromAsync(openResult, factory.EndOpen);
+        openTask.GetAwaiter().GetResult();
+
+        ICustomChannelServiceInterface channel = factory.CreateChannel();
+
+        // *** EXECUTE *** \\
+        Task<Message> processTask = channel.ProcessAsync(inputMessage);
+
+        // The mock's default behavior is just to loopback what we sent.
+        Message outputMessage = processTask.GetAwaiter().GetResult();
+        var result = outputMessage.GetBody<string>();
+
+        // Explicitly close the channel factory asynchronously.
+        // One of the important aspects of this test is that an asynchronous
+        // close of the factory also asynchronously closes the channel.
+        IAsyncResult asyncResult = factory.BeginClose(null, null);
+        Task task = Task.Factory.FromAsync(asyncResult, factory.EndClose);
+        task.GetAwaiter().GetResult();
+
+        // *** VALIDATE *** \\
+        Assert.True(String.Equals(testMessageBody, result),
+                    String.Format("Expected body to be '{0}' but actual was '{1}'", testMessageBody, result));
+
+        string expectedOpens = "OnOpening,OnBeginOpen,OnOpened";
+        string expectedCloses = "OnClosing,OnBeginClose,OnClosed";
+
+        string actualOpens = String.Join(",", channelOpenMethodsCalled);
+        Assert.True(String.Equals(expectedOpens, actualOpens, StringComparison.Ordinal),
+               String.Format("Expected channel open methods to be '{0}' but actual was '{1}'.",
+                             expectedOpens, actualOpens));
+
+        string actualCloses = String.Join(",", channelCloseMethodsCalled);
+        Assert.True(String.Equals(expectedCloses, actualCloses, StringComparison.Ordinal),
+               String.Format("Expected channel close methods to be '{0}' but actual was '{1}'.",
+                             expectedCloses, actualCloses));
+
+        actualOpens = String.Join(",", factoryOpenMethodsCalled);
+        Assert.True(String.Equals(expectedOpens, actualOpens, StringComparison.Ordinal),
+               String.Format("Expected factory open methods to be '{0}' but actual was '{1}'.",
+                             expectedOpens, actualOpens));
+
+        actualCloses = String.Join(",", factoryCloseMethodsCalled);
+        Assert.True(String.Equals(expectedCloses, actualCloses, StringComparison.Ordinal),
+               String.Format("Expected factory close methods to be '{0}' but actual was '{1}'.",
+                             expectedCloses, actualCloses));
+
+        Assert.True(factory.State == CommunicationState.Closed,
+            String.Format("Expected factory's final state to be Closed but was '{0}'", factory.State));
+
+        Assert.True(((ICommunicationObject)channel).State == CommunicationState.Closed,
+            String.Format("Expected channel's final state to be Closed but was '{0}'", ((ICommunicationObject)channel).State));
+
+    }
+
+    [WcfFact]
+    public static void CustomChannel_Sync_Request_Exception_Propagates()
+    {
+        MockChannelFactory<IRequestChannel> mockChannelFactory = null;
+        MockRequestChannel mockRequestChannel = null;
+        string testMessageBody = "CustomChannelTest_Sync";
+        Message inputMessage = Message.CreateMessage(MessageVersion.Default, action: "Test", body: testMessageBody);
+        string expectedExceptionMessage = "Sync exception message";
+
+        // *** SETUP *** \\
+        // Intercept the creation of the factory so we can intercept creation of the channel
+        Func<Type, BindingContext, IChannelFactory> buildFactoryAction = (Type type, BindingContext context) =>
+        {
+            // Create the channel factory so we can intercept channel creation
+            mockChannelFactory = new MockChannelFactory<IRequestChannel>(context, new TextMessageEncodingBindingElement().CreateMessageEncoderFactory());
+
+            // Override the OnCreateChannel call so we can fault inject an exception
+            mockChannelFactory.OnCreateChannelOverride = (EndpointAddress endpoint, Uri via) =>
+            {
+                // Create the mock channel and fault inject an exception in the Request
+                mockRequestChannel = (MockRequestChannel)mockChannelFactory.DefaultOnCreateChannel(endpoint, via);
+                mockRequestChannel.RequestOverride = (Message m, TimeSpan t) =>
+                {
+                    throw new InvalidOperationException(expectedExceptionMessage);
+                };
+                return mockRequestChannel;
+            };
+            return mockChannelFactory;
+        };
+
+        MockTransportBindingElement mockBindingElement = new MockTransportBindingElement();
+        mockBindingElement.BuildChannelFactoryOverride = buildFactoryAction;
+
+        CustomBinding binding = new CustomBinding(mockBindingElement);
+        EndpointAddress address = new EndpointAddress("myprotocol://localhost:5000");
+        var factory = new ChannelFactory<ICustomChannelServiceInterface>(binding, address);
+        ICustomChannelServiceInterface channel = factory.CreateChannel();
+
+        // *** EXECUTE *** \\
+        InvalidOperationException actualException = Assert.Throws<InvalidOperationException>(() =>
+        {
+            channel.Process(inputMessage);
+        });
+
+        // *** VALIDATE *** \\
+        Assert.True(String.Equals(expectedExceptionMessage, actualException.Message),
+                    String.Format("Expected exception message to be '{0}' but actual was '{1}'", 
+                                  expectedExceptionMessage, actualException.Message));
+        
+    }
+
+    [WcfFact]
+    public static void CustomChannel_Async_Request_Exception_Propagates()
+    {
+        MockChannelFactory<IRequestChannel> mockChannelFactory = null;
+        MockRequestChannel mockRequestChannel = null;
+        string testMessageBody = "CustomChannelTest_Async";
+        Message inputMessage = Message.CreateMessage(MessageVersion.Default, action: "Test", body: testMessageBody);
+        string expectedExceptionMessage = "Async exception message";
+
+        // *** SETUP *** \\
+        // Intercept the creation of the factory so we can intercept creation of the channel
+        Func<Type, BindingContext, IChannelFactory> buildFactoryAction = (Type type, BindingContext context) =>
+        {
+            // Create the channel factory so we can intercept channel creation
+            mockChannelFactory = new MockChannelFactory<IRequestChannel>(context, new TextMessageEncodingBindingElement().CreateMessageEncoderFactory());
+
+            // Override the OnCreateChannel call so we can fault inject an exception
+            mockChannelFactory.OnCreateChannelOverride = (EndpointAddress endpoint, Uri via) =>
+            {
+                // Create the mock channel and fault inject an exception in the EndRequest
+                mockRequestChannel = (MockRequestChannel)mockChannelFactory.DefaultOnCreateChannel(endpoint, via);
+                mockRequestChannel.EndRequestOverride = (IAsyncResult ar) =>
+                {
+                    throw new InvalidOperationException(expectedExceptionMessage);
+                };
+                return mockRequestChannel;
+            };
+            return mockChannelFactory;
+        };
+
+        MockTransportBindingElement mockBindingElement = new MockTransportBindingElement();
+        mockBindingElement.BuildChannelFactoryOverride = buildFactoryAction;
+
+        CustomBinding binding = new CustomBinding(mockBindingElement);
+        EndpointAddress address = new EndpointAddress("myprotocol://localhost:5000");
+        var factory = new ChannelFactory<ICustomChannelServiceInterface>(binding, address);
+        ICustomChannelServiceInterface channel = factory.CreateChannel();
+
+        // *** EXECUTE *** \\
+        // The ProcessAsync should not throw -- the fault comes in the EndRequest
+        Task<Message> processTask = channel.ProcessAsync(inputMessage);
+
+        InvalidOperationException actualException = Assert.Throws<InvalidOperationException>(() =>
+        {
+            // awaiting the task will invoke the EndRequest
+            processTask.GetAwaiter().GetResult();
+        });
+
+        // *** VALIDATE *** \\
+        Assert.True(String.Equals(expectedExceptionMessage, actualException.Message),
+                    String.Format("Expected exception message to be '{0}' but actual was '{1}'",
+                                  expectedExceptionMessage, actualException.Message));
+    }
+
+    [WcfFact]
+    public static void CustomChannel_Factory_Abort_Aborts_Channel()
+    {
+        MockChannelFactory<IRequestChannel> mockChannelFactory = null;
+        MockRequestChannel mockRequestChannel = null;
+        List<string> channelOpenMethodsCalled = new List<string>();
+        List<string> channelCloseMethodsCalled = new List<string>();
+        List<string> factoryOpenMethodsCalled = new List<string>();
+        List<string> factoryCloseMethodsCalled = new List<string>();
+        string testMessageBody = "CustomChannelTest_Sync";
+        Message inputMessage = Message.CreateMessage(MessageVersion.Default, action: "Test", body: testMessageBody);
+
+        // *** SETUP *** \\
+        // Intercept the creation of the factory so we can intercept creation of the channel
+        Func<Type, BindingContext, IChannelFactory> buildFactoryAction = (Type type, BindingContext context) =>
+        {
+            // Create the channel factory and intercept all open and close method calls
+            mockChannelFactory = new MockChannelFactory<IRequestChannel>(context, new TextMessageEncodingBindingElement().CreateMessageEncoderFactory());
+            MockCommunicationObject.InterceptAllOpenMethods(mockChannelFactory, factoryOpenMethodsCalled);
+            MockCommunicationObject.InterceptAllCloseMethods(mockChannelFactory, factoryCloseMethodsCalled);
+
+            // Override the OnCreateChannel call so we get the mock channel created by the factory
+            mockChannelFactory.OnCreateChannelOverride = (EndpointAddress endpoint, Uri via) =>
+            {
+                // Create the mock channel and intercept all its open and close method calls
+                mockRequestChannel = (MockRequestChannel)mockChannelFactory.DefaultOnCreateChannel(endpoint, via);
+                MockCommunicationObject.InterceptAllOpenMethods(mockRequestChannel, channelOpenMethodsCalled);
+                MockCommunicationObject.InterceptAllCloseMethods(mockRequestChannel, channelCloseMethodsCalled);
+                return mockRequestChannel;
+            };
+            return mockChannelFactory;
+        };
+
+        MockTransportBindingElement mockBindingElement = new MockTransportBindingElement();
+        mockBindingElement.BuildChannelFactoryOverride = buildFactoryAction;
+
+        CustomBinding binding = new CustomBinding(mockBindingElement);
+        EndpointAddress address = new EndpointAddress("myprotocol://localhost:5000");
+        var factory = new ChannelFactory<ICustomChannelServiceInterface>(binding, address);
+
+        // We rely on the implicit open of the channel to be synchronous.
+        // This is true for both the full framework and this NET Core version.
+        ICustomChannelServiceInterface channel = factory.CreateChannel();
+
+        // *** EXECUTE *** \\
+        Message outputMessage = channel.Process(inputMessage);
+
+        // The mock's default behavior is just to loopback what we sent.
+        var result = outputMessage.GetBody<string>();
+
+        // Abort the factory and expect both factory and channel to be aborted.
+        factory.Abort();
+
+        // *** VALIDATE *** \\
+        Assert.True(String.Equals(testMessageBody, result),
+                    String.Format("Expected body to be '{0}' but actual was '{1}'", testMessageBody, result));
+
+        string expectedOpens = "OnOpening,OnOpen,OnOpened";
+        string expectedCloses = "OnClosing,OnAbort,OnClosed";
+
+        string actualOpens = String.Join(",", channelOpenMethodsCalled);
+        Assert.True(String.Equals(expectedOpens, actualOpens, StringComparison.Ordinal),
+               String.Format("Expected channel open methods to be '{0}' but actual was '{1}'.",
+                             expectedOpens, actualOpens));
+
+        string actualCloses = String.Join(",", channelCloseMethodsCalled);
+        Assert.True(String.Equals(expectedCloses, actualCloses, StringComparison.Ordinal),
+               String.Format("Expected channel close methods to be '{0}' but actual was '{1}'.",
+                             expectedCloses, actualCloses));
+
+        actualOpens = String.Join(",", factoryOpenMethodsCalled);
+        Assert.True(String.Equals(expectedOpens, actualOpens, StringComparison.Ordinal),
+               String.Format("Expected factory open methods to be '{0}' but actual was '{1}'.",
+                             expectedOpens, actualOpens));
+
+        actualCloses = String.Join(",", factoryCloseMethodsCalled);
+        Assert.True(String.Equals(expectedCloses, actualCloses, StringComparison.Ordinal),
+               String.Format("Expected factory close methods to be '{0}' but actual was '{1}'.",
+                             expectedCloses, actualCloses));
+
+        Assert.True(factory.State == CommunicationState.Closed,
+                    String.Format("Expected factory's final state to be Closed but was '{0}'", factory.State));
+
+        Assert.True(((ICommunicationObject)channel).State == CommunicationState.Closed,
+            String.Format("Expected channel's final state to be Closed but was '{0}'", ((ICommunicationObject)channel).State));
+    }
+
+    #region Helpers
+
+    [ServiceContract]
+    public interface ICustomChannelServiceInterface
+    {
+        [OperationContract(Action = "*", ReplyAction = "*")]
+        Message Process(Message input);
+
+        [OperationContract(Action = "*", ReplyAction = "*")]
+        Task<Message> ProcessAsync(Message input);
+    }
+
+    #endregion Helpers
+}


### PR DESCRIPTION
Fixes the issue where OnOpen/OnBeginOpen and
OnClose/OnBeginClose were incorrectly called when
using custom channels.

Fixes the product issue by propagating knowledge of
sync and async open/close requests down the channel
stack so they stay sync or async based on the original
call.

Created mocks and unit tests for custom channels

**READY FOR REVIEW NOW**

Fixes #1544