### PR TITLE
Fixing #1402

### DIFF
--- a/src/System.Private.ServiceModel/src/Internals/System/Runtime/Fx.cs
+++ b/src/System.Private.ServiceModel/src/Internals/System/Runtime/Fx.cs
@@ -288,6 +288,11 @@ namespace System.Runtime
             return (new AsyncThunk(callback)).ThunkFrame;
         }
 
+        public static Action<T1> ThunkCallback<T1>(Action<T1> callback)
+        {
+            return (new ActionThunk<T1>(callback)).ThunkFrame;
+        }
+
         [SuppressMessage(FxCop.Category.ReliabilityBasic, FxCop.Rule.UseNewGuidHelperRule,
             Justification = "These are the core methods that should be used for all other Guid(string) calls.")]
         public static Guid CreateGuid(string guidString)

--- a/src/System.Private.ServiceModel/src/Resources/Strings.resx
+++ b/src/System.Private.ServiceModel/src/Resources/Strings.resx
@@ -1950,4 +1950,10 @@
   <data name="SFxInvalidSoapAttribute" xml:space="preserve">
     <value>XmlSerializer attribute {0} is not valid in {1}. Only SoapElement attribute is supported.</value>
   </data>
+  <data name="SFxTerminatingOperationAlreadyCalled1" xml:space="preserve">
+    <value>This channel cannot send any more messages because IsTerminating operation '{0}' has already been called. </value>
+  </data>
+  <data name="SFxChannelTerminated0" xml:space="preserve">
+    <value>An operation marked as IsTerminating has already been invoked on this channel, causing the channel's connection to terminate.  No more operations may be invoked on this channel.  Please re-create the channel to continue communication.</value>
+  </data>
 </root>

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Description/ContractDescription.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Description/ContractDescription.cs
@@ -228,7 +228,7 @@ namespace System.ServiceModel.Description
                 operationDescription.EnsureInvariants();
                 if (operationDescription.IsInitiating)
                     thereIsAtLeastOneInitiatingOperation = true;
-                if ((!operationDescription.IsInitiating)
+                if ((!operationDescription.IsInitiating || operationDescription.IsTerminating)
                     && (this.SessionMode != SessionMode.Required))
                 {
                     throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Description/DispatcherBuilder.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Description/DispatcherBuilder.cs
@@ -134,6 +134,7 @@ namespace System.ServiceModel.Description
             child.EndMethod = operation.EndMethod;
             child.IsOneWay = operation.IsOneWay;
             child.IsInitiating = operation.IsInitiating;
+            child.IsTerminating = operation.IsTerminating;
             child.IsSessionOpenNotificationEnabled = operation.IsSessionOpenNotificationEnabled;
             for (int i = 0; i < operation.Faults.Count; i++)
             {
@@ -160,6 +161,7 @@ namespace System.ServiceModel.Description
 
             child.HasNoDisposableParameters = operation.HasNoDisposableParameters;
 
+            child.IsTerminating = operation.IsTerminating;
             child.IsSessionOpenNotificationEnabled = operation.IsSessionOpenNotificationEnabled;
             for (int i = 0; i < operation.Faults.Count; i++)
             {

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Description/OperationDescription.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Description/OperationDescription.cs
@@ -11,13 +11,14 @@ using System.Reflection;
 
 namespace System.ServiceModel.Description
 {
-    [DebuggerDisplay("Name={_name}, IsInitiating={_isInitiating}")]
+    [DebuggerDisplay("Name={_name}, IsInitiating={_isInitiating}, IsTerminating={_isTerminating}")]
     public class OperationDescription
     {
         internal const string SessionOpenedAction = Channels.WebSocketTransportSettings.ConnectionOpenedAction;
 
         private XmlName _name;
         private bool _isInitiating;
+        private bool _isTerminating;
         private bool _isSessionOpenNotificationEnabled;
         private ContractDescription _declaringContract;
         private FaultDescriptionCollection _faults;
@@ -49,6 +50,7 @@ namespace System.ServiceModel.Description
             }
             _declaringContract = declaringContract;
             _isInitiating = true;
+            _isTerminating = false;
             _faults = new FaultDescriptionCollection();
             _messages = new MessageDescriptionCollection();
             _behaviors = new KeyedByTypeCollection<IOperationBehavior>();
@@ -162,6 +164,12 @@ namespace System.ServiceModel.Description
         {
             EnsureInvariants();
             return Messages[0].Direction == MessageDirection.Output;
+        }
+
+        public bool IsTerminating
+        {
+            get { return _isTerminating; }
+            set { _isTerminating = value; }
         }
 
         public Collection<Type> KnownTypes

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Description/TypeLoader.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Description/TypeLoader.cs
@@ -954,6 +954,8 @@ namespace System.ServiceModel.Description
 
             OperationDescription operationDescription = new OperationDescription(operationName.EncodedName, declaringContract);
             operationDescription.IsInitiating = opAttr.IsInitiating;
+            operationDescription.IsTerminating = opAttr.IsTerminating;
+
             operationDescription.IsSessionOpenNotificationEnabled = opAttr.IsSessionOpenNotificationEnabled;
 
             operationDescription.HasNoDisposableParameters = ServiceReflector.HasNoDisposableParameters(methodInfo);

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Dispatcher/ClientOperation.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Dispatcher/ClientOperation.cs
@@ -37,6 +37,7 @@ namespace System.ServiceModel.Dispatcher
         private IClientFaultFormatter _faultFormatter;
         private bool _isInitiating = true;
         private bool _isOneWay;
+        private bool _isTerminating;
         private bool _isSessionOpenNotificationEnabled;
         private string _name;
 
@@ -190,6 +191,19 @@ namespace System.ServiceModel.Dispatcher
                 {
                     _parent.InvalidateRuntime();
                     _isOneWay = value;
+                }
+            }
+        }
+
+        public bool IsTerminating
+        {
+            get { return _isTerminating; }
+            set
+            {
+                lock (_parent.ThisLock)
+                {
+                    _parent.InvalidateRuntime();
+                    _isTerminating = value;
                 }
             }
         }

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Dispatcher/DispatchOperation.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Dispatcher/DispatchOperation.cs
@@ -14,6 +14,7 @@ namespace System.ServiceModel.Dispatcher
         private IDispatchMessageFormatter _formatter;
         private IDispatchFaultFormatter _faultFormatter;
         private IOperationInvoker _invoker;
+        private bool _isTerminating;
         private bool _isSessionOpenNotificationEnabled;
         private readonly string _name;
         private readonly SynchronizedCollection<IParameterInspector> _parameterInspectors;
@@ -144,6 +145,19 @@ namespace System.ServiceModel.Dispatcher
                 {
                     _parent.InvalidateRuntime();
                     _invoker = value;
+                }
+            }
+        }
+
+        public bool IsTerminating
+        {
+            get { return _isTerminating; }
+            set
+            {
+                lock (_parent.ThisLock)
+                {
+                    _parent.InvalidateRuntime();
+                    _isTerminating = value;
                 }
             }
         }

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Dispatcher/DispatchOperationRuntime.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Dispatcher/DispatchOperationRuntime.cs
@@ -23,6 +23,7 @@ namespace System.ServiceModel.Dispatcher
         private readonly IDispatchMessageFormatter _formatter;
         private IParameterInspector[] _inspectors;
         private readonly IOperationInvoker _invoker;
+        private readonly bool _isTerminating;
         private readonly bool _isSessionOpenNotificationEnabled;
         private readonly string _name;
         private readonly ImmutableDispatchRuntime _parent;
@@ -55,7 +56,7 @@ namespace System.ServiceModel.Dispatcher
             _serializeReply = operation.SerializeReply;
             _formatter = operation.Formatter;
             _invoker = operation.Invoker;
-
+            _isTerminating = operation.IsTerminating;
             _isSessionOpenNotificationEnabled = operation.IsSessionOpenNotificationEnabled;
             _action = operation.Action;
             _name = operation.Name;
@@ -96,6 +97,11 @@ namespace System.ServiceModel.Dispatcher
         internal bool IsOneWay
         {
             get { return _isOneWay; }
+        }
+
+        internal bool IsTerminating
+        {
+            get { return _isTerminating; }
         }
 
         internal string Name

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Dispatcher/ProxyOperationRuntime.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Dispatcher/ProxyOperationRuntime.cs
@@ -17,6 +17,7 @@ namespace System.ServiceModel.Dispatcher
         private readonly IClientMessageFormatter _formatter;
         private readonly bool _isInitiating;
         private readonly bool _isOneWay;
+        private readonly bool _isTerminating;
         private readonly bool _isSessionOpenNotificationEnabled;
         private readonly string _name;
         private readonly IParameterInspector[] _parameterInspectors;
@@ -46,6 +47,7 @@ namespace System.ServiceModel.Dispatcher
             _formatter = operation.Formatter;
             _isInitiating = operation.IsInitiating;
             _isOneWay = operation.IsOneWay;
+            _isTerminating = operation.IsTerminating;
             _isSessionOpenNotificationEnabled = operation.IsSessionOpenNotificationEnabled;
             _name = operation.Name;
             _parameterInspectors = EmptyArray<IParameterInspector>.ToArray(operation.ParameterInspectors);
@@ -104,6 +106,11 @@ namespace System.ServiceModel.Dispatcher
         internal bool IsOneWay
         {
             get { return _isOneWay; }
+        }
+
+        internal bool IsTerminating
+        {
+            get { return _isTerminating; }
         }
 
         internal bool IsSessionOpenNotificationEnabled

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Dispatcher/TerminatingOperationBehavior.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Dispatcher/TerminatingOperationBehavior.cs
@@ -1,0 +1,69 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+
+using System.ServiceModel.Channels;
+using System.ServiceModel.Description;
+using System.Collections.Generic;
+using System.Net.Sockets;
+using System.Reflection;
+using System.Runtime;
+using System.Threading;
+
+namespace System.ServiceModel.Dispatcher
+{
+    internal class TerminatingOperationBehavior
+    {
+        private static TimerCallback s_abortChannelTimerCallback = new TimerCallback(Fx.ThunkCallback<object>(AbortChannel));
+
+        private static void AbortChannel(object state)
+        {
+            ((IChannel)state).Abort();
+        }
+
+        public static TerminatingOperationBehavior CreateIfNecessary(DispatchRuntime dispatch)
+        {
+            if (IsTerminatingOperationBehaviorNeeded(dispatch))
+            {
+                return new TerminatingOperationBehavior();
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+        private static bool IsTerminatingOperationBehaviorNeeded(DispatchRuntime dispatch)
+        {
+            for (int i = 0; i < dispatch.Operations.Count; i++)
+            {
+                DispatchOperation operation = dispatch.Operations[i];
+
+                if (operation.IsTerminating)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        internal void AfterReply(ref MessageRpc rpc)
+        {
+            if (rpc.Operation.IsTerminating && rpc.Channel.HasSession)
+            {
+                var timer = new Timer(s_abortChannelTimerCallback, rpc.Channel.Binder.Channel, rpc.Channel.CloseTimeout, TimeSpan.FromMilliseconds(-1));
+            }
+        }
+
+        internal static void AfterReply(ref ProxyRpc rpc)
+        {
+            if (rpc.Operation.IsTerminating && rpc.Channel.HasSession)
+            {
+                IChannel sessionChannel = rpc.Channel.Binder.Channel;
+                rpc.Channel.Close(rpc.TimeoutHelper.RemainingTime());
+            }
+        }
+    }
+}

--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/ClientBase/SessionTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/ClientBase/SessionTests.cs
@@ -116,7 +116,6 @@ public static class SessionTests
         }
     }
 
-    [Issue(1402)]
     [WcfFact]
     [OuterLoop]
     public static void Test_Negative_Calling_Initiating_After_Calling_Terminating()
@@ -141,7 +140,6 @@ public static class SessionTests
         }
     }
 
-    [Issue(1402)]
     [WcfFact]
     [OuterLoop]
     public static void Test_Negative_Calling_Terminating_Twice()

--- a/src/System.ServiceModel.Primitives/ref/System.ServiceModel.Primitives.cs
+++ b/src/System.ServiceModel.Primitives/ref/System.ServiceModel.Primitives.cs
@@ -528,6 +528,8 @@ namespace System.ServiceModel
         public System.ServiceModel.Channels.MessageProperties OutgoingMessageProperties { get { return default(System.ServiceModel.Channels.MessageProperties); } }
         public System.ServiceModel.Channels.RequestContext RequestContext { get { return default(System.ServiceModel.Channels.RequestContext); } set { } }
         public event System.EventHandler OperationCompleted { add { } remove { } }
+        public T GetCallbackChannel<T>() { return default(T); }
+        public System.ServiceModel.IContextChannel Channel { get { return default(System.ServiceModel.IContextChannel); } }
     }
     public sealed partial class OperationContextScope : System.IDisposable
     {

--- a/src/System.ServiceModel.Primitives/tests/Description/OperationContractAttributeTest.cs
+++ b/src/System.ServiceModel.Primitives/tests/Description/OperationContractAttributeTest.cs
@@ -34,6 +34,19 @@ public static class OperationContractAttributeTest
         Assert.True(exception.Message.Contains("INonInitiatingNonTerminatingService"));
     }
 
+    [WcfFact]
+    public static void IsInitiating_And_IsTerminating_Method_Requires_Proper_SessionMode()
+    {
+        var channelFactory = CreateChannelFactoryHelper<IInitiatingTerminatingService>("net.tcp://localhost/dummy.svc");
+        // We no longer ignore IsTerminating = true in our contract invariant checks 
+        // so they will now fail if the ServiceContract's SessionMode isn't SessionMode.Required
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+        {
+            channelFactory.CreateChannel();
+        });
+        Assert.True(exception.Message.Contains("IInitiatingTerminatingService"));
+    }
+
     static ChannelFactory<T> CreateChannelFactoryHelper<T>(string url)
     {
         var helloEndpoint = new EndpointAddress(url);
@@ -46,6 +59,13 @@ public static class OperationContractAttributeTest
     public interface INonInitiatingNonTerminatingService
     {
         [OperationContract(IsInitiating = false, IsTerminating = false)]
+        int MethodA(int a);
+    }
+
+    [ServiceContract]
+    public interface IInitiatingTerminatingService
+    {
+        [OperationContract(IsInitiating = true, IsTerminating = true)]
         int MethodA(int a);
     }
 }


### PR DESCRIPTION
Fixing #1402
Removing IssueAttribute from failing session tests
Exposing OperationContext.GetCallbackChannel in the contract