### PR TITLE
Update index for 4.3.0 packages

### DIFF
--- a/pkg/baseline/packageIndex.json
+++ b/pkg/baseline/packageIndex.json
@@ -5,18 +5,18 @@
         "4.0.0",
         "4.1.0"
       ],
-      "BaselineVersion": "4.1.0"
+      "BaselineVersion": "4.3.0"
     },
     "System.ServiceModel.Duplex": {
       "StableVersions": [
         "4.0.0",
         "4.0.1"
       ],
-      "BaselineVersion": "4.0.1",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.0.1.0": "4.0.1",
-        "4.0.2.0": "4.0.2"
+        "4.0.2.0": "4.3.0"
       }
     },
     "System.ServiceModel.Http": {
@@ -26,13 +26,13 @@
         "4.0.10",
         "4.1.0"
       ],
-      "BaselineVersion": "4.1.0",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "3.9.0.0": "3.9.0",
         "4.0.0.0": "4.0.0",
         "4.0.10.0": "4.0.10",
         "4.1.0.0": "4.1.0",
-        "4.1.1.0": "4.1.1"
+        "4.1.1.0": "4.3.0"
       }
     },
     "System.ServiceModel.NetTcp": {
@@ -40,11 +40,11 @@
         "4.0.0",
         "4.1.0"
       ],
-      "BaselineVersion": "4.1.0",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.1.0.0": "4.1.0",
-        "4.1.1.0": "4.1.1"
+        "4.1.1.0": "4.3.0"
       }
     },
     "System.ServiceModel.Primitives": {
@@ -53,12 +53,12 @@
         "4.0.0",
         "4.1.0"
       ],
-      "BaselineVersion": "4.1.0",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "3.9.0.0": "3.9.0",
         "4.0.0.0": "4.0.0",
         "4.1.0.0": "4.1.0",
-        "4.1.1.0": "4.1.1"
+        "4.1.1.0": "4.3.0"
       }
     },
     "System.ServiceModel.Security": {
@@ -67,12 +67,12 @@
         "4.0.0",
         "4.0.1"
       ],
-      "BaselineVersion": "4.0.1",
+      "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "3.9.0.0": "3.9.0",
         "4.0.0.0": "4.0.0",
         "4.0.1.0": "4.0.1",
-        "4.0.2.0": "4.0.2"
+        "4.0.2.0": "4.3.0"
       }
     }
   },


### PR DESCRIPTION
Live built packages changed their version to 4.3.0, update assembly maps
to represent this.

Rebase all packages on latest version since 1.1.0 release is shipping as
a set.

/cc @StephenBonikowsky @zhenlan @mconnew 