### PR TITLE
Force to add reference to System.ServiceModel.Primitives.dll

### DIFF
--- a/src/svcutilcore/pkg/files/dotnet-svcutil.xmlserializer.targets
+++ b/src/svcutilcore/pkg/files/dotnet-svcutil.xmlserializer.targets
@@ -10,11 +10,15 @@
   </PropertyGroup>
 
   <Target Name="SvcUtilGenerateSerializationAssembly" AfterTargets="Build">
+    <ItemGroup>
+      <_ReferenceAssembly Include="@(ReferencePath)"/>
+      <_ReferenceSMAssembly Include="@(_ReferenceAssembly)" Condition="$([System.String]::new('%(_ReferenceAssembly.Identity)').EndsWith('System.ServiceModel.Primitives.dll'))" />
+    </ItemGroup>
     <Delete Condition="Exists('$(_SerializerDllIntermediateFolder)') == 'true'" Files="$(_SerializerDllIntermediateFolder)" ContinueOnError="true" />
     <Delete Condition="Exists('$(_SerializerPdbIntermediateFolder)') == 'true'" Files="$(_SerializerPdbIntermediateFolder)" ContinueOnError="true" />
     <Delete Condition="Exists('$(_SerializerCsIntermediateFolder)') == 'true'" Files="$(_SerializerCsIntermediateFolder)" ContinueOnError="true" />
     <Message Text="Running SvcUtil Serialization Tool" Importance="normal" />
-    <Exec Command="dotnet svcutil.xmlserializer $(IntermediateOutputPath)$(AssemblyName)$(TargetExt) /out:$(IntermediateOutputPath)$(_SerializationAssemblyName)" ContinueOnError="true" />
+    <Exec Command="dotnet svcutil.xmlserializer $(IntermediateOutputPath)$(AssemblyName)$(TargetExt) /out:$(IntermediateOutputPath)$(_SerializationAssemblyName) /smreference:&quot;@(_ReferenceSMAssembly)&quot;" ContinueOnError="true" />
     <Warning Condition="Exists('$(_SerializerCsIntermediateFolder)') != 'true'" Text="$(_SvcUtilWarningText)" />
     <Csc Condition="Exists('$(_SerializerCsIntermediateFolder)') == 'true'" ContinueOnError="true" OutputAssembly="$(_SerializerDllIntermediateFolder)" References="@(ReferencePath);@(IntermediateAssembly)" EmitDebugInformation="$(DebugSymbols)" Sources="$(_SerializerCsIntermediateFolder)" TargetType="Library" ToolExe="$(CscToolExe)" ToolPath="$(CscToolPath)" DisabledWarnings="$(_SerializationAssemblyDisabledWarnings)" />
     <Warning Condition="Exists('$(_SerializerDllIntermediateFolder)') != 'true' And Exists('$(_SerializerCsIntermediateFolder)') == 'true'" Text="$(_SvcUtilWarningText)" />

--- a/src/svcutilcore/src/Microsoft/Tools/ServiceModel/SvcUtil/Options.cs
+++ b/src/svcutilcore/src/Microsoft/Tools/ServiceModel/SvcUtil/Options.cs
@@ -148,8 +148,8 @@ namespace Microsoft.Tools.ServiceModel.SvcUtil.XmlSerializer
                 ProcessOutputOption();
                 ReadInputArguments();
                 ParseNamespaceMappings();
-                ParseReferenceAssemblies();
                 ParseSMReferenceAssembly();
+                ParseReferenceAssemblies();
             }
 
             private bool CheckForHelpOption()

--- a/src/svcutilcore/src/Microsoft/Tools/ServiceModel/SvcUtil/Options.cs
+++ b/src/svcutilcore/src/Microsoft/Tools/ServiceModel/SvcUtil/Options.cs
@@ -295,7 +295,7 @@ namespace Microsoft.Tools.ServiceModel.SvcUtil.XmlSerializer
             private void ParseSMReferenceAssembly()
             {
                 IList<string> referencedAssembliesArgs = _arguments.GetArguments(Options.Cmd.SMReference);
-                if(referencedAssembliesArgs!= null && referencedAssembliesArgs.Count >= 0)
+                if(referencedAssembliesArgs!= null && referencedAssembliesArgs.Count > 0)
                 {
                     var smassembly = referencedAssembliesArgs[0];
                     try

--- a/src/svcutilcore/src/Microsoft/Tools/ServiceModel/SvcUtil/Options.cs
+++ b/src/svcutilcore/src/Microsoft/Tools/ServiceModel/SvcUtil/Options.cs
@@ -149,6 +149,7 @@ namespace Microsoft.Tools.ServiceModel.SvcUtil.XmlSerializer
                 ReadInputArguments();
                 ParseNamespaceMappings();
                 ParseReferenceAssemblies();
+                ParseSMReferenceAssembly();
             }
 
             private bool CheckForHelpOption()
@@ -291,6 +292,26 @@ namespace Microsoft.Tools.ServiceModel.SvcUtil.XmlSerializer
                 _parent._typeResolver = CreateTypeResolver(_parent);
             }
 
+            private void ParseSMReferenceAssembly()
+            {
+                IList<string> referencedAssembliesArgs = _arguments.GetArguments(Options.Cmd.SMReference);
+                if(referencedAssembliesArgs!= null && referencedAssembliesArgs.Count >= 0)
+                {
+                    var smassembly = referencedAssembliesArgs[0];
+                    try
+                    {
+                        InputModule.LoadAssembly(smassembly);
+                    }
+                    catch(Exception e)
+                    {
+                        if (Tool.IsFatal(e))
+                            throw;
+                    }
+                }
+                
+                
+            }
+
             private void SetAllowedModesFromOption(ToolMode newDefaultMode, ToolMode allowedModes, string option, string value)
             {
                 try
@@ -365,8 +386,6 @@ namespace Microsoft.Tools.ServiceModel.SvcUtil.XmlSerializer
                     {
                         if (Tool.IsFatal(e))
                             throw;
-
-                        throw new ToolOptionException(SR.Format(SR.ErrCouldNotLoadReferenceAssemblyAt, path), e);
                     }
                 }
             }

--- a/src/svcutilcore/src/Microsoft/Tools/ServiceModel/SvcUtil/Options.cs
+++ b/src/svcutilcore/src/Microsoft/Tools/ServiceModel/SvcUtil/Options.cs
@@ -295,7 +295,7 @@ namespace Microsoft.Tools.ServiceModel.SvcUtil.XmlSerializer
             private void ParseSMReferenceAssembly()
             {
                 IList<string> referencedAssembliesArgs = _arguments.GetArguments(Options.Cmd.SMReference);
-                if(referencedAssembliesArgs!= null && referencedAssembliesArgs.Count > 0)
+                if(referencedAssembliesArgs != null && referencedAssembliesArgs.Count > 0)
                 {
                     var smassembly = referencedAssembliesArgs[0];
                     try
@@ -304,6 +304,7 @@ namespace Microsoft.Tools.ServiceModel.SvcUtil.XmlSerializer
                     }
                     catch(Exception e)
                     {
+                        ToolConsole.WriteWarning(string.Format("Fail to load the reference assembly {0} with the error {2}", smassembly, e.Message));
                         if (Tool.IsFatal(e))
                             throw;
                     }

--- a/src/svcutilcore/src/Microsoft/Tools/ServiceModel/SvcUtil/OptionsStatics.cs
+++ b/src/svcutilcore/src/Microsoft/Tools/ServiceModel/SvcUtil/OptionsStatics.cs
@@ -14,6 +14,7 @@ namespace Microsoft.Tools.ServiceModel.SvcUtil.XmlSerializer
             internal const string Out = "out";
             internal const string Directory = "directory";
             internal const string Reference = "reference";
+            internal const string SMReference = "smreference";
             internal const string Nostdlib = "noStdLib";
             internal const string ExcludeType = "excludeType";
             internal const string CollectionType = "collectionType";
@@ -30,6 +31,7 @@ namespace Microsoft.Tools.ServiceModel.SvcUtil.XmlSerializer
             internal const string Out = "o";
             internal const string Directory = "d";
             internal const string Reference = "r";
+            internal const string SMReference = "sr";
             internal const string ExcludeType = "et";
             internal const string CollectionType = "ct";
             internal const string Namespace = "n";
@@ -52,6 +54,7 @@ namespace Microsoft.Tools.ServiceModel.SvcUtil.XmlSerializer
             public static readonly CommandSwitch NoLogo = new CommandSwitch(Options.Cmd.NoLogo, Options.Cmd.NoLogo, SwitchType.Flag);
             public static readonly CommandSwitch Out = new CommandSwitch(Options.Cmd.Out, Abbr.Out, SwitchType.SingletonValue);
             public static readonly CommandSwitch Reference = new CommandSwitch(Options.Cmd.Reference, Abbr.Reference, SwitchType.ValueList);
+            public static readonly CommandSwitch SMReference = new CommandSwitch(Options.Cmd.SMReference, Abbr.SMReference, SwitchType.ValueList);
             public static readonly CommandSwitch Nostdlib = new CommandSwitch(Options.Cmd.Nostdlib, Options.Cmd.Nostdlib, SwitchType.Flag);
             public static readonly CommandSwitch ExcludeType = new CommandSwitch(Options.Cmd.ExcludeType, Abbr.ExcludeType, SwitchType.ValueList);
             public static readonly CommandSwitch Namespace = new CommandSwitch(Options.Cmd.Namespace, Abbr.Namespace, SwitchType.ValueList);
@@ -59,7 +62,7 @@ namespace Microsoft.Tools.ServiceModel.SvcUtil.XmlSerializer
             public static readonly CommandSwitch Debug = new CommandSwitch(Options.Cmd.Debug, Options.Cmd.Debug, SwitchType.Flag);
 #endif
             public static readonly CommandSwitch[] All = new CommandSwitch[] { Directory, Help, NoLogo, Out,
-                                                                        Nostdlib, ExcludeType, Namespace,
+                                                                        Nostdlib, ExcludeType, Namespace, Reference, SMReference,
 #if DEBUG
                                                                         Debug,
 #endif


### PR DESCRIPTION
Force to add reference to System.ServiceModel.Primitives.dll through new defined smreference parameter to avoid mismatched SM assembly error. 

#3004 
@mconnew @Lxiamail @yujayee 