### PR TITLE
Adding support for quoted char set in Content-Type

### DIFF
--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/TextMessageEncoder.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/TextMessageEncoder.cs
@@ -354,7 +354,18 @@ namespace System.ServiceModel.Channels
             internal override bool IsCharSetSupported(string charSet)
             {
                 Encoding tmp;
-                return TextEncoderDefaults.TryGetEncoding(charSet, out tmp);
+                if (!TextEncoderDefaults.TryGetEncoding(charSet, out tmp))
+                {
+                    // GetEncodingFromContentType supports charset with quotes (by simply stripping them) so we do the same here
+                    // This also gives us parity with Desktop WCF behavior
+                    if (charSet.Length > 2 && charSet[0] == '"' && charSet[charSet.Length - 1] == '"')
+                    {
+                        charSet = charSet.Substring(1, charSet.Length - 2);
+                        return TextEncoderDefaults.TryGetEncoding(charSet, out tmp);
+                    }
+                    return false;
+                }
+                return true;
             }
 
             public override bool IsContentTypeSupported(string contentType)

--- a/src/System.Private.ServiceModel/tests/Scenarios/Encoding/Encoders/TextEncodingTests.4.1.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Encoding/Encoders/TextEncodingTests.4.1.0.cs
@@ -42,4 +42,31 @@ public static partial class TextEncodingTests
             ScenarioTestHelpers.CloseCommunicationObjects((ICommunicationObject)serviceProxy, factory);
         }
     }
+
+    [WcfFact]
+    [OuterLoop]
+    public static void TextMessageEncoder_QuotedCharSet_In_Response_ContentType()
+    {
+        ChannelFactory<IWcfService> factory = null;
+        IWcfService channel = null;
+        string testQuotedCharSetContentType = "text/xml; param1 = value1; charset=\"utf-8\"; param2 = value2; param3 = \"value3\"";
+
+        Binding binding = null;
+
+        try
+        {
+            // *** SETUP *** \\
+            binding = new BasicHttpBinding(BasicHttpSecurityMode.None);
+            factory = new ChannelFactory<IWcfService>(binding, new EndpointAddress(Endpoints.HttpBaseAddress_Basic));
+            channel = factory.CreateChannel();
+
+            // *** EXECUTE *** \\
+            channel.ReturnContentType(testQuotedCharSetContentType);
+        }
+        finally
+        {
+            // *** CLEANUP *** \\
+            ScenarioTestHelpers.CloseCommunicationObjects((ICommunicationObject)channel, factory);
+        }
+    }
 }


### PR DESCRIPTION
The fix is to simply match the quotes handing logic in IsCharSetSupported() to the one already implemented in GetEncodingFromContentType().

Tests to follow shortly...