### PR TITLE
Skipping test case for WCF Issue #2624

### DIFF
--- a/src/System.Private.ServiceModel/tests/Scenarios/Binding/Http/BasicHttpBindingTests.4.0.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Binding/Http/BasicHttpBindingTests.4.0.0.cs
@@ -46,6 +46,7 @@ public static class Binding_Http_BasicHttpBindingTests
 
     [WcfFact]
     [OuterLoop]
+    [Issue(2624, OperatingSystem = OSID.OSX_10_13 | OSID.Debian_9 | OSID.AnyFedora)]
     public static void HttpKeepAliveDisabled_Echo_RoundTrips_True()
     {
         ChannelFactory<IWcfService> factory = null;

--- a/src/System.Private.ServiceModel/tests/Scenarios/Binding/Http/BasicHttpBindingTests.4.0.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Binding/Http/BasicHttpBindingTests.4.0.0.cs
@@ -46,7 +46,7 @@ public static class Binding_Http_BasicHttpBindingTests
 
     [WcfFact]
     [OuterLoop]
-    [Issue(2624, OperatingSystem = OSID.OSX_10_13 | OSID.Debian_9 | OSID.AnyFedora)]
+    [Issue(2624, OS = OSID.OSX_10_13 | OSID.Debian_9 | OSID.AnyFedora)]
     public static void HttpKeepAliveDisabled_Echo_RoundTrips_True()
     {
         ChannelFactory<IWcfService> factory = null;


### PR DESCRIPTION
* Test case: Binding_Http_BasicHttpBindingTests/HttpKeepAliveDisabled_Echo_RoundTrips_True