### PR TITLE
Update the buildtools and xunit runner packages

### DIFF
--- a/BuildToolsVersion.txt
+++ b/BuildToolsVersion.txt
@@ -1,1 +1,1 @@
-2.0.0-prerelease-01803-02
+2.0.0-prerelease-01902-02

--- a/external/test-runtime/XUnit.Runtime.depproj
+++ b/external/test-runtime/XUnit.Runtime.depproj
@@ -83,6 +83,16 @@
     <PackageToInclude Include="$(XUnitRunnerPackageId)" />
   </ItemGroup>
 
+  <PropertyGroup Condition="'$(TargetGroup)' == 'uap'">
+    <UAPToolsPackageVersion>1.0.14</UAPToolsPackageVersion>
+  </PropertyGroup>
+ 
+  <ItemGroup Condition="'$(TargetGroup)' == 'uap'">
+    <PackageReference Include="Microsoft.DotNet.UAP.TestTools">
+      <Version>$(UAPToolsPackageVersion)</Version>
+    </PackageReference>
+  </ItemGroup>  
+
   <ItemGroup Condition="'$(TargetGroup)' != 'uapaot'">
     <PackageToInclude Include="xunit.performance.core"/>
     <PackageToInclude Include="xunit.performance.api"/>
@@ -101,10 +111,9 @@
           Condition="'$(TargetGroup)'=='uap'" >
 
     <PropertyGroup>
-      <UAPToolsPackageVersion>1.0.2</UAPToolsPackageVersion>
       <UAPToolsPackageName>microsoft.dotnet.uap.testtools</UAPToolsPackageName>
 
-      <UAPToolsFolder Condition="'$(UAPToolsFolder)'==''">$(PackagesDir)$(UAPToolsPackageName)\$(UAPToolsPackageVersion)\Tools</UAPToolsFolder>
+      <UAPToolsFolder Condition="'$(UAPToolsFolder)'==''">$(PackagesDir)$(UAPToolsPackageName)\$(UAPToolsPackageVersion)\Tools\$(ArchGroup)</UAPToolsFolder>
       <UAPToolsFolder>$(UAPToolsFolder.Replace('/', '\'))</UAPToolsFolder>
     </PropertyGroup>
 

--- a/external/test-runtime/optional.json
+++ b/external/test-runtime/optional.json
@@ -3,7 +3,6 @@
     "net45": {
       "dependencies": {
         "Microsoft.DotNet.IBCMerge": "4.6.0-alpha-00001",
-        "Microsoft.DotNet.UAP.TestTools": "1.0.2",
         "TestILC.amd64ret": "1.0.0-beta-25331-00",
         "TestILC.armret": "1.0.0-beta-25331-00",
         "TestILC.x86ret": "1.0.0-beta-25331-00"


### PR DESCRIPTION
Lengthy explanation but want to make sure I capture all the info in one place.

In order to move to TLS 1.2 Security Protocol as required by GitHubClient @MattGal created a buildtools branch for uwp6.1 containing [This Fix](https://github.com/dotnet/buildtools/commit/1459748487f6da9be11806fda384f7ab56f5ce4c).

This new buildtools uwp6.1 branch was snapped before [This Fix](https://github.com/dotnet/buildtools/pull/1630) was made in buildtools that fixed a [CoreClr breaking change](https://github.com/dotnet/wcf/pull/2157) for any Repos that have external dependencies.

A PR will be ready in buildtools shortly to update the uwp6.1 branch with the fix from @safern (tracked with dotnet/buildtools#1954)

This PR is a cherry-pick of @tarekgh 's #2151 which is needed together with the buildtools change.

Once buildtools uwp6.1 has been fixed we will create a buildtools uwp6.0 branch and update this WCF uwp6.0 to use that buildtools version.

All of this applies to our WCF uwp6.1 branch as well.