### PR TITLE
Make SslStreamSecurityBindingElement.RequireClientCertificate public.

### DIFF
--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/SslStreamSecurityBindingElement.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/SslStreamSecurityBindingElement.cs
@@ -47,7 +47,7 @@ namespace System.ServiceModel.Channels
         }
 
         [DefaultValue(TransportDefaults.RequireClientCertificate)]
-        internal bool RequireClientCertificate { get; set; }
+        public bool RequireClientCertificate { get; set; }
 
         [DefaultValue(TransportDefaults.SslProtocols)]
         public SslProtocols SslProtocols

--- a/src/System.ServiceModel.NetTcp/ref/System.ServiceModel.NetTcp.cs
+++ b/src/System.ServiceModel.NetTcp/ref/System.ServiceModel.NetTcp.cs
@@ -73,7 +73,7 @@ namespace System.ServiceModel.Channels
     public partial class SslStreamSecurityBindingElement : System.ServiceModel.Channels.BindingElement
     {
         public SslStreamSecurityBindingElement() { }
-        [System.ComponentModel.DefaultValueAttribute((System.Security.Authentication.SslProtocols)(4080))]
+        public bool RequireClientCertificate { get { return default(bool); } set { } }
         public System.Security.Authentication.SslProtocols SslProtocols { get { return default(System.Security.Authentication.SslProtocols); } set { } }
         public override System.ServiceModel.Channels.IChannelFactory<TChannel> BuildChannelFactory<TChannel>(System.ServiceModel.Channels.BindingContext context) { return default(System.ServiceModel.Channels.IChannelFactory<TChannel>); }
         public override bool CanBuildChannelFactory<TChannel>(System.ServiceModel.Channels.BindingContext context) { return default(bool); }


### PR DESCRIPTION
* Making this property public and adding it to the public API surface area.
* Fixes #3678