### PR TITLE
Disable the DataContractResolver test in UWP. 

### DIFF
--- a/src/System.Private.ServiceModel/tests/Scenarios/Contract/Data/DataContractTests.4.1.1.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Contract/Data/DataContractTests.4.1.1.cs
@@ -17,6 +17,7 @@ public static partial class DataContractTests
 {
     [WcfFact]
     [OuterLoop]
+    [Issue(1708, Framework = FrameworkID.NetNative)]
     public static void DataContractResolverTest()
     {
         IDataContractResolverService client = null;


### PR DESCRIPTION
This scenario currently doesn't work in UWP since the DataContractResolver doesn't work in UWP, which is a serialization bug. Filed a serialization issue https://github.com/dotnet/corefx/issues/14879

#1708 #1709 