### PR TITLE
Fix http timeout on windows

### DIFF
--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/ServiceModelHttpMessageHandler.CoreClr.Windows.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/ServiceModelHttpMessageHandler.CoreClr.Windows.cs
@@ -7,6 +7,7 @@ using System.Net;
 using System.Net.Http;
 using System.Net.Security;
 using System.Security.Cryptography.X509Certificates;
+using System.Threading;
 
 namespace System.ServiceModel.Channels
 {
@@ -18,6 +19,12 @@ namespace System.ServiceModel.Channels
         public ServiceModelHttpMessageHandler()
         {
             _innerHandler = new WinHttpHandler();
+            // WCF doesn't care about the granular WinHttpHandler timeout properties and the default value is 30 seconds
+            // so we need to set them to infinite and allow the HttpClient.Timeout property to have precedence.
+            _innerHandler.ReceiveHeadersTimeout = Timeout.InfiniteTimeSpan;
+            _innerHandler.ReceiveDataTimeout = Timeout.InfiniteTimeSpan;
+            _innerHandler.SendTimeout = Timeout.InfiniteTimeSpan;
+
             InnerHandler = _innerHandler;
         }
 

--- a/src/System.Private.ServiceModel/tests/Common/Infrastructure/ConditionalTestDetectors.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Infrastructure/ConditionalTestDetectors.cs
@@ -180,6 +180,12 @@ namespace Infrastructure.Common
             return !String.IsNullOrWhiteSpace(GetUPN());
         }
 
+        // Returns false to provide default to non-detectable test condition
+        public static bool DontRunDefault()
+        {
+            return false;
+        }
+
         // Returns the explicit user name if available
         internal static string GetExplicitUserName()
         {

--- a/src/System.Private.ServiceModel/tests/Common/Infrastructure/ConditionalWcfTest.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Infrastructure/ConditionalWcfTest.cs
@@ -305,6 +305,13 @@ namespace Infrastructure.Common
                                      ConditionalTestDetectors.IsWindows);
         }
 
+        // Returns 'true' is Long Running tests are enabled
+        public static bool Long_Running()
+        {
+            return GetConditionValue(nameof(Long_Running),
+                                     ConditionalTestDetectors.DontRunDefault);
+        }
+
         // Returns the Domain if available.
         // TestProperties takes precedence, but if it has not been specified
         // and this is a Windows client, we infer it.

--- a/src/System.Private.ServiceModel/tests/Common/Infrastructure/testproperties.props
+++ b/src/System.Private.ServiceModel/tests/Common/Infrastructure/testproperties.props
@@ -131,6 +131,10 @@
       <SSL_Available></SSL_Available>
     </PropertyGroup>
 
+    <PropertyGroup Condition="'$(Long_Running)' == ''">
+      <Long_Running></Long_Running>
+    </PropertyGroup>
+
     <!-- The default value of $(IncludeTestsWithIssues) is blank, which is equivalent fo 'false'.
          The check of $(WithCategories) preserves the convention used by other repo's where the
          keyword 'failing' inside $(WithCategories) asks that tests with [ActiveIssue] be run.

--- a/src/System.Private.ServiceModel/tests/Common/Infrastructure/testproperties.targets
+++ b/src/System.Private.ServiceModel/tests/Common/Infrastructure/testproperties.targets
@@ -50,6 +50,7 @@ namespace Infrastructure.Common
         public static readonly string SSL_Available_PropertyName = "SSL_Available"%3B
         public static readonly string TestNugetRuntimeId_PropertyName = "TestNugetRuntimeId"%3B
         public static readonly string IncludeTestsWithIssues_PropertyName = "IncludeTestsWithIssues"%3B
+        public static readonly string Long_Running_PropertyName = "Long_Running"%3B
                 
         static partial void Initialize(Dictionary<string, string> properties)
         {
@@ -86,6 +87,7 @@ namespace Infrastructure.Common
             properties["SSL_Available"] = "$(SSL_Available)"%3B
             properties["TestNugetRuntimeId"] = "$(TestNugetRuntimeId)"%3B
             properties["IncludeTestsWithIssues"] = "$(IncludeTestsWithIssues)"%3B
+            properties["Long_Running"] = "$(Long_Running)"%3B
         }
     }
 }

--- a/src/System.Private.ServiceModel/tests/Scenarios/Binding/Http/BasicHttpBindingTests.4.0.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Binding/Http/BasicHttpBindingTests.4.0.0.cs
@@ -8,7 +8,7 @@ using System.ServiceModel.Channels;
 using Infrastructure.Common;
 using Xunit;
 
-public static class Binding_Http_BasicHttpBindingTests
+public class Binding_Http_BasicHttpBindingTests : ConditionalWcfTest
 {
     [WcfFact]
     [OuterLoop]
@@ -35,6 +35,47 @@ public static class Binding_Http_BasicHttpBindingTests
             // *** CLEANUP *** \\
             factory.Close();
             ((ICommunicationObject)serviceProxy).Close();
+        }
+        finally
+        {
+            // *** ENSURE CLEANUP *** \\
+            ScenarioTestHelpers.CloseCommunicationObjects((ICommunicationObject)serviceProxy, factory);
+        }
+    }
+
+    [WcfFact]
+    [Condition(nameof(Long_Running))]
+    [OuterLoop]
+    public static void EchoWithTimeout_LongTimeout_RoundTrips_String()
+    {
+        TimeSpan serviceOperationTimeout = TimeSpan.FromMilliseconds(65000);
+        TimeSpan bindingSendTimeout = TimeSpan.FromMilliseconds(75000);
+        ChannelFactory<IWcfService> factory = null;
+        IWcfService serviceProxy = null;
+        string testString = "Hello";
+        BasicHttpBinding binding = null;
+
+        try
+        {
+            // *** SETUP *** \\
+            binding = new BasicHttpBinding();
+            binding.SendTimeout = bindingSendTimeout;
+            factory = new ChannelFactory<IWcfService>(binding, new EndpointAddress(Endpoints.HttpBaseAddress_Basic));
+            serviceProxy = factory.CreateChannel();
+
+            // *** EXECUTE *** \\
+            string result = serviceProxy.EchoWithTimeout(testString, serviceOperationTimeout);
+
+            // *** VALIDATE *** \\
+            Assert.True(result == testString,
+                String.Format("Error: expected response from service: '{0}' Actual was: '{1}'", testString, result));
+
+            // *** CLEANUP *** \\
+            factory.Close();
+            ((ICommunicationObject) serviceProxy).Close();
+
+            // *** ENSURE CLEANUP *** \\
+            ScenarioTestHelpers.CloseCommunicationObjects((ICommunicationObject) serviceProxy, factory);
         }
         finally
         {


### PR DESCRIPTION
Also adds test that's only enabled when setting the Long_Running property. This is to enable running the test in CI and nightly's but not slow down individual local runs.