### PR TITLE
Expected exception changed on Linux machines

### DIFF
--- a/src/System.Private.ServiceModel/tests/Common/Infrastructure/CertificateManager.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Infrastructure/CertificateManager.cs
@@ -54,6 +54,12 @@ namespace Infrastructure.Common
                         // Linux
                         s_PlatformSpecificRootStoreLocation = StoreLocation.CurrentUser; 
                     }
+                    catch(CryptographicException)
+                    {
+                        // Linux
+                        s_PlatformSpecificRootStoreLocation = StoreLocation.CurrentUser;
+                    }
+
                     s_PlatformSpecificStoreLocationIsSet = true;
                 }
                 return s_PlatformSpecificRootStoreLocation;


### PR DESCRIPTION
* Linux machines used to throw a PNSE when trying to cert store location LocalMachine which is when we knew to use the CurrentUser location instead.
* At some point it began wrapping the PNSE inside of a CryptographicException, just need our infra logic to account for this change.