### PR TITLE
Fix ChannelLayer tests

### DIFF
--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/WebSocketTransportDuplexSessionChannel.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/WebSocketTransportDuplexSessionChannel.cs
@@ -516,7 +516,13 @@ namespace System.ServiceModel.Channels
 
             public Message Receive(TimeSpan timeout)
             {
-                return ReceiveAsync(timeout).WaitForCompletionNoSpin();
+                return ReceiveAsyncInternal(timeout).WaitForCompletionNoSpin();
+            }
+
+            private async Task<Message> ReceiveAsyncInternal(TimeSpan timeout)
+            {
+                await TaskHelpers.EnsureDefaultTaskScheduler();
+                return await ReceiveAsync(timeout);
             }
 
             private async Task ReadBufferedMessageAsync()

--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/ChannelLayer/DuplexChannelShapeTests.4.1.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/ChannelLayer/DuplexChannelShapeTests.4.1.0.cs
@@ -64,6 +64,7 @@ public partial class DuplexChannelShapeTests : ConditionalWcfTest
 
             // *** CLEANUP *** \\
             replyMessage.Close();
+            channel.Session.CloseOutputSession();
             channel.Close();
             factory.Close();
         }
@@ -121,6 +122,7 @@ public partial class DuplexChannelShapeTests : ConditionalWcfTest
 
             // *** CLEANUP *** \\
             replyMessage.Close();
+            channel.Session.CloseOutputSession();
             channel.Close();
             factory.Close();
         }


### PR DESCRIPTION
Fix SynchronizationContext issue when calling IDuplexSessionChannel.Receive directly.
Fix tests which aren't correctly closing session.