### PR TITLE
Update the release 2.0.0 branch to reference WCF pkgs built in same b…

### DIFF
--- a/dependencies.props
+++ b/dependencies.props
@@ -2,61 +2,76 @@
   <!-- Source of truth for dependency tooling: the commit hash of the dotnet/versions master branch as of the last auto-upgrade. -->
   <PropertyGroup>
     <CoreFxCurrentRef>534770cbd98c4083de4d93b809f2e0968f0f856a</CoreFxCurrentRef>
-    <WCFCurrentRef>c9a03fe0c3309508cb509a4ffdd6dc8b79ed525e</WCFCurrentRef>
+    <WCFCurrentRef>a2ba4d6141ef25bdb4c2d2c014b9e1f305a0ea90</WCFCurrentRef>
     <StandardCurrentRef>8f8313cbe4b0f4d89c4d0835e08e3e340a18eec0</StandardCurrentRef>
+    <CoreSetupCurrentRef>c2c072242cb0bdea99efb7349d69492f83200a7d</CoreSetupCurrentRef>
   </PropertyGroup>
 
   <!-- Auto-upgraded properties for each build info dependency. -->
   <PropertyGroup>
     <CoreFxExpectedPrerelease>preview2-25405-01</CoreFxExpectedPrerelease>
+    <WcfExpectedPrerelease>preview2-25413-01</WcfExpectedPrerelease>
     <NETStandardPackageVersion>2.0.0-preview2-25401-01</NETStandardPackageVersion>
     <NETStandardPackageId>NETStandard.Library</NETStandardPackageId>
+    <MicrosoftNETCoreAppPackageVersion>2.0.0-preview2-25407-01</MicrosoftNETCoreAppPackageVersion>
   </PropertyGroup>
 
   <!-- Full package version strings that are used in other parts of the build. -->
   <PropertyGroup>
     <AppXRunnerVersion>1.0.3-prerelease-00921-01</AppXRunnerVersion>
-    <MicrosoftNETCoreAppPackageVersion>2.0.0-preview2-25407-01</MicrosoftNETCoreAppPackageVersion>
   </PropertyGroup>
 
   <!-- Package dependency verification/auto-upgrade configuration. -->
   <PropertyGroup>
     <BaseDotNetBuildInfo>build-info/dotnet/</BaseDotNetBuildInfo>
-    <DependencyBranch>master</DependencyBranch>
     <CoreDependencyBranch>release/2.0.0</CoreDependencyBranch>
     <CurrentRefXmlPath>$(MSBuildThisFileFullPath)</CurrentRefXmlPath>
   </PropertyGroup>
 
   <ItemGroup>
-    <RemoteDependencyBuildInfo Include="WCF">
-      <BuildInfoPath>$(BaseDotNetBuildInfo)wcf/$(DependencyBranch)</BuildInfoPath>
+    <!--<RemoteDependencyBuildInfo Include="WCF">
+      <BuildInfoPath>$(BaseDotNetBuildInfo)wcf/$(CoreDependencyBranch)</BuildInfoPath>
       <CurrentRef>$(WCFCurrentRef)</CurrentRef>
     </RemoteDependencyBuildInfo>
     <RemoteDependencyBuildInfo Include="CoreFx">
       <BuildInfoPath>$(BaseDotNetBuildInfo)corefx/$(CoreDependencyBranch)</BuildInfoPath>
       <CurrentRef>$(CoreFxCurrentRef)</CurrentRef>
-      <!-- manually pick up a new baseline in order to get package dependencies updated -->
+      --><!-- manually pick up a new baseline in order to get package dependencies updated --><!--
       <DisabledPackages>Microsoft.Private.PackageBaseline</DisabledPackages>
     </RemoteDependencyBuildInfo>
     <RemoteDependencyBuildInfo Include="Standard">
       <BuildInfoPath>$(BaseDotNetBuildInfo)standard/$(CoreDependencyBranch)</BuildInfoPath>
       <CurrentRef>$(StandardCurrentRef)</CurrentRef>
     </RemoteDependencyBuildInfo>
+    <RemoteDependencyBuildInfo Include="CoreSetup">
+      <BuildInfoPath>$(BaseDotNetBuildInfo)core-setup/$(CoreDependencyBranch)</BuildInfoPath>
+      <CurrentRef>$(CoreSetupCurrentRef)</CurrentRef>
+    </RemoteDependencyBuildInfo>-->
 
     <DependencyBuildInfo Include="@(RemoteDependencyBuildInfo)">
       <RawVersionsBaseUrl>https://raw.githubusercontent.com/dotnet/versions</RawVersionsBaseUrl>
     </DependencyBuildInfo>
 
-    <XmlUpdateStep Include="CoreFx">
+    <!--<XmlUpdateStep Include="CoreFx">
       <Path>$(MSBuildThisFileFullPath)</Path>
       <ElementName>CoreFxExpectedPrerelease</ElementName>
       <BuildInfoName>CoreFx</BuildInfoName>
+    </XmlUpdateStep>
+    <XmlUpdateStep Include="WCF">
+      <Path>$(MSBuildThisFileFullPath)</Path>
+      <ElementName>WcfExpectedPrerelease</ElementName>
+      <BuildInfoName>WCF</BuildInfoName>
     </XmlUpdateStep>
     <XmlUpdateStep Include="Standard">
       <Path>$(MSBuildThisFileFullPath)</Path>
       <ElementName>NETStandardPackageVersion</ElementName>
       <PackageId>$(NETStandardPackageId)</PackageId>
     </XmlUpdateStep>
+    <XmlUpdateStep Include="CoreSetup">
+      <Path>$(MSBuildThisFileFullPath)</Path>
+      <ElementName>MicrosoftNETCoreAppPackageVersion</ElementName>
+      <PackageId>Microsoft.NETCore.App</PackageId>
+    </XmlUpdateStep>-->
   </ItemGroup>
 
   <!-- Set up dependencies on packages that aren't found in a BuildInfo. -->

--- a/src/Common/test-runtime/project.json
+++ b/src/Common/test-runtime/project.json
@@ -13,11 +13,11 @@
         "Microsoft.xunit.netcore.extensions": "1.0.1-prerelease-01001-04",
         "System.Reflection.DispatchProxy": "4.4.0-preview2-25405-01",
         "System.Net.Http.WinHttpHandler": "4.4.0-preview2-25405-01",
-        "System.ServiceModel.Duplex": "4.4.0-preview1-25302-01",
-        "System.ServiceModel.Http": "4.4.0-preview1-25302-01",
-        "System.ServiceModel.NetTcp": "4.4.0-preview1-25302-01",
-        "System.ServiceModel.Primitives": "4.4.0-preview1-25302-01",
-        "System.ServiceModel.Security": "4.4.0-preview1-25302-01"
+        "System.ServiceModel.Duplex": "4.4.0-preview2-25413-01",
+        "System.ServiceModel.Http": "4.4.0-preview2-25413-01",
+        "System.ServiceModel.NetTcp": "4.4.0-preview2-25413-01",
+        "System.ServiceModel.Primitives": "4.4.0-preview2-25413-01",
+        "System.ServiceModel.Security": "4.4.0-preview2-25413-01"
       }
     },
     "netcoreapp2.0": {
@@ -31,11 +31,11 @@
         "xunit.console.netcore": "1.0.3-prerelease-00925-01",
         "Microsoft.xunit.netcore.extensions": "1.0.1-prerelease-01001-04",
         "System.Net.Http.WinHttpHandler": "4.4.0-preview2-25405-01",
-        "System.ServiceModel.Duplex": "4.4.0-preview1-25302-01",
-        "System.ServiceModel.Http": "4.4.0-preview1-25302-01",
-        "System.ServiceModel.NetTcp": "4.4.0-preview1-25302-01",
-        "System.ServiceModel.Primitives": "4.4.0-preview1-25302-01",
-        "System.ServiceModel.Security": "4.4.0-preview1-25302-01",
+        "System.ServiceModel.Duplex": "4.4.0-preview2-25413-01",
+        "System.ServiceModel.Http": "4.4.0-preview2-25413-01",
+        "System.ServiceModel.NetTcp": "4.4.0-preview2-25413-01",
+        "System.ServiceModel.Primitives": "4.4.0-preview2-25413-01",
+        "System.ServiceModel.Security": "4.4.0-preview2-25413-01",
         "Microsoft.CSharp": {
           "version": "4.3.0",
           "exclude": "all"

--- a/src/System.ServiceModel.Duplex/ref/project.json
+++ b/src/System.ServiceModel.Duplex/ref/project.json
@@ -4,7 +4,7 @@
       "dependencies": {
         "NETStandard.Library": "2.0.0-preview2-25401-01",
         "System.Security.Principal.Windows": "4.4.0-preview2-25405-01",
-        "System.ServiceModel.Primitives": "4.4.0-preview1-25302-01",
+        "System.ServiceModel.Primitives": "4.4.0-preview2-25413-01",
         "System.Reflection.DispatchProxy": "4.4.0-preview2-25405-01",
         "System.Runtime.InteropServices.RuntimeInformation": "4.4.0-preview1-25218-03"
       }

--- a/src/System.ServiceModel.Http/ref/project.json
+++ b/src/System.ServiceModel.Http/ref/project.json
@@ -4,7 +4,7 @@
       "dependencies": {
         "NETStandard.Library": "2.0.0-preview2-25401-01",
         "System.Security.Principal.Windows": "4.4.0-preview2-25405-01",
-        "System.ServiceModel.Primitives": "4.4.0-preview1-25302-01",
+        "System.ServiceModel.Primitives": "4.4.0-preview2-25413-01",
         "System.Reflection.DispatchProxy": "4.4.0-preview2-25405-01",
         "System.Runtime.InteropServices.RuntimeInformation": "4.4.0-preview1-25218-03"
       }

--- a/src/System.ServiceModel.NetTcp/ref/project.json
+++ b/src/System.ServiceModel.NetTcp/ref/project.json
@@ -4,7 +4,7 @@
       "dependencies": {
         "NETStandard.Library": "2.0.0-preview2-25401-01",
         "System.Security.Principal.Windows": "4.4.0-preview2-25405-01",
-        "System.ServiceModel.Primitives": "4.4.0-preview1-25302-01",
+        "System.ServiceModel.Primitives": "4.4.0-preview2-25413-01",
         "System.Reflection.DispatchProxy": "4.4.0-preview2-25405-01",
         "System.Runtime.InteropServices.RuntimeInformation": "4.4.0-preview1-25218-03"
       }

--- a/src/System.ServiceModel.Security/ref/project.json
+++ b/src/System.ServiceModel.Security/ref/project.json
@@ -4,7 +4,7 @@
       "dependencies": {
         "NETStandard.Library": "2.0.0-preview2-25401-01",
         "System.Security.Principal.Windows": "4.4.0-preview2-25405-01",
-        "System.ServiceModel.Primitives": "4.4.0-preview1-25302-01",
+        "System.ServiceModel.Primitives": "4.4.0-preview2-25413-01",
         "System.Reflection.DispatchProxy": "4.4.0-preview2-25405-01",
         "System.Runtime.InteropServices.RuntimeInformation": "4.4.0-preview1-25218-03"
       }


### PR DESCRIPTION
…ranch.

* Also adding CoreSetup for updating "Microsoft.NETCore.App".
* Commenting out all RemoteDependencyBuildInfo and their matching XmlUpdateSteps.
* As of this PR these dependencies are the official candidates for release 2.0.0.

        - CoreFx packages: 4.4.0-preview2-25405-01
        - "NETStandard.Library": 2.0.0-preview2-25401-01
        - "Microsoft.NETCore.App": 2.0.0-preview2-25407-01
        - WCF Packages: 4.4.0-preview2-25413-01