### PR TITLE
Do not use CredentialCache when building for uap.

### DIFF
--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/HttpChannelFactory.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/HttpChannelFactory.cs
@@ -366,10 +366,14 @@ namespace System.ServiceModel.Channels
                 }
                 else
                 {
+#if !FEATURE_NETNATIVE // HttpClientHandler for uap does not support a non-NetworkCredential type.
                     CredentialCache credentials = new CredentialCache();
                     credentials.Add(GetCredentialCacheUriPrefix(via),
                         AuthenticationSchemesHelper.ToString(_authenticationScheme), credential);
                     clientHandler.Credentials = credentials;
+#else
+                    clientHandler.Credentials = credential;
+#endif
                 }
 
                 HttpMessageHandler handler = clientHandler;


### PR DESCRIPTION
*** This is a cherry-pick of #3120 ***

* HttpClientHandler for uap does not support a non-NetworkCredentialManager type.
* #if/#endif ...ing the piece of code that is causing this PNSE error.
* Regression was introduced via: https://github.com/dotnet/wcf/pull/2668