### PR TITLE
Skip tests for Issue 3610.

### DIFF
--- a/src/System.Private.ServiceModel/tests/Scenarios/Binding/WS/TransportWithMessageCredentialSecurity/BasicHttpTransportWithMessageCredentialSecurityTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Binding/WS/TransportWithMessageCredentialSecurity/BasicHttpTransportWithMessageCredentialSecurityTests.cs
@@ -11,6 +11,7 @@ using Xunit;
 public class BasicHttpTransportWithMessageCredentialSecurityTests : ConditionalWcfTest
 {
     [WcfFact]
+    [Issue(3610)]
     [Condition(nameof(Root_Certificate_Installed),
                nameof(Client_Certificate_Installed),
                nameof(SSL_Available))]

--- a/src/System.Private.ServiceModel/tests/Scenarios/Binding/WS/TransportWithMessageCredentialSecurity/WSHttpTransportWithMessageCredentialSecurityTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Binding/WS/TransportWithMessageCredentialSecurity/WSHttpTransportWithMessageCredentialSecurityTests.cs
@@ -13,6 +13,7 @@ using Xunit;
 public class WSHttpTransportWithMessageCredentialSecurityTests : ConditionalWcfTest
 {
     [WcfFact]
+    [Issue(3610)]
     [Condition(nameof(Root_Certificate_Installed),
            nameof(Client_Certificate_Installed),
            nameof(SSL_Available))]

--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/ChannelLayer/DuplexChannelShapeTests.4.0.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/ChannelLayer/DuplexChannelShapeTests.4.0.0.cs
@@ -21,6 +21,7 @@ public partial class DuplexChannelShapeTests : ConditionalWcfTest
 
     [WcfFact]
     [OuterLoop]
+    [Issue(3610)]
     public static void IDuplexSessionChannel_Tcp_NetTcpBinding()
     {
         IChannelFactory<IDuplexSessionChannel> factory = null;

--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/ChannelLayer/RequestReplyChannelShapeTests.4.0.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/ChannelLayer/RequestReplyChannelShapeTests.4.0.0.cs
@@ -127,6 +127,7 @@ public partial class RequestReplyChannelShapeTests
 
     [WcfFact]
     [OuterLoop]
+    [Issue(3610)]
     public static void IRequestChannel_Async_Http_BasicHttpBinding()
     {
         IChannelFactory<IRequestChannel> factory = null;
@@ -180,6 +181,7 @@ public partial class RequestReplyChannelShapeTests
 
     [WcfFact]
     [OuterLoop]
+    [Issue(3610)]
     public static void IRequestChannel_Async_Http_CustomBinding()
     {
         IChannelFactory<IRequestChannel> factory = null;


### PR DESCRIPTION
Test cases being skipped...
...Scenarios/Client/ChannelLayer/RequestReplyChannelShapeTests.4.0.0.cs
IRequestChannel_Async_Http_BasicHttpBinding
IRequestChannel_Async_Http_CustomBinding

...Scenarios/Client/ChannelLayer/DuplexChannelShapeTests.4.0.0.cs
IDuplexSessionChannel_Async_Tcp_NetTcpBinding

...Scenarios\Binding\WS\TransportWithMessageCredentialSecurity\WSHttpTransportWithMessageCredentialSecurityTests.cs
Https_SecModeTransWithMessCred_CertClientCredential_Succeeds

...Scenarios\Binding\WS\TransportWithMessageCredentialSecurity\BasicHttpTransportWithMessageCredentialSecurityTests.cs
Https_SecModeTransWithMessCred_CertClientCredential_Succeeds