### PR TITLE
Fixing #1760 (timeout tracking)

### DIFF
--- a/src/System.Private.ServiceModel/tests/Stress/SharedPoolsOfWCFObjects/OperationTimeoutTracker.cs
+++ b/src/System.Private.ServiceModel/tests/Stress/SharedPoolsOfWCFObjects/OperationTimeoutTracker.cs
@@ -1,0 +1,187 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Linq;
+using System.Threading;
+using System.Diagnostics;
+
+namespace SharedPoolsOfWCFObjects
+{
+    /// <summary>
+    /// This class is designed to efficiently track operation timeouts in stress when the following conditions apply:
+    /// 1. the rate of requests is high (> 100K rq/s) so creating/disposing individual cancellation tockens is expensive (CPU & memory)
+    /// 2. the timeout duration is the same for all requests being tracked
+    /// 3. we only care about "truly" stuck requests (e.g. didn't finish even after exceeding ~2x timeout)
+    /// </summary>
+    /// <typeparam name="TOperationToken"> token type used to identify the operation in progress </typeparam>
+    public class OperationTimeoutTracker<TOperationToken>
+        where TOperationToken : class
+    {
+        int _timeoutMs;
+        Action<TOperationToken[]> _timeoutCallback;
+        TimeoutTracker _currentTimeoutTracker;
+
+        /// <summary>
+        /// All operations tracked by this instance will need to have
+        ///  - the same timeout length timeoutMs
+        ///  - the same timeout callback timeoutCallback
+        /// </summary>
+        /// <param name="timeoutCallback"> 
+        /// This callback will be called when OperationTimeoutTracker detects operations that exceeded timeouts.
+        /// </param> 
+        public OperationTimeoutTracker(int timeoutMs, Action<TOperationToken[]> timeoutCallback)
+        {
+            _timeoutMs = timeoutMs;
+            _timeoutCallback = timeoutCallback;
+            _currentTimeoutTracker = new TimeoutTracker(_timeoutMs, _timeoutCallback);
+        }
+
+        /// <param name="t"> A token identifying an operation being tracked </param>
+        /// <returns> Returns a disposable object which (when disposed) will release the token from being tracked </returns>
+        public IDisposable StartTrackingOperation(TOperationToken t)
+        {
+            if (DateTime.Now > _currentTimeoutTracker.StopUsingDueTime)
+            {
+                // Create a new tracker
+                var currentTimeoutTracker = _currentTimeoutTracker;
+                var newTimeoutTracker = new TimeoutTracker(_timeoutMs, _timeoutCallback);
+                // and make sure we only use one new tracker
+                if (Interlocked.CompareExchange(ref _currentTimeoutTracker, newTimeoutTracker, currentTimeoutTracker) != currentTimeoutTracker)
+                {
+                    newTimeoutTracker.Dispose();
+                }
+                
+                // Don't touch the old currentTimeoutTracker which still tracks its stuff for completion
+            }
+            return _currentTimeoutTracker.TrackOperationTimeout(t);
+        }
+
+        public class TimeoutTracker : IDisposable
+        {
+            ITrackingList<TOperationToken> _list = new CircularArrayList<TOperationToken>();
+            Timer _timer;
+            int _disposed;
+            Action<TOperationToken[]> _timeoutCallback;
+
+            public TimeoutTracker(int timeoutMs, Action<TOperationToken[]> timeoutCallback)
+            {
+                _timeoutCallback = timeoutCallback;
+                // stop using this tracker in timeoutMs
+                StopUsingDueTime = DateTime.Now.AddMilliseconds(timeoutMs);
+
+                // fire the timer in 2 * timeoutMs to be sure to exceed timeouts for the most recent operations
+                _timer = new Timer(NotifyTimeoutCallbackOnce, null, 2 * timeoutMs, Timeout.Infinite);
+            }
+
+            public DateTime StopUsingDueTime { get; private set; }
+
+            public void Dispose()
+            {
+                if (Interlocked.CompareExchange(ref _disposed, 1, 0) == 0)
+                {
+                    _timer.Dispose();
+                }
+            }
+
+            // Return a disposable token to be able to remove finished operation from the tracking list
+            public IDisposable TrackOperationTimeout(TOperationToken r)
+            {
+                int listIndex = _list.Add(r);
+                return new StopTrackingToken(_list, listIndex);
+            }
+
+            private void NotifyTimeoutCallbackOnce(Object _)
+            {
+                _timeoutCallback(_list.ToArray());
+                Dispose();
+            }
+        }
+
+        public class StopTrackingToken : IDisposable
+        {
+            ITrackingList<TOperationToken> _list;
+            int _index;
+            public StopTrackingToken(ITrackingList<TOperationToken> list, int index)
+            {
+                _list = list;
+                _index = index;
+            }
+            public void Dispose()
+            {
+                _list.Remove(_index);
+            }
+        }
+    }
+
+    public interface ITrackingList<T>
+    {
+        int Add(T t);
+        void Remove(int i);
+        T[] ToArray();
+    }
+
+    /// <summary>
+    /// This is a specialized collection to handle fast rate of adding/removing elements.
+    /// To avoid serializing threads its Add and Remove operations are lock free.
+    /// </summary>
+    public class CircularArrayList<T> : ITrackingList<T>
+        where T : class
+    {
+        const int Capacity = 1000;
+        const int MaxCapacity = 8000;
+        // Small initial capacity may significantly impact its performance when going over its size.
+        // To deal with this it has a self-adjusting capacity multiplier for future collection instances.
+        static int s_capacityMultiplier = 1;
+        int _sizeAdjustedOnce = 0;
+        int _currentSize = Capacity * s_capacityMultiplier;
+        T[] _list = new T[Capacity * s_capacityMultiplier];
+        long _currIdx = 0;
+
+        public int Add(T t)
+        {
+            int idx = 0;
+            long startIdx = _currIdx;
+            do
+            {
+                // There are several different strategies for choosing the initial index in the array
+                // Depending on size, NUMA architecture, and cuncurrency some may work better than others...
+                idx = (int)(Interlocked.Increment(ref _currIdx) % _currentSize);
+
+                // A context switch can cause a large difference between _currIdx and startIdx so this check is not reliable
+                // but we still treat it as a sign that we need to increase the array capacity next time
+                if (idx > startIdx + _currentSize)
+                {
+                    if (Interlocked.CompareExchange(ref _sizeAdjustedOnce, 1, 0) == 0)
+                    {
+                        if (Capacity * s_capacityMultiplier < MaxCapacity)
+                        {
+                            s_capacityMultiplier *= 2;
+                        }
+                    }
+                }
+            }
+            while (_list[idx] != null);
+
+            // If a thread makes a full loop ahead of the other one then both threads get the same index
+            // so we use interlocked compare exchange to take care of this case
+            if (Interlocked.CompareExchange(ref _list[idx], t, null) == null)
+            {
+                return idx;
+            }
+            // This thread will have to try again
+            return Add(t);
+        }
+
+        public void Remove(int index)
+        {
+            Debug.Assert(_list[index] != null, "Missing element");
+            _list[index] = null;
+        }
+
+        public T[] ToArray()
+        {
+            return _list.Where(_ => _ != null).ToArray();
+        }
+    }
+}

--- a/src/System.Private.ServiceModel/tests/Stress/SharedPoolsOfWCFObjects/Program.cs
+++ b/src/System.Private.ServiceModel/tests/Stress/SharedPoolsOfWCFObjects/Program.cs
@@ -129,7 +129,6 @@ namespace SharedPoolsOfWCFObjects
 
         public static void Main(string[] args)
         {
-            Console.WriteLine(System.Diagnostics.Process.GetCurrentProcess().PrivateMemorySize64);
             var test = new Program();
 
             if (test.ProcessRunOptions(args))

--- a/src/System.Private.ServiceModel/tests/Stress/SharedPoolsOfWCFObjects/RunReportingService.cs
+++ b/src/System.Private.ServiceModel/tests/Stress/SharedPoolsOfWCFObjects/RunReportingService.cs
@@ -23,6 +23,8 @@ namespace SharedPoolsOfWCFObjects
         private Func<Task<IStressDataCollector>> _ensureReportingChannelFunc = null;
 
         private RunId _rsRunId = null;
+        private int _heartBeatFailures = 0;
+        private const int MaxHeartBeatFailuresToReport = 10;
 
         public RunReportingService(string url)
         {
@@ -79,7 +81,15 @@ namespace SharedPoolsOfWCFObjects
                 }
                 catch (Exception e)
                 {
-                    Console.WriteLine("HeartBeat Failed " + e.ToString());
+                    var hb = Interlocked.Increment(ref _heartBeatFailures);
+                    if (hb < MaxHeartBeatFailuresToReport)
+                    {
+                        Console.WriteLine("HeartBeat Failed " + e.ToString());
+                    }
+                    else if (hb == MaxHeartBeatFailuresToReport)
+                    {
+                        Console.WriteLine("Too many heartbeat failures, ignoring from now.");
+                    }
                 }
             }
         }

--- a/src/System.Private.ServiceModel/tests/Stress/SharedPoolsOfWCFObjects/TestHelpers.cs
+++ b/src/System.Private.ServiceModel/tests/Stress/SharedPoolsOfWCFObjects/TestHelpers.cs
@@ -851,6 +851,14 @@ namespace SharedPoolsOfWCFObjects
             }
             return false;
         }
+
+        public static int SendTimeoutMs
+        {
+            get
+            {
+                return s_sendTimeoutMSeconds;
+            }
+        }
     }
 
 

--- a/src/System.Private.ServiceModel/tests/Stress/SharedPoolsOfWCFObjects/Tests/DuplexStreamingTest.cs
+++ b/src/System.Private.ServiceModel/tests/Stress/SharedPoolsOfWCFObjects/Tests/DuplexStreamingTest.cs
@@ -43,7 +43,7 @@ namespace SharedPoolsOfWCFObjects
 
     internal class DuplexStreamingTest<StreamingService, TestParams> : StreamingTest<StreamingService, TestParams>
         where TestParams : IExceptionHandlingPolicyParameter, IPoolTestParameter, IStatsCollectingTestParameter, IDuplexStreamingTestParams, IStreamingTestParams, new()
-        where StreamingService : IDuplexStreamingService
+        where StreamingService : class, IDuplexStreamingService
     {
         public override EndpointAddress CreateEndPointAddress()
         {

--- a/src/System.Private.ServiceModel/tests/Stress/SharedPoolsOfWCFObjects/Tests/DuplexTest.cs
+++ b/src/System.Private.ServiceModel/tests/Stress/SharedPoolsOfWCFObjects/Tests/DuplexTest.cs
@@ -54,12 +54,12 @@ namespace SharedPoolsOfWCFObjects
             var duplexCallback = new DuplexCallback();
             return TestHelpers.CreateDuplexChannelFactory<WcfService1.IDuplexService>(CreateEndPointAddress(), CreateBinding(), duplexCallback);
         }
-        public override Func<WcfService1.IDuplexService, int> UseChannel()
+        public override Func<WcfService1.IDuplexService, int> UseChannelImpl()
         {
             return (channel) =>
             {
                 int callbacks = _params.CallbacksToExpect;
-                int result = _useChannelStats.CallFuncAndRecordStats(() => { return channel.GetAsyncCallbackData(1, callbacks); }, RelaxedExceptionPolicy);
+                int result = channel.GetAsyncCallbackData(1, callbacks);
                 // we can't guarantee the correctness of the result in case of relaxed exception policy
                 if (!RelaxedExceptionPolicy)
                 {
@@ -72,12 +72,12 @@ namespace SharedPoolsOfWCFObjects
                 return callbacks + 1;
             };
         }
-        public override Func<WcfService1.IDuplexService, Task<int>> UseAsyncChannel()
+        public override Func<WcfService1.IDuplexService, Task<int>> UseAsyncChannelImpl()
         {
             return async (channel) =>
             {
                 int callbacks = _params.CallbacksToExpect;
-                int result = await _useChannelAsyncStats.CallAsyncFuncAndRecordStatsAsync<int>(() => channel.GetAsyncCallbackDataAsync(1, callbacks), RelaxedExceptionPolicy);
+                int result = await channel.GetAsyncCallbackDataAsync(1, callbacks);
 
                 // we can't guarantee the correctness of the result in case of relaxed exception policy
                 if (!RelaxedExceptionPolicy)

--- a/src/System.Private.ServiceModel/tests/Stress/SharedPoolsOfWCFObjects/Tests/HelloWorldTest.cs
+++ b/src/System.Private.ServiceModel/tests/Stress/SharedPoolsOfWCFObjects/Tests/HelloWorldTest.cs
@@ -11,19 +11,19 @@ namespace SharedPoolsOfWCFObjects
     public class HelloWorldTest<TestParams> : CommonTest<WcfService1.IService1, TestParams>
         where TestParams : IExceptionHandlingPolicyParameter, IPoolTestParameter, IStatsCollectingTestParameter, new()
     {
-        public override Func<WcfService1.IService1, int> UseChannel()
+        public override Func<WcfService1.IService1, int> UseChannelImpl()
         {
             return (channel) =>
             {
-                _useChannelStats.CallActionAndRecordStats(() => channel.GetData(44), RelaxedExceptionPolicy);
+                channel.GetData(44);
                 return 1;
             };
         }
-        public override Func<WcfService1.IService1, Task<int>> UseAsyncChannel()
+        public override Func<WcfService1.IService1, Task<int>> UseAsyncChannelImpl()
         {
             return async (channel) =>
             {
-                await _useChannelAsyncStats.CallAsyncFuncAndRecordStatsAsync(() => channel.GetDataAsync(44), RelaxedExceptionPolicy);
+                await channel.GetDataAsync(44);
                 return 1;
             };
         }
@@ -32,12 +32,11 @@ namespace SharedPoolsOfWCFObjects
     public class HelloWorldAPMTest<TestParams> : HelloWorldTest<TestParams>
         where TestParams : IExceptionHandlingPolicyParameter, IPoolTestParameter, IStatsCollectingTestParameter, new()
     {
-        public override Func<WcfService1.IService1, Task<int>> UseAsyncChannel()
+        public override Func<WcfService1.IService1, Task<int>> UseAsyncChannelImpl()
         {
             return async (channel) =>
             {
-                await _useChannelAsyncStats.CallAsyncFuncAndRecordStatsAsync(() => Task.Factory.FromAsync(channel.BeginGetData, channel.EndGetData, 44, null),
-                    RelaxedExceptionPolicy);
+                await Task.Factory.FromAsync(channel.BeginGetData, channel.EndGetData, 44, null);
                 return 1;
             };
         }

--- a/src/System.Private.ServiceModel/tests/Stress/SharedPoolsOfWCFObjects/Tests/ITestTemplate.cs
+++ b/src/System.Private.ServiceModel/tests/Stress/SharedPoolsOfWCFObjects/Tests/ITestTemplate.cs
@@ -42,6 +42,7 @@ namespace SharedPoolsOfWCFObjects
         Func<Exception, bool> ExceptionHandler { get; }
         bool ReplaceInvalidPooledFactories { get; }
         bool ReplaceInvalidPooledChannels { get; }
+        bool TrackServiceCallTimeouts { get; }
     }
 
     public interface IPoolTestParameter

--- a/src/System.Private.ServiceModel/tests/Stress/SharedPoolsOfWCFObjects/Tests/StreamingTest.cs
+++ b/src/System.Private.ServiceModel/tests/Stress/SharedPoolsOfWCFObjects/Tests/StreamingTest.cs
@@ -110,7 +110,7 @@ namespace SharedPoolsOfWCFObjects
 
     public class StreamingTest<StreamingService, TestParams> : CommonTest<StreamingService, TestParams>
         where TestParams : IExceptionHandlingPolicyParameter, IPoolTestParameter, IStatsCollectingTestParameter, IStreamingTestParams, new()
-        where StreamingService : IStreamingService
+        where StreamingService : class, IStreamingService
     {
         public override Binding CreateBinding()
         {
@@ -122,10 +122,9 @@ namespace SharedPoolsOfWCFObjects
             return TestHelpers.CreateEndPointStreamingAddress();
         }
 
-        public override Func<StreamingService, Task<int>> UseAsyncChannel()
+        public override Func<StreamingService, Task<int>> UseAsyncChannelImpl()
         {
-            return async (channel) =>
-                await _useChannelAsyncStats.CallAsyncFuncAndRecordStatsAsync(() => RunAllScenariosAsync(channel), RelaxedExceptionPolicy);
+            return async (channel) => await RunAllScenariosAsync(channel);
         }
         public async Task<int> RunAllScenariosAsync(StreamingService channel)
         {
@@ -187,12 +186,9 @@ namespace SharedPoolsOfWCFObjects
             }
         }
 
-        public override Func<StreamingService, int> UseChannel()
+        public override Func<StreamingService, int> UseChannelImpl()
         {
-            return (channel) =>
-            {
-                return _useChannelStats.CallFuncAndRecordStats(() => RunAllScenarios(channel), RelaxedExceptionPolicy);
-            };
+            return (channel) => RunAllScenarios(channel);
         }
         public int RunAllScenarios(StreamingService channel)
         {


### PR DESCRIPTION
This will allow us to detect stuck requests during stress (we saw signs of it in previous stress runs)