### PR TITLE
Adding support for Linux platform SLES version 15.

### DIFF
--- a/src/System.Private.ServiceModel/tests/Common/Infrastructure/OSHelper.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Infrastructure/OSHelper.cs
@@ -41,7 +41,7 @@ namespace Infrastructure.Common
 
             new Tuple<string, OSID>("sles.12", OSID.SLES_12),
             new Tuple<string, OSID>("opensuse.42.3", OSID.OpenSUSE_42_3),
-            new Tuple<string, OSID>("opensuse.13.2", OSID.OpenSUSE_13_2),
+            new Tuple<string, OSID>("sles.15", OSID.SLES_15),
             new Tuple<string, OSID>("opensuse", OSID.AnyOpenSUSE),
 
             new Tuple<string, OSID>("osx.10.12", OSID.OSX_10_12),

--- a/src/System.Private.ServiceModel/tests/Common/Infrastructure/OsID.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Infrastructure/OsID.cs
@@ -48,10 +48,10 @@ namespace Infrastructure.Common
         Fedora_27 =              0x00010000,
         AnyFedora = Fedora_26 | Fedora_27,
 
-        OpenSUSE_13_2 =          0x00020000,
+        SLES_15 =                0x00020000,
         OpenSUSE_42_3 =          0x00040000,
         SLES_12 =                0x00080000,
-        AnyOpenSUSE = OpenSUSE_13_2 | OpenSUSE_42_3 | SLES_12,
+        AnyOpenSUSE = SLES_15 | OpenSUSE_42_3 | SLES_12,
 
         OSX_10_12 =              0x00100000,
         OSX_10_13 =              0x00200000,

--- a/src/System.Private.ServiceModel/tests/Scenarios/Infrastructure/OSAndFrameworkTests.4.1.1.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Infrastructure/OSAndFrameworkTests.4.1.1.cs
@@ -23,9 +23,11 @@ public class OSAndFrameworkTests
     public static void OSID_Was_Detected()
     {
         Assert.True(OSHelper.Current != OSID.None,
-                String.Format("OSID was not properly detected:{0}  The RuntimeInformation.OSDescription is = \'{1}\"",
+                String.Format("OSID was not properly detected:{0}  The RuntimeInformation.OSDescription is = \'{1}\" {2}  The RuntimeIdentifier is = {3}",
                                Environment.NewLine,
-                               RuntimeInformation.OSDescription));
+                               RuntimeInformation.OSDescription,
+                               Environment.NewLine,
+                               OSHelper.GetRuntimeIdentifier()));
     }
 
     [WcfFact]


### PR DESCRIPTION
* Our infrastructure needs to get the RID of the platform it is running on in order to properly support our conditional facts.
* I also updated the error messaging on the OSAndFrameworkTests.OSID_Was_Detected() test so that when we hit this failure in the future the logs tell us what the RID was so we don't have to guess when updating the OSHelper class List<Tuple> like I am this time with "sles.15".