### PR TITLE
Make BasicHttpSecurity default constructor public in the contract.

### DIFF
--- a/src/System.Private.ServiceModel/src/System/ServiceModel/BasicHttpSecurity.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/BasicHttpSecurity.cs
@@ -31,9 +31,15 @@ namespace System.ServiceModel
             get { return _mode; }
             set
             {
+                if (value == BasicHttpSecurityMode.Message ||
+                    value == BasicHttpSecurityMode.TransportWithMessageCredential)
+                {
+                    throw ExceptionHelper.PlatformNotSupported(SR.Format(SR.UnsupportedSecuritySetting, nameof(value), value));
+                }
+
                 if (!BasicHttpSecurityModeHelper.IsDefined(value))
                 {
-                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("value"));
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException(nameof(value)));
                 }
                 _mode = value;
             }

--- a/src/System.ServiceModel.Http/ref/System.ServiceModel.Http.cs
+++ b/src/System.ServiceModel.Http/ref/System.ServiceModel.Http.cs
@@ -22,7 +22,7 @@ namespace System.ServiceModel
     }
     public sealed partial class BasicHttpSecurity
     {
-        internal BasicHttpSecurity() { }
+        public BasicHttpSecurity() { }
         public System.ServiceModel.BasicHttpSecurityMode Mode { get { return default(System.ServiceModel.BasicHttpSecurityMode); } set { } }
         public System.ServiceModel.HttpTransportSecurity Transport { get { return default(System.ServiceModel.HttpTransportSecurity); } set { } }
     }

--- a/src/System.ServiceModel.Http/tests/ServiceModel/BasicHttpSecurityTest.cs
+++ b/src/System.ServiceModel.Http/tests/ServiceModel/BasicHttpSecurityTest.cs
@@ -1,0 +1,25 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+
+using System;
+using System.ServiceModel;
+using System.ServiceModel.Channels;
+using System.ServiceModel.Tests.Common;
+using System.Text;
+using System.Xml;
+using Infrastructure.Common;
+using Xunit;
+
+public static class BasicHttpSecurityTest
+{
+    [WcfTheory]
+    [InlineData(BasicHttpSecurityMode.Message)]
+    [InlineData(BasicHttpSecurityMode.TransportWithMessageCredential)]
+    public static void BasicHttpSecurity_MessageSecurityMode_ThrowsPNSE(BasicHttpSecurityMode value)
+    {
+        var security = new BasicHttpSecurity();
+        Assert.Throws<PlatformNotSupportedException>(() => security.Mode = value);
+    }
+}


### PR DESCRIPTION
* Already public in the implementation.
* If BasicHttpSecurityMode is set to Message or TransportWithMessageCredential throw PNSE.
* Fixes #2365 
* Including a unit test.