### PR TITLE
Add net461 as a supported framework for S.SM.Security.

### DIFF
--- a/src/System.ServiceModel.Security/pkg/System.ServiceModel.Security.pkgproj
+++ b/src/System.ServiceModel.Security/pkg/System.ServiceModel.Security.pkgproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
     <ProjectReference Include="..\ref\System.ServiceModel.Security.csproj">
-      <SupportedFramework>netcoreapp2.0;$(UAPvNextTFM);$(AllXamarinFrameworks)</SupportedFramework>
+      <SupportedFramework>netcoreapp2.0;net461;$(UAPvNextTFM);$(AllXamarinFrameworks)</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.ServiceModel.Security.csproj" />
     <HarvestIncludePaths Include="ref/netcore50;lib/netcore50" />


### PR DESCRIPTION
* Prior to pkg 4.5.0 the minor number of the assembly version for S.SM.Security had not been incremented since the last facade contract which was in box for .NET Framework v4.6.1. Therefore our packages did not need to provide a facade, now we do, so adding net461 as a supported framework will trigger package validation for this framework.