### PR TITLE
Resource string cleanup

### DIFF
--- a/src/System.Private.ServiceModel/src/Resources/Strings.resx
+++ b/src/System.Private.ServiceModel/src/Resources/Strings.resx
@@ -126,101 +126,14 @@
   <data name="RequiredAttributeMissing" xml:space="preserve">
     <value>Attribute '{0}' is required on element '{1}'.</value>
   </data>
-  <data name="UnsupportedCryptoAlgorithm" xml:space="preserve">
-    <value>Crypto algorithm {0} not supported in this context.</value>
-  </data>
-  <data name="CustomCryptoAlgorithmIsNotValidHashAlgorithm" xml:space="preserve">
-    <value>The custom crypto algorithm '{0}' obtained using CryptoConfig is not a valid or supported hash algorithm.</value>
-  </data>
-  <data name="InvalidClientCredentials" xml:space="preserve">
-    <value>The client credential entered was invalid.</value>
-  </data>
-  <data name="SspiErrorOrInvalidClientCredentials" xml:space="preserve">
-    <value>Either the client credential was invalid or there was an error collecting the client credentials by the SSPI.</value>
-  </data>
-  <data name="CustomCryptoAlgorithmIsNotValidAsymmetricSignature" xml:space="preserve">
-    <value>The custom crypto algorithm '{0}' obtained using CryptoConfig is not a valid or supported asymmetric signature algorithm.</value>
-  </data>
-  <data name="TokenSerializerNotSetonFederationProvider" xml:space="preserve">
-    <value>The security token serializer must be specified on the security token provider.</value>
-  </data>
-  <data name="IssuerBindingNotPresentInTokenRequirement" xml:space="preserve">
-    <value>The key length '{0}' is not a multiple of 8 for symmetric keys.</value>
-  </data>
-  <data name="IssuerChannelBehaviorsCannotContainSecurityCredentialsManager" xml:space="preserve">
-    <value>The channel behaviors configured for the issuer address '{0}' cannot contain a behavior of type '{1}'.</value>
-  </data>
-  <data name="ServiceBusyCountTrace" xml:space="preserve">
-    <value>Operation Action={0}</value>
-  </data>
   <data name="SecurityTokenManagerCannotCreateProviderForRequirement" xml:space="preserve">
     <value>The security token manager cannot create a token provider for requirement '{0}'.</value>
   </data>
   <data name="SecurityTokenManagerCannotCreateAuthenticatorForRequirement" xml:space="preserve">
     <value>The security token manager cannot create a token authenticator for requirement '{0}'.</value>
   </data>
-  <data name="FailedSignatureVerification" xml:space="preserve">
-    <value>The signature verification failed. Please see inner exception for fault details.</value>
-  </data>
-  <data name="SecurityTokenManagerCannotCreateSerializerForVersion" xml:space="preserve">
-    <value>The security token manager cannot create a token serializer for security token version '{0}'.</value>
-  </data>
-  <data name="SupportingSignatureIsNotDerivedFrom" xml:space="preserve">
-    <value>The supporting signature is not signed with a derived key. The binding's supporting token parameter '{0}' requires key derivation.</value>
-  </data>
-  <data name="PrimarySignatureWasNotSignedByDerivedKey" xml:space="preserve">
-    <value>The primary signature is not signed with a derived key. The binding's primary token parameter '{0}' requires key derivation.</value>
-  </data>
-  <data name="PrimarySignatureWasNotSignedByDerivedWrappedKey" xml:space="preserve">
-    <value>The primary signature is not signed with a key derived from the encrypted key. The binding's token parameter '{0}' requires key derivation.</value>
-  </data>
-  <data name="MessageWasNotEncryptedByDerivedWrappedKey" xml:space="preserve">
-    <value>The message is not encrypted with a key derived from the encrypted key. The binding's token parameter '{0}' requires key derivation.</value>
-  </data>
-  <data name="SecurityStateEncoderDecodingFailure" xml:space="preserve">
-    <value>The DataProtectionSecurityStateEncoder is unable to decode the byte array. Ensure that a 'UserProfile' is loaded, if this is a 'web farm scenario' ensure all servers are running as the same user with the roaming profiles or provide a custom SecurityStateEncoder'.</value>
-  </data>
-  <data name="SecurityStateEncoderEncodingFailure" xml:space="preserve">
-    <value>The DataProtectionSecurityStateEncoder is unable to encode the byte array. Ensure that a 'UserProfile' is loaded, if this is a 'web farm scenario' ensure all servers are running as the same user with the roaming profiles or provide a custom SecurityStateEncoder'.</value>
-  </data>
-  <data name="MessageWasNotEncryptedByDerivedEncryptionToken" xml:space="preserve">
-    <value>The message is not encrypted with a key derived from the encryption token. The binding's token parameter '{0}' requires key derivation.</value>
-  </data>
-  <data name="TokenAuthenticatorRequiresSecurityBindingElement" xml:space="preserve">
-    <value>The security token manager requires the security binding element to be specified in order to create a token authenticator for requirement '{0}'.</value>
-  </data>
-  <data name="TokenProviderRequiresSecurityBindingElement" xml:space="preserve">
-    <value>The security token manager requires the security binding element to be specified in order to create a token provider for requirement '{0}'.</value>
-  </data>
-  <data name="UnexpectedSecuritySessionCloseResponse" xml:space="preserve">
-    <value>The security session received an unexpected close response from the other party.</value>
-  </data>
-  <data name="UnexpectedSecuritySessionClose" xml:space="preserve">
-    <value>The security session received an unexpected close from the other party.</value>
-  </data>
-  <data name="CannotObtainSslConnectionInfo" xml:space="preserve">
-    <value>The service was unable to verify the cipher strengths negotiated as part of the SSL handshake.</value>
-  </data>
-  <data name="HeaderEncryptionNotSupportedInWsSecurityJan2004" xml:space="preserve">
-    <value>SecurityVersion.WSSecurityJan2004 does not support header encryption. Header with name '{0}' and namespace '{1}' is configured for encryption. Consider using SecurityVersion.WsSecurity11 and above or use transport security to encrypt the full message.</value>
-  </data>
-  <data name="EncryptedHeaderNotSigned" xml:space="preserve">
-    <value>The Header ('{0}', '{1}') was encrypted but not signed. All encrypted headers outside the security header should be signed.</value>
-  </data>
   <data name="EncodingBindingElementDoesNotHandleReaderQuotas" xml:space="preserve">
     <value>Unable to obtain XmlDictionaryReaderQuotas from the Binding. If you have specified a custom EncodingBindingElement, verify that the EncodingBindingElement can handle XmlDictionaryReaderQuotas in its GetProperty&lt;T&gt;() method.</value>
-  </data>
-  <data name="HeaderDecryptionNotSupportedInWsSecurityJan2004" xml:space="preserve">
-    <value>SecurityVersion.WSSecurityJan2004 does not support header decryption. Use SecurityVersion.WsSecurity11 and above or use transport security to encrypt the full message.</value>
-  </data>
-  <data name="DecryptionFailed" xml:space="preserve">
-    <value>Unable to decrypt an encrypted data block. Please verify that the encryption algorithm and keys used by the sender and receiver match.</value>
-  </data>
-  <data name="AuthenticationManagerShouldNotReturnNull" xml:space="preserve">
-    <value>The authenticate method in the ServiceAuthenticationManager returned null. If you do not want to return any authorization policies in the collection then return an empty ReadOnlyCollection instead. </value>
-  </data>
-  <data name="ErrorSerializingSecurityToken" xml:space="preserve">
-    <value>There was an error serializing the security token. Please see the inner exception for more details.</value>
   </data>
   <data name="ErrorDeserializingKeyIdentifierClauseFromTokenXml" xml:space="preserve">
     <value>There was an error creating the security key identifier clause from the security token XML. Please see the inner exception for more details.</value>
@@ -234,98 +147,8 @@
   <data name="DerivedKeyNotInitialized" xml:space="preserve">
     <value>The derived key has not been computed for the security token.</value>
   </data>
-  <data name="IssuedKeySizeNotCompatibleWithAlgorithmSuite" xml:space="preserve">
-    <value>The binding ('{0}', '{1}') has been configured with a security algorithm suite '{2}' that is incompatible with the issued token key size '{3}' specified on the binding.</value>
-  </data>
-  <data name="IssuedTokenAuthenticationModeRequiresSymmetricIssuedKey" xml:space="preserve">
-    <value>The IssuedToken security authentication mode requires the issued token to contain a symmetric key.</value>
-  </data>
-  <data name="InvalidBearerKeyUsage" xml:space="preserve">
-    <value>The binding ('{0}', '{1}') uses an Issued Token with Bearer Key Type in a invalid context. The Issued Token with a Bearer Key Type can only be used as a Signed Supporting token or a Signed Encrypted Supporting token. See the SecurityBindingElement.EndpointSupportingTokenParameters property.</value>
-  </data>
-  <data name="MultipleIssuerEndpointsFound" xml:space="preserve">
-    <value>Policy for multiple issuer endpoints was retrieved from '{0}' but the relying party's policy does not specify which issuer endpoint to use. One of the endpoints was selected as the issuer endpoint to use. If you are using svcutil, the other endpoints will be available in commented form in the configuration as &lt;alternativeIssuedTokenParameters&gt;. Check the configuration to ensure that the right issuer endpoint was selected.</value>
-  </data>
-  <data name="MultipleAuthenticationManagersInServiceBindingParameters" xml:space="preserve">
-    <value>The AuthenticationManager cannot be added to the binding parameters because the binding parameters already contains a AuthenticationManager '{0}'. If you are configuring a custom AuthenticationManager for the service, please first remove any existing AuthenticationManagers from the behaviors collection before adding the custom AuthenticationManager.</value>
-  </data>
-  <data name="MultipleAuthenticationSchemesInServiceBindingParameters" xml:space="preserve">
-    <value>The AuthenticationSchemes cannot be added to the binding parameters because the binding parameters already contains AuthenticationSchemes '{0}'. If you are configuring custom AuthenticationSchemes for the service, please first remove any existing AuthenticationSchemes from the behaviors collection before adding custom AuthenticationSchemes.</value>
-  </data>
-  <data name="NoSecurityBindingElementFound" xml:space="preserve">
-    <value>Unable to find a SecurityBindingElement.</value>
-  </data>
-  <data name="MultipleSecurityCredentialsManagersInServiceBindingParameters" xml:space="preserve">
-    <value>The ServiceCredentials cannot be added to the binding parameters because the binding parameters already contains a SecurityCredentialsManager '{0}'. If you are configuring custom credentials for the service, please first remove any existing ServiceCredentials from the behaviors collection before adding the custom credential.</value>
-  </data>
   <data name="MultipleSecurityCredentialsManagersInChannelBindingParameters" xml:space="preserve">
     <value>The ClientCredentials cannot be added to the binding parameters because the binding parameters already contains a SecurityCredentialsManager '{0}'. If you are configuring custom credentials for the channel, please first remove any existing ClientCredentials from the behaviors collection before adding the custom credential.</value>
-  </data>
-  <data name="NoClientCertificate" xml:space="preserve">
-    <value>The binding ('{0}', '{1}') has been configured with a MutualCertificateDuplexBindingElement that requires a client certificate. The client certificate is currently missing.</value>
-  </data>
-  <data name="SecurityTokenParametersHasIncompatibleInclusionMode" xml:space="preserve">
-    <value>The binding ('{0}', '{1}') is configured with a security token parameter '{2}' that has an incompatible security token inclusion mode '{3}'. Specify an alternate security token inclusion mode (for example, '{4}').</value>
-  </data>
-  <data name="CannotCreateTwoWayListenerForNegotiation" xml:space="preserve">
-    <value>Unable to create a bi-directional (request-reply or duplex) channel for security negotiation. Please ensure that the binding is capable of creating a bi-directional channel.</value>
-  </data>
-  <data name="NegotiationQuotasExceededFaultReason" xml:space="preserve">
-    <value>There are too many active security negotiations or secure conversations at the service. Please retry later.</value>
-  </data>
-  <data name="PendingSessionsExceededFaultReason" xml:space="preserve">
-    <value>There are too many pending secure conversations on the server. Please retry later.</value>
-  </data>
-  <data name="RequestSecurityTokenDoesNotMatchEndpointFilters" xml:space="preserve">
-    <value>The RequestSecurityToken message does not match the endpoint filters the service '{0}' is expecting incoming messages to match. This may be because the RequestSecurityToken was intended to be sent to a different service.</value>
-  </data>
-  <data name="SecuritySessionRequiresIssuanceAuthenticator" xml:space="preserve">
-    <value>The security session requires a security token authenticator that implements '{0}'. '{1}' does not implement '{0}'.</value>
-  </data>
-  <data name="SecuritySessionRequiresSecurityContextTokenCache" xml:space="preserve">
-    <value>The security session requires a security token resolver that implements '{1}'. The security token resolver '{0}' does not implement '{1}'.</value>
-  </data>
-  <data name="SessionTokenIsNotSecurityContextToken" xml:space="preserve">
-    <value>The session security token authenticator returned a token of type '{0}'. The token type expected is '{1}'.</value>
-  </data>
-  <data name="SessionTokenIsNotGenericXmlToken" xml:space="preserve">
-    <value>The session security token provider returned a token of type '{0}'. The token type expected is '{1}'.</value>
-  </data>
-  <data name="SecurityStandardsManagerNotSet" xml:space="preserve">
-    <value>The security standards manager was not specified on  '{0}'.</value>
-  </data>
-  <data name="SecurityNegotiationMessageTooLarge" xml:space="preserve">
-    <value>The security negotiation message with action '{0}' is larger than the maximum allowed buffer size '{1}'. If you are using a streamed transport consider increasing the maximum buffer size on the transport.</value>
-  </data>
-  <data name="PreviousChannelDemuxerOpenFailed" xml:space="preserve">
-    <value>The channel demuxer Open failed previously with exception '{0}'.</value>
-  </data>
-  <data name="SecurityChannelListenerNotSet" xml:space="preserve">
-    <value>The security channel listener was not specified on  '{0}'.</value>
-  </data>
-  <data name="SecurityChannelListenerChannelExtendedProtectionNotSupported" xml:space="preserve">
-    <value>ExtendedProtectionPolicy specified a PolicyEnforcement of 'Always' which is not supported for the authentication mode requested.  This prevents the ExtendedProtectionPolicy from being enforced. For StandardBindings use a SecurityMode of TransportWithMessageCredential and a ClientCredential type of Windows. For CustomBindings use SspiNegotiationOverTransport or KerberosOverTransport.  Alternatively, specify a PolicyEnforcement of 'Never'.</value>
-  </data>
-  <data name="SecurityChannelBindingMissing" xml:space="preserve">
-    <value>ExtendedProtectionPolicy specified a PolicyEnforcement of 'Always' and a ChannelBinding was not found.  This prevents the ExtendedProtectionPolicy from being enforced. Change the binding to make a ChannelBinding available, for StandardBindings use a SecurityMode of TransportWithMessageCredential and a ClientCredential type of Windows. For CustomBindings use SspiNegotiationOverTransport or KerberosOverTransport.  Alternatively, specify a PolicyEnforcement of 'Never'.</value>
-  </data>
-  <data name="SecuritySettingsLifetimeManagerNotSet" xml:space="preserve">
-    <value>The security settings lifetime manager was not specified on  '{0}'.</value>
-  </data>
-  <data name="SecurityListenerClosing" xml:space="preserve">
-    <value>The listener is not accepting new secure conversations because it is closing.</value>
-  </data>
-  <data name="SecurityListenerClosingFaultReason" xml:space="preserve">
-    <value>The server is not accepting new secure conversations currently because it is closing. Please retry later.</value>
-  </data>
-  <data name="SslCipherKeyTooSmall" xml:space="preserve">
-    <value>The cipher key negotiated by SSL is too small ('{0}' bits). Keys of such lengths are not allowed as they may result in information disclosure. Please configure the initiator machine to negotiate SSL cipher keys that are '{1}' bits or longer.</value>
-  </data>
-  <data name="DerivedKeyTokenNonceTooLong" xml:space="preserve">
-    <value>The length ('{0}' bytes) of the derived key's Nonce exceeds the maximum length ('{1}' bytes) allowed.</value>
-  </data>
-  <data name="DerivedKeyTokenLabelTooLong" xml:space="preserve">
-    <value>The length ('{0}' bytes) of the derived key's Label exceeds the maximum length ('{1}' bytes) allowed.</value>
   </data>
   <data name="DerivedKeyTokenOffsetTooHigh" xml:space="preserve">
     <value>The derived key's Offset ('{0}' bytes) exceeds the maximum offset ('{1}' bytes) allowed.</value>
@@ -333,197 +156,20 @@
   <data name="DerivedKeyTokenGenerationAndLengthTooHigh" xml:space="preserve">
     <value>The derived key's generation ('{0}') and length ('{1}' bytes) result in a key derivation offset that is greater than the maximum offset ('{2}' bytes) allowed.</value>
   </data>
-  <data name="DerivedKeyLimitExceeded" xml:space="preserve">
-    <value>The number of derived keys in the message has exceeded the maximum allowed number '{0}'.</value>
-  </data>
-  <data name="WrappedKeyLimitExceeded" xml:space="preserve">
-    <value>The number of encrypted keys in the message has exceeded the maximum allowed number '{0}'.</value>
-  </data>
-  <data name="BufferQuotaExceededReadingBase64" xml:space="preserve">
-    <value>Unable to finish reading Base64 data as the given buffer quota has been exceeded. Buffer quota: {0}. Consider increasing the MaxReceivedMessageSize quota on the TransportBindingElement. Please note that a very high value for MaxReceivedMessageSize will result in buffering a large message and might open the system to DOS attacks.</value>
-  </data>
-  <data name="MessageSecurityDoesNotWorkWithManualAddressing" xml:space="preserve">
-    <value>Manual addressing is not supported with message level security. Configure the binding ('{0}', '{1}') to use transport security or to not do manual addressing.</value>
-  </data>
-  <data name="TargetAddressIsNotSet" xml:space="preserve">
-    <value>The target service address was not specified on '{0}'.</value>
-  </data>
-  <data name="IssuedTokenCacheNotSet" xml:space="preserve">
-    <value>The issued token cache was not specified on '{0}'.</value>
-  </data>
-  <data name="SecurityAlgorithmSuiteNotSet" xml:space="preserve">
-    <value>The security algorithm suite was not specified on '{0}'.</value>
-  </data>
-  <data name="SecurityTokenFoundOutsideSecurityHeader" xml:space="preserve">
-    <value>A security token ('{0}', '{1}') was found outside the security header. The message may have been altered in transit.</value>
-  </data>
-  <data name="SecurityTokenNotResolved" xml:space="preserve">
-    <value>The SecurityTokenProvider '{0}' could not resolve the token.</value>
-  </data>
-  <data name="SecureConversationCancelNotAllowedFaultReason" xml:space="preserve">
-    <value>A secure conversation cancellation is not allowed by the binding.</value>
-  </data>
-  <data name="BootstrapSecurityBindingElementNotSet" xml:space="preserve">
-    <value>The security binding element for bootstrap security was not specified on '{0}'.</value>
-  </data>
-  <data name="IssuerBuildContextNotSet" xml:space="preserve">
-    <value>The context for building the issuer channel was  not specified on '{0}'.</value>
-  </data>
-  <data name="StsBindingNotSet" xml:space="preserve">
-    <value>The binding to use to communicate to the federation service at '{0}' is not specified.</value>
-  </data>
-  <data name="SslCertMayNotDoKeyExchange" xml:space="preserve">
-    <value>It is likely that certificate '{0}' may not have a private key that is capable of key exchange or the process may not have access rights for the private key. Please see inner exception for detail.</value>
-  </data>
-  <data name="SslCertMustHavePrivateKey" xml:space="preserve">
-    <value>The certificate '{0}' must have a private key. The process must have access rights for the private key.</value>
-  </data>
-  <data name="NoOutgoingEndpointAddressAvailableForDoingIdentityCheck" xml:space="preserve">
-    <value>No outgoing EndpointAddress is available to check the identity on a message to be sent.</value>
-  </data>
-  <data name="NoOutgoingEndpointAddressAvailableForDoingIdentityCheckOnReply" xml:space="preserve">
-    <value>No outgoing EndpointAddress is available to check the identity on a received reply.</value>
-  </data>
-  <data name="NoSigningTokenAvailableToDoIncomingIdentityCheck" xml:space="preserve">
-    <value>No signing token is available to do an incoming identity check.</value>
-  </data>
   <data name="Psha1KeyLengthInvalid" xml:space="preserve">
     <value>The PSHA1 key length '{0}' is invalid.</value>
   </data>
   <data name="CloneNotImplementedCorrectly" xml:space="preserve">
     <value>Clone() was not implemented properly by '{0}'. The cloned object was '{1}'.</value>
   </data>
-  <data name="BadIssuedTokenType" xml:space="preserve">
-    <value>The issued token is of unexpected type '{0}'. Expected token type '{1}'.</value>
-  </data>
-  <data name="OperationDoesNotAllowImpersonation" xml:space="preserve">
-    <value>The service operation '{0}' that belongs to the contract with the '{1}' name and the '{2}' namespace does not allow impersonation.</value>
-  </data>
-  <data name="RstrHasMultipleIssuedTokens" xml:space="preserve">
-    <value>The RequestSecurityTokenResponse has multiple RequestedSecurityToken elements.</value>
-  </data>
-  <data name="RstrHasMultipleProofTokens" xml:space="preserve">
-    <value>The RequestSecurityTokenResponse has multiple RequestedProofToken elements.</value>
-  </data>
-  <data name="ProofTokenXmlUnexpectedInRstr" xml:space="preserve">
-    <value>The proof token XML element is not expected in the response.</value>
-  </data>
-  <data name="InvalidKeyLengthRequested" xml:space="preserve">
-    <value>The key length '{0}' requested is invalid.</value>
-  </data>
-  <data name="IssuedSecurityTokenParametersNotSet" xml:space="preserve">
-    <value>The security token parameters to use for the issued token are not set on '{0}'.</value>
-  </data>
-  <data name="InvalidOrUnrecognizedAction" xml:space="preserve">
-    <value>The message could not be processed because the action '{0}' is invalid or unrecognized.</value>
-  </data>
-  <data name="UnsupportedTokenInclusionMode" xml:space="preserve">
-    <value>Token inclusion mode '{0}' is not supported.</value>
-  </data>
-  <data name="CannotImportProtectionLevelForContract" xml:space="preserve">
-    <value>The policy to import a process cannot import a binding for contract ({0},{1}). The protection requirements for the binding are not compatible with a binding already imported for the contract. You must reconfigure the binding.</value>
-  </data>
-  <data name="OnlyOneOfEncryptedKeyOrSymmetricBindingCanBeSelected" xml:space="preserve">
-    <value>The symmetric security protocol can either be configured with a symmetric token provider and a symmetric token authenticator or an asymmetric token provider. It cannot be configured with both.</value>
-  </data>
-  <data name="ClientCredentialTypeMustBeSpecifiedForMixedMode" xml:space="preserve">
-    <value>ClientCredentialType.None is not valid for the TransportWithMessageCredential security mode. Specify a message credential type or use a different security mode.</value>
-  </data>
-  <data name="SecuritySessionIdAlreadyPresentInFilterTable" xml:space="preserve">
-    <value>The security session id '{0}' is already present in the filter table.</value>
-  </data>
-  <data name="SupportingTokenNotProvided" xml:space="preserve">
-    <value>A supporting token that satisfies parameters '{0}' and attachment mode '{1}' was not provided.</value>
-  </data>
-  <data name="SupportingTokenIsNotEndorsing" xml:space="preserve">
-    <value>The supporting token provided for parameters '{0}' did not endorse the primary signature.</value>
-  </data>
-  <data name="SupportingTokenIsNotSigned" xml:space="preserve">
-    <value>The supporting token provided for parameters '{0}' was not signed as part of the primary signature.</value>
-  </data>
-  <data name="SupportingTokenIsNotEncrypted" xml:space="preserve">
-    <value>The supporting token provided for parameters '{0}' was not encrypted.</value>
-  </data>
-  <data name="BasicTokenNotExpected" xml:space="preserve">
-    <value>A basic token is not expected in the security header in this context.</value>
-  </data>
-  <data name="FailedAuthenticationTrustFaultCode" xml:space="preserve">
-    <value>The request for security token could not be satisfied because authentication failed.</value>
-  </data>
-  <data name="AuthenticationOfClientFailed" xml:space="preserve">
-    <value>The caller was not authenticated by the service.</value>
-  </data>
-  <data name="InvalidRequestTrustFaultCode" xml:space="preserve">
-    <value>The request for security token has invalid or malformed elements.</value>
-  </data>
-  <data name="SignedSupportingTokenNotExpected" xml:space="preserve">
-    <value>A signed supporting token is not expected in the security header in this context.</value>
-  </data>
-  <data name="SenderSideSupportingTokensMustSpecifySecurityTokenParameters" xml:space="preserve">
-    <value>Security token parameters must be specified with supporting tokens for each message.</value>
-  </data>
-  <data name="SignatureAndEncryptionTokenMismatch" xml:space="preserve">
-    <value>The signature token '{0}' is not the same token as the encryption token '{1}'.</value>
-  </data>
-  <data name="RevertingPrivilegeFailed" xml:space="preserve">
-    <value>The reverting operation failed with the exception '{0}'.</value>
-  </data>
-  <data name="UnknownSupportingToken" xml:space="preserve">
-    <value>Unrecognized supporting token '{0}' was encountered.</value>
-  </data>
-  <data name="MoreThanOneSupportingSignature" xml:space="preserve">
-    <value>More than one supporting signature was encountered using the same supporting token '{0}'.</value>
-  </data>
-  <data name="UnsecuredMessageFaultReceived" xml:space="preserve">
-    <value>An unsecured or incorrectly secured fault was received from the other party. See the inner FaultException for the fault code and detail.</value>
-  </data>
-  <data name="FailedAuthenticationFaultReason" xml:space="preserve">
-    <value>At least one security token in the message could not be validated.</value>
-  </data>
-  <data name="BadContextTokenOrActionFaultReason" xml:space="preserve">
-    <value>The message could not be processed. This is most likely because the action '{0}' is incorrect or because the message contains an invalid or expired security context token or because there is a mismatch between bindings. The security context token would be invalid if the service aborted the channel due to inactivity. To prevent the service from aborting idle sessions prematurely increase the Receive timeout on the service endpoint's binding.</value>
-  </data>
-  <data name="BadContextTokenFaultReason" xml:space="preserve">
-    <value>The security context token is expired or is not valid. The message was not processed.</value>
-  </data>
   <data name="NegotiationFailedIO" xml:space="preserve">
     <value>Transport security negotiation failed due to an underlying IO error: {0}.</value>
-  </data>
-  <data name="SecurityNegotiationCannotProtectConfidentialEndpointHeader" xml:space="preserve">
-    <value>The security negotiation with '{0}' cannot be initiated because the confidential endpoint address header ('{1}', '{2}') cannot be encrypted during the course of the negotiation.</value>
-  </data>
-  <data name="InvalidSecurityTokenFaultReason" xml:space="preserve">
-    <value>An error occurred when processing the security tokens in the message.</value>
-  </data>
-  <data name="InvalidSecurityFaultReason" xml:space="preserve">
-    <value>An error occurred when verifying security for the message.</value>
   </data>
   <data name="AnonymousLogonsAreNotAllowed" xml:space="preserve">
     <value>The service does not allow you to log on anonymously.</value>
   </data>
-  <data name="UnableToObtainIssuerMetadata" xml:space="preserve">
-    <value>Obtaining metadata from issuer '{0}' failed with error '{1}'.</value>
-  </data>
-  <data name="ErrorImportingIssuerMetadata" xml:space="preserve">
-    <value>Importing metadata from issuer '{0}' failed with error '{1}'.</value>
-  </data>
-  <data name="MultipleCorrelationTokensFound" xml:space="preserve">
-    <value>Multiple correlation tokens were found in the security correlation state.</value>
-  </data>
-  <data name="NoCorrelationTokenFound" xml:space="preserve">
-    <value>No correlation token was found in the security correlation state.</value>
-  </data>
   <data name="MultipleSupportingAuthenticatorsOfSameType" xml:space="preserve">
     <value>Multiple supporting token authenticators with the token parameter type equal to '{0}' cannot be specified. If more than one Supporting Token of the same type is expected in the response, then configure the supporting token collection with just one entry for that SecurityTokenParameters. The SecurityTokenAuthenticator that gets created from the SecurityTokenParameters will be used to authenticate multiple tokens. It is not possible to add SecurityTokenParameters of the same type in the SupportingTokenParameters collection or repeat it across EndpointSupportingTokenParameters and OperationSupportingTokenParameters.</value>
-  </data>
-  <data name="TooManyIssuedSecurityTokenParameters" xml:space="preserve">
-    <value>A leg of the federated security chain contains multiple IssuedSecurityTokenParameters. The InfoCard system only supports one IssuedSecurityTokenParameters for each leg.</value>
-  </data>
-  <data name="UnknownTokenAuthenticatorUsedInTokenProcessing" xml:space="preserve">
-    <value>An unrecognized token authenticator '{0}' was used for token processing.</value>
-  </data>
-  <data name="TokenMustBeNullWhenTokenParametersAre" xml:space="preserve">
-    <value>The SecurityTokenParameters and SecurityToken tuple specified for use in the security header must both be null or must both be non-null.</value>
   </data>
   <data name="SecurityTokenParametersCloneInvalidResult" xml:space="preserve">
     <value>The CloneCore method of {0} type returned an invalid result. </value>
@@ -531,191 +177,8 @@
   <data name="CertificateUnsupportedForHttpTransportCredentialOnly" xml:space="preserve">
     <value>Certificate-based client authentication is not supported in TransportCredentialOnly security mode. Select the Transport security mode.</value>
   </data>
-  <data name="EntropyModeRequiresRequestorEntropy" xml:space="preserve">
-    <value>The client must provide key entropy in key entropy mode '{0}'.</value>
-  </data>
-  <data name="BearerKeyTypeCannotHaveProofKey" xml:space="preserve">
-    <value>A Proof Token was found in the response that was returned by the Security Token Service for a Bearer Key Type token request. Note that Proof Tokens should not be generated when a Bearer Key Type request is made.</value>
-  </data>
-  <data name="BearerKeyIncompatibleWithWSFederationHttpBinding" xml:space="preserve">
-    <value>Bearer Key Type is not supported with WSFederationHttpBinding. Please use WS2007FederationHttpBinding.</value>
-  </data>
-  <data name="UnableToCreateKeyTypeElementForUnknownKeyType" xml:space="preserve">
-    <value>Unable to create Key Type element for the Key Type '{0}'. This might be due to a wrong version of MessageSecurityVersion set on the SecurityBindingElement.</value>
-  </data>
-  <data name="EntropyModeCannotHaveProofTokenOrIssuerEntropy" xml:space="preserve">
-    <value>The issuer cannot provide key entropy or a proof token in key entropy mode '{0}'.</value>
-  </data>
-  <data name="EntropyModeCannotHaveRequestorEntropy" xml:space="preserve">
-    <value>The client cannot provide key entropy in key entropy mode '{0}'.</value>
-  </data>
-  <data name="EntropyModeRequiresProofToken" xml:space="preserve">
-    <value>The issuer must provide a proof token in key entropy mode '{0}'.</value>
-  </data>
-  <data name="EntropyModeRequiresComputedKey" xml:space="preserve">
-    <value>The issuer must provide a computed key in key entropy mode '{0}'.</value>
-  </data>
-  <data name="EntropyModeRequiresIssuerEntropy" xml:space="preserve">
-    <value>The issuer must provide key entropy in key entropy mode '{0}'.</value>
-  </data>
-  <data name="EntropyModeCannotHaveComputedKey" xml:space="preserve">
-    <value>The issuer cannot provide a computed key in key entropy mode '{0}'.</value>
-  </data>
-  <data name="UnknownComputedKeyAlgorithm" xml:space="preserve">
-    <value>The computed key algorithm '{0}' is not supported.</value>
-  </data>
   <data name="NoncesCachedInfinitely" xml:space="preserve">
     <value>The ReplayWindow and ClockSkew cannot be the maximum possible value when replay detection is enabled.</value>
-  </data>
-  <data name="ChannelMustBeOpenedToGetSessionId" xml:space="preserve">
-    <value>The session channel must be opened before the session ID can be accessed.</value>
-  </data>
-  <data name="SecurityVersionDoesNotSupportEncryptedKeyBinding" xml:space="preserve">
-    <value>The binding ('{0}','{1}') for contract ('{2}','{3}') has been configured with an incompatible security version that does not support unattached references to EncryptedKeys. Use '{4}' or higher as the security version for the binding.</value>
-  </data>
-  <data name="SecurityVersionDoesNotSupportThumbprintX509KeyIdentifierClause" xml:space="preserve">
-    <value>The '{0}','{1}' binding for the '{2}','{3}' contract is configured with a security version that does not support external references to X.509 tokens using the certificate's thumbprint value. Use '{4}' or higher as the security version for the binding.</value>
-  </data>
-  <data name="SecurityBindingSupportsOneWayOnly" xml:space="preserve">
-    <value>The SecurityBinding for the ('{0}','{1}') binding for the ('{2}','{3}') contract only supports the OneWay operation.</value>
-  </data>
-  <data name="DownlevelNameCannotMapToUpn" xml:space="preserve">
-    <value>Cannot map Windows user '{0}' to a UserPrincipalName that can be used for S4U impersonation.</value>
-  </data>
-  <data name="ResolvingExternalTokensRequireSecurityTokenParameters" xml:space="preserve">
-    <value>Resolving an External reference token requires appropriate SecurityTokenParameters to be specified.</value>
-  </data>
-  <data name="SecurityRenewFaultReason" xml:space="preserve">
-    <value>The SecurityContextSecurityToken's key needs to be renewed.</value>
-  </data>
-  <data name="ClientSecurityOutputSessionCloseTimeout" xml:space="preserve">
-    <value>The client's security session was not able to close its output session within the configured timeout ({0}).</value>
-  </data>
-  <data name="ClientSecurityNegotiationTimeout" xml:space="preserve">
-    <value>Client is unable to finish the security negotiation within the configured timeout ({0}).  The current negotiation leg is {1} ({2}).  </value>
-  </data>
-  <data name="ClientSecuritySessionRequestTimeout" xml:space="preserve">
-    <value>Client is unable to request the security session within the configured timeout ({0}).</value>
-  </data>
-  <data name="ServiceSecurityCloseOutputSessionTimeout" xml:space="preserve">
-    <value>The service's security session was not able to close its output session within the configured timeout ({0}).</value>
-  </data>
-  <data name="ServiceSecurityCloseTimeout" xml:space="preserve">
-    <value>The service's security session did not receive a 'close' message from the client within the configured timeout ({0}).</value>
-  </data>
-  <data name="ClientSecurityCloseTimeout" xml:space="preserve">
-    <value>The client's security session did not receive a 'close response' message from the service within the configured timeout ({0}).</value>
-  </data>
-  <data name="UnableToRenewSessionKey" xml:space="preserve">
-    <value>Cannot renew the security session key.</value>
-  </data>
-  <data name="SessionKeyRenewalNotSupported" xml:space="preserve">
-    <value>Cannot renew the security session key. Session Key Renewal is not supported.</value>
-  </data>
-  <data name="SctCookieXmlParseError" xml:space="preserve">
-    <value>Error parsing SecurityContextSecurityToken Cookie XML.</value>
-  </data>
-  <data name="SctCookieValueMissingOrIncorrect" xml:space="preserve">
-    <value>The SecurityContextSecurityToken's Cookie element either does not contain '{0}' or has a wrong value for it.</value>
-  </data>
-  <data name="SctCookieBlobDecodeFailure" xml:space="preserve">
-    <value>Error decoding the Cookie element of SecurityContextSecurityToken.</value>
-  </data>
-  <data name="SctCookieNotSupported" xml:space="preserve">
-    <value>Issuing cookie SecurityContextSecurityToken is not supported.</value>
-  </data>
-  <data name="CannotImportSupportingTokensForOperationWithoutRequestAction" xml:space="preserve">
-    <value>Security policy import failed. The security policy contains supporting token requirements at the operation scope. The contract description does not specify the action for the request message associated with this operation.</value>
-  </data>
-  <data name="SignatureConfirmationsNotExpected" xml:space="preserve">
-    <value>Signature confirmation is not expected in the security header.</value>
-  </data>
-  <data name="SignatureConfirmationsOccursAfterPrimarySignature" xml:space="preserve">
-    <value>The signature confirmation elements cannot occur after the primary signature.</value>
-  </data>
-  <data name="SignatureConfirmationWasExpected" xml:space="preserve">
-    <value>Signature confirmation was expected to be present in the security header.</value>
-  </data>
-  <data name="SecurityVersionDoesNotSupportSignatureConfirmation" xml:space="preserve">
-    <value>The SecurityVersion '{0}' does not support signature confirmation. Use a later SecurityVersion.</value>
-  </data>
-  <data name="SignatureConfirmationRequiresRequestReply" xml:space="preserve">
-    <value>The protocol factory must support Request/Reply security in order to offer signature confirmation.</value>
-  </data>
-  <data name="NotAllSignaturesConfirmed" xml:space="preserve">
-    <value>Not all the signatures in the request message were confirmed in the reply message.</value>
-  </data>
-  <data name="FoundUnexpectedSignatureConfirmations" xml:space="preserve">
-    <value>The request did not have any signatures but the reply has signature confirmations.</value>
-  </data>
-  <data name="TooManyPendingSessionKeys" xml:space="preserve">
-    <value>There are too many renewed session keys that have not been used.</value>
-  </data>
-  <data name="SecuritySessionKeyIsStale" xml:space="preserve">
-    <value>The session key must be renewed before it can secure application messages.</value>
-  </data>
-  <data name="MultipleMatchingCryptosFound" xml:space="preserve">
-    <value>The token's crypto collection has multiple objects of type '{0}'.</value>
-  </data>
-  <data name="CannotFindMatchingCrypto" xml:space="preserve">
-    <value>The token's crypto collection does not support algorithm '{0}'.</value>
-  </data>
-  <data name="SymmetricSecurityBindingElementNeedsProtectionTokenParameters" xml:space="preserve">
-    <value>SymmetricSecurityBindingElement cannot build a channel or listener factory. The ProtectionTokenParameters property is required but not set. Binding element configuration: {0}</value>
-  </data>
-  <data name="AsymmetricSecurityBindingElementNeedsInitiatorTokenParameters" xml:space="preserve">
-    <value>AsymmetricSecurityBindingElement cannot build a channel or listener factory. The InitiatorTokenParameters property is required but not set. Binding element configuration: {0}</value>
-  </data>
-  <data name="AsymmetricSecurityBindingElementNeedsRecipientTokenParameters" xml:space="preserve">
-    <value>AsymmetricSecurityBindingElement cannot build a channel or listener factory. The RecipientTokenParameters property is required but not set. Binding element configuration: {0}</value>
-  </data>
-  <data name="CachedNegotiationStateQuotaReached" xml:space="preserve">
-    <value>The service cannot cache the negotiation state as the capacity '{0}' has been reached. Retry the request.</value>
-  </data>
-  <data name="LsaAuthorityNotContacted" xml:space="preserve">
-    <value>Internal SSL error (refer to Win32 status code for details). Check the server certificate to determine if it is capable of key exchange.</value>
-  </data>
-  <data name="KeyRolloverGreaterThanKeyRenewal" xml:space="preserve">
-    <value>The key rollover interval cannot be greater than the key renewal interval.</value>
-  </data>
-  <data name="AtLeastOneContractOperationRequestRequiresProtectionLevelNotSupportedByBinding" xml:space="preserve">
-    <value>The request message must be protected. This is required by an operation of the contract ('{0}','{1}'). The protection must be provided by the binding ('{2}','{3}').</value>
-  </data>
-  <data name="AtLeastOneContractOperationResponseRequiresProtectionLevelNotSupportedByBinding" xml:space="preserve">
-    <value>The response message must be protected. This is required by an operation of the contract ('{0}', '{1}'). The protection must be provided by the binding ('{2}', '{3}').</value>
-  </data>
-  <data name="UnknownHeaderCannotProtected" xml:space="preserve">
-    <value>The contract ('{0}','{1}') contains some unknown header ('{2}','{3}') which cannot be secured. Please choose ProtectionLevel.None for this header.   </value>
-  </data>
-  <data name="NoStreamingWithSecurity" xml:space="preserve">
-    <value>The binding ('{0}','{1}') supports streaming which cannot be configured together with message level security.  Consider choosing a different transfer mode or choosing the transport level security.</value>
-  </data>
-  <data name="CurrentSessionTokenNotRenewed" xml:space="preserve">
-    <value>The supporting token in the renew message has a different generation '{0}' than the current session token's generation '{1}'.</value>
-  </data>
-  <data name="IncorrectSpnOrUpnSpecified" xml:space="preserve">
-    <value>Security Support Provider Interface (SSPI) authentication failed. The server may not be running in an account with identity '{0}'. If the server is running in a service account (Network Service for example), specify the account's ServicePrincipalName as the identity in the EndpointAddress for the server. If the server is running in a user account, specify the account's UserPrincipalName as the identity in the EndpointAddress for the server.</value>
-  </data>
-  <data name="IncomingSigningTokenMustBeAnEncryptedKey" xml:space="preserve">
-    <value>For this security protocol, the incoming signing token must be an EncryptedKey.</value>
-  </data>
-  <data name="SecuritySessionAbortedFaultReason" xml:space="preserve">
-    <value>The security session was terminated This may be because no messages were received on the session for too long.</value>
-  </data>
-  <data name="NoAppliesToPresent" xml:space="preserve">
-    <value>No AppliesTo element is present in the deserialized RequestSecurityToken/RequestSecurityTokenResponse.</value>
-  </data>
-  <data name="UnsupportedKeyLength" xml:space="preserve">
-    <value>Symmetric Key length {0} is not supported by the algorithm suite '{1}'.</value>
-  </data>
-  <data name="ForReplayDetectionToBeDoneRequireIntegrityMustBeSet" xml:space="preserve">
-    <value>For replay detection to be done ProtectionLevel must be Sign or EncryptAndSign.</value>
-  </data>
-  <data name="CantInferReferenceForToken" xml:space="preserve">
-    <value>Can't infer an external reference for '{0}' token type.</value>
-  </data>
-  <data name="TrustDriverIsUnableToCreatedNecessaryAttachedOrUnattachedReferences" xml:space="preserve">
-    <value>Unable to create Attached or Unattached reference for '{0}'.</value>
   </data>
   <data name="TrustDriverVersionDoesNotSupportSession" xml:space="preserve">
     <value>The configured Trust version does not support sessions. Use WSTrustFeb2005 or above.</value>
@@ -723,29 +186,11 @@
   <data name="TrustDriverVersionDoesNotSupportIssuedTokens" xml:space="preserve">
     <value>The configured WS-Trust version does not support issued tokens. WS-Trust February 2005 or later is required.</value>
   </data>
-  <data name="CannotPerformS4UImpersonationOnPlatform" xml:space="preserve">
-    <value>The binding ('{0}','{1}') for contract ('{2}','{3}') supports impersonation only on Windows 2003 Server and newer version of Windows. Use SspiNegotiated authentication and a binding with Secure Conversation with cancellation enabled.</value>
-  </data>
-  <data name="CannotPerformImpersonationOnUsernameToken" xml:space="preserve">
-    <value>Impersonation using the client token is not possible. The binding ('{0}', '{1}') for contract ('{2}', '{3}') uses the Username Security Token for client authentication with a Membership Provider registered. Use a different type of security token for the client.</value>
-  </data>
-  <data name="RevertImpersonationFailure" xml:space="preserve">
-    <value>Failed to revert impersonation. {0}</value>
-  </data>
-  <data name="TransactionFlowRequiredIssuedTokens" xml:space="preserve">
-    <value>In order to flow a transaction, flowing issued tokens must also be supported.</value>
-  </data>
   <data name="SignatureConfirmationNotSupported" xml:space="preserve">
     <value>The configured SecurityVersion does not support signature confirmation. Use WsSecurity11 or above.</value>
   </data>
   <data name="SecureConversationDriverVersionDoesNotSupportSession" xml:space="preserve">
     <value>The configured SecureConversation version does not support sessions. Use WSSecureConversationFeb2005 or above.</value>
-  </data>
-  <data name="SoapSecurityNegotiationFailed" xml:space="preserve">
-    <value>SOAP security negotiation failed. See inner exception for more details.</value>
-  </data>
-  <data name="SoapSecurityNegotiationFailedForIssuerAndTarget" xml:space="preserve">
-    <value>SOAP security negotiation with '{0}' for target '{1}' failed. See inner exception for more details.</value>
   </data>
   <data name="OneWayOperationReturnedFault" xml:space="preserve">
     <value>The one-way operation returned a fault message.  The reason for the fault was '{0}'.</value>
@@ -756,116 +201,23 @@
   <data name="OneWayOperationReturnedMessage" xml:space="preserve">
     <value>The one-way operation returned a non-null message with Action='{0}'.</value>
   </data>
-  <data name="CannotFindSecuritySession" xml:space="preserve">
-    <value>Cannot find the security session with the ID '{0}'.</value>
-  </data>
-  <data name="SecurityContextKeyExpired" xml:space="preserve">
-    <value>The SecurityContextSecurityToken with Context-id={0} (generation-id={1}) has expired.</value>
-  </data>
-  <data name="SecurityContextKeyExpiredNoKeyGeneration" xml:space="preserve">
-    <value>The SecurityContextSecurityToken with Context-id={0} (no key generation-id) has expired.</value>
-  </data>
-  <data name="SecuritySessionRequiresMessageIntegrity" xml:space="preserve">
-    <value>Security sessions require all messages to be signed.</value>
-  </data>
-  <data name="RequiredTimestampMissingInSecurityHeader" xml:space="preserve">
-    <value>Required timestamp missing in security header.</value>
-  </data>
-  <data name="ReceivedMessageInRequestContextNull" xml:space="preserve">
-    <value>The request message in the request context received from channel '{0}' is null.</value>
-  </data>
   <data name="KeyLifetimeNotWithinTokenLifetime" xml:space="preserve">
     <value>The key effective and expiration times must be bounded by the token effective and expiration times.</value>
   </data>
   <data name="EffectiveGreaterThanExpiration" xml:space="preserve">
     <value>The valid from time is greater than the valid to time.</value>
   </data>
-  <data name="NoSessionTokenPresentInMessage" xml:space="preserve">
-    <value>No session token was present in the message.</value>
-  </data>
   <data name="LengthMustBeGreaterThanZero" xml:space="preserve">
     <value>The length of this argument must be greater than 0.</value>
-  </data>
-  <data name="KeyLengthMustBeMultipleOfEight" xml:space="preserve">
-    <value>Key length '{0}' is not a multiple of 8 for symmetric keys.</value>
-  </data>
-  <data name="InvalidX509RawData" xml:space="preserve">
-    <value>Invalid binary representation of an X.509 certificate.</value>
-  </data>
-  <data name="ExportOfBindingWithTransportSecurityBindingElementAndNoTransportSecurityNotSupported" xml:space="preserve">
-    <value>Security policy export failed. The binding contains a TransportSecurityBindingElement but no transport binding element that implements ITransportTokenAssertionProvider. Policy export for such a binding is not supported. Make sure the transport binding element in the binding implements the ITransportTokenAssertionProvider interface.</value>
-  </data>
-  <data name="UnsupportedSecureConversationBootstrapProtectionRequirements" xml:space="preserve">
-    <value>Cannot import the security policy. The protection requirements for the secure conversation bootstrap binding are not supported. Protection requirements for the secure conversation bootstrap must require both the request and the response to be signed and encrypted.</value>
-  </data>
-  <data name="UnsupportedBooleanAttribute" xml:space="preserve">
-    <value>Cannot import the policy. The value of the attribute '{0}' must be either 'true', 'false', '1' or '0'. The following error occurred: '{1}'.</value>
-  </data>
-  <data name="NoTransportTokenAssertionProvided" xml:space="preserve">
-    <value>The security policy expert failed. The provided transport token assertion of type '{0}' did not create a transport token assertion to include the sp:TransportBinding security policy assertion.</value>
-  </data>
-  <data name="PolicyRequiresConfidentialityWithoutIntegrity" xml:space="preserve">
-    <value>Message security policy for the '{0}' action requires confidentiality without integrity. Confidentiality without integrity is not supported.</value>
-  </data>
-  <data name="PrimarySignatureIsRequiredToBeEncrypted" xml:space="preserve">
-    <value>The primary signature must be encrypted.</value>
-  </data>
-  <data name="TokenCannotCreateSymmetricCrypto" xml:space="preserve">
-    <value>A symmetric crypto could not be created from token '{0}'.</value>
-  </data>
-  <data name="TokenDoesNotMeetKeySizeRequirements" xml:space="preserve">
-    <value>The key size requirements for the '{0}' algorithm suite are not met by the '{1}' token which has key size of '{2}'.</value>
-  </data>
-  <data name="MessageProtectionOrderMismatch" xml:space="preserve">
-    <value>The received message does not meet the required message protection order '{0}'.</value>
-  </data>
-  <data name="PrimarySignatureMustBeComputedBeforeSupportingTokenSignatures" xml:space="preserve">
-    <value>Primary signature must be computed before supporting token signatures.</value>
-  </data>
-  <data name="ElementToSignMustHaveId" xml:space="preserve">
-    <value>Element to sign must have id.</value>
-  </data>
-  <data name="StandardsManagerCannotWriteObject" xml:space="preserve">
-    <value>The token Serializer cannot serialize '{0}'.  If this is a custom type you must supply a custom serializer.</value>
-  </data>
-  <data name="SigningWithoutPrimarySignatureRequiresTimestamp" xml:space="preserve">
-    <value>Signing without primary signature requires timestamp.</value>
   </data>
   <data name="OperationCannotBeDoneAfterProcessingIsStarted" xml:space="preserve">
     <value>This operation cannot be done after processing is started.</value>
   </data>
-  <data name="MaximumPolicyRedirectionsExceeded" xml:space="preserve">
-    <value>The recursive policy fetching limit has been reached. Check to determine if there is a loop in the federation service chain.</value>
-  </data>
-  <data name="InvalidAttributeInSignedHeader" xml:space="preserve">
-    <value>The ('{0}', '{1}') signed header contains the ('{2}', '{3}') attribute. The expected attribute is ('{4}', '{5}').</value>
-  </data>
-  <data name="StsAddressNotSet" xml:space="preserve">
-    <value>The address of the security token issuer is not specified. An explicit issuer address must be specified in the binding for target '{0}' or the local issuer address must be configured in the credentials.</value>
-  </data>
-  <data name="MoreThanOneSecurityBindingElementInTheBinding" xml:space="preserve">
-    <value>More than one SecurityBindingElement found in the binding ('{0}', '{1}) for contract ('{2}', '{3}'). Only one SecurityBindingElement is allowed. </value>
-  </data>
   <data name="ClientCredentialsUnableToCreateLocalTokenProvider" xml:space="preserve">
     <value>ClientCredentials cannot create a local token provider for token requirement {0}.</value>
   </data>
-  <data name="SecurityBindingElementCannotBeExpressedInConfig" xml:space="preserve">
-    <value>A security policy was imported for the endpoint. The security policy contains requirements that cannot be represented in a Windows Communication Foundation configuration. Look for a comment about the SecurityBindingElement parameters that are required in the configuration file that was generated. Create the correct binding element with code. The binding configuration that is in the configuration file is not secure.</value>
-  </data>
   <data name="SecurityProtocolCannotDoReplayDetection" xml:space="preserve">
     <value>The security protocol '{0}' cannot do replay detection.</value>
-  </data>
-  <data name="UnableToFindSecurityHeaderInMessage" xml:space="preserve">
-    <value>Security processor was unable to find a security header with actor '{0}' in the message. This might be because the message is an unsecured fault or because there is a binding mismatch between the communicating parties.  This can occur if the service is configured for security and the client is not using security.</value>
-  </data>
-  <data name="UnableToFindSecurityHeaderInMessageNoActor" xml:space="preserve">
-    <value>Security processor was unable to find a security header in the message. This might be because the message is an unsecured fault or because there is a binding mismatch between the communicating parties.   This can occur if the service is configured for security and the client is not using security.</value>
-  </data>
-  <data name="NoPrimarySignatureAvailableForSupportingTokenSignatureVerification" xml:space="preserve">
-    <value>No primary signature available for supporting token signature verification.</value>
-  </data>
-  <data name="SupportingTokenSignaturesNotExpected" xml:space="preserve">
-    <value>Supporting token signatures not expected.</value>
   </data>
   <data name="CannotReadToken" xml:space="preserve">
     <value>Cannot read the token from the '{0}' element with the '{1}' namespace for BinarySecretSecurityToken, with a '{2}' ValueType. If this element is expected to be valid, ensure that security is configured to consume tokens with the name, namespace and value type specified.</value>
@@ -873,122 +225,11 @@
   <data name="ExpectedElementMissing" xml:space="preserve">
     <value>Element '{0}' with namespace '{1}' not found.</value>
   </data>
-  <data name="ExpectedOneOfTwoElementsFromNamespace" xml:space="preserve">
-    <value>Expected element '{0}' or element '{1}' (from namespace '{2}').</value>
-  </data>
-  <data name="RstDirectDoesNotExpectRstr" xml:space="preserve">
-    <value>AcceleratedTokenAuthenticator does not expect RequestSecurityTokenResponse from the client.</value>
-  </data>
-  <data name="RequireNonCookieMode" xml:space="preserve">
-    <value>The '{0}' binding with the '{1}' namespace is configured to issue cookie security context tokens. COM+ Integration services does not support cookie security context tokens.</value>
-  </data>
-  <data name="RequiredSignatureMissing" xml:space="preserve">
-    <value>The signature must be in the security header.</value>
-  </data>
-  <data name="RequiredMessagePartNotSigned" xml:space="preserve">
-    <value>The '{0}' required message part was not signed.</value>
-  </data>
-  <data name="RequiredMessagePartNotSignedNs" xml:space="preserve">
-    <value>The '{0}', '{1}' required message part  was not signed.</value>
-  </data>
-  <data name="RequiredMessagePartNotEncrypted" xml:space="preserve">
-    <value>The '{0}' required message part was not encrypted.</value>
-  </data>
-  <data name="RequiredMessagePartNotEncryptedNs" xml:space="preserve">
-    <value>The '{0}', '{1}' required message part  was not encrypted.</value>
-  </data>
-  <data name="SignatureVerificationFailed" xml:space="preserve">
-    <value>Signature verification failed.</value>
-  </data>
-  <data name="CannotIssueRstTokenType" xml:space="preserve">
-    <value>Cannot issue the token type '{0}'.</value>
-  </data>
-  <data name="NoNegotiationMessageToSend" xml:space="preserve">
-    <value>There is no negotiation message to send.</value>
-  </data>
-  <data name="InvalidIssuedTokenKeySize" xml:space="preserve">
-    <value>The issued token has an invalid key size '{0}'.</value>
-  </data>
-  <data name="CannotObtainIssuedTokenKeySize" xml:space="preserve">
-    <value>Cannot determine the key size of the issued token.</value>
-  </data>
-  <data name="NegotiationIsNotCompleted" xml:space="preserve">
-    <value>The negotiation has not yet completed.</value>
-  </data>
-  <data name="NegotiationIsCompleted" xml:space="preserve">
-    <value>The negotiation has already completed.</value>
-  </data>
   <data name="MissingMessageID" xml:space="preserve">
     <value>Request Message is missing a MessageID header. One is required to correlate a reply.</value>
   </data>
-  <data name="SecuritySessionLimitReached" xml:space="preserve">
-    <value>Cannot create a security session. Retry later.</value>
-  </data>
-  <data name="SecuritySessionAlreadyPending" xml:space="preserve">
-    <value>The security session with id '{0}' is already pending.</value>
-  </data>
-  <data name="SecuritySessionNotPending" xml:space="preserve">
-    <value>No security session with id '{0}' is pending.</value>
-  </data>
-  <data name="SecuritySessionListenerNotFound" xml:space="preserve">
-    <value>No security session listener was found for message with action '{0}'.</value>
-  </data>
-  <data name="SessionTokenWasNotClosed" xml:space="preserve">
-    <value>The session token was not closed by the server.</value>
-  </data>
-  <data name="ProtocolMustBeInitiator" xml:space="preserve">
-    <value>'{0}' protocol can only be used by the Initiator.</value>
-  </data>
-  <data name="ProtocolMustBeRecipient" xml:space="preserve">
-    <value>'{0}' protocol can only be used at the Recipient.</value>
-  </data>
-  <data name="SendingOutgoingmessageOnRecipient" xml:space="preserve">
-    <value>Unexpected code path for server security application, sending outgoing message on Recipient.</value>
-  </data>
   <data name="OnlyBodyReturnValuesSupported" xml:space="preserve">
     <value>Only body return values are supported currently for protection, MessagePartDescription was specified.</value>
-  </data>
-  <data name="UnknownTokenAttachmentMode" xml:space="preserve">
-    <value>Unknown token attachment mode: {0}.</value>
-  </data>
-  <data name="ProtocolMisMatch" xml:space="preserve">
-    <value>Security protocol must be '{0}', type is: '{1}'.;</value>
-  </data>
-  <data name="AttemptToCreateMultipleRequestContext" xml:space="preserve">
-    <value>The initial request context was already specified.  Can not create two for same message.</value>
-  </data>
-  <data name="ServerReceivedCloseMessageStateIsCreated" xml:space="preserve">
-    <value>{0}.OnCloseMessageReceived when state == Created.</value>
-  </data>
-  <data name="ShutdownRequestWasNotReceived" xml:space="preserve">
-    <value>Shutdown request was not received.</value>
-  </data>
-  <data name="UnknownFilterType" xml:space="preserve">
-    <value>Unknown filter type: '{0}'.</value>
-  </data>
-  <data name="StandardsManagerDoesNotMatch" xml:space="preserve">
-    <value>Standards manager of filter does not match that of filter table.  Can not have two different filters.</value>
-  </data>
-  <data name="FilterStrictModeDifferent" xml:space="preserve">
-    <value>Session filter's isStrictMode differs from filter table's isStrictMode.</value>
-  </data>
-  <data name="SSSSCreateAcceptor" xml:space="preserve">
-    <value>SecuritySessionServerSettings.CreateAcceptor, channelAcceptor must be null, can not create twice.</value>
-  </data>
-  <data name="TransactionFlowBadOption" xml:space="preserve">
-    <value>Invalid TransactionFlowOption value.</value>
-  </data>
-  <data name="TokenManagerCouldNotReadToken" xml:space="preserve">
-    <value>Security token manager could not parse token with name '{0}', namespace '{1}', valueType '{2}'.</value>
-  </data>
-  <data name="InvalidActionForNegotiationMessage" xml:space="preserve">
-    <value>Security negotiation message has incorrect action '{0}'.</value>
-  </data>
-  <data name="InvalidKeySizeSpecifiedInNegotiation" xml:space="preserve">
-    <value>The specified key size {0} is invalid. The key size must be between {1} and {2}.</value>
-  </data>
-  <data name="GetTokenInfoFailed" xml:space="preserve">
-    <value>Could not get token information (error=0x{0:X}).</value>
   </data>
   <data name="UnexpectedEndOfFile" xml:space="preserve">
     <value>Unexpected end of file.</value>
@@ -1005,24 +246,6 @@
   <data name="TimeStampWasCreatedTooLongAgo" xml:space="preserve">
     <value>The security timestamp is stale because its creation time ('{0}') is too far back in the past. Current time is '{1}', maximum timestamp lifetime is '{2}' and allowed clock skew is '{3}'.</value>
   </data>
-  <data name="InvalidOrReplayedNonce" xml:space="preserve">
-    <value>The nonce is invalid or replayed.</value>
-  </data>
-  <data name="MessagePartSpecificationMustBeImmutable" xml:space="preserve">
-    <value>Message part specification must be made constant before being set.</value>
-  </data>
-  <data name="UnsupportedIssuerEntropyType" xml:space="preserve">
-    <value>Issuer entropy is not BinarySecretSecurityToken or WrappedKeySecurityToken.</value>
-  </data>
-  <data name="NoRequestSecurityTokenResponseElements" xml:space="preserve">
-    <value>No RequestSecurityTokenResponse elements were found.</value>
-  </data>
-  <data name="NoCookieInSct" xml:space="preserve">
-    <value>The SecurityContextSecurityToken does not have a cookie.</value>
-  </data>
-  <data name="TokenProviderReturnedBadToken" xml:space="preserve">
-    <value>TokenProvider returned token of incorrect type '{0}'.</value>
-  </data>
   <data name="ItemNotAvailableInDeserializedRST" xml:space="preserve">
     <value>{0} is not available in deserialized RequestSecurityToken.</value>
   </data>
@@ -1035,137 +258,14 @@
   <data name="ItemAvailableInDeserializedRSTROnly" xml:space="preserve">
     <value>{0} is only available in a deserialized RequestSecurityTokenResponse.</value>
   </data>
-  <data name="MoreThanOneRSTRInRSTRC" xml:space="preserve">
-    <value>The RequestSecurityTokenResponseCollection received has more than one RequestSecurityTokenResponse element. Only one RequestSecurityTokenResponse element was expected.</value>
-  </data>
-  <data name="Hosting_VirtualPathExtenstionCanNotBeDetached" xml:space="preserve">
-    <value>VirtualPathExtension is not allowed to be removed.</value>
-  </data>
-  <data name="Hosting_NotSupportedProtocol" xml:space="preserve">
-    <value>The protocol '{0}' is not supported.</value>
-  </data>
-  <data name="Hosting_BaseUriDeserializedNotValid" xml:space="preserve">
-    <value>The BaseUriWithWildcard object has invalid fields after deserialization.</value>
-  </data>
-  <data name="Hosting_RelativeAddressFormatError" xml:space="preserve">
-    <value>Registered relativeAddress '{0}' in configuration file is not a valid one. Possible causes could be : You specified an empty addreess or an absolute address (i.e., starting with '/' or '\\'), or the address contains invalid character[s]. The supported relativeAddress formats are \"[folder/]filename\" or \"~/[folder/]filename\".  </value>
-  </data>
-  <data name="Hosting_NoAbsoluteRelativeAddress" xml:space="preserve">
-    <value> '{0}' is an absolute address. The supported relativeAddress formats are \"[subfolder/]filename\" or \"~/[subfolder/]filename\".  </value>
-  </data>
-  <data name="SecureConversationNeedsBootstrapSecurity" xml:space="preserve">
-    <value>Cannot create security binding element based on the configuration data. When secure conversation authentication mode is selected, the secure conversation bootstrap binding element must also be specified. </value>
-  </data>
-  <data name="Hosting_MemoryGatesCheckFailedUnderPartialTrust" xml:space="preserve">
-    <value>Setting minFreeMemoryPercentageToActivateService requires full trust privilege. Please change the application's trust level or remove this setting from the configuration file.</value>
-  </data>
-  <data name="Hosting_CompatibilityServiceNotHosted" xml:space="preserve">
-    <value>This service requires ASP.NET compatibility and must be hosted in IIS.  Either host the service in IIS with ASP.NET compatibility turned on in web.config or set the AspNetCompatibilityRequirementsAttribute.AspNetCompatibilityRequirementsMode property to a value other than Required.</value>
-  </data>
-  <data name="Hosting_MisformattedPort" xml:space="preserve">
-    <value>The '{0}' protocol binding '{1}' specifies an invalid port number '{2}'.</value>
-  </data>
-  <data name="Hosting_MisformattedBinding" xml:space="preserve">
-    <value>The protocol binding '{0}' does not conform to the syntax for '{1}'. The following is an example of valid '{1}' protocol bindings: '{2}'.</value>
-  </data>
-  <data name="Hosting_MisformattedBindingData" xml:space="preserve">
-    <value>The protocol binding '{0}' is not valid for '{1}'.  This might be because the port number is out of range.</value>
-  </data>
-  <data name="Hosting_NoHttpTransportManagerForUri" xml:space="preserve">
-    <value>There is no compatible TransportManager found for URI '{0}'. This may be because you have used an absolute address that points outside of the virtual application. Please use a relative address instead.</value>
-  </data>
-  <data name="Hosting_NoTcpPipeTransportManagerForUri" xml:space="preserve">
-    <value>There is no compatible TransportManager found for URI '{0}'. This may be because you have used an absolute address that points outside of the virtual application, or the binding settings of the endpoint do not match those that have been set by other services or endpoints. Note that all bindings for the same protocol should have the same settings in the same application.</value>
-  </data>
-  <data name="Hosting_ProcessNotExecutingUnderHostedContext" xml:space="preserve">
-    <value>'{0}' cannot be invoked within the current hosting environment. This API requires that the calling application be hosted in IIS or WAS.</value>
-  </data>
   <data name="Hosting_ServiceActivationFailed" xml:space="preserve">
     <value>The requested service, '{0}' could not be activated. See the server's diagnostic trace logs for more information.</value>
-  </data>
-  <data name="Hosting_ServiceTypeNotProvided" xml:space="preserve">
-    <value>The value for the Service attribute was not provided in the ServiceHost directive.</value>
-  </data>
-  <data name="SharedEndpointReadDenied" xml:space="preserve">
-    <value>The service endpoint failed to listen on the URI '{0}' because access was denied.  Verify that the current user is granted access in the appropriate allowAccounts section of SMSvcHost.exe.config.</value>
-  </data>
-  <data name="SharedEndpointReadNotFound" xml:space="preserve">
-    <value>The service endpoint failed to listen on the URI '{0}' because the shared memory section was not found.  Verify that the '{1}' service is running.</value>
-  </data>
-  <data name="SharedManagerBase" xml:space="preserve">
-    <value>The TransportManager failed to listen on the supplied URI using the {0} service: {1}.</value>
-  </data>
-  <data name="SharedManagerServiceStartFailure" xml:space="preserve">
-    <value>failed to start the service ({0}). Refer to the Event Log for more details</value>
-  </data>
-  <data name="SharedManagerServiceStartFailureDisabled" xml:space="preserve">
-    <value>failed to start the service because it is disabled. An administrator can enable it by running 'sc.exe config {0} start= demand'.</value>
-  </data>
-  <data name="SharedManagerServiceStartFailureNoError" xml:space="preserve">
-    <value>failed to start the service. Refer to the Event Log for more details</value>
-  </data>
-  <data name="SharedManagerServiceLookupFailure" xml:space="preserve">
-    <value>failed to look up the service process in the SCM ({0})</value>
-  </data>
-  <data name="SharedManagerServiceSidLookupFailure" xml:space="preserve">
-    <value>failed to look up the service SID in the SCM ({0})</value>
-  </data>
-  <data name="SharedManagerServiceEndpointReadFailure" xml:space="preserve">
-    <value>failed to read the service's endpoint with native error code {0}.  See inner exception for details</value>
-  </data>
-  <data name="SharedManagerServiceSecurityFailed" xml:space="preserve">
-    <value>the service failed the security checks</value>
-  </data>
-  <data name="SharedManagerUserSidLookupFailure" xml:space="preserve">
-    <value>failed to retrieve the UserSid of the service process ({0})</value>
-  </data>
-  <data name="SharedManagerCurrentUserSidLookupFailure" xml:space="preserve">
-    <value>failed to retrieve the UserSid of the current process</value>
-  </data>
-  <data name="SharedManagerLogonSidLookupFailure" xml:space="preserve">
-    <value>failed to retrieve the LogonSid of the service process ({0})</value>
-  </data>
-  <data name="SharedManagerDataConnectionFailure" xml:space="preserve">
-    <value>failed to establish a data connection to the service</value>
-  </data>
-  <data name="SharedManagerDataConnectionCreateFailure" xml:space="preserve">
-    <value>failed to create a data connection to the service</value>
-  </data>
-  <data name="SharedManagerDataConnectionPipeFailed" xml:space="preserve">
-    <value>failed to establish the data connection because of an I/O error</value>
-  </data>
-  <data name="SharedManagerVersionUnsupported" xml:space="preserve">
-    <value>the version is not supported by the service</value>
-  </data>
-  <data name="SharedManagerAllowDupHandleFailed" xml:space="preserve">
-    <value>failed to grant the PROCESS_DUP_HANDLE access right to the target service's account SID '{0}'.</value>
-  </data>
-  <data name="SharedManagerPathTooLong" xml:space="preserve">
-    <value>the URI is too long</value>
-  </data>
-  <data name="SharedManagerRegistrationQuotaExceeded" xml:space="preserve">
-    <value>the quota was exceeded</value>
-  </data>
-  <data name="SharedManagerProtocolUnsupported" xml:space="preserve">
-    <value>the protocol is not supported</value>
-  </data>
-  <data name="SharedManagerConflictingRegistration" xml:space="preserve">
-    <value>the URI is already registered with the service</value>
-  </data>
-  <data name="SharedManagerFailedToListen" xml:space="preserve">
-    <value>the service failed to listen</value>
   </data>
   <data name="Sharing_ConnectionDispatchFailed" xml:space="preserve">
     <value>The message could not be dispatched to the service at address '{0}'. Refer to the server Event Log for more details</value>
   </data>
   <data name="Sharing_EndpointUnavailable" xml:space="preserve">
     <value>The message could not be dispatched because the service at the endpoint address '{0}' is unavailable for the protocol of the address.</value>
-  </data>
-  <data name="Sharing_EmptyListenerEndpoint" xml:space="preserve">
-    <value>The endpoint address for the NT service '{0}' read from shared memory is empty.</value>
-  </data>
-  <data name="Sharing_ListenerProxyStopped" xml:space="preserve">
-    <value>The message could not be dispatched because the transport manager has been stopped.  This can happen if the application is being recycled or disabled.</value>
   </data>
   <data name="UnexpectedEmptyElementExpectingClaim" xml:space="preserve">
     <value>The '{0}' from the '{1}' namespace is empty and does not specify a valid identity claim. </value>
@@ -1176,35 +276,11 @@
   <data name="UnexpectedDuplicateElement" xml:space="preserve">
     <value>'{0}' from namespace '{1}' is not expected to appear more than once</value>
   </data>
-  <data name="UnsupportedSecurityPolicyAssertion" xml:space="preserve">
-    <value>An unsupported security policy assertion was detected during the security policy import: {0}</value>
-  </data>
   <data name="MultipleIdentities" xml:space="preserve">
     <value>The extensions cannot contain an Identity if one is supplied as a constructor argument.</value>
   </data>
   <data name="InvalidUriValue" xml:space="preserve">
     <value>Value '{0}' provided for '{1}' from namespace '{2}' is an invalid absolute URI.</value>
-  </data>
-  <data name="BindingDoesNotSupportProtectionForRst" xml:space="preserve">
-    <value>The binding ('{0}','{1}') for contract ('{2}','{3}') is configured with SecureConversation, but the authentication mode is not able to provide the request/reply-based integrity and confidentiality required for the negotiation.</value>
-  </data>
-  <data name="TransportDoesNotProtectMessage" xml:space="preserve">
-    <value>The '{0}'.'{1}' binding for the '{2}'.'{3}' contract is configured with an authentication mode that requires transport level integrity and confidentiality. However the transport cannot provide integrity and confidentiality.</value>
-  </data>
-  <data name="BindingDoesNotSupportWindowsIdenityForImpersonation" xml:space="preserve">
-    <value>The contract operation '{0}' requires Windows identity for automatic impersonation. A Windows identity that represents the caller is not provided by binding ('{1}','{2}') for contract ('{3}','{4}'.</value>
-  </data>
-  <data name="ListenUriNotSet" xml:space="preserve">
-    <value>A listen URI must be specified in order to open this {0}.</value>
-  </data>
-  <data name="UnsupportedChannelInterfaceType" xml:space="preserve">
-    <value>Channel interface type '{0}' is not supported.</value>
-  </data>
-  <data name="TransportManagerOpen" xml:space="preserve">
-    <value>This property cannot be changed after the transport manager has been opened.</value>
-  </data>
-  <data name="TransportManagerNotOpen" xml:space="preserve">
-    <value>This operation is only valid after the transport manager has been opened.</value>
   </data>
   <data name="UnrecognizedIdentityType" xml:space="preserve">
     <value>Unrecognized identity type Name='{0}', Namespace='{1}'.</value>
@@ -1212,14 +288,8 @@
   <data name="InvalidIdentityElement" xml:space="preserve">
     <value>Cannot read the Identity element. The Identity type is not supported or the Identity element is empty.</value>
   </data>
-  <data name="UnableToLoadCertificateIdentity" xml:space="preserve">
-    <value>Cannot load the X.509 certificate identity specified in the configuration.</value>
-  </data>
   <data name="UnrecognizedClaimTypeForIdentity" xml:space="preserve">
     <value>The ClaimType '{0}' is not recognized. Expected ClaimType '{1}'.</value>
-  </data>
-  <data name="AsyncCallbackException" xml:space="preserve">
-    <value>An AsyncCallback threw an exception.</value>
   </data>
   <data name="SendCannotBeCalledAfterCloseOutputSession" xml:space="preserve">
     <value>You cannot Send messages on a channel after CloseOutputSession has been called.</value>
@@ -1227,32 +297,20 @@
   <data name="CommunicationObjectCannotBeModifiedInState" xml:space="preserve">
     <value>The communication object, {0}, cannot be modified while it is in the {1} state.</value>
   </data>
-  <data name="CommunicationObjectCannotBeModified" xml:space="preserve">
-    <value>The communication object, {0}, cannot be modified unless it is in the Created state.</value>
-  </data>
   <data name="CommunicationObjectCannotBeUsed" xml:space="preserve">
     <value>The communication object, {0}, is in the {1} state.  Communication objects cannot be used for communication unless they are in the Opened state.</value>
   </data>
   <data name="CommunicationObjectFaulted1" xml:space="preserve">
     <value>The communication object, {0}, cannot be used for communication because it is in the Faulted state.</value>
   </data>
-  <data name="CommunicationObjectFaultedStack2" xml:space="preserve">
-    <value>The communication object, {0}, cannot be used for communication because it is in the Faulted state: {1}</value>
-  </data>
   <data name="CommunicationObjectAborted1" xml:space="preserve">
     <value>The communication object, {0}, cannot be used for communication because it has been Aborted.</value>
-  </data>
-  <data name="CommunicationObjectAbortedStack2" xml:space="preserve">
-    <value>The communication object, {0}, cannot be used for communication because it has been Aborted: {1}</value>
   </data>
   <data name="CommunicationObjectBaseClassMethodNotCalled" xml:space="preserve">
     <value>The communication object, {0}, has overridden the virtual function {1} but it does not call version defined in the base class.</value>
   </data>
   <data name="CommunicationObjectInInvalidState" xml:space="preserve">
     <value>The communication object, {0}, is not part of WCF and is in an unsupported state '{1}'.  This indicates an internal error in the implementation of that communication object.</value>
-  </data>
-  <data name="CommunicationObjectCloseInterrupted1" xml:space="preserve">
-    <value>The communication object, {0}, cannot be used due to an error that occurred during close.</value>
   </data>
   <data name="ChannelFactoryCannotBeUsedToCreateChannels" xml:space="preserve">
     <value>A call to IChannelFactory.CreateChannel made on an object of type {0} failed because Open has not been called on this object.</value>
@@ -1263,32 +321,14 @@
   <data name="ChannelParametersCannotBePropagated" xml:space="preserve">
     <value>Cannot propagate channel parameters because the {0} is in the {1} state.  This operation is only supported in the Opening or Opened state when the collection is locked.</value>
   </data>
-  <data name="OneWayInternalTypeNotSupported" xml:space="preserve">
-    <value>Binding '{0}' is not configured properly. OneWayBindingElement requires an inner binding element that supports IRequestChannel/IReplyChannel or IDuplexSessionChannel. </value>
-  </data>
   <data name="ChannelTypeNotSupported" xml:space="preserve">
     <value>The specified channel type {0} is not supported by this channel manager.</value>
-  </data>
-  <data name="SecurityContextMissing" xml:space="preserve">
-    <value>SecurityContext for the UltimateReceiver role is missing from the SecurityContextProperty of the request message with action '{0}'.</value>
-  </data>
-  <data name="SecurityContextDoesNotAllowImpersonation" xml:space="preserve">
-    <value>Cannot start impersonation because the SecurityContext for the UltimateReceiver role from the request message with the '{0}' action is not mapped to a Windows identity.</value>
   </data>
   <data name="InvalidEnumValue" xml:space="preserve">
     <value>Unexpected internal enum value: {0}.</value>
   </data>
   <data name="InvalidDecoderStateMachine" xml:space="preserve">
     <value>Invalid decoder state machine.</value>
-  </data>
-  <data name="OperationPropertyIsRequiredForAttributeGeneration" xml:space="preserve">
-    <value>Operation property of OperationAttributeGenerationContext is required to generate an attribute based on settings. </value>
-  </data>
-  <data name="InvalidMembershipProviderSpecifiedInConfig" xml:space="preserve">
-    <value>The username/password Membership provider {0} specified in the configuration is invalid. No such provider was found registered under system.web/membership/providers.</value>
-  </data>
-  <data name="InvalidRoleProviderSpecifiedInConfig" xml:space="preserve">
-    <value>The RoleProvider {0} specified in the configuration is invalid. No such provider was found registered under system.web/roleManager/providers.</value>
   </data>
   <data name="ObjectDisposed" xml:space="preserve">
     <value>The {0} object has been disposed.</value>
@@ -1326,17 +366,11 @@
   <data name="MessageClosed" xml:space="preserve">
     <value>Message is closed.</value>
   </data>
-  <data name="StreamClosed" xml:space="preserve">
-    <value>The operation cannot be completed because the stream is closed.</value>
-  </data>
   <data name="BodyWriterReturnedIsNotBuffered" xml:space="preserve">
     <value>The body writer returned from OnCreateBufferedCopy was not buffered.</value>
   </data>
   <data name="BodyWriterCanOnlyBeWrittenOnce" xml:space="preserve">
     <value>The body writer does not support writing more than once because it is not buffered.</value>
-  </data>
-  <data name="RstrKeySizeNotProvided" xml:space="preserve">
-    <value>KeySize element not present in RequestSecurityTokenResponse.</value>
   </data>
   <data name="RequestMessageDoesNotHaveAMessageID" xml:space="preserve">
     <value>A reply message cannot be created because the request message does not have a MessageID.</value>
@@ -1398,20 +432,8 @@
   <data name="EncoderMessageVersionMismatch" xml:space="preserve">
     <value>The message version of the outgoing message ({0}) does not match that of the encoder ({1}). Make sure the binding is configured with the same version as the message.</value>
   </data>
-  <data name="MtomEncoderBadMessageVersion" xml:space="preserve">
-    <value>MessageVersion '{0}' not supported by MTOM encoder.</value>
-  </data>
-  <data name="SPS_ReadNotSupported" xml:space="preserve">
-    <value>Read is not supported on this stream.</value>
-  </data>
   <data name="SPS_SeekNotSupported" xml:space="preserve">
     <value>Seek is not supported on this stream.</value>
-  </data>
-  <data name="WriterAsyncWritePending" xml:space="preserve">
-    <value>An asynchronous write is pending on the stream. Ensure that there are no uncompleted asynchronous writes before attempting the next write. </value>
-  </data>
-  <data name="ChannelInitializationTimeout" xml:space="preserve">
-    <value>A newly accepted connection did not receive initialization data from the sender within the configured ChannelInitializationTimeout ({0}).  As a result, the connection will be aborted.  If you are on a highly congested network, or your sending machine is heavily loaded, consider increasing this value or load-balancing your server.</value>
   </data>
   <data name="SocketCloseReadTimeout" xml:space="preserve">
     <value>The remote endpoint of the socket ({0}) did not respond to a close request within the allotted timeout ({1}). It is likely that the remote endpoint is not calling Close after receiving the EOF signal (null) from Receive. The time allotted to this operation may have been a portion of a longer timeout.</value>
@@ -1421,9 +443,6 @@
   </data>
   <data name="SessionValueInvalid" xml:space="preserve">
     <value>The Session value '{0}' is invalid. Please specify 'CurrentSession','ServiceSession' or a valid non-negative Windows Session Id.</value>
-  </data>
-  <data name="PackageFullNameInvalid" xml:space="preserve">
-    <value>The package full name '{0}' is invalid.</value>
   </data>
   <data name="SocketAbortedReceiveTimedOut" xml:space="preserve">
     <value>The socket was aborted because an asynchronous receive from the socket did not complete within the allotted timeout of {0}. The time allotted to this operation may have been a portion of a longer timeout.</value>
@@ -1470,9 +489,6 @@
   <data name="FramingAtEnd" xml:space="preserve">
     <value>An attempt was made to decode a value after the framing stream was ended.</value>
   </data>
-  <data name="RemoteSecurityNotNegotiatedOnStreamUpgrade" xml:space="preserve">
-    <value>Stream Security is required at {0}, but no security context was negotiated. This is likely caused by the remote endpoint missing a StreamSecurityBindingElement from its binding.</value>
-  </data>
   <data name="BinaryEncoderSessionTooLarge" xml:space="preserve">
     <value>The binary encoder session information exceeded the maximum size quota ({0}). To increase this quota, use the MaxSessionSize property on the BinaryMessageEncodingBindingElement.</value>
   </data>
@@ -1503,116 +519,8 @@
   <data name="StreamDoesNotSupportTimeout" xml:space="preserve">
     <value>TimeoutStream requires an inner Stream that supports timeouts; its CanTimeout property must be true.</value>
   </data>
-  <data name="FilterExists" xml:space="preserve">
-    <value>The filter already exists in the filter table.</value>
-  </data>
-  <data name="FilterUnexpectedError" xml:space="preserve">
-    <value>An internal error has occurred. Unexpected error modifying filter table.</value>
-  </data>
-  <data name="FilterNodeQuotaExceeded" xml:space="preserve">
-    <value>The number of XML infoset nodes inspected by the navigator has exceeded the quota ({0}).</value>
-  </data>
-  <data name="FilterCapacityNegative" xml:space="preserve">
-    <value>Value cannot be negative.</value>
-  </data>
-  <data name="ActionFilterEmptyList" xml:space="preserve">
-    <value>The set of actions cannot be empty.</value>
-  </data>
-  <data name="FilterUndefinedPrefix" xml:space="preserve">
-    <value>The prefix '{0}' is not defined.</value>
-  </data>
-  <data name="FilterMultipleMatches" xml:space="preserve">
-    <value>Multiple filters matched.</value>
-  </data>
-  <data name="FilterTableTypeMismatch" xml:space="preserve">
-    <value>The type of IMessageFilterTable created for a particular Filter type must always be the same.</value>
-  </data>
-  <data name="FilterTableInvalidForLookup" xml:space="preserve">
-    <value>The MessageFilterTable state is corrupt. The requested lookup cannot be performed.</value>
-  </data>
-  <data name="FilterBadTableType" xml:space="preserve">
-    <value>The IMessageFilterTable created for a Filter cannot be a MessageFilterTable or a subclass of MessageFilterTable.</value>
-  </data>
-  <data name="FilterQuotaRange" xml:space="preserve">
-    <value>NodeQuota must be greater than 0.</value>
-  </data>
-  <data name="FilterEmptyString" xml:space="preserve">
-    <value>Parameter value cannot be an empty string.</value>
-  </data>
-  <data name="FilterInvalidInner" xml:space="preserve">
-    <value>Required inner element '{0}' was not found.</value>
-  </data>
-  <data name="FilterInvalidAttribute" xml:space="preserve">
-    <value>Invalid attribute on the XPath.</value>
-  </data>
-  <data name="FilterInvalidDialect" xml:space="preserve">
-    <value>When present, the dialect attribute must have the value '{0}'.</value>
-  </data>
-  <data name="FilterCouldNotCompile" xml:space="preserve">
-    <value>Could not compile the XPath expression '{0}' with the given XsltContext.</value>
-  </data>
-  <data name="FilterReaderNotStartElem" xml:space="preserve">
-    <value>XmlReader not positioned at a start element.</value>
-  </data>
-  <data name="SeekableMessageNavInvalidPosition" xml:space="preserve">
-    <value>The position is not valid for this navigator.</value>
-  </data>
-  <data name="SeekableMessageNavNonAtomized" xml:space="preserve">
-    <value>Cannot call '{0}' on a non-atomized navigator.</value>
-  </data>
-  <data name="SeekableMessageNavIDNotSupported" xml:space="preserve">
-    <value>XML unique ID not supported.</value>
-  </data>
-  <data name="SeekableMessageNavBodyForbidden" xml:space="preserve">
-    <value>A filter has attempted to access the body of a Message. Use a MessageBuffer instead if body filtering is required.</value>
-  </data>
-  <data name="SeekableMessageNavOverrideForbidden" xml:space="preserve">
-    <value>Not allowed to override prefix '{0}'.</value>
-  </data>
-  <data name="QueryNotImplemented" xml:space="preserve">
-    <value>The function '{0}' is not implemented.</value>
-  </data>
-  <data name="QueryNotSortable" xml:space="preserve">
-    <value>XPathNavigator positions cannot be compared.</value>
-  </data>
-  <data name="QueryMustBeSeekable" xml:space="preserve">
-    <value>XPathNavigator must be a SeekableXPathNavigator.</value>
-  </data>
-  <data name="QueryContextNotSupportedInSequences" xml:space="preserve">
-    <value>Context node is not supported in node sequences.</value>
-  </data>
-  <data name="QueryFunctionTypeNotSupported" xml:space="preserve">
-    <value>IXsltContextFunction return type '{0}' not supported.</value>
-  </data>
-  <data name="QueryVariableTypeNotSupported" xml:space="preserve">
-    <value>IXsltContextVariable type '{0}' not supported.</value>
-  </data>
-  <data name="QueryVariableNull" xml:space="preserve">
-    <value>IXsltContextVariables cannot return null.</value>
-  </data>
-  <data name="QueryFunctionStringArg" xml:space="preserve">
-    <value>The argument to an IXsltContextFunction could not be converted to a string.</value>
-  </data>
-  <data name="QueryItemAlreadyExists" xml:space="preserve">
-    <value>An internal error has occurred. Item already exists.</value>
-  </data>
-  <data name="QueryBeforeNodes" xml:space="preserve">
-    <value>Positioned before first element.</value>
-  </data>
-  <data name="QueryAfterNodes" xml:space="preserve">
-    <value>Positioned after last element.</value>
-  </data>
-  <data name="QueryIteratorOutOfScope" xml:space="preserve">
-    <value>The XPathNodeIterator has been invalidated. XPathNodeIterators passed as arguments to IXsltContextFunctions are only valid within the function. They cannot be cached for later use or returned as the result of the function.</value>
-  </data>
-  <data name="QueryCantGetStringForMovedIterator" xml:space="preserve">
-    <value>The string value can't be determined because the XPathNodeIterator has been moved past the first node.</value>
-  </data>
   <data name="AddressingVersionNotSupported" xml:space="preserve">
     <value>Addressing Version '{0}' is not supported.</value>
-  </data>
-  <data name="SupportedAddressingModeNotSupported" xml:space="preserve">
-    <value>The '{0}' addressing mode is not supported.</value>
   </data>
   <data name="MessagePropertyReturnedNullCopy" xml:space="preserve">
     <value>The IMessageProperty could not be copied. CreateCopy returned null.</value>
@@ -1671,26 +579,11 @@
   <data name="ManualAddressingRequiresAddressedMessages" xml:space="preserve">
     <value>Manual addressing is enabled on this factory, so all messages sent must be pre-addressed.</value>
   </data>
-  <data name="OneWayHeaderNotFound" xml:space="preserve">
-    <value>A one-way header was expected on this message and none was found. It is possible that your bindings are mismatched.</value>
-  </data>
-  <data name="ReceiveTimedOut" xml:space="preserve">
-    <value>Receive on local address {0} timed out after {1}. The time allotted to this operation may have been a portion of a longer timeout.</value>
-  </data>
   <data name="ReceiveTimedOut2" xml:space="preserve">
     <value>Receive timed out after {0}. The time allotted to this operation may have been a portion of a longer timeout.</value>
   </data>
   <data name="WaitForMessageTimedOut" xml:space="preserve">
     <value>WaitForMessage timed out after {0}. The time allotted to this operation may have been a portion of a longer timeout.</value>
-  </data>
-  <data name="ReceiveTimedOutNoLocalAddress" xml:space="preserve">
-    <value>Receive timed out after {0}. The time allotted to this operation may have been a portion of a longer timeout.</value>
-  </data>
-  <data name="ReceiveRequestTimedOutNoLocalAddress" xml:space="preserve">
-    <value>Receive request timed out after {0}. The time allotted to this operation may have been a portion of a longer timeout.</value>
-  </data>
-  <data name="ReceiveRequestTimedOut" xml:space="preserve">
-    <value>Receive request on local address {0} timed out after {1}. The time allotted to this operation may have been a portion of a longer timeout.</value>
   </data>
   <data name="SendToViaTimedOut" xml:space="preserve">
     <value>Sending to via {0} timed out after {1}. The time allotted to this operation may have been a portion of a longer timeout.</value>
@@ -1713,15 +606,6 @@
   <data name="RequestChannelWaitForReplyTimedOut" xml:space="preserve">
     <value>The request channel timed out while waiting for a reply after {0}. Increase the timeout value passed to the call to Request or increase the SendTimeout value on the Binding. The time allotted to this operation may have been a portion of a longer timeout.</value>
   </data>
-  <data name="HttpTransportCannotHaveMultipleAuthenticationSchemes" xml:space="preserve">
-    <value>The policy being imported for contract '{0}:{1}' contains multiple HTTP authentication scheme assertions.  Since at most one such assertion is allowed, policy import has failed.  This may be resolved by updating the policy to contain no more than one HTTP authentication scheme assertion.</value>
-  </data>
-  <data name="MultipleCCbesInParameters" xml:space="preserve">
-    <value>More than one '{0}' objects were found in the BindingParameters of the BindingContext.  This is usually caused by having multiple '{0}' objects in a CustomBinding. Remove all but one of these elements.</value>
-  </data>
-  <data name="CookieContainerBindingElementNeedsHttp" xml:space="preserve">
-    <value>The '{0}' can only be used with HTTP (or HTTPS) transport.</value>
-  </data>
   <data name="HttpIfModifiedSinceParseError" xml:space="preserve">
     <value>The value specified, '{0}', for the If-Modified-Since header does not parse into a valid date. Check the property value and ensure that it is of the proper format.</value>
   </data>
@@ -1731,17 +615,11 @@
   <data name="HttpSoapActionMismatchContentType" xml:space="preserve">
     <value>The SOAP action specified on the message, '{0}', does not match the action specified in the content-type of the HttpRequestMessageProperty, '{1}'.</value>
   </data>
-  <data name="HttpSoapActionMismatchFault" xml:space="preserve">
-    <value>The SOAP action specified on the message, '{0}', does not match the HTTP SOAP Action, '{1}'. </value>
-  </data>
   <data name="HttpContentTypeFormatException" xml:space="preserve">
     <value>An error ({0}) occurred while parsing the content type of the HTTP request. The content type was: {1}.</value>
   </data>
   <data name="HttpServerTooBusy" xml:space="preserve">
     <value>The HTTP service located at {0} is unavailable.  This could be because the service is too busy or because no endpoint was found listening at the specified address. Please ensure that the address is correct and try accessing the service again later.</value>
-  </data>
-  <data name="HttpRequestAborted" xml:space="preserve">
-    <value>The HTTP request to '{0}' was aborted.  This may be due to the local channel being closed while the request was still in progress.  If this behavior is not desired, then update your code so that it does not close the channel while request operations are still in progress.</value>
   </data>
   <data name="HttpRequestTimedOut" xml:space="preserve">
     <value>The HTTP request to '{0}' has exceeded the allotted timeout of {1}. The time allotted to this operation may have been a portion of a longer timeout.</value>
@@ -1749,14 +627,8 @@
   <data name="HttpResponseTimedOut" xml:space="preserve">
     <value>The HTTP request to '{0}' has exceeded the allotted timeout of {1} while reading the response. The time allotted to this operation may have been a portion of a longer timeout.</value>
   </data>
-  <data name="HttpTransferError" xml:space="preserve">
-    <value>An error ({0}) occurred while transmitting data over the HTTP channel.</value>
-  </data>
   <data name="HttpReceiveFailure" xml:space="preserve">
     <value>An error occurred while receiving the HTTP response to {0}. This could be due to the service endpoint binding not using the HTTP protocol. This could also be due to an HTTP request context being aborted by the server (possibly due to the service shutting down). See server logs for more details.</value>
-  </data>
-  <data name="HttpSendFailure" xml:space="preserve">
-    <value>An error occurred while making the HTTP request to {0}. This could be due to the fact that the server certificate is not configured properly with HTTP.SYS in the HTTPS case. This could also be caused by a mismatch of the security binding between the client and the server.</value>
   </data>
   <data name="HttpAuthDoesNotSupportRequestStreaming" xml:space="preserve">
     <value>HTTP request streaming cannot be used in conjunction with HTTP authentication.  Either disable request streaming or specify anonymous HTTP authentication.</value>
@@ -1764,107 +636,11 @@
   <data name="ReplyAlreadySent" xml:space="preserve">
     <value>A reply has already been sent from this RequestContext.</value>
   </data>
-  <data name="HttpInvalidListenURI" xml:space="preserve">
-    <value>Unable to start the HTTP listener. The URI provided, '{0}', is invalid for listening. Check the base address of your service and verify that it is a valid URI.</value>
-  </data>
   <data name="RequestContextAborted" xml:space="preserve">
     <value>The requestContext has been aborted.</value>
   </data>
-  <data name="ReceiveContextCannotBeUsed" xml:space="preserve">
-    <value>The receive context, {0}, is in the {1} state.  Receive contexts cannot be used for sending delayed acks unless they are in the Received state.</value>
-  </data>
-  <data name="ReceiveContextInInvalidState" xml:space="preserve">
-    <value>The receive context, {0}, is in an unsupported state '{1}'.  This indicates an internal error in the implementation of that receive context.</value>
-  </data>
-  <data name="ReceiveContextFaulted" xml:space="preserve">
-    <value>The receive context, {0}, cannot be used for sending delayed acks because it is in the Faulted state.</value>
-  </data>
-  <data name="UnrecognizedHostNameComparisonMode" xml:space="preserve">
-    <value>Invalid HostNameComparisonMode value: {0}.</value>
-  </data>
-  <data name="BadData" xml:space="preserve">
-    <value>Invalid data buffer.</value>
-  </data>
-  <data name="InvalidRenewResponseAction" xml:space="preserve">
-    <value>A security session renew response was received with an invalid action '{0}'.</value>
-  </data>
-  <data name="InvalidCloseResponseAction" xml:space="preserve">
-    <value>A security session close response was received with an invalid action '{0}',</value>
-  </data>
-  <data name="IncompatibleBehaviors" xml:space="preserve">
-    <value>TransactedBatchingBehavior cannot be used when ReceiveContext is being used.</value>
-  </data>
-  <data name="NullSessionRequestMessage" xml:space="preserve">
-    <value>Could not formulate request message for security session operation '{0}'.</value>
-  </data>
-  <data name="IssueSessionTokenHandlerNotSet" xml:space="preserve">
-    <value>There is no handler registered for session token issuance event.</value>
-  </data>
-  <data name="RenewSessionTokenHandlerNotSet" xml:space="preserve">
-    <value>There is no handler registered for session token renew event.</value>
-  </data>
-  <data name="WrongIdentityRenewingToken" xml:space="preserve">
-    <value>The identity of the security session renew message does not match the identity of the session token.</value>
-  </data>
-  <data name="InvalidRstRequestType" xml:space="preserve">
-    <value>The RequestSecurityToken has an invalid or unspecified RequestType '{0}'.</value>
-  </data>
-  <data name="NoCloseTargetSpecified" xml:space="preserve">
-    <value>The RequestSecurityToken must specify a CloseTarget.</value>
-  </data>
-  <data name="FailedSspiNegotiation" xml:space="preserve">
-    <value>Secure channel cannot be opened because security negotiation with the remote endpoint has failed. This may be due to absent or incorrectly specified EndpointIdentity in the EndpointAddress used to create the channel. Please verify the EndpointIdentity specified or implied by the EndpointAddress correctly identifies the remote endpoint. </value>
-  </data>
-  <data name="BadCloseTarget" xml:space="preserve">
-    <value>The CloseTarget specified '{0}' does not identify the security token that signed the message.</value>
-  </data>
-  <data name="RenewSessionMissingSupportingToken" xml:space="preserve">
-    <value>The renew security session message does not have the session token as a supporting token.</value>
-  </data>
-  <data name="NoRenewTargetSpecified" xml:space="preserve">
-    <value>The RequestSecurityToken must specify a RenewTarget.</value>
-  </data>
-  <data name="BadRenewTarget" xml:space="preserve">
-    <value>There is no endorsing session token that matches the specified RenewTarget '{0}'.</value>
-  </data>
-  <data name="BadEncryptedBody" xml:space="preserve">
-    <value>Invalid format for encrypted body.</value>
-  </data>
-  <data name="BadEncryptionState" xml:space="preserve">
-    <value>The EncryptedData or EncryptedKey is in an invalid state for this operation.</value>
-  </data>
-  <data name="NoSignaturePartsSpecified" xml:space="preserve">
-    <value>No signature message parts were specified for messages with the '{0}' action.</value>
-  </data>
-  <data name="NoEncryptionPartsSpecified" xml:space="preserve">
-    <value>No encryption message parts were specified for messages with the '{0}' action.</value>
-  </data>
-  <data name="SecuritySessionFaultReplyWasSent" xml:space="preserve">
-    <value>The receiver sent back a security session fault message. Retry the request.</value>
-  </data>
-  <data name="InnerListenerFactoryNotSet" xml:space="preserve">
-    <value>The Inner listener factory of {0} must be set before this operation.</value>
-  </data>
-  <data name="SecureConversationBootstrapCannotUseSecureConversation" xml:space="preserve">
-    <value>Cannot create security binding element based on configuration data. The secure conversation bootstrap requires another secure conversation which is not supported. </value>
-  </data>
   <data name="InnerChannelFactoryWasNotSet" xml:space="preserve">
     <value>Cannot open ChannelFactory as the inner channel factory was not set during the initialization process.</value>
-  </data>
-  <data name="SecurityProtocolFactoryDoesNotSupportDuplex" xml:space="preserve">
-    <value>Duplex security is not supported by the security protocol factory '{0}'.</value>
-  </data>
-  <data name="SecurityProtocolFactoryDoesNotSupportRequestReply" xml:space="preserve">
-    <value>Request-reply security is not supported by the security protocol factory '{0}'.</value>
-  </data>
-  <data name="SecurityProtocolFactoryShouldBeSetBeforeThisOperation" xml:space="preserve">
-    <value>The security protocol factory must be set before this operation is performed.</value>
-  </data>
-  <data name="SecuritySessionProtocolFactoryShouldBeSetBeforeThisOperation" xml:space="preserve">
-    <value>Security session protocol factory must be set before this operation is performed.</value>
-  </data>
-  <data name="SecureConversationSecurityTokenParametersRequireBootstrapBinding" xml:space="preserve">
-    <value>Security channel or listener factory creation failed. Secure conversation security token parameters do not specify the bootstrap security binding element.</value>
   </data>
   <data name="PropertySettingErrorOnProtocolFactory" xml:space="preserve">
     <value>The required '{0}' property on the '{1}' security protocol factory is not set or has an invalid value.</value>
@@ -1890,38 +666,8 @@
   <data name="DnsIdentityCheckFailedForOutgoingMessage" xml:space="preserve">
     <value>Identity check failed for outgoing message. The expected DNS identity of the remote endpoint was '{0}' but the remote endpoint provided DNS claim '{1}'. If this is a legitimate remote endpoint, you can fix the problem by explicitly specifying DNS identity '{1}' as the Identity property of EndpointAddress when creating channel proxy. </value>
   </data>
-  <data name="SerializedTokenVersionUnsupported" xml:space="preserve">
-    <value>The serialized token version {0} is unsupported.</value>
-  </data>
-  <data name="AuthenticatorNotPresentInRSTRCollection" xml:space="preserve">
-    <value>The RequestSecurityTokenResponseCollection does not contain an authenticator.</value>
-  </data>
-  <data name="RSTRAuthenticatorHasBadContext" xml:space="preserve">
-    <value>The negotiation RequestSecurityTokenResponse has a different context from the authenticator RequestSecurityTokenResponse.</value>
-  </data>
-  <data name="ServerCertificateNotProvided" xml:space="preserve">
-    <value>The recipient did not provide its certificate.  This certificate is required by the TLS protocol.  Both parties must have access to their certificates.</value>
-  </data>
-  <data name="RSTRAuthenticatorNotPresent" xml:space="preserve">
-    <value>The authenticator was not included in the final leg of negotiation.</value>
-  </data>
-  <data name="RSTRAuthenticatorIncorrect" xml:space="preserve">
-    <value>The RequestSecurityTokenResponse CombinedHash is incorrect.</value>
-  </data>
-  <data name="ClientCertificateNotProvided" xml:space="preserve">
-    <value>The certificate for the client has not been provided.  The certificate can be set on the ClientCredentials or ServiceCredentials.</value>
-  </data>
-  <data name="ClientCertificateNotProvidedOnServiceCredentials" xml:space="preserve">
-    <value>The client certificate is not provided. Specify a client certificate in ServiceCredentials. </value>
-  </data>
   <data name="ClientCertificateNotProvidedOnClientCredentials" xml:space="preserve">
     <value>The client certificate is not provided. Specify a client certificate in ClientCredentials. </value>
-  </data>
-  <data name="ServiceCertificateNotProvidedOnServiceCredentials" xml:space="preserve">
-    <value>The service certificate is not provided. Specify a service certificate in ServiceCredentials. </value>
-  </data>
-  <data name="ServiceCertificateNotProvidedOnClientCredentials" xml:space="preserve">
-    <value>The service certificate is not provided for target '{0}'. Specify a service certificate in ClientCredentials. </value>
   </data>
   <data name="UserNamePasswordNotProvidedOnClientCredentials" xml:space="preserve">
     <value>The username is not provided. Specify username in ClientCredentials.</value>
@@ -1935,101 +681,11 @@
   <data name="UnexpectedXmlChildNode" xml:space="preserve">
     <value>XML child node {0} of type {1} is unexpected for element {2}.</value>
   </data>
-  <data name="ContextAlreadyRegistered" xml:space="preserve">
-    <value>The context-id={0} (generation-id={1}) is already registered with SecurityContextSecurityTokenAuthenticator.</value>
-  </data>
-  <data name="ContextAlreadyRegisteredNoKeyGeneration" xml:space="preserve">
-    <value>The context-id={0} (no key generation-id) is already registered with SecurityContextSecurityTokenAuthenticator.</value>
-  </data>
-  <data name="ContextNotPresent" xml:space="preserve">
-    <value>There is no SecurityContextSecurityToken with context-id={0} (generation-id={1}) registered with SecurityContextSecurityTokenAuthenticator.</value>
-  </data>
-  <data name="ContextNotPresentNoKeyGeneration" xml:space="preserve">
-    <value>There is no SecurityContextSecurityToken with context-id={0} (no key generation-id) registered with SecurityContextSecurityTokenAuthenticator.</value>
-  </data>
-  <data name="InvalidSecurityContextCookie" xml:space="preserve">
-    <value>The SecurityContextSecurityToken has an invalid Cookie. The following error occurred when processing the Cookie: '{0}'.</value>
-  </data>
-  <data name="SecurityContextNotRegistered" xml:space="preserve">
-    <value>The SecurityContextSecurityToken with context-id={0} (key generation-id={1}) is not registered.</value>
-  </data>
-  <data name="SecurityContextExpired" xml:space="preserve">
-    <value>The SecurityContextSecurityToken with context-id={0} (key generation-id={1}) has expired.</value>
-  </data>
-  <data name="SecurityContextExpiredNoKeyGeneration" xml:space="preserve">
-    <value>The SecurityContextSecurityToken with context-id={0} (no key generation-id) has expired.</value>
-  </data>
-  <data name="NoSecurityContextIdentifier" xml:space="preserve">
-    <value>The SecurityContextSecurityToken does not have a context-id.</value>
-  </data>
-  <data name="MessageMustHaveViaOrToSetForSendingOnServerSideCompositeDuplexChannels" xml:space="preserve">
-    <value>For sending a message on server side composite duplex channels, the message must have either the 'Via' property or the 'To' header set.</value>
-  </data>
-  <data name="MessageViaCannotBeAddressedToAnonymousOnServerSideCompositeDuplexChannels" xml:space="preserve">
-    <value>The 'Via' property on the message is set to Anonymous Uri '{0}'. Please set the 'Via' property to a non-anonymous address as message cannot be addressed to anonymous Uri on server side composite duplex channels.</value>
-  </data>
-  <data name="MessageToCannotBeAddressedToAnonymousOnServerSideCompositeDuplexChannels" xml:space="preserve">
-    <value>The 'To' header on the message is set to Anonymous Uri '{0}'. Please set the 'To' header to a non-anonymous address as message cannot be addressed to anonymous Uri on server side composite duplex channels.</value>
-  </data>
-  <data name="SecurityBindingNotSetUpToProcessOutgoingMessages" xml:space="preserve">
-    <value>This SecurityProtocol instance was not set up to process outgoing messages.</value>
-  </data>
-  <data name="SecurityBindingNotSetUpToProcessIncomingMessages" xml:space="preserve">
-    <value>This SecurityProtocol instance was not set up to process incoming messages.</value>
-  </data>
-  <data name="TokenProviderCannotGetTokensForTarget" xml:space="preserve">
-    <value>The token provider cannot get tokens for target '{0}'.</value>
-  </data>
-  <data name="UnsupportedKeyDerivationAlgorithm" xml:space="preserve">
-    <value>Key derivation algorithm '{0}' is not supported.</value>
-  </data>
-  <data name="CannotFindCorrelationStateForApplyingSecurity" xml:space="preserve">
-    <value>Cannot find the correlation state for applying security to reply at the responder.</value>
-  </data>
-  <data name="ReplyWasNotSignedWithRequiredSigningToken" xml:space="preserve">
-    <value>The reply was not signed with the required signing token.</value>
-  </data>
-  <data name="EncryptionNotExpected" xml:space="preserve">
-    <value>Encryption not expected for this message.</value>
-  </data>
-  <data name="SignatureNotExpected" xml:space="preserve">
-    <value>A signature is not expected for this message.</value>
-  </data>
   <data name="InvalidQName" xml:space="preserve">
     <value>The QName is invalid.</value>
   </data>
-  <data name="UnknownICryptoType" xml:space="preserve">
-    <value>The ICrypto implementation '{0}' is not supported.</value>
-  </data>
-  <data name="SameProtocolFactoryCannotBeSetForBothDuplexDirections" xml:space="preserve">
-    <value>On DuplexSecurityProtocolFactory, the same protocol factory cannot be set for the forward and reverse directions.</value>
-  </data>
   <data name="SuiteDoesNotAcceptAlgorithm" xml:space="preserve">
     <value>The algorithm '{0}' is not accepted for operation '{1}' by algorithm suite {2}.</value>
-  </data>
-  <data name="TokenDoesNotSupportKeyIdentifierClauseCreation" xml:space="preserve">
-    <value>'{0}' does not support '{1}' creation.</value>
-  </data>
-  <data name="UnableToCreateICryptoFromTokenForSignatureVerification" xml:space="preserve">
-    <value>Cannot create an ICrypto interface from the '{0}' token for signature verification.</value>
-  </data>
-  <data name="MessageSecurityVerificationFailed" xml:space="preserve">
-    <value>Message security verification failed.</value>
-  </data>
-  <data name="TransportSecurityRequireToHeader" xml:space="preserve">
-    <value>Transport secured messages should have the 'To' header specified.</value>
-  </data>
-  <data name="TransportSecuredMessageMissingToHeader" xml:space="preserve">
-    <value>The message received over Transport security was missing the 'To' header.</value>
-  </data>
-  <data name="UnsignedToHeaderInTransportSecuredMessage" xml:space="preserve">
-    <value>The message received over Transport security has unsigned 'To' header.</value>
-  </data>
-  <data name="TransportSecuredMessageHasMoreThanOneToHeader" xml:space="preserve">
-    <value>More than one 'To' header specified in a message secured by Transport Security.</value>
-  </data>
-  <data name="TokenNotExpectedInSecurityHeader" xml:space="preserve">
-    <value>Received security header contains unexpected token '{0}'.</value>
   </data>
   <data name="CannotFindCert" xml:space="preserve">
     <value>Cannot find the X.509 certificate using the following search criteria: StoreName '{0}', StoreLocation '{1}', FindType '{2}', FindValue '{3}'.</value>
@@ -2043,257 +699,38 @@
   <data name="FoundMultipleCertsForTarget" xml:space="preserve">
     <value>Found multiple X.509 certificates using the following search criteria: StoreName '{0}', StoreLocation '{1}', FindType '{2}', FindValue '{3}' for target '{4}'. Provide a more specific find value.</value>
   </data>
-  <data name="MissingKeyInfoInEncryptedKey" xml:space="preserve">
-    <value>The KeyInfo clause is missing or empty in EncryptedKey.</value>
-  </data>
-  <data name="EncryptedKeyWasNotEncryptedWithTheRequiredEncryptingToken" xml:space="preserve">
-    <value>The EncryptedKey clause was not wrapped with the required encryption token '{0}'.</value>
-  </data>
-  <data name="MessageWasNotEncryptedWithTheRequiredEncryptingToken" xml:space="preserve">
-    <value>The message was not encrypted with the required encryption token.</value>
-  </data>
-  <data name="TimestampMustOccurFirstInSecurityHeaderLayout" xml:space="preserve">
-    <value>The timestamp must occur first in this security header layout.</value>
-  </data>
-  <data name="TimestampMustOccurLastInSecurityHeaderLayout" xml:space="preserve">
-    <value>The timestamp must occur last in this security header layout.</value>
-  </data>
-  <data name="AtMostOnePrimarySignatureInReceiveSecurityHeader" xml:space="preserve">
-    <value>Only one primary signature is allowed in a security header.</value>
-  </data>
   <data name="SigningTokenHasNoKeys" xml:space="preserve">
     <value>The signing token {0} has no keys. The security token is used in a context that requires it to perform cryptographic operations, but the token contains no cryptographic keys. Either the token type does not support cryptographic operations, or the particular token instance does not contain cryptographic keys. Check your configuration to ensure that cryptographically disabled token types (for example, UserNameSecurityToken) are not specified in a context that requires cryptographic operations (for example, an endorsing supporting token).</value>
   </data>
   <data name="SigningTokenHasNoKeysSupportingTheAlgorithmSuite" xml:space="preserve">
     <value>The signing token {0} has no key that supports the algorithm suite {1}.</value>
   </data>
-  <data name="DelayedSecurityApplicationAlreadyCompleted" xml:space="preserve">
-    <value>Delayed security application has already been completed.</value>
-  </data>
-  <data name="UnableToResolveKeyInfoClauseInDerivedKeyToken" xml:space="preserve">
-    <value>Cannot resolve KeyInfo in derived key token for resolving source token: KeyInfoClause '{0}'.</value>
-  </data>
-  <data name="UnableToDeriveKeyFromKeyInfoClause" xml:space="preserve">
-    <value>KeyInfo clause '{0}' resolved to token '{1}', which does not contain a Symmetric key that can be used for derivation.</value>
-  </data>
-  <data name="UnableToResolveKeyInfoForVerifyingSignature" xml:space="preserve">
-    <value>Cannot resolve KeyInfo for verifying signature: KeyInfo '{0}', available tokens '{1}'.</value>
-  </data>
-  <data name="UnableToResolveKeyInfoForUnwrappingToken" xml:space="preserve">
-    <value>Cannot resolve KeyInfo for unwrapping key: KeyInfo '{0}', available tokens '{1}'.</value>
-  </data>
-  <data name="UnableToResolveKeyInfoForDecryption" xml:space="preserve">
-    <value>Cannot resolve KeyInfo for decryption: KeyInfo '{0}', available tokens '{1}'.</value>
-  </data>
   <data name="EmptyBase64Attribute" xml:space="preserve">
     <value>An empty value was found for the required base-64 attribute name '{0}', namespace '{1}'.</value>
-  </data>
-  <data name="RequiredSecurityHeaderElementNotSigned" xml:space="preserve">
-    <value>The security header element '{0}' with the '{1}' id must be signed.</value>
-  </data>
-  <data name="RequiredSecurityTokenNotSigned" xml:space="preserve">
-    <value>The '{0}' security token with the '{1}' attachment mode must be signed.</value>
-  </data>
-  <data name="RequiredSecurityTokenNotEncrypted" xml:space="preserve">
-    <value>The '{0}' security token with the '{1}' attachment mode must be encrypted.</value>
-  </data>
-  <data name="MessageBodyOperationNotValidInBodyState" xml:space="preserve">
-    <value>Operation '{0}' is not valid in message body state '{1}'.</value>
-  </data>
-  <data name="EncryptedKeyWithReferenceListNotAllowed" xml:space="preserve">
-    <value>EncryptedKey with ReferenceList is not allowed according to the current settings.</value>
-  </data>
-  <data name="UnableToFindTokenAuthenticator" xml:space="preserve">
-    <value>Cannot find a token authenticator for the '{0}' token type. Tokens of that type cannot be accepted according to current security settings.</value>
-  </data>
-  <data name="NoPartsOfMessageMatchedPartsToSign" xml:space="preserve">
-    <value>No signature was created because not part of the message matched the supplied message part specification.</value>
-  </data>
-  <data name="BasicTokenCannotBeWrittenWithoutEncryption" xml:space="preserve">
-    <value>Supporting SecurityToken cannot be written without encryption.</value>
-  </data>
-  <data name="DuplicateIdInMessageToBeVerified" xml:space="preserve">
-    <value>The '{0}' id occurred twice in the message that is supplied for verification.</value>
-  </data>
-  <data name="UnsupportedCanonicalizationAlgorithm" xml:space="preserve">
-    <value>Canonicalization algorithm '{0}' is not supported.</value>
-  </data>
-  <data name="NoKeyInfoInEncryptedItemToFindDecryptingToken" xml:space="preserve">
-    <value>The KeyInfo value was not found in the encrypted item to find the decrypting token.</value>
-  </data>
-  <data name="NoKeyInfoInSignatureToFindVerificationToken" xml:space="preserve">
-    <value>No KeyInfo in signature to find verification token.</value>
-  </data>
-  <data name="SecurityHeaderIsEmpty" xml:space="preserve">
-    <value>Security header is empty.</value>
-  </data>
-  <data name="EncryptionMethodMissingInEncryptedData" xml:space="preserve">
-    <value>The encryption method is missing in encrypted data.</value>
-  </data>
-  <data name="EncryptedHeaderAttributeMismatch" xml:space="preserve">
-    <value>The Encrypted Header and the Security Header '{0}' attribute did not match. Encrypted Header: {1}. Security Header: {2}.</value>
-  </data>
-  <data name="AtMostOneReferenceListIsSupportedWithDefaultPolicyCheck" xml:space="preserve">
-    <value>At most one reference list is supported with default policy check.</value>
-  </data>
-  <data name="AtMostOneSignatureIsSupportedWithDefaultPolicyCheck" xml:space="preserve">
-    <value>At most one signature is supported with default policy check.</value>
-  </data>
-  <data name="UnexpectedEncryptedElementInSecurityHeader" xml:space="preserve">
-    <value>Unexpected encrypted element in security header.</value>
-  </data>
-  <data name="MissingIdInEncryptedElement" xml:space="preserve">
-    <value>Id is missing in encrypted item in security header.</value>
-  </data>
-  <data name="TokenManagerCannotCreateTokenReference" xml:space="preserve">
-    <value>The supplied token manager cannot create a token reference.</value>
-  </data>
-  <data name="TimestampToSignHasNoId" xml:space="preserve">
-    <value>The timestamp element added to security header to sign has no id.</value>
-  </data>
-  <data name="EncryptedHeaderXmlMustHaveId" xml:space="preserve">
-    <value>An encrypted header must have an id.</value>
-  </data>
-  <data name="UnableToResolveDataReference" xml:space="preserve">
-    <value>The data reference '{0}' could not be resolved in the received message.</value>
-  </data>
-  <data name="TimestampAlreadySetForSecurityHeader" xml:space="preserve">
-    <value>A timestamp element has already been set for this security header.</value>
-  </data>
-  <data name="DuplicateTimestampInSecurityHeader" xml:space="preserve">
-    <value>More than one Timestamp element was present in security header.</value>
-  </data>
-  <data name="MismatchInSecurityOperationToken" xml:space="preserve">
-    <value>The incoming message was signed with a token which was different from what used to encrypt the body.  This was not expected.</value>
-  </data>
-  <data name="UnableToCreateSymmetricAlgorithmFromToken" xml:space="preserve">
-    <value>Cannot create the '{0}' symmetric algorithm from the token.</value>
-  </data>
-  <data name="UnknownEncodingInBinarySecurityToken" xml:space="preserve">
-    <value>Unrecognized encoding occurred while reading the binary security token.</value>
-  </data>
-  <data name="UnableToResolveReferenceUriForSignature" xml:space="preserve">
-    <value>Cannot resolve reference URI '{0}' in signature to compute digest.</value>
-  </data>
-  <data name="NoTimestampAvailableInSecurityHeaderToDoReplayDetection" xml:space="preserve">
-    <value>No timestamp is available in the security header to do replay detection.</value>
-  </data>
-  <data name="NoSignatureAvailableInSecurityHeaderToDoReplayDetection" xml:space="preserve">
-    <value>No signature is available in the security header to provide the nonce for replay detection.</value>
   </data>
   <data name="CouldNotFindNamespaceForPrefix" xml:space="preserve">
     <value>There is no namespace binding for prefix '{0}' in scope.</value>
   </data>
-  <data name="DerivedKeyCannotDeriveFromSecret" xml:space="preserve">
-    <value>Derived Key Token cannot derive key from the secret.</value>
-  </data>
-  <data name="DerivedKeyPosAndGenBothSpecified" xml:space="preserve">
-    <value>Both offset and generation cannot be specified for Derived Key Token.</value>
-  </data>
-  <data name="DerivedKeyPosAndGenNotSpecified" xml:space="preserve">
-    <value>Either offset or generation must be specified for Derived Key Token.</value>
-  </data>
-  <data name="DerivedKeyTokenRequiresTokenReference" xml:space="preserve">
-    <value>DerivedKeyToken requires a reference to a token.</value>
-  </data>
-  <data name="DerivedKeyLengthTooLong" xml:space="preserve">
-    <value>DerivedKey length ({0}) exceeds the allowed settings ({1}).</value>
-  </data>
-  <data name="DerivedKeyLengthSpecifiedInImplicitDerivedKeyClauseTooLong" xml:space="preserve">
-    <value>The Implicit derived key clause '{0}' specifies a derivation key length ({1}) which exceeds the allowed maximum length ({2}).</value>
-  </data>
-  <data name="DerivedKeyInvalidOffsetSpecified" xml:space="preserve">
-    <value>The received derived key token has a invalid offset value specified. Value: {0}. The value should be greater than or equal to zero.</value>
-  </data>
-  <data name="DerivedKeyInvalidGenerationSpecified" xml:space="preserve">
-    <value>The received derived key token has a invalid generation value specified. Value: {0}. The value should be greater than or equal to zero.</value>
-  </data>
   <data name="ChildNodeTypeMissing" xml:space="preserve">
     <value>The XML element {0} does not have a child of type {1}.</value>
-  </data>
-  <data name="NoLicenseXml" xml:space="preserve">
-    <value>RequestedSecurityToken not specified in RequestSecurityTokenResponse.</value>
-  </data>
-  <data name="UnsupportedBinaryEncoding" xml:space="preserve">
-    <value>Binary encoding {0} is not supported.</value>
-  </data>
-  <data name="BadKeyEncryptionAlgorithm" xml:space="preserve">
-    <value>Invalid key encryption algorithm {0}.</value>
   </data>
   <data name="SPS_InvalidAsyncResult" xml:space="preserve">
     <value>The asynchronous result object used to end this operation was not the object that was returned when the operation was initiated.</value>
   </data>
-  <data name="UnableToCreateTokenReference" xml:space="preserve">
-    <value>Unable to create token reference.</value>
-  </data>
   <data name="NonceLengthTooShort" xml:space="preserve">
     <value>The specified nonce is too short. The minimum required nonce length is 4 bytes.</value>
-  </data>
-  <data name="NoBinaryNegoToSend" xml:space="preserve">
-    <value>There is no binary negotiation to send to the other party.</value>
-  </data>
-  <data name="BadSecurityNegotiationContext" xml:space="preserve">
-    <value>Security negotiation failure because an incorrect Context attribute specified in RequestSecurityToken/RequestSecurityTokenResponse from the other party.</value>
-  </data>
-  <data name="NoBinaryNegoToReceive" xml:space="preserve">
-    <value>No binary negotiation was received from the other party.</value>
-  </data>
-  <data name="ProofTokenWasNotWrappedCorrectly" xml:space="preserve">
-    <value>The proof token was not wrapped correctly in the RequestSecurityTokenResponse.</value>
-  </data>
-  <data name="NoServiceTokenReceived" xml:space="preserve">
-    <value>Final RSTR from other party does not contain a service token.</value>
-  </data>
-  <data name="InvalidSspiNegotiation" xml:space="preserve">
-    <value>The Security Support Provider Interface (SSPI) negotiation failed.</value>
-  </data>
-  <data name="CannotAuthenticateServer" xml:space="preserve">
-    <value>Cannot authenticate the other party.</value>
   </data>
   <data name="IncorrectBinaryNegotiationValueType" xml:space="preserve">
     <value>Incoming binary negotiation has invalid ValueType {0}.</value>
   </data>
-  <data name="ChannelNotOpen" xml:space="preserve">
-    <value>The channel is not open.</value>
-  </data>
-  <data name="FailToRecieveReplyFromNegotiation" xml:space="preserve">
-    <value>Security negotiation failed because the remote party did not send back a reply in a timely manner. This may be because the underlying transport connection was aborted.</value>
-  </data>
-  <data name="MessageSecurityVersionOutOfRange" xml:space="preserve">
-    <value>SecurityVersion must be WsSecurity10 or WsSecurity11.</value>
-  </data>
   <data name="CreationTimeUtcIsAfterExpiryTime" xml:space="preserve">
     <value>Creation time must be before expiration time.</value>
-  </data>
-  <data name="NegotiationStateAlreadyPresent" xml:space="preserve">
-    <value>Negotiation state already exists for context '{0}'.</value>
-  </data>
-  <data name="CannotFindNegotiationState" xml:space="preserve">
-    <value>Cannot find the negotiation state for the context '{0}'.</value>
-  </data>
-  <data name="OutputNotExpected" xml:space="preserve">
-    <value>Send cannot be called when the session does not expect output.</value>
-  </data>
-  <data name="SessionClosedBeforeDone" xml:space="preserve">
-    <value>The session was closed before message transfer was complete.</value>
   </data>
   <data name="CacheQuotaReached" xml:space="preserve">
     <value>The item cannot be added. The maximum cache size is ({0} items).</value>
   </data>
-  <data name="NoServerX509TokenProvider" xml:space="preserve">
-    <value>The server's X509SecurityTokenProvider cannot be null.</value>
-  </data>
-  <data name="UnexpectedBinarySecretType" xml:space="preserve">
-    <value>Expected binary secret of type {0} but got secret of type {1}.</value>
-  </data>
-  <data name="UnsupportedPasswordType" xml:space="preserve">
-    <value>The '{0}' username token has an unsupported password type.</value>
-  </data>
   <data name="UnrecognizedIdentityPropertyType" xml:space="preserve">
     <value>Unrecognized identity property type: '{0}'.</value>
-  </data>
-  <data name="UnableToDemuxChannel" xml:space="preserve">
-    <value>There was no channel that could accept the message with action '{0}'.</value>
   </data>
   <data name="EndpointNotFound" xml:space="preserve">
     <value>There was no endpoint listening at {0} that could accept the message. This is often caused by an incorrect address or SOAP action. See InnerException, if present, for more details.</value>
@@ -2307,38 +744,17 @@
   <data name="MaxBufferSizeMustNotExceedMaxReceivedMessageSize" xml:space="preserve">
     <value>MaxBufferSize must not exceed MaxReceivedMessageSize.</value>
   </data>
-  <data name="MessageSizeMustBeInIntegerRange" xml:space="preserve">
-    <value>This Factory buffers messages, so the message sizes must be in the range of a int value.</value>
-  </data>
-  <data name="UriLengthExceedsMaxSupportedSize" xml:space="preserve">
-    <value>URI {0} could not be set because its size ({1}) exceeds the max supported size ({2}).</value>
-  </data>
   <data name="InValidateIdPrefix" xml:space="preserve">
     <value>Expecting first char - c - to be in set [Char.IsLetter(c) &amp;&amp; c == '_', found '{0}'.</value>
   </data>
   <data name="InValidateId" xml:space="preserve">
     <value>Expecting all chars - c - of id to be in set [Char.IsLetter(c), Char.IsNumber(c), '.', '_', '-'], found '{0}'.</value>
   </data>
-  <data name="HttpRegistrationAlreadyExists" xml:space="preserve">
-    <value>HTTP could not register URL {0}. Another application has already registered this URL with HTTP.SYS.</value>
-  </data>
-  <data name="HttpRegistrationAccessDenied" xml:space="preserve">
-    <value>HTTP could not register URL {0}. Your process does not have access rights to this namespace (see http://go.microsoft.com/fwlink/?LinkId=70353 for details).</value>
-  </data>
-  <data name="HttpRegistrationPortInUse" xml:space="preserve">
-    <value>HTTP could not register URL {0} because TCP port {1} is being used by another application.</value>
-  </data>
-  <data name="HttpRegistrationLimitExceeded" xml:space="preserve">
-    <value>HTTP could not register URL {0} because the MaxEndpoints quota has been exceeded. To correct this, either close other HTTP-based services, or increase your MaxEndpoints registry key setting (see http://go.microsoft.com/fwlink/?LinkId=70352 for details).</value>
-  </data>
   <data name="UnexpectedHttpResponseCode" xml:space="preserve">
     <value>The remote server returned an unexpected response: ({0}) {1}.</value>
   </data>
   <data name="HttpContentLengthIncorrect" xml:space="preserve">
     <value>The number of bytes available is inconsistent with the HTTP Content-Length header.  There may have been a network error or the client may be sending invalid requests.</value>
-  </data>
-  <data name="OneWayUnexpectedResponse" xml:space="preserve">
-    <value>A response was received from a one-way send over the underlying IRequestChannel. Make sure the remote endpoint has a compatible binding at its endpoint (one that contains OneWayBindingElement).</value>
   </data>
   <data name="MissingContentType" xml:space="preserve">
     <value>The receiver returned an error indicating that the content type was missing on the request to {0}.  See the inner exception for more information.</value>
@@ -2355,18 +771,6 @@
   <data name="MessageXmlProtocolError" xml:space="preserve">
     <value>There is a problem with the XML that was received from the network. See inner exception for more details.</value>
   </data>
-  <data name="TcpV4AddressInvalid" xml:space="preserve">
-    <value>An IPv4 address was specified ({0}), but IPv4 is not enabled on this machine. </value>
-  </data>
-  <data name="TcpV6AddressInvalid" xml:space="preserve">
-    <value>An IPv6 address was specified ({0}), but IPv6 is not enabled on this machine. </value>
-  </data>
-  <data name="UniquePortNotAvailable" xml:space="preserve">
-    <value>Cannot find a unique port number that is available for both IPv4 and IPv6.</value>
-  </data>
-  <data name="TcpAddressInUse" xml:space="preserve">
-    <value>There is already a listener on IP endpoint {0}. This could happen if there is another application already listening on this endpoint or if you have multiple service endpoints in your service host with the same IP endpoint but with incompatible binding configurations.</value>
-  </data>
   <data name="TcpConnectNoBufs" xml:space="preserve">
     <value>Insufficient winsock resources available to complete socket connection initiation.</value>
   </data>
@@ -2379,65 +783,29 @@
   <data name="TcpConnectErrorWithTimeSpan" xml:space="preserve">
     <value>Could not connect to {0}. The connection attempt lasted for a time span of {3}. TCP error code {1}: {2}. </value>
   </data>
-  <data name="TcpListenError" xml:space="preserve">
-    <value>A TCP error ({0}: {1}) occurred while listening on IP Endpoint={2}.</value>
-  </data>
   <data name="TcpTransferError" xml:space="preserve">
     <value>A TCP error ({0}: {1}) occurred while transmitting data.</value>
-  </data>
-  <data name="TcpTransferErrorWithIP" xml:space="preserve">
-    <value>A TCP error ({0}: {1}) occurred while transmitting data. The local IP address and port is {2}. The remote IP address and port is {3}.</value>
   </data>
   <data name="TcpLocalConnectionAborted" xml:space="preserve">
     <value>The socket connection was aborted by your local machine. This could be caused by a channel Abort(), or a transmission error from another thread using this socket.</value>
   </data>
-  <data name="HttpResponseAborted" xml:space="preserve">
-    <value>The HTTP request context was aborted while writing the response.  As a result, the response may not have been completely written to the network.  This can be remedied by gracefully closing the request context rather than aborting it.</value>
-  </data>
   <data name="TcpConnectionResetError" xml:space="preserve">
     <value>The socket connection was aborted. This could be caused by an error processing your message or a receive timeout being exceeded by the remote host, or an underlying network resource issue. Local socket timeout was '{0}'.</value>
-  </data>
-  <data name="TcpConnectionResetErrorWithIP" xml:space="preserve">
-    <value>The socket connection was aborted. This could be caused by an error processing your message or a receive timeout being exceeded by the remote host, or an underlying network resource issue. Local socket timeout was '{0}'. The local IP address and port is {1}. The remote IP address and port is {2}.</value>
   </data>
   <data name="TcpConnectionTimedOut" xml:space="preserve">
     <value>The socket transfer timed out after {0}. You have exceeded the timeout set on your binding. The time allotted to this operation may have been a portion of a longer timeout.</value>
   </data>
-  <data name="TcpConnectionTimedOutWithIP" xml:space="preserve">
-    <value>The socket transfer timed out after {0}. You have exceeded the timeout set on your binding. The time allotted to this operation may have been a portion of a longer timeout. The local IP address and port is {1}. The remote IP address and port is {2}.</value>
-  </data>
   <data name="SocketConnectionDisposed" xml:space="preserve">
     <value>The socket connection has been disposed.</value>
-  </data>
-  <data name="SocketListenerDisposed" xml:space="preserve">
-    <value>The socket listener has been disposed.</value>
-  </data>
-  <data name="SocketListenerNotListening" xml:space="preserve">
-    <value>The socket listener is not listening.</value>
-  </data>
-  <data name="DuplexSessionListenerNotFound" xml:space="preserve">
-    <value>No duplex session listener was listening at {0}. This could be due to an incorrect via set on the client or a binding mismatch.</value>
-  </data>
-  <data name="HttpTargetNameDictionaryConflict" xml:space="preserve">
-    <value>The entry found in AuthenticationManager's CustomTargetNameDictionary for {0} does not match the requested identity of {1}.</value>
   </data>
   <data name="HttpContentTypeHeaderRequired" xml:space="preserve">
     <value>An HTTP Content-Type header is required for SOAP messaging and none was found.</value>
   </data>
-  <data name="ContentTypeMismatch" xml:space="preserve">
-    <value>Content Type {0} was sent to a service expecting {1}.  The client and service bindings may be mismatched.</value>
-  </data>
   <data name="ResponseContentTypeMismatch" xml:space="preserve">
     <value>The content type {0} of the response message does not match the content type of the binding ({1}). If using a custom encoder, be sure that the IsContentTypeSupported method is implemented properly. The first {2} bytes of the response were: '{3}'.</value>
   </data>
-  <data name="ResponseContentTypeNotSupported" xml:space="preserve">
-    <value>The content type {0} of the message is not supported by the encoder.</value>
-  </data>
   <data name="HttpToMustEqualVia" xml:space="preserve">
     <value>The binding specified requires that the to and via URIs must match because the Addressing Version is set to None. The to URI specified was '{0}'. The via URI specified was '{1}'.</value>
-  </data>
-  <data name="NullReferenceOnHttpResponse" xml:space="preserve">
-    <value>The server challenged this request and streamed requests cannot be resubmitted. To enable HTTP server challenges, set your TransferMode to Buffered or StreamedResponse.</value>
   </data>
   <data name="FramingContentTypeMismatch" xml:space="preserve">
     <value>Content Type {0} was not supported by service {1}.  The client and service bindings may be mismatched.</value>
@@ -2460,20 +828,8 @@
   <data name="FramingUpgradeInvalid" xml:space="preserve">
     <value>The requested upgrade is not supported by '{0}'. This could be due to mismatched bindings (for example security enabled on the client and not on the server).</value>
   </data>
-  <data name="SecurityServerTooBusy" xml:space="preserve">
-    <value>Server '{0}' sent back a fault indicating it is too busy to process the request. Please retry later. Please see the inner exception for fault details.</value>
-  </data>
-  <data name="SecurityEndpointNotFound" xml:space="preserve">
-    <value>Server '{0}' sent back a fault indicating it is in the process of shutting down. Please see the inner exception for fault details.</value>
-  </data>
   <data name="ServerTooBusy" xml:space="preserve">
     <value>Server '{0}' is too busy to process this request. Try again later.</value>
-  </data>
-  <data name="UpgradeProtocolNotSupported" xml:space="preserve">
-    <value>Protocol Type {0} was sent to a service that does not support that type of upgrade.</value>
-  </data>
-  <data name="UpgradeRequestToNonupgradableService" xml:space="preserve">
-    <value>.Net Framing upgrade request for {0} was sent to a service that is not setup to receive upgrades.</value>
   </data>
   <data name="PreambleAckIncorrect" xml:space="preserve">
     <value>You have tried to create a channel to a service that does not support .Net Framing. </value>
@@ -2499,17 +855,8 @@
   <data name="HttpAuthSchemeCannotBeNone" xml:space="preserve">
     <value>The value specified for the AuthenticationScheme property on the HttpTransportBindingElement ('{0}') is not allowed when building a ChannelFactory. If you used a standard binding, ensure the ClientCredentialType is not set to HttpClientCredentialType.InheritedFromHost, a value which is invalid on a client. If you set the value to '{0}' directly on the HttpTransportBindingElement, please set it to Digest, Negotiate, NTLM, Basic, or Anonymous.</value>
   </data>
-  <data name="HttpProxyRequiresSingleAuthScheme" xml:space="preserve">
-    <value>The '{0}' authentication scheme has been specified for the proxy on the HTTP factory. However, the factory only supports specification of exactly one authentication scheme. Valid authentication schemes are Digest, Negotiate, NTLM, Basic, or Anonymous.</value>
-  </data>
-  <data name="HttpMutualAuthNotSatisfied" xml:space="preserve">
-    <value>The remote HTTP server did not satisfy the mutual authentication requirement.</value>
-  </data>
   <data name="HttpAuthorizationFailed" xml:space="preserve">
     <value>The HTTP request is unauthorized with client authentication scheme '{0}'. The authentication header received from the server was '{1}'.</value>
-  </data>
-  <data name="HttpAuthenticationFailed" xml:space="preserve">
-    <value>The HTTP request with client authentication scheme '{0}' failed with '{1}' status.</value>
   </data>
   <data name="HttpAuthorizationForbidden" xml:space="preserve">
     <value>The HTTP request was forbidden with client authentication scheme '{0}'.</value>
@@ -2517,44 +864,14 @@
   <data name="InvalidUriScheme" xml:space="preserve">
     <value>The provided URI scheme '{0}' is invalid; expected '{1}'.</value>
   </data>
-  <data name="HttpAuthSchemeAndClientCert" xml:space="preserve">
-    <value>The HTTPS listener factory was configured to require a client certificate and the '{0}' authentication scheme. However, only one form of client authentication can be required at once.</value>
-  </data>
-  <data name="NoTransportManagerForUri" xml:space="preserve">
-    <value>Could not find an appropriate transport manager for listen URI '{0}'.</value>
-  </data>
-  <data name="ListenerFactoryNotRegistered" xml:space="preserve">
-    <value>The specified channel listener at '{0}' is not registered with this transport manager.</value>
-  </data>
-  <data name="HttpsExplicitIdentity" xml:space="preserve">
-    <value>The HTTPS channel factory does not support explicit specification of an identity in the EndpointAddress unless the authentication scheme is NTLM or Negotiate.</value>
-  </data>
-  <data name="HttpsIdentityMultipleCerts" xml:space="preserve">
-    <value>The endpoint identity specified when creating the HTTPS channel to '{0}' contains multiple server certificates.  However, the HTTPS transport only supports the specification of a single server certificate.  In order to create an HTTPS channel, please specify no more than one server certificate in the endpoint identity.</value>
-  </data>
   <data name="HttpsServerCertThumbprintMismatch" xml:space="preserve">
     <value>The server certificate with name '{0}' failed identity verification because its thumbprint ('{1}') does not match the one specified in the endpoint identity ('{2}').  As a result, the current HTTPS request has failed.  Please update the endpoint identity used on the client or the certificate used by the server.</value>
-  </data>
-  <data name="DuplicateRegistration" xml:space="preserve">
-    <value>A registration already exists for URI '{0}'.</value>
-  </data>
-  <data name="SecureChannelFailure" xml:space="preserve">
-    <value>Could not establish secure channel for SSL/TLS with authority '{0}'.</value>
   </data>
   <data name="TrustFailure" xml:space="preserve">
     <value>Could not establish trust relationship for the SSL/TLS secure channel with authority '{0}'.</value>
   </data>
-  <data name="NoCompatibleTransportManagerForUri" xml:space="preserve">
-    <value>Could not find a compatible transport manager for URI '{0}'.</value>
-  </data>
-  <data name="HttpSpnNotFound" xml:space="preserve">
-    <value>The SPN for the responding server at URI '{0}' could not be determined.</value>
-  </data>
   <data name="StreamMutualAuthNotSatisfied" xml:space="preserve">
     <value>The remote server did not satisfy the mutual authentication requirement.</value>
-  </data>
-  <data name="TransferModeNotSupported" xml:space="preserve">
-    <value>Transfer mode {0} is not supported by {1}.</value>
   </data>
   <data name="InvalidTokenProvided" xml:space="preserve">
     <value>The token provider of type '{0}' did not return a token of type '{1}'. Check the credential configuration.</value>
@@ -2565,32 +882,14 @@
   <data name="RemoteIdentityFailedVerification" xml:space="preserve">
     <value>The following remote identity failed verification: '{0}'.</value>
   </data>
-  <data name="UseDefaultWebProxyCantBeUsedWithExplicitProxyAddress" xml:space="preserve">
-    <value>You cannot specify an explicit Proxy Address as well as UseDefaultWebProxy=true in your HTTP Transport Binding Element.</value>
-  </data>
-  <data name="ProxyImpersonationLevelMismatch" xml:space="preserve">
-    <value>The HTTP proxy authentication credential specified an impersonation level restriction ({0}) that is stricter than the restriction for target server authentication ({1}).</value>
-  </data>
-  <data name="ProxyAuthenticationLevelMismatch" xml:space="preserve">
-    <value>The HTTP proxy authentication credential specified an mutual authentication requirement ({0}) that is stricter than the requirement for target server authentication ({1}).</value>
-  </data>
   <data name="CredentialDisallowsNtlm" xml:space="preserve">
     <value>The NTLM authentication scheme was specified, but the target credential does not allow NTLM.</value>
-  </data>
-  <data name="DigestExplicitCredsImpersonationLevel" xml:space="preserve">
-    <value>The impersonation level '{0}' was specified, yet HTTP Digest authentication can only support 'Impersonation' level when used with an explicit credential.</value>
   </data>
   <data name="UriGeneratorSchemeMustNotBeEmpty" xml:space="preserve">
     <value>The scheme parameter must not be empty.</value>
   </data>
   <data name="UnsupportedSslProtectionLevel" xml:space="preserve">
     <value>The protection level '{0}' was specified, yet SSL transport security only supports EncryptAndSign.</value>
-  </data>
-  <data name="HttpNoTrackingService" xml:space="preserve">
-    <value>{0}. This often indicates that a service that HTTP.SYS depends upon (such as httpfilter) is not started.</value>
-  </data>
-  <data name="HttpNetnameDeleted" xml:space="preserve">
-    <value>{0}. This often indicates that the HTTP client has prematurely closed the underlying TCP connection.</value>
   </data>
   <data name="TimeoutServiceChannelConcurrentOpen1" xml:space="preserve">
     <value>Opening the channel timed out after {0}. The time allotted to this operation may have been a portion of a longer timeout.</value>
@@ -2600,9 +899,6 @@
   </data>
   <data name="TimeSpanMustbeGreaterThanTimeSpanZero" xml:space="preserve">
     <value>TimeSpan must be greater than TimeSpan.Zero.</value>
-  </data>
-  <data name="TimeSpanCannotBeLessThanTimeSpanZero" xml:space="preserve">
-    <value>TimeSpan cannot be less than TimeSpan.Zero.</value>
   </data>
   <data name="AsyncResultCompletedTwice" xml:space="preserve">
     <value>AsyncResult completed twice.</value>
@@ -2618,9 +914,6 @@
   </data>
   <data name="ValueMustBeInRange" xml:space="preserve">
     <value>The value of this argument must fall within the range {0} to {1}.</value>
-  </data>
-  <data name="OffsetExceedsBufferBound" xml:space="preserve">
-    <value>The specified offset exceeds the upper bound of the buffer ({0}).</value>
   </data>
   <data name="OffsetExceedsBufferSize" xml:space="preserve">
     <value>The specified offset exceeds the buffer size ({0} bytes).</value>
@@ -2643,59 +936,8 @@
   <data name="FaultConverterCreatedException" xml:space="preserve">
     <value>{0} returned false from OnTryCreateException, but returned a non-null Exception (See InnerException for details).</value>
   </data>
-  <data name="InfoCardInvalidChain" xml:space="preserve">
-    <value>Policy chain contains self issued URI or a managed issuer in the wrong position.</value>
-  </data>
-  <data name="FullTrustOnlyBindingElementSecurityCheck1" xml:space="preserve">
-    <value>The Binding with name {0} failed validation because it contains a BindingElement with type {1} which is not supported in partial trust. Consider using BasicHttpBinding or WSHttpBinding, or hosting your application in a full-trust environment.</value>
-  </data>
-  <data name="FullTrustOnlyBindingElementSecurityCheckWSHttpBinding1" xml:space="preserve">
-    <value>The WSHttpBinding with name {0} failed validation because it contains a BindingElement with type {1} which is not supported in partial trust. Consider disabling the message security and reliable session options, using BasicHttpBinding, or hosting your application in a full-trust environment.</value>
-  </data>
-  <data name="FullTrustOnlyBindingSecurityCheck1" xml:space="preserve">
-    <value>The Binding with name {0} failed validation because the Binding type {1} is not supported in partial trust. Consider using BasicHttpBinding or WSHttpBinding, or hosting your application in a full-trust environment.</value>
-  </data>
-  <data name="PartialTrustServiceCtorNotVisible" xml:space="preserve">
-    <value>The Service with name '{0}' could not be constructed because the application does not have permission to construct the type: both the Type and its default parameter-less constructor must be public.</value>
-  </data>
-  <data name="PartialTrustServiceMethodNotVisible" xml:space="preserve">
-    <value>The Method with name '{1}' in Type '{0}' could not be invoked because the application does not have permission to invoke the method: both the Method and its containing Type must be public.</value>
-  </data>
-  <data name="PartialTrustPerformanceCountersNotEnabled" xml:space="preserve">
-    <value>Access to performance counters is denied. Application may be running in partial trust. Either disable performance counters or configure the application to run in full trust.</value>
-  </data>
-  <data name="PartialTrustWMINotEnabled" xml:space="preserve">
-    <value>Access to windows management instrumentation (WMI) is denied. Application may be running in partial trust. Either disable WMI or configure the application to run in full trust.</value>
-  </data>
-  <data name="PartialTrustMessageLoggingNotEnabled" xml:space="preserve">
-    <value>Unable to log messages. Application may be running in partial trust. Either disable message logging or configure the application to run in full trust.</value>
-  </data>
-  <data name="ScopeNameMustBeSpecified" xml:space="preserve">
-    <value>The 'scopeName' argument to the InstanceKey constructor must be a non-empty string which indicates the scope of uniqueness for the key. Durable services use the service namespace and name as the scope of uniqueness.</value>
-  </data>
-  <data name="ProviderCannotBeEmptyString" xml:space="preserve">
-    <value>The 'provider' argument to the InstanceKey constructor must be a non-empty string which identifies the source of the key data. The 'provider' argument can be null, in which case the default correlation provider name is used.</value>
-  </data>
-  <data name="CannotSetNameOnTheInvalidKey" xml:space="preserve">
-    <value>The 'Name' property cannot be set on an invalid InstanceKey.</value>
-  </data>
-  <data name="UnsupportedMessageQueryResultType" xml:space="preserve">
-    <value>The type {0} is not a supported result type.</value>
-  </data>
-  <data name="CannotRepresentResultAsNodeset" xml:space="preserve">
-    <value>The result cannot be represented as a nodeset. Only results of type XPathResultType.NodeSet can be represented as nodesets.</value>
-  </data>
-  <data name="MessageNotInLockedState" xml:space="preserve">
-    <value>Message with id {0} was not in a locked state.</value>
-  </data>
-  <data name="MessageValidityExpired" xml:space="preserve">
-    <value>Validity of message with id {0} has expired.</value>
-  </data>
   <data name="UnsupportedUpgradeInitiator" xml:space="preserve">
     <value>The StreamUpgradeInitiator specified ({0}) is not supported by this IStreamUpgradeChannelBindingProvider  implementation.  The most likely cause of this is passing a StreamUpgradeInitiator that was not created by the StreamUpgradeProvider associated with the current IStreamUpgradeChannelBindingProvider  implementation.</value>
-  </data>
-  <data name="UnsupportedUpgradeAcceptor" xml:space="preserve">
-    <value>The StreamUpgradeAcceptor specified ({0}) is not supported by this IStreamUpgradeChannelBindingProvider  implementation.  The most likely cause of this is passing a StreamUpgradeAcceptor that was not created by the StreamUpgradeProvider associated with this IStreamUpgradeChannelBindingProvider  implementation.</value>
   </data>
   <data name="StreamUpgradeUnsupportedChannelBindingKind" xml:space="preserve">
     <value>The StreamUpgradeProvider {0} does not support the specified ChannelBindingKind ({1}). </value>
@@ -2703,38 +945,8 @@
   <data name="ExtendedProtectionNotSupported" xml:space="preserve">
     <value>Extended protection is not supported on this platform.  Please install the appropriate patch or change the ExtendedProtectionPolicy on the Binding or BindingElement to a value with a PolicyEnforcement value of \"Never\" or \"WhenSupported\".</value>
   </data>
-  <data name="ExtendedProtectionPolicyBasicAuthNotSupported" xml:space="preserve">
-    <value>The Authentication Scheme \"Basic\" does not support Extended Protection.  Please use a different authentication scheme or disable the ExtendedProtectionPolicy on the Binding or BindingElement by creating a new ExtendedProtectionPolicy with a PolicyEnforcement value of \"Never\".</value>
-  </data>
-  <data name="ExtendedProtectionPolicyCustomChannelBindingNotSupported" xml:space="preserve">
-    <value>CustomChannelBindings are not supported.  Please remove the CustomChannelBinding from the ExtendedProtectionPolicy\".</value>
-  </data>
   <data name="HttpClientCredentialTypeInvalid" xml:space="preserve">
     <value>ClientCredentialType '{0}' can only be used on the server side, not the client side. Please use one of the following values instead 'None, Basic, Client, Digest, Ntlm, Windows'.</value>
-  </data>
-  <data name="SecurityTokenProviderIncludeWindowsGroupsInconsistent" xml:space="preserve">
-    <value>When authentication schemes 'Basic' and also '{0}' are enabled, the value of IncludeWindowsGroups for Windows ('{1}') and UserName authentication ('{2}') must match. Please consider using the same value in both places.</value>
-  </data>
-  <data name="AuthenticationSchemesCannotBeInheritedFromHost" xml:space="preserve">
-    <value>The authentication schemes cannot be inherited from the host for binding '{0}'. No AuthenticationScheme was specified on the ServiceHost or in the virtual application in IIS. This may be resolved by enabling at least one authentication scheme for this virtual application in IIS, through the ServiceHost.Authentication.AuthenticationSchemes property or in the configuration at the &lt;serviceAuthenticationManager&gt; element.</value>
-  </data>
-  <data name="AuthenticationSchemes_BindingAndHostConflict" xml:space="preserve">
-    <value>The authentication schemes configured on the host ('{0}') do not allow those configured on the binding '{1}' ('{2}').  Please ensure that the SecurityMode is set to Transport or TransportCredentialOnly.  Additionally, this may be resolved by changing the authentication schemes for this application through the IIS management tool, through the ServiceHost.Authentication.AuthenticationSchemes property, in the application configuration file at the &lt;serviceAuthenticationManager&gt; element, by updating the ClientCredentialType property on the binding, or by adjusting the AuthenticationScheme property on the HttpTransportBindingElement.</value>
-  </data>
-  <data name="FlagEnumTypeExpected" xml:space="preserve">
-    <value>Object type must be an enum with the flag attribute. '{0}' is not an enum - or the flag attribute is not set. Please use an enum type with the flag attribute instead.</value>
-  </data>
-  <data name="InvalidFlagEnumType" xml:space="preserve">
-    <value>Object type must be an enum with the flag attribute and may only contain powers of two for the flags enum values or a combination of such values. Please use an enum type according to these rules.</value>
-  </data>
-  <data name="NoAsyncWritePending" xml:space="preserve">
-    <value>There is no pending asynchronous write on this stream. Ensure that there is pending write on the stream or verify that the implementation does not try to complete the same operation multiple times.</value>
-  </data>
-  <data name="FlushBufferAlreadyInUse" xml:space="preserve">
-    <value>Cannot write to a buffer which is currently being flushed. </value>
-  </data>
-  <data name="WriteAsyncWithoutFreeBuffer" xml:space="preserve">
-    <value>An asynchronous write was called on the stream without a free buffer.</value>
   </data>
   <data name="TransportDoesNotSupportCompression" xml:space="preserve">
     <value>The transport configured on this binding does not appear to support the CompressionFormat specified ({0}) on the message encoder.  To resolve this issue, set the CompressionFormat on the {1} to '{2}' or use a different transport.</value>
@@ -2748,254 +960,17 @@
   <data name="HttpMaxPendingAcceptsTooLargeError" xml:space="preserve">
     <value>The value of MaxPendingAccepts should not be larger than {0}.</value>
   </data>
-  <data name="RequestInitializationTimeoutReached" xml:space="preserve">
-    <value>The initialization process of the request message timed out after {0}. To increase this quota, use the '{1}' property on the '{2}'.</value>
-  </data>
   <data name="UnsupportedTokenImpersonationLevel" xml:space="preserve">
     <value>The value '{1}' for the '{0}' property is not supported in Windows Store apps.</value>
-  </data>
-  <data name="AcksToMustBeSameAsRemoteAddress" xml:space="preserve">
-    <value>The remote endpoint requested an address for acknowledgements that is not the same as the address for application messages. The channel could not be opened because this is not supported. Ensure the endpoint address used to create the channel is identical to the one the remote endpoint was set up with.</value>
-  </data>
-  <data name="AcksToMustBeSameAsRemoteAddressReason" xml:space="preserve">
-    <value>The address for acknowledgements must be the same as the address for application messages. Verify that your endpoint is configured to use the same URI for these two addresses.</value>
-  </data>
-  <data name="AssertionNotSupported" xml:space="preserve">
-    <value>The {0}:{1} assertion is not supported.</value>
-  </data>
-  <data name="ConflictingOffer" xml:space="preserve">
-    <value>The remote endpoint sent conflicting requests to create a reliable session. The remote endpoint requested both a one way and a two way session. The reliable session has been faulted.</value>
-  </data>
-  <data name="CouldNotParseWithAction" xml:space="preserve">
-    <value>A message with action {0} could not be parsed.</value>
-  </data>
-  <data name="CSRefusedDuplexNoOffer" xml:space="preserve">
-    <value>The endpoint at {0} processes duplex sessions. The create sequence request must contain an offer for a return sequence. This is likely caused by a binding mismatch.</value>
-  </data>
-  <data name="CSRefusedInputOffer" xml:space="preserve">
-    <value>The endpoint at {0} processes input sessions. The create sequence request must not contain an offer for a return sequence. This is likely caused by a binding mismatch.</value>
-  </data>
-  <data name="CSRefusedReplyNoOffer" xml:space="preserve">
-    <value>The endpoint at {0} processes reply sessions. The create sequence request must contain an offer for a return sequence. This is likely caused by a binding mismatch.</value>
-  </data>
-  <data name="CSRefusedUnexpectedElementAtEndOfCSMessage" xml:space="preserve">
-    <value>The message is not a valid SOAP message. The body contains more than 1 root element.</value>
-  </data>
-  <data name="CSResponseOfferRejected" xml:space="preserve">
-    <value>The remote endpoint replied to a request for a two way session with an offer for a one way session. This is likely caused by a binding mismatch. The channel could not be opened.</value>
-  </data>
-  <data name="CSResponseOfferRejectedReason" xml:space="preserve">
-    <value>The client requested creation of a two way session. A one way session was created. The session cannot continue without as a one way session. This is likely caused by a binding mismatch.</value>
-  </data>
-  <data name="CSResponseWithOfferReason" xml:space="preserve">
-    <value>A return sequence was not offered by the create sequence request. The create sequence response cannot accept a return sequence.</value>
-  </data>
-  <data name="CSResponseWithoutOfferReason" xml:space="preserve">
-    <value>A return sequence was offered by the create sequence request but the create sequence response did not accept this sequence.</value>
-  </data>
-  <data name="DeliveryAssuranceRequiredNothingFound" xml:space="preserve">
-    <value>The WS-RM policy under the namespace {0} requires the wsrmp:ExactlyOnce, wsrmp:AtLeastOnce, or wsrmp:AtMostOnce assertion. Nothing was found.</value>
-  </data>
-  <data name="DeliveryAssuranceRequired" xml:space="preserve">
-    <value>The WS-RM policy under the namespace {0} requires the wsrmp:ExactlyOnce, wsrmp:AtLeastOnce, or wsrmp:AtMostOnce assertion. The {1} element under the {2} namespace was found.</value>
-  </data>
-  <data name="EarlyTerminateSequence" xml:space="preserve">
-    <value>The remote endpoint has errantly sent a TerminateSequence protocol message before the sequence finished.</value>
-  </data>
-  <data name="ElementFound" xml:space="preserve">
-    <value>The {0}:{1} element requires a {2}:{3} child element but has the {4} child element under the {5} namespace.</value>
-  </data>
-  <data name="ElementRequired" xml:space="preserve">
-    <value>The {0}:{1} element requires a {2}:{3} child element but has no child elements.</value>
-  </data>
-  <data name="InvalidAcknowledgementFaultReason" xml:space="preserve">
-    <value>The SequenceAcknowledgement violates the cumulative acknowledgement invariant.</value>
-  </data>
-  <data name="InvalidWsrmResponseChannelNotOpened" xml:space="preserve">
-    <value>The remote endpoint responded to the {0} request with a response with action {1}. The response must be a {0}Response with action {2}. The channel could not be opened.</value>
-  </data>
-  <data name="InvalidWsrmResponseSessionFaultedExceptionString" xml:space="preserve">
-    <value>The remote endpoint responded to the {0} request with a response with action {1}. The response must be a {0}Response with action {2}. The channel was faulted.</value>
-  </data>
-  <data name="LastMessageNumberExceededFaultReason" xml:space="preserve">
-    <value>The value for wsrm:MessageNumber exceeds the value of the MessageNumber accompanying a LastMessage element in this Sequence.</value>
-  </data>
-  <data name="ManualAddressingNotSupported" xml:space="preserve">
-    <value>Binding validation failed because the TransportBindingElement's ManualAddressing property was set to true on a binding that is configured to create reliable sessions. This combination is not supported and the channel factory or service host was not opened.</value>
-  </data>
-  <data name="MessageExceptionOccurred" xml:space="preserve">
-    <value>A problem occurred while reading a message. See inner exception for details.</value>
-  </data>
-  <data name="MessageNumberRolloverFaultReason" xml:space="preserve">
-    <value>The maximum value for wsrm:MessageNumber has been exceeded.</value>
-  </data>
-  <data name="MissingMessageIdOnWsrmRequest" xml:space="preserve">
-    <value>The wsa:MessageId header must be present on a wsrm:{0} message.</value>
-  </data>
-  <data name="MissingReplyToOnWsrmRequest" xml:space="preserve">
-    <value>The wsa:ReplyTo header must be present on a wsrm:{0} message.</value>
-  </data>
-  <data name="NonWsrmFeb2005ActionNotSupported" xml:space="preserve">
-    <value>The action {0} is not supported by this endpoint. Only WS-ReliableMessaging February 2005 messages are processed by this endpoint.</value>
-  </data>
-  <data name="ReceivedResponseBeforeRequestFaultString" xml:space="preserve">
-    <value>The {0}Response was received when the {0} request had not been sent. This is a WS-ReliableMessaging protocol violation. The reliable session cannot continue.</value>
-  </data>
-  <data name="RMEndpointNotFoundReason" xml:space="preserve">
-    <value>The endpoint at {0} has stopped accepting wsrm sessions.</value>
-  </data>
-  <data name="SequenceClosedFaultString" xml:space="preserve">
-    <value>The Sequence is closed and cannot accept new messages.</value>
-  </data>
-  <data name="SequenceTerminatedAddLastToWindowTimedOut" xml:space="preserve">
-    <value>The RM Source could not transfer the last message within the timeout the user specified.</value>
-  </data>
-  <data name="SequenceTerminatedBeforeReplySequenceAcked" xml:space="preserve">
-    <value>The server received a TerminateSequence message before all reply sequence messages were acknowledged. This is a violation of the reply sequence acknowledgement protocol.</value>
-  </data>
-  <data name="SequenceTerminatedEarlyTerminateSequence" xml:space="preserve">
-    <value>The wsrm:TerminateSequence protocol message was transmitted before the sequence was successfully completed.</value>
-  </data>
-  <data name="SequenceTerminatedInactivityTimeoutExceeded" xml:space="preserve">
-    <value>The inactivity timeout of ({0}) has been exceeded.</value>
-  </data>
-  <data name="SequenceTerminatedMaximumRetryCountExceeded" xml:space="preserve">
-    <value>The user specified maximum retry count for a particular message has been exceeded. Because of this the reliable session cannot continue.</value>
-  </data>
-  <data name="SequenceTerminatedQuotaExceededException" xml:space="preserve">
-    <value>The necessary size to buffer a sequence message has exceeded the configured buffer quota. Because of this the reliable session cannot continue.</value>
-  </data>
-  <data name="SequenceTerminatedReplyMissingAcknowledgement" xml:space="preserve">
-    <value>A reply message was received with no acknowledgement.</value>
-  </data>
-  <data name="SequenceTerminatedNotAllRepliesAcknowledged" xml:space="preserve">
-    <value>All of the reply sequence's messages must be acknowledged prior to closing the request sequence. This is a violation of the reply sequence's delivery guarantee. The session cannot continue.</value>
-  </data>
-  <data name="SequenceTerminatedSmallLastMsgNumber" xml:space="preserve">
-    <value>The wsrm:LastMsgNumber value is too small. A message with a larger sequence number has already been received.</value>
-  </data>
-  <data name="SequenceTerminatedUnexpectedAcknowledgement" xml:space="preserve">
-    <value>The RM destination received an acknowledgement message. The RM destination does not process acknowledgement messages.</value>
-  </data>
-  <data name="SequenceTerminatedUnexpectedAckRequested" xml:space="preserve">
-    <value>The RM source received an AckRequested message. The RM source does not process AckRequested messages.</value>
-  </data>
-  <data name="SequenceTerminatedUnexpectedCloseSequence" xml:space="preserve">
-    <value>The RM source received an CloseSequence message. The RM source does not process CloseSequence messages.</value>
-  </data>
-  <data name="SequenceTerminatedUnexpectedCloseSequenceResponse" xml:space="preserve">
-    <value>The RM destination received an CloseSequenceResponse message. The RM destination does not process CloseSequenceResponse messages.</value>
-  </data>
-  <data name="SequenceTerminatedUnexpectedCS" xml:space="preserve">
-    <value>The RM source received a CreateSequence request. The RM source does not process CreateSequence requests.</value>
-  </data>
-  <data name="SequenceTerminatedUnexpectedCSOfferId" xml:space="preserve">
-    <value>The RM destination received multiple CreateSequence requests with different OfferId values over the same session.</value>
-  </data>
-  <data name="SequenceTerminatedUnexpectedCSR" xml:space="preserve">
-    <value>The RM destination received a CreateSequenceResponse message. The RM destination does not process CreateSequenceResponse messages.</value>
-  </data>
-  <data name="SequenceTerminatedUnexpectedCSROfferId" xml:space="preserve">
-    <value>The RM source received multiple CreateSequenceResponse messages with different sequence identifiers over the same session.</value>
-  </data>
-  <data name="SequenceTerminatedUnexpectedTerminateSequence" xml:space="preserve">
-    <value>The RM source received a TerminateSequence message. The RM source does not process TerminateSequence messages.</value>
-  </data>
-  <data name="SequenceTerminatedUnexpectedTerminateSequenceResponse" xml:space="preserve">
-    <value>The RM destination received a TerminateSequenceResponse message. The RM destination does not process TerminateSequenceResponse messages.</value>
-  </data>
-  <data name="SequenceTerminatedUnsupportedTerminateSequence" xml:space="preserve">
-    <value>The RM source does not support an RM destination initiated termination since messages can be lost. The reliable session cannot continue.</value>
-  </data>
-  <data name="SequenceTerminatedUnknownAddToWindowError" xml:space="preserve">
-    <value>An unknown error occurred while trying to add a sequence message to the window.</value>
-  </data>
-  <data name="TimeoutOnAddToWindow" xml:space="preserve">
-    <value>The message could not be transferred within the allotted timeout of {0}. There was no space available in the reliable channel's transfer window. The time allotted to this operation may have been a portion of a longer timeout.</value>
-  </data>
-  <data name="TimeoutOnClose" xml:space="preserve">
-    <value>The close operation did not complete within the allotted timeout of {0}. The time allotted to this operation may have been a portion of a longer timeout.</value>
   </data>
   <data name="TimeoutOnOpen" xml:space="preserve">
     <value>The open operation did not complete within the allotted timeout of {0}. The time allotted to this operation may have been a portion of a longer timeout.</value>
   </data>
-  <data name="TimeoutOnOperation" xml:space="preserve">
-    <value>The operation did not complete within the allotted timeout of {0}. The time allotted to this operation may have been a portion of a longer timeout.</value>
-  </data>
   <data name="TimeoutOnRequest" xml:space="preserve">
     <value>The request operation did not complete within the allotted timeout of {0}. The time allotted to this operation may have been a portion of a longer timeout.</value>
   </data>
-  <data name="TimeoutOnSend" xml:space="preserve">
-    <value>The send operation did not complete within the allotted timeout of {0}. The time allotted to this operation may have been a portion of a longer timeout.</value>
-  </data>
-  <data name="UnexpectedAcknowledgement" xml:space="preserve">
-    <value>The remote endpoint sent an unexpected ack. Simplex servers do not process acks.</value>
-  </data>
-  <data name="UnexpectedAckRequested" xml:space="preserve">
-    <value>The remote endpoint sent an unexpected request for an ack. Simplex clients do not send acks and do not process requests for acks.</value>
-  </data>
-  <data name="UnexpectedCloseSequence" xml:space="preserve">
-    <value>The remote endpoint sent an unexpected close sequence message. Simplex clients do not process this message.</value>
-  </data>
-  <data name="UnexpectedCloseSequenceResponse" xml:space="preserve">
-    <value>The remote endpoint sent an unexpected close sequence response message. Simplex servers do not process this message.</value>
-  </data>
-  <data name="UnexpectedCS" xml:space="preserve">
-    <value>The remote endpoint sent an unexpected request to create a sequence. Clients do not process requests for a sequence.</value>
-  </data>
-  <data name="UnexpectedCSR" xml:space="preserve">
-    <value>The remote endpoint sent an unexpected create sequence response. Servers do not process this message.</value>
-  </data>
-  <data name="UnexpectedCSOfferId" xml:space="preserve">
-    <value>The remote endpoint sent inconsistent requests to create the same sequence. The OfferId values are not identical.</value>
-  </data>
-  <data name="UnexpectedCSROfferId" xml:space="preserve">
-    <value>The remote endpoint sent inconsistent responses to the same create sequence request. The sequence identifiers are not identical.</value>
-  </data>
-  <data name="UnexpectedTerminateSequence" xml:space="preserve">
-    <value>The remote endpoint sent an unexpected terminate sequence message. Simplex clients do not process this message.</value>
-  </data>
-  <data name="UnexpectedTerminateSequenceResponse" xml:space="preserve">
-    <value>The remote endpoint sent an unexpected terminate sequence response message. Simplex servers do not process this message.</value>
-  </data>
-  <data name="UnparsableCSResponse" xml:space="preserve">
-    <value>The remote endpoint replied to the request for a sequence with a response that could not be parsed. See inner exception for details. The channel could not be opened.</value>
-  </data>
-  <data name="UnknownSequenceFaultReason" xml:space="preserve">
-    <value>The value of wsrm:Identifier is not a known Sequence identifier.</value>
-  </data>
-  <data name="UnknownSequenceMessageReceived" xml:space="preserve">
-    <value>The remote endpoint has sent a message containing an unrecognized sequence identifier. The reliable session was faulted.</value>
-  </data>
-  <data name="UnrecognizedFaultReceivedOnOpen" xml:space="preserve">
-    <value>The remote endpoint has sent an unrecognized fault with namespace, {0}, name {1}, and reason {2}. The channel could not be opened.</value>
-  </data>
-  <data name="WsrmFaultReceived" xml:space="preserve">
-    <value>The sequence has been terminated by the remote endpoint. {0} The reliable session was faulted.</value>
-  </data>
-  <data name="WsrmMessageProcessingError" xml:space="preserve">
-    <value>An error occurred while processing a message. {0}</value>
-  </data>
-  <data name="WsrmMessageWithWrongRelatesToFaultString" xml:space="preserve">
-    <value>The remote endpoint has responded to a {0} request message with an invalid reply. The reply has a wsa:RelatesTo header with an unexpected identifier. The reliable session cannot continue.</value>
-  </data>
-  <data name="WsrmRequestIncorrectReplyToFaultString" xml:space="preserve">
-    <value>The wsrm:{0} request message's wsa:ReplyTo address containing a URI which is not equivalent to the remote address. This is not supported. The reliable session was faulted.</value>
-  </data>
-  <data name="WsrmRequiredFaultString" xml:space="preserve">
-    <value>The RM server requires the use of WS-ReliableMessaging 1.1 protocol. This is likely caused by a binding mismatch.</value>
-  </data>
   <data name="SFxActionDemuxerDuplicate" xml:space="preserve">
     <value>The operations {0} and {1} have the same action ({2}).  Every operation must have a unique action value.</value>
-  </data>
-  <data name="SFxActionMismatch" xml:space="preserve">
-    <value>Cannot create a typed message due to action mismatch, expecting {0} encountered {1}</value>
-  </data>
-  <data name="SFxAnonymousTypeNotSupported" xml:space="preserve">
-    <value>Part {1} in message {0} cannot be exported with RPC or encoded since its type is anonymous.</value>
-  </data>
-  <data name="SFxAsyncResultsDontMatch0" xml:space="preserve">
-    <value>The IAsyncResult returned from Begin and the IAsyncResult supplied to the Callback are on different objects. These are required to be the same object.</value>
   </data>
   <data name="SFXBindingNameCannotBeNullOrEmpty" xml:space="preserve">
     <value>Binding name cannot be null or empty.</value>
@@ -3009,83 +984,17 @@
   <data name="SFXHeaderNameCannotBeNullOrEmpty" xml:space="preserve">
     <value>Header name cannot be null or empty.</value>
   </data>
-  <data name="SFxEndpointNoMatchingScheme" xml:space="preserve">
-    <value>Could not find a base address that matches scheme {0} for the endpoint with binding {1}. Registered base address schemes are [{2}].</value>
-  </data>
-  <data name="SFxBindingSchemeDoesNotMatch" xml:space="preserve">
-    <value>The scheme '{0}' used by binding {1} does not match the required scheme '{2}'.</value>
-  </data>
-  <data name="SFxGetChannelDispatcherDoesNotSupportScheme" xml:space="preserve">
-    <value>Only a '{0}' using '{1}' or '{2}' is supported in this scenario.</value>
-  </data>
-  <data name="SFxIncorrectMessageVersion" xml:space="preserve">
-    <value>MessageVersion '{0}' is not supported in this scenario.  Only MessageVersion '{1}' is supported.</value>
-  </data>
-  <data name="SFxBindingNotSupportedForMetadataHttpGet" xml:space="preserve">
-    <value>The binding associated with ServiceMetadataBehavior or ServiceDebugBehavior is not supported.  The inner binding elements used by this binding must support IReplyChannel. Verify that HttpGetBinding/HttpsGetBinding (on ServiceMetadataBehavior) and HttpHelpPageBinding/HttpsHelpPageBinding (on ServiceDebugBehavior) are supported.</value>
-  </data>
   <data name="SFxBadByReferenceParameterMetadata" xml:space="preserve">
     <value>Method '{0}' in class '{1}' has bad parameter metadata: a pass-by-reference parameter is marked with the 'in' but not the 'out' parameter mode.</value>
   </data>
   <data name="SFxBadByValueParameterMetadata" xml:space="preserve">
     <value>Method '{0}' in class '{1}' has bad parameter metadata: a pass-by-value parameter is marked with the 'out' parameter mode.</value>
   </data>
-  <data name="SFxBadMetadataMustBePolicy" xml:space="preserve">
-    <value>When calling the CreateFromPolicy method, the policy argument must be an XmlElement instance with LocalName '{1}' and NamespaceUri '{0}'. This XmlElement has LocalName '{3}' and NamespaceUri '{2}'. </value>
-  </data>
-  <data name="SFxBadMetadataLocationUri" xml:space="preserve">
-    <value>The URI supplied to ServiceMetadataBehavior via the ExternalMetadataLocation property or the externalMetadataLocation attribute in the serviceMetadata section in config must be a relative URI or an absolute URI with an http or https scheme. '{0}' was specified, which is a absolute URI with {1} scheme.</value>
-  </data>
-  <data name="SFxBadMetadataLocationNoAppropriateBaseAddress" xml:space="preserve">
-    <value>The URL supplied to ServiceMetadataBehavior via the ExternalMetadataLocation property or the externalMetadataLocation attribute in the serviceMetadata section in config was a relative URL and there is no base address with which to resolve it. '{0}' was specified.</value>
-  </data>
-  <data name="SFxBadMetadataDialect" xml:space="preserve">
-    <value>There was a problem reading the MetadataSet argument: a MetadataSection instance with identifier '{0}' and dialect '{1}' has a Metadata property whose type does not match the dialect. The expected Metadata type for this dialect is '{2}' but was found to be '{3}'.</value>
-  </data>
-  <data name="SFxBadMetadataReference" xml:space="preserve">
-    <value>Metadata contains a reference that cannot be resolved: '{0}'.</value>
-  </data>
-  <data name="SFxMaximumResolvedReferencesOutOfRange" xml:space="preserve">
-    <value>The MaximumResolvedReferences property of MetadataExchangeClient must be greater than or equal to one.  '{0}' was specified.</value>
-  </data>
-  <data name="SFxMetadataExchangeClientNoMetadataAddress" xml:space="preserve">
-    <value>The MetadataExchangeClient was not supplied with a MetadataReference or MetadataLocation from which to get metadata.  You must supply one to the constructor, to the GetMetadata method, or to the BeginGetMetadata method.</value>
-  </data>
-  <data name="SFxMetadataExchangeClientCouldNotCreateChannelFactory" xml:space="preserve">
-    <value>The MetadataExchangeClient could not create an IChannelFactory for: address='{0}', dialect='{1}', and  identifier='{2}'. </value>
-  </data>
-  <data name="SFxMetadataExchangeClientCouldNotCreateWebRequest" xml:space="preserve">
-    <value>The MetadataExchangeClient could not create an HttpWebRequest for: address='{0}', dialect='{1}', and  identifier='{2}'. </value>
-  </data>
-  <data name="SFxMetadataExchangeClientCouldNotCreateChannelFactoryBadScheme" xml:space="preserve">
-    <value>The MetadataExchangeClient instance could not be initialized because no Binding is available for scheme '{0}'. You can supply a Binding in the constructor, or specify a configurationName.</value>
-  </data>
-  <data name="SFxBadTransactionProtocols" xml:space="preserve">
-    <value>The TransactionProtocol setting was not understood. A supported protocol must be specified.</value>
-  </data>
-  <data name="SFxMetadataResolverKnownContractsArgumentCannotBeEmpty" xml:space="preserve">
-    <value>The MetadataResolver cannot recieve an empty contracts argument to the Resolve or BeginResolve methods.  You must supply at least one ContractDescription.</value>
-  </data>
-  <data name="SFxMetadataResolverKnownContractsUniqueQNames" xml:space="preserve">
-    <value>The ContractDescriptions in contracts must all have unique Name and Namespace pairs.  More than one ContractDescription had the pair Name='{0}' and Namespace='{1}'. </value>
-  </data>
-  <data name="SFxMetadataResolverKnownContractsCannotContainNull" xml:space="preserve">
-    <value>The contracts argument to the Resolve or BeginResolve methods cannot contain a null ContractDescription.</value>
-  </data>
-  <data name="SFxBindingDoesNotHaveATransportBindingElement" xml:space="preserve">
-    <value>The binding specified to do metadata exchange does not contain a TransportBindingElement.</value>
-  </data>
   <data name="SFxBindingMustContainTransport2" xml:space="preserve">
     <value>The binding (Name={0}, Namespace={1}) does not contain a TransportBindingElement.</value>
   </data>
   <data name="SFxBodyCannotBeNull" xml:space="preserve">
     <value>Body object cannot be null in message {0}</value>
-  </data>
-  <data name="SFxBodyObjectTypeCannotBeInherited" xml:space="preserve">
-    <value>Type {0} cannot inherit from any class other than object to be used as body object in RPC style.</value>
-  </data>
-  <data name="SFxBodyObjectTypeCannotBeInterface" xml:space="preserve">
-    <value>Type {0} implements interface {1} which is not supported for body object in RPC style.</value>
   </data>
   <data name="SFxCallbackBehaviorAttributeOnlyOnDuplex" xml:space="preserve">
     <value>CallbackBehaviorAttribute can only be run as a behavior on an endpoint with a duplex contract. Contract '{0}' is not duplex, as it contains no callback operations.</value>
@@ -3099,65 +1008,11 @@
   <data name="SFxCannotActivateCallbackInstace" xml:space="preserve">
     <value>The dispatch instance for duplex callbacks cannot be activated - you must provide an instance.</value>
   </data>
-  <data name="SFxCannotCallAddBaseAddress" xml:space="preserve">
-    <value>ServiceHostBase's AddBaseAddress method cannot be called after the InitializeDescription method has completed.</value>
-  </data>
   <data name="SFxCannotCallAutoOpenWhenExplicitOpenCalled" xml:space="preserve">
     <value>Cannot make a call on this channel because a call to Open() is in progress.</value>
   </data>
-  <data name="SFxCannotGetMetadataFromRelativeAddress" xml:space="preserve">
-    <value>The MetadataExchangeClient can only get metadata from absolute addresses.  It cannot get metadata from '{0}'.</value>
-  </data>
-  <data name="SFxCannotHttpGetMetadataFromAddress" xml:space="preserve">
-    <value>The MetadataExchangeClient can only get metadata from http or https addresses when using MetadataExchangeClientMode HttpGet. It cannot get metadata from '{0}'.</value>
-  </data>
-  <data name="SFxCannotGetMetadataFromLocation" xml:space="preserve">
-    <value>The MetadataExchangeClient can only get metadata from http and https MetadataLocations.  It cannot get metadata from '{0}'.</value>
-  </data>
-  <data name="SFxCannotHaveDifferentTransactionProtocolsInOneBinding" xml:space="preserve">
-    <value>The configured policy specifies more than one TransactionProtocol across the operations. A single TransactionProtocol for each endpoint must be specified.</value>
-  </data>
-  <data name="SFxCannotImportAsParameters_Bare" xml:space="preserve">
-    <value>Generating message contract since the operation {0} is neither RPC nor document wrapped.</value>
-  </data>
-  <data name="SFxCannotImportAsParameters_DifferentWrapperNs" xml:space="preserve">
-    <value>Generating message contract since the wrapper namespace ({1}) of message {0} does not match the default value ({2})</value>
-  </data>
-  <data name="SFxCannotImportAsParameters_DifferentWrapperName" xml:space="preserve">
-    <value>Generating message contract since the wrapper name ({1}) of message {0} does not match the default value ({2})</value>
-  </data>
-  <data name="SFxCannotImportAsParameters_ElementIsNotNillable" xml:space="preserve">
-    <value>Generating message contract since element name {0} from namespace {1} is not marked nillable</value>
-  </data>
-  <data name="SFxCannotImportAsParameters_MessageHasProtectionLevel" xml:space="preserve">
-    <value>Generating message contract since message {0} requires protection.</value>
-  </data>
-  <data name="SFxCannotImportAsParameters_HeadersAreIgnoredInEncoded" xml:space="preserve">
-    <value>Headers are not supported in RPC encoded format. Headers are ignored in message {0}.</value>
-  </data>
-  <data name="SFxCannotImportAsParameters_HeadersAreUnsupported" xml:space="preserve">
-    <value>Generating message contract since message {0} has headers</value>
-  </data>
-  <data name="SFxCannotImportAsParameters_Message" xml:space="preserve">
-    <value>Generating message contract since the operation {0} has untyped Message as argument or return type</value>
-  </data>
-  <data name="SFxCannotImportAsParameters_NamespaceMismatch" xml:space="preserve">
-    <value>Generating message contract since message part namespace ({0}) does not match the default value ({1})</value>
-  </data>
-  <data name="SFxCannotRequireBothSessionAndDatagram3" xml:space="preserve">
-    <value>There are two contracts listening on the same binding ({2}) and address with conflicting settings.  Specifically, the contract '{0}' specifies SessionMode.NotAllowed while the contract '{1}' specifies SessionMode.Required.  You should either change one of the SessionMode values or specify a different address (or ListenUri) for each endpoint.</value>
-  </data>
   <data name="SFxCannotSetExtensionsByIndex" xml:space="preserve">
     <value>This collection does not support setting extensions by index.  Please consider using the InsertItem or RemoveItem methods.</value>
-  </data>
-  <data name="SFxChannelDispatcherDifferentHost0" xml:space="preserve">
-    <value>This ChannelDispatcher is not currently attached to the provided ServiceHost.</value>
-  </data>
-  <data name="SFxChannelDispatcherMultipleHost0" xml:space="preserve">
-    <value>Cannot add a ChannelDispatcher to more than one ServiceHost.</value>
-  </data>
-  <data name="SFxChannelDispatcherNoHost0" xml:space="preserve">
-    <value>Cannot open ChannelDispatcher because it is not attached to a ServiceHost.</value>
   </data>
   <data name="SFxChannelDispatcherNoMessageVersion" xml:space="preserve">
     <value>Cannot open ChannelDispatcher because it is does not have a MessageVersion set.</value>
@@ -3171,35 +1026,11 @@
   <data name="SFxChannelFactoryTypeMustBeInterface" xml:space="preserve">
     <value>The type argument passed to the generic ChannelFactory class must be an interface type.</value>
   </data>
-  <data name="SFxChannelFactoryCannotApplyConfigurationWithoutEndpoint" xml:space="preserve">
-    <value>ApplyConfiguration requires that the Endpoint property be initialized. Either provide a valid ServiceEndpoint in the CreateDescription method or override the ApplyConfiguration method to provide an alternative implementation.</value>
-  </data>
   <data name="SFxChannelFactoryCannotCreateFactoryWithoutDescription" xml:space="preserve">
     <value>CreateFactory requires that the Endpoint property be initialized. Either provide a valid ServiceEndpoint in the CreateDescription method or override the CreateFactory method to provide an alternative implementation.</value>
   </data>
   <data name="SFxClientOutputSessionAutoClosed" xml:space="preserve">
     <value>This channel can no longer be used to send messages as the output session was auto-closed due to a server-initiated shutdown. Either disable auto-close by setting the DispatchRuntime.AutomaticInputSessionShutdown to false, or consider modifying the shutdown protocol with the remote server.</value>
-  </data>
-  <data name="SFxCodeGenArrayTypeIsNotSupported" xml:space="preserve">
-    <value>Array of type {0} is not supported.</value>
-  </data>
-  <data name="SFxCodeGenCanOnlyStoreIntoArgOrLocGot0" xml:space="preserve">
-    <value>Can only store into ArgBuilder or LocalBuilder. Got: {0}.</value>
-  </data>
-  <data name="SFxCodeGenExpectingEnd" xml:space="preserve">
-    <value>Expecting End {0}.</value>
-  </data>
-  <data name="SFxCodeGenIsNotAssignableFrom" xml:space="preserve">
-    <value>{0} is not assignable from {1}.</value>
-  </data>
-  <data name="SFxCodeGenNoConversionPossibleTo" xml:space="preserve">
-    <value>No conversion possible to {0}.</value>
-  </data>
-  <data name="SFxCodeGenWarning" xml:space="preserve">
-    <value>CODEGEN: {0}</value>
-  </data>
-  <data name="SFxCodeGenUnknownConstantType" xml:space="preserve">
-    <value>Internal Error: Unrecognized constant type {0}.</value>
   </data>
   <data name="SFxCollectionDoesNotSupportSet0" xml:space="preserve">
     <value>This collection does not support setting items by index.</value>
@@ -3209,12 +1040,6 @@
   </data>
   <data name="SFxCollectionWrongType2" xml:space="preserve">
     <value>The collection of type {0} does not support values of type {1}.</value>
-  </data>
-  <data name="SFxConflictingGlobalElement" xml:space="preserve">
-    <value>Top level XML element with name {0} in namespace {1} cannot reference {2} type because it already references a different type ({3}). Use a different operation name or MessageBodyMemberAttribute to specify a different name for the Message or Message parts.</value>
-  </data>
-  <data name="SFxConflictingGlobalType" xml:space="preserve">
-    <value>Duplicate top level XML Schema type with name {0} in namespace {1}.</value>
   </data>
   <data name="SFxContextModifiedInsideScope0" xml:space="preserve">
     <value>The value of OperationContext.Current is not the OperationContext value installed by this OperationContextScope.</value>
@@ -3258,26 +1083,11 @@
   <data name="SFxCustomBindingNeedsTransport1" xml:space="preserve">
     <value>The CustomBinding on the ServiceEndpoint with contract '{0}' lacks a TransportBindingElement.  Every binding must have at least one binding element that derives from TransportBindingElement.</value>
   </data>
-  <data name="SFxCustomBindingWithoutTransport" xml:space="preserve">
-    <value>The Scheme cannot be computed for this binding because this CustomBinding lacks a TransportBindingElement.  Every binding must have at least one binding element that derives from TransportBindingElement.</value>
-  </data>
   <data name="SFxDeserializationFailed1" xml:space="preserve">
     <value>The formatter threw an exception while trying to deserialize the message: {0}</value>
   </data>
-  <data name="SFxDictionaryIsEmpty" xml:space="preserve">
-    <value>This operation is not possible since the dictionary is empty.</value>
-  </data>
   <data name="SFxDisallowedAttributeCombination" xml:space="preserve">
     <value>The type or member named '{0}' could not be loaded because it has two incompatible attributes: '{1}' and '{2}'. To fix the problem, remove one of the attributes from the type or member.</value>
-  </data>
-  <data name="SFxEndpointAddressNotSpecified" xml:space="preserve">
-    <value>The endpoint's address is not specified. </value>
-  </data>
-  <data name="SFxEndpointContractNotSpecified" xml:space="preserve">
-    <value>The endpoint's contract is not specified.</value>
-  </data>
-  <data name="SFxEndpointBindingNotSpecified" xml:space="preserve">
-    <value>The endpoint's binding is not specified.</value>
   </data>
   <data name="SFxInitializationUINotCalled" xml:space="preserve">
     <value>The channel is configured to use interactive initializer '{0}', but the channel was Opened without calling DisplayInitializationUI.  Call DisplayInitializationUI before calling Open or other methods on this channel.</value>
@@ -3285,74 +1095,11 @@
   <data name="SFxInitializationUIDisallowed" xml:space="preserve">
     <value>AllowInitializationUI was set to false for this channel, but the channel is configured to use the '{0}' as an interactive initializer.</value>
   </data>
-  <data name="SFxDocExt_NoMetadataSection1" xml:space="preserve">
-    <value>This is a Windows&amp;#169; Communication Foundation service.&lt;BR/&gt;&lt;BR/&gt;&lt;B&gt;Metadata publishing for this service is currently disabled.&lt;/B&gt;&lt;BR/&gt;&lt;BR/&gt;If you have access to the service, you can enable metadata publishing by completing the following steps to modify your web or application configuration file:&lt;BR/&gt;&lt;BR/&gt;1. Create the following service behavior configuration, or add the &amp;lt;serviceMetadata&amp;gt; element to an existing service behavior configuration:</value>
-  </data>
-  <data name="SFxDocExt_NoMetadataSection2" xml:space="preserve">
-    <value>2. Add the behavior configuration to the service:</value>
-  </data>
-  <data name="SFxDocExt_NoMetadataSection3" xml:space="preserve">
-    <value>Note: the service name must match the configuration name for the service implementation.&lt;BR/&gt;&lt;BR/&gt;3. Add the following endpoint to your service configuration:</value>
-  </data>
-  <data name="SFxDocExt_NoMetadataSection4" xml:space="preserve">
-    <value>Note: your service must have an http base address to add this endpoint.&lt;BR/&gt;&lt;BR/&gt;The following is an example service configuration file with metadata publishing enabled:</value>
-  </data>
-  <data name="SFxDocExt_NoMetadataSection5" xml:space="preserve">
-    <value>For more information on publishing metadata please see the following documentation: &lt;a href=\"http://go.microsoft.com/fwlink/?LinkId=65455\"&gt;http://go.microsoft.com/fwlink/?LinkId=65455&lt;/a&gt;.</value>
-  </data>
-  <data name="SFxDocExt_NoMetadataConfigComment1" xml:space="preserve">
-    <value>Note: the service name must match the configuration name for the service implementation.</value>
-  </data>
-  <data name="SFxDocExt_NoMetadataConfigComment2" xml:space="preserve">
-    <value>Add the following endpoint. </value>
-  </data>
-  <data name="SFxDocExt_NoMetadataConfigComment3" xml:space="preserve">
-    <value>Note: your service must have an http base address to add this endpoint.</value>
-  </data>
-  <data name="SFxDocExt_NoMetadataConfigComment4" xml:space="preserve">
-    <value>Add the following element to your service behavior configuration.</value>
-  </data>
-  <data name="SFxDocExt_CS" xml:space="preserve">
-    <value>&lt;P class='intro'&gt;&lt;B&gt;C#&lt;/B&gt;&lt;/P&gt;</value>
-  </data>
-  <data name="SFxDocExt_VB" xml:space="preserve">
-    <value>&lt;P class='intro'&gt;&lt;B&gt;Visual Basic&lt;/B&gt;&lt;/P&gt;</value>
-  </data>
-  <data name="SFxDocExt_MainPageTitleNoServiceName" xml:space="preserve">
-    <value>Service</value>
-  </data>
-  <data name="SFxDocExt_MainPageTitle" xml:space="preserve">
-    <value>{0} Service</value>
-  </data>
-  <data name="SFxDocExt_MainPageIntro1a" xml:space="preserve">
-    <value>You have created a service.&lt;P class='intro'&gt;To test this service, you will need to create a client and use it to call the service. You can do this using the svcutil.exe tool from the command line with the following syntax:&lt;/P&gt; </value>
-  </data>
-  <data name="SFxDocExt_MainPageIntro1b" xml:space="preserve">
-    <value>You have created a service.&lt;P class='intro'&gt;To test this service, you will need to create a client and use it to call the service; however, metadata publishing via ?WSDL is currently disabled. This can be enabled via the service's configuration file. &lt;/P&gt;</value>
-  </data>
-  <data name="SFxDocExt_MainPageIntro2" xml:space="preserve">
-    <value>This will generate a configuration file and a code file that contains the client class. Add the two files to your client application and use the generated client class to call the Service. For example:&lt;BR/&gt;</value>
-  </data>
-  <data name="SFxDocExt_MainPageComment" xml:space="preserve">
-    <value>Use the 'client' variable to call operations on the service.</value>
-  </data>
-  <data name="SFxDocExt_MainPageComment2" xml:space="preserve">
-    <value>Always close the client.</value>
-  </data>
-  <data name="SFxDocExt_Error" xml:space="preserve">
-    <value>The service encountered an error.</value>
-  </data>
   <data name="SFxDocEncodedNotSupported" xml:space="preserve">
     <value>Operation '{0}' could not be loaded as it uses an unsupported combination of Use and Style settings: Document with Encoded. To fix the problem, change the Use setting to Literal or change the Style setting to Rpc.</value>
   </data>
-  <data name="SFxDocEncodedFaultNotSupported" xml:space="preserve">
-    <value>Fault could not be loaded as the Use setting is Encoded and it references a schema definition using Element attribute. To fix the problem, change the Use setting to Literal.</value>
-  </data>
   <data name="SFxDuplicateMessageParts" xml:space="preserve">
     <value>Message part {0} in namespace {1} appears more than once in Message.</value>
-  </data>
-  <data name="SFxDuplicateInitiatingActionAtSameVia" xml:space="preserve">
-    <value>This service has multiple endpoints listening at '{0}' which share the same initiating action '{1}'.  As a result, messages with this action would be dropped since the dispatcher would not be able to determine the correct endpoint for handling the message.  Please consider hosting these Endpoints at separate ListenUris.</value>
   </data>
   <data name="SFXEndpointBehaviorUsedOnWrongSide" xml:space="preserve">
     <value>The IEndpointBehavior '{0}' cannot be used on the server side; this behavior can only be applied to clients.</value>
@@ -3362,9 +1109,6 @@
   </data>
   <data name="SFxEndpointDispatcherDifferentChannelDispatcher0" xml:space="preserve">
     <value>This EndpointDispatcher is not currently attached to the provided ChannelDispatcher.</value>
-  </data>
-  <data name="SFxErrorCreatingMtomReader" xml:space="preserve">
-    <value>Error creating a reader for the MTOM message</value>
   </data>
   <data name="SFxErrorDeserializingRequestBody" xml:space="preserve">
     <value>Error in deserializing body of request message for operation '{0}'.</value>
@@ -3408,15 +1152,6 @@
   <data name="SFxExceptionDetailFormat" xml:space="preserve">
     <value>An ExceptionDetail, likely created by IncludeExceptionDetailInFaults=true, whose value is:</value>
   </data>
-  <data name="SFxExpectedIMethodCallMessage" xml:space="preserve">
-    <value>Internal Error: Message must be a valid IMethodCallMessage.</value>
-  </data>
-  <data name="SFxExportMustHaveType" xml:space="preserve">
-    <value>The specified ContractDescription could not be exported to WSDL because the Type property of the MessagePartDescription with name '{1}' in the OperationDescription with name '{0}' is not set.  The Type property must be set in order to create WSDL.</value>
-  </data>
-  <data name="SFxFaultCannotBeImported" xml:space="preserve">
-    <value>Fault named {0} in operation {1} cannot be imported. {2}</value>
-  </data>
   <data name="SFxFaultContractDuplicateDetailType" xml:space="preserve">
     <value>In operation {0}, more than one fault is declared with detail type {1}</value>
   </data>
@@ -3447,44 +1182,11 @@
   <data name="SFxHeaderNotUnderstood" xml:space="preserve">
     <value>The header '{0}' from the namespace '{1}' was not understood by the recipient of this message, causing the message to not be processed.  This error typically indicates that the sender of this message has enabled a communication protocol that the receiver cannot process.  Please ensure that the configuration of the client's binding is consistent with the service's binding. </value>
   </data>
-  <data name="SFxHeadersAreNotSupportedInEncoded" xml:space="preserve">
-    <value>Message {0} must not have headers to be used in RPC encoded style.</value>
-  </data>
   <data name="SFxImmutableServiceHostBehavior0" xml:space="preserve">
     <value>This value cannot be changed after the ServiceHost has opened.</value>
   </data>
   <data name="SFxImmutableChannelFactoryBehavior0" xml:space="preserve">
     <value>This value cannot be changed after the ChannelFactory has opened.</value>
-  </data>
-  <data name="SFxImmutableClientBaseCacheSetting" xml:space="preserve">
-    <value>This value cannot be changed after the first ClientBase of type '{0}' has been created.</value>
-  </data>
-  <data name="SFxImmutableThrottle1" xml:space="preserve">
-    <value>{0} cannot be changed after the ServiceHost has opened.</value>
-  </data>
-  <data name="SFxInconsistentBindingBodyParts" xml:space="preserve">
-    <value>Operation {0} binding {1} has extra part {2} that is not present in other bindings</value>
-  </data>
-  <data name="SFxInconsistentWsdlOperationStyleInHeader" xml:space="preserve">
-    <value>Style {1} on header {0} does not match expected style {2}.</value>
-  </data>
-  <data name="SFxInconsistentWsdlOperationStyleInMessageParts" xml:space="preserve">
-    <value>All parts of message in operation {0} must either contain type or element. </value>
-  </data>
-  <data name="SFxInconsistentWsdlOperationStyleInOperationMessages" xml:space="preserve">
-    <value>Style {1} inferred from messages in operation {0} does not match expected style {2} specified via bindings.</value>
-  </data>
-  <data name="SFxInconsistentWsdlOperationUseAndStyleInBinding" xml:space="preserve">
-    <value>Bindings for operation {0} cannot specify different use and style values. Binding {1} specifies use {2} and style {3} while binding {4} specifies use {5} and style {6}.</value>
-  </data>
-  <data name="SFxInconsistentWsdlOperationUseInBindingExtensions" xml:space="preserve">
-    <value>Extensions for operation {0} in binding {1} cannot specify different use values.</value>
-  </data>
-  <data name="SFxInconsistentWsdlOperationUseInBindingMessages" xml:space="preserve">
-    <value>Message bindings for operation {0} in binding {1} cannot specify different use values.</value>
-  </data>
-  <data name="SFxInconsistentWsdlOperationUseInBindingFaults" xml:space="preserve">
-    <value>Fault bindings for operation {0} in binding {1} cannot specify different use values.</value>
   </data>
   <data name="SFxInputParametersToServiceInvalid" xml:space="preserve">
     <value>Service implementation object invoked with wrong number of input parameters, operation expects {0} parameters but was called with {1} parameters.</value>
@@ -3515,9 +1217,6 @@
   </data>
   <data name="SFxInvalidChannelToOperationContext" xml:space="preserve">
     <value>Invalid IContextChannel passed to OperationContext. Must be either a server dispatching channel or a client proxy channel.</value>
-  </data>
-  <data name="SFxInvalidContextScopeThread0" xml:space="preserve">
-    <value>This OperationContextScope is being disposed on a different thread than it was created.</value>
   </data>
   <data name="SFxInvalidMessageBody" xml:space="preserve">
     <value>OperationFormatter encountered an invalid Message body. Expected to find node type 'Element' with name '{0}' and namespace '{1}'. Found node type '{2}' with name '{3}' and namespace '{4}'</value>
@@ -3564,9 +1263,6 @@
   <data name="SFxInvalidStaticOverloadCalledForDuplexChannelFactory1" xml:space="preserve">
     <value>The static CreateChannel method cannot be used with the contract {0} because that contract defines a callback contract.  Please try using one of the static CreateChannel overloads on DuplexChannelFactory&lt;TChannel&gt;.</value>
   </data>
-  <data name="SFxInvalidSoapAttribute" xml:space="preserve">
-    <value>XmlSerializer attribute {0} is not valid in {1}. Only SoapElement attribute is supported.</value>
-  </data>
   <data name="SFxInvalidXmlAttributeInBare" xml:space="preserve">
     <value>XmlSerializer attribute {0} is not valid in {1}. Only XmlElement, XmlArray, XmlArrayItem and XmlAnyElement attributes are supported in MessageContract when IsWrapped is false.</value>
   </data>
@@ -3591,9 +1287,6 @@
   <data name="SFxMessageContractRequiresDefaultConstructor" xml:space="preserve">
     <value>The message cannot be deserialized into MessageContract type {0} since it does not have a default (parameterless) constructor.</value>
   </data>
-  <data name="SFxMessageOperationFormatterCannotSerializeFault" xml:space="preserve">
-    <value>MessageOperationFormatter cannot serialize faults.</value>
-  </data>
   <data name="SFxMetadataReferenceInvalidLocation" xml:space="preserve">
     <value>The value '{0}' is not valid for the Location property. The Location property must be a valid absolute or relative URI.</value>
   </data>
@@ -3602,9 +1295,6 @@
   </data>
   <data name="SFxMethodNotSupportedOnCallback1" xml:space="preserve">
     <value>Callback method {0} is not supported, this can happen if the method is not marked with OperationContractAttribute or if its interface type is not the target of the ServiceContractAttribute's CallbackContract.</value>
-  </data>
-  <data name="SFxMethodNotSupportedByType2" xml:space="preserve">
-    <value>ServiceHost implementation type {0} does not implement ServiceContract {1}.</value>
   </data>
   <data name="SFxMismatchedOperationParent" xml:space="preserve">
     <value>A DispatchOperation (or ClientOperation) can only be added to its parent DispatchRuntime (or ClientRuntime).</value>
@@ -3624,12 +1314,6 @@
   <data name="SFxMultipleContractStarOperations0" xml:space="preserve">
     <value>A ServiceContract has more the one operation with an Action of \"*\".  A ServiceContract can have at most one operation an Action = \"*\".</value>
   </data>
-  <data name="SFxMultipleContractsWithSameName" xml:space="preserve">
-    <value>The Service contains multiple ServiceEndpoints with different ContractDescriptions which each have Name='{0}' and Namespace='{1}'.  Either provide ContractDescriptions with unique Name and Namespaces, or ensure the ServiceEndpoints have the same ContractDescription instance.</value>
-  </data>
-  <data name="SFxMultiplePartsNotAllowedInEncoded" xml:space="preserve">
-    <value>Part {1}:{0} is repeating and is not supported in Soap Encoding.</value>
-  </data>
   <data name="SFxNameCannotBeEmpty" xml:space="preserve">
     <value>The Name property must be a non-empty string.</value>
   </data>
@@ -3645,29 +1329,11 @@
   <data name="SFxNoMostDerivedContract" xml:space="preserve">
     <value>The contract specified by type '{0}' is ambiguous.  The type derives from at least two different types that each define its own service contract.  For this type to be used as a contract type, exactly one of its inherited contracts must be more derived than any of the others.</value>
   </data>
-  <data name="SFxNullReplyFromExtension2" xml:space="preserve">
-    <value>Extension {0} prevented call to operation '{1}' from replying by setting the reply to null.</value>
-  </data>
   <data name="SFxNullReplyFromFormatter2" xml:space="preserve">
     <value>Formatter {0} returned a null reply message for call to operation '{1}'.</value>
   </data>
   <data name="SFxServiceChannelIdleAborted" xml:space="preserve">
     <value>The operation '{0}' could not be completed because the sessionful channel timed out waiting to receive a message.  To increase the timeout, either set the receiveTimeout property on the binding in your configuration file, or set the ReceiveTimeout property on the Binding directly.</value>
-  </data>
-  <data name="SFxServiceMetadataBehaviorUrlMustBeHttpOrRelative" xml:space="preserve">
-    <value>{0} must be a relative URI or an absolute URI with scheme '{1}'.  '{2}' is an absolute URI with scheme '{3}'. </value>
-  </data>
-  <data name="SFxServiceMetadataBehaviorNoHttpBaseAddress" xml:space="preserve">
-    <value>The HttpGetEnabled property of ServiceMetadataBehavior is set to true and the HttpGetUrl property is a relative address, but there is no http base address.  Either supply an http base address or set HttpGetUrl to an absolute address.</value>
-  </data>
-  <data name="SFxServiceMetadataBehaviorNoHttpsBaseAddress" xml:space="preserve">
-    <value>The HttpsGetEnabled property of ServiceMetadataBehavior is set to true and the HttpsGetUrl property is a relative address, but there is no https base address.  Either supply an https base address or set HttpsGetUrl to an absolute address.</value>
-  </data>
-  <data name="SFxServiceMetadataBehaviorInstancingError" xml:space="preserve">
-    <value>The ChannelDispatcher with ListenUri '{0}' has endpoints with the following contracts: {1}. Metadata endpoints cannot share ListenUris. The conflicting endpoints were either specified in AddServiceEndpoint() calls, in a config file, or a combination of AddServiceEndpoint() and config.</value>
-  </data>
-  <data name="SFxServiceTypeNotCreatable" xml:space="preserve">
-    <value>Service implementation type is an interface or abstract class and no implementation object was provided.</value>
   </data>
   <data name="SFxSetEnableFaultsOnChannelDispatcher0" xml:space="preserve">
     <value>This property sets EnableFaults on the client. To set EnableFaults on the server, use ChannelDispatcher's EnableFaults.</value>
@@ -3675,17 +1341,8 @@
   <data name="SFxSetManualAddresssingOnChannelDispatcher0" xml:space="preserve">
     <value>This property sets ManualAddressing on the client. To set ManualAddressing on the server, use ChannelDispatcher's ManualAddressing.</value>
   </data>
-  <data name="SFxNoBatchingForSession" xml:space="preserve">
-    <value>TransactedBatchingBehavior validation failed. Service or client cannot be started. Transacted batching is not supported for session contracts. Remove transacted batching behavior from the endpoint or define a non-sessionful contract.</value>
-  </data>
-  <data name="SFxNoBatchingForReleaseOnComplete" xml:space="preserve">
-    <value>TransactedBatchingBehavior validation failed. Service cannot be started. Transacted batching requires ServiceBehavior.ReleaseServiceInstanceOnTransactionComplete to be false.</value>
-  </data>
   <data name="SFxNoServiceObject" xml:space="preserve">
     <value>The service implementation object was not initialized or is not available.</value>
-  </data>
-  <data name="SFxNone2004" xml:space="preserve">
-    <value>The WS-Addressing \"none\" value is not valid for the August 2004 version of WS-Addressing.</value>
   </data>
   <data name="SFxNonExceptionThrown" xml:space="preserve">
     <value>An object that is not an exception was thrown.</value>
@@ -3693,20 +1350,8 @@
   <data name="SFxNonInitiatingOperation1" xml:space="preserve">
     <value>The operation '{0}' cannot be the first operation to be called because IsInitiating is false.</value>
   </data>
-  <data name="SfxNoTypeSpecifiedForParameter" xml:space="preserve">
-    <value>There was no CLR type specified for parameter {0}, preventing the operation from being generated.</value>
-  </data>
-  <data name="SFxOneWayAndTransactionsIncompatible" xml:space="preserve">
-    <value>The one-way operation '{1}' on ServiceContract '{0}' is configured for transaction flow. Transactions cannot be flowed over one-way operations.</value>
-  </data>
   <data name="SFxOneWayMessageToTwoWayMethod0" xml:space="preserve">
     <value>The incoming message with action could not be processed because it is targeted at a request-reply operation, but cannot be replied to as the MessageId property is not set.</value>
-  </data>
-  <data name="SFxOperationBehaviorAttributeOnlyOnServiceClass" xml:space="preserve">
-    <value>OperationBehaviorAttribute can only go on the service class, it cannot be put on the ServiceContract interface. Method '{0}' on type '{1}' violates this.</value>
-  </data>
-  <data name="SFxOperationBehaviorAttributeReleaseInstanceModeDoesNotApplyToCallback" xml:space="preserve">
-    <value>The ReleaseInstanceMode property on OperationBehaviorAttribute can only be set on non-callback operations. Method '{0}' violates this.</value>
   </data>
   <data name="SFxOperationContractOnNonServiceContract" xml:space="preserve">
     <value>Method '{0}' has OperationContractAttribute, but enclosing type '{1}' does not have ServiceContractAttribute. OperationContractAttribute can only be used on methods in ServiceContractAttribute types or on their CallbackContract types.</value>
@@ -3735,32 +1380,11 @@
   <data name="SFxParameterMustBeArrayOfOneElement" xml:space="preserve">
     <value>The 'parameters' argument must be an array of one element.</value>
   </data>
-  <data name="SFxPartNameMustBeUniqueInRpc" xml:space="preserve">
-    <value>Message part name {0} is not unique in an RPC Message.</value>
-  </data>
-  <data name="SFxReceiveContextSettingsPropertyMissing" xml:space="preserve">
-    <value>The contract '{0}' has at least one operation annotated with '{1}', but the binding used for the contract endpoint at address '{2}' does not support required binding property '{3}'. Please ensure that the binding used for the contract supports the ReceiveContext capability.</value>
-  </data>
-  <data name="SFxReceiveContextPropertyMissing" xml:space="preserve">
-    <value>Required message property '{0}' is missing from the IncomingProperties collections of the received message. Ensure that when the receive context is enabled on the binding, the created channel ensures that '{0}' is present on all received messages.</value>
-  </data>
   <data name="SFxRequestHasInvalidReplyToOnClient" xml:space="preserve">
     <value>The request message has ReplyTo='{0}' but IContextChannel.LocalAddress is '{1}'.  When ManualAddressing is false, these values must be the same, null, or EndpointAddress.AnonymousAddress.  Enable ManualAddressing or avoid setting ReplyTo on the message.</value>
   </data>
   <data name="SFxRequestHasInvalidFaultToOnClient" xml:space="preserve">
     <value>The request message has FaultTo='{0}' but IContextChannel.LocalAddress is '{1}'.  When ManualAddressing is false, these values must be the same, null, or EndpointAddress.AnonymousAddress.  Enable ManualAddressing or avoid setting FaultTo on the message.</value>
-  </data>
-  <data name="SFxRequestHasInvalidFromOnClient" xml:space="preserve">
-    <value>The request message has From='{0}' but IContextChannel.LocalAddress is '{1}'.  When ManualAddressing is false, these values must be the same, null, or EndpointAddress.AnonymousAddress.  Enable ManualAddressing or avoid setting From on the message.</value>
-  </data>
-  <data name="SFxRequestHasInvalidReplyToOnServer" xml:space="preserve">
-    <value>The request message has ReplyTo='{0}' but IContextChannel.RemoteAddress is '{1}'.  When ManualAddressing is false, these values must be the same, null, or EndpointAddress.AnonymousAddress because sending a reply to a different address than the original sender can create a security risk.  If you want to process such messages, enable ManualAddressing.</value>
-  </data>
-  <data name="SFxRequestHasInvalidFaultToOnServer" xml:space="preserve">
-    <value>The request message has FaultTo='{0}' but IContextChannel.RemoteAddress is '{1}'.  When ManualAddressing is false, these values must be the same, null, or EndpointAddress.AnonymousAddress because sending a reply to a different address than the original sender can create a security risk.  If you want to process such messages, enable ManualAddressing.</value>
-  </data>
-  <data name="SFxRequestHasInvalidFromOnServer" xml:space="preserve">
-    <value>The request message has From='{0}' but IContextChannel.RemoteAddress is '{1}'.  When ManualAddressing is false, these values must be the same, null, or EndpointAddress.AnonymousAddress because sending a reply to a different address than the original sender can create a security risk.  If you want to process such messages, enable ManualAddressing.</value>
   </data>
   <data name="SFxRequestReplyNone" xml:space="preserve">
     <value>A message was received with a WS-Addressing ReplyTo or FaultTo header targeted at the \"None\" address.  These values are not valid for request-reply operations.  Please consider using a one-way operation or enabling ManualAddressing if you need to support ReplyTo or FaultTo values of \"None.\"</value>
@@ -3774,59 +1398,14 @@
   <data name="SFxReplyActionMismatch3" xml:space="preserve">
     <value>A reply message was received for operation '{0}' with action '{1}'. However, your client code requires action '{2}'.</value>
   </data>
-  <data name="SFxRequiredRuntimePropertyMissing" xml:space="preserve">
-    <value>Required runtime property '{0}' is not initialized on DispatchRuntime. Do not remove ServiceBehaviorAttribute from ServiceDescription.Behaviors or ensure that you include a third-party service behavior that supplies this value.</value>
-  </data>
-  <data name="SFxResolvedMaxResolvedReferences" xml:space="preserve">
-    <value>The MetadataExchangeClient has resolved more than MaximumResolvedReferences.</value>
-  </data>
   <data name="SFxResultMustBeMessage" xml:space="preserve">
     <value>The 'result' argument must be of type Message.</value>
-  </data>
-  <data name="SFxRevertImpersonationFailed0" xml:space="preserve">
-    <value>Could not revert impersonation on current thread. Continuing would compromise system security. Terminating process.</value>
   </data>
   <data name="SFxRpcMessageBodyPartNameInvalid" xml:space="preserve">
     <value>RPC Message {1} in operation {0} has an invalid body name {2}. It must be {3}</value>
   </data>
-  <data name="SFxRpcMessageMustHaveASingleBody" xml:space="preserve">
-    <value>RPC Message {1} in operation {0} must have a single MessageBodyMember.</value>
-  </data>
-  <data name="SFxSchemaDoesNotContainElement" xml:space="preserve">
-    <value>There was a problem loading the XSD documents provided: a reference to a schema element with name '{0}' and namespace '{1}' could not be resolved because the element definition could not be found in the schema for targetNamespace '{1}'. Please check the XSD documents provided and try again.</value>
-  </data>
-  <data name="SFxSchemaDoesNotContainType" xml:space="preserve">
-    <value>There was a problem loading the XSD documents provided: a reference to a schema type with name '{0}' and namespace '{1}' could not be resolved because the type definition could not be found in the schema for targetNamespace '{1}'. Please check the XSD documents provided and try again.</value>
-  </data>
-  <data name="SFxWsdlMessageDoesNotContainPart3" xml:space="preserve">
-    <value>Service description message '{1}' from target namespace '{2}' does not contain part named '{0}'.</value>
-  </data>
-  <data name="SFxSchemaNotFound" xml:space="preserve">
-    <value>Schema with target namespace '{0}' could not be found.</value>
-  </data>
-  <data name="SFxSecurityContextPropertyMissingFromRequestMessage" xml:space="preserve">
-    <value>SecurityContextProperty is missing from the request Message, this may indicate security is configured incorrectly.</value>
-  </data>
   <data name="SFxServerDidNotReply" xml:space="preserve">
     <value>The server did not provide a meaningful reply; this might be caused by a contract mismatch, a premature session shutdown or an internal server error.</value>
-  </data>
-  <data name="SFxServiceHostBaseCannotAddEndpointAfterOpen" xml:space="preserve">
-    <value>Endpoints cannot be added after the ServiceHost has been opened/faulted/aborted/closed.</value>
-  </data>
-  <data name="SFxServiceHostBaseCannotAddEndpointWithoutDescription" xml:space="preserve">
-    <value>Endpoints cannot be added before the Description property has been initialized.</value>
-  </data>
-  <data name="SFxServiceHostBaseCannotApplyConfigurationWithoutDescription" xml:space="preserve">
-    <value>ApplyConfiguration requires that the Description property be initialized. Either provide a valid ServiceDescription in the CreateDescription method or override the ApplyConfiguration method to provide an alternative implementation.</value>
-  </data>
-  <data name="SFxServiceHostBaseCannotLoadConfigurationSectionWithoutDescription" xml:space="preserve">
-    <value>LoadConfigurationSection requires that the Description property be initialized. Provide a valid ServiceDescription in the CreateDescription method.</value>
-  </data>
-  <data name="SFxServiceHostBaseCannotInitializeRuntimeWithoutDescription" xml:space="preserve">
-    <value>InitializeRuntime requires that the Description property be initialized. Either provide a valid ServiceDescription in the CreateDescription method or override the InitializeRuntime method to provide an alternative implementation.</value>
-  </data>
-  <data name="SFxServiceHostCannotCreateDescriptionWithoutServiceType" xml:space="preserve">
-    <value>InitializeDescription must be called with a serviceType or singletonInstance parameter.</value>
   </data>
   <data name="SFxStaticMessageHeaderPropertiesNotAllowed" xml:space="preserve">
     <value>Header properties cannot be set in MessageHeaderAttribute of {0} as its type is MessageHeader&lt;T&gt;.</value>
@@ -3840,92 +1419,11 @@
   <data name="SFxStreamResponseMessageClosed" xml:space="preserve">
     <value>The message containing this stream has been closed. </value>
   </data>
-  <data name="SFxThrottleLimitMustBeGreaterThanZero0" xml:space="preserve">
-    <value>Throttle limit must be greater than zero. To disable, set to Int32.MaxValue.</value>
-  </data>
-  <data name="SFxTimeoutInvalidStringFormat" xml:space="preserve">
-    <value>The timeout value provided was not of a recognized format.  Please see InnerException for more details.</value>
-  </data>
   <data name="SFxTimeoutOutOfRange0" xml:space="preserve">
     <value>Timeout must be greater than or equal to TimeSpan.Zero. To disable timeout, specify TimeSpan.MaxValue.</value>
   </data>
   <data name="SFxTimeoutOutOfRangeTooBig" xml:space="preserve">
     <value>Timeouts larger than Int32.MaxValue TotalMilliseconds (approximately 24 days) cannot be honored. To disable timeout, specify TimeSpan.MaxValue.</value>
-  </data>
-  <data name="SFxTooManyPartsWithSameName" xml:space="preserve">
-    <value>Cannot create a unique part name for {0}.</value>
-  </data>
-  <data name="SFxTraceCodeElementIgnored" xml:space="preserve">
-    <value>An unrecognized element was encountered in the XML during deserialization which was ignored.</value>
-  </data>
-  <data name="SfxTransactedBindingNeeded" xml:space="preserve">
-    <value>TransactedBatchingBehavior validation failed. The service endpoint cannot be started. TransactedBatchingBehavior requires a binding that contains a binding element ITransactedBindingElement that returns true for ITransactedBindingElement.TransactedReceiveEnabled. If you are using NetMsmqBinding or MsmqIntegrationBinding make sure that ExactlyOnce is set to true.</value>
-  </data>
-  <data name="SFxTransactionNonConcurrentOrAutoComplete2" xml:space="preserve">
-    <value>TThe operation '{1}' on contract '{0}' is configured with TransactionAutoComplete set to false and with ConcurrencyMode not set to Single. TransactionAutoComplete set to false requires ConcurrencyMode.Single.</value>
-  </data>
-  <data name="SFxTransactionNonConcurrentOrReleaseServiceInstanceOnTxComplete" xml:space="preserve">
-    <value>The '{0}' service is configured with ReleaseServiceInstanceOnTransactionComplete set to true, but the ConcurrencyMode is not set to Single. The ReleaseServiceInstanceOnTransactionComplete requires the use of ConcurrencyMode.Single.</value>
-  </data>
-  <data name="SFxNonConcurrentOrEnsureOrderedDispatch" xml:space="preserve">
-    <value>The '{0}' service is configured with EnsureOrderedDispatch set to true, but the ConcurrencyMode is not set to Single. EnsureOrderedDispatch requires the use of ConcurrencyMode.Single.</value>
-  </data>
-  <data name="SfxDispatchRuntimeNonConcurrentOrEnsureOrderedDispatch" xml:space="preserve">
-    <value>The DispatchRuntime.EnsureOrderedDispatch property is set to true, but the DispatchRuntime.ConcurrencyMode is not set to Single. EnsureOrderedDispatch requires the use of ConcurrencyMode.Single.</value>
-  </data>
-  <data name="SFxTransactionsNotSupported" xml:space="preserve">
-    <value>The service does not support concurrent transactions.</value>
-  </data>
-  <data name="SFxTransactionAsyncAborted" xml:space="preserve">
-    <value>The transaction under which this method call was executing was asynchronously aborted.</value>
-  </data>
-  <data name="SFxTransactionInvalidSetTransactionComplete" xml:space="preserve">
-    <value>The SetTransactionComplete method was called in the operation '{0}' on contract '{1}' when TransactionAutoComplete was set to true. The SetTransactionComplete method can only be called when TransactionAutoComplete is set to false. This is an invalid scenario and the current transaction was aborted.</value>
-  </data>
-  <data name="SFxMultiSetTransactionComplete" xml:space="preserve">
-    <value>The SetTransactionComplete method was wrongly called more than once in the operation '{0}' on contract '{1}'. The SetTransactionComplete method can only be called once. This is an invalid scenario and the current transaction was aborted.</value>
-  </data>
-  <data name="SFxTransactionFlowAndMSMQ" xml:space="preserve">
-    <value>The binding for the endpoint at address '{0}' is configured with both the MsmqTransportBindingElement and the TransactionFlowBindingElement. These two elements cannot be used together.</value>
-  </data>
-  <data name="SFxTransactionAutoCompleteFalseAndInstanceContextMode" xml:space="preserve">
-    <value>The operation '{1}' on contract '{0}' is configured with TransactionAutoComplete set to false and the InstanceContextMode is not set to PerSession. TransactionAutoComplete set to false requires the use of InstanceContextMode.PerSession.</value>
-  </data>
-  <data name="SFxTransactionAutoCompleteFalseOnCallbackContract" xml:space="preserve">
-    <value>The operation '{0}' on callback contract '{1}' is configured with TransactionAutoComplete set to false. TransactionAutoComplete set to false cannot be used with operations on callback contracts.</value>
-  </data>
-  <data name="SFxTransactionAutoCompleteFalseAndSupportsSession" xml:space="preserve">
-    <value>The operation '{1}' on contract '{0}' is configured with TransactionAutoComplete set to false but SessionMode is not set to Required. TransactionAutoComplete set to false requires SessionMode.Required.</value>
-  </data>
-  <data name="SFxTransactionAutoCompleteOnSessionCloseNoSession" xml:space="preserve">
-    <value>The service '{0}' is configured with TransactionAutoCompleteOnSessionClose set to true and with an InstanceContextMode not set to PerSession. TransactionAutoCompleteOnSessionClose set to true requires an instancing mode that uses sessions.</value>
-  </data>
-  <data name="SFxTransactionTransactionTimeoutNeedsScope" xml:space="preserve">
-    <value>The service '{0}' is configured with a TransactionTimeout but no operations are configured with TransactionScopeRequired set to true. TransactionTimeout requires at least one operation with TransactionScopeRequired set to true.</value>
-  </data>
-  <data name="SFxTransactionIsolationLevelNeedsScope" xml:space="preserve">
-    <value>The service '{0}' is configured with a TransactionIsolationLevel but no operations are configured with TransactionScopeRequired set to true. TransactionIsolationLevel requires at least one operation with TransactionScopeRequired set to true.</value>
-  </data>
-  <data name="SFxTransactionReleaseServiceInstanceOnTransactionCompleteNeedsScope" xml:space="preserve">
-    <value>The service '{0}' is configured with ReleaseServiceInstanceOnTransactionComplete but no operations are configured with TransactionScopeRequired set to true. The ReleaseServiceInstanceOnTransactionComplete property requires at least one operation with TransactionScopeRequired set to true. Remove the ReleaseServiceInstanceOnTransactionComplete property from the service if this is the case.</value>
-  </data>
-  <data name="SFxTransactionTransactionAutoCompleteOnSessionCloseNeedsScope" xml:space="preserve">
-    <value>The service '{0}' is configured with TransactionAutoCompleteOnSessionClose, but no operations are configured with TransactionScopeRequired set to true. The TransactionAutoCompleteOnSessionClose property requires at least one operation with TransactionScopeRequired set to true. Remove the TransactionAutoCompleteOnSessionClose property from the service if this is the case.</value>
-  </data>
-  <data name="SFxTransactionFlowRequired" xml:space="preserve">
-    <value>The service operation requires a transaction to be flowed.</value>
-  </data>
-  <data name="SFxTransactionUnmarshalFailed" xml:space="preserve">
-    <value>The flowed transaction could not be unmarshaled. The following exception occurred: {0}</value>
-  </data>
-  <data name="SFxTransactionDeserializationFailed" xml:space="preserve">
-    <value>The incoming transaction cannot be deserialized. The transaction header in the message was either malformed or in an unrecognized format. The client and the service must be configured to use the same protocol and protocol version. The following exception occurred: {0}</value>
-  </data>
-  <data name="SFxTransactionHeaderNotUnderstood" xml:space="preserve">
-    <value>The transaction header '{0}' within the namespace '{1}' was not understood by the service. The client and the service must be configured to use the same protocol and protocol version ('{2}').</value>
-  </data>
-  <data name="SFxTryAddMultipleTransactionsOnMessage" xml:space="preserve">
-    <value>An attempt was made to add more than one transaction to a message. At most one transaction can be added.</value>
   </data>
   <data name="SFxTypedMessageCannotBeNull" xml:space="preserve">
     <value>Internal Error: The instance of the MessageContract cannot be null in {0}.</value>
@@ -3948,35 +1446,11 @@
   <data name="SFxUnknownFaultZeroReasons0" xml:space="preserve">
     <value>This fault did not provide a reason (MessageFault.Reason.Translations.Count was 0).</value>
   </data>
-  <data name="SFxUserCodeThrewException" xml:space="preserve">
-    <value>User operation '{0}.{1}' threw an exception that is unhandled in user code. This exception will be rethrown. If this is a recurring problem, it may indicate an error in the implementation of the '{0}.{1}' method.</value>
-  </data>
-  <data name="SfxUseTypedMessageForCustomAttributes" xml:space="preserve">
-    <value>Parameter '{0}' requires additional schema information that cannot be captured using the parameter mode. The specific attribute is '{1}'.</value>
-  </data>
-  <data name="SFxWellKnownNonSingleton0" xml:space="preserve">
-    <value>In order to use one of the ServiceHost constructors that takes a service instance, the InstanceContextMode of the service must be set to InstanceContextMode.Single.  This can be configured via the ServiceBehaviorAttribute.  Otherwise, please consider using the ServiceHost constructors that take a Type argument.</value>
-  </data>
   <data name="SFxVersionMismatchInOperationContextAndMessage2" xml:space="preserve">
     <value>Cannot add outgoing headers to message as MessageVersion in OperationContext.Current '{0}' does not match with the header version of message being processed '{1}'.</value>
   </data>
-  <data name="SFxWhenMultipleEndpointsShareAListenUriTheyMustHaveSameIdentity" xml:space="preserve">
-    <value>When multiple endpoints on a service share the same ListenUri, those endpoints must all have the same Identity in their EndpointAddress. The endpoints at ListenUri '{0}' do not meet this criteria.</value>
-  </data>
   <data name="SFxWrapperNameCannotBeEmpty" xml:space="preserve">
     <value>Wrapper element name cannot be empty.</value>
-  </data>
-  <data name="SFxWrapperTypeHasMultipleNamespaces" xml:space="preserve">
-    <value>Wrapper type for message {0} cannot be projected as a data contract type since it has multiple namespaces. Consider using the XmlSerializer</value>
-  </data>
-  <data name="SFxWsdlPartMustHaveElementOrType" xml:space="preserve">
-    <value>WSDL part {0} in message {1} from namespace {2} must have either an element or a type name</value>
-  </data>
-  <data name="SFxDataContractSerializerDoesNotSupportBareArray" xml:space="preserve">
-    <value>DataContractSerializer does not support collection specified on element '{0}' </value>
-  </data>
-  <data name="SFxDataContractSerializerDoesNotSupportEncoded" xml:space="preserve">
-    <value>Invalid OperationFormatUse specified in the OperationFormatStyle of operation {0}, DataContractSerializer supports only Literal.</value>
   </data>
   <data name="SFxXmlArrayNotAllowedForMultiple" xml:space="preserve">
     <value>XmlArrayAttribute cannot be used in repeating part {1}:{0}.</value>
@@ -3984,17 +1458,8 @@
   <data name="SFxXmlSerializerIsNotFound" xml:space="preserve">
     <value>Could not find XmlSerializer for type {0}.</value>
   </data>
-  <data name="SFxConfigContractNotFound" xml:space="preserve">
-    <value>Could not find default endpoint element that references contract '{0}' in the ServiceModel client configuration section. This might be because no configuration file was found for your application, or because no endpoint element matching this contract could be found in the client element.</value>
-  </data>
-  <data name="SFxConfigChannelConfigurationNotFound" xml:space="preserve">
-    <value>Could not find endpoint element with name '{0}' and contract '{1}' in the ServiceModel client configuration section. This might be because no configuration file was found for your application, or because no endpoint element matching this name could be found in the client element.</value>
-  </data>
   <data name="SFxChannelFactoryEndpointAddressUri" xml:space="preserve">
     <value>The Address property on ChannelFactory.Endpoint was null.  The ChannelFactory's Endpoint must have a valid Address specified.</value>
-  </data>
-  <data name="SFxServiceContractGeneratorConfigRequired" xml:space="preserve">
-    <value>In order to generate configuration information using the GenerateServiceEndpoint method, the ServiceContractGenerator instance must have been initialized with a valid Configuration object.</value>
   </data>
   <data name="SFxCloseTimedOut1" xml:space="preserve">
     <value>The ServiceHost close operation timed out after {0}.  This could be because a client failed to close a sessionful channel within the required time.  The time allotted to this operation may have been a portion of a longer timeout.</value>
@@ -4002,23 +1467,11 @@
   <data name="SfxCloseTimedOutWaitingForDispatchToComplete" xml:space="preserve">
     <value>Close process timed out waiting for service dispatch to complete.</value>
   </data>
-  <data name="SFxInvalidWsdlBindingOpMismatch2" xml:space="preserve">
-    <value>The WSDL binding named {0} is not valid because no match for operation {1} was found in the corresponding portType definition.</value>
-  </data>
-  <data name="SFxInvalidWsdlBindingOpNoName" xml:space="preserve">
-    <value>The WSDL binding named {0} is not valid because an operation binding doesn't have a name specified.</value>
-  </data>
   <data name="SFxChannelFactoryNoBindingFoundInConfig1" xml:space="preserve">
     <value>The underlying channel factory could not be created because no binding information was found in the configuration file for endpoint with name '{0}'.  Please check the endpoint configuration section with name '{0}' to ensure that binding information is present and correct.</value>
   </data>
   <data name="SFxChannelFactoryNoBindingFoundInConfigOrCode" xml:space="preserve">
     <value>The underlying channel factory could not be created because no Binding was passed to the ChannelFactory. Please supply a valid Binding instance via the ChannelFactory constructor.</value>
-  </data>
-  <data name="SFxConfigLoaderMultipleEndpointMatchesSpecified2" xml:space="preserve">
-    <value>The endpoint configuration section for contract '{0}' with name '{1}' could not be loaded because more than one endpoint configuration with the same name and contract were found. Please check your config and try again.</value>
-  </data>
-  <data name="SFxConfigLoaderMultipleEndpointMatchesWildcard1" xml:space="preserve">
-    <value>An endpoint configuration section for contract '{0}' could not be loaded because more than one endpoint configuration for that contract was found. Please indicate the preferred endpoint configuration section by name.</value>
   </data>
   <data name="SFxProxyRuntimeMessageCannotBeNull" xml:space="preserve">
     <value>In operation '{0}', cannot pass null to methods that take Message as input parameter.</value>
@@ -4026,41 +1479,8 @@
   <data name="SFxDispatchRuntimeMessageCannotBeNull" xml:space="preserve">
     <value>In operation '{0}', cannot return null from methods that return Message.</value>
   </data>
-  <data name="SFxServiceHostNeedsClass" xml:space="preserve">
-    <value>ServiceHost only supports class service types.</value>
-  </data>
-  <data name="SfxReflectedContractKeyNotFound2" xml:space="preserve">
-    <value>The contract name '{0}' could not be found in the list of contracts implemented by the service '{1}'.</value>
-  </data>
-  <data name="SfxReflectedContractKeyNotFoundEmpty" xml:space="preserve">
-    <value>In order to add an endpoint to the service '{0}', a non-empty contract name must be specified.</value>
-  </data>
-  <data name="SfxReflectedContractKeyNotFoundIMetadataExchange" xml:space="preserve">
-    <value>The contract name 'IMetadataExchange' could not be found in the list of contracts implemented by the service {0}.  Add a ServiceMetadataBehavior to the configuration file or to the ServiceHost directly to enable support for this contract.</value>
-  </data>
-  <data name="SfxServiceContractAttributeNotFound" xml:space="preserve">
-    <value>The contract type {0} is not attributed with ServiceContractAttribute.  In order to define a valid contract, the specified type (either contract interface or service class) must be attributed with ServiceContractAttribute.</value>
-  </data>
-  <data name="SfxReflectedContractsNotInitialized1" xml:space="preserve">
-    <value>An endpoint for type '{0}' could not be added because the ServiceHost instance was not initialized properly.  In order to add endpoints by Type, the CreateDescription method must be called.  If you are using a class derived from ServiceHost, ensure that the class is properly calling base.CreateDescription.</value>
-  </data>
   <data name="SFxMessagePartDescriptionMissingType" xml:space="preserve">
     <value>Instance of MessagePartDescription Name='{0}' Namespace='{1}' cannot be used in this context: required 'Type' property was not set.</value>
-  </data>
-  <data name="SFxWsdlOperationInputNeedsMessageAttribute2" xml:space="preserve">
-    <value>The wsdl operation input {0} in portType {1} does not reference a message. This is either because the message attribute is missing or empty.</value>
-  </data>
-  <data name="SFxWsdlOperationOutputNeedsMessageAttribute2" xml:space="preserve">
-    <value>The wsdl operation output {0} in portType {1} does not reference a message. This is either because the message attribute is missing or empty.</value>
-  </data>
-  <data name="SFxWsdlOperationFaultNeedsMessageAttribute2" xml:space="preserve">
-    <value>The wsdl operation {0} in portType {1} contains a fault that does not reference a message. This is either because the message attribute is missing or empty.</value>
-  </data>
-  <data name="SFxMessageContractAttributeRequired" xml:space="preserve">
-    <value>Cannot create a typed message from type '{0}'.  The functionality only valid for types decorated with MessageContractAttribute.</value>
-  </data>
-  <data name="AChannelServiceEndpointIsNull0" xml:space="preserve">
-    <value>A Channel/Service Endpoint is null.</value>
   </data>
   <data name="AChannelServiceEndpointSBindingIsNull0" xml:space="preserve">
     <value>A Channel/Service endpoint's Binding is null.</value>
@@ -4073,30 +1493,6 @@
   </data>
   <data name="AChannelServiceEndpointSContractSNamespace0" xml:space="preserve">
     <value>A Channel/Service endpoint's Contract's namespace is null.</value>
-  </data>
-  <data name="ServiceHasZeroAppEndpoints" xml:space="preserve">
-    <value>Service '{0}' has zero application (non-infrastructure) endpoints. This might be because no configuration file was found for your application, or because no service element matching the service name could be found in the configuration file, or because no endpoints were defined in the service element.</value>
-  </data>
-  <data name="BindingRequirementsAttributeRequiresQueuedDelivery1" xml:space="preserve">
-    <value>DeliveryRequirementsAttribute requires QueuedDelivery, but binding for the endpoint with contract '{0}' doesn't support it or isn't configured properly to support it.</value>
-  </data>
-  <data name="BindingRequirementsAttributeDisallowsQueuedDelivery1" xml:space="preserve">
-    <value>DeliveryRequirementsAttribute disallows QueuedDelivery, but binding for the endpoint with contract '{0}' supports it.</value>
-  </data>
-  <data name="SinceTheBindingForDoesnTSupportIBindingCapabilities1_1" xml:space="preserve">
-    <value>The DeliveryRequirementsAttribute on contract '{0}' specifies that the binding must support ordered delivery (RequireOrderedDelivery).  This condition could not be verified because the configured binding does not implement IBindingDeliveryCapabilities.  The DeliveryRequirementsAttribute may only be used with bindings that implement the IBindingDeliveryCapabilities interface.</value>
-  </data>
-  <data name="SinceTheBindingForDoesnTSupportIBindingCapabilities2_1" xml:space="preserve">
-    <value>The DeliveryRequirementsAttribute on contract '{0}' specifies a QueuedDeliveryRequirements constraint.  This condition could not be verified because the configured binding does not implement IBindingDeliveryCapabilities.  The DeliveryRequirementsAttribute may only be used with bindings that implement the IBindingDeliveryCapabilities interface.</value>
-  </data>
-  <data name="TheBindingForDoesnTSupportOrderedDelivery1" xml:space="preserve">
-    <value>The DeliveryRequirementsAttribute on contract '{0}' specifies a QueuedDeliveryRequirements value of NotAllowed.  However, the configured binding for this contract specifies that it does support queued delivery.  A queued binding may not be used with this contract.</value>
-  </data>
-  <data name="ChannelHasAtLeastOneOperationWithTransactionFlowEnabled" xml:space="preserve">
-    <value>At least one operation on the '{0}' contract is configured with the TransactionFlowAttribute attribute set to Mandatory but the channel's binding '{1}' is not configured with a TransactionFlowBindingElement. The TransactionFlowAttribute attribute set to Mandatory cannot be used without a TransactionFlowBindingElement.</value>
-  </data>
-  <data name="ServiceHasAtLeastOneOperationWithTransactionFlowEnabled" xml:space="preserve">
-    <value>At least one operation on the '{0}' contract is configured with the TransactionFlowAttribute attribute set to Mandatory but the channel's binding '{1}' is not configured with a TransactionFlowBindingElement. The TransactionFlowAttribute attribute set to Mandatory cannot be used without a TransactionFlowBindingElement.</value>
   </data>
   <data name="SFxNoEndpointMatchingContract" xml:space="preserve">
     <value>The message with Action '{0}' cannot be processed at the receiver, due to a ContractFilter mismatch at the EndpointDispatcher. This may be because of either a contract mismatch (mismatched Actions between sender and receiver) or a binding/security mismatch between the sender and the receiver.  Check that sender and receiver have the same contract and the same binding (including security requirements, e.g. Message, Transport, None).</value>
@@ -4112,12 +1508,6 @@
   </data>
   <data name="EndMethodsCannotBeDecoratedWithOperationContractAttribute" xml:space="preserve">
     <value>When using the IAsyncResult design pattern, the End method cannot be decorated with OperationContractAttribute. Only the corresponding Begin method can be decorated with OperationContractAttribute; that attribute will apply to the Begin-End pair of methods. Method '{0}' in type '{1}' violates this.</value>
-  </data>
-  <data name="WsatMessagingInitializationFailed" xml:space="preserve">
-    <value>The WS-AT messaging library failed to initialize.</value>
-  </data>
-  <data name="WsatProxyCreationFailed" xml:space="preserve">
-    <value>A client-side channel to the WS-AT protocol service could not be created.</value>
   </data>
   <data name="DispatchRuntimeRequiresFormatter0" xml:space="preserve">
     <value>The DispatchOperation '{0}' requires Formatter, since DeserializeRequest and SerializeReply are not both false.</value>
@@ -4167,18 +1557,6 @@
   <data name="ContractIsNotSelfConsistentWhenIsSessionOpenNotificationEnabled" xml:space="preserve">
     <value>The operation contract '{0}' is not self-consistent. When the '{1}' is set to '{2}', both '{3}' and '{4}' properties must be true, and the operation must not have any input parameters.</value>
   </data>
-  <data name="InstanceSettingsMustHaveTypeOrWellKnownObject0" xml:space="preserve">
-    <value>The ServiceHost must be configured with either a serviceType or a serviceInstance.  Both of these values are currently null.</value>
-  </data>
-  <data name="TheServiceMetadataExtensionInstanceCouldNot2_0" xml:space="preserve">
-    <value>The ServiceMetadataExtension instance could not be added to the ServiceHost instance because it has already been added to another ServiceHost instance.</value>
-  </data>
-  <data name="TheServiceMetadataExtensionInstanceCouldNot3_0" xml:space="preserve">
-    <value>The ServiceMetadataExtension instance could not be removed from the ServiceHost instance because it has not been added to any ServiceHost instance.</value>
-  </data>
-  <data name="TheServiceMetadataExtensionInstanceCouldNot4_0" xml:space="preserve">
-    <value>The ServiceMetadataExtension instance could not be removed from the ServiceHost instance because it has already been added to a different ServiceHost instance.</value>
-  </data>
   <data name="SynchronizedCollectionWrongType1" xml:space="preserve">
     <value>A value of type '{0}' cannot be added to the generic collection, because the collection has been parameterized with a different type.</value>
   </data>
@@ -4200,149 +1578,8 @@
   <data name="channelDoesNotHaveADuplexSession0" xml:space="preserve">
     <value>The current channel does not support closing the output session as this channel does not implement ISessionChannel&lt;IDuplexSession&gt;.</value>
   </data>
-  <data name="EndpointsMustHaveAValidBinding1" xml:space="preserve">
-    <value>The ServiceEndpoint with name '{0}' could not be exported to WSDL because the Binding property is null. To fix this, set the Binding property to a valid Binding instance.</value>
-  </data>
-  <data name="ABindingInstanceHasAlreadyBeenAssociatedTo1" xml:space="preserve">
-    <value>A binding instance has already been associated to listen URI '{0}'. If two endpoints want to share the same ListenUri, they must also share the same binding object instance. The two conflicting endpoints were either specified in AddServiceEndpoint() calls, in a config file, or a combination of AddServiceEndpoint() and config. </value>
-  </data>
-  <data name="UnabletoImportPolicy" xml:space="preserve">
-    <value>The following Policy Assertions were not Imported:\r\n</value>
-  </data>
-  <data name="UnImportedAssertionList" xml:space="preserve">
-    <value>   XPath:{0}\r\n  Assertions:</value>
-  </data>
-  <data name="XPathUnavailable" xml:space="preserve">
-    <value>\"XPath Unavailable\"</value>
-  </data>
-  <data name="DuplicatePolicyInWsdlSkipped" xml:space="preserve">
-    <value>A policy expression was ignored because another policy expression with that ID has already been read in this document.\r\nXPath:{0}</value>
-  </data>
-  <data name="DuplicatePolicyDocumentSkipped" xml:space="preserve">
-    <value>A policy document was ignored because a policy expression with that ID has already been imported.\r\nPolicy ID:{0}</value>
-  </data>
-  <data name="PolicyDocumentMustHaveIdentifier" xml:space="preserve">
-    <value>A metadata section containing policy did not have an identifier so it cannot be referenced. </value>
-  </data>
-  <data name="XPathPointer" xml:space="preserve">
-    <value>XPath:{0}</value>
-  </data>
-  <data name="UnableToFindPolicyWithId" xml:space="preserve">
-    <value>A policy reference was ignored because the policy with ID '{0}' could not be found.</value>
-  </data>
-  <data name="PolicyReferenceInvalidId" xml:space="preserve">
-    <value>A policy reference was ignored because the URI of the reference was empty.</value>
-  </data>
-  <data name="PolicyReferenceMissingURI" xml:space="preserve">
-    <value>A policy reference was ignored because the required {0} attribute was missing.</value>
-  </data>
-  <data name="ExceededMaxPolicyComplexity" xml:space="preserve">
-    <value>The policy expression was not fully imported because it exceeded the maximum allowable complexity. The import stopped at element '{0}' '{1}'.</value>
-  </data>
-  <data name="ExceededMaxPolicySize" xml:space="preserve">
-    <value>The policy expression was not fully imported because its normalized form was too large.</value>
-  </data>
-  <data name="UnrecognizedPolicyElementInNamespace" xml:space="preserve">
-    <value>Unrecognized policy element {0} in namespace {1}.</value>
-  </data>
-  <data name="UnsupportedPolicyDocumentRoot" xml:space="preserve">
-    <value>\"{0}\" is not a supported WS-Policy document root element.</value>
-  </data>
-  <data name="UnrecognizedPolicyDocumentNamespace" xml:space="preserve">
-    <value>The \"{0}\" namespace is not a recognized WS-Policy namespace.</value>
-  </data>
-  <data name="NoUsablePolicyAssertions" xml:space="preserve">
-    <value>Cannot find usable policy alternatives.</value>
-  </data>
-  <data name="PolicyInWsdlMustHaveFragmentId" xml:space="preserve">
-    <value>Unreachable policy detected.\r\nA WS-Policy element embedded in WSDL is missing a fragment identifier. This policy cannot be referenced by any WS-PolicyAttachment mechanisms.\r\nXPath:{0}</value>
-  </data>
-  <data name="FailedImportOfWsdl" xml:space="preserve">
-    <value>The processing of the WSDL parameter failed. Error: {0}</value>
-  </data>
-  <data name="OptionalWSDLExtensionIgnored" xml:space="preserve">
-    <value>The optional WSDL extension element '{0}' from namespace '{1}' was not handled.\r\nXPath: {2}</value>
-  </data>
-  <data name="RequiredWSDLExtensionIgnored" xml:space="preserve">
-    <value>The required WSDL extension element '{0}' from namespace '{1}' was not handled.</value>
-  </data>
-  <data name="UnknownWSDLExtensionIgnored" xml:space="preserve">
-    <value>An unrecognized WSDL extension of Type '{0}' was not handled.</value>
-  </data>
-  <data name="WsdlExporterIsFaulted" xml:space="preserve">
-    <value>A previous call to this WsdlExporter left it in a faulted state. It is no longer usable.</value>
-  </data>
-  <data name="WsdlImporterIsFaulted" xml:space="preserve">
-    <value>A previous call to this WsdlImporter left it in a faulted state. It is no longer usable.</value>
-  </data>
-  <data name="WsdlImporterContractMustBeInKnownContracts" xml:space="preserve">
-    <value>The ContractDescription argument to ImportEndpoints must be contained in the KnownContracts collection.</value>
-  </data>
-  <data name="WsdlItemAlreadyFaulted" xml:space="preserve">
-    <value>A previous attempt to import this {0} already failed.</value>
-  </data>
-  <data name="InvalidPolicyExtensionTypeInConfig" xml:space="preserve">
-    <value>The type {0} registered as a policy extension does not implement IPolicyImportExtension</value>
-  </data>
-  <data name="PolicyExtensionTypeRequiresDefaultConstructor" xml:space="preserve">
-    <value>The type {0} registered as a policy extension does not have a public default constructor. Policy extensions must have a public default constructor</value>
-  </data>
-  <data name="PolicyExtensionImportError" xml:space="preserve">
-    <value>An exception was thrown in a call to a policy import extension.\r\nExtension: {0}\r\nError: {1}</value>
-  </data>
-  <data name="PolicyExtensionExportError" xml:space="preserve">
-    <value>An exception was thrown in a call to a policy export extension.\r\nExtension: {0}\r\nError: {1}</value>
-  </data>
-  <data name="MultipleCallsToExportContractWithSameContract" xml:space="preserve">
-    <value>Calling IWsdlExportExtension.ExportContract twice with the same ContractDescription is not supported.</value>
-  </data>
-  <data name="DuplicateContractQNameNameOnExport" xml:space="preserve">
-    <value>Duplicate contract XmlQualifiedNames are not supported.\r\nAnother ContractDescription with the Name: {0} and Namespace: {1} has already been exported.</value>
-  </data>
-  <data name="WarnDuplicateBindingQNameNameOnExport" xml:space="preserve">
-    <value>Similar ServiceEndpoints were exported. The WSDL export process was forced to suffix wsdl:binding names to avoid naming conflicts.\r\n Similar ServiceEndpoints means different binding instances having the Name: {0} and Namespace: {1} and either the same ContractDescription or at least the same contract Name: {2}.</value>
-  </data>
-  <data name="WarnSkippingOpertationWithWildcardAction" xml:space="preserve">
-    <value>An operation was skipped during export because it has a wildcard action. This is not supported in WSDL.\r\nContract Name:{0}\r\nContract Namespace:{1}\r\nOperation Name:{2}</value>
-  </data>
-  <data name="WarnSkippingOpertationWithSessionOpenNotificationEnabled" xml:space="preserve">
-    <value>An operation was skipped during export because the property '{0}' is set to '{1}'. This operation should be used for server only and should not be exposed from WSDL. \r\nContract Name:{2}\r\nContract Namespace:{3}\r\nOperation Name:{4}</value>
-  </data>
-  <data name="InvalidWsdlExtensionTypeInConfig" xml:space="preserve">
-    <value>The type {0} registered as a WSDL extension does not implement IWsdlImportExtension.</value>
-  </data>
-  <data name="WsdlExtensionTypeRequiresDefaultConstructor" xml:space="preserve">
-    <value>The type {0} registered as a WSDL extension does not have a public default constructor. WSDL extensions must have a public default constructor.</value>
-  </data>
-  <data name="WsdlExtensionContractExportError" xml:space="preserve">
-    <value>An exception was thrown in a call to a WSDL export extension: {0}\r\n contract: {1}</value>
-  </data>
-  <data name="WsdlExtensionEndpointExportError" xml:space="preserve">
-    <value>An exception was thrown in a call to a WSDL export extension: {0}\r\n Endpoint: {1}</value>
-  </data>
-  <data name="WsdlExtensionBeforeImportError" xml:space="preserve">
-    <value>A WSDL import extension threw an exception during the BeforeImport call: {0}\r\nError: {1}</value>
-  </data>
-  <data name="WsdlExtensionImportError" xml:space="preserve">
-    <value>An exception was thrown while running a WSDL import extension: {0}\r\nError: {1}</value>
-  </data>
-  <data name="WsdlImportErrorMessageDetail" xml:space="preserve">
-    <value>Cannot import {0}\r\nDetail: {2}\r\nXPath to Error Source: {1}</value>
-  </data>
-  <data name="WsdlImportErrorDependencyDetail" xml:space="preserve">
-    <value>There was an error importing a {0} that the {1} is dependent on.\r\nXPath to {0}: {2}</value>
-  </data>
   <data name="UnsupportedEnvelopeVersion" xml:space="preserve">
     <value>The {0} binding element requires envelope version '{1}' It doesn't support '{2}'.</value>
-  </data>
-  <data name="NoValue0" xml:space="preserve">
-    <value>No value.</value>
-  </data>
-  <data name="UnsupportedBindingElementClone" xml:space="preserve">
-    <value>The '{0}' binding element does not support cloning.</value>
-  </data>
-  <data name="UnrecognizedBindingAssertions1" xml:space="preserve">
-    <value>WsdlImporter encountered unrecognized policy assertions in ServiceDescription '{0}':</value>
   </data>
   <data name="ServicesWithoutAServiceContractAttributeCan2" xml:space="preserve">
     <value>The {0} declared on method '{1}' in type '{2}' is invalid. {0}s are only valid on methods that are declared in a type that has ServiceContractAttribute. Either add ServiceContractAttribute to type '{2}' or remove {0} from method '{1}'.</value>
@@ -4376,9 +1613,6 @@
   </data>
   <data name="CannotHaveTwoOperationsWithTheSameName3" xml:space="preserve">
     <value>Cannot have two operations in the same contract with the same name, methods {0} and {1} in type {2} violate this rule. You can change the name of one of the operations by changing the method name or by using the Name property of OperationContractAttribute.</value>
-  </data>
-  <data name="CannotHaveTwoOperationsWithTheSameElement5" xml:space="preserve">
-    <value>The {0}.{1} operation references a message element [{2}] that has already been exported from the {3}.{4} operation. You can change the name of one of the operations by changing the method name or using the Name property of OperationContractAttribute. Alternatively, you can control the element name in greater detail using the MessageContract programming model.</value>
   </data>
   <data name="CannotInheritTwoOperationsWithTheSameName3" xml:space="preserve">
     <value>Cannot inherit two different operations with the same name, operation '{0}' from contracts '{1}' and '{2}' violate this rule. You can change the name of one of the operations by changing the method name or by using the Name property of OperationContractAttribute.</value>
@@ -4428,26 +1662,11 @@
   <data name="OneWayAndFaultsIncompatible2" xml:space="preserve">
     <value>The method '{1}' in type '{0}' is marked IsOneWay=true and declares one or more FaultContractAttributes. One-way methods cannot declare FaultContractAttributes. To fix it, change IsOneWay to false or remove the FaultContractAttributes.</value>
   </data>
-  <data name="OnlyMalformedMessagesAreSupported" xml:space="preserve">
-    <value>Only malformed Messages are supported.</value>
-  </data>
-  <data name="UnableToLocateOperation2" xml:space="preserve">
-    <value>Cannot locate operation {0} in Contract {1}.</value>
-  </data>
-  <data name="UnsupportedWSDLOnlyOneMessage" xml:space="preserve">
-    <value>Unsupported WSDL, only one message part is supported for fault messages. This fault message references zero or more than one message part. If you have edit access to the WSDL file, you can fix the problem by removing the extra message parts such that fault message references just one part.</value>
-  </data>
-  <data name="UnsupportedWSDLTheFault" xml:space="preserve">
-    <value>Unsupported WSDL, the fault message part must reference an element. This fault message does not reference an element. If you have edit access to the WSDL document, you can fix the problem by referencing a schema element using the 'element' attribute.</value>
-  </data>
   <data name="AsyncEndCalledOnWrongChannel" xml:space="preserve">
     <value>Async End called on wrong channel.</value>
   </data>
   <data name="AsyncEndCalledWithAnIAsyncResult" xml:space="preserve">
     <value>Async End called with an IAsyncResult from a different Begin method.</value>
-  </data>
-  <data name="IsolationLevelMismatch2" xml:space="preserve">
-    <value>The received transaction has an isolation level of '{0}' but the service is configured with a TransactionIsolationLevel of '{1}'. The isolation level for received transactions and the service must be the same.</value>
   </data>
   <data name="MessageHeaderIsNull0" xml:space="preserve">
     <value>The value of the addressHeaders argument is invalid because the collection contains null values. Null is not a valid value for the AddressHeaderCollection.</value>
@@ -4461,35 +1680,8 @@
   <data name="CantCreateChannelWithManualAddressing" xml:space="preserve">
     <value>Cannot create channel for a contract that requires request/reply and a binding that requires manual addressing but only supports duplex communication.</value>
   </data>
-  <data name="XsdMissingRequiredAttribute1" xml:space="preserve">
-    <value>Missing required '{0}' attribute.</value>
-  </data>
-  <data name="IgnoreSoapHeaderBinding3" xml:space="preserve">
-    <value>Ignoring invalid SOAP header extension in wsdl:operation name='{0}' from targetNamespace='{1}'. Reason: {2}</value>
-  </data>
-  <data name="IgnoreSoapFaultBinding3" xml:space="preserve">
-    <value>Ignoring invalid SOAP fault extension in wsdl:operation name='{0}' from targetNamespace='{1}'. Reason: {2}</value>
-  </data>
-  <data name="IgnoreMessagePart3" xml:space="preserve">
-    <value>Ignoring invalid part in wsdl:message name='{0}' from targetNamespace='{1}'. Reason: {2}</value>
-  </data>
-  <data name="CannotImportPrivacyNoticeElementWithoutVersionAttribute" xml:space="preserve">
-    <value>PrivacyNotice element must have a Version attribute.</value>
-  </data>
-  <data name="PrivacyNoticeElementVersionAttributeInvalid" xml:space="preserve">
-    <value>PrivacyNotice element Version attribute must have an integer value.</value>
-  </data>
   <data name="XDCannotFindValueInDictionaryString" xml:space="preserve">
     <value>Cannot find '{0}' value in dictionary string.</value>
-  </data>
-  <data name="WmiGetObject" xml:space="preserve">
-    <value>WMI GetObject Query: {0}</value>
-  </data>
-  <data name="WmiPutInstance" xml:space="preserve">
-    <value>WMI PutInstance Class: {0}</value>
-  </data>
-  <data name="ObjectMustBeOpenedToDequeue" xml:space="preserve">
-    <value>Cannot dequeue a '{0}' object while in the Created state.</value>
   </data>
   <data name="NoChannelBuilderAvailable" xml:space="preserve">
     <value>The binding (Name={0}, Namespace={1}) cannot be used to create a ChannelFactory or a ChannelListener because it appears to be missing a TransportBindingElement.  Every binding must have at least one binding element that derives from TransportBindingElement.</value>
@@ -4527,12 +1719,6 @@
   <data name="BaseAddressCannotHaveUserInfo" xml:space="preserve">
     <value>A base address cannot contain a Uri user info section.</value>
   </data>
-  <data name="TransportBindingElementNotFound" xml:space="preserve">
-    <value>The binding does not contain a TransportBindingElement.</value>
-  </data>
-  <data name="ChannelDemuxerBindingElementNotFound" xml:space="preserve">
-    <value>The binding does not contain a ChannelDemuxerBindingElement.</value>
-  </data>
   <data name="BaseAddressCannotHaveQuery" xml:space="preserve">
     <value>A base address cannot contain a Uri query string.</value>
   </data>
@@ -4542,560 +1728,14 @@
   <data name="UriMustBeAbsolute" xml:space="preserve">
     <value>The given URI must be absolute.</value>
   </data>
-  <data name="BindingProtocolMappingNotDefined" xml:space="preserve">
-    <value>The binding for scheme '{0}' specified in the protocol mapping does not exist and must be created.</value>
-  </data>
-  <data name="Default" xml:space="preserve">
-    <value>(Default)</value>
-  </data>
-  <data name="AdminMTAWorkerThreadException" xml:space="preserve">
-    <value>MTAWorkerThread exception</value>
-  </data>
-  <data name="InternalError" xml:space="preserve">
-    <value>An unexpected error has occurred.</value>
-  </data>
-  <data name="ClsidNotInApplication" xml:space="preserve">
-    <value>The CLSID specified in the service file is not configured in the specified application. (The CLSID is {0}, the AppID is {1}.)</value>
-  </data>
-  <data name="ClsidNotInConfiguration" xml:space="preserve">
-    <value>The CLSID specified in the service file does not have a service element in a configuration file. (The CLSID is {0}.)</value>
-  </data>
-  <data name="EndpointNotAnIID" xml:space="preserve">
-    <value>An endpoint configured for the COM+ CLSID {0} is not a configured interface on the class. (The contract type is {1}.)</value>
-  </data>
-  <data name="ServiceStringFormatError" xml:space="preserve">
-    <value>The COM+ string in the .svc file was formatted incorrectly. (The string is \"{0}\".)</value>
-  </data>
-  <data name="ContractTypeNotAnIID" xml:space="preserve">
-    <value>The contract type name in the configuration file was not in the form of an interface identifier. (The string is \"{0}\".)</value>
-  </data>
-  <data name="ApplicationNotFound" xml:space="preserve">
-    <value>The configured application was not found. (The Application ID was {0}.)</value>
-  </data>
-  <data name="NoVoteIssued" xml:space="preserve">
-    <value> A transaction vote request was completed, but there was no outstanding vote request.</value>
-  </data>
-  <data name="FailedToConvertTypelibraryToAssembly" xml:space="preserve">
-    <value>Failed to convert type library to assembly</value>
-  </data>
-  <data name="BadInterfaceVersion" xml:space="preserve">
-    <value>Incorrect Interface version in registry</value>
-  </data>
-  <data name="FailedToLoadTypeLibrary" xml:space="preserve">
-    <value>Failed to load type library</value>
-  </data>
-  <data name="NativeTypeLibraryNotAllowed" xml:space="preserve">
-    <value> An attempt to load the native type library '{0}' was made. Native type libraries cannot be loaded.</value>
-  </data>
-  <data name="InterfaceNotFoundInAssembly" xml:space="preserve">
-    <value>Could not find interface in the Assembly</value>
-  </data>
-  <data name="UdtNotFoundInAssembly" xml:space="preserve">
-    <value>The '{0}' user-defined type could not be found. Ensure that the correct type and type library are registered and specified.</value>
-  </data>
-  <data name="UnknownMonikerKeyword" xml:space="preserve">
-    <value>Could not find keyword {0}.</value>
-  </data>
-  <data name="MonikerIncorectSerializer" xml:space="preserve">
-    <value>Invalid serializer specified. The only valid values are 'xml' and 'datacontract'.</value>
-  </data>
-  <data name="NoEqualSignFound" xml:space="preserve">
-    <value>The keyword '{0}' has no equal sign following it. Ensure that each keyword is followed by an equal sign and a value. </value>
-  </data>
-  <data name="KewordMissingValue" xml:space="preserve">
-    <value>No value found for a keyword.</value>
-  </data>
-  <data name="BadlyTerminatedValue" xml:space="preserve">
-    <value>Badly terminated value {0}.</value>
-  </data>
-  <data name="MissingQuote" xml:space="preserve">
-    <value>Missing Quote in value {0}.</value>
-  </data>
-  <data name="RepeatedKeyword" xml:space="preserve">
-    <value>Repeated moniker keyword.</value>
-  </data>
-  <data name="InterfaceNotFoundInConfig" xml:space="preserve">
-    <value>Interface {0} not found in configuration.</value>
-  </data>
-  <data name="CannotHaveNullOrEmptyNameOrNamespaceForIID" xml:space="preserve">
-    <value>Interface {0} has a null namespace or name.</value>
-  </data>
-  <data name="MethodGivenInConfigNotFoundOnInterface" xml:space="preserve">
-    <value>Method {0} given in config was not found on interface {1}.</value>
-  </data>
-  <data name="MonikerIncorrectServerIdentityForMex" xml:space="preserve">
-    <value>Only one type of server identity can be specified.</value>
-  </data>
-  <data name="MonikerAddressNotSpecified" xml:space="preserve">
-    <value>Address not specified.</value>
-  </data>
-  <data name="MonikerMexBindingSectionNameNotSpecified" xml:space="preserve">
-    <value>Mex binding section name attribute not specified.</value>
-  </data>
-  <data name="MonikerMexAddressNotSpecified" xml:space="preserve">
-    <value>Mex address not specified.</value>
-  </data>
-  <data name="MonikerContractNotSpecified" xml:space="preserve">
-    <value>Contract not specified.</value>
-  </data>
-  <data name="MonikerBindingNotSpecified" xml:space="preserve">
-    <value>Binding not specified.</value>
-  </data>
-  <data name="MonikerBindingNamespacetNotSpecified" xml:space="preserve">
-    <value>Binding namespace not specified.</value>
-  </data>
-  <data name="MonikerFailedToDoMexRetrieve" xml:space="preserve">
-    <value>Failed to do mex retrieval:{0}.</value>
-  </data>
-  <data name="MonikerContractNotFoundInRetreivedMex" xml:space="preserve">
-    <value>None of the contract in metadata matched the contract specified.</value>
-  </data>
-  <data name="MonikerNoneOfTheBindingMatchedTheSpecifiedBinding" xml:space="preserve">
-    <value>The contract does not have an endpoint supporting the binding specified.</value>
-  </data>
-  <data name="MonikerMissingColon" xml:space="preserve">
-    <value>Moniker Missing Colon</value>
-  </data>
-  <data name="MonikerIncorrectServerIdentity" xml:space="preserve">
-    <value>Multiple server identity keywords were specified. Ensure that at most one identity keyword is specified.</value>
-  </data>
-  <data name="NoInterface" xml:space="preserve">
-    <value>The object does not support the interface '{0}'.</value>
-  </data>
-  <data name="DuplicateTokenExFailed" xml:space="preserve">
-    <value>Could not duplicate the token (error=0x{0:X}).</value>
-  </data>
-  <data name="AccessCheckFailed" xml:space="preserve">
-    <value>Could not perform an AccessCheck (error=0x{0:X}).</value>
-  </data>
-  <data name="ImpersonateAnonymousTokenFailed" xml:space="preserve">
-    <value>Could not impersonate the anonymous user (error=0x{0:X}).</value>
-  </data>
-  <data name="OnlyByRefVariantSafeArraysAllowed" xml:space="preserve">
-    <value>The provided SafeArray parameter was passed by value. SafeArray parameters must be passed by reference.</value>
-  </data>
-  <data name="OnlyOneDimensionalSafeArraysAllowed" xml:space="preserve">
-    <value> Multi-dimensional SafeArray parameters cannot be used.</value>
-  </data>
-  <data name="OnlyVariantTypeElementsAllowed" xml:space="preserve">
-    <value>The elements of the SafeArray must be of the type VARIANT.</value>
-  </data>
-  <data name="OnlyZeroLBoundAllowed" xml:space="preserve">
-    <value>The lower bound of the SafeArray was not zero. SafeArrays with a lower bound other than zero cannot be used.</value>
-  </data>
-  <data name="OpenThreadTokenFailed" xml:space="preserve">
-    <value>Could not open the thread token (error=0x{0:X}).</value>
-  </data>
-  <data name="OpenProcessTokenFailed" xml:space="preserve">
-    <value>Could not open the process token (error=0x{0:X}).</value>
-  </data>
-  <data name="InvalidIsolationLevelValue" xml:space="preserve">
-    <value>The isolation level for component {0} is invalid. (The value was {1}.)</value>
-  </data>
-  <data name="UnsupportedConversion" xml:space="preserve">
-    <value>The conversion between the client parameter type '{0}' to the required server parameter type '{1}' cannot be performed.</value>
-  </data>
-  <data name="FailedProxyProviderCreation" xml:space="preserve">
-    <value>The required outer proxy could not be created. Ensure that the service moniker is correctly installed and registered.</value>
-  </data>
-  <data name="UnableToLoadDll" xml:space="preserve">
-    <value>Cannot load library {0}. Ensure that WCF is properly installed.</value>
-  </data>
-  <data name="InterfaceNotRegistered" xml:space="preserve">
-    <value>Interface Not Registered</value>
-  </data>
-  <data name="BadInterfaceRegistration" xml:space="preserve">
-    <value>Bad Interface Registration</value>
-  </data>
-  <data name="NoTypeLibraryFoundForInterface" xml:space="preserve">
-    <value>No type library available for interface</value>
-  </data>
-  <data name="VariantArrayNull" xml:space="preserve">
-    <value>Parameter at index {0} is null.</value>
-  </data>
-  <data name="UnableToRetrievepUnk" xml:space="preserve">
-    <value>Unable to retrieve IUnknown for object.</value>
-  </data>
-  <data name="PersistWrapperIsNull" xml:space="preserve">
-    <value>QueryInterface succeeded but the persistable type wrapper was null.</value>
-  </data>
-  <data name="UnexpectedThreadingModel" xml:space="preserve">
-    <value>Unexpected threading model. WCF/COM+ integration only supports STA and MTA threading models.</value>
-  </data>
-  <data name="NoneOfTheMethodsForInterfaceFoundInConfig" xml:space="preserve">
-    <value>None of the methods were found for interface {0}.</value>
-  </data>
-  <data name="InvalidWebServiceInterface" xml:space="preserve">
-    <value>The interface with IID {0} cannot be exposed as a web service</value>
-  </data>
-  <data name="InvalidWebServiceParameter" xml:space="preserve">
-    <value>The parameter named {0} of type {1} on method {2} of interface {3} cannot be serialized.</value>
-  </data>
-  <data name="InvalidWebServiceReturnValue" xml:space="preserve">
-    <value>The return value of type {0} on method {1} of interface {2} cannot be serialized.</value>
-  </data>
-  <data name="OperationNotFound" xml:space="preserve">
-    <value>The method '{0}' could not be found. Ensure that the correct method name is specified.</value>
-  </data>
-  <data name="BadDispID" xml:space="preserve">
-    <value>The Dispatch ID '{0}' could not be found or is invalid.</value>
-  </data>
-  <data name="BadParamCount" xml:space="preserve">
-    <value>The number of parameters in the request did not match the number supported by the method. Ensure that the correct number of parameters are specified.</value>
-  </data>
-  <data name="BindingNotFoundInConfig" xml:space="preserve">
-    <value>Binding type {0} instance {1} not found in config.</value>
-  </data>
-  <data name="AddressNotSpecified" xml:space="preserve">
-    <value>The required address keyword was not specified.</value>
-  </data>
-  <data name="BindingNotSpecified" xml:space="preserve">
-    <value>The required binding keyword was not specified or is not valid.</value>
-  </data>
-  <data name="OnlyVariantAllowedByRef" xml:space="preserve">
-    <value>A VARIANT parameter was passed by value. VARIANT parameters must be passed by reference.</value>
-  </data>
-  <data name="CannotResolveTypeForParamInMessageDescription" xml:space="preserve">
-    <value>The type for the '{0}' parameter in '{1}' within the namespace '{2}' cannot not be resolved.</value>
-  </data>
-  <data name="TooLate" xml:space="preserve">
-    <value>The operation cannot be performed after the communications channel has been created.</value>
-  </data>
-  <data name="RequireConfiguredMethods" xml:space="preserve">
-    <value>The interface with IID {0} has no methods configured in the COM+ catalog and cannot be exposed as a web service.</value>
-  </data>
-  <data name="RequireConfiguredInterfaces" xml:space="preserve">
-    <value>The interface with IID {0} is not configured in the COM+ catalog and cannot be exposed as a web service.</value>
-  </data>
-  <data name="CannotCreateChannelOption" xml:space="preserve">
-    <value>The channeloption intrinsic object cannot be created because the channel builder is not initialized.</value>
-  </data>
-  <data name="NoTransactionInContext" xml:space="preserve">
-    <value>There is no transaction in the context of the operation.</value>
-  </data>
-  <data name="IssuedTokenFlowNotAllowed" xml:space="preserve">
-    <value>The service does not accept issued tokens.</value>
-  </data>
-  <data name="GeneralSchemaValidationError" xml:space="preserve">
-    <value>There was an error verifying some XML Schemas generated during export:\r\n{0}</value>
-  </data>
-  <data name="SchemaValidationError" xml:space="preserve">
-    <value>There was a validation error on a schema generated during export:\r\n    Source: {0}\r\n    Line: {1} Column: {2}\r\n   Validation Error: {3}</value>
-  </data>
-  <data name="ContractBindingAddressCannotBeNull" xml:space="preserve">
-    <value>The Address, Binding and Contract keywords are required.</value>
-  </data>
-  <data name="TypeLoadForContractTypeIIDFailedWith" xml:space="preserve">
-    <value>Type load for contract interface ID {0} failed with Error:{1}.</value>
-  </data>
-  <data name="BindingLoadFromConfigFailedWith" xml:space="preserve">
-    <value>Fail to load binding {0} from config. Error:{1}.</value>
-  </data>
-  <data name="PooledApplicationNotSupportedForComplusHostedScenarios" xml:space="preserve">
-    <value>Application {0} is marked Pooled. Pooled applications are not supported under COM+ hosting.</value>
-  </data>
-  <data name="RecycledApplicationNotSupportedForComplusHostedScenarios" xml:space="preserve">
-    <value>Application {0} has recycling enabled. Recycling of applications is not supported under COM+ hosting.</value>
-  </data>
-  <data name="BadImpersonationLevelForOutOfProcWas" xml:space="preserve">
-    <value>The client token at least needs to have the SecurityImpersonationLevel of at least Impersonation for Out of process Webhost activations.</value>
-  </data>
-  <data name="ComPlusInstanceProviderRequiresMessage0" xml:space="preserve">
-    <value>This InstanceContext requires a valid Message to obtain the instance.</value>
-  </data>
-  <data name="ComPlusInstanceCreationRequestSchema" xml:space="preserve">
-    <value>From: {0}\nAppId: {1}\nClsId: {2}\nIncoming TransactionId: {3}\nRequesting Identity: {4}</value>
-  </data>
-  <data name="ComPlusMethodCallSchema" xml:space="preserve">
-    <value>From: {0}\nAppId: {1}\nClsId: {2}\nIid: {3}\nAction: {4}\nInstance Id: {5}\nManaged Thread Id: {6}\nUnmanaged Thread Id: {7}\nRequesting Identity: {8}</value>
-  </data>
-  <data name="ComPlusServiceSchema" xml:space="preserve">
-    <value>AppId: {0}\nClsId: {1}\n</value>
-  </data>
-  <data name="ComPlusServiceSchemaDllHost" xml:space="preserve">
-    <value>AppId: {0}</value>
-  </data>
-  <data name="ComPlusTLBImportSchema" xml:space="preserve">
-    <value>Iid: {0}\nType Library ID: {1}</value>
-  </data>
-  <data name="ComPlusServiceHostStartingServiceErrorNoQFE" xml:space="preserve">
-    <value>A Windows hotfix or later service pack is required on Windows XP and Windows Server 2003 to use WS-AtomicTransaction and COM+ Integration Web service transaction functionality. See the Microsoft .NET Framework release notes for instructions on installing the required hotfix.</value>
-  </data>
-  <data name="ComIntegrationManifestCreationFailed" xml:space="preserve">
-    <value>Generating manifest file {0} failed with {1}.</value>
-  </data>
-  <data name="TempDirectoryNotFound" xml:space="preserve">
-    <value>Directory {0} not found.</value>
-  </data>
-  <data name="CannotAccessDirectory" xml:space="preserve">
-    <value>Cannot access directory {0}.</value>
-  </data>
-  <data name="CLSIDDoesNotSupportIPersistStream" xml:space="preserve">
-    <value>The object with CLSID '{0}' does not support the required IPersistStream interface.</value>
-  </data>
-  <data name="CLSIDOfTypeDoesNotMatch" xml:space="preserve">
-    <value>CLSID of type {0} does not match the CLSID on PersistStreamTypeWrapper which is {1}.</value>
-  </data>
-  <data name="TargetObjectDoesNotSupportIPersistStream" xml:space="preserve">
-    <value>Target object does not support IPersistStream.</value>
-  </data>
-  <data name="TargetTypeIsAnIntefaceButCorrespoindingTypeIsNotPersistStreamTypeWrapper" xml:space="preserve">
-    <value>Target type is an interface but corresponding type is not PersistStreamTypeWrapper.</value>
-  </data>
-  <data name="NotAllowedPersistableCLSID" xml:space="preserve">
-    <value>CLSID {0} is not allowed.</value>
-  </data>
-  <data name="TransferringToComplus" xml:space="preserve">
-    <value>Transferring to ComPlus logical thread {0}.</value>
-  </data>
-  <data name="NamedArgsNotSupported" xml:space="preserve">
-    <value>The cNamedArgs parameter is not supported and must be 0.</value>
-  </data>
-  <data name="MexBindingNotFoundInConfig" xml:space="preserve">
-    <value>Binding '{0}' was not found in config. The config file must be present and contain a binding matching the one specified in the moniker.</value>
-  </data>
   <data name="ClaimTypeCannotBeEmpty" xml:space="preserve">
     <value>The claimType cannot be an empty string.</value>
-  </data>
-  <data name="X509ChainIsEmpty" xml:space="preserve">
-    <value>X509Chain does not have any valid certificates.</value>
   </data>
   <data name="MissingCustomCertificateValidator" xml:space="preserve">
     <value>X509CertificateValidationMode.Custom requires a CustomCertificateValidator. Specify the CustomCertificateValidator property.</value>
   </data>
-  <data name="MissingMembershipProvider" xml:space="preserve">
-    <value>UserNamePasswordValidationMode.MembershipProvider requires a MembershipProvider. Specify the MembershipProvider property.</value>
-  </data>
-  <data name="MissingCustomUserNamePasswordValidator" xml:space="preserve">
-    <value>UserNamePasswordValidationMode.Custom requires a CustomUserNamePasswordValidator. Specify the CustomUserNamePasswordValidator property.</value>
-  </data>
-  <data name="SpnegoImpersonationLevelCannotBeSetToNone" xml:space="preserve">
-    <value>The Security Support Provider Interface does not support Impersonation level 'None'. Specify Identification, Impersonation or Delegation level.</value>
-  </data>
-  <data name="PublicKeyNotRSA" xml:space="preserve">
-    <value>The public key is not an RSA key.</value>
-  </data>
-  <data name="SecurityAuditFailToLoadDll" xml:space="preserve">
-    <value>The '{0}' dynamic link library (dll) failed to load.</value>
-  </data>
   <data name="SecurityAuditPlatformNotSupported" xml:space="preserve">
     <value>Writing audit messages to the Security log is not supported by the current platform. You must write audit messages to the Application log.</value>
-  </data>
-  <data name="NoPrincipalSpecifiedInAuthorizationContext" xml:space="preserve">
-    <value>No custom principal is specified in the authorization context.</value>
-  </data>
-  <data name="AccessDenied" xml:space="preserve">
-    <value>Access is denied.</value>
-  </data>
-  <data name="SecurityAuditNotSupportedOnChannelFactory" xml:space="preserve">
-    <value>SecurityAuditBehavior is not supported on the channel factory.</value>
-  </data>
-  <data name="ExpiredTokenInChannelParameters" xml:space="preserve">
-    <value>The Infocard token created during channel intialization has expired. Please create a new channel to reacquire token. </value>
-  </data>
-  <data name="NoTokenInChannelParameters" xml:space="preserve">
-    <value>No Infocard token was found in the ChannelParameters. Infocard requires that the security token be created during channel intialization.</value>
-  </data>
-  <data name="ArgumentOutOfRange" xml:space="preserve">
-    <value>value must be &gt;= {0} and &lt;= {1}.</value>
-  </data>
-  <data name="InsufficientCryptoSupport" xml:space="preserve">
-    <value>The binding's PeerTransportSecuritySettings can not be supported under the current system security configuration.</value>
-  </data>
-  <data name="InsufficientCredentials" xml:space="preserve">
-    <value>Credentials specified are not sufficient to carry requested operation. Please specify a valid value for {0}. </value>
-  </data>
-  <data name="UnexpectedSecurityTokensDuringHandshake" xml:space="preserve">
-    <value>Connection was not accepted because the SecurityContext contained tokens that do not match the current security settings.</value>
-  </data>
-  <data name="InsufficientResolverSettings" xml:space="preserve">
-    <value>Provided information is Insufficient to create a valid connection to the resolver service.</value>
-  </data>
-  <data name="InvalidResolverMode" xml:space="preserve">
-    <value>Specified PeerResolverMode value {0} is invalid. Please specify either PeerResolveMode.Auto, Default, or Pnrp.</value>
-  </data>
-  <data name="MustOverrideInitialize" xml:space="preserve">
-    <value>concrete PeerResolver implementation must override Initialize to accept metadata about resolver service.</value>
-  </data>
-  <data name="NotValidWhenOpen" xml:space="preserve">
-    <value>The operation: {0} is not valid while the object is in open state.</value>
-  </data>
-  <data name="NotValidWhenClosed" xml:space="preserve">
-    <value>The operation: {0} is not valid while the object is in closed state.</value>
-  </data>
-  <data name="DuplicatePeerRegistration" xml:space="preserve">
-    <value>A peer registration with the service address {0} already exists.</value>
-  </data>
-  <data name="MessagePropagationException" xml:space="preserve">
-    <value>The MessagePropagationFilter threw an exception. Please refer to InnerException.</value>
-  </data>
-  <data name="NotificationException" xml:space="preserve">
-    <value>An event notification threw an exception. Please refer to InnerException.</value>
-  </data>
-  <data name="ResolverException" xml:space="preserve">
-    <value>The Peer resolver threw an exception.  Please refer to InnerException.</value>
-  </data>
-  <data name="RefreshIntervalMustBeGreaterThanZero" xml:space="preserve">
-    <value>Invalid RefreshInterval value of {0}; it must be greater than zero</value>
-  </data>
-  <data name="CleanupIntervalMustBeGreaterThanZero" xml:space="preserve">
-    <value>Invalid CleanupInterval value of {0}; it must be greater than zero</value>
-  </data>
-  <data name="AmbiguousConnectivitySpec" xml:space="preserve">
-    <value>Multiple link-local only interfaces detected.  Please specifiy the interface you require by using the ListenIpAddress attribute in the PeerTransportBindingElement</value>
-  </data>
-  <data name="MustRegisterMoreThanZeroAddresses" xml:space="preserve">
-    <value>Registration with zero addresses detected.   Please call Register with more than zero addresses.</value>
-  </data>
-  <data name="BasicHttpContextBindingRequiresAllowCookie" xml:space="preserve">
-    <value>BasicHttpContextBinding {0}:{1} requires that AllowCookies property is set to true.</value>
-  </data>
-  <data name="CallbackContextOnlySupportedInWSAddressing10" xml:space="preserve">
-    <value>The message contains a callback context header with an endpoint reference for AddressingVersion '{0}'. Callback context can only be transmitted when the AddressingVersion is configured with 'WSAddressing10'.</value>
-  </data>
-  <data name="ListenAddressAlreadyContainsContext" xml:space="preserve">
-    <value>The callback address already has a context header in it.</value>
-  </data>
-  <data name="MultipleContextHeadersFoundInCallbackAddress" xml:space="preserve">
-    <value>The callback address contains multiple context headers. There can be at most one context header in a callback address.</value>
-  </data>
-  <data name="CallbackContextNotExpectedOnIncomingMessageAtClient" xml:space="preserve">
-    <value>The incoming message with action '{0}' contains a callback context header with name '{1}' and namespace '{2}'. Callback context headers are not expected in incoming messages at the client.</value>
-  </data>
-  <data name="CallbackContextOnlySupportedInSoap" xml:space="preserve">
-    <value>The message contains a callback context message property. Callback context can be transmitted only when the ContextBindingElement is configured with ContextExchangeMechanism of ContextSoapHeader.</value>
-  </data>
-  <data name="ContextBindingElementCannotProvideChannelFactory" xml:space="preserve">
-    <value>ContextBindingElement cannot provide channel factory for the requested channel shape {0}.</value>
-  </data>
-  <data name="ContextBindingElementCannotProvideChannelListener" xml:space="preserve">
-    <value>ContextBindingElement cannot provide channel listener for the requested channel shape {0}.</value>
-  </data>
-  <data name="InvalidCookieContent" xml:space="preserve">
-    <value>Value '{0}' specified for 'name' attribute of ContextMessageProperty is either null or has invalid character(s). Please ensure value of 'name' is within the allowed value space.</value>
-  </data>
-  <data name="SchemaViolationInsideContextHeader" xml:space="preserve">
-    <value>Context protocol was unable to parse the context header. Nodes disallowed by the context header schema were found inside the context header.</value>
-  </data>
-  <data name="CallbackContextNotExpectedOnOutgoingMessageAtServer" xml:space="preserve">
-    <value>The outgoing message with action '{0}' contains a callback context message property. Callback context cannot be transmitted in outgoing messages at the server.</value>
-  </data>
-  <data name="ChannelIsOpen" xml:space="preserve">
-    <value>Channel context management cannot be enabled or disabled after the channel is opened.</value>
-  </data>
-  <data name="ContextManagementNotEnabled" xml:space="preserve">
-    <value>Context cached at the channel cannot be set or retrieved when the context management is disabled at the channel layer. Ensure context channel property 'IContextManager.Enabled' is set to true.</value>
-  </data>
-  <data name="CachedContextIsImmutable" xml:space="preserve">
-    <value>Context cached at the channel layer cannot be changed after the channel is opened.</value>
-  </data>
-  <data name="InvalidMessageContext" xml:space="preserve">
-    <value>Cannot specify 'ContextMessageProperty' in message when using context channel with context management enabled. Ensure the message does not have 'ContextMessageProperty' or disable context management by setting channel property 'IContextManager.Enabled' to false.</value>
-  </data>
-  <data name="InvalidContextReceived" xml:space="preserve">
-    <value>Context channel received a message with context which does not match the current context cached at the channel. Ensure service does not change context after it was originally set or disable context management by setting channel property 'IContextManager.Enabled' to false.</value>
-  </data>
-  <data name="BehaviorRequiresContextProtocolSupportInBinding" xml:space="preserve">
-    <value>Service behavior {0} requires that the binding associated with endpoint {1} listening on {2} supports the context protocol, because the contract associated with this endpoint may require a session. Currently configured binding for this endpoint does not support the context protocol. Please modify the binding to add support for the context protocol or modify the SessionMode on the contract to NotAllowed.</value>
-  </data>
-  <data name="HttpCookieContextExchangeMechanismNotCompatibleWithTransportType" xml:space="preserve">
-    <value>Binding {1}:{2} is configured with ContextExchangeMechanism.HttpCookie which is not compatible with the transport type {0}. Please modify the ContextExchangeMechanism or use HTTP or HTTPS transport.</value>
-  </data>
-  <data name="HttpCookieContextExchangeMechanismNotCompatibleWithTransportCookieSetting" xml:space="preserve">
-    <value>ContextBindingElement of binding {0}:{1} is configured with ContextExchangeMode.HttpCookie but the configuration of this binding's HttpTransportBindingElement prevents upper channel layers from managing cookies. Please set the HttpTransportBindingElement.AllowCookies property to false or change the ContextExchangeMechanism of ContextBindingElement to SoapHeader.</value>
-  </data>
-  <data name="PolicyImportContextBindingElementCollectionIsNull" xml:space="preserve">
-    <value>ContextBindingElementImporter cannot import policy because PolicyImportContext.BindingElements collection is null.</value>
-  </data>
-  <data name="ContextChannelFactoryChannelCreatedDetail" xml:space="preserve">
-    <value>EndpointAddress: {0}, Via:{1}</value>
-  </data>
-  <data name="XmlFormatViolationInContextHeader" xml:space="preserve">
-    <value>Context protocol was unable to parse the context header.</value>
-  </data>
-  <data name="XmlFormatViolationInCallbackContextHeader" xml:space="preserve">
-    <value>Context protocol was unable to parse the callback context header.</value>
-  </data>
-  <data name="OleTxHeaderCorrupt" xml:space="preserve">
-    <value>The OLE Transactions header was invalid or corrupt.</value>
-  </data>
-  <data name="WsatHeaderCorrupt" xml:space="preserve">
-    <value>The WS-AtomicTransaction header was invalid or corrupt.</value>
-  </data>
-  <data name="FailedToDeserializeIssuedToken" xml:space="preserve">
-    <value>The issued token accompanying the WS-AtomicTransaction coordination context was invalid or corrupt.</value>
-  </data>
-  <data name="InvalidPropagationToken" xml:space="preserve">
-    <value>The OLE Transactions propagation token received in the message could not be used to unmarshal a transaction. It may be invalid or corrupt.</value>
-  </data>
-  <data name="InvalidWsatExtendedInfo" xml:space="preserve">
-    <value>The WS-AtomicTransaction extended information included in the OLE Transactions propagation token was invalid or corrupt.</value>
-  </data>
-  <data name="TMCommunicationError" xml:space="preserve">
-    <value>An error occurred communicating with the distributed transaction manager.</value>
-  </data>
-  <data name="UnmarshalTransactionFaulted" xml:space="preserve">
-    <value>The WS-AtomicTransaction protocol service could not unmarshal the flowed transaction. The following exception occured: {0}</value>
-  </data>
-  <data name="InvalidRegistrationHeaderTransactionId" xml:space="preserve">
-    <value>The transaction identifier element in the registration header is invalid</value>
-  </data>
-  <data name="InvalidRegistrationHeaderIdentifier" xml:space="preserve">
-    <value>The context identifier element in the registration header is invalid.</value>
-  </data>
-  <data name="InvalidRegistrationHeaderTokenId" xml:space="preserve">
-    <value>The token identifier element in the registration header is invalid.</value>
-  </data>
-  <data name="InvalidCoordinationContextTransactionId" xml:space="preserve">
-    <value>The transaction identifier element in the coordination context is invalid.</value>
-  </data>
-  <data name="WsatRegistryValueReadError" xml:space="preserve">
-    <value>The WS-AtomicTransaction transaction formatter could not read the registry value '{0}'.</value>
-  </data>
-  <data name="WsatProtocolServiceDisabled" xml:space="preserve">
-    <value>The MSDTC transaction manager's WS-AtomicTransaction protocol service '{0}' is disabled and cannot unmarshal incoming transactions.</value>
-  </data>
-  <data name="InboundTransactionsDisabled" xml:space="preserve">
-    <value>The MSDTC transaction manager has disabled incoming transactions.</value>
-  </data>
-  <data name="SourceTransactionsDisabled" xml:space="preserve">
-    <value>The incoming transaction cannot be unmarshaled because the source MSDTC transaction manager has either disabled outbound transactions or disabled its WS-AtomicTransaction protocol service.</value>
-  </data>
-  <data name="WsatUriCreationFailed" xml:space="preserve">
-    <value>A registration service address could not be created from MSDTC whereabouts information.</value>
-  </data>
-  <data name="InvalidWsatProtocolVersion" xml:space="preserve">
-    <value>The specified WSAT protocol version is invalid.</value>
-  </data>
-  <data name="ParameterCannotBeEmpty" xml:space="preserve">
-    <value>The parameter cannot be empty.</value>
-  </data>
-  <data name="RedirectCache" xml:space="preserve">
-    <value>The requested resouce has not changed and should be taken from cache.</value>
-  </data>
-  <data name="RedirectResource" xml:space="preserve">
-    <value>The requested resource has moved to one of the following locations:\n{0}</value>
-  </data>
-  <data name="RedirectUseIntermediary" xml:space="preserve">
-    <value>The requested resource must be accessed through one of the following intermediary service locations:\n{0}</value>
-  </data>
-  <data name="RedirectGenericMessage" xml:space="preserve">
-    <value>The requested resource has been moved.</value>
-  </data>
-  <data name="RedirectMustProvideLocation" xml:space="preserve">
-    <value>At least one RedirectionLocation must be provided for this RedirectionType.</value>
-  </data>
-  <data name="RedirectCacheNoLocationAllowed" xml:space="preserve">
-    <value>RedirectionType 'Cache' does not allow any RedirectionLocation objects be passed into the constructor.</value>
-  </data>
-  <data name="RedirectionInfoStringFormatWithNamespace" xml:space="preserve">
-    <value>{0} ({1})</value>
-  </data>
-  <data name="RedirectionInfoStringFormatNoNamespace" xml:space="preserve">
-    <value>{0}</value>
-  </data>
-  <data name="RetryGenericMessage" xml:space="preserve">
-    <value>The requested resource is available.</value>
   </data>
   <data name="ActivityCallback" xml:space="preserve">
     <value>Executing user callback.</value>
@@ -5106,35 +1746,11 @@
   <data name="ActivityConstructChannelFactory" xml:space="preserve">
     <value>Construct ChannelFactory. Contract type: '{0}'.</value>
   </data>
-  <data name="ActivityConstructServiceHost" xml:space="preserve">
-    <value>Construct ServiceHost '{0}'.</value>
-  </data>
   <data name="ActivityExecuteMethod" xml:space="preserve">
     <value>Execute '{0}.{1}'.</value>
   </data>
-  <data name="ActivityExecuteAsyncMethod" xml:space="preserve">
-    <value>Execute Async: Begin: '{0}.{1}'; End: '{2}.{3}'.</value>
-  </data>
-  <data name="ActivityCloseChannelFactory" xml:space="preserve">
-    <value>Close ChannelFactory. Contract type: '{0}'.</value>
-  </data>
   <data name="ActivityCloseClientBase" xml:space="preserve">
     <value>Close ClientBase. Contract type: '{0}'.</value>
-  </data>
-  <data name="ActivityCloseServiceHost" xml:space="preserve">
-    <value>Close ServiceHost '{0}'.</value>
-  </data>
-  <data name="ActivityListenAt" xml:space="preserve">
-    <value>Listen at '{0}'.</value>
-  </data>
-  <data name="ActivityOpen" xml:space="preserve">
-    <value>Open '{0}'.</value>
-  </data>
-  <data name="ActivityOpenServiceHost" xml:space="preserve">
-    <value>Open ServiceHost '{0}'.</value>
-  </data>
-  <data name="ActivityOpenChannelFactory" xml:space="preserve">
-    <value>Open ChannelFactory. Contract type: '{0}'.</value>
   </data>
   <data name="ActivityOpenClientBase" xml:space="preserve">
     <value>Open ClientBase. Contract type: '{0}'.</value>
@@ -5145,96 +1761,6 @@
   <data name="ActivityProcessingMessage" xml:space="preserve">
     <value>Processing message {0}.</value>
   </data>
-  <data name="ActivityReceiveBytes" xml:space="preserve">
-    <value>Receive bytes on connection '{0}'.</value>
-  </data>
-  <data name="ActivitySecuritySetup" xml:space="preserve">
-    <value>Set up Secure Session.</value>
-  </data>
-  <data name="ActivitySecurityRenew" xml:space="preserve">
-    <value>Renew Secure Session.</value>
-  </data>
-  <data name="ActivitySecurityClose" xml:space="preserve">
-    <value>Close Security Session.</value>
-  </data>
-  <data name="ActivitySharedListenerConnection" xml:space="preserve">
-    <value>Shared listener connection: '{0}'.</value>
-  </data>
-  <data name="ActivitySocketConnection" xml:space="preserve">
-    <value>Socket connection: '{0}'.</value>
-  </data>
-  <data name="ActivityReadOnConnection" xml:space="preserve">
-    <value>Reading data from connection on '{0}'.</value>
-  </data>
-  <data name="ActivityReceiveAtVia" xml:space="preserve">
-    <value>Receiving data at via '{0}'.</value>
-  </data>
-  <data name="TraceCodeBeginExecuteMethod" xml:space="preserve">
-    <value>Begin method execution.</value>
-  </data>
-  <data name="TraceCodeChannelCreated" xml:space="preserve">
-    <value>Created: {0}</value>
-  </data>
-  <data name="TraceCodeChannelDisposed" xml:space="preserve">
-    <value>Disposed: {0}</value>
-  </data>
-  <data name="TraceCodeChannelMessageSent" xml:space="preserve">
-    <value>Sent a message over a channel</value>
-  </data>
-  <data name="TraceCodeChannelPreparedMessage" xml:space="preserve">
-    <value>Prepared message for sending over a channel</value>
-  </data>
-  <data name="TraceCodeCommunicationObjectAborted" xml:space="preserve">
-    <value>Aborted '{0}'.</value>
-  </data>
-  <data name="TraceCodeCommunicationObjectAbortFailed" xml:space="preserve">
-    <value>Failed to abort {0}</value>
-  </data>
-  <data name="TraceCodeCommunicationObjectCloseFailed" xml:space="preserve">
-    <value>Failed to close {0}</value>
-  </data>
-  <data name="TraceCodeCommunicationObjectClosed" xml:space="preserve">
-    <value>Closed {0}</value>
-  </data>
-  <data name="TraceCodeCommunicationObjectCreated" xml:space="preserve">
-    <value>Created {0}</value>
-  </data>
-  <data name="TraceCodeCommunicationObjectClosing" xml:space="preserve">
-    <value>Closing {0}</value>
-  </data>
-  <data name="TraceCodeCommunicationObjectDisposing" xml:space="preserve">
-    <value>Disposing {0}</value>
-  </data>
-  <data name="TraceCodeCommunicationObjectFaultReason" xml:space="preserve">
-    <value>CommunicationObject faulted due to exception.</value>
-  </data>
-  <data name="TraceCodeCommunicationObjectFaulted" xml:space="preserve">
-    <value>Faulted {0}</value>
-  </data>
-  <data name="TraceCodeCommunicationObjectOpenFailed" xml:space="preserve">
-    <value>Failed to open {0}</value>
-  </data>
-  <data name="TraceCodeCommunicationObjectOpened" xml:space="preserve">
-    <value>Opened {0}</value>
-  </data>
-  <data name="TraceCodeCommunicationObjectOpening" xml:space="preserve">
-    <value>Opening {0}</value>
-  </data>
-  <data name="TraceCodeConfigurationIsReadOnly" xml:space="preserve">
-    <value>The configuration is read-only.</value>
-  </data>
-  <data name="TraceCodeConfiguredExtensionTypeNotFound" xml:space="preserve">
-    <value>Extension type is not configured.</value>
-  </data>
-  <data name="TraceCodeConnectionAbandoned" xml:space="preserve">
-    <value>The connection has been abandoned.</value>
-  </data>
-  <data name="TraceCodeConnectToIPEndpoint" xml:space="preserve">
-    <value>Connection information.</value>
-  </data>
-  <data name="TraceCodeConnectionPoolCloseException" xml:space="preserve">
-    <value>An exception occurred while closing the connections in this connection pool.</value>
-  </data>
   <data name="TraceCodeConnectionPoolIdleTimeoutReached" xml:space="preserve">
     <value>A connection has exceeded the idle timeout of this connection pool ({0}) and been closed.</value>
   </data>
@@ -5243,1230 +1769,6 @@
   </data>
   <data name="TraceCodeConnectionPoolMaxOutboundConnectionsPerEndpointQuotaReached" xml:space="preserve">
     <value>MaxOutboundConnectionsPerEndpoint quota ({0}) has been reached, so connection was closed and not stored in this connection pool.</value>
-  </data>
-  <data name="TraceCodeServerMaxPooledConnectionsQuotaReached" xml:space="preserve">
-    <value>MaxOutboundConnectionsPerEndpoint quota ({0}) has been reached, so the connection was closed and not reused by the listener.</value>
-  </data>
-  <data name="TraceCodeDefaultEndpointsAdded" xml:space="preserve">
-    <value>No matching &lt;service&gt; tag was found. Default endpoints added.</value>
-  </data>
-  <data name="TraceCodeDiagnosticsFailedMessageTrace" xml:space="preserve">
-    <value>Failed to trace a message</value>
-  </data>
-  <data name="TraceCodeDidNotUnderstandMessageHeader" xml:space="preserve">
-    <value>Did not understand message header.</value>
-  </data>
-  <data name="TraceCodeDroppedAMessage" xml:space="preserve">
-    <value>A response message was received, but there are no outstanding requests waiting for this message. The message is being dropped.</value>
-  </data>
-  <data name="TraceCodeCannotBeImportedInCurrentFormat" xml:space="preserve">
-    <value>The given schema cannot be imported in this format.</value>
-  </data>
-  <data name="TraceCodeElementTypeDoesntMatchConfiguredType" xml:space="preserve">
-    <value>The type of the element does not match the configuration type.</value>
-  </data>
-  <data name="TraceCodeEndExecuteMethod" xml:space="preserve">
-    <value>End method execution.</value>
-  </data>
-  <data name="TraceCodeEndpointListenerClose" xml:space="preserve">
-    <value>Endpoint listener closed.</value>
-  </data>
-  <data name="TraceCodeEndpointListenerOpen" xml:space="preserve">
-    <value>Endpoint listener opened.</value>
-  </data>
-  <data name="TraceCodeErrorInvokingUserCode" xml:space="preserve">
-    <value>Error invoking user code</value>
-  </data>
-  <data name="TraceCodeEvaluationContextNotFound" xml:space="preserve">
-    <value>Configuration evaluation context not found.</value>
-  </data>
-  <data name="TraceCodeExportSecurityChannelBindingEntry" xml:space="preserve">
-    <value>Starting Security ExportChannelBinding</value>
-  </data>
-  <data name="TraceCodeExportSecurityChannelBindingExit" xml:space="preserve">
-    <value>Finished Security ExportChannelBinding</value>
-  </data>
-  <data name="TraceCodeExtensionCollectionDoesNotExist" xml:space="preserve">
-    <value>The extension collection does not exist.</value>
-  </data>
-  <data name="TraceCodeExtensionCollectionIsEmpty" xml:space="preserve">
-    <value>The extension collection is empty.</value>
-  </data>
-  <data name="TraceCodeExtensionCollectionNameNotFound" xml:space="preserve">
-    <value>Extension element not associated with an extension collection.</value>
-  </data>
-  <data name="TraceCodeExtensionElementAlreadyExistsInCollection" xml:space="preserve">
-    <value>The extension element already exists in the collection.</value>
-  </data>
-  <data name="TraceCodeExtensionTypeNotFound" xml:space="preserve">
-    <value>Extension type not found.</value>
-  </data>
-  <data name="TraceCodeFailedToAddAnActivityIdHeader" xml:space="preserve">
-    <value>Failed to set an activity id header on an outgoing message</value>
-  </data>
-  <data name="TraceCodeFailedToReadAnActivityIdHeader" xml:space="preserve">
-    <value>Failed to read an activity id header on a message</value>
-  </data>
-  <data name="TraceCodeFilterNotMatchedNodeQuotaExceeded" xml:space="preserve">
-    <value>Evaluating message logging filter against the message exceeded the node quota set on the filter.</value>
-  </data>
-  <data name="TraceCodeGetBehaviorElement" xml:space="preserve">
-    <value>Get BehaviorElement.</value>
-  </data>
-  <data name="TraceCodeGetChannelEndpointElement" xml:space="preserve">
-    <value>Get ChannelEndpointElement.</value>
-  </data>
-  <data name="TraceCodeGetCommonBehaviors" xml:space="preserve">
-    <value>Get machine.config common behaviors.</value>
-  </data>
-  <data name="TraceCodeGetConfigurationSection" xml:space="preserve">
-    <value>Get configuration section.</value>
-  </data>
-  <data name="TraceCodeGetConfiguredBinding" xml:space="preserve">
-    <value>Get configured binding.</value>
-  </data>
-  <data name="TraceCodeGetDefaultConfiguredBinding" xml:space="preserve">
-    <value>Get default configured binding.</value>
-  </data>
-  <data name="TraceCodeGetConfiguredEndpoint" xml:space="preserve">
-    <value>Get configured endpoint.</value>
-  </data>
-  <data name="TraceCodeGetDefaultConfiguredEndpoint" xml:space="preserve">
-    <value>Get default configured endpoint.</value>
-  </data>
-  <data name="TraceCodeGetServiceElement" xml:space="preserve">
-    <value>Get ServiceElement.</value>
-  </data>
-  <data name="TraceCodeHttpAuthFailed" xml:space="preserve">
-    <value>Authentication failed for HTTP(S) connection</value>
-  </data>
-  <data name="TraceCodeHttpActionMismatch" xml:space="preserve">
-    <value>The HTTP SOAPAction header and the wsa:Action SOAP header did not match. </value>
-  </data>
-  <data name="TraceCodeHttpChannelMessageReceiveFailed" xml:space="preserve">
-    <value>Failed to lookup a channel to receive an incoming message. Either the endpoint or the SOAP action was not found.</value>
-  </data>
-  <data name="TraceCodeHttpChannelRequestAborted" xml:space="preserve">
-    <value>Failed to send request message over HTTP</value>
-  </data>
-  <data name="TraceCodeHttpChannelResponseAborted" xml:space="preserve">
-    <value>Failed to send response message over HTTP</value>
-  </data>
-  <data name="TraceCodeHttpChannelUnexpectedResponse" xml:space="preserve">
-    <value>Received bad HTTP response</value>
-  </data>
-  <data name="TraceCodeHttpResponseReceived" xml:space="preserve">
-    <value>HTTP response was received</value>
-  </data>
-  <data name="TraceCodeHttpChannelConcurrentReceiveQuotaReached" xml:space="preserve">
-    <value>The HTTP concurrent receive quota was reached.</value>
-  </data>
-  <data name="TraceCodeHttpsClientCertificateInvalid" xml:space="preserve">
-    <value>Client certificate is invalid.</value>
-  </data>
-  <data name="TraceCodeHttpsClientCertificateInvalid1" xml:space="preserve">
-    <value>Client certificate is invalid with native error code {0} (see http://go.microsoft.com/fwlink/?LinkId=187517 for details).</value>
-  </data>
-  <data name="TraceCodeHttpsClientCertificateNotPresent" xml:space="preserve">
-    <value>Client certificate is required.  No certificate was found in the request.  This might be because the client certificate could not be successfully validated by the operating system or IIS.  For information on how to bypass those validations and use a custom X509CertificateValidator in WCF please see http://go.microsoft.com/fwlink/?LinkId=208540.</value>
-  </data>
-  <data name="TraceCodeImportSecurityChannelBindingEntry" xml:space="preserve">
-    <value>Starting Security ImportChannelBinding</value>
-  </data>
-  <data name="TraceCodeImportSecurityChannelBindingExit" xml:space="preserve">
-    <value>Finished Security ImportChannelBinding</value>
-  </data>
-  <data name="TraceCodeIncompatibleExistingTransportManager" xml:space="preserve">
-    <value>An existing incompatible transport manager was found for the specified URI.</value>
-  </data>
-  <data name="TraceCodeInitiatingNamedPipeConnection" xml:space="preserve">
-    <value>Initiating Named Pipe connection.</value>
-  </data>
-  <data name="TraceCodeInitiatingTcpConnection" xml:space="preserve">
-    <value>Initiating TCP connection.</value>
-  </data>
-  <data name="TraceCodeIssuanceTokenProviderBeginSecurityNegotiation" xml:space="preserve">
-    <value>The IssuanceTokenProvider has started a new security negotiation.</value>
-  </data>
-  <data name="TraceCodeIssuanceTokenProviderEndSecurityNegotiation" xml:space="preserve">
-    <value>The IssuanceTokenProvider has completed the security negotiation.</value>
-  </data>
-  <data name="TraceCodeIssuanceTokenProviderRedirectApplied" xml:space="preserve">
-    <value>The IssuanceTokenProvider applied a redirection header.</value>
-  </data>
-  <data name="TraceCodeIssuanceTokenProviderRemovedCachedToken" xml:space="preserve">
-    <value>The IssuanceTokenProvider removed the expired service token.</value>
-  </data>
-  <data name="TraceCodeIssuanceTokenProviderServiceTokenCacheFull" xml:space="preserve">
-    <value>IssuanceTokenProvider pruned service token cache.</value>
-  </data>
-  <data name="TraceCodeIssuanceTokenProviderUsingCachedToken" xml:space="preserve">
-    <value>The IssuanceTokenProvider used the cached service token.</value>
-  </data>
-  <data name="TraceCodeListenerCreated" xml:space="preserve">
-    <value>Listener created</value>
-  </data>
-  <data name="TraceCodeListenerDisposed" xml:space="preserve">
-    <value>Listener disposed</value>
-  </data>
-  <data name="TraceCodeMaxPendingConnectionsReached" xml:space="preserve">
-    <value>Maximum number of pending connections has been reached. </value>
-  </data>
-  <data name="TraceCodeMaxAcceptedChannelsReached" xml:space="preserve">
-    <value>Maximum number of inbound session channel has been reached. </value>
-  </data>
-  <data name="TraceCodeMessageClosed" xml:space="preserve">
-    <value>A message was closed</value>
-  </data>
-  <data name="TraceCodeMessageClosedAgain" xml:space="preserve">
-    <value>A message was closed again</value>
-  </data>
-  <data name="TraceCodeMessageCopied" xml:space="preserve">
-    <value>A message was copied</value>
-  </data>
-  <data name="TraceCodeMessageCountLimitExceeded" xml:space="preserve">
-    <value>Reached the limit of messages to log. Message logging is stopping. </value>
-  </data>
-  <data name="TraceCodeMessageNotLoggedQuotaExceeded" xml:space="preserve">
-    <value>Message not logged because its size exceeds configured quota</value>
-  </data>
-  <data name="TraceCodeMessageRead" xml:space="preserve">
-    <value>A message was read</value>
-  </data>
-  <data name="TraceCodeMessageSent" xml:space="preserve">
-    <value>Sent a message over a channel.</value>
-  </data>
-  <data name="TraceCodeMessageReceived" xml:space="preserve">
-    <value>Received a message over a channel.</value>
-  </data>
-  <data name="TraceCodeMessageWritten" xml:space="preserve">
-    <value>A message was written</value>
-  </data>
-  <data name="TraceCodeMessageProcessingPaused" xml:space="preserve">
-    <value>Switched threads while processing a message.</value>
-  </data>
-  <data name="TraceCodeNegotiationAuthenticatorAttached" xml:space="preserve">
-    <value>NegotiationTokenAuthenticator was attached.</value>
-  </data>
-  <data name="TraceCodeNegotiationTokenProviderAttached" xml:space="preserve">
-    <value>NegotiationTokenProvider was attached.</value>
-  </data>
-  <data name="TraceCodeNoExistingTransportManager" xml:space="preserve">
-    <value>No existing transport manager was found for the specified URI.</value>
-  </data>
-  <data name="TraceCodeOpenedListener" xml:space="preserve">
-    <value>Transport is listening at base URI.</value>
-  </data>
-  <data name="TraceCodeOverridingDuplicateConfigurationKey" xml:space="preserve">
-    <value>The configuration system has detected a duplicate key in a different configuration scope and is overriding with the more recent value.</value>
-  </data>
-  <data name="TraceCodePerformanceCounterFailedToLoad" xml:space="preserve">
-    <value>A performance counter failed to load. Some performance counters will not be available.</value>
-  </data>
-  <data name="TraceCodePerformanceCountersFailed" xml:space="preserve">
-    <value>Failed to load the performance counter '{0}'. Some performance counters will not be available</value>
-  </data>
-  <data name="TraceCodePerformanceCountersFailedDuringUpdate" xml:space="preserve">
-    <value>There was an error while updating the performance counter '{0}'. This performance counter will be disabled.</value>
-  </data>
-  <data name="TraceCodePerformanceCountersFailedForService" xml:space="preserve">
-    <value>Loading performance counters for the service failed. Performance counters will not be available for this service.</value>
-  </data>
-  <data name="TraceCodePerformanceCountersFailedOnRelease" xml:space="preserve">
-    <value>Unloading the performance counters failed.</value>
-  </data>
-  <data name="TraceCodePrematureDatagramEof" xml:space="preserve">
-    <value>A null Message (signalling end of channel) was received from a datagram channel, but the channel is still in the Opened state. This indicates a bug in the datagram channel, and the demuxer receive loop has been prematurely stalled. </value>
-  </data>
-  <data name="TraceCodeRemoveBehavior" xml:space="preserve">
-    <value>Behavior type already exists in the collection</value>
-  </data>
-  <data name="TraceCodeRequestChannelReplyReceived" xml:space="preserve">
-    <value>Received reply over request channel</value>
-  </data>
-  <data name="TraceCodeSecurity" xml:space="preserve">
-    <value>A failure occured while performing a security related operation.</value>
-  </data>
-  <data name="TraceCodeSecurityActiveServerSessionRemoved" xml:space="preserve">
-    <value>An active security session was removed by the server.</value>
-  </data>
-  <data name="TraceCodeSecurityAuditWrittenFailure" xml:space="preserve">
-    <value>A failure occurred while writing to the security audit log.</value>
-  </data>
-  <data name="TraceCodeSecurityAuditWrittenSuccess" xml:space="preserve">
-    <value>The security audit log is written successfully.</value>
-  </data>
-  <data name="TraceCodeSecurityBindingIncomingMessageVerified" xml:space="preserve">
-    <value>The security protocol verified the incoming message.</value>
-  </data>
-  <data name="TraceCodeSecurityBindingOutgoingMessageSecured" xml:space="preserve">
-    <value>The security protocol secured the outgoing message.</value>
-  </data>
-  <data name="TraceCodeSecurityBindingSecureOutgoingMessageFailure" xml:space="preserve">
-    <value>The security protocol cannot secure the outgoing message.</value>
-  </data>
-  <data name="TraceCodeSecurityBindingVerifyIncomingMessageFailure" xml:space="preserve">
-    <value>The security protocol cannot verify the incoming message.</value>
-  </data>
-  <data name="TraceCodeSecurityClientSessionKeyRenewed" xml:space="preserve">
-    <value>The client security session renewed the session key.</value>
-  </data>
-  <data name="TraceCodeSecurityClientSessionCloseSent" xml:space="preserve">
-    <value>A Close message was sent by the client security session.</value>
-  </data>
-  <data name="TraceCodeSecurityClientSessionCloseResponseSent" xml:space="preserve">
-    <value>Close response message was sent by client security session.</value>
-  </data>
-  <data name="TraceCodeSecurityClientSessionCloseMessageReceived" xml:space="preserve">
-    <value>Close message was received by client security session.TraceCodeSecurityClientSessionKeyRenewed=Client security session renewed session key.</value>
-  </data>
-  <data name="TraceCodeSecurityClientSessionPreviousKeyDiscarded" xml:space="preserve">
-    <value>The client security session discarded the previous session key.</value>
-  </data>
-  <data name="TraceCodeSecurityContextTokenCacheFull" xml:space="preserve">
-    <value>The SecurityContextSecurityToken cache is full.</value>
-  </data>
-  <data name="TraceCodeSecurityIdentityDeterminationFailure" xml:space="preserve">
-    <value>Identity cannot be determined for an EndpointReference.</value>
-  </data>
-  <data name="TraceCodeSecurityIdentityDeterminationSuccess" xml:space="preserve">
-    <value>Identity was determined for an EndpointReference.</value>
-  </data>
-  <data name="TraceCodeSecurityIdentityHostNameNormalizationFailure" xml:space="preserve">
-    <value>The HostName portion of an endpoint address cannot be normalized.</value>
-  </data>
-  <data name="TraceCodeSecurityIdentityVerificationFailure" xml:space="preserve">
-    <value>Identity verification failed.</value>
-  </data>
-  <data name="TraceCodeSecurityIdentityVerificationSuccess" xml:space="preserve">
-    <value>Identity verification succeeded.</value>
-  </data>
-  <data name="TraceCodeSecurityImpersonationFailure" xml:space="preserve">
-    <value>Security impersonation failed at the server.</value>
-  </data>
-  <data name="TraceCodeSecurityImpersonationSuccess" xml:space="preserve">
-    <value>Security Impersonation succeeded at the server.</value>
-  </data>
-  <data name="TraceCodeSecurityInactiveSessionFaulted" xml:space="preserve">
-    <value>An inactive security session was faulted by the server.</value>
-  </data>
-  <data name="TraceCodeSecurityNegotiationProcessingFailure" xml:space="preserve">
-    <value>Service security negotiation processing failure.</value>
-  </data>
-  <data name="TraceCodeSecurityNewServerSessionKeyIssued" xml:space="preserve">
-    <value>A new security session key was issued by the server.</value>
-  </data>
-  <data name="TraceCodeSecurityPendingServerSessionAdded" xml:space="preserve">
-    <value>A pending security session was added to the server.</value>
-  </data>
-  <data name="TraceCodeSecurityPendingServerSessionClosed" xml:space="preserve">
-    <value>The pending security session was closed by the server.</value>
-  </data>
-  <data name="TraceCodeSecurityPendingServerSessionActivated" xml:space="preserve">
-    <value>A pending security session was activated by the server.</value>
-  </data>
-  <data name="TraceCodeSecurityServerSessionCloseReceived" xml:space="preserve">
-    <value>The server security session received a close message from the client.</value>
-  </data>
-  <data name="TraceCodeSecurityServerSessionCloseResponseReceived" xml:space="preserve">
-    <value>Server security session received Close response message from client.</value>
-  </data>
-  <data name="TraceCodeSecurityServerSessionAbortedFaultSent" xml:space="preserve">
-    <value>Server security session sent session aborted fault to client.</value>
-  </data>
-  <data name="TraceCodeSecurityServerSessionKeyUpdated" xml:space="preserve">
-    <value>The security session key was updated by the server.</value>
-  </data>
-  <data name="TraceCodeSecurityServerSessionRenewalFaultSent" xml:space="preserve">
-    <value>The server security session sent a key renewal fault to the client.</value>
-  </data>
-  <data name="TraceCodeSecuritySessionCloseResponseSent" xml:space="preserve">
-    <value>The server security session sent a close response to the client.</value>
-  </data>
-  <data name="TraceCodeSecuritySessionServerCloseSent" xml:space="preserve">
-    <value>Server security session sent Close to client.</value>
-  </data>
-  <data name="TraceCodeSecuritySessionAbortedFaultReceived" xml:space="preserve">
-    <value>Client security session received session aborted fault from server.</value>
-  </data>
-  <data name="TraceCodeSecuritySessionAbortedFaultSendFailure" xml:space="preserve">
-    <value>Failure sending security session aborted fault to client.</value>
-  </data>
-  <data name="TraceCodeSecuritySessionClosedResponseReceived" xml:space="preserve">
-    <value>The client security session received a closed reponse from the server.</value>
-  </data>
-  <data name="TraceCodeSecuritySessionClosedResponseSendFailure" xml:space="preserve">
-    <value>A failure occurred when sending a security session Close response to the client.</value>
-  </data>
-  <data name="TraceCodeSecuritySessionServerCloseSendFailure" xml:space="preserve">
-    <value>Failure sending security session Close to client.</value>
-  </data>
-  <data name="TraceCodeSecuritySessionKeyRenewalFaultReceived" xml:space="preserve">
-    <value>The client security session received a key renewal fault from the server.</value>
-  </data>
-  <data name="TraceCodeSecuritySessionRedirectApplied" xml:space="preserve">
-    <value>The client security session was redirected.</value>
-  </data>
-  <data name="TraceCodeSecuritySessionRenewFaultSendFailure" xml:space="preserve">
-    <value>A failure occurred when sending a renewal fault on the security session key to the client.</value>
-  </data>
-  <data name="TraceCodeSecuritySessionRequestorOperationFailure" xml:space="preserve">
-    <value>The client security session operation failed.</value>
-  </data>
-  <data name="TraceCodeSecuritySessionRequestorOperationSuccess" xml:space="preserve">
-    <value>The security session operation completed successfully at the client.</value>
-  </data>
-  <data name="TraceCodeSecuritySessionRequestorStartOperation" xml:space="preserve">
-    <value>A security session operation was started at the client.</value>
-  </data>
-  <data name="TraceCodeSecuritySessionResponderOperationFailure" xml:space="preserve">
-    <value>The security session operation failed at the server.</value>
-  </data>
-  <data name="TraceCodeSecuritySpnToSidMappingFailure" xml:space="preserve">
-    <value>The ServicePrincipalName could not be mapped to a SecurityIdentifier.</value>
-  </data>
-  <data name="TraceCodeSecurityTokenAuthenticatorClosed" xml:space="preserve">
-    <value>Security Token Authenticator was closed.</value>
-  </data>
-  <data name="TraceCodeSecurityTokenAuthenticatorOpened" xml:space="preserve">
-    <value>Security Token Authenticator was opened.</value>
-  </data>
-  <data name="TraceCodeSecurityTokenProviderClosed" xml:space="preserve">
-    <value>Security Token Provider was closed.</value>
-  </data>
-  <data name="TraceCodeSecurityTokenProviderOpened" xml:space="preserve">
-    <value>Security Token Provider was opened.</value>
-  </data>
-  <data name="TraceCodeServiceChannelLifetime" xml:space="preserve">
-    <value>ServiceChannel information.</value>
-  </data>
-  <data name="TraceCodeServiceHostBaseAddresses" xml:space="preserve">
-    <value>ServiceHost base addresses.</value>
-  </data>
-  <data name="TraceCodeServiceHostTimeoutOnClose" xml:space="preserve">
-    <value>ServiceHost close operation timedout.</value>
-  </data>
-  <data name="TraceCodeServiceHostFaulted" xml:space="preserve">
-    <value>ServiceHost faulted.</value>
-  </data>
-  <data name="TraceCodeServiceHostErrorOnReleasePerformanceCounter" xml:space="preserve">
-    <value>ServiceHost error on calling ReleasePerformanceCounters.</value>
-  </data>
-  <data name="TraceCodeServiceThrottleLimitReached" xml:space="preserve">
-    <value>The system hit the limit set for throttle '{0}'. Limit for this throttle was set to {1}. Throttle value can be changed by modifying attribute '{2}' in serviceThrottle element or by modifying '{0}' property on behavior ServiceThrottlingBehavior.</value>
-  </data>
-  <data name="TraceCodeServiceThrottleLimitReachedInternal" xml:space="preserve">
-    <value>The system hit an internal throttle limit. Limit for this throttle was set to {0}. This throttle cannot be configured.</value>
-  </data>
-  <data name="TraceCodeManualFlowThrottleLimitReached" xml:space="preserve">
-    <value>The system hit the limit set for the '{0}' throttle. Throttle value can be changed by modifying {0} property on {1}.</value>
-  </data>
-  <data name="TraceCodeProcessMessage2Paused" xml:space="preserve">
-    <value>Switched threads while processing a message for Contract '{0}' at Address '{1}'. ConcurrencyMode for service is set to Single/Reentrant and the service is currently processing another message.</value>
-  </data>
-  <data name="TraceCodeProcessMessage3Paused" xml:space="preserve">
-    <value>Switched threads while processing a message for Contract '{0}' at Address '{1}'. Cannot process more than one transaction at a time and the transaction associated with the previous message is not yet complete. Ensure that the caller has committed the transaction.</value>
-  </data>
-  <data name="TraceCodeProcessMessage31Paused" xml:space="preserve">
-    <value>Switched threads while processing a message for Contract '{0}' at Address '{1}'. Waiting for the completion of ReceiveContext acknowledgement. If your service seems to be not processing the message ensure that the channel implementation of receive context completes the operation.</value>
-  </data>
-  <data name="TraceCodeProcessMessage4Paused" xml:space="preserve">
-    <value>Switched threads while processing a message for Contract '{0}' at Address '{1}'. UseSynchronizationContext property on ServiceBehaviorAttribute is set to true, and SynchronizationContext.Current was non-null when opening ServiceHost.  If your service seems to be not processing messages, consider setting UseSynchronizationContext to false.</value>
-  </data>
-  <data name="TraceCodeServiceOperationExceptionOnReply" xml:space="preserve">
-    <value>Replying to an operation threw a exception.</value>
-  </data>
-  <data name="TraceCodeServiceOperationMissingReply" xml:space="preserve">
-    <value>The Request/Reply operation {0} has no Reply Message.</value>
-  </data>
-  <data name="TraceCodeServiceOperationMissingReplyContext" xml:space="preserve">
-    <value>The Request/Reply operation {0} has no IRequestContext to use for the reply.</value>
-  </data>
-  <data name="TraceCodeServiceSecurityNegotiationCompleted" xml:space="preserve">
-    <value>Service security negotiation completed.</value>
-  </data>
-  <data name="TraceCodeSecuritySessionDemuxFailure" xml:space="preserve">
-    <value>The incoming message is not part of an existing security session.</value>
-  </data>
-  <data name="TraceCodeServiceHostCreation" xml:space="preserve">
-    <value>Create ServiceHost.</value>
-  </data>
-  <data name="TraceCodeSkipBehavior" xml:space="preserve">
-    <value>Behavior type is not of expected type</value>
-  </data>
-  <data name="TraceCodeFailedAcceptFromPool" xml:space="preserve">
-    <value>An attempt to reuse a pooled connection failed. Another attempt will be made with {0} remaining in the overall timeout.</value>
-  </data>
-  <data name="TraceCodeSystemTimeResolution" xml:space="preserve">
-    <value>The operating system's timer resolution was detected as {0} ticks, which is about {1} milliseconds.</value>
-  </data>
-  <data name="TraceCodeRequestContextAbort" xml:space="preserve">
-    <value>RequestContext aborted</value>
-  </data>
-  <data name="TraceCodeSharedManagerServiceEndpointNotExist" xml:space="preserve">
-    <value>The shared memory for the endpoint of the service '{0}' does not exist. The service may not be started.</value>
-  </data>
-  <data name="TraceCodeSocketConnectionAbort" xml:space="preserve">
-    <value>SocketConnection aborted</value>
-  </data>
-  <data name="TraceCodeSocketConnectionAbortClose" xml:space="preserve">
-    <value>SocketConnection aborted under Close</value>
-  </data>
-  <data name="TraceCodeSocketConnectionClose" xml:space="preserve">
-    <value>SocketConnection close</value>
-  </data>
-  <data name="TraceCodeSocketConnectionCreate" xml:space="preserve">
-    <value>SocketConnection create</value>
-  </data>
-  <data name="TraceCodeSpnegoClientNegotiationCompleted" xml:space="preserve">
-    <value>SpnegoTokenProvider completed SSPI negotiation.</value>
-  </data>
-  <data name="TraceCodeSpnegoServiceNegotiationCompleted" xml:space="preserve">
-    <value>SpnegoTokenAuthenticator completed SSPI negotiation.</value>
-  </data>
-  <data name="TraceCodeSpnegoClientNegotiation" xml:space="preserve">
-    <value>Client's outgoing SSPI negotiation.</value>
-  </data>
-  <data name="TraceCodeSpnegoServiceNegotiation" xml:space="preserve">
-    <value>Service's outgoing SSPI negotiation.</value>
-  </data>
-  <data name="TraceCodeSslClientCertMissing" xml:space="preserve">
-    <value>The remote SSL client failed to provide a required certificate.</value>
-  </data>
-  <data name="TraceCodeStreamSecurityUpgradeAccepted" xml:space="preserve">
-    <value>The stream security upgrade was accepted successfully.</value>
-  </data>
-  <data name="TraceCodeTcpChannelMessageReceiveFailed" xml:space="preserve">
-    <value>Failed to receive a message over TCP channel</value>
-  </data>
-  <data name="TraceCodeTcpChannelMessageReceived" xml:space="preserve">
-    <value>Received a message over TCP channel</value>
-  </data>
-  <data name="TraceCodeUnderstoodMessageHeader" xml:space="preserve">
-    <value>Understood message header.</value>
-  </data>
-  <data name="TraceCodeUnhandledAction" xml:space="preserve">
-    <value>No service available to handle this action</value>
-  </data>
-  <data name="TraceCodeUnhandledExceptionInUserOperation" xml:space="preserve">
-    <value>Unhandled exception in user operation '{0}.{1}'.</value>
-  </data>
-  <data name="TraceCodeWebHostFailedToActivateService" xml:space="preserve">
-    <value>Webhost could not activate service</value>
-  </data>
-  <data name="TraceCodeWebHostFailedToCompile" xml:space="preserve">
-    <value>Webhost couldn't compile service</value>
-  </data>
-  <data name="TraceCodeWmiPut" xml:space="preserve">
-    <value>Setting a value via WMI.</value>
-  </data>
-  <data name="TraceCodeWsmexNonCriticalWsdlExportError" xml:space="preserve">
-    <value>A non-critical error or warning occurred during WSDL Export</value>
-  </data>
-  <data name="TraceCodeWsmexNonCriticalWsdlImportError" xml:space="preserve">
-    <value>A non-critical error or warning occurred in the MetadataExchangeClient during WSDL Import This could result in some endpoints not being imported.</value>
-  </data>
-  <data name="TraceCodeFailedToOpenIncomingChannel" xml:space="preserve">
-    <value>An incoming channel was disposed because there was an error while attempting to open it.</value>
-  </data>
-  <data name="TraceCodeTransportListen" xml:space="preserve">
-    <value>Listen at '{0}'.</value>
-  </data>
-  <data name="TraceCodeWsrmInvalidCreateSequence" xml:space="preserve">
-    <value>An invalid create sequence message was received.</value>
-  </data>
-  <data name="TraceCodeWsrmInvalidMessage" xml:space="preserve">
-    <value>An invalid WS-RM message was received.</value>
-  </data>
-  <data name="TraceCodeWsrmMaxPendingChannelsReached" xml:space="preserve">
-    <value>An incoming create sequence request was rejected because the maximum pending channel count was reached.</value>
-  </data>
-  <data name="TraceCodeWsrmMessageDropped" xml:space="preserve">
-    <value>A message in a WS-RM sequence has been dropped because it could not be buffered.</value>
-  </data>
-  <data name="TraceCodeWsrmReceiveAcknowledgement" xml:space="preserve">
-    <value>WS-RM SequenceAcknowledgement received.</value>
-  </data>
-  <data name="TraceCodeWsrmReceiveLastSequenceMessage" xml:space="preserve">
-    <value>WS-RM Last Sequence message received.</value>
-  </data>
-  <data name="TraceCodeWsrmReceiveSequenceMessage" xml:space="preserve">
-    <value>WS-RM Sequence message received.</value>
-  </data>
-  <data name="TraceCodeWsrmSendAcknowledgement" xml:space="preserve">
-    <value>WS-RM SequenceAcknowledgement sent.</value>
-  </data>
-  <data name="TraceCodeWsrmSendLastSequenceMessage" xml:space="preserve">
-    <value>WS-RM Last Sequence message sent.</value>
-  </data>
-  <data name="TraceCodeWsrmSendSequenceMessage" xml:space="preserve">
-    <value>WS-RM Sequence message sent.</value>
-  </data>
-  <data name="TraceCodeWsrmSequenceFaulted" xml:space="preserve">
-    <value>A WS-RM sequence has faulted.</value>
-  </data>
-  <data name="TraceCodeChannelConnectionDropped" xml:space="preserve">
-    <value>Channel connection was dropped</value>
-  </data>
-  <data name="TraceCodeAsyncCallbackThrewException" xml:space="preserve">
-    <value>An async callback threw an exception!</value>
-  </data>
-  <data name="TraceCodeMetadataExchangeClientSendRequest" xml:space="preserve">
-    <value>The MetadataExchangeClient is sending a request for metadata.</value>
-  </data>
-  <data name="TraceCodeMetadataExchangeClientReceiveReply" xml:space="preserve">
-    <value>The MetadataExchangeClient received a reply.</value>
-  </data>
-  <data name="TraceCodeWarnHelpPageEnabledNoBaseAddress" xml:space="preserve">
-    <value>The ServiceDebugBehavior Help Page is enabled at a relative address and cannot be created because there is no base address.</value>
-  </data>
-  <data name="TraceCodeTcpConnectError" xml:space="preserve">
-    <value>The TCP connect operation failed.</value>
-  </data>
-  <data name="TraceCodeTxSourceTxScopeRequiredIsTransactedTransport" xml:space="preserve">
-    <value>The transaction '{0}' was received for operation '{1}' from a transacted transport, such as MSMQ.</value>
-  </data>
-  <data name="TraceCodeTxSourceTxScopeRequiredIsTransactionFlow" xml:space="preserve">
-    <value>The transaction '{0}' was flowed to operation '{1}'.</value>
-  </data>
-  <data name="TraceCodeTxSourceTxScopeRequiredIsAttachedTransaction" xml:space="preserve">
-    <value>The transaction '{0}' was received for operation '{1}' from an InstanceContext transaction.</value>
-  </data>
-  <data name="TraceCodeTxSourceTxScopeRequiredUsingExistingTransaction" xml:space="preserve">
-    <value>Existing transaction '{0}' being used for operation '{1}'.</value>
-  </data>
-  <data name="TraceCodeTxCompletionStatusCompletedForAutocomplete" xml:space="preserve">
-    <value>The transaction '{0}' for operation '{1}' was completed due to the TransactionAutoComplete OperationBehaviorAttribute member being set to true.</value>
-  </data>
-  <data name="TraceCodeTxCompletionStatusCompletedForError" xml:space="preserve">
-    <value>The transaction '{0}' for operation '{1}' was completed due to an unhandled execution exception.</value>
-  </data>
-  <data name="TraceCodeTxCompletionStatusCompletedForSetComplete" xml:space="preserve">
-    <value>The transaction '{0}' for operation '{1}' was completed due to a call to SetTransactionComplete.</value>
-  </data>
-  <data name="TraceCodeTxCompletionStatusCompletedForTACOSC" xml:space="preserve">
-    <value>The transaction '{0}' was completed when the session was closed due to the TransactionAutoCompleteOnSessionClose ServiceBehaviorAttribute member.</value>
-  </data>
-  <data name="TraceCodeTxCompletionStatusCompletedForAsyncAbort" xml:space="preserve">
-    <value>The transaction '{0}' for operation '{1}' was completed due to asynchronous abort.</value>
-  </data>
-  <data name="TraceCodeTxCompletionStatusRemainsAttached" xml:space="preserve">
-    <value>The transaction '{0}' for operation '{1}' remains attached to the InstanceContext.</value>
-  </data>
-  <data name="TraceCodeTxCompletionStatusAbortedOnSessionClose" xml:space="preserve">
-    <value>The transaction '{0}' was aborted because it was uncompleted when the session was closed and the TransactionAutoCompleteOnSessionClose OperationBehaviorAttribute was set to false.</value>
-  </data>
-  <data name="TraceCodeTxReleaseServiceInstanceOnCompletion" xml:space="preserve">
-    <value>The service instance was released on the completion of the transaction '{0}' because the ReleaseServiceInstanceOnTransactionComplete ServiceBehaviorAttribute was set to true.</value>
-  </data>
-  <data name="TraceCodeTxAsyncAbort" xml:space="preserve">
-    <value>The transaction '{0}' was asynchronously aborted.</value>
-  </data>
-  <data name="TraceCodeTxFailedToNegotiateOleTx" xml:space="preserve">
-    <value>The OleTransactions protocol negotiation failed for coordination context '{0}'.</value>
-  </data>
-  <data name="TraceCodeTxSourceTxScopeRequiredIsCreateNewTransaction" xml:space="preserve">
-    <value>The transaction '{0}' for operation '{1}' was newly created.</value>
-  </data>
-  <data name="TraceCodeActivatingMessageReceived" xml:space="preserve">
-    <value>Activating message received.</value>
-  </data>
-  <data name="TraceCodeDICPInstanceContextCached" xml:space="preserve">
-    <value>InstanceContext cached for InstanceId {0}.</value>
-  </data>
-  <data name="TraceCodeDICPInstanceContextRemovedFromCache" xml:space="preserve">
-    <value>InstanceContext for InstanceId {0} removed from cache.</value>
-  </data>
-  <data name="TraceCodeInstanceContextBoundToDurableInstance" xml:space="preserve">
-    <value>DurableInstance's InstanceContext refcount incremented.</value>
-  </data>
-  <data name="TraceCodeInstanceContextDetachedFromDurableInstance" xml:space="preserve">
-    <value>DurableInstance's InstanceContext refcount decremented.</value>
-  </data>
-  <data name="TraceCodeContextChannelFactoryChannelCreated" xml:space="preserve">
-    <value>ContextChannel created.</value>
-  </data>
-  <data name="TraceCodeContextChannelListenerChannelAccepted" xml:space="preserve">
-    <value>A new ContextChannel was accepted.</value>
-  </data>
-  <data name="TraceCodeContextProtocolContextAddedToMessage" xml:space="preserve">
-    <value>Context added to Message.</value>
-  </data>
-  <data name="TraceCodeContextProtocolContextRetrievedFromMessage" xml:space="preserve">
-    <value>Context retrieved from Message.</value>
-  </data>
-  <data name="TraceCodeWorkflowServiceHostCreated" xml:space="preserve">
-    <value>WorkflowServiceHost created.</value>
-  </data>
-  <data name="TraceCodeServiceDurableInstanceDeleted" xml:space="preserve">
-    <value>ServiceDurableInstance '{0}' deleted from persistence store.</value>
-  </data>
-  <data name="TraceCodeServiceDurableInstanceDisposed" xml:space="preserve">
-    <value>ServiceDurableInstance '{0}' disposed.</value>
-  </data>
-  <data name="TraceCodeServiceDurableInstanceLoaded" xml:space="preserve">
-    <value>ServiceDurableInstance loaded from persistence store.</value>
-  </data>
-  <data name="TraceCodeServiceDurableInstanceSaved" xml:space="preserve">
-    <value>ServiceDurableInstance saved to persistence store.</value>
-  </data>
-  <data name="TraceCodeWorkflowDurableInstanceLoaded" xml:space="preserve">
-    <value>WorkflowDurableInstance '{0}' loaded.</value>
-  </data>
-  <data name="TraceCodeWorkflowDurableInstanceActivated" xml:space="preserve">
-    <value>WorkflowDurableInstance '{0}' activated.</value>
-  </data>
-  <data name="TraceCodeWorkflowDurableInstanceAborted" xml:space="preserve">
-    <value>WorkflowDurableInstance aborted.</value>
-  </data>
-  <data name="TraceCodeWorkflowOperationInvokerItemQueued" xml:space="preserve">
-    <value>Work item enqueued.</value>
-  </data>
-  <data name="TraceCodeWorkflowRequestContextReplySent" xml:space="preserve">
-    <value>Reply sent for InstanceId {0}.</value>
-  </data>
-  <data name="TraceCodeWorkflowRequestContextFaultSent" xml:space="preserve">
-    <value>Fault Sent for InstanceId {0}.</value>
-  </data>
-  <data name="TraceCodeSqlPersistenceProviderSQLCallStart" xml:space="preserve">
-    <value>Sql execution started.</value>
-  </data>
-  <data name="TraceCodeSqlPersistenceProviderSQLCallEnd" xml:space="preserve">
-    <value>Sql execution complete.</value>
-  </data>
-  <data name="TraceCodeSqlPersistenceProviderOpenParameters" xml:space="preserve">
-    <value>SqlPersistenceProvider.Open() parameters.</value>
-  </data>
-  <data name="TraceCodeSyncContextSchedulerServiceTimerCancelled" xml:space="preserve">
-    <value>SynchronizationContextWorkflowSchedulerService - Timer {0} cancelled.</value>
-  </data>
-  <data name="TraceCodeSyncContextSchedulerServiceTimerCreated" xml:space="preserve">
-    <value>SynchronizationContextWorkflowSchedulerService - Timer {0} created for InstanceId {1}.</value>
-  </data>
-  <data name="TraceCodeSyndicationReadFeedBegin" xml:space="preserve">
-    <value>Reading of a syndication feed started.</value>
-  </data>
-  <data name="TraceCodeSyndicationReadFeedEnd" xml:space="preserve">
-    <value>Reading of a syndication feed completed.</value>
-  </data>
-  <data name="TraceCodeSyndicationReadItemBegin" xml:space="preserve">
-    <value>Reading of a syndication item started.</value>
-  </data>
-  <data name="TraceCodeSyndicationReadItemEnd" xml:space="preserve">
-    <value>Reading of a syndication item completed.</value>
-  </data>
-  <data name="TraceCodeSyndicationWriteFeedBegin" xml:space="preserve">
-    <value>Writing of a syndication feed started.</value>
-  </data>
-  <data name="TraceCodeSyndicationWriteFeedEnd" xml:space="preserve">
-    <value>Writing of a syndication feed completed.</value>
-  </data>
-  <data name="TraceCodeSyndicationWriteItemBegin" xml:space="preserve">
-    <value>Writing of a syndication item started.</value>
-  </data>
-  <data name="TraceCodeSyndicationWriteItemEnd" xml:space="preserve">
-    <value>Writing of a syndication item completed.</value>
-  </data>
-  <data name="TraceCodeSyndicationProtocolElementIgnoredOnWrite" xml:space="preserve">
-    <value>Syndication element with name '{0}' and namespace '{1}' was not written.</value>
-  </data>
-  <data name="TraceCodeSyndicationProtocolElementInvalid" xml:space="preserve">
-    <value>Syndication element with name '{0}' and namespace '{1}' is invalid.</value>
-  </data>
-  <data name="TraceCodeWebUnknownQueryParameterIgnored" xml:space="preserve">
-    <value>HTTP query string parameter with name '{0}' was ignored.</value>
-  </data>
-  <data name="TraceCodeWebRequestMatchesOperation" xml:space="preserve">
-    <value>Incoming HTTP request with URI '{0}' matched operation '{1}'.</value>
-  </data>
-  <data name="TraceCodeWebRequestDoesNotMatchOperations" xml:space="preserve">
-    <value>Incoming HTTP request with URI '{0}' does not match any operation.</value>
-  </data>
-  <data name="UTTMustBeAbsolute" xml:space="preserve">
-    <value>Parameter 'baseAddress' must an absolute uri.</value>
-  </data>
-  <data name="UTTBaseAddressMustBeAbsolute" xml:space="preserve">
-    <value>BaseAddress must an absolute uri.</value>
-  </data>
-  <data name="UTTCannotChangeBaseAddress" xml:space="preserve">
-    <value>Cannot change BaseAddress after calling MakeReadOnly.</value>
-  </data>
-  <data name="UTTMultipleMatches" xml:space="preserve">
-    <value>There were multiple UriTemplateMatch results, but MatchSingle was called.</value>
-  </data>
-  <data name="UTTBaseAddressNotSet" xml:space="preserve">
-    <value>BaseAddress has not been set. Set the BaseAddress property before calling MakeReadOnly, Match, or MatchSingle.</value>
-  </data>
-  <data name="UTTEmptyKeyValuePairs" xml:space="preserve">
-    <value>KeyValuePairs must have at least one element.</value>
-  </data>
-  <data name="UTBindByPositionWrongCount" xml:space="preserve">
-    <value>UriTemplate '{0}' contains {1} path variables and {2} query variables but {3} values were passed to the BindByPosition method. The number of values passed to BindByPosition should be greater than or equal to the number of path variables in the template and cannot be greater than the total number of variables in the template.</value>
-  </data>
-  <data name="UTBadBaseAddress" xml:space="preserve">
-    <value>baseAddress must an absolute Uri.</value>
-  </data>
-  <data name="UTQueryNamesMustBeUnique" xml:space="preserve">
-    <value>The UriTemplate '{0}' is not valid; each portion of the query string must be of the form 'name' or of the form 'name=value', where each name is unique. Note that the names are case-insensitive. See the documentation for UriTemplate for more details.</value>
-  </data>
-  <data name="UTQueryCannotEndInAmpersand" xml:space="preserve">
-    <value>The UriTemplate '{0}' is not valid; the query string cannot end with '&amp;amp;'. See the documentation for UriTemplate for more details.</value>
-  </data>
-  <data name="UTQueryCannotHaveEmptyName" xml:space="preserve">
-    <value>The UriTemplate '{0}' is not valid; each portion of the query string must be of the form 'name' or of the form 'name=value'. See the documentation for UriTemplate for more details.</value>
-  </data>
-  <data name="UTVarNamesMustBeUnique" xml:space="preserve">
-    <value>The UriTemplate '{0}' is not valid; the UriTemplate variable named '{1}' appears multiple times in the template. Note that UriTemplate variable names are case-insensitive. See the documentation for UriTemplate for more details.</value>
-  </data>
-  <data name="UTTAmbiguousQueries" xml:space="preserve">
-    <value>UriTemplateTable does not support '{0}' and '{1}' since they are not equivalent, but cannot be disambiguated because they have equivalent paths and the same common literal values for the query string. See the documentation for UriTemplateTable for more detail.</value>
-  </data>
-  <data name="UTTOtherAmbiguousQueries" xml:space="preserve">
-    <value>UriTemplateTable does not support multiple templates that have equivalent path as template '{0}' but have different query strings, where the query strings cannot all be disambiguated via literal values. See the documentation for UriTemplateTable for more detail.</value>
-  </data>
-  <data name="UTTDuplicate" xml:space="preserve">
-    <value>UriTemplateTable (with allowDuplicateEquivalentUriTemplates = false) does not support both '{0}' and '{1}', since they are equivalent. Call MakeReadOnly with allowDuplicateEquivalentUriTemplates = true to use both of these UriTemplates in the same table. See the documentation for UriTemplateTable for more detail.</value>
-  </data>
-  <data name="UTInvalidFormatSegmentOrQueryPart" xml:space="preserve">
-    <value>UriTemplate does not support '{0}' as a valid format for a segment or a query part.</value>
-  </data>
-  <data name="BindUriTemplateToNullOrEmptyPathParam" xml:space="preserve">
-    <value>The path variable '{0}' in the UriTemplate must be bound to a non-empty string value.</value>
-  </data>
-  <data name="UTBindByPositionNoVariables" xml:space="preserve">
-    <value>UriTemplate '{0}' contains no variables; yet the BindByPosition method was called with {1} values.</value>
-  </data>
-  <data name="UTCSRLookupBeforeMatch" xml:space="preserve">
-    <value>UTCSR - Lookup was called before match</value>
-  </data>
-  <data name="UTDoesNotSupportAdjacentVarsInCompoundSegment" xml:space="preserve">
-    <value>The UriTemplate '{0}' is not valid; UriTemplate does not support two adjacent variables with no literal in compound segments, such as in the segment '{1}'.</value>
-  </data>
-  <data name="UTQueryCannotHaveCompoundValue" xml:space="preserve">
-    <value>The UriTemplate '{0}' is not valid; each portion of the query string must be of the form 'name=value', when value cannot be a compound segment. See the documentation for UriTemplate for more details.</value>
-  </data>
-  <data name="UTQueryMustHaveLiteralNames" xml:space="preserve">
-    <value>The UriTemplate '{0}' is not valid; each portion of the query string must be of the form 'name' or of the form 'name=value', where name is a simple literal. See the documentation for UriTemplate for more details.</value>
-  </data>
-  <data name="UTAdditionalDefaultIsInvalid" xml:space="preserve">
-    <value>Changing an inline default value with information from the additional default values is not supported; the default value to the variable '{0}' was already provided as part of the UriTemplate '{1}'. See the documentation for UriTemplate for more details.</value>
-  </data>
-  <data name="UTDefaultValuesAreImmutable" xml:space="preserve">
-    <value>The default values of UriTemplate are immutable; they cannot be modified after the construction of the UriTemplate instance. See the documentation of UriTemplate for more details.</value>
-  </data>
-  <data name="UTDefaultValueToCompoundSegmentVar" xml:space="preserve">
-    <value>The UriTemplate '{0}' is not valid; the UriTemplate compound path segment '{1}' provides a default value to variable '{2}'. Note that UriTemplate doesn't support default values to variables in compound segments. See the documentation for UriTemplate for more details.</value>
-  </data>
-  <data name="UTDefaultValueToQueryVar" xml:space="preserve">
-    <value>The UriTemplate '{0}' is not valid; the UriTemplate variable declaration '{1}' provides a default value to query variable '{2}'. Note that UriTemplate doesn't support default values to query variables. See the documentation for UriTemplate for more details.</value>
-  </data>
-  <data name="UTInvalidDefaultPathValue" xml:space="preserve">
-    <value>The UriTemplate '{0}' is not valid; the UriTemplate variable declaration '{1}' provides an empty default value to path variable '{2}'. Note that UriTemplate path variables cannot be bound to a null or empty value. See the documentation for UriTemplate for more details.</value>
-  </data>
-  <data name="UTInvalidVarDeclaration" xml:space="preserve">
-    <value>The UriTemplate '{0}' is not valid; the UriTemplate variable declaration '{1}' isn't a valid variable construct. Note that UriTemplate variable definitions are either a simple, non-empty, variable name or a 'name=value' format, where the name must not be empty and the value provides a default value to the variable. See the documentation for UriTemplate for more details.</value>
-  </data>
-  <data name="UTInvalidWildcardInVariableOrLiteral" xml:space="preserve">
-    <value>The UriTemplate '{0}' is not valid; the wildcard ('{1}') cannot appear in a variable name or literal, unless as a construct for a wildcard segment. Note that a wildcard segment, either a literal or a variable, is valid only as the last path segment in the template; the wildcard can appear only once. See the documentation for UriTemplate for more details.</value>
-  </data>
-  <data name="UTStarVariableWithDefaults" xml:space="preserve">
-    <value>The UriTemplate '{0}' is not valid; the UriTemplate last path segment '{1}' provides a default value to final star variable '{2}'. Note that UriTemplate doesn't support default values to final star variable. See the documentation for UriTemplate for more details.</value>
-  </data>
-  <data name="UTDefaultValueToCompoundSegmentVarFromAdditionalDefaults" xml:space="preserve">
-    <value>The UriTemplate '{0}' is not valid; the path variable '{1}', defined as part of a compound path segment has been provided with a default value as part of the additional defaults. Note that UriTemplate doesn't support default values to variables in compound segments. See the documentation for UriTemplate for more details.</value>
-  </data>
-  <data name="UTDefaultValueToQueryVarFromAdditionalDefaults" xml:space="preserve">
-    <value>The UriTemplate '{0}' is not valid; the query variable '{1}' has been provided a default value as part of the additional defaults. Note that UriTemplate doesn't support default values to query variables. See the documentation for UriTemplate for more details.</value>
-  </data>
-  <data name="UTNullableDefaultAtAdditionalDefaults" xml:space="preserve">
-    <value>The UriTemplate '{0}' is not valid; the additional default value '{1}' has a null value as default value. Note that null default values must be only provided to concrete path variables. See the documentation for UriTemplate for more details.</value>
-  </data>
-  <data name="UTNullableDefaultMustBeFollowedWithNullables" xml:space="preserve">
-    <value>The UriTemplate '{0}' is not valid; the UriTemplate path variable '{1}' has a null default value while following path variable '{2}' has no defaults or provides a non-null default value. Note that UriTemplate path variable with null default value must be followed only with other path variables with null defaulted values. See the documentation for UriTemplate for more details.</value>
-  </data>
-  <data name="UTNullableDefaultMustNotBeFollowedWithLiteral" xml:space="preserve">
-    <value>The UriTemplate '{0}' is not valid; the UriTemplate path variable '{1}' has a null default value while the following path segment '{2}' is not a variable segment with a null default value. Note that UriTemplate path variable with null default values must be followed only with other path variables with null defaulted value. See the documentation for UriTemplate for more details.</value>
-  </data>
-  <data name="UTNullableDefaultMustNotBeFollowedWithWildcard" xml:space="preserve">
-    <value>The UriTemplate '{0}' is not valid; the UriTemplate path variable '{1}' has a null default value while the template is finished with a wildcard. Note that UriTemplate path variable with null default values must be followed only with other path variables with null defaulted value. See the documentation for UriTemplate for more details.</value>
-  </data>
-  <data name="UTStarVariableWithDefaultsFromAdditionalDefaults" xml:space="preserve">
-    <value>The UriTemplate '{0}' is not valid; the UriTemplate final star variable '{1}' has been provides a default value as part of the additional defaults information. Note that UriTemplate doesn't support default values to final star variable. See the documentation for UriTemplate for more details.</value>
-  </data>
-  <data name="UTTInvalidTemplateKey" xml:space="preserve">
-    <value>An invalid template '{0}' was passed as the key in a pair of template and its associated object. UriTemplateTable Key-Value pairs must always contain a valid UriTemplate object as key; note that UriTemplateTable doesn't support templates that are ignoring the trailing slash in respect to matching. See the documentation for UriTemplateTable for more details.</value>
-  </data>
-  <data name="UTTNullTemplateKey" xml:space="preserve">
-    <value>A null UriTemplate was passed as the key in a pair of template and its associated object. UriTemplateTable Key-Value pairs must always contain a valid UriTemplate object as key. See the documentation for UriTemplateTable for more details.</value>
-  </data>
-  <data name="UTBindByNameCalledWithEmptyKey" xml:space="preserve">
-    <value>The BindByName method of UriTemplate was called with an empty name in the collection of arguments for the bind. Note that the NameValueCollection or the Dictionary passed to BindByName cannot contain an empty (or null) name as a key. See the documentation of UriTemplate for more details.</value>
-  </data>
-  <data name="UTBothLiteralAndNameValueCollectionKey" xml:space="preserve">
-    <value>The UriTemplate contains a literal value for query key '{0}', but that key also is present in the NameValueCollection. Either remove that key from the NameValueCollection, or else change the UriTemplate to not have a query literal for that key.</value>
-  </data>
-  <data name="ExtensionNameNotSpecified" xml:space="preserve">
-    <value>The name of the extension element must be specified.</value>
-  </data>
-  <data name="UnsupportedRssVersion" xml:space="preserve">
-    <value>The Rss20Serializer does not support RSS version '{0}'.</value>
-  </data>
-  <data name="Atom10SpecRequiresTextConstruct" xml:space="preserve">
-    <value>The Atom10 specification requires '{0}' to have one of these values: \"text\", \"html\", \"xhtml\", however this value is '{1}' in the document being deserialized.</value>
-  </data>
-  <data name="ErrorInLine" xml:space="preserve">
-    <value>Error in line {0} position {1}.</value>
-  </data>
-  <data name="ErrorParsingFeed" xml:space="preserve">
-    <value>An error was encountered when parsing the feed's XML. Refer to the inner exception for more details.</value>
-  </data>
-  <data name="ErrorParsingDocument" xml:space="preserve">
-    <value>An error was encountered when parsing the document's XML. Refer to the inner exception for more details.</value>
-  </data>
-  <data name="ErrorParsingItem" xml:space="preserve">
-    <value>An error was encountered when parsing the item's XML. Refer to the inner exception for more details.</value>
-  </data>
-  <data name="ErrorParsingDateTime" xml:space="preserve">
-    <value>An error was encountered when parsing a DateTime value in the XML.</value>
-  </data>
-  <data name="OuterElementNameNotSpecified" xml:space="preserve">
-    <value>The outer element name must be specified.</value>
-  </data>
-  <data name="UnknownFeedXml" xml:space="preserve">
-    <value>The element with name '{0}' and namespace '{1}' is not an allowed feed format.</value>
-  </data>
-  <data name="UnknownDocumentXml" xml:space="preserve">
-    <value>The element with name '{0}' and namespace '{1}' is not an allowed document format.</value>
-  </data>
-  <data name="UnknownItemXml" xml:space="preserve">
-    <value>The element with name '{0}' and namespace '{1}' is not an allowed item format.</value>
-  </data>
-  <data name="FeedFormatterDoesNotHaveFeed" xml:space="preserve">
-    <value>The syndication feed formatter must be configured with a syndication feed.</value>
-  </data>
-  <data name="DocumentFormatterDoesNotHaveDocument" xml:space="preserve">
-    <value>The document formatter must be configured with a document.</value>
-  </data>
-  <data name="ItemFormatterDoesNotHaveItem" xml:space="preserve">
-    <value>The syndication item formatter must be configured with a syndication item.</value>
-  </data>
-  <data name="UnbufferedItemsCannotBeCloned" xml:space="preserve">
-    <value>A feed containing items that are not buffered (i.e. the items are not stored in an IList) cannot clone its items. Buffer the items in the feed before calling Clone on it or pass false to the Clone method.</value>
-  </data>
-  <data name="FeedHasNonContiguousItems" xml:space="preserve">
-    <value>The feed being deserialized has non-contiguous sets of items in it. This is not supported by '{0}'.</value>
-  </data>
-  <data name="FeedCreatedNullCategory" xml:space="preserve">
-    <value>The feed created a null category.</value>
-  </data>
-  <data name="ItemCreatedNullCategory" xml:space="preserve">
-    <value>The item created a null category.</value>
-  </data>
-  <data name="FeedCreatedNullPerson" xml:space="preserve">
-    <value>The feed created a null person.</value>
-  </data>
-  <data name="ItemCreatedNullPerson" xml:space="preserve">
-    <value>The item created a null person.</value>
-  </data>
-  <data name="FeedCreatedNullItem" xml:space="preserve">
-    <value>=The feed created a null item.</value>
-  </data>
-  <data name="TraceCodeSyndicationFeedReadBegin" xml:space="preserve">
-    <value>Reading of a syndication feed started.</value>
-  </data>
-  <data name="TraceCodeSyndicationFeedReadEnd" xml:space="preserve">
-    <value>Reading of a syndication feed completed.</value>
-  </data>
-  <data name="TraceCodeSyndicationItemReadBegin" xml:space="preserve">
-    <value>Reading of a syndication item started.</value>
-  </data>
-  <data name="TraceCodeSyndicationItemReadEnd" xml:space="preserve">
-    <value>Reading of a syndication item completed.</value>
-  </data>
-  <data name="TraceCodeSyndicationFeedWriteBegin" xml:space="preserve">
-    <value>Writing of a syndication feed started.</value>
-  </data>
-  <data name="TraceCodeSyndicationFeedWriteEnd" xml:space="preserve">
-    <value>Writing of a syndication feed completed.</value>
-  </data>
-  <data name="TraceCodeSyndicationItemWriteBegin" xml:space="preserve">
-    <value>Writing of a syndication item started.</value>
-  </data>
-  <data name="TraceCodeSyndicationItemWriteEnd" xml:space="preserve">
-    <value>Writing of a syndication item completed.</value>
-  </data>
-  <data name="TraceCodeSyndicationProtocolElementIgnoredOnRead" xml:space="preserve">
-    <value>Syndication XML node of type '{0}' with name '{1}' and namespace '{2}' ignored on read.</value>
-  </data>
-  <data name="TraceCodeSyndicationReadServiceDocumentBegin" xml:space="preserve">
-    <value>Reading of a service document started.</value>
-  </data>
-  <data name="TraceCodeSyndicationReadServiceDocumentEnd" xml:space="preserve">
-    <value>Reading of a service document completed.</value>
-  </data>
-  <data name="TraceCodeSyndicationWriteServiceDocumentBegin" xml:space="preserve">
-    <value>Writing of a service document started.</value>
-  </data>
-  <data name="TraceCodeSyndicationWriteServiceDocumentEnd" xml:space="preserve">
-    <value>Writing of a service document completed.</value>
-  </data>
-  <data name="TraceCodeSyndicationReadCategoriesDocumentBegin" xml:space="preserve">
-    <value>Reading of a categories document started.</value>
-  </data>
-  <data name="TraceCodeSyndicationReadCategoriesDocumentEnd" xml:space="preserve">
-    <value>Reading of a categories document completed.</value>
-  </data>
-  <data name="TraceCodeSyndicationWriteCategoriesDocumentBegin" xml:space="preserve">
-    <value>Writing of a categories document started.</value>
-  </data>
-  <data name="TraceCodeSyndicationWriteCategoriesDocumentEnd" xml:space="preserve">
-    <value>Writing of a categories document completed.</value>
-  </data>
-  <data name="FeedAuthorsIgnoredOnWrite" xml:space="preserve">
-    <value>The feed's authors were not serialized as part of serializing the feed in RSS 2.0 format.</value>
-  </data>
-  <data name="FeedContributorsIgnoredOnWrite" xml:space="preserve">
-    <value>The feed's contributors were not serialized as part of serializing the feed in RSS 2.0 format.</value>
-  </data>
-  <data name="FeedIdIgnoredOnWrite" xml:space="preserve">
-    <value>The feed's id was not serialized as part of serializing the feed in RSS 2.0 format.</value>
-  </data>
-  <data name="FeedLinksIgnoredOnWrite" xml:space="preserve">
-    <value>The feed's links were not serialized as part of serializing the feed in RSS 2.0 format.</value>
-  </data>
-  <data name="ItemAuthorsIgnoredOnWrite" xml:space="preserve">
-    <value>The item's authors were not serialized as part of serializing the feed in RSS 2.0 format.</value>
-  </data>
-  <data name="ItemContributorsIgnoredOnWrite" xml:space="preserve">
-    <value>The item's contributors were not serialized as part of serializing the feed in RSS 2.0 format.</value>
-  </data>
-  <data name="ItemLinksIgnoredOnWrite" xml:space="preserve">
-    <value>The item's links were not serialized as part of serializing the feed in RSS 2.0 format.</value>
-  </data>
-  <data name="ItemCopyrightIgnoredOnWrite" xml:space="preserve">
-    <value>The item's copyrights were not serialized as part of serializing the feed in RSS 2.0 format.</value>
-  </data>
-  <data name="ItemContentIgnoredOnWrite" xml:space="preserve">
-    <value>The item's content was not serialized as part of serializing the feed in RSS 2.0 format.</value>
-  </data>
-  <data name="ItemLastUpdatedTimeIgnoredOnWrite" xml:space="preserve">
-    <value>The item's last updated time was not serialized as part of serializing the feed in RSS 2.0 format.</value>
-  </data>
-  <data name="OuterNameOfElementExtensionEmpty" xml:space="preserve">
-    <value>The outer name of the element extension cannot be empty.</value>
-  </data>
-  <data name="InvalidObjectTypePassed" xml:space="preserve">
-    <value>The Type of object passed as parameter '{0}' is not derived from {1}. Ensure that the type of object passed is either of type {1} or derived from {1}.</value>
-  </data>
-  <data name="UnableToImpersonateWhileSerializingReponse" xml:space="preserve">
-    <value>Failed to impersonate client identity during serialization of the response message.</value>
-  </data>
-  <data name="XmlLineInfo" xml:space="preserve">
-    <value>Line {0}, position {1}.</value>
-  </data>
-  <data name="XmlFoundEndOfFile" xml:space="preserve">
-    <value>end of file</value>
-  </data>
-  <data name="XmlFoundElement" xml:space="preserve">
-    <value>element '{0}' from namespace '{1}'</value>
-  </data>
-  <data name="XmlFoundEndElement" xml:space="preserve">
-    <value>end element '{0}' from namespace '{1}'</value>
-  </data>
-  <data name="XmlFoundText" xml:space="preserve">
-    <value>text '{0}'</value>
-  </data>
-  <data name="XmlFoundCData" xml:space="preserve">
-    <value>cdata '{0}'</value>
-  </data>
-  <data name="XmlFoundComment" xml:space="preserve">
-    <value>comment '{0}'</value>
-  </data>
-  <data name="XmlFoundNodeType" xml:space="preserve">
-    <value>node {0}</value>
-  </data>
-  <data name="XmlStartElementExpected" xml:space="preserve">
-    <value>Start element expected. Found {0}.</value>
-  </data>
-  <data name="SingleWsdlNotGenerated" xml:space="preserve">
-    <value>A single WSDL document could not be generated for this service. Multiple service contract namespaces were found ({0}). Ensure that all your service contracts have the same namespace.</value>
-  </data>
-  <data name="SFxDocExt_MainPageIntroSingleWsdl" xml:space="preserve">
-    <value>You can also access the service description as a single file:</value>
-  </data>
-  <data name="TaskMethodParameterNotSupported" xml:space="preserve">
-    <value>The use of '{0}' on the task-based asynchronous method is not supported.</value>
-  </data>
-  <data name="TaskMethodMustNotHaveOutParameter" xml:space="preserve">
-    <value>Client side task-based asynchronous method must not have any out or ref parameters. Any data that would have been returned through an out or ref parameter should instead be returned as part of the TResult in the resulting task.</value>
-  </data>
-  <data name="SFxCannotImportAsParameters_OutputParameterAndTask" xml:space="preserve">
-    <value>Generating message contract since the operation has multiple return values.</value>
-  </data>
-  <data name="ID0020" xml:space="preserve">
-    <value>ID0020: The collection is empty.</value>
-  </data>
-  <data name="ID0023" xml:space="preserve">
-    <value>ID0023: Failed to create an instance of '{0}' from configuration. A custom configuration element was specified, but the method LoadCustomConfiguration was not implemented. Override LoadCustomConfiguration to handle custom configuration loading.</value>
-  </data>
-  <data name="ID2004" xml:space="preserve">
-    <value>ID2004: IAsyncResult must be the AsyncResult instance returned from the Begin call. The runtime is expecting '{0}', and the actual type is '{1}'.</value>
-  </data>
-  <data name="ID3002" xml:space="preserve">
-    <value>ID3002: WSTrustServiceContract could not create a SecurityTokenService instance from WSTrustServiceContract.SecurityTokenServiceConfiguration.</value>
-  </data>
-  <data name="ID3004" xml:space="preserve">
-    <value>ID3004: Cannot obtain the schema for namespace: '{0}'.</value>
-  </data>
-  <data name="ID3022" xml:space="preserve">
-    <value>ID3022: The WSTrustServiceContract only supports receiving RequestSecurityToken messages. If you need to support more message types, override the WSTrustServiceContract.DispatchRequest method.</value>
-  </data>
-  <data name="ID3023" xml:space="preserve">
-    <value>ID3023: The WSTrustServiceContract only supports receiving RequestSecurityToken messages asynchronously. If you need to support more message types, override the WSTrustServiceContract.BeginDispatchRequest and EndDispatchRequest.</value>
-  </data>
-  <data name="ID3097" xml:space="preserve">
-    <value>ID3097: ServiceHost does not contain any valid Endpoints. Add at least one valid endpoint in the SecurityTokenServiceConfiguration.TrustEndpoints collection.</value>
-  </data>
-  <data name="ID3112" xml:space="preserve">
-    <value>ID3112: Unrecognized RequestType '{0}' specified in the incoming request.</value>
-  </data>
-  <data name="ID3113" xml:space="preserve">
-    <value>ID3113: The WSTrustServiceContract does not support receiving '{0}' messages with the '{1}' SOAP action. If you need to support this, override the ValidateDispatchContext method.</value>
-  </data>
-  <data name="ID3114" xml:space="preserve">
-    <value>ID3114: The WSTrustServiceContract cannot deserialize the WS-Trust request.</value>
-  </data>
-  <data name="ID3137" xml:space="preserve">
-    <value>ID3137: The TrustVersion '{0}', is not supported, only 'TrustVersion.WSTrust13' and 'TrustVersion.WSTrustFeb2005' is supported.</value>
-  </data>
-  <data name="ID3138" xml:space="preserve">
-    <value>ID3138: The RequestSecurityTokenResponse that was received did not contain a SecurityToken.</value>
-  </data>
-  <data name="ID3139" xml:space="preserve">
-    <value>ID3139: The WSTrustChannel cannot compute a proof key. The KeyType '{0}' is not supported. Valid proof key types supported by the WSTrustChannel are WSTrust13 and WSTrustFeb2005.</value>
-  </data>
-  <data name="ID3140" xml:space="preserve">
-    <value>ID3140: Specify one or more BaseAddresses to enable metadata or set DisableWsdl to true in the SecurityTokenServiceConfiguration.</value>
-  </data>
-  <data name="ID3141" xml:space="preserve">
-    <value>ID3141: The RequestType '{0}', is not supported. If you need to support this RequestType, override the corresponding virtual method in your SecurityTokenService derived class.</value>
-  </data>
-  <data name="ID3144" xml:space="preserve">
-    <value>ID3144: The PortType '{0}' Operation '{1}' has Message '{2}' is expected to have only one part but contains '{3}'.</value>
-  </data>
-  <data name="ID3146" xml:space="preserve">
-    <value>ID3146: WsdlEndpointConversionContext.WsdlPort cannot be null.</value>
-  </data>
-  <data name="ID3147" xml:space="preserve">
-    <value>ID3147: WsdlEndpointConversionContext.WsdlPort.Service cannot be null.</value>
-  </data>
-  <data name="ID3148" xml:space="preserve">
-    <value>ID3148: WsdlEndpointConversionContext.WsdlPort.Service.ServiceDescription cannot be null.</value>
-  </data>
-  <data name="ID3149" xml:space="preserve">
-    <value>ID3149: Cannot find an input message type for PortType '({0}, {1})' for operation '{2}' in the given ServiceDescription.</value>
-  </data>
-  <data name="ID3150" xml:space="preserve">
-    <value>ID3150: Cannot find an output message type for PortType '({0}, {1})' for operation '{2}' in the given ServiceDescription.</value>
-  </data>
-  <data name="ID3190" xml:space="preserve">
-    <value>ID3190: The WSTrustChannel cannot compute a proof key without a valid SecurityToken set as the RequestSecurityToken.UseKey when the RequestSecurityToken.KeyType is '{0}'.</value>
-  </data>
-  <data name="ID3191" xml:space="preserve">
-    <value>ID3191: The WSTrustChannel received a RequestedSecurityTokenResponse message containing an Entropy without a ComputedKeyAlgorithm.</value>
-  </data>
-  <data name="ID3192" xml:space="preserve">
-    <value>ID3192: The WSTrustChannel cannot compute a proof key. The received RequestedSecurityTokenResponse does not contain a RequestedProofToken and the ComputedKeyAlgorithm specified in the response is not supported: '{0}'.</value>
-  </data>
-  <data name="ID3193" xml:space="preserve">
-    <value>ID3193: The WSTrustChannel cannot compute a proof key. The received RequestedSecurityTokenResponse indicates that the proof key is computed using combined entropy. However, the response does not include an entropy.</value>
-  </data>
-  <data name="ID3194" xml:space="preserve">
-    <value>ID3194: The WSTrustChannel cannot compute a proof key. The received RequestedSecurityTokenResponse indicates that the proof key is computed using combined entropy. However, the request does not include an entropy.</value>
-  </data>
-  <data name="ID3269" xml:space="preserve">
-    <value>ID3269: Cannot determine the TrustVersion. It must either be specified explicitly, or a SecurityBindingElement must be present in the binding.</value>
-  </data>
-  <data name="ID3270" xml:space="preserve">
-    <value>ID3270: The WSTrustChannel does not support multi-leg issuance protocols. The RSTR received from the STS must be enclosed in a RequestSecurityTokenResponseCollection element.</value>
-  </data>
-  <data name="ID3285" xml:space="preserve">
-    <value>ID3285: The WS-Trust operation '{0}' is not valid or unsupported.</value>
-  </data>
-  <data name="ID3286" xml:space="preserve">
-    <value>ID3286: The 'inner' parameter must implement the 'System.ServiceModel.Channels.IChannel' interface.</value>
-  </data>
-  <data name="ID3287" xml:space="preserve">
-    <value>ID3287: WSTrustChannelFactory does not support changing the value of this property after a channel is created.</value>
-  </data>
-  <data name="ID4008" xml:space="preserve">
-    <value>ID4008: '{0}' does not provide an implementation for '{1}'.</value>
-  </data>
-  <data name="ID4039" xml:space="preserve">
-    <value>ID4039: A custom ServiceAuthorizationManager has been configured. Any custom ServiceAuthorizationManager must be derived from IdentityModelServiceAuthorizationManager.</value>
-  </data>
-  <data name="ID4041" xml:space="preserve">
-    <value>ID4041: Cannot configure the ServiceHost '{0}'. The ServiceHost is in a bad state and cannot be configured.</value>
-  </data>
-  <data name="ID4053" xml:space="preserve">
-    <value>ID4053: The token has WS-SecureConversation version '{0}'.  Version '{1}' was expected.</value>
-  </data>
-  <data name="ID4072" xml:space="preserve">
-    <value>ID4072: The SecurityTokenHandler '{0}' registered for TokenType '{1}' must derive from '{2}'.</value>
-  </data>
-  <data name="ID4101" xml:space="preserve">
-    <value>ID4101: The token cannot be validated because it is not a SamlSecurityToken or a Saml2SecurityToken. Token type: '{0}'</value>
-  </data>
-  <data name="ID4192" xml:space="preserve">
-    <value>ID4192: The reader is not positioned on a KeyInfo element that can be read.</value>
-  </data>
-  <data name="ID4240" xml:space="preserve">
-    <value>ID4240: The tokenRequirement must derived from 'RecipientServiceModelSecurityTokenRequirement' for SecureConversationSecurityTokens. The tokenRequirement is of type '{0}'.</value>
-  </data>
-  <data name="ID4244" xml:space="preserve">
-    <value>ID4244: Internal error: sessionAuthenticator must support IIssuanceSecurityTokenAuthenticator.</value>
-  </data>
-  <data name="ID4245" xml:space="preserve">
-    <value>ID4245: Internal error: sessionAuthenticator must support ICommunicationObject.</value>
-  </data>
-  <data name="ID4268" xml:space="preserve">
-    <value>ID4268: MergeClaims must have at least one identity that is not null.</value>
-  </data>
-  <data name="ID4271" xml:space="preserve">
-    <value>ID4271: No IAuthorizationPolicy was found for the Transport security token '{0}'.</value>
-  </data>
-  <data name="ID4274" xml:space="preserve">
-    <value>ID4274: The Configuration property of this SecurityTokenHandler is set to null. Tokens cannot be read or validated in this state. Set this property or add this SecurityTokenHandler to a SecurityTokenHandlerCollection with a valid Configuration property.</value>
-  </data>
-  <data name="ID4285" xml:space="preserve">
-    <value>ID4285: Cannot replace SecurityToken with Id '{0}' in cache with new one. Token must exist in cache to be replaced.</value>
-  </data>
-  <data name="ID4287" xml:space="preserve">
-    <value>ID4287: The SecurityTokenRequirement '{0}' doesn't contain a ListenUri.</value>
-  </data>
-  <data name="ID5004" xml:space="preserve">
-    <value>ID5004: Unrecognized namespace: '{0}'.</value>
-  </data>
-  <data name="TraceAuthorize" xml:space="preserve">
-    <value>Authorize</value>
-  </data>
-  <data name="TraceOnAuthorizeRequestFailed" xml:space="preserve">
-    <value>OnAuthorizeRequest Failed.</value>
-  </data>
-  <data name="TraceOnAuthorizeRequestSucceed" xml:space="preserve">
-    <value>OnAuthorizeRequest Succeeded.</value>
-  </data>
-  <data name="AuthFailed" xml:space="preserve">
-    <value>Authentication failed.</value>
-  </data>
-  <data name="DuplicateFederatedClientCredentialsParameters" xml:space="preserve">
-    <value>The IssuedSecurityTokenProvider cannot support the FederatedClientCredentialsParameters. The FederatedClientCredentialsParameters has already provided the '{0}' parameter.</value>
-  </data>
-  <data name="UnsupportedTrustVersion" xml:space="preserve">
-    <value>The TrustVersion '{0}', is not supported, only 'TrustVersion.WSTrust13' and 'TrustVersion.WSTrustFeb2005' is supported.</value>
-  </data>
-  <data name="InputMustBeDelegatingHandlerElementError" xml:space="preserve">
-    <value>The input {0} must be a '{1}' object.</value>
   </data>
   <data name="InputTypeListEmptyError" xml:space="preserve">
     <value>The input handler list cannot be empty.</value>
@@ -6477,44 +1779,11 @@
   <data name="DelegatingHandlerArrayFromFuncContainsNullItem" xml:space="preserve">
     <value>The '{0}' list created by the Func '{1}' is invalid because it contains one or more null items.</value>
   </data>
-  <data name="HttpMessageHandlerFactoryConfigInvalid_WithBothTypeAndHandlerList" xml:space="preserve">
-    <value>The config element '{0}' is invalid because the attribute '{1}' and the sub element '{2}' were both specified. These are mutually exclusive items and cannot be used simultaneouly.</value>
-  </data>
-  <data name="HttpMessageHandlerFactoryWithFuncCannotGenerateConfig" xml:space="preserve">
-    <value>This '{0}' object cannot be used to generate configuration because it was created with the constructor that takes a '{1}' as the paramter.  This functionality is not supported through configuration files.  Please use a different constructor if you wish to generate a configuration file.</value>
-  </data>
   <data name="HttpMessageHandlerTypeNotSupported" xml:space="preserve">
     <value>Invalid type: '{0}'. It must inherit from base type '{1}', cannot be abstract, and must expose a public default constructor.</value>
   </data>
-  <data name="HttpMessageHandlerChannelFactoryNullPipeline" xml:space="preserve">
-    <value>'{0}' cannot return a null '{1}' instance. Please ensure that '{0}' returns a valid '{1}' instance.</value>
-  </data>
-  <data name="HttpPipelineOperationCanceledError" xml:space="preserve">
-    <value>HTTP pipeline operation cancelled.</value>
-  </data>
-  <data name="HttpPipelineMessagePropertyMissingError" xml:space="preserve">
-    <value>The message property '{0}' is missing in the HttpRequestMessage. Please make sure this property not removed or changed from the properties of the HttpRequestMessage. If you are creating a new HttpRequestMessage, please copy this property from the old message to the new one.</value>
-  </data>
-  <data name="HttpPipelineMessagePropertyTypeError" xml:space="preserve">
-    <value>The message property '{0}' inside the HttpRequestMessage is not with expected type '{1}'. Please make sure this property not removed or changed from the properties of the HttpRequestMessage. If you are creating a new HttpRequestMessage, please copy this property from the old message to the new one.</value>
-  </data>
-  <data name="InvalidContentTypeError" xml:space="preserve">
-    <value>The value '{0}' is not a valid content type.</value>
-  </data>
   <data name="HttpPipelineNotSupportedOnClientSide" xml:space="preserve">
     <value>The property '{0}' is not supported when building a ChannelFactory. The property value must be null when calling BuildChannelFactory.</value>
-  </data>
-  <data name="CanNotLoadTypeGotFromConfig" xml:space="preserve">
-    <value>Cound not load type '{0}' from the assemblies in current AppDomain.</value>
-  </data>
-  <data name="HttpPipelineNotSupportNullResponseMessage" xml:space="preserve">
-    <value>The HTTP response message should not be null. Please ensure your '{0}' instance returns a non-null '{1}' object.</value>
-  </data>
-  <data name="WebSocketInvalidProtocolNoHeader" xml:space="preserve">
-    <value>The subprotocol '{0}' was not requested by the client - no '{1}' header was included in the request.</value>
-  </data>
-  <data name="WebSocketInvalidProtocolNotInClientList" xml:space="preserve">
-    <value>The subprotocol '{0}' was not requested by the client. The client requested the following subprotocol(s): '{1}'.</value>
   </data>
   <data name="WebSocketInvalidProtocolInvalidCharInProtocolString" xml:space="preserve">
     <value>The subprotocol '{0}' is invalid because it contains the invalid character '{1}'.</value>
@@ -6525,36 +1794,6 @@
   <data name="WebSocketInvalidProtocolEmptySubprotocolString" xml:space="preserve">
     <value>Empty string is not a valid subprotocol value. Please use \"null\" to specify no value.</value>
   </data>
-  <data name="WebSocketOpaqueStreamContentNotSupportError" xml:space="preserve">
-    <value>This method is not supported for this HTTP content.</value>
-  </data>
-  <data name="WebSocketElementConfigInvalidHttpMessageHandlerFactoryType" xml:space="preserve">
-    <value>Invalid value for the {0} type. The type '{1}' does not derive from the appropriate base class '{2}' or is abstract.</value>
-  </data>
-  <data name="WebSocketEndpointOnlySupportWebSocketError" xml:space="preserve">
-    <value>This service only supports WebSocket connections.</value>
-  </data>
-  <data name="WebSocketEndpointDoesNotSupportWebSocketError" xml:space="preserve">
-    <value>This service does not support WebSocket connections.</value>
-  </data>
-  <data name="WebSocketUpgradeFailedError" xml:space="preserve">
-    <value>WebSocket upgrade request failed. Received response status code '{0} ({1})', expected: '{2} ({3})'.</value>
-  </data>
-  <data name="WebSocketUpgradeFailedHeaderMissingError" xml:space="preserve">
-    <value>WebSocket upgrade request failed. The header '{0}' is missing in the response.</value>
-  </data>
-  <data name="WebSocketUpgradeFailedWrongHeaderError" xml:space="preserve">
-    <value>WebSocket upgrade request failed. The value of header '{0}' is '{1}'. The expected value is '{2}'.</value>
-  </data>
-  <data name="WebSocketUpgradeFailedInvalidProtocolError" xml:space="preserve">
-    <value>Unexpected response - the server accepted the upgrade request but specified the subprotocol '{0}' when no subprotocol was requested.</value>
-  </data>
-  <data name="WebSocketContextWebSocketCannotBeAccessedError" xml:space="preserve">
-    <value>WebSocket object cannot be accessed directly.</value>
-  </data>
-  <data name="WebSocketTransportError" xml:space="preserve">
-    <value>A WebSocket error occurred.</value>
-  </data>
   <data name="WebSocketUnexpectedCloseMessageError" xml:space="preserve">
     <value>Unexpected WebSocket close message received when receiving a message.</value>
   </data>
@@ -6563,24 +1802,6 @@
   </data>
   <data name="WebSocketCannotCreateRequestClientChannelWithCertainWebSocketTransportUsage" xml:space="preserve">
     <value>HttpChannelFactory cannot create the channel with shape '{0}' when the {1} of {2} was set as '{3}'.</value>
-  </data>
-  <data name="WebSocketMaxPendingConnectionsReached" xml:space="preserve">
-    <value>Maximum number of pending WebSocket connections ({0}) has been reached. Consider increasing the '{1}' quota on the '{2}' property of the transport.</value>
-  </data>
-  <data name="WebSocketOpeningHandshakePropertiesNotAvailable" xml:space="preserve">
-    <value>The opening handshake properties associated with the current WebSocket connection are not available. The most likely cause is that the property '{0}' on the '{1}' object returned from the custom '{2}' is not set.</value>
-  </data>
-  <data name="AcceptWebSocketTimedOutError" xml:space="preserve">
-    <value>The operation to establish the WebSocket connection timed out. To increase this time limit, use the OpenTimeout property on the service endpoint's binding.</value>
-  </data>
-  <data name="TaskCancelledError" xml:space="preserve">
-    <value>The task was cancelled.</value>
-  </data>
-  <data name="ClientWebSocketFactory_GetWebSocketVersionFailed" xml:space="preserve">
-    <value>An error occured when getting the WebSocketVersion from the WebSocket factory of type '{0}'. See the inner exception for details.</value>
-  </data>
-  <data name="ClientWebSocketFactory_InvalidWebSocketVersion" xml:space="preserve">
-    <value>The WebSocketVersion returned by the WebSocket factory of type '{0}' is either null, empty or invalid.</value>
   </data>
   <data name="ClientWebSocketFactory_CreateWebSocketFailed" xml:space="preserve">
     <value>An error occurred when creating the WebSocket with the factory of type '{0}'. See the inner exception for details.</value>
@@ -6591,9 +1812,6 @@
   <data name="ClientWebSocketFactory_InvalidSubProtocol" xml:space="preserve">
     <value>The WebSocket returned by the factory of type '{0}' has the SubProtocol '{1}' that doesn't match the requested SubProtocol value '{2}'.</value>
   </data>
-  <data name="MultipleClientWebSocketFactoriesSpecified" xml:space="preserve">
-    <value>The '{0}' contains multiple '{1}' objects, which is invalid. At most one '{1}' should be specified.</value>
-  </data>
   <data name="WebSocketSendTimedOut" xml:space="preserve">
     <value>The Send operation timed out after '{0}'. Increase the SendTimeout value on the Binding. The time allotted to this operation may have been a portion of a longer timeout.</value>
   </data>
@@ -6603,62 +1821,11 @@
   <data name="WebSocketOperationTimedOut" xml:space="preserve">
     <value>The '{0}' operation timed out after '{1}'. The time allotted to this operation may have been a portion of a longer timeout.</value>
   </data>
-  <data name="WebSocketsServerSideNotSupported" xml:space="preserve">
-    <value>This platform does not support server side WebSockets.</value>
-  </data>
-  <data name="WebSocketsClientSideNotSupported" xml:space="preserve">
-    <value>This platform does not support client side WebSockets natively. Support for client side WebSockets can be enabled on this platform by providing an implementation of {0}.</value>
-  </data>
-  <data name="WebSocketsNotSupportedInClassicPipeline" xml:space="preserve">
-    <value>WebSockets are not supported in the classic pipeline mode. Consider using the integrated pipeline mode for the application pool.</value>
-  </data>
-  <data name="WebSocketModuleNotLoaded" xml:space="preserve">
-    <value>The WebSocketModule is not loaded. Check if the WebSocket feature is installed and the WebSocketModule is enabled in the list of IIS modules (see http://go.microsoft.com/fwlink/?LinkId=231398 for details).</value>
-  </data>
-  <data name="WebSocketTransportPolicyAssertionInvalid" xml:space="preserve">
-    <value>The name of the policy being imported for contract '{0}:{1}' is invalid:'{2}'. It should be either '{3}', '{4}' or '{5}'.</value>
-  </data>
   <data name="WebSocketVersionMismatchFromServer" xml:space="preserve">
     <value>The server didn't accept the connection request. It is possible that the WebSocket protocol version on your client doesn't match the one on the server('{0}').</value>
   </data>
   <data name="WebSocketSubProtocolMismatchFromServer" xml:space="preserve">
     <value>The server didn't accept the connection request. It is possible that the WebSocket subprotocol sent by your client is not supported by the server. Protocol(s) supported by the server are '{0}'.</value>
-  </data>
-  <data name="WebSocketContentTypeMismatchFromServer" xml:space="preserve">
-    <value>The server didn't accept the connection request. It is possible that the client side message encoding format doesn't match the setting on the server side. Please check your binding settings.</value>
-  </data>
-  <data name="WebSocketContentTypeAndTransferModeMismatchFromServer" xml:space="preserve">
-    <value>The server didn't accept the connection request. It is possible that the client side message encoding format or message transfer mode doesn't match the setting on the server side. Please check your binding settings.</value>
-  </data>
-  <data name="ResponseHeaderWithRequestHeadersCollection" xml:space="preserve">
-    <value>This collection holds request headers and cannot contain the specified response header '{0}'.</value>
-  </data>
-  <data name="RequestHeaderWithResponseHeadersCollection" xml:space="preserve">
-    <value>This collection holds response headers and cannot contain the specified request header '{0}'.</value>
-  </data>
-  <data name="MessageVersionNoneRequiredForHttpMessageSupport" xml:space="preserve">
-    <value>Support for {0} and {1} can not be enabled with {2} when the {3} of the {4} is '{5}'.  Ensure the {4} used with the binding has a {3} of '{6}'. </value>
-  </data>
-  <data name="WebHeaderEnumOperationCantHappen" xml:space="preserve">
-    <value>Enumeration has either not started or has already finished.</value>
-  </data>
-  <data name="WebHeaderEmptyStringCall" xml:space="preserve">
-    <value>The parameter '{0}' cannot be an empty string.</value>
-  </data>
-  <data name="WebHeaderInvalidControlChars" xml:space="preserve">
-    <value>Specified value has invalid Control characters.</value>
-  </data>
-  <data name="WebHeaderInvalidCRLFChars" xml:space="preserve">
-    <value>Specified value has invalid CRLF characters.</value>
-  </data>
-  <data name="WebHeaderInvalidHeaderChars" xml:space="preserve">
-    <value>Specified value has invalid HTTP Header characters.</value>
-  </data>
-  <data name="WebHeaderInvalidNonAsciiChars" xml:space="preserve">
-    <value>Specified value has invalid non-ASCII characters.</value>
-  </data>
-  <data name="WebHeaderArgumentOutOfRange" xml:space="preserve">
-    <value>Specified argument was out of the range of valid values.</value>
   </data>
   <data name="CopyHttpHeaderFailed" xml:space="preserve">
     <value>Failed to copy the HTTP header '{0}' with value '{1}' to '{2}'.</value>
@@ -6680,9 +1847,6 @@
   </data>
   <data name="FailedToCreateTypedProxy" xml:space="preserve">
     <value>Failed to create a typed proxy for type '{0}'</value>
-  </data>
-  <data name="Arg_SystemException" xml:space="preserve">
-    <value>System error.</value>
   </data>
   <data name="SecurityTokenRequirementDoesNotContainProperty" xml:space="preserve">
     <value>The token requirement does not contain a property '{0}'.</value>
@@ -6732,14 +1896,8 @@
   <data name="LocalIdCannotBeEmpty" xml:space="preserve">
     <value>The localId cannot be empty. Specify a valid 'localId'.</value>
   </data>
-  <data name="UnableToResolveKeyReference" xml:space="preserve">
-    <value>The token resolver is unable to resolve the security key reference '{0}'.</value>
-  </data>
   <data name="CannotValidateSecurityTokenType" xml:space="preserve">
     <value>The security token authenticator '{0}' cannot validate a token of type '{1}'.</value>
-  </data>
-  <data name="UnableToResolveTokenReference" xml:space="preserve">
-    <value>The token resolver is unable to resolve the token reference '{0}'.</value>
   </data>
   <data name="UnauthorizedAccess_MemStreamBuffer" xml:space="preserve">
     <value>MemoryStream's internal buffer cannot be accessed.</value>


### PR DESCRIPTION
Automated cleanup of unused resources in System.Private.ServiceModel. This removes about 75% of the file or roughly 300kb from the binary. The automated tool scanned for source references to resource strings. Github's diffing is showing additions, but there are no actual additions or edits, just removals. Verification was build+unit tests.