### PR TITLE
Update release/2.1.0 to use latest preview2 buildtools version.

### DIFF
--- a/dependencies.props
+++ b/dependencies.props
@@ -14,7 +14,7 @@
     <StandardCurrentRef>6298244e25cf84d91e3cda9627315f2425274624</StandardCurrentRef>
     <ProjectNTfsCurrentRef>65f2e19b242b2d5ba1a3b058d01130cef8e8c045</ProjectNTfsCurrentRef>
     <ProjectNTfsTestILCCurrentRef>65f2e19b242b2d5ba1a3b058d01130cef8e8c045</ProjectNTfsTestILCCurrentRef>
-    <BuildToolsCurrentRef>39ff9d67dee0e90452f4c23a7c9edf5b74cf1ff1</BuildToolsCurrentRef>
+    <BuildToolsCurrentRef>60ae25a6bc387949a93a2542a39f9c07deda4811</BuildToolsCurrentRef>
     <CoreClrCurrentRef>39ff9d67dee0e90452f4c23a7c9edf5b74cf1ff1</CoreClrCurrentRef>
   </PropertyGroup>
 
@@ -41,7 +41,7 @@
     <AppXRunnerVersion>1.0.3-prerelease-00921-01</AppXRunnerVersion>
     <CoreFxBaseLinePackageVersion>2.2.0-preview1-26216-02</CoreFxBaseLinePackageVersion>
     <XunitPerfAnalysisPackageVersion>1.0.0-beta-build0015</XunitPerfAnalysisPackageVersion>
-    <XunitNetcoreExtensionsVersion>2.1.0-preview1-02609-02</XunitNetcoreExtensionsVersion>
+    <XunitNetcoreExtensionsVersion>2.1.0-preview2-02621-01</XunitNetcoreExtensionsVersion>
 
     <CoreClrPackageVersion>2.1.0-preview1-26216-04</CoreClrPackageVersion>
     <DotNetHostPackageVersion>2.0.0-preview2-25310-02</DotNetHostPackageVersion>
@@ -53,7 +53,7 @@
   <!-- Package versions used as toolsets -->
   <PropertyGroup>
     <FeedTasksPackage>Microsoft.DotNet.Build.Tasks.Feed</FeedTasksPackage>
-    <FeedTasksPackageVersion>2.1.0-preview1-02609-02</FeedTasksPackageVersion>
+    <FeedTasksPackageVersion>2.1.0-preview2-02621-01</FeedTasksPackageVersion>
   </PropertyGroup>
 
   <!-- Package dependency verification/auto-upgrade configuration. -->


### PR DESCRIPTION
Current set of CI failures for PRs in release/2.1.0 are in part because we need to update the buildtools version and the Microsoft.DotNet.Build.Tasks.Feed package.