### PR TITLE
Extend test timeout to 40 secs.

### DIFF
--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/ExpectedExceptions/ExpectedExceptionTests.4.1.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/ExpectedExceptions/ExpectedExceptionTests.4.1.0.cs
@@ -29,7 +29,7 @@ public partial class ExpectedExceptionTests : ConditionalWcfTest
         {
             // *** SETUP *** \\
             binding = new BasicHttpBinding();
-            binding.SendTimeout = TimeSpan.FromMilliseconds(20000);
+            binding.SendTimeout = TimeSpan.FromMilliseconds(40000);
             endpointAddress = new EndpointAddress(nonExistentHost);
             factory = new ChannelFactory<IWcfService>(binding, endpointAddress);
             serviceProxy = factory.CreateChannel();


### PR DESCRIPTION
* See dotnet/core-eng#3510