### PR TITLE
Move win7 harvested binaries under runtimes/win/lib

### DIFF
--- a/src/System.Private.ServiceModel/pkg/System.Private.ServiceModel.pkgproj
+++ b/src/System.Private.ServiceModel/pkg/System.Private.ServiceModel.pkgproj
@@ -7,8 +7,12 @@
   <ItemGroup>
     <ProjectReference Include="..\src\System.Private.ServiceModel.csproj" />
     <HarvestIncludePaths Include="runtimes/unix/lib/netstandard1.3" />
-    <HarvestIncludePaths Include="runtimes/win7/lib/netstandard1.3" />
-    <HarvestIncludePaths Include="runtimes/win7/lib/netcore50" />
+    <HarvestIncludePaths Include="runtimes/win7/lib/netstandard1.3">
+      <TargetPath>runtimes/win/lib/netstandard1.3</TargetPath>
+    </HarvestIncludePaths>
+    <HarvestIncludePaths Include="runtimes/win7/lib/netcore50">
+      <TargetPath>runtimes/win/lib/netcore50</TargetPath>
+    </HarvestIncludePaths>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 


### PR DESCRIPTION
* On Win10 machines NuGet is picking win7 instead of win which is technically correct.
* Moving the win7 assets under win/lib/<TFM> fixes the problem.