### PR TITLE
Fix public key token used for ref assemblies.

### DIFF
--- a/src/System.ServiceModel.Duplex/ref/System.ServiceModel.Duplex.Ref.csproj
+++ b/src/System.ServiceModel.Duplex/ref/System.ServiceModel.Duplex.Ref.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyVersion>4.6.0.0</AssemblyVersion>
+    <StrongNameKeyId>Microsoft</StrongNameKeyId>
     <TargetFrameworks>netstandard2.0;net461;</TargetFrameworks>
     <AssemblyName>System.ServiceModel.Duplex</AssemblyName>
     <RootNamespace>System.ServiceModel</RootNamespace>

--- a/src/System.ServiceModel.Http/ref/System.ServiceModel.Http.Ref.csproj
+++ b/src/System.ServiceModel.Http/ref/System.ServiceModel.Http.Ref.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyVersion>4.6.0.0</AssemblyVersion>
+    <StrongNameKeyId>Microsoft</StrongNameKeyId>
     <TargetFrameworks>netstandard2.0;net461;</TargetFrameworks>
     <AssemblyName>System.ServiceModel.Http</AssemblyName>
     <RootNamespace>System.ServiceModel</RootNamespace>

--- a/src/System.ServiceModel.NetTcp/ref/System.ServiceModel.NetTcp.Ref.csproj
+++ b/src/System.ServiceModel.NetTcp/ref/System.ServiceModel.NetTcp.Ref.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyVersion>4.6.0.0</AssemblyVersion>
+    <StrongNameKeyId>Microsoft</StrongNameKeyId>
     <TargetFrameworks>netstandard2.0;net461;</TargetFrameworks>
     <AssemblyName>System.ServiceModel.NetTcp</AssemblyName>
     <RootNamespace>System.ServiceModel</RootNamespace>

--- a/src/System.ServiceModel.Primitives/ref/System.ServiceModel.Primitives.Ref.csproj
+++ b/src/System.ServiceModel.Primitives/ref/System.ServiceModel.Primitives.Ref.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyVersion>4.6.0.0</AssemblyVersion>
+    <StrongNameKeyId>Microsoft</StrongNameKeyId>
     <TargetFrameworks>netstandard2.0;netcoreapp2.1;net461;</TargetFrameworks>
     <AssemblyName>System.ServiceModel.Primitives</AssemblyName>
     <RootNamespace>System.ServiceModel</RootNamespace>

--- a/src/System.ServiceModel.Security/ref/System.ServiceModel.Security.Ref.csproj
+++ b/src/System.ServiceModel.Security/ref/System.ServiceModel.Security.Ref.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyVersion>4.6.0.0</AssemblyVersion>
+    <StrongNameKeyId>Microsoft</StrongNameKeyId>
     <TargetFrameworks>netstandard2.0;net461;</TargetFrameworks>
     <AssemblyName>System.ServiceModel.Security</AssemblyName>
     <RootNamespace>System.ServiceModel</RootNamespace>


### PR DESCRIPTION
* Reference assemblies also needed to be explicitly told to use the proper public key token.
* Fixes #3829