### PR TITLE
Adding MessageVersions with AddressingVersion August2004

### DIFF
--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/Addressing.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/Addressing.cs
@@ -350,6 +350,7 @@ namespace System.ServiceModel.Channels
         private const bool mustUnderstandValue = true;
 
         private static ToHeader s_anonymousToHeader10;
+        private static ToHeader s_anonymousToHeader200408;
 
         protected ToHeader(Uri to, AddressingVersion version)
             : base(version)
@@ -367,6 +368,15 @@ namespace System.ServiceModel.Channels
             }
         }
 
+        private static ToHeader AnonymousTo200408
+        {
+            get
+            {
+                if (s_anonymousToHeader200408 == null)
+                    s_anonymousToHeader200408 = new AnonymousToHeader(AddressingVersion.WSAddressing200408);
+                return s_anonymousToHeader200408;
+            }
+        }
 
         public override XmlDictionaryString DictionaryName
         {
@@ -392,8 +402,10 @@ namespace System.ServiceModel.Channels
             {
                 if (addressingVersion == AddressingVersion.WSAddressing10)
                     return AnonymousTo10;
+                else if (addressingVersion == AddressingVersion.WSAddressing200408)
+                    return AnonymousTo200408;
                 else
-                    // Verify that only WSA10 is supported
+                    // Verify that only WSA10 and WSA200408 is supported
                     throw ExceptionHelper.PlatformNotSupported();
             }
             else
@@ -412,6 +424,8 @@ namespace System.ServiceModel.Channels
             {
                 if (addressingVersion == AddressingVersion.WSAddressing10)
                     return AnonymousTo10;
+                else if (addressingVersion == AddressingVersion.WSAddressing200408)
+                    return AnonymousTo200408;
                 else
                     // Verify that only WSA10 is supported
                     throw ExceptionHelper.PlatformNotSupported();
@@ -462,6 +476,8 @@ namespace System.ServiceModel.Channels
                 {
                     if (version == AddressingVersion.WSAddressing10)
                         return AnonymousTo10;
+                    else if (version == AddressingVersion.WSAddressing200408)
+                        return AnonymousTo200408;
                     else
                         throw ExceptionHelper.PlatformNotSupported();
                 }

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/Addressing.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/Addressing.cs
@@ -373,7 +373,7 @@ namespace System.ServiceModel.Channels
             get
             {
                 if (s_anonymousToHeader200408 == null)
-                    s_anonymousToHeader200408 = new AnonymousToHeader(AddressingVersion.WSAddressing200408);
+                    s_anonymousToHeader200408 = new AnonymousToHeader(AddressingVersion.WSAddressingAugust2004);
                 return s_anonymousToHeader200408;
             }
         }
@@ -402,7 +402,7 @@ namespace System.ServiceModel.Channels
             {
                 if (addressingVersion == AddressingVersion.WSAddressing10)
                     return AnonymousTo10;
-                else if (addressingVersion == AddressingVersion.WSAddressing200408)
+                else if (addressingVersion == AddressingVersion.WSAddressingAugust2004)
                     return AnonymousTo200408;
                 else
                     // Verify that only WSA10 and WSA200408 is supported
@@ -424,7 +424,7 @@ namespace System.ServiceModel.Channels
             {
                 if (addressingVersion == AddressingVersion.WSAddressing10)
                     return AnonymousTo10;
-                else if (addressingVersion == AddressingVersion.WSAddressing200408)
+                else if (addressingVersion == AddressingVersion.WSAddressingAugust2004)
                     return AnonymousTo200408;
                 else
                     // Verify that only WSA10 is supported
@@ -476,7 +476,7 @@ namespace System.ServiceModel.Channels
                 {
                     if (version == AddressingVersion.WSAddressing10)
                         return AnonymousTo10;
-                    else if (version == AddressingVersion.WSAddressing200408)
+                    else if (version == AddressingVersion.WSAddressingAugust2004)
                         return AnonymousTo200408;
                     else
                         throw ExceptionHelper.PlatformNotSupported();

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/AddressingVersion.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/AddressingVersion.cs
@@ -39,7 +39,6 @@ namespace System.ServiceModel.Channels
             Addressing200408Strings.FaultAction, Addressing200408Strings.DefaultFaultAction);
         private static MessagePartSpecification s_addressing200408SignedMessageParts;
 
-
         private AddressingVersion(string ns, XmlDictionaryString dictionaryNs, string toStringFormat,
             MessagePartSpecification signedMessageParts, string anonymous, XmlDictionaryString dictionaryAnonymous, string none, string faultAction, string defaultFaultAction)
         {

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/AddressingVersion.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/AddressingVersion.cs
@@ -22,6 +22,7 @@ namespace System.ServiceModel.Channels
         private string _defaultFaultAction;
         private const string AddressingNoneToStringFormat = "AddressingNone ({0})";
         private const string Addressing10ToStringFormat = "Addressing10 ({0})";
+        private const string Addressing200408ToStringFormat = "Addressing200408 ({0})";
 
         private static AddressingVersion s_none = new AddressingVersion(AddressingNoneStrings.Namespace, XD.AddressingNoneDictionary.Namespace,
             AddressingNoneToStringFormat, new MessagePartSpecification(), null, null, null, null, null);
@@ -33,7 +34,7 @@ namespace System.ServiceModel.Channels
         private static MessagePartSpecification s_addressing10SignedMessageParts;
 
         private static AddressingVersion s_addressing200408 = new AddressingVersion(Addressing200408Strings.Namespace,
-            XD.Addressing200408Dictionary.Namespace, SR.Addressing200408ToStringFormat, Addressing200408SignedMessageParts,
+            XD.Addressing200408Dictionary.Namespace, Addressing200408ToStringFormat, Addressing200408SignedMessageParts,
             Addressing200408Strings.Anonymous, XD.Addressing200408Dictionary.Anonymous, null,
             Addressing200408Strings.FaultAction, Addressing200408Strings.DefaultFaultAction);
         private static MessagePartSpecification s_addressing200408SignedMessageParts;

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/AddressingVersion.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/AddressingVersion.cs
@@ -32,6 +32,12 @@ namespace System.ServiceModel.Channels
             Addressing10Strings.FaultAction, Addressing10Strings.DefaultFaultAction);
         private static MessagePartSpecification s_addressing10SignedMessageParts;
 
+        private static AddressingVersion s_addressing200408 = new AddressingVersion(Addressing200408Strings.Namespace,
+            XD.Addressing200408Dictionary.Namespace, SR.Addressing200408ToStringFormat, Addressing200408SignedMessageParts,
+            Addressing200408Strings.Anonymous, XD.Addressing200408Dictionary.Anonymous, null,
+            Addressing200408Strings.FaultAction, Addressing200408Strings.DefaultFaultAction);
+        private static MessagePartSpecification s_addressing200408SignedMessageParts;
+
 
         private AddressingVersion(string ns, XmlDictionaryString dictionaryNs, string toStringFormat,
             MessagePartSpecification signedMessageParts, string anonymous, XmlDictionaryString dictionaryAnonymous, string none, string faultAction, string defaultFaultAction)
@@ -57,6 +63,11 @@ namespace System.ServiceModel.Channels
             _defaultFaultAction = defaultFaultAction;
         }
 
+
+        public static AddressingVersion WSAddressingAugust2004
+        {
+            get { return s_addressing200408; }
+        }
 
         public static AddressingVersion WSAddressing10
         {
@@ -96,6 +107,28 @@ namespace System.ServiceModel.Channels
             }
         }
 
+        private static MessagePartSpecification Addressing200408SignedMessageParts
+        {
+            get
+            {
+                if (s_addressing200408SignedMessageParts == null)
+                {
+                    MessagePartSpecification s = new MessagePartSpecification(
+                        new XmlQualifiedName(AddressingStrings.To, Addressing200408Strings.Namespace),
+                        new XmlQualifiedName(AddressingStrings.From, Addressing200408Strings.Namespace),
+                        new XmlQualifiedName(AddressingStrings.FaultTo, Addressing200408Strings.Namespace),
+                        new XmlQualifiedName(AddressingStrings.ReplyTo, Addressing200408Strings.Namespace),
+                        new XmlQualifiedName(AddressingStrings.MessageId, Addressing200408Strings.Namespace),
+                        new XmlQualifiedName(AddressingStrings.RelatesTo, Addressing200408Strings.Namespace),
+                        new XmlQualifiedName(AddressingStrings.Action, Addressing200408Strings.Namespace)
+                        );
+                    s.MakeReadOnly();
+                    s_addressing200408SignedMessageParts = s;
+                }
+
+                return s_addressing200408SignedMessageParts;
+            }
+        }
 
         internal XmlDictionaryString DictionaryNamespace
         {

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/MessageHeader.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/MessageHeader.cs
@@ -63,9 +63,17 @@ namespace System.ServiceModel.Channels
                         {
                             WriteHeader(writer, MessageVersion.Soap12WSAddressing10);
                         }
+                        else if (IsMessageVersionSupported(MessageVersion.Soap12WSAddressingAugust2004))
+                        {
+                            WriteHeader(writer, MessageVersion.Soap12WSAddressingAugust2004);
+                        }
                         else if (IsMessageVersionSupported(MessageVersion.Soap11WSAddressing10))
                         {
                             WriteHeader(writer, MessageVersion.Soap11WSAddressing10);
+                        }
+                        else if (IsMessageVersionSupported(MessageVersion.Soap11WSAddressingAugust2004))
+                        {
+                            WriteHeader(writer, MessageVersion.Soap11WSAddressingAugust2004);
                         }
                         else if (IsMessageVersionSupported(MessageVersion.Soap12))
                         {

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/MessageVersion.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/MessageVersion.cs
@@ -17,6 +17,8 @@ namespace System.ServiceModel.Channels
         private static MessageVersion s_soap12;
         private static MessageVersion s_soap11Addressing10;
         private static MessageVersion s_soap12Addressing10;
+        private static MessageVersion s_soap11Addressing200408;
+        private static MessageVersion s_soap12Addressing200408;
         private const string MessageVersionToStringFormat = "{0} {1}";
 
         static MessageVersion()
@@ -26,6 +28,8 @@ namespace System.ServiceModel.Channels
             s_soap12 = new MessageVersion(EnvelopeVersion.Soap12, AddressingVersion.None);
             s_soap11Addressing10 = new MessageVersion(EnvelopeVersion.Soap11, AddressingVersion.WSAddressing10);
             s_soap12Addressing10 = new MessageVersion(EnvelopeVersion.Soap12, AddressingVersion.WSAddressing10);
+            s_soap11Addressing200408 = new MessageVersion(EnvelopeVersion.Soap11, AddressingVersion.WSAddressingAugust2004);
+            s_soap12Addressing200408 = new MessageVersion(EnvelopeVersion.Soap12, AddressingVersion.WSAddressingAugust2004);
         }
 
         private MessageVersion(EnvelopeVersion envelopeVersion, AddressingVersion addressingVersion)
@@ -57,6 +61,10 @@ namespace System.ServiceModel.Channels
                 {
                     return s_soap12Addressing10;
                 }
+                else if (addressingVersion == AddressingVersion.WSAddressingAugust2004)
+                {
+                    return s_soap12Addressing200408;
+                }
                 else if (addressingVersion == AddressingVersion.None)
                 {
                     return s_soap12;
@@ -72,6 +80,10 @@ namespace System.ServiceModel.Channels
                 if (addressingVersion == AddressingVersion.WSAddressing10)
                 {
                     return s_soap11Addressing10;
+                }
+                else if (addressingVersion == AddressingVersion.WSAddressingAugust2004)
+                {
+                    return s_soap11Addressing200408;
                 }
                 else if (addressingVersion == AddressingVersion.None)
                 {
@@ -143,6 +155,16 @@ namespace System.ServiceModel.Channels
         public static MessageVersion Soap11WSAddressing10
         {
             get { return s_soap11Addressing10; }
+        }
+
+        public static MessageVersion Soap12WSAddressingAugust2004
+        {
+            get { return s_soap12Addressing200408; }
+        }
+
+        public static MessageVersion Soap11WSAddressingAugust2004
+        {
+            get { return s_soap11Addressing200408; }
         }
 
         public static MessageVersion Soap11

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/MessageVersion.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/MessageVersion.cs
@@ -139,6 +139,8 @@ namespace System.ServiceModel.Channels
             int code = 0;
             if (this.Envelope == EnvelopeVersion.Soap11)
                 code += 1;
+            if (this.Addressing == AddressingVersion.WSAddressingAugust2004)
+                code += 2;
             return code;
         }
 

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/RequestReplyCorrelator.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/RequestReplyCorrelator.cs
@@ -99,6 +99,17 @@ namespace System.ServiceModel.Channels
             {
                 destination = info.ReplyTo;
             }
+            else if (reply.Version.Addressing == AddressingVersion.WSAddressingAugust2004)
+            {
+                if (info.HasFrom)
+                {
+                    destination = info.From;
+                }
+                else
+                {
+                    destination = EndpointAddress.AnonymousAddress;
+                }
+            }
 
             if (destination != null)
             {
@@ -180,7 +191,14 @@ namespace System.ServiceModel.Channels
             {
                 _faultTo = message.Headers.FaultTo;
                 _replyTo = message.Headers.ReplyTo;
-                _from = null;
+                if (message.Version.Addressing == AddressingVersion.WSAddressingAugust2004)
+                {
+                    this.from = message.Headers.From;
+                }
+                else 
+                {
+                    _from = null;
+                }
             }
 
             internal EndpointAddress FaultTo

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/RequestReplyCorrelator.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/RequestReplyCorrelator.cs
@@ -193,7 +193,7 @@ namespace System.ServiceModel.Channels
                 _replyTo = message.Headers.ReplyTo;
                 if (message.Version.Addressing == AddressingVersion.WSAddressingAugust2004)
                 {
-                    this.from = message.Headers.From;
+                    _from = message.Headers.From;
                 }
                 else 
                 {

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/ServiceChannel.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/ServiceChannel.cs
@@ -610,6 +610,18 @@ namespace System.ServiceModel.Channels
                         Exception error = new InvalidOperationException(text);
                         throw TraceUtility.ThrowHelperError(error, rpc.Request);
                     }
+ 
+                    if (this._messageVersion.Addressing == AddressingVersion.WSAddressingAugust2004)
+                    {
+                        EndpointAddress from = headers.From;
+                        if ((from != null) && !from.IsAnonymous && (localUri != from.Uri))
+                        {
+                            // FIXME: string text = SR.Format(SR.SFxRequestHasInvalidFromOnClient, from.Uri, localUri);
+                            string text = SR.Format("The request message has From='{0}' but IContextChannel.LocalAddress is '{1}'.  When ManualAddressing is false, these values must be the same, null, or EndpointAddress.AnonymousAddress.  Enable ManualAddressing or avoid setting From on the message.", faultTo.Uri, localUri);
+                            Exception error = new InvalidOperationException(text);
+                            throw TraceUtility.ThrowHelperError(error, rpc.Request);
+                        }
+                    }
                 }
             }
 

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Dispatcher/PrimitiveOperationFormatter.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Dispatcher/PrimitiveOperationFormatter.cs
@@ -21,8 +21,10 @@ namespace System.ServiceModel.Dispatcher
         private XmlDictionaryString _replyAction;
         private ActionHeader _actionHeaderNone;
         private ActionHeader _actionHeader10;
+        private ActionHeader _actionHeaderAugust2004;
         private ActionHeader _replyActionHeaderNone;
         private ActionHeader _replyActionHeader10;
+        private ActionHeader _replyActionHeaderAugust2004;
         private XmlDictionaryString _requestWrapperName;
         private XmlDictionaryString _requestWrapperNamespace;
         private XmlDictionaryString _responseWrapperName;
@@ -108,6 +110,20 @@ namespace System.ServiceModel.Dispatcher
                 return _actionHeader10;
             }
         }
+ 
+        private ActionHeader ActionHeaderAugust2004
+        {
+            get
+            {
+                if (_actionHeaderAugust2004 == null)
+                {
+                    _actionHeaderAugust2004 =
+                        ActionHeader.Create(_action, AddressingVersion.WSAddressingAugust2004);
+                }
+ 
+                return _actionHeaderAugust2004;
+            }
+        }
 
 
         private ActionHeader ReplyActionHeaderNone
@@ -138,6 +154,19 @@ namespace System.ServiceModel.Dispatcher
             }
         }
 
+        private ActionHeader ReplyActionHeaderAugust2004
+        {
+            get
+            {
+                if (_replyActionHeaderAugust2004 == null)
+                {
+                    _replyActionHeaderAugust2004 =
+                        ActionHeader.Create(_replyAction, AddressingVersion.WSAddressingAugust2004);
+                }
+ 
+                return _replyActionHeaderAugust2004;
+            }
+        }
 
         private static XmlDictionaryString AddToDictionary(XmlDictionary dictionary, string s)
         {
@@ -166,7 +195,11 @@ namespace System.ServiceModel.Dispatcher
                 return null;
             }
 
-            if (addressing == AddressingVersion.WSAddressing10)
+            if (addressing == AddressingVersion.WSAddressingAugust2004)
+            {
+                return ActionHeaderAugust2004;
+            }
+            else if (addressing == AddressingVersion.WSAddressing10)
             {
                 return ActionHeader10;
             }
@@ -188,7 +221,11 @@ namespace System.ServiceModel.Dispatcher
                 return null;
             }
 
-            if (addressing == AddressingVersion.WSAddressing10)
+            if (addressing == AddressingVersion.WSAddressingAugust2004)
+            {
+                return ReplyActionHeaderAugust2004;
+            }
+            else if (addressing == AddressingVersion.WSAddressing10)
             {
                 return ReplyActionHeader10;
             }

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/EndpointAddress.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/EndpointAddress.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Runtime;
 using System.ServiceModel.Channels;
@@ -293,6 +294,10 @@ namespace System.ServiceModel
                 {
                     message.Headers.To = null;
                 }
+                else if (message.Version.Addressing == AddressingVersion.WSAddressingAugust2004)
+                {
+                    message.Headers.To = message.Version.Addressing.AnonymousUri;
+                }
                 else
                 {
                     throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(
@@ -528,6 +533,10 @@ namespace System.ServiceModel
             {
                 version = AddressingVersion.WSAddressing10;
             }
+            else if (reader.IsNamespaceUri(AddressingVersion.WSAddressingAugust2004.DictionaryNamespace))
+            {
+                version = AddressingVersion.WSAddressingAugust2004;
+            }
             else if (reader.NodeType != XmlNodeType.Element)
             {
                 throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgument(
@@ -572,6 +581,10 @@ namespace System.ServiceModel
             {
                 isAnonymous = ReadContentsFrom10(reader, out uri, out headers, out identity, out buffer, out metadataSection, out extensionSection);
             }
+            else if (addressingVersion == AddressingVersion.WSAddressingAugust2004)
+            {
+                isAnonymous = ReadContentsFrom200408(reader, out uri, out headers, out identity, out buffer, out metadataSection, out extensionSection, out pspSection);
+            } 
             else
             {
                 throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgument("addressingVersion",
@@ -642,6 +655,161 @@ namespace System.ServiceModel
             return buffer;
         }
 
+        private static bool ReadContentsFrom200408(XmlDictionaryReader reader, out Uri uri, out AddressHeaderCollection headers, out EndpointIdentity identity, out XmlBuffer buffer, out int metadataSection, out int extensionSection, out int pspSection)
+        {
+            buffer = null;
+            headers = null;
+            extensionSection = -1;
+            metadataSection = -1;
+            pspSection = -1;
+ 
+            // Cache address string
+            reader.MoveToContent();
+            if (!reader.IsStartElement(XD.AddressingDictionary.Address, AddressingVersion.WSAddressingAugust2004.DictionaryNamespace))
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(CreateXmlException(reader, SR.Format(SR.UnexpectedElementExpectingElement, reader.LocalName, reader.NamespaceURI, XD.AddressingDictionary.Address.Value, XD.Addressing200408Dictionary.Namespace.Value)));
+            }
+            string address = reader.ReadElementContentAsString();
+ 
+            // ReferenceProperites
+            reader.MoveToContent();
+            if (reader.IsStartElement(XD.AddressingDictionary.ReferenceProperties, AddressingVersion.WSAddressingAugust2004.DictionaryNamespace))
+            {
+                headers = AddressHeaderCollection.ReadServiceParameters(reader, true);
+            }
+ 
+            // ReferenceParameters
+            reader.MoveToContent();
+            if (reader.IsStartElement(XD.AddressingDictionary.ReferenceParameters, AddressingVersion.WSAddressingAugust2004.DictionaryNamespace))
+            {
+                if (headers != null)
+                {
+                    List<AddressHeader> headerList = new List<AddressHeader>();
+                    foreach (AddressHeader ah in headers)
+                    {
+                        headerList.Add(ah);
+                    }
+                    AddressHeaderCollection tmp = AddressHeaderCollection.ReadServiceParameters(reader);
+                    foreach (AddressHeader ah in tmp)
+                    {
+                        headerList.Add(ah);
+                    }
+                    headers = new AddressHeaderCollection(headerList);
+                }
+                else
+                {
+                    headers = AddressHeaderCollection.ReadServiceParameters(reader);
+                }
+            }
+ 
+            XmlDictionaryWriter bufferWriter = null;
+ 
+            // PortType
+            reader.MoveToContent();
+            if (reader.IsStartElement(XD.AddressingDictionary.PortType, AddressingVersion.WSAddressingAugust2004.DictionaryNamespace))
+            {
+                if (bufferWriter == null)
+                {
+                    if (buffer == null)
+                        buffer = new XmlBuffer(short.MaxValue);
+                    bufferWriter = buffer.OpenSection(reader.Quotas);
+                    bufferWriter.WriteStartElement(DummyName, DummyNamespace);
+                }
+                bufferWriter.WriteNode(reader, true);
+            }
+ 
+            // ServiceName
+            reader.MoveToContent();
+            if (reader.IsStartElement(XD.AddressingDictionary.ServiceName, AddressingVersion.WSAddressingAugust2004.DictionaryNamespace))
+            {
+                if (bufferWriter == null)
+                {
+                    if (buffer == null)
+                        buffer = new XmlBuffer(short.MaxValue);
+                    bufferWriter = buffer.OpenSection(reader.Quotas);
+                    bufferWriter.WriteStartElement(DummyName, DummyNamespace);
+                }
+                bufferWriter.WriteNode(reader, true);
+            }
+ 
+            // Policy
+            reader.MoveToContent();
+            while (reader.IsNamespaceUri(PolicyStrings.Namespace))
+            {
+                if (bufferWriter == null)
+                {
+                    if (buffer == null)
+                        buffer = new XmlBuffer(short.MaxValue);
+                    bufferWriter = buffer.OpenSection(reader.Quotas);
+                    bufferWriter.WriteStartElement(DummyName, DummyNamespace);
+                }
+                bufferWriter.WriteNode(reader, true);
+                reader.MoveToContent();
+            }
+ 
+            // Finish PSP
+            if (bufferWriter != null)
+            {
+                bufferWriter.WriteEndElement();
+                buffer.CloseSection();
+                pspSection = buffer.SectionCount - 1;
+                bufferWriter = null;
+            }
+            else
+            {
+                pspSection = -1;
+            }
+ 
+ 
+            // Metadata
+            if (reader.IsStartElement(System.ServiceModel.Description.MetadataStrings.MetadataExchangeStrings.Metadata,
+                                      System.ServiceModel.Description.MetadataStrings.MetadataExchangeStrings.Namespace))
+            {
+                if (bufferWriter == null)
+                {
+                    if (buffer == null)
+                        buffer = new XmlBuffer(short.MaxValue);
+                    bufferWriter = buffer.OpenSection(reader.Quotas);
+                    bufferWriter.WriteStartElement(DummyName, DummyNamespace);
+                }
+                bufferWriter.WriteNode(reader, true);
+            }
+ 
+            // Finish metadata
+            if (bufferWriter != null)
+            {
+                bufferWriter.WriteEndElement();
+                buffer.CloseSection();
+                metadataSection = buffer.SectionCount - 1;
+                bufferWriter = null;
+            }
+            else
+            {
+                metadataSection = -1;
+            }
+ 
+            // Extensions
+            reader.MoveToContent();
+            buffer = ReadExtensions(reader, AddressingVersion.WSAddressingAugust2004, buffer, out identity, out extensionSection);
+ 
+            // Finished reading
+            if (buffer != null)
+                buffer.Close();
+ 
+            // Process Address
+            if (address == Addressing200408Strings.Anonymous)
+            {
+                uri = AddressingVersion.WSAddressingAugust2004.AnonymousUri;
+                if (headers == null && identity == null)
+                    return true;
+            }
+            else
+            {
+                if (!Uri.TryCreate(address, UriKind.Absolute, out uri))
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new XmlException(SR.Format(SR.InvalidUriValue, address, XD.AddressingDictionary.Address.Value, AddressingVersion.WSAddressingAugust2004.Namespace)));
+            }
+            return false;
+        }
 
         private static bool ReadContentsFrom10(XmlDictionaryReader reader, out Uri uri, out AddressHeaderCollection headers, out EndpointIdentity identity, out XmlBuffer buffer, out int metadataSection, out int extensionSection)
         {
@@ -760,6 +928,10 @@ namespace System.ServiceModel
             {
                 WriteContentsTo10(writer);
             }
+            else if (addressingVersion == AddressingVersion.WSAddressingAugust2004)
+            {
+                WriteContentsTo200408(writer);
+            }
             else if (addressingVersion == AddressingVersion.None)
             {
                 WriteContentsToNone(writer);
@@ -776,6 +948,78 @@ namespace System.ServiceModel
             writer.WriteString(this.Uri.AbsoluteUri);
         }
 
+        private void WriteContentsTo200408(XmlDictionaryWriter writer)
+        {
+            // Address
+            writer.WriteStartElement(XD.AddressingDictionary.Address, XD.Addressing200408Dictionary.Namespace);
+            if (IsAnonymous)
+            {
+                writer.WriteString(XD.Addressing200408Dictionary.Anonymous);
+            }
+            else if (IsNone)
+            {
+                //FIXME: throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgument("addressingVersion", SR.Format(SR.SFxNone2004));
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgument("addressingVersion", SR.Format("The WS-Addressing \"none\" value is not valid for the August 2004 version of WS-Addressing."));
+            }
+            else
+            {
+                writer.WriteString(this.Uri.AbsoluteUri);
+            }
+            writer.WriteEndElement();
+ 
+            // ReferenceProperties
+            if (_headers != null && _headers.HasReferenceProperties)
+            {
+                writer.WriteStartElement(XD.AddressingDictionary.ReferenceProperties, XD.Addressing200408Dictionary.Namespace);
+                _headers.WriteReferencePropertyContentsTo(writer);
+                writer.WriteEndElement();
+            }
+ 
+            // ReferenceParameters
+            if (_headers != null && _headers.HasNonReferenceProperties)
+            {
+                writer.WriteStartElement(XD.AddressingDictionary.ReferenceParameters, XD.Addressing200408Dictionary.Namespace);
+                _headers.WriteNonReferencePropertyContentsTo(writer);
+                writer.WriteEndElement();
+            }
+ 
+            // PSP (PortType, ServiceName, Policy)
+            XmlDictionaryReader reader = null;
+            if (_pspSection >= 0)
+            {
+                reader = GetReaderAtSection(_buffer, _pspSection);
+                Copy(writer, reader);
+            }
+ 
+            // Metadata
+            reader = null;
+            if (_metadataSection >= 0)
+            {
+                reader = GetReaderAtSection(_buffer, _metadataSection);
+                Copy(writer, reader);
+            }
+ 
+            // EndpointIdentity
+            if (this.Identity != null)
+            {
+                this.Identity.WriteTo(writer);
+            }
+ 
+            // Extensions
+            if (_extensionSection >= 0)
+            {
+                reader = GetReaderAtSection(_buffer, _extensionSection);
+                while (reader.IsStartElement())
+                {
+                    if (reader.NamespaceURI == AddressingVersion.WSAddressingAugust2004.Namespace)
+                    {
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(CreateXmlException(reader, SR.Format(SR.AddressingExtensionInBadNS, reader.LocalName, reader.NamespaceURI)));
+                    }
+ 
+                    writer.WriteNode(reader, true);
+                }
+            }
+        }
 
         private void WriteContentsTo10(XmlDictionaryWriter writer)
         {

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/XD.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/XD.cs
@@ -17,6 +17,7 @@ namespace System.ServiceModel
         private static ActivityIdFlowDictionary s_activityIdFlowDictionary;
         private static AddressingDictionary s_addressingDictionary;
         private static Addressing10Dictionary s_addressing10Dictionary;
+        private static Addressing200408Dictionary s_addressing200408Dictionary;
         private static AddressingNoneDictionary s_addressingNoneDictionary;
         private static MessageDictionary s_messageDictionary;
         private static Message11Dictionary s_message11Dictionary;
@@ -56,6 +57,16 @@ namespace System.ServiceModel
                 if (s_addressing10Dictionary == null)
                     s_addressing10Dictionary = new Addressing10Dictionary(Dictionary);
                 return s_addressing10Dictionary;
+            }
+        }
+
+        static public Addressing200408Dictionary Addressing200408Dictionary
+        {
+            get
+            {
+                if (s_addressing200408Dictionary == null)
+                    s_addressing200408Dictionary = new Addressing200408Dictionary(Dictionary);
+                return s_addressing200408Dictionary;
             }
         }
 
@@ -259,6 +270,20 @@ namespace System.ServiceModel
             this.ReplyRelationship = dictionary.CreateString(ServiceModelStringsVersion1.String102, 102);
             this.NoneAddress = dictionary.CreateString(ServiceModelStringsVersion1.String103, 103);
             this.Metadata = dictionary.CreateString(ServiceModelStringsVersion1.String104, 104);
+        }
+    }
+
+    internal class Addressing200408Dictionary
+    {
+        public XmlDictionaryString Namespace;
+        public XmlDictionaryString Anonymous;
+        public XmlDictionaryString FaultAction;
+ 
+        public Addressing200408Dictionary(ServiceModelDictionary dictionary)
+        {
+            this.Namespace = dictionary.CreateString(ServiceModelStringsVersion1.String105, 105);
+            this.Anonymous = dictionary.CreateString(ServiceModelStringsVersion1.String106, 106);
+            this.FaultAction = dictionary.CreateString(ServiceModelStringsVersion1.String107, 107);
         }
     }
 

--- a/src/System.ServiceModel.Primitives/ref/System.ServiceModel.Primitives.cs
+++ b/src/System.ServiceModel.Primitives/ref/System.ServiceModel.Primitives.cs
@@ -682,6 +682,7 @@ namespace System.ServiceModel.Channels
         internal AddressingVersion() { }
         public static System.ServiceModel.Channels.AddressingVersion None { get { return default(System.ServiceModel.Channels.AddressingVersion); } }
         public static System.ServiceModel.Channels.AddressingVersion WSAddressing10 { get { return default(System.ServiceModel.Channels.AddressingVersion); } }
+        public static System.ServiceModel.Channels.AddressingVersion WSAddressingAugust2004 { get { return default(System.ServiceModel.Channels.AddressingVersion); } }
         public override string ToString() { return default(string); }
     }
     public sealed partial class BinaryMessageEncodingBindingElement : System.ServiceModel.Channels.MessageEncodingBindingElement
@@ -1224,6 +1225,8 @@ namespace System.ServiceModel.Channels
         public static System.ServiceModel.Channels.MessageVersion None { get { return default(System.ServiceModel.Channels.MessageVersion); } }
         public static System.ServiceModel.Channels.MessageVersion Soap11 { get { return default(System.ServiceModel.Channels.MessageVersion); } }
         public static System.ServiceModel.Channels.MessageVersion Soap12WSAddressing10 { get { return default(System.ServiceModel.Channels.MessageVersion); } }
+        public static System.ServiceModel.Channels.MessageVersion Soap11WSAddressingAugust2004 { get { return default(System.ServiceModel.Channels.MessageVersion); } }
+        public static System.ServiceModel.Channels.MessageVersion Soap12WSAddressingAugust2004 { get { return default(System.ServiceModel.Channels.MessageVersion); } }
         public static System.ServiceModel.Channels.MessageVersion CreateVersion(System.ServiceModel.EnvelopeVersion envelopeVersion) { return default(System.ServiceModel.Channels.MessageVersion); }
         public static System.ServiceModel.Channels.MessageVersion CreateVersion(System.ServiceModel.EnvelopeVersion envelopeVersion, System.ServiceModel.Channels.AddressingVersion addressingVersion) { return default(System.ServiceModel.Channels.MessageVersion); }
         public override bool Equals(object obj) { return default(bool); }

--- a/src/System.ServiceModel.Primitives/ref/System.ServiceModel.Primitives.cs
+++ b/src/System.ServiceModel.Primitives/ref/System.ServiceModel.Primitives.cs
@@ -1224,8 +1224,8 @@ namespace System.ServiceModel.Channels
         public System.ServiceModel.EnvelopeVersion Envelope { get { return default(System.ServiceModel.EnvelopeVersion); } }
         public static System.ServiceModel.Channels.MessageVersion None { get { return default(System.ServiceModel.Channels.MessageVersion); } }
         public static System.ServiceModel.Channels.MessageVersion Soap11 { get { return default(System.ServiceModel.Channels.MessageVersion); } }
-        public static System.ServiceModel.Channels.MessageVersion Soap12WSAddressing10 { get { return default(System.ServiceModel.Channels.MessageVersion); } }
         public static System.ServiceModel.Channels.MessageVersion Soap11WSAddressingAugust2004 { get { return default(System.ServiceModel.Channels.MessageVersion); } }
+        public static System.ServiceModel.Channels.MessageVersion Soap12WSAddressing10 { get { return default(System.ServiceModel.Channels.MessageVersion); } }
         public static System.ServiceModel.Channels.MessageVersion Soap12WSAddressingAugust2004 { get { return default(System.ServiceModel.Channels.MessageVersion); } }
         public static System.ServiceModel.Channels.MessageVersion CreateVersion(System.ServiceModel.EnvelopeVersion envelopeVersion) { return default(System.ServiceModel.Channels.MessageVersion); }
         public static System.ServiceModel.Channels.MessageVersion CreateVersion(System.ServiceModel.EnvelopeVersion envelopeVersion, System.ServiceModel.Channels.AddressingVersion addressingVersion) { return default(System.ServiceModel.Channels.MessageVersion); }


### PR DESCRIPTION
As requested in #2096.

@mconnew wrote:
> As for contributing, there are 3 pieces to make this change:
>1. Add it to the contract. This involves adding the relevant items to the [reference definitions here](https://github.com/dotnet/wcf/blob/master/src/System.ServiceModel.Primitives/ref/System.ServiceModel.Primitives.cs). `MessageVersion.Soap12WSAddressingAugust2014` and `AddressingVersion.WSAddressingAugust2004` would both need to be added. It would be a good idea to add MessageVersion.Soap11WSAddressingAugust2014 at the same time. The only difference in implementation is in `MessageVersion` itself and one place where it's referenced elsewhere.
>2. Add the message version and addressing version implementations. The full framework implementations can be found [here](http://referencesource.microsoft.com/#System.ServiceModel/System/ServiceModel/Channels/MessageVersion.cs,13) and [here](http://referencesource.microsoft.com/#System.ServiceModel/System/ServiceModel/Channels/AddressingVersion.cs,10). The layout of the code has changed a little bit but you should still be able to follow how the code needs to be changed for .Net Core.
>3. Wire up the usage of WSAddressingAugust2004 throughout the code base.
>4. Write tests.

- [x] Add it to the contract
- [x] Add the message version and addressing version implementations
- [x] Wire up the usage
- [ ] Write tests