### PR TITLE
Enable a Few Tests on NetNative.

### DIFF
--- a/src/System.Private.ServiceModel/tests/Scenarios/Contract/Data/DataContractTests.4.1.1.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Contract/Data/DataContractTests.4.1.1.cs
@@ -17,7 +17,6 @@ public static partial class DataContractTests
 {
     [WcfFact]
     [OuterLoop]
-    [Issue(1708, Framework = FrameworkID.NetNative)]
     public static void DataContractResolverTest()
     {
         IDataContractResolverService client = null;

--- a/src/System.Private.ServiceModel/tests/Scenarios/Contract/Message/MessageContractTests.4.4.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Contract/Message/MessageContractTests.4.4.0.cs
@@ -11,7 +11,6 @@ using Xunit;
 public static class MessageContractTests_4_4_0
 {
     [WcfFact]
-    [Issue(1745, Framework = FrameworkID.NetNative)]
     [OuterLoop]
     public static void Message_With_MessageHeaders_RoundTrips()
     {
@@ -86,7 +85,6 @@ public static class MessageContractTests_4_4_0
 
     [WcfFact]
     [OuterLoop]
-    [Issue(1730, Framework = FrameworkID.NetNative)]
     public static void Message_With_XmlElementMessageHeader_RoundTrip()
     {
         BasicHttpBinding binding = null;

--- a/src/System.Private.ServiceModel/tests/Scenarios/Contract/XmlSerializer/XmlSerializerFormatTest.4.1.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Contract/XmlSerializer/XmlSerializerFormatTest.4.1.0.cs
@@ -39,7 +39,6 @@ public static partial class XmlSerializerFormatTests
 
     [WcfFact]
     [OuterLoop]
-    [Issue(702, Framework = FrameworkID.NetCore | FrameworkID.NetNative)]
     public static void MessageHeader_RequestTypeWithUsesMessageHeaderAttribute()
     {
         // *** SETUP *** \\


### PR DESCRIPTION
The tests were disabled on NetNative. They now pass with NetCore2.0 and the latest UWP toolchain.

Fix #1708
Fix #1745
Fix #1730
Fix #702