### PR TITLE
Fix Bug in XmlSerializerOperationFormatter.

### DIFF
--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Dispatcher/XmlSerializerOperationFormatter.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Dispatcher/XmlSerializerOperationFormatter.cs
@@ -31,7 +31,7 @@ namespace System.ServiceModel.Dispatcher
 
         public XmlSerializerOperationFormatter(OperationDescription description, XmlSerializerFormatAttribute xmlSerializerFormatAttribute,
             MessageInfo requestMessageInfo, MessageInfo replyMessageInfo) :
-            base(description, xmlSerializerFormatAttribute.Style == OperationFormatStyle.Rpc, false/*isEncoded*/)
+            base(description, xmlSerializerFormatAttribute.Style == OperationFormatStyle.Rpc, xmlSerializerFormatAttribute.IsEncoded)
         {
             _requestMessageInfo = requestMessageInfo;
             _replyMessageInfo = replyMessageInfo;

--- a/src/System.Private.ServiceModel/tests/Common/Scenarios/ScenarioTestTypes.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Scenarios/ScenarioTestTypes.cs
@@ -1423,3 +1423,24 @@ public class FaultDetailWithXmlSerializerFormatAttribute
         set { _usedDataContractSerializer = value; }
     }
 }
+
+[MessageContract(WrapperName = "PingResponse", IsWrapped = true)]
+public class PingEncodedResponse
+{
+    [MessageBodyMember(Namespace = "", Order = 0)]
+    public int @Return;
+}
+
+[MessageContract(WrapperName = "Ping", IsWrapped = true)]
+public class PingEncodedRequest
+{
+    [MessageBodyMember(Namespace = "", Order = 0)]
+    public string Pinginfo;
+
+    public PingEncodedRequest() { }
+
+    public PingEncodedRequest(string pinginfo)
+    {
+        this.Pinginfo = pinginfo;
+    }
+}

--- a/src/System.Private.ServiceModel/tests/Common/Scenarios/ServiceInterfaces.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Scenarios/ServiceInterfaces.cs
@@ -136,6 +136,10 @@ public interface IWcfSoapService
     [ServiceKnownType(typeof(AdditionalData))]
     [return: MessageParameter(Name = "ProcessCustomerDataReturn")]
     string ProcessCustomerData(CustomerObject CustomerData);
+
+    [OperationContract(Action = "http://tempuri.org/IWcfService/Ping", ReplyAction = "http://tempuri.org/IWcfSoapService/PingResponse")]
+    [XmlSerializerFormat(Style = OperationFormatStyle.Rpc, SupportFaults = true, Use = OperationFormatUse.Encoded)]
+    PingEncodedResponse Ping(PingEncodedRequest request);
 }
 
 // This type share the same name space with IWcfServiceXmlGenerated.

--- a/src/System.Private.ServiceModel/tests/Scenarios/Contract/XmlSerializer/XmlSerializerFormatSoapTest.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Contract/XmlSerializer/XmlSerializerFormatSoapTest.cs
@@ -59,6 +59,24 @@ public static partial class XmlSerializerFormatTests
         });
     }
 
+    [WcfFact]
+    [OuterLoop]
+    public static void TestCreateChannel()
+    {
+        RunWcfSoapServiceTest((serviceProxy) =>
+        {
+            // *** EXECUTE *** \\
+            int intValue = 11;
+            string intString = intValue.ToString();
+            var request = new PingEncodedRequest(intString);
+            PingEncodedResponse response = serviceProxy.Ping(request);
+
+            // *** VALIDATE *** \\
+            Assert.NotNull(response);
+            Assert.Equal(intValue, response.@Return);
+        });
+    }
+
     private static void RunWcfSoapServiceTest(Action<IWcfSoapService> testMethod)
     {
         BasicHttpBinding binding;

--- a/src/System.Private.ServiceModel/tools/IISHostedWcfService/App_code/CompositeType.cs
+++ b/src/System.Private.ServiceModel/tools/IISHostedWcfService/App_code/CompositeType.cs
@@ -351,3 +351,25 @@ public partial class AdditionalData
         get; set;
     }
 }
+
+[MessageContract(WrapperName = "PingResponse", IsWrapped = true)]
+public class PingEncodedResponse
+{
+    [MessageBodyMember(Namespace = "", Order = 0)]
+    public int @Return;
+}
+
+[MessageContract(WrapperName = "Ping", IsWrapped = true)]
+public class PingEncodedRequest
+{
+
+    [MessageBodyMember(Namespace = "", Order = 0)]
+    public string Pinginfo;
+
+    public PingEncodedRequest() { }
+
+    public PingEncodedRequest(string pinginfo)
+    {
+        this.Pinginfo = pinginfo;
+    }
+}

--- a/src/System.Private.ServiceModel/tools/IISHostedWcfService/App_code/IWcfSoapService.cs
+++ b/src/System.Private.ServiceModel/tools/IISHostedWcfService/App_code/IWcfSoapService.cs
@@ -27,5 +27,9 @@ namespace WcfService
         [return: MessageParameter(Name = "ProcessCustomerDataReturn")]
         [return: System.Xml.Serialization.SoapElement(DataType = "string")]
         string ProcessCustomerData([MessageParameter(Name = "CustomerData")]CustomerObject customerData);
+        
+        [OperationContract(Action = "http://tempuri.org/IWcfService/Ping", ReplyAction = "http://tempuri.org/IWcfSoapService/PingResponse")]
+        [XmlSerializerFormat(Style = OperationFormatStyle.Rpc, SupportFaults = true, Use = OperationFormatUse.Encoded)]
+        PingEncodedResponse Ping(PingEncodedRequest request);
     }
 }

--- a/src/System.Private.ServiceModel/tools/IISHostedWcfService/App_code/WcfSoapService.cs
+++ b/src/System.Private.ServiceModel/tools/IISHostedWcfService/App_code/WcfSoapService.cs
@@ -35,7 +35,8 @@ namespace WcfService
         
         public PingEncodedResponse Ping(PingEncodedRequest request)
         {
-            return new PingEncodedResponse() { @Return = Int32.TryParse(request.Pinginfo, out int requestIntValue) ? requestIntValue : -1 };
+            int requestIntValue;
+            return new PingEncodedResponse() { @Return = Int32.TryParse(request.Pinginfo, out requestIntValue) ? requestIntValue : -1 };
         }
     }
 }

--- a/src/System.Private.ServiceModel/tools/IISHostedWcfService/App_code/WcfSoapService.cs
+++ b/src/System.Private.ServiceModel/tools/IISHostedWcfService/App_code/WcfSoapService.cs
@@ -32,5 +32,10 @@ namespace WcfService
         {
             return customerData.Name + ((AdditionalData)customerData.Data).Field;
         }
+        
+        public PingEncodedResponse Ping(PingEncodedRequest request)
+        {
+            return new PingEncodedResponse() { @Return = Int32.TryParse(request.Pinginfo, out int requestIntValue) ? requestIntValue : -1 };
+        }
     }
 }


### PR DESCRIPTION
XmlSerializerOperationFormatter's ctor did not use XmlSerializerFormatAttribute.IsEncoded value, which was wrong.

Fix #2264 