### PR TITLE
Removing extra slash from URLs generated by ServiceUtilHelper

### DIFF
--- a/src/System.Private.ServiceModel/tests/Common/Infrastructure/ServiceUtilHelper.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Infrastructure/ServiceUtilHelper.cs
@@ -412,7 +412,7 @@ public static class ServiceUtilHelper
 
     public static string GetEndpointAddress(string endpoint, string protocol = "http")
     {
-        return string.Format(@"{0}/{1}", BuildBaseUri(protocol), endpoint);
+        return string.Format(@"{0}{1}", BuildBaseUri(protocol), endpoint);
     }
 
     private static string GetResourceAddress(string resource, string protocol = "http")


### PR DESCRIPTION
BuildBaseUri() already leaves a trailing slash so we don't need to add an extra one when generating the endpoint address.