### PR TITLE
Adding ActiveIssue to ServiceRestart_Throws_CommunicationException test

### DIFF
--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/ExpectedExceptions/ExpectedExceptionTests.4.1.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/ExpectedExceptions/ExpectedExceptionTests.4.1.0.cs
@@ -52,6 +52,7 @@ public partial class ExpectedExceptionTests : ConditionalWcfTest
     }
 
     [WcfFact]
+    [Issue(1717, Framework = FrameworkID.NetNative)]
     [OuterLoop]
     public static void ServiceRestart_Throws_CommunicationException()
     {

--- a/src/System.Private.ServiceModel/tests/Scenarios/Contract/Message/MessageContractTests.4.4.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Contract/Message/MessageContractTests.4.4.0.cs
@@ -11,6 +11,7 @@ using Xunit;
 public static class MessageContractTests_4_4_0
 {
     [WcfFact]
+    [Issue(1745, Framework = FrameworkID.NetNative)]
     [OuterLoop]
     public static void Message_With_MessageHeaders_RoundTrips()
     {


### PR DESCRIPTION
* This test failure is due to an underlying problem in WinRTHttpClient behavior.
* Until that gets fixed we can skip this test on netnative runs.
* Amended this commit to also add an ActiveIssue for test case 'Message_With_MessageHeaders_RoundTrips'.