### PR TITLE
Adding uapvNext support to System.Private.ServiceModel

### DIFF
--- a/src/System.Private.ServiceModel/src/System.Private.ServiceModel.csproj
+++ b/src/System.Private.ServiceModel/src/System.Private.ServiceModel.csproj
@@ -12,7 +12,12 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
     <ProjectGuid>{9E50E7BF-CD6E-4269-A6DD-59FD0BD6C0FD}</ProjectGuid>
     <CommonPath Condition="'$(CommonPath)' == ''">..\..\Common\src</CommonPath>
+    <!-- UAPvNext is not yet mapped to netstandard2.0, manually duplicate this ref -->
+    <PackageTargetFramework Condition="'$(TargetGroup)' == 'netstandard'">netstandard2.0;$(UAPvNextTFM)</PackageTargetFramework>
   </PropertyGroup>
+  <ItemGroup>
+    <SuppressPackageTargetFrameworkCompatibility Include="$(UAPvNextTFM)" />
+  </ItemGroup>
   <!-- Default configurations to help VS understand the options -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Unix-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Unix-Release|AnyCPU'" />


### PR DESCRIPTION
System.Private.ServiceModel didn't support uapvNext, which was causing the restore of that TFM to pick the netcore50 assets instead of the netstandard2.0 ones. This change fixes that.

cc: @dagood @StephenBonikowsky @ericstj 