### PR TITLE
Synchronizing connection writes in ClientFramingDuplexSessionChannel

### DIFF
--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/TransportDuplexSessionChannel.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/TransportDuplexSessionChannel.cs
@@ -61,6 +61,14 @@ namespace System.ServiceModel.Channels
             protected set { _duplexSession = value; }
         }
 
+        protected SemaphoreSlim SendLock
+        {
+            get
+            {
+                return _sendLock;
+            }
+        }
+
         protected BufferManager BufferManager
         {
             get


### PR DESCRIPTION
The base class TransportDuplexSessionChannel writes are already synchronized by its SemaphoreSlim _sendLock. It's grand-grand-child ClientFramingDuplexSessionChannel needs to do the same while writing to the connection in SendPreamble methods.