### PR TITLE
Change svcutil.xmlserializer's command line argument from "/option" to "--option"

### DIFF
--- a/src/svcutilcore/src/Microsoft/Tools/ServiceModel/SvcUtil/CommandLineParser.cs
+++ b/src/svcutilcore/src/Microsoft/Tools/ServiceModel/SvcUtil/CommandLineParser.cs
@@ -25,13 +25,14 @@ namespace Microsoft.Tools.ServiceModel.SvcUtil.XmlSerializer
 
         internal CommandSwitch(string name, string abbreviation, SwitchType switchType)
         {
-            //ensure that either name doesn't start with '/' or '-'
+            //ensure that either name doesn't start with '--' or '-'
             //also convert to lower-case
-            if ((name[0] == '/') || (name[0] == '-'))
-                _name = (name.Substring(1)).ToLower(CultureInfo.InvariantCulture);
+            if (name.Length > 1 && name[0] == '-' && name[1] == '-')
+                _name = (name.Substring(2)).ToLower(CultureInfo.InvariantCulture);
             else
                 _name = name.ToLower(CultureInfo.InvariantCulture);
-            if ((abbreviation[0] == '/') || (abbreviation[0] == '-'))
+
+            if (abbreviation[0] == '-')
                 _abbreviation = (abbreviation.Substring(1)).ToLower(CultureInfo.InvariantCulture);
             else
                 _abbreviation = abbreviation.ToLower(CultureInfo.InvariantCulture);
@@ -60,12 +61,17 @@ namespace Microsoft.Tools.ServiceModel.SvcUtil.XmlSerializer
         {
             string temp;
 
-            //ensure that compare doesn't start with '/' or '-'
+            //ensure that compare doesn't start with '--' or '-'
             //also convert to lower-case
-            if ((other[0] == '/') || (other[0] == '-'))
-                temp = (other.Substring(1)).ToLower(CultureInfo.InvariantCulture);
-            else
-                temp = other.ToLower(CultureInfo.InvariantCulture);
+            if (other[0] == '-')
+            {
+                if (other.Length > 1 && other[1] == '-')
+                    other = other.Substring(2);
+                else
+                    other = other.Substring(1);
+            }
+            temp = other.ToLower(CultureInfo.InvariantCulture);
+
 
             //if equal to name, then return the OK
             if (_name.Equals(temp))
@@ -166,18 +172,21 @@ namespace Microsoft.Tools.ServiceModel.SvcUtil.XmlSerializer
                 bool argIsFlag = true;
 
                 //if argument does not start with switch indicator, place into "default" arguments
-                if ((arg[0] != '/') && (arg[0] != '-'))
+                if (arg[0] != '-')
                 {
                     arguments.Add(String.Empty, arg);
                     continue;
                 }
 
                 //if we have something which begins with '/' or '-', throw if nothing after it
-                if (arg.Length == 1)
+                if (arg.Length == 1 || (arg.Length ==2 && arg[1] == '-'))
                     throw new ArgumentException(SR.Format(SR.ErrSwitchMissing, arg));
 
-                //yank switch indicator ('/' or '-') off of command argument
-                arg = arg.Substring(1);
+                //yank switch indicator ('--' or '-') off of command argument
+                if (arg[1] != '-')
+                    arg = arg.Substring(1);
+                else
+                    arg = arg.Substring(2);
 
                 //check to make sure delimiter does not start off switch
                 delim = arg.IndexOfAny(new char[] { ':', '=' });

--- a/src/svcutilcore/src/Microsoft/Tools/ServiceModel/SvcUtil/CommandLineParser.cs
+++ b/src/svcutilcore/src/Microsoft/Tools/ServiceModel/SvcUtil/CommandLineParser.cs
@@ -25,17 +25,17 @@ namespace Microsoft.Tools.ServiceModel.SvcUtil.XmlSerializer
 
         internal CommandSwitch(string name, string abbreviation, SwitchType switchType)
         {
-            //ensure that either name doesn't start with '--' or '-'
+            //ensure name doesn't start with '--' and abbreviation doesn't start with '-'
             //also convert to lower-case
-            if (name.Length > 1 && name[0] == '-' && name[1] == '-')
-                _name = (name.Substring(2)).ToLower(CultureInfo.InvariantCulture);
-            else
-                _name = name.ToLower(CultureInfo.InvariantCulture);
+            if (name.StartsWith("--"))
+                name = name.Substring(2);
+          
+            _name = name.ToLower(CultureInfo.InvariantCulture);
 
-            if (abbreviation[0] == '-')
-                _abbreviation = (abbreviation.Substring(1)).ToLower(CultureInfo.InvariantCulture);
-            else
-                _abbreviation = abbreviation.ToLower(CultureInfo.InvariantCulture);
+            if (abbreviation.StartsWith("-"))
+                abbreviation = abbreviation.Substring(1);
+
+            _abbreviation = abbreviation.ToLower(CultureInfo.InvariantCulture);
 
             _switchType = switchType;
         }
@@ -58,26 +58,19 @@ namespace Microsoft.Tools.ServiceModel.SvcUtil.XmlSerializer
         }
 
         internal bool Equals(string other)
-        {
-            string temp;
-
+        { 
             //ensure that compare doesn't start with '--' or '-'
             //also convert to lower-case
-            if (other[0] == '-')
-            {
-                if (other.Length > 1 && other[1] == '-')
-                    other = other.Substring(2);
-                else
-                    other = other.Substring(1);
-            }
-            temp = other.ToLower(CultureInfo.InvariantCulture);
-
-
+            if(other.StartsWith("--"))
+                other = other.Substring(2);
+            else if(other.StartsWith("-"))
+                other = other.Substring(1);
+            
             //if equal to name, then return the OK
-            if (_name.Equals(temp))
+            if (_name.Equals(other, StringComparison.InvariantCultureIgnoreCase))
                 return true;
             //now check abbreviation
-            return _abbreviation.Equals(temp);
+            return _abbreviation.Equals(other, StringComparison.InvariantCultureIgnoreCase);
         }
 
         internal static CommandSwitch FindSwitch(string name, CommandSwitch[] switches)
@@ -178,8 +171,8 @@ namespace Microsoft.Tools.ServiceModel.SvcUtil.XmlSerializer
                     continue;
                 }
 
-                //if we have something which begins with '/' or '-', throw if nothing after it
-                if (arg.Length == 1 || (arg.Length ==2 && arg[1] == '-'))
+                //if we have something which begins with '--' or '-', throw if nothing after it
+                if (arg == "-" || arg == "--")
                     throw new ArgumentException(SR.Format(SR.ErrSwitchMissing, arg));
 
                 //yank switch indicator ('--' or '-') off of command argument

--- a/src/svcutilcore/src/Microsoft/Tools/ServiceModel/SvcUtil/CommandLineParser.cs
+++ b/src/svcutilcore/src/Microsoft/Tools/ServiceModel/SvcUtil/CommandLineParser.cs
@@ -61,9 +61,9 @@ namespace Microsoft.Tools.ServiceModel.SvcUtil.XmlSerializer
         { 
             //ensure that compare doesn't start with '--' or '-'
             //also convert to lower-case
-            if(other.StartsWith("--"))
+            if (other.StartsWith("--"))
                 other = other.Substring(2);
-            else if(other.StartsWith("-"))
+            else if (other.StartsWith("-"))
                 other = other.Substring(1);
             
             //if equal to name, then return the OK

--- a/src/svcutilcore/src/Microsoft/Tools/ServiceModel/SvcUtil/ToolConsole.cs
+++ b/src/svcutilcore/src/Microsoft/Tools/ServiceModel/SvcUtil/ToolConsole.cs
@@ -270,14 +270,14 @@ namespace Microsoft.Tools.ServiceModel.SvcUtil.XmlSerializer
                 internal static ArgumentInfo CreateFlagHelpInfo(string option)
                 {
                     ArgumentInfo argInfo = new ArgumentInfo();
-                    argInfo._name = String.Format(CultureInfo.InvariantCulture, "/{0}", option);
+                    argInfo._name = String.Format(CultureInfo.InvariantCulture, "--{0}", option);
                     return argInfo;
                 }
 
                 internal static ArgumentInfo CreateParameterHelpInfo(string option, string optionUse)
                 {
                     ArgumentInfo argInfo = new ArgumentInfo();
-                    argInfo._name = String.Format(CultureInfo.InvariantCulture, "/{0}:{1}", option, optionUse);
+                    argInfo._name = String.Format(CultureInfo.InvariantCulture, "--{0}:{1}", option, optionUse);
                     return argInfo;
                 }
 

--- a/src/svcutilcore/src/Microsoft/Tools/ServiceModel/SvcUtil/ToolConsole.cs
+++ b/src/svcutilcore/src/Microsoft/Tools/ServiceModel/SvcUtil/ToolConsole.cs
@@ -202,7 +202,7 @@ namespace Microsoft.Tools.ServiceModel.SvcUtil.XmlSerializer
                 HelpCategory helpCategory = new HelpCategory(SR.Format(SR.HelpCodeGenerationCategory));
 
                 helpCategory.Description = SR.Format(SR.HelpCodeGenerationDescription, ThisAssembly.Title);
-                helpCategory.Syntax = SR.Format(SR.HelpCodeGenerationSyntax, ThisAssembly.Title, Options.Abbr.Target, Options.Targets.Code,
+                helpCategory.Syntax = SR.Format(SR.HelpCodeGenerationAbbreviationSyntax, ThisAssembly.Title, Options.Abbr.Target, Options.Targets.Code,
                     SR.Format(SR.HelpInputMetadataDocumentPath), SR.Format(SR.HelpInputUrl), SR.Format(SR.HelpInputEpr));
 
                 helpCategory.Inputs = new ArgumentInfo[3];
@@ -270,14 +270,14 @@ namespace Microsoft.Tools.ServiceModel.SvcUtil.XmlSerializer
                 internal static ArgumentInfo CreateFlagHelpInfo(string option)
                 {
                     ArgumentInfo argInfo = new ArgumentInfo();
-                    argInfo._name = String.Format(CultureInfo.InvariantCulture, "--{0}", option);
+                    argInfo._name = $"--{option}";
                     return argInfo;
                 }
 
                 internal static ArgumentInfo CreateParameterHelpInfo(string option, string optionUse)
                 {
                     ArgumentInfo argInfo = new ArgumentInfo();
-                    argInfo._name = String.Format(CultureInfo.InvariantCulture, "--{0}:{1}", option, optionUse);
+                    argInfo._name = $"--{option}:{optionUse}";
                     return argInfo;
                 }
 

--- a/src/svcutilcore/src/Resources/Strings.resx
+++ b/src/svcutilcore/src/Resources/Strings.resx
@@ -154,10 +154,10 @@
     <value>-= METADATA EXPORT =-</value>
   </data>
   <data name="HelpMetadataExportDescription" xml:space="preserve">
-    <value>Description: {0} can export metadata for services, contracts and data types in compiled assemblies. To export metadata for a service, you must use the /{1} option to indicate the service you would like to export. To export all Data Contract types within an assembly use the /{2} option. By default metadata is exported for all Service Contracts in the input assemblies.</value>
+    <value>Description: {0} can export metadata for services, contracts and data types in compiled assemblies. To export metadata for a service, you must use the --{1} option to indicate the service you would like to export. To export all Data Contract types within an assembly use the --{2} option. By default metadata is exported for all Service Contracts in the input assemblies.</value>
   </data>
   <data name="HelpMetadataExportSyntax" xml:space="preserve">
-    <value>Syntax: {0} [/{1}:{2}] [/{3}:{4}] [/{5}] {6}*</value>
+    <value>Syntax: {0} [--{1}:{2}] [--{3}:{4}] [--{5}] {6}*</value>
   </data>
   <data name="HelpMetadataExportSyntaxInput1" xml:space="preserve">
     <value>The path to an assembly that contains services, contracts or Data Contract types to be exported. Standard command-line wildcards can be used to provide multiple files as input.</value>
@@ -168,7 +168,7 @@
   <data name="HelpCodeGenerationDescription" xml:space="preserve">
     <value>Description: {0} can generate code for service contracts, clients and data types from metadata documents. These metadata documents can be on disk or retrieved online. Online retrieval follows either the WS-Metadata Exchange protocol or the DISCO protocol.</value>
   </data>
-  <data name="HelpCodeGenerationSyntax" xml:space="preserve">
+  <data name="HelpCodeGenerationAbbreviationSyntax" xml:space="preserve">
     <value>Syntax: {0} [-{1}:{2}]  {3}* | {4}* | {5}</value>
   </data>
   <data name="HelpCodeGenerationSyntaxInput1" xml:space="preserve">
@@ -184,10 +184,10 @@
     <value>-= METADATA DOWNLOAD =-</value>
   </data>
   <data name="HelpMetadataDownloadDescription" xml:space="preserve">
-    <value>Description: {0} can be used to download metadata from running services and save the metadata to local files. To download metadata, you must explicitly specify the /{1}:{2} option. Otherwise, client code will be generated. For http and https URL schemes svcutil.exe will try to retrieve metadata using WS-Metadata Exchange and DISCO. For all other URL schemes {0} will only try WS-Metadata Exchange. By default, {0} uses the bindings defined in the System.ServiceModel.Description.MetadataExchangeBindings class. To configure the binding used for WS-Metadata Exchange you must define a client endpoint in config that uses the IMetadataExchange contract. This can be defined either in {0}'s config file or in another config file specified using the /{3} option.</value>
+    <value>Description: {0} can be used to download metadata from running services and save the metadata to local files. To download metadata, you must explicitly specify the --{1}:{2} option. Otherwise, client code will be generated. For http and https URL schemes svcutil.exe will try to retrieve metadata using WS-Metadata Exchange and DISCO. For all other URL schemes {0} will only try WS-Metadata Exchange. By default, {0} uses the bindings defined in the System.ServiceModel.Description.MetadataExchangeBindings class. To configure the binding used for WS-Metadata Exchange you must define a client endpoint in config that uses the IMetadataExchange contract. This can be defined either in {0}'s config file or in another config file specified using the --{3} option.</value>
   </data>
   <data name="HelpMetadataDownloadSyntax" xml:space="preserve">
-    <value>Syntax: {0} /{1}:{2}  {3}* | {4}</value>
+    <value>Syntax: {0} --{1}:{2}  {3}* | {4}</value>
   </data>
   <data name="HelpMetadataDownloadSyntaxInput1" xml:space="preserve">
     <value>The URL to a service endpoint that provides metadata or an URL that points to a metadata document hosted online. </value>
@@ -220,10 +220,10 @@
     <value>-= SERVICE VALIDATION =-</value>
   </data>
   <data name="HelpValidationDescription" xml:space="preserve">
-    <value>Description: Validation is useful to detect errors in service implementations without hosting the service. You must use the /{0} option to indicate the service you would like to validate.</value>
+    <value>Description: Validation is useful to detect errors in service implementations without hosting the service. You must use the --{0} option to indicate the service you would like to validate.</value>
   </data>
   <data name="HelpValidationSyntax" xml:space="preserve">
-    <value>Syntax: {0} /{1} /{2}:{3}  {4}*</value>
+    <value>Syntax: {0} --{1} --{2}:{3}  {4}*</value>
   </data>
   <data name="HelpValidationSyntaxInput1" xml:space="preserve">
     <value>The path to an assembly containing service types to be validated. The assembly must have an associated config file to provide service configuration. Standard command-line wildcards can be used to provide multiple assemblies.</value>
@@ -292,7 +292,7 @@
     <value>A fully-qualified or assembly-qualified type name to exclude from referenced contract types. (Short Form: -{0})</value>
   </data>
   <data name="HelpExcludeTypeExport" xml:space="preserve">
-    <value>The fully-qualified or assembly-qualified name of a type to exclude from export. This option can be used when exporting metadata for a service or a set of service contracts to exclude types from being exported. This option cannot be used with the /{1} option. (Short Form: -{0})</value>
+    <value>The fully-qualified or assembly-qualified name of a type to exclude from export. This option can be used when exporting metadata for a service or a set of service contracts to exclude types from being exported. This option cannot be used with the --{1} option. (Short Form: -{0})</value>
   </data>
   <data name="HelpValidationExcludeTypeExport" xml:space="preserve">
     <value>The fully-qualified or assembly-qualified name of a service type to exclude from validation. (Short Form: -{0})</value>
@@ -358,58 +358,58 @@
     <value>The intended output for the tool could not be inferred from the inputs and the options.</value>
   </data>
   <data name="ErrOptionModeConflict" xml:space="preserve">
-    <value>The /{1} option cannot be used with the /{0} option because they imply different output types.</value>
+    <value>The --{1} option cannot be used with the --{0} option because they imply different output types.</value>
   </data>
   <data name="ErrAmbiguousOptionModeConflict" xml:space="preserve">
-    <value>The /{0} option conflicts with other options. Review your use of the tool.</value>
+    <value>The --{0} option conflicts with other options. Review your use of the tool.</value>
   </data>
   <data name="ErrOptionConflictsWithTarget" xml:space="preserve">
-    <value> The use of the /{2} option is not supported with the /{0} option set to '{1}'.</value>
+    <value> The use of the --{2} option is not supported with the --{0} option set to '{1}'.</value>
   </data>
   <data name="ErrExclusiveOptionsSpecified" xml:space="preserve">
-    <value>The /{0} option cannot be used when the /{1} option has been specified.</value>
+    <value>The --{0} option cannot be used when the --{1} option has been specified.</value>
   </data>
   <data name="ErrDirectoryPointsToAFile" xml:space="preserve">
-    <value>Invalid value '{1}' passed to the /{0} option. '{1}' is a path to a file.</value>
+    <value>Invalid value '{1}' passed to the --{0} option. '{1}' is a path to a file.</value>
   </data>
   <data name="ErrDirectoryContainsInvalidCharacters" xml:space="preserve">
-    <value>Invalid value '{1}' passed to the /{0} option. The {2} character is not permitted in a path</value>
+    <value>Invalid value '{1}' passed to the --{0} option. The {2} character is not permitted in a path</value>
   </data>
   <data name="ErrInvalidTarget" xml:space="preserve">
-    <value>Invalid target '{1}' specified via the /{0} option. The supported Targets are: {2}</value>
+    <value>Invalid target '{1}' specified via the --{0} option. The supported Targets are: {2}</value>
   </data>
   <data name="ErrValidateInvalidUse" xml:space="preserve">
     <value>The {0} option cannot be used with the {1} option.</value>
   </data>
   <data name="ErrValidateRequiresServiceName" xml:space="preserve">
-    <value>To validate a service, the /{0} option must be used to specify the service to validate.</value>
+    <value>To validate a service, the --{0} option must be used to specify the service to validate.</value>
   </data>
   <data name="ErrInvalidSerializer" xml:space="preserve">
-    <value>Invalid serializer value passed to the /{0} option. The supported serializers are: {2}</value>
+    <value>Invalid serializer value passed to the --{0} option. The supported serializers are: {2}</value>
   </data>
   <data name="ErrInvalidTargetClientVersion" xml:space="preserve">
-    <value>Invalid targetClientVersion value passed to the /{0} option. The supported targetClientVersions are: {2}</value>
+    <value>Invalid targetClientVersion value passed to the --{0} option. The supported targetClientVersions are: {2}</value>
   </data>
   <data name="HintConsiderUseXmlSerializer" xml:space="preserve">
-    <value>If you are using the /{0} option to import data contract types and are getting this error message, consider using xsd.exe instead. Types generated by xsd.exe may be used in the Windows Communication Foundation after applying the XmlSerializerFormatAttribute attribute on your service contract. Alternatively, consider using the /{1} option to import these types as XML types to use with DataContractFormatAttribute attribute on your service contract.</value>
+    <value>If you are using the --{0} option to import data contract types and are getting this error message, consider using xsd.exe instead. Types generated by xsd.exe may be used in the Windows Communication Foundation after applying the XmlSerializerFormatAttribute attribute on your service contract. Alternatively, consider using the --{1} option to import these types as XML types to use with DataContractFormatAttribute attribute on your service contract.</value>
   </data>
   <data name="ErrCouldNotCreateCodeProvider" xml:space="preserve">
-    <value>A code provider could not be created for the value: '{0}' passed to the /{1} argument. Verify that the code provider is properly installed and configured.</value>
+    <value>A code provider could not be created for the value: '{0}' passed to the --{1} argument. Verify that the code provider is properly installed and configured.</value>
   </data>
   <data name="ErrNotLanguageOrCodeDomType" xml:space="preserve">
-    <value>The value '{0}' passed to the /{1} argument does not represent a defined language and it could not be loaded as a fully qualified CLR type.</value>
+    <value>The value '{0}' passed to the --{1} argument does not represent a defined language and it could not be loaded as a fully qualified CLR type.</value>
   </data>
   <data name="ErrNotCodeDomType" xml:space="preserve">
-    <value>The type '{0}' passed to the /{1} argument is not a subclass of {2}.</value>
+    <value>The type '{0}' passed to the --{1} argument is not a subclass of {2}.</value>
   </data>
   <data name="ErrCouldNotCreateInstance" xml:space="preserve">
-    <value>Could not create instance of the type '{0}' passed to the /{1} argument.</value>
+    <value>Could not create instance of the type '{0}' passed to the --{1} argument.</value>
   </data>
   <data name="ErrToolConfigDoesNotExist" xml:space="preserve">
-    <value>The config File {0} specified for the /{1} option does not exist.</value>
+    <value>The config File {0} specified for the --{1} option does not exist.</value>
   </data>
   <data name="ErrMergeConfigUsedWithoutConfig" xml:space="preserve">
-    <value>Cannot use the /{0} option without specifying the /{1} option.</value>
+    <value>Cannot use the --{0} option without specifying the --{1} option.</value>
   </data>
   <data name="ErrMergeConfigUsedWhenConfigDoesNotExist" xml:space="preserve">
     <value>Cannot merge config file. The file '{1}' does not exist.</value>
@@ -418,28 +418,28 @@
     <value>Cannot load the config file {0}</value>
   </data>
   <data name="ErrCannotDeleteExistingConfig" xml:space="preserve">
-    <value>There is an existing config file that cannot be overwritten. Either fix the problem or provide a different config file name using the /{0} option.</value>
+    <value>There is an existing config file that cannot be overwritten. Either fix the problem or provide a different config file name using the --{0} option.</value>
   </data>
   <data name="ErrInvalidNamespaceArgument" xml:space="preserve">
-    <value> Invalid value {1} passed to the /{0} option. Specify a comma-separated target namespace and CLR namespace pair.</value>
+    <value> Invalid value {1} passed to the --{0} option. Specify a comma-separated target namespace and CLR namespace pair.</value>
   </data>
   <data name="ErrCannotSpecifyMultipleMappingsForNamespace" xml:space="preserve">
-    <value>Invalid value passed to the /{0} option. Target namespace '{1}' cannot be mapped to multiple CLR namespaces '{2}' and '{3}'</value>
+    <value>Invalid value passed to the --{0} option. Target namespace '{1}' cannot be mapped to multiple CLR namespaces '{2}' and '{3}'</value>
   </data>
   <data name="ErrCouldNotLoadReferenceAssemblyAt" xml:space="preserve">
     <value>Cannot load reference assembly '{0}'</value>
   </data>
   <data name="ErrDuplicateReferenceValues" xml:space="preserve">
-    <value>The assembly {1} was loaded twice through the /{0} option. You may reference each assembly only once.</value>
+    <value>The assembly {1} was loaded twice through the --{0} option. You may reference each assembly only once.</value>
   </data>
   <data name="ErrDuplicateValuePassedToTypeArg" xml:space="preserve">
-    <value>The value {1} was passed to the /{0} option multiple times. Each type may be specified only once.</value>
+    <value>The value {1} was passed to the --{0} option multiple times. Each type may be specified only once.</value>
   </data>
   <data name="ErrCannotDisambiguateSpecifiedTypes" xml:space="preserve">
-    <value>More than one type with the same name exists in the set of referenced assemblies. Use assembly-qualified names to disambiguate between the /{0} types '{1}' and '{2}'</value>
+    <value>More than one type with the same name exists in the set of referenced assemblies. Use assembly-qualified names to disambiguate between the --{0} types '{1}' and '{2}'</value>
   </data>
   <data name="ErrCannotLoadSpecifiedType" xml:space="preserve">
-    <value>No type could be loaded for the value {1} passed to the /{0} option. Ensure that the assembly this type belongs to is specified via the /{2} option.</value>
+    <value>No type could be loaded for the value {1} passed to the --{0} option. Ensure that the assembly this type belongs to is specified via the --{2} option.</value>
   </data>
   <data name="ErrAssemblyLoadFailed" xml:space="preserve">
     <value>Cannot load file {0} as an Assembly. Check the FusionLogs for more Information.</value>
@@ -475,10 +475,10 @@
     <value>The input path '{0}' doesn't appear to refer to any existing files</value>
   </data>
   <data name="ErrInputConflictsWithOption" xml:space="preserve">
-    <value>The input read from '{1}' cannot be used with the /{0} option because they imply different modes of tool operation.</value>
+    <value>The input read from '{1}' cannot be used with the --{0} option because they imply different modes of tool operation.</value>
   </data>
   <data name="ErrInputConflictsWithTarget" xml:space="preserve">
-    <value>The type of input read from '{2}' is not supported with the /{0} option set to '{1}'.</value>
+    <value>The type of input read from '{2}' is not supported with the --{0} option set to '{1}'.</value>
   </data>
   <data name="ErrInputConflictsWithMode" xml:space="preserve">
     <value>The input read from '{0}' is inconsistent with other options.</value>
@@ -490,7 +490,7 @@
     <value>There was a validation error on a schema generated during export:\r\n    Source: {0}\r\n    Line: {1} Column: {2}\r\n   Validation Error: {3}</value>
   </data>
   <data name="ErrUnableToLoadExtensions" xml:space="preserve">
-    <value>There was an error loading import extensions. Make sure to provide the assemblies containing these extensions as reference assemblies using the /{0} option.</value>
+    <value>There was an error loading import extensions. Make sure to provide the assemblies containing these extensions as reference assemblies using the --{0} option.</value>
   </data>
   <data name="ErrUnableToLoadReferenceType" xml:space="preserve">
     <value>There was an error loading a referenced contract type. This type will be ignored.\r\n    Type: {0}</value>
@@ -499,13 +499,13 @@
     <value>Cannot create output filename. Too many files are being created with the prefix '{0}'.</value>
   </data>
   <data name="ErrInvalidPath" xml:space="preserve">
-    <value>Invalid path {0}. Check the /{1} argument</value>
+    <value>Invalid path {0}. Check the --{1} argument</value>
   </data>
   <data name="ErrPathTooLongDirOnly" xml:space="preserve">
-    <value>The resultant path '{0}' is too long. Review the /{1} argument</value>
+    <value>The resultant path '{0}' is too long. Review the --{1} argument</value>
   </data>
   <data name="ErrPathTooLong" xml:space="preserve">
-    <value>The resultant path '{0}' is too long. Review the /{1} and /{2} arguments</value>
+    <value>The resultant path '{0}' is too long. Review the --{1} and --{2} arguments</value>
   </data>
   <data name="ErrCannotCreateDirectory" xml:space="preserve">
     <value>Cannot create directory: {0}</value>
@@ -526,7 +526,7 @@
     <value>Cannot generate XmlSerializer for assembly: {0}. No service contract in the assembly has an operation with XmlSerializerOperationBehavior.</value>
   </data>
   <data name="WrnOptionConflictsWithInput" xml:space="preserve">
-    <value>Option /{0} cannot be used with multiple input assemblies. Ignoring {0} option. </value>
+    <value>Option --{0} cannot be used with multiple input assemblies. Ignoring {0} option. </value>
   </data>
   <data name="GeneratingFiles" xml:space="preserve">
     <value>Generating files...</value>
@@ -544,7 +544,7 @@
     <value>Could not load assembly '{0}'. 2  reference assemblies ('{1}' and '{2}') were found that match the string '{0}'. This is usually caused by an insufficient type reference in a config file. Resolve this issue by passing only the reference assembly needed or by adding more information like a version number or a public key to the reference.</value>
   </data>
   <data name="WrnVJSharpNamespace" xml:space="preserve">
-    <value>When using the '/{0}:{1}' argument, only one namespace mapping is supported. Use '/{2}:*,&lt;string&gt;' to set the namespace.</value>
+    <value>When using the '--{0}:{1}' argument, only one namespace mapping is supported. Use '--{2}:*,&lt;string&gt;' to set the namespace.</value>
   </data>
   <data name="CopyrightForCmdLine" xml:space="preserve">
     <value>Copyright (c) Microsoft Corporation.  All rights reserved.</value>

--- a/src/svcutilcore/src/Resources/Strings.resx
+++ b/src/svcutilcore/src/Resources/Strings.resx
@@ -169,7 +169,7 @@
     <value>Description: {0} can generate code for service contracts, clients and data types from metadata documents. These metadata documents can be on disk or retrieved online. Online retrieval follows either the WS-Metadata Exchange protocol or the DISCO protocol.</value>
   </data>
   <data name="HelpCodeGenerationSyntax" xml:space="preserve">
-    <value>Syntax: {0} [/{1}:{2}]  {3}* | {4}* | {5}</value>
+    <value>Syntax: {0} [-{1}:{2}]  {3}* | {4}* | {5}</value>
   </data>
   <data name="HelpCodeGenerationSyntaxInput1" xml:space="preserve">
     <value>The path to a metadata document (wsdl or xsd). Standard command-line wildcards can be used in the file path.</value>
@@ -208,13 +208,13 @@
     <value>The path to an assembly containing Service Contract types. Serialization types will be generated for all Xml Serializable types in each contract</value>
   </data>
   <data name="HelpXmlSerializerTypeGenerationSyntaxInput2" xml:space="preserve">
-    <value>Add the specified assembly to the set of assemblies used for resolving type references. (Short Form: /{0})</value>
+    <value>Add the specified assembly to the set of assemblies used for resolving type references. (Short Form: -{0})</value>
   </data>
   <data name="HelpXmlSerializerTypeGenerationSyntaxInput3" xml:space="preserve">
-    <value>Fully-qualified or assembly-qualified type name to exclude from export or validation. This option can be used when exporting metadata for a service or a set of service contracts to exclude types from being exported. (Short Form: /{0})</value>
+    <value>Fully-qualified or assembly-qualified type name to exclude from export or validation. This option can be used when exporting metadata for a service or a set of service contracts to exclude types from being exported. (Short Form: -{0})</value>
   </data>
   <data name="HelpXmlSerializerTypeGenerationSyntaxInput4" xml:space="preserve">
-    <value>Filename for the generated code. This option will be ignored when multiple assemblies are passed as input to the tool. Default: derived from the assembly name. (Short Form: /{0})</value>
+    <value>Filename for the generated code. This option will be ignored when multiple assemblies are passed as input to the tool. Default: derived from the assembly name. (Short Form: -{0})</value>
   </data>
   <data name="HelpValidationCategory" xml:space="preserve">
     <value>-= SERVICE VALIDATION =-</value>
@@ -274,55 +274,55 @@
     <value>Suppress the copyright and banner message.</value>
   </data>
   <data name="HelpDirectory" xml:space="preserve">
-    <value>Directory to create files in (default: current directory) (Short Form: /{0})</value>
+    <value>Directory to create files in (default: current directory) (Short Form: -{0})</value>
   </data>
   <data name="HelpOut" xml:space="preserve">
-    <value> The filename for the generated code. Default: derived from the WSDL definition name, WSDL service name or targetNamespace of one of the schemas. (Short Form: /{0})</value>
+    <value> The filename for the generated code. Default: derived from the WSDL definition name, WSDL service name or targetNamespace of one of the schemas. (Short Form: -{0})</value>
   </data>
   <data name="HelpReferenceCodeGeneration" xml:space="preserve">
-    <value>Reference types in the specified assembly. When generating clients, use this option to specify assemblies that might contain types representing the metadata being imported.  (Short Form: /{0})</value>
+    <value>Reference types in the specified assembly. When generating clients, use this option to specify assemblies that might contain types representing the metadata being imported.  (Short Form: -{0})</value>
   </data>
   <data name="HelpReferenceOther" xml:space="preserve">
-    <value>Add the specified assembly to the set of assemblies used for resolving type references. If you are exporting or validating a service that uses 3rd-party extensions (Behaviors, Bindings and BindingElements) registered in config use this option to locate extension assemblies that are not in the GAC.  (Short Form: /{0})</value>
+    <value>Add the specified assembly to the set of assemblies used for resolving type references. If you are exporting or validating a service that uses 3rd-party extensions (Behaviors, Bindings and BindingElements) registered in config use this option to locate extension assemblies that are not in the GAC.  (Short Form: -{0})</value>
   </data>
   <data name="HelpNostdlib" xml:space="preserve">
     <value>Do not reference standard libraries. By default mscorlib.dll and system.servicemodel.dll are referenced.</value>
   </data>
   <data name="HelpExcludeTypeCodeGeneration" xml:space="preserve">
-    <value>A fully-qualified or assembly-qualified type name to exclude from referenced contract types. (Short Form: /{0})</value>
+    <value>A fully-qualified or assembly-qualified type name to exclude from referenced contract types. (Short Form: -{0})</value>
   </data>
   <data name="HelpExcludeTypeExport" xml:space="preserve">
-    <value>The fully-qualified or assembly-qualified name of a type to exclude from export. This option can be used when exporting metadata for a service or a set of service contracts to exclude types from being exported. This option cannot be used with the /{1} option. (Short Form: /{0})</value>
+    <value>The fully-qualified or assembly-qualified name of a type to exclude from export. This option can be used when exporting metadata for a service or a set of service contracts to exclude types from being exported. This option cannot be used with the /{1} option. (Short Form: -{0})</value>
   </data>
   <data name="HelpValidationExcludeTypeExport" xml:space="preserve">
-    <value>The fully-qualified or assembly-qualified name of a service type to exclude from validation. (Short Form: /{0})</value>
+    <value>The fully-qualified or assembly-qualified name of a service type to exclude from validation. (Short Form: -{0})</value>
   </data>
   <data name="HelpCollectionType" xml:space="preserve">
-    <value>A fully-qualified or assembly-qualified name of the type to use as a collection data type when code is generated from schemas. (Short Form: /{0})</value>
+    <value>A fully-qualified or assembly-qualified name of the type to use as a collection data type when code is generated from schemas. (Short Form: -{0})</value>
   </data>
   <data name="HelpTargetOutputType" xml:space="preserve">
     <value>The target output for the tool: {0}, {1} or {2}.</value>
   </data>
   <data name="HelpNamespace" xml:space="preserve">
-    <value>A mapping from a WSDL or XML Schema targetNamespace to a CLR namespace. Using the '*' for the targetNamespace maps all targetNamespaces without an explicit mapping to that CLR namespace. Default: derived from the target namespace of the schema document for Data Contracts. The default namespace is used for all other generated types. (Short Form: /{0})</value>
+    <value>A mapping from a WSDL or XML Schema targetNamespace to a CLR namespace. Using the '*' for the targetNamespace maps all targetNamespaces without an explicit mapping to that CLR namespace. Default: derived from the target namespace of the schema document for Data Contracts. The default namespace is used for all other generated types. (Short Form: -{0})</value>
   </data>
   <data name="HelpHelp" xml:space="preserve">
-    <value>Display command syntax and options for the tool. (Short Form: /{0})</value>
+    <value>Display command syntax and options for the tool. (Short Form: -{0})</value>
   </data>
   <data name="HelpVersion30TargetClientVersion" xml:space="preserve">
-    <value>Generate code that references functionality in .NET Framework assemblies 3.0 and before. Use this switch if you are generating code for clients that use .NET Framework version 3.0.(Short Form: /{0})</value>
+    <value>Generate code that references functionality in .NET Framework assemblies 3.0 and before. Use this switch if you are generating code for clients that use .NET Framework version 3.0.(Short Form: -{0})</value>
   </data>
   <data name="HelpVersion35TargetClientVersion" xml:space="preserve">
-    <value>Generate code that references functionality in .NET Framework assemblies 3.5 and before. Use this switch if you are generating code for clients that use .NET Framework version 3.5.(Short Form: /{0})</value>
+    <value>Generate code that references functionality in .NET Framework assemblies 3.5 and before. Use this switch if you are generating code for clients that use .NET Framework version 3.5.(Short Form: -{0})</value>
   </data>
   <data name="HelpWrapped" xml:space="preserve">
     <value>Generated code will not unwrap "parameters" member of document-wrapped-literal messages.</value>
   </data>
   <data name="HelpCodeGenerationServiceContract" xml:space="preserve">
-    <value>Generate code for Service Contracts. Client class and configuration will not be generated. (Short Form: /{0})</value>
+    <value>Generate code for Service Contracts. Client class and configuration will not be generated. (Short Form: -{0})</value>
   </data>
   <data name="MoreHelp" xml:space="preserve">
-    <value>If you would like more help, type "svcutil /{0}"</value>
+    <value>If you would like more help, type "svcutil -{0}"</value>
   </data>
   <data name="Error" xml:space="preserve">
     <value>Error: </value>

--- a/src/svcutilcore/tests/SvcutilTests.cs
+++ b/src/svcutilcore/tests/SvcutilTests.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Tools.ServiceModel.SvcUtil.XmlSerializer.Tests
             string smassemblypath = testassemblypath.Replace("dotnet-svcutil.xmlserializer.Tests", "System.ServiceModel.Primitives").Replace("Microsoft.Tools.ServiceModel.SvcUtil.XmlSerializer.Tests.dll", "System.ServiceModel.Primitives.dll").Replace("netcoreapp", "netstandard");
             if (File.Exists(smassemblypath))
             {
-                Tool.Main(new string[] { Assembly.GetExecutingAssembly().Location, $"/out:{outputFile}", $"/smreference:{smassemblypath}" });
+                Tool.Main(new string[] { Assembly.GetExecutingAssembly().Location, $"--out:{outputFile}", $"--smreference:{smassemblypath}" });
                 Assert.True(File.Exists(outputFile));
                 File.Delete(outputFile);
             }

--- a/src/svcutilcore/tests/dotnet-svcutil.xmlserializer.Tests.csproj
+++ b/src/svcutilcore/tests/dotnet-svcutil.xmlserializer.Tests.csproj
@@ -81,10 +81,10 @@
       <CorrectedOutputPath>$(OutputPath.Replace('/', '\'))</CorrectedOutputPath>
       <SMOutputPath>$(RuntimePath)</SMOutputPath>
     </PropertyGroup>
-    <Message Text="Run XmlSerializer: $(GeneratorCliPath)dotnet $(CorrectedOutputPath)dotnet-svcutil.xmlserializer.dll $(CorrectedOutputPath)$(InputAssembly).dll /out:$(CorrectedOutputPath)$(SerializerName).cs /smreference:$(SMOutputPath)System.ServiceModel.Primitives.dll" Importance="high" />
+    <Message Text="Run XmlSerializer: $(GeneratorCliPath)dotnet $(CorrectedOutputPath)dotnet-svcutil.xmlserializer.dll $(CorrectedOutputPath)$(InputAssembly).dll --out:$(CorrectedOutputPath)$(SerializerName).cs --smreference:$(SMOutputPath)System.ServiceModel.Primitives.dll" Importance="high" />
     <Message Text="System.ServiceModel.Primitives.dll exists in $(SMOutputPath)" Condition="Exists('$(SMOutputPath)System.ServiceModel.Primitives.dll') == 'true'" Importance="high" />
     <Error Text="System.ServiceModel.Primitives.dll not exists in $(SMOutputPath)" Condition="Exists('$(SMOutputPath)System.ServiceModel.Primitives.dll') != 'true'" Importance="high" />
-    <Exec Command="$(GeneratorCliPath)dotnet $(CorrectedOutputPath)dotnet-svcutil.xmlserializer.dll $(CorrectedOutputPath)$(InputAssembly).dll /out:$(CorrectedOutputPath)$(SerializerName).cs /smreference:$(SMOutputPath)System.ServiceModel.Primitives.dll"  />
+    <Exec Command="$(GeneratorCliPath)dotnet $(CorrectedOutputPath)dotnet-svcutil.xmlserializer.dll $(CorrectedOutputPath)$(InputAssembly).dll --out:$(CorrectedOutputPath)$(SerializerName).cs --smreference:$(SMOutputPath)System.ServiceModel.Primitives.dll"  />
     <Warning Condition="Exists('$(CorrectedOutputPath)$(SerializerName).cs') != 'true'" Text="Fail to generate $(CorrectedOutputPath)$(SerializerName).cs"/>
     <Csc Condition="Exists('$(CorrectedOutputPath)$(SerializerName).cs') == 'true'"
          OutputAssembly="$(CorrectedOutputPath)$(SerializerName).dll"


### PR DESCRIPTION
Fixes #2882
With this code change, we only want to support "--" before name and "-" before abbreviation. 
Take command line option "out" for an example:
Before change, argument should start with "/out", "-out", "/o" or "-o"
After change, we only allow "--out" and "-o"