### PR TITLE
Adding unit test for ContractDescription.GetContract

### DIFF
--- a/src/System.ServiceModel.Primitives/ref/System.ServiceModel.Primitives.cs
+++ b/src/System.ServiceModel.Primitives/ref/System.ServiceModel.Primitives.cs
@@ -1274,7 +1274,7 @@ namespace System.ServiceModel.Description
         public string ConfigurationName { get { return default(string); } set { } }
         public System.Collections.ObjectModel.KeyedCollection<System.Type, System.ServiceModel.Description.IContractBehavior> ContractBehaviors { get { return default(System.Collections.ObjectModel.KeyedCollection<System.Type, System.ServiceModel.Description.IContractBehavior>); } }
         public System.Type ContractType { get { return default(System.Type); } set { } }
-        public System.ServiceModel.Description.ContractDescription GetContract(System.Type contractType) { return default(System.ServiceModel.Description.ContractDescription); }
+        public static System.ServiceModel.Description.ContractDescription GetContract(System.Type contractType) { return default(System.ServiceModel.Description.ContractDescription); }
         public string Name { get { return default(string); } set { } }
         public string Namespace { get { return default(string); } set { } }
         public System.ServiceModel.Description.OperationDescriptionCollection Operations { get { return default(System.ServiceModel.Description.OperationDescriptionCollection); } }

--- a/src/System.ServiceModel.Primitives/tests/Description/ContractDescriptionTest.cs
+++ b/src/System.ServiceModel.Primitives/tests/Description/ContractDescriptionTest.cs
@@ -192,4 +192,13 @@ public static class ContractDescriptionTest
         Assert.True(operation != null, "Failed to find Reply operation in contract.");
         Assert.True(operation.IsOneWay, "Expected Reply operation to be IsOneWay.");
     }
+
+    [WcfFact]
+    public static void ContractDescription_GetContract()
+    {
+        // Simple validation of the newly exposed "public ContractDescription GetContract(Type contractType);" method
+        ContractDescription contractDescription = ContractDescription.GetContract(typeof(IDescriptionTestsService));
+        Assert.True(String.Equals(typeof(IDescriptionTestsService).Name, contractDescription.ContractType.Name));
+        Assert.True(String.Equals("http://tempuri.org/", contractDescription.Namespace));
+    }
 }


### PR DESCRIPTION
* PR #1836 exposed a method in the ContractDescription class, this commit adds a simple test to validate this method.
* We already have extensive tests that validate the rest of the ContractDescription class.