### PR TITLE
Updating the assembly version of S.P.SM for servicing.

### DIFF
--- a/Packaging.props
+++ b/Packaging.props
@@ -1,6 +1,6 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <PreReleaseLabel>preview1</PreReleaseLabel>
+    <PreReleaseLabel>servicing</PreReleaseLabel>
     <PackageDescriptionFile>$(ProjectDir)pkg/descriptions.json</PackageDescriptionFile>
     <PackageLicenseFile>$(ProjectDir)LICENSE.TXT</PackageLicenseFile>
     <PackageThirdPartyNoticesFile>$(ProjectDir)THIRD-PARTY-NOTICES.TXT</PackageThirdPartyNoticesFile>
@@ -28,7 +28,7 @@
     <SkipBaseLineCheck>true</SkipBaseLineCheck>
 
     <!-- by default all packages will use the same version which revs with respect to product version -->
-    <PackageVersion Condition="'$(PackageVersion)' == ''">4.5.0</PackageVersion>
+    <PackageVersion Condition="'$(PackageVersion)' == ''">4.5.1</PackageVersion>
     <SkipValidatePackageTargetFramework>true</SkipValidatePackageTargetFramework>
     <SkipGenerationCheck>true</SkipGenerationCheck>
   </PropertyGroup>

--- a/pkg/baseline/packageIndex.json
+++ b/pkg/baseline/packageIndex.json
@@ -16,30 +16,33 @@
       "StableVersions": [
         "4.0.0",
         "4.1.0",
-        "4.3.0"
+        "4.3.0",
+        "4.5.1"
       ],
-      "BaselineVersion": "4.5.0",
+      "BaselineVersion": "4.5.1",
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
         "4.1.1.0": "4.3.0",
         "4.1.2.0": "4.4.0",
-        "4.1.3.0": "4.5.0"
+        "4.1.3.0": "4.5.0",
+        "4.1.3.1": "4.5.1"
       }
     },
     "System.ServiceModel.Duplex": {
       "StableVersions": [
         "4.0.0",
         "4.0.1",
-        "4.3.0"
+        "4.3.0",
+        "4.5.1"
       ],
-      "BaselineVersion": "4.5.0",
+      "BaselineVersion": "4.5.1",
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.0.1.0": "4.0.1",
         "4.0.2.0": "4.3.0",
         "4.1.0.0": "4.4.0",
-        "4.1.1.0": "4.5.0"
+        "4.1.1.0": "4.5.1"
       }
     },
     "System.ServiceModel.Http": {
@@ -48,9 +51,10 @@
         "4.0.0",
         "4.0.10",
         "4.1.0",
-        "4.3.0"
+        "4.3.0",
+        "4.5.1"
       ],
-      "BaselineVersion": "4.5.0",
+      "BaselineVersion": "4.5.1",
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
         "3.9.0.0": "3.9.0",
@@ -59,23 +63,24 @@
         "4.1.0.0": "4.1.0",
         "4.1.1.0": "4.3.0",
         "4.1.2.0": "4.4.0",
-        "4.1.3.0": "4.5.0"
+        "4.1.3.0": "4.5.1"
       }
     },
     "System.ServiceModel.NetTcp": {
       "StableVersions": [
         "4.0.0",
         "4.1.0",
-        "4.3.0"
+        "4.3.0",
+        "4.5.1"
       ],
-      "BaselineVersion": "4.5.0",
+      "BaselineVersion": "4.5.1",
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.1.0.0": "4.1.0",
         "4.1.1.0": "4.3.0",
         "4.1.2.0": "4.4.0",
-        "4.1.3.0": "4.5.0"
+        "4.1.3.0": "4.5.1"
       }
     },
     "System.ServiceModel.Primitives": {
@@ -83,9 +88,10 @@
         "3.9.0",
         "4.0.0",
         "4.1.0",
-        "4.3.0"
+        "4.3.0",
+        "4.5.1"
       ],
-      "BaselineVersion": "4.5.0",
+      "BaselineVersion": "4.5.1",
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
         "3.9.0.0": "3.9.0",
@@ -93,7 +99,7 @@
         "4.1.0.0": "4.1.0",
         "4.1.1.0": "4.3.0",
         "4.2.0.0": "4.4.0",
-        "4.2.1.0": "4.5.0"
+        "4.2.1.0": "4.5.1"
       }
     },
     "System.ServiceModel.Security": {
@@ -101,9 +107,10 @@
         "3.9.0",
         "4.0.0",
         "4.0.1",
-        "4.3.0"
+        "4.3.0",
+        "4.5.1"
       ],
-      "BaselineVersion": "4.5.0",
+      "BaselineVersion": "4.5.1",
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
         "3.9.0.0": "3.9.0",
@@ -111,7 +118,7 @@
         "4.0.1.0": "4.0.1",
         "4.0.2.0": "4.3.0",
         "4.0.3.0": "4.4.0",
-        "4.0.4.0": "4.5.0"
+        "4.0.4.0": "4.5.1"
       }
     }
   },

--- a/src/System.Private.ServiceModel/dir.props
+++ b/src/System.Private.ServiceModel/dir.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.1.3.0</AssemblyVersion>
+    <AssemblyVersion>4.1.3.1</AssemblyVersion>
     <AssemblyKey>Open</AssemblyKey>
     <IsNETCoreApp>true</IsNETCoreApp>
     <IsNETCoreAppRef>false</IsNETCoreAppRef>


### PR DESCRIPTION
@zhenlan made these changes in VSTS to create servicing packages with stable versions while having incremented the S.P.SM assembly version and package version.