### PR TITLE
Exclude old version of S.P.SM from getting pulled in.

### DIFF
--- a/external/runtime/runtime.depproj
+++ b/external/runtime/runtime.depproj
@@ -22,6 +22,7 @@
     <FileToExclude Include="System.Private.CoreLib.Augments" />
     <FileToExclude Include="System.Private.CoreLib.DynamicDelegate" />
     <FileToExclude Include="System.Private.CoreLib.WinRTInterop" />
+    <FileToExclude Include="System.Private.ServiceModel" />
     <PackageReference Include="NETStandard.Library">
       <Version>$(NETStandardPackageVersion)</Version>
     </PackageReference>

--- a/src/tests.builds
+++ b/src/tests.builds
@@ -30,7 +30,7 @@
   
   <ItemGroup>
     <!--If a uapaot run use the single scenario test project by default-->
-    <Project Include="$(MSBuildThisFileDirectory)System.Private.ServiceModel\tests\Scenarios\AllScenarioTests.csproj" Condition="'$(TargetGroup)'=='uapaot' and '$(BuildSeparateScenarioProjects)'!='true'" />
+    <Project Include="$(MSBuildThisFileDirectory)System.Private.ServiceModel\tests\Scenarios\AllScenarioTests.csproj" Condition="'$(TargetGroup)'=='uapaot' and '$(BuildSeparateScenarioProjects)'!='true' and '$(OuterLoop)' == 'true'" />
 
     <!--In VSTS build separate scenario projects even for uapaot.-->
     <Project Include="$(MSBuildThisFileDirectory)*\tests\Scenarios\**\*$(_ProjectPattern).csproj" Exclude="@(TestProjectExclusions)" Condition="'$(TargetGroup)'=='uapaot' and '$(BuildSeparateScenarioProjects)'=='true'" />


### PR DESCRIPTION
* When syncing Microsoft.TargetingPack.Private.NETNative was pulling in an old version of S.P.SM into the runtime folder which was causing some type not found failures.
* The failure was only observed when building against packages using the OverridePackageSource property which is the Helix scenario, the typical local dev workflow avoided this issue due to how the test bin dirs are put together.
* Also adding a condition so that the new single scenario test project will only be compiled if OuterLoop is true.