### PR TITLE
Fix S.SM.NetTcp dependency on NETStandard.Library v1.6.1

### DIFF
--- a/src/System.ServiceModel.NetTcp/src/System.ServiceModel.NetTcp.Facade.csproj
+++ b/src/System.ServiceModel.NetTcp/src/System.ServiceModel.NetTcp.Facade.csproj
@@ -29,6 +29,7 @@
     <Reference Include="System.ServiceModel" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net46'">
+    <PackageReference Include="NETStandard.Library" Version="2.0.3" />
     <PackageReference Include="System.ServiceModel.Primitives" Version="4.5.3" />
     <Reference Include="System.IdentityModel" />
     <Reference Include="System.ServiceModel" />


### PR DESCRIPTION
* The S.SM.NetTcp package has a dependency on S.SM.Primitives 4.5.3 for .NETFx 4.6
* S.SM.Primitives 4.5.3 has a dependency on NETStandard.Library 1.6.1 or greater.
* NETStandard.Library 1.6.1 pulls in System.Net.Http version 4.3.0 which has a security advisory dotnet/aspnet#239
* Fixed by explicitly referencing NETStandard.Library version 2.0.3