### PR TITLE
Roll pkgs and assemblies forward after 2.0.9 servicing release.

### DIFF
--- a/Packaging.props
+++ b/Packaging.props
@@ -20,7 +20,7 @@
     <PlatformPackageVersion Condition="'$(PlatformPackageVersion)' == ''">1.2.0</PlatformPackageVersion>
 
     <!-- by default all packages will use the same version which revs with respect to product version -->
-    <PackageVersion Condition="'$(PackageVersion)' == ''">4.4.3</PackageVersion>
+    <PackageVersion Condition="'$(PackageVersion)' == ''">4.4.4</PackageVersion>
     <SkipValidatePackageTargetFramework>true</SkipValidatePackageTargetFramework>
     <LicenseUrl>https://github.com/dotnet/wcf/blob/master/LICENSE.TXT</LicenseUrl>    
   </PropertyGroup>

--- a/pkg/baseline/packageIndex.json
+++ b/pkg/baseline/packageIndex.json
@@ -9,7 +9,8 @@
       ],
       "_AssemblyVersionInPackageVersion": [
         "Used to understand what version of a package to reference.",
-        "Then raise the package version of the reference so that its at least the baseline version."
+        "Then raise the package version of the reference so that its at least the baseline version.",
+        "In cases where the assembly version did not rev but the package did, use the first package version."
       ]
     },
     "System.Runtime.WindowsRuntime": {
@@ -27,7 +28,7 @@
         "4.4.2",
         "4.4.3"
       ],
-      "BaselineVersion": "4.4.3",
+      "BaselineVersion": "4.4.4",
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
         "4.1.1.0": "4.3.0",
@@ -36,7 +37,8 @@
         "4.1.2.0": "4.4.0",
         "4.1.2.1": "4.4.1",
         "4.1.2.2": "4.4.2",
-        "4.1.2.3": "4.4.3"
+        "4.1.2.3": "4.4.3",
+        "4.1.2.4": "4.4.4"
       }
     },
     "System.ServiceModel.Duplex": {
@@ -51,7 +53,7 @@
         "4.4.2",
         "4.4.3"
       ],
-      "BaselineVersion": "4.4.3",
+      "BaselineVersion": "4.4.4",
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
@@ -60,7 +62,8 @@
         "4.0.2.1": "4.3.2",
         "4.1.0.0": "4.4.1",
         "4.1.0.1": "4.4.2",
-        "4.1.0.2": "4.4.3"
+        "4.1.0.2": "4.4.3",
+        "4.1.0.3": "4.4.4"
       }
     },
     "System.ServiceModel.Http": {
@@ -77,7 +80,7 @@
         "4.4.2",
         "4.4.3"
       ],
-      "BaselineVersion": "4.4.3",
+      "BaselineVersion": "4.4.4",
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
         "3.9.0.0": "3.9.0",
@@ -88,7 +91,8 @@
         "4.1.1.1": "4.3.2",
         "4.1.2.0": "4.4.1",
         "4.1.2.1": "4.4.2",
-        "4.1.2.2": "4.4.3"
+        "4.1.2.2": "4.4.3",
+        "4.1.2.3": "4.4.4"
       }
     },
     "System.ServiceModel.NetTcp": {
@@ -103,7 +107,7 @@
         "4.4.2",
         "4.4.3"
       ],
-      "BaselineVersion": "4.4.3",
+      "BaselineVersion": "4.4.4",
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
@@ -112,7 +116,8 @@
         "4.1.1.1": "4.3.2",
         "4.1.2.0": "4.4.1",
         "4.1.2.1": "4.4.2",
-        "4.1.2.2": "4.4.3"
+        "4.1.2.2": "4.4.3",
+        "4.1.2.3": "4.4.4"
       }
     },
     "System.ServiceModel.Primitives": {
@@ -128,7 +133,7 @@
         "4.4.2",
         "4.4.3"
       ],
-      "BaselineVersion": "4.4.3",
+      "BaselineVersion": "4.4.4",
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
         "3.9.0.0": "3.9.0",
@@ -138,7 +143,8 @@
         "4.1.1.1": "4.3.2",
         "4.2.0.0": "4.4.1",
         "4.2.0.1": "4.4.2",
-        "4.2.0.2": "4.4.3"
+        "4.2.0.2": "4.4.3",
+        "4.2.0.3": "4.4.4"
       }
     },
     "System.ServiceModel.Security": {
@@ -154,7 +160,7 @@
         "4.4.2",
         "4.4.3"
       ],
-      "BaselineVersion": "4.4.3",
+      "BaselineVersion": "4.4.4",
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
         "3.9.0.0": "3.9.0",
@@ -164,7 +170,8 @@
         "4.0.2.1": "4.3.2",
         "4.0.3.0": "4.4.1",
         "4.0.3.1": "4.4.2",
-        "4.0.3.2": "4.4.3"
+        "4.0.3.2": "4.4.3",
+        "4.0.3.3": "4.4.4"
       }
     }
   },

--- a/src/System.Private.ServiceModel/dir.props
+++ b/src/System.Private.ServiceModel/dir.props
@@ -2,6 +2,6 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.1.2.3</AssemblyVersion>
+    <AssemblyVersion>4.1.2.4</AssemblyVersion>
   </PropertyGroup>
 </Project>

--- a/src/System.ServiceModel.Duplex/dir.props
+++ b/src/System.ServiceModel.Duplex/dir.props
@@ -2,6 +2,6 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.1.0.2</AssemblyVersion>
+    <AssemblyVersion>4.1.0.3</AssemblyVersion>
   </PropertyGroup>
 </Project>

--- a/src/System.ServiceModel.Http/dir.props
+++ b/src/System.ServiceModel.Http/dir.props
@@ -2,6 +2,6 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.1.2.2</AssemblyVersion>
+    <AssemblyVersion>4.1.2.3</AssemblyVersion>
   </PropertyGroup>
 </Project>

--- a/src/System.ServiceModel.NetTcp/dir.props
+++ b/src/System.ServiceModel.NetTcp/dir.props
@@ -2,6 +2,6 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.1.2.2</AssemblyVersion>
+    <AssemblyVersion>4.1.2.3</AssemblyVersion>
   </PropertyGroup>
 </Project>

--- a/src/System.ServiceModel.Primitives/dir.props
+++ b/src/System.ServiceModel.Primitives/dir.props
@@ -2,6 +2,6 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.2.0.2</AssemblyVersion>
+    <AssemblyVersion>4.2.0.3</AssemblyVersion>
   </PropertyGroup>
 </Project>

--- a/src/System.ServiceModel.Security/dir.props
+++ b/src/System.ServiceModel.Security/dir.props
@@ -2,6 +2,6 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.0.3.2</AssemblyVersion>
+    <AssemblyVersion>4.0.3.3</AssemblyVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
* Incremented assembly and package versions.
* Update comments in the packageIndex.props.