### PR TITLE
Adding duplex session tests

### DIFF
--- a/src/System.Private.ServiceModel/tests/Common/Scenarios/Endpoints.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Scenarios/Endpoints.cs
@@ -559,6 +559,13 @@ public static partial class Endpoints
         }
     }
 
+    public static string Tcp_Session_Tests_Duplex_Service
+    {
+        get
+        {
+            return GetEndpointAddress("SessionTestsDuplexService.svc", protocol: "net.tcp");
+        }
+    }
 
     #endregion net.tcp Addresses
 }

--- a/src/System.Private.ServiceModel/tests/Common/Scenarios/ServiceInterfaces.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Scenarios/ServiceInterfaces.cs
@@ -580,6 +580,45 @@ public interface ISessionTestsShortTimeoutService : ISessionTestsDefaultService
 {
 }
 
+[ServiceContract(CallbackContract = typeof(ISessionTestsDuplexCallback), SessionMode = SessionMode.Required)]
+public interface ISessionTestsDuplexService
+{
+    [OperationContract]
+    int NonTerminatingMethodCallingDuplexCallbacks(
+       int callsToClientCallbackToMake,
+       int callsToTerminatingClientCallbackToMake,
+       int callsToClientSideOnlyTerminatingClientCallbackToMake,
+       int callsToNonTerminatingMethodToMakeInsideClientCallback,
+       int callsToTerminatingMethodToMakeInsideClientCallback);
+
+    [OperationContract]
+    int TerminatingMethodCallingDuplexCallbacks(
+        int callsToClientCallbackToMake,
+        int callsToTerminatingClientCallbackToMake,
+        int callsToClientSideOnlyTerminatingClientCallbackToMake,
+        int callsToNonTerminatingMethodToMakeInsideClientCallback,
+        int callsToTerminatingMethodToMakeInsideClientCallback);
+
+    [OperationContract(IsInitiating = true, IsTerminating = false)]
+    int NonTerminatingMethod();
+
+    [OperationContract(IsInitiating = true, IsTerminating = true)]
+    int TerminatingMethod();
+}
+
+[ServiceContract(SessionMode = SessionMode.Required)]
+public interface ISessionTestsDuplexCallback
+{
+    [OperationContract(IsInitiating = true, IsTerminating = false)]
+    int ClientCallback(int callsToNonTerminatingMethodToMake, int callsToTerminatingMethodToMake);
+
+    [OperationContract(IsInitiating = true, IsTerminating = true)]
+    int TerminatingClientCallback(int callsToNonTerminatingMethodToMake, int callsToTerminatingMethodToMake);
+
+    [OperationContract(IsInitiating = true, IsTerminating = true)]
+    int ClientSideOnlyTerminatingClientCallback(int callsToNonTerminatingMethodToMake, int callsToTerminatingMethodToMake);
+}
+
 [ServiceContract, XmlSerializerFormat]
 public interface IXmlSFAttribute
 {

--- a/src/System.Private.ServiceModel/tools/IISHostedWcfService/App_code/ISessionTests.cs
+++ b/src/System.Private.ServiceModel/tools/IISHostedWcfService/App_code/ISessionTests.cs
@@ -35,3 +35,43 @@ public class SessionTestsCompositeType
     [DataMember]
     public int MethodBValue { get; set; }
 }
+
+[ServiceContract(CallbackContract = typeof(ISessionTestsDuplexCallback), SessionMode = SessionMode.Required)]
+public interface ISessionTestsDuplexService
+{
+    [OperationContract(IsInitiating = true, IsTerminating = false)]
+    int NonTerminatingMethodCallingDuplexCallbacks(
+       int callsToClientCallbackToMake,
+       int callsToTerminatingClientCallbackToMake,
+       int callsToClientSideOnlyTerminatingClientCallbackToMake,
+       int callsToNonTerminatingMethodToMakeInsideClientCallback,
+       int callsToTerminatingMethodToMakeInsideClientCallback);
+
+    [OperationContract(IsInitiating = true, IsTerminating = true)]
+    int TerminatingMethodCallingDuplexCallbacks(
+        int callsToClientCallbackToMake,
+        int callsToTerminatingClientCallbackToMake,
+        int callsToClientSideOnlyTerminatingClientCallbackToMake,
+        int callsToNonTerminatingMethodToMakeInsideClientCallback,
+        int callsToTerminatingMethodToMakeInsideClientCallback);
+
+    [OperationContract]
+    int NonTerminatingMethod();
+
+    [OperationContract]
+    int TerminatingMethod();
+}
+
+[ServiceContract(SessionMode = SessionMode.Required)]
+public interface ISessionTestsDuplexCallback
+{
+    [OperationContract(IsInitiating = true, IsTerminating = false)]
+    int ClientCallback(int callsToNonTerminatingMethodToMake, int callsToTerminatingMethodToMake);
+
+    [OperationContract(IsInitiating = true, IsTerminating = true)]
+    int TerminatingClientCallback(int callsToNonTerminatingMethodToMake, int callsToTerminatingMethodToMake);
+
+    // note IsTerminating = false while the client callback has IsTerminating = true
+    [OperationContract(IsInitiating = true, IsTerminating = false)]
+    int ClientSideOnlyTerminatingClientCallback(int callsToNonTerminatingMethodToMake, int callsToTerminatingMethodToMake);
+}

--- a/src/System.Private.ServiceModel/tools/IISHostedWcfService/App_code/SessionTestsService.cs
+++ b/src/System.Private.ServiceModel/tools/IISHostedWcfService/App_code/SessionTestsService.cs
@@ -33,4 +33,146 @@ namespace WcfService
     public class SessionTestsShortTimeoutService : SessionTestsDefaultService, ISessionTestsShortTimeoutService
     {
     }
+
+    [ServiceBehavior(InstanceContextMode = InstanceContextMode.PerSession, ConcurrencyMode = ConcurrencyMode.Multiple)]
+    public class SessionTestsDuplexService : ISessionTestsDuplexService
+    {
+        /// <summary>
+        ///     This method is designed to test many intricacies of session-bound duplex calls 
+        ///     especially when terminating methods are involved on both sides.
+        ///     All calls are made sequentially to avoid possible inconsistencies due to concurrency
+        /// </summary>
+        /// <param name="callsToClientCallbackToMake">
+        ///     number of times to call a non terminating "ClientCallback" client callback method </param>
+        /// <param name="callsToTerminatingClientCallbackToMake">
+        ///     number of times to call a terminating "TerminatingClientCallback" client callback method </param>
+        /// <param name="callsToClientSideOnlyTerminatingClientCallbackToMake">
+        ///     same as callsToTerminatingClientCallbackToMake except for the client callback is marked 
+        ///     as IsTerminating=true only on the client side.
+        ///
+        ///     Even though this particular combination is allowed it steps into an uncommon area where 
+        ///     the client's and server's OperationContract don't match. 
+        ///     We only test this particular case because it affects which calls will fail or pass. </param>
+        /// <param name="callsToNonTerminatingMethodToMakeInsideClientCallback">
+        ///     number of times client callback needs to call our NonTerminatingMethod </param>
+        /// <param name="callsToTerminatingMethodToMakeInsideTerminatingClientCallback">
+        ///     number of times terminating client callback needs to call our "TerminatingMethod" </param>
+        ///
+        /// <returns>
+        ///     total number of calls made
+        /// </returns>
+        public int NonTerminatingMethodCallingDuplexCallbacks(
+            int callsToClientCallbackToMake,
+            int callsToTerminatingClientCallbackToMake,
+            int callsToClientSideOnlyTerminatingClientCallbackToMake,
+            int callsToNonTerminatingMethodToMakeInsideClientCallback,
+            int callsToTerminatingMethodToMakeInsideClientCallback)
+        {
+            return MethodCallingDuplexCallbacks(
+                callsToClientCallbackToMake,
+                callsToTerminatingClientCallbackToMake,
+                callsToClientSideOnlyTerminatingClientCallbackToMake,
+                callsToNonTerminatingMethodToMakeInsideClientCallback,
+                callsToTerminatingMethodToMakeInsideClientCallback);
+        }
+
+        /// <summary>
+        ///     Essentially the same as NonTerminatingMethodCallingDuplexCallbacks. 
+        ///     The only difference is it is marked as IsTerminating=true on the client side
+        /// </summary>
+        public int TerminatingMethodCallingDuplexCallbacks(
+            int callsToClientCallbackToMake,
+            int callsToTerminatingClientCallbackToMake,
+            int callsToClientSideOnlyTerminatingClientCallbackToMake,
+            int callsToNonTerminatingMethodToMakeInsideClientCallback,
+            int callsToTerminatingMethodToMakeInsideClientCallback)
+        {
+            return MethodCallingDuplexCallbacks(
+                callsToClientCallbackToMake,
+                callsToTerminatingClientCallbackToMake,
+                callsToClientSideOnlyTerminatingClientCallbackToMake,
+                callsToNonTerminatingMethodToMakeInsideClientCallback,
+                callsToTerminatingMethodToMakeInsideClientCallback);
+        }
+
+        private int MethodCallingDuplexCallbacks(
+            int callsToClientCallbackToMake,
+            int callsToTerminatingClientCallbackToMake,
+            int callsToClientSideOnlyTerminatingClientCallbackToMake,
+            int callsToNonTerminatingMethodToMakeInsideClientCallback,
+            int callsToTerminatingMethodToMakeInsideClientCallback)
+        {
+            int numCalls = 1;  // 1 - for this call
+            var cb = OperationContext.Current.GetCallbackChannel<ISessionTestsDuplexCallback>();
+
+            // we keep these for debugging purposes
+            ((IContextChannel)cb).Closing += (sender, e) =>
+            {
+                System.Console.WriteLine("Closing");
+            };
+            ((IContextChannel)cb).Closed += (sender, e) =>
+            {
+                System.Console.WriteLine("Closed");
+            };
+            ((IContextChannel)cb).Faulted += (sender, e) =>
+            {
+                System.Console.WriteLine("Faulted");
+            };
+
+            // Rather than dealing with a large number of combinations of various exceptions arising from both sides,
+            // the test is structured to return the total count of successful calls that were made both directions.
+
+            // Terminating ones go first
+            for (int i = 0; i < callsToTerminatingClientCallbackToMake; i++)
+            {
+                try
+                {
+                    numCalls += cb.TerminatingClientCallback(
+                        callsToNonTerminatingMethodToMakeInsideClientCallback,
+                        callsToTerminatingMethodToMakeInsideClientCallback);
+                }
+                catch
+                {
+                }
+            }
+
+            for (int i = 0; i < callsToClientSideOnlyTerminatingClientCallbackToMake; i++)
+            {
+                try
+                {
+                    numCalls += cb.ClientSideOnlyTerminatingClientCallback(
+                        callsToNonTerminatingMethodToMakeInsideClientCallback,
+                        callsToTerminatingMethodToMakeInsideClientCallback);
+                }
+                catch
+                {
+                }
+            }
+
+            for (int i = 0; i < callsToClientCallbackToMake; i++)
+            {
+                try
+                {
+                    numCalls += cb.ClientCallback(
+                        callsToNonTerminatingMethodToMakeInsideClientCallback,
+                        callsToTerminatingMethodToMakeInsideClientCallback);
+                }
+                catch
+                {
+                }
+            }
+
+            return numCalls;
+        }
+
+        public int NonTerminatingMethod()
+        {
+            return 1;
+        }
+
+        public int TerminatingMethod()
+        {
+            return 1;
+        }
+    }
 }

--- a/src/System.Private.ServiceModel/tools/IISHostedWcfService/App_code/testhosts/TcpSessionTestServiceHost.cs
+++ b/src/System.Private.ServiceModel/tools/IISHostedWcfService/App_code/testhosts/TcpSessionTestServiceHost.cs
@@ -56,4 +56,26 @@ namespace WcfService
         {
         }
     }
+
+    public class TcpSessionDuplexTestServiceHostFactory : ServiceHostFactory
+    {
+        protected override ServiceHost CreateServiceHost(Type serviceType, Uri[] baseAddresses)
+        {
+            TcpSessionDuplexTestServiceHost serviceHost = new TcpSessionDuplexTestServiceHost(serviceType, baseAddresses);
+            return serviceHost;
+        }
+    }
+    public class TcpSessionDuplexTestServiceHost : TestServiceHostBase<ISessionTestsDuplexService>
+    {
+        protected override string Address { get { return ""; } }
+        protected override Binding GetBinding()
+        {
+            return new NetTcpBinding(SecurityMode.None) { PortSharingEnabled = false};
+        }
+
+        public TcpSessionDuplexTestServiceHost(Type serviceType, params Uri[] baseAddresses)
+            : base(serviceType, baseAddresses)
+        {
+        }
+    }
 }

--- a/src/System.Private.ServiceModel/tools/IISHostedWcfService/Web.config
+++ b/src/System.Private.ServiceModel/tools/IISHostedWcfService/Web.config
@@ -78,6 +78,7 @@
         <add factory="WcfService.TcpCertificateValidationPeerTrustTestServiceHostFactory" service="WcfService.WcfService" relativeAddress="~\NetTcpCertValModePeerTrust.svc" />
         <add factory="WcfService.TcpSessionTestServiceHostFactory" service="WcfService.SessionTestsDefaultService" relativeAddress="~\SessionTestsDefaultService.svc" />
         <add factory="WcfService.TcpSessionShortTimeoutTestServiceHostFactory" service="WcfService.SessionTestsShortTimeoutService" relativeAddress="~\SessionTestsShortTimeoutService.svc" />
+        <add factory="WcfService.TcpSessionDuplexTestServiceHostFactory" service="WcfService.SessionTestsDuplexService" relativeAddress="~\SessionTestsDuplexService.svc" />
         <add factory="WcfService.DuplexWebSocketTestServiceHostFactory" service="WcfService.WcfWebSocketService" relativeAddress="~\DuplexWebSocket.svc" />
         <add factory="WcfService.WebSocketTransportTestServiceHostFactory" service="WcfService.WcfWebSocketTransportUsageAlwaysService" relativeAddress="~\WebSocketTransport.svc" />
         <add factory="WcfService.WebSocketHttpDuplexBinaryStreamedTestServiceHostFactory" service="WcfService.WSDuplexService" relativeAddress="~\WebSocketHttpDuplexBinaryStreamed.svc" />

--- a/src/System.Private.ServiceModel/tools/SelfHostedWcfService/Program.cs
+++ b/src/System.Private.ServiceModel/tools/SelfHostedWcfService/Program.cs
@@ -94,6 +94,7 @@ namespace SelfHostedWCFService
             CreateHost<TcpCertificateValidationPeerTrustTestServiceHost, WcfService.WcfService>("NetTcpCertValModePeerTrust.svc", tcpBaseAddress);
             CreateHost<TcpSessionTestServiceHost, WcfService.SessionTestsDefaultService>("SessionTestsDefaultService.svc", tcpBaseAddress);
             CreateHost<TcpSessionShortTimeoutTestServiceHost, WcfService.SessionTestsShortTimeoutService>("SessionTestsShortTimeoutService.svc", tcpBaseAddress);
+            CreateHost<TcpSessionDuplexTestServiceHost, WcfService.SessionTestsDuplexService>("SessionTestsDuplexService.svc", tcpBaseAddress);
             CreateHost<DuplexWebSocketTestServiceHost, WcfWebSocketService>("DuplexWebSocket.svc", websocketBaseAddress);
             CreateHost<WebSocketTransportTestServiceHost, WcfWebSocketTransportUsageAlwaysService>("WebSocketTransport.svc", websocketBaseAddress);
             CreateHost<WebSocketHttpDuplexBinaryStreamedTestServiceHost, WSDuplexService>("WebSocketHttpDuplexBinaryStreamed.svc", websocketBaseAddress);


### PR DESCRIPTION
This fixes #1933 and #1902
Some of the scenarios are currently blocked by #1959 and had to be disabled.