### PR TITLE
depproj fixes for uapaot framework testing

### DIFF
--- a/external/corefx-runtime/Configurations.props
+++ b/external/corefx-runtime/Configurations.props
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <BuildConfigurations>
+      netcoreapp-Windows_NT;
+      netcoreapp-Unix;
+      uap-Windows_NT;
+      uapaot-Windows_NT;
+    </BuildConfigurations>
+  </PropertyGroup>
+</Project>

--- a/external/corefx-runtime/corefx-runtime.depproj
+++ b/external/corefx-runtime/corefx-runtime.depproj
@@ -1,0 +1,30 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <!-- support cross-targeting by choosing a RID to restore when running on a different machine that what we're build for -->
+    <NugetRuntimeIdentifier Condition="'$(OSGroup)' == 'Windows_NT' AND '$(RunningOnUnix)' == 'true'">win7-x64</NugetRuntimeIdentifier>
+    <NugetRuntimeIdentifier Condition="'$(OSGroup)' == 'Unix' AND '$(RunningOnUnix)' != 'true'">ubuntu.14.04-x64</NugetRuntimeIdentifier>
+    <NugetRuntimeIdentifier Condition="'$(TargetGroup)' == 'uap'">win10-$(ArchGroup)</NugetRuntimeIdentifier>
+    <NugetRuntimeIdentifier Condition="'$(TargetGroup)' == 'uapaot'">win10-$(ArchGroup)-aot</NugetRuntimeIdentifier>
+    <RidSpecificAssets>true</RidSpecificAssets>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="@(RefAndRuntimePackageReference)" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetGroup)' == 'netstandard' or
+                        '$(TargetGroup)' == 'netcoreapp'">
+    <PackageReference Include="System.Security.Principal.Windows">
+      <Version>$(MicrosoftPrivateCoreFxNETCoreAppPackageVersion)</Version>
+    </PackageReference>
+
+    <PackageReference Include="System.Net.Http.WinHttpHandler"
+                      Condition="'$(TargetsWindows)'=='true'">
+      <Version>$(MicrosoftPrivateCoreFxNETCoreAppPackageVersion)</Version>
+    </PackageReference>
+  </ItemGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/external/corefx-runtime/corefx-runtime.depproj
+++ b/external/corefx-runtime/corefx-runtime.depproj
@@ -14,8 +14,7 @@
     <PackageReference Include="@(RefAndRuntimePackageReference)" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetGroup)' == 'netstandard' or
-                        '$(TargetGroup)' == 'netcoreapp'">
+  <ItemGroup Condition="'$(TargetGroup)' == 'netcoreapp'">
     <PackageReference Include="System.Security.Principal.Windows">
       <Version>$(MicrosoftPrivateCoreFxNETCoreAppPackageVersion)</Version>
     </PackageReference>

--- a/external/dir.proj
+++ b/external/dir.proj
@@ -10,6 +10,7 @@
     <Project Include="netstandard/netstandard.depproj" />
     <Project Include="netfx/netfx.depproj" />
     <Project Include="runtime/runtime.depproj" />
+    <Project Include="corefx-runtime/corefx-runtime.depproj" />
     <Project Include="test-runtime/XUnit.Runtime.depproj" />
     <Project Include="harvestPackages/harvestPackages.netstandard1.6.depproj" />
     <Project Include="winrt/winrt.depproj" />

--- a/external/runtime/runtime.depproj
+++ b/external/runtime/runtime.depproj
@@ -48,22 +48,6 @@
     </PackageReference>
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="@(RefAndRuntimePackageReference)" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetGroup)' == 'netstandard' or
-                        '$(TargetGroup)' == 'netcoreapp'">
-    <PackageReference Include="System.Security.Principal.Windows">
-      <Version>$(MicrosoftPrivateCoreFxNETCoreAppPackageVersion)</Version>
-    </PackageReference>
-
-    <PackageReference Include="System.Net.Http.WinHttpHandler"
-                      Condition="'$(TargetsWindows)'=='true'">
-      <Version>$(MicrosoftPrivateCoreFxNETCoreAppPackageVersion)</Version>
-    </PackageReference>
-  </ItemGroup>
-
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 
   <!-- Setup the testing shared framework host -->

--- a/external/test-runtime/XUnit.Runtime.depproj
+++ b/external/test-runtime/XUnit.Runtime.depproj
@@ -157,19 +157,6 @@
           DestinationFiles="$(TestHostRootPath)\TestILC\%(TestILCFolderContents.RecursiveDir)%(TestILCFolderContents.Filename)%(TestILCFolderContents.Extension)"
           SkipUnchangedFiles="true" />
 
-    <!--
-      Copy clrcompression.dll into ILCInputFolder. This is needed in WCF and not
-      CoreFX: in CoreFX, clrcompression.dll is a build output.
-
-      Without clrcompression.dll, the xunit runner no-ops when using RunTests.
-      It works during a vertical build because Run.cmd adds environment
-      variables that allow the runner to find the BuildTools clrcompression.dll.
-    -->
-    <Copy Condition="'$(TestILCFolder)'!=''"
-          SourceFiles="$(TestILCFolder)\ExternalFiles\Framework\clrcompression.dll"
-          DestinationFiles="$(TestHostRootPath)\ILCInputFolder\clrcompression.dll"
-          SkipUnchangedFiles="true" />
-
   </Target>
 
   <Target Name="AddXunitConsoleRunner" BeforeTargets="ResolveReferences" Condition="'$(TargetGroup)' == 'netfx'">


### PR DESCRIPTION
 * Get clrcompression.dll from CoreFX package
 * Create corefx-runtime.depproj for specific CoreFX assembly placement

Applied @joperezr's suggestions, and they worked: `build.cmd -framework=uapaot -tests` runs cleanly on my machine.

Something I didn't do is move the `Microsoft.Private.CoreFx.UAP` ref copying into a new depproj: I left it in `netstandard.depproj` for now. For clarity, it makes sense to me to move it to a new depproj (the `uap;` in `netstandard/Configurations.props` seems weird) but it didn't seem needed. I couldn't figure out how to make a single `corefx.depproj` that deploys both ref and runtimes, otherwise I would have done that.

Fixes https://github.com/dotnet/wcf/issues/2019