### PR TITLE
Workaround for path not supported error when syncing sources.

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -64,15 +64,15 @@
 
   <!-- list of nuget package sources passed to nuget restore -->
   <ItemGroup Condition="'$(ExcludeInternetFeeds)' != 'true'">
-    <!-- Example to consume local CoreCLR package:
-         /p:OverridePackageSource=C:\coreclr\bin\Product\Windows_NT.x64.Debug\.nuget\pkg
-    -->
-    <DotnetSourceList Include="$(OverridePackageSource)" />
     <!-- Need to escape double forward slash (%2F) or MSBuild will normalize to one slash on Unix. -->
     <!-- Including buildtools to pull in TestSuite packages and repackaged xunit dependencies-->
     <DotnetSourceList Include="https:%2F%2Fdotnet.myget.org/F/dotnet-buildtools/api/v3/index.json" />
     <DotnetSourceList Include="https:%2F%2Fdotnet.myget.org/F/dotnet-core/api/v3/index.json" />
     <DotnetSourceList Include="https:%2F%2Fapi.nuget.org/v3/index.json" />
+    <!-- Example to consume local CoreCLR package:
+         /p:OverridePackageSource=C:\coreclr\bin\Product\Windows_NT.x64.Debug\.nuget\pkg
+    -->
+    <DotnetSourceList Include="$(OverridePackageSource)" />
   </ItemGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
* See issue #4094 at NuGet: https://github.com/NuGet/Home

Bug in 2.0.0 preview versions of CLI do not like it when the first item in a list of sources to restore is a file path and not a url. By making sure a url is first we work around the issue.