### PR TITLE
Download packages for harvesting.

### DIFF
--- a/pkg/baseline/project.json
+++ b/pkg/baseline/project.json
@@ -1,11 +1,11 @@
 {
   "dependencies": {
     "Microsoft.Private.PackageBaseline": "2.0.0-preview3-25519-03",
-    "System.ServiceModel.Duplex": "4.3.0",
-    "System.ServiceModel.Http": "4.3.0",
-    "System.ServiceModel.NetTcp": "4.3.0",
-    "System.ServiceModel.Primitives": "4.3.0",
-    "System.ServiceModel.Security": "4.3.0"
+    "System.ServiceModel.Duplex": "4.3.1",
+    "System.ServiceModel.Http": "4.3.1",
+    "System.ServiceModel.NetTcp": "4.3.1",
+    "System.ServiceModel.Primitives": "4.3.1",
+    "System.ServiceModel.Security": "4.3.1"
   },
   "frameworks": {
     "netstandard1.6": {}


### PR DESCRIPTION
* The last servicing release of branch 2.0.0 was simultaneous with the servicing release of 1.1.0, since 2.0.0 is a 'fat package' it also contains 1.1.0 binaries. Because of the simultaneous release the new 1.1.0 packages (4.3.1) were not yet on NuGet, therefore we had to privately provide 2.0.0 the "not-yet released" 1.1.0 package in order to build the package for 2.0.0.
* Updating 2.0.0 so that it pulls down the 1.1.0 packages it needs from NuGet for harvesting.

Fixes #2658 