### PR TITLE
Updating stress tests with the latest version.

### DIFF
--- a/src/System.Private.ServiceModel/tests/Stress/SharedPoolsOfWCFObjects/PoolOfThings.cs
+++ b/src/System.Private.ServiceModel/tests/Stress/SharedPoolsOfWCFObjects/PoolOfThings.cs
@@ -316,7 +316,9 @@ namespace SharedPoolsOfWCFObjects
             }
             if (instance != null && !_instanceValidator(instance))
             {
-                TestUtils.ReportFailure("returning bad instance", debugBreak: true);
+                // This is really not a failure because the same instance may be obtained by multiple threads
+                // so the validation will fail if one of these threads closes it before others had a chance to validate
+                TestUtils.ReportFailure("returning bad instance", debugBreak: false);
             }
             return instance;
         }

--- a/src/System.Private.ServiceModel/tests/Stress/SharedPoolsOfWCFObjects/Program.cs
+++ b/src/System.Private.ServiceModel/tests/Stress/SharedPoolsOfWCFObjects/Program.cs
@@ -47,6 +47,11 @@ namespace SharedPoolsOfWCFObjects
         public const string StressRunName = "stressrunname";
         public const string RecycleFrequencyThrottle = "recyclefrequencythrottle";
         public const string StressIterations = "stressiterations";
+        public const string OpenTimeoutMSecs = "opentimeoutmsecs";
+        public const string CloseTimeoutMSecs = "closetimeoutmsecs";
+        public const string ReceiveTimeoutMSecs = "receivetimeoutmsecs";
+        public const string SendTimeoutMSecs = "sendtimeoutmsecs";
+        public const string CustomConnectionPoolSize = "customconnectionpoolsize";
 
         public const string BindingSecurityMode = "bindingsecuritymode";
         public const string HttpClientCredentialType = "httpclientcredentialtype";
@@ -85,6 +90,11 @@ namespace SharedPoolsOfWCFObjects
         private int _paramRecycleFrequencyThrottle = 5000;
         private long _recycleThrottle = 0;
         private long _paramStressIterations = DefaultStressIterations;
+        private int _paramOpenTimeoutMSecs = 0;
+        private int _paramCloseTimeoutMSecs = 0;
+        private int _paramReceiveTimeoutMSecs = 0;
+        private int _paramSendTimeoutMSecs = 0;
+        private int _customConnectionPoolSize = -1;
 
         // Right now this is just a boolean switch to allow more tracing
         private bool _paramDebugMode = false;
@@ -175,8 +185,9 @@ namespace SharedPoolsOfWCFObjects
                 "[HostName:servername] [AppName:serverappname] [Program2Run:Stress|Perf] [Async:true|false] \r\n" +
                 "[Binding:Http|Https|NetTcp|NetHttpBinding] [Test:HelloWorld|Streaming|Duplex|DuplexStreaming] \r\n" +
                 "[SelfHostedPortStartNumber:port#] [SelfHostedPorts:#ports] [DebugMode:false|true] [ReportingUrl:reportingUrl]\r\n" +
+                "[(Open/Close/Receive/Send)TimeoutMSecs:milliseconds] [CustomConnectionPoolSize:size] \r\n" +
                 "    Stress parameters:\r\n" +
-                "[StressRunDuration:minutes] [StressLevel:#threads] \r\n" +
+                "[StressRunDuration:minutes] [StressLevel:#threads] [RecycleFrequencyThrottle:#requests]\r\n" +
                 "    Perf parameters: \r\n" +
                 "[PoolFactoriesForPerfStartup:false|true] [PerfMaxStartupTasks:#tasks] [PerfStartupIterations:#iterations] \r\n" +
                 "[PerfMaxThroughputTasks:#tasks] [PerfThroughputTaskStep:#tasks] [UseSeparateTaskForEachChannel:false|true] \r\n" +
@@ -376,6 +387,36 @@ namespace SharedPoolsOfWCFObjects
                             return ReportWrongArgument(s);
                         }
                         break;
+                    case Parameters.OpenTimeoutMSecs:
+                        if (!Int32.TryParse(p[1], out _paramOpenTimeoutMSecs))
+                        {
+                            return ReportWrongArgument(s);
+                        }
+                        break;
+                    case Parameters.CloseTimeoutMSecs:
+                        if (!Int32.TryParse(p[1], out _paramCloseTimeoutMSecs))
+                        {
+                            return ReportWrongArgument(s);
+                        }
+                        break;
+                    case Parameters.ReceiveTimeoutMSecs:
+                        if (!Int32.TryParse(p[1], out _paramReceiveTimeoutMSecs))
+                        {
+                            return ReportWrongArgument(s);
+                        }
+                        break;
+                    case Parameters.SendTimeoutMSecs:
+                        if (!Int32.TryParse(p[1], out _paramSendTimeoutMSecs))
+                        {
+                            return ReportWrongArgument(s);
+                        }
+                        break;
+                    case Parameters.CustomConnectionPoolSize:
+                        if (!Int32.TryParse(p[1], out _customConnectionPoolSize))
+                        {
+                            return ReportWrongArgument(s);
+                        }
+                        break;
                     case Parameters.ReportingUrl:
                         _paramReportingUrl = p[1];
                         break;
@@ -413,6 +454,11 @@ namespace SharedPoolsOfWCFObjects
                 clientCertThumbprint: _paramClientCertThumbprint,
                 clientCertStoreName: _paramCertStoreName,
                 clientCertStoreLocation: _paramCertStoreLocation,
+                openTimeoutMSecs: _paramOpenTimeoutMSecs,
+                closeTimeoutMSecs: _paramCloseTimeoutMSecs,
+                receiveTimeoutMSecs: _paramReceiveTimeoutMSecs,
+                sendTimeoutMSecs: _paramSendTimeoutMSecs,
+                customConnectionPoolSize: _customConnectionPoolSize,
                 debugMode: _paramDebugMode);
 
             // Rather than passing additional parameters to the test via generic types we use a static method

--- a/src/System.Private.ServiceModel/tests/Stress/SharedPoolsOfWCFObjects/RunReportingService.cs
+++ b/src/System.Private.ServiceModel/tests/Stress/SharedPoolsOfWCFObjects/RunReportingService.cs
@@ -179,6 +179,10 @@ namespace SharedPoolsOfWCFObjects
                     Console.WriteLine("Reporting unavailable. Error: " + e.ToString());
                     return null;
                 }
+                finally
+                {
+                    Console.WriteLine("done");
+                }
             }
         }
     }

--- a/src/System.Private.ServiceModel/tests/Stress/SharedPoolsOfWCFObjects/SharedPoolsOfWCFObjects.cs
+++ b/src/System.Private.ServiceModel/tests/Stress/SharedPoolsOfWCFObjects/SharedPoolsOfWCFObjects.cs
@@ -28,6 +28,8 @@ namespace SharedPoolsOfWCFObjects
         static CreateAndCloseFactoryAndChannelFullCycleTest()
         {
             s_test = new TestTemplate();
+            // we do not expect exceptions here since we're not closing anything during usage
+            (s_test as IExceptionPolicy).RelaxedExceptionPolicy = false;
         }
 
         // A full cycle of creating a pool of channel factories, using each factory to create
@@ -72,6 +74,8 @@ namespace SharedPoolsOfWCFObjects
         static CreateAndCloseFactoryAndChannelFullCycleTestAsync()
         {
             s_test = new TestTemplate();
+            // we do not expect exceptions here since we're not closing anything during usage
+            (s_test as IExceptionPolicy).RelaxedExceptionPolicy = false;
         }
         public static async Task<int> CreateFactoriesAndChannelsUseAllOnceCloseAllAsync()
         {
@@ -126,6 +130,8 @@ namespace SharedPoolsOfWCFObjects
         static PooledFactories()
         {
             s_test = new TestTemplate();
+            // we do not expect exceptions here since we're not closing anything during usage
+            (s_test as IExceptionPolicy).RelaxedExceptionPolicy = false;
             s_pooledChannelFactories = StaticDisposablesHelper.AddDisposable(
                 new PoolOfThings<ChannelFactory<ChannelType>>(
                     maxSize: s_test.TestParameters.MaxPooledFactories,
@@ -160,6 +166,8 @@ namespace SharedPoolsOfWCFObjects
         static PooledFactoriesAsync()
         {
             s_test = new TestTemplate();
+            // we do not expect exceptions here since we're not closing anything during usage
+            (s_test as IExceptionPolicy).RelaxedExceptionPolicy = false;
             s_pooledChannelFactories = StaticDisposablesHelper.AddDisposable(
                 new PoolOfAsyncThings<ChannelFactory<ChannelType>>(
                     maxSize: s_test.TestParameters.MaxPooledFactories,
@@ -206,6 +214,8 @@ namespace SharedPoolsOfWCFObjects
         static PooledFactoriesAndChannels()
         {
             s_test = new TestTemplate();
+            // we do not expect exceptions here since we're not closing anything during usage
+            (s_test as IExceptionPolicy).RelaxedExceptionPolicy = false;
             s_pooledFactoriesAndChannels = StaticDisposablesHelper.AddDisposable(
                 new PoolOfThings<FactoryAndPoolOfItsObjects<ChannelFactory<ChannelType>, ChannelType>>(
                     maxSize: s_test.TestParameters.MaxPooledFactories, // # of pooled FactoryAndPoolOfItsObjects
@@ -268,6 +278,8 @@ namespace SharedPoolsOfWCFObjects
         static PooledFactoriesAndChannelsAsync()
         {
             s_test = new TestTemplate();
+            // we do not expect exceptions here since we're not closing anything during usage
+            (s_test as IExceptionPolicy).RelaxedExceptionPolicy = false;
             s_pooledFactoriesAndChannels = StaticDisposablesHelper.AddDisposable(
                 new PoolOfAsyncThings<FactoryAndPoolOfItsAsyncObjects<ChannelFactory<ChannelType>, ChannelType>>(
                     maxSize: s_test.TestParameters.MaxPooledFactories, // # of pooled FactoryAndPoolOfItsObjects

--- a/src/System.Private.ServiceModel/tests/Stress/readme.md
+++ b/src/System.Private.ServiceModel/tests/Stress/readme.md
@@ -14,8 +14,9 @@ The only purpose of SharedPoolsOfWCFObjectsServer is to provide the correspondin
 1.	Follow links on https://www.microsoft.com/net/download/core#/current to install the latest released .NET Core SDK.
 2.	Make a local clone of WCF repo
 3.	Go to src\System.Private.ServiceModel\tests\Stress\SharedPoolsOfWCFObjects
-4.	Run “dotnet build”
-5.	You may want to run “dotnet publish” to be able to run this app on other machines without installing the core framework. Follow the “dotnet help publish” guidelines to target the desired options. Typically I’d run something like 
+4.	Run “dotnet restore” (before running this you may want to edit the project file to target a different version)
+5.	Run “dotnet build”
+6.	You may want to run “dotnet publish” to be able to run this app on other machines without installing the core framework. Follow the “dotnet help publish” guidelines to target the desired options. Typically I’d run something like 
 ~~~
 dotnet publish -o MyPublishedAppFolder -r win7-x64
 ~~~


### PR DESCRIPTION
The changes include:
- adding parameters to control timeouts
- adding a parameter to control channel pool size
- fixing error handling
- adding a missing instruction to readme