### PR TITLE
Updated baseline for non-shared framework CoreFx packages ns1.3

### DIFF
--- a/src/System.Private.ServiceModel/pkg/System.Private.ServiceModel.pkgproj
+++ b/src/System.Private.ServiceModel/pkg/System.Private.ServiceModel.pkgproj
@@ -10,4 +10,15 @@
     <HarvestIncludePaths Include="runtimes/win7/lib/netstandard1.3" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+
+  <Target Name="SetDependencyVersion" AfterTargets="GetNuGetPackageDependencies">
+    <ItemGroup>
+      <Dependency Condition="'%(Identity)' == 'System.Reflection.DispatchProxy' AND '%(TargetFramework)' == 'netstandard1.3'">
+        <Version>4.3.0</Version>
+      </Dependency>
+      <Dependency Condition="'%(Identity)' == 'System.Security.Principal.Windows' AND '%(TargetFramework)' == 'netstandard1.3'">
+        <Version>4.3.0</Version>
+      </Dependency>
+    </ItemGroup>
+  </Target>
 </Project>


### PR DESCRIPTION
* Using 4.3.0 baseline for System.Reflection.DispatchProxy and System.Security.Principal.Windows in our NetStandard 1.3 dependency tree.