### PR TITLE
Fix test services for addding service reference

### DIFF
--- a/src/System.Private.ServiceModel/tests/Common/Scenarios/ScenarioTestTypes.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Scenarios/ScenarioTestTypes.cs
@@ -1294,7 +1294,7 @@ public partial class XmlMessageContractTestRequest
 [MessageContract(WrapperName = "XmlMessageContractTestRequestWithMessageHeader", WrapperNamespace = "http://www.contoso.com/XmlMessageContarctTestMessages", IsWrapped = true)]
 public partial class XmlMessageContractTestRequestWithMessageHeader
 {
-    [MessageHeader(Name = "OutOfBandData", Namespace = "http://www.contoso.com", MustUnderstand = false)]
+    [MessageHeader(Name = "XmlMessageContractTestRequestWithMessageHeaderMessage", Namespace = "http://www.contoso.com", MustUnderstand = false)]
     public string Message;
 
     public XmlMessageContractTestRequestWithMessageHeader()

--- a/src/System.Private.ServiceModel/tests/Scenarios/Contract/Message/MessageContractCommon.4.1.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Contract/Message/MessageContractCommon.4.1.0.cs
@@ -15,7 +15,6 @@ namespace MessageContractCommon
     public class MessageContractConstants
     {
         // CONSTANTS
-        public const string wrapperName = "CustomWrapperName";
         public const string wrapperNamespace = "http://www.contoso.com";
         public const string dateElementName = "Date_of_Request";
         public static string dateElementValue = "";
@@ -24,7 +23,6 @@ namespace MessageContractCommon
         public const string customerElementName = "Customer_Name";
         public const string customerElementNamespace = "http://www.contoso.com";
         public const string customerElementValue = "Michael Jordan";
-        public const string extraValuesName = "OutOfBandData";
         public const string extraValuesNamespace = "http://www.contoso.com";
     }
 
@@ -78,7 +76,7 @@ namespace MessageContractCommon
 
     public class MessageContractTypes
     {
-        [MessageContract(IsWrapped = true, WrapperName = "CustomWrapperName", WrapperNamespace = "http://www.contoso.com")]
+        [MessageContract(IsWrapped = true, WrapperName = "RequestBankingDataWrapper", WrapperNamespace = "http://www.contoso.com")]
         public class RequestBankingData
         {
             [MessageBodyMember(Order = 1, Name = "Date_of_Request")]
@@ -89,7 +87,7 @@ namespace MessageContractCommon
             public int amount;
         }
 
-        [MessageContract(IsWrapped = true, WrapperName = "CustomWrapperName", WrapperNamespace = "http://www.contoso.com")]
+        [MessageContract(IsWrapped = true, WrapperName = "ReplyBankingDataWrapper", WrapperNamespace = "http://www.contoso.com")]
         public class ReplyBankingData
         {
             [MessageBodyMember(Order = 1, Name = "Date_of_Request")]
@@ -100,7 +98,7 @@ namespace MessageContractCommon
             public int amount;
         }
 
-        [MessageContract(IsWrapped = false, WrapperName = "CustomWrapperName", WrapperNamespace = "http://www.contoso.com")]
+        [MessageContract(IsWrapped = false)]
         public class ReplyBankingDataNotWrapped
         {
             [MessageBodyMember(Order = 1, Name = "Date_of_Request")]
@@ -111,7 +109,7 @@ namespace MessageContractCommon
             public int amount;
         }
 
-        [MessageContract(IsWrapped = true, WrapperName = "CustomWrapperName", WrapperNamespace = "http://www.contoso.com")]
+        [MessageContract(IsWrapped = true, WrapperName = "ReplyBankingDataWithMessageHeaderWrapper", WrapperNamespace = "http://www.contoso.com")]
         public class ReplyBankingDataWithMessageHeader
         {
             [MessageBodyMember(Order = 1, Name = "Date_of_Request")]
@@ -120,11 +118,11 @@ namespace MessageContractCommon
             public string accountName;
             [MessageBodyMember(Order = 2, Name = "Transaction_Amount")]
             public int amount;
-            [MessageHeader(Name = "OutOfBandData", Namespace = "http://www.contoso.com", MustUnderstand = true)]
+            [MessageHeader(Name = "ReplyBankingDataWithMessageHeaderExtraValues", Namespace = "http://www.contoso.com", MustUnderstand = true)]
             public string extraValues;
         }
 
-        [MessageContract(IsWrapped = true, WrapperName = "CustomWrapperName", WrapperNamespace = "http://www.contoso.com")]
+        [MessageContract(IsWrapped = true, WrapperName = "ReplyBankingDataWithMessageHeaderNotNecessaryUnderstoodWrapper", WrapperNamespace = "http://www.contoso.com")]
         public class ReplyBankingDataWithMessageHeaderNotNecessaryUnderstood
         {
             [MessageBodyMember(Order = 1, Name = "Date_of_Request")]
@@ -133,7 +131,7 @@ namespace MessageContractCommon
             public string accountName;
             [MessageBodyMember(Order = 2, Name = "Transaction_Amount")]
             public int amount;
-            [MessageHeader(Name = "OutOfBandData", Namespace = "http://www.contoso.com", MustUnderstand = false)]
+            [MessageHeader(Name = "ReplyBankingDataWithMessageHeaderNotNecessaryUnderstoodExtraValue", Namespace = "http://www.contoso.com", MustUnderstand = false)]
             public string extraValues;
         }
     }

--- a/src/System.Private.ServiceModel/tests/Scenarios/Contract/Message/MessageContractTests.4.1.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Contract/Message/MessageContractTests.4.1.0.cs
@@ -21,8 +21,9 @@ public static class MessageContractTests
         clientProxy.MessageContractRequestReply(requestData);
         XmlDictionaryReader reader = MessageContractHelpers.GetResponseBodyReader(inspector);
 
-        Assert.True(reader.LocalName.Equals(MessageContractConstants.wrapperName),
-            string.Format("reader.LocalName - Expected: {0}, Actual: {1}", MessageContractConstants.wrapperName, reader.LocalName));
+        string wrapperName = "ReplyBankingDataWrapper";
+        Assert.True(reader.LocalName.Equals(wrapperName),
+            string.Format("reader.LocalName - Expected: {0}, Actual: {1}", wrapperName, reader.LocalName));
 
         Assert.True(reader.NamespaceURI.Equals(MessageContractConstants.wrapperNamespace),
             string.Format("reader.NamespaceURI - Expected: {0}, Actual: {1}", MessageContractConstants.wrapperNamespace, reader.NamespaceURI));
@@ -38,7 +39,8 @@ public static class MessageContractTests
         clientProxy.MessageContractRequestReplyNotWrapped(requestData);
         XmlDictionaryReader reader = MessageContractHelpers.GetResponseBodyReader(inspector);
 
-        Assert.False(reader.LocalName.Equals(MessageContractConstants.wrapperName),
+        string wrapperName = "ReplyBankingDataWrapper";
+        Assert.False(reader.LocalName.Equals(wrapperName),
             "When IsWrapped set to false, the message body should not be wrapped with an extra element.");
     }
 
@@ -52,8 +54,9 @@ public static class MessageContractTests
         clientProxy.MessageContractRequestReply(requestData);
         XmlDictionaryReader reader = MessageContractHelpers.GetResponseBodyReader(inspector);
 
-        Assert.True(reader.LocalName.Equals(MessageContractConstants.wrapperName),
-            string.Format("Unexpected element order (1/5). Expected {0}, Actual: {1}", MessageContractConstants.wrapperName, reader.LocalName));
+        string wrapperName = "ReplyBankingDataWrapper";
+        Assert.True(reader.LocalName.Equals(wrapperName),
+            string.Format("Unexpected element order (1/5). Expected {0}, Actual: {1}", wrapperName, reader.LocalName));
 
         reader.Read();
 
@@ -79,8 +82,8 @@ public static class MessageContractTests
         reader.Read(); // Move to the end tag
         reader.ReadEndElement(); // Checks that the current content node is an end tag and advances the reader to the next node.
 
-        Assert.True(reader.IsStartElement() == false && reader.LocalName.Equals(MessageContractConstants.wrapperName),
-            string.Format("Unexpected element order (5/5). Expected: {0}, Actual: {1}", MessageContractConstants.wrapperName, reader.LocalName));
+        Assert.True(reader.IsStartElement() == false && reader.LocalName.Equals(wrapperName),
+            string.Format("Unexpected element order (5/5). Expected: {0}, Actual: {1}", wrapperName, reader.LocalName));
     }
 
     [WcfFact]
@@ -123,7 +126,8 @@ public static class MessageContractTests
         clientProxy.MessageContractRequestReplyWithMessageHeader(requestData);
         MessageHeaders headers = MessageContractHelpers.GetHeaders(inspector);
 
-        int index = headers.FindHeader(MessageContractConstants.extraValuesName, MessageContractConstants.extraValuesNamespace);
+        string extraValue = "ReplyBankingDataWithMessageHeaderExtraValues";
+        int index = headers.FindHeader(extraValue, MessageContractConstants.extraValuesNamespace);
         var header = headers[index];
 
         Assert.True(header != null, "There's no header in the message.");
@@ -140,7 +144,8 @@ public static class MessageContractTests
         clientProxy.MessageContractRequestReplyWithMessageHeaderNotNecessaryUnderstood(requestData);
         MessageHeaders headers = MessageContractHelpers.GetHeaders(inspector);
 
-        int index = headers.FindHeader(MessageContractConstants.extraValuesName, MessageContractConstants.extraValuesNamespace);
+        string extraValue = "ReplyBankingDataWithMessageHeaderNotNecessaryUnderstoodExtraValue";
+        int index = headers.FindHeader(extraValue, MessageContractConstants.extraValuesNamespace);
         var header = headers[index];
 
         Assert.True(header != null, "There's no header in the message.");

--- a/src/System.Private.ServiceModel/tools/IISHostedWcfService/App_code/CompositeType.cs
+++ b/src/System.Private.ServiceModel/tools/IISHostedWcfService/App_code/CompositeType.cs
@@ -217,7 +217,7 @@ public partial class XmlMessageContractTestRequest
 [MessageContract(WrapperName = "XmlMessageContractTestRequestWithMessageHeader", WrapperNamespace = "http://www.contoso.com/XmlMessageContarctTestMessages", IsWrapped = true)]
 public partial class XmlMessageContractTestRequestWithMessageHeader
 {
-    [MessageHeader(Name = "OutOfBandData", Namespace = "http://www.contoso.com", MustUnderstand = false)]
+    [MessageHeader(Name = "XmlMessageContractTestRequestWithMessageHeaderMessage", Namespace = "http://www.contoso.com", MustUnderstand = false)]
     public string Message;
 
     public XmlMessageContractTestRequestWithMessageHeader()

--- a/src/System.Private.ServiceModel/tools/IISHostedWcfService/App_code/DigestServiceAuthorizationManager.cs
+++ b/src/System.Private.ServiceModel/tools/IISHostedWcfService/App_code/DigestServiceAuthorizationManager.cs
@@ -50,6 +50,13 @@ namespace WcfService
 
         public override bool CheckAccess(OperationContext operationContext, ref Message message)
         {
+           var contractName = operationContext.EndpointDispatcher.ContractName; 
+           if (contractName == "IMetadataExchange" || contractName == "IHttpGetHelpPageAndMetadataContract") 
+           { 
+               // support for MEX 
+               return true; 
+            }
+             
             var digestState = new DigestAuthenticationState(operationContext, GetRealm(ref message));
             if (!digestState.IsRequestDigestAuth)
             {

--- a/src/System.Private.ServiceModel/tools/IISHostedWcfService/App_code/ReplyBankingData.cs
+++ b/src/System.Private.ServiceModel/tools/IISHostedWcfService/App_code/ReplyBankingData.cs
@@ -8,7 +8,7 @@ using System.ServiceModel;
 
 namespace WcfService
 {
-    [MessageContract(IsWrapped = true, WrapperName = "CustomWrapperName", WrapperNamespace = "http://www.contoso.com")]
+    [MessageContract(IsWrapped = true, WrapperName = "ReplyBankingDataWrapper", WrapperNamespace = "http://www.contoso.com")]
     public class ReplyBankingData
     {
         [MessageBodyMember(Order = 1, Name = "Date_of_Request")]

--- a/src/System.Private.ServiceModel/tools/IISHostedWcfService/App_code/ReplyBankingDataNotWrapped.cs
+++ b/src/System.Private.ServiceModel/tools/IISHostedWcfService/App_code/ReplyBankingDataNotWrapped.cs
@@ -8,7 +8,7 @@ using System.ServiceModel;
 
 namespace WcfService
 {
-    [MessageContract(IsWrapped = false, WrapperName = "CustomWrapperName", WrapperNamespace = "http://www.contoso.com")]
+    [MessageContract(IsWrapped = false)]
     public class ReplyBankingDataNotWrapped
     {
         [MessageBodyMember(Order = 1, Name = "Date_of_Request")]
@@ -19,7 +19,7 @@ namespace WcfService
         public int amount;
     }
 
-    [MessageContract(IsWrapped = true, WrapperName = "CustomWrapperName", WrapperNamespace = "http://www.contoso.com")]
+    [MessageContract(IsWrapped = true, WrapperName = "ReplyBankingDataWithMessageHeaderWrapper", WrapperNamespace = "http://www.contoso.com")]
     public class ReplyBankingDataWithMessageHeader
     {
         [MessageBodyMember(Order = 1, Name = "Date_of_Request")]
@@ -28,11 +28,11 @@ namespace WcfService
         public string accountName;
         [MessageBodyMember(Order = 2, Name = "Transaction_Amount")]
         public int amount;
-        [MessageHeader(Name = "OutOfBandData", Namespace = "http://www.contoso.com", MustUnderstand = true)]
+        [MessageHeader(Name = "ReplyBankingDataWithMessageHeaderExtraValues", Namespace = "http://www.contoso.com", MustUnderstand = true)]
         public string extraValues;
     }
 
-    [MessageContract(IsWrapped = true, WrapperName = "CustomWrapperName", WrapperNamespace = "http://www.contoso.com")]
+    [MessageContract(IsWrapped = true, WrapperName = "ReplyBankingDataWithMessageHeaderNotNecessaryUnderstoodWrapper", WrapperNamespace = "http://www.contoso.com")]
     public class ReplyBankingDataWithMessageHeaderNotNecessaryUnderstood
     {
         [MessageBodyMember(Order = 1, Name = "Date_of_Request")]
@@ -41,7 +41,7 @@ namespace WcfService
         public string accountName;
         [MessageBodyMember(Order = 2, Name = "Transaction_Amount")]
         public int amount;
-        [MessageHeader(Name = "OutOfBandData", Namespace = "http://www.contoso.com", MustUnderstand = false)]
+        [MessageHeader(Name = "ReplyBankingDataWithMessageHeaderNotNecessaryUnderstoodExtraValue", Namespace = "http://www.contoso.com", MustUnderstand = false)]
         public string extraValues;
     }
 }

--- a/src/System.Private.ServiceModel/tools/IISHostedWcfService/App_code/RequestBankingData.cs
+++ b/src/System.Private.ServiceModel/tools/IISHostedWcfService/App_code/RequestBankingData.cs
@@ -8,7 +8,7 @@ using System.ServiceModel;
 
 namespace WcfService
 {
-    [MessageContract(IsWrapped = true, WrapperName = "CustomWrapperName", WrapperNamespace = "http://www.contoso.com")]
+    [MessageContract(IsWrapped = true, WrapperName = "RequestBankingDataWrapper", WrapperNamespace = "http://www.contoso.com")]
     public class RequestBankingData
     {
 #pragma warning disable 0649	// fields not assigned to statically

--- a/src/System.Private.ServiceModel/tools/IISHostedWcfService/App_code/testhosts/TestServiceHostBase.cs
+++ b/src/System.Private.ServiceModel/tools/IISHostedWcfService/App_code/testhosts/TestServiceHostBase.cs
@@ -68,6 +68,14 @@ namespace WcfService
                                             MetadataExchangeBindings.CreateMexHttpBinding(),
                                             "mex");
                 }
+
+                if (baseAddress.Scheme == Uri.UriSchemeNetTcp)
+                {
+                    mexBehavior.HttpGetEnabled = false;
+                    this.AddServiceEndpoint(ServiceMetadataBehavior.MexContractName,
+                                            MetadataExchangeBindings.CreateMexTcpBinding(),
+                                            "mex");
+                }
             }
         }
     }


### PR DESCRIPTION
* We would like to leverge the same test server for WCF connected service
testing.
* I have verified the updated test service can be used for adding service references, both http and net.tcp
bindings.