### PR TITLE
Restore CoreFX runtimes and refs in one depproj

### DIFF
--- a/external/corefx/Configurations.props
+++ b/external/corefx/Configurations.props
@@ -2,8 +2,9 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <BuildConfigurations>
-      netcoreapp-Windows_NT;
       netcoreapp-Unix;
+      netcoreapp-Windows_NT;
+      netstandard;
       uap-Windows_NT;
       uapaot-Windows_NT;
     </BuildConfigurations>

--- a/external/corefx/corefx.depproj
+++ b/external/corefx/corefx.depproj
@@ -11,19 +11,47 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="@(RefAndRuntimePackageReference)" />
+    <PackageReference Include="System.Security.AccessControl">
+      <Version>$(MicrosoftPrivateCoreFxNETCoreAppPackageVersion)</Version>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetGroup)' == 'netcoreapp'">
+    <PackageReference Include="Microsoft.Private.CoreFx.NETCoreApp">
+      <Version>$(MicrosoftPrivateCoreFxNETCoreAppPackageVersion)</Version>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetGroup)' == 'uap' or
+                        '$(TargetGroup)' == 'uapaot'">
+    <PackageReference Include="Microsoft.Private.CoreFx.UAP">
+      <Version>$(MicrosoftPrivateCoreFxNETCoreAppPackageVersion)</Version>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetGroup)' == 'netcoreapp' or
+                        '$(TargetGroup)' == 'netstandard'">
+    <PackageReference Include="System.Reflection.DispatchProxy">
+      <Version>$(MicrosoftPrivateCoreFxNETCoreAppPackageVersion)</Version>
+    </PackageReference>
     <PackageReference Include="System.Security.Principal.Windows">
       <Version>$(MicrosoftPrivateCoreFxNETCoreAppPackageVersion)</Version>
     </PackageReference>
 
     <PackageReference Include="System.Net.Http.WinHttpHandler"
-                      Condition="'$(TargetsWindows)'=='true'">
+                      Condition="'$(TargetsWindows)' == 'true' or
+                                 '$(TargetGroup)' == 'netstandard'">
       <Version>$(MicrosoftPrivateCoreFxNETCoreAppPackageVersion)</Version>
     </PackageReference>
   </ItemGroup>
+
+  <!-- The depproj deploys runtime assets. This target also deploys reference assets. -->
+  <Target Name="CopyRefAssets" BeforeTargets="CoreCompile">
+    <ItemGroup>
+      <_ReferenceAssets Include="@(Reference)" Condition="'%(Reference.NuGetPackageId)' != ''" />
+    </ItemGroup>
+    <Copy SourceFiles="@(_ReferenceAssets)" DestinationFolder="$(RefPath)" />
+  </Target>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/external/dir.proj
+++ b/external/dir.proj
@@ -7,10 +7,10 @@
 
   <!-- Build for all configurations -->
   <ItemGroup>
+    <Project Include="corefx/corefx.depproj" />
     <Project Include="netstandard/netstandard.depproj" />
     <Project Include="netfx/netfx.depproj" />
     <Project Include="runtime/runtime.depproj" />
-    <Project Include="corefx-runtime/corefx-runtime.depproj" />
     <Project Include="test-runtime/XUnit.Runtime.depproj" />
     <Project Include="harvestPackages/harvestPackages.netstandard1.6.depproj" />
     <Project Include="winrt/winrt.depproj" />

--- a/external/dir.props
+++ b/external/dir.props
@@ -11,28 +11,6 @@
     <RestoreOutputPath>$(IntermediateOutputPath)</RestoreOutputPath>
   </PropertyGroup>
 
-  <!-- Packages needed in multiple depprojs. -->
-  <ItemGroup Condition="'$(IsNETStandard2x)' == 'true' or
-                        '$(TargetGroup)' == 'uap' or
-                        '$(TargetGroup)' == 'netcoreapp'">
-    <RefAndRuntimePackageReference Include="System.Security.AccessControl">
-      <Version>$(MicrosoftPrivateCoreFxNETCoreAppPackageVersion)</Version>
-    </RefAndRuntimePackageReference>
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetGroup)' == 'netcoreapp'">
-    <RefAndRuntimePackageReference Include="Microsoft.Private.CoreFx.NETCoreApp">
-      <Version>$(MicrosoftPrivateCoreFxNETCoreAppPackageVersion)</Version>
-    </RefAndRuntimePackageReference>
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetGroup)' == 'uap' or
-                        '$(TargetGroup)' == 'uapaot'">
-    <RefAndRuntimePackageReference Include="Microsoft.Private.CoreFx.UAP">
-      <Version>$(MicrosoftPrivateCoreFxNETCoreAppPackageVersion)</Version>
-    </RefAndRuntimePackageReference>
-  </ItemGroup>
-
   <ItemGroup>
     <!-- Assemblies to skip copying from packages because they build in WCF. -->
     <CoreSetupWcfAssemblies Include="System.Private.ServiceModel" />

--- a/external/netstandard/Configurations.props
+++ b/external/netstandard/Configurations.props
@@ -11,7 +11,6 @@
       netstandard1.6;
       netstandard2.0;
       netstandard;
-      uap;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/external/netstandard/netstandard.depproj
+++ b/external/netstandard/netstandard.depproj
@@ -4,7 +4,6 @@
   <PropertyGroup>
     <NETStandardVersion Condition="$(NuGetTargetMoniker.StartsWith('.NETStandard,Version=v'))">$(NuGetTargetMoniker.SubString(22))</NETStandardVersion>
     <IsNETStandard1x Condition="$(NETStandardVersion.StartsWith('1.'))">true</IsNETStandard1x>
-    <IsNETStandard2x Condition="$(NETStandardVersion.StartsWith('2.'))">true</IsNETStandard2x>
     <BinPlaceRef>true</BinPlaceRef>
     <NuGetDeploySourceItem>Reference</NuGetDeploySourceItem>
     <NugetRuntimeIdentifier>None</NugetRuntimeIdentifier>
@@ -14,28 +13,6 @@
   <ItemGroup>
     <PackageReference Include="NETStandard.Library">
       <Version>$(NETStandardPackageVersion)</Version>
-    </PackageReference>
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="@(RefAndRuntimePackageReference)" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(IsNETStandard2x)' == 'true' or
-                        '$(TargetGroup)' == 'uap'">
-    <PackageReference Include="System.Reflection.DispatchProxy">
-      <Version>$(MicrosoftPrivateCoreFxNETCoreAppPackageVersion)</Version>
-    </PackageReference>
-
-    <!--
-      Always include these packages to compile against, even though their
-      runtimes may not be included depending on configuration.
-    -->
-    <PackageReference Include="System.Security.Principal.Windows">
-      <Version>$(MicrosoftPrivateCoreFxNETCoreAppPackageVersion)</Version>
-    </PackageReference>
-    <PackageReference Include="System.Net.Http.WinHttpHandler">
-      <Version>$(MicrosoftPrivateCoreFxNETCoreAppPackageVersion)</Version>
     </PackageReference>
   </ItemGroup>
 

--- a/src/System.Private.ServiceModel/src/System.Private.ServiceModel.csproj
+++ b/src/System.Private.ServiceModel/src/System.Private.ServiceModel.csproj
@@ -29,7 +29,7 @@
   <PropertyGroup Condition="'$(TargetsWindows)'=='true'">
     <DefineConstants>$(DefineConstants);TARGETS_WINDOWS</DefineConstants>
   </PropertyGroup>
-  <ItemGroup Condition="'$(TargetsWindows)'=='true'">
+  <ItemGroup Condition="'$(TargetGroup)' != 'uap' AND '$(TargetsWindows)'=='true'">
     <Reference Include="System.Net.Http.WinHttpHandler" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Take the CoreFX ref-copy code out of netstandard.depproj and put it in the CoreFX depproj. The CoreFX depproj now copies runtime bits, but also copies ref bits with a custom target.

See https://github.com/dotnet/wcf/pull/2027