### PR TITLE
Fix component dependency vulnerabilities.

### DIFF
--- a/src/System.ServiceModel.Duplex/src/System.ServiceModel.Duplex.Facade.csproj
+++ b/src/System.ServiceModel.Duplex/src/System.ServiceModel.Duplex.Facade.csproj
@@ -21,6 +21,7 @@
   <PropertyGroup Condition="'$(IsHarvesting)' == 'true'">
     <IsPartialFacadeAssembly>false</IsPartialFacadeAssembly>
     <HarvestFromPackage>true</HarvestFromPackage>
+    <NetStandardImplicitPackageVersion Condition="'$(TargetFramework)' == 'netstandard1.1' or '$(TargetFramework)' == 'netstandard1.3'">2.0.3</NetStandardImplicitPackageVersion>
   </PropertyGroup>
 
   <!-- the following represent dependencies copied from the old package -->
@@ -32,9 +33,13 @@
     <Reference Include="System.ServiceModel" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netcore50'">
-    <PackageReference Include="NETStandard.Library" Version="1.6.1" />
+    <PackageReference Include="NETStandard.Library" Version="2.0.3" />
     <PackageReference Include="System.Private.ServiceModel" Version="4.5.3" ExcludeAssets="Compile" />
     <PackageReference Include="System.ServiceModel.Primitives" Version="4.5.3" />
+    <!--S.Private.ServiceModel indirectly pulls in these two packages of version 4.3.0 by way of the harvest project
+    Explicitly referencing them from here to avoid a security vulnerability in the 4.3.0 version.-->
+    <PackageReference Include="System.Net.Security" Version="4.3.1" />
+    <PackageReference Include="System.Net.WebSockets.Client" Version="4.3.1" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.1'">
     <PackageReference Include="System.ServiceModel.Primitives" Version="4.5.3" />
@@ -42,5 +47,9 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">
     <PackageReference Include="System.Private.ServiceModel" version="4.5.3" ExcludeAssets="Compile" />
     <PackageReference Include="System.ServiceModel.Primitives" Version="4.5.3" />
+    <!--S.Private.ServiceModel indirectly pulls in these two packages of version 4.3.0 by way of the harvest project
+    Explicitly referencing them from here to avoid a security vulnerability in the 4.3.0 version.-->
+    <PackageReference Include="System.Net.Security" Version="4.3.1" />
+    <PackageReference Include="System.Net.WebSockets.Client" Version="4.3.1" />
   </ItemGroup>
 </Project>

--- a/src/System.ServiceModel.Http/src/System.ServiceModel.Http.Facade.csproj
+++ b/src/System.ServiceModel.Http/src/System.ServiceModel.Http.Facade.csproj
@@ -21,6 +21,7 @@
   <PropertyGroup Condition="'$(IsHarvesting)' == 'true'">
     <IsPartialFacadeAssembly>false</IsPartialFacadeAssembly>
     <HarvestFromPackage>true</HarvestFromPackage>
+    <NetStandardImplicitPackageVersion Condition="'$(TargetFramework)' == 'netstandard1.0' or '$(TargetFramework)' == 'netstandard1.1' or '$(TargetFramework)' == 'netstandard1.3'">2.0.3</NetStandardImplicitPackageVersion>
   </PropertyGroup>
 
   <!-- the following represent dependencies copied from the old package -->
@@ -36,11 +37,15 @@
     <Reference Include="System.ServiceModel" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netcore50'">
-    <PackageReference Include="NETStandard.Library" Version="1.6.1" />
+    <PackageReference Include="NETStandard.Library" Version="2.0.3" />
     <PackageReference Include="System.Net.WebHeaderCollection" Version="4.3.0" />
     <PackageReference Include="System.Private.ServiceModel" Version="4.5.3" ExcludeAssets="Compile" />
     <PackageReference Include="System.Runtime.Serialization.Xml" Version="4.3.0" />
     <PackageReference Include="System.ServiceModel.Primitives" Version="4.5.3" />
+    <!--S.Private.ServiceModel indirectly pulls in these two packages of version 4.3.0 by way of the harvest project
+    Explicitly referencing them from here to avoid a security vulnerability in the 4.3.0 version.-->
+    <PackageReference Include="System.Net.Security" Version="4.3.1" />
+    <PackageReference Include="System.Net.WebSockets.Client" Version="4.3.1" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.0'">
     <PackageReference Include="System.Net.Requests" Version="4.3.0" />
@@ -56,5 +61,9 @@
     <PackageReference Include="System.Private.ServiceModel" version="4.5.3" ExcludeAssets="Compile" />
     <PackageReference Include="System.Runtime.Serialization.Xml" Version="4.3.0" />
     <PackageReference Include="System.ServiceModel.Primitives" Version="4.5.3" />
+    <!--S.Private.ServiceModel indirectly pulls in these two packages of version 4.3.0 by way of the harvest project
+    Explicitly referencing them from here to avoid a security vulnerability in the 4.3.0 version.-->
+    <PackageReference Include="System.Net.Security" Version="4.3.1" />
+    <PackageReference Include="System.Net.WebSockets.Client" Version="4.3.1" />
   </ItemGroup>
 </Project>

--- a/src/System.ServiceModel.NetTcp/src/System.ServiceModel.NetTcp.Facade.csproj
+++ b/src/System.ServiceModel.NetTcp/src/System.ServiceModel.NetTcp.Facade.csproj
@@ -21,6 +21,7 @@
   <PropertyGroup Condition="'$(IsHarvesting)' == 'true'">
     <IsPartialFacadeAssembly>false</IsPartialFacadeAssembly>
     <HarvestFromPackage>true</HarvestFromPackage>
+    <NetStandardImplicitPackageVersion Condition="'$(TargetFramework)' == 'netstandard1.1' or '$(TargetFramework)' == 'netstandard1.3'">2.0.3</NetStandardImplicitPackageVersion>
   </PropertyGroup>
 
   <!-- the following represent dependencies copied from the old package -->
@@ -37,10 +38,14 @@
     <Reference Include="System.ServiceModel" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netcore50'">
-    <PackageReference Include="NETStandard.Library" Version="1.6.1" />
+    <PackageReference Include="NETStandard.Library" Version="2.0.3" />
     <PackageReference Include="System.Private.ServiceModel" Version="4.5.3" ExcludeAssets="Compile" />
     <PackageReference Include="System.Runtime.Serialization.Xml" Version="4.3.0" />
     <PackageReference Include="System.ServiceModel.Primitives" Version="4.5.3" />
+    <!--S.Private.ServiceModel indirectly pulls in these two packages of version 4.3.0 by way of the harvest project
+    Explicitly referencing them from here to avoid a security vulnerability in the 4.3.0 version.-->
+    <PackageReference Include="System.Net.Security" Version="4.3.1" />
+    <PackageReference Include="System.Net.WebSockets.Client" Version="4.3.1" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.1'">
     <PackageReference Include="System.Runtime.Serialization.Xml" Version="4.3.0" />
@@ -50,5 +55,9 @@
     <PackageReference Include="System.Private.ServiceModel" version="4.5.3" ExcludeAssets="Compile" />
     <PackageReference Include="System.Runtime.Serialization.Xml" Version="4.3.0" />
     <PackageReference Include="System.ServiceModel.Primitives" Version="4.5.3" />
+    <!--S.Private.ServiceModel indirectly pulls in these two packages of version 4.3.0 by way of the harvest project
+    Explicitly referencing them from here to avoid a security vulnerability in the 4.3.0 version.-->
+    <PackageReference Include="System.Net.Security" Version="4.3.1" />
+    <PackageReference Include="System.Net.WebSockets.Client" Version="4.3.1" />
   </ItemGroup>
 </Project>

--- a/src/System.ServiceModel.Primitives/src/System.ServiceModel.Primitives.Facade.csproj
+++ b/src/System.ServiceModel.Primitives/src/System.ServiceModel.Primitives.Facade.csproj
@@ -26,6 +26,7 @@
   <PropertyGroup Condition="'$(IsHarvesting)' == 'true'">
     <IsPartialFacadeAssembly>false</IsPartialFacadeAssembly>
     <HarvestFromPackage>true</HarvestFromPackage>
+    <NetStandardImplicitPackageVersion Condition="'$(TargetFramework)' == 'netstandard1.0' or '$(TargetFramework)' == 'netstandard1.1' or '$(TargetFramework)' == 'netstandard1.3'">2.0.3</NetStandardImplicitPackageVersion>
   </PropertyGroup>
 
   <!-- the following represent dependencies copied from the old package -->
@@ -33,7 +34,7 @@
     <Reference Include="System.ServiceModel" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net46'">
-    <PackageReference Include="NETStandard.Library" Version="1.6.1" />
+    <PackageReference Include="NETStandard.Library" Version="2.0.3" />
     <Reference Include="System.IdentityModel" />
     <Reference Include="System.ServiceModel" />
   </ItemGroup>
@@ -42,12 +43,16 @@
     <Reference Include="System.ServiceModel" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netcore50'">
-    <PackageReference Include="NETStandard.Library" Version="1.6.1" />
+    <PackageReference Include="NETStandard.Library" Version="2.0.3" />
     <PackageReference Include="System.ComponentModel.EventBasedAsync" Version="4.3.0" />
-    <PackageReference Include="System.Private.ServiceModel" Version="4.5.3" ExcludeAssets="Compile" />
+    <PackageReference Include="System.Private.ServiceModel" Version="4.5.3" ExcludeAssets="Compile" PrivateAssets="contentfiles;analyzers;build;compile" />
     <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
     <PackageReference Include="System.Runtime.Serialization.Xml" Version="4.3.0" />
     <PackageReference Include="System.Security.Principal" Version="4.3.0" />
+    <!--S.Private.ServiceModel indirectly pulls in these two packages of version 4.3.0 by way of the harvest project
+    Explicitly referencing them from here to avoid a security vulnerability in the 4.3.0 version.-->
+    <PackageReference Include="System.Net.Security" Version="4.3.1" />
+    <PackageReference Include="System.Net.WebSockets.Client" Version="4.3.1" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.0'">
     <PackageReference Include="System.ComponentModel.EventBasedAsync" Version="4.3.0" />
@@ -66,5 +71,9 @@
     <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
     <PackageReference Include="System.Runtime.Serialization.Xml" Version="4.3.0" />
     <PackageReference Include="System.Security.Principal" Version="4.3.0" />
+    <!--S.Private.ServiceModel indirectly pulls in these two packages of version 4.3.0 by way of the harvest project
+    Explicitly referencing them from here to avoid a security vulnerability in the 4.3.0 version.-->
+    <PackageReference Include="System.Net.Security" Version="4.3.1" />
+    <PackageReference Include="System.Net.WebSockets.Client" Version="4.3.1" />
   </ItemGroup>
 </Project>

--- a/src/System.ServiceModel.Security/src/System.ServiceModel.Security.Facade.csproj
+++ b/src/System.ServiceModel.Security/src/System.ServiceModel.Security.Facade.csproj
@@ -21,6 +21,7 @@
   <PropertyGroup Condition="'$(IsHarvesting)' == 'true'">
     <IsPartialFacadeAssembly>false</IsPartialFacadeAssembly>
     <HarvestFromPackage>true</HarvestFromPackage>
+    <NetStandardImplicitPackageVersion Condition="'$(TargetFramework)' == 'netstandard1.0' or '$(TargetFramework)' == 'netstandard1.1' or '$(TargetFramework)' == 'netstandard1.3'">2.0.3</NetStandardImplicitPackageVersion>
   </PropertyGroup>
 
   <!-- the following represent dependencies copied from the old package -->
@@ -32,10 +33,14 @@
     <Reference Include="System.ServiceModel" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netcore50'">
-    <PackageReference Include="NETStandard.Library" Version="1.6.1" />
+    <PackageReference Include="NETStandard.Library" Version="2.0.3" />
     <PackageReference Include="System.Private.ServiceModel" Version="4.5.3" ExcludeAssets="Compile" />
     <PackageReference Include="System.Runtime.Serialization.Xml" Version="4.3.0" />
     <PackageReference Include="System.ServiceModel.Primitives" Version="4.5.3" />
+    <!--S.Private.ServiceModel indirectly pulls in these two packages of version 4.3.0 by way of the harvest project
+    Explicitly referencing them from here to avoid a security vulnerability in the 4.3.0 version.-->
+    <PackageReference Include="System.Net.Security" Version="4.3.1" />
+    <PackageReference Include="System.Net.WebSockets.Client" Version="4.3.1" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.0'">
     <PackageReference Include="System.ServiceModel.Primitives" Version="4.5.3" />
@@ -48,5 +53,9 @@
     <PackageReference Include="System.Private.ServiceModel" version="4.5.3" ExcludeAssets="Compile" />
     <PackageReference Include="System.Runtime.Serialization.Xml" Version="4.3.0" />
     <PackageReference Include="System.ServiceModel.Primitives" Version="4.5.3" />
+    <!--S.Private.ServiceModel indirectly pulls in these two packages of version 4.3.0 by way of the harvest project
+    Explicitly referencing them from here to avoid a security vulnerability in the 4.3.0 version.-->
+    <PackageReference Include="System.Net.Security" Version="4.3.1" />
+    <PackageReference Include="System.Net.WebSockets.Client" Version="4.3.1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
* Update "NETStandard.Library" pkg dependencies to version 2.0.3 to get the latest serviced netstandard packages.
* Explicitly added "System.Net.Security" and "System.Net.WebSockets.Client" to use updated serviced versions not being picked-up implicitly by S.P.SM.