### PR TITLE
Increment WCF packages and assemblies in release/1.0.0

### DIFF
--- a/pkg/baseline/baseline.packages.props
+++ b/pkg/baseline/baseline.packages.props
@@ -5,24 +5,24 @@
   </PropertyGroup>
   <ItemGroup>
     <BaseLinePackage Include="System.ServiceModel.Duplex">
-      <Version>4.0.2</Version>
+      <Version>4.0.3</Version>
     </BaseLinePackage>
     <BaseLinePackage Include="System.ServiceModel.Http">
-      <Version>4.1.1</Version>
+      <Version>4.1.2</Version>
     </BaseLinePackage>
     <BaseLinePackage Include="System.ServiceModel.NetTcp">
-      <Version>4.1.1</Version>
+      <Version>4.1.2</Version>
     </BaseLinePackage>
     <BaseLinePackage Include="System.ServiceModel.Primitives">
-      <Version>4.1.1</Version>
+      <Version>4.1.2</Version>
     </BaseLinePackage>
     <BaseLinePackage Include="System.ServiceModel.Security">
-      <Version>4.0.2</Version>
+      <Version>4.0.3</Version>
     </BaseLinePackage>
 
     <!-- private dependencies -->
     <BaseLinePackage Include="System.Private.ServiceModel">
-      <Version>4.1.1</Version>
+      <Version>4.1.2</Version>
     </BaseLinePackage>
   </ItemGroup>
 </Project>

--- a/src/System.Private.ServiceModel/pkg/System.Private.ServiceModel.pkgproj
+++ b/src/System.Private.ServiceModel/pkg/System.Private.ServiceModel.pkgproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <!-- Ideally we'd harvest this from the runtime dependencies -->
-    <Version>4.1.1</Version>
+    <Version>4.1.2</Version>
     <PreventImplementationReference>true</PreventImplementationReference>
   </PropertyGroup>
 

--- a/src/System.Private.ServiceModel/src/System.Private.ServiceModel.csproj
+++ b/src/System.Private.ServiceModel/src/System.Private.ServiceModel.csproj
@@ -6,7 +6,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Private.ServiceModel</AssemblyName>
-    <AssemblyVersion>4.1.0.1</AssemblyVersion>
+    <AssemblyVersion>4.1.0.2</AssemblyVersion>
     <RootNamespace>System.ServiceModel</RootNamespace>
     <OutputType>Library</OutputType>
     <NoWarn>$(NoWarn);1634;1691;649</NoWarn>

--- a/src/System.ServiceModel.Duplex/pkg/System.ServiceModel.Duplex.pkgproj
+++ b/src/System.ServiceModel.Duplex/pkg/System.ServiceModel.Duplex.pkgproj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <Version>4.0.2</Version>
+    <Version>4.0.3</Version>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ref\System.ServiceModel.Duplex.csproj">

--- a/src/System.ServiceModel.Duplex/ref/System.ServiceModel.Duplex.csproj
+++ b/src/System.ServiceModel.Duplex/ref/System.ServiceModel.Duplex.csproj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <AssemblyVersion>4.0.1.1</AssemblyVersion>
     <OutputType>Library</OutputType>
     <PackageTargetFramework>netstandard1.1</PackageTargetFramework>
     <NuGetTargetMoniker>.NETStandard,Version=v1.1</NuGetTargetMoniker>

--- a/src/System.ServiceModel.Duplex/src/System.ServiceModel.Duplex.csproj
+++ b/src/System.ServiceModel.Duplex/src/System.ServiceModel.Duplex.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.ServiceModel.Duplex</AssemblyName>
-    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <AssemblyVersion>4.0.1.1</AssemblyVersion>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
     <PackageTargetFramework Condition="'$(PackageTargetFramework)'==''">netstandard1.3</PackageTargetFramework>
     <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.3</NuGetTargetMoniker>

--- a/src/System.ServiceModel.Http/pkg/System.ServiceModel.Http.pkgproj
+++ b/src/System.ServiceModel.Http/pkg/System.ServiceModel.Http.pkgproj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <Version>4.1.1</Version>
+    <Version>4.1.2</Version>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ref\3.9.0\System.ServiceModel.Http.depproj">

--- a/src/System.ServiceModel.Http/ref/System.ServiceModel.Http.csproj
+++ b/src/System.ServiceModel.Http/ref/System.ServiceModel.Http.csproj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.1.0.0</AssemblyVersion>
+    <AssemblyVersion>4.1.0.1</AssemblyVersion>
     <OutputType>Library</OutputType>
     <PackageTargetFramework>netstandard1.3</PackageTargetFramework>
     <NuGetTargetMoniker>.NETStandard,Version=v1.3</NuGetTargetMoniker>

--- a/src/System.ServiceModel.Http/src/System.ServiceModel.Http.csproj
+++ b/src/System.ServiceModel.Http/src/System.ServiceModel.Http.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.ServiceModel.Http</AssemblyName>
-    <AssemblyVersion>4.1.0.0</AssemblyVersion>
+    <AssemblyVersion>4.1.0.1</AssemblyVersion>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
     <PackageTargetFramework Condition="'$(PackageTargetFramework)'==''">netstandard1.3</PackageTargetFramework>
     <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.3</NuGetTargetMoniker>

--- a/src/System.ServiceModel.NetTcp/pkg/System.ServiceModel.NetTcp.pkgproj
+++ b/src/System.ServiceModel.NetTcp/pkg/System.ServiceModel.NetTcp.pkgproj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <Version>4.1.1</Version>
+    <Version>4.1.2</Version>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ref\4.0.0\System.ServiceModel.NetTcp.depproj">

--- a/src/System.ServiceModel.NetTcp/ref/System.ServiceModel.NetTcp.csproj
+++ b/src/System.ServiceModel.NetTcp/ref/System.ServiceModel.NetTcp.csproj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.1.0.0</AssemblyVersion>
+    <AssemblyVersion>4.1.0.1</AssemblyVersion>
     <OutputType>Library</OutputType>
     <PackageTargetFramework>netstandard1.3</PackageTargetFramework>
     <NuGetTargetMoniker>.NETStandard,Version=v1.3</NuGetTargetMoniker>

--- a/src/System.ServiceModel.NetTcp/src/System.ServiceModel.NetTcp.csproj
+++ b/src/System.ServiceModel.NetTcp/src/System.ServiceModel.NetTcp.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.ServiceModel.NetTcp</AssemblyName>
-    <AssemblyVersion>4.1.0.0</AssemblyVersion>
+    <AssemblyVersion>4.1.0.1</AssemblyVersion>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
     <PackageTargetFramework Condition="'$(PackageTargetFramework)'==''">netstandard1.3</PackageTargetFramework>
     <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.3</NuGetTargetMoniker>

--- a/src/System.ServiceModel.Primitives/pkg/System.ServiceModel.Primitives.pkgproj
+++ b/src/System.ServiceModel.Primitives/pkg/System.ServiceModel.Primitives.pkgproj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <Version>4.1.1</Version>
+    <Version>4.1.2</Version>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ref\3.9.0\System.ServiceModel.Primitives.depproj">

--- a/src/System.ServiceModel.Primitives/ref/System.ServiceModel.Primitives.csproj
+++ b/src/System.ServiceModel.Primitives/ref/System.ServiceModel.Primitives.csproj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.1.0.0</AssemblyVersion>
+    <AssemblyVersion>4.1.0.1</AssemblyVersion>
     <OutputType>Library</OutputType>
     <PackageTargetFramework>netstandard1.3</PackageTargetFramework>
     <NuGetTargetMoniker>.NETStandard,Version=v1.3</NuGetTargetMoniker>

--- a/src/System.ServiceModel.Primitives/src/System.ServiceModel.Primitives.csproj
+++ b/src/System.ServiceModel.Primitives/src/System.ServiceModel.Primitives.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.ServiceModel.Primitives</AssemblyName>
-    <AssemblyVersion>4.1.0.0</AssemblyVersion>
+    <AssemblyVersion>4.1.0.1</AssemblyVersion>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
     <PackageTargetFramework Condition="'$(PackageTargetFramework)'==''">netstandard1.3</PackageTargetFramework>
     <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.3</NuGetTargetMoniker>

--- a/src/System.ServiceModel.Security/pkg/System.ServiceModel.Security.pkgproj
+++ b/src/System.ServiceModel.Security/pkg/System.ServiceModel.Security.pkgproj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <Version>4.0.2</Version>
+    <Version>4.0.3</Version>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ref\3.9.0\System.ServiceModel.Security.depproj">

--- a/src/System.ServiceModel.Security/ref/System.ServiceModel.Security.csproj
+++ b/src/System.ServiceModel.Security/ref/System.ServiceModel.Security.csproj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <AssemblyVersion>4.0.1.1</AssemblyVersion>
     <OutputType>Library</OutputType>
     <PackageTargetFramework>netstandard1.1</PackageTargetFramework>
     <NuGetTargetMoniker>.NETStandard,Version=v1.1</NuGetTargetMoniker>

--- a/src/System.ServiceModel.Security/src/System.ServiceModel.Security.csproj
+++ b/src/System.ServiceModel.Security/src/System.ServiceModel.Security.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.ServiceModel.Security</AssemblyName>
-    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <AssemblyVersion>4.0.1.1</AssemblyVersion>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
     <PackageTargetFramework Condition="'$(PackageTargetFramework)'==''">netstandard1.3</PackageTargetFramework>
     <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.3</NuGetTargetMoniker>


### PR DESCRIPTION
* Also produces non-stable versioned packages.

The new packages produced look like...

System.Private.ServiceModel.4.1.2-servicing-26227-0.nupkg
System.ServiceModel.Duplex.4.0.3-servicing-26227-0.nupkg
System.ServiceModel.Http.4.1.2-servicing-26227-0.nupkg
System.ServiceModel.NetTcp.4.1.2-servicing-26227-0.nupkg
System.ServiceModel.Primitives.4.1.2-servicing-26227-0.nupkg
System.ServiceModel.Security.4.0.3-servicing-26227-0.nupkg

The assembly versions are...
System.Private.ServiceModel.4.1.2   -   4.1.0.2
System.ServiceModel.Duplex.4.0.3   -   4.0.1.1
System.ServiceModel.Http.4.1.2   -   4.1.0.1
System.ServiceModel.NetTcp.4.1.2   -   4.1.0.1
System.ServiceModel.Primitives.4.1.2   -   4.1.0.1
System.ServiceModel.Security.4.0.3   -   4.0.1.1