### PR TITLE
Harvest old netcore50 asset and insert into package.

### DIFF
--- a/src/System.Private.ServiceModel/pkg/System.Private.ServiceModel.pkgproj
+++ b/src/System.Private.ServiceModel/pkg/System.Private.ServiceModel.pkgproj
@@ -8,6 +8,7 @@
     <ProjectReference Include="..\src\System.Private.ServiceModel.builds" />
     <HarvestIncludePaths Include="runtimes/unix/lib/netstandard1.3" />
     <HarvestIncludePaths Include="runtimes/win7/lib/netstandard1.3" />
+    <HarvestIncludePaths Include="runtimes/win7/lib/netcore50" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 


### PR DESCRIPTION
After moving to netstandard2.0 netcore50 assets were lost, harvesting the old ones and inserting them to the package for now until we can replace it with newly built versions of WCF for UWP, coming soon.