### PR TITLE
Disable tests due to CoreFx breaking change.

### DIFF
--- a/src/System.Private.ServiceModel/tests/Scenarios/Infrastructure/SetupValidationTests.4.1.1.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Infrastructure/SetupValidationTests.4.1.1.cs
@@ -11,6 +11,7 @@ using Xunit;
 public class SetupValidationTests : ConditionalWcfTest
 {
     [WcfFact]
+    [Issue(1913, OS = OSID.AnyUnix)]
     [Issue(1886, OS = OSID.AnyOSX)]
     [Condition(nameof(Root_Certificate_Installed))]
     [OuterLoop]
@@ -36,6 +37,7 @@ public class SetupValidationTests : ConditionalWcfTest
     }
 
     [WcfFact]
+    [Issue(1913, OS = OSID.AnyUnix)]
     [Condition(nameof(Client_Certificate_Installed))]
     [OuterLoop]
     public static void Client_Certificate_Correctly_Installed()
@@ -60,6 +62,7 @@ public class SetupValidationTests : ConditionalWcfTest
     }
 
     [WcfFact]
+    [Issue(1913, OS = OSID.AnyUnix)]
     [Issue(1886, OS = OSID.AnyOSX)]
     [Condition(nameof(Peer_Certificate_Installed))]
     [OuterLoop]

--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Tcp/ClientCredentialTypeTests.4.1.1.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Tcp/ClientCredentialTypeTests.4.1.1.cs
@@ -14,6 +14,7 @@ using Xunit;
 public partial class Tcp_ClientCredentialTypeTests : ConditionalWcfTest
 {
     [WcfFact]
+    [Issue(1913, OS = OSID.AnyUnix)]
     [Issue(1886, OS = OSID.AnyOSX)]
     [Condition(nameof(Root_Certificate_Installed),
                nameof(Client_Certificate_Installed),


### PR DESCRIPTION
* Issue #1913: Breaking change from cofefx causing Peer trust scenarios to fail on Linux