### PR TITLE
Fix Duplex Channel shaped tests using http.

### DIFF
--- a/src/System.Private.ServiceModel/tests/Common/Scenarios/Endpoints.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Scenarios/Endpoints.cs
@@ -39,6 +39,11 @@ public static partial class Endpoints
         get { return GetEndpointAddress("NetHttp.svc//NetHttp"); }
     }
 
+    public static string HttpBaseAddress_NetHttpWebSockets
+    {
+        get { return GetEndpointAddress("NetHttpWebSockets.svc//NetHttpWebSockets"); }
+    }
+
     public static string HttpSoap11_Address
     {
         get { return GetEndpointAddress("HttpSoap11.svc//http-soap11"); }
@@ -255,6 +260,14 @@ public static partial class Endpoints
         get
         {
             return GetEndpointAddress("NetHttps.svc//NetHttps", protocol: "https");
+        }
+    }
+
+    public static string HttpBaseAddress_NetHttpsWebSockets
+    {
+        get
+        {
+            return GetEndpointAddress("NetHttpsWebSockets.svc//NetHttpsWebSockets", protocol: "https");
         }
     }
 

--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/ChannelLayer/DuplexChannelShapeTests.4.1.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/ChannelLayer/DuplexChannelShapeTests.4.1.0.cs
@@ -17,7 +17,6 @@ public partial class DuplexChannelShapeTests : ConditionalWcfTest
     [WcfFact]
     [Condition(nameof(Root_Certificate_Installed))]
     [OuterLoop]
-    [Issue(1157)]
     public static void IDuplexSessionChannel_Https_NetHttpsBinding()
     {
         IChannelFactory<IDuplexSessionChannel> factory = null;
@@ -34,7 +33,7 @@ public partial class DuplexChannelShapeTests : ConditionalWcfTest
             factory.Open();
 
             // Create the channel.
-            channel = factory.CreateChannel(new EndpointAddress(Endpoints.HttpBaseAddress_NetHttps));
+            channel = factory.CreateChannel(new EndpointAddress(Endpoints.HttpBaseAddress_NetHttpsWebSockets));
             channel.Open();
 
             // Create the Message object to send to the service.
@@ -76,8 +75,7 @@ public partial class DuplexChannelShapeTests : ConditionalWcfTest
     [WcfFact]
     [Condition(nameof(Root_Certificate_Installed))]
     [OuterLoop]
-    [Issue(1157)]
-    public static void IDuplexSessionChannel_Http_BasicHttpBinding()
+    public static void IDuplexSessionChannel_Http_NetHttpBinding()
     {
         IChannelFactory<IDuplexSessionChannel> factory = null;
         IDuplexSessionChannel channel = null;
@@ -86,14 +84,14 @@ public partial class DuplexChannelShapeTests : ConditionalWcfTest
         try
         {
             // *** SETUP *** \\
-            BasicHttpBinding binding = new BasicHttpBinding();
+            NetHttpBinding binding = new NetHttpBinding();
 
             // Create the channel factory
             factory = binding.BuildChannelFactory<IDuplexSessionChannel>(new BindingParameterCollection());
             factory.Open();
 
             // Create the channel.
-            channel = factory.CreateChannel(new EndpointAddress(Endpoints.HttpBaseAddress_NetHttps));
+            channel = factory.CreateChannel(new EndpointAddress(Endpoints.HttpBaseAddress_NetHttpWebSockets));
             channel.Open();
 
             // Create the Message object to send to the service.

--- a/src/System.Private.ServiceModel/tools/IISHostedWcfService/App_code/testhosts/NetHttpTestServiceHost.cs
+++ b/src/System.Private.ServiceModel/tools/IISHostedWcfService/App_code/testhosts/NetHttpTestServiceHost.cs
@@ -32,4 +32,30 @@ namespace WcfService
         {
         }
     }
+
+    public class NetHttpTestServiceHostUsingWebSocketsFactory : ServiceHostFactory
+    {
+        protected override ServiceHost CreateServiceHost(Type serviceType, Uri[] baseAddresses)
+        {
+            NetHttpTestServiceHostUsingWebSockets serviceHost = new NetHttpTestServiceHostUsingWebSockets(serviceType, baseAddresses);
+            return serviceHost;
+        }
+    }
+
+    public class NetHttpTestServiceHostUsingWebSockets : TestServiceHostBase<IWcfService>
+    {
+        protected override string Address { get { return "NetHttpWebSockets"; } }
+
+        protected override Binding GetBinding()
+        {
+            var binding = new NetHttpBinding();
+            binding.WebSocketSettings.TransportUsage = WebSocketTransportUsage.Always;
+            return binding;
+        }
+
+        public NetHttpTestServiceHostUsingWebSockets(Type serviceType, params Uri[] baseAddresses)
+            : base(serviceType, baseAddresses)
+        {
+        }
+    }
 }

--- a/src/System.Private.ServiceModel/tools/IISHostedWcfService/App_code/testhosts/NetHttpsTestServiceHost.cs
+++ b/src/System.Private.ServiceModel/tools/IISHostedWcfService/App_code/testhosts/NetHttpsTestServiceHost.cs
@@ -32,4 +32,29 @@ namespace WcfService
         {
         }
     }
+
+    public class NetHttpsTestServiceHostUsingWebSocketsFactory : ServiceHostFactory
+    {
+        protected override ServiceHost CreateServiceHost(Type serviceType, Uri[] baseAddresses)
+        {
+            NetHttpsTestServiceHostUsingWebSockets serviceHost = new NetHttpsTestServiceHostUsingWebSockets(serviceType, baseAddresses);
+            return serviceHost;
+        }
+    }
+    public class NetHttpsTestServiceHostUsingWebSockets : TestServiceHostBase<IWcfService>
+    {
+        protected override string Address { get { return "NetHttpsWebSockets"; } }
+
+        protected override Binding GetBinding()
+        {
+            var binding = new NetHttpsBinding();
+            binding.WebSocketSettings.TransportUsage = WebSocketTransportUsage.Always;
+            return binding;
+        }
+
+        public NetHttpsTestServiceHostUsingWebSockets(Type serviceType, params Uri[] baseAddresses)
+            : base(serviceType, baseAddresses)
+        {
+        }
+    }
 }

--- a/src/System.Private.ServiceModel/tools/IISHostedWcfService/Web.config
+++ b/src/System.Private.ServiceModel/tools/IISHostedWcfService/Web.config
@@ -48,7 +48,9 @@
         <add factory="WcfService.HttpsWindowsTestServiceHostFactory" service="WcfService.WcfService" relativeAddress="~\WindowAuthenticationNegotiate\HttpsWindows.svc" />
         <add factory="WcfService.HttpWindowsTestServiceHostFactory" service="WcfService.WcfService" relativeAddress="~\WindowAuthenticationNegotiate\HttpWindows.svc" />
         <add factory="WcfService.NetHttpTestServiceHostFactory" service="WcfService.WcfService" relativeAddress="~\NetHttp.svc" />
+        <add factory="WcfService.NetHttpTestServiceHostUsingWebSocketsFactory" service="WcfService.WcfService" relativeAddress="~\NetHttpWebSockets.svc" />
         <add factory="WcfService.NetHttpsTestServiceHostFactory" service="WcfService.WcfService" relativeAddress="~\NetHttps.svc" />
+        <add factory="WcfService.NetHttpsTestServiceHostUsingWebSocketsFactory" service="WcfService.WcfService" relativeAddress="~\NetHttpsWebSockets.svc" />
         <add factory="WcfService.HttpsCertificateValidationPeerTrustTestServiceHostFactory" service="WcfService.WcfService" relativeAddress="~\HttpsCertValModePeerTrust.svc" />
         <add factory="WcfService.HttpsCertificateValidationChainTrustTestServiceHostFactory" service="WcfService.WcfService" relativeAddress="~\HttpsCertValModeChainTrust.svc" />
         <add factory="WcfService.ServiceContractAsyncIntOutTestServiceHostFactory" service="WcfService.ServiceContractIntOutService" relativeAddress="~\ServiceContractAsyncIntOut.svc" />

--- a/src/System.Private.ServiceModel/tools/SelfHostedWcfService/Program.cs
+++ b/src/System.Private.ServiceModel/tools/SelfHostedWcfService/Program.cs
@@ -64,7 +64,9 @@ namespace SelfHostedWCFService
             CreateHost<HttpsWindowsTestServiceHost, WcfService.WcfService>("WindowAuthenticationNegotiate/HttpsWindows.svc", httpsBaseAddress);
             CreateHost<HttpWindowsTestServiceHost, WcfService.WcfService>("WindowAuthenticationNegotiate/HttpWindows.svc", httpBaseAddress);
             CreateHost<NetHttpTestServiceHost, WcfService.WcfService>("NetHttp.svc", httpBaseAddress);
+            CreateHost<NetHttpTestServiceHostUsingWebSockets, WcfService.WcfService>("NetHttpWebSockets.svc", httpBaseAddress);
             CreateHost<NetHttpsTestServiceHost, WcfService.WcfService>("NetHttps.svc", httpsBaseAddress);
+            CreateHost<NetHttpsTestServiceHostUsingWebSockets, WcfService.WcfService>("NetHttpsWebSockets.svc", httpsBaseAddress);
             CreateHost<HttpsCertificateValidationPeerTrustTestServiceHost, WcfService.WcfService>("HttpsCertValModePeerTrust.svc", httpsBaseAddress);
             CreateHost<HttpsCertificateValidationChainTrustTestServiceHost, WcfService.WcfService>("HttpsCertValModeChainTrust.svc", httpsBaseAddress);
             CreateHost<ServiceContractAsyncIntOutTestServiceHost, ServiceContractIntOutService>("ServiceContractAsyncIntOut.svc", httpBaseAddress);


### PR DESCRIPTION
* One test was using the wrong binding, both needed seperate endpoints on the server configured to receive incoming messages using websockets.