### PR TITLE
Updating scenario TypeClientTests

### DIFF
--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/TypedClient/Client.TypedClient.Tests.sln
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/TypedClient/Client.TypedClient.Tests.sln
@@ -7,6 +7,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Client.TypedClient.Tests", 
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ScenarioTests.Common", "..\..\..\Common\Scenarios\ScenarioTests.Common.csproj", "{9098B41C-9C2E-4FC6-B7D8-FC3411736A22}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Infrastructure.Common", "..\..\..\Common\Infrastructure\Infrastructure.Common.csproj", "{AFD69665-89A3-42AE-A32E-AB2CBBE6EE7E}"
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Private.ServiceModel", "..\..\..\..\src\System.Private.ServiceModel.csproj", "{9E50E7BF-CD6E-4269-A6DD-59FD0BD6C0FD}"
 EndProject
 Global


### PR DESCRIPTION
* Updated sln with a ref to common.infrastructure to fix intellisense in VS.
* Removed StringBuilder wherever used and replaced with xunit Asserts.
* Added setup/execute/validate/cleanup comments.
* Instantiated most variables at the top of the test case and set to appropriate values in the setup section.