### PR TITLE
Fix possible thread issue with some tests.

### DIFF
--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/ClientBase/Client.ClientBase.Tests.csproj
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/ClientBase/Client.ClientBase.Tests.csproj
@@ -13,6 +13,9 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ProjectGuid>{E0142AC1-DA3D-4143-BFF1-7A70EE0981D4}</ProjectGuid>
   </PropertyGroup>
+  <PropertyGroup>
+    <_XunitOptions>$(_XunitOptions) -parallel none</_XunitOptions>
+  </PropertyGroup>
   <ItemGroup>
     <Compile Include="**\*.cs" />
   </ItemGroup>

--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Security.TransportSecurity.Tests.csproj
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Security.TransportSecurity.Tests.csproj
@@ -13,6 +13,9 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ProjectGuid>{452BA2A7-81AD-4146-AD02-35EC242FF0EB}</ProjectGuid>
   </PropertyGroup>
+  <PropertyGroup>
+    <_XunitOptions>$(_XunitOptions) -parallel none</_XunitOptions>
+  </PropertyGroup>
   <ItemGroup>
     <Compile Include="**\*.cs" />
   </ItemGroup>


### PR DESCRIPTION
* Tests that switch threads using Task.Run or similar methods may hang or get the wrong callback.
* May have something to do with the number of cores on the test machine.
* The only way to test this is to merge the possible fix in order to run it through VSTS and the Helix machines.