### PR TITLE
Adding support for AddressingVersion WSAddressingAugust2004

### DIFF
--- a/src/System.Private.ServiceModel/src/Resources/Strings.resx
+++ b/src/System.Private.ServiceModel/src/Resources/Strings.resx
@@ -1971,4 +1971,10 @@
   <data name="PeerTrustNotSupportedOnOSX" xml:space="preserve">
     <value>Peer Trust certificate validation is not supported on OSX. See https://go.microsoft.com/fwlink/?linkid=849976 for details.</value>
   </data>
+  <data name="SFxNone2004" xml:space="preserve">
+    <value>The WS-Addressing "none" value is not valid for the August 2004 version of WS-Addressing.</value>
+  </data>
+  <data name="SFxRequestHasInvalidFromOnClient" xml:space="preserve">
+    <value>The request message has From='{0}' but IContextChannel.LocalAddress is '{1}'.  When ManualAddressing is false, these values must be the same, null, or EndpointAddress.AnonymousAddress.  Enable ManualAddressing or avoid setting From on the message.</value>
+  </data>
 </root>

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/Addressing.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/Addressing.cs
@@ -350,6 +350,7 @@ namespace System.ServiceModel.Channels
         private const bool mustUnderstandValue = true;
 
         private static ToHeader s_anonymousToHeader10;
+        private static ToHeader s_anonymousToHeader200408;
 
         protected ToHeader(Uri to, AddressingVersion version)
             : base(version)
@@ -367,6 +368,15 @@ namespace System.ServiceModel.Channels
             }
         }
 
+        private static ToHeader AnonymousTo200408
+        {
+            get
+            {
+                if (s_anonymousToHeader200408 == null)
+                    s_anonymousToHeader200408 = new AnonymousToHeader(AddressingVersion.WSAddressing200408);
+                return s_anonymousToHeader200408;
+            }
+        }
 
         public override XmlDictionaryString DictionaryName
         {
@@ -392,8 +402,10 @@ namespace System.ServiceModel.Channels
             {
                 if (addressingVersion == AddressingVersion.WSAddressing10)
                     return AnonymousTo10;
+                else if (addressingVersion == AddressingVersion.WSAddressing200408)
+                    return AnonymousTo200408;
                 else
-                    // Verify that only WSA10 is supported
+                    // Verify that only WSA10 and WSA200408 is supported
                     throw ExceptionHelper.PlatformNotSupported();
             }
             else
@@ -412,6 +424,8 @@ namespace System.ServiceModel.Channels
             {
                 if (addressingVersion == AddressingVersion.WSAddressing10)
                     return AnonymousTo10;
+                else if (addressingVersion == AddressingVersion.WSAddressing200408)
+                    return AnonymousTo200408;
                 else
                     // Verify that only WSA10 is supported
                     throw ExceptionHelper.PlatformNotSupported();
@@ -462,6 +476,8 @@ namespace System.ServiceModel.Channels
                 {
                     if (version == AddressingVersion.WSAddressing10)
                         return AnonymousTo10;
+                    else if (version == AddressingVersion.WSAddressing200408)
+                        return AnonymousTo200408;
                     else
                         throw ExceptionHelper.PlatformNotSupported();
                 }

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/Addressing.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/Addressing.cs
@@ -402,11 +402,8 @@ namespace System.ServiceModel.Channels
             {
                 if (addressingVersion == AddressingVersion.WSAddressing10)
                     return AnonymousTo10;
-                else if (addressingVersion == AddressingVersion.WSAddressingAugust2004)
-                    return AnonymousTo200408;
                 else
-                    // Verify that only WSA10 and WSA200408 is supported
-                    throw ExceptionHelper.PlatformNotSupported();
+                    return AnonymousTo200408;
             }
             else
             {
@@ -424,11 +421,8 @@ namespace System.ServiceModel.Channels
             {
                 if (addressingVersion == AddressingVersion.WSAddressing10)
                     return AnonymousTo10;
-                else if (addressingVersion == AddressingVersion.WSAddressingAugust2004)
-                    return AnonymousTo200408;
                 else
-                    // Verify that only WSA10 is supported
-                    throw ExceptionHelper.PlatformNotSupported();
+                    return AnonymousTo200408;
             }
             else
             {

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/Addressing.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/Addressing.cs
@@ -373,7 +373,7 @@ namespace System.ServiceModel.Channels
             get
             {
                 if (s_anonymousToHeader200408 == null)
-                    s_anonymousToHeader200408 = new AnonymousToHeader(AddressingVersion.WSAddressing200408);
+                    s_anonymousToHeader200408 = new AnonymousToHeader(AddressingVersion.WSAddressingAugust2004);
                 return s_anonymousToHeader200408;
             }
         }
@@ -402,7 +402,7 @@ namespace System.ServiceModel.Channels
             {
                 if (addressingVersion == AddressingVersion.WSAddressing10)
                     return AnonymousTo10;
-                else if (addressingVersion == AddressingVersion.WSAddressing200408)
+                else if (addressingVersion == AddressingVersion.WSAddressingAugust2004)
                     return AnonymousTo200408;
                 else
                     // Verify that only WSA10 and WSA200408 is supported
@@ -424,7 +424,7 @@ namespace System.ServiceModel.Channels
             {
                 if (addressingVersion == AddressingVersion.WSAddressing10)
                     return AnonymousTo10;
-                else if (addressingVersion == AddressingVersion.WSAddressing200408)
+                else if (addressingVersion == AddressingVersion.WSAddressingAugust2004)
                     return AnonymousTo200408;
                 else
                     // Verify that only WSA10 is supported
@@ -476,7 +476,7 @@ namespace System.ServiceModel.Channels
                 {
                     if (version == AddressingVersion.WSAddressing10)
                         return AnonymousTo10;
-                    else if (version == AddressingVersion.WSAddressing200408)
+                    else if (version == AddressingVersion.WSAddressingAugust2004)
                         return AnonymousTo200408;
                     else
                         throw ExceptionHelper.PlatformNotSupported();

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/AddressingVersion.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/AddressingVersion.cs
@@ -39,7 +39,6 @@ namespace System.ServiceModel.Channels
             Addressing200408Strings.FaultAction, Addressing200408Strings.DefaultFaultAction);
         private static MessagePartSpecification s_addressing200408SignedMessageParts;
 
-
         private AddressingVersion(string ns, XmlDictionaryString dictionaryNs, string toStringFormat,
             MessagePartSpecification signedMessageParts, string anonymous, XmlDictionaryString dictionaryAnonymous, string none, string faultAction, string defaultFaultAction)
         {

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/AddressingVersion.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/AddressingVersion.cs
@@ -22,6 +22,7 @@ namespace System.ServiceModel.Channels
         private string _defaultFaultAction;
         private const string AddressingNoneToStringFormat = "AddressingNone ({0})";
         private const string Addressing10ToStringFormat = "Addressing10 ({0})";
+        private const string Addressing200408ToStringFormat = "Addressing200408 ({0})";
 
         private static AddressingVersion s_none = new AddressingVersion(AddressingNoneStrings.Namespace, XD.AddressingNoneDictionary.Namespace,
             AddressingNoneToStringFormat, new MessagePartSpecification(), null, null, null, null, null);
@@ -33,7 +34,7 @@ namespace System.ServiceModel.Channels
         private static MessagePartSpecification s_addressing10SignedMessageParts;
 
         private static AddressingVersion s_addressing200408 = new AddressingVersion(Addressing200408Strings.Namespace,
-            XD.Addressing200408Dictionary.Namespace, SR.Addressing200408ToStringFormat, Addressing200408SignedMessageParts,
+            XD.Addressing200408Dictionary.Namespace, Addressing200408ToStringFormat, Addressing200408SignedMessageParts,
             Addressing200408Strings.Anonymous, XD.Addressing200408Dictionary.Anonymous, null,
             Addressing200408Strings.FaultAction, Addressing200408Strings.DefaultFaultAction);
         private static MessagePartSpecification s_addressing200408SignedMessageParts;

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/AddressingVersion.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/AddressingVersion.cs
@@ -32,6 +32,12 @@ namespace System.ServiceModel.Channels
             Addressing10Strings.FaultAction, Addressing10Strings.DefaultFaultAction);
         private static MessagePartSpecification s_addressing10SignedMessageParts;
 
+        private static AddressingVersion s_addressing200408 = new AddressingVersion(Addressing200408Strings.Namespace,
+            XD.Addressing200408Dictionary.Namespace, SR.Addressing200408ToStringFormat, Addressing200408SignedMessageParts,
+            Addressing200408Strings.Anonymous, XD.Addressing200408Dictionary.Anonymous, null,
+            Addressing200408Strings.FaultAction, Addressing200408Strings.DefaultFaultAction);
+        private static MessagePartSpecification s_addressing200408SignedMessageParts;
+
 
         private AddressingVersion(string ns, XmlDictionaryString dictionaryNs, string toStringFormat,
             MessagePartSpecification signedMessageParts, string anonymous, XmlDictionaryString dictionaryAnonymous, string none, string faultAction, string defaultFaultAction)
@@ -57,6 +63,11 @@ namespace System.ServiceModel.Channels
             _defaultFaultAction = defaultFaultAction;
         }
 
+
+        public static AddressingVersion WSAddressingAugust2004
+        {
+            get { return s_addressing200408; }
+        }
 
         public static AddressingVersion WSAddressing10
         {
@@ -96,6 +107,28 @@ namespace System.ServiceModel.Channels
             }
         }
 
+        private static MessagePartSpecification Addressing200408SignedMessageParts
+        {
+            get
+            {
+                if (s_addressing200408SignedMessageParts == null)
+                {
+                    MessagePartSpecification s = new MessagePartSpecification(
+                        new XmlQualifiedName(AddressingStrings.To, Addressing200408Strings.Namespace),
+                        new XmlQualifiedName(AddressingStrings.From, Addressing200408Strings.Namespace),
+                        new XmlQualifiedName(AddressingStrings.FaultTo, Addressing200408Strings.Namespace),
+                        new XmlQualifiedName(AddressingStrings.ReplyTo, Addressing200408Strings.Namespace),
+                        new XmlQualifiedName(AddressingStrings.MessageId, Addressing200408Strings.Namespace),
+                        new XmlQualifiedName(AddressingStrings.RelatesTo, Addressing200408Strings.Namespace),
+                        new XmlQualifiedName(AddressingStrings.Action, Addressing200408Strings.Namespace)
+                        );
+                    s.MakeReadOnly();
+                    s_addressing200408SignedMessageParts = s;
+                }
+
+                return s_addressing200408SignedMessageParts;
+            }
+        }
 
         internal XmlDictionaryString DictionaryNamespace
         {

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/MessageHeader.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/MessageHeader.cs
@@ -63,9 +63,17 @@ namespace System.ServiceModel.Channels
                         {
                             WriteHeader(writer, MessageVersion.Soap12WSAddressing10);
                         }
+                        else if (IsMessageVersionSupported(MessageVersion.Soap12WSAddressingAugust2004))
+                        {
+                            WriteHeader(writer, MessageVersion.Soap12WSAddressingAugust2004);
+                        }
                         else if (IsMessageVersionSupported(MessageVersion.Soap11WSAddressing10))
                         {
                             WriteHeader(writer, MessageVersion.Soap11WSAddressing10);
+                        }
+                        else if (IsMessageVersionSupported(MessageVersion.Soap11WSAddressingAugust2004))
+                        {
+                            WriteHeader(writer, MessageVersion.Soap11WSAddressingAugust2004);
                         }
                         else if (IsMessageVersionSupported(MessageVersion.Soap12))
                         {

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/MessageVersion.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/MessageVersion.cs
@@ -17,6 +17,8 @@ namespace System.ServiceModel.Channels
         private static MessageVersion s_soap12;
         private static MessageVersion s_soap11Addressing10;
         private static MessageVersion s_soap12Addressing10;
+        private static MessageVersion s_soap11Addressing200408;
+        private static MessageVersion s_soap12Addressing200408;
         private const string MessageVersionToStringFormat = "{0} {1}";
 
         static MessageVersion()
@@ -26,6 +28,8 @@ namespace System.ServiceModel.Channels
             s_soap12 = new MessageVersion(EnvelopeVersion.Soap12, AddressingVersion.None);
             s_soap11Addressing10 = new MessageVersion(EnvelopeVersion.Soap11, AddressingVersion.WSAddressing10);
             s_soap12Addressing10 = new MessageVersion(EnvelopeVersion.Soap12, AddressingVersion.WSAddressing10);
+            s_soap11Addressing200408 = new MessageVersion(EnvelopeVersion.Soap11, AddressingVersion.WSAddressingAugust2004);
+            s_soap12Addressing200408 = new MessageVersion(EnvelopeVersion.Soap12, AddressingVersion.WSAddressingAugust2004);
         }
 
         private MessageVersion(EnvelopeVersion envelopeVersion, AddressingVersion addressingVersion)
@@ -57,6 +61,10 @@ namespace System.ServiceModel.Channels
                 {
                     return s_soap12Addressing10;
                 }
+                else if (addressingVersion == AddressingVersion.WSAddressingAugust2004)
+                {
+                    return s_soap12Addressing200408;
+                }
                 else if (addressingVersion == AddressingVersion.None)
                 {
                     return s_soap12;
@@ -72,6 +80,10 @@ namespace System.ServiceModel.Channels
                 if (addressingVersion == AddressingVersion.WSAddressing10)
                 {
                     return s_soap11Addressing10;
+                }
+                else if (addressingVersion == AddressingVersion.WSAddressingAugust2004)
+                {
+                    return s_soap11Addressing200408;
                 }
                 else if (addressingVersion == AddressingVersion.None)
                 {
@@ -143,6 +155,16 @@ namespace System.ServiceModel.Channels
         public static MessageVersion Soap11WSAddressing10
         {
             get { return s_soap11Addressing10; }
+        }
+
+        public static MessageVersion Soap12WSAddressingAugust2004
+        {
+            get { return s_soap12Addressing200408; }
+        }
+
+        public static MessageVersion Soap11WSAddressingAugust2004
+        {
+            get { return s_soap11Addressing200408; }
         }
 
         public static MessageVersion Soap11

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/MessageVersion.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/MessageVersion.cs
@@ -139,6 +139,8 @@ namespace System.ServiceModel.Channels
             int code = 0;
             if (this.Envelope == EnvelopeVersion.Soap11)
                 code += 1;
+            if (this.Addressing == AddressingVersion.WSAddressingAugust2004)
+                code += 2;
             return code;
         }
 

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/RequestReplyCorrelator.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/RequestReplyCorrelator.cs
@@ -99,6 +99,17 @@ namespace System.ServiceModel.Channels
             {
                 destination = info.ReplyTo;
             }
+            else if (reply.Version.Addressing == AddressingVersion.WSAddressingAugust2004)
+            {
+                if (info.HasFrom)
+                {
+                    destination = info.From;
+                }
+                else
+                {
+                    destination = EndpointAddress.AnonymousAddress;
+                }
+            }
 
             if (destination != null)
             {
@@ -180,7 +191,14 @@ namespace System.ServiceModel.Channels
             {
                 _faultTo = message.Headers.FaultTo;
                 _replyTo = message.Headers.ReplyTo;
-                _from = null;
+                if (message.Version.Addressing == AddressingVersion.WSAddressingAugust2004)
+                {
+                    this.from = message.Headers.From;
+                }
+                else 
+                {
+                    _from = null;
+                }
             }
 
             internal EndpointAddress FaultTo

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/RequestReplyCorrelator.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/RequestReplyCorrelator.cs
@@ -193,7 +193,7 @@ namespace System.ServiceModel.Channels
                 _replyTo = message.Headers.ReplyTo;
                 if (message.Version.Addressing == AddressingVersion.WSAddressingAugust2004)
                 {
-                    this.from = message.Headers.From;
+                    _from = message.Headers.From;
                 }
                 else 
                 {

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/ServiceChannel.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/ServiceChannel.cs
@@ -616,8 +616,7 @@ namespace System.ServiceModel.Channels
                         EndpointAddress from = headers.From;
                         if ((from != null) && !from.IsAnonymous && (localUri != from.Uri))
                         {
-                            // FIXME: string text = SR.Format(SR.SFxRequestHasInvalidFromOnClient, from.Uri, localUri);
-                            string text = SR.Format("The request message has From='{0}' but IContextChannel.LocalAddress is '{1}'.  When ManualAddressing is false, these values must be the same, null, or EndpointAddress.AnonymousAddress.  Enable ManualAddressing or avoid setting From on the message.", faultTo.Uri, localUri);
+                            string text = SR.Format(SR.SFxRequestHasInvalidFromOnClient, from.Uri, localUri);
                             Exception error = new InvalidOperationException(text);
                             throw TraceUtility.ThrowHelperError(error, rpc.Request);
                         }

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/ServiceChannel.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/ServiceChannel.cs
@@ -610,6 +610,18 @@ namespace System.ServiceModel.Channels
                         Exception error = new InvalidOperationException(text);
                         throw TraceUtility.ThrowHelperError(error, rpc.Request);
                     }
+ 
+                    if (this._messageVersion.Addressing == AddressingVersion.WSAddressingAugust2004)
+                    {
+                        EndpointAddress from = headers.From;
+                        if ((from != null) && !from.IsAnonymous && (localUri != from.Uri))
+                        {
+                            // FIXME: string text = SR.Format(SR.SFxRequestHasInvalidFromOnClient, from.Uri, localUri);
+                            string text = SR.Format("The request message has From='{0}' but IContextChannel.LocalAddress is '{1}'.  When ManualAddressing is false, these values must be the same, null, or EndpointAddress.AnonymousAddress.  Enable ManualAddressing or avoid setting From on the message.", faultTo.Uri, localUri);
+                            Exception error = new InvalidOperationException(text);
+                            throw TraceUtility.ThrowHelperError(error, rpc.Request);
+                        }
+                    }
                 }
             }
 

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Dispatcher/PrimitiveOperationFormatter.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Dispatcher/PrimitiveOperationFormatter.cs
@@ -21,8 +21,10 @@ namespace System.ServiceModel.Dispatcher
         private XmlDictionaryString _replyAction;
         private ActionHeader _actionHeaderNone;
         private ActionHeader _actionHeader10;
+        private ActionHeader _actionHeaderAugust2004;
         private ActionHeader _replyActionHeaderNone;
         private ActionHeader _replyActionHeader10;
+        private ActionHeader _replyActionHeaderAugust2004;
         private XmlDictionaryString _requestWrapperName;
         private XmlDictionaryString _requestWrapperNamespace;
         private XmlDictionaryString _responseWrapperName;
@@ -108,6 +110,20 @@ namespace System.ServiceModel.Dispatcher
                 return _actionHeader10;
             }
         }
+ 
+        private ActionHeader ActionHeaderAugust2004
+        {
+            get
+            {
+                if (_actionHeaderAugust2004 == null)
+                {
+                    _actionHeaderAugust2004 =
+                        ActionHeader.Create(_action, AddressingVersion.WSAddressingAugust2004);
+                }
+ 
+                return _actionHeaderAugust2004;
+            }
+        }
 
 
         private ActionHeader ReplyActionHeaderNone
@@ -138,6 +154,19 @@ namespace System.ServiceModel.Dispatcher
             }
         }
 
+        private ActionHeader ReplyActionHeaderAugust2004
+        {
+            get
+            {
+                if (_replyActionHeaderAugust2004 == null)
+                {
+                    _replyActionHeaderAugust2004 =
+                        ActionHeader.Create(_replyAction, AddressingVersion.WSAddressingAugust2004);
+                }
+ 
+                return _replyActionHeaderAugust2004;
+            }
+        }
 
         private static XmlDictionaryString AddToDictionary(XmlDictionary dictionary, string s)
         {
@@ -166,7 +195,11 @@ namespace System.ServiceModel.Dispatcher
                 return null;
             }
 
-            if (addressing == AddressingVersion.WSAddressing10)
+            if (addressing == AddressingVersion.WSAddressingAugust2004)
+            {
+                return ActionHeaderAugust2004;
+            }
+            else if (addressing == AddressingVersion.WSAddressing10)
             {
                 return ActionHeader10;
             }
@@ -188,7 +221,11 @@ namespace System.ServiceModel.Dispatcher
                 return null;
             }
 
-            if (addressing == AddressingVersion.WSAddressing10)
+            if (addressing == AddressingVersion.WSAddressingAugust2004)
+            {
+                return ReplyActionHeaderAugust2004;
+            }
+            else if (addressing == AddressingVersion.WSAddressing10)
             {
                 return ReplyActionHeader10;
             }

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/EndpointAddress.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/EndpointAddress.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Runtime;
 using System.ServiceModel.Channels;
@@ -293,6 +294,10 @@ namespace System.ServiceModel
                 {
                     message.Headers.To = null;
                 }
+                else if (message.Version.Addressing == AddressingVersion.WSAddressingAugust2004)
+                {
+                    message.Headers.To = message.Version.Addressing.AnonymousUri;
+                }
                 else
                 {
                     throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(
@@ -528,6 +533,10 @@ namespace System.ServiceModel
             {
                 version = AddressingVersion.WSAddressing10;
             }
+            else if (reader.IsNamespaceUri(AddressingVersion.WSAddressingAugust2004.DictionaryNamespace))
+            {
+                version = AddressingVersion.WSAddressingAugust2004;
+            }
             else if (reader.NodeType != XmlNodeType.Element)
             {
                 throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgument(
@@ -572,6 +581,10 @@ namespace System.ServiceModel
             {
                 isAnonymous = ReadContentsFrom10(reader, out uri, out headers, out identity, out buffer, out metadataSection, out extensionSection);
             }
+            else if (addressingVersion == AddressingVersion.WSAddressingAugust2004)
+            {
+                isAnonymous = ReadContentsFrom200408(reader, out uri, out headers, out identity, out buffer, out metadataSection, out extensionSection, out pspSection);
+            } 
             else
             {
                 throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgument("addressingVersion",
@@ -642,6 +655,161 @@ namespace System.ServiceModel
             return buffer;
         }
 
+        private static bool ReadContentsFrom200408(XmlDictionaryReader reader, out Uri uri, out AddressHeaderCollection headers, out EndpointIdentity identity, out XmlBuffer buffer, out int metadataSection, out int extensionSection, out int pspSection)
+        {
+            buffer = null;
+            headers = null;
+            extensionSection = -1;
+            metadataSection = -1;
+            pspSection = -1;
+ 
+            // Cache address string
+            reader.MoveToContent();
+            if (!reader.IsStartElement(XD.AddressingDictionary.Address, AddressingVersion.WSAddressingAugust2004.DictionaryNamespace))
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(CreateXmlException(reader, SR.Format(SR.UnexpectedElementExpectingElement, reader.LocalName, reader.NamespaceURI, XD.AddressingDictionary.Address.Value, XD.Addressing200408Dictionary.Namespace.Value)));
+            }
+            string address = reader.ReadElementContentAsString();
+ 
+            // ReferenceProperites
+            reader.MoveToContent();
+            if (reader.IsStartElement(XD.AddressingDictionary.ReferenceProperties, AddressingVersion.WSAddressingAugust2004.DictionaryNamespace))
+            {
+                headers = AddressHeaderCollection.ReadServiceParameters(reader, true);
+            }
+ 
+            // ReferenceParameters
+            reader.MoveToContent();
+            if (reader.IsStartElement(XD.AddressingDictionary.ReferenceParameters, AddressingVersion.WSAddressingAugust2004.DictionaryNamespace))
+            {
+                if (headers != null)
+                {
+                    List<AddressHeader> headerList = new List<AddressHeader>();
+                    foreach (AddressHeader ah in headers)
+                    {
+                        headerList.Add(ah);
+                    }
+                    AddressHeaderCollection tmp = AddressHeaderCollection.ReadServiceParameters(reader);
+                    foreach (AddressHeader ah in tmp)
+                    {
+                        headerList.Add(ah);
+                    }
+                    headers = new AddressHeaderCollection(headerList);
+                }
+                else
+                {
+                    headers = AddressHeaderCollection.ReadServiceParameters(reader);
+                }
+            }
+ 
+            XmlDictionaryWriter bufferWriter = null;
+ 
+            // PortType
+            reader.MoveToContent();
+            if (reader.IsStartElement(XD.AddressingDictionary.PortType, AddressingVersion.WSAddressingAugust2004.DictionaryNamespace))
+            {
+                if (bufferWriter == null)
+                {
+                    if (buffer == null)
+                        buffer = new XmlBuffer(short.MaxValue);
+                    bufferWriter = buffer.OpenSection(reader.Quotas);
+                    bufferWriter.WriteStartElement(DummyName, DummyNamespace);
+                }
+                bufferWriter.WriteNode(reader, true);
+            }
+ 
+            // ServiceName
+            reader.MoveToContent();
+            if (reader.IsStartElement(XD.AddressingDictionary.ServiceName, AddressingVersion.WSAddressingAugust2004.DictionaryNamespace))
+            {
+                if (bufferWriter == null)
+                {
+                    if (buffer == null)
+                        buffer = new XmlBuffer(short.MaxValue);
+                    bufferWriter = buffer.OpenSection(reader.Quotas);
+                    bufferWriter.WriteStartElement(DummyName, DummyNamespace);
+                }
+                bufferWriter.WriteNode(reader, true);
+            }
+ 
+            // Policy
+            reader.MoveToContent();
+            while (reader.IsNamespaceUri(PolicyStrings.Namespace))
+            {
+                if (bufferWriter == null)
+                {
+                    if (buffer == null)
+                        buffer = new XmlBuffer(short.MaxValue);
+                    bufferWriter = buffer.OpenSection(reader.Quotas);
+                    bufferWriter.WriteStartElement(DummyName, DummyNamespace);
+                }
+                bufferWriter.WriteNode(reader, true);
+                reader.MoveToContent();
+            }
+ 
+            // Finish PSP
+            if (bufferWriter != null)
+            {
+                bufferWriter.WriteEndElement();
+                buffer.CloseSection();
+                pspSection = buffer.SectionCount - 1;
+                bufferWriter = null;
+            }
+            else
+            {
+                pspSection = -1;
+            }
+ 
+ 
+            // Metadata
+            if (reader.IsStartElement(System.ServiceModel.Description.MetadataStrings.MetadataExchangeStrings.Metadata,
+                                      System.ServiceModel.Description.MetadataStrings.MetadataExchangeStrings.Namespace))
+            {
+                if (bufferWriter == null)
+                {
+                    if (buffer == null)
+                        buffer = new XmlBuffer(short.MaxValue);
+                    bufferWriter = buffer.OpenSection(reader.Quotas);
+                    bufferWriter.WriteStartElement(DummyName, DummyNamespace);
+                }
+                bufferWriter.WriteNode(reader, true);
+            }
+ 
+            // Finish metadata
+            if (bufferWriter != null)
+            {
+                bufferWriter.WriteEndElement();
+                buffer.CloseSection();
+                metadataSection = buffer.SectionCount - 1;
+                bufferWriter = null;
+            }
+            else
+            {
+                metadataSection = -1;
+            }
+ 
+            // Extensions
+            reader.MoveToContent();
+            buffer = ReadExtensions(reader, AddressingVersion.WSAddressingAugust2004, buffer, out identity, out extensionSection);
+ 
+            // Finished reading
+            if (buffer != null)
+                buffer.Close();
+ 
+            // Process Address
+            if (address == Addressing200408Strings.Anonymous)
+            {
+                uri = AddressingVersion.WSAddressingAugust2004.AnonymousUri;
+                if (headers == null && identity == null)
+                    return true;
+            }
+            else
+            {
+                if (!Uri.TryCreate(address, UriKind.Absolute, out uri))
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new XmlException(SR.Format(SR.InvalidUriValue, address, XD.AddressingDictionary.Address.Value, AddressingVersion.WSAddressingAugust2004.Namespace)));
+            }
+            return false;
+        }
 
         private static bool ReadContentsFrom10(XmlDictionaryReader reader, out Uri uri, out AddressHeaderCollection headers, out EndpointIdentity identity, out XmlBuffer buffer, out int metadataSection, out int extensionSection)
         {
@@ -760,6 +928,10 @@ namespace System.ServiceModel
             {
                 WriteContentsTo10(writer);
             }
+            else if (addressingVersion == AddressingVersion.WSAddressingAugust2004)
+            {
+                WriteContentsTo200408(writer);
+            }
             else if (addressingVersion == AddressingVersion.None)
             {
                 WriteContentsToNone(writer);
@@ -776,6 +948,78 @@ namespace System.ServiceModel
             writer.WriteString(this.Uri.AbsoluteUri);
         }
 
+        private void WriteContentsTo200408(XmlDictionaryWriter writer)
+        {
+            // Address
+            writer.WriteStartElement(XD.AddressingDictionary.Address, XD.Addressing200408Dictionary.Namespace);
+            if (IsAnonymous)
+            {
+                writer.WriteString(XD.Addressing200408Dictionary.Anonymous);
+            }
+            else if (IsNone)
+            {
+                //FIXME: throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgument("addressingVersion", SR.Format(SR.SFxNone2004));
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgument("addressingVersion", SR.Format("The WS-Addressing \"none\" value is not valid for the August 2004 version of WS-Addressing."));
+            }
+            else
+            {
+                writer.WriteString(this.Uri.AbsoluteUri);
+            }
+            writer.WriteEndElement();
+ 
+            // ReferenceProperties
+            if (_headers != null && _headers.HasReferenceProperties)
+            {
+                writer.WriteStartElement(XD.AddressingDictionary.ReferenceProperties, XD.Addressing200408Dictionary.Namespace);
+                _headers.WriteReferencePropertyContentsTo(writer);
+                writer.WriteEndElement();
+            }
+ 
+            // ReferenceParameters
+            if (_headers != null && _headers.HasNonReferenceProperties)
+            {
+                writer.WriteStartElement(XD.AddressingDictionary.ReferenceParameters, XD.Addressing200408Dictionary.Namespace);
+                _headers.WriteNonReferencePropertyContentsTo(writer);
+                writer.WriteEndElement();
+            }
+ 
+            // PSP (PortType, ServiceName, Policy)
+            XmlDictionaryReader reader = null;
+            if (_pspSection >= 0)
+            {
+                reader = GetReaderAtSection(_buffer, _pspSection);
+                Copy(writer, reader);
+            }
+ 
+            // Metadata
+            reader = null;
+            if (_metadataSection >= 0)
+            {
+                reader = GetReaderAtSection(_buffer, _metadataSection);
+                Copy(writer, reader);
+            }
+ 
+            // EndpointIdentity
+            if (this.Identity != null)
+            {
+                this.Identity.WriteTo(writer);
+            }
+ 
+            // Extensions
+            if (_extensionSection >= 0)
+            {
+                reader = GetReaderAtSection(_buffer, _extensionSection);
+                while (reader.IsStartElement())
+                {
+                    if (reader.NamespaceURI == AddressingVersion.WSAddressingAugust2004.Namespace)
+                    {
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(CreateXmlException(reader, SR.Format(SR.AddressingExtensionInBadNS, reader.LocalName, reader.NamespaceURI)));
+                    }
+ 
+                    writer.WriteNode(reader, true);
+                }
+            }
+        }
 
         private void WriteContentsTo10(XmlDictionaryWriter writer)
         {

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/EndpointAddress.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/EndpointAddress.cs
@@ -958,8 +958,7 @@ namespace System.ServiceModel
             }
             else if (IsNone)
             {
-                //FIXME: throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgument("addressingVersion", SR.Format(SR.SFxNone2004));
-                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgument("addressingVersion", SR.Format("The WS-Addressing \"none\" value is not valid for the August 2004 version of WS-Addressing."));
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgument("addressingVersion", SR.Format(SR.SFxNone2004));
             }
             else
             {

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/XD.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/XD.cs
@@ -17,6 +17,7 @@ namespace System.ServiceModel
         private static ActivityIdFlowDictionary s_activityIdFlowDictionary;
         private static AddressingDictionary s_addressingDictionary;
         private static Addressing10Dictionary s_addressing10Dictionary;
+        private static Addressing200408Dictionary s_addressing200408Dictionary;
         private static AddressingNoneDictionary s_addressingNoneDictionary;
         private static MessageDictionary s_messageDictionary;
         private static Message11Dictionary s_message11Dictionary;
@@ -56,6 +57,16 @@ namespace System.ServiceModel
                 if (s_addressing10Dictionary == null)
                     s_addressing10Dictionary = new Addressing10Dictionary(Dictionary);
                 return s_addressing10Dictionary;
+            }
+        }
+
+        static public Addressing200408Dictionary Addressing200408Dictionary
+        {
+            get
+            {
+                if (s_addressing200408Dictionary == null)
+                    s_addressing200408Dictionary = new Addressing200408Dictionary(Dictionary);
+                return s_addressing200408Dictionary;
             }
         }
 
@@ -259,6 +270,20 @@ namespace System.ServiceModel
             this.ReplyRelationship = dictionary.CreateString(ServiceModelStringsVersion1.String102, 102);
             this.NoneAddress = dictionary.CreateString(ServiceModelStringsVersion1.String103, 103);
             this.Metadata = dictionary.CreateString(ServiceModelStringsVersion1.String104, 104);
+        }
+    }
+
+    internal class Addressing200408Dictionary
+    {
+        public XmlDictionaryString Namespace;
+        public XmlDictionaryString Anonymous;
+        public XmlDictionaryString FaultAction;
+ 
+        public Addressing200408Dictionary(ServiceModelDictionary dictionary)
+        {
+            this.Namespace = dictionary.CreateString(ServiceModelStringsVersion1.String105, 105);
+            this.Anonymous = dictionary.CreateString(ServiceModelStringsVersion1.String106, 106);
+            this.FaultAction = dictionary.CreateString(ServiceModelStringsVersion1.String107, 107);
         }
     }
 

--- a/src/System.Private.ServiceModel/tests/Common/Scenarios/Endpoints.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Scenarios/Endpoints.cs
@@ -53,12 +53,22 @@ public static partial class Endpoints
     {
         get { return GetEndpointAddress("HttpSoap11.svc//http-soap11"); }
     }
+	
+	public static string HttpSoap11WSA2004_Address
+	{
+		get { return GetEndpointAddress("HttpSoap11WSA2004.svc//http-Soap11WSA2004"); }
+	}
 
     public static string HttpSoap12_Address
     {
         get { return GetEndpointAddress("HttpSoap12.svc//http-soap12"); }
     }
 
+	public static string HttpSoap12WSA2004_Address
+	{
+		get { return GetEndpointAddress("HttpSoap12WSA2004.svc//http-Soap12WSA2004"); }
+	}
+	
     public static string HttpBinary_Address
     {
         get { return GetEndpointAddress("HttpBinary.svc//http-binary"); }

--- a/src/System.Private.ServiceModel/tests/Scenarios/Encoding/MessageVersion/Encoding.MessageVersion.Tests.sln
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Encoding/MessageVersion/Encoding.MessageVersion.Tests.sln
@@ -1,7 +1,6 @@
-
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25123.0
+# Visual Studio 15
+VisualStudioVersion = 15.0.26430.6
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Encoding.MessageVersion.Tests", "Encoding.MessageVersion.Tests.csproj", "{604EBABB-0160-48EF-AE10-FEAE8DE39F19}"
 EndProject
@@ -71,22 +70,22 @@ Global
 		{9098B41C-9C2E-4FC6-B7D8-FC3411736A22}.Windows_netcore50_Release|Any CPU.Build.0 = Debug|Any CPU
 		{9098B41C-9C2E-4FC6-B7D8-FC3411736A22}.Windows_Release|Any CPU.ActiveCfg = Debug|Any CPU
 		{9098B41C-9C2E-4FC6-B7D8-FC3411736A22}.Windows_Release|Any CPU.Build.0 = Debug|Any CPU
-		{9E50E7BF-CD6E-4269-A6DD-59FD0BD6C0FD}.Debug|Any CPU.ActiveCfg = Windows_Debug|Any CPU
-		{9E50E7BF-CD6E-4269-A6DD-59FD0BD6C0FD}.Debug|Any CPU.Build.0 = Windows_Debug|Any CPU
-		{9E50E7BF-CD6E-4269-A6DD-59FD0BD6C0FD}.Release|Any CPU.ActiveCfg = Windows_Release|Any CPU
-		{9E50E7BF-CD6E-4269-A6DD-59FD0BD6C0FD}.Release|Any CPU.Build.0 = Windows_Release|Any CPU
-		{9E50E7BF-CD6E-4269-A6DD-59FD0BD6C0FD}.Unix_Debug|Any CPU.ActiveCfg = Unix_Debug|Any CPU
-		{9E50E7BF-CD6E-4269-A6DD-59FD0BD6C0FD}.Unix_Debug|Any CPU.Build.0 = Unix_Debug|Any CPU
-		{9E50E7BF-CD6E-4269-A6DD-59FD0BD6C0FD}.Unix_Release|Any CPU.ActiveCfg = Unix_Release|Any CPU
-		{9E50E7BF-CD6E-4269-A6DD-59FD0BD6C0FD}.Unix_Release|Any CPU.Build.0 = Unix_Release|Any CPU
-		{9E50E7BF-CD6E-4269-A6DD-59FD0BD6C0FD}.Windows_Debug|Any CPU.ActiveCfg = Windows_Debug|Any CPU
-		{9E50E7BF-CD6E-4269-A6DD-59FD0BD6C0FD}.Windows_Debug|Any CPU.Build.0 = Windows_Debug|Any CPU
-		{9E50E7BF-CD6E-4269-A6DD-59FD0BD6C0FD}.Windows_netcore50_Debug|Any CPU.ActiveCfg = Windows_netcore50_Debug|Any CPU
-		{9E50E7BF-CD6E-4269-A6DD-59FD0BD6C0FD}.Windows_netcore50_Debug|Any CPU.Build.0 = Windows_netcore50_Debug|Any CPU
-		{9E50E7BF-CD6E-4269-A6DD-59FD0BD6C0FD}.Windows_netcore50_Release|Any CPU.ActiveCfg = Windows_netcore50_Release|Any CPU
-		{9E50E7BF-CD6E-4269-A6DD-59FD0BD6C0FD}.Windows_netcore50_Release|Any CPU.Build.0 = Windows_netcore50_Release|Any CPU
-		{9E50E7BF-CD6E-4269-A6DD-59FD0BD6C0FD}.Windows_Release|Any CPU.ActiveCfg = Windows_Release|Any CPU
-		{9E50E7BF-CD6E-4269-A6DD-59FD0BD6C0FD}.Windows_Release|Any CPU.Build.0 = Windows_Release|Any CPU
+		{9E50E7BF-CD6E-4269-A6DD-59FD0BD6C0FD}.Debug|Any CPU.ActiveCfg = uap-Windows_NT-Debug|Any CPU
+		{9E50E7BF-CD6E-4269-A6DD-59FD0BD6C0FD}.Debug|Any CPU.Build.0 = uap-Windows_NT-Debug|Any CPU
+		{9E50E7BF-CD6E-4269-A6DD-59FD0BD6C0FD}.Release|Any CPU.ActiveCfg = uap-Windows_NT-Release|Any CPU
+		{9E50E7BF-CD6E-4269-A6DD-59FD0BD6C0FD}.Release|Any CPU.Build.0 = uap-Windows_NT-Release|Any CPU
+		{9E50E7BF-CD6E-4269-A6DD-59FD0BD6C0FD}.Unix_Debug|Any CPU.ActiveCfg = uap-Windows_NT-Release|Any CPU
+		{9E50E7BF-CD6E-4269-A6DD-59FD0BD6C0FD}.Unix_Debug|Any CPU.Build.0 = uap-Windows_NT-Release|Any CPU
+		{9E50E7BF-CD6E-4269-A6DD-59FD0BD6C0FD}.Unix_Release|Any CPU.ActiveCfg = uap-Windows_NT-Release|Any CPU
+		{9E50E7BF-CD6E-4269-A6DD-59FD0BD6C0FD}.Unix_Release|Any CPU.Build.0 = uap-Windows_NT-Release|Any CPU
+		{9E50E7BF-CD6E-4269-A6DD-59FD0BD6C0FD}.Windows_Debug|Any CPU.ActiveCfg = uap-Windows_NT-Release|Any CPU
+		{9E50E7BF-CD6E-4269-A6DD-59FD0BD6C0FD}.Windows_Debug|Any CPU.Build.0 = uap-Windows_NT-Release|Any CPU
+		{9E50E7BF-CD6E-4269-A6DD-59FD0BD6C0FD}.Windows_netcore50_Debug|Any CPU.ActiveCfg = uap-Windows_NT-Release|Any CPU
+		{9E50E7BF-CD6E-4269-A6DD-59FD0BD6C0FD}.Windows_netcore50_Debug|Any CPU.Build.0 = uap-Windows_NT-Release|Any CPU
+		{9E50E7BF-CD6E-4269-A6DD-59FD0BD6C0FD}.Windows_netcore50_Release|Any CPU.ActiveCfg = uap-Windows_NT-Release|Any CPU
+		{9E50E7BF-CD6E-4269-A6DD-59FD0BD6C0FD}.Windows_netcore50_Release|Any CPU.Build.0 = uap-Windows_NT-Release|Any CPU
+		{9E50E7BF-CD6E-4269-A6DD-59FD0BD6C0FD}.Windows_Release|Any CPU.ActiveCfg = uap-Windows_NT-Release|Any CPU
+		{9E50E7BF-CD6E-4269-A6DD-59FD0BD6C0FD}.Windows_Release|Any CPU.Build.0 = uap-Windows_NT-Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/System.Private.ServiceModel/tests/Scenarios/Encoding/MessageVersion/MessageVersionTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Encoding/MessageVersion/MessageVersionTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -15,7 +15,7 @@ public static partial class MessageVersionTests
     // Client and Server bindings setup exactly the same using Soap12WSA10
     [WcfFact]
     [OuterLoop]
-    public static void SameBinding_Soap12WSA10_EchoString()
+    public static void SameBinding_Soap12WSA2004_EchoString()
     {
         CustomBinding binding = null;
         EndpointAddress endpointAddress = null;
@@ -27,8 +27,8 @@ public static partial class MessageVersionTests
         try
         {
             // *** SETUP *** \\
-            binding = new CustomBinding(new TextMessageEncodingBindingElement(MessageVersion.Soap12WSAddressing10, Encoding.UTF8), new HttpTransportBindingElement());
-            endpointAddress = new EndpointAddress(Endpoints.HttpSoap12_Address);
+            binding = new CustomBinding(new TextMessageEncodingBindingElement(MessageVersion.Soap12WSAddressingAugust2004, Encoding.UTF8), new HttpTransportBindingElement());
+            endpointAddress = new EndpointAddress(Endpoints.HttpSoap12WSA2004_Address);
             factory = new ChannelFactory<IWcfService>(binding, endpointAddress);
             serviceProxy = factory.CreateChannel();
 
@@ -51,20 +51,20 @@ public static partial class MessageVersionTests
 
     [WcfFact]
     [OuterLoop]
-    public static void SameBinding_Soap11_EchoString()
+    public static void SameBinding_Soap11WSA2004_EchoString()
     {
         CustomBinding binding = null;
         EndpointAddress endpointAddress = null;
         ChannelFactory<IWcfService> factory = null;
         IWcfService serviceProxy = null;
-        string testString = "Hello";
         string result = null;
+        string testString = "Hello";
 
         try
         {
             // *** SETUP *** \\
-            binding = new CustomBinding(new TextMessageEncodingBindingElement(MessageVersion.Soap11, Encoding.UTF8), new HttpTransportBindingElement());
-            endpointAddress = new EndpointAddress(Endpoints.HttpSoap11_Address);
+            binding = new CustomBinding(new TextMessageEncodingBindingElement(MessageVersion.Soap11WSAddressingAugust2004, Encoding.UTF8), new HttpTransportBindingElement());
+            endpointAddress = new EndpointAddress(Endpoints.HttpSoap11WSA2004_Address);
             factory = new ChannelFactory<IWcfService>(binding, endpointAddress);
             serviceProxy = factory.CreateChannel();
 

--- a/src/System.Private.ServiceModel/tools/IISHostedWcfService/App_code/testhosts/HttpSoap11WSA2004ServiceHost.cs
+++ b/src/System.Private.ServiceModel/tools/IISHostedWcfService/App_code/testhosts/HttpSoap11WSA2004ServiceHost.cs
@@ -1,0 +1,35 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.ServiceModel;
+using System.ServiceModel.Activation;
+using System.ServiceModel.Channels;
+using System.Text;
+
+namespace WcfService
+{
+    public class HttpSoap11WSA2004TestServiceHostFactory : ServiceHostFactory
+    {
+        protected override ServiceHost CreateServiceHost(Type serviceType, Uri[] baseAddresses)
+        {
+            HttpSoap11WSA2004TestServiceHost serviceHost = new HttpSoap11WSA2004TestServiceHost(serviceType, baseAddresses);
+            return serviceHost;
+        }
+    }
+    public class HttpSoap11WSA2004TestServiceHost : TestServiceHostBase<IWcfService>
+    {
+        protected override string Address { get { return "http-soap11WSA2004"; } }
+
+        protected override Binding GetBinding()
+        {
+            return new CustomBinding(new TextMessageEncodingBindingElement(MessageVersion.Soap11WSAddressingAugust2004, Encoding.UTF8), new HttpTransportBindingElement());
+        }
+
+        public HttpSoap11WSA2004TestServiceHost(Type serviceType, params Uri[] baseAddresses)
+            : base(serviceType, baseAddresses)
+        {
+        }
+    }
+}

--- a/src/System.Private.ServiceModel/tools/IISHostedWcfService/App_code/testhosts/HttpSoap12WSA2004ServiceHost.cs
+++ b/src/System.Private.ServiceModel/tools/IISHostedWcfService/App_code/testhosts/HttpSoap12WSA2004ServiceHost.cs
@@ -1,0 +1,35 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.ServiceModel;
+using System.ServiceModel.Activation;
+using System.ServiceModel.Channels;
+using System.Text;
+
+namespace WcfService
+{
+    public class HttpSoap12WSA2004TestServiceHostFactory : ServiceHostFactory
+    {
+        protected override ServiceHost CreateServiceHost(Type serviceType, Uri[] baseAddresses)
+        {
+            HttpSoap12WSA2004TestServiceHost serviceHost = new HttpSoap12WSA2004TestServiceHost(serviceType, baseAddresses);
+            return serviceHost;
+        }
+    }
+    public class HttpSoap12WSA2004TestServiceHost : TestServiceHostBase<IWcfService>
+    {
+        protected override string Address { get { return "http-soap12WSA2004"; } }
+
+        protected override Binding GetBinding()
+        {
+            return new CustomBinding(new TextMessageEncodingBindingElement(MessageVersion.Soap12WSAddressingAugust2004, Encoding.UTF8), new HttpTransportBindingElement());
+        }
+
+        public HttpSoap12WSA2004TestServiceHost(Type serviceType, params Uri[] baseAddresses)
+            : base(serviceType, baseAddresses)
+        {
+        }
+    }
+}

--- a/src/System.Private.ServiceModel/tools/IISHostedWcfService/Web.config
+++ b/src/System.Private.ServiceModel/tools/IISHostedWcfService/Web.config
@@ -44,8 +44,10 @@
         <add factory="WcfService.HttpsNtlmTestServiceHostFactory" service="WcfService.WcfService" relativeAddress="~\WindowAuthenticationNtlm\HttpsNtlm.svc" />
         <add factory="WcfService.HttpSoap11TestServiceHostFactory" service="WcfService.WcfService" relativeAddress="~\HttpSoap11.svc" />
         <add factory="WcfService.HttpsSoap11TestServiceHostFactory" service="WcfService.WcfService" relativeAddress="~\HttpsSoap11.svc" />
+        <add factory="WcfService.HttpSoap11WSA2004TestServiceHostFactory" service="WcfService.WcfService" relativeAddress="~\HttpSoap11WSA2004.svc" />
         <add factory="WcfService.HttpsSoap12TestServiceHostFactory" service="WcfService.WcfService" relativeAddress="~\HttpsSoap12.svc" />
         <add factory="WcfService.HttpSoap12TestServiceHostFactory" service="WcfService.WcfService" relativeAddress="~\HttpSoap12.svc" />
+        <add factory="WcfService.HttpSoap12WSA2004TestServiceHostFactory" service="WcfService.WcfService" relativeAddress="~\HttpSoap12WSA2004.svc" />
         <add factory="WcfService.HttpsWindowsTestServiceHostFactory" service="WcfService.WcfService" relativeAddress="~\WindowAuthenticationNegotiate\HttpsWindows.svc" />
         <add factory="WcfService.HttpWindowsTestServiceHostFactory" service="WcfService.WcfService" relativeAddress="~\WindowAuthenticationNegotiate\HttpWindows.svc" />
         <add factory="WcfService.NetHttpTestServiceHostFactory" service="WcfService.WcfService" relativeAddress="~\NetHttp.svc" />
@@ -103,15 +105,15 @@
     </serviceHostingEnvironment>
   </system.serviceModel>
   <system.webServer>
-     <modules runAllManagedModulesForAllRequests="true">
-        <add name="UrlRoutingModule" type="System.Web.Routing.UrlRoutingModule, System.Web.Routing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35" />
+    <modules runAllManagedModulesForAllRequests="true">
+      <add name="UrlRoutingModule" type="System.Web.Routing.UrlRoutingModule, System.Web.Routing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35" />
     </modules>
-   <handlers>
-    <add name="UrlRoutingHandler" preCondition="integratedMode" verb="*" path="UrlRouting.axd" type="System.Web.HttpForbiddenHandler, System.Web, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-   </handlers>
+    <handlers>
+      <add name="UrlRoutingHandler" preCondition="integratedMode" verb="*" path="UrlRouting.axd" type="System.Web.HttpForbiddenHandler, System.Web, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+    </handlers>
     <directoryBrowse enabled="false" />
-        <staticContent>
-            <clientCache cacheControlMode="DisableCache" />
-        </staticContent>
+    <staticContent>
+      <clientCache cacheControlMode="DisableCache" />
+    </staticContent>
   </system.webServer>
 </configuration>

--- a/src/System.Private.ServiceModel/tools/SelfHostedWcfService/Program.cs
+++ b/src/System.Private.ServiceModel/tools/SelfHostedWcfService/Program.cs
@@ -60,8 +60,10 @@ namespace SelfHostedWCFService
             CreateHost<HttpsNtlmTestServiceHost, WcfService.WcfService>("WindowAuthenticationNtlm/HttpsNtlm.svc", httpsBaseAddress);
             CreateHost<HttpSoap11TestServiceHost, WcfService.WcfService>("HttpSoap11.svc", httpBaseAddress);
             CreateHost<HttpsSoap11TestServiceHost, WcfService.WcfService>("HttpsSoap11.svc", httpsBaseAddress);
+            CreateHost<HttpSoap11WSA2004TestServiceHost, WcfService.WcfService>("HttpSoap11WSA2004.svc", httpBaseAddress);
             CreateHost<HttpsSoap12TestServiceHost, WcfService.WcfService>("HttpsSoap12.svc", httpsBaseAddress);
             CreateHost<HttpSoap12TestServiceHost, WcfService.WcfService>("HttpSoap12.svc", httpBaseAddress);
+            CreateHost<HttpSoap12WSA2004TestServiceHost, WcfService.WcfService>("HttpSoap12WSA2004.svc", httpBaseAddress);
             CreateHost<HttpsWindowsTestServiceHost, WcfService.WcfService>("WindowAuthenticationNegotiate/HttpsWindows.svc", httpsBaseAddress);
             CreateHost<HttpWindowsTestServiceHost, WcfService.WcfService>("WindowAuthenticationNegotiate/HttpWindows.svc", httpBaseAddress);
             CreateHost<NetHttpTestServiceHost, WcfService.WcfService>("NetHttp.svc", httpBaseAddress);

--- a/src/System.ServiceModel.Primitives/ref/System.ServiceModel.Primitives.cs
+++ b/src/System.ServiceModel.Primitives/ref/System.ServiceModel.Primitives.cs
@@ -682,6 +682,7 @@ namespace System.ServiceModel.Channels
         internal AddressingVersion() { }
         public static System.ServiceModel.Channels.AddressingVersion None { get { return default(System.ServiceModel.Channels.AddressingVersion); } }
         public static System.ServiceModel.Channels.AddressingVersion WSAddressing10 { get { return default(System.ServiceModel.Channels.AddressingVersion); } }
+        public static System.ServiceModel.Channels.AddressingVersion WSAddressingAugust2004 { get { return default(System.ServiceModel.Channels.AddressingVersion); } }
         public override string ToString() { return default(string); }
     }
     public sealed partial class BinaryMessageEncodingBindingElement : System.ServiceModel.Channels.MessageEncodingBindingElement
@@ -1224,6 +1225,8 @@ namespace System.ServiceModel.Channels
         public static System.ServiceModel.Channels.MessageVersion None { get { return default(System.ServiceModel.Channels.MessageVersion); } }
         public static System.ServiceModel.Channels.MessageVersion Soap11 { get { return default(System.ServiceModel.Channels.MessageVersion); } }
         public static System.ServiceModel.Channels.MessageVersion Soap12WSAddressing10 { get { return default(System.ServiceModel.Channels.MessageVersion); } }
+        public static System.ServiceModel.Channels.MessageVersion Soap11WSAddressingAugust2004 { get { return default(System.ServiceModel.Channels.MessageVersion); } }
+        public static System.ServiceModel.Channels.MessageVersion Soap12WSAddressingAugust2004 { get { return default(System.ServiceModel.Channels.MessageVersion); } }
         public static System.ServiceModel.Channels.MessageVersion CreateVersion(System.ServiceModel.EnvelopeVersion envelopeVersion) { return default(System.ServiceModel.Channels.MessageVersion); }
         public static System.ServiceModel.Channels.MessageVersion CreateVersion(System.ServiceModel.EnvelopeVersion envelopeVersion, System.ServiceModel.Channels.AddressingVersion addressingVersion) { return default(System.ServiceModel.Channels.MessageVersion); }
         public override bool Equals(object obj) { return default(bool); }

--- a/src/System.ServiceModel.Primitives/ref/System.ServiceModel.Primitives.cs
+++ b/src/System.ServiceModel.Primitives/ref/System.ServiceModel.Primitives.cs
@@ -1224,8 +1224,8 @@ namespace System.ServiceModel.Channels
         public System.ServiceModel.EnvelopeVersion Envelope { get { return default(System.ServiceModel.EnvelopeVersion); } }
         public static System.ServiceModel.Channels.MessageVersion None { get { return default(System.ServiceModel.Channels.MessageVersion); } }
         public static System.ServiceModel.Channels.MessageVersion Soap11 { get { return default(System.ServiceModel.Channels.MessageVersion); } }
-        public static System.ServiceModel.Channels.MessageVersion Soap12WSAddressing10 { get { return default(System.ServiceModel.Channels.MessageVersion); } }
         public static System.ServiceModel.Channels.MessageVersion Soap11WSAddressingAugust2004 { get { return default(System.ServiceModel.Channels.MessageVersion); } }
+        public static System.ServiceModel.Channels.MessageVersion Soap12WSAddressing10 { get { return default(System.ServiceModel.Channels.MessageVersion); } }
         public static System.ServiceModel.Channels.MessageVersion Soap12WSAddressingAugust2004 { get { return default(System.ServiceModel.Channels.MessageVersion); } }
         public static System.ServiceModel.Channels.MessageVersion CreateVersion(System.ServiceModel.EnvelopeVersion envelopeVersion) { return default(System.ServiceModel.Channels.MessageVersion); }
         public static System.ServiceModel.Channels.MessageVersion CreateVersion(System.ServiceModel.EnvelopeVersion envelopeVersion, System.ServiceModel.Channels.AddressingVersion addressingVersion) { return default(System.ServiceModel.Channels.MessageVersion); }


### PR DESCRIPTION
This uses PR #2099 by @davidreher as the base. Changes from that PR are:
- Rebased to master
- Fixed the string resource references
- A couple of small fixes to remove throwing some PNSE which were effectively dead code
- Added ended to end scenario tests for SOAP11 and SOAP12 varients