### PR TITLE
Update UAP package version.

### DIFF
--- a/dependencies.props
+++ b/dependencies.props
@@ -29,6 +29,7 @@
       versions. Make more properties for CoreFX if split versions are required.
     -->
     <MicrosoftPrivateCoreFxNETCoreAppPackageVersion>4.5.0-preview1-25718-03</MicrosoftPrivateCoreFxNETCoreAppPackageVersion>
+    <MicrosoftPrivateCoreFxUAPPackageVersion>4.6.0-preview1-25718-03</MicrosoftPrivateCoreFxUAPPackageVersion>
 
     <ProjectNTfsExpectedPrerelease>beta-25725-00</ProjectNTfsExpectedPrerelease>
     <ProjectNTfsTestILCExpectedPrerelease>beta-25725-00</ProjectNTfsTestILCExpectedPrerelease>
@@ -107,6 +108,11 @@
       <Path>$(MSBuildThisFileFullPath)</Path>
       <ElementName>MicrosoftPrivateCoreFxNETCoreAppPackageVersion</ElementName>
       <PackageId>Microsoft.Private.CoreFx.NETCoreApp</PackageId>
+    </XmlUpdateStep>
+    <XmlUpdateStep Include="CoreFx">
+      <Path>$(MSBuildThisFileFullPath)</Path>
+      <ElementName>MicrosoftPrivateCoreFxUAPPackageVersion</ElementName>
+      <PackageId>Microsoft.Private.CoreFx.UAP</PackageId>
     </XmlUpdateStep>
     <XmlUpdateStep Include="Standard">
       <Path>$(MSBuildThisFileFullPath)</Path>

--- a/external/corefx/corefx.depproj
+++ b/external/corefx/corefx.depproj
@@ -31,7 +31,7 @@
   <ItemGroup Condition="'$(TargetGroup)' == 'uap' or
                         '$(TargetGroup)' == 'uapaot'">
     <PackageReference Include="Microsoft.Private.CoreFx.UAP">
-      <Version>$(MicrosoftPrivateCoreFxNETCoreAppPackageVersion)</Version>
+      <Version>$(MicrosoftPrivateCoreFxUAPPackageVersion)</Version>
     </PackageReference>
   </ItemGroup>
 


### PR DESCRIPTION
* The UAP package in corefx was recently changed to be version 4.6 but the NETCore.App package is still 4.5.
* We were using a single variable for the version of all CoreFx packages, now need to split it so there is a separate one for the UAP package.