### PR TITLE
Rename test properties and members to remove "Bridge"

### DIFF
--- a/src/System.Private.ServiceModel/tests/Common/Infrastructure/ServiceUtilHelper.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Infrastructure/ServiceUtilHelper.cs
@@ -386,21 +386,21 @@ public static class ServiceUtilHelper
             switch (protocol)
             {
                 case "http":
-                    builder.Port = int.Parse(TestProperties.GetProperty(TestProperties.BridgeHttpPort_PropertyName));
+                    builder.Port = int.Parse(TestProperties.GetProperty(TestProperties.ServiceHttpPort_PropertyName));
                     break;
                 case "ws":
-                    builder.Port = int.Parse(TestProperties.GetProperty(TestProperties.BridgeWebSocketPort_PropertyName));
+                    builder.Port = int.Parse(TestProperties.GetProperty(TestProperties.ServiceWebSocketPort_PropertyName));
                     builder.Scheme = "http";
                     break;
                 case "https":
-                    builder.Port = int.Parse(TestProperties.GetProperty(TestProperties.BridgeHttpsPort_PropertyName));
+                    builder.Port = int.Parse(TestProperties.GetProperty(TestProperties.ServiceHttpsPort_PropertyName));
                     break;
                 case "wss":
-                    builder.Port = int.Parse(TestProperties.GetProperty(TestProperties.BridgeSecureWebSocketPort_PropertyName));
+                    builder.Port = int.Parse(TestProperties.GetProperty(TestProperties.ServiceSecureWebSocketPort_PropertyName));
                     builder.Scheme = "https";
                     break;
                 case "net.tcp":
-                    builder.Port = int.Parse(TestProperties.GetProperty(TestProperties.BridgeTcpPort_PropertyName));
+                    builder.Port = int.Parse(TestProperties.GetProperty(TestProperties.ServiceTcpPort_PropertyName));
                     break;
                 default:
                     break;

--- a/src/System.Private.ServiceModel/tests/Common/Infrastructure/testproperties.props
+++ b/src/System.Private.ServiceModel/tests/Common/Infrastructure/testproperties.props
@@ -6,32 +6,28 @@
            When adding or removing TestProperties, update testproperties.targets
            to generate code at build time.
     -->
-    <PropertyGroup Condition="'$(BridgeHost)' == ''">
-      <BridgeHost>localhost</BridgeHost>
+    <PropertyGroup Condition="'$(ServicePort)' == ''">
+      <ServicePort>44283</ServicePort>
     </PropertyGroup>
 
-    <PropertyGroup Condition="'$(BridgePort)' == ''">
-      <BridgePort>44283</BridgePort>
+    <PropertyGroup Condition="'$(ServiceHttpPort)' == ''">
+      <ServiceHttpPort>8081</ServiceHttpPort>
     </PropertyGroup>
 
-    <PropertyGroup Condition="'$(BridgeHttpPort)' == ''">
-      <BridgeHttpPort>8081</BridgeHttpPort>
+    <PropertyGroup Condition="'$(ServiceHttpsPort)' == ''">
+      <ServiceHttpsPort>44285</ServiceHttpsPort>
     </PropertyGroup>
 
-    <PropertyGroup Condition="'$(BridgeHttpsPort)' == ''">
-      <BridgeHttpsPort>44285</BridgeHttpsPort>
+    <PropertyGroup Condition="'$(ServiceTcpPort)' == ''">
+      <ServiceTcpPort>809</ServiceTcpPort>
     </PropertyGroup>
 
-    <PropertyGroup Condition="'$(BridgeTcpPort)' == ''">
-      <BridgeTcpPort>809</BridgeTcpPort>
+    <PropertyGroup Condition="'$(ServiceWebSocketPort)' == ''">
+      <ServiceWebSocketPort>8083</ServiceWebSocketPort>
     </PropertyGroup>
 
-    <PropertyGroup Condition="'$(BridgeWebSocketPort)' == ''">
-      <BridgeWebSocketPort>8083</BridgeWebSocketPort>
-    </PropertyGroup>
-
-    <PropertyGroup Condition="'$(BridgeSecureWebSocketPort)' == ''">
-      <BridgeSecureWebSocketPort>8084</BridgeSecureWebSocketPort>
+    <PropertyGroup Condition="'$(ServiceSecureWebSocketPort)' == ''">
+      <ServiceSecureWebSocketPort>8084</ServiceSecureWebSocketPort>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(TestRootCertificatePassword)' == ''">

--- a/src/System.Private.ServiceModel/tests/Common/Infrastructure/testproperties.targets
+++ b/src/System.Private.ServiceModel/tests/Common/Infrastructure/testproperties.targets
@@ -18,13 +18,12 @@ namespace Infrastructure.Common
 {
     public static partial class TestProperties
     {
-        public static readonly string BridgeHost_PropertyName = "BridgeHost"%3B
-        public static readonly string BridgePort_PropertyName = "BridgePort"%3B
-        public static readonly string BridgeHttpPort_PropertyName = "BridgeHttpPort"%3B
-        public static readonly string BridgeHttpsPort_PropertyName = "BridgeHttpsPort"%3B
-        public static readonly string BridgeTcpPort_PropertyName = "BridgeTcpPort"%3B
-        public static readonly string BridgeWebSocketPort_PropertyName = "BridgeWebSocketPort"%3B
-        public static readonly string BridgeSecureWebSocketPort_PropertyName = "BridgeSecureWebSocketPort"%3B
+        public static readonly string ServicePort_PropertyName = "ServicePort"%3B
+        public static readonly string ServiceHttpPort_PropertyName = "ServiceHttpPort"%3B
+        public static readonly string ServiceHttpsPort_PropertyName = "ServiceHttpsPort"%3B
+        public static readonly string ServiceTcpPort_PropertyName = "ServiceTcpPort"%3B
+        public static readonly string ServiceWebSocketPort_PropertyName = "ServiceWebSocketPort"%3B
+        public static readonly string ServiceSecureWebSocketPort_PropertyName = "ServiceSecureWebSocketPort"%3B
         public static readonly string TestRootCertificatePassword_PropertyName = "TestRootCertificatePassword"%3B
         public static readonly string TestRootCertificateValidityPeriod_PropertyName = "TestRootCertificateValidityPeriod"%3B
         public static readonly string MaxTestTimeSpan_PropertyName = "MaxTestTimeSpan"%3B
@@ -54,13 +53,12 @@ namespace Infrastructure.Common
                 
         static partial void Initialize(Dictionary<string, string> properties)
         {
-            properties["BridgeHost"] = "$(BridgeHost)"%3B
-            properties["BridgePort"] = "$(BridgePort)"%3B
-            properties["BridgeHttpPort"] = "$(BridgeHttpPort)"%3B
-            properties["BridgeHttpsPort"] = "$(BridgeHttpsPort)"%3B
-            properties["BridgeTcpPort"] = "$(BridgeTcpPort)"%3B
-            properties["BridgeWebSocketPort"] = "$(BridgeWebSocketPort)"%3B
-            properties["BridgeSecureWebSocketPort"] = "$(BridgeSecureWebSocketPort)"%3B
+            properties["ServicePort"] = "$(ServicePort)"%3B
+            properties["ServiceHttpPort"] = "$(ServiceHttpPort)"%3B
+            properties["ServiceHttpsPort"] = "$(ServiceHttpsPort)"%3B
+            properties["ServiceTcpPort"] = "$(ServiceTcpPort)"%3B
+            properties["ServiceWebSocketPort"] = "$(ServiceWebSocketPort)"%3B
+            properties["ServiceSecureWebSocketPort"] = "$(ServiceSecureWebSocketPort)"%3B
             properties["TestRootCertificatePassword"] = "$(TestRootCertificatePassword)"%3B
             properties["TestRootCertificateValidityPeriod"] = "$(TestRootCertificateValidityPeriod)"%3B
             properties["MaxTestTimeSpan"] = "$(MaxTestTimeSpan)"%3B

--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Negotiate/NegotiateStream_Http_Tests.4.1.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Negotiate/NegotiateStream_Http_Tests.4.1.0.cs
@@ -35,8 +35,9 @@ public class NegotiateStream_Http_Tests : ConditionalWcfTest
     //   
     //     By default, the SPN is the same as the host's fully qualified domain name, for example, 
     //     'host.domain.com'
-    //     On a Windows host, one has to register the SPN using 'setspn', or run the process as LOCAL SYSTEM
-    //     by using a tool like psexec and running 'psexec -s -h <WcfBridge.exe>' 
+    //     On a Windows host, one has to register the SPN using 'setspn', or run the process as LOCAL SYSTEM.
+    //     This can be done by setting the PSEXEC_PATH environment variable to point to the folder containing
+    //     psexec.exe prior to starting the WCF self-host service. 
     // 
     // NegotiateStream_*_With_Upn
     //     Windows: Set the NegotiateTestUPN TestProperties to match a valid UPN for the server in the form of 

--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Negotiate/NegotiateStream_Tcp_Tests.4.1.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Negotiate/NegotiateStream_Tcp_Tests.4.1.0.cs
@@ -33,7 +33,8 @@ public class NegotiateStream_Tcp_Tests : ConditionalWcfTest
     //     By default, the SPN is the same as the host's fully qualified domain name, for example, 
     //     'host.domain.com'
     //     On a Windows host, one has to register the SPN using 'setspn', or run the process as LOCAL SYSTEM
-    //     by using a tool like psexec and running 'psexec -s -h <WcfBridge.exe>' 
+    //     This can be done by setting the PSEXEC_PATH environment variable to point to the folder containing
+    //     psexec.exe prior to starting the WCF self-host service. 
     // 
     // NegotiateStream_*_With_Upn
     //     Windows: Set the NegotiateTestUPN TestProperties to match a valid UPN for the server in the form of 

--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Tcp/ClientCredentialTypeCertificateCanonicalNameTests.4.1.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Tcp/ClientCredentialTypeCertificateCanonicalNameTests.4.1.0.cs
@@ -15,13 +15,13 @@ using System.Text;
 
 public class Tcp_ClientCredentialTypeCertificateCanonicalNameTests : ConditionalWcfTest
 {
-    // We set up three endpoints on the Bridge (server) side, each with a different certificate: 
+    // We set up three endpoints on the WCF service (server) side, each with a different certificate: 
     // Tcp_ClientCredentialType_Certificate_With_CanonicalName_Localhost_Address - is bound to a cert where CN=localhost
     // Tcp_ClientCredentialType_Certificate_With_CanonicalName_DomainName_Address - is bound to a cert where CN=domainname
     // Tcp_ClientCredentialType_Certificate_With_CanonicalName_Fqdn_Address - is bound to a cert with a fqdn, e.g., CN=domainname.example.com
     //
-    // When tests are run, a /p:BridgeHost=<name> is specified; if none is specified, then "localhost" is used
-    // Hence, we are only able to determine at runtime whether a particular endpoint presented by the Bridge is going 
+    // When tests are run, a /p:ServiceHost=<name> is specified; if none is specified, then "localhost" is used
+    // Hence, we are only able to determine at runtime whether a particular endpoint presented by the WCF Service is going 
     // to pass a variation or fail a variation. 
 
     [WcfFact]
@@ -104,8 +104,8 @@ public class Tcp_ClientCredentialTypeCertificateCanonicalNameTests : Conditional
         var endpointAddress = new EndpointAddress(domainNameEndpointUri);
 
         // We check that: 
-        // 1. The Bridge's reported hostname does not contain a '.' (which means we're hitting the FQDN)
-        // 2. The Bridge's reported hostname is not "localhost" (which means we're hitting localhost)
+        // 1. The WCF service's reported hostname does not contain a '.' (which means we're hitting the FQDN)
+        // 2. The WCF service's reported hostname is not "localhost" (which means we're hitting localhost)
         // If both these conditions are true, expect the test to pass. Otherwise, it should fail
         bool shouldCallSucceed = domainNameEndpointUri.Host.IndexOf('.') == -1 && string.Compare(domainNameEndpointUri.Host, "localhost", StringComparison.OrdinalIgnoreCase) != 0;
 
@@ -184,8 +184,8 @@ public class Tcp_ClientCredentialTypeCertificateCanonicalNameTests : Conditional
         var fqdnEndpointUri = new Uri(Endpoints.Tcp_ClientCredentialType_Certificate_With_CanonicalName_Fqdn_Address);
         var endpointAddress = new EndpointAddress(fqdnEndpointUri);
 
-        // If the Bridge's reported FQDN is the same as the Bridge's reported hostname, 
-        // it means that there the bridge is set up on a network where FQDNs aren't used, only hostnames.
+        // If the WCF service's reported FQDN is the same as the services's reported hostname, 
+        // it means that there the WCF service is set up on a network where FQDNs aren't used, only hostnames.
         // Since our pass/fail detection logic on whether or not this is an FQDN depends on whether the host name has a '.', we don't test this case
         if (string.Compare(domainNameHost, fqdnEndpointUri.Host, StringComparison.OrdinalIgnoreCase) != 0)
         {

--- a/src/System.Private.ServiceModel/tools/CertificateGenerator/CertificateCreationSettings.cs
+++ b/src/System.Private.ServiceModel/tools/CertificateGenerator/CertificateCreationSettings.cs
@@ -8,7 +8,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 
-namespace WcfTestBridgeCommon
+namespace WcfTestCommon
 {
     [Serializable]
     public class CertificateCreationSettings

--- a/src/System.Private.ServiceModel/tools/CertificateGenerator/CertificateGenerator.cs
+++ b/src/System.Private.ServiceModel/tools/CertificateGenerator/CertificateGenerator.cs
@@ -21,7 +21,7 @@ using Org.BouncyCastle.X509.Extension;
 using X509Certificate2 = System.Security.Cryptography.X509Certificates.X509Certificate2;
 using X509KeyStorageFlags = System.Security.Cryptography.X509Certificates.X509KeyStorageFlags;
 
-namespace WcfTestBridgeCommon
+namespace WcfTestCommon
 {
     // NOT THREADSAFE. Callers should lock before doing work with this class if multithreaded operation is expected
     public class CertificateGenerator
@@ -30,7 +30,7 @@ namespace WcfTestBridgeCommon
 
         // Settable properties prior to initialization
         private string _crlUri;
-        private string _crlUriBridgeHost;
+        private string _crlServiceUri;
         private string _crlUriRelativePath;
         private string _password;
         private TimeSpan _validityPeriod = TimeSpan.FromDays(1);
@@ -86,7 +86,7 @@ namespace WcfTestBridgeCommon
                     throw new ArgumentException("CrlUri must be a valid relative URI", "CrlUriRelativePath");
                 }
 
-                _crlUri = string.Format("http://{0}{1}", _crlUriBridgeHost, _crlUriRelativePath);
+                _crlUri = string.Format("http://{0}{1}", _crlServiceUri, _crlUriRelativePath);
 
                 _initializationDateTime = DateTime.UtcNow;
                 _defaultValidityNotBefore = _initializationDateTime.Subtract(_gracePeriod);
@@ -174,16 +174,16 @@ namespace WcfTestBridgeCommon
             }
         }
 
-        public string CrlUriBridgeHost
+        public string CrlServiceUri
         {
             get
             {
-                return _crlUriBridgeHost;
+                return _crlServiceUri;
             }
             set
             {
-                EnsureNotInitialized("CrlUriBridgeHost");
-                _crlUriBridgeHost = value;
+                EnsureNotInitialized("CrlServiceUri");
+                _crlServiceUri = value;
             }
         }
 

--- a/src/System.Private.ServiceModel/tools/CertificateGenerator/CertificateManager.cs
+++ b/src/System.Private.ServiceModel/tools/CertificateGenerator/CertificateManager.cs
@@ -10,7 +10,7 @@ using System.Linq;
 using System.Net;
 using System.Security.Cryptography.X509Certificates;
 
-namespace WcfTestBridgeCommon
+namespace WcfTestCommon
 {
     // This class manages the adding and removal of certificates.
     // It also handles informing http.sys of which certificate to associate with SSL ports.

--- a/src/System.Private.ServiceModel/tools/CertificateGenerator/Program.cs
+++ b/src/System.Private.ServiceModel/tools/CertificateGenerator/Program.cs
@@ -9,7 +9,7 @@ using System.Text;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
-using WcfTestBridgeCommon;
+using WcfTestCommon;
 using X509Certificate2 = System.Security.Cryptography.X509Certificates.X509Certificate2;
 using X509KeyStorageFlags = System.Security.Cryptography.X509Certificates.X509KeyStorageFlags;
 using System.IO;
@@ -91,7 +91,7 @@ namespace CertUtil
 
             CertificateGenerator certificateGenerate = new CertificateGenerator();
             certificateGenerate.CertificatePassword = "test";
-            certificateGenerate.CrlUriBridgeHost = s_fqdn;
+            certificateGenerate.CrlServiceUri = s_fqdn;
             certificateGenerate.ValidityPeriod = s_ValidatePeriod;
 
             if (!string.IsNullOrEmpty(s_testserverbase))
@@ -112,9 +112,7 @@ namespace CertUtil
                 ValidityNotAfter = DateTime.UtcNow - TimeSpan.FromDays(2),
                 //If you specify multiple subjects, the first one becomes the subject, and all of them become Subject Alt Names.
                 //In this case, the certificate subject is  CN=fqdn, OU=..., O=... , and SANs will be  fqdn, hostname, localhost
-                //We do this so that a single bridge setup can deal with all the possible addresses that a client might use.
-                //If we don't put "localhost' here, a long-running bridge will not be able to receive requests from both fqdn  and  localhost
-                //because the certs won't match.
+                //We do this so that a single WCF service setup can deal with all the possible addresses that a client might use.
                 Subject = s_fqdn,
                 SubjectAlternativeNames = new string[] { s_fqdn, s_hostname, "localhost" }
             };

--- a/wcf.targets
+++ b/wcf.targets
@@ -15,34 +15,6 @@
      <WcfRootFolder>$(MSBuildThisFileDirectory)</WcfRootFolder>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(BridgeResourceFolder)' == ''">
-     <BridgeResourceFolder>$(WcfRootFolder)bin\Wcf\Bridge\Resources\</BridgeResourceFolder>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(BridgeHost)' == ''">
-     <BridgeHost>localhost</BridgeHost>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(BridgePort)' == ''">
-     <BridgePort>44283</BridgePort>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(BridgeHttpPort)' == ''">
-     <BridgeHttpPort>8081</BridgeHttpPort>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(BridgeHttpsPort)' == ''">
-     <BridgeHttpsPort>44285</BridgeHttpsPort>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(BridgeTcpPort)' == ''">
-     <BridgeTcpPort>809</BridgeTcpPort>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(BridgeWebSocketPort)' == ''">
-     <BridgeWebSocketPort>8083</BridgeWebSocketPort>
-  </PropertyGroup>
-
   <PropertyGroup Condition="'$(WcfToolsOutputPath)' == ''">
      <WcfToolsOutputPath>$(WcfRootFolder)bin\Wcf\tools\</WcfToolsOutputPath>
   </PropertyGroup>


### PR DESCRIPTION
This is the 2nd of 2 steps to remove the old infrastructure.
The first step deleted all old infrastructure code.

This follow-up PR just renames variables, constants, member names,
etc. to remove "Bridge" from any names.