### PR TITLE
picking up an older no longer used authenticode cert

### DIFF
--- a/src/shims/shims.proj
+++ b/src/shims/shims.proj
@@ -49,7 +49,7 @@
 
     <WriteSigningRequired
         Condition="'@(NetFxContracts)' != '' and '$(SkipSigning)' != 'true' and '$(SignType)' != 'oss'"
-        AuthenticodeSig="Microsoft"
+        AuthenticodeSig="Microsoft400"
         StrongNameSig="%(NetFxContracts.StrongNameSig)"
         MarkerFile="$(GenFacadesOutputPath)%(NetFxContracts.Filename)%(NetFxContracts.Extension).requires_signing" />
 


### PR DESCRIPTION
This is similar to : https://github.com/dotnet/wcf/pull/3828
where an older, not valid, cert is being requested.

@StephenBonikowsky 
@MattGal 
