### PR TITLE
Release 1.1.0 resolving the common projects ref issue.

### DIFF
--- a/src/Common/test-runtime/project.json
+++ b/src/Common/test-runtime/project.json
@@ -14,6 +14,7 @@
     "System.Linq.Parallel": "4.3.0",
     "System.Net.Http": "4.3.0",
     "System.Net.Security": "4.3.0",
+    "System.Net.WebSockets.Client": "4.3.0",
     "System.Security.Cryptography.X509Certificates": "4.3.0",
     "System.Xml.XmlSerializer": "4.3.0",
     "coveralls.io": "1.4",

--- a/src/System.Private.ServiceModel/pkg/System.Private.ServiceModel.pkgproj
+++ b/src/System.Private.ServiceModel/pkg/System.Private.ServiceModel.pkgproj
@@ -9,5 +9,6 @@
   <ItemGroup>
     <ProjectReference Include="..\src\System.Private.ServiceModel.builds" />
   </ItemGroup>
+  <Target Name="GetTargetFrameworkProperties"></Target>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Private.ServiceModel/tests/Scenarios/Binding/Custom/Binding.Custom.Tests.csproj
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Binding/Custom/Binding.Custom.Tests.csproj
@@ -17,8 +17,90 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ProjectGuid>{EDC88742-E7BF-4B7A-9DE2-55055B81B8F2}</ProjectGuid>
   </PropertyGroup>
+  <!-- Test Source -->
   <ItemGroup>
     <Compile Include="**\*.cs" />
+  </ItemGroup>
+  <!-- Infrastructure Test Helpers -->
+  <ItemGroup>
+    <Compile Include="$(CommonInfrastructureTestPath)\BridgeClient.cs">
+      <Link>Common\BridgeClient.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\BridgeClientAuthenticationManager.cs">
+      <Link>Common\BridgeClientAuthenticationManager.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\CertificateManager.cs">
+      <Link>Common\CertificateManager.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\ConditionalTestDetectors.cs">
+      <Link>Common\ConditionalTestDetectors.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\ConditionalWcfTest.cs">
+      <Link>Common\ConditionalWcfTest.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\FrameworkHelper.cs">
+      <Link>Common\FrameworkHelper.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\FrameworkID.cs">
+      <Link>Common\FrameworkID.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\JsonSerializer.cs">
+      <Link>Common\JsonSerializer.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\OSHelper.cs">
+      <Link>Common\OSHelper.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\OsID.cs">
+      <Link>Common\OsID.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\ServiceUtilHelper.cs">
+      <Link>Common\ServiceUtilHelper.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\TestEventListener.cs">
+      <Link>Common\TestEventListener.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\TestProperties.cs">
+      <Link>Common\TestProperties.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\ConditionAttribute.cs">
+      <Link>Common\xunit\ConditionAttribute.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\IssueAttribute.cs">
+      <Link>Common\xunit\IssueAttribute.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfFactDiscoverer.cs">
+      <Link>Common\xunit\WcfFactDiscoverer.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfSkippableAttribute.cs">
+      <Link>Common\xunit\WcfSkippableAttribute.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfTestCase.cs">
+      <Link>Common\xunit\WcfTestCase.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfTestDiscoverer.cs">
+      <Link>Common\xunit\WcfTestDiscoverer.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfTheoryDiscoverer.cs">
+      <Link>Common\xunit\WcfTheoryDiscoverer.cs</Link>
+    </Compile>
+  </ItemGroup>
+  <!-- Scenario Test Helpers -->
+  <ItemGroup>
+    <Compile Include="$(CommonScenarioTestPath)\Endpoints.cs">
+      <Link>Common\Endpoints.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonScenarioTestPath)\ScenarioTestHelpers.cs">
+      <Link>Common\ScenarioTestHelpers.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonScenarioTestPath)\ScenarioTestTypes.cs">
+      <Link>Common\ScenarioTestTypes.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonScenarioTestPath)\ServiceInterfaces.cs">
+      <Link>Common\ServiceInterfaces.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonScenarioTestPath)\TestMockStream.cs">
+      <Link>Common\TestMockStream.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />
@@ -39,14 +121,12 @@
     <ProjectReference Include='$(WcfSecurityPkgProj)'>
       <Name>System.ServiceModel.Security</Name>
     </ProjectReference>
-    <ProjectReference Include="$(WcfInfrastructureCommonProj)">
-      <Project>{AFD69665-89A3-42AE-A32E-AB2CBBE6EE7E}</Project>
-      <Name>Infrastructure.Common</Name>
-    </ProjectReference>
-    <ProjectReference Include='$(WcfScenarioTestCommonProj)'>
-      <Project>{9098B41C-9C2E-4FC6-B7D8-FC3411736A22}</Project>
-      <Name>ScenarioTests.Common</Name>
-    </ProjectReference>
   </ItemGroup>
+  <Import Project="$(CommonInfrastructureTestPath)\testproperties.props" />
+  <Import Project="$(CommonInfrastructureTestPath)\testproperties.targets" />
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <!-- Add our code-gen target after the imports above because they reset $(CoreCompileDependsOn) -->
+  <PropertyGroup>
+    <CoreCompileDependsOn>$(CoreCompileDependsOn);CreateTestProperties</CoreCompileDependsOn>
+  </PropertyGroup>
 </Project>

--- a/src/System.Private.ServiceModel/tests/Scenarios/Binding/Custom/WcfCustomXunitAttribute.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Binding/Custom/WcfCustomXunitAttribute.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Xunit;
+using Xunit.Sdk;
+
+namespace Infrastructure.Common
+{
+    [XunitTestCaseDiscoverer("Infrastructure.Common.WcfFactDiscoverer", "Binding.Custom.Tests")]
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+    public class WcfFactAttribute : FactAttribute
+    {
+    }
+
+    [XunitTestCaseDiscoverer("Infrastructure.Common.WcfTheoryDiscoverer", "Binding.Custom.Tests")]
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+    public class WcfTheoryAttribute : TheoryAttribute
+    {
+    }
+}

--- a/src/System.Private.ServiceModel/tests/Scenarios/Binding/Custom/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Binding/Custom/project.json
@@ -7,6 +7,7 @@
     "System.ServiceModel.Primitives": "4.3.0-preview1-24530-01",
     "System.ServiceModel.Security": "4.3.0-preview1-24530-01",
     "System.Threading.Timer": "4.3.0",
+    "System.Xml.XmlSerializer": "4.3.0",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Private.ServiceModel/tests/Scenarios/Binding/Http/Binding.Http.Tests.csproj
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Binding/Http/Binding.Http.Tests.csproj
@@ -17,8 +17,90 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ProjectGuid>{15636BB6-CD0B-4EC7-B7A8-9AB59A17B625}</ProjectGuid>
   </PropertyGroup>
+  <!-- Test Source -->
   <ItemGroup>
     <Compile Include="**\*.cs" />
+  </ItemGroup>
+  <!-- Infrastructure Test Helpers -->
+  <ItemGroup>
+    <Compile Include="$(CommonInfrastructureTestPath)\BridgeClient.cs">
+      <Link>Common\BridgeClient.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\BridgeClientAuthenticationManager.cs">
+      <Link>Common\BridgeClientAuthenticationManager.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\CertificateManager.cs">
+      <Link>Common\CertificateManager.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\ConditionalTestDetectors.cs">
+      <Link>Common\ConditionalTestDetectors.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\ConditionalWcfTest.cs">
+      <Link>Common\ConditionalWcfTest.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\FrameworkHelper.cs">
+      <Link>Common\FrameworkHelper.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\FrameworkID.cs">
+      <Link>Common\FrameworkID.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\JsonSerializer.cs">
+      <Link>Common\JsonSerializer.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\OSHelper.cs">
+      <Link>Common\OSHelper.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\OsID.cs">
+      <Link>Common\OsID.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\ServiceUtilHelper.cs">
+      <Link>Common\ServiceUtilHelper.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\TestEventListener.cs">
+      <Link>Common\TestEventListener.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\TestProperties.cs">
+      <Link>Common\TestProperties.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\ConditionAttribute.cs">
+      <Link>Common\xunit\ConditionAttribute.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\IssueAttribute.cs">
+      <Link>Common\xunit\IssueAttribute.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfFactDiscoverer.cs">
+      <Link>Common\xunit\WcfFactDiscoverer.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfSkippableAttribute.cs">
+      <Link>Common\xunit\WcfSkippableAttribute.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfTestCase.cs">
+      <Link>Common\xunit\WcfTestCase.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfTestDiscoverer.cs">
+      <Link>Common\xunit\WcfTestDiscoverer.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfTheoryDiscoverer.cs">
+      <Link>Common\xunit\WcfTheoryDiscoverer.cs</Link>
+    </Compile>
+  </ItemGroup>
+  <!-- Scenario Test Helpers -->
+  <ItemGroup>
+    <Compile Include="$(CommonScenarioTestPath)\Endpoints.cs">
+      <Link>Common\Endpoints.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonScenarioTestPath)\ScenarioTestHelpers.cs">
+      <Link>Common\ScenarioTestHelpers.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonScenarioTestPath)\ScenarioTestTypes.cs">
+      <Link>Common\ScenarioTestTypes.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonScenarioTestPath)\ServiceInterfaces.cs">
+      <Link>Common\ServiceInterfaces.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonScenarioTestPath)\TestMockStream.cs">
+      <Link>Common\TestMockStream.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />
@@ -33,14 +115,12 @@
     <ProjectReference Include='$(WcfPrimitivesPkgProj)'>
       <Name>System.ServiceModel.Primitives</Name>
     </ProjectReference>
-    <ProjectReference Include="$(WcfInfrastructureCommonProj)">
-      <Project>{AFD69665-89A3-42AE-A32E-AB2CBBE6EE7E}</Project>
-      <Name>Infrastructure.Common</Name>
-    </ProjectReference>
-    <ProjectReference Include='$(WcfScenarioTestCommonProj)'>
-      <Project>{9098B41C-9C2E-4FC6-B7D8-FC3411736A22}</Project>
-      <Name>ScenarioTests.Common</Name>
-    </ProjectReference>
   </ItemGroup>
+  <Import Project="$(CommonInfrastructureTestPath)\testproperties.props" />
+  <Import Project="$(CommonInfrastructureTestPath)\testproperties.targets" />
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <!-- Add our code-gen target after the imports above because they reset $(CoreCompileDependsOn) -->
+  <PropertyGroup>
+    <CoreCompileDependsOn>$(CoreCompileDependsOn);CreateTestProperties</CoreCompileDependsOn>
+  </PropertyGroup>
 </Project>

--- a/src/System.Private.ServiceModel/tests/Scenarios/Binding/Http/WcfCustomXunitAttribute.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Binding/Http/WcfCustomXunitAttribute.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Xunit;
+using Xunit.Sdk;
+
+namespace Infrastructure.Common
+{
+    [XunitTestCaseDiscoverer("Infrastructure.Common.WcfFactDiscoverer", "Binding.Http.Tests")]
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+    public class WcfFactAttribute : FactAttribute
+    {
+    }
+
+    [XunitTestCaseDiscoverer("Infrastructure.Common.WcfTheoryDiscoverer", "Binding.Http.Tests")]
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+    public class WcfTheoryAttribute : TheoryAttribute
+    {
+    }
+}

--- a/src/System.Private.ServiceModel/tests/Scenarios/Binding/Http/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Binding/Http/project.json
@@ -7,6 +7,7 @@
     "System.ServiceModel.Primitives": "4.3.0-preview1-24530-01",
     "System.ServiceModel.Security": "4.3.0-preview1-24530-01",
     "System.Threading.Timer": "4.3.0",
+    "System.Xml.XmlSerializer": "4.3.0",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Private.ServiceModel/tests/Scenarios/Binding/Tcp/Binding.Tcp.Tests.csproj
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Binding/Tcp/Binding.Tcp.Tests.csproj
@@ -16,8 +16,90 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ProjectGuid>{b10e2b70-c5b6-4824-b8f1-691b1170e4f5}</ProjectGuid>
   </PropertyGroup>
+  <!-- Test Source -->
   <ItemGroup>
     <Compile Include="**\*.cs" />
+  </ItemGroup>
+  <!-- Infrastructure Test Helpers -->
+  <ItemGroup>
+    <Compile Include="$(CommonInfrastructureTestPath)\BridgeClient.cs">
+      <Link>Common\BridgeClient.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\BridgeClientAuthenticationManager.cs">
+      <Link>Common\BridgeClientAuthenticationManager.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\CertificateManager.cs">
+      <Link>Common\CertificateManager.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\ConditionalTestDetectors.cs">
+      <Link>Common\ConditionalTestDetectors.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\ConditionalWcfTest.cs">
+      <Link>Common\ConditionalWcfTest.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\FrameworkHelper.cs">
+      <Link>Common\FrameworkHelper.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\FrameworkID.cs">
+      <Link>Common\FrameworkID.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\JsonSerializer.cs">
+      <Link>Common\JsonSerializer.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\OSHelper.cs">
+      <Link>Common\OSHelper.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\OsID.cs">
+      <Link>Common\OsID.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\ServiceUtilHelper.cs">
+      <Link>Common\ServiceUtilHelper.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\TestEventListener.cs">
+      <Link>Common\TestEventListener.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\TestProperties.cs">
+      <Link>Common\TestProperties.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\ConditionAttribute.cs">
+      <Link>Common\xunit\ConditionAttribute.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\IssueAttribute.cs">
+      <Link>Common\xunit\IssueAttribute.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfFactDiscoverer.cs">
+      <Link>Common\xunit\WcfFactDiscoverer.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfSkippableAttribute.cs">
+      <Link>Common\xunit\WcfSkippableAttribute.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfTestCase.cs">
+      <Link>Common\xunit\WcfTestCase.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfTestDiscoverer.cs">
+      <Link>Common\xunit\WcfTestDiscoverer.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfTheoryDiscoverer.cs">
+      <Link>Common\xunit\WcfTheoryDiscoverer.cs</Link>
+    </Compile>
+  </ItemGroup>
+  <!-- Scenario Test Helpers -->
+  <ItemGroup>
+    <Compile Include="$(CommonScenarioTestPath)\Endpoints.cs">
+      <Link>Common\Endpoints.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonScenarioTestPath)\ScenarioTestHelpers.cs">
+      <Link>Common\ScenarioTestHelpers.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonScenarioTestPath)\ScenarioTestTypes.cs">
+      <Link>Common\ScenarioTestTypes.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonScenarioTestPath)\ServiceInterfaces.cs">
+      <Link>Common\ServiceInterfaces.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonScenarioTestPath)\TestMockStream.cs">
+      <Link>Common\TestMockStream.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />
@@ -38,14 +120,12 @@
     <ProjectReference Include='$(WcfSecurityPkgProj)'>
       <Name>System.ServiceModel.Security</Name>
     </ProjectReference>
-    <ProjectReference Include="$(WcfInfrastructureCommonProj)">
-      <Project>{AFD69665-89A3-42AE-A32E-AB2CBBE6EE7E}</Project>
-      <Name>Infrastructure.Common</Name>
-    </ProjectReference>
-    <ProjectReference Include='$(WcfScenarioTestCommonProj)'>
-      <Project>{9098B41C-9C2E-4FC6-B7D8-FC3411736A22}</Project>
-      <Name>ScenarioTests.Common</Name>
-    </ProjectReference>
   </ItemGroup>
+  <Import Project="$(CommonInfrastructureTestPath)\testproperties.props" />
+  <Import Project="$(CommonInfrastructureTestPath)\testproperties.targets" />
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <!-- Add our code-gen target after the imports above because they reset $(CoreCompileDependsOn) -->
+  <PropertyGroup>
+    <CoreCompileDependsOn>$(CoreCompileDependsOn);CreateTestProperties</CoreCompileDependsOn>
+  </PropertyGroup>
 </Project>

--- a/src/System.Private.ServiceModel/tests/Scenarios/Binding/Tcp/WcfCustomXunitAttribute.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Binding/Tcp/WcfCustomXunitAttribute.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Xunit;
+using Xunit.Sdk;
+
+namespace Infrastructure.Common
+{
+    [XunitTestCaseDiscoverer("Infrastructure.Common.WcfFactDiscoverer", "Binding.Tcp.Tests")]
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+    public class WcfFactAttribute : FactAttribute
+    {
+    }
+
+    [XunitTestCaseDiscoverer("Infrastructure.Common.WcfTheoryDiscoverer", "Binding.Tcp.Tests")]
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+    public class WcfTheoryAttribute : TheoryAttribute
+    {
+    }
+}

--- a/src/System.Private.ServiceModel/tests/Scenarios/Binding/Tcp/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Binding/Tcp/project.json
@@ -7,6 +7,7 @@
     "System.ServiceModel.Primitives": "4.3.0-preview1-24530-01",
     "System.ServiceModel.Security": "4.3.0-preview1-24530-01",
     "System.Threading.Timer": "4.3.0",
+    "System.Xml.XmlSerializer": "4.3.0",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/ChannelLayer/Client.ChannelLayer.Tests.csproj
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/ChannelLayer/Client.ChannelLayer.Tests.csproj
@@ -17,8 +17,90 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ProjectGuid>{1DFF7AF1-5873-4984-B871-73F2F9A84239}</ProjectGuid>
   </PropertyGroup>
+  <!-- Test Source -->
   <ItemGroup>
     <Compile Include="**\*.cs" />
+  </ItemGroup>
+  <!-- Infrastructure Test Helpers -->
+  <ItemGroup>
+    <Compile Include="$(CommonInfrastructureTestPath)\BridgeClient.cs">
+      <Link>Common\BridgeClient.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\BridgeClientAuthenticationManager.cs">
+      <Link>Common\BridgeClientAuthenticationManager.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\CertificateManager.cs">
+      <Link>Common\CertificateManager.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\ConditionalTestDetectors.cs">
+      <Link>Common\ConditionalTestDetectors.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\ConditionalWcfTest.cs">
+      <Link>Common\ConditionalWcfTest.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\FrameworkHelper.cs">
+      <Link>Common\FrameworkHelper.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\FrameworkID.cs">
+      <Link>Common\FrameworkID.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\JsonSerializer.cs">
+      <Link>Common\JsonSerializer.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\OSHelper.cs">
+      <Link>Common\OSHelper.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\OsID.cs">
+      <Link>Common\OsID.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\ServiceUtilHelper.cs">
+      <Link>Common\ServiceUtilHelper.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\TestEventListener.cs">
+      <Link>Common\TestEventListener.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\TestProperties.cs">
+      <Link>Common\TestProperties.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\ConditionAttribute.cs">
+      <Link>Common\xunit\ConditionAttribute.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\IssueAttribute.cs">
+      <Link>Common\xunit\IssueAttribute.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfFactDiscoverer.cs">
+      <Link>Common\xunit\WcfFactDiscoverer.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfSkippableAttribute.cs">
+      <Link>Common\xunit\WcfSkippableAttribute.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfTestCase.cs">
+      <Link>Common\xunit\WcfTestCase.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfTestDiscoverer.cs">
+      <Link>Common\xunit\WcfTestDiscoverer.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfTheoryDiscoverer.cs">
+      <Link>Common\xunit\WcfTheoryDiscoverer.cs</Link>
+    </Compile>
+  </ItemGroup>
+  <!-- Scenario Test Helpers -->
+  <ItemGroup>
+    <Compile Include="$(CommonScenarioTestPath)\Endpoints.cs">
+      <Link>Common\Endpoints.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonScenarioTestPath)\ScenarioTestHelpers.cs">
+      <Link>Common\ScenarioTestHelpers.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonScenarioTestPath)\ScenarioTestTypes.cs">
+      <Link>Common\ScenarioTestTypes.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonScenarioTestPath)\ServiceInterfaces.cs">
+      <Link>Common\ServiceInterfaces.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonScenarioTestPath)\TestMockStream.cs">
+      <Link>Common\TestMockStream.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />
@@ -36,14 +118,12 @@
     <ProjectReference Include='$(WcfPrimitivesPkgProj)'>
       <Name>System.ServiceModel.Primitives</Name>
     </ProjectReference>
-    <ProjectReference Include="$(WcfInfrastructureCommonProj)">
-      <Project>{AFD69665-89A3-42AE-A32E-AB2CBBE6EE7E}</Project>
-      <Name>Infrastructure.Common</Name>
-    </ProjectReference>
-    <ProjectReference Include='$(WcfScenarioTestCommonProj)'>
-      <Project>{9098B41C-9C2E-4FC6-B7D8-FC3411736A22}</Project>
-      <Name>ScenarioTests.Common</Name>
-    </ProjectReference>
   </ItemGroup>
+  <Import Project="$(CommonInfrastructureTestPath)\testproperties.props" />
+  <Import Project="$(CommonInfrastructureTestPath)\testproperties.targets" />
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <!-- Add our code-gen target after the imports above because they reset $(CoreCompileDependsOn) -->
+  <PropertyGroup>
+    <CoreCompileDependsOn>$(CoreCompileDependsOn);CreateTestProperties</CoreCompileDependsOn>
+  </PropertyGroup>
 </Project>

--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/ChannelLayer/WcfCustomXunitAttribute.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/ChannelLayer/WcfCustomXunitAttribute.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Xunit;
+using Xunit.Sdk;
+
+namespace Infrastructure.Common
+{
+    [XunitTestCaseDiscoverer("Infrastructure.Common.WcfFactDiscoverer", "Client.ChannelLayer.Tests")]
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+    public class WcfFactAttribute : FactAttribute
+    {
+    }
+
+    [XunitTestCaseDiscoverer("Infrastructure.Common.WcfTheoryDiscoverer", "Client.ChannelLayer.Tests")]
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+    public class WcfTheoryAttribute : TheoryAttribute
+    {
+    }
+}

--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/ChannelLayer/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/ChannelLayer/project.json
@@ -7,6 +7,7 @@
     "System.ServiceModel.Primitives": "4.3.0-preview1-24530-01",
     "System.ServiceModel.Security": "4.3.0-preview1-24530-01",
     "System.Threading.Timer": "4.3.0",
+    "System.Xml.XmlSerializer": "4.3.0",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/ClientBase/Client.ClientBase.Tests.csproj
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/ClientBase/Client.ClientBase.Tests.csproj
@@ -17,8 +17,90 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ProjectGuid>{E0142AC1-DA3D-4143-BFF1-7A70EE0981D4}</ProjectGuid>
   </PropertyGroup>
+  <!-- Test Source -->
   <ItemGroup>
     <Compile Include="**\*.cs" />
+  </ItemGroup>
+  <!-- Infrastructure Test Helpers -->
+  <ItemGroup>
+    <Compile Include="$(CommonInfrastructureTestPath)\BridgeClient.cs">
+      <Link>Common\BridgeClient.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\BridgeClientAuthenticationManager.cs">
+      <Link>Common\BridgeClientAuthenticationManager.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\CertificateManager.cs">
+      <Link>Common\CertificateManager.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\ConditionalTestDetectors.cs">
+      <Link>Common\ConditionalTestDetectors.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\ConditionalWcfTest.cs">
+      <Link>Common\ConditionalWcfTest.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\FrameworkHelper.cs">
+      <Link>Common\FrameworkHelper.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\FrameworkID.cs">
+      <Link>Common\FrameworkID.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\JsonSerializer.cs">
+      <Link>Common\JsonSerializer.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\OSHelper.cs">
+      <Link>Common\OSHelper.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\OsID.cs">
+      <Link>Common\OsID.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\ServiceUtilHelper.cs">
+      <Link>Common\ServiceUtilHelper.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\TestEventListener.cs">
+      <Link>Common\TestEventListener.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\TestProperties.cs">
+      <Link>Common\TestProperties.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\ConditionAttribute.cs">
+      <Link>Common\xunit\ConditionAttribute.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\IssueAttribute.cs">
+      <Link>Common\xunit\IssueAttribute.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfFactDiscoverer.cs">
+      <Link>Common\xunit\WcfFactDiscoverer.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfSkippableAttribute.cs">
+      <Link>Common\xunit\WcfSkippableAttribute.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfTestCase.cs">
+      <Link>Common\xunit\WcfTestCase.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfTestDiscoverer.cs">
+      <Link>Common\xunit\WcfTestDiscoverer.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfTheoryDiscoverer.cs">
+      <Link>Common\xunit\WcfTheoryDiscoverer.cs</Link>
+    </Compile>
+  </ItemGroup>
+  <!-- Scenario Test Helpers -->
+  <ItemGroup>
+    <Compile Include="$(CommonScenarioTestPath)\Endpoints.cs">
+      <Link>Common\Endpoints.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonScenarioTestPath)\ScenarioTestHelpers.cs">
+      <Link>Common\ScenarioTestHelpers.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonScenarioTestPath)\ScenarioTestTypes.cs">
+      <Link>Common\ScenarioTestTypes.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonScenarioTestPath)\ServiceInterfaces.cs">
+      <Link>Common\ServiceInterfaces.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonScenarioTestPath)\TestMockStream.cs">
+      <Link>Common\TestMockStream.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />
@@ -39,14 +121,12 @@
     <ProjectReference Include='$(WcfPrimitivesPkgProj)'>
       <Name>System.ServiceModel.Primitives</Name>
     </ProjectReference>
-    <ProjectReference Include="$(WcfInfrastructureCommonProj)">
-      <Project>{AFD69665-89A3-42AE-A32E-AB2CBBE6EE7E}</Project>
-      <Name>Infrastructure.Common</Name>
-    </ProjectReference>
-    <ProjectReference Include='$(WcfScenarioTestCommonProj)'>
-      <Project>{9098B41C-9C2E-4FC6-B7D8-FC3411736A22}</Project>
-      <Name>ScenarioTests.Common</Name>
-    </ProjectReference>
   </ItemGroup>
+  <Import Project="$(CommonInfrastructureTestPath)\testproperties.props" />
+  <Import Project="$(CommonInfrastructureTestPath)\testproperties.targets" />
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <!-- Add our code-gen target after the imports above because they reset $(CoreCompileDependsOn) -->
+  <PropertyGroup>
+    <CoreCompileDependsOn>$(CoreCompileDependsOn);CreateTestProperties</CoreCompileDependsOn>
+  </PropertyGroup>
 </Project>

--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/ClientBase/WcfCustomXunitAttribute.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/ClientBase/WcfCustomXunitAttribute.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Xunit;
+using Xunit.Sdk;
+
+namespace Infrastructure.Common
+{
+    [XunitTestCaseDiscoverer("Infrastructure.Common.WcfFactDiscoverer", "Client.ClientBase.Tests")]
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+    public class WcfFactAttribute : FactAttribute
+    {
+    }
+
+    [XunitTestCaseDiscoverer("Infrastructure.Common.WcfTheoryDiscoverer", "Client.ClientBase.Tests")]
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+    public class WcfTheoryAttribute : TheoryAttribute
+    {
+    }
+}

--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/ClientBase/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/ClientBase/project.json
@@ -7,6 +7,7 @@
     "System.ServiceModel.Primitives": "4.3.0-preview1-24530-01",
     "System.ServiceModel.Security": "4.3.0-preview1-24530-01",
     "System.Threading.Timer": "4.3.0",
+    "System.Xml.XmlSerializer": "4.3.0",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/ExpectedExceptions/Client.ExpectedExceptions.Tests.csproj
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/ExpectedExceptions/Client.ExpectedExceptions.Tests.csproj
@@ -17,8 +17,90 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ProjectGuid>{C9DBD082-1903-4367-894F-DDF3CEC28A64}</ProjectGuid>
   </PropertyGroup>
+  <!-- Test Source -->
   <ItemGroup>
     <Compile Include="**\*.cs" />
+  </ItemGroup>
+  <!-- Infrastructure Test Helpers -->
+  <ItemGroup>
+    <Compile Include="$(CommonInfrastructureTestPath)\BridgeClient.cs">
+      <Link>Common\BridgeClient.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\BridgeClientAuthenticationManager.cs">
+      <Link>Common\BridgeClientAuthenticationManager.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\CertificateManager.cs">
+      <Link>Common\CertificateManager.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\ConditionalTestDetectors.cs">
+      <Link>Common\ConditionalTestDetectors.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\ConditionalWcfTest.cs">
+      <Link>Common\ConditionalWcfTest.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\FrameworkHelper.cs">
+      <Link>Common\FrameworkHelper.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\FrameworkID.cs">
+      <Link>Common\FrameworkID.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\JsonSerializer.cs">
+      <Link>Common\JsonSerializer.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\OSHelper.cs">
+      <Link>Common\OSHelper.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\OsID.cs">
+      <Link>Common\OsID.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\ServiceUtilHelper.cs">
+      <Link>Common\ServiceUtilHelper.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\TestEventListener.cs">
+      <Link>Common\TestEventListener.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\TestProperties.cs">
+      <Link>Common\TestProperties.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\ConditionAttribute.cs">
+      <Link>Common\xunit\ConditionAttribute.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\IssueAttribute.cs">
+      <Link>Common\xunit\IssueAttribute.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfFactDiscoverer.cs">
+      <Link>Common\xunit\WcfFactDiscoverer.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfSkippableAttribute.cs">
+      <Link>Common\xunit\WcfSkippableAttribute.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfTestCase.cs">
+      <Link>Common\xunit\WcfTestCase.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfTestDiscoverer.cs">
+      <Link>Common\xunit\WcfTestDiscoverer.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfTheoryDiscoverer.cs">
+      <Link>Common\xunit\WcfTheoryDiscoverer.cs</Link>
+    </Compile>
+  </ItemGroup>
+  <!-- Scenario Test Helpers -->
+  <ItemGroup>
+    <Compile Include="$(CommonScenarioTestPath)\Endpoints.cs">
+      <Link>Common\Endpoints.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonScenarioTestPath)\ScenarioTestHelpers.cs">
+      <Link>Common\ScenarioTestHelpers.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonScenarioTestPath)\ScenarioTestTypes.cs">
+      <Link>Common\ScenarioTestTypes.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonScenarioTestPath)\ServiceInterfaces.cs">
+      <Link>Common\ServiceInterfaces.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonScenarioTestPath)\TestMockStream.cs">
+      <Link>Common\TestMockStream.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />
@@ -42,14 +124,12 @@
     <ProjectReference Include='$(WcfSecurityPkgProj)'>
       <Name>System.ServiceModel.Security</Name>
     </ProjectReference>
-    <ProjectReference Include="$(WcfInfrastructureCommonProj)">
-      <Project>{AFD69665-89A3-42AE-A32E-AB2CBBE6EE7E}</Project>
-      <Name>Infrastructure.Common</Name>
-    </ProjectReference>
-    <ProjectReference Include='$(WcfScenarioTestCommonProj)'>
-      <Project>{9098B41C-9C2E-4FC6-B7D8-FC3411736A22}</Project>
-      <Name>ScenarioTests.Common</Name>
-    </ProjectReference>
   </ItemGroup>
+  <Import Project="$(CommonInfrastructureTestPath)\testproperties.props" />
+  <Import Project="$(CommonInfrastructureTestPath)\testproperties.targets" />
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <!-- Add our code-gen target after the imports above because they reset $(CoreCompileDependsOn) -->
+  <PropertyGroup>
+    <CoreCompileDependsOn>$(CoreCompileDependsOn);CreateTestProperties</CoreCompileDependsOn>
+  </PropertyGroup>
 </Project>

--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/ExpectedExceptions/WcfCustomXunitAttribute.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/ExpectedExceptions/WcfCustomXunitAttribute.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Xunit;
+using Xunit.Sdk;
+
+namespace Infrastructure.Common
+{
+    [XunitTestCaseDiscoverer("Infrastructure.Common.WcfFactDiscoverer", "Client.ExpectedExceptions.Tests")]
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+    public class WcfFactAttribute : FactAttribute
+    {
+    }
+
+    [XunitTestCaseDiscoverer("Infrastructure.Common.WcfTheoryDiscoverer", "Client.ExpectedExceptions.Tests")]
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+    public class WcfTheoryAttribute : TheoryAttribute
+    {
+    }
+}

--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/ExpectedExceptions/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/ExpectedExceptions/project.json
@@ -7,6 +7,7 @@
     "System.ServiceModel.Primitives": "4.3.0-preview1-24530-01",
     "System.ServiceModel.Security": "4.3.0-preview1-24530-01",
     "System.Threading.Timer": "4.3.0",
+    "System.Xml.XmlSerializer": "4.3.0",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/TypedClient/Client.TypedClient.Tests.csproj
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/TypedClient/Client.TypedClient.Tests.csproj
@@ -16,8 +16,90 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ProjectGuid>{09EB5A34-9F50-4349-B8D9-D8E82A3FAE8E}</ProjectGuid>
   </PropertyGroup>
+  <!-- Test Source -->
   <ItemGroup>
     <Compile Include="**\*.cs" />
+  </ItemGroup>
+  <!-- Infrastructure Test Helpers -->
+  <ItemGroup>
+    <Compile Include="$(CommonInfrastructureTestPath)\BridgeClient.cs">
+      <Link>Common\BridgeClient.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\BridgeClientAuthenticationManager.cs">
+      <Link>Common\BridgeClientAuthenticationManager.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\CertificateManager.cs">
+      <Link>Common\CertificateManager.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\ConditionalTestDetectors.cs">
+      <Link>Common\ConditionalTestDetectors.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\ConditionalWcfTest.cs">
+      <Link>Common\ConditionalWcfTest.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\FrameworkHelper.cs">
+      <Link>Common\FrameworkHelper.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\FrameworkID.cs">
+      <Link>Common\FrameworkID.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\JsonSerializer.cs">
+      <Link>Common\JsonSerializer.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\OSHelper.cs">
+      <Link>Common\OSHelper.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\OsID.cs">
+      <Link>Common\OsID.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\ServiceUtilHelper.cs">
+      <Link>Common\ServiceUtilHelper.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\TestEventListener.cs">
+      <Link>Common\TestEventListener.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\TestProperties.cs">
+      <Link>Common\TestProperties.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\ConditionAttribute.cs">
+      <Link>Common\xunit\ConditionAttribute.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\IssueAttribute.cs">
+      <Link>Common\xunit\IssueAttribute.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfFactDiscoverer.cs">
+      <Link>Common\xunit\WcfFactDiscoverer.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfSkippableAttribute.cs">
+      <Link>Common\xunit\WcfSkippableAttribute.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfTestCase.cs">
+      <Link>Common\xunit\WcfTestCase.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfTestDiscoverer.cs">
+      <Link>Common\xunit\WcfTestDiscoverer.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfTheoryDiscoverer.cs">
+      <Link>Common\xunit\WcfTheoryDiscoverer.cs</Link>
+    </Compile>
+  </ItemGroup>
+  <!-- Scenario Test Helpers -->
+  <ItemGroup>
+    <Compile Include="$(CommonScenarioTestPath)\Endpoints.cs">
+      <Link>Common\Endpoints.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonScenarioTestPath)\ScenarioTestHelpers.cs">
+      <Link>Common\ScenarioTestHelpers.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonScenarioTestPath)\ScenarioTestTypes.cs">
+      <Link>Common\ScenarioTestTypes.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonScenarioTestPath)\ServiceInterfaces.cs">
+      <Link>Common\ServiceInterfaces.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonScenarioTestPath)\TestMockStream.cs">
+      <Link>Common\TestMockStream.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />
@@ -38,14 +120,12 @@
     <ProjectReference Include='$(WcfPrimitivesPkgProj)'>
       <Name>System.ServiceModel.Primitives</Name>
     </ProjectReference>
-    <ProjectReference Include='$(WcfScenarioTestCommonProj)'>
-      <Project>{9098B41C-9C2E-4FC6-B7D8-FC3411736A22}</Project>
-      <Name>ScenarioTests.Common</Name>
-    </ProjectReference>
-        <ProjectReference Include="$(WcfInfrastructureCommonProj)">
-      <Project>{AFD69665-89A3-42AE-A32E-AB2CBBE6EE7E}</Project>
-      <Name>Infrastructure.Common</Name>
-    </ProjectReference>
   </ItemGroup>
+  <Import Project="$(CommonInfrastructureTestPath)\testproperties.props" />
+  <Import Project="$(CommonInfrastructureTestPath)\testproperties.targets" />
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <!-- Add our code-gen target after the imports above because they reset $(CoreCompileDependsOn) -->
+  <PropertyGroup>
+    <CoreCompileDependsOn>$(CoreCompileDependsOn);CreateTestProperties</CoreCompileDependsOn>
+  </PropertyGroup>
 </Project>

--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/TypedClient/WcfCustomXunitAttribute.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/TypedClient/WcfCustomXunitAttribute.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Xunit;
+using Xunit.Sdk;
+
+namespace Infrastructure.Common
+{
+    [XunitTestCaseDiscoverer("Infrastructure.Common.WcfFactDiscoverer", "Client.TypedClient.Tests")]
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+    public class WcfFactAttribute : FactAttribute
+    {
+    }
+
+    [XunitTestCaseDiscoverer("Infrastructure.Common.WcfTheoryDiscoverer", "Client.TypedClient.Tests")]
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+    public class WcfTheoryAttribute : TheoryAttribute
+    {
+    }
+}

--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/TypedClient/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/TypedClient/project.json
@@ -7,6 +7,7 @@
     "System.ServiceModel.Primitives": "4.3.0-preview1-24530-01",
     "System.ServiceModel.Security": "4.3.0-preview1-24530-01",
     "System.Threading.Timer": "4.3.0",
+    "System.Xml.XmlSerializer": "4.3.0",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Private.ServiceModel/tests/Scenarios/Contract/Data/Contract.Data.Tests.csproj
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Contract/Data/Contract.Data.Tests.csproj
@@ -16,8 +16,90 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ProjectGuid>{4361D851-B56C-44CD-B7BD-D9EFD32F94AD}</ProjectGuid>
   </PropertyGroup>
+  <!-- Test Source -->
   <ItemGroup>
     <Compile Include="**\*.cs" />
+  </ItemGroup>
+  <!-- Infrastructure Test Helpers -->
+  <ItemGroup>
+    <Compile Include="$(CommonInfrastructureTestPath)\BridgeClient.cs">
+      <Link>Common\BridgeClient.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\BridgeClientAuthenticationManager.cs">
+      <Link>Common\BridgeClientAuthenticationManager.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\CertificateManager.cs">
+      <Link>Common\CertificateManager.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\ConditionalTestDetectors.cs">
+      <Link>Common\ConditionalTestDetectors.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\ConditionalWcfTest.cs">
+      <Link>Common\ConditionalWcfTest.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\FrameworkHelper.cs">
+      <Link>Common\FrameworkHelper.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\FrameworkID.cs">
+      <Link>Common\FrameworkID.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\JsonSerializer.cs">
+      <Link>Common\JsonSerializer.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\OSHelper.cs">
+      <Link>Common\OSHelper.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\OsID.cs">
+      <Link>Common\OsID.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\ServiceUtilHelper.cs">
+      <Link>Common\ServiceUtilHelper.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\TestEventListener.cs">
+      <Link>Common\TestEventListener.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\TestProperties.cs">
+      <Link>Common\TestProperties.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\ConditionAttribute.cs">
+      <Link>Common\xunit\ConditionAttribute.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\IssueAttribute.cs">
+      <Link>Common\xunit\IssueAttribute.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfFactDiscoverer.cs">
+      <Link>Common\xunit\WcfFactDiscoverer.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfSkippableAttribute.cs">
+      <Link>Common\xunit\WcfSkippableAttribute.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfTestCase.cs">
+      <Link>Common\xunit\WcfTestCase.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfTestDiscoverer.cs">
+      <Link>Common\xunit\WcfTestDiscoverer.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfTheoryDiscoverer.cs">
+      <Link>Common\xunit\WcfTheoryDiscoverer.cs</Link>
+    </Compile>
+  </ItemGroup>
+  <!-- Scenario Test Helpers -->
+  <ItemGroup>
+    <Compile Include="$(CommonScenarioTestPath)\Endpoints.cs">
+      <Link>Common\Endpoints.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonScenarioTestPath)\ScenarioTestHelpers.cs">
+      <Link>Common\ScenarioTestHelpers.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonScenarioTestPath)\ScenarioTestTypes.cs">
+      <Link>Common\ScenarioTestTypes.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonScenarioTestPath)\ServiceInterfaces.cs">
+      <Link>Common\ServiceInterfaces.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonScenarioTestPath)\TestMockStream.cs">
+      <Link>Common\TestMockStream.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />
@@ -38,14 +120,12 @@
     <ProjectReference Include='$(WcfPrimitivesPkgProj)'>
       <Name>System.ServiceModel.Primitives</Name>
     </ProjectReference>
-    <ProjectReference Include="$(WcfInfrastructureCommonProj)">
-      <Project>{AFD69665-89A3-42AE-A32E-AB2CBBE6EE7E}</Project>
-      <Name>Infrastructure.Common</Name>
-    </ProjectReference>
-    <ProjectReference Include='$(WcfScenarioTestCommonProj)'>
-      <Project>{9098B41C-9C2E-4FC6-B7D8-FC3411736A22}</Project>
-      <Name>ScenarioTests.Common</Name>
-    </ProjectReference>
   </ItemGroup>
+  <Import Project="$(CommonInfrastructureTestPath)\testproperties.props" />
+  <Import Project="$(CommonInfrastructureTestPath)\testproperties.targets" />
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <!-- Add our code-gen target after the imports above because they reset $(CoreCompileDependsOn) -->
+  <PropertyGroup>
+    <CoreCompileDependsOn>$(CoreCompileDependsOn);CreateTestProperties</CoreCompileDependsOn>
+  </PropertyGroup>
 </Project>

--- a/src/System.Private.ServiceModel/tests/Scenarios/Contract/Data/WcfCustomXunitAttribute.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Contract/Data/WcfCustomXunitAttribute.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Xunit;
+using Xunit.Sdk;
+
+namespace Infrastructure.Common
+{
+    [XunitTestCaseDiscoverer("Infrastructure.Common.WcfFactDiscoverer", "Contract.Data.Tests")]
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+    public class WcfFactAttribute : FactAttribute
+    {
+    }
+
+    [XunitTestCaseDiscoverer("Infrastructure.Common.WcfTheoryDiscoverer", "Contract.Data.Tests")]
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+    public class WcfTheoryAttribute : TheoryAttribute
+    {
+    }
+}

--- a/src/System.Private.ServiceModel/tests/Scenarios/Contract/Data/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Contract/Data/project.json
@@ -7,6 +7,7 @@
     "System.ServiceModel.Primitives": "4.3.0-preview1-24530-01",
     "System.ServiceModel.Security": "4.3.0-preview1-24530-01",
     "System.Threading.Timer": "4.3.0",
+    "System.Xml.XmlSerializer": "4.3.0",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Private.ServiceModel/tests/Scenarios/Contract/Fault/Contract.Fault.Tests.csproj
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Contract/Fault/Contract.Fault.Tests.csproj
@@ -16,8 +16,90 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ProjectGuid>{0324E738-B6EF-43FB-8321-DC49640D2615}</ProjectGuid>
   </PropertyGroup>
+  <!-- Test Source -->
   <ItemGroup>
     <Compile Include="**\*.cs" />
+  </ItemGroup>
+  <!-- Infrastructure Test Helpers -->
+  <ItemGroup>
+    <Compile Include="$(CommonInfrastructureTestPath)\BridgeClient.cs">
+      <Link>Common\BridgeClient.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\BridgeClientAuthenticationManager.cs">
+      <Link>Common\BridgeClientAuthenticationManager.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\CertificateManager.cs">
+      <Link>Common\CertificateManager.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\ConditionalTestDetectors.cs">
+      <Link>Common\ConditionalTestDetectors.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\ConditionalWcfTest.cs">
+      <Link>Common\ConditionalWcfTest.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\FrameworkHelper.cs">
+      <Link>Common\FrameworkHelper.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\FrameworkID.cs">
+      <Link>Common\FrameworkID.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\JsonSerializer.cs">
+      <Link>Common\JsonSerializer.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\OSHelper.cs">
+      <Link>Common\OSHelper.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\OsID.cs">
+      <Link>Common\OsID.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\ServiceUtilHelper.cs">
+      <Link>Common\ServiceUtilHelper.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\TestEventListener.cs">
+      <Link>Common\TestEventListener.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\TestProperties.cs">
+      <Link>Common\TestProperties.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\ConditionAttribute.cs">
+      <Link>Common\xunit\ConditionAttribute.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\IssueAttribute.cs">
+      <Link>Common\xunit\IssueAttribute.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfFactDiscoverer.cs">
+      <Link>Common\xunit\WcfFactDiscoverer.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfSkippableAttribute.cs">
+      <Link>Common\xunit\WcfSkippableAttribute.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfTestCase.cs">
+      <Link>Common\xunit\WcfTestCase.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfTestDiscoverer.cs">
+      <Link>Common\xunit\WcfTestDiscoverer.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfTheoryDiscoverer.cs">
+      <Link>Common\xunit\WcfTheoryDiscoverer.cs</Link>
+    </Compile>
+  </ItemGroup>
+  <!-- Scenario Test Helpers -->
+  <ItemGroup>
+    <Compile Include="$(CommonScenarioTestPath)\Endpoints.cs">
+      <Link>Common\Endpoints.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonScenarioTestPath)\ScenarioTestHelpers.cs">
+      <Link>Common\ScenarioTestHelpers.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonScenarioTestPath)\ScenarioTestTypes.cs">
+      <Link>Common\ScenarioTestTypes.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonScenarioTestPath)\ServiceInterfaces.cs">
+      <Link>Common\ServiceInterfaces.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonScenarioTestPath)\TestMockStream.cs">
+      <Link>Common\TestMockStream.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />
@@ -32,14 +114,12 @@
     <ProjectReference Include='$(WcfPrimitivesPkgProj)'>
       <Name>System.ServiceModel.Primitives</Name>
     </ProjectReference>
-    <ProjectReference Include="$(WcfInfrastructureCommonProj)">
-      <Project>{AFD69665-89A3-42AE-A32E-AB2CBBE6EE7E}</Project>
-      <Name>Infrastructure.Common</Name>
-    </ProjectReference>
-    <ProjectReference Include='$(WcfScenarioTestCommonProj)'>
-      <Project>{9098B41C-9C2E-4FC6-B7D8-FC3411736A22}</Project>
-      <Name>ScenarioTests.Common</Name>
-    </ProjectReference>
   </ItemGroup>
+  <Import Project="$(CommonInfrastructureTestPath)\testproperties.props" />
+  <Import Project="$(CommonInfrastructureTestPath)\testproperties.targets" />
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <!-- Add our code-gen target after the imports above because they reset $(CoreCompileDependsOn) -->
+  <PropertyGroup>
+    <CoreCompileDependsOn>$(CoreCompileDependsOn);CreateTestProperties</CoreCompileDependsOn>
+  </PropertyGroup>
 </Project>

--- a/src/System.Private.ServiceModel/tests/Scenarios/Contract/Fault/WcfCustomXunitAttribute.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Contract/Fault/WcfCustomXunitAttribute.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Xunit;
+using Xunit.Sdk;
+
+namespace Infrastructure.Common
+{
+    [XunitTestCaseDiscoverer("Infrastructure.Common.WcfFactDiscoverer", "Contract.Fault.Tests")]
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+    public class WcfFactAttribute : FactAttribute
+    {
+    }
+
+    [XunitTestCaseDiscoverer("Infrastructure.Common.WcfTheoryDiscoverer", "Contract.Fault.Tests")]
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+    public class WcfTheoryAttribute : TheoryAttribute
+    {
+    }
+}

--- a/src/System.Private.ServiceModel/tests/Scenarios/Contract/Fault/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Contract/Fault/project.json
@@ -7,6 +7,7 @@
     "System.ServiceModel.Primitives": "4.3.0-preview1-24530-01",
     "System.ServiceModel.Security": "4.3.0-preview1-24530-01",
     "System.Threading.Timer": "4.3.0",
+    "System.Xml.XmlSerializer": "4.3.0",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Private.ServiceModel/tests/Scenarios/Contract/Message/Contract.Message.Tests.csproj
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Contract/Message/Contract.Message.Tests.csproj
@@ -16,8 +16,90 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ProjectGuid>{A835C2BC-DFD0-4ED6-A240-59FBEE7F0157}</ProjectGuid>
   </PropertyGroup>
+  <!-- Test Source -->
   <ItemGroup>
     <Compile Include="**\*.cs" />
+  </ItemGroup>
+  <!-- Infrastructure Test Helpers -->
+  <ItemGroup>
+    <Compile Include="$(CommonInfrastructureTestPath)\BridgeClient.cs">
+      <Link>Common\BridgeClient.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\BridgeClientAuthenticationManager.cs">
+      <Link>Common\BridgeClientAuthenticationManager.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\CertificateManager.cs">
+      <Link>Common\CertificateManager.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\ConditionalTestDetectors.cs">
+      <Link>Common\ConditionalTestDetectors.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\ConditionalWcfTest.cs">
+      <Link>Common\ConditionalWcfTest.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\FrameworkHelper.cs">
+      <Link>Common\FrameworkHelper.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\FrameworkID.cs">
+      <Link>Common\FrameworkID.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\JsonSerializer.cs">
+      <Link>Common\JsonSerializer.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\OSHelper.cs">
+      <Link>Common\OSHelper.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\OsID.cs">
+      <Link>Common\OsID.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\ServiceUtilHelper.cs">
+      <Link>Common\ServiceUtilHelper.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\TestEventListener.cs">
+      <Link>Common\TestEventListener.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\TestProperties.cs">
+      <Link>Common\TestProperties.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\ConditionAttribute.cs">
+      <Link>Common\xunit\ConditionAttribute.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\IssueAttribute.cs">
+      <Link>Common\xunit\IssueAttribute.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfFactDiscoverer.cs">
+      <Link>Common\xunit\WcfFactDiscoverer.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfSkippableAttribute.cs">
+      <Link>Common\xunit\WcfSkippableAttribute.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfTestCase.cs">
+      <Link>Common\xunit\WcfTestCase.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfTestDiscoverer.cs">
+      <Link>Common\xunit\WcfTestDiscoverer.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfTheoryDiscoverer.cs">
+      <Link>Common\xunit\WcfTheoryDiscoverer.cs</Link>
+    </Compile>
+  </ItemGroup>
+  <!-- Scenario Test Helpers -->
+  <ItemGroup>
+    <Compile Include="$(CommonScenarioTestPath)\Endpoints.cs">
+      <Link>Common\Endpoints.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonScenarioTestPath)\ScenarioTestHelpers.cs">
+      <Link>Common\ScenarioTestHelpers.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonScenarioTestPath)\ScenarioTestTypes.cs">
+      <Link>Common\ScenarioTestTypes.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonScenarioTestPath)\ServiceInterfaces.cs">
+      <Link>Common\ServiceInterfaces.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonScenarioTestPath)\TestMockStream.cs">
+      <Link>Common\TestMockStream.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />
@@ -32,14 +114,12 @@
     <ProjectReference Include='$(WcfPrimitivesPkgProj)'>
       <Name>System.ServiceModel.Primitives</Name>
     </ProjectReference>
-    <ProjectReference Include="$(WcfInfrastructureCommonProj)">
-      <Project>{AFD69665-89A3-42AE-A32E-AB2CBBE6EE7E}</Project>
-      <Name>Infrastructure.Common</Name>
-    </ProjectReference>
-    <ProjectReference Include='$(WcfScenarioTestCommonProj)'>
-      <Project>{9098B41C-9C2E-4FC6-B7D8-FC3411736A22}</Project>
-      <Name>ScenarioTests.Common</Name>
-    </ProjectReference>
   </ItemGroup>
+  <Import Project="$(CommonInfrastructureTestPath)\testproperties.props" />
+  <Import Project="$(CommonInfrastructureTestPath)\testproperties.targets" />
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <!-- Add our code-gen target after the imports above because they reset $(CoreCompileDependsOn) -->
+  <PropertyGroup>
+    <CoreCompileDependsOn>$(CoreCompileDependsOn);CreateTestProperties</CoreCompileDependsOn>
+  </PropertyGroup>
 </Project>

--- a/src/System.Private.ServiceModel/tests/Scenarios/Contract/Message/WcfCustomXunitAttribute.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Contract/Message/WcfCustomXunitAttribute.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Xunit;
+using Xunit.Sdk;
+
+namespace Infrastructure.Common
+{
+    [XunitTestCaseDiscoverer("Infrastructure.Common.WcfFactDiscoverer", "Contract.Message.Tests")]
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+    public class WcfFactAttribute : FactAttribute
+    {
+    }
+
+    [XunitTestCaseDiscoverer("Infrastructure.Common.WcfTheoryDiscoverer", "Contract.Message.Tests")]
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+    public class WcfTheoryAttribute : TheoryAttribute
+    {
+    }
+}

--- a/src/System.Private.ServiceModel/tests/Scenarios/Contract/Message/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Contract/Message/project.json
@@ -7,6 +7,7 @@
     "System.ServiceModel.Primitives": "4.3.0-preview1-24530-01",
     "System.ServiceModel.Security": "4.3.0-preview1-24530-01",
     "System.Threading.Timer": "4.3.0",
+    "System.Xml.XmlSerializer": "4.3.0",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Private.ServiceModel/tests/Scenarios/Contract/Service/Contract.Service.Tests.csproj
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Contract/Service/Contract.Service.Tests.csproj
@@ -16,8 +16,90 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ProjectGuid>{8773AC5C-5B4D-4745-BECF-01415CB10F1C}</ProjectGuid>
   </PropertyGroup>
+  <!-- Test Source -->
   <ItemGroup>
     <Compile Include="**\*.cs" />
+  </ItemGroup>
+  <!-- Infrastructure Test Helpers -->
+  <ItemGroup>
+    <Compile Include="$(CommonInfrastructureTestPath)\BridgeClient.cs">
+      <Link>Common\BridgeClient.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\BridgeClientAuthenticationManager.cs">
+      <Link>Common\BridgeClientAuthenticationManager.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\CertificateManager.cs">
+      <Link>Common\CertificateManager.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\ConditionalTestDetectors.cs">
+      <Link>Common\ConditionalTestDetectors.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\ConditionalWcfTest.cs">
+      <Link>Common\ConditionalWcfTest.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\FrameworkHelper.cs">
+      <Link>Common\FrameworkHelper.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\FrameworkID.cs">
+      <Link>Common\FrameworkID.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\JsonSerializer.cs">
+      <Link>Common\JsonSerializer.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\OSHelper.cs">
+      <Link>Common\OSHelper.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\OsID.cs">
+      <Link>Common\OsID.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\ServiceUtilHelper.cs">
+      <Link>Common\ServiceUtilHelper.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\TestEventListener.cs">
+      <Link>Common\TestEventListener.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\TestProperties.cs">
+      <Link>Common\TestProperties.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\ConditionAttribute.cs">
+      <Link>Common\xunit\ConditionAttribute.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\IssueAttribute.cs">
+      <Link>Common\xunit\IssueAttribute.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfFactDiscoverer.cs">
+      <Link>Common\xunit\WcfFactDiscoverer.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfSkippableAttribute.cs">
+      <Link>Common\xunit\WcfSkippableAttribute.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfTestCase.cs">
+      <Link>Common\xunit\WcfTestCase.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfTestDiscoverer.cs">
+      <Link>Common\xunit\WcfTestDiscoverer.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfTheoryDiscoverer.cs">
+      <Link>Common\xunit\WcfTheoryDiscoverer.cs</Link>
+    </Compile>
+  </ItemGroup>
+  <!-- Scenario Test Helpers -->
+  <ItemGroup>
+    <Compile Include="$(CommonScenarioTestPath)\Endpoints.cs">
+      <Link>Common\Endpoints.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonScenarioTestPath)\ScenarioTestHelpers.cs">
+      <Link>Common\ScenarioTestHelpers.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonScenarioTestPath)\ScenarioTestTypes.cs">
+      <Link>Common\ScenarioTestTypes.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonScenarioTestPath)\ServiceInterfaces.cs">
+      <Link>Common\ServiceInterfaces.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonScenarioTestPath)\TestMockStream.cs">
+      <Link>Common\TestMockStream.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />
@@ -35,14 +117,12 @@
     <ProjectReference Include='$(WcfPrimitivesPkgProj)'>
       <Name>System.ServiceModel.Primitives</Name>
     </ProjectReference>
-    <ProjectReference Include="$(WcfInfrastructureCommonProj)">
-      <Project>{AFD69665-89A3-42AE-A32E-AB2CBBE6EE7E}</Project>
-      <Name>Infrastructure.Common</Name>
-    </ProjectReference>
-    <ProjectReference Include='$(WcfScenarioTestCommonProj)'>
-      <Project>{9098B41C-9C2E-4FC6-B7D8-FC3411736A22}</Project>
-      <Name>ScenarioTests.Common</Name>
-    </ProjectReference>
   </ItemGroup>
+  <Import Project="$(CommonInfrastructureTestPath)\testproperties.props" />
+  <Import Project="$(CommonInfrastructureTestPath)\testproperties.targets" />
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <!-- Add our code-gen target after the imports above because they reset $(CoreCompileDependsOn) -->
+  <PropertyGroup>
+    <CoreCompileDependsOn>$(CoreCompileDependsOn);CreateTestProperties</CoreCompileDependsOn>
+  </PropertyGroup>
 </Project>

--- a/src/System.Private.ServiceModel/tests/Scenarios/Contract/Service/WcfCustomXunitAttribute.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Contract/Service/WcfCustomXunitAttribute.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Xunit;
+using Xunit.Sdk;
+
+namespace Infrastructure.Common
+{
+    [XunitTestCaseDiscoverer("Infrastructure.Common.WcfFactDiscoverer", "Contract.Service.Tests")]
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+    public class WcfFactAttribute : FactAttribute
+    {
+    }
+
+    [XunitTestCaseDiscoverer("Infrastructure.Common.WcfTheoryDiscoverer", "Contract.Service.Tests")]
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+    public class WcfTheoryAttribute : TheoryAttribute
+    {
+    }
+}

--- a/src/System.Private.ServiceModel/tests/Scenarios/Contract/Service/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Contract/Service/project.json
@@ -7,6 +7,7 @@
     "System.ServiceModel.Primitives": "4.3.0-preview1-24530-01",
     "System.ServiceModel.Security": "4.3.0-preview1-24530-01",
     "System.Threading.Timer": "4.3.0",
+    "System.Xml.XmlSerializer": "4.3.0",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Private.ServiceModel/tests/Scenarios/Contract/XmlSerializer/Contract.XmlSerializer.Tests.csproj
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Contract/XmlSerializer/Contract.XmlSerializer.Tests.csproj
@@ -16,8 +16,90 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ProjectGuid>{DA0F8A1F-30A4-4AD4-9C5E-F6743D7ACEFE}</ProjectGuid>
   </PropertyGroup>
+  <!-- Test Source -->
   <ItemGroup>
     <Compile Include="**\*.cs" />
+  </ItemGroup>
+  <!-- Infrastructure Test Helpers -->
+  <ItemGroup>
+    <Compile Include="$(CommonInfrastructureTestPath)\BridgeClient.cs">
+      <Link>Common\BridgeClient.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\BridgeClientAuthenticationManager.cs">
+      <Link>Common\BridgeClientAuthenticationManager.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\CertificateManager.cs">
+      <Link>Common\CertificateManager.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\ConditionalTestDetectors.cs">
+      <Link>Common\ConditionalTestDetectors.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\ConditionalWcfTest.cs">
+      <Link>Common\ConditionalWcfTest.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\FrameworkHelper.cs">
+      <Link>Common\FrameworkHelper.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\FrameworkID.cs">
+      <Link>Common\FrameworkID.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\JsonSerializer.cs">
+      <Link>Common\JsonSerializer.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\OSHelper.cs">
+      <Link>Common\OSHelper.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\OsID.cs">
+      <Link>Common\OsID.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\ServiceUtilHelper.cs">
+      <Link>Common\ServiceUtilHelper.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\TestEventListener.cs">
+      <Link>Common\TestEventListener.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\TestProperties.cs">
+      <Link>Common\TestProperties.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\ConditionAttribute.cs">
+      <Link>Common\xunit\ConditionAttribute.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\IssueAttribute.cs">
+      <Link>Common\xunit\IssueAttribute.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfFactDiscoverer.cs">
+      <Link>Common\xunit\WcfFactDiscoverer.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfSkippableAttribute.cs">
+      <Link>Common\xunit\WcfSkippableAttribute.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfTestCase.cs">
+      <Link>Common\xunit\WcfTestCase.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfTestDiscoverer.cs">
+      <Link>Common\xunit\WcfTestDiscoverer.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfTheoryDiscoverer.cs">
+      <Link>Common\xunit\WcfTheoryDiscoverer.cs</Link>
+    </Compile>
+  </ItemGroup>
+  <!-- Scenario Test Helpers -->
+  <ItemGroup>
+    <Compile Include="$(CommonScenarioTestPath)\Endpoints.cs">
+      <Link>Common\Endpoints.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonScenarioTestPath)\ScenarioTestHelpers.cs">
+      <Link>Common\ScenarioTestHelpers.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonScenarioTestPath)\ScenarioTestTypes.cs">
+      <Link>Common\ScenarioTestTypes.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonScenarioTestPath)\ServiceInterfaces.cs">
+      <Link>Common\ServiceInterfaces.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonScenarioTestPath)\TestMockStream.cs">
+      <Link>Common\TestMockStream.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />
@@ -32,14 +114,12 @@
     <ProjectReference Include='$(WcfPrimitivesPkgProj)'>
       <Name>System.ServiceModel.Primitives</Name>
     </ProjectReference>
-    <ProjectReference Include="$(WcfInfrastructureCommonProj)">
-      <Project>{AFD69665-89A3-42AE-A32E-AB2CBBE6EE7E}</Project>
-      <Name>Infrastructure.Common</Name>
-    </ProjectReference>
-    <ProjectReference Include='$(WcfScenarioTestCommonProj)'>
-      <Project>{9098B41C-9C2E-4FC6-B7D8-FC3411736A22}</Project>
-      <Name>ScenarioTests.Common</Name>
-    </ProjectReference>
   </ItemGroup>
+  <Import Project="$(CommonInfrastructureTestPath)\testproperties.props" />
+  <Import Project="$(CommonInfrastructureTestPath)\testproperties.targets" />
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <!-- Add our code-gen target after the imports above because they reset $(CoreCompileDependsOn) -->
+  <PropertyGroup>
+    <CoreCompileDependsOn>$(CoreCompileDependsOn);CreateTestProperties</CoreCompileDependsOn>
+  </PropertyGroup>
 </Project>

--- a/src/System.Private.ServiceModel/tests/Scenarios/Contract/XmlSerializer/WcfCustomXunitAttribute.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Contract/XmlSerializer/WcfCustomXunitAttribute.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Xunit;
+using Xunit.Sdk;
+
+namespace Infrastructure.Common
+{
+    [XunitTestCaseDiscoverer("Infrastructure.Common.WcfFactDiscoverer", "Contract.XmlSerializer.Tests")]
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+    public class WcfFactAttribute : FactAttribute
+    {
+    }
+
+    [XunitTestCaseDiscoverer("Infrastructure.Common.WcfTheoryDiscoverer", "Contract.XmlSerializer.Tests")]
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+    public class WcfTheoryAttribute : TheoryAttribute
+    {
+    }
+}

--- a/src/System.Private.ServiceModel/tests/Scenarios/Contract/XmlSerializer/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Contract/XmlSerializer/project.json
@@ -7,6 +7,7 @@
     "System.ServiceModel.Primitives": "4.3.0-preview1-24530-01",
     "System.ServiceModel.Security": "4.3.0-preview1-24530-01",
     "System.Threading.Timer": "4.3.0",
+    "System.Xml.XmlSerializer": "4.3.0",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Private.ServiceModel/tests/Scenarios/Encoding/Encoders/Encoding.Encoders.Tests.csproj
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Encoding/Encoders/Encoding.Encoders.Tests.csproj
@@ -16,8 +16,90 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ProjectGuid>{F7193054-CE9B-4BC7-8CA9-4FA722CF8CEF}</ProjectGuid>
   </PropertyGroup>
+  <!-- Test Source -->
   <ItemGroup>
     <Compile Include="**\*.cs" />
+  </ItemGroup>
+  <!-- Infrastructure Test Helpers -->
+  <ItemGroup>
+    <Compile Include="$(CommonInfrastructureTestPath)\BridgeClient.cs">
+      <Link>Common\BridgeClient.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\BridgeClientAuthenticationManager.cs">
+      <Link>Common\BridgeClientAuthenticationManager.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\CertificateManager.cs">
+      <Link>Common\CertificateManager.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\ConditionalTestDetectors.cs">
+      <Link>Common\ConditionalTestDetectors.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\ConditionalWcfTest.cs">
+      <Link>Common\ConditionalWcfTest.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\FrameworkHelper.cs">
+      <Link>Common\FrameworkHelper.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\FrameworkID.cs">
+      <Link>Common\FrameworkID.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\JsonSerializer.cs">
+      <Link>Common\JsonSerializer.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\OSHelper.cs">
+      <Link>Common\OSHelper.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\OsID.cs">
+      <Link>Common\OsID.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\ServiceUtilHelper.cs">
+      <Link>Common\ServiceUtilHelper.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\TestEventListener.cs">
+      <Link>Common\TestEventListener.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\TestProperties.cs">
+      <Link>Common\TestProperties.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\ConditionAttribute.cs">
+      <Link>Common\xunit\ConditionAttribute.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\IssueAttribute.cs">
+      <Link>Common\xunit\IssueAttribute.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfFactDiscoverer.cs">
+      <Link>Common\xunit\WcfFactDiscoverer.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfSkippableAttribute.cs">
+      <Link>Common\xunit\WcfSkippableAttribute.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfTestCase.cs">
+      <Link>Common\xunit\WcfTestCase.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfTestDiscoverer.cs">
+      <Link>Common\xunit\WcfTestDiscoverer.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfTheoryDiscoverer.cs">
+      <Link>Common\xunit\WcfTheoryDiscoverer.cs</Link>
+    </Compile>
+  </ItemGroup>
+  <!-- Scenario Test Helpers -->
+  <ItemGroup>
+    <Compile Include="$(CommonScenarioTestPath)\Endpoints.cs">
+      <Link>Common\Endpoints.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonScenarioTestPath)\ScenarioTestHelpers.cs">
+      <Link>Common\ScenarioTestHelpers.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonScenarioTestPath)\ScenarioTestTypes.cs">
+      <Link>Common\ScenarioTestTypes.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonScenarioTestPath)\ServiceInterfaces.cs">
+      <Link>Common\ServiceInterfaces.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonScenarioTestPath)\TestMockStream.cs">
+      <Link>Common\TestMockStream.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />
@@ -35,14 +117,12 @@
     <ProjectReference Include='$(WcfPrimitivesPkgProj)'>
       <Name>System.ServiceModel.Primitives</Name>
     </ProjectReference>
-    <ProjectReference Include="$(WcfInfrastructureCommonProj)">
-      <Project>{AFD69665-89A3-42AE-A32E-AB2CBBE6EE7E}</Project>
-      <Name>Infrastructure.Common</Name>
-    </ProjectReference>
-    <ProjectReference Include='$(WcfScenarioTestCommonProj)'>
-      <Project>{9098B41C-9C2E-4FC6-B7D8-FC3411736A22}</Project>
-      <Name>ScenarioTests.Common</Name>
-    </ProjectReference>
   </ItemGroup>
+  <Import Project="$(CommonInfrastructureTestPath)\testproperties.props" />
+  <Import Project="$(CommonInfrastructureTestPath)\testproperties.targets" />
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <!-- Add our code-gen target after the imports above because they reset $(CoreCompileDependsOn) -->
+  <PropertyGroup>
+    <CoreCompileDependsOn>$(CoreCompileDependsOn);CreateTestProperties</CoreCompileDependsOn>
+  </PropertyGroup>
 </Project>

--- a/src/System.Private.ServiceModel/tests/Scenarios/Encoding/Encoders/WcfCustomXunitAttribute.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Encoding/Encoders/WcfCustomXunitAttribute.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Xunit;
+using Xunit.Sdk;
+
+namespace Infrastructure.Common
+{
+    [XunitTestCaseDiscoverer("Infrastructure.Common.WcfFactDiscoverer", "Encoding.Encoders.Tests")]
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+    public class WcfFactAttribute : FactAttribute
+    {
+    }
+
+    [XunitTestCaseDiscoverer("Infrastructure.Common.WcfTheoryDiscoverer", "Encoding.Encoders.Tests")]
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+    public class WcfTheoryAttribute : TheoryAttribute
+    {
+    }
+}

--- a/src/System.Private.ServiceModel/tests/Scenarios/Encoding/Encoders/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Encoding/Encoders/project.json
@@ -7,6 +7,7 @@
     "System.ServiceModel.Primitives": "4.3.0-preview1-24530-01",
     "System.ServiceModel.Security": "4.3.0-preview1-24530-01",
     "System.Threading.Timer": "4.3.0",
+    "System.Xml.XmlSerializer": "4.3.0",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Private.ServiceModel/tests/Scenarios/Encoding/MessageVersion/Encoding.MessageVersion.Tests.csproj
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Encoding/MessageVersion/Encoding.MessageVersion.Tests.csproj
@@ -16,8 +16,90 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ProjectGuid>{604EBABB-0160-48EF-AE10-FEAE8DE39F19}</ProjectGuid>
   </PropertyGroup>
+  <!-- Test Source -->
   <ItemGroup>
     <Compile Include="**\*.cs" />
+  </ItemGroup>
+  <!-- Infrastructure Test Helpers -->
+  <ItemGroup>
+    <Compile Include="$(CommonInfrastructureTestPath)\BridgeClient.cs">
+      <Link>Common\BridgeClient.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\BridgeClientAuthenticationManager.cs">
+      <Link>Common\BridgeClientAuthenticationManager.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\CertificateManager.cs">
+      <Link>Common\CertificateManager.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\ConditionalTestDetectors.cs">
+      <Link>Common\ConditionalTestDetectors.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\ConditionalWcfTest.cs">
+      <Link>Common\ConditionalWcfTest.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\FrameworkHelper.cs">
+      <Link>Common\FrameworkHelper.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\FrameworkID.cs">
+      <Link>Common\FrameworkID.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\JsonSerializer.cs">
+      <Link>Common\JsonSerializer.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\OSHelper.cs">
+      <Link>Common\OSHelper.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\OsID.cs">
+      <Link>Common\OsID.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\ServiceUtilHelper.cs">
+      <Link>Common\ServiceUtilHelper.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\TestEventListener.cs">
+      <Link>Common\TestEventListener.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\TestProperties.cs">
+      <Link>Common\TestProperties.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\ConditionAttribute.cs">
+      <Link>Common\xunit\ConditionAttribute.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\IssueAttribute.cs">
+      <Link>Common\xunit\IssueAttribute.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfFactDiscoverer.cs">
+      <Link>Common\xunit\WcfFactDiscoverer.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfSkippableAttribute.cs">
+      <Link>Common\xunit\WcfSkippableAttribute.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfTestCase.cs">
+      <Link>Common\xunit\WcfTestCase.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfTestDiscoverer.cs">
+      <Link>Common\xunit\WcfTestDiscoverer.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfTheoryDiscoverer.cs">
+      <Link>Common\xunit\WcfTheoryDiscoverer.cs</Link>
+    </Compile>
+  </ItemGroup>
+  <!-- Scenario Test Helpers -->
+  <ItemGroup>
+    <Compile Include="$(CommonScenarioTestPath)\Endpoints.cs">
+      <Link>Common\Endpoints.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonScenarioTestPath)\ScenarioTestHelpers.cs">
+      <Link>Common\ScenarioTestHelpers.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonScenarioTestPath)\ScenarioTestTypes.cs">
+      <Link>Common\ScenarioTestTypes.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonScenarioTestPath)\ServiceInterfaces.cs">
+      <Link>Common\ServiceInterfaces.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonScenarioTestPath)\TestMockStream.cs">
+      <Link>Common\TestMockStream.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />
@@ -32,14 +114,12 @@
     <ProjectReference Include='$(WcfPrimitivesPkgProj)'>
       <Name>System.ServiceModel.Primitives</Name>
     </ProjectReference>
-    <ProjectReference Include="$(WcfInfrastructureCommonProj)">
-      <Project>{AFD69665-89A3-42AE-A32E-AB2CBBE6EE7E}</Project>
-      <Name>Infrastructure.Common</Name>
-    </ProjectReference>
-    <ProjectReference Include='$(WcfScenarioTestCommonProj)'>
-      <Project>{9098B41C-9C2E-4FC6-B7D8-FC3411736A22}</Project>
-      <Name>ScenarioTests.Common</Name>
-    </ProjectReference>
   </ItemGroup>
+  <Import Project="$(CommonInfrastructureTestPath)\testproperties.props" />
+  <Import Project="$(CommonInfrastructureTestPath)\testproperties.targets" />
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <!-- Add our code-gen target after the imports above because they reset $(CoreCompileDependsOn) -->
+  <PropertyGroup>
+    <CoreCompileDependsOn>$(CoreCompileDependsOn);CreateTestProperties</CoreCompileDependsOn>
+  </PropertyGroup>
 </Project>

--- a/src/System.Private.ServiceModel/tests/Scenarios/Encoding/MessageVersion/WcfCustomXunitAttribute.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Encoding/MessageVersion/WcfCustomXunitAttribute.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Xunit;
+using Xunit.Sdk;
+
+namespace Infrastructure.Common
+{
+    [XunitTestCaseDiscoverer("Infrastructure.Common.WcfFactDiscoverer", "Encoding.MessageVersion.Tests")]
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+    public class WcfFactAttribute : FactAttribute
+    {
+    }
+
+    [XunitTestCaseDiscoverer("Infrastructure.Common.WcfTheoryDiscoverer", "Encoding.MessageVersion.Tests")]
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+    public class WcfTheoryAttribute : TheoryAttribute
+    {
+    }
+}

--- a/src/System.Private.ServiceModel/tests/Scenarios/Encoding/MessageVersion/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Encoding/MessageVersion/project.json
@@ -7,6 +7,7 @@
     "System.ServiceModel.Primitives": "4.3.0-preview1-24530-01",
     "System.ServiceModel.Security": "4.3.0-preview1-24530-01",
     "System.Threading.Timer": "4.3.0",
+    "System.Xml.XmlSerializer": "4.3.0",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Private.ServiceModel/tests/Scenarios/Extensibility/MessageEncoder/Extensibility.MessageEncoder.Tests.csproj
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Extensibility/MessageEncoder/Extensibility.MessageEncoder.Tests.csproj
@@ -16,8 +16,90 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ProjectGuid>{79551997-6C99-446E-B4BF-6F3659FA6B64}</ProjectGuid>
   </PropertyGroup>
+  <!-- Test Source -->
   <ItemGroup>
     <Compile Include="**\*.cs" />
+  </ItemGroup>
+  <!-- Infrastructure Test Helpers -->
+  <ItemGroup>
+    <Compile Include="$(CommonInfrastructureTestPath)\BridgeClient.cs">
+      <Link>Common\BridgeClient.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\BridgeClientAuthenticationManager.cs">
+      <Link>Common\BridgeClientAuthenticationManager.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\CertificateManager.cs">
+      <Link>Common\CertificateManager.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\ConditionalTestDetectors.cs">
+      <Link>Common\ConditionalTestDetectors.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\ConditionalWcfTest.cs">
+      <Link>Common\ConditionalWcfTest.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\FrameworkHelper.cs">
+      <Link>Common\FrameworkHelper.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\FrameworkID.cs">
+      <Link>Common\FrameworkID.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\JsonSerializer.cs">
+      <Link>Common\JsonSerializer.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\OSHelper.cs">
+      <Link>Common\OSHelper.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\OsID.cs">
+      <Link>Common\OsID.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\ServiceUtilHelper.cs">
+      <Link>Common\ServiceUtilHelper.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\TestEventListener.cs">
+      <Link>Common\TestEventListener.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\TestProperties.cs">
+      <Link>Common\TestProperties.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\ConditionAttribute.cs">
+      <Link>Common\xunit\ConditionAttribute.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\IssueAttribute.cs">
+      <Link>Common\xunit\IssueAttribute.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfFactDiscoverer.cs">
+      <Link>Common\xunit\WcfFactDiscoverer.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfSkippableAttribute.cs">
+      <Link>Common\xunit\WcfSkippableAttribute.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfTestCase.cs">
+      <Link>Common\xunit\WcfTestCase.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfTestDiscoverer.cs">
+      <Link>Common\xunit\WcfTestDiscoverer.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfTheoryDiscoverer.cs">
+      <Link>Common\xunit\WcfTheoryDiscoverer.cs</Link>
+    </Compile>
+  </ItemGroup>
+  <!-- Scenario Test Helpers -->
+  <ItemGroup>
+    <Compile Include="$(CommonScenarioTestPath)\Endpoints.cs">
+      <Link>Common\Endpoints.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonScenarioTestPath)\ScenarioTestHelpers.cs">
+      <Link>Common\ScenarioTestHelpers.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonScenarioTestPath)\ScenarioTestTypes.cs">
+      <Link>Common\ScenarioTestTypes.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonScenarioTestPath)\ServiceInterfaces.cs">
+      <Link>Common\ServiceInterfaces.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonScenarioTestPath)\TestMockStream.cs">
+      <Link>Common\TestMockStream.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />
@@ -38,14 +120,12 @@
     <ProjectReference Include='$(WcfPrimitivesPkgProj)'>
       <Name>System.ServiceModel.Primitives</Name>
     </ProjectReference>
-    <ProjectReference Include="$(WcfInfrastructureCommonProj)">
-      <Project>{AFD69665-89A3-42AE-A32E-AB2CBBE6EE7E}</Project>
-      <Name>Infrastructure.Common</Name>
-    </ProjectReference>
-    <ProjectReference Include='$(WcfScenarioTestCommonProj)'>
-      <Project>{9098B41C-9C2E-4FC6-B7D8-FC3411736A22}</Project>
-      <Name>ScenarioTests.Common</Name>
-    </ProjectReference>
   </ItemGroup>
+  <Import Project="$(CommonInfrastructureTestPath)\testproperties.props" />
+  <Import Project="$(CommonInfrastructureTestPath)\testproperties.targets" />
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <!-- Add our code-gen target after the imports above because they reset $(CoreCompileDependsOn) -->
+  <PropertyGroup>
+    <CoreCompileDependsOn>$(CoreCompileDependsOn);CreateTestProperties</CoreCompileDependsOn>
+  </PropertyGroup>
 </Project>

--- a/src/System.Private.ServiceModel/tests/Scenarios/Extensibility/MessageEncoder/WcfCustomXunitAttribute.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Extensibility/MessageEncoder/WcfCustomXunitAttribute.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Xunit;
+using Xunit.Sdk;
+
+namespace Infrastructure.Common
+{
+    [XunitTestCaseDiscoverer("Infrastructure.Common.WcfFactDiscoverer", "Extensibility.MessageEncoder.Tests")]
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+    public class WcfFactAttribute : FactAttribute
+    {
+    }
+
+    [XunitTestCaseDiscoverer("Infrastructure.Common.WcfTheoryDiscoverer", "Extensibility.MessageEncoder.Tests")]
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+    public class WcfTheoryAttribute : TheoryAttribute
+    {
+    }
+}

--- a/src/System.Private.ServiceModel/tests/Scenarios/Extensibility/MessageEncoder/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Extensibility/MessageEncoder/project.json
@@ -7,6 +7,7 @@
     "System.ServiceModel.Primitives": "4.3.0-preview1-24530-01",
     "System.ServiceModel.Security": "4.3.0-preview1-24530-01",
     "System.Threading.Timer": "4.3.0",
+    "System.Xml.XmlSerializer": "4.3.0",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Private.ServiceModel/tests/Scenarios/Extensibility/MessageInterceptor/Extensibility.MessageInterceptor.Tests.csproj
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Extensibility/MessageInterceptor/Extensibility.MessageInterceptor.Tests.csproj
@@ -16,8 +16,90 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ProjectGuid>{FDB2A8DE-C0D5-4536-A9CC-126E4A543907}</ProjectGuid>
   </PropertyGroup>
+  <!-- Test Source -->
   <ItemGroup>
     <Compile Include="**\*.cs" />
+  </ItemGroup>
+  <!-- Infrastructure Test Helpers -->
+  <ItemGroup>
+    <Compile Include="$(CommonInfrastructureTestPath)\BridgeClient.cs">
+      <Link>Common\BridgeClient.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\BridgeClientAuthenticationManager.cs">
+      <Link>Common\BridgeClientAuthenticationManager.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\CertificateManager.cs">
+      <Link>Common\CertificateManager.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\ConditionalTestDetectors.cs">
+      <Link>Common\ConditionalTestDetectors.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\ConditionalWcfTest.cs">
+      <Link>Common\ConditionalWcfTest.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\FrameworkHelper.cs">
+      <Link>Common\FrameworkHelper.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\FrameworkID.cs">
+      <Link>Common\FrameworkID.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\JsonSerializer.cs">
+      <Link>Common\JsonSerializer.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\OSHelper.cs">
+      <Link>Common\OSHelper.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\OsID.cs">
+      <Link>Common\OsID.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\ServiceUtilHelper.cs">
+      <Link>Common\ServiceUtilHelper.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\TestEventListener.cs">
+      <Link>Common\TestEventListener.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\TestProperties.cs">
+      <Link>Common\TestProperties.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\ConditionAttribute.cs">
+      <Link>Common\xunit\ConditionAttribute.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\IssueAttribute.cs">
+      <Link>Common\xunit\IssueAttribute.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfFactDiscoverer.cs">
+      <Link>Common\xunit\WcfFactDiscoverer.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfSkippableAttribute.cs">
+      <Link>Common\xunit\WcfSkippableAttribute.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfTestCase.cs">
+      <Link>Common\xunit\WcfTestCase.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfTestDiscoverer.cs">
+      <Link>Common\xunit\WcfTestDiscoverer.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfTheoryDiscoverer.cs">
+      <Link>Common\xunit\WcfTheoryDiscoverer.cs</Link>
+    </Compile>
+  </ItemGroup>
+  <!-- Scenario Test Helpers -->
+  <ItemGroup>
+    <Compile Include="$(CommonScenarioTestPath)\Endpoints.cs">
+      <Link>Common\Endpoints.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonScenarioTestPath)\ScenarioTestHelpers.cs">
+      <Link>Common\ScenarioTestHelpers.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonScenarioTestPath)\ScenarioTestTypes.cs">
+      <Link>Common\ScenarioTestTypes.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonScenarioTestPath)\ServiceInterfaces.cs">
+      <Link>Common\ServiceInterfaces.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonScenarioTestPath)\TestMockStream.cs">
+      <Link>Common\TestMockStream.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />
@@ -38,14 +120,12 @@
     <ProjectReference Include='$(WcfSecurityPkgProj)'>
       <Name>System.ServiceModel.Security</Name>
     </ProjectReference>
-    <ProjectReference Include="$(WcfInfrastructureCommonProj)">
-      <Project>{AFD69665-89A3-42AE-A32E-AB2CBBE6EE7E}</Project>
-      <Name>Infrastructure.Common</Name>
-    </ProjectReference>
-    <ProjectReference Include='$(WcfScenarioTestCommonProj)'>
-      <Project>{9098B41C-9C2E-4FC6-B7D8-FC3411736A22}</Project>
-      <Name>ScenarioTests.Common</Name>
-    </ProjectReference>
   </ItemGroup>
+  <Import Project="$(CommonInfrastructureTestPath)\testproperties.props" />
+  <Import Project="$(CommonInfrastructureTestPath)\testproperties.targets" />
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <!-- Add our code-gen target after the imports above because they reset $(CoreCompileDependsOn) -->
+  <PropertyGroup>
+    <CoreCompileDependsOn>$(CoreCompileDependsOn);CreateTestProperties</CoreCompileDependsOn>
+  </PropertyGroup>
 </Project>

--- a/src/System.Private.ServiceModel/tests/Scenarios/Extensibility/MessageInterceptor/WcfCustomXunitAttribute.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Extensibility/MessageInterceptor/WcfCustomXunitAttribute.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Xunit;
+using Xunit.Sdk;
+
+namespace Infrastructure.Common
+{
+    [XunitTestCaseDiscoverer("Infrastructure.Common.WcfFactDiscoverer", "Extensibility.MessageInterceptor.Tests")]
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+    public class WcfFactAttribute : FactAttribute
+    {
+    }
+
+    [XunitTestCaseDiscoverer("Infrastructure.Common.WcfTheoryDiscoverer", "Extensibility.MessageInterceptor.Tests")]
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+    public class WcfTheoryAttribute : TheoryAttribute
+    {
+    }
+}

--- a/src/System.Private.ServiceModel/tests/Scenarios/Extensibility/MessageInterceptor/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Extensibility/MessageInterceptor/project.json
@@ -7,6 +7,7 @@
     "System.ServiceModel.Primitives": "4.3.0-preview1-24530-01",
     "System.ServiceModel.Security": "4.3.0-preview1-24530-01",
     "System.Threading.Timer": "4.3.0",
+    "System.Xml.XmlSerializer": "4.3.0",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Private.ServiceModel/tests/Scenarios/Extensibility/WebSockets/Extensibility.WebSockets.Tests.csproj
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Extensibility/WebSockets/Extensibility.WebSockets.Tests.csproj
@@ -17,8 +17,90 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ProjectGuid>{BAF18A70-9EDA-46E9-80A1-7B5F62215C02}</ProjectGuid>
   </PropertyGroup>
+  <!-- Test Source -->
   <ItemGroup>
     <Compile Include="**\*.cs" />
+  </ItemGroup>
+  <!-- Infrastructure Test Helpers -->
+  <ItemGroup>
+    <Compile Include="$(CommonInfrastructureTestPath)\BridgeClient.cs">
+      <Link>Common\BridgeClient.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\BridgeClientAuthenticationManager.cs">
+      <Link>Common\BridgeClientAuthenticationManager.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\CertificateManager.cs">
+      <Link>Common\CertificateManager.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\ConditionalTestDetectors.cs">
+      <Link>Common\ConditionalTestDetectors.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\ConditionalWcfTest.cs">
+      <Link>Common\ConditionalWcfTest.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\FrameworkHelper.cs">
+      <Link>Common\FrameworkHelper.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\FrameworkID.cs">
+      <Link>Common\FrameworkID.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\JsonSerializer.cs">
+      <Link>Common\JsonSerializer.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\OSHelper.cs">
+      <Link>Common\OSHelper.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\OsID.cs">
+      <Link>Common\OsID.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\ServiceUtilHelper.cs">
+      <Link>Common\ServiceUtilHelper.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\TestEventListener.cs">
+      <Link>Common\TestEventListener.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\TestProperties.cs">
+      <Link>Common\TestProperties.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\ConditionAttribute.cs">
+      <Link>Common\xunit\ConditionAttribute.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\IssueAttribute.cs">
+      <Link>Common\xunit\IssueAttribute.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfFactDiscoverer.cs">
+      <Link>Common\xunit\WcfFactDiscoverer.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfSkippableAttribute.cs">
+      <Link>Common\xunit\WcfSkippableAttribute.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfTestCase.cs">
+      <Link>Common\xunit\WcfTestCase.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfTestDiscoverer.cs">
+      <Link>Common\xunit\WcfTestDiscoverer.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfTheoryDiscoverer.cs">
+      <Link>Common\xunit\WcfTheoryDiscoverer.cs</Link>
+    </Compile>
+  </ItemGroup>
+  <!-- Scenario Test Helpers -->
+  <ItemGroup>
+    <Compile Include="$(CommonScenarioTestPath)\Endpoints.cs">
+      <Link>Common\Endpoints.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonScenarioTestPath)\ScenarioTestHelpers.cs">
+      <Link>Common\ScenarioTestHelpers.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonScenarioTestPath)\ScenarioTestTypes.cs">
+      <Link>Common\ScenarioTestTypes.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonScenarioTestPath)\ServiceInterfaces.cs">
+      <Link>Common\ServiceInterfaces.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonScenarioTestPath)\TestMockStream.cs">
+      <Link>Common\TestMockStream.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />
@@ -39,14 +121,12 @@
     <ProjectReference Include='$(WcfPrimitivesPkgProj)'>
       <Name>System.ServiceModel.Primitives</Name>
     </ProjectReference>
-    <ProjectReference Include="$(WcfInfrastructureCommonProj)">
-      <Project>{AFD69665-89A3-42AE-A32E-AB2CBBE6EE7E}</Project>
-      <Name>Infrastructure.Common</Name>
-    </ProjectReference>
-    <ProjectReference Include='$(WcfScenarioTestCommonProj)'>
-      <Project>{9098B41C-9C2E-4FC6-B7D8-FC3411736A22}</Project>
-      <Name>ScenarioTests.Common</Name>
-    </ProjectReference>
   </ItemGroup>
+  <Import Project="$(CommonInfrastructureTestPath)\testproperties.props" />
+  <Import Project="$(CommonInfrastructureTestPath)\testproperties.targets" />
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <!-- Add our code-gen target after the imports above because they reset $(CoreCompileDependsOn) -->
+  <PropertyGroup>
+    <CoreCompileDependsOn>$(CoreCompileDependsOn);CreateTestProperties</CoreCompileDependsOn>
+  </PropertyGroup>
 </Project>

--- a/src/System.Private.ServiceModel/tests/Scenarios/Extensibility/WebSockets/WcfCustomXunitAttribute.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Extensibility/WebSockets/WcfCustomXunitAttribute.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Xunit;
+using Xunit.Sdk;
+
+namespace Infrastructure.Common
+{
+    [XunitTestCaseDiscoverer("Infrastructure.Common.WcfFactDiscoverer", "Extensibility.WebSockets.Tests")]
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+    public class WcfFactAttribute : FactAttribute
+    {
+    }
+
+    [XunitTestCaseDiscoverer("Infrastructure.Common.WcfTheoryDiscoverer", "Extensibility.WebSockets.Tests")]
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+    public class WcfTheoryAttribute : TheoryAttribute
+    {
+    }
+}

--- a/src/System.Private.ServiceModel/tests/Scenarios/Extensibility/WebSockets/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Extensibility/WebSockets/project.json
@@ -7,6 +7,7 @@
     "System.ServiceModel.Primitives": "4.3.0-preview1-24530-01",
     "System.ServiceModel.Security": "4.3.0-preview1-24530-01",
     "System.Threading.Timer": "4.3.0",
+    "System.Xml.XmlSerializer": "4.3.0",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Private.ServiceModel/tests/Scenarios/Infrastructure/Infrastructure.Tests.csproj
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Infrastructure/Infrastructure.Tests.csproj
@@ -17,8 +17,90 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ProjectGuid>{034CA8C4-5C34-40F9-A9B1-09369F8B80B3}</ProjectGuid>
   </PropertyGroup>
+  <!-- Test Source -->
   <ItemGroup>
     <Compile Include="**\*.cs" />
+  </ItemGroup>
+  <!-- Infrastructure Test Helpers -->
+  <ItemGroup>
+    <Compile Include="$(CommonInfrastructureTestPath)\BridgeClient.cs">
+      <Link>Common\BridgeClient.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\BridgeClientAuthenticationManager.cs">
+      <Link>Common\BridgeClientAuthenticationManager.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\CertificateManager.cs">
+      <Link>Common\CertificateManager.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\ConditionalTestDetectors.cs">
+      <Link>Common\ConditionalTestDetectors.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\ConditionalWcfTest.cs">
+      <Link>Common\ConditionalWcfTest.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\FrameworkHelper.cs">
+      <Link>Common\FrameworkHelper.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\FrameworkID.cs">
+      <Link>Common\FrameworkID.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\JsonSerializer.cs">
+      <Link>Common\JsonSerializer.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\OSHelper.cs">
+      <Link>Common\OSHelper.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\OsID.cs">
+      <Link>Common\OsID.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\ServiceUtilHelper.cs">
+      <Link>Common\ServiceUtilHelper.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\TestEventListener.cs">
+      <Link>Common\TestEventListener.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\TestProperties.cs">
+      <Link>Common\TestProperties.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\ConditionAttribute.cs">
+      <Link>Common\xunit\ConditionAttribute.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\IssueAttribute.cs">
+      <Link>Common\xunit\IssueAttribute.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfFactDiscoverer.cs">
+      <Link>Common\xunit\WcfFactDiscoverer.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfSkippableAttribute.cs">
+      <Link>Common\xunit\WcfSkippableAttribute.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfTestCase.cs">
+      <Link>Common\xunit\WcfTestCase.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfTestDiscoverer.cs">
+      <Link>Common\xunit\WcfTestDiscoverer.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfTheoryDiscoverer.cs">
+      <Link>Common\xunit\WcfTheoryDiscoverer.cs</Link>
+    </Compile>
+  </ItemGroup>
+  <!-- Scenario Test Helpers -->
+  <ItemGroup>
+    <Compile Include="$(CommonScenarioTestPath)\Endpoints.cs">
+      <Link>Common\Endpoints.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonScenarioTestPath)\ScenarioTestHelpers.cs">
+      <Link>Common\ScenarioTestHelpers.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonScenarioTestPath)\ScenarioTestTypes.cs">
+      <Link>Common\ScenarioTestTypes.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonScenarioTestPath)\ServiceInterfaces.cs">
+      <Link>Common\ServiceInterfaces.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonScenarioTestPath)\TestMockStream.cs">
+      <Link>Common\TestMockStream.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />
@@ -39,14 +121,12 @@
     <ProjectReference Include='$(WcfSecurityPkgProj)'>
       <Name>System.ServiceModel.Security</Name>
     </ProjectReference>
-    <ProjectReference Include="$(WcfInfrastructureCommonProj)">
-      <Project>{AFD69665-89A3-42AE-A32E-AB2CBBE6EE7E}</Project>
-      <Name>Infrastructure.Common</Name>
-    </ProjectReference>
-    <ProjectReference Include='$(WcfScenarioTestCommonProj)'>
-      <Project>{9098B41C-9C2E-4FC6-B7D8-FC3411736A22}</Project>
-      <Name>ScenarioTests.Common</Name>
-    </ProjectReference>
   </ItemGroup>
+  <Import Project="$(CommonInfrastructureTestPath)\testproperties.props" />
+  <Import Project="$(CommonInfrastructureTestPath)\testproperties.targets" />
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <!-- Add our code-gen target after the imports above because they reset $(CoreCompileDependsOn) -->
+  <PropertyGroup>
+    <CoreCompileDependsOn>$(CoreCompileDependsOn);CreateTestProperties</CoreCompileDependsOn>
+  </PropertyGroup>
 </Project>

--- a/src/System.Private.ServiceModel/tests/Scenarios/Infrastructure/WcfCustomXunitAttribute.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Infrastructure/WcfCustomXunitAttribute.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Xunit;
+using Xunit.Sdk;
+
+namespace Infrastructure.Common
+{
+    [XunitTestCaseDiscoverer("Infrastructure.Common.WcfFactDiscoverer", "Infrastructure.Tests")]
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+    public class WcfFactAttribute : FactAttribute
+    {
+    }
+
+    [XunitTestCaseDiscoverer("Infrastructure.Common.WcfTheoryDiscoverer", "Infrastructure.Tests")]
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+    public class WcfTheoryAttribute : TheoryAttribute
+    {
+    }
+}

--- a/src/System.Private.ServiceModel/tests/Scenarios/Infrastructure/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Infrastructure/project.json
@@ -7,6 +7,7 @@
     "System.ServiceModel.Primitives": "4.3.0-preview1-24530-01",
     "System.ServiceModel.Security": "4.3.0-preview1-24530-01",
     "System.Threading.Timer": "4.3.0",
+    "System.Xml.XmlSerializer": "4.3.0",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Security.TransportSecurity.Tests.csproj
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Security.TransportSecurity.Tests.csproj
@@ -17,8 +17,90 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ProjectGuid>{452BA2A7-81AD-4146-AD02-35EC242FF0EB}</ProjectGuid>
   </PropertyGroup>
+  <!-- Test Source -->
   <ItemGroup>
     <Compile Include="**\*.cs" />
+  </ItemGroup>
+  <!-- Infrastructure Test Helpers -->
+  <ItemGroup>
+    <Compile Include="$(CommonInfrastructureTestPath)\BridgeClient.cs">
+      <Link>Common\BridgeClient.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\BridgeClientAuthenticationManager.cs">
+      <Link>Common\BridgeClientAuthenticationManager.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\CertificateManager.cs">
+      <Link>Common\CertificateManager.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\ConditionalTestDetectors.cs">
+      <Link>Common\ConditionalTestDetectors.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\ConditionalWcfTest.cs">
+      <Link>Common\ConditionalWcfTest.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\FrameworkHelper.cs">
+      <Link>Common\FrameworkHelper.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\FrameworkID.cs">
+      <Link>Common\FrameworkID.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\JsonSerializer.cs">
+      <Link>Common\JsonSerializer.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\OSHelper.cs">
+      <Link>Common\OSHelper.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\OsID.cs">
+      <Link>Common\OsID.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\ServiceUtilHelper.cs">
+      <Link>Common\ServiceUtilHelper.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\TestEventListener.cs">
+      <Link>Common\TestEventListener.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\TestProperties.cs">
+      <Link>Common\TestProperties.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\ConditionAttribute.cs">
+      <Link>Common\xunit\ConditionAttribute.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\IssueAttribute.cs">
+      <Link>Common\xunit\IssueAttribute.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfFactDiscoverer.cs">
+      <Link>Common\xunit\WcfFactDiscoverer.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfSkippableAttribute.cs">
+      <Link>Common\xunit\WcfSkippableAttribute.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfTestCase.cs">
+      <Link>Common\xunit\WcfTestCase.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfTestDiscoverer.cs">
+      <Link>Common\xunit\WcfTestDiscoverer.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfTheoryDiscoverer.cs">
+      <Link>Common\xunit\WcfTheoryDiscoverer.cs</Link>
+    </Compile>
+  </ItemGroup>
+  <!-- Scenario Test Helpers -->
+  <ItemGroup>
+    <Compile Include="$(CommonScenarioTestPath)\Endpoints.cs">
+      <Link>Common\Endpoints.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonScenarioTestPath)\ScenarioTestHelpers.cs">
+      <Link>Common\ScenarioTestHelpers.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonScenarioTestPath)\ScenarioTestTypes.cs">
+      <Link>Common\ScenarioTestTypes.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonScenarioTestPath)\ServiceInterfaces.cs">
+      <Link>Common\ServiceInterfaces.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonScenarioTestPath)\TestMockStream.cs">
+      <Link>Common\TestMockStream.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />
@@ -39,14 +121,12 @@
     <ProjectReference Include='$(WcfSecurityPkgProj)'>
       <Name>System.ServiceModel.Security</Name>
     </ProjectReference>
-    <ProjectReference Include="$(WcfInfrastructureCommonProj)">
-      <Project>{AFD69665-89A3-42AE-A32E-AB2CBBE6EE7E}</Project>
-      <Name>Infrastructure.Common</Name>
-    </ProjectReference>
-    <ProjectReference Include='$(WcfScenarioTestCommonProj)'>
-      <Project>{9098B41C-9C2E-4FC6-B7D8-FC3411736A22}</Project>
-      <Name>ScenarioTests.Common</Name>
-    </ProjectReference>
   </ItemGroup>
+  <Import Project="$(CommonInfrastructureTestPath)\testproperties.props" />
+  <Import Project="$(CommonInfrastructureTestPath)\testproperties.targets" />
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <!-- Add our code-gen target after the imports above because they reset $(CoreCompileDependsOn) -->
+  <PropertyGroup>
+    <CoreCompileDependsOn>$(CoreCompileDependsOn);CreateTestProperties</CoreCompileDependsOn>
+  </PropertyGroup>
 </Project>

--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/WcfCustomXunitAttribute.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/WcfCustomXunitAttribute.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Xunit;
+using Xunit.Sdk;
+
+namespace Infrastructure.Common
+{
+    [XunitTestCaseDiscoverer("Infrastructure.Common.WcfFactDiscoverer", "Security.TransportSecurity.Tests")]
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+    public class WcfFactAttribute : FactAttribute
+    {
+    }
+
+    [XunitTestCaseDiscoverer("Infrastructure.Common.WcfTheoryDiscoverer", "Security.TransportSecurity.Tests")]
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+    public class WcfTheoryAttribute : TheoryAttribute
+    {
+    }
+}

--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/project.json
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/project.json
@@ -1,12 +1,15 @@
 {
   "dependencies": {
+    "System.Collections.Concurrent": "4.3.0",
     "System.Net.Http": "4.3.0",
+    "System.Runtime.Extensions": "4.3.0",
     "System.ServiceModel.Duplex": "4.3.0-preview1-24530-01",
     "System.ServiceModel.Http": "4.3.0-preview1-24530-01",
     "System.ServiceModel.NetTcp": "4.3.0-preview1-24530-01",
     "System.ServiceModel.Primitives": "4.3.0-preview1-24530-01",
     "System.ServiceModel.Security": "4.3.0-preview1-24530-01",
     "System.Threading.Timer": "4.3.0",
+    "System.Xml.XmlSerializer": "4.3.0",
     "test-runtime": {
       "target": "project",
       "exclude": "compile"

--- a/src/System.ServiceModel.Duplex/pkg/System.ServiceModel.Duplex.pkgproj
+++ b/src/System.ServiceModel.Duplex/pkg/System.ServiceModel.Duplex.pkgproj
@@ -18,5 +18,6 @@
     <InboxOnTargetFramework Include="xamarintvos10" />
     <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
+  <Target Name="GetTargetFrameworkProperties"></Target>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.ServiceModel.Duplex/tests/System.ServiceModel.Duplex.Tests.csproj
+++ b/src/System.ServiceModel.Duplex/tests/System.ServiceModel.Duplex.Tests.csproj
@@ -1,11 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition="'$(Configuration)'==''">$(OS)_Debug</Configuration>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
@@ -15,9 +14,74 @@
     <SignAssembly>false</SignAssembly>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ProjectGuid>{D18E6999-B42A-449C-91FE-2F78E7A20E6E}</ProjectGuid>
+    <CLSCompliant>false</CLSCompliant>
   </PropertyGroup>
+  <!-- Test Source -->
   <ItemGroup>
     <Compile Include="**\*.cs" />
+  </ItemGroup>
+  <!-- Infrastructure Test Helpers -->
+  <ItemGroup>
+    <Compile Include="$(CommonInfrastructureTestPath)\BridgeClient.cs">
+      <Link>Common\BridgeClient.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\BridgeClientAuthenticationManager.cs">
+      <Link>Common\BridgeClientAuthenticationManager.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\CertificateManager.cs">
+      <Link>Common\CertificateManager.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\ConditionalTestDetectors.cs">
+      <Link>Common\ConditionalTestDetectors.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\ConditionalWcfTest.cs">
+      <Link>Common\ConditionalWcfTest.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\FrameworkHelper.cs">
+      <Link>Common\FrameworkHelper.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\FrameworkID.cs">
+      <Link>Common\FrameworkID.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\JsonSerializer.cs">
+      <Link>Common\JsonSerializer.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\OSHelper.cs">
+      <Link>Common\OSHelper.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\OsID.cs">
+      <Link>Common\OsID.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\ServiceUtilHelper.cs">
+      <Link>Common\ServiceUtilHelper.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\TestEventListener.cs">
+      <Link>Common\TestEventListener.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\TestProperties.cs">
+      <Link>Common\TestProperties.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\ConditionAttribute.cs">
+      <Link>Common\xunit\ConditionAttribute.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\IssueAttribute.cs">
+      <Link>Common\xunit\IssueAttribute.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfFactDiscoverer.cs">
+      <Link>Common\xunit\WcfFactDiscoverer.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfSkippableAttribute.cs">
+      <Link>Common\xunit\WcfSkippableAttribute.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfTestCase.cs">
+      <Link>Common\xunit\WcfTestCase.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfTestDiscoverer.cs">
+      <Link>Common\xunit\WcfTestDiscoverer.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfTheoryDiscoverer.cs">
+      <Link>Common\xunit\WcfTheoryDiscoverer.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />
@@ -29,10 +93,12 @@
     <ProjectReference Include="$(WcfDuplexPkgProj)">
       <Name>System.ServiceModel.Duplex</Name>
     </ProjectReference>
-    <ProjectReference Include="$(WcfInfrastructureCommonProj)">
-      <Project>{AFD69665-89A3-42AE-A32E-AB2CBBE6EE7E}</Project>
-      <Name>Infrastructure.Common</Name>
-    </ProjectReference>
   </ItemGroup>
+  <Import Project="$(CommonInfrastructureTestPath)\testproperties.props" />
+  <Import Project="$(CommonInfrastructureTestPath)\testproperties.targets" />
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <!-- Add our code-gen target after the imports above because they reset $(CoreCompileDependsOn) -->
+  <PropertyGroup>
+    <CoreCompileDependsOn>$(CoreCompileDependsOn);CreateTestProperties</CoreCompileDependsOn>
+  </PropertyGroup>
 </Project>

--- a/src/System.ServiceModel.Duplex/tests/WcfCustomXunitAttribute.cs
+++ b/src/System.ServiceModel.Duplex/tests/WcfCustomXunitAttribute.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Xunit;
+using Xunit.Sdk;
+
+namespace Infrastructure.Common
+{
+    [XunitTestCaseDiscoverer("Infrastructure.Common.WcfFactDiscoverer", "System.ServiceModel.Duplex.Tests")]
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+    public class WcfFactAttribute : FactAttribute
+    {
+    }
+
+    [XunitTestCaseDiscoverer("Infrastructure.Common.WcfTheoryDiscoverer", "System.ServiceModel.Duplex.Tests")]
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+    public class WcfTheoryAttribute : TheoryAttribute
+    {
+    }
+}

--- a/src/System.ServiceModel.Http/pkg/System.ServiceModel.Http.pkgproj
+++ b/src/System.ServiceModel.Http/pkg/System.ServiceModel.Http.pkgproj
@@ -25,5 +25,6 @@
     <InboxOnTargetFramework Include="xamarintvos10" />
     <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
+  <Target Name="GetTargetFrameworkProperties"></Target>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.ServiceModel.Http/tests/System.ServiceModel.Http.Tests.csproj
+++ b/src/System.ServiceModel.Http/tests/System.ServiceModel.Http.Tests.csproj
@@ -1,11 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition="'$(Configuration)'==''">$(OS)_Debug</Configuration>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
@@ -15,19 +14,136 @@
     <SignAssembly>false</SignAssembly>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ProjectGuid>{0DE9D9C2-10FB-4DF0-9668-7BD5290EC936}</ProjectGuid>
+    <CLSCompliant>false</CLSCompliant>
   </PropertyGroup>
+  <!-- Test Source -->
   <ItemGroup>
     <Compile Include="**\*.cs" />
   </ItemGroup>
+  <!-- Unit Test Helpers -->
+  <ItemGroup>
+    <Compile Include="$(CommonUnitTestPath)\FakeAddress.cs">
+      <Link>Common\FakeAddress.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonUnitTestPath)\IMockCommunicationObject.cs">
+      <Link>Common\IMockCommunicationObject.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonUnitTestPath)\MemberDataSet.cs">
+      <Link>Common\MemberDataSet.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonUnitTestPath)\MockAsyncResult.cs">
+      <Link>Common\MockAsyncResult.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonUnitTestPath)\MockChannelBase.cs">
+      <Link>Common\MockChannelBase.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonUnitTestPath)\MockChannelFactory.cs">
+      <Link>Common\MockChannelFactory.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonUnitTestPath)\MockCommunicationObject.cs">
+      <Link>Common\MockCommunicationObject.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonUnitTestPath)\MockRequestChannel.cs">
+      <Link>Common\MockRequestChannel.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonUnitTestPath)\MockTransportBindingElement.cs">
+      <Link>Common\MockTransportBindingElement.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonUnitTestPath)\ServiceInterfaces.cs">
+      <Link>Common\ServiceInterfaces.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonUnitTestPath)\TestData.cs">
+      <Link>Common\TestData.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonUnitTestPath)\TestHelpers.cs">
+      <Link>Common\TestHelpers.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonUnitTestPath)\TestTypes.cs">
+      <Link>Common\TestTypes.cs</Link>
+    </Compile>
+  </ItemGroup>
+  <!-- Infrastructure Test Helpers -->
+  <ItemGroup>
+    <Compile Include="$(CommonInfrastructureTestPath)\BridgeClient.cs">
+      <Link>Common\BridgeClient.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\BridgeClientAuthenticationManager.cs">
+      <Link>Common\BridgeClientAuthenticationManager.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\CertificateManager.cs">
+      <Link>Common\CertificateManager.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\ConditionalTestDetectors.cs">
+      <Link>Common\ConditionalTestDetectors.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\ConditionalWcfTest.cs">
+      <Link>Common\ConditionalWcfTest.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\FrameworkHelper.cs">
+      <Link>Common\FrameworkHelper.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\FrameworkID.cs">
+      <Link>Common\FrameworkID.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\JsonSerializer.cs">
+      <Link>Common\JsonSerializer.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\OSHelper.cs">
+      <Link>Common\OSHelper.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\OsID.cs">
+      <Link>Common\OsID.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\ServiceUtilHelper.cs">
+      <Link>Common\ServiceUtilHelper.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\TestEventListener.cs">
+      <Link>Common\TestEventListener.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\TestProperties.cs">
+      <Link>Common\TestProperties.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\ConditionAttribute.cs">
+      <Link>Common\xunit\ConditionAttribute.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\IssueAttribute.cs">
+      <Link>Common\xunit\IssueAttribute.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfFactDiscoverer.cs">
+      <Link>Common\xunit\WcfFactDiscoverer.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfSkippableAttribute.cs">
+      <Link>Common\xunit\WcfSkippableAttribute.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfTestCase.cs">
+      <Link>Common\xunit\WcfTestCase.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfTestDiscoverer.cs">
+      <Link>Common\xunit\WcfTestDiscoverer.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfTheoryDiscoverer.cs">
+      <Link>Common\xunit\WcfTheoryDiscoverer.cs</Link>
+    </Compile>
+  </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />
+    <None Include="$(CommonUnitTestPath)\UnitTests.Common.rd.xml">
+      <Link>Common\UnitTests.Common.rd.xml</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(WcfSourcePkgProj)">
       <Name>System.Private.ServiceModel</Name>
     </ProjectReference>
+    <ProjectReference Include='$(WcfDuplexPkgProj)'>
+      <Name>System.ServiceModel.Duplex</Name>
+    </ProjectReference>
     <ProjectReference Include='$(WcfHttpPkgProj)'>
       <Name>System.ServiceModel.Http</Name>
+    </ProjectReference>
+    <ProjectReference Include='$(WcfNetTcpPkgProj)'>
+      <Name>System.ServiceModel.NetTcp</Name>
     </ProjectReference>
     <ProjectReference Include='$(WcfPrimitivesPkgProj)'>
       <Name>System.ServiceModel.Primitives</Name>
@@ -35,14 +151,12 @@
     <ProjectReference Include='$(WcfSecurityPkgProj)'>
       <Name>System.ServiceModel.Security</Name>
     </ProjectReference>
-    <ProjectReference Include='$(WcfUnitTestCommonProj)'>
-      <Project>{E896294A-AB4A-4AF5-A01C-A19E3972EFF9}</Project>
-      <Name>UnitTests.Common</Name>
-    </ProjectReference>
-    <ProjectReference Include="$(WcfInfrastructureCommonProj)">
-      <Project>{AFD69665-89A3-42AE-A32E-AB2CBBE6EE7E}</Project>
-      <Name>Infrastructure.Common</Name>
-    </ProjectReference>
   </ItemGroup>
+  <Import Project="$(CommonInfrastructureTestPath)\testproperties.props" />
+  <Import Project="$(CommonInfrastructureTestPath)\testproperties.targets" />
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <!-- Add our code-gen target after the imports above because they reset $(CoreCompileDependsOn) -->
+  <PropertyGroup>
+    <CoreCompileDependsOn>$(CoreCompileDependsOn);CreateTestProperties</CoreCompileDependsOn>
+  </PropertyGroup>
 </Project>

--- a/src/System.ServiceModel.Http/tests/WcfCustomXunitAttribute.cs
+++ b/src/System.ServiceModel.Http/tests/WcfCustomXunitAttribute.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Xunit;
+using Xunit.Sdk;
+
+namespace Infrastructure.Common
+{
+    [XunitTestCaseDiscoverer("Infrastructure.Common.WcfFactDiscoverer", "System.ServiceModel.Http.Tests")]
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+    public class WcfFactAttribute : FactAttribute
+    {
+    }
+
+    [XunitTestCaseDiscoverer("Infrastructure.Common.WcfTheoryDiscoverer", "System.ServiceModel.Http.Tests")]
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+    public class WcfTheoryAttribute : TheoryAttribute
+    {
+    }
+}

--- a/src/System.ServiceModel.NetTcp/pkg/System.ServiceModel.NetTcp.pkgproj
+++ b/src/System.ServiceModel.NetTcp/pkg/System.ServiceModel.NetTcp.pkgproj
@@ -22,5 +22,6 @@
     <InboxOnTargetFramework Include="xamarintvos10" />
     <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
+  <Target Name="GetTargetFrameworkProperties"></Target>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.ServiceModel.NetTcp/tests/System.ServiceModel.NetTcp.Tests.csproj
+++ b/src/System.ServiceModel.NetTcp/tests/System.ServiceModel.NetTcp.Tests.csproj
@@ -1,11 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition="'$(Configuration)'==''">$(OS)_Debug</Configuration>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
@@ -15,12 +14,123 @@
     <SignAssembly>false</SignAssembly>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ProjectGuid>{135C7EE5-6E44-4619-ADD5-589034443AE7}</ProjectGuid>
+    <CLSCompliant>false</CLSCompliant>
   </PropertyGroup>
+  <!-- Test Source -->
   <ItemGroup>
     <Compile Include="**\*.cs" />
   </ItemGroup>
+  <!-- Unit Test Helpers -->
+  <ItemGroup>
+    <Compile Include="$(CommonUnitTestPath)\FakeAddress.cs">
+      <Link>Common\FakeAddress.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonUnitTestPath)\IMockCommunicationObject.cs">
+      <Link>Common\IMockCommunicationObject.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonUnitTestPath)\MemberDataSet.cs">
+      <Link>Common\MemberDataSet.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonUnitTestPath)\MockAsyncResult.cs">
+      <Link>Common\MockAsyncResult.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonUnitTestPath)\MockChannelBase.cs">
+      <Link>Common\MockChannelBase.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonUnitTestPath)\MockChannelFactory.cs">
+      <Link>Common\MockChannelFactory.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonUnitTestPath)\MockCommunicationObject.cs">
+      <Link>Common\MockCommunicationObject.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonUnitTestPath)\MockRequestChannel.cs">
+      <Link>Common\MockRequestChannel.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonUnitTestPath)\MockTransportBindingElement.cs">
+      <Link>Common\MockTransportBindingElement.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonUnitTestPath)\ServiceInterfaces.cs">
+      <Link>Common\ServiceInterfaces.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonUnitTestPath)\TestData.cs">
+      <Link>Common\TestData.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonUnitTestPath)\TestHelpers.cs">
+      <Link>Common\TestHelpers.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonUnitTestPath)\TestTypes.cs">
+      <Link>Common\TestTypes.cs</Link>
+    </Compile>
+  </ItemGroup>
+  <!-- Infrastructure Test Helpers -->
+  <ItemGroup>
+    <Compile Include="$(CommonInfrastructureTestPath)\BridgeClient.cs">
+      <Link>Common\BridgeClient.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\BridgeClientAuthenticationManager.cs">
+      <Link>Common\BridgeClientAuthenticationManager.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\CertificateManager.cs">
+      <Link>Common\CertificateManager.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\ConditionalTestDetectors.cs">
+      <Link>Common\ConditionalTestDetectors.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\ConditionalWcfTest.cs">
+      <Link>Common\ConditionalWcfTest.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\FrameworkHelper.cs">
+      <Link>Common\FrameworkHelper.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\FrameworkID.cs">
+      <Link>Common\FrameworkID.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\JsonSerializer.cs">
+      <Link>Common\JsonSerializer.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\OSHelper.cs">
+      <Link>Common\OSHelper.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\OsID.cs">
+      <Link>Common\OsID.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\ServiceUtilHelper.cs">
+      <Link>Common\ServiceUtilHelper.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\TestEventListener.cs">
+      <Link>Common\TestEventListener.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\TestProperties.cs">
+      <Link>Common\TestProperties.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\ConditionAttribute.cs">
+      <Link>Common\xunit\ConditionAttribute.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\IssueAttribute.cs">
+      <Link>Common\xunit\IssueAttribute.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfFactDiscoverer.cs">
+      <Link>Common\xunit\WcfFactDiscoverer.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfSkippableAttribute.cs">
+      <Link>Common\xunit\WcfSkippableAttribute.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfTestCase.cs">
+      <Link>Common\xunit\WcfTestCase.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfTestDiscoverer.cs">
+      <Link>Common\xunit\WcfTestDiscoverer.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfTheoryDiscoverer.cs">
+      <Link>Common\xunit\WcfTheoryDiscoverer.cs</Link>
+    </Compile>
+  </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />
+    <None Include="$(CommonUnitTestPath)\UnitTests.Common.rd.xml">
+      <Link>Common\UnitTests.Common.rd.xml</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(WcfSourcePkgProj)">
@@ -28,6 +138,9 @@
     </ProjectReference>
     <ProjectReference Include='$(WcfDuplexPkgProj)'>
       <Name>System.ServiceModel.Duplex</Name>
+    </ProjectReference>
+    <ProjectReference Include='$(WcfHttpPkgProj)'>
+      <Name>System.ServiceModel.Http</Name>
     </ProjectReference>
     <ProjectReference Include='$(WcfNetTcpPkgProj)'>
       <Name>System.ServiceModel.NetTcp</Name>
@@ -38,14 +151,12 @@
     <ProjectReference Include='$(WcfSecurityPkgProj)'>
       <Name>System.ServiceModel.Security</Name>
     </ProjectReference>
-    <ProjectReference Include='$(WcfUnitTestCommonProj)'>
-      <Project>{E896294A-AB4A-4AF5-A01C-A19E3972EFF9}</Project>
-      <Name>UnitTests.Common</Name>
-    </ProjectReference>
-    <ProjectReference Include="$(WcfInfrastructureCommonProj)">
-      <Project>{AFD69665-89A3-42AE-A32E-AB2CBBE6EE7E}</Project>
-      <Name>Infrastructure.Common</Name>
-    </ProjectReference>
   </ItemGroup>
+  <Import Project="$(CommonInfrastructureTestPath)\testproperties.props" />
+  <Import Project="$(CommonInfrastructureTestPath)\testproperties.targets" />
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <!-- Add our code-gen target after the imports above because they reset $(CoreCompileDependsOn) -->
+  <PropertyGroup>
+    <CoreCompileDependsOn>$(CoreCompileDependsOn);CreateTestProperties</CoreCompileDependsOn>
+  </PropertyGroup>
 </Project>

--- a/src/System.ServiceModel.NetTcp/tests/WcfCustomXunitAttribute.cs
+++ b/src/System.ServiceModel.NetTcp/tests/WcfCustomXunitAttribute.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Xunit;
+using Xunit.Sdk;
+
+namespace Infrastructure.Common
+{
+    [XunitTestCaseDiscoverer("Infrastructure.Common.WcfFactDiscoverer", "System.ServiceModel.NetTcp.Tests")]
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+    public class WcfFactAttribute : FactAttribute
+    {
+    }
+
+    [XunitTestCaseDiscoverer("Infrastructure.Common.WcfTheoryDiscoverer", "System.ServiceModel.NetTcp.Tests")]
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+    public class WcfTheoryAttribute : TheoryAttribute
+    {
+    }
+}

--- a/src/System.ServiceModel.Primitives/pkg/System.ServiceModel.Primitives.pkgproj
+++ b/src/System.ServiceModel.Primitives/pkg/System.ServiceModel.Primitives.pkgproj
@@ -26,5 +26,6 @@
     <InboxOnTargetFramework Include="xamarintvos10" />
     <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
+  <Target Name="GetTargetFrameworkProperties"></Target>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.ServiceModel.Primitives/tests/System.ServiceModel.Primitives.Tests.csproj
+++ b/src/System.ServiceModel.Primitives/tests/System.ServiceModel.Primitives.Tests.csproj
@@ -1,11 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition="'$(Configuration)'==''">$(OS)_Debug</Configuration>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
@@ -15,12 +14,123 @@
     <SignAssembly>false</SignAssembly>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ProjectGuid>{856A232C-4292-4AC7-87FE-41AE0C22C4E4}</ProjectGuid>
+    <CLSCompliant>false</CLSCompliant>
   </PropertyGroup>
+  <!-- Test Source -->
   <ItemGroup>
     <Compile Include="**\*.cs" />
   </ItemGroup>
+  <!-- Unit Test Helpers -->
+  <ItemGroup>
+    <Compile Include="$(CommonUnitTestPath)\FakeAddress.cs">
+      <Link>Common\FakeAddress.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonUnitTestPath)\IMockCommunicationObject.cs">
+      <Link>Common\IMockCommunicationObject.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonUnitTestPath)\MemberDataSet.cs">
+      <Link>Common\MemberDataSet.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonUnitTestPath)\MockAsyncResult.cs">
+      <Link>Common\MockAsyncResult.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonUnitTestPath)\MockChannelBase.cs">
+      <Link>Common\MockChannelBase.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonUnitTestPath)\MockChannelFactory.cs">
+      <Link>Common\MockChannelFactory.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonUnitTestPath)\MockCommunicationObject.cs">
+      <Link>Common\MockCommunicationObject.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonUnitTestPath)\MockRequestChannel.cs">
+      <Link>Common\MockRequestChannel.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonUnitTestPath)\MockTransportBindingElement.cs">
+      <Link>Common\MockTransportBindingElement.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonUnitTestPath)\ServiceInterfaces.cs">
+      <Link>Common\ServiceInterfaces.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonUnitTestPath)\TestData.cs">
+      <Link>Common\TestData.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonUnitTestPath)\TestHelpers.cs">
+      <Link>Common\TestHelpers.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonUnitTestPath)\TestTypes.cs">
+      <Link>Common\TestTypes.cs</Link>
+    </Compile>
+  </ItemGroup>
+  <!-- Infrastructure Test Helpers -->
+  <ItemGroup>
+    <Compile Include="$(CommonInfrastructureTestPath)\BridgeClient.cs">
+      <Link>Common\BridgeClient.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\BridgeClientAuthenticationManager.cs">
+      <Link>Common\BridgeClientAuthenticationManager.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\CertificateManager.cs">
+      <Link>Common\CertificateManager.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\ConditionalTestDetectors.cs">
+      <Link>Common\ConditionalTestDetectors.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\ConditionalWcfTest.cs">
+      <Link>Common\ConditionalWcfTest.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\FrameworkHelper.cs">
+      <Link>Common\FrameworkHelper.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\FrameworkID.cs">
+      <Link>Common\FrameworkID.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\JsonSerializer.cs">
+      <Link>Common\JsonSerializer.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\OSHelper.cs">
+      <Link>Common\OSHelper.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\OsID.cs">
+      <Link>Common\OsID.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\ServiceUtilHelper.cs">
+      <Link>Common\ServiceUtilHelper.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\TestEventListener.cs">
+      <Link>Common\TestEventListener.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\TestProperties.cs">
+      <Link>Common\TestProperties.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\ConditionAttribute.cs">
+      <Link>Common\xunit\ConditionAttribute.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\IssueAttribute.cs">
+      <Link>Common\xunit\IssueAttribute.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfFactDiscoverer.cs">
+      <Link>Common\xunit\WcfFactDiscoverer.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfSkippableAttribute.cs">
+      <Link>Common\xunit\WcfSkippableAttribute.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfTestCase.cs">
+      <Link>Common\xunit\WcfTestCase.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfTestDiscoverer.cs">
+      <Link>Common\xunit\WcfTestDiscoverer.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfTheoryDiscoverer.cs">
+      <Link>Common\xunit\WcfTheoryDiscoverer.cs</Link>
+    </Compile>
+  </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />
+    <None Include="$(CommonUnitTestPath)\UnitTests.Common.rd.xml">
+      <Link>Common\UnitTests.Common.rd.xml</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(WcfSourcePkgProj)">
@@ -41,14 +151,12 @@
     <ProjectReference Include='$(WcfSecurityPkgProj)'>
       <Name>System.ServiceModel.Security</Name>
     </ProjectReference>
-    <ProjectReference Include='$(WcfUnitTestCommonProj)'>
-      <Project>{E896294A-AB4A-4AF5-A01C-A19E3972EFF9}</Project>
-      <Name>UnitTests.Common</Name>
-    </ProjectReference>
-    <ProjectReference Include="$(WcfInfrastructureCommonProj)">
-      <Project>{AFD69665-89A3-42AE-A32E-AB2CBBE6EE7E}</Project>
-      <Name>Infrastructure.Common</Name>
-    </ProjectReference>
   </ItemGroup>
+  <Import Project="$(CommonInfrastructureTestPath)\testproperties.props" />
+  <Import Project="$(CommonInfrastructureTestPath)\testproperties.targets" />
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <!-- Add our code-gen target after the imports above because they reset $(CoreCompileDependsOn) -->
+  <PropertyGroup>
+    <CoreCompileDependsOn>$(CoreCompileDependsOn);CreateTestProperties</CoreCompileDependsOn>
+  </PropertyGroup>
 </Project>

--- a/src/System.ServiceModel.Primitives/tests/WcfCustomXunitAttribute.cs
+++ b/src/System.ServiceModel.Primitives/tests/WcfCustomXunitAttribute.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Xunit;
+using Xunit.Sdk;
+
+namespace Infrastructure.Common
+{
+    [XunitTestCaseDiscoverer("Infrastructure.Common.WcfFactDiscoverer", "System.ServiceModel.Primitives.Tests")]
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+    public class WcfFactAttribute : FactAttribute
+    {
+    }
+
+    [XunitTestCaseDiscoverer("Infrastructure.Common.WcfTheoryDiscoverer", "System.ServiceModel.Primitives.Tests")]
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+    public class WcfTheoryAttribute : TheoryAttribute
+    {
+    }
+}

--- a/src/System.ServiceModel.Security/pkg/System.ServiceModel.Security.pkgproj
+++ b/src/System.ServiceModel.Security/pkg/System.ServiceModel.Security.pkgproj
@@ -23,5 +23,6 @@
     <InboxOnTargetFramework Include="xamarintvos10" />
     <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
+  <Target Name="GetTargetFrameworkProperties"></Target>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.ServiceModel.Security/tests/System.ServiceModel.Security.Tests.csproj
+++ b/src/System.ServiceModel.Security/tests/System.ServiceModel.Security.Tests.csproj
@@ -1,11 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition="'$(Configuration)'==''">$(OS)_Debug</Configuration>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
@@ -15,9 +14,74 @@
     <SignAssembly>false</SignAssembly>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ProjectGuid>{595D6586-EE25-453D-8249-5E7BE6EE8EEB}</ProjectGuid>
+    <CLSCompliant>false</CLSCompliant>
   </PropertyGroup>
+  <!-- Test Source -->
   <ItemGroup>
     <Compile Include="**\*.cs" />
+  </ItemGroup>
+  <!-- Infrastructure Test Helpers -->
+  <ItemGroup>
+    <Compile Include="$(CommonInfrastructureTestPath)\BridgeClient.cs">
+      <Link>Common\BridgeClient.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\BridgeClientAuthenticationManager.cs">
+      <Link>Common\BridgeClientAuthenticationManager.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\CertificateManager.cs">
+      <Link>Common\CertificateManager.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\ConditionalTestDetectors.cs">
+      <Link>Common\ConditionalTestDetectors.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\ConditionalWcfTest.cs">
+      <Link>Common\ConditionalWcfTest.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\FrameworkHelper.cs">
+      <Link>Common\FrameworkHelper.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\FrameworkID.cs">
+      <Link>Common\FrameworkID.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\JsonSerializer.cs">
+      <Link>Common\JsonSerializer.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\OSHelper.cs">
+      <Link>Common\OSHelper.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\OsID.cs">
+      <Link>Common\OsID.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\ServiceUtilHelper.cs">
+      <Link>Common\ServiceUtilHelper.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\TestEventListener.cs">
+      <Link>Common\TestEventListener.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\TestProperties.cs">
+      <Link>Common\TestProperties.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\ConditionAttribute.cs">
+      <Link>Common\xunit\ConditionAttribute.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\IssueAttribute.cs">
+      <Link>Common\xunit\IssueAttribute.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfFactDiscoverer.cs">
+      <Link>Common\xunit\WcfFactDiscoverer.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfSkippableAttribute.cs">
+      <Link>Common\xunit\WcfSkippableAttribute.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfTestCase.cs">
+      <Link>Common\xunit\WcfTestCase.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfTestDiscoverer.cs">
+      <Link>Common\xunit\WcfTestDiscoverer.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonInfrastructureTestPath)\xunit\WcfTheoryDiscoverer.cs">
+      <Link>Common\xunit\WcfTheoryDiscoverer.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />
@@ -29,10 +93,12 @@
     <ProjectReference Include='$(WcfSecurityPkgProj)'>
       <Name>System.ServiceModel.Security</Name>
     </ProjectReference>
-    <ProjectReference Include="$(WcfInfrastructureCommonProj)">
-      <Project>{AFD69665-89A3-42AE-A32E-AB2CBBE6EE7E}</Project>
-      <Name>Infrastructure.Common</Name>
-    </ProjectReference>
   </ItemGroup>
+  <Import Project="$(CommonInfrastructureTestPath)\testproperties.props" />
+  <Import Project="$(CommonInfrastructureTestPath)\testproperties.targets" />
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <!-- Add our code-gen target after the imports above because they reset $(CoreCompileDependsOn) -->
+  <PropertyGroup>
+    <CoreCompileDependsOn>$(CoreCompileDependsOn);CreateTestProperties</CoreCompileDependsOn>
+  </PropertyGroup>
 </Project>

--- a/src/System.ServiceModel.Security/tests/WcfCustomXunitAttribute.cs
+++ b/src/System.ServiceModel.Security/tests/WcfCustomXunitAttribute.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Xunit;
+using Xunit.Sdk;
+
+namespace Infrastructure.Common
+{
+    [XunitTestCaseDiscoverer("Infrastructure.Common.WcfFactDiscoverer", "System.ServiceModel.Security.Tests")]
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+    public class WcfFactAttribute : FactAttribute
+    {
+    }
+
+    [XunitTestCaseDiscoverer("Infrastructure.Common.WcfTheoryDiscoverer", "System.ServiceModel.Security.Tests")]
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+    public class WcfTheoryAttribute : TheoryAttribute
+    {
+    }
+}

--- a/src/test.props
+++ b/src/test.props
@@ -10,6 +10,9 @@
     <WcfUnitTestCommonProj>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)\System.Private.ServiceModel\tests\Common\Unit\UnitTests.Common.csproj'))</WcfUnitTestCommonProj>
     <WcfScenarioTestCommonProj>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)\System.Private.ServiceModel\tests\Common\Scenarios\ScenarioTests.Common.csproj'))</WcfScenarioTestCommonProj>
     <WcfInfrastructureCommonProj>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)\System.Private.ServiceModel\tests\Common\Infrastructure\Infrastructure.Common.csproj'))</WcfInfrastructureCommonProj>
+    <CommonUnitTestPath>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)\System.Private.ServiceModel\tests\Common\Unit'))</CommonUnitTestPath>
+    <CommonInfrastructureTestPath>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)\System.Private.ServiceModel\tests\Common\Infrastructure'))</CommonInfrastructureTestPath>
+    <CommonScenarioTestPath>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)\System.Private.ServiceModel\tests\Common\Scenarios'))</CommonScenarioTestPath>
   </PropertyGroup>
   <PropertyGroup Condition="$(MSBuildProjectName.EndsWith('.Tests')) AND $(TestCategories.Contains('OuterLoop'))">
     <XunitOptions>-parallel none</XunitOptions>


### PR DESCRIPTION
* A buildtools issue is blocking the WCF common projects from working correctly, when building test against packages the Common projects are not using the correct version of the product causing test build errors.
* After several weeks and not getting sufficient support for fixing this in buildtools this PR works around the issue by doing without common projects.
* It's ugly but un-blocks us in a servicing branch.