### PR TITLE
Updating infrastructure dependencies.

### DIFF
--- a/dependencies.props
+++ b/dependencies.props
@@ -11,8 +11,9 @@
     <CoreFxExpectedPrerelease>beta-24910-02</CoreFxExpectedPrerelease>
   </PropertyGroup>
 
+  <!-- Full package version strings that are used in other parts of the build. -->
   <PropertyGroup>
-    <AppXRunnerVersion>1.0.3-prerelease-00925-01</AppXRunnerVersion>
+    <AppXRunnerVersion>1.0.3-prerelease-00921-01</AppXRunnerVersion>
   </PropertyGroup>
 
   <!-- Package dependency verification/auto-upgrade configuration. -->
@@ -49,14 +50,22 @@
 
   <!-- Set up dependencies on packages that aren't found in a BuildInfo. -->
   <ItemGroup>
+    <TargetingPackDependency Include="Microsoft.TargetingPack.NETFramework.v4.5" />
+    <TargetingPackDependency Include="Microsoft.TargetingPack.NETFramework.v4.5.1" />
+    <TargetingPackDependency Include="Microsoft.TargetingPack.NETFramework.v4.5.2" />
     <TargetingPackDependency Include="Microsoft.TargetingPack.NETFramework.v4.6" />
-    <TargetingPackDependency Include="Microsoft.TargetingPack.Private.WinRT" />
+    <TargetingPackDependency Include="Microsoft.TargetingPack.NETFramework.v4.6.1" />
+    <TargetingPackDependency Include="Microsoft.TargetingPack.NETFramework.v4.6.2" />
     <StaticDependency Include="@(TargetingPackDependency)">
       <Version>1.0.1</Version>
     </StaticDependency>
 
+    <StaticDependency Include="Microsoft.TargetingPack.Private.WinRT">
+      <Version>1.0.3</Version>
+    </StaticDependency>
+
     <StaticDependency Include="Microsoft.xunit.netcore.extensions;Microsoft.DotNet.BuildTools.TestSuite">
-      <Version>1.0.0-prerelease-00925-01</Version>
+      <Version>1.0.1-prerelease-01001-04</Version>
     </StaticDependency>
 
     <StaticDependency Include="Microsoft.TargetingPack.Private.NETNative">
@@ -67,5 +76,11 @@
       <PackageId>%(Identity)</PackageId>
       <UpdateStableVersions>true</UpdateStableVersions>
     </DependencyBuildInfo>
+
+    <DependencyBuildInfo Include="uwpRunnerVersion">
+      <PackageId>microsoft.xunit.runner.uwp</PackageId>
+      <Version>$(AppXRunnerVersion)</Version>
+    </DependencyBuildInfo>
+    
   </ItemGroup>
 </Project>

--- a/src/Common/test-runtime/project.json
+++ b/src/Common/test-runtime/project.json
@@ -5,9 +5,9 @@
     "ReportGenerator": "2.4.3",
     "Microsoft.NETCore.TestHost": "1.2.0-beta-24910-02",
     "Microsoft.NETCore.Runtime.CoreCLR": "1.2.0-beta-24910-02",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00925-01",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.1-prerelease-01001-04",
     "xunit.console.netcore": "1.0.3-prerelease-00925-01",
-    "Microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00925-01",
+    "Microsoft.xunit.netcore.extensions": "1.0.1-prerelease-01001-04",
     "System.Collections.Concurrent": "4.4.0-beta-24910-02",
     "System.Console": "4.4.0-beta-24910-02",
     "System.Diagnostics.Contracts": "4.4.0-beta-24910-02",
@@ -42,7 +42,7 @@
       "dependencies": {
         "Microsoft.NETCore.UniversalWindowsPlatform": "5.2.2",
         "System.Console": "4.4.0-beta-24910-02",
-        "microsoft.xunit.runner.uwp": "1.0.3-prerelease-00925-01"
+        "microsoft.xunit.runner.uwp": "1.0.3-prerelease-00921-01"
       }
     }
   },

--- a/src/System.Private.ServiceModel/src/windows/project.json
+++ b/src/System.Private.ServiceModel/src/windows/project.json
@@ -73,7 +73,7 @@
         "System.Runtime.WindowsRuntime": "4.4.0-beta-24910-02",
         "Microsoft.TargetingPack.Private.NETNative": "1.1.0-beta-24607-01",
         "Microsoft.NETCore.Portable.Compatibility": "1.0.1",
-        "Microsoft.TargetingPack.Private.WinRT": "1.0.1"
+        "Microsoft.TargetingPack.Private.WinRT": "1.0.3"
       }
     }
   }


### PR DESCRIPTION
* Several dependent packages were out-of-date as compared to corefx.
* This may resolve some F5 infrastructure failures.