### PR TITLE
Fix user-agent headers

### DIFF
--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/HttpChannelFactory.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/HttpChannelFactory.cs
@@ -1264,7 +1264,7 @@ namespace System.ServiceModel.Channels
                             }
                             else if (string.Compare(name, "user-agent", StringComparison.OrdinalIgnoreCase) == 0)
                             {
-                                _httpRequestMessage.Headers.UserAgent.Add(ProductInfoHeaderValue.Parse(value));
+                                _httpRequestMessage.Headers.Add(name, value);
                             }
                             else if (string.Compare(name, "if-modified-since", StringComparison.OrdinalIgnoreCase) == 0)
                             {


### PR DESCRIPTION
We were incorrectly directly parsing the User-Agent header when it's a multi-valued header. This change causes `HttpRequestHeaders` to handle the special multi-value parsing that it required for the User-Agent header.

Fixes #2673