### PR TITLE
Skipping test case for WCF Issue #2626

### DIFF
--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/ExpectedExceptions/ExpectedExceptionTests.4.1.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/ExpectedExceptions/ExpectedExceptionTests.4.1.0.cs
@@ -53,6 +53,7 @@ public partial class ExpectedExceptionTests : ConditionalWcfTest
 
     [WcfFact]
     [Issue(1717, Framework = FrameworkID.NetNative)]
+    [Issue(2626, OS = OSID.OSX_10_13)]
     [OuterLoop]
     public static void ServiceRestart_Throws_CommunicationException()
     {


### PR DESCRIPTION
* Test Case: ExpectedExceptionTests/ServiceRestart_Throws_CommunicationException