### PR TITLE
Fixed NullRef in SocketConnection.CancelSendTimer.

### DIFF
--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/SocketConnection.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/SocketConnection.cs
@@ -315,7 +315,7 @@ namespace System.ServiceModel.Channels
 
         private void CancelSendTimer()
         {
-            _sendTimer.Cancel();
+            _sendTimer?.Cancel();
         }
 
         private void CloseAsyncAndLinger()


### PR DESCRIPTION
We also need to have the fix in uwp6 branch.

Fix #2145 