### PR TITLE
Do not use PreleaseLabel when to get the version.

### DIFF
--- a/src/svcutilcore/src/GenerateThisAssemblyCs.targets
+++ b/src/svcutilcore/src/GenerateThisAssemblyCs.targets
@@ -37,14 +37,7 @@ namespace Microsoft.Tools.ServiceModel.SvcUtil.XmlSerializer
         {
             get
             {
-                if (string.IsNullOrEmpty(PreReleaseLabel))
-                {
-                    return PackageVersion%3B
-                }
-                else
-                {
-                    return $"{PackageVersion}-{PreReleaseLabel}"%3B
-                }
+                return PackageVersion%3B
             }
             
             internal set {}


### PR DESCRIPTION
The assembly version in the text will be 1.0.0-preview1 because it read the value https://github.com/dotnet/wcf/blob/f483e9fd6610aefd728aeb76a7df32d707240295/Packaging.props#L5. However we cannot change it to empty string. This change is to workaround this issue for the tool RTM release. Need review this issue later. 

@StephenBonikowsky @mconnew @Lxiamail 