### PR TITLE
Fix the issue that we use WindowsIdentity.Current on *NIX

### DIFF
--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Negotiate/NegotiateStream_Http_Tests.4.1.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Negotiate/NegotiateStream_Http_Tests.4.1.0.cs
@@ -61,7 +61,7 @@ public class NegotiateStream_Http_Tests : ConditionalWcfTest
                nameof(Root_Certificate_Installed),
                nameof(Ambient_Credentials_Available))]
     [OuterLoop]
-    [Issue(1569, OS = OSID.AnyUnix)]
+    [Issue(1589, OS = OSID.AnyUnix)]
     public static void NegotiateStream_Http_AmbientCredentials()
     {
         string testString = "Hello";
@@ -158,7 +158,7 @@ public class NegotiateStream_Http_Tests : ConditionalWcfTest
     //          "NegotiateTestDomain"
     //          "NegotiateTestSpn" (host/<servername>)
     //          "ServiceUri" (server running as machine context)
-    [Issue(1569, OS = OSID.AnyUnix)]
+    [Issue(1589, OS = OSID.AnyUnix)]
     public static void NegotiateStream_Http_With_ExplicitSpn()
     {
         string testString = "Hello";


### PR DESCRIPTION
* We use try/catch to catch PlatformNotSupported exception
and use the same way to set default user on UWP.

Fix #1569