### PR TITLE
Fix packaging issues for release of WCF 4.5.1 packages.

### DIFF
--- a/external/harvestPackages/harvestPackages.netstandard1.6.depproj
+++ b/external/harvestPackages/harvestPackages.netstandard1.6.depproj
@@ -15,22 +15,22 @@
 
   <ItemGroup>
     <PackageReference Include="System.Private.ServiceModel">
-      <Version>4.5.0</Version>
+      <Version>4.3.1</Version>
     </PackageReference>
     <PackageReference Include="System.ServiceModel.Duplex">
-      <Version>4.5.0</Version>
+      <Version>4.3.1</Version>
     </PackageReference>
     <PackageReference Include="System.ServiceModel.Http">
-      <Version>4.5.0</Version>
+      <Version>4.3.1</Version>
     </PackageReference>
     <PackageReference Include="System.ServiceModel.NetTcp">
-      <Version>4.5.0</Version>
+      <Version>4.3.1</Version>
     </PackageReference>
     <PackageReference Include="System.ServiceModel.Primitives">
-      <Version>4.5.0</Version>
+      <Version>4.3.1</Version>
     </PackageReference>
     <PackageReference Include="System.ServiceModel.Security">
-      <Version>4.5.0</Version>
+      <Version>4.3.1</Version>
     </PackageReference>
   </ItemGroup>
 

--- a/pkg/baseline/packageIndex.json
+++ b/pkg/baseline/packageIndex.json
@@ -2,10 +2,11 @@
     "Packages": {
         "_Comments": {
             "_StableVersions": [
-                "Released versions."
+                "Released versions. The last one listed is the package that will be used for harvesting assemblies in the current package."
             ],
             "_BaselineVersion": [
-                "Used to determine the minimum version used for all packages in the repo."
+                "Used to determine the minimum version used for all packages in the repo.",
+                "It is the package version that will be used for WCF dependencies for prior target frameworks."
             ],
             "_AssemblyVersionInPackageVersion": [
                 "Used to understand what version of a package to reference.",
@@ -17,10 +18,9 @@
                 "4.0.0",
                 "4.1.0",
                 "4.3.0",
-                "4.3.1",
-                "4.5.0"
+                "4.3.1"
             ],
-            "BaselineVersion": "4.5.0",
+            "BaselineVersion": "4.5.1",
             "InboxOn": {},
             "AssemblyVersionInPackageVersion": {
                 "4.1.1.0": "4.3.0",
@@ -35,10 +35,9 @@
                 "4.0.0",
                 "4.0.1",
                 "4.3.0",
-                "4.3.1",
-                "4.5.0"
+                "4.3.1"
             ],
-            "BaselineVersion": "4.5.0",
+            "BaselineVersion": "4.5.1",
             "InboxOn": {
                 "uap10.0.16299": "4.1.1.0"
             },
@@ -58,10 +57,9 @@
                 "4.0.10",
                 "4.1.0",
                 "4.3.0",
-                "4.3.1",
-                "4.5.0"
+                "4.3.1"
             ],
-            "BaselineVersion": "4.5.0",
+            "BaselineVersion": "4.5.1",
             "InboxOn": {
                 "uap10.0.16299": "4.1.3.0"
             },
@@ -81,10 +79,9 @@
                 "4.0.0",
                 "4.1.0",
                 "4.3.0",
-                "4.3.1",
-                "4.5.0"
+                "4.3.1"
             ],
-            "BaselineVersion": "4.5.0",
+            "BaselineVersion": "4.5.1",
             "InboxOn": {
                 "uap10.0.16299": "4.1.3.0"
             },
@@ -103,10 +100,9 @@
                 "4.0.0",
                 "4.1.0",
                 "4.3.0",
-                "4.3.1",
-                "4.5.0"
+                "4.3.1"
             ],
-            "BaselineVersion": "4.5.0",
+            "BaselineVersion": "4.5.1",
             "InboxOn": {
                 "uap10.0.16299": "4.2.1.0"
             },
@@ -126,10 +122,9 @@
                 "4.0.0",
                 "4.0.1",
                 "4.3.0",
-                "4.3.1",
-                "4.5.0"
+                "4.3.1"
             ],
-            "BaselineVersion": "4.5.0",
+            "BaselineVersion": "4.5.1",
             "InboxOn": {
                 "uap10.0.16299": "4.0.4.0"
             },

--- a/src/System.Private.ServiceModel/pkg/System.Private.ServiceModel.pkgproj
+++ b/src/System.Private.ServiceModel/pkg/System.Private.ServiceModel.pkgproj
@@ -1,25 +1,29 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
-  <PropertyGroup>
-    <PreventImplementationReference>true</PreventImplementationReference>
-  </PropertyGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\src\System.Private.ServiceModel.csproj" />
-    <HarvestIncludePaths Include="runtimes/unix/lib/netstandard1.3" />
-    <HarvestIncludePaths Include="runtimes/win/lib/netstandard1.3" />
-    <HarvestIncludePaths Include="runtimes/win/lib/netcore50" />
-  </ItemGroup>
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
-
-  <Target Name="SetDependencyVersion" AfterTargets="GetNuGetPackageDependencies">
+    <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+    <PropertyGroup>
+        <PreventImplementationReference>true</PreventImplementationReference>
+    </PropertyGroup>
     <ItemGroup>
-      <Dependency Condition="'%(Identity)' == 'System.Reflection.DispatchProxy' AND '%(TargetFramework)' == 'netstandard1.3'">
-        <Version>4.3.0</Version>
-      </Dependency>
-      <Dependency Condition="'%(Identity)' == 'System.Security.Principal.Windows' AND '%(TargetFramework)' == 'netstandard1.3'">
-        <Version>4.3.0</Version>
-      </Dependency>
+        <ProjectReference Include="..\src\System.Private.ServiceModel.csproj" />
+        <HarvestIncludePaths Include="runtimes/unix/lib/netstandard1.3" />
+        <HarvestIncludePaths Include="runtimes/win7/lib/netstandard1.3">
+            <TargetPath>runtimes/win/lib/netstandard1.3</TargetPath>
+        </HarvestIncludePaths>
+        <HarvestIncludePaths Include="runtimes/win7/lib/netcore50">
+            <TargetPath>runtimes/win/lib/netcore50</TargetPath>
+        </HarvestIncludePaths>
     </ItemGroup>
-  </Target>
+    <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+
+    <Target Name="SetDependencyVersion" AfterTargets="GetNuGetPackageDependencies">
+        <ItemGroup>
+            <Dependency Condition="'%(Identity)' == 'System.Reflection.DispatchProxy' AND '%(TargetFramework)' == 'netstandard1.3'">
+                <Version>4.3.0</Version>
+            </Dependency>
+            <Dependency Condition="'%(Identity)' == 'System.Security.Principal.Windows' AND '%(TargetFramework)' == 'netstandard1.3'">
+                <Version>4.3.0</Version>
+            </Dependency>
+        </ItemGroup>
+    </Target>
 </Project>


### PR DESCRIPTION
* For target frameworks netstandard 1.0, 1.1 and 1.3 we should be harvesting assemblies from the latest package released from the 2.0.0 branch, in this case package version 4.3.1. This is because the 2.0.0 branch will continue to be serviced and we should be harvesting those most recent servicing updates.

* The package dependencies between WCF packages should always be of the same version since we now release all the WCF packages in sync.