### PR TITLE
Updating all tests to run using netcoreapp1.1 test TFM.

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -492,7 +492,7 @@
 
   <!-- Default Test platform to deploy the netstandard compiled tests to -->
   <PropertyGroup>
-    <DefaultTestTFM>netcoreapp1.0</DefaultTestTFM> <!-- netcoreapp1.0 is correct as long as WCF packages build as netstandard1.6 or lower, when they move to 1.7 then update this to netcoreapp1.1 -->
+    <DefaultTestTFM>netcoreapp1.1</DefaultTestTFM>
     <TestTFM Condition="'$(TestTFM)'==''">$(DefaultTestTFM)</TestTFM>
     <!-- we default FilterToTestTFM to DefaultTestTFM if it is not explicity defined -->
     <FilterToTestTFM Condition="'$(FilterToTestTFM)'==''">$(DefaultTestTFM)</FilterToTestTFM>

--- a/src/System.Private.ServiceModel/tests/Common/Infrastructure/project.json
+++ b/src/System.Private.ServiceModel/tests/Common/Infrastructure/project.json
@@ -21,7 +21,7 @@
   },
   "supports": {
     "coreFx.Test.netcore50": {},
-    "coreFx.Test.netcoreapp1.0": {},
+    "coreFx.Test.netcoreapp1.1": {},
     "coreFx.Test.net46": {},
     "coreFx.Test.net461": {},
     "coreFx.Test.net462": {},

--- a/src/System.Private.ServiceModel/tests/Common/Scenarios/project.json
+++ b/src/System.Private.ServiceModel/tests/Common/Scenarios/project.json
@@ -18,7 +18,7 @@
   },
   "supports": {
     "coreFx.Test.netcore50": {},
-    "coreFx.Test.netcoreapp1.0": {},
+    "coreFx.Test.netcoreapp1.1": {},
     "coreFx.Test.net46": {},
     "coreFx.Test.net461": {},
     "coreFx.Test.net462": {},

--- a/src/System.Private.ServiceModel/tests/Common/Unit/project.json
+++ b/src/System.Private.ServiceModel/tests/Common/Unit/project.json
@@ -17,7 +17,7 @@
   },
   "supports": {
     "coreFx.Test.netcore50": {},
-    "coreFx.Test.netcoreapp1.0": {},
+    "coreFx.Test.netcoreapp1.1": {},
     "coreFx.Test.net46": {},
     "coreFx.Test.net461": {},
     "coreFx.Test.net462": {},

--- a/src/System.Private.ServiceModel/tests/Scenarios/Binding/Custom/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Binding/Custom/project.json
@@ -19,7 +19,7 @@
   },
   "supports": {
     "coreFx.Test.netcore50": {},
-    "coreFx.Test.netcoreapp1.0": {},
+    "coreFx.Test.netcoreapp1.1": {},
     "coreFx.Test.net46": {},
     "coreFx.Test.net461": {},
     "coreFx.Test.net462": {},

--- a/src/System.Private.ServiceModel/tests/Scenarios/Binding/Http/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Binding/Http/project.json
@@ -19,7 +19,7 @@
   },
   "supports": {
     "coreFx.Test.netcore50": {},
-    "coreFx.Test.netcoreapp1.0": {},
+    "coreFx.Test.netcoreapp1.1": {},
     "coreFx.Test.net46": {},
     "coreFx.Test.net461": {},
     "coreFx.Test.net462": {},

--- a/src/System.Private.ServiceModel/tests/Scenarios/Binding/Tcp/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Binding/Tcp/project.json
@@ -19,7 +19,7 @@
   },
   "supports": {
     "coreFx.Test.netcore50": {},
-    "coreFx.Test.netcoreapp1.0": {},
+    "coreFx.Test.netcoreapp1.1": {},
     "coreFx.Test.net46": {},
     "coreFx.Test.net461": {},
     "coreFx.Test.net462": {},

--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/ChannelLayer/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/ChannelLayer/project.json
@@ -19,7 +19,7 @@
   },
   "supports": {
     "coreFx.Test.netcore50": {},
-    "coreFx.Test.netcoreapp1.0": {},
+    "coreFx.Test.netcoreapp1.1": {},
     "coreFx.Test.net46": {},
     "coreFx.Test.net461": {},
     "coreFx.Test.net462": {},

--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/ClientBase/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/ClientBase/project.json
@@ -19,7 +19,7 @@
   },
   "supports": {
     "coreFx.Test.netcore50": {},
-    "coreFx.Test.netcoreapp1.0": {},
+    "coreFx.Test.netcoreapp1.1": {},
     "coreFx.Test.net46": {},
     "coreFx.Test.net461": {},
     "coreFx.Test.net462": {},

--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/ExpectedExceptions/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/ExpectedExceptions/project.json
@@ -19,7 +19,7 @@
   },
   "supports": {
     "coreFx.Test.netcore50": {},
-    "coreFx.Test.netcoreapp1.0": {},
+    "coreFx.Test.netcoreapp1.1": {},
     "coreFx.Test.net46": {},
     "coreFx.Test.net461": {},
     "coreFx.Test.net462": {},

--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/TypedClient/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/TypedClient/project.json
@@ -19,7 +19,7 @@
   },
   "supports": {
     "coreFx.Test.netcore50": {},
-    "coreFx.Test.netcoreapp1.0": {},
+    "coreFx.Test.netcoreapp1.1": {},
     "coreFx.Test.net46": {},
     "coreFx.Test.net461": {},
     "coreFx.Test.net462": {},

--- a/src/System.Private.ServiceModel/tests/Scenarios/Contract/Data/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Contract/Data/project.json
@@ -19,7 +19,7 @@
   },
   "supports": {
     "coreFx.Test.netcore50": {},
-    "coreFx.Test.netcoreapp1.0": {},
+    "coreFx.Test.netcoreapp1.1": {},
     "coreFx.Test.net46": {},
     "coreFx.Test.net461": {},
     "coreFx.Test.net462": {},

--- a/src/System.Private.ServiceModel/tests/Scenarios/Contract/Fault/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Contract/Fault/project.json
@@ -19,7 +19,7 @@
   },
   "supports": {
     "coreFx.Test.netcore50": {},
-    "coreFx.Test.netcoreapp1.0": {},
+    "coreFx.Test.netcoreapp1.1": {},
     "coreFx.Test.net46": {},
     "coreFx.Test.net461": {},
     "coreFx.Test.net462": {},

--- a/src/System.Private.ServiceModel/tests/Scenarios/Contract/Message/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Contract/Message/project.json
@@ -19,7 +19,7 @@
   },
   "supports": {
     "coreFx.Test.netcore50": {},
-    "coreFx.Test.netcoreapp1.0": {},
+    "coreFx.Test.netcoreapp1.1": {},
     "coreFx.Test.net46": {},
     "coreFx.Test.net461": {},
     "coreFx.Test.net462": {},

--- a/src/System.Private.ServiceModel/tests/Scenarios/Contract/Service/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Contract/Service/project.json
@@ -19,7 +19,7 @@
   },
   "supports": {
     "coreFx.Test.netcore50": {},
-    "coreFx.Test.netcoreapp1.0": {},
+    "coreFx.Test.netcoreapp1.1": {},
     "coreFx.Test.net46": {},
     "coreFx.Test.net461": {},
     "coreFx.Test.net462": {},

--- a/src/System.Private.ServiceModel/tests/Scenarios/Contract/XmlSerializer/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Contract/XmlSerializer/project.json
@@ -19,7 +19,7 @@
   },
   "supports": {
     "coreFx.Test.netcore50": {},
-    "coreFx.Test.netcoreapp1.0": {},
+    "coreFx.Test.netcoreapp1.1": {},
     "coreFx.Test.net46": {},
     "coreFx.Test.net461": {},
     "coreFx.Test.net462": {},

--- a/src/System.Private.ServiceModel/tests/Scenarios/Encoding/Encoders/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Encoding/Encoders/project.json
@@ -19,7 +19,7 @@
   },
   "supports": {
     "coreFx.Test.netcore50": {},
-    "coreFx.Test.netcoreapp1.0": {},
+    "coreFx.Test.netcoreapp1.1": {},
     "coreFx.Test.net46": {},
     "coreFx.Test.net461": {},
     "coreFx.Test.net462": {},

--- a/src/System.Private.ServiceModel/tests/Scenarios/Encoding/MessageVersion/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Encoding/MessageVersion/project.json
@@ -19,7 +19,7 @@
   },
   "supports": {
     "coreFx.Test.netcore50": {},
-    "coreFx.Test.netcoreapp1.0": {},
+    "coreFx.Test.netcoreapp1.1": {},
     "coreFx.Test.net46": {},
     "coreFx.Test.net461": {},
     "coreFx.Test.net462": {},

--- a/src/System.Private.ServiceModel/tests/Scenarios/Extensibility/MessageEncoder/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Extensibility/MessageEncoder/project.json
@@ -19,7 +19,7 @@
   },
   "supports": {
     "coreFx.Test.netcore50": {},
-    "coreFx.Test.netcoreapp1.0": {},
+    "coreFx.Test.netcoreapp1.1": {},
     "coreFx.Test.net46": {},
     "coreFx.Test.net461": {},
     "coreFx.Test.net462": {},

--- a/src/System.Private.ServiceModel/tests/Scenarios/Extensibility/MessageInterceptor/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Extensibility/MessageInterceptor/project.json
@@ -19,7 +19,7 @@
   },
   "supports": {
     "coreFx.Test.netcore50": {},
-    "coreFx.Test.netcoreapp1.0": {},
+    "coreFx.Test.netcoreapp1.1": {},
     "coreFx.Test.net46": {},
     "coreFx.Test.net461": {},
     "coreFx.Test.net462": {},

--- a/src/System.Private.ServiceModel/tests/Scenarios/Extensibility/WebSockets/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Extensibility/WebSockets/project.json
@@ -19,7 +19,7 @@
   },
   "supports": {
     "coreFx.Test.netcore50": {},
-    "coreFx.Test.netcoreapp1.0": {},
+    "coreFx.Test.netcoreapp1.1": {},
     "coreFx.Test.net46": {},
     "coreFx.Test.net461": {},
     "coreFx.Test.net462": {},

--- a/src/System.Private.ServiceModel/tests/Scenarios/Infrastructure/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Infrastructure/project.json
@@ -19,7 +19,7 @@
   },
   "supports": {
     "coreFx.Test.netcore50": {},
-    "coreFx.Test.netcoreapp1.0": {},
+    "coreFx.Test.netcoreapp1.1": {},
     "coreFx.Test.net46": {},
     "coreFx.Test.net461": {},
     "coreFx.Test.net462": {},

--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/project.json
@@ -19,7 +19,7 @@
   },
   "supports": {
     "coreFx.Test.netcore50": {},
-    "coreFx.Test.netcoreapp1.0": {},
+    "coreFx.Test.netcoreapp1.1": {},
     "coreFx.Test.net46": {},
     "coreFx.Test.net461": {},
     "coreFx.Test.net462": {},

--- a/src/System.Private.ServiceModel/tests/Stress/SharedPoolsOfWCFObjects/project.json
+++ b/src/System.Private.ServiceModel/tests/Stress/SharedPoolsOfWCFObjects/project.json
@@ -29,7 +29,7 @@
   },
   "supports": {
     "coreFx.Test.netcore50": {},
-    "coreFx.Test.netcoreapp1.0": {},
+    "coreFx.Test.netcoreapp1.1": {},
     "coreFx.Test.net46": {},
     "coreFx.Test.net461": {},
     "coreFx.Test.net462": {},

--- a/src/System.ServiceModel.Duplex/tests/project.json
+++ b/src/System.ServiceModel.Duplex/tests/project.json
@@ -13,7 +13,7 @@
   },
   "supports": {
     "coreFx.Test.netcore50": {},
-    "coreFx.Test.netcoreapp1.0": {},
+    "coreFx.Test.netcoreapp1.1": {},
     "coreFx.Test.net46": {},
     "coreFx.Test.net461": {},
     "coreFx.Test.net462": {},

--- a/src/System.ServiceModel.Http/tests/project.json
+++ b/src/System.ServiceModel.Http/tests/project.json
@@ -15,7 +15,7 @@
   },
   "supports": {
     "coreFx.Test.netcore50": {},
-    "coreFx.Test.netcoreapp1.0": {},
+    "coreFx.Test.netcoreapp1.1": {},
     "coreFx.Test.net46": {},
     "coreFx.Test.net461": {},
     "coreFx.Test.net462": {},

--- a/src/System.ServiceModel.NetTcp/tests/project.json
+++ b/src/System.ServiceModel.NetTcp/tests/project.json
@@ -16,7 +16,7 @@
   },
   "supports": {
     "coreFx.Test.netcore50": {},
-    "coreFx.Test.netcoreapp1.0": {},
+    "coreFx.Test.netcoreapp1.1": {},
     "coreFx.Test.net46": {},
     "coreFx.Test.net461": {},
     "coreFx.Test.net462": {},

--- a/src/System.ServiceModel.Primitives/tests/project.json
+++ b/src/System.ServiceModel.Primitives/tests/project.json
@@ -17,7 +17,7 @@
   },
   "supports": {
     "coreFx.Test.netcore50": {},
-    "coreFx.Test.netcoreapp1.0": {},
+    "coreFx.Test.netcoreapp1.1": {},
     "coreFx.Test.net46": {},
     "coreFx.Test.net461": {},
     "coreFx.Test.net462": {},

--- a/src/System.ServiceModel.Security/tests/project.json
+++ b/src/System.ServiceModel.Security/tests/project.json
@@ -13,7 +13,7 @@
   },
   "supports": {
     "coreFx.Test.netcore50": {},
-    "coreFx.Test.netcoreapp1.0": {},
+    "coreFx.Test.netcoreapp1.1": {},
     "coreFx.Test.net46": {},
     "coreFx.Test.net461": {},
     "coreFx.Test.net462": {},


### PR DESCRIPTION
* We are going to have to eventually, next step is to move product packages to NetStandard1.7