### PR TITLE
Fix issue with WebSocket already being closed sometimes

### DIFF
--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/WebSocketTransportDuplexSessionChannel.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/WebSocketTransportDuplexSessionChannel.cs
@@ -337,6 +337,11 @@ namespace System.ServiceModel.Channels
         {
             try
             {
+                if (WebSocket.State == WebSocketState.Closed)
+                {
+                    return Task.CompletedTask; // Nothing to do here.
+                }
+
                 return WebSocket.CloseAsync(_webSocketCloseDetails.OutputCloseStatus, _webSocketCloseDetails.OutputCloseStatusDescription, CancellationToken.None);
             }
             catch (Exception e)


### PR DESCRIPTION
Sometimes DuplexChannelShapeTests were throwing when running locally as the WebSocket was already closed. This fixes the it by not attempting to close and already closed WebSocket.