### PR TITLE
Active issue on tests failing with same issue.

### DIFF
--- a/src/System.Private.ServiceModel/tests/Scenarios/Binding/Custom/CustomBindingTests.4.1.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Binding/Custom/CustomBindingTests.4.1.0.cs
@@ -15,6 +15,7 @@ public partial class CustomBindingTests : ConditionalWcfTest
     // Tcp: Client and Server bindings setup exactly the same using default settings.
     [WcfFact]
     [Condition(nameof(Root_Certificate_Installed), nameof(Client_Certificate_Installed))]
+    [Issue(2561, OS = OSID.SLES_12)] // Active Issue - needs investigation
     [OuterLoop]
     public static void DefaultSettings_Tcp_Binary_Echo_RoundTrips_String()
     {
@@ -56,6 +57,7 @@ public partial class CustomBindingTests : ConditionalWcfTest
     [WcfFact]
     [Condition(nameof(Root_Certificate_Installed),
                nameof(SSL_Available))]
+    [Issue(2561, OS = OSID.SLES_12)] // Active Issue - needs investigation
     [OuterLoop]
     public static void DefaultSettings_Https_Text_Echo_RoundTrips_String()
     {

--- a/src/System.Private.ServiceModel/tests/Scenarios/Binding/Http/NetHttpsBindingTests.4.1.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Binding/Http/NetHttpsBindingTests.4.1.0.cs
@@ -13,6 +13,7 @@ public class Binding_Http_NetHttpsBindingTests : ConditionalWcfTest
     [WcfFact]
     [Condition(nameof(Root_Certificate_Installed),
                nameof(SSL_Available))]
+    [Issue(2561, OS = OSID.SLES_12)] // Active Issue - needs investigation
     [OuterLoop]
     public static void DefaultCtor_NetHttps_Echo_RoundTrips_String()
     {
@@ -78,6 +79,7 @@ public class Binding_Http_NetHttpsBindingTests : ConditionalWcfTest
     [WcfFact]
     [Condition(nameof(Root_Certificate_Installed),
                nameof(SSL_Available))]
+    [Issue(2561, OS = OSID.SLES_12)] // Active Issue - needs investigation
     [OuterLoop]
     public static void NonDefaultCtor_NetHttps_Echo_RoundTrips_String()
     {

--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/ChannelLayer/DuplexChannelShapeTests.4.1.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/ChannelLayer/DuplexChannelShapeTests.4.1.0.cs
@@ -17,6 +17,7 @@ public partial class DuplexChannelShapeTests : ConditionalWcfTest
     [WcfFact]
     [Condition(nameof(Root_Certificate_Installed))]
     [Issue(1438, OS = OSID.Windows_7)]
+    [Issue(2561, OS = OSID.SLES_12)] // Active Issue - needs investigation
     [OuterLoop]
     public static void IDuplexSessionChannel_Https_NetHttpsBinding()
     {

--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/ChannelLayer/RequestReplyChannelShapeTests.4.1.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/ChannelLayer/RequestReplyChannelShapeTests.4.1.0.cs
@@ -18,6 +18,7 @@ public partial class RequestReplyChannelShapeTests : ConditionalWcfTest
     [WcfFact]
     [Condition(nameof(Root_Certificate_Installed),
                nameof(SSL_Available))]
+    [Issue(2561, OS = OSID.SLES_12)] // Active Issue - needs investigation
     [OuterLoop]
     public static void IRequestChannel_Https_NetHttpsBinding()
     {

--- a/src/System.Private.ServiceModel/tests/Scenarios/Extensibility/WebSockets/WebSocketTests.4.1.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Extensibility/WebSockets/WebSocketTests.4.1.0.cs
@@ -172,6 +172,7 @@ public class WebSocketTests : ConditionalWcfTest
     [Condition(nameof(Root_Certificate_Installed))]
     [Issue(526, Framework = FrameworkID.NetNative)]
     [Issue(1438, OS = OSID.Windows_7)]  // not supported on Win7
+    [Issue(2561, OS = OSID.SLES_12)] // Active Issue - needs investigation
     [OuterLoop]
     public static void WebSocket_Https_Duplex_BinaryStreamed()
     {
@@ -645,6 +646,7 @@ public class WebSocketTests : ConditionalWcfTest
     [Condition(nameof(Root_Certificate_Installed))]
     [Issue(526, Framework = FrameworkID.NetNative)]
     [Issue(1438, OS = OSID.Windows_7)]  // not supported on Win7
+    [Issue(2561, OS = OSID.SLES_12)] // Active Issue - needs investigation
     [OuterLoop]
     public static void WebSocket_Https_RequestReply_BinaryBuffered()
     {
@@ -698,6 +700,7 @@ public class WebSocketTests : ConditionalWcfTest
     [Condition(nameof(Root_Certificate_Installed))]
     [Issue(526, Framework = FrameworkID.NetNative)]
     [Issue(1438, OS = OSID.Windows_7)]  // not supported on Win7
+    [Issue(2561, OS = OSID.SLES_12)] // Active Issue - needs investigation
     [OuterLoop]
     public static void WebSocket_Https_RequestReply_TextBuffered_KeepAlive()
     {
@@ -753,6 +756,7 @@ public class WebSocketTests : ConditionalWcfTest
     [Condition(nameof(Root_Certificate_Installed))]
     [Issue(526, Framework = FrameworkID.NetNative)]
     [Issue(1438, OS = OSID.Windows_7)]  // not supported on Win7
+    [Issue(2561, OS = OSID.SLES_12)] // Active Issue - needs investigation
     [OuterLoop]
     public static void WebSocket_Https_Duplex_BinaryBuffered()
     {
@@ -821,6 +825,7 @@ public class WebSocketTests : ConditionalWcfTest
     [Condition(nameof(Root_Certificate_Installed))]
     [Issue(526, Framework = FrameworkID.NetNative)]
     [Issue(1438, OS = OSID.Windows_7)]  // not supported on Win7
+    [Issue(2561, OS = OSID.SLES_12)] // Active Issue - needs investigation
     [OuterLoop]
     public static void WebSocket_Https_Duplex_TextBuffered_KeepAlive()
     {

--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Https/ClientCredentialTypeTests.4.1.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Https/ClientCredentialTypeTests.4.1.0.cs
@@ -26,6 +26,7 @@ public class Https_ClientCredentialTypeTests : ConditionalWcfTest
 
     [WcfFact]
     [Condition(nameof(Root_Certificate_Installed))]
+    [Issue(2561, OS = OSID.SLES_12)] // Active Issue - needs investigation
     [OuterLoop]
     public static void BasicAuthentication_RoundTrips_Echo()
     {
@@ -94,6 +95,7 @@ public class Https_ClientCredentialTypeTests : ConditionalWcfTest
 
     [WcfFact]
     [Condition(nameof(Root_Certificate_Installed))]
+    [Issue(2561, OS = OSID.SLES_12)] // Active Issue - needs investigation
     [OuterLoop]
     public static void BasicAuthenticationInvalidPwd_throw_MessageSecurityException()
     {

--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Https/HttpsTests.4.1.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Https/HttpsTests.4.1.0.cs
@@ -21,6 +21,7 @@ public partial class HttpsTests : ConditionalWcfTest
     [OuterLoop]
     [Condition(nameof(Root_Certificate_Installed),
                nameof(SSL_Available))]
+    [Issue(2561, OS = OSID.SLES_12)] // Active Issue - needs investigation
     public static void CrossBinding_Soap11_EchoString()
     {
         string variationDetails = "Client:: CustomBinding/MessageVersion=Soap11\nServer:: BasicHttpsBinding/DefaultValues";
@@ -58,6 +59,7 @@ public partial class HttpsTests : ConditionalWcfTest
     [WcfFact]
     [Condition(nameof(Root_Certificate_Installed),
                nameof(SSL_Available))]
+    [Issue(2561, OS = OSID.SLES_12)] // Active Issue - needs investigation
     [OuterLoop]
     public static void SameBinding_DefaultSettings_EchoString()
     {
@@ -96,6 +98,7 @@ public partial class HttpsTests : ConditionalWcfTest
     [WcfFact]
     [Condition(nameof(Root_Certificate_Installed),
                nameof(SSL_Available))]
+    [Issue(2561, OS = OSID.SLES_12)] // Active Issue - needs investigation
     [OuterLoop]
     public static void SameBinding_Soap11_EchoString()
     {
@@ -134,6 +137,7 @@ public partial class HttpsTests : ConditionalWcfTest
     [WcfFact]
     [Condition(nameof(Root_Certificate_Installed),
                nameof(SSL_Available))]
+    [Issue(2561, OS = OSID.SLES_12)] // Active Issue - needs investigation
     [OuterLoop]
     public static void SameBinding_Soap12_EchoString()
     {
@@ -271,6 +275,7 @@ public partial class HttpsTests : ConditionalWcfTest
            nameof(Client_Certificate_Installed),
            nameof(Server_Accepts_Certificates),
            nameof(SSL_Available))]
+    [Issue(2561, OS = OSID.SLES_12)] // Active Issue - needs investigation
     [OuterLoop]
     public static void HttpExpect100Continue_ClientCertificate_True()
     {

--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Tcp/ClientCredentialTypeCertificateCanonicalNameTests.4.1.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Tcp/ClientCredentialTypeCertificateCanonicalNameTests.4.1.0.cs
@@ -173,6 +173,7 @@ public class Tcp_ClientCredentialTypeCertificateCanonicalNameTests : Conditional
 
     [WcfFact]
     [Condition(nameof(Root_Certificate_Installed))]
+    [Issue(2561, OS = OSID.SLES_12)] // Active Issue - needs investigation
     [OuterLoop]
     public static void Certificate_With_CanonicalName_Fqdn_Address_EchoString()
     {

--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Tcp/ClientCredentialTypeTests.4.1.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Tcp/ClientCredentialTypeTests.4.1.0.cs
@@ -116,6 +116,7 @@ public partial class Tcp_ClientCredentialTypeTests : ConditionalWcfTest
 
     [WcfFact]
     [Condition(nameof(Root_Certificate_Installed))]
+    [Issue(2561, OS = OSID.SLES_12)] // Active Issue - needs investigation
     [OuterLoop]
     public static void TcpClientCredentialType_None_With_ServerAltName_EchoString()
     {

--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Tcp/ClientCredentialTypeTests.4.1.1.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Tcp/ClientCredentialTypeTests.4.1.1.cs
@@ -125,6 +125,7 @@ public partial class Tcp_ClientCredentialTypeTests : ConditionalWcfTest
     [Condition(nameof(Root_Certificate_Installed),
                nameof(Client_Certificate_Installed),
                nameof(SSL_Available))]
+    [Issue(2561, OS = OSID.SLES_12)] // Active Issue - needs investigation
     [OuterLoop]
     // Asking for PeerOrChainTrust should succeed if the certificate is
     // chain-trusted, even though it is not in the TrustedPeople store.
@@ -172,6 +173,7 @@ public partial class Tcp_ClientCredentialTypeTests : ConditionalWcfTest
     [Condition(nameof(Root_Certificate_Installed),
                nameof(Client_Certificate_Installed),
                nameof(SSL_Available))]
+    [Issue(2561, OS = OSID.SLES_12)] // Active Issue - needs investigation
     [OuterLoop]
     // Asking for ChainTrust only should succeed if the certificate is
     // chain-trusted.
@@ -219,6 +221,7 @@ public partial class Tcp_ClientCredentialTypeTests : ConditionalWcfTest
     [Condition(nameof(Root_Certificate_Installed),
                nameof(Client_Certificate_Installed),
                nameof(SSL_Available))]
+    [Issue(2561, OS = OSID.SLES_12)] // Active Issue - needs investigation
     [OuterLoop]
     // Asking for ChainTrust only should succeed if the certificate is
     // chain-trusted.

--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Tcp/IdentityTests.4.1.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Tcp/IdentityTests.4.1.0.cs
@@ -15,6 +15,7 @@ public partial class IdentityTests : ConditionalWcfTest
 {
     [WcfFact]
     [Condition(nameof(Root_Certificate_Installed), nameof(Client_Certificate_Installed))]
+    [Issue(2561, OS = OSID.SLES_12)] // Active Issue - needs investigation
     [OuterLoop]
     // The product code will check the Dns identity from the server and throw if it does not match what is specified in DnsEndpointIdentity
     public static void VerifyServiceIdentityMatchDnsEndpointIdentity()

--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Tcp/IdentityTests.4.1.1.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Tcp/IdentityTests.4.1.1.cs
@@ -15,6 +15,7 @@ public partial class IdentityTests : ConditionalWcfTest
 {
     [WcfFact]
     [Condition(nameof(Root_Certificate_Installed), nameof(Client_Certificate_Installed))]
+    [Issue(2561, OS = OSID.SLES_12)] // Active Issue - needs investigation
     [OuterLoop]
     // Verify product throws MessageSecurityException when the Dns identity from the server does not match the expectation
     public static void ServiceIdentityNotMatch_Throw_MessageSecurityException()


### PR DESCRIPTION
Numerous tests were getting skipped in VSTS runs by accident.
After enabling them we found these failing on SLES for an already discovered issue that needs investigation.
See issue #2561