### PR TITLE
Move target needed for test.

### DIFF
--- a/src/GenerateDepsJson.targets
+++ b/src/GenerateDepsJson.targets
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <UsingTask TaskName="GenerateDepsJson" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll"/>
+
+  <!-- After we build all the source libraries we need to generate a deps.json file for the shared test framework -->
+  <Target Name="GenerateTestSharedFrameworkDepsFile" AfterTargets="BuildAllProjects" Condition="'$(BinplaceTestSharedFramework)' == 'true'">
+
+    <ItemGroup>
+      <!-- This is for HostPolicy, CoreCLR and Jit dependencies to continue to remain inside of the dep.json -->
+      <ExceptionForDepsJson Include="microsoft.netcore.app" />
+
+      <!-- TODO: We should see about generating this from scratch instead of relying on a previous deps file as a template -->
+      <_sharedFrameworkDepsJson Include="$(ToolsDir)dotnetcli\shared\Microsoft.NETCore.App\*\Microsoft.NETCore.App.deps.json" />
+    </ItemGroup>
+
+    <PropertyGroup>
+      <_OriginalDepsJsonPath>%(_sharedFrameworkDepsJson.FullPath)</_OriginalDepsJsonPath>
+      <_OutputTestSharedFrameworkDepsPath>$(NETCoreAppTestSharedFrameworkPath)\Microsoft.NETCore.App.deps.json</_OutputTestSharedFrameworkDepsPath>
+    </PropertyGroup>
+
+    <GenerateDepsJson DepsJsonPath="$(_OriginalDepsJsonPath)"
+                      RuntimeDirectory="$(NETCoreAppTestSharedFrameworkPath)"
+                      DepsExceptions="@(ExceptionForDepsJson)"
+                      OutputPath="$(_OutputTestSharedFrameworkDepsPath)"/>
+  </Target>
+</Project>

--- a/src/src.builds
+++ b/src/src.builds
@@ -8,28 +8,5 @@
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 
-  <UsingTask TaskName="GenerateDepsJson" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll"/>
-
-
-  <!-- After we build all the source libraries we need to generate a deps.json file for the shared test framework -->
-  <Target Name="GenerateTestSharedFrameworkDepsFile" AfterTargets="BuildAllProjects" Condition="'$(BinplaceTestSharedFramework)' == 'true'">
-
-    <ItemGroup>
-      <!-- This is for HostPolicy, CoreCLR and Jit dependencies to continue to remain inside of the dep.json -->
-      <ExceptionForDepsJson Include="microsoft.netcore.app" />
-
-      <!-- TODO: We should see about generating this from scratch instead of relying on a previous deps file as a template -->
-      <_sharedFrameworkDepsJson Include="$(ToolsDir)dotnetcli\shared\Microsoft.NETCore.App\*\Microsoft.NETCore.App.deps.json" />
-    </ItemGroup>
-
-    <PropertyGroup>
-      <_OriginalDepsJsonPath>%(_sharedFrameworkDepsJson.FullPath)</_OriginalDepsJsonPath>
-      <_OutputTestSharedFrameworkDepsPath>$(NETCoreAppTestSharedFrameworkPath)\Microsoft.NETCore.App.deps.json</_OutputTestSharedFrameworkDepsPath>
-    </PropertyGroup>
-
-    <GenerateDepsJson DepsJsonPath="$(_OriginalDepsJsonPath)"
-                      RuntimeDirectory="$(NETCoreAppTestSharedFrameworkPath)"
-                      DepsExceptions="@(ExceptionForDepsJson)"
-                      OutputPath="$(_OutputTestSharedFrameworkDepsPath)"/>
-  </Target>
+  <Import Project="$(MSBuildThisFileDirectory)GenerateDepsJson.targets" />
 </Project>

--- a/src/tests.builds
+++ b/src/tests.builds
@@ -60,4 +60,6 @@
       RelativePathBaseDirectory="$(PackagesDir)"
       OverwriteDestination="true" />
   </Target>
+
+  <Import Project="$(MSBuildThisFileDirectory)GenerateDepsJson.targets" />
 </Project>


### PR DESCRIPTION
* Target named GenerateTestSharedFrameworkDepsFile is needed for test but was located in src.builds which is the product build path.
* Moving it to tests.builds which is where it should be.
* This fixes an issue in VSTS where we have to build product and test in separate build definitions.