### PR TITLE
Update test infrastructure to detect what OS it is running on.

### DIFF
--- a/external/test-runtime/XUnit.Runtime.depproj
+++ b/external/test-runtime/XUnit.Runtime.depproj
@@ -67,6 +67,9 @@
     <PackageReference Include="System.Net.TestData">
       <Version>1.0.0-prerelease</Version>
     </PackageReference>
+    <PackageReference Include="Microsoft.DotNet.PlatformAbstractions">
+      <Version>2.0.4</Version>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == 'netfx'">
     <PackageReference Include="xunit.runner.console">
@@ -82,6 +85,7 @@
     <PackageToInclude Include="Microsoft.xunit.netcore.extensions"/>
     <PackageToInclude Include="Newtonsoft.Json"/>
     <PackageToInclude Include="$(XUnitRunnerPackageId)" />
+    <PackageToInclude Include="Microsoft.DotNet.PlatformAbstractions" />
   </ItemGroup>
 
   <PropertyGroup Condition="'$(TargetGroup)' == 'uap'">

--- a/src/System.Private.ServiceModel/tests/Common/Infrastructure/Infrastructure.Common.csproj
+++ b/src/System.Private.ServiceModel/tests/Common/Infrastructure/Infrastructure.Common.csproj
@@ -26,6 +26,7 @@
   <ItemGroup>
     <ProjectReference Include="$(WcfPrimitivesRefProj)" />
     <ReferenceFromRuntime Include="xunit.execution.dotnet" />
+    <ReferenceFromRuntime Include="Microsoft.DotNet.PlatformAbstractions" />
   </ItemGroup>
   <ItemGroup>
     <None Include="testproperties.props" />

--- a/src/System.Private.ServiceModel/tests/Common/Infrastructure/OSHelper.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Infrastructure/OSHelper.cs
@@ -142,27 +142,6 @@ namespace Infrastructure.Common
             return osid;
         }
 
-        // The $(TestNugetRuntimeId) property was deprecated in build tools v2.
-        // No longer calling this method.
-        private static OSID OSIDfromTestRuntime()
-        {
-            string testRuntime = TestProperties.GetProperty(TestProperties.TestNugetRuntimeId_PropertyName);
-            if (string.IsNullOrEmpty(testRuntime))
-            {
-                return OSID.None;
-            }
-
-            foreach (var pair in _runtimeToOSID)
-            {
-                string runtime = pair.Item1;
-                if (testRuntime.IndexOf(runtime, StringComparison.OrdinalIgnoreCase) >= 0)
-                {
-                    return pair.Item2;
-                }
-            }
-            return OSID.None;
-        }
-
         // Detects the OSID based on the current OS description.
         // Currently this is used only for Windows because the non-Windows
         // descriptions vary widely in format.

--- a/src/System.Private.ServiceModel/tests/Common/Infrastructure/OSHelper.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Infrastructure/OSHelper.cs
@@ -22,30 +22,31 @@ namespace Infrastructure.Common
         private static OSID _currentOSID = 0;
         private static string _currentOSDescription;
 
-        // Test runtimes are specified via the $(TestNugetRuntimeId) property.
         // This list associates names with their corresponding OSID.
         // It falls back to "any" for partial matches so that future versions
         // choose at least the correct OS category.
 
         private static List<Tuple<string, OSID>> _runtimeToOSID = new List<Tuple<string, OSID>>
         {
-            new Tuple<string, OSID>("centos.7.1", OSID.CentOS_7_1),
             new Tuple<string, OSID>("centos.7", OSID.CentOS_7),
             new Tuple<string, OSID>("centos.", OSID.AnyCentOS),
 
-            new Tuple<string, OSID>("debian.8.2", OSID.Debian_8_2),
+            new Tuple<string, OSID>("debian.9", OSID.Debian_9),
             new Tuple<string, OSID>("debian.8", OSID.Debian_8),
             new Tuple<string, OSID>("debian", OSID.AnyDebian),
 
-            new Tuple<string, OSID>("fedora_23", OSID.Fedora_23),
+            new Tuple<string, OSID>("fedora.26", OSID.Fedora_26),
+            new Tuple<string, OSID>("fedora.27", OSID.Fedora_27),
             new Tuple<string, OSID>("fedora", OSID.AnyFedora),
 
+            new Tuple<string, OSID>("sles.12", OSID.SLES_12),
+            new Tuple<string, OSID>("opensuse.42.3", OSID.OpenSUSE_42_3),
             new Tuple<string, OSID>("opensuse.13.2", OSID.OpenSUSE_13_2),
             new Tuple<string, OSID>("opensuse", OSID.AnyOpenSUSE),
 
-            new Tuple<string, OSID>("osx.10.10", OSID.OSX_10_10),
             new Tuple<string, OSID>("osx.10.11", OSID.OSX_10_11),
             new Tuple<string, OSID>("osx.10.12", OSID.OSX_10_12),
+            new Tuple<string, OSID>("osx.10.13", OSID.OSX_10_13),
             new Tuple<string, OSID>("osx", OSID.AnyOSX),
 
             new Tuple<string, OSID>("rhel.7", OSID.RHEL_7),
@@ -53,16 +54,16 @@ namespace Infrastructure.Common
 
             new Tuple<string, OSID>("ubuntu.14.04", OSID.Ubuntu_14_04),
             new Tuple<string, OSID>("ubuntu.16.04", OSID.Ubuntu_16_04),
+            new Tuple<string, OSID>("ubuntu.17.10", OSID.Ubuntu_17_10),
             new Tuple<string, OSID>("ubuntu", OSID.AnyUbuntu),
 
-            // Currently, win7 is used for the windows runtime, regardless
-            // which version of Windows is actually used to run the test.
-            // So we can't determine the OS from the runtime in this list.
+            // Currently, the same RID and OS Description is used for Win10 Core, Nano and Normal
+            // So can't differentiate between those three flavors of Win10
+            new Tuple<string, OSID>("win81", OSID.Windows_8_1 | OSID.Windows_Server_2012_R2),
+            new Tuple<string, OSID>("win7", OSID.Windows_7 | OSID.Windows_Server_2008_R2),
         };
 
-        // All Windows version currently use the runtime "win7" so cannot be distinguished by that.
-        // However the windows major and minor versions are known and can be used.  Some versions are
-        // shared by different OSes, so at this level we can only say it is all of them.
+        // Some versions are shared by different OSes, so at this level we can only say it is all of them.
         // Applications that have not been manifested for Win 8.1 or Win 10 will return Win 8.
         // This lookup table assumes the test running application has been manifested.
         // This mapping is described at https://msdn.microsoft.com/en-us/library/windows/desktop/ms724832(v=vs.85).aspx
@@ -75,14 +76,9 @@ namespace Infrastructure.Common
             new Tuple<string, OSID>("Microsoft Windows 10.", OSID.Windows_10 | OSID.Windows_Server_2016),
             new Tuple<string, OSID>(MicrosoftWindowsPhoneName, OSID.WindowsPhone),
             new Tuple<string, OSID>(MicrosoftWindowsName, OSID.AnyWindows),  // reserved for "Don't know which version"
-            new Tuple<string, OSID>("Darwin 14", OSID.OSX_10_10),
             new Tuple<string, OSID>("Darwin 15", OSID.OSX_10_11),
             new Tuple<string, OSID>("Darwin 16", OSID.OSX_10_12),
             new Tuple<string, OSID>("Darwin", OSID.AnyOSX),
-            new Tuple<string, OSID>("Debian", OSID.AnyDebian),
-            new Tuple<string, OSID>("generic", OSID.AnyUbuntu),
-            new Tuple<string, OSID>("3.10.0-229.11.1.el7.x86_64", OSID.CentOS_7_1),
-            new Tuple<string, OSID>("3.10.0-327.el7.x86_64", OSID.RHEL_7),
         };
 
         private static string CurrentOSDescription
@@ -108,9 +104,8 @@ namespace Infrastructure.Common
                     _detectedOSID = true;
 
                     // Log this to the console so that lab run artifacts will show what we detected.
-                    Console.WriteLine(String.Format("Detected current OSID as \"{0}\" from test runtime \"{1}\" and description \"{2}\"",
+                    Console.WriteLine(String.Format("Detected current OSID as \"{0}\" from RuntimeEnvironment and description \"{1}\"",
                                                      _currentOSID.Name(), 
-                                                     TestProperties.GetProperty(TestProperties.TestNugetRuntimeId_PropertyName),
                                                      CurrentOSDescription));
                 }
 
@@ -136,7 +131,7 @@ namespace Infrastructure.Common
         {
             // First attempt to map from the test runtime.
             // All the non-Windows OSes are mapped this way.
-            OSID osid = OSIDfromTestRuntime();
+            OSID osid = OSIDfromRuntimeEnvironment();
             if (osid == OSID.None)
             {
                 // The Windows OSes are mapped based on description
@@ -147,8 +142,8 @@ namespace Infrastructure.Common
             return osid;
         }
 
-        // Maps from the $(TestNugetRuntimeId) property to corresponding OSID.
-        // Returns OSID.None if cannot determine the OSID.
+        // The $(TestNugetRuntimeId) property was deprecated in build tools v2.
+        // No longer calling this method.
         private static OSID OSIDfromTestRuntime()
         {
             string testRuntime = TestProperties.GetProperty(TestProperties.TestNugetRuntimeId_PropertyName);
@@ -225,6 +220,33 @@ namespace Infrastructure.Common
             }
 
             return OSID.None;
+        }
+
+        public static OSID OSIDfromRuntimeEnvironment()
+        {
+            var testRuntime = Microsoft.DotNet.PlatformAbstractions.RuntimeEnvironment.GetRuntimeIdentifier();
+            if (string.IsNullOrEmpty(testRuntime))
+            {
+                return OSID.None;
+            }
+
+            foreach (var pair in _runtimeToOSID)
+            {
+                string runtime = pair.Item1;
+                if (testRuntime.IndexOf(runtime, StringComparison.OrdinalIgnoreCase) >= 0)
+                {
+                    return pair.Item2;
+                }
+            }
+            return OSID.None;
+        }
+
+        // Needed when enabling test case OSAndFrameworkTests.ListAllOSRIDs
+        // For the purpose of determining the actual RID string being returned by lab machine
+        // Useful when new OSes are added to the lab runs
+        public static string GetRuntimeIdentifier()
+        {
+            return Microsoft.DotNet.PlatformAbstractions.RuntimeEnvironment.GetRuntimeIdentifier();
         }
     }
 }

--- a/src/System.Private.ServiceModel/tests/Common/Infrastructure/OsID.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Infrastructure/OsID.cs
@@ -36,31 +36,35 @@ namespace Infrastructure.Common
              Windows_Server_2008 | Windows_Server_2008_R2 | Windows_Server_2012 | Windows_Server_2012_R2 | Windows_Server_2016 |
              WindowsPhone | Windows_Nano,
 
-        CentOS_7 =               0x00000800,
-        CentOS_7_1 =             0x00001000,
-        AnyCentOS = CentOS_7 | CentOS_7_1,
+        CentOS_7 =             0x00000800,
+        CentOS_7_3 =             0x00001000,
+        AnyCentOS = CentOS_7 | CentOS_7_3,
 
         Debian_8 =               0x00002000,
-        Debian_8_2 =             0x00004000, 
-        AnyDebian = Debian_8 | Debian_8_2,
+        Debian_9 =               0x00004000,
+        AnyDebian = Debian_8 | Debian_9,
 
-        Fedora_23 =              0x00008000,
-        AnyFedora = Fedora_23,
+        Fedora_26 =              0x00008000,
+        Fedora_27 =              0x00010000,
+        AnyFedora = Fedora_26 | Fedora_27,
 
-        OpenSUSE_13_2 =          0x00010000,
-        AnyOpenSUSE = OpenSUSE_13_2,
+        OpenSUSE_13_2 =          0x00020000,
+        OpenSUSE_42_3 =          0x00040000,
+        SLES_12 =                0x00080000,
+        AnyOpenSUSE = OpenSUSE_13_2 | OpenSUSE_42_3 | SLES_12,
 
-        OSX_10_10 =              0x00020000,
-        OSX_10_11 =              0x00040000,
-        OSX_10_12 =              0x00080000,
-        AnyOSX = OSX_10_10 | OSX_10_11 | OSX_10_12,
+        OSX_10_11 =              0x00100000,
+        OSX_10_12 =              0x00200000,
+        OSX_10_13 =              0x00400000,
+        AnyOSX = OSX_10_11 | OSX_10_12 | OSX_10_13,
 
-        RHEL_7 =                 0x00100000,
+        RHEL_7 =                 0x00800000,
         AnyRHEL = RHEL_7,
 
-        Ubuntu_14_04 =           0x00200000,
-        Ubuntu_16_04 =           0x00400000,
-        AnyUbuntu = Ubuntu_14_04 | Ubuntu_16_04,
+        Ubuntu_14_04 =           0x01000000,
+        Ubuntu_16_04 =           0x02000000,
+        Ubuntu_17_10 =           0x04000000,
+        AnyUbuntu = Ubuntu_14_04 | Ubuntu_16_04 | Ubuntu_17_10,
 
         // Note, check all values to work out the next number. OSX_10_12 is out of sequence as it
         // appeared after all the previous values has already been assigned.

--- a/src/System.Private.ServiceModel/tests/Common/Infrastructure/testproperties.targets
+++ b/src/System.Private.ServiceModel/tests/Common/Infrastructure/testproperties.targets
@@ -49,7 +49,6 @@ namespace Infrastructure.Common
         public static readonly string ExplicitUserName_PropertyName = "ExplicitUserName"%3B
         public static readonly string ExplicitPassword_PropertyName = "ExplicitPassword"%3B
         public static readonly string SSL_Available_PropertyName = "SSL_Available"%3B
-        public static readonly string TestNugetRuntimeId_PropertyName = "TestNugetRuntimeId"%3B
         public static readonly string IncludeTestsWithIssues_PropertyName = "IncludeTestsWithIssues"%3B
                 
         static partial void Initialize(Dictionary<string, string> properties)
@@ -86,7 +85,6 @@ namespace Infrastructure.Common
             properties["ExplicitUserName"] = "$(ExplicitUserName)"%3B
             properties["ExplicitPassword"] = "$(ExplicitPassword)"%3B
             properties["SSL_Available"] = "$(SSL_Available)"%3B
-            properties["TestNugetRuntimeId"] = "$(TestNugetRuntimeId)"%3B
             properties["IncludeTestsWithIssues"] = "$(IncludeTestsWithIssues)"%3B
         }
     }

--- a/src/System.Private.ServiceModel/tests/Scenarios/Infrastructure/OSAndFrameworkTests.4.1.1.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Infrastructure/OSAndFrameworkTests.4.1.1.cs
@@ -18,16 +18,14 @@ public class OSAndFrameworkTests
                                    RuntimeInformation.FrameworkDescription));
     }
 
-    [Issue(2024)]
     [WcfFact]
     [OuterLoop]
     public static void OSID_Was_Detected()
     {
         Assert.True(OSHelper.Current != OSID.None,
-                    String.Format("OSID was not properly detected from:{0}  TestProperties[TestNugetRuntimeId] = \"{1}\"{0}  RuntimeInformation.OSDescription = \'{2}\"",
-                                   Environment.NewLine,
-                                   TestProperties.GetProperty(TestProperties.TestNugetRuntimeId_PropertyName),
-                                   RuntimeInformation.OSDescription));
+                String.Format("OSID was not properly detected:{0}  The RuntimeInformation.OSDescription is = \'{1}\"",
+                               Environment.NewLine,
+                               RuntimeInformation.OSDescription));
     }
 
     [WcfFact]
@@ -51,5 +49,20 @@ public class OSAndFrameworkTests
         Assert.True(formatted.Contains("Windows_7") && formatted.Contains("Ubuntu_14_04"),
                     String.Format("FrameworkID.Name should have contained Windows_7 and Ubuntu_14_04, but actual was \"{0}\"", formatted));
     }
-}
 
+    // Enable this test to get the RID string of lab machines.
+    // New RIDs should be added to Infrastructure.Common OSHelper and OSID classes.
+    [Issue(0000)]
+    [WcfFact]
+    [OuterLoop]
+    public static void ListAllOSRIDs()
+    {
+        string testRuntime = OSHelper.GetRuntimeIdentifier();
+        OSID id = OSHelper.OSIDfromRuntimeEnvironment();
+        string runtimeOSDescription = RuntimeInformation.OSDescription;
+
+        Assert.True(false, string.Format("Detected the current Runtime Identifier as: '{0}'\n" + 
+                                         "Which maps to OSID: '{1}'\n" +
+                                           "Detected the current runtimeOSDescription as: '{2}'", testRuntime, id.Name(), runtimeOSDescription));
+    }
+}


### PR DESCRIPTION
* This has been broken since moving to buildtoolsv2 as the 'TestNugetRuntimeId' property that was used for this purpose was removed.
* Also removing a few OS versions that are EOL and adding a couple new ones.
* Adding a test case that can be enabled whenever a new OS version is added to the lab so the RID can be confirmed in a temp run and then added to Infrastructure.Common