### PR TITLE
Test syncing fails to pull in this needed assembly.

### DIFF
--- a/external/corefx/corefx.depproj
+++ b/external/corefx/corefx.depproj
@@ -26,6 +26,9 @@
     <PackageReference Include="Microsoft.Private.CoreFx.NETCoreApp">
       <Version>$(MicrosoftPrivateCoreFxNETCoreAppPackageVersion)</Version>
     </PackageReference>
+    <PackageReference Include="System.ComponentModel.Composition">
+      <Version>$(MicrosoftPrivateCoreFxNETCoreAppPackageVersion)</Version>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetGroup)' == 'uap' or


### PR DESCRIPTION
* System.ComponentModel.Composition
* Looks like package Microsoft.Private.CoreFx.NETCoreApp is failing to pull this in, manually adding this package reference.