### PR TITLE
Add unit tests to validate the value of properties set in ISecurityCa…

### DIFF
--- a/src/System.ServiceModel.Security/tests/ServiceModel/ISecurityCapabilitiesTest.cs
+++ b/src/System.ServiceModel.Security/tests/ServiceModel/ISecurityCapabilitiesTest.cs
@@ -1,0 +1,82 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+
+using System;
+using System.ServiceModel;
+using System.ServiceModel.Channels;
+using Infrastructure.Common;
+using Xunit;
+
+public static class ISecurityCapabilitiesTest
+{
+    [WcfFact]
+    public static void SecurityCapabilities_HttpsTransportBindingElement()
+    {
+        ISecurityCapabilities capability = CreateISecurityCapabilities(new HttpsTransportBindingElement());
+
+        Assert.Equal("EncryptAndSign", capability.SupportedRequestProtectionLevel.ToString());
+        Assert.Equal("EncryptAndSign", capability.SupportedResponseProtectionLevel.ToString());
+        Assert.Equal("False", capability.SupportsClientAuthentication.ToString());
+        Assert.Equal("False", capability.SupportsClientWindowsIdentity.ToString());
+        Assert.Equal("True", capability.SupportsServerAuthentication.ToString());
+    }
+
+    [WcfFact]
+    public static void SecurityCapabilities_HttpTransportBindingElement()
+    {
+        ISecurityCapabilities capability = CreateISecurityCapabilities(new HttpTransportBindingElement());
+
+        Assert.Equal("None", capability.SupportedRequestProtectionLevel.ToString());
+        Assert.Equal("None", capability.SupportedResponseProtectionLevel.ToString());
+        Assert.Equal("False", capability.SupportsClientAuthentication.ToString());
+        Assert.Equal("False", capability.SupportsClientWindowsIdentity.ToString());
+        Assert.Equal("False", capability.SupportsServerAuthentication.ToString());
+    }
+
+    [WcfFact]
+    public static void SecurityCapabilities_TransportSecurityBindingElement()
+    {
+        ISecurityCapabilities capability = CreateISecurityCapabilities(new TransportSecurityBindingElement());
+
+        Assert.Equal("None", capability.SupportedRequestProtectionLevel.ToString());
+        Assert.Equal("None", capability.SupportedResponseProtectionLevel.ToString());
+        Assert.Equal("False", capability.SupportsClientAuthentication.ToString());
+        Assert.Equal("False", capability.SupportsClientWindowsIdentity.ToString());
+        Assert.Equal("False", capability.SupportsServerAuthentication.ToString());
+    }
+
+    [WcfFact]
+    public static void SecurityCapabilities_SslStreamSecurityBindingElement()
+    {
+        ISecurityCapabilities capability = CreateISecurityCapabilities(new SslStreamSecurityBindingElement());
+
+        Assert.Equal("EncryptAndSign", capability.SupportedRequestProtectionLevel.ToString());
+        Assert.Equal("EncryptAndSign", capability.SupportedResponseProtectionLevel.ToString());
+        Assert.Equal("False", capability.SupportsClientAuthentication.ToString());
+        Assert.Equal("False", capability.SupportsClientWindowsIdentity.ToString());
+        Assert.Equal("True", capability.SupportsServerAuthentication.ToString());
+    }
+
+    [WcfFact]
+    public static void SecurityCapabilities_WindowsStreamSecurityBindingElement()
+    {
+        ISecurityCapabilities capability = CreateISecurityCapabilities(new WindowsStreamSecurityBindingElement());
+
+        Assert.Equal("EncryptAndSign", capability.SupportedRequestProtectionLevel.ToString());
+        Assert.Equal("EncryptAndSign", capability.SupportedResponseProtectionLevel.ToString());
+        Assert.Equal("True", capability.SupportsClientAuthentication.ToString());
+        Assert.Equal("True", capability.SupportsClientWindowsIdentity.ToString());
+        Assert.Equal("True", capability.SupportsServerAuthentication.ToString());
+    }
+
+    public static ISecurityCapabilities CreateISecurityCapabilities(BindingElement bindingElement)
+    {
+        CustomBinding binding = new CustomBinding(bindingElement);
+        BindingParameterCollection collection = new BindingParameterCollection();
+        BindingContext context = new BindingContext(binding, collection);
+        ISecurityCapabilities capability = binding.GetProperty<ISecurityCapabilities>(collection);
+        return capability;
+    }
+}

--- a/src/System.ServiceModel.Security/tests/ServiceModel/ISecurityCapabilitiesTest.cs
+++ b/src/System.ServiceModel.Security/tests/ServiceModel/ISecurityCapabilitiesTest.cs
@@ -6,6 +6,7 @@
 using System;
 using System.ServiceModel;
 using System.ServiceModel.Channels;
+using System.Net.Security;
 using Infrastructure.Common;
 using Xunit;
 
@@ -16,11 +17,11 @@ public static class ISecurityCapabilitiesTest
     {
         ISecurityCapabilities capability = CreateISecurityCapabilities(new HttpsTransportBindingElement());
 
-        Assert.Equal("EncryptAndSign", capability.SupportedRequestProtectionLevel.ToString());
-        Assert.Equal("EncryptAndSign", capability.SupportedResponseProtectionLevel.ToString());
-        Assert.Equal("False", capability.SupportsClientAuthentication.ToString());
-        Assert.Equal("False", capability.SupportsClientWindowsIdentity.ToString());
-        Assert.Equal("True", capability.SupportsServerAuthentication.ToString());
+        Assert.Equal(ProtectionLevel.EncryptAndSign, capability.SupportedRequestProtectionLevel);
+        Assert.Equal(ProtectionLevel.EncryptAndSign, capability.SupportedResponseProtectionLevel);
+        Assert.False(capability.SupportsClientAuthentication);
+        Assert.False(capability.SupportsClientWindowsIdentity);
+        Assert.True(capability.SupportsServerAuthentication);
     }
 
     [WcfFact]
@@ -28,11 +29,11 @@ public static class ISecurityCapabilitiesTest
     {
         ISecurityCapabilities capability = CreateISecurityCapabilities(new HttpTransportBindingElement());
 
-        Assert.Equal("None", capability.SupportedRequestProtectionLevel.ToString());
-        Assert.Equal("None", capability.SupportedResponseProtectionLevel.ToString());
-        Assert.Equal("False", capability.SupportsClientAuthentication.ToString());
-        Assert.Equal("False", capability.SupportsClientWindowsIdentity.ToString());
-        Assert.Equal("False", capability.SupportsServerAuthentication.ToString());
+        Assert.Equal(ProtectionLevel.None, capability.SupportedRequestProtectionLevel);
+        Assert.Equal(ProtectionLevel.None, capability.SupportedResponseProtectionLevel);
+        Assert.False(capability.SupportsClientAuthentication);
+        Assert.False(capability.SupportsClientWindowsIdentity);
+        Assert.False(capability.SupportsServerAuthentication);
     }
 
     [WcfFact]
@@ -40,11 +41,11 @@ public static class ISecurityCapabilitiesTest
     {
         ISecurityCapabilities capability = CreateISecurityCapabilities(new TransportSecurityBindingElement());
 
-        Assert.Equal("None", capability.SupportedRequestProtectionLevel.ToString());
-        Assert.Equal("None", capability.SupportedResponseProtectionLevel.ToString());
-        Assert.Equal("False", capability.SupportsClientAuthentication.ToString());
-        Assert.Equal("False", capability.SupportsClientWindowsIdentity.ToString());
-        Assert.Equal("False", capability.SupportsServerAuthentication.ToString());
+        Assert.Equal(ProtectionLevel.None, capability.SupportedRequestProtectionLevel);
+        Assert.Equal(ProtectionLevel.None, capability.SupportedResponseProtectionLevel);
+        Assert.False(capability.SupportsClientAuthentication);
+        Assert.False(capability.SupportsClientWindowsIdentity);
+        Assert.False(capability.SupportsServerAuthentication);
     }
 
     [WcfFact]
@@ -52,11 +53,11 @@ public static class ISecurityCapabilitiesTest
     {
         ISecurityCapabilities capability = CreateISecurityCapabilities(new SslStreamSecurityBindingElement());
 
-        Assert.Equal("EncryptAndSign", capability.SupportedRequestProtectionLevel.ToString());
-        Assert.Equal("EncryptAndSign", capability.SupportedResponseProtectionLevel.ToString());
-        Assert.Equal("False", capability.SupportsClientAuthentication.ToString());
-        Assert.Equal("False", capability.SupportsClientWindowsIdentity.ToString());
-        Assert.Equal("True", capability.SupportsServerAuthentication.ToString());
+        Assert.Equal(ProtectionLevel.EncryptAndSign, capability.SupportedRequestProtectionLevel);
+        Assert.Equal(ProtectionLevel.EncryptAndSign, capability.SupportedResponseProtectionLevel);
+        Assert.False(capability.SupportsClientAuthentication);
+        Assert.False(capability.SupportsClientWindowsIdentity);
+        Assert.True(capability.SupportsServerAuthentication);
     }
 
     [WcfFact]
@@ -64,11 +65,11 @@ public static class ISecurityCapabilitiesTest
     {
         ISecurityCapabilities capability = CreateISecurityCapabilities(new WindowsStreamSecurityBindingElement());
 
-        Assert.Equal("EncryptAndSign", capability.SupportedRequestProtectionLevel.ToString());
-        Assert.Equal("EncryptAndSign", capability.SupportedResponseProtectionLevel.ToString());
-        Assert.Equal("True", capability.SupportsClientAuthentication.ToString());
-        Assert.Equal("True", capability.SupportsClientWindowsIdentity.ToString());
-        Assert.Equal("True", capability.SupportsServerAuthentication.ToString());
+        Assert.Equal(ProtectionLevel.EncryptAndSign, capability.SupportedRequestProtectionLevel);
+        Assert.Equal(ProtectionLevel.EncryptAndSign, capability.SupportedResponseProtectionLevel);
+        Assert.True(capability.SupportsClientAuthentication);
+        Assert.True(capability.SupportsClientWindowsIdentity);
+        Assert.True(capability.SupportsServerAuthentication);
     }
 
     public static ISecurityCapabilities CreateISecurityCapabilities(BindingElement bindingElement)


### PR DESCRIPTION
…pabilities.

* WCF uses ISecurityCapabilities and since we just made it part of the public contract adding tests to verify the expected values for its properties in all the cases where WCF uses it.