### PR TITLE
Stebon/master/updates to support uwp tests

### DIFF
--- a/dependencies.props
+++ b/dependencies.props
@@ -27,17 +27,17 @@
     <MicrosoftPrivateCoreFxNETCoreAppPackageVersion>4.5.0-preview3-26430-04</MicrosoftPrivateCoreFxNETCoreAppPackageVersion>
     <MicrosoftPrivateCoreFxUAPPackageVersion>4.6.0-preview3-26430-04</MicrosoftPrivateCoreFxUAPPackageVersion>
 
-    <ProjectNTfsExpectedPrerelease>beta-26226-00</ProjectNTfsExpectedPrerelease>
-    <ProjectNTfsTestILCExpectedPrerelease>beta-26226-00</ProjectNTfsTestILCExpectedPrerelease>
-    <ProjectNTfsTestILCPackageVersion>DEPENDENCY 'TestILC.amd64ret' NOT FOUND</ProjectNTfsTestILCPackageVersion>
+    <ProjectNTfsExpectedPrerelease>beta-26413-00</ProjectNTfsExpectedPrerelease>
+    <ProjectNTfsTestILCExpectedPrerelease>beta-26413-00</ProjectNTfsTestILCExpectedPrerelease>
+    <ProjectNTfsTestILCPackageVersion>1.0.0-beta-26413-00</ProjectNTfsTestILCPackageVersion>
   </PropertyGroup>
 
   <!-- Full package version strings that are used in other parts of the build. -->
   <PropertyGroup>
     <AppXRunnerVersion>1.0.3-prerelease-00921-01</AppXRunnerVersion>
     <CoreFxBaseLinePackageVersion>2.2.0-preview1-26020-03</CoreFxBaseLinePackageVersion>
-    <XunitPerfAnalysisPackageVersion>1.0.0-beta-build0007</XunitPerfAnalysisPackageVersion>
-    <XunitNetcoreExtensionsVersion>2.1.0-prerelease-02312-02</XunitNetcoreExtensionsVersion>
+    <XunitPerfAnalysisPackageVersion>1.0.0-beta-build0019</XunitPerfAnalysisPackageVersion>
+    <XunitNetcoreExtensionsVersion>2.1.0-rc1-03006-01</XunitNetcoreExtensionsVersion>
 
     <CoreClrPackageVersion>2.2.0-preview1-26430-05</CoreClrPackageVersion>
     <DotNetHostPackageVersion>2.0.0-preview2-25310-02</DotNetHostPackageVersion>

--- a/dir.targets
+++ b/dir.targets
@@ -90,7 +90,7 @@
 
   <ItemGroup Condition="'$(NuGetTargetMoniker)'=='.NETStandard,Version=v1.7'">
     <!-- Temporarily suppress the message until we get a nuget version that knows about the mapping between netstandard1.7 and uapvNext -->
-    <SuppressPackageTargetFrameworkCompatibility Include="$(UAPvNextTFMF)" />
+    <SuppressPackageTargetFrameworkCompatibility Include="$(UAPvNextTFM)" />
   </ItemGroup>
 
   <Target Name="ProducesPackageId"

--- a/external/test-runtime/optional.json
+++ b/external/test-runtime/optional.json
@@ -3,9 +3,9 @@
     "net45": {
         "dependencies": {
             "Microsoft.DotNet.IBCMerge": "4.6.0-alpha-00001",
-            "TestILC.amd64ret": "1.0.0-beta-25725-00",
-            "TestILC.armret": "1.0.0-beta-25725-00",
-            "TestILC.x86ret": "1.0.0-beta-25725-00"
+            "TestILC.amd64ret": "1.0.0-beta-26413-00",
+            "TestILC.armret": "1.0.0-beta-26413-00",
+            "TestILC.x86ret": "1.0.0-beta-26413-00"
         }
     }
   }

--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/ExpectedExceptions/ExpectedExceptionTests.4.1.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/ExpectedExceptions/ExpectedExceptionTests.4.1.0.cs
@@ -52,7 +52,7 @@ public partial class ExpectedExceptionTests : ConditionalWcfTest
     }
 
     [WcfFact]
-    [Issue(1717, Framework = FrameworkID.NetNative)]
+    [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "Issue: https://github.com/dotnet/wcf/issues/1717")]
     [OuterLoop]
     public static void ServiceRestart_Throws_CommunicationException()
     {

--- a/src/System.Private.ServiceModel/tests/Scenarios/Extensibility/WebSockets/WebSocketTests.4.1.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Extensibility/WebSockets/WebSocketTests.4.1.0.cs
@@ -14,6 +14,7 @@ using Infrastructure.Common;
 public class WebSocketTests : ConditionalWcfTest
 {
     [WcfFact]
+    [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "Issue: https://github.com/dotnet/wcf/issues/526")]
     [Issue(1438, OS = OSID.Windows_7)]  // not supported on Win7
     [OuterLoop]
     public static void WebSocket_Http_RequestReply_BinaryStreamed()
@@ -77,7 +78,7 @@ public class WebSocketTests : ConditionalWcfTest
 
     [WcfFact]
     [OuterLoop]
-    [Issue(526, Framework = FrameworkID.NetNative)]
+    [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "Issue: https://github.com/dotnet/wcf/issues/526")]
     [Issue(1438, OS = OSID.Windows_7)]  // not supported on Win7
     public static void WebSocket_Http_Duplex_BinaryStreamed()
     {
@@ -170,7 +171,7 @@ public class WebSocketTests : ConditionalWcfTest
 
     [WcfFact]
     [Condition(nameof(Root_Certificate_Installed))]
-    [Issue(526, Framework = FrameworkID.NetNative)]
+    [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "Issue: https://github.com/dotnet/wcf/issues/526")]
     [Issue(1438, OS = OSID.Windows_7)]  // not supported on Win7
     [OuterLoop]
     public static void WebSocket_Https_Duplex_BinaryStreamed()
@@ -266,7 +267,7 @@ public class WebSocketTests : ConditionalWcfTest
     }
 
     [WcfFact]
-    [Issue(526, Framework = FrameworkID.NetNative)]
+    [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "Issue: https://github.com/dotnet/wcf/issues/526")]
     [Issue(1438, OS = OSID.Windows_7)]  // not supported on Win7
     [OuterLoop]
     public static void WebSocket_Https_Duplex_TextStreamed()
@@ -362,7 +363,7 @@ public class WebSocketTests : ConditionalWcfTest
     }
 
     [WcfFact]
-    [Issue(526, Framework = FrameworkID.NetNative)]
+    [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "Issue: https://github.com/dotnet/wcf/issues/526")]
     [Issue(1438, OS = OSID.Windows_7)]  // not supported on Win7
     [OuterLoop]
     public static void WebSocket_Http_Duplex_TextStreamed()
@@ -455,6 +456,7 @@ public class WebSocketTests : ConditionalWcfTest
     }
 
     [WcfFact]
+    [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "Issue: https://github.com/dotnet/wcf/issues/526")]
     [Issue(1438, OS = OSID.Windows_7)]  // not supported on Win7
     [OuterLoop]
     public static void WebSocket_Http_RequestReply_TextStreamed()
@@ -642,7 +644,7 @@ public class WebSocketTests : ConditionalWcfTest
 
     [WcfFact]
     [Condition(nameof(Root_Certificate_Installed))]
-    [Issue(526, Framework = FrameworkID.NetNative)]
+    [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "Issue: https://github.com/dotnet/wcf/issues/526")]
     [Issue(1438, OS = OSID.Windows_7)]  // not supported on Win7
     [OuterLoop]
     public static void WebSocket_Https_RequestReply_BinaryBuffered()
@@ -695,7 +697,7 @@ public class WebSocketTests : ConditionalWcfTest
 
     [WcfFact]
     [Condition(nameof(Root_Certificate_Installed))]
-    [Issue(526, Framework = FrameworkID.NetNative)]
+    [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "Issue: https://github.com/dotnet/wcf/issues/526")]
     [Issue(1438, OS = OSID.Windows_7)]  // not supported on Win7
     [OuterLoop]
     public static void WebSocket_Https_RequestReply_TextBuffered_KeepAlive()
@@ -750,7 +752,7 @@ public class WebSocketTests : ConditionalWcfTest
 
     [WcfFact]
     [Condition(nameof(Root_Certificate_Installed))]
-    [Issue(526, Framework = FrameworkID.NetNative)]
+    [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "Issue: https://github.com/dotnet/wcf/issues/526")]
     [Issue(1438, OS = OSID.Windows_7)]  // not supported on Win7
     [OuterLoop]
     public static void WebSocket_Https_Duplex_BinaryBuffered()
@@ -818,7 +820,7 @@ public class WebSocketTests : ConditionalWcfTest
 
     [WcfFact]
     [Condition(nameof(Root_Certificate_Installed))]
-    [Issue(526, Framework = FrameworkID.NetNative)]
+    [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "Issue: https://github.com/dotnet/wcf/issues/526")]
     [Issue(1438, OS = OSID.Windows_7)]  // not supported on Win7
     [OuterLoop]
     public static void WebSocket_Https_Duplex_TextBuffered_KeepAlive()
@@ -885,7 +887,7 @@ public class WebSocketTests : ConditionalWcfTest
     }
 
     [WcfFact]
-    [Issue(526, Framework = FrameworkID.NetNative)]
+    [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "Issue: https://github.com/dotnet/wcf/issues/526")]
     [Issue(1438, OS = OSID.Windows_7)]  // not supported on Win7
     [OuterLoop]
     public static void WebSocket_Http_RequestReply_TextBuffered()
@@ -935,7 +937,7 @@ public class WebSocketTests : ConditionalWcfTest
     }
 
     [WcfFact]
-    [Issue(526, Framework = FrameworkID.NetNative)]
+    [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "Issue: https://github.com/dotnet/wcf/issues/526")]
     [Issue(1438, OS = OSID.Windows_7)]  // not supported on Win7
     [OuterLoop]
     public static void WebSocket_Http_RequestReply_BinaryBuffered_KeepAlive()
@@ -986,7 +988,7 @@ public class WebSocketTests : ConditionalWcfTest
     }
 
     [WcfFact]
-    [Issue(526, Framework = FrameworkID.NetNative)]
+    [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "Issue: https://github.com/dotnet/wcf/issues/526")]
     [Issue(1438, OS = OSID.Windows_7)]  // not supported on Win7
     [OuterLoop]
     public static void WebSocket_Http_Duplex_TextBuffered_KeepAlive()
@@ -1050,7 +1052,7 @@ public class WebSocketTests : ConditionalWcfTest
     }
 
     [WcfFact]
-    [Issue(526, Framework = FrameworkID.NetNative)]
+    [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "Issue: https://github.com/dotnet/wcf/issues/526")]
     [Issue(1438, OS = OSID.Windows_7)]  // not supported on Win7
     [OuterLoop]
     public static void WebSocket_Http_Duplex_BinaryBuffered()
@@ -1116,7 +1118,7 @@ public class WebSocketTests : ConditionalWcfTest
     // When not using a callback you can still force WCF to use WebSockets.
     // This test verifies that it actually uses WebSockets when not using a callback.
     [WcfFact]
-    [Issue(526, Framework = FrameworkID.NetNative)]
+    [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "Issue: https://github.com/dotnet/wcf/issues/526")]
     [Issue(1438, OS = OSID.Windows_7)]  // not supported on Win7
     [OuterLoop]
     public static void WebSocket_Http_VerifyWebSocketsUsed()

--- a/src/svcutilcore/tests/Configurations.props
+++ b/src/svcutilcore/tests/Configurations.props
@@ -2,9 +2,6 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <BuildConfigurations>
-      uap;
-      netfx;
-      netstandard;
       netcoreapp;
     </BuildConfigurations>
   </PropertyGroup>


### PR DESCRIPTION
Several commits needed to get our tests running again for uap.

Running these tests revealed the following product issues...

Security.TransportSecurity.Tests.dll (5 FAIL)

Test cases...
Https_ClientCredentialTypeTests.BasicAuthenticationInvalidPwd_throw_MessageSecurityException
Https_ClientCredentialTypeTests.BasicAuthentication_RoundTrips_Echo
Http_ClientCredentialTypeTests.HttpExpect100Continue_DigestAuthentication_True
Http_ClientCredentialTypeTests.DigestAuthentication_Echo_RoundTrips_String_No_Domain

Opened issue: https://github.com/dotnet/wcf/issues/3110 

HttpsTests.Https_SecModeTrans_CertValMode_PeerTrust_Fails_Not_In_TrustedPeople

Opened issue: https://github.com/dotnet/wcf/issues/3112 

This also fixes https://github.com/dotnet/wcf/issues/3111 and https://github.com/dotnet/wcf/issues/3104