### PR TITLE
Skip failing test on UAP runs.

### DIFF
--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Https/HttpsTests.4.1.1.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Https/HttpsTests.4.1.1.cs
@@ -67,6 +67,7 @@ public partial class HttpsTests : ConditionalWcfTest
                nameof(Peer_Certificate_Installed),
                nameof(SSL_Available))]
     [Issue(1945, OS = OSID.AnyOSX)] // OSX doesn't support the TrustedPeople certificate store
+    [Issue(3112, Framework = FrameworkID.NetNative)]
     [OuterLoop]
     // Asking for PeerTrust alone should throw SecurityNegotiationException
     // if the certificate is not in the TrustedPeople store.  For this test


### PR DESCRIPTION
* Issue tracked by https://github.com/dotnet/wcf/issues/3112