### PR TITLE
Use Expect 100-Continue header

### DIFF
--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/HttpChannelHelpers.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/HttpChannelHelpers.cs
@@ -136,9 +136,12 @@ namespace System.ServiceModel.Channels
             var innerSocketException = exception.InnerException as SocketException;
             if (innerSocketException != null)
             {
-                var socketErrorCode = innerSocketException.SocketErrorCode;
+                SocketError socketErrorCode = innerSocketException.SocketErrorCode;
                 switch (socketErrorCode)
                 {
+                    case SocketError.TryAgain:
+                    case SocketError.NoRecovery:
+                    case SocketError.NoData:
                     case SocketError.HostNotFound:
                         return new EndpointNotFoundException(SR.Format(SR.EndpointNotFound, request.RequestUri.AbsoluteUri), exception);
                     default:


### PR DESCRIPTION
Now that SocketsHttpHandler is the HTTP client being used, we can add the Expect header to avoid sending the body twice when there's an authentication challenge.

Also improved error handling for when DNS lookup fails. This was causing a test failure (wrong exception) on win7.