### PR TITLE
Exlude test failed by active issue 2147

### DIFF
--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Negotiate/NegotiateStream_Tcp_Tests.4.1.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Negotiate/NegotiateStream_Tcp_Tests.4.1.0.cs
@@ -281,6 +281,7 @@ public class NegotiateStream_Tcp_Tests : ConditionalWcfTest
     }
 
     [WcfFact]
+    [Issue(2147, OS = OSID.AnyOSX | OSID.AnyUnix)]
     [Condition(nameof(Windows_Authentication_Available),
                nameof(Explicit_Credentials_Available),
                nameof(Domain_Available),


### PR DESCRIPTION
* The UPN test on Linux/Osx is failing because of issue 2147
* Need to update release/2.0.0 as well