### PR TITLE
Workaround for GitHub disabling weak crypto.

### DIFF
--- a/UpdatePublishedVersions.ps1
+++ b/UpdatePublishedVersions.ps1
@@ -16,7 +16,7 @@ param(
     # A pattern matching all packages in the set that the versions repository should be set to.
     [Parameter(Mandatory=$true)][string]$nupkgPath)
 
-. "$PSScriptRoot\build-managed.cmd" -- /t:UpdatePublishedVersions `
+. "$PSScriptRoot\Tools\dotnetcli\dotnet.exe" Tools\msbuild.exe build.proj /t:UpdatePublishedVersions `
     /p:GitHubUser="$gitHubUser" `
     /p:GitHubEmail="$gitHubEmail" `
     /p:GitHubAuthToken="$gitHubAuthToken" `


### PR DESCRIPTION
* Needed to publish build info to dotnet/versions.
* See https://github.com/dotnet/core-eng/issues/2734
* See https://github.com/dotnet/core-eng/issues/2772