### PR TITLE
Make properties as local.

### DIFF
--- a/src/packages.builds
+++ b/src/packages.builds
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="BuildAndTest" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<!-- Properties listed as TreatAsLocalProperty are so that they can be modified when set globaly via command prompt and VSTS. -->
+<Project TreatAsLocalProperty="BuildServiceModelPackages;BuildSvcUtilPackage" ToolsVersion="14.0" DefaultTargets="BuildAndTest" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
 
   <PropertyGroup>


### PR DESCRIPTION
* In order to be able to modify these properties based on their values, in particular as set in VSTS builds they need to be treated as local properties.