### PR TITLE
Work around X509Certificate2 copy constructor omission 

### DIFF
--- a/src/System.Private.ServiceModel/src/Extensions/X509Certificate2Extensions.cs
+++ b/src/System.Private.ServiceModel/src/Extensions/X509Certificate2Extensions.cs
@@ -1,0 +1,40 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Security.Cryptography.X509Certificates;
+
+namespace System.ServiceModel
+{
+    internal static class X509Certificate2Extensions
+    {
+        // dotnet/wcf#1574 - This is a workaround for dotnet/corefx#12214
+        // The copy constructor was removed in .NET Core, this is the workaround to allow us to make copies of certificates
+
+        internal static X509Certificate2 CloneCertificateInternal(this X509Certificate2 certificateToClone)
+        {
+#if TARGETS_WINDOWS
+            return new X509Certificate2(certificateToClone.Handle);
+#else
+            X509Certificate2Collection collection = new X509Certificate2Collection(certificateToClone);
+            X509Certificate2Collection copyCollection = collection.Find(X509FindType.FindByThumbprint, certificateToClone.Thumbprint, false);
+            return copyCollection[0];
+#endif
+        }
+
+        // dotnet/wcf#1574 - This is a workaround for dotnet/corefx#12214
+        internal static X509Certificate2 CloneCertificateInternal(this X509Certificate certificateToClone)
+        {
+#if TARGETS_WINDOWS
+            return new X509Certificate2(certificateToClone.Handle);
+#else
+            byte[] certificateBytes = certificateToClone.Export(X509ContentType.Pfx, string.Empty);
+            X509Certificate2 certificateToClone2 = new X509Certificate2(certificateBytes, string.Empty);
+
+            X509Certificate2Collection collection = new X509Certificate2Collection(certificateToClone2);
+            X509Certificate2Collection copyCollection = collection.Find(X509FindType.FindByThumbprint, certificateToClone2.Thumbprint, false);
+            return copyCollection[0];
+#endif
+        }
+    }
+}

--- a/src/System.Private.ServiceModel/src/System/IdentityModel/Claims/X509CertificateClaimSet.cs
+++ b/src/System.Private.ServiceModel/src/System/IdentityModel/Claims/X509CertificateClaimSet.cs
@@ -32,7 +32,12 @@ namespace System.IdentityModel.Claims
         {
             if (certificate == null)
                 throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("certificate");
-            _certificate = clone ? new X509Certificate2(certificate.Handle) : certificate;
+            
+            // dotnet/wcf#1574
+            // ORIGINAL CODE: 
+            // _certificate = clone ? new X509Certificate2(certificate.Handle) : certificate;
+
+            _certificate = clone ? certificate.CloneCertificateInternal() : certificate;
         }
 
         private X509CertificateClaimSet(X509CertificateClaimSet from)
@@ -510,7 +515,12 @@ namespace System.IdentityModel.Claims
         internal X509Identity(X509Certificate2 certificate, bool clone, bool disposable)
             : base(X509, X509)
         {
-            _certificate = clone ? new X509Certificate2(certificate.Handle) : certificate;
+            // dotnet/wcf#1574
+            // ORIGINAL CODE: 
+            // _certificate = clone ? new X509Certificate2(certificate.Handle) : certificate;
+
+            _certificate = clone ? certificate.CloneCertificateInternal() : certificate;
+
             _disposable = clone || disposable;
         }
 

--- a/src/System.Private.ServiceModel/src/System/IdentityModel/Selectors/X509SecurityTokenProvider.cs
+++ b/src/System.Private.ServiceModel/src/System/IdentityModel/Selectors/X509SecurityTokenProvider.cs
@@ -28,7 +28,11 @@ namespace System.IdentityModel.Selectors
             _clone = clone;
             if (_clone)
             {
-                _certificate = new X509Certificate2(certificate.Handle);
+                // dotnet/wcf#1574
+                // ORIGINAL CODE: 
+                // _certificate = new X509Certificate2(certificate.Handle);
+
+                _certificate = certificate.CloneCertificateInternal();
             }
             else
             {

--- a/src/System.Private.ServiceModel/src/System/IdentityModel/Tokens/X509SecurityToken.cs
+++ b/src/System.Private.ServiceModel/src/System/IdentityModel/Tokens/X509SecurityToken.cs
@@ -54,7 +54,11 @@ namespace System.IdentityModel.Tokens
 
             _id = id;
 
-            _certificate = clone ? new X509Certificate2(certificate.Handle) : certificate;
+            // dotnet/wcf#1574
+            // ORIGINAL CODE: 
+            // _certificate = clone ? new X509Certificate2(certificate.Handle) : certificate;
+            _certificate = clone ? certificate.CloneCertificateInternal() : certificate;
+
             // if the cert needs to be cloned then the token owns the clone and should dispose it
             _disposable = clone || disposable;
         }

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/SslStreamSecurityUpgradeProvider.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/SslStreamSecurityUpgradeProvider.cs
@@ -251,7 +251,11 @@ namespace System.ServiceModel.Channels
                 throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(
                     SR.InvalidTokenProvided, _serverTokenProvider.GetType(), typeof(X509SecurityToken))));
             }
-            _serverCertificate = new X509Certificate2(x509Token.Certificate.Handle);
+
+            // dotnet/wcf#1574
+            // ORIGINAL CODE: 
+            // _serverCertificate = new X509Certificate2(x509Token.Certificate.Handle);
+            _serverCertificate = x509Token.Certificate.CloneCertificateInternal(); 
         }
 
         private void CleanupServerCertificate()
@@ -708,7 +712,12 @@ namespace System.ServiceModel.Channels
             SslPolicyErrors sslPolicyErrors)
         {
             // Note: add ref to handle since the caller will reset the cert after the callback return.
-            X509Certificate2 certificate2 = new X509Certificate2(certificate.Handle);
+
+            // dotnet/wcf#1574
+            // ORIGINAL CODE: 
+            // X509Certificate2 certificate2 = new X509Certificate2(certificate.Handle);
+            X509Certificate2 certificate2 = certificate.CloneCertificateInternal(); 
+
             SecurityToken token = new X509SecurityToken(certificate2, false);
             ReadOnlyCollection<IAuthorizationPolicy> authorizationPolicies = _serverCertificateAuthenticator.ValidateToken(token);
             _serverSecurity = new SecurityMessageProperty();

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SecurityUtils.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SecurityUtils.cs
@@ -863,7 +863,10 @@ namespace System.ServiceModel.Security
                 certs = store.Certificates.Find(findType, findValue, false);
                 if (certs.Count == 1)
                 {
-                    return new X509Certificate2(certs[0].Handle);
+                    // dotnet/wcf#1574
+                    // ORIGINAL CODE: 
+                    // return new X509Certificate2(certs[0].Handle);
+                    return certs[0].CloneCertificateInternal();
                 }
                 if (throwIfMultipleOrNoMatch)
                 {

--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Https/HttpsTests.4.1.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Https/HttpsTests.4.1.0.cs
@@ -172,7 +172,7 @@ public partial class HttpsTests : ConditionalWcfTest
                nameof(Client_Certificate_Installed),
                nameof(SSL_Available))]
     [Issue(959, Framework = FrameworkID.NetNative)] // Server certificate validation not supported in NET Native
-    [Issue(1295, OS = OSID.AnyUnix)] // A libcurl built with OpenSSL is required
+    [Issue(1295, OS = OSID.AnyCentOS | OSID.AnyFedora | OSID.AnyOpenSUSE | OSID.AnyOSX | OSID.AnyRHEL)] // A libcurl built with OpenSSL is required
     [OuterLoop]
     public static void ServerCertificateValidation_EchoString()
     {
@@ -221,7 +221,7 @@ public partial class HttpsTests : ConditionalWcfTest
                nameof(Client_Certificate_Installed),
                nameof(Server_Accepts_Certificates),
                nameof(SSL_Available))]
-    [Issue(1295, OS = OSID.AnyUnix)] // A libcurl built with OpenSSL is required
+    [Issue(1295, OS = OSID.AnyCentOS | OSID.AnyFedora | OSID.AnyOpenSUSE | OSID.AnyOSX | OSID.AnyRHEL)] // A libcurl built with OpenSSL is required
     [OuterLoop]
     public static void ClientCertificate_EchoString()
     {


### PR DESCRIPTION
In .NET Core, the X509Certificate2 copy constructor was missing; where WCF code
needed to clone a certificate, we replaced the references to the copy constructor
with code that uses the certificate.Handle instead

However, in Linux, OpenSSL does not provide the private key when using this handle,
meaning the private key goes missing in all subsequent copies; as such, client cert
authentication doesn't work.

This is a stopgap solution only, as we await the inclusion of the X509Certificate2
copy ctor in a future .NET Core version

Relates to #1574