### PR TITLE
Modified a test case for uapaot run.

### DIFF
--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/ClientBase/SessionTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/ClientBase/SessionTests.cs
@@ -196,7 +196,7 @@ public static class SessionTests
                 }
                 catch (System.IO.IOException)
                 {
-                    // channel.MethodCTerminating threw CommunicationException on uap
+                    // channel.MethodCTerminating threw IOException on uap
                 }
                 catch (Exception e)
                 {

--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/ClientBase/SessionTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/ClientBase/SessionTests.cs
@@ -185,10 +185,23 @@ public static class SessionTests
                 // But it has a different binding with a very short receiveTimeout ="00:00:05"
                 // So waiting for just 10 seconds is enough to get the connection and the session implicitly closed
                 Task.Delay(10000).Wait();
-                Assert.Throws<System.ServiceModel.CommunicationException>(() =>
+                try
                 {
                     channel.MethodCTerminating();
-                });
+                    Assert.True(false, "channel.MethodCTerminating() should throw, but it didn't.");
+                }
+                catch(CommunicationException)
+                {
+                    // channel.MethodCTerminating threw CommunicationException on NetCore
+                }
+                catch (System.IO.IOException)
+                {
+                    // channel.MethodCTerminating threw CommunicationException on uap
+                }
+                catch (Exception e)
+                {
+                    Assert.True(false, $"channel.MethodCTerminating() threw unexpected exception: {e}");
+                }
             }
             finally
             {


### PR DESCRIPTION
System.ServiceModel.Channels.SocketConnection.Write calls different methods on different platforms:
On NetCore it calls CoreClrSocketConnection.WriteCore;
On uap/uapaot, it calls RTSocketConnection.WriteCore.

The two WriteCore use different networking APIs. As the networking APIs throw different exceptions, we get different exceptions in error cases. The fix is to let the test accept both exceptions. I opened https://github.com/dotnet/wcf/issues/2035 for tracking the actual issue.

Fix #2018