### PR TITLE
Add IChannelInitializer to public API

### DIFF
--- a/src/System.Private.ServiceModel/tests/Common/Unit/MockChannelInitializer.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Unit/MockChannelInitializer.cs
@@ -1,0 +1,28 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.ServiceModel;
+using System.ServiceModel.Channels;
+using System.ServiceModel.Description;
+using System.ServiceModel.Dispatcher;
+
+public class MockChannelInitializer : IChannelInitializer
+{
+    public MockChannelInitializer()
+    {
+        InitializeOverride = DefaultInitialize;
+    }
+
+    public Action<IClientChannel> InitializeOverride { get; set; }
+
+    public void Initialize(IClientChannel channel)
+    {
+        InitializeOverride(channel);
+    }
+
+    public void DefaultInitialize(IClientChannel channel)
+    {
+    }
+}

--- a/src/System.Private.ServiceModel/tests/Common/Unit/MockEndpointBehavior.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Unit/MockEndpointBehavior.cs
@@ -1,0 +1,58 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.ServiceModel.Channels;
+using System.ServiceModel.Description;
+using System.ServiceModel.Dispatcher;
+
+public class MockEndpointBehavior : IEndpointBehavior
+{
+    public MockEndpointBehavior()
+    {
+        ValidateOverride = DefaultValidate;
+        AddBindingParametersOverride = DefaultAddBindingParameters;
+        ApplyDispatchBehaviorOverride = DefaultApplyDispatchBehavior;
+        ApplyClientBehaviorOverride = DefaultApplyClientBehavior;
+    }
+
+    public Action<ServiceEndpoint> ValidateOverride { get; set; }
+    public Action<ServiceEndpoint, BindingParameterCollection> AddBindingParametersOverride { get; set; }
+    public Action<ServiceEndpoint, EndpointDispatcher> ApplyDispatchBehaviorOverride { get; set; }
+    public Action<ServiceEndpoint, ClientRuntime> ApplyClientBehaviorOverride { get; set; }
+
+    public void Validate(ServiceEndpoint endpoint)
+    {
+        ValidateOverride(endpoint);
+    }
+    public void DefaultValidate(ServiceEndpoint endpoint)
+    {
+    }
+
+    public void AddBindingParameters(ServiceEndpoint endpoint, BindingParameterCollection bindingParameters)
+    {
+        AddBindingParametersOverride(endpoint, bindingParameters);
+    }
+
+    public void DefaultAddBindingParameters(ServiceEndpoint endpoint, BindingParameterCollection bindingParameters)
+    {
+    }
+
+    public void ApplyDispatchBehavior(ServiceEndpoint endpoint, EndpointDispatcher endpointDispatcher)
+    {
+        ApplyDispatchBehaviorOverride(endpoint, endpointDispatcher);
+    }
+
+    public void DefaultApplyDispatchBehavior(ServiceEndpoint endpoint, EndpointDispatcher endpointDispatcher)
+    {
+    }
+
+    public void ApplyClientBehavior(ServiceEndpoint endpoint, ClientRuntime clientRuntime)
+    {
+        ApplyClientBehaviorOverride(endpoint, clientRuntime);
+    }
+    public void DefaultApplyClientBehavior(ServiceEndpoint endpoint, ClientRuntime clientRuntime)
+    {
+    }
+}

--- a/src/System.ServiceModel.Primitives/ref/System.ServiceModel.Primitives.cs
+++ b/src/System.ServiceModel.Primitives/ref/System.ServiceModel.Primitives.cs
@@ -1409,6 +1409,7 @@ namespace System.ServiceModel.Dispatcher
     public sealed partial class ClientRuntime
     {
         internal ClientRuntime() { }
+        public System.Collections.Generic.SynchronizedCollection<IChannelInitializer> ChannelInitializers { get { return default(System.Collections.Generic.SynchronizedCollection<IChannelInitializer>); } }
         public System.Collections.Generic.ICollection<System.ServiceModel.Dispatcher.IClientMessageInspector> ClientMessageInspectors { get { return default(System.Collections.Generic.ICollection<System.ServiceModel.Dispatcher.IClientMessageInspector>); } }
         public System.Collections.Generic.ICollection<System.ServiceModel.Dispatcher.ClientOperation> ClientOperations { get { return default(System.Collections.Generic.ICollection<System.ServiceModel.Dispatcher.ClientOperation>); } }
         public System.Type ContractClientType { get { return default(System.Type); } set { } }
@@ -1444,6 +1445,10 @@ namespace System.ServiceModel.Dispatcher
          public FaultContractInfo(string action, Type detail) {}
          public string Action { get { return default(string); } }
          public Type Detail { get { return default(Type); } }
+    }
+    public partial interface IChannelInitializer
+    {
+        void Initialize(IClientChannel channel);
     }
     public partial interface IClientMessageFormatter
     {


### PR DESCRIPTION
Also adds ClientRuntime.ChannelInitializers to public API because
this is needed to register a custom IChannelInitializer.

Also creates new mock initializer and unit tests to verify it
is called properly.

Fixes #1422