### PR TITLE
Fix test project sync error in VSO

### DIFF
--- a/dir.targets
+++ b/dir.targets
@@ -109,6 +109,7 @@
   
   <!-- This import is needed because we're still using project.json to restore packages. 
        Once we switch to MSBuild it will automatically handle target imports from the packages themselves. -->
-  <Import Condition="'$(TargetGroup)'=='netstandard2.0'" Project="$(PackagesDir)NETStandard.Library\2.0.0-$(StandardExpectedPrerelease)\build\netstandard2.0\NETStandard.Library.targets" />
+  <Import Condition="'$(TargetGroup)'=='netstandard2.0' and Exists('$(PackagesDir)NETStandard.Library\2.0.0-$(StandardExpectedPrerelease)\build\netstandard2.0\NETStandard.Library.targets')"
+          Project="$(PackagesDir)NETStandard.Library\2.0.0-$(StandardExpectedPrerelease)\build\netstandard2.0\NETStandard.Library.targets" />
 
 </Project>


### PR DESCRIPTION
* Attempt to import the netstandard2.0 package fails during the sync.cmd step which is trying to do a package restore, at this point the package to import does not yet exist.