### PR TITLE
Remove comments regarding 1449 workaround

### DIFF
--- a/src/System.ServiceModel.Http/tests/ServiceModel/BasicHttpBindingTest.cs
+++ b/src/System.ServiceModel.Http/tests/ServiceModel/BasicHttpBindingTest.cs
@@ -167,7 +167,7 @@ public static class BasicHttpBindingTest
     }
 
     [WcfTheory]
-    [InlineData(new object[] { null } )]  // Work-around issue #1449 with this syntax
+    [InlineData(new object[] { null } )]
     [InlineData("")]
     public static void Name_Property_Set_Invalid_Value_Throws(string value)
     {
@@ -187,7 +187,7 @@ public static class BasicHttpBindingTest
     }
 
     [WcfTheory]
-    [InlineData(new object[] { null } )]  // Work-around issue #1449 with this syntax
+    [InlineData(new object[] { null } )]
     public static void Namespace_Property_Set_Invalid_Value_Throws(string value)
     {
         var binding = new BasicHttpBinding();

--- a/src/System.ServiceModel.Primitives/tests/Channels/CustomBindingTest.cs
+++ b/src/System.ServiceModel.Primitives/tests/Channels/CustomBindingTest.cs
@@ -49,7 +49,7 @@ public static class CustomBindingTest
 
     [WcfTheory]
     [InlineData("")]
-    [InlineData(new object[] { null } )]  // Work-around issue #1449 with this syntax
+    [InlineData(new object[] { null } )]
     public static void CustomBinding_Name_Property_Set_Throws(string bindingName)
     {
         CustomBinding customBinding = new CustomBinding();

--- a/src/System.ServiceModel.Primitives/tests/ServiceModel/MessageContractTest.cs
+++ b/src/System.ServiceModel.Primitives/tests/ServiceModel/MessageContractTest.cs
@@ -53,7 +53,7 @@ public static class MessageContractTest
     }
 
     [WcfTheory]
-    [InlineData(new object[] { null } )]  // Work-around issue #1449 with this syntax
+    [InlineData(new object[] { null } )]
     public static void WrapperName_Property_Sets_Throws_ArgumentNull(string wrapperName)
     {
         MessageContractAttribute messageCA = new MessageContractAttribute();
@@ -64,7 +64,7 @@ public static class MessageContractTest
     [InlineData("http://www.contoso.com")]
     [InlineData("testNamespace")]
     [InlineData("")]
-    [InlineData(new object[] { null } )]  // Work-around issue #1449 with this syntax
+    [InlineData(new object[] { null } )]
     public static void WrapperNamespace_Property_Sets(string wrapperNamespace)
     {
         MessageContractAttribute messageCA = new MessageContractAttribute();


### PR DESCRIPTION
The issue behind #1449 has been opened against the
ILC team, and the workaround already in place is adequate.
This PR merely removes the unnecessary comment references to
issue #1449.

skip ci please

Fixes #1449