### PR TITLE
Fixes to tests to enable UWP certificate scenarios to succeed

### DIFF
--- a/dependencies.props
+++ b/dependencies.props
@@ -9,7 +9,7 @@
        These ref versions are pulled from https://github.com/dotnet/versions.
   -->
   <PropertyGroup>
-    <CoreFxCurrentRef>893c05a4163f89f9ef0bdc69b2f1debda10a05c4</CoreFxCurrentRef>
+    <CoreFxCurrentRef>d7e1980e8fa83a2155544c683df8762db8c71623</CoreFxCurrentRef>
     <WCFCurrentRef>c9a03fe0c3309508cb509a4ffdd6dc8b79ed525e</WCFCurrentRef>
     <StandardCurrentRef>9d670595478e52f203b9b8925576ce5e7f6826dd</StandardCurrentRef>
     <ProjectNTfsCurrentRef>d1cec650123d1124f51b6144a149453abd45bee4</ProjectNTfsCurrentRef>
@@ -19,14 +19,14 @@
   <!-- Auto-upgraded properties for each build info dependency. -->
   <PropertyGroup>
     <WCFExpectedPrerelease>preview1-25302-01</WCFExpectedPrerelease>
-    <CoreFxExpectedPrerelease>preview2-25506-02</CoreFxExpectedPrerelease>
+    <CoreFxExpectedPrerelease>preview2-25524-02</CoreFxExpectedPrerelease>
     <NETStandardPackageVersion>2.1.0-preview1-25319-01</NETStandardPackageVersion>
     <NETStandardPackageId>NETStandard.Library</NETStandardPackageId>
     <!--
       This property is used for many CoreFX packages, because they have the same
       versions. Make more properties for CoreFX if split versions are required.
     -->
-    <MicrosoftPrivateCoreFxNETCoreAppPackageVersion>4.5.0-preview2-25506-02</MicrosoftPrivateCoreFxNETCoreAppPackageVersion>
+    <MicrosoftPrivateCoreFxNETCoreAppPackageVersion>4.5.0-preview2-25524-02</MicrosoftPrivateCoreFxNETCoreAppPackageVersion>
 
     <ProjectNTfsExpectedPrerelease>beta-25331-00</ProjectNTfsExpectedPrerelease>
     <ProjectNTfsTestILCExpectedPrerelease>beta-25331-00</ProjectNTfsTestILCExpectedPrerelease>

--- a/src/System.Private.ServiceModel/tests/Common/Infrastructure/ServiceUtilHelper.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Infrastructure/ServiceUtilHelper.cs
@@ -274,7 +274,7 @@ public static class ServiceUtilHelper
     // propagated back to the caller.
     private static X509Certificate2 InstallClientCertificateFromServer()
     {
-        X509Certificate2 clientCertificate = new X509Certificate2(GetResourceFromServiceAsByteArray(ClientCertificateResource), "test", X509KeyStorageFlags.PersistKeySet);
+        X509Certificate2 clientCertificate = new X509Certificate2(GetResourceFromServiceAsByteArray(ClientCertificateResource), "test", X509KeyStorageFlags.PersistKeySet | X509KeyStorageFlags.UserKeySet);
         return CertificateManager.InstallCertificateToMyStore(clientCertificate);
     }
 
@@ -283,7 +283,7 @@ public static class ServiceUtilHelper
     // propagated back to the caller.
     private static X509Certificate2 InstallPeerCertificateFromServer()
     {
-        X509Certificate2 peerCertificate = new X509Certificate2(GetResourceFromServiceAsByteArray(PeerCertificateResource), "test", X509KeyStorageFlags.PersistKeySet);
+        X509Certificate2 peerCertificate = new X509Certificate2(GetResourceFromServiceAsByteArray(PeerCertificateResource), "test", X509KeyStorageFlags.PersistKeySet | X509KeyStorageFlags.UserKeySet);
         return CertificateManager.InstallCertificateToTrustedPeopleStore(peerCertificate);
     }
 


### PR DESCRIPTION
Move forward the dependent versions to pick up latest networking libraries and modify test security helper to account for differences in behavior on UWP.
