### PR TITLE
Skip test WebSocket_Https_Duplex_TextStreamed

### DIFF
--- a/src/System.Private.ServiceModel/tests/Scenarios/Extensibility/WebSockets/WebSocketTests.4.1.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Extensibility/WebSockets/WebSocketTests.4.1.0.cs
@@ -268,6 +268,7 @@ public class WebSocketTests : ConditionalWcfTest
     [WcfFact]
     [Issue(526, Framework = FrameworkID.NetNative)]
     [Issue(1438, OS = OSID.Windows_7)]  // not supported on Win7
+    [Issue(2561, OS = OSID.SLES_12)] // Active Issue - needs investigation
     [OuterLoop]
     public static void WebSocket_Https_Duplex_TextStreamed()
     {


### PR DESCRIPTION
* Skip while the failure is investigated.
* Only failing on SLES, not other Linux OSes or even opensuse.423

Tracked with Issue #2561