### PR TITLE
Update some dependencies that aren't done by the auto updates.

### DIFF
--- a/dependencies.props
+++ b/dependencies.props
@@ -39,9 +39,9 @@
   <!-- Full package version strings that are used in other parts of the build. -->
   <PropertyGroup>
     <AppXRunnerVersion>1.0.3-prerelease-00921-01</AppXRunnerVersion>
-    <CoreFxBaseLinePackageVersion>2.1.0-preview2-25506-02</CoreFxBaseLinePackageVersion>
+    <CoreFxBaseLinePackageVersion>2.2.0-preview1-26020-03</CoreFxBaseLinePackageVersion>
     <XunitPerfAnalysisPackageVersion>1.0.0-beta-build0007</XunitPerfAnalysisPackageVersion>
-    <XunitNetcoreExtensionsVersion>2.1.0-prerelease-02220-02</XunitNetcoreExtensionsVersion>
+    <XunitNetcoreExtensionsVersion>2.1.0-prerelease-02312-02</XunitNetcoreExtensionsVersion>
 
     <CoreClrPackageVersion>2.1.0-preview1-26018-01</CoreClrPackageVersion>
     <DotNetHostPackageVersion>2.0.0-preview2-25310-02</DotNetHostPackageVersion>

--- a/external/test-runtime/XUnit.Runtime.depproj
+++ b/external/test-runtime/XUnit.Runtime.depproj
@@ -52,10 +52,10 @@
       <Version>4.6.519</Version>
     </PackageReference>
     <PackageReference Include="ReportGenerator">
-      <Version>2.5.0</Version>
+      <Version>3.0.1</Version>
     </PackageReference>
     <PackageReference Include="System.IO.Compression.TestData">
-      <Version>1.0.5-prerelease</Version>
+      <Version>1.0.6-prerelease</Version>
     </PackageReference>
     <PackageReference Include="System.IO.Packaging.TestData">
       <Version>1.0.0-prerelease</Version>
@@ -84,7 +84,7 @@
   </ItemGroup>
 
   <PropertyGroup Condition="'$(TargetGroup)' == 'uap'">
-    <UAPToolsPackageVersion>1.0.14</UAPToolsPackageVersion>
+    <UAPToolsPackageVersion>1.0.17</UAPToolsPackageVersion>
   </PropertyGroup>
  
   <ItemGroup Condition="'$(TargetGroup)' == 'uap'">


### PR DESCRIPTION
* CoreFxBaseLinePackageVersion, this was causing us to pull in some old packages of CoreFx.
* XunitNetcoreExtensionsVersion, this older version needed to be updated to work with newer CoreFx packages.
* A couple packages that XUnit depends on also needed to be updated.