### PR TITLE
Remove redundant copyright.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -15,7 +15,6 @@
 
   <!-- Packaging props -->
   <PropertyGroup Condition="'$(CopyrightNetFoundation)' != ''">
-    <Copyright>$(CopyrightNetFoundation)</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
 


### PR DESCRIPTION
* Remove copyright made redundant by dotnet/arcade#2635.
* Fixes #3632 , technically this issue was already fixed with the last Arcade update we took, just using this PR to close the issue.