### PR TITLE
WCF 1.1 Stress Tests

### DIFF
--- a/src/System.Private.ServiceModel/tests/Stress/SharedPoolsOfWCFObjects/IService1.cs
+++ b/src/System.Private.ServiceModel/tests/Stress/SharedPoolsOfWCFObjects/IService1.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using System.IO;
 using System.ServiceModel;
 using System.Runtime.Serialization;
+using System;
 
 namespace WcfService1
 {
@@ -17,6 +18,10 @@ namespace WcfService1
 
         [OperationContract(Name = "GetData")]
         Task<string> GetDataAsync(int value);
+
+        [OperationContract(Name = "GetData", AsyncPattern = true)]
+        IAsyncResult BeginGetData(int value, AsyncCallback callback, object state);
+        string EndGetData(IAsyncResult iar);
 
         [OperationContract]
         CompositeType GetDataUsingDataContract(CompositeType composite);

--- a/src/System.Private.ServiceModel/tests/Stress/SharedPoolsOfWCFObjects/IStressDataCollector.cs
+++ b/src/System.Private.ServiceModel/tests/Stress/SharedPoolsOfWCFObjects/IStressDataCollector.cs
@@ -1,0 +1,111 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.Serialization;
+using System.ServiceModel;
+using System.Threading.Tasks;
+
+namespace ReportingService
+{
+    [ServiceContract]
+    public interface IStressDataCollector
+    {
+        [OperationContract]
+        RunId RunStarted(RunStartupData startupData);
+
+        [OperationContract(IsOneWay = true)]
+        Task RunHeartBeatAsync(RunId runId, int threadId, long iteration, DateTime time);
+
+        [OperationContract(IsOneWay = true)]
+        Task LogMessageAsync(RunId runId, string message);
+
+        [OperationContract]
+        Task RunFinishedAsync(RunId runId, bool success, string message);
+    }
+
+    public enum ProgramToRun { Stress, Perf }
+    public enum TestToRun { HelloWorld, HelloWorldAPM, Streaming, Duplex, DuplexStreaming }
+    public enum TestBinding { Http, Https, NetTcp, NetHttpBinding }
+    public enum StreamingScenarios
+    {
+        StreamNone = 0,
+        StreamOut = 1,
+        StreamIn = 2,
+        StreamEcho = 4,
+        StreamAll = StreamOut | StreamIn | StreamEcho
+    };
+
+    [DataContract]
+    public class RunStartupData
+    {
+        [DataMember]
+        public string MachineName { get; set; }
+        [DataMember]
+        public ProgramToRun Program2Run { get; set; }
+        [DataMember]
+        public int StressLevel { get; set; }
+        [DataMember]
+        public TimeSpan StressRunDuration { get; set; }
+        [DataMember]
+        public string HostName { get; set; }
+        [DataMember]
+        public string AppName { get; set; }
+        [DataMember]
+        public TestBinding Binding { get; set; }
+        [DataMember]
+        public bool UseAsync { get; set; }
+        [DataMember]
+        public TestToRun TestToRun { get; set; }
+        [DataMember]
+        public StreamingScenarios StreamingScenario { get; set; }
+        [DataMember]
+        public bool PoolFactoriesForPerfStartup { get; set; }
+        [DataMember]
+        public bool UseSeparateTaskForEachChannel { get; set; }
+        [DataMember]
+        public int PerfMaxStartupTasks { get; set; }
+        [DataMember]
+        public int PerfMaxThroughputTasks { get; set; }
+        [DataMember]
+        public int PerfThroughputTaskStep { get; set; }
+        [DataMember]
+        public int PerfStartupIterations { get; set; }
+        [DataMember]
+        public TimeSpan PerfMeasurementDuration { get; set; }
+        [DataMember]
+        public int SHPortNum { get; set; }
+        [DataMember]
+        public int SHPorts { get; set; }
+
+        // Security
+        [DataMember]
+        public SecurityMode BindingSecurityMode { get; set; }
+        [DataMember]
+        public HttpClientCredentialType HttpClientCredentialType { get; set; }
+        [DataMember]
+        public TcpClientCredentialType TcpClientCredentialType { get; set; }
+        [DataMember]
+        public string ServerDnsEndpointIdentity { get; set; }
+        [DataMember]
+        public string ClientCertThumbprint { get; set; }
+
+        // Results
+        [DataMember]
+        public string ResultsLog { get; set; }
+        [DataMember]
+        public string RunName { get; set; }
+
+        [DataMember]
+        public long Iterations { get; set; }
+    }
+
+    [DataContract]
+    public class RunId
+    {
+        [DataMember]
+        public string RunIdPartitionKey { get; set; }
+        [DataMember]
+        public string RunIdRowKey { get; set; }
+    }
+}

--- a/src/System.Private.ServiceModel/tests/Stress/SharedPoolsOfWCFObjects/RunReportingService.cs
+++ b/src/System.Private.ServiceModel/tests/Stress/SharedPoolsOfWCFObjects/RunReportingService.cs
@@ -1,0 +1,185 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.ServiceModel;
+using System.Threading;
+using System.Linq;
+using System.Threading.Tasks;
+using ReportingService;
+
+namespace SharedPoolsOfWCFObjects
+{
+    // This is a simple wrapper around the reporting stuff
+    // The goal is to provide a non blocking "fire and forget" semantics for logging
+    // while taking care of handling error cases
+    public class RunReportingService : IDisposable
+    {
+        private string _url;
+        private volatile IStressDataCollector _rsChannel = null;
+        private long _connectAttempts = 0;
+        private const long MaxConnectAttempts = 1000;
+        private Task<Task<IStressDataCollector>> _ensureReportingChannelTask = null;
+        private Func<Task<IStressDataCollector>> _ensureReportingChannelFunc = null;
+
+        private RunId _rsRunId = null;
+
+        public RunReportingService(string url)
+        {
+            _url = url;
+            _ensureReportingChannelFunc = async () => { return await EnsureReportingChannelImplAsync(); };
+        }
+
+        #region blocking calls
+        public void RunStarted(RunStartupData startupData)
+        {
+            try
+            {
+                _rsRunId = EnsureReportingChannelAsync().Result?.RunStarted(startupData);
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine("Failed to call RunStarted. Further reporting will be disabled. Error: " + e.ToString());
+            }
+        }
+        public void RunFinished(bool success, string message)
+        {
+            if (_rsRunId != null)
+            {
+                try
+                {
+                    EnsureReportingChannelAsync().Result?.RunFinishedAsync(_rsRunId, success, message);
+                }
+                catch { }
+            }
+        }
+        #endregion
+
+        #region  'Fire and forget' calls
+
+
+        private IStressDataCollector __rsClient;
+        public void HeartBeat(int threadId, long iteration)
+        {
+            if (_rsRunId != null)
+            {
+                var now = DateTime.Now;
+                if (__rsClient == null)
+                {
+                    var rsEndPointAddress = new EndpointAddress(_url);
+                    var rsBinding = new BasicHttpBinding();
+                    var rsCF = new ChannelFactory<IStressDataCollector>(rsBinding, rsEndPointAddress);
+                    var rsClient = rsCF.CreateChannel();
+                    (rsClient as ICommunicationObject).Open();
+                    __rsClient = rsClient;
+                }
+                try
+                {
+                    __rsClient.RunHeartBeatAsync(_rsRunId, threadId, iteration, now).Wait();
+                }
+                catch (Exception e)
+                {
+                    Console.WriteLine("HeartBeat Failed " + e.ToString());
+                }
+            }
+        }
+
+        public void LogMessage(string message)
+        {
+            if (_rsRunId != null)
+            {
+                Task.Run(async () =>
+                {
+                    try
+                    {
+                        await (await EnsureReportingChannelAsync())?.LogMessageAsync(_rsRunId, message);
+                    }
+                    catch { Console.WriteLine("LogMessage Failed"); }
+                });
+            }
+        }
+        #endregion
+
+
+        public void Dispose()
+        {
+            (_rsChannel as IClientChannel)?.Dispose();
+        }
+
+        private async Task<IStressDataCollector> EnsureReportingChannelImplAsync()
+        {
+            var rsEndPointAddress = new EndpointAddress(_url);
+            var rsBinding = new BasicHttpBinding();
+            var rsCF = new ChannelFactory<IStressDataCollector>(rsBinding, rsEndPointAddress);
+            var rsClient = rsCF.CreateChannel();
+            var rsCC = rsClient as IClientChannel;
+            await Task.Factory.FromAsync(rsCC.BeginOpen, rsCC.EndOpen, TaskCreationOptions.None);
+            return rsClient;
+        }
+
+
+        // Ensures that the reporting channel is ready to use.
+        // The caller must still be prepared to get a disconnected channel or null in case of an error
+        private async Task<IStressDataCollector> EnsureReportingChannelAsync()
+        {
+            if (String.IsNullOrEmpty(_url))
+            {
+                return null;
+            }
+
+            var channel = _rsChannel;
+            if (channel != null && (channel as ICommunicationObject).State == CommunicationState.Opened)
+            {
+                // Hopefully this is the most common case - connected and usable
+                return channel;
+            }
+            else
+            {
+                Console.Write("Connecting to reporting server... ");
+                try
+                {
+                    // early exit in case we gave up on connecting
+                    if (_connectAttempts > MaxConnectAttempts)
+                    {
+                        return null;
+                    }
+
+                    var tcs = new CancellationTokenSource();
+                    var t = new Task<Task<IStressDataCollector>>(_ensureReportingChannelFunc, tcs.Token);
+
+                    var connectTask = Interlocked.CompareExchange(ref _ensureReportingChannelTask, t, null);
+                    if (connectTask == null)
+                    {
+                        // check the (re)connection limit before trying to connect
+                        if (Interlocked.Increment(ref _connectAttempts) > MaxConnectAttempts)
+                        {
+                            // Cancel the cold connectTask
+                            tcs.Cancel();
+                            return null;
+                        }
+
+                        // attempt to connect
+                        t.Start();
+                        _rsChannel = await t.Unwrap();
+
+                        // Success! But before we return the brand new channel we must null out 
+                        // the _ensureReportingChannelTask so others can retry again if necessary
+                        _ensureReportingChannelTask = null;
+                        return _rsChannel;
+                    }
+                    else
+                    {
+                        // simply await for someone's else attempt to connect
+                        await connectTask.Unwrap();
+                        return _rsChannel;
+                    }
+                }
+                catch (Exception e)
+                {
+                    Console.WriteLine("Reporting unavailable. Error: " + e.ToString());
+                    return null;
+                }
+            }
+        }
+    }
+}

--- a/src/System.Private.ServiceModel/tests/Stress/SharedPoolsOfWCFObjects/TestHelpers.cs
+++ b/src/System.Private.ServiceModel/tests/Stress/SharedPoolsOfWCFObjects/TestHelpers.cs
@@ -7,50 +7,216 @@ using System.ServiceModel.Channels;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Diagnostics;
+using System.Security.Cryptography.X509Certificates;
 
 namespace SharedPoolsOfWCFObjects
 {
-    public enum TestBinding
-    {
-        Http = 0,
-        NetTcp = 1,
-        NetHttpBinding = 2
-    }
     public static class TestHelpers
     {
         private static TestBinding UseBinding { get; set; }
-        private static string HostName { get; set; }
+        private static string s_hostName;
+        private static bool s_debugMode;
+
+        private static int s_selfHostPorts;
+        private static int s_shPortIdx = 1;
+
+        private static SecurityMode s_bindingSecurityMode = SecurityMode.None;
+        private static HttpClientCredentialType s_httpClientCredentialType = HttpClientCredentialType.None;
+        private static TcpClientCredentialType s_tcpClientCredentialType = TcpClientCredentialType.None;
+        private static string s_serverDnsEndpointIdentity;
+        private static string s_clientCertThumbprint;
+        private static StoreName s_clientCertStoreName;
+        private static StoreLocation s_clientCertStoreLocation;
+
+        private static string s_httpHelloUrl;
+        private static string[] s_sh_httpHelloUrls;
+        private static string s_httpsHelloUrl;
+        private static string[] s_sh_httpsHelloUrls;
+        private static string s_httpStreamingUrl;
+        private static string[] s_sh_httpStreamingUrls;
+        private static string s_httpsStreamingUrl;
+        private static string[] s_sh_httpsStreamingUrls;
+        private static string s_httpDuplexUrl;
 
         private static string s_tcpHelloUrl;
-        private static string s_httpHelloUrl;
-        private static string s_netHttpHelloUrl;
-
-        private static string s_tcpDupUrl;
-        private static string s_httpDupUrl;
-        private static string s_netHttpDupUrl;
-
+        private static string[] s_sh_tcpHelloUrls;
         private static string s_tcpStreamingUrl;
-        private static string s_httpStreamingUrl;
+        private static string[] s_sh_tcpStreamingUrls;
+        private static string s_tcpDupUrl;
+        private static string[] s_sh_tcpDupUrls;
+
+        private static string s_netHttpHelloUrl;
+        private static string[] s_sh_netHttpHelloUrl;
+        private static string s_netHttpDupUrl;
+        private static string[] s_sh_netHttpDupUrl;
+        private static string s_netHttpStreamingUrl;
+        private static string[] s_sh_netHttpStreamingUrl;
         private static string s_netHttpDupStreamingUrl;
+        private static string[] s_sh_netHttpDupStreamingUrl;
 
-        public static int MaxPooledFactories { get; set; }
-        public static int MaxPooledChannels { get; set; }
+        // address modifiers for Http, NetTcp, and NetHttp bindings
+        private const string HttpCert = "/httpCert";
+        private const string HttpWind = "/httpWind";
+        private const string NetTcpCert = "/netTcpCert";
+        private const string NetTcpWind = "/netTcpWind";
 
-        public static void SetHostAndProtocol(TestBinding useBinding, string hostName, string appName)
+        // This is one-stop setup for TestHelpers methods to start doing the desired work.
+        public static void SetHelperParameters(
+            TestBinding useBinding,
+            string hostName,
+            string appName,
+            int selfHostPortStartingNumber,
+            int numSelfHostPorts,
+            // security-related parameters
+            SecurityMode bindingSecurityMode,
+            HttpClientCredentialType httpClientCredentialType,
+            TcpClientCredentialType tcpClientCredentialType,
+            string serverDnsEndpointIdentity,
+            string clientCertThumbprint,
+            StoreName clientCertStoreName,
+            StoreLocation clientCertStoreLocation,
+            bool debugMode
+            )
         {
             UseBinding = useBinding;
-            HostName = hostName;
-            s_httpHelloUrl = "http://" + hostName + "/" + appName + "/Service1.svc";
-            s_httpDupUrl = "http://" + hostName + "/" + appName + "/DuplexService.svc";
-            s_httpStreamingUrl = "http://" + hostName + "/" + appName + "/StreamingService.svc";
+            s_debugMode = debugMode;
+            s_hostName = hostName;
+            s_selfHostPorts = numSelfHostPorts;
 
-            s_netHttpHelloUrl = "http://" + hostName + "/" + appName + "/Service1.svc/nethttp";
-            s_netHttpDupUrl = "ws://" + hostName + "/" + appName + "/DuplexService.svc/websocket";
-            s_netHttpDupStreamingUrl = "ws://" + hostName + "/" + appName + "/DuplexStreamingService.svc";
+            s_bindingSecurityMode = bindingSecurityMode;
+            s_httpClientCredentialType = httpClientCredentialType;
+            s_tcpClientCredentialType = tcpClientCredentialType;
+            s_serverDnsEndpointIdentity = serverDnsEndpointIdentity;
+            s_clientCertThumbprint = clientCertThumbprint;
+            s_clientCertStoreLocation = clientCertStoreLocation;
+            s_clientCertStoreName = clientCertStoreName;
+
+            //
+            // validate security parameters to make it easier to identify incorrect ones
+            //
+            if (bindingSecurityMode == SecurityMode.Transport)
+            {
+                // For cert auth we need:
+                if (httpClientCredentialType == HttpClientCredentialType.Certificate || tcpClientCredentialType == TcpClientCredentialType.Certificate)
+                {
+                    // a thumbprint
+                    if (string.IsNullOrEmpty(clientCertThumbprint))
+                    {
+                        throw new ArgumentException("Client certificate thumbprint must be provided for certificate authentication");
+                    }
+                    // server's DNS endpoint identity string
+                    if (string.IsNullOrEmpty(serverDnsEndpointIdentity))
+                    {
+                        throw new ArgumentException("Server's DNS endpoint identity must be provided for certificate authentication");
+                    }
+
+                    // WCF authentication errors are not always informative so we place some diagnostics here
+                    if (debugMode)
+                    {
+                        using (X509Store store = new X509Store(s_clientCertStoreName, s_clientCertStoreLocation))
+                        {
+                            Console.WriteLine(String.Format("Looking for cert in store: {0} location:{1}",
+                                s_clientCertStoreName.ToString(), s_clientCertStoreLocation.ToString()));
+                            store.Open(OpenFlags.ReadOnly);
+                            X509Certificate2Collection foundCertificates = store.Certificates.Find(X509FindType.FindByThumbprint, clientCertThumbprint, false);
+                            foreach (var cert in foundCertificates)
+                            {
+                                string hasPrivateKey, dnsName = "", altDnsName = "", privateKeys = "";
+                                try
+                                {
+                                    dnsName = cert.GetNameInfo(X509NameType.DnsName, false);
+                                }
+                                catch { }
+                                try
+                                {
+                                    altDnsName = cert.GetNameInfo(X509NameType.DnsFromAlternativeName, false);
+                                }
+                                catch { }
+                                try
+                                {
+                                    hasPrivateKey = cert.HasPrivateKey.ToString();
+                                }
+                                catch (Exception e)
+                                {
+                                    hasPrivateKey = e.Message;
+                                }
+                                try
+                                {
+                                    privateKeys += "RSA key: " + (cert.GetRSAPrivateKey()?.KeySize).ToString();
+                                }
+                                catch (Exception ee)
+                                {
+                                    privateKeys = ee.Message;
+                                }
+                                Console.WriteLine(String.Format("Found cert with Name: {0}, Authority: {1}, Subject {2}, Has private key: {3}, privateKeyLength: {4} dnsName: {5}, altDnsName: {6} .",
+                                    cert.FriendlyName, cert.Issuer, cert.Subject, hasPrivateKey, privateKeys, dnsName, altDnsName));
+                            }
+                        }
+                    }
+                }
+            }
+            else if (bindingSecurityMode == SecurityMode.None)
+            {
+                // Reject incompatible parameters
+                if (s_httpClientCredentialType != HttpClientCredentialType.None || s_tcpClientCredentialType != TcpClientCredentialType.None)
+                {
+                    throw new ArgumentException(String.Format("Client credential types ({0} {1}) are incompatible with binding security mode {2}",
+                        s_httpClientCredentialType, s_tcpClientCredentialType, bindingSecurityMode));
+                }
+            }
+            else
+            {
+                throw new ArgumentException("Only SecurityMode.None and SecurityMode.Transport are supported", "bindingSecurityMode");
+            }
+
+            // pre-set urls
+            s_httpHelloUrl = "http://" + hostName + "/" + appName + "/Service1.svc";
+            MultiPortUrlHelper(selfHostPortStartingNumber, numSelfHostPorts, hostName, "http://{0}:{1}/Service1.svc", out s_sh_httpHelloUrls);
+            s_httpsHelloUrl = "https://" + hostName + "/" + appName + "/Service1.svc";
+            MultiPortUrlHelper(selfHostPortStartingNumber, numSelfHostPorts, hostName, "https://{0}:{1}/Service1.svc", out s_sh_httpsHelloUrls);
+            s_httpStreamingUrl = "http://" + hostName + "/" + appName + "/StreamingService.svc";
+            MultiPortUrlHelper(selfHostPortStartingNumber, numSelfHostPorts, hostName, "http://{0}:{1}/StreamingService.svc", out s_sh_httpStreamingUrls);
+            s_httpsStreamingUrl = "https://" + hostName + "/" + appName + "/StreamingService.svc";
+            MultiPortUrlHelper(selfHostPortStartingNumber, numSelfHostPorts, hostName, "https://{0}:{1}/StreamingService.svc", out s_sh_httpsStreamingUrls);
+            s_httpDuplexUrl = "http://" + hostName + "/" + appName + "/DuplexService.svc";
 
             s_tcpHelloUrl = "net.tcp://" + hostName + ":808/" + appName + "/Service1.svc";
+            MultiPortUrlHelper(selfHostPortStartingNumber, numSelfHostPorts, hostName, "net.tcp://{0}:{1}/Service1.svc", out s_sh_tcpHelloUrls);
             s_tcpDupUrl = "net.tcp://" + hostName + ":808/" + appName + "/DuplexService.svc";
+            MultiPortUrlHelper(selfHostPortStartingNumber, numSelfHostPorts, hostName, "net.tcp://{0}:{1}/DuplexService.svc", out s_sh_tcpDupUrls);
             s_tcpStreamingUrl = "net.tcp://" + hostName + ":808/" + appName + "/StreamingService.svc";
+            MultiPortUrlHelper(selfHostPortStartingNumber, numSelfHostPorts, hostName, "net.tcp://{0}:{1}/StreamingService.svc", out s_sh_tcpStreamingUrls);
+
+            s_netHttpHelloUrl = "ws://" + hostName + "/" + appName + "/Service1.svc/websocket";
+            MultiPortUrlHelper(selfHostPortStartingNumber, numSelfHostPorts, hostName, "net.tcp://{0}:{1}/Service1.svc/nethttp", out s_sh_netHttpHelloUrl);
+            s_netHttpDupUrl = "ws://" + hostName + "/" + appName + "/DuplexService.svc/websocket";
+            MultiPortUrlHelper(selfHostPortStartingNumber, numSelfHostPorts, hostName, "net.tcp://{0}:{1}/DuplexService.svc/websocket", out s_sh_netHttpDupUrl);
+            s_netHttpStreamingUrl = "ws://" + hostName + "/" + appName + "/StreamingService.svc/websocket";
+            MultiPortUrlHelper(selfHostPortStartingNumber, numSelfHostPorts, hostName, "net.tcp://{0}:{1}/StreamingService.svc", out s_sh_netHttpStreamingUrl);
+            s_netHttpDupStreamingUrl = "ws://" + hostName + "/" + appName + "/DuplexStreamingService.svc";
+            MultiPortUrlHelper(selfHostPortStartingNumber, numSelfHostPorts, hostName, "net.tcp://{0}:{1}/DuplexStreamingService.svc", out s_sh_netHttpDupStreamingUrl);
+        }
+
+        private static void MultiPortUrlHelper(int selfHostPortStartingNumber, int numSelfHostPorts, string hostName, string urlTemplate, out String[] sh_urls)
+        {
+            sh_urls = null;
+            if (selfHostPortStartingNumber != 0)
+            {
+                if (numSelfHostPorts <= 0)
+                {
+                    throw new ArgumentException("Must specify non zero numSelfHostPorts when selfHostPortNumber is set", "numSelfHostPorts");
+                }
+
+                Console.WriteLine(String.Format("Using {0} services starting from port {1}", numSelfHostPorts, selfHostPortStartingNumber));
+                sh_urls = new string[numSelfHostPorts];
+                for (int p = 0; p < numSelfHostPorts; p++)
+                {
+                    sh_urls[p] = String.Format(urlTemplate, hostName, selfHostPortStartingNumber + p);
+#if DEBUG
+                    Console.WriteLine(sh_urls[p]);
+#endif
+                }
+            }
         }
 
         public static EndpointAddress CreateEndPointHelloAddress()
@@ -58,28 +224,112 @@ namespace SharedPoolsOfWCFObjects
             switch (UseBinding)
             {
                 case TestBinding.Http:
-                    return CreateHttpEndpointAddress();
+                    return CreateHttpEndpointHelloAddress();
+                case TestBinding.Https:
+                    return CreateHttpsEndpointHelloAddress();
                 case TestBinding.NetHttpBinding:
-                    return CreateNetHttpEndpointAddress();
+                    return CreateNetHttpEndpointHelloAddress();
                 case TestBinding.NetTcp:
-                    return CreateNetTcpEndpointAddress();
+                    return CreateNetTcpEndpointHelloAddress();
                 default:
                     return null;
             }
         }
-        public static EndpointAddress CreateHttpEndpointAddress()
+        public static EndpointAddress CreateHttpEndpointHelloAddress()
         {
-            return new EndpointAddress(s_httpHelloUrl);
+            if (s_selfHostPorts == 0)
+            {
+                return CreateHttpEndpointAddressImpl(s_httpHelloUrl);
+            }
+            else
+            {
+                var index = Interlocked.Increment(ref s_shPortIdx) % s_selfHostPorts;
+                return CreateHttpEndpointAddressImpl(s_sh_httpHelloUrls[index]);
+            }
         }
-        public static EndpointAddress CreateNetHttpEndpointAddress()
+        public static EndpointAddress CreateHttpsEndpointHelloAddress()
         {
+            if (s_selfHostPorts == 0)
+            {
+                return CreateHttpEndpointAddressImpl(s_httpsHelloUrl);
+            }
+            else
+            {
+                var index = Interlocked.Increment(ref s_shPortIdx) % s_selfHostPorts;
+                return CreateHttpEndpointAddressImpl(s_sh_httpsHelloUrls[index]);
+            }
+        }
+        public static EndpointAddress CreateNetHttpEndpointHelloAddress()
+        {
+            if (s_debugMode)
+            {
+                Console.WriteLine(s_netHttpHelloUrl);
+            }
             return new EndpointAddress(s_netHttpHelloUrl);
         }
-        public static EndpointAddress CreateNetTcpEndpointAddress()
+        public static EndpointAddress CreateNetTcpEndpointHelloAddress()
         {
-            return new EndpointAddress(s_tcpHelloUrl);
+            if (s_selfHostPorts == 0)
+            {
+                return CreateNetTcpEndpointAddressImpl(s_tcpHelloUrl);
+            }
+            else
+            {
+                var index = Interlocked.Increment(ref s_shPortIdx) % s_selfHostPorts;
+                return CreateNetTcpEndpointAddressImpl(s_sh_tcpHelloUrls[index]);
+            }
         }
+        private static EndpointAddress CreateHttpEndpointAddressImpl(string url)
+        {
+            if (s_httpClientCredentialType == HttpClientCredentialType.Certificate)
+            {
+                if (String.IsNullOrEmpty(s_serverDnsEndpointIdentity))
+                {
+                    throw new NotSupportedException("Server DnsEndpointIdentity is required for certificate authentication");
+                }
+                url += HttpCert;
+                if (s_debugMode)
+                {
+                    Console.WriteLine(String.Format("URL: {0} DNSIdentity: {1} ", url, s_serverDnsEndpointIdentity));
+                }
+                return new EndpointAddress(new Uri(url), new DnsEndpointIdentity(s_serverDnsEndpointIdentity));
+            }
+            else if (s_httpClientCredentialType == HttpClientCredentialType.Windows)
+            {
+                url += HttpWind;
+            }
+            if (s_debugMode)
+            {
+                Console.WriteLine(String.Format("URL: {0}", url));
+            }
+            return new EndpointAddress(url);
+        }
+        private static EndpointAddress CreateNetTcpEndpointAddressImpl(string url)
+        {
+            if (s_tcpClientCredentialType == TcpClientCredentialType.Certificate)
+            {
+                if (String.IsNullOrEmpty(s_serverDnsEndpointIdentity))
+                {
+                    throw new NotSupportedException("Server DnsEndpointIdentity is required for certificate authentication");
+                }
+                url = url + NetTcpCert;
+                if (s_debugMode)
+                {
+                    Console.WriteLine(String.Format("URL: {0} DNSIdentity: {1} ", url, s_serverDnsEndpointIdentity));
+                }
+                return new EndpointAddress(new Uri(url), new DnsEndpointIdentity(s_serverDnsEndpointIdentity));
+            }
+            else if (s_tcpClientCredentialType == TcpClientCredentialType.Windows)
+            {
+                url = url + NetTcpWind;
+            }
 
+            if (s_debugMode)
+            {
+                Console.WriteLine(String.Format("URL: {0}", url));
+            }
+            return new EndpointAddress(url);
+        }
 
         public static EndpointAddress CreateEndPointDuplexAddress()
         {
@@ -95,19 +345,29 @@ namespace SharedPoolsOfWCFObjects
                     return null;
             }
         }
-
-
         public static EndpointAddress CreateHttpEndpointDuplexAddress()
         {
-            return new EndpointAddress(s_httpDupUrl);
+            return new EndpointAddress(s_httpDuplexUrl);
         }
         public static EndpointAddress CreateNetHttpEndpointDuplexAddress()
         {
+            if (s_debugMode)
+            {
+                Console.WriteLine(s_netHttpDupUrl);
+            }
             return new EndpointAddress(s_netHttpDupUrl);
         }
         public static EndpointAddress CreateNetTcpEndpointDuplexAddress()
         {
-            return new EndpointAddress(s_tcpDupUrl);
+            if (s_selfHostPorts == 0)
+            {
+                return CreateNetTcpEndpointAddressImpl(s_tcpDupUrl);
+            }
+            else
+            {
+                var index = Interlocked.Increment(ref s_shPortIdx) % s_selfHostPorts;
+                return CreateNetTcpEndpointAddressImpl(s_sh_tcpDupUrls[index]);
+            }
         }
 
         public static EndpointAddress CreateEndPointStreamingAddress()
@@ -116,8 +376,10 @@ namespace SharedPoolsOfWCFObjects
             {
                 case TestBinding.Http:
                     return CreateHttpEndpointStreamingAddress();
+                case TestBinding.Https:
+                    return CreateHttpsEndpointStreamingAddress();
                 case TestBinding.NetHttpBinding:
-                    return CreateNetHttpEndpointDuplexStreamingAddress();
+                    return CreateNetHttpEndpointStreamingAddress();
                 case TestBinding.NetTcp:
                     return CreateNetTcpEndpointStreamingAddress();
                 default:
@@ -126,16 +388,68 @@ namespace SharedPoolsOfWCFObjects
         }
         public static EndpointAddress CreateHttpEndpointStreamingAddress()
         {
-            return new EndpointAddress(s_httpStreamingUrl);
+            if (s_selfHostPorts == 0)
+            {
+                return CreateHttpEndpointAddressImpl(s_httpStreamingUrl);
+            }
+            else
+            {
+                var index = Interlocked.Increment(ref s_shPortIdx) % s_selfHostPorts;
+                return CreateHttpEndpointAddressImpl(s_sh_httpStreamingUrls[index]);
+            }
         }
-        public static EndpointAddress CreateNetHttpEndpointDuplexStreamingAddress()
+        public static EndpointAddress CreateHttpsEndpointStreamingAddress()
         {
-            return new EndpointAddress(s_netHttpDupStreamingUrl);
+            if (s_selfHostPorts == 0)
+            {
+                return CreateHttpEndpointAddressImpl(s_httpsStreamingUrl);
+            }
+            else
+            {
+                var index = Interlocked.Increment(ref s_shPortIdx) % s_selfHostPorts;
+                return CreateHttpEndpointAddressImpl(s_sh_httpsStreamingUrls[index]);
+            }
+        }
+        public static EndpointAddress CreateNetHttpEndpointStreamingAddress()
+        {
+            if (s_debugMode)
+            {
+                Console.WriteLine(s_netHttpStreamingUrl);
+            }
+            return new EndpointAddress(s_netHttpStreamingUrl);
         }
         public static EndpointAddress CreateNetTcpEndpointStreamingAddress()
         {
-            return new EndpointAddress(s_tcpStreamingUrl);
+            if (s_selfHostPorts == 0)
+            {
+                return CreateNetTcpEndpointAddressImpl(s_tcpStreamingUrl);
+            }
+            else
+            {
+                var index = Interlocked.Increment(ref s_shPortIdx) % s_selfHostPorts;
+                return CreateNetTcpEndpointAddressImpl(s_sh_tcpStreamingUrls[index]);
+            }
         }
+
+        public static EndpointAddress CreateEndPointDuplexStreamingAddress()
+        {
+            switch (UseBinding)
+            {
+                case TestBinding.NetHttpBinding:
+                    return CreateNetHttpEndpointDuplexStreamingAddress();
+                default:
+                    throw new NotImplementedException("Duplex streaming is only supported for NetHttp binding");
+            }
+        }
+        public static EndpointAddress CreateNetHttpEndpointDuplexStreamingAddress()
+        {
+            if (s_debugMode)
+            {
+                Console.WriteLine(s_netHttpDupStreamingUrl);
+            }
+            return new EndpointAddress(s_netHttpDupStreamingUrl);
+        }
+
 
         public static Binding CreateBinding()
         {
@@ -143,6 +457,8 @@ namespace SharedPoolsOfWCFObjects
             {
                 case TestBinding.Http:
                     return CreateHttpBinding();
+                case TestBinding.Https:
+                    return CreateHttpsBinding();
                 case TestBinding.NetHttpBinding:
                     return CreateNetHttpBinding();
                 case TestBinding.NetTcp:
@@ -151,22 +467,41 @@ namespace SharedPoolsOfWCFObjects
                     return null;
             }
         }
-        public static NetTcpBinding CreateNetTcpBinding()
-        {
-            NetTcpBinding binding = new NetTcpBinding();
-            binding.Security = new NetTcpSecurity();
-            binding.Security.Mode = SecurityMode.None;
-            return binding;
-        }
         public static Binding CreateHttpBinding()
         {
             return new BasicHttpBinding();
         }
+        public static Binding CreateHttpsBinding()
+        {
+            var b = new BasicHttpsBinding();
+            SetupHttpsBindingSecurity(b);
+            return b;
+        }
+
+        private static void SetupHttpsBindingSecurity(BasicHttpsBinding binding)
+        {
+            binding.Security.Mode = (s_bindingSecurityMode == SecurityMode.Transport) ? BasicHttpsSecurityMode.Transport : BasicHttpsSecurityMode.TransportWithMessageCredential;
+            binding.Security.Transport = new HttpTransportSecurity();
+            binding.Security.Transport.ClientCredentialType = s_httpClientCredentialType;
+            if (s_debugMode)
+            {
+                Console.WriteLine(String.Format(
+                    "SetupHttpsBindingSecurity: binding.Security.Mode: {0}, binding.Security.Transport.ClientCredentialType: {1}",
+                    binding.Security.Mode, binding.Security.Transport.ClientCredentialType));
+            }
+        }
 
         public static Binding CreateNetHttpBinding()
         {
-            Binding netHttp = new NetHttpBinding();
+            NetHttpBinding netHttp = new NetHttpBinding();
+            netHttp.WebSocketSettings.TransportUsage = WebSocketTransportUsage.Always;
             return netHttp;
+        }
+        public static NetTcpBinding CreateNetTcpBinding()
+        {
+            var binding = new NetTcpBinding();
+            SetupNetTcpBindingSecurity(binding);
+            return binding;
         }
 
         public static Binding CreateStreamingBinding(int maxStreamSize)
@@ -175,12 +510,13 @@ namespace SharedPoolsOfWCFObjects
             {
                 case TestBinding.Http:
                     return CreateHttpStreamingBinding(maxStreamSize);
+                case TestBinding.Https:
+                    return CreateHttpsStreamingBinding(maxStreamSize);
                 case TestBinding.NetHttpBinding:
                     return CreateNetHttpStreamingBinding(maxStreamSize);
                 case TestBinding.NetTcp:
                     return CreateNetTcpStreamingBinding(maxStreamSize);
                 default:
-                    //Debug.Break
                     return null;
             }
         }
@@ -191,11 +527,30 @@ namespace SharedPoolsOfWCFObjects
             binding.TransferMode = TransferMode.Streamed;
             return binding;
         }
+        public static Binding CreateHttpsStreamingBinding(int maxStreamSize)
+        {
+            var binding = new BasicHttpsBinding();
+            binding.MaxReceivedMessageSize = maxStreamSize * 2;
+            binding.TransferMode = TransferMode.Streamed;
+            SetupHttpsBindingSecurity(binding);
+            return binding;
+        }
+        public static CustomBinding CreateCustomNetTcpStreamingBinding(int maxStreamSize)
+        {
+            NetTcpBinding netTcpBinding = new NetTcpBinding();
+            SetupNetTcpBindingSecurity(netTcpBinding);
+            netTcpBinding.MaxReceivedMessageSize = maxStreamSize * 2;
+            netTcpBinding.TransferMode = TransferMode.Streamed;
+
+            CustomBinding binding = new CustomBinding(netTcpBinding);
+            binding.Elements.Find<TcpTransportBindingElement>().ConnectionPoolSettings.MaxOutboundConnectionsPerEndpoint = 1000;
+
+            return binding;
+        }
         public static NetTcpBinding CreateNetTcpStreamingBinding(int maxStreamSize)
         {
             NetTcpBinding binding = new NetTcpBinding();
-            binding.Security = new NetTcpSecurity();
-            binding.Security.Mode = SecurityMode.None;
+            SetupNetTcpBindingSecurity(binding);
             binding.MaxReceivedMessageSize = maxStreamSize * 2;
             binding.TransferMode = TransferMode.Streamed;
             return binding;
@@ -209,10 +564,17 @@ namespace SharedPoolsOfWCFObjects
             binding.WebSocketSettings.TransportUsage = WebSocketTransportUsage.Always;
             return binding;
         }
+        private static void SetupNetTcpBindingSecurity(NetTcpBinding binding)
+        {
+            binding.Security = new NetTcpSecurity();
+            binding.Security.Mode = s_bindingSecurityMode;
+            binding.Security.Transport.ClientCredentialType = s_tcpClientCredentialType;
+        }
 
         public static ChannelFactory<C> CreateChannelFactory<C>(EndpointAddress a, Binding b)
         {
             var factory = new ChannelFactory<C>(b, a);
+            SetupChannelFactorySecurity(factory);
             new CommunicationObjectEventVerifier(factory);
             return factory;
         }
@@ -220,11 +582,28 @@ namespace SharedPoolsOfWCFObjects
         public static DuplexChannelFactory<C> CreateDuplexChannelFactory<C>(EndpointAddress a, Binding b, object duplexCallback)
         {
             var instanceContext = new InstanceContext(duplexCallback);
-
             var factory = new DuplexChannelFactory<C>(instanceContext, b, a);
+            SetupChannelFactorySecurity(factory);
+
             new CommunicationObjectEventVerifier(factory);
             new CommunicationObjectEventVerifier(instanceContext);
             return factory;
+        }
+
+        private static void SetupChannelFactorySecurity<C>(ChannelFactory<C> factory)
+        {
+            if (s_bindingSecurityMode == SecurityMode.Transport &&
+                !String.IsNullOrEmpty(s_clientCertThumbprint) &&
+                (s_httpClientCredentialType == HttpClientCredentialType.Certificate || s_tcpClientCredentialType == TcpClientCredentialType.Certificate))
+            {
+                factory.Credentials.ClientCertificate.SetCertificate(s_clientCertStoreLocation, s_clientCertStoreName, X509FindType.FindByThumbprint, s_clientCertThumbprint);
+                factory.Credentials.ServiceCertificate.SslCertificateAuthentication = new System.ServiceModel.Security.X509ServiceCertificateAuthentication();
+
+                // We won't repeatedly check cert revocation for stress as this could take a significant hit on performance.
+                // This could be a coverage hole though as this ommits a valid code path.
+                factory.Credentials.ServiceCertificate.SslCertificateAuthentication.RevocationMode = X509RevocationMode.NoCheck;
+                // use default CertificateValidationMode for now
+            }
         }
 
         public static void CloseFactory<C>(ChannelFactory<C> factory)
@@ -232,9 +611,31 @@ namespace SharedPoolsOfWCFObjects
             factory.Close();
         }
 
-        public static async Task CloseFactoryAsync<C>(ChannelFactory<C> factory)
+        public static Task CloseFactoryAsync<C>(ChannelFactory<C> factory)
         {
-            await Task.Factory.FromAsync(factory.BeginClose, factory.EndClose, TaskCreationOptions.None);
+            return Task.Factory.FromAsync(factory.BeginClose, factory.EndClose, TaskCreationOptions.None);
+        }
+
+        private static int s_factoryPreemptiveTimeoutsFailed = 0;
+        public static async Task CloseFactoryPreemptiveTimeoutAsync<C>(ChannelFactory<C> factory, int timeoutms, bool failOnPreemptiveTimeout)
+        {
+            var closeTask = CloseFactoryAsync(factory);
+            var timeoutTask = Task.Delay(timeoutms);
+            var taskThatCompleted = await Task.WhenAny(closeTask, timeoutTask);
+            if (taskThatCompleted == timeoutTask)
+            {
+                if (failOnPreemptiveTimeout)
+                {
+                    TestUtils.ReportFailure("CloseFactoryAsync timed out! " + factory.State);
+                    GC.KeepAlive(factory);
+                }
+                else
+                {
+                    Console.WriteLine("CloseFactoryAsync preemptive timeout: #" + Interlocked.Increment(ref s_factoryPreemptiveTimeoutsFailed));
+                }
+                // don't return until we actually do close it
+                await closeTask;
+            }
         }
 
         public static C CreateChannel<C>(ChannelFactory<C> factory)
@@ -252,17 +653,26 @@ namespace SharedPoolsOfWCFObjects
             private int _closingFired;
             private int _faultedFired;
 
-            public CommunicationObjectEventVerifier(ICommunicationObject channel)
+            private static long s_commObjectsCreated = 0;
+            private static long s_commObjectsOpened = 0;
+            private static long s_commObjectsClosed = 0;
+            private static long s_commObjectsFailed = 0;
+
+
+            public CommunicationObjectEventVerifier(ICommunicationObject communicationObj)
             {
-                channel.Opened += (_, __) =>
+                Interlocked.Increment(ref s_commObjectsCreated);
+
+                communicationObj.Opened += (_, __) =>
                 {
+                    Interlocked.Increment(ref s_commObjectsOpened);
                     if (Interlocked.CompareExchange(ref _openedFired, 1, 0) != 0)
                     {
                         TestUtils.ReportFailure("ICommunicationObject.Opened event fired more than once");
                     }
                 };
 
-                channel.Opening += (_, __) =>
+                communicationObj.Opening += (_, __) =>
                 {
                     if (Interlocked.CompareExchange(ref _openingFired, 1, 0) != 0)
                     {
@@ -270,15 +680,16 @@ namespace SharedPoolsOfWCFObjects
                     }
                 };
 
-                channel.Closed += (_, __) =>
+                communicationObj.Closed += (_, __) =>
                 {
+                    Interlocked.Increment(ref s_commObjectsClosed);
                     if (Interlocked.CompareExchange(ref _closedFired, 1, 0) != 0)
                     {
                         TestUtils.ReportFailure("ICommunicationObject.Closed event fired more than once");
                     }
                 };
 
-                channel.Closing += (_, __) =>
+                communicationObj.Closing += (_, __) =>
                 {
                     if (Interlocked.CompareExchange(ref _closingFired, 1, 0) != 0)
                     {
@@ -286,14 +697,49 @@ namespace SharedPoolsOfWCFObjects
                     }
                 };
 
-                channel.Faulted += (_, __) =>
+                communicationObj.Faulted += (_, __) =>
                 {
+                    Interlocked.Increment(ref s_commObjectsFailed);
                     if (Interlocked.CompareExchange(ref _faultedFired, 1, 0) != 0)
                     {
                         TestUtils.ReportFailure("ICommunicationObject.Faulted event fired more than once");
                     }
                 };
             }
+        }
+
+
+        public static void OpenChannel<C>(C channel)
+        {
+            // Getting a null would indicate an issue in harness
+            if (channel == null)
+            {
+                TestUtils.ReportFailure("channel == null");
+            }
+            var cc = channel as ICommunicationObject;
+            // Getting a null would indicate an issue in tests
+            if (cc == null)
+            {
+                TestUtils.ReportFailure("channel is not ICommunicationObject");
+            }
+
+            cc.Open();
+        }
+
+        public static async Task OpenChannelAsync<C>(C channel)
+        {
+            // Getting a null would indicate an issue in harness
+            if (channel == null)
+            {
+                TestUtils.ReportFailure("channel == null");
+            }
+            var cc = (channel as IClientChannel);
+            // Getting a null would indicate an issue in tests
+            if (cc == null)
+            {
+                TestUtils.ReportFailure("channel is not IClientChannel");
+            }
+            await Task.Factory.FromAsync(cc.BeginOpen, cc.EndOpen, TaskCreationOptions.None);
         }
 
         public static void CloseChannel<C>(C channel)
@@ -309,10 +755,10 @@ namespace SharedPoolsOfWCFObjects
             {
                 TestUtils.ReportFailure("channel is not ICommunicationObject");
             }
-
             cc.Close();
         }
-        public static async Task CloseChannelAsync<C>(C channel)
+
+        public static Task CloseChannelAsync<C>(C channel)
         {
             // Getting a null would indicate an issue in harness
             if (channel == null)
@@ -325,17 +771,89 @@ namespace SharedPoolsOfWCFObjects
             {
                 TestUtils.ReportFailure("channel is not IClientChannel");
             }
-            await Task.Factory.FromAsync(cc.BeginClose, cc.EndClose, TaskCreationOptions.None);
+            return Task.Factory.FromAsync(cc.BeginClose, cc.EndClose, TaskCreationOptions.None);
+        }
+
+        private static int s_channelPreemptiveTimeoutsFailed = 0;
+
+        public static async Task CloseChannelPreemptiveTimeoutAsync<C>(C channel, int timeout, bool failOnPreemptiveTimeout)
+        {
+            var closeTask = CloseChannelAsync(channel);
+            var timeoutTask = Task.Delay(timeout);
+            var taskThatCompleted = await Task.WhenAny(closeTask, timeoutTask);
+            if (taskThatCompleted == timeoutTask)
+            {
+                if (failOnPreemptiveTimeout)
+                {
+                    TestUtils.ReportFailure("CloseChannelAsync time out! " + (channel as IClientChannel).State);
+                    GC.KeepAlive(channel);
+                }
+                else
+                {
+                    Console.WriteLine("CloseChannelAsync preemptive timeout: #" + Interlocked.Increment(ref s_channelPreemptiveTimeoutsFailed));
+                }
+                // don't return until we actually do close it
+                await closeTask;
+            }
+        }
+
+        public static bool IsCommunicationObjectUsable<C>(Object obj)
+        {
+            var cObj = obj as ICommunicationObject;
+            if (cObj != null)
+            {
+                if (cObj.State < CommunicationState.Closing)
+                {
+                    return true;
+                }
+            }
+            return false;
         }
     }
 
+
     public static class TestUtils
     {
-        public static void ReportFailure(string message)
+        private static Action<string, bool> s_logger = null;
+        public static void SetFailureLogger(Action<string, bool> logger)
+        {
+            s_logger = logger;
+        }
+        public static bool ReportFailureDontEatException(Exception e)
+        {
+            ReportFailure(e.ToString());
+            GC.KeepAlive(e);
+            return false;
+        }
+
+        public static bool ReportFailureNoBreakEatException(Exception e)
+        {
+            ReportFailure(e.ToString(), debugBreak: false);
+            return true;
+        }
+
+        private static int s_exceptionsEaten = 0;
+        public static bool ReportFailureAndBreakIfNotTimeout(Exception e)
+        {
+            bool eatException = (e is System.TimeoutException);
+            if (eatException)
+            {
+                Console.WriteLine("Eating timeout #" + Interlocked.Increment(ref s_exceptionsEaten));
+            }
+            ReportFailure(e.ToString(), debugBreak: eatException ? false : true);
+            return eatException;
+        }
+
+        public static void ReportFailure(string message, bool debugBreak = true)
         {
             Console.WriteLine(message);
-            Debugger.Break();
-            GC.KeepAlive(message);
+            var logger = s_logger;
+            logger?.Invoke(message, debugBreak);
+            if (debugBreak)
+            {
+                Debugger.Break();
+                GC.KeepAlive(message);
+            }
         }
     }
 }

--- a/src/System.Private.ServiceModel/tests/Stress/SharedPoolsOfWCFObjects/Tests/CommonTest.cs
+++ b/src/System.Private.ServiceModel/tests/Stress/SharedPoolsOfWCFObjects/Tests/CommonTest.cs
@@ -8,41 +8,80 @@ using System.Threading.Tasks;
 
 namespace SharedPoolsOfWCFObjects
 {
-    // Common test params are shared by all the tests which makes the results comparable between different 
-    // bindings and tests. E.g. the throughput perf test running say Http&HelloWorld and NetTcp&Streaming 
-    // will have the same number of channels, factories, and calls per test so it is possible to compare
-    // the results.
-
-    public class CommonStressTestParams : IPoolTestParameter, IStatsCollectingTestParameter
+    // The following classes are used as generic parameters to test templates which in turn are used as generic parameters to test scenarios.
+    // Common test params are shared by all the tests which makes the results comparable between different
+    // bindings and tests. E.g. the throughput perf test running Http&HelloWorld and NetTcp&Streaming
+    // will have the same number of channels, factories, and calls per iteration
+    // which allows for comparing the results.
+    // These classes also define all the "magic" constants such as #stat collection samples, timeout values, etc
+    public class CommonPerfExceptionPolicyParam : IExceptionHandlingPolicyParameter
     {
-        public virtual int MaxPooledChannels { get { return 3; } }
-        public virtual int MaxPooledFactories { get { return 3; } }
-        public virtual int SunnyDayMaxStatsSamples { get { return 10000; } }
-        public virtual int RainyDayMaxStatsSamples { get { return 10000; } }
+        virtual public Func<Exception, bool> ExceptionHandler { get { return TestUtils.ReportFailureDontEatException; } }
+        // For perf we do not want to ignore/replace pooled factories and channels that did not pass ITestTemplate validation checks
+        public bool ReplaceInvalidPooledFactories { get { return false; } }
+        public bool ReplaceInvalidPooledChannels { get { return false; } }
+    }
+
+    // This class represents a relaxed failure criteria currently used for stress tests.
+    // In its current shape it makes the tests to:
+    // -    print and ignore timeout exceptions originated from our calls to Channels and Factories
+    // -    replace faulted/closed Channels and Factories (otherwise the tests will continue using them)
+    // Depending on the severity of stress issues we target we can tighten it to have absolutely no tolerance towards any unexpected behavior 
+    // or we can implement some limited tolerance logic
+    //
+    // Notes for the future refactoring:
+    // - Rather than being a part of *TestParams classes, the IExceptionHandlingPolicyParameter could be a generic parameter 
+    //   to the Test/TestParameter class itself. This would allow the caller to explicitly control the exception policy 
+    //   from the place where the tests are invoked.
+    public class CommonStressExceptionPolicyParam : IExceptionHandlingPolicyParameter
+    {
+        virtual public Func<Exception, bool> ExceptionHandler { get { return TestUtils.ReportFailureAndBreakIfNotTimeout; } }
+
+        // For some stress tests we might want to ignore/replace pooled factories and channels that did not pass ITestTemplate validation checks
+        virtual public bool ReplaceInvalidPooledFactories { get { return true; } }
+        virtual public bool ReplaceInvalidPooledChannels { get { return true; } }
+    }
+
+    public class CommonStressTestParams : CommonStressExceptionPolicyParam, IPoolTestParameter, IStatsCollectingTestParameter
+    {
+        virtual public int MaxPooledChannels { get { return 3; } }
+        virtual public int MaxPooledFactories { get { return 3; } }
+        virtual public int SunnyDayMaxStatsSamples { get { return 10000; } }
+        virtual public int RainyDayMaxStatsSamples { get { return 10000; } }
+        // Investigation of timeouts could be tricky when exceptions are already thrown and stacks unwound.
+        // To help with the investigations we preemptively break into debuggers just before the actual timeout happens
+        // so we have a chance to analyze the reasons for the upcoming WCF timeout.
+        public int PreemptiveCloseChannelTimeout { get { return 50000; } }
+        public int PreemptiveCloseFactoryTimeout { get { return 50000; } }
     }
 
     // For startup we're going to have 1 channel factory and 1 channel created per call.
     // Failures aren't expected in perf startup/throughput scenarios and we don't have a lot of calls 
     // so we can reduce the number of samples collected (hence we use different magic numbers).
-    public class CommonPerfStartupTestParams : IPoolTestParameter, IStatsCollectingTestParameter
+    public class CommonPerfStartupTestParams : CommonPerfExceptionPolicyParam, IPoolTestParameter, IStatsCollectingTestParameter
     {
-        public int MaxPooledChannels { get { return 1; } }
-        public int MaxPooledFactories { get { return 1; } }
-        public int SunnyDayMaxStatsSamples { get { return 100; } }
-        public int RainyDayMaxStatsSamples { get { return 10; } }
+        virtual public int MaxPooledChannels { get { return 1; } }
+        virtual public int MaxPooledFactories { get { return 1; } }
+        virtual public int SunnyDayMaxStatsSamples { get { return 100; } }
+        virtual public int RainyDayMaxStatsSamples { get { return 10; } }
+        public int PreemptiveCloseChannelTimeout { get { return 0; } }
+        public int PreemptiveCloseFactoryTimeout { get { return 0; } }
     }
 
     // For the throughput perf we're using several factories and several channels per factory
     // Again, the failures aren't expected in perf tests so we're reducing the number of samples
-    public class CommonPerfThroughputTestParams : IPoolTestParameter, IStatsCollectingTestParameter
+    public class CommonPerfThroughputTestParams : CommonPerfExceptionPolicyParam, IPoolTestParameter, IStatsCollectingTestParameter
     {
-        public int MaxPooledChannels { get { return 3; } }
-        public int MaxPooledFactories { get { return 3; } }
-        public int SunnyDayMaxStatsSamples { get { return 1000; } }
-        public int RainyDayMaxStatsSamples { get { return 10; } }
+        virtual public int MaxPooledChannels { get { return 8; } }
+        virtual public int MaxPooledFactories { get { return 12; } }
+        virtual public int SunnyDayMaxStatsSamples { get { return 1000; } }
+        virtual public int RainyDayMaxStatsSamples { get { return 10; } }
+        public int PreemptiveCloseChannelTimeout { get { return 0; } }
+        public int PreemptiveCloseFactoryTimeout { get { return 0; } }
     }
+
     public abstract class CommonTest<ChannelType, TestParams> : ITestTemplate<ChannelType, TestParams>, IExceptionPolicy
-    where TestParams : IPoolTestParameter, IStatsCollectingTestParameter, new()
+    where TestParams : IExceptionHandlingPolicyParameter, IPoolTestParameter, IStatsCollectingTestParameter, new()
     {
         protected TestParams _params;
         protected CallStats _createChannelStats;
@@ -52,17 +91,22 @@ namespace SharedPoolsOfWCFObjects
         protected CallStats _closeFactoryAsyncStats;
         protected CallStats _useChannelStats;
         protected CallStats _useChannelAsyncStats;
+        protected CallStats _openChannelStats;
+        protected CallStats _openChannelAsyncStats;
+
 
         public CommonTest()
         {
             _params = new TestParams();
-            _createChannelStats = new CallStats(_params.SunnyDayMaxStatsSamples, _params.RainyDayMaxStatsSamples);
-            _useChannelStats = new CallStats(_params.SunnyDayMaxStatsSamples, _params.RainyDayMaxStatsSamples);
-            _useChannelAsyncStats = new CallStats(_params.SunnyDayMaxStatsSamples, _params.RainyDayMaxStatsSamples);
-            _closeChannelStats = new CallStats(_params.SunnyDayMaxStatsSamples, _params.RainyDayMaxStatsSamples);
-            _closeChannelAsyncStats = new CallStats(_params.SunnyDayMaxStatsSamples, _params.RainyDayMaxStatsSamples);
-            _closeFactoryStats = new CallStats(_params.SunnyDayMaxStatsSamples, _params.RainyDayMaxStatsSamples);
-            _closeFactoryAsyncStats = new CallStats(_params.SunnyDayMaxStatsSamples, _params.RainyDayMaxStatsSamples);
+            _createChannelStats = new CallStats(_params.SunnyDayMaxStatsSamples, _params.RainyDayMaxStatsSamples, _params.ExceptionHandler);
+            _useChannelStats = new CallStats(_params.SunnyDayMaxStatsSamples, _params.RainyDayMaxStatsSamples, _params.ExceptionHandler);
+            _useChannelAsyncStats = new CallStats(_params.SunnyDayMaxStatsSamples, _params.RainyDayMaxStatsSamples, _params.ExceptionHandler);
+            _closeChannelStats = new CallStats(_params.SunnyDayMaxStatsSamples, _params.RainyDayMaxStatsSamples, _params.ExceptionHandler);
+            _closeChannelAsyncStats = new CallStats(_params.SunnyDayMaxStatsSamples, _params.RainyDayMaxStatsSamples, _params.ExceptionHandler);
+            _closeFactoryStats = new CallStats(_params.SunnyDayMaxStatsSamples, _params.RainyDayMaxStatsSamples, _params.ExceptionHandler);
+            _closeFactoryAsyncStats = new CallStats(_params.SunnyDayMaxStatsSamples, _params.RainyDayMaxStatsSamples, _params.ExceptionHandler);
+            _openChannelStats = new CallStats(_params.SunnyDayMaxStatsSamples, _params.RainyDayMaxStatsSamples, _params.ExceptionHandler);
+            _openChannelAsyncStats = new CallStats(_params.SunnyDayMaxStatsSamples, _params.RainyDayMaxStatsSamples, _params.ExceptionHandler);
         }
 
         public TestParams TestParameters
@@ -73,44 +117,75 @@ namespace SharedPoolsOfWCFObjects
             }
         }
 
-        public bool RelaxedExceptionPolicy { get; set; }
+        virtual public bool RelaxedExceptionPolicy { get; set; }
 
-        public virtual EndpointAddress CreateEndPointAddress()
+        virtual public EndpointAddress CreateEndPointAddress()
         {
             return TestHelpers.CreateEndPointHelloAddress();
         }
 
-        public virtual Binding CreateBinding()
+        virtual public Binding CreateBinding()
         {
             return TestHelpers.CreateBinding();
         }
 
-        public virtual ChannelFactory<ChannelType> CreateChannelFactory()
+        virtual public ChannelFactory<ChannelType> CreateChannelFactory()
         {
             return TestHelpers.CreateChannelFactory<ChannelType>(CreateEndPointAddress(), CreateBinding());
         }
-        public void CloseFactory(ChannelFactory<ChannelType> factory)
+        virtual public void CloseFactory(ChannelFactory<ChannelType> factory)
         {
             _closeFactoryStats.CallActionAndRecordStats(() => TestHelpers.CloseFactory(factory), RelaxedExceptionPolicy);
         }
-        public Task CloseFactoryAsync(ChannelFactory<ChannelType> factory)
+        virtual public Task CloseFactoryAsync(ChannelFactory<ChannelType> factory)
         {
-            return _closeFactoryAsyncStats.CallAsyncFuncAndRecordStatsAsync(TestHelpers.CloseFactoryAsync, factory, RelaxedExceptionPolicy);
+            return _params.PreemptiveCloseFactoryTimeout > 0
+                ? _closeFactoryAsyncStats.CallAsyncFuncAndRecordStatsAsync(() =>
+                    TestHelpers.CloseFactoryPreemptiveTimeoutAsync(factory, _params.PreemptiveCloseFactoryTimeout, failOnPreemptiveTimeout: false), RelaxedExceptionPolicy)
+                : _closeFactoryAsyncStats.CallAsyncFuncAndRecordStatsAsync(() =>
+                    TestHelpers.CloseFactoryAsync(factory), RelaxedExceptionPolicy);
         }
 
-        public ChannelType CreateChannel(ChannelFactory<ChannelType> factory)
+        virtual public ChannelType CreateChannel(ChannelFactory<ChannelType> factory)
         {
             return _createChannelStats.CallFuncAndRecordStats(TestHelpers.CreateChannel, factory, RelaxedExceptionPolicy);
         }
-        public void CloseChannel(ChannelType channel)
+        virtual public void OpenChannel(ChannelType channel)
+        {
+            _openChannelStats.CallActionAndRecordStats(() => TestHelpers.OpenChannel(channel), RelaxedExceptionPolicy);
+        }
+
+        virtual public Task OpenChannelAsync(ChannelType channel)
+        {
+            return _openChannelAsyncStats.CallAsyncFuncAndRecordStatsAsync(() => TestHelpers.OpenChannelAsync(channel), RelaxedExceptionPolicy);
+        }
+
+        virtual public void CloseChannel(ChannelType channel)
         {
             _closeChannelStats.CallActionAndRecordStats(() => TestHelpers.CloseChannel(channel), RelaxedExceptionPolicy);
         }
-        public Task CloseChannelAsync(ChannelType channel)
+        virtual public Task CloseChannelAsync(ChannelType channel)
         {
-            return _closeChannelAsyncStats.CallAsyncFuncAndRecordStatsAsync(TestHelpers.CloseChannelAsync, channel, RelaxedExceptionPolicy);
+            return _params.PreemptiveCloseChannelTimeout > 0
+                ? _closeChannelAsyncStats.CallAsyncFuncAndRecordStatsAsync(() =>
+                    TestHelpers.CloseChannelPreemptiveTimeoutAsync(channel, _params.PreemptiveCloseChannelTimeout, failOnPreemptiveTimeout: false), RelaxedExceptionPolicy)
+                : _closeChannelAsyncStats.CallAsyncFuncAndRecordStatsAsync(() =>
+                    TestHelpers.CloseChannelAsync(channel), RelaxedExceptionPolicy);
         }
-        public abstract Action<ChannelType> UseChannel();
-        public abstract Func<ChannelType, Task> UseAsyncChannel();
+        public abstract Func<ChannelType, int> UseChannel();
+        public abstract Func<ChannelType, Task<int>> UseAsyncChannel();
+
+        virtual public bool ValidateChannel(ChannelType channel)
+        {
+            // if the scenario that uses our test may close/fault our channel (RelaxedExceptionPolicy)
+            // && if this test parameters (ReplaceInvalidPooledChannels) allow us to replace the objects that went bad
+            // then we validate the channel, otherwise we skip the validation
+            return (RelaxedExceptionPolicy && _params.ReplaceInvalidPooledChannels) ? TestHelpers.IsCommunicationObjectUsable<ChannelType>(channel) : true;
+        }
+
+        virtual public bool ValidateFactory(ChannelFactory<ChannelType> factory)
+        {
+            return (RelaxedExceptionPolicy && _params.ReplaceInvalidPooledFactories) ? TestHelpers.IsCommunicationObjectUsable<ChannelType>(factory) : true;
+        }
     }
 }

--- a/src/System.Private.ServiceModel/tests/Stress/SharedPoolsOfWCFObjects/Tests/ITestTemplate.cs
+++ b/src/System.Private.ServiceModel/tests/Stress/SharedPoolsOfWCFObjects/Tests/ITestTemplate.cs
@@ -18,10 +18,14 @@ namespace SharedPoolsOfWCFObjects
         void CloseFactory(ChannelFactory<ChannelType> factory);
         Task CloseFactoryAsync(ChannelFactory<ChannelType> factory);
         ChannelType CreateChannel(ChannelFactory<ChannelType> factory);
+        void OpenChannel(ChannelType channel);
+        Task OpenChannelAsync(ChannelType channel);
         void CloseChannel(ChannelType channel);
         Task CloseChannelAsync(ChannelType channel);
-        Action<ChannelType> UseChannel();
-        Func<ChannelType, Task> UseAsyncChannel();
+        bool ValidateChannel(ChannelType channel);
+        bool ValidateFactory(ChannelFactory<ChannelType> factory);
+        Func<ChannelType, int> UseChannel();
+        Func<ChannelType, Task<int>> UseAsyncChannel();
 
         Params TestParameters { get; }
     }
@@ -33,13 +37,19 @@ namespace SharedPoolsOfWCFObjects
         bool RelaxedExceptionPolicy { get; set; }
     }
 
-    // Need interfaces to control:
-    // - bindings
-    
+    public interface IExceptionHandlingPolicyParameter
+    {
+        Func<Exception, bool> ExceptionHandler { get; }
+        bool ReplaceInvalidPooledFactories { get; }
+        bool ReplaceInvalidPooledChannels { get; }
+    }
+
     public interface IPoolTestParameter
     {
         int MaxPooledFactories { get; }
         int MaxPooledChannels { get; }
+        int PreemptiveCloseChannelTimeout { get; }
+        int PreemptiveCloseFactoryTimeout { get; }
     }
 
 

--- a/src/System.Private.ServiceModel/tests/Stress/SharedPoolsOfWCFObjects/project.json
+++ b/src/System.Private.ServiceModel/tests/Stress/SharedPoolsOfWCFObjects/project.json
@@ -1,38 +1,33 @@
-{
-  "dependencies": {
-    "Microsoft.NETCore.Platforms": "1.2.0-beta-24605-03",
-    "System.Collections": "4.4.0-beta-24605-03",
-    "System.Collections.Specialized": "4.4.0-beta-24605-03",
-    "System.Console": "4.4.0-beta-24605-03",
-    "System.Diagnostics.Debug": "4.4.0-beta-24605-03",
-    "System.Diagnostics.Tools": "4.4.0-beta-24605-03",
-    "System.Linq": "4.4.0-beta-24605-03",
-    "System.Net.Http": "4.4.0-beta-24605-03",
-    "System.Net.Sockets": "4.4.0-beta-24605-03",
-    "System.Private.ServiceModel": "4.4.0-beta-24709-02",
-    "System.ServiceModel.Duplex": "4.4.0-beta-24709-02",
-    "System.ServiceModel.Http": "4.4.0-beta-24709-02",
-    "System.ServiceModel.NetTcp": "4.4.0-beta-24709-02",
-    "System.ServiceModel.Primitives": "4.4.0-beta-24709-02",
-    "System.ServiceModel.Security": "4.4.0-beta-24709-02",
-    "System.Threading": "4.4.0-beta-24605-03",
-    "test-runtime": {
-      "target": "project",
-      "exclude": "compile"
+﻿{
+  "version": "1.0.0-*",
+  "buildOptions": {
+    "emitEntryPoint": true
+  },
+
+  "dependencies": {},
+
+  "frameworks": {
+    "netcoreapp1.1": {
+      "dependencies": {
+        "Microsoft.NETCore.App": {
+          "version": "1.1.0"
+        },
+        "System.Private.ServiceModel": "4.3.0",
+        "System.ServiceModel.Http": "4.3.0",
+        "System.ServiceModel.NetTcp": "4.3.0",
+        "System.ServiceModel.Primitives": "4.3.0",
+        "System.ServiceModel.Duplex": "4.3.0",
+        "System.ServiceModel.Security": "4.3.0"
+      }
     }
   },
-  "commands": {
-    "SharedPoolsOfWCFObjects": "SharedPoolsOfWCFObjects"
+  "runtimeOptions": {
+    "configProperties": {
+      "System.GC.Server": true
+    }
   },
-  "frameworks": {
-    "netstandard1.3": {}
-  },
-  "supports": {
-    "coreFx.Test.netcore50": {},
-    "coreFx.Test.netcoreapp1.1": {},
-    "coreFx.Test.net46": {},
-    "coreFx.Test.net461": {},
-    "coreFx.Test.net462": {},
-    "coreFx.Test.net463": {}
+  "runtimes": {
+    "win7-x64": {},
+    "ubuntu.14.04-x64": {}
   }
 }

--- a/src/System.Private.ServiceModel/tests/Stress/SharedPoolsOfWCFObjectsServer/App_Code/DuplexStreamingService.svc.cs
+++ b/src/System.Private.ServiceModel/tests/Stress/SharedPoolsOfWCFObjectsServer/App_Code/DuplexStreamingService.svc.cs
@@ -30,13 +30,6 @@ namespace WcfService1
         public Stream GetStreamFromInt(int bytesToStream)
         {
             return OperationContext.Current.GetCallbackChannel<IDuplexStreamingCallback>().GetStreamFromInt(bytesToStream);
-            //var stream = new VerifiableStream(bytesToStream);
-            //OperationContext clientContext = OperationContext.Current;
-            //clientContext.OperationCompleted += new EventHandler(delegate (object sender, EventArgs args)
-            //{
-            //    stream.Dispose();
-            //});
-            //return stream;
         }
     }
 }

--- a/src/System.Private.ServiceModel/tests/Stress/SharedPoolsOfWCFObjectsServer/Web.config
+++ b/src/System.Private.ServiceModel/tests/Stress/SharedPoolsOfWCFObjectsServer/Web.config
@@ -7,66 +7,145 @@
     <compilation debug="true" targetFramework="4.5.2" />
     <httpRuntime targetFramework="4.5.2" />
   </system.web>
-  
+    
   <system.serviceModel>
     <services>
       <service name="WcfService1.Service1">
-        <endpoint address="mex" binding="mexTcpBinding" contract="IMetadataExchange" />
-        <endpoint name="MyEndPoint" binding="netTcpBinding" bindingConfiguration="EndPointConfiguration" contract="WcfService1.IService1" />
-        <endpoint name="httpEndpoint" binding="basicHttpBinding" bindingConfiguration="BasicHttp" contract="WcfService1.IService1" />
-        <endpoint address="netHttp" name="nethttpEndpoint" binding="netHttpBinding" bindingConfiguration="NetHttp" contract="WcfService1.IService1" />
+        <endpoint address="mex" name="meta" binding="mexTcpBinding" contract="IMetadataExchange" />
+
+        <endpoint address =""           name="httpEndpoint"       binding="basicHttpBinding" bindingConfiguration="BasicHttp"   contract="WcfService1.IService1" />
+        <endpoint address ="httpCert"   name="httpCertEndpoint"   binding="basicHttpsBinding" bindingConfiguration="CertHttps"    contract="WcfService1.IService1" />
+        <endpoint address ="httpWind"   name="httpWindEndpoint"   binding="basicHttpsBinding" bindingConfiguration="WindHttps"    contract="WcfService1.IService1" />
+        
+        <endpoint address =""           name="netTcpEndPoint"     binding="netTcpBinding"   bindingConfiguration="BasicNetTcp"  contract="WcfService1.IService1" />
+        <endpoint address ="netTcpCert" name="netTcpCertEndPoint" binding="netTcpBinding"   bindingConfiguration="CertNetTcp"   contract="WcfService1.IService1" />
+        <endpoint address ="netTcpWind" name="netTcpWindEndPoint" binding="netTcpBinding"   bindingConfiguration="WindNetTcp"   contract="WcfService1.IService1" />
+        <endpoint address ="websocket"  name="nethttpEndpoint"    binding="netHttpBinding"  bindingConfiguration="HelloNetHttp" contract="WcfService1.IService1" />
       </service>
 
       <service name="WcfService1.DuplexService">
-        <endpoint name="MyDuplexEndPoint" binding="netTcpBinding" bindingConfiguration="EndPointConfiguration" contract="WcfService1.IDuplexService" />
         <endpoint address="mex" binding="mexTcpBinding" contract="IMetadataExchange" />
-        <endpoint address="websocket" name="WebsocketEndpoint" binding="netHttpBinding" bindingConfiguration="NetHttp" contract="WcfService1.IDuplexService" />
+
+        <endpoint address =""           name="netTcpDupEndPoint"      binding="netTcpBinding" bindingConfiguration="BasicNetTcp"  contract="WcfService1.IDuplexService" />
+        <endpoint address ="netTcpCert" name="netTcpCertDupEndPoint"  binding="netTcpBinding" bindingConfiguration="CertNetTcp"   contract="WcfService1.IDuplexService" />
+        <endpoint address ="netTcpWind" name="netTcpWindDupEndPoint"  binding="netTcpBinding" bindingConfiguration="WindNetTcp"   contract="WcfService1.IDuplexService" />
+        <endpoint address ="websocket"  name="WebsocketEndpoint"      binding="netHttpBinding" bindingConfiguration="DuplexNetHttp" contract="WcfService1.IDuplexService" />
       </service>
 
       <service name="WcfService1.StreamingService">
-        <endpoint name="StreamingHttpEndpoint" binding="basicHttpBinding" bindingConfiguration="StreamingHttp" contract="WcfService1.IStreamingService" />
-        <endpoint name="StreamingNetTcpEndpoint" binding="netTcpBinding" bindingConfiguration="StreamingNetTcp" contract="WcfService1.IStreamingService" />
         <endpoint address="mex" binding="mexTcpBinding" contract="IMetadataExchange" />
+
+        <endpoint address =""           name="HttpStreamingEndpoint"    binding="basicHttpBinding" bindingConfiguration="StreamingHttp" contract="WcfService1.IStreamingService" />
+        <endpoint address ="httpCert"   name="HttpCertStreamingEndpoint" binding="basicHttpsBinding" bindingConfiguration="CertStreamingHttps" contract="WcfService1.IStreamingService" />
+        <endpoint address ="httpWind"   name="HttpWindStreamingEndpoint" binding="basicHttpsBinding" bindingConfiguration="WindStreamingHttps" contract="WcfService1.IStreamingService" />
+        
+        <endpoint address =""           name="NetTcpStreamingEndpoint"  binding="netTcpBinding" bindingConfiguration="StreamingNetTcp" contract="WcfService1.IStreamingService" />
+        <endpoint address ="netTcpCert" name="NetTcpCertStrEndpoint"    binding="netTcpBinding" bindingConfiguration="CertStreamingNetTcp" contract="WcfService1.IStreamingService" />
+        <endpoint address ="netTcpWind" name="NetTcpWindStrEndpoint"    binding="netTcpBinding" bindingConfiguration="WindStreamingNetTcp" contract="WcfService1.IStreamingService" />
+
+        <endpoint address ="websocket" name="StreamingNetHttpEndpoint"  binding="netHttpBinding" bindingConfiguration="StreamingNetHttp" contract="WcfService1.IStreamingService" />
       </service>
       <service name ="WcfService1.DuplexStreamingService">
         <endpoint name ="DuplexStreamingNetHttpEndpoint" binding ="netHttpBinding" bindingConfiguration ="DuplexStreamingNetHttp" contract ="WcfService1.IDuplexStreamingService" />
       </service>
-
     </services>
     <bindings>
       <netTcpBinding>
-        <binding name="EndPointConfiguration" portSharingEnabled="true" sendTimeout="00:01:00">
-          <security mode="None" />
+        <binding name="BasicNetTcp" portSharingEnabled="true" sendTimeout="00:01:00">
+          <security mode="None"/>
         </binding>
+        <binding name="CertNetTcp" portSharingEnabled="true" sendTimeout="00:01:00">
+          <security mode="Transport">
+            <transport clientCredentialType="Certificate">
+            </transport>
+          </security>
+        </binding>
+        <binding name="WindNetTcp" portSharingEnabled="true" sendTimeout="00:01:00">
+          <security mode="Transport">
+            <transport clientCredentialType="Windows"> </transport>
+          </security>
+        </binding>
+        
         <binding name ="StreamingNetTcp" maxReceivedMessageSize ="1671088640" transferMode="Streamed">
           <security mode ="None" />
         </binding>
+        <binding name ="CertStreamingNetTcp" maxReceivedMessageSize ="1671088640" transferMode="Streamed">
+          <security mode="Transport">
+            <transport clientCredentialType="Certificate"></transport>
+          </security>
+        </binding>
+        <binding name ="WindStreamingNetTcp" maxReceivedMessageSize ="1671088640" transferMode="Streamed">
+          <security mode="Transport">
+            <transport clientCredentialType="Windows"></transport>
+          </security>
+        </binding>
       </netTcpBinding>
-
+        
       <basicHttpBinding>
         <binding name="BasicHttp">
           <security mode="None" />
         </binding>
+
         <binding name="StreamingHttp" maxReceivedMessageSize="1671088640" transferMode="Streamed">
           <security mode="None" />
         </binding>
       </basicHttpBinding>
       
+      <basicHttpsBinding>
+        <binding name ="CertHttps">
+          <security mode ="Transport">
+            <transport clientCredentialType="Certificate">
+            </transport>
+          </security>
+        </binding>
+        <binding name ="WindHttps">
+          <security mode ="Transport">
+            <transport clientCredentialType="Windows">
+            </transport>
+          </security>
+        </binding>
+      
+        <binding name="CertStreamingHttps" maxReceivedMessageSize="1671088640" transferMode="Streamed">
+          <security mode ="Transport">
+            <transport clientCredentialType="Certificate"></transport>
+          </security>
+        </binding>
+        <binding name="WindStreamingHttps" maxReceivedMessageSize="1671088640" transferMode="Streamed">
+          <security mode ="Transport">
+            <transport clientCredentialType="Windows">
+            </transport>
+          </security>
+        </binding>
+      </basicHttpsBinding>
+
       <netHttpBinding>
-        <binding name="NetHttp">
-          <webSocketSettings transportUsage="WhenDuplex" /> 
+        <binding name="HelloNetHttp">
+          <webSocketSettings transportUsage="Always" />
+        </binding>
+        <binding name="DuplexNetHttp">
+          <webSocketSettings transportUsage="Always" /> 
+        </binding>
+        <binding name="StreamingNetHttp"  maxReceivedMessageSize="1671088640" transferMode="Streamed">
+                    <webSocketSettings transportUsage="Always" /> 
         </binding>
         <binding name="DuplexStreamingNetHttp"  maxReceivedMessageSize="1671088640" transferMode="Streamed">
                     <webSocketSettings transportUsage="Always" /> 
         </binding>
       </netHttpBinding>
-
     </bindings>
     
     
     <behaviors>
       <serviceBehaviors>
         <behavior>
+          <!-- -->
+          <serviceCredentials>
+            <clientCertificate>
+              <authentication certificateValidationMode="ChainTrust" revocationMode="NoCheck"/>
+            </clientCertificate>
+            <serviceCertificate findValue ="CertThumbprintHere" x509FindType="FindByThumbprint" storeName="My" storeLocation="LocalMachine" />
+          </serviceCredentials>
+          <!-- -->
           <!-- To avoid disclosing metadata information, set the values below to false before deployment -->
           <serviceMetadata httpGetEnabled="true" httpsGetEnabled="true" />
           <!-- To receive exception details in faults for debugging purposes, set the value below to true.  Set to false before deployment to avoid disclosing exception information -->
@@ -80,6 +159,7 @@
     <serviceHostingEnvironment aspNetCompatibilityEnabled="true" multipleSiteBindingsEnabled="true" />
   </system.serviceModel>
   <system.webServer>
+
     <modules runAllManagedModulesForAllRequests="true" />
     <directoryBrowse enabled="true" />
         <urlCompression doStaticCompression="true" doDynamicCompression="true" />


### PR DESCRIPTION
Refactored tests to support more stress scenarios
Added numerous command line parameters to control both perf and stress tests
Added basic stress results reporting
Tuned perf scenario tests to achieve stable results
Addressed some of the previous PR feedback
Added various security bindings