### PR TITLE
Stop building a package for the System.ServiceModel.Shim project.

### DIFF
--- a/eng/FacadeAssemblies.targets
+++ b/eng/FacadeAssemblies.targets
@@ -4,7 +4,6 @@
   <PropertyGroup Condition="'$(IsPartialFacadeAssembly)'=='true'">
     <!--Don't produce or publish symbols for Facade assemblies.-->
     <PublishWindowsPdb>false</PublishWindowsPdb>
-    <IsPackable>true</IsPackable>
     <!-- GenFacades requires a PDB -->
     <DebugType>portable</DebugType>
     <NoWarn Condition="'$(IsReferenceAssembly)' == 'true'">$(NoWarn);0436</NoWarn>

--- a/src/System.ServiceModel.Shim/System.ServiceModel.Shim.csproj
+++ b/src/System.ServiceModel.Shim/System.ServiceModel.Shim.csproj
@@ -18,6 +18,7 @@
     <AssetTargetFallback>net472</AssetTargetFallback>
     <NoWarn>$(NoWarn);NU1701</NoWarn>
     <MicrosoftTargetingPackNETFrameworkv472Package>Microsoft.TargetingPack.NETFramework.v4.7.2</MicrosoftTargetingPackNETFrameworkv472Package>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
* This project is used to create a binary that is inserted to the System.ServiceModel.Primitives package.
* The package should not have been getting generated.