### PR TITLE
Enable test after Peer trust fix in CoreFx (for Release 2.0).

### DIFF
--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Tcp/ClientCredentialTypeTests.4.1.1.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Tcp/ClientCredentialTypeTests.4.1.1.cs
@@ -14,7 +14,6 @@ using Xunit;
 public partial class Tcp_ClientCredentialTypeTests : ConditionalWcfTest
 {
     [WcfFact]
-    [Issue(1913, OS = OSID.AnyUnix)]
     [Issue(1886, OS = OSID.AnyOSX)]
     [Condition(nameof(Root_Certificate_Installed),
                nameof(Client_Certificate_Installed),


### PR DESCRIPTION
* Re-enable test case NetTcp_SecModeTrans_CertValMode_PeerTrust_Succeeds_In_TrustedPeople to run on any unix.

PR #1949 for Master branch, release 2.1

Fixes #1913