### PR TITLE
Add S.SM.ExtensionCollection to public contract.

### DIFF
--- a/src/System.ServiceModel.Duplex/ref/System.ServiceModel.Duplex.cs
+++ b/src/System.ServiceModel.Duplex/ref/System.ServiceModel.Duplex.cs
@@ -44,7 +44,7 @@ namespace System.ServiceModel
         protected override System.TimeSpan DefaultCloseTimeout { get { return default(System.TimeSpan); } }
         protected override System.TimeSpan DefaultOpenTimeout { get { return default(System.TimeSpan); } }
         public System.Threading.SynchronizationContext SynchronizationContext { get { return default(System.Threading.SynchronizationContext); } set { } }
-        System.ServiceModel.IExtensionCollection<System.ServiceModel.InstanceContext> System.ServiceModel.IExtensibleObject<System.ServiceModel.InstanceContext>.Extensions { get { return default(System.ServiceModel.IExtensionCollection<System.ServiceModel.InstanceContext>); } }
+        public System.ServiceModel.IExtensionCollection<System.ServiceModel.InstanceContext> Extensions { get { return default(System.ServiceModel.IExtensionCollection<System.ServiceModel.InstanceContext>); } }
         public object GetServiceInstance(System.ServiceModel.Channels.Message message) { return default(object); }
         protected override void OnAbort() { }
         protected override System.IAsyncResult OnBeginClose(System.TimeSpan timeout, System.AsyncCallback callback, object state) { return default(System.IAsyncResult); }

--- a/src/System.ServiceModel.Primitives/ref/System.ServiceModel.Primitives.cs
+++ b/src/System.ServiceModel.Primitives/ref/System.ServiceModel.Primitives.cs
@@ -303,6 +303,17 @@ namespace System.ServiceModel
         public string Type { get { return default(string); } set { } }
         public override string ToString() { return default(string); }
     }
+    public sealed partial class ExtensionCollection<T> : System.Collections.Generic.SynchronizedCollection<System.ServiceModel.IExtension<T>>, System.ServiceModel.IExtensionCollection<T> where T : System.ServiceModel.IExtensibleObject<T>
+    {
+        public ExtensionCollection(T owner) { }
+        public ExtensionCollection(T owner, object syncRoot) : base(syncRoot) { }
+        protected override void ClearItems() { }
+        public E Find<E>() { return default(E); }
+        public System.Collections.ObjectModel.Collection<E> FindAll<E>() { return default(System.Collections.ObjectModel.Collection<E>); }
+        protected override void InsertItem(int index, System.ServiceModel.IExtension<T> item) { }
+        protected override void RemoveItem(int index) { }
+        protected override void SetItem(int index, System.ServiceModel.IExtension<T> item) { }
+    }
     public partial class FaultCode
     {
         public FaultCode(string name) { }

--- a/src/System.ServiceModel.Primitives/tests/ServiceModel/ExtensionCollection.cs
+++ b/src/System.ServiceModel.Primitives/tests/ServiceModel/ExtensionCollection.cs
@@ -1,0 +1,65 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.ObjectModel;
+using System.ServiceModel;
+
+using Infrastructure.Common;
+using Xunit;
+
+public class ExtensionCollectionTest
+{
+    [WcfFact]
+    public static void ExtensionCollectionPublicMembersTest()
+    {
+        ExtensionCollection<IMyExtensibleObject> collection = new ExtensionCollection<IMyExtensibleObject>(new MyExtensibleObject(), "syncRoot");
+
+        collection.Add(new MyExtension1());
+        collection.Add(new MyExtension2());
+
+        Assert.True(collection.Count == 2, $"Expected the collection to contain 2 items, instead it contained '{collection.Count}' items.");
+
+        IMyExtension result = collection.Find<IMyExtension>();
+        Assert.NotNull(result);
+
+        Collection<IMyExtension> myCollection = collection.FindAll<IMyExtension>();
+        Assert.True(myCollection.Count == 2, $"Expected the collection to contain 2 items of type 'IMyExtension', instead it contained: '{myCollection.Count}' items.");
+    }
+
+    public interface IMyExtensibleObject : IExtensibleObject<IMyExtensibleObject> { }
+
+    public class MyExtensibleObject : IMyExtensibleObject
+    {
+        public IExtensionCollection<IMyExtensibleObject> Extensions
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+        }
+    }
+
+    public interface IMyExtension : IExtension<IMyExtensibleObject> { }
+
+    public class MyExtension1 : IMyExtension
+    {
+        private IMyExtensibleObject _ownerAttached;
+        private IMyExtensibleObject _ownerDetached;
+
+        public void Attach(IMyExtensibleObject owner)
+        {
+            _ownerAttached = owner;
+        }
+
+        public void Detach(IMyExtensibleObject owner)
+        {
+            _ownerDetached = owner;
+        }
+    }
+
+    public class MyExtension2 : MyExtension1
+    {
+    }
+}


### PR DESCRIPTION
* Already used by WCF internally, no tests need to be explicitly written for it.