### PR TITLE
Updating UAPvNext TFM

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -11,7 +11,7 @@
 
   <!-- Define vNext UAP Moniker -->
   <PropertyGroup>
-    <UAPvNextVersion>10.0.15138</UAPvNextVersion>
+    <UAPvNextVersion>10.0.16300</UAPvNextVersion>
     <UAPvNextTFMFull>UAP,Version=v$(UAPvNextVersion)</UAPvNextTFMFull>
     <UAPvNextTFM>uap$(UAPvNextVersion)</UAPvNextTFM>
   </PropertyGroup>

--- a/pkg/baseline/packageIndex.json
+++ b/pkg/baseline/packageIndex.json
@@ -36,7 +36,9 @@
         "4.3.1"
       ],
       "BaselineVersion": "4.5.0",
-      "InboxOn": {},
+      "InboxOn": {
+        "uap10.0.16299": "4.1.1.0"
+      },
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.0.1.0": "4.0.1",
@@ -55,7 +57,9 @@
         "4.3.1"
       ],
       "BaselineVersion": "4.5.0",
-      "InboxOn": {},
+      "InboxOn": {
+        "uap10.0.16299": "4.1.3.0"
+      },
       "AssemblyVersionInPackageVersion": {
         "3.9.0.0": "3.9.0",
         "4.0.0.0": "4.0.0",
@@ -74,7 +78,9 @@
         "4.3.1"
       ],
       "BaselineVersion": "4.5.0",
-      "InboxOn": {},
+      "InboxOn": {
+        "uap10.0.16299": "4.1.3.0"
+      },
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
         "4.1.0.0": "4.1.0",
@@ -92,7 +98,9 @@
         "4.3.1"
       ],
       "BaselineVersion": "4.5.0",
-      "InboxOn": {},
+      "InboxOn": {
+        "uap10.0.16299": "4.2.1.0"
+      },
       "AssemblyVersionInPackageVersion": {
         "3.9.0.0": "3.9.0",
         "4.0.0.0": "4.0.0",
@@ -111,7 +119,9 @@
         "4.3.1"
       ],
       "BaselineVersion": "4.5.0",
-      "InboxOn": {},
+      "InboxOn": {
+        "uap10.0.16299": "4.0.4.0"
+      },
       "AssemblyVersionInPackageVersion": {
         "3.9.0.0": "3.9.0",
         "4.0.0.0": "4.0.0",

--- a/src/System.ServiceModel.Http/pkg/System.ServiceModel.Http.pkgproj
+++ b/src/System.ServiceModel.Http/pkg/System.ServiceModel.Http.pkgproj
@@ -27,6 +27,11 @@
       <!-- Supported inbox by all ns1.0-1.2 frameworks -->
       <Value>.NETStandard,Version=v1.0;.NETStandard,Version=v1.1;.NETStandard,Version=v1.2</Value>
     </ValidatePackageSuppression>
+    <!-- Implementation shipped inbox on UAP but we want to keep it as out of box so that we can keep
+    making API changes -->
+    <ValidatePackageSuppression Include="TreatAsOutOfBox">
+      <Value>UAP</Value>
+    </ValidatePackageSuppression>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.ServiceModel.NetTcp/pkg/System.ServiceModel.NetTcp.pkgproj
+++ b/src/System.ServiceModel.NetTcp/pkg/System.ServiceModel.NetTcp.pkgproj
@@ -26,6 +26,11 @@
       <!-- Supported inbox by all ns1.0-1.2 frameworks -->
       <Value>.NETStandard,Version=v1.1;.NETStandard,Version=v1.2</Value>
     </ValidatePackageSuppression>
+    <!-- Implementation shipped inbox on UAP but we want to keep it as out of box so that we can keep
+    making API changes -->
+    <ValidatePackageSuppression Include="TreatAsOutOfBox">
+      <Value>UAP</Value>
+    </ValidatePackageSuppression>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>


### PR DESCRIPTION
cc: @zhenlan @weshaggard @ericstj 

Updating the UAP TFM on WCF to match corefx.

@ericstj I didn't update the packageIndex inboOn for uap RS3, since these guys are a bit special given that we still had assets that applied to RS3 on the packages. Do we want to update the package index and have these guys have a placeholder for RS3 instead? or should we do the TreatAsOutOfBox supression?