### PR TITLE
The exe does not exist, point to the dll instead.

### DIFF
--- a/UpdatePublishedVersions.ps1
+++ b/UpdatePublishedVersions.ps1
@@ -16,7 +16,7 @@ param(
     # A pattern matching all packages in the set that the versions repository should be set to.
     [Parameter(Mandatory=$true)][string]$nupkgPath)
 
-. "$PSScriptRoot\Tools\dotnetcli\dotnet.exe" Tools\msbuild.exe build.proj /t:UpdatePublishedVersions `
+. "$PSScriptRoot\Tools\dotnetcli\dotnet.exe" Tools\msbuild.dll build.proj /t:UpdatePublishedVersions `
     /p:GitHubUser="$gitHubUser" `
     /p:GitHubEmail="$gitHubEmail" `
     /p:GitHubAuthToken="$gitHubAuthToken" `


### PR DESCRIPTION
Minor fix to get the script working. This allows our build definitions to update the versions repo with new builds.