### PR TITLE
Disable PeerTrust certificate validation on OSX

### DIFF
--- a/src/System.Private.ServiceModel/src/Resources/Strings.resx
+++ b/src/System.Private.ServiceModel/src/Resources/Strings.resx
@@ -1968,4 +1968,7 @@
   <data name="SFxChannelTerminated0" xml:space="preserve">
     <value>An operation marked as IsTerminating has already been invoked on this channel, causing the channel's connection to terminate.  No more operations may be invoked on this channel.  Please re-create the channel to continue communication.</value>
   </data>
+  <data name="PeerTrustNotSupportedOnOSX" xml:space="preserve">
+    <value>Peer Trust certificate validation is not supported on OSX. See https://go.microsoft.com/fwlink/?linkid=849976 for details.</value>
+  </data>
 </root>

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/X509ServiceCertificateAuthentication.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/X509ServiceCertificateAuthentication.cs
@@ -5,6 +5,7 @@
 
 using System.IdentityModel.Selectors;
 using System.Runtime;
+using System.Runtime.InteropServices;
 using System.Security.Cryptography.X509Certificates;
 
 namespace System.ServiceModel.Security
@@ -59,6 +60,13 @@ namespace System.ServiceModel.Security
             set
             {
                 X509CertificateValidationModeHelper.Validate(value);
+
+                if ((value == X509CertificateValidationMode.PeerTrust || value == X509CertificateValidationMode.PeerOrChainTrust) && 
+                    RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+                {
+                    throw ExceptionHelper.PlatformNotSupported(SR.PeerTrustNotSupportedOnOSX);
+                }
+
                 ThrowIfImmutable();
                 _certificateValidationMode = value;
             }


### PR DESCRIPTION
This changes an exception happening deep inside a call stack which is non-obvious to an earlier exception with a message which the customer can easily reason about.