### PR TITLE
Add command-line option "quiet" for svcutil.xmlserializer, and fail the run when customer trying to use the tool directly

### DIFF
--- a/src/svcutilcore/src/Microsoft/Tools/ServiceModel/SvcUtil/Options.cs
+++ b/src/svcutilcore/src/Microsoft/Tools/ServiceModel/SvcUtil/Options.cs
@@ -26,6 +26,7 @@ namespace Microsoft.Tools.ServiceModel.SvcUtil.XmlSerializer
         private string _configFileArg;
 
         private bool _noLogo;
+        private bool _quiet;
         private List<string> _inputParameters;
         private List<Type> _referencedTypes;
         private List<Assembly> _referencedAssemblies;
@@ -36,6 +37,7 @@ namespace Microsoft.Tools.ServiceModel.SvcUtil.XmlSerializer
         internal string OutputFileArg { get { return _outputFileArg; } }
         internal string DirectoryArg { get { return _directoryArg; } }
         internal bool NoLogo { get { return _noLogo; } }
+        internal bool Quiet { get { return _quiet; } }
 
         internal List<string> InputParameters { get { return _inputParameters; } }
         internal List<Type> ReferencedTypes { get { return _referencedTypes; } }
@@ -140,7 +142,7 @@ namespace Microsoft.Tools.ServiceModel.SvcUtil.XmlSerializer
             {
                 CheckForBasicOptions();
 
-                if (CheckForHelpOption())
+                if (CheckForHelpOption() || !CheckForQuietOption())
                     return;
 
                 LoadSMReferenceAssembly();
@@ -159,6 +161,12 @@ namespace Microsoft.Tools.ServiceModel.SvcUtil.XmlSerializer
                     return true;
                 }
                 return false;
+            }
+
+            private bool CheckForQuietOption()
+            {
+                _parent._quiet = _arguments.ContainsArgument(Options.Cmd.Quiet);
+                return _parent._quiet;
             }
 
             private void CheckForBasicOptions()

--- a/src/svcutilcore/src/Microsoft/Tools/ServiceModel/SvcUtil/OptionsStatics.cs
+++ b/src/svcutilcore/src/Microsoft/Tools/ServiceModel/SvcUtil/OptionsStatics.cs
@@ -19,6 +19,7 @@ namespace Microsoft.Tools.ServiceModel.SvcUtil.XmlSerializer
             internal const string ExcludeType = "excludeType";
             internal const string CollectionType = "collectionType";
             internal const string Namespace = "namespace";
+            internal const string Quiet = "quiet";
 #if DEBUG
             internal const string Debug = "debug";
 #endif
@@ -35,7 +36,7 @@ namespace Microsoft.Tools.ServiceModel.SvcUtil.XmlSerializer
             internal const string ExcludeType = "et";
             internal const string CollectionType = "ct";
             internal const string Namespace = "n";
-            internal const string Validate = "v";
+            internal const string Quiet = "q";
         }
 
         internal static class Targets
@@ -58,11 +59,12 @@ namespace Microsoft.Tools.ServiceModel.SvcUtil.XmlSerializer
             public static readonly CommandSwitch Nostdlib = new CommandSwitch(Options.Cmd.Nostdlib, Options.Cmd.Nostdlib, SwitchType.Flag);
             public static readonly CommandSwitch ExcludeType = new CommandSwitch(Options.Cmd.ExcludeType, Abbr.ExcludeType, SwitchType.ValueList);
             public static readonly CommandSwitch Namespace = new CommandSwitch(Options.Cmd.Namespace, Abbr.Namespace, SwitchType.ValueList);
+            public static readonly CommandSwitch Quiet = new CommandSwitch(Options.Cmd.Quiet, Abbr.Quiet, SwitchType.Flag);
 #if DEBUG
             public static readonly CommandSwitch Debug = new CommandSwitch(Options.Cmd.Debug, Options.Cmd.Debug, SwitchType.Flag);
 #endif
             public static readonly CommandSwitch[] All = new CommandSwitch[] { Directory, Help, NoLogo, Out,
-                                                                        Nostdlib, ExcludeType, Namespace, Reference, SMReference, 
+                                                                        Nostdlib, ExcludeType, Namespace, Reference, SMReference, Quiet,
 #if DEBUG
                                                                         Debug,
 #endif

--- a/src/svcutilcore/src/Microsoft/Tools/ServiceModel/SvcUtil/ToolRuntime.cs
+++ b/src/svcutilcore/src/Microsoft/Tools/ServiceModel/SvcUtil/ToolRuntime.cs
@@ -26,6 +26,11 @@ namespace Microsoft.Tools.ServiceModel.SvcUtil.XmlSerializer
                 ToolConsole.WriteHelpText();
                 return ToolExitCodes.Success;
             }
+            else if(!_options.Quiet)
+            {
+                ToolConsole.WriteWarning(System.SR.WrnToolIsUsedDirectly);
+                return ToolExitCodes.InputError;
+            }
             else
             {
                 InputModule inputModule = InputModule.LoadInputs(_options);

--- a/src/svcutilcore/src/Resources/Strings.resx
+++ b/src/svcutilcore/src/Resources/Strings.resx
@@ -528,6 +528,9 @@
   <data name="WrnOptionConflictsWithInput" xml:space="preserve">
     <value>Option /{0} cannot be used with multiple input assemblies. Ignoring {0} option. </value>
   </data>
+  <data name="WrnToolIsUsedDirectly" xml:space="preserve">
+    <value>This tool is not intended to be used directly. </value>
+  </data>
   <data name="GeneratingFiles" xml:space="preserve">
     <value>Generating files...</value>
   </data>

--- a/src/svcutilcore/tests/SvcutilTests.cs
+++ b/src/svcutilcore/tests/SvcutilTests.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Tools.ServiceModel.SvcUtil.XmlSerializer.Tests
             string smassemblypath = testassemblypath.Replace("dotnet-svcutil.xmlserializer.Tests", "System.ServiceModel.Primitives").Replace("Microsoft.Tools.ServiceModel.SvcUtil.XmlSerializer.Tests.dll", "System.ServiceModel.Primitives.dll").Replace("netcoreapp", "netstandard");
             if (File.Exists(smassemblypath))
             {
-                Tool.Main(new string[] { Assembly.GetExecutingAssembly().Location, $"/out:{outputFile}", $"/smreference:{smassemblypath}" });
+                Tool.Main(new string[] { Assembly.GetExecutingAssembly().Location, $"/out:{outputFile}", $"/smreference:{smassemblypath}", $"/quiet"});
                 Assert.True(File.Exists(outputFile));
                 File.Delete(outputFile);
             }

--- a/src/svcutilcore/tests/dotnet-svcutil.xmlserializer.Tests.csproj
+++ b/src/svcutilcore/tests/dotnet-svcutil.xmlserializer.Tests.csproj
@@ -81,10 +81,10 @@
       <CorrectedOutputPath>$(OutputPath.Replace('/', '\'))</CorrectedOutputPath>
       <SMOutputPath>$(RuntimePath)</SMOutputPath>
     </PropertyGroup>
-    <Message Text="Run XmlSerializer: $(GeneratorCliPath)dotnet $(CorrectedOutputPath)dotnet-svcutil.xmlserializer.dll $(CorrectedOutputPath)$(InputAssembly).dll /out:$(CorrectedOutputPath)$(SerializerName).cs /smreference:$(SMOutputPath)System.ServiceModel.Primitives.dll" Importance="high" />
+    <Message Text="Run XmlSerializer: $(GeneratorCliPath)dotnet $(CorrectedOutputPath)dotnet-svcutil.xmlserializer.dll $(CorrectedOutputPath)$(InputAssembly).dll /quiet /out:$(CorrectedOutputPath)$(SerializerName).cs /smreference:$(SMOutputPath)System.ServiceModel.Primitives.dll" Importance="high" />
     <Message Text="System.ServiceModel.Primitives.dll exists in $(SMOutputPath)" Condition="Exists('$(SMOutputPath)System.ServiceModel.Primitives.dll') == 'true'" Importance="high" />
     <Error Text="System.ServiceModel.Primitives.dll not exists in $(SMOutputPath)" Condition="Exists('$(SMOutputPath)System.ServiceModel.Primitives.dll') != 'true'" Importance="high" />
-    <Exec Command="$(GeneratorCliPath)dotnet $(CorrectedOutputPath)dotnet-svcutil.xmlserializer.dll $(CorrectedOutputPath)$(InputAssembly).dll /out:$(CorrectedOutputPath)$(SerializerName).cs /smreference:$(SMOutputPath)System.ServiceModel.Primitives.dll"  />
+    <Exec Command="$(GeneratorCliPath)dotnet $(CorrectedOutputPath)dotnet-svcutil.xmlserializer.dll $(CorrectedOutputPath)$(InputAssembly).dll /quiet /out:$(CorrectedOutputPath)$(SerializerName).cs /smreference:$(SMOutputPath)System.ServiceModel.Primitives.dll"  />
     <Warning Condition="Exists('$(CorrectedOutputPath)$(SerializerName).cs') != 'true'" Text="Fail to generate $(CorrectedOutputPath)$(SerializerName).cs"/>
     <Csc Condition="Exists('$(CorrectedOutputPath)$(SerializerName).cs') == 'true'"
          OutputAssembly="$(CorrectedOutputPath)$(SerializerName).dll"


### PR DESCRIPTION
Fixes #2884 
