### PR TITLE
Adding message for AsyncResultCompletedTwice error

### DIFF
--- a/src/System.Private.ServiceModel/src/Internals/InternalSR.cs
+++ b/src/System.Private.ServiceModel/src/Internals/InternalSR.cs
@@ -29,11 +29,11 @@ namespace System.Runtime
         internal static string ThreadNeutralSemaphoreAborted = "ThreadNeutralSemaphoreAborted";
         internal static string ValueCollectionUpdatesNotAllowed = "ValueCollectionUpdatesNotAllowed";
         internal static string ValueMustBeNonNegative = "ValueMustBeNonNegative";
+        internal static string AsyncResultCompletedTwice = "AsyncResultCompletedTwice";
 
         internal static string ArgumentNullOrEmpty(object param0) { throw ExceptionHelper.PlatformNotSupported(); }
         internal static string AsyncEventArgsCompletedTwice(object param0) { throw ExceptionHelper.PlatformNotSupported(); }
         internal static string AsyncEventArgsCompletionPending(object param0) { throw ExceptionHelper.PlatformNotSupported(); }
-        internal static string AsyncResultCompletedTwice(object param0) { throw ExceptionHelper.PlatformNotSupported(); }
         internal static string BufferAllocationFailed(object param0) { throw ExceptionHelper.PlatformNotSupported(); }
         internal static string BufferedOutputStreamQuotaExceeded(object param0) { throw ExceptionHelper.PlatformNotSupported(); }
         internal static string CannotConvertObject(object param0, object param1) { throw ExceptionHelper.PlatformNotSupported(); }

--- a/src/System.Private.ServiceModel/src/Internals/System/Runtime/AsyncResult.cs
+++ b/src/System.Private.ServiceModel/src/Internals/System/Runtime/AsyncResult.cs
@@ -114,7 +114,7 @@ namespace System.Runtime
         {
             if (_isCompleted)
             {
-                throw Fx.Exception.AsError(new InvalidOperationException(InternalSR.AsyncResultCompletedTwice(GetType())));
+                throw Fx.Exception.AsError(new InvalidOperationException(InternalSR.AsyncResultCompletedTwice));
             }
 
 

--- a/src/System.Private.ServiceModel/src/Resources/Strings.resx
+++ b/src/System.Private.ServiceModel/src/Resources/Strings.resx
@@ -2604,6 +2604,9 @@
   <data name="TimeSpanCannotBeLessThanTimeSpanZero" xml:space="preserve">
     <value>TimeSpan cannot be less than TimeSpan.Zero.</value>
   </data>
+  <data name="AsyncResultCompletedTwice" xml:space="preserve">
+    <value>AsyncResult completed twice.</value>
+  </data>
   <data name="ValueMustBeNonNegative" xml:space="preserve">
     <value>The value of this argument must be non-negative.</value>
   </data>


### PR DESCRIPTION
Adding the missing message for an exception when an async result is completed twice.