### PR TITLE
Provide ServiceUri prop to Helix environment.

### DIFF
--- a/eng/SendToHelix.proj
+++ b/eng/SendToHelix.proj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="!$(HelixTargetQueue.StartsWith('Windows'))">
-    <HelixPreCommands>"$(HelixPreCommands);chmod a+x $HELIX_CORRELATION_PAYLOAD/InstallRootCertificate.sh;sudo -E -n $HELIX_CORRELATION_PAYLOAD/InstallRootCertificate.sh --service-host $(ServiceUri) --cert-file /tmp/wcfrootca.crt"</HelixPreCommands>
+    <HelixPreCommands>$(HelixPreCommands);chmod a+x $HELIX_CORRELATION_PAYLOAD/InstallRootCertificate.sh;sudo -E -n $HELIX_CORRELATION_PAYLOAD/InstallRootCertificate.sh --service-host $(ServiceUri) --cert-file /tmp/wcfrootca.crt</HelixPreCommands>
   </PropertyGroup>
 
   <ItemGroup>

--- a/eng/pipelines/wcf-base.yml
+++ b/eng/pipelines/wcf-base.yml
@@ -175,6 +175,7 @@ jobs:
                     XUnitWorkItemTimeout: $(_xUnitWorkItemTimeout)
                     _helixAccessToken: $(HelixApiAccessToken)
                     _isOfficialBuild: ${{ parameters.isOfficialBuild }}
+                    ServiceUri: $(_serviceUri)
                   continueOnError: false
               - ${{ if ne(parameters.targetOS, 'Windows_NT') }}:
                 - script: $BUILD_SOURCESDIRECTORY/eng/common/msbuild.sh $BUILD_SOURCESDIRECTORY/eng/SendToHelix.proj /restore /t:Test /bl:$BUILD_SOURCESDIRECTORY/artifacts/log/$BuildConfig/SendToHelix.binlog
@@ -195,4 +196,5 @@ jobs:
                     XUnitWorkItemTimeout: $(_xUnitWorkItemTimeout)
                     _helixAccessToken: $(HelixApiAccessToken)
                     _isOfficialBuild: ${{ parameters.isOfficialBuild }}
+                    ServiceUri: $(_serviceUri)
                   continueOnError: false


### PR DESCRIPTION
The ServiceUri variable was not set and available to the InstallRootCertificate.sh script at the time it was run.