### PR TITLE
Fix Authenticode signing

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -23,6 +23,11 @@
     <IsDotNetFrameworkProductAssembly>true</IsDotNetFrameworkProductAssembly>
   </PropertyGroup>
 
+  <!-- The certificate named Microsoft has been deprecated, default to the newer Microsoft400 -->
+  <PropertyGroup>
+    <AuthenticodeSig Condition="'$(AuthenticodeSig)' == ''">Microsoft400</AuthenticodeSig>
+  </PropertyGroup>
+
   <!-- Common repo directories -->
   <PropertyGroup>
     <ProjectDir>$(MSBuildThisFileDirectory)</ProjectDir>


### PR DESCRIPTION
BuildTools picks up the old one by default:

https://github.com/dotnet/buildtools/blob/6736870b84e06b75e7df32bb84d442db1b2afa10/src/Microsoft.DotNet.Build.Tasks/PackageFiles/sign.targets#L5

.. .adding this to repos is in the end less work than updating build tools' default, though we could do that too. 