### PR TITLE
Enabling tests to run against netcore50 test tfm

### DIFF
--- a/src/System.Private.ServiceModel/tests/Scenarios/ServiceModel.Scenario.Tests.builds
+++ b/src/System.Private.ServiceModel/tests/Scenarios/ServiceModel.Scenario.Tests.builds
@@ -4,6 +4,7 @@
   <ItemGroup Condition="($(WithCategories.Contains('OuterLoop'))) or ('$(OuterLoop)' == 'true')">
     <Project Include="**\*.csproj" >
       <TargetGroup>netstandard1.3</TargetGroup>
+      <TestTFMs>netcore50;netcoreapp1.1</TestTFMs>
     </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />

--- a/src/System.ServiceModel.Duplex/tests/System.ServiceModel.Duplex.Tests.builds
+++ b/src/System.ServiceModel.Duplex/tests/System.ServiceModel.Duplex.Tests.builds
@@ -4,6 +4,7 @@
   <ItemGroup>
     <Project Include="System.ServiceModel.Duplex.Tests.csproj" >
       <TargetGroup>netstandard1.3</TargetGroup>
+      <TestTFMs>netcore50;netcoreapp1.1</TestTFMs>
     </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />

--- a/src/System.ServiceModel.Http/tests/System.ServiceModel.Http.Tests.builds
+++ b/src/System.ServiceModel.Http/tests/System.ServiceModel.Http.Tests.builds
@@ -4,6 +4,7 @@
   <ItemGroup>
     <Project Include="System.ServiceModel.Http.Tests.csproj" >
       <TargetGroup>netstandard1.3</TargetGroup>
+      <TestTFMs>netcore50;netcoreapp1.1</TestTFMs>
     </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />

--- a/src/System.ServiceModel.NetTcp/tests/System.ServiceModel.NetTcp.Tests.builds
+++ b/src/System.ServiceModel.NetTcp/tests/System.ServiceModel.NetTcp.Tests.builds
@@ -4,6 +4,7 @@
   <ItemGroup>
     <Project Include="System.ServiceModel.NetTcp.Tests.csproj" >
       <TargetGroup>netstandard1.3</TargetGroup>
+      <TestTFMs>netcore50;netcoreapp1.1</TestTFMs>
     </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />

--- a/src/System.ServiceModel.Primitives/tests/System.ServiceModel.Primitives.Tests.builds
+++ b/src/System.ServiceModel.Primitives/tests/System.ServiceModel.Primitives.Tests.builds
@@ -4,6 +4,7 @@
   <ItemGroup>
     <Project Include="System.ServiceModel.Primitives.Tests.csproj" >
       <TargetGroup>netstandard1.3</TargetGroup>
+      <TestTFMs>netcore50;netcoreapp1.1</TestTFMs>
     </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />

--- a/src/System.ServiceModel.Security/tests/System.ServiceModel.Security.Tests.builds
+++ b/src/System.ServiceModel.Security/tests/System.ServiceModel.Security.Tests.builds
@@ -4,6 +4,7 @@
   <ItemGroup>
     <Project Include="System.ServiceModel.Security.Tests.csproj" >
       <TargetGroup>netstandard1.3</TargetGroup>
+      <TestTFMs>netcore50;netcoreapp1.1</TestTFMs>
     </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />


### PR DESCRIPTION
* WCF currently supports two TestTFMs, they need to be explicitly listed for test projects now so that the 'FilterToTestTFM' property used in Helix runs works as expected. This "may" fix the netcore50 runs in Helix.