### PR TITLE
Give more options for deciding which packages to build.

### DIFF
--- a/src/packages.builds
+++ b/src/packages.builds
@@ -4,13 +4,39 @@
 
   <PropertyGroup>
     <PackageReportDir Condition="'$(PackageReportDir)' == ''">$(BinDir)pkg/reports/</PackageReportDir>
+    <BuildAllPackages>true</BuildAllPackages>
+    <BuildWcfPackages>true</BuildWcfPackages>
   </PropertyGroup>
 
-  <ItemGroup>
-    <Project Include="$(MSBuildThisFileDirectory)..\pkg\*\*.builds" Condition="'$(SkipManagedPackageBuild)' != 'true'">
+  <ItemGroup Condition="'$(BuildAllPackages)' == 'true' AND '$(SkipManagedPackageBuild)' != 'true'" >
+    <Project Include="$(MSBuildThisFileDirectory)..\pkg\*\*.builds" >
       <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
     </Project>
-    <Project Include="*\pkg\**\*.pkgproj" Condition="'$(SkipManagedPackageBuild)' != 'true' AND '$(BuildAllConfigurations)' == 'true'">
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(BuildAllPackages)' == 'false' AND '$(BuildWcfPackages)' == 'true'" >
+    <Project Include="$(MSBuildThisFileDirectory)\System.Private.ServiceModel\pkg\System.Private.ServiceModel.pkgproj">
+      <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
+    </Project>
+    <Project Include="$(MSBuildThisFileDirectory)\System.ServiceModel.Duplex\pkg\System.ServiceModel.Duplex.pkgproj">
+      <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
+    </Project>
+    <Project Include="$(MSBuildThisFileDirectory)\System.ServiceModel.Http\pkg\System.ServiceModel.Http.pkgproj">
+      <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
+    </Project>
+    <Project Include="$(MSBuildThisFileDirectory)\System.ServiceModel.NetTcp\pkg\System.ServiceModel.NetTcp.pkgproj">
+      <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
+    </Project>
+    <Project Include="$(MSBuildThisFileDirectory)\System.ServiceModel.Primitives\pkg\System.ServiceModel.Primitives.pkgproj">
+      <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
+    </Project>
+    <Project Include="$(MSBuildThisFileDirectory)\System.ServiceModel.Security\pkg\System.ServiceModel.Security.pkgproj">
+      <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
+    </Project>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(BuildAllPackages)' == 'false' AND '$(BuildWcfPackages)' == false" >
+    <Project Include="$(MSBuildThisFileDirectory)\svcutilcore\pkg\dotnet-svcutil.xmlserializer.pkgproj">
       <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
     </Project>
   </ItemGroup>

--- a/src/packages.builds
+++ b/src/packages.builds
@@ -4,17 +4,16 @@
 
   <PropertyGroup>
     <PackageReportDir Condition="'$(PackageReportDir)' == ''">$(BinDir)pkg/reports/</PackageReportDir>
-    <BuildAllPackages>true</BuildAllPackages>
-    <BuildWcfPackages>true</BuildWcfPackages>
+    
+    <!-- 'StabilizePackageVersion' is used in conjunction with 'PackageVersionStamp' to determine whether or not a label and build number should be appended to a package name. -->
+    <!-- Default behavior when not building stable packages is to build both ServiceModel and SvcUtil packages. -->
+    <!-- 'StabilizePackageVersion' is a flag set manually when stable packages are needed. -->
+    <!-- 'BuildServiceModelPackages' and 'BuildSvcUtilPackage' should also be explicitly set when stable packages are desired, otherwise no packages will be built. -->
+    <BuildServiceModelPackages Condition="'$(StabilizePackageVersion)' != 'true' AND '$(BuildServiceModelPackages)' == ''">true</BuildServiceModelPackages>
+    <BuildSvcUtilPackage Condition="'$(StabilizePackageVersion)' != 'true' AND '$(BuildSvcUtilPackage)' == ''">true</BuildSvcUtilPackage>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(BuildAllPackages)' == 'true' AND '$(SkipManagedPackageBuild)' != 'true'" >
-    <Project Include="$(MSBuildThisFileDirectory)..\pkg\*\*.builds" >
-      <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
-    </Project>
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(BuildAllPackages)' == 'false' AND '$(BuildWcfPackages)' == 'true'" >
+  <ItemGroup Condition="'$(BuildServiceModelPackages)' == 'true'" >
     <Project Include="$(MSBuildThisFileDirectory)\System.Private.ServiceModel\pkg\System.Private.ServiceModel.pkgproj">
       <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
     </Project>
@@ -35,7 +34,7 @@
     </Project>
   </ItemGroup>
 
-  <ItemGroup Condition="'$(BuildAllPackages)' == 'false' AND '$(BuildWcfPackages)' == false" >
+  <ItemGroup Condition="'$(BuildSvcUtilPackage)' == 'true'" >
     <Project Include="$(MSBuildThisFileDirectory)\svcutilcore\pkg\dotnet-svcutil.xmlserializer.pkgproj">
       <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
     </Project>


### PR DESCRIPTION
***EDITED***

I included comments with the code, should be pretty self explanatory, here are the scenarios...

1. Nightly builds, local builds not setting any flags.
               All WCF and SvcUtil packages get built.

2. Stable packages are needed for either release or for release candidate testing.
               -If the flag for stable packages is set but the WCF or SvcUtil flags are not then no packages are built.
               -The WCF and/or SvcUtil flags must be set in conjunction with the flag for building stable packages in order to produce the desired packages.
               -The reason for this is because we don't want stable packages getting built unintentionally which would then mean we need to clean-up MyGet.