### PR TITLE
Fix ServiceModel.SyndicationFeed project dependencies

### DIFF
--- a/lab/src/Microsoft.ServiceModel.Syndication/src/Microsoft.ServiceModel.Syndication.csproj
+++ b/lab/src/Microsoft.ServiceModel.Syndication/src/Microsoft.ServiceModel.Syndication.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <PackagingToolsInsufficientSDKVersion>false</PackagingToolsInsufficientSDKVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/lab/src/Microsoft.ServiceModel.Syndication/src/csprojForCodeFormatter.txt
+++ b/lab/src/Microsoft.ServiceModel.Syndication/src/csprojForCodeFormatter.txt
@@ -4,7 +4,6 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
-    <RuntimeFrameworkVersion>2.0.0-preview2-25309-07</RuntimeFrameworkVersion>
     <PackagingToolsInsufficientSDKVersion>false</PackagingToolsInsufficientSDKVersion>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/lab/src/Microsoft.ServiceModel.Syndication/tests/Microsoft.ServiceModel.Syndication.Tests.csproj
+++ b/lab/src/Microsoft.ServiceModel.Syndication/tests/Microsoft.ServiceModel.Syndication.Tests.csproj
@@ -2,7 +2,6 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
-    <RuntimeFrameworkVersion>2.0.0-preview2-25309-07</RuntimeFrameworkVersion>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 


### PR DESCRIPTION
- Change M.SM.SyndicationFeed to be a .NET Standard 2.0 library
- Change tests to use official .NET Core 2.0 release from preview