### PR TITLE
Move package baseline version to 4.4.1

### DIFF
--- a/Packaging.props
+++ b/Packaging.props
@@ -20,7 +20,7 @@
     <PlatformPackageVersion Condition="'$(PlatformPackageVersion)' == ''">1.2.0</PlatformPackageVersion>
 
     <!-- by default all packages will use the same version which revs with respect to product version -->
-    <PackageVersion Condition="'$(PackageVersion)' == ''">4.4.0</PackageVersion>
+    <PackageVersion Condition="'$(PackageVersion)' == ''">4.4.1</PackageVersion>
     <SkipValidatePackageTargetFramework>true</SkipValidatePackageTargetFramework>
     <LicenseUrl>https://github.com/dotnet/wcf/blob/master/LICENSE.TXT</LicenseUrl>    
   </PropertyGroup>

--- a/pkg/baseline/packageIndex.json
+++ b/pkg/baseline/packageIndex.json
@@ -22,7 +22,7 @@
         "4.3.0",
         "4.4.0"
       ],
-      "BaselineVersion": "4.4.0",
+      "BaselineVersion": "4.4.1",
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
         "4.1.1.0": "4.3.0",
@@ -37,7 +37,7 @@
         "4.3.0",
         "4.4.0"
       ],
-      "BaselineVersion": "4.4.0",
+      "BaselineVersion": "4.4.1",
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
@@ -55,7 +55,7 @@
         "4.3.0",
         "4.4.0"
       ],
-      "BaselineVersion": "4.4.0",
+      "BaselineVersion": "4.4.1",
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
         "3.9.0.0": "3.9.0",
@@ -73,7 +73,7 @@
         "4.3.0",
         "4.4.0"
       ],
-      "BaselineVersion": "4.4.0",
+      "BaselineVersion": "4.4.1",
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
@@ -90,7 +90,7 @@
         "4.3.0",
         "4.4.0"
       ],
-      "BaselineVersion": "4.4.0",
+      "BaselineVersion": "4.4.1",
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
         "3.9.0.0": "3.9.0",
@@ -108,7 +108,7 @@
         "4.3.0",
         "4.4.0"
       ],
-      "BaselineVersion": "4.4.0",
+      "BaselineVersion": "4.4.1",
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
         "3.9.0.0": "3.9.0",


### PR DESCRIPTION
* This will update the nuspecs to show a dependency on 4.4.1 instead of the previous 4.4.0 version.
* Will dual check-in to VSTS