### PR TITLE
Fix XmlSerializerFormatAttribute test issue

### DIFF
--- a/src/System.Private.ServiceModel/tests/Common/Scenarios/ServiceInterfaces.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Scenarios/ServiceInterfaces.cs
@@ -657,10 +657,10 @@ public interface ICalculator
     string Concatenate(IntParams par);
 
     [OperationContract, XmlSerializerFormat]
-    void SetIntParamsProperty(IntParams par);
+    void AddIntParams(Guid guid, IntParams par);
 
     [OperationContract, XmlSerializerFormat]
-    IntParams GetIntParamsProperty();
+    IntParams GetAndRemoveIntParams(Guid guid);
 
     [OperationContract, XmlSerializerFormat]
     DateTime ReturnInputDateTime(DateTime dt);
@@ -673,10 +673,10 @@ public interface ICalculator
 public interface IHelloWorld
 {
     [OperationContract, XmlSerializerFormat]
-    void SetStringField(string testString);
+    void AddString(Guid guid, string testString);
 
     [OperationContract, XmlSerializerFormat]
-    string GetStringField();
+    string GetAndRemoveString(Guid guid);
 }
 
 public class IntParams

--- a/src/System.Private.ServiceModel/tests/Scenarios/Contract/XmlSerializer/XmlSerializerFormatTest.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Contract/XmlSerializer/XmlSerializerFormatTest.cs
@@ -148,7 +148,6 @@ public static partial class XmlSerializerFormatTests
             Assert.Equal((new byte[] { byteParams.P1, byteParams.P2 }), serviceProxy1.CreateSet(byteParams));
             Assert.Equal(dateTime, serviceProxy1.ReturnInputDateTime(dateTime));
 
-
             Guid guid = Guid.NewGuid();
             serviceProxy1.AddIntParams(guid, intParams);
             IntParams outputIntParams = serviceProxy1.GetAndRemoveIntParams(guid);

--- a/src/System.Private.ServiceModel/tests/Scenarios/Contract/XmlSerializer/XmlSerializerFormatTest.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Contract/XmlSerializer/XmlSerializerFormatTest.cs
@@ -148,20 +148,19 @@ public static partial class XmlSerializerFormatTests
             Assert.Equal((new byte[] { byteParams.P1, byteParams.P2 }), serviceProxy1.CreateSet(byteParams));
             Assert.Equal(dateTime, serviceProxy1.ReturnInputDateTime(dateTime));
 
-            serviceProxy1.SetIntParamsProperty(null);
-            Assert.Null(serviceProxy1.GetIntParamsProperty());
-            serviceProxy1.SetIntParamsProperty(intParams);
-            IntParams intParamsProp = serviceProxy1.GetIntParamsProperty();
-            Assert.NotNull(intParamsProp);
-            Assert.Equal(intParams.P1, intParamsProp.P1);
-            Assert.Equal(intParams.P2, intParamsProp.P2);
+
+            Guid guid = Guid.NewGuid();
+            serviceProxy1.AddIntParams(guid, intParams);
+            IntParams outputIntParams = serviceProxy1.GetAndRemoveIntParams(guid);
+            Assert.NotNull(outputIntParams);
+            Assert.Equal(intParams.P1, outputIntParams.P1);
+            Assert.Equal(intParams.P2, outputIntParams.P2);
 
             if (isMultiNs)
             {
-                serviceProxy2.SetStringField(null);
-                Assert.Null(serviceProxy2.GetStringField());
-                serviceProxy2.SetStringField(testStr);
-                Assert.Equal(testStr, serviceProxy2.GetStringField());
+                Guid guid2 = Guid.NewGuid();
+                serviceProxy2.AddString(guid2, testStr);                
+                Assert.Equal(testStr, serviceProxy2.GetAndRemoveString(guid2));
             }
         }
         catch (Exception ex)

--- a/src/System.Private.ServiceModel/tools/IISHostedWcfService/App_code/IXmlSerFormatAttrServices.cs
+++ b/src/System.Private.ServiceModel/tools/IISHostedWcfService/App_code/IXmlSerFormatAttrServices.cs
@@ -24,10 +24,10 @@ namespace WcfService
         string Concatenate(IntParams par);
 
         [OperationContract, XmlSerializerFormat]
-        void SetIntParamsProperty(IntParams par);
+        void AddIntParams(Guid guid, IntParams par);
 
         [OperationContract, XmlSerializerFormat]
-        IntParams GetIntParamsProperty();
+        IntParams GetAndRemoveIntParams(Guid guid);
 
         [OperationContract, XmlSerializerFormat]
         DateTime ReturnInputDateTime(DateTime dt);
@@ -40,10 +40,10 @@ namespace WcfService
     public interface IHelloWorld
     {
         [OperationContract, XmlSerializerFormat]
-        void SetStringField(string testString);
+        void AddString(Guid guid, string testString);
 
         [OperationContract, XmlSerializerFormat]
-        string GetStringField();
+        string GetAndRemoveString(Guid guid);
     }
 
     public class IntParams

--- a/src/System.Private.ServiceModel/tools/IISHostedWcfService/App_code/XmlSerFormatAttrServices.cs
+++ b/src/System.Private.ServiceModel/tools/IISHostedWcfService/App_code/XmlSerFormatAttrServices.cs
@@ -56,8 +56,7 @@ namespace WcfService
         [XmlSerializerFormat(Style = OperationFormatStyle.Rpc, Use = OperationFormatUse.Encoded)]
         public IntParams GetAndRemoveIntParams(Guid guid)
         {
-            object value;
-            s_sessions.TryRemove(guid, out value);
+            s_sessions.TryRemove(guid, out object value);
             return value as IntParams;
         }
 
@@ -123,8 +122,7 @@ namespace WcfService
         [XmlSerializerFormat(Style = OperationFormatStyle.Rpc, Use = OperationFormatUse.Literal)]
         public IntParams GetAndRemoveIntParams(Guid guid)
         {
-            object value;
-            s_sessions.TryRemove(guid, out value);
+            s_sessions.TryRemove(guid, out object value);
             return value as IntParams;
         }
 
@@ -190,8 +188,7 @@ namespace WcfService
         [XmlSerializerFormat(Style = OperationFormatStyle.Document, Use = OperationFormatUse.Literal)]
         public IntParams GetAndRemoveIntParams(Guid guid)
         {
-            object value;
-            s_sessions.TryRemove(guid, out value);
+            s_sessions.TryRemove(guid, out object value);
             return value as IntParams;
         }
 
@@ -257,8 +254,7 @@ namespace WcfService
         [XmlSerializerFormat(Style = OperationFormatStyle.Rpc, Use = OperationFormatUse.Encoded)]
         public IntParams GetAndRemoveIntParams(Guid guid)
         {
-            object value;
-            s_sessions.TryRemove(guid, out value);
+            s_sessions.TryRemove(guid, out object value);
             return value as IntParams;
         }
 
@@ -290,8 +286,7 @@ namespace WcfService
         [XmlSerializerFormat(Style = OperationFormatStyle.Rpc, Use = OperationFormatUse.Encoded)]
         public string GetAndRemoveString(Guid guid)
         {
-            object value;
-            s_sessions.TryRemove(guid, out value);
+            s_sessions.TryRemove(guid, out object value);
             return value as string;
         }
     }
@@ -343,8 +338,7 @@ namespace WcfService
         [XmlSerializerFormat(Style = OperationFormatStyle.Rpc, Use = OperationFormatUse.Literal)]
         public IntParams GetAndRemoveIntParams(Guid guid)
         {
-            object value;
-            s_sessions.TryRemove(guid, out value);
+            s_sessions.TryRemove(guid, out object value);
             return value as IntParams;
         }
 
@@ -376,8 +370,7 @@ namespace WcfService
         [XmlSerializerFormat(Style = OperationFormatStyle.Rpc, Use = OperationFormatUse.Literal)]
         public string GetAndRemoveString(Guid guid)
         {
-            object value;
-            s_sessions.TryRemove(guid, out value);
+            s_sessions.TryRemove(guid, out object value);
             return value as string;
         }
     }
@@ -429,8 +422,7 @@ namespace WcfService
         [XmlSerializerFormat(Style = OperationFormatStyle.Document, Use = OperationFormatUse.Literal)]
         public IntParams GetAndRemoveIntParams(Guid guid)
         {
-            object value;
-            s_sessions.TryRemove(guid, out value);
+            s_sessions.TryRemove(guid, out object value);
             return value as IntParams;
         }
 
@@ -462,8 +454,7 @@ namespace WcfService
         [XmlSerializerFormat(Style = OperationFormatStyle.Document, Use = OperationFormatUse.Literal)]
         public string GetAndRemoveString(Guid guid)
         {
-            object value;
-            s_sessions.TryRemove(guid, out value);
+            s_sessions.TryRemove(guid, out object value);
             return value as string;
         }
     }

--- a/src/System.Private.ServiceModel/tools/IISHostedWcfService/App_code/XmlSerFormatAttrServices.cs
+++ b/src/System.Private.ServiceModel/tools/IISHostedWcfService/App_code/XmlSerFormatAttrServices.cs
@@ -48,7 +48,7 @@ namespace WcfService
         {
             if (!s_sessions.TryAdd(guid, par))
             {
-                throw new InvalidOperationException($"Guid {guid} already existed, and the value was {s_sessions[guid]}.");
+                throw new InvalidOperationException(string.Format("Guid {0} already existed, and the value was {1}.", guid, s_sessions[guid]));
             }                
         }
 
@@ -115,7 +115,7 @@ namespace WcfService
         {
             if (!s_sessions.TryAdd(guid, par))
             {
-                throw new InvalidOperationException($"Guid {guid} already existed, and the value was {s_sessions[guid]}.");
+                throw new InvalidOperationException(string.Format("Guid {0} already existed, and the value was {1}.", guid, s_sessions[guid]));
             }
         }
 
@@ -182,7 +182,7 @@ namespace WcfService
         {
             if (!s_sessions.TryAdd(guid, par))
             {
-                throw new InvalidOperationException($"Guid {guid} already existed, and the value was {s_sessions[guid]}.");
+                throw new InvalidOperationException(string.Format("Guid {0} already existed, and the value was {1}.", guid, s_sessions[guid]));
             }
         }
 
@@ -249,7 +249,7 @@ namespace WcfService
         {
             if (!s_sessions.TryAdd(guid, par))
             {
-                throw new InvalidOperationException($"Guid {guid} already existed, and the value was {s_sessions[guid]}.");
+                throw new InvalidOperationException(string.Format("Guid {0} already existed, and the value was {1}.", guid, s_sessions[guid]));
             }
         }
 
@@ -282,7 +282,7 @@ namespace WcfService
         {
             if (!s_sessions.TryAdd(guid, testString))
             {
-                throw new InvalidOperationException($"Guid {guid} already existed, and the value was {s_sessions[guid]}.");
+                throw new InvalidOperationException(string.Format("Guid {0} already existed, and the value was {1}.", guid, s_sessions[guid]));
             }
         }
 
@@ -335,7 +335,7 @@ namespace WcfService
         {
             if (!s_sessions.TryAdd(guid, par))
             {
-                throw new InvalidOperationException($"Guid {guid} already existed, and the value was {s_sessions[guid]}.");
+                throw new InvalidOperationException(string.Format("Guid {0} already existed, and the value was {1}.", guid, s_sessions[guid]));
             }
         }
 
@@ -368,7 +368,7 @@ namespace WcfService
         {
             if (!s_sessions.TryAdd(guid, testString))
             {
-                throw new InvalidOperationException($"Guid {guid} already existed, and the value was {s_sessions[guid]}.");
+                throw new InvalidOperationException(string.Format("Guid {0} already existed, and the value was {1}.", guid, s_sessions[guid]));
             }
         }
 
@@ -421,7 +421,7 @@ namespace WcfService
         {
             if (!s_sessions.TryAdd(guid, par))
             {
-                throw new InvalidOperationException($"Guid {guid} already existed, and the value was {s_sessions[guid]}.");
+                throw new InvalidOperationException(string.Format("Guid {0} already existed, and the value was {1}.", guid, s_sessions[guid]));
             }
         }
 
@@ -454,7 +454,7 @@ namespace WcfService
         {
             if (!s_sessions.TryAdd(guid, testString))
             {
-                throw new InvalidOperationException($"Guid {guid} already existed, and the value was {s_sessions[guid]}.");
+                throw new InvalidOperationException(string.Format("Guid {0} already existed, and the value was {1}.", guid, s_sessions[guid]));
             }
         }
 

--- a/src/System.Private.ServiceModel/tools/IISHostedWcfService/App_code/XmlSerFormatAttrServices.cs
+++ b/src/System.Private.ServiceModel/tools/IISHostedWcfService/App_code/XmlSerFormatAttrServices.cs
@@ -4,6 +4,7 @@
 
 
 using System;
+using System.Collections.Concurrent;
 using System.ServiceModel;
 
 namespace WcfService
@@ -11,7 +12,7 @@ namespace WcfService
     [ServiceBehavior(IncludeExceptionDetailInFaults = true)]
     public class RpcEncSingleNsService : ICalculator
     {
-        public static IntParams IntParamsProp { get; set; }
+        private static ConcurrentDictionary<Guid, object> s_sessions = new ConcurrentDictionary<Guid, object>();
 
         [OperationBehavior]
         [XmlSerializerFormat(Style = OperationFormatStyle.Rpc, Use = OperationFormatUse.Encoded)]
@@ -43,16 +44,21 @@ namespace WcfService
 
         [OperationBehavior]
         [XmlSerializerFormat(Style = OperationFormatStyle.Rpc, Use = OperationFormatUse.Encoded)]
-        public void SetIntParamsProperty(IntParams par)
+        public void AddIntParams(Guid guid, IntParams par)
         {
-            IntParamsProp = par;
+            if (!s_sessions.TryAdd(guid, par))
+            {
+                throw new InvalidOperationException($"Guid {guid} already existed, and the value was {s_sessions[guid]}.");
+            }                
         }
 
         [OperationBehavior]
         [XmlSerializerFormat(Style = OperationFormatStyle.Rpc, Use = OperationFormatUse.Encoded)]
-        public IntParams GetIntParamsProperty()
+        public IntParams GetAndRemoveIntParams(Guid guid)
         {
-            return IntParamsProp;
+            object value;
+            s_sessions.TryRemove(guid, out value);
+            return value as IntParams;
         }
 
         [OperationBehavior]
@@ -73,7 +79,7 @@ namespace WcfService
     [ServiceBehavior(IncludeExceptionDetailInFaults = true)]
     public class RpcLitSingleNsService : ICalculator
     {
-        public static IntParams IntParamsProp { get; set; }
+        private static ConcurrentDictionary<Guid, object> s_sessions = new ConcurrentDictionary<Guid, object>();
 
         [OperationBehavior]
         [XmlSerializerFormat(Style = OperationFormatStyle.Rpc, Use = OperationFormatUse.Literal)]
@@ -105,16 +111,21 @@ namespace WcfService
 
         [OperationBehavior]
         [XmlSerializerFormat(Style = OperationFormatStyle.Rpc, Use = OperationFormatUse.Literal)]
-        public void SetIntParamsProperty(IntParams par)
+        public void AddIntParams(Guid guid, IntParams par)
         {
-            IntParamsProp = par;
+            if (!s_sessions.TryAdd(guid, par))
+            {
+                throw new InvalidOperationException($"Guid {guid} already existed, and the value was {s_sessions[guid]}.");
+            }
         }
 
         [OperationBehavior]
         [XmlSerializerFormat(Style = OperationFormatStyle.Rpc, Use = OperationFormatUse.Literal)]
-        public IntParams GetIntParamsProperty()
+        public IntParams GetAndRemoveIntParams(Guid guid)
         {
-            return IntParamsProp;
+            object value;
+            s_sessions.TryRemove(guid, out value);
+            return value as IntParams;
         }
 
         [OperationBehavior]
@@ -135,7 +146,7 @@ namespace WcfService
     [ServiceBehavior(IncludeExceptionDetailInFaults = true)]
     public class DocLitSingleNsService : ICalculator
     {
-        public static IntParams IntParamsProp { get; set; }
+        private static ConcurrentDictionary<Guid, object> s_sessions = new ConcurrentDictionary<Guid, object>();
 
         [OperationBehavior]
         [XmlSerializerFormat(Style = OperationFormatStyle.Document, Use = OperationFormatUse.Literal)]
@@ -167,16 +178,21 @@ namespace WcfService
 
         [OperationBehavior]
         [XmlSerializerFormat(Style = OperationFormatStyle.Document, Use = OperationFormatUse.Literal)]
-        public void SetIntParamsProperty(IntParams par)
+        public void AddIntParams(Guid guid, IntParams par)
         {
-            IntParamsProp = par;
+            if (!s_sessions.TryAdd(guid, par))
+            {
+                throw new InvalidOperationException($"Guid {guid} already existed, and the value was {s_sessions[guid]}.");
+            }
         }
 
         [OperationBehavior]
         [XmlSerializerFormat(Style = OperationFormatStyle.Document, Use = OperationFormatUse.Literal)]
-        public IntParams GetIntParamsProperty()
+        public IntParams GetAndRemoveIntParams(Guid guid)
         {
-            return IntParamsProp;
+            object value;
+            s_sessions.TryRemove(guid, out value);
+            return value as IntParams;
         }
 
         [OperationBehavior]
@@ -197,8 +213,7 @@ namespace WcfService
     [ServiceBehavior(IncludeExceptionDetailInFaults = true)]
     public class RpcEncDualNsService : ICalculator, IHelloWorld
     {
-        public static IntParams IntParamsProp { get; set; }
-        public static string StringField;
+        private static ConcurrentDictionary<Guid, object> s_sessions = new ConcurrentDictionary<Guid, object>();
 
         [OperationBehavior]
         [XmlSerializerFormat(Style = OperationFormatStyle.Rpc, Use = OperationFormatUse.Encoded)]
@@ -230,16 +245,21 @@ namespace WcfService
 
         [OperationBehavior]
         [XmlSerializerFormat(Style = OperationFormatStyle.Rpc, Use = OperationFormatUse.Encoded)]
-        public void SetIntParamsProperty(IntParams par)
+        public void AddIntParams(Guid guid, IntParams par)
         {
-            IntParamsProp = par;
+            if (!s_sessions.TryAdd(guid, par))
+            {
+                throw new InvalidOperationException($"Guid {guid} already existed, and the value was {s_sessions[guid]}.");
+            }
         }
 
         [OperationBehavior]
         [XmlSerializerFormat(Style = OperationFormatStyle.Rpc, Use = OperationFormatUse.Encoded)]
-        public IntParams GetIntParamsProperty()
+        public IntParams GetAndRemoveIntParams(Guid guid)
         {
-            return IntParamsProp;
+            object value;
+            s_sessions.TryRemove(guid, out value);
+            return value as IntParams;
         }
 
         [OperationBehavior]
@@ -258,24 +278,28 @@ namespace WcfService
 
         [OperationBehavior]
         [XmlSerializerFormat(Style = OperationFormatStyle.Rpc, Use = OperationFormatUse.Encoded)]
-        public void SetStringField(string str)
+        public void AddString(Guid guid, string testString)
         {
-            StringField = str;
+            if (!s_sessions.TryAdd(guid, testString))
+            {
+                throw new InvalidOperationException($"Guid {guid} already existed, and the value was {s_sessions[guid]}.");
+            }
         }
 
         [OperationBehavior]
         [XmlSerializerFormat(Style = OperationFormatStyle.Rpc, Use = OperationFormatUse.Encoded)]
-        public string GetStringField()
+        public string GetAndRemoveString(Guid guid)
         {
-            return StringField;
+            object value;
+            s_sessions.TryRemove(guid, out value);
+            return value as string;
         }
     }
 
     [ServiceBehavior(IncludeExceptionDetailInFaults = true)]
     public class RpcLitDualNsService : ICalculator, IHelloWorld
     {
-        public static IntParams IntParamsProp { get; set; }
-        public static string StringField;
+        private static ConcurrentDictionary<Guid, object> s_sessions = new ConcurrentDictionary<Guid, object>();
 
         [OperationBehavior]
         [XmlSerializerFormat(Style = OperationFormatStyle.Rpc, Use = OperationFormatUse.Literal)]
@@ -307,16 +331,21 @@ namespace WcfService
 
         [OperationBehavior]
         [XmlSerializerFormat(Style = OperationFormatStyle.Rpc, Use = OperationFormatUse.Literal)]
-        public void SetIntParamsProperty(IntParams par)
+        public void AddIntParams(Guid guid, IntParams par)
         {
-            IntParamsProp = par;
+            if (!s_sessions.TryAdd(guid, par))
+            {
+                throw new InvalidOperationException($"Guid {guid} already existed, and the value was {s_sessions[guid]}.");
+            }
         }
 
         [OperationBehavior]
         [XmlSerializerFormat(Style = OperationFormatStyle.Rpc, Use = OperationFormatUse.Literal)]
-        public IntParams GetIntParamsProperty()
+        public IntParams GetAndRemoveIntParams(Guid guid)
         {
-            return IntParamsProp;
+            object value;
+            s_sessions.TryRemove(guid, out value);
+            return value as IntParams;
         }
 
         [OperationBehavior]
@@ -335,24 +364,28 @@ namespace WcfService
 
         [OperationBehavior]
         [XmlSerializerFormat(Style = OperationFormatStyle.Rpc, Use = OperationFormatUse.Literal)]
-        public void SetStringField(string str)
+        public void AddString(Guid guid, string testString)
         {
-            StringField = str;
+            if (!s_sessions.TryAdd(guid, testString))
+            {
+                throw new InvalidOperationException($"Guid {guid} already existed, and the value was {s_sessions[guid]}.");
+            }
         }
 
         [OperationBehavior]
         [XmlSerializerFormat(Style = OperationFormatStyle.Rpc, Use = OperationFormatUse.Literal)]
-        public string GetStringField()
+        public string GetAndRemoveString(Guid guid)
         {
-            return StringField;
+            object value;
+            s_sessions.TryRemove(guid, out value);
+            return value as string;
         }
     }
 
     [ServiceBehavior(IncludeExceptionDetailInFaults = true)]
     public class DocLitDualNsService : ICalculator, IHelloWorld
     {
-        public static IntParams IntParamsProp { get; set; }
-        public static string StringField;
+        private static ConcurrentDictionary<Guid, object> s_sessions = new ConcurrentDictionary<Guid, object>();
 
         [OperationBehavior]
         [XmlSerializerFormat(Style = OperationFormatStyle.Document, Use = OperationFormatUse.Literal)]
@@ -384,16 +417,21 @@ namespace WcfService
 
         [OperationBehavior]
         [XmlSerializerFormat(Style = OperationFormatStyle.Document, Use = OperationFormatUse.Literal)]
-        public void SetIntParamsProperty(IntParams par)
+        public void AddIntParams(Guid guid, IntParams par)
         {
-            IntParamsProp = par;
+            if (!s_sessions.TryAdd(guid, par))
+            {
+                throw new InvalidOperationException($"Guid {guid} already existed, and the value was {s_sessions[guid]}.");
+            }
         }
 
         [OperationBehavior]
         [XmlSerializerFormat(Style = OperationFormatStyle.Document, Use = OperationFormatUse.Literal)]
-        public IntParams GetIntParamsProperty()
+        public IntParams GetAndRemoveIntParams(Guid guid)
         {
-            return IntParamsProp;
+            object value;
+            s_sessions.TryRemove(guid, out value);
+            return value as IntParams;
         }
 
         [OperationBehavior]
@@ -412,16 +450,21 @@ namespace WcfService
 
         [OperationBehavior]
         [XmlSerializerFormat(Style = OperationFormatStyle.Document, Use = OperationFormatUse.Literal)]
-        public void SetStringField(string str)
+        public void AddString(Guid guid, string testString)
         {
-            StringField = str;
+            if (!s_sessions.TryAdd(guid, testString))
+            {
+                throw new InvalidOperationException($"Guid {guid} already existed, and the value was {s_sessions[guid]}.");
+            }
         }
 
         [OperationBehavior]
         [XmlSerializerFormat(Style = OperationFormatStyle.Document, Use = OperationFormatUse.Literal)]
-        public string GetStringField()
+        public string GetAndRemoveString(Guid guid)
         {
-            return StringField;
+            object value;
+            s_sessions.TryRemove(guid, out value);
+            return value as string;
         }
     }
 }

--- a/src/System.Private.ServiceModel/tools/IISHostedWcfService/App_code/XmlSerFormatAttrServices.cs
+++ b/src/System.Private.ServiceModel/tools/IISHostedWcfService/App_code/XmlSerFormatAttrServices.cs
@@ -56,7 +56,8 @@ namespace WcfService
         [XmlSerializerFormat(Style = OperationFormatStyle.Rpc, Use = OperationFormatUse.Encoded)]
         public IntParams GetAndRemoveIntParams(Guid guid)
         {
-            s_sessions.TryRemove(guid, out object value);
+            object value;
+            s_sessions.TryRemove(guid, out value);
             return value as IntParams;
         }
 
@@ -122,7 +123,8 @@ namespace WcfService
         [XmlSerializerFormat(Style = OperationFormatStyle.Rpc, Use = OperationFormatUse.Literal)]
         public IntParams GetAndRemoveIntParams(Guid guid)
         {
-            s_sessions.TryRemove(guid, out object value);
+            object value;
+            s_sessions.TryRemove(guid, out value);
             return value as IntParams;
         }
 
@@ -188,7 +190,8 @@ namespace WcfService
         [XmlSerializerFormat(Style = OperationFormatStyle.Document, Use = OperationFormatUse.Literal)]
         public IntParams GetAndRemoveIntParams(Guid guid)
         {
-            s_sessions.TryRemove(guid, out object value);
+            object value;
+            s_sessions.TryRemove(guid, out value);
             return value as IntParams;
         }
 
@@ -254,7 +257,8 @@ namespace WcfService
         [XmlSerializerFormat(Style = OperationFormatStyle.Rpc, Use = OperationFormatUse.Encoded)]
         public IntParams GetAndRemoveIntParams(Guid guid)
         {
-            s_sessions.TryRemove(guid, out object value);
+            object value;
+            s_sessions.TryRemove(guid, out value);
             return value as IntParams;
         }
 
@@ -286,7 +290,8 @@ namespace WcfService
         [XmlSerializerFormat(Style = OperationFormatStyle.Rpc, Use = OperationFormatUse.Encoded)]
         public string GetAndRemoveString(Guid guid)
         {
-            s_sessions.TryRemove(guid, out object value);
+            object value;
+            s_sessions.TryRemove(guid, out value);
             return value as string;
         }
     }
@@ -338,7 +343,8 @@ namespace WcfService
         [XmlSerializerFormat(Style = OperationFormatStyle.Rpc, Use = OperationFormatUse.Literal)]
         public IntParams GetAndRemoveIntParams(Guid guid)
         {
-            s_sessions.TryRemove(guid, out object value);
+            object value;
+            s_sessions.TryRemove(guid, out value);
             return value as IntParams;
         }
 
@@ -370,7 +376,8 @@ namespace WcfService
         [XmlSerializerFormat(Style = OperationFormatStyle.Rpc, Use = OperationFormatUse.Literal)]
         public string GetAndRemoveString(Guid guid)
         {
-            s_sessions.TryRemove(guid, out object value);
+            object value;
+            s_sessions.TryRemove(guid, out value);
             return value as string;
         }
     }
@@ -422,7 +429,8 @@ namespace WcfService
         [XmlSerializerFormat(Style = OperationFormatStyle.Document, Use = OperationFormatUse.Literal)]
         public IntParams GetAndRemoveIntParams(Guid guid)
         {
-            s_sessions.TryRemove(guid, out object value);
+            object value;
+            s_sessions.TryRemove(guid, out value);
             return value as IntParams;
         }
 
@@ -454,7 +462,8 @@ namespace WcfService
         [XmlSerializerFormat(Style = OperationFormatStyle.Document, Use = OperationFormatUse.Literal)]
         public string GetAndRemoveString(Guid guid)
         {
-            s_sessions.TryRemove(guid, out object value);
+            object value;
+            s_sessions.TryRemove(guid, out value);
             return value as string;
         }
     }


### PR DESCRIPTION
**Issue**
In the original implementation , to verify the return void service method in client, a static variable in service was used in the void set method to set the variable and call a get method to return the static variable for result verification.
It caused some problem which looks due to multithreading access to the static variable, test fail intermittently in helix run as the GetIntParamsProperty not always return expected result.

**Fix**
Thanks for Shin's advice, use ConcurrentDictionary(Guid, Object) to set and get value fixes the muti-thread access issue (without involving WCF session).

cc: @shmao , @StephenBonikowsky, @huanwu 
