### PR TITLE
Propagate all relevant properties from HttpTransportSecurity to HttpTransportBindingElement

### DIFF
--- a/src/System.Private.ServiceModel/src/System/ServiceModel/HttpProxyCredentialType.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/HttpProxyCredentialType.cs
@@ -27,6 +27,33 @@ namespace System.ServiceModel
                     value == HttpProxyCredentialType.Windows);
         }
 
+        internal static AuthenticationSchemes MapToAuthenticationScheme(HttpProxyCredentialType proxyCredentialType)
+        {
+            AuthenticationSchemes result;
+            switch (proxyCredentialType)
+            {
+                case HttpProxyCredentialType.None:
+                    result = AuthenticationSchemes.Anonymous;
+                    break;
+                case HttpProxyCredentialType.Basic:
+                    result = AuthenticationSchemes.Basic;
+                    break;
+                case HttpProxyCredentialType.Digest:
+                    result = AuthenticationSchemes.Digest;
+                    break;
+                case HttpProxyCredentialType.Ntlm:
+                    result = AuthenticationSchemes.Ntlm;
+                    break;
+                case HttpProxyCredentialType.Windows:
+                    result = AuthenticationSchemes.Negotiate;
+                    break;
+                default:
+                    Fx.Assert("unsupported proxy credential type");
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new NotSupportedException());
+            }
+            return result;
+        }
+
         internal static HttpProxyCredentialType MapToProxyCredentialType(AuthenticationSchemes authenticationSchemes)
         {
             HttpProxyCredentialType result;

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/HttpTransportSecurity.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/HttpTransportSecurity.cs
@@ -90,7 +90,9 @@ namespace System.ServiceModel
         private void ConfigureAuthentication(HttpTransportBindingElement http)
         {
             http.AuthenticationScheme = HttpClientCredentialTypeHelper.MapToAuthenticationScheme(_clientCredentialType);
+            http.ProxyAuthenticationScheme = HttpProxyCredentialTypeHelper.MapToAuthenticationScheme(_proxyCredentialType);
             http.Realm = Realm;
+            http.ExtendedProtectionPolicy = ExtendedProtectionPolicy;
         }
 
         private static void ConfigureAuthentication(HttpTransportBindingElement http, HttpTransportSecurity transportSecurity)


### PR DESCRIPTION
Fixes #3551 