### PR TITLE
Port of dotnet/corefx#25644

### DIFF
--- a/run.cmd
+++ b/run.cmd
@@ -34,6 +34,12 @@ if not defined VisualStudioVersion (
 :: misleading value (such as 'MCD' in HP PCs) may lead to build breakage (issue: #69).
 set Platform=
 
+
+:: Disable telemetry, first time experience, and global sdk look for the CLI
+set DOTNET_CLI_TELEMETRY_OPTOUT=1
+set DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
+set DOTNET_MULTILEVEL_LOOKUP=0
+
 :: Restore the Tools directory
 call %~dp0init-tools.cmd
 if NOT [%ERRORLEVEL%]==[0] exit /b 1

--- a/run.sh
+++ b/run.sh
@@ -2,6 +2,11 @@
 
 __scriptpath=$(cd "$(dirname "$0")"; pwd -P)
 
+# Disable telemetry, first time experience, and global sdk look for the CLI
+export DOTNET_CLI_TELEMETRY_OPTOUT=1
+export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
+export DOTNET_MULTILEVEL_LOOKUP=0
+
 # Source the init-tools.sh script rather than execute in order to preserve ulimit values in child-processes. https://github.com/dotnet/corefx/issues/19152
 . $__scriptpath/init-tools.sh
 


### PR DESCRIPTION
* Restoring buildtools failed with...
* NuGet.Configuration.NuGetConfigurationException: Failed to read NuGet.Config due to unauthorized access.
* This PR in CoreFx fixes the problem.