### PR TITLE
Stebon/master/add client base constructor to public contract

### DIFF
--- a/src/System.Private.ServiceModel/src/System/ServiceModel/ClientBase.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/ClientBase.cs
@@ -54,6 +54,15 @@ namespace System.ServiceModel
             _channelFactory.TraceOpenAndClose = false;
         }
 
+        protected ClientBase(ServiceEndpoint endpoint)
+        {
+            if (endpoint == null)
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("endpoint");
+
+            _channelFactory = new ChannelFactory<TChannel>(endpoint);
+            _channelFactory.TraceOpenAndClose = false;
+        }
+
         protected ClientBase(InstanceContext callbackInstance, Binding binding, EndpointAddress remoteAddress)
         {
             if (callbackInstance == null)

--- a/src/System.Private.ServiceModel/tests/Common/Scenarios/ScenarioTestTypes.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Scenarios/ScenarioTestTypes.cs
@@ -12,6 +12,7 @@ using System.Runtime.Serialization;
 using System.Security.Cryptography.X509Certificates;
 using System.ServiceModel;
 using System.ServiceModel.Channels;
+using System.ServiceModel.Description;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -735,6 +736,11 @@ public class MyClientBase<T> : ClientBase<T> where T : class
 {
     public MyClientBase(Binding binding, EndpointAddress endpointAddress)
         : base(binding, endpointAddress)
+    {
+    }
+
+    public MyClientBase(ServiceEndpoint serviceEndpoint)
+        : base(serviceEndpoint)
     {
     }
 }

--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/ClientBase/ClientBaseTests.4.4.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/ClientBase/ClientBaseTests.4.4.0.cs
@@ -51,4 +51,3 @@ public static partial class ClientBaseTests_4_4_0
         }
     }
 }
-

--- a/src/System.ServiceModel.Primitives/ref/System.ServiceModel.Primitives.cs
+++ b/src/System.ServiceModel.Primitives/ref/System.ServiceModel.Primitives.cs
@@ -99,6 +99,7 @@ namespace System.ServiceModel
     public partial class ChannelFactory<TChannel> : System.ServiceModel.ChannelFactory, System.ServiceModel.Channels.IChannelFactory, System.ServiceModel.Channels.IChannelFactory<TChannel>, System.ServiceModel.ICommunicationObject
     {
         public ChannelFactory(System.ServiceModel.Channels.Binding binding, System.ServiceModel.EndpointAddress remoteAddress) { }
+        public ChannelFactory(System.ServiceModel.Description.ServiceEndpoint endpoint) { }
         public ChannelFactory(string endpointConfigurationName) { }
         public ChannelFactory(string endpointConfigurationName, System.ServiceModel.EndpointAddress remoteAddress) { }
         protected ChannelFactory(System.Type channelType) { }
@@ -118,6 +119,7 @@ namespace System.ServiceModel
     {
         protected ClientBase() { }
         protected ClientBase(System.ServiceModel.Channels.Binding binding, System.ServiceModel.EndpointAddress remoteAddress) { }
+        protected ClientBase(System.ServiceModel.Description.ServiceEndpoint endpoint) { }
         protected ClientBase(string endpointConfigurationName) { }
         protected ClientBase(string endpointConfigurationName, System.ServiceModel.EndpointAddress remoteAddress) { }
         protected ClientBase(string endpointConfigurationName, string remoteAddress) { }


### PR DESCRIPTION
* This time I leveraged a test that is actually making a service call.
* @mconnew you were correct, creating a default new ContractDescription was not sufficient, it required adding operations, etc...
* @mconnew regarding your suggestion to use `nameof(endpoint)` should we be concerned with consistency? If it is important to make that change should we also change all the other cases where we just use the string?

Fixes #3332 