### PR TITLE
Skip the "UploadToAzure" step if the build didn't produce any packages.

### DIFF
--- a/Packaging.props
+++ b/Packaging.props
@@ -1,10 +1,11 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
+    <PlatformPackageVersion Condition="'$(PlatformPackageVersion)' == ''">1.0.2</PlatformPackageVersion>
     <PreReleaseLabel>servicing</PreReleaseLabel>
     <PackageDescriptionFile>$(ProjectDir)pkg/descriptions.json</PackageDescriptionFile>
     <PackageLicenseFile>$(ProjectDir)pkg/dotnet_library_license.txt</PackageLicenseFile>
     <PackageThirdPartyNoticesFile>$(ProjectDir)pkg/ThirdPartyNotices.txt</PackageThirdPartyNoticesFile>
-    <RuntimeIdGraphDefinitionFile>$(PackagesDir)Microsoft.NETCore.Platforms/1.0.1/runtime.json</RuntimeIdGraphDefinitionFile> <!-- WCF Content -->
+    <RuntimeIdGraphDefinitionFile>$(PackagesDir)Microsoft.NETCore.Platforms/$(PlatformPackageVersion)/runtime.json</RuntimeIdGraphDefinitionFile> <!-- WCF Content -->
     <ReleaseNotes>https://go.microsoft.com/fwlink/?LinkID=799417</ReleaseNotes>
     <ProjectUrl>https://dot.net</ProjectUrl>
 

--- a/src/publish.proj
+++ b/src/publish.proj
@@ -17,5 +17,19 @@
     </PropertyGroup>
   </Target>
 
-  <Target Name="Build" DependsOnTargets="CreateContainerName;UploadToAzure" />
+  <!-- For servicing branches, we may not be producing packages on a given platform, and that's ok. -->
+  <Target Name="DetermineIfPackagesAreAvailableForUpload">
+    <ItemGroup>
+      <_PackagesForPublishing Include="$(PublishPattern)" />
+    </ItemGroup>
+    <Message Condition="'@(_PackagesForPublishing)' == ''" Text="Skipping Azure upload, no packages available matching this pattern, '$(PublishPattern)'" />
+  </Target>
+
+  <!-- If 'BuildAllPackages' is 'false', then we are producing a servicing build and it is not an error if packages are not available. -->
+  <Target Name="UploadToAzureTargets"
+          Condition="'@(_PackagesForPublishing)' != '' and '$(BuildAllPackages)' != 'true'"
+          DependsOnTargets="CreateContainerName;UploadToAzure"
+          AfterTargets="DetermineIfPackagesAreAvailableForUpload" />
+
+  <Target Name="Build" DependsOnTargets="DetermineIfPackagesAreAvailableForUpload" />
 </Project>


### PR DESCRIPTION
* Version forward Microsoft.NETCore.Platforms

This is based on dotnet/corefx#12353

@ericstj and @chcosta WCF never actually build the 1.0.0 packages we released out of VSO, at the time we were having issues with publishing and so I believe we did it in a combination of TFS and manually.

And then the VSO build defs and pipeline were used going forward for vNext, so I am only now creating the pipeline and setting-up the build defs in order to service release/1.0.0.

The fixes in this PR based on Chris' old PR in corefx get me passed the final product build error...
`PublishContent.targets(22,5): error : No items were found matching pattern 'E:\A\_work\1129\s\wcf\bin/packages/**\*.nupkg'. [E:\A\_work\1129\s\wcf\src\publish.proj]`

I would like your review, I'm not sure that I need to version forward Microsoft.NETCore.Platforms.