### PR TITLE
Build single scenario test project for uapaot.

### DIFF
--- a/src/System.Private.ServiceModel/tests/Scenarios/AllScenarioTests.csproj
+++ b/src/System.Private.ServiceModel/tests/Scenarios/AllScenarioTests.csproj
@@ -1,0 +1,33 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), certtest.props))\certtest.props" />
+  <PropertyGroup>
+    <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>AllScenarioTests</RootNamespace>
+    <AssemblyName>AllScenarioTests</AssemblyName>
+    <TestCategories>OuterLoop</TestCategories>
+    <SignAssembly>false</SignAssembly>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <ProjectGuid>{3DD4C6E6-349B-4D9E-983D-785D420BB0AF}</ProjectGuid>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="**\*.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <TargetingPackExclusions Include="System.ServiceModel.Duplex" />
+    
+    <ReferenceFromRuntime Include="System.Private.ServiceModel" />
+    <ReferenceFromRuntime Include="System.ServiceModel.Duplex" />
+    <ReferenceFromRuntime Include="System.ServiceModel.Http" />
+    <ReferenceFromRuntime Include="System.ServiceModel.NetTcp" />
+    <ReferenceFromRuntime Include="System.ServiceModel.Primitives" />
+    <ReferenceFromRuntime Include="System.ServiceModel.Security" />
+    
+    <ProjectReference Include='$(WcfScenarioTestCommonProj)' />
+    <ProjectReference Include="$(WcfInfrastructureCommonProj)" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Private.ServiceModel/tests/Scenarios/Configurations.props
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Configurations.props
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <BuildConfigurations>
+      uap-Windows_NT;
+      uapaot-Windows_NT;
+      netfx-Windows_NT;
+      netstandard;
+    </BuildConfigurations>
+  </PropertyGroup>
+</Project>

--- a/src/dir.props
+++ b/src/dir.props
@@ -1,6 +1,4 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\dir.props" />
-  <!-- *** start WCF Content *** -->
   <Import Project=".\test.props" />
-  <!-- *** end WCF Content *** -->
 </Project>

--- a/src/test.props
+++ b/src/test.props
@@ -25,6 +25,9 @@
     <WcfScenarioTestCommonDir>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)\System.Private.ServiceModel\tests\Common\Scenarios\'))</WcfScenarioTestCommonDir>
     <WcfInfrastructureCommonDir>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)\System.Private.ServiceModel\tests\Common\Infrastructure\'))</WcfInfrastructureCommonDir>
   </PropertyGroup>
+  <PropertyGroup>
+    <BuildSeparateScenarioProjects Condition=" '$(BuildSeparateScenarioProjects)' == '' ">false</BuildSeparateScenarioProjects>
+  </PropertyGroup>
   <PropertyGroup Condition="$(MSBuildProjectName.EndsWith('.Tests')) AND $(TestCategories.Contains('OuterLoop'))">
     <XunitOptions>-parallel none</XunitOptions>
   </PropertyGroup>

--- a/src/tests.builds
+++ b/src/tests.builds
@@ -10,11 +10,8 @@
     <GenerateCodeCoverageReportForAll>true</GenerateCodeCoverageReportForAll>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(RunningSharedFrameworkValidation)'=='true'">
-    <TestProjectExclusions Include="$(MSBuildThisFileDirectory)*\tests\**\System.Data.Odbc.Tests.csproj" />
-    <TestProjectExclusions Include="$(MSBuildThisFileDirectory)*\tests\**\System.IO.Pipes.Tests.csproj" />
-    <TestProjectExclusions Include="$(MSBuildThisFileDirectory)*\tests\**\Microsoft.XmlSerializer.Generator.Tests.csproj" />
-    <TestProjectExclusions Include="$(MSBuildThisFileDirectory)*\tests\**\System.Reflection.Context.Tests.csproj" />
+  <ItemGroup>
+    <TestProjectExclusions Include="$(MSBuildThisFileDirectory)System.Private.ServiceModel\tests\Scenarios\AllScenarioTests.csproj" />
   </ItemGroup>
 
   <!-- For UAP we are using an APPX that is registered with a unique ID. Because of that we need to run tests sequentially -->
@@ -32,7 +29,17 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <Project Include="$(MSBuildThisFileDirectory)*\tests\**\*$(_ProjectPattern).csproj" Exclude="@(TestProjectExclusions)" />
+    <!--If a uapaot run use the single scenario test project by default-->
+    <Project Include="$(MSBuildThisFileDirectory)System.Private.ServiceModel\tests\Scenarios\AllScenarioTests.csproj" Condition="'$(TargetGroup)'=='uapaot' and '$(BuildSeparateScenarioProjects)'!='true'" />
+
+    <!--In VSTS build separate scenario projects even for uapaot.-->
+    <Project Include="$(MSBuildThisFileDirectory)*\tests\Scenarios\**\*$(_ProjectPattern).csproj" Exclude="@(TestProjectExclusions)" Condition="'$(TargetGroup)'=='uapaot' and '$(BuildSeparateScenarioProjects)'=='true'" />
+    
+    <!--All non-uapaot runs use the separate scenario test projects.-->
+    <Project Include="$(MSBuildThisFileDirectory)*\tests\Scenarios\**\*$(_ProjectPattern).csproj" Exclude="@(TestProjectExclusions)" Condition="'$(TargetGroup)'!='uapaot'" />
+
+    <!--Always include unit test projects.-->
+    <Project Include="$(MSBuildThisFileDirectory)*\tests\*$(_ProjectPattern).csproj" />
   </ItemGroup>
 
   <Import Project="$(ToolsDir)Build.Post.targets" Condition="Exists('$(ToolsDir)Build.Post.targets')" />


### PR DESCRIPTION
* This is a cherry-pick of #2110 into release/uwp6.0
* Because of how long it takes to run a project through the ILC toolchain, collapse all the scenario test projects into a single test project for uapaot builds.
* Allow this option to be ignored in VSTS so that test result reporting in MC still looks good.
* Can still override locally if separate projects are desired.
* Had to update the expected test ILC package version.