### PR TITLE
Change the public key of WCF assemblies to MSFT. (#2812)

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -80,7 +80,7 @@
     <Platform>AnyCPU</Platform>
     <OutputType>Library</OutputType>
     <!-- Default any assembly not specifying a key to use the Open Key -->
-    <AssemblyKey>Open</AssemblyKey>
+    <AssemblyKey>MSFT</AssemblyKey>
     <!--<RunApiCompat>true</RunApiCompat>-->
     <!-- Build as portable by default -->
     <PortableBuild Condition="'$(PortableBuild)' == ''">true</PortableBuild>

--- a/src/System.Private.ServiceModel/dir.props
+++ b/src/System.Private.ServiceModel/dir.props
@@ -3,7 +3,6 @@
   <Import Project="..\dir.props" />
   <PropertyGroup>
     <AssemblyVersion>4.5.0.0</AssemblyVersion>
-    <AssemblyKey>Open</AssemblyKey>
     <IsNETCoreApp>true</IsNETCoreApp>
     <IsNETCoreAppRef>false</IsNETCoreAppRef>
     <IsUAP>false</IsUAP>


### PR DESCRIPTION
* Change the public key of WCF assemblies to MSFT.

* Remove AssemblyKey from library specific dir.props

* We only need to set this once in the root dir.props

(cherry picked from commit 39e11fac133c972ffb97a7e54544fdc1a46bdc78)