### PR TITLE
Fix S.P.SM 2.0 package adding harvested netcore50.

### DIFF
--- a/src/System.Private.ServiceModel/pkg/System.Private.ServiceModel.pkgproj
+++ b/src/System.Private.ServiceModel/pkg/System.Private.ServiceModel.pkgproj
@@ -8,6 +8,7 @@
     <ProjectReference Include="..\src\System.Private.ServiceModel.builds" />
     <HarvestIncludePaths Include="runtimes/unix/lib/netstandard1.3" />
     <HarvestIncludePaths Include="runtimes/win7/lib/netstandard1.3" />
+	<HarvestIncludePaths Include="runtimes/win7/lib/netcore50" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 


### PR DESCRIPTION
* Fixes #1983
* Anyone using the WCF 2.0 package in a UWP app would have failed because it would have been using a netstandard build instead of a netcore50 build.
* Adding a harvested build of Netcore50.