### PR TITLE
Change powershell command back to 'powershell'.

### DIFF
--- a/eng/pipelines/linux.yml
+++ b/eng/pipelines/linux.yml
@@ -52,7 +52,7 @@ jobs:
               _sign: false
               _unitTests: false
               _integrationTests: false
-              _pack: true
+              _pack: false
               _publish: true
               _helixQueues: $(linuxDefaultQueues)
               _dockerContainer: ubuntu_1604_Powershell_62
@@ -63,7 +63,7 @@ jobs:
               _sign: false
               _unitTests: false
               _integrationTests: false
-              _pack: true
+              _pack: false
               _publish: true
               _helixQueues: $(linuxDefaultQueues)
               _dockerContainer: ubuntu_1604_Powershell_62

--- a/eng/pipelines/macos.yml
+++ b/eng/pipelines/macos.yml
@@ -50,7 +50,7 @@ jobs:
               _sign: false
               _unitTests: false
               _integrationTests: false
-              _pack: true
+              _pack: false
               _publish: true
               _helixQueues: $(macOSQueues)
               _useIISHostedTestArgs: true
@@ -60,7 +60,7 @@ jobs:
               _sign: false
               _unitTests: false
               _integrationTests: false
-              _pack: true
+              _pack: false
               _publish: true
               _helixQueues: $(macOSQueues)
               _useIISHostedTestArgs: true

--- a/src/svcutilcore/src/dotnet-svcutil.xmlserializer.csproj
+++ b/src/svcutilcore/src/dotnet-svcutil.xmlserializer.csproj
@@ -88,7 +88,7 @@
 
   <Target Name="ModifyPackage" AfterTargets="Pack">
     <Message Text="Call $(WcfRootFolder)\src\svcutilcore\tools\scripts\UpdateSvcutilDotXmlSerializerPackage.ps1 to modify the svcutil.xmlserializer.nuspec" />
-    <Exec Command="pwsh -ExecutionPolicy UnRestricted -File $(WcfRootFolder)/src/svcutilcore/tools/scripts/UpdateSvcutilDotXmlSerializerPackage.ps1 $(PackageOutputPath)"/>
+    <Exec Command="powershell -ExecutionPolicy UnRestricted -File $(WcfRootFolder)/src/svcutilcore/tools/scripts/UpdateSvcutilDotXmlSerializerPackage.ps1 $(PackageOutputPath)"/>
   </Target>
 
 </Project>


### PR DESCRIPTION
* Windows build machines do not have PS v6 so we can't use "pwsh" to run powershell scripts.
* Removing the packing step from the Linux and MacOS builds as we don't need to build packages on those build legs.