### PR TITLE
Fix bug with sending Message with XmlElement MessageHeader

### DIFF
--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Dispatcher/OperationFormatter.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Dispatcher/OperationFormatter.cs
@@ -877,7 +877,14 @@ namespace System.ServiceModel.Dispatcher
 
             protected override void OnWriteHeaderAttributes(XmlDictionaryWriter writer, MessageVersion messageVersion)
             {
+#if NETStandard13
                 throw ExceptionHelper.PlatformNotSupported();
+#else
+                base.WriteHeaderAttributes(writer, messageVersion);
+                XmlDictionaryReader nodeReader = XmlDictionaryReader.CreateDictionaryReader(new XmlNodeReader(headerValue));
+                nodeReader.MoveToContent();
+                writer.WriteAttributes(nodeReader, false);
+#endif
             }
 
             protected override void OnWriteHeaderContents(XmlDictionaryWriter writer, MessageVersion messageVersion)

--- a/src/System.Private.ServiceModel/tests/Scenarios/Contract/Message/MessageContractTests.4.4.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Contract/Message/MessageContractTests.4.4.0.cs
@@ -82,4 +82,45 @@ public static class MessageContractTests_4_4_0
                                         i, elementName, array1[i], array2[i]));
         }
     }
+
+    [WcfFact]
+    [OuterLoop]
+    [Issue(1730, Framework = FrameworkID.NetNative)]
+    public static void Message_With_XmlElementMessageHeader_RoundTrip()
+    {
+        BasicHttpBinding binding = null;
+        IWcfService_4_4_0 clientProxy = null;
+        ChannelFactory<IWcfService_4_4_0> factory = null;
+
+        // *** SETUP *** \\
+        try
+        {
+            binding = new BasicHttpBinding();
+            factory = new ChannelFactory<IWcfService_4_4_0>(binding, new EndpointAddress(Endpoints.HttpBaseAddress_4_4_0_Basic));
+            clientProxy = factory.CreateChannel();
+
+            string testString = "test string";
+            var header = new XmlElementMessageHeader() { HeaderValue = testString };
+            var request = new XmlElementMessageHeaderRequest(header);
+
+            // *** EXECUTE *** \\
+            XmlElementMessageHeaderResponse response = clientProxy.SendRequestWithXmlElementMessageHeader(request);
+
+            // *** VALIDATE *** \\
+            Assert.True(response != null,
+                        $"Expected {nameof(response)} not to be null , but it was null");
+
+            Assert.True(String.Equals(testString, response.TestResult),
+                        $"Expected {nameof(response.TestResult)} = {testString}, actual was {response.TestResult}");
+
+            // *** CLEANUP *** \\
+            factory.Close();
+            ((ICommunicationObject)clientProxy).Close();
+        }
+        finally
+        {
+            // *** ENSURE CLEANUP *** \\
+            ScenarioTestHelpers.CloseCommunicationObjects((ICommunicationObject)clientProxy, factory);
+        }
+    }
 }

--- a/src/System.Private.ServiceModel/tests/Scenarios/Contract/Message/TestTypes.4.4.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Contract/Message/TestTypes.4.4.0.cs
@@ -9,6 +9,7 @@ using System.ServiceModel.Channels;
 using System.ServiceModel.Description;
 using System.ServiceModel.Dispatcher;
 using System.Xml;
+using System.Xml.Serialization;
 
 namespace WcfService
 {
@@ -19,6 +20,11 @@ namespace WcfService
         [OperationContract(Action = "http://tempuri.org/IWcfService_4_4_0/MessageContractRequestReply", 
                            ReplyAction = "http://tempuri.org/IWcfService_4_4_0/MessageContractRequestReplyResponse")]
         ReplyBankingData_4_4_0 MessageContractRequestReply(RequestBankingData_4_4_0 bt);
+        
+        [OperationContract(Action = "http://tempuri.org/IWcfService_4_4_0/SendRequestWithXmlElementMessageHeader", 
+                           ReplyAction = "http://tempuri.org/IWcfService_4_4_0/SendRequestWithXmlElementMessageHeaderResponse")]
+        [XmlSerializerFormat(SupportFaults = true)]
+        XmlElementMessageHeaderResponse SendRequestWithXmlElementMessageHeader(XmlElementMessageHeaderRequest request);
     }
 
     [MessageContract(IsWrapped = true,
@@ -82,5 +88,59 @@ namespace WcfService
 
         [MessageHeaderArray(Name = "ArrayMultipleElement")]
         public string[] replyArrayMultipleValues;
+    }
+    
+    [XmlType(Namespace = "http://tempuri.org/")]
+    public partial class XmlElementMessageHeader
+    {
+
+        private string _headerValue;
+
+        [XmlElement(Order = 0)]
+        public string HeaderValue
+        {
+            get
+            {
+                return _headerValue;
+            }
+            set
+            {
+                _headerValue = value;
+            }
+        }
+    }
+
+    [MessageContract(WrapperName = "SendRequestWithXmlElementMessageHeader", WrapperNamespace = "http://tempuri.org/", IsWrapped = true)]
+    public partial class XmlElementMessageHeaderRequest
+    {
+
+        [MessageHeader(Namespace = "http://tempuri.org/")]
+        public XmlElementMessageHeader TestHeader;
+
+        public XmlElementMessageHeaderRequest()
+        {
+        }
+
+        public XmlElementMessageHeaderRequest(XmlElementMessageHeader testHeader)
+        {
+            TestHeader = testHeader;
+        }
+    }
+
+    [MessageContract(WrapperName = "SendRequestWithXmlElementMessageHeaderResponse", WrapperNamespace = "http://tempuri.org/", IsWrapped = true)]
+    public partial class XmlElementMessageHeaderResponse
+    {
+
+        [MessageBodyMember(Namespace = "http://tempuri.org/", Order = 0)]
+        public string TestResult;
+
+        public XmlElementMessageHeaderResponse()
+        {
+        }
+
+        public XmlElementMessageHeaderResponse(string testResult)
+        {
+            TestResult = testResult;
+        }
     }
 }

--- a/src/System.Private.ServiceModel/tools/IISHostedWcfService/App_code/IWcfService.4.4.0.cs
+++ b/src/System.Private.ServiceModel/tools/IISHostedWcfService/App_code/IWcfService.4.4.0.cs
@@ -17,5 +17,9 @@ namespace WcfService
     {
         [OperationContract(Action = "http://tempuri.org/IWcfService_4_4_0/MessageContractRequestReply")]
         ReplyBankingData_4_4_0 MessageContractRequestReply(RequestBankingData_4_4_0 bt);
+        
+        [OperationContract(Action = "http://tempuri.org/IWcfService_4_4_0/SendRequestWithXmlElementMessageHeader")]
+        [XmlSerializerFormat(SupportFaults = true)]
+        XmlElementMessageHeaderResponse SendRequestWithXmlElementMessageHeader(XmlElementMessageHeaderRequest request);
     }
 }

--- a/src/System.Private.ServiceModel/tools/IISHostedWcfService/App_code/WcfService.4.4.0.cs
+++ b/src/System.Private.ServiceModel/tools/IISHostedWcfService/App_code/WcfService.4.4.0.cs
@@ -35,5 +35,10 @@ namespace WcfService
 
             return bankingData;
         }
+        
+        public XmlElementMessageHeaderResponse SendRequestWithXmlElementMessageHeader(XmlElementMessageHeaderRequest request)
+        {
+            return new XmlElementMessageHeaderResponse(request.TestHeader.HeaderValue);
+        }
     }
 }

--- a/src/System.Private.ServiceModel/tools/IISHostedWcfService/App_code/XmlElementMessageHeader.cs
+++ b/src/System.Private.ServiceModel/tools/IISHostedWcfService/App_code/XmlElementMessageHeader.cs
@@ -1,0 +1,65 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.ServiceModel;
+using System.ServiceModel.Channels;
+using System.Xml.Serialization;
+
+namespace WcfService
+{    
+    [XmlType(Namespace = "http://tempuri.org/")]
+    public partial class XmlElementMessageHeader
+    {
+
+        private string _headerValue;
+
+        [XmlElement(Order = 0)]
+        public string HeaderValue
+        {
+            get
+            {
+                return _headerValue;
+            }
+            set
+            {
+                _headerValue = value;
+            }
+        }
+    }
+
+    [MessageContract(WrapperName = "SendRequestWithXmlElementMessageHeader", WrapperNamespace = "http://tempuri.org/", IsWrapped = true)]
+    public partial class XmlElementMessageHeaderRequest
+    {
+
+        [MessageHeader(Namespace = "http://tempuri.org/")]
+        public XmlElementMessageHeader TestHeader;
+
+        public XmlElementMessageHeaderRequest()
+        {
+        }
+
+        public XmlElementMessageHeaderRequest(XmlElementMessageHeader testHeader)
+        {
+            TestHeader = testHeader;
+        }
+    }
+
+    [MessageContract(WrapperName = "SendRequestWithXmlElementMessageHeaderResponse", WrapperNamespace = "http://tempuri.org/", IsWrapped = true)]
+    public partial class XmlElementMessageHeaderResponse
+    {
+
+        [MessageBodyMember(Namespace = "http://tempuri.org/", Order = 0)]
+        public string TestResult;
+
+        public XmlElementMessageHeaderResponse()
+        {
+        }
+
+        public XmlElementMessageHeaderResponse(string testResult)
+        {
+            TestResult = testResult;
+        }
+    }
+}


### PR DESCRIPTION
XmlElementMessageHeader.OnWriteHeaderAttributes threw PNSE because one required API was not available on NetCore. Adding the implementation for the method as the missing API is available now.

Fix #702.