### PR TITLE
Fix some threading issues when using a non-default sync context

### DIFF
--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/RequestChannel.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/RequestChannel.cs
@@ -208,7 +208,7 @@ namespace System.ServiceModel.Channels
 
         public IAsyncResult BeginRequest(Message message, TimeSpan timeout, AsyncCallback callback, object state)
         {
-            return RequestAsync(message, timeout).ToApm(callback, state);
+            return RequestAsyncInternal(message, timeout).ToApm(callback, state);
         }
 
         protected abstract IAsyncRequest CreateAsyncRequest(Message message);

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/SecurityChannelFactory.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/SecurityChannelFactory.cs
@@ -416,7 +416,7 @@ namespace System.ServiceModel.Channels
 
             public IAsyncResult BeginRequest(Message message, TimeSpan timeout, AsyncCallback callback, object state)
             {
-                return RequestAsync(message, timeout).ToApm(callback, state);
+                return RequestAsyncInternal(message, timeout).ToApm(callback, state);
             }
 
             public Message EndRequest(IAsyncResult result)
@@ -481,9 +481,15 @@ namespace System.ServiceModel.Channels
                 return ProcessReply(reply, correlationState, timeoutHelper.RemainingTime());
             }
 
+            private async Task<Message> RequestAsyncInternal(Message message, TimeSpan timeout)
+            {
+                await TaskHelpers.EnsureDefaultTaskScheduler();
+                return await RequestAsync(message, timeout);
+            }
+
             public Message Request(Message message, TimeSpan timeout)
             {
-                return RequestAsync(message, timeout).GetAwaiter().GetResult();
+                return RequestAsyncInternal(message, timeout).GetAwaiter().GetResult();
             }
         }
 

--- a/src/System.Private.ServiceModel/tests/Scenarios/Binding/WS/TransportWithMessageCredentialSecurity/BasicHttpTransportWithMessageCredentialSecurityTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Binding/WS/TransportWithMessageCredentialSecurity/BasicHttpTransportWithMessageCredentialSecurityTests.cs
@@ -11,7 +11,6 @@ using Xunit;
 public class BasicHttpTransportWithMessageCredentialSecurityTests : ConditionalWcfTest
 {
     [WcfFact]
-    [Issue(3610)]
     [Condition(nameof(Root_Certificate_Installed),
                nameof(Client_Certificate_Installed),
                nameof(SSL_Available))]
@@ -59,7 +58,6 @@ public class BasicHttpTransportWithMessageCredentialSecurityTests : ConditionalW
     }
 
     [WcfFact]
-    [Issue(3610)]
     [Condition(nameof(Root_Certificate_Installed),
                nameof(SSL_Available))]
     [OuterLoop]


### PR DESCRIPTION
We have a policy that if a non-default sync context is being used, to avoid potential deadlock (e.g. with a single threaded sync context such as used by winforms and WPF) or thread starvation problems, we forcefully asynchronously continue execution on the worker thread pool.
We had a few code paths where this didn't happen. This fixes those code paths.