### PR TITLE
FrameworkID.NetNative does not return NetNative when running on "UAP"…

### DIFF
--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Http/ClientCredentialTypeTests.4.1.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Http/ClientCredentialTypeTests.4.1.0.cs
@@ -79,7 +79,7 @@ public static class Http_ClientCredentialTypeTests
 
     [WcfFact]
     [OuterLoop]
-    [Issue(0000, Framework = FrameworkID.NetNative)] // Expect100Continue header is not supported in UWP.
+    [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "Issue: Expect100Continue header is not supported in UWP.")]
     public static void HttpExpect100Continue_DigestAuthentication_True()
     {
         ChannelFactory<IWcfService> factory = null;

--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Https/HttpsTests.4.1.1.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Https/HttpsTests.4.1.1.cs
@@ -67,7 +67,7 @@ public partial class HttpsTests : ConditionalWcfTest
                nameof(Peer_Certificate_Installed),
                nameof(SSL_Available))]
     [Issue(1945, OS = OSID.AnyOSX)] // OSX doesn't support the TrustedPeople certificate store
-    [Issue(3112, Framework = FrameworkID.NetNative)]
+    [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "Issue: https://github.com/dotnet/wcf/issues/3112")]
     [OuterLoop]
     // Asking for PeerTrust alone should throw SecurityNegotiationException
     // if the certificate is not in the TrustedPeople store.  For this test


### PR DESCRIPTION
… framework.

* See commit: https://github.com/dotnet/wcf/pull/3113/commits/b92808d4d3e0c985027491f42c63091c7e65e3e4