### PR TITLE
Update manual dependencies for release/2.1

### DIFF
--- a/dependencies.props
+++ b/dependencies.props
@@ -14,20 +14,21 @@
     <StandardCurrentRef>6298244e25cf84d91e3cda9627315f2425274624</StandardCurrentRef>
     <BuildToolsCurrentRef>b00fcd5465aea9a6cbf0762aa0f34f33cd7a208a</BuildToolsCurrentRef>
     <CoreClrCurrentRef>d5ab69777647515ec8671bd46ad19aeafa289dd1</CoreClrCurrentRef>
+    <CoreSetupCurrentRef>d5ab69777647515ec8671bd46ad19aeafa289dd1</CoreSetupCurrentRef>
   </PropertyGroup>
 
   <!-- Auto-upgraded properties for each build info dependency. -->
   <PropertyGroup>
     <WCFExpectedPrerelease>preview2-26328-01</WCFExpectedPrerelease>
-    <CoreFxExpectedPrerelease>preview2-26403-05</CoreFxExpectedPrerelease>
+    <CoreFxExpectedPrerelease>preview2-26404-05</CoreFxExpectedPrerelease>
     <NETStandardPackageVersion>2.0.1</NETStandardPackageVersion>
     <NETStandardPackageId>NETStandard.Library</NETStandardPackageId>
     <!--
       This property is used for many CoreFX packages, because they have the same
       versions. Make more properties for CoreFX if split versions are required.
     -->
-    <MicrosoftPrivateCoreFxNETCoreAppPackageVersion>4.5.0-preview2-26403-05</MicrosoftPrivateCoreFxNETCoreAppPackageVersion>
-    <MicrosoftPrivateCoreFxUAPPackageVersion>4.6.0-preview2-26403-05</MicrosoftPrivateCoreFxUAPPackageVersion>
+    <MicrosoftPrivateCoreFxNETCoreAppPackageVersion>4.5.0-preview2-26404-05</MicrosoftPrivateCoreFxNETCoreAppPackageVersion>
+    <MicrosoftPrivateCoreFxUAPPackageVersion>4.6.0-preview2-26404-05</MicrosoftPrivateCoreFxUAPPackageVersion>
 
     <ProjectNTfsExpectedPrerelease>beta-26123-01</ProjectNTfsExpectedPrerelease>
     <ProjectNTfsTestILCExpectedPrerelease>beta-26123-01</ProjectNTfsTestILCExpectedPrerelease>
@@ -37,15 +38,16 @@
   <!-- Full package version strings that are used in other parts of the build. -->
   <PropertyGroup>
     <AppXRunnerVersion>1.0.3-prerelease-00921-01</AppXRunnerVersion>
-    <CoreFxBaseLinePackageVersion>2.2.0-preview2-26403-05</CoreFxBaseLinePackageVersion>
+    <CoreFxBaseLinePackageVersion>2.2.0-preview2-26404-05</CoreFxBaseLinePackageVersion>
     <XunitPerfAnalysisPackageVersion>1.0.0-beta-build0018</XunitPerfAnalysisPackageVersion>
     <XunitNetcoreExtensionsVersion>2.1.0-preview2-02629-01</XunitNetcoreExtensionsVersion>
 
-    <CoreClrPackageVersion>2.1.0-preview2-26403-07</CoreClrPackageVersion>
-    <DotNetHostPackageVersion>2.1.0-preview2-26403-06</DotNetHostPackageVersion>
+    <CoreClrPackageVersion>2.1.0-preview2-26404-07</CoreClrPackageVersion>
+    <MicrosoftNETCoreDotNetHostPackageVersion>2.1.0-preview2-26404-04</MicrosoftNETCoreDotNetHostPackageVersion>
+    <MicrosoftNETCoreDotNetHostPolicyPackageVersion>2.1.0-preview2-26404-04</MicrosoftNETCoreDotNetHostPolicyPackageVersion>
 
     <!-- Microsoft.NETCore.Platforms is part of CoreFX, but allow separate upgrade. -->
-    <PlatformPackageVersion>2.1.0-preview2-26403-05</PlatformPackageVersion>
+    <PlatformPackageVersion>2.1.0-preview2-26404-05</PlatformPackageVersion>
   </PropertyGroup>
 
   <!-- Package versions used as toolsets -->
@@ -70,8 +72,6 @@
     <RemoteDependencyBuildInfo Include="CoreFx">
       <BuildInfoPath>$(BaseDotNetBuildInfo)corefx/$(CoreDependencyBranch)</BuildInfoPath>
       <CurrentRef>$(CoreFxCurrentRef)</CurrentRef>
-      <!-- manually pick up a new baseline in order to get package dependencies updated -->
-      <DisabledPackages>Microsoft.Private.PackageBaseline;NETStandard.Library</DisabledPackages>
     </RemoteDependencyBuildInfo>
     <RemoteDependencyBuildInfo Include="Standard">
       <BuildInfoPath>$(BaseDotNetBuildInfo)standard/release/2.0.0</BuildInfoPath>
@@ -84,6 +84,10 @@
     <RemoteDependencyBuildInfo Include="CoreClr">
       <BuildInfoPath>$(BaseDotNetBuildInfo)coreclr/$(CoreDependencyBranch)</BuildInfoPath>
       <CurrentRef>$(CoreClrCurrentRef)</CurrentRef>
+    </RemoteDependencyBuildInfo>
+    <RemoteDependencyBuildInfo Include="CoreSetup">
+      <BuildInfoPath>$(BaseDotNetBuildInfo)core-setup/$(CoreDependencyBranch)</BuildInfoPath>
+      <CurrentRef>$(CoreSetupCurrentRef)</CurrentRef>
     </RemoteDependencyBuildInfo>
 
     <DependencyBuildInfo Include="@(RemoteDependencyBuildInfo)">
@@ -109,6 +113,26 @@
       <Path>$(MSBuildThisFileFullPath)</Path>
       <ElementName>MicrosoftPrivateCoreFxUAPPackageVersion</ElementName>
       <PackageId>Microsoft.Private.CoreFx.UAP</PackageId>
+    </XmlUpdateStep>
+    <XmlUpdateStep Include="CoreFx">
+      <Path>$(MSBuildThisFileFullPath)</Path>
+      <ElementName>CoreFxBaseLinePackageVersion</ElementName>
+      <PackageId>Microsoft.Private.PackageBaseline</PackageId>
+    </XmlUpdateStep>
+    <XmlUpdateStep Include="CoreFx">
+      <Path>$(MSBuildThisFileFullPath)</Path>
+      <ElementName>PlatformPackageVersion</ElementName>
+      <PackageId>Microsoft.NETCore.Platforms</PackageId>
+    </XmlUpdateStep>
+    <XmlUpdateStep Include="CoreSetup">
+      <Path>$(MSBuildThisFileFullPath)</Path>
+      <ElementName>MicrosoftNETCoreDotNetHostPackageVersion</ElementName>
+      <PackageId>Microsoft.NETCore.DotNetHost</PackageId>
+    </XmlUpdateStep>
+    <XmlUpdateStep Include="CoreSetup">
+      <Path>$(MSBuildThisFileFullPath)</Path>
+      <ElementName>MicrosoftNETCoreDotNetHostPolicyPackageVersion</ElementName>
+      <PackageId>Microsoft.NETCore.DotNetHostPolicy</PackageId>
     </XmlUpdateStep>
     <XmlUpdateStep Include="Standard">
       <Path>$(MSBuildThisFileFullPath)</Path>

--- a/dependencies.props
+++ b/dependencies.props
@@ -9,7 +9,7 @@
        These ref versions are pulled from https://github.com/dotnet/versions.
   -->
   <PropertyGroup>
-    <CoreFxCurrentRef>32f4de432d25f9738e630d9ba66e22c94d1feee4</CoreFxCurrentRef>
+    <CoreFxCurrentRef>d5ab69777647515ec8671bd46ad19aeafa289dd1</CoreFxCurrentRef>
     <WCFCurrentRef>72c84cf65d2f9a9c93c279413820171adec596d8</WCFCurrentRef>
     <StandardCurrentRef>6298244e25cf84d91e3cda9627315f2425274624</StandardCurrentRef>
     <BuildToolsCurrentRef>b00fcd5465aea9a6cbf0762aa0f34f33cd7a208a</BuildToolsCurrentRef>
@@ -19,15 +19,15 @@
   <!-- Auto-upgraded properties for each build info dependency. -->
   <PropertyGroup>
     <WCFExpectedPrerelease>preview2-26328-01</WCFExpectedPrerelease>
-    <CoreFxExpectedPrerelease>preview2-26401-03</CoreFxExpectedPrerelease>
+    <CoreFxExpectedPrerelease>preview2-26403-05</CoreFxExpectedPrerelease>
     <NETStandardPackageVersion>2.0.1</NETStandardPackageVersion>
     <NETStandardPackageId>NETStandard.Library</NETStandardPackageId>
     <!--
       This property is used for many CoreFX packages, because they have the same
       versions. Make more properties for CoreFX if split versions are required.
     -->
-    <MicrosoftPrivateCoreFxNETCoreAppPackageVersion>4.5.0-preview2-26401-03</MicrosoftPrivateCoreFxNETCoreAppPackageVersion>
-    <MicrosoftPrivateCoreFxUAPPackageVersion>4.6.0-preview2-26401-03</MicrosoftPrivateCoreFxUAPPackageVersion>
+    <MicrosoftPrivateCoreFxNETCoreAppPackageVersion>4.5.0-preview2-26403-05</MicrosoftPrivateCoreFxNETCoreAppPackageVersion>
+    <MicrosoftPrivateCoreFxUAPPackageVersion>4.6.0-preview2-26403-05</MicrosoftPrivateCoreFxUAPPackageVersion>
 
     <ProjectNTfsExpectedPrerelease>beta-26123-01</ProjectNTfsExpectedPrerelease>
     <ProjectNTfsTestILCExpectedPrerelease>beta-26123-01</ProjectNTfsTestILCExpectedPrerelease>
@@ -37,15 +37,15 @@
   <!-- Full package version strings that are used in other parts of the build. -->
   <PropertyGroup>
     <AppXRunnerVersion>1.0.3-prerelease-00921-01</AppXRunnerVersion>
-    <CoreFxBaseLinePackageVersion>2.2.0-preview1-26216-02</CoreFxBaseLinePackageVersion>
+    <CoreFxBaseLinePackageVersion>2.2.0-preview2-26403-05</CoreFxBaseLinePackageVersion>
     <XunitPerfAnalysisPackageVersion>1.0.0-beta-build0018</XunitPerfAnalysisPackageVersion>
     <XunitNetcoreExtensionsVersion>2.1.0-preview2-02629-01</XunitNetcoreExtensionsVersion>
 
     <CoreClrPackageVersion>2.1.0-preview2-26403-07</CoreClrPackageVersion>
-    <DotNetHostPackageVersion>2.1.0-preview2-26314-02</DotNetHostPackageVersion>
+    <DotNetHostPackageVersion>2.1.0-preview2-26403-06</DotNetHostPackageVersion>
 
     <!-- Microsoft.NETCore.Platforms is part of CoreFX, but allow separate upgrade. -->
-    <PlatformPackageVersion>2.1.0-preview2-26314-06</PlatformPackageVersion>
+    <PlatformPackageVersion>2.1.0-preview2-26403-05</PlatformPackageVersion>
   </PropertyGroup>
 
   <!-- Package versions used as toolsets -->
@@ -154,7 +154,7 @@
     </StaticDependency>
 
     <StaticDependency Include="Microsoft.TargetingPack.Private.WinRT">
-      <Version>1.0.3</Version>
+      <Version>1.0.5</Version>
     </StaticDependency>
 
     <XUnitDependency Include="xunit"/>

--- a/external/runtime/runtime.depproj
+++ b/external/runtime/runtime.depproj
@@ -43,10 +43,10 @@
       <Version>$(MicrosoftPrivateCoreFxNETCoreAppPackageVersion)</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.NETCore.DotNetHost">
-      <Version>$(DotNetHostPackageVersion)</Version>
+      <Version>$(MicrosoftNETCoreDotNetHostPackageVersion)</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.NETCore.DotNetHostPolicy">
-      <Version>$(DotNetHostPackageVersion)</Version>
+      <Version>$(MicrosoftNETCoreDotNetHostPolicyPackageVersion)</Version>
     </PackageReference>
   </ItemGroup>
 


### PR DESCRIPTION
WCF dependencies should now be updated based on the [ProdCon release candidate](https://github.com/dotnet/versions/tree/8f78fc523bfef40b28d4fbf5a0a51d4da7e373cf/build-info/dotnet/product/cli/release/2.1).

@dagood I would like a review of the manual dependencies I'm updating in this PR. I don't remember why these were not part of the auto-update, I updated them now and haven't seen any negative side effects so far.

`<CoreFxBaseLinePackageVersion>2.2.0-preview1-26216-02</CoreFxBaseLinePackageVersion>`
	- Used in pkg\baseline\baseline.props
	- Used in external\harvestPackages\harvestPackages.netstandard1.6.depproj

`<DotNetHostPackageVersion>2.1.0-preview2-26314-02</DotNetHostPackageVersion>`
	- Used in external\runtime\runtime.depproj for packages...
		-    Microsoft.NETCore.DotNetHost
		-    Microsoft.NETCore.DotNetHostPolicy

`<PlatformPackageVersion>2.1.0-preview2-26314-06</PlatformPackageVersion>`
	- Used in external\runtime\runtime.depproj for packages...
		-    Microsoft.NETCore.Platforms
