### PR TITLE
Enable broken test for investigation.

### DIFF
--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/ChannelLayer/DuplexChannelShapeTests.4.0.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/ChannelLayer/DuplexChannelShapeTests.4.0.0.cs
@@ -74,8 +74,8 @@ public partial class DuplexChannelShapeTests : ConditionalWcfTest
         }
     }
 
-    //[WcfFact]
-    //[OuterLoop]
+    [WcfFact]
+    [OuterLoop]
     public static void IDuplexSessionChannel_Async_Tcp_NetTcpBinding()
     {
         IChannelFactory<IDuplexSessionChannel> factory = null;


### PR DESCRIPTION
* This test case is know to be failing, we need it to fail on Helix in order to get a repro environment.