### PR TITLE
Adds IInteractiveChannelInitializer to public API

### DIFF
--- a/src/System.Private.ServiceModel/tests/Common/Unit/MockClientMessageInspector.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Unit/MockClientMessageInspector.cs
@@ -1,0 +1,89 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.ServiceModel;
+using System.ServiceModel.Channels;
+using System.ServiceModel.Description;
+using System.ServiceModel.Dispatcher;
+
+public delegate void AfterReceiveReplyDelegate(ref Message reply, object correlationState);
+public delegate object BeforeSendRequestDelegate(ref Message request, IClientChannel channel);
+
+public class MockClientMessageInspector : IClientMessageInspector, IEndpointBehavior
+{
+    public MockClientMessageInspector()
+    {
+        ValidateOverride = DefaultValidate;
+        AddBindingParametersOverride = DefaultAddBindingParameters;
+        ApplyDispatchBehaviorOverride = DefaultApplyDispatchBehavior;
+        ApplyClientBehaviorOverride = DefaultApplyClientBehavior;
+
+        AfterReceiveReplyOverride = DefaultAfterReceiveReply;
+        BeforeSendRequestOverride = DefaultBeforeSendRequest;
+    }
+
+    public Action<ServiceEndpoint> ValidateOverride { get; set; }
+    public Action<ServiceEndpoint, BindingParameterCollection> AddBindingParametersOverride { get; set; }
+    public Action<ServiceEndpoint, EndpointDispatcher> ApplyDispatchBehaviorOverride { get; set; }
+    public Action<ServiceEndpoint, ClientRuntime> ApplyClientBehaviorOverride { get; set; }
+
+    public AfterReceiveReplyDelegate AfterReceiveReplyOverride { get; set; }
+    public BeforeSendRequestDelegate BeforeSendRequestOverride { get; set; }
+
+    public void Validate(ServiceEndpoint endpoint)
+    {
+        ValidateOverride(endpoint);
+    }
+    public void DefaultValidate(ServiceEndpoint endpoint)
+    {
+    }
+
+    public void AddBindingParameters(ServiceEndpoint endpoint, BindingParameterCollection bindingParameters)
+    {
+        AddBindingParametersOverride(endpoint, bindingParameters);
+    }
+
+    public void DefaultAddBindingParameters(ServiceEndpoint endpoint, BindingParameterCollection bindingParameters)
+    {
+    }
+
+    public void ApplyDispatchBehavior(ServiceEndpoint endpoint, EndpointDispatcher endpointDispatcher)
+    {
+        ApplyDispatchBehaviorOverride(endpoint, endpointDispatcher);
+    }
+
+    public void DefaultApplyDispatchBehavior(ServiceEndpoint endpoint, EndpointDispatcher endpointDispatcher)
+    {
+    }
+
+    public void ApplyClientBehavior(ServiceEndpoint endpoint, ClientRuntime clientRuntime)
+    {
+        ApplyClientBehaviorOverride(endpoint, clientRuntime);
+    }
+    public void DefaultApplyClientBehavior(ServiceEndpoint endpoint, ClientRuntime clientRuntime)
+    {
+    }
+
+    public void AfterReceiveReply(ref Message reply, object correlationState)
+    {
+        AfterReceiveReplyOverride(ref reply, correlationState);
+    }
+
+    public void DefaultAfterReceiveReply(ref Message reply, object correlationState)
+    {
+    }
+
+    public object BeforeSendRequest(ref Message request, IClientChannel channel)
+    {
+        return BeforeSendRequestOverride(ref request, channel);
+    }
+
+    public object DefaultBeforeSendRequest(ref Message request, IClientChannel channel)
+    {
+        return null;
+    }
+}
+
+

--- a/src/System.Private.ServiceModel/tests/Common/Unit/MockInteractiveChannelInitializer.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Unit/MockInteractiveChannelInitializer.cs
@@ -1,0 +1,42 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.ServiceModel;
+using System.ServiceModel.Channels;
+using System.ServiceModel.Description;
+using System.ServiceModel.Dispatcher;
+
+public class MockInteractiveChannelInitializer : IInteractiveChannelInitializer
+{
+    public MockInteractiveChannelInitializer()
+    {
+        BeginDisplayInitializationUIOverride = DefaultBeginDisplayInitializationUI;
+        EndDisplayInitializationUIOverride = DefaultEndDisplayInitializationUI;
+    }
+
+    public Func<IClientChannel, AsyncCallback, object, IAsyncResult> BeginDisplayInitializationUIOverride { get; set; }
+    public Action<IAsyncResult> EndDisplayInitializationUIOverride { get; set; }
+
+    public IAsyncResult BeginDisplayInitializationUI(IClientChannel channel, AsyncCallback callback, object state)
+    {
+        return BeginDisplayInitializationUIOverride(channel, callback, state);
+    }
+
+    public IAsyncResult DefaultBeginDisplayInitializationUI(IClientChannel channel, AsyncCallback callback, object state)
+    {
+        MockAsyncResult result = new MockAsyncResult(TimeSpan.FromSeconds(30), callback, state);
+        result.Complete();
+        return result;
+    }
+
+    public void EndDisplayInitializationUI(IAsyncResult result)
+    {
+        EndDisplayInitializationUIOverride(result);
+    }
+
+    public void DefaultEndDisplayInitializationUI(IAsyncResult result)
+    {
+    }
+}

--- a/src/System.ServiceModel.Primitives/ref/System.ServiceModel.Primitives.cs
+++ b/src/System.ServiceModel.Primitives/ref/System.ServiceModel.Primitives.cs
@@ -1415,6 +1415,7 @@ namespace System.ServiceModel.Dispatcher
         public System.Type ContractClientType { get { return default(System.Type); } set { } }
         public string ContractName { get { return default(string); } }
         public string ContractNamespace { get { return default(string); } }
+        public System.Collections.Generic.SynchronizedCollection<IInteractiveChannelInitializer> InteractiveChannelInitializers { get { return default(System.Collections.Generic.SynchronizedCollection<IInteractiveChannelInitializer>); } }
         public bool ManualAddressing { get { return default(bool); } set { } }
         public int MaxFaultSize { get { return default(int); } set { } }
         public System.ServiceModel.Dispatcher.IClientOperationSelector OperationSelector { get { return default(System.ServiceModel.Dispatcher.IClientOperationSelector); } set { } }
@@ -1464,6 +1465,11 @@ namespace System.ServiceModel.Dispatcher
     {
         bool AreParametersRequiredForSelection { get; }
         string SelectOperation(System.Reflection.MethodBase method, object[] parameters);
+    }
+    public partial interface IInteractiveChannelInitializer
+    {
+        IAsyncResult BeginDisplayInitializationUI(IClientChannel channel, AsyncCallback callback, object state);
+        void EndDisplayInitializationUI(IAsyncResult result);
     }
     public partial interface IParameterInspector
     {

--- a/src/System.ServiceModel.Primitives/tests/Channels/CustomChannelTest.cs
+++ b/src/System.ServiceModel.Primitives/tests/Channels/CustomChannelTest.cs
@@ -472,6 +472,260 @@ public static class CustomChannelTest
                     String.Format("Expected exception message '{0}' but actual was '{1}'",
                                     thrownException.Message, caughtException.Message));
     }
+    
+        [WcfFact]
+    public static void CustomChannel_InteractiveInitializer_Called_Implicit_Open()
+    {
+        string testMessageBody = "CustomChannelTest_Sync";
+        Message inputMessage = Message.CreateMessage(MessageVersion.Default, action: "Test", body: testMessageBody);
+
+        // *** SETUP *** \\
+        MockTransportBindingElement mockBindingElement = new MockTransportBindingElement();
+        CustomBinding binding = new CustomBinding(mockBindingElement);
+        EndpointAddress address = new EndpointAddress("myprotocol://localhost:5000");
+        var factory = new ChannelFactory<ICustomChannelServiceInterface>(binding, address);
+
+        // Create a mock interactive channel initializer to observe whether
+        // its methods are invoked.
+        bool beginInitializeCalled = false;
+        bool endInitializeCalled = false;
+        MockInteractiveChannelInitializer mockInitializer = new MockInteractiveChannelInitializer();
+        mockInitializer.BeginDisplayInitializationUIOverride = (chnl, callback, state) =>
+        {
+            beginInitializeCalled = true;
+            return mockInitializer.DefaultBeginDisplayInitializationUI(chnl, callback, state);
+        };
+
+        mockInitializer.EndDisplayInitializationUIOverride = (ar) =>
+        {
+            endInitializeCalled = true;
+            mockInitializer.DefaultEndDisplayInitializationUI(ar);
+        };
+
+        // Create a mock endpoint behavior that adds the mock interactive initializer
+        MockEndpointBehavior mockEndpointBehavior = new MockEndpointBehavior();
+        mockEndpointBehavior.ApplyClientBehaviorOverride = (ServiceEndpoint serviceEndpoint, ClientRuntime clientRuntime) =>
+        {
+            clientRuntime.InteractiveChannelInitializers.Add(mockInitializer);
+        };
+
+        // Attach our mock endpoint behavior to the ServiceEndpoint
+        // so that our mock channel initializer is registered.
+        factory.Endpoint.EndpointBehaviors.Add(mockEndpointBehavior);
+
+        ICustomChannelServiceInterface channel = factory.CreateChannel();
+
+        // *** EXECUTE *** \\
+        // The implicit open does the call to display interactive UI.
+        channel.Process(inputMessage);
+
+        // *** VALIDATE *** \\
+        Assert.True(beginInitializeCalled, "BeginDisplayInitializationUI was not called.");
+        Assert.True(endInitializeCalled, "EndDisplayInitializationUI was not called.");
+    }
+
+    [WcfFact]
+    public static void CustomChannel_InteractiveInitializer_Called_Explicitly()
+    {
+        string testMessageBody = "CustomChannelTest_Sync";
+        Message inputMessage = Message.CreateMessage(MessageVersion.Default, action: "Test", body: testMessageBody);
+
+        // *** SETUP *** \\
+        MockTransportBindingElement mockBindingElement = new MockTransportBindingElement();
+        CustomBinding binding = new CustomBinding(mockBindingElement);
+        EndpointAddress address = new EndpointAddress("myprotocol://localhost:5000");
+        var factory = new ChannelFactory<ICustomChannelServiceInterface>(binding, address);
+
+        // Create a mock interactive channel initializer to observe whether
+        // its methods are invoked.
+        bool beginInitializeCalled = false;
+        bool endInitializeCalled = false;
+        MockInteractiveChannelInitializer mockInitializer = new MockInteractiveChannelInitializer();
+        mockInitializer.BeginDisplayInitializationUIOverride = (chnl, callback, state) =>
+        {
+            beginInitializeCalled = true;
+            return mockInitializer.DefaultBeginDisplayInitializationUI(chnl, callback, state);
+        };
+
+        mockInitializer.EndDisplayInitializationUIOverride = (ar) =>
+        {
+            endInitializeCalled = true;
+            mockInitializer.DefaultEndDisplayInitializationUI(ar);
+        };
+
+        // Create a mock endpoint behavior that adds the mock interactive initializer
+        MockEndpointBehavior mockEndpointBehavior = new MockEndpointBehavior();
+        mockEndpointBehavior.ApplyClientBehaviorOverride = (ServiceEndpoint serviceEndpoint, ClientRuntime clientRuntime) =>
+        {
+            clientRuntime.InteractiveChannelInitializers.Add(mockInitializer);
+        };
+
+        // Attach our mock endpoint behavior to the ServiceEndpoint
+        // so that our mock channel initializer is registered.
+        factory.Endpoint.EndpointBehaviors.Add(mockEndpointBehavior);
+
+        ICustomChannelServiceInterface channel = factory.CreateChannel();
+
+        // *** EXECUTE *** \\
+        // Invoke the interative UI explicitly
+        ((IClientChannel)channel).DisplayInitializationUI();
+
+        // *** VALIDATE *** \\
+        Assert.True(beginInitializeCalled, "BeginDisplayInitializationUI was not called.");
+        Assert.True(endInitializeCalled, "EndDisplayInitializationUI was not called.");
+    }
+
+    [WcfFact]
+    public static void CustomChannel_InteractiveInitializer_Direct_Open_To_Bypass_UI_Throws()
+    {
+        string testMessageBody = "CustomChannelTest_Sync";
+        Message inputMessage = Message.CreateMessage(MessageVersion.Default, action: "Test", body: testMessageBody);
+
+        // *** SETUP *** \\
+        MockTransportBindingElement mockBindingElement = new MockTransportBindingElement();
+        CustomBinding binding = new CustomBinding(mockBindingElement);
+        EndpointAddress address = new EndpointAddress("myprotocol://localhost:5000");
+        var factory = new ChannelFactory<ICustomChannelServiceInterface>(binding, address);
+
+        // Create a mock interactive channel initializer to observe whether
+        // its methods are invoked.
+        bool beginInitializeCalled = false;
+        bool endInitializeCalled = false;
+        MockInteractiveChannelInitializer mockInitializer = new MockInteractiveChannelInitializer();
+        mockInitializer.BeginDisplayInitializationUIOverride = (chnl, callback, state) =>
+        {
+            beginInitializeCalled = true;
+            return mockInitializer.DefaultBeginDisplayInitializationUI(chnl, callback, state);
+        };
+
+        mockInitializer.EndDisplayInitializationUIOverride = (ar) =>
+        {
+            endInitializeCalled = true;
+            mockInitializer.DefaultEndDisplayInitializationUI(ar);
+        };
+
+        // Create a mock endpoint behavior that adds the mock interactive initializer
+        MockEndpointBehavior mockEndpointBehavior = new MockEndpointBehavior();
+        mockEndpointBehavior.ApplyClientBehaviorOverride = (ServiceEndpoint serviceEndpoint, ClientRuntime clientRuntime) =>
+        {
+            clientRuntime.InteractiveChannelInitializers.Add(mockInitializer);
+        };
+
+        // Attach our mock endpoint behavior to the ServiceEndpoint
+        // so that our mock channel initializer is registered.
+        factory.Endpoint.EndpointBehaviors.Add(mockEndpointBehavior);
+
+        ICustomChannelServiceInterface channel = factory.CreateChannel();
+
+        // *** EXECUTE *** \\
+        // Attempting to open a channel explicitly without first calling DisplayInteractiveUI
+        // throws an exception.
+        Assert.Throws<InvalidOperationException>(() => ((IClientChannel)channel).Open());
+
+        // *** VALIDATE *** \\
+        Assert.False(beginInitializeCalled, "BeginDisplayInitializationUI should not have been called.");
+        Assert.False(endInitializeCalled, "EndDisplayInitializationUI should not have been  called.");
+    }
+
+    [WcfFact]
+    public static void CustomChannel_InteractiveInitializer_Can_Be_Blocked()
+    {
+        string testMessageBody = "CustomChannelTest_Sync";
+        Message inputMessage = Message.CreateMessage(MessageVersion.Default, action: "Test", body: testMessageBody);
+
+        // *** SETUP *** \\
+        MockTransportBindingElement mockBindingElement = new MockTransportBindingElement();
+        CustomBinding binding = new CustomBinding(mockBindingElement);
+        EndpointAddress address = new EndpointAddress("myprotocol://localhost:5000");
+        var factory = new ChannelFactory<ICustomChannelServiceInterface>(binding, address);
+
+        // Create a mock interactive channel initializer to observe whether
+        // its methods are invoked.
+        bool beginInitializeCalled = false;
+        bool endInitializeCalled = false;
+        MockInteractiveChannelInitializer mockInitializer = new MockInteractiveChannelInitializer();
+        mockInitializer.BeginDisplayInitializationUIOverride = (chnl, callback, state) =>
+        {
+            beginInitializeCalled = true;
+            return mockInitializer.DefaultBeginDisplayInitializationUI(chnl, callback, state);
+        };
+
+        mockInitializer.EndDisplayInitializationUIOverride = (ar) =>
+        {
+            endInitializeCalled = true;
+            mockInitializer.DefaultEndDisplayInitializationUI(ar);
+        };
+
+        // Create a mock endpoint behavior that adds the mock interactive initializer
+        MockEndpointBehavior mockEndpointBehavior = new MockEndpointBehavior();
+        mockEndpointBehavior.ApplyClientBehaviorOverride = (ServiceEndpoint serviceEndpoint, ClientRuntime clientRuntime) =>
+        {
+            clientRuntime.InteractiveChannelInitializers.Add(mockInitializer);
+        };
+
+        // Attach our mock endpoint behavior to the ServiceEndpoint
+        // so that our mock channel initializer is registered.
+        factory.Endpoint.EndpointBehaviors.Add(mockEndpointBehavior);
+
+        ICustomChannelServiceInterface channel = factory.CreateChannel();
+
+        // block attempts to use interactive UI
+        ((IClientChannel)channel).AllowInitializationUI = false;
+
+        // *** EXECUTE *** \\
+        Assert.Throws<InvalidOperationException>(() => ((IClientChannel)channel).DisplayInitializationUI());
+
+        // *** VALIDATE *** \\
+        Assert.False(beginInitializeCalled, "BeginDisplayInitializationUI should not have been called.");
+        Assert.False(endInitializeCalled, "EndDisplayInitializationUI should not have been called.");
+    }
+
+    [WcfFact]
+    public static void CustomChannel_InteractiveInitializer_Error_Blocks_Open()
+    {
+        string testMessageBody = "CustomChannelTest_Sync";
+        Message inputMessage = Message.CreateMessage(MessageVersion.Default, action: "Test", body: testMessageBody);
+
+        // *** SETUP *** \\
+        MockTransportBindingElement mockBindingElement = new MockTransportBindingElement();
+        CustomBinding binding = new CustomBinding(mockBindingElement);
+        EndpointAddress address = new EndpointAddress("myprotocol://localhost:5000");
+        var factory = new ChannelFactory<ICustomChannelServiceInterface>(binding, address);
+
+        // Create a mock interactive channel initializer to throw during initialization
+        InvalidOperationException thrownException = new InvalidOperationException("ui initialization failed");
+        MockInteractiveChannelInitializer mockInitializer = new MockInteractiveChannelInitializer();
+        mockInitializer.EndDisplayInitializationUIOverride = (ar) =>
+        {
+            // Throw from the EndDisplayInitializationUI call to simulate a UI
+            // action that throws an error to prevent the open.
+            mockInitializer.DefaultEndDisplayInitializationUI(ar);
+            throw thrownException;
+        };
+
+        // Create a mock endpoint behavior that adds the mock interactive initializer
+        MockEndpointBehavior mockEndpointBehavior = new MockEndpointBehavior();
+        mockEndpointBehavior.ApplyClientBehaviorOverride = (ServiceEndpoint serviceEndpoint, ClientRuntime clientRuntime) =>
+        {
+            clientRuntime.InteractiveChannelInitializers.Add(mockInitializer);
+        };
+
+        // Attach our mock endpoint behavior to the ServiceEndpoint
+        // so that our mock channel initializer is registered.
+        factory.Endpoint.EndpointBehaviors.Add(mockEndpointBehavior);
+
+        ICustomChannelServiceInterface channel = factory.CreateChannel();
+
+        // *** EXECUTE *** \\
+        // The implicit open does the call to display interactive UI.
+        InvalidOperationException caughtException = 
+            Assert.Throws<InvalidOperationException>(() => channel.Process(inputMessage));
+
+        // *** VALIDATE *** \\
+        Assert.True(string.Equals(thrownException.Message, caughtException.Message),
+                    String.Format("Expected exception message to be '{0}' but actual was '{1}'",
+                                  thrownException.Message, caughtException.Message));
+    }
 
     #region Helpers
 


### PR DESCRIPTION
Also adds ClientRuntime.InteractiveInitializers to public API,
which is the only way to register interactive initializers.

New mocks and unit tests added to verify the interative
initializer is called properly.