### PR TITLE
Update and cleanup dependencies.

### DIFF
--- a/dependencies.props
+++ b/dependencies.props
@@ -10,42 +10,40 @@
   -->
   <PropertyGroup>
     <WCFCurrentRef>97e12b6c3db77604d6af25a13680f1bc9ecae0d1</WCFCurrentRef>
-    <StandardCurrentRef>fba36b56ad15b7f7c9b9e3dea41c8276926df27e</StandardCurrentRef>
+    <StandardCurrentRef>c520a2569b40fc53cf51e4f6970c3e7411adc173</StandardCurrentRef>
     <BuildToolsCurrentRef>97e12b6c3db77604d6af25a13680f1bc9ecae0d1</BuildToolsCurrentRef>
   </PropertyGroup>
 
-  <!-- Auto-upgraded properties for each build info dependency. -->
+  <!-- Product dependency versions. -->
+  <PropertyGroup>
+    <CoreFxPkgStableVersion>4.5.0</CoreFxPkgStableVersion>
+    <NETStandardPackageVersion>2.0.3</NETStandardPackageVersion>
+    <NETStandardPackageId>NETStandard.Library</NETStandardPackageId>
+  </PropertyGroup>
+
+  <!-- Tests/infrastructure dependency versions. -->
   <PropertyGroup>
     <WCFExpectedPrerelease>servicing-26818-01</WCFExpectedPrerelease>
     <CoreFxExpectedPrerelease>rtm-26515-03</CoreFxExpectedPrerelease>
-    <NETStandardPackageVersion>2.0.3</NETStandardPackageVersion>
-    <NETStandardPackageId>NETStandard.Library</NETStandardPackageId>
+    
     <!--
-      This property is used for many CoreFX packages, because they have the same
-      versions. Make more properties for CoreFX if split versions are required.
+    Microsoft.NETCore.Platforms is part of CoreFX, Do not auto-update.
+    WCF servicing releases will keep dependencies set to RTM versions.
     -->
-    <MicrosoftPrivateCoreFxNETCoreAppPackageVersion>4.5.0-rtm</MicrosoftPrivateCoreFxNETCoreAppPackageVersion>
-    <MicrosoftPrivateCoreFxUAPPackageVersion>4.6.0-rtm-26515-03</MicrosoftPrivateCoreFxUAPPackageVersion>
-    <CoreFxPkgStableVersion>4.5.0</CoreFxPkgStableVersion>
-
+    <MicrosoftNETCorePlatformsPackageVersion>2.1.0</MicrosoftNETCorePlatformsPackageVersion>
+    
+    <MicrosoftNETCoreRuntimeCoreCLRPackageVersion>2.1.0-rtm-26515-07</MicrosoftNETCoreRuntimeCoreCLRPackageVersion>
     <ProjectNTfsExpectedPrerelease>beta-26413-00</ProjectNTfsExpectedPrerelease>
     <ProjectNTfsTestILCExpectedPrerelease>beta-26413-00</ProjectNTfsTestILCExpectedPrerelease>
     <ProjectNTfsTestILCPackageVersion>1.0.0-beta-26413-00</ProjectNTfsTestILCPackageVersion>
-  </PropertyGroup>
-
-  <!-- Full package version strings that are used in other parts of the build. -->
-  <PropertyGroup>
+    <MicrosoftNETCoreDotNetHostPackageVersion>2.1.0</MicrosoftNETCoreDotNetHostPackageVersion>
+    <MicrosoftNETCoreDotNetHostPolicyPackageVersion>2.1.0</MicrosoftNETCoreDotNetHostPolicyPackageVersion>
+    <MicrosoftPrivateCoreFxNETCoreAppPackageVersion>4.5.0-rtm</MicrosoftPrivateCoreFxNETCoreAppPackageVersion>
+    <MicrosoftPrivateCoreFxUAPPackageVersion>4.6.0-rtm-26515-03</MicrosoftPrivateCoreFxUAPPackageVersion>
     <AppXRunnerVersion>1.0.3-prerelease-00921-01</AppXRunnerVersion>
     <CoreFxBaseLinePackageVersion>2.2.0-rtm</CoreFxBaseLinePackageVersion>
     <XunitPerfAnalysisPackageVersion>1.0.0-beta-build0019</XunitPerfAnalysisPackageVersion>
     <XunitNetcoreExtensionsVersion>2.1.0-rc1-03006-01</XunitNetcoreExtensionsVersion>
-
-    <CoreClrPackageVersion>2.1.0-rtm-26515-07</CoreClrPackageVersion>
-    <MicrosoftNETCoreDotNetHostPackageVersion>2.1.0</MicrosoftNETCoreDotNetHostPackageVersion>
-    <MicrosoftNETCoreDotNetHostPolicyPackageVersion>2.1.0</MicrosoftNETCoreDotNetHostPolicyPackageVersion>
-
-    <!-- Microsoft.NETCore.Platforms is part of CoreFX, but allow separate upgrade. -->
-    <PlatformPackageVersion>2.1.0</PlatformPackageVersion>
   </PropertyGroup>
 
   <!-- Package versions used as toolsets -->

--- a/external/corefx/corefx.depproj
+++ b/external/corefx/corefx.depproj
@@ -46,12 +46,6 @@
     <PackageReference Include="System.Security.Principal.Windows">
       <Version>$(CoreFxPkgStableVersion)</Version>
     </PackageReference>
-
-    <PackageReference Include="System.Net.Http.WinHttpHandler"
-                      Condition="'$(TargetsWindows)' == 'true' or
-                                 '$(TargetGroup)' == 'netstandard'">
-      <Version>$(CoreFxPkgStableVersion)</Version>
-    </PackageReference>
   </ItemGroup>
 
   <!-- The depproj deploys runtime assets. This target also deploys reference assets. -->

--- a/external/runtime/runtime.depproj
+++ b/external/runtime/runtime.depproj
@@ -31,16 +31,10 @@
 
   <ItemGroup Condition="'$(TargetGroup)'!='uapaot'">
     <PackageReference Include="Microsoft.NETCore.Platforms">
-      <Version>$(PlatformPackageVersion)</Version>
+      <Version>$(MicrosoftNETCorePlatformsPackageVersion)</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.NETCore.Runtime.CoreCLR">
-      <Version>$(CoreClrPackageVersion)</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.NETCore.TestHost">
-      <Version>$(CoreClrPackageVersion)</Version>
-    </PackageReference>
-    <PackageReference Include="runtime.native.System.Data.SqlClient.sni">
-      <Version>$(MicrosoftPrivateCoreFxNETCoreAppPackageVersion)</Version>
+      <Version>$(MicrosoftNETCoreRuntimeCoreCLRPackageVersion)</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.NETCore.DotNetHost">
       <Version>$(MicrosoftNETCoreDotNetHostPackageVersion)</Version>


### PR DESCRIPTION
* Renamed variable "PlatformPackageVersion" to "MicrosoftNETCorePlatformsPackageVersion" for clarity.
* Removed "Microsoft.NETCore.TestHost" from the runtime dependency project as it does not appear to be used anywhere.
* Renamed variable "CoreClrPackageVersion" to "MicrosoftNETCoreRuntimeCoreCLRPackageVersion" for clarity.
* Set NETStandard.Library version to the stable 2.0.3 release.
* Remove "System.Net.Http.WinHttpHandler" as we no longer have that dependency.
* Removed "CoreFxExpectedPrerelease" in dependencies.props as it is not used anywhere.
* Remove package reference to "runtime.native.System.Data.SqlClient.sni" as it is not needed for WCF.