### PR TITLE
Propagating EnableUnsecuredResponse while cloning

### DIFF
--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/SecurityBindingElement.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/SecurityBindingElement.cs
@@ -65,15 +65,16 @@ namespace System.ServiceModel.Channels
             {
                 _operationSupportingTokenParameters[key] = elementToBeCloned._operationSupportingTokenParameters[key].Clone();
             }
+            
             _optionalOperationSupportingTokenParameters = new Dictionary<string, SupportingTokenParameters>();
             foreach (string key in elementToBeCloned._optionalOperationSupportingTokenParameters.Keys)
             {
                 _optionalOperationSupportingTokenParameters[key] = elementToBeCloned._optionalOperationSupportingTokenParameters[key].Clone();
             }
+            
             LocalClientSettings = elementToBeCloned.LocalClientSettings.Clone();
             MaxReceivedMessageSize = elementToBeCloned.MaxReceivedMessageSize;
             ReaderQuotas = elementToBeCloned.ReaderQuotas;
-
             EnableUnsecuredResponse = elementToBeCloned.EnableUnsecuredResponse;
         }
 

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/SecurityBindingElement.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/SecurityBindingElement.cs
@@ -73,6 +73,8 @@ namespace System.ServiceModel.Channels
             LocalClientSettings = elementToBeCloned.LocalClientSettings.Clone();
             MaxReceivedMessageSize = elementToBeCloned.MaxReceivedMessageSize;
             ReaderQuotas = elementToBeCloned.ReaderQuotas;
+
+            EnableUnsecuredResponse = elementToBeCloned.EnableUnsecuredResponse;
         }
 
         public SupportingTokenParameters EndpointSupportingTokenParameters { get; }


### PR DESCRIPTION
This is to fix the issue #38609 (Cloning SecurityBindingElement misses EnableUnsecuredResponse).
Also ref #3653  (EnableUnsecuredResponse flag not supported)