### PR TITLE
Fix script to use the correct branch name for updating the test service.

### DIFF
--- a/eng/UpdatePRService.yml
+++ b/eng/UpdatePRService.yml
@@ -42,10 +42,15 @@ steps:
       goto done
 
       :branch
-      echo Set the repo branch to be what build.SourceBranchName is: %BUILD_SOURCEBRANCHNAME%
-      REM The following vso call sets a variable that is accessible further down in the PowerShell script to Sync the PR Service.
-      echo ##vso[task.setvariable variable=branchNameorPrId]origin/%BUILD_SOURCEBRANCHNAME%
-      goto done
+      IF '%BUILD_SOURCEBRANCHNAME%'=='3.0.0' OR '%BUILD_SOURCEBRANCHNAME%'=='2.1.0' (
+          REM The following vso call sets a variable that is accessible further down in the PowerShell script to Sync the PR Service.
+          echo ##vso[task.setvariable variable=branchNameorPrId]origin/release/%BUILD_SOURCEBRANCHNAME%
+      ) ELSE (
+          echo Set the repo branch to be what build.SourceBranchName is: %BUILD_SOURCEBRANCHNAME%
+          REM The following vso call sets a variable that is accessible further down in the PowerShell script to Sync the PR Service.
+          echo ##vso[task.setvariable variable=branchNameorPrId]origin/%BUILD_SOURCEBRANCHNAME%
+          goto done
+      )
 
       :done
       exit /b %_EXITCODE%
@@ -73,8 +78,13 @@ steps:
         _OPERATION=branch
         echo "Operation mode has been set to: $_OPERATION"
         echo "##vso[task.setvariable variable=operation]$_OPERATION"
-        echo "Set the repo branch to be what build.SourceBranchName is: $BUILD_SOURCEBRANCHNAME"
-        echo "##vso[task.setvariable variable=branchNameorPrId]origin/$BUILD_SOURCEBRANCHNAME"
+        if [[ $BUILD_SOURCEBRANCHNAME = 3.0.0 || $BUILD_SOURCEBRANCHNAME = 2.1.0 ]]; then
+          echo "Set the repo branch to be what build.SourceBranchName is: $BUILD_SOURCEBRANCHNAME"
+          echo "##vso[task.setvariable variable=branchNameorPrId]origin/release/$BUILD_SOURCEBRANCHNAME"
+        else 
+          echo "Set the repo branch to be what build.SourceBranchName is: $BUILD_SOURCEBRANCHNAME"
+          echo "##vso[task.setvariable variable=branchNameorPrId]origin/$BUILD_SOURCEBRANCHNAME"
+        fi
       fi
 
     displayName: Set_Operation_PR_or_Branch_Unix


### PR DESCRIPTION
The CI build that happens right after a PR is merged will sync our test service to the head of the branch the PR was merged into.
The logic in the script that gets the name of the branch expected a one word branch name such as "master" and broke when the branch it tried to get the name of was "release/3.0.0".
This is a minor fix to first check if it is one of our 'release' branches so it does the right thing.