### PR TITLE
Version forward S.P.SM

### DIFF
--- a/pkg/baseline/packageIndex.json
+++ b/pkg/baseline/packageIndex.json
@@ -23,7 +23,7 @@
       "AssemblyVersionInPackageVersion": {
         "4.1.1.0": "4.3.0",
         "4.1.2.0": "4.4.0",
-        "4.1.3.0": "4.5.0"
+        "4.1.3.2": "4.5.0"
       }
     },
     "System.ServiceModel.Duplex": {

--- a/pkg/baseline/packageIndex.json
+++ b/pkg/baseline/packageIndex.json
@@ -23,7 +23,7 @@
       "AssemblyVersionInPackageVersion": {
         "4.1.1.0": "4.3.0",
         "4.1.2.0": "4.4.0",
-        "4.1.3.2": "4.5.0"
+        "4.1.4.0": "4.5.0"
       }
     },
     "System.ServiceModel.Duplex": {

--- a/src/System.Private.ServiceModel/dir.props
+++ b/src/System.Private.ServiceModel/dir.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.1.3.2</AssemblyVersion>
+    <AssemblyVersion>4.1.4.0</AssemblyVersion>
     <AssemblyKey>Open</AssemblyKey>
     <IsNETCoreApp>true</IsNETCoreApp>
     <IsNETCoreAppRef>false</IsNETCoreAppRef>

--- a/src/System.Private.ServiceModel/dir.props
+++ b/src/System.Private.ServiceModel/dir.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.1.3.0</AssemblyVersion>
+    <AssemblyVersion>4.1.3.2</AssemblyVersion>
     <AssemblyKey>Open</AssemblyKey>
     <IsNETCoreApp>true</IsNETCoreApp>
     <IsNETCoreAppRef>false</IsNETCoreAppRef>


### PR DESCRIPTION
* Skipping forward to 4.1.3.2 because the servicing release of uwp6.0 used version 4.1.3.1