### PR TITLE
Fixing a flaky test.

### DIFF
--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Tcp/StreamingTests.4.1.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Tcp/StreamingTests.4.1.0.cs
@@ -214,6 +214,7 @@ public class StreamingTests : ConditionalWcfTest
             binding.SendTimeout = TimeSpan.FromMilliseconds(5000);
             factory = new ChannelFactory<IWcfService>(binding, new EndpointAddress(Endpoints.Tcp_Transport_Security_Streamed_Address));
             serviceProxy = factory.CreateChannel();
+            ((ICommunicationObject)serviceProxy).Open();
             Stopwatch watch = new Stopwatch();
             watch.Start();
 


### PR DESCRIPTION
* Test case "NetTcp_TransportSecurity_Streamed_TimeOut_Long_Running_Operation" is just testing the 'SendTimeout' property on the binding, to make sure it is working as expected we only pass the test when the elapsed time falls within a narrow range.
* This test has occasionally been failing by taking longer than expected, we don't believe this is a product bug most likely caused because we were not explicitly opening the channel before starting the Stopwatch, by doing this we are remove this small but variable amount of time that was getting added to the elapsed time calculation.