### PR TITLE
Fix pathing issue.

### DIFF
--- a/src/System.Private.ServiceModel/tools/scripts/SetupWcfIISHostedService.cmd
+++ b/src/System.Private.ServiceModel/tools/scripts/SetupWcfIISHostedService.cmd
@@ -187,7 +187,7 @@ if ERRORLEVEL 1 goto :Failure
 
 echo Run CertificateGenerator tool. This will take a little while...
 md %_wcfTestDir%
-set certGen=%_certRepo%\bin\Wcf\tools\CertificateGenerator\CertificateGenerator.exe
+set certGen=%_certRepo%\artifacts\bin\CertificateGenerator\Release\CertificateGenerator.exe
 echo ^<?xml version="1.0" encoding="utf-8"?^>^<configuration^>^<appSettings^>^<add key="testserverbase" value="%_certService%"/^>^<add key="CertExpirationInDay" value="%_certExpirationInDays%"/^>^<add key="CrlFileLocation" value="%_wcfTestDir%\test.crl"/^>^</appSettings^>^<startup^>^<supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/^>^</startup^>^</configuration^>>%certGen%.config
 call :Run %certGen%
 if ERRORLEVEL 1 goto :Failure


### PR DESCRIPTION
* With the move to Arcade the destination bin drop is a little different.

We made this same change to the StartWCFSelfHostedSvcDoWork.cmd script.
We didn't realize it was also needed initially because this script is run on our server machines not locally.
But when it ran on our servers and failed tests started failing due to not being able to find the CRL certificate on the server, which is one of the things that this script does when it builds and runs the certificate generator.