### PR TITLE
Enable WCF to Use ReflectionBased Serialization on Uapaot

### DIFF
--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Description/XmlSerializerOperationBehavior.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Description/XmlSerializerOperationBehavior.cs
@@ -1127,16 +1127,24 @@ namespace System.ServiceModel.Description
         private static XmlSerializer[] FromMappingsViaInjection(XmlMapping[] mappings, Type type)
         {
             XmlSerializer[] serializers = new XmlSerializer[mappings.Length];
+
+            bool generatedSerializerNotFound = false;
             for (int i = 0; i < serializers.Length; i++)
             {
                 Type t;
                 GeneratedXmlSerializers.GetGeneratedSerializers().TryGetValue(mappings[i].GetKey(), out t);
                 if (t == null)
                 {
-                    throw new InvalidOperationException(SR.Format(SR.SFxXmlSerializerIsNotFound, type));
+                    generatedSerializerNotFound = true;
+                    break;
                 }
 
                 serializers[i] = new XmlSerializer(t);
+            }
+
+            if (generatedSerializerNotFound)
+            {
+                return XmlSerializer.FromMappings(mappings, type);
             }
 
             return serializers;


### PR DESCRIPTION
The fix is to enable WCF to use ReflectionBased serialization for soap encoded message on uapaot.

Fix #2017