### PR TITLE
Enforce Service and Client Certificate tests on non windows platforms - Testing CI change

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -199,12 +199,21 @@ def supportedFullCycleOuterloopPlatforms = ['Windows_NT', 'Ubuntu14.04', 'Ubuntu
                         batchFile("build-tests.cmd -framework:${targetGroup} -${configurationGroup} -os:${osGroupMap[os]} -outerloop -- /p:ServiceUri=%WcfServiceUri% /p:SSL_Available=true /p:Root_Certificate_Installed=true /p:Client_Certificate_Installed=true /p:Peer_Certificate_Installed=true /p:IsCIBuild=true")
                     }
                 }
-            } 
-            else {
+            }
+            else if (isPR) {
                 newJob.with {
                     steps {
                         shell("HOME=\$WORKSPACE/tempHome ./build.sh -${configurationGroup.toLowerCase()}")
                         shell("HOME=\$WORKSPACE/tempHome ./build-tests.sh -${configurationGroup.toLowerCase()} -outerloop -testWithLocalLibraries -- /p:OSGroup=${osGroupMap[os]} /p:ServiceUri=\$WcfServiceUri /p:SSL_Available=true /p:IsCIBuild=true")
+                    }
+                }
+            }
+            //Enable Certificate Tests on non PR runs first to ensure they are reliable, will enable on PR if we are green for one week
+            else {
+                newJob.with {
+                    steps {
+                        shell("HOME=\$WORKSPACE/tempHome ./build.sh -${configurationGroup.toLowerCase()}")
+                        shell("HOME=\$WORKSPACE/tempHome ./build-tests.sh -${configurationGroup.toLowerCase()} -outerloop -testWithLocalLibraries -- /p:OSGroup=${osGroupMap[os]} /p:ServiceUri=\$WcfServiceUri /p:SSL_Available=true /p:Client_Certificate_Installed=true /p:Root_Certificate_Installed=true /p:IsCIBuild=true")
                     }
                 }
             }


### PR DESCRIPTION
* We should enforce Service and Client certificate tests on non windows
platforms as well.
* The change will be in two stages. The first stage is to change the CI
nightly runs that won't affect PRs. If it is reliable for more than one
week, will change the PR runs.