### PR TITLE
Remove support section for UAP 10.1

### DIFF
--- a/Packaging.props
+++ b/Packaging.props
@@ -53,4 +53,6 @@
         <SkipPackageFileCheck>true</SkipPackageFileCheck>
     </File>
   </ItemGroup>
+
+  <Import Condition="'$(MSBuildProjectExtension)' == '.pkgproj'" Project="$(MSBuildThisFileDirectory)pkg/disableUap10.1.targets" />
 </Project>

--- a/pkg/disableUap10.1.targets
+++ b/pkg/disableUap10.1.targets
@@ -1,0 +1,12 @@
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Target Name="RemoveUap101Content"
+          Condition="'$(KeepUAPContent)' != 'true'"
+          DependsOnTargets="GetPackageReport"
+          BeforeTargets="GenerateNuSpec">
+    <ItemGroup>
+      <PackageFile Remove="@(PackageFile)" Condition="'%(PackageFile.TargetFramework)' == 'uap10.1'" />
+      <PackageFile Remove="@(PackageFile)" Condition="$([System.String]::new('%(PackageFile.TargetPath)').Contains('/uap10.1'))" />
+      <Dependency Remove="@(Dependency)" Condition="'%(Dependency.TargetFramework)' == 'uap10.1'" />
+    </ItemGroup>
+  </Target>
+</Project>


### PR DESCRIPTION
* S.SM packages in 2.0 release do not support UAP 10.1, remove the section in the packages that claim this support.
* Fixes #1942