### PR TITLE
Port System.ServiceModel.Security.SecurityAlgorithmSuite.TripleDes

### DIFF
--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SecurityAlgorithmSuite.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SecurityAlgorithmSuite.cs
@@ -11,6 +11,7 @@ namespace System.ServiceModel.Security
     public abstract class SecurityAlgorithmSuite
     {
         private static SecurityAlgorithmSuite s_basic256;
+        private static SecurityAlgorithmSuite s_tripleDes;
 
         static public SecurityAlgorithmSuite Default
         {
@@ -30,6 +31,19 @@ namespace System.ServiceModel.Security
                 }
 
                 return s_basic256;
+            }
+        }
+
+        static public SecurityAlgorithmSuite TripleDes
+        {
+            get
+            {
+                if (s_tripleDes == null)
+                {
+                    s_tripleDes = new TripleDesSecurityAlgorithmSuite();
+                }
+                    
+                return s_tripleDes;
             }
         }
 
@@ -124,6 +138,38 @@ namespace System.ServiceModel.Security
         public override string ToString()
         {
             return "Basic256";
+        }
+    }
+
+    public class TripleDesSecurityAlgorithmSuite : SecurityAlgorithmSuite
+    {
+        public TripleDesSecurityAlgorithmSuite() : base() { }
+
+        public override string DefaultCanonicalizationAlgorithm { get { return DefaultCanonicalizationAlgorithmDictionaryString.Value; } }
+        public override string DefaultDigestAlgorithm { get { return DefaultDigestAlgorithmDictionaryString.Value; } }
+        public override string DefaultEncryptionAlgorithm { get { return DefaultEncryptionAlgorithmDictionaryString.Value; } }
+        public override int DefaultEncryptionKeyDerivationLength { get { return 192; } }
+        public override string DefaultSymmetricKeyWrapAlgorithm { get { return DefaultSymmetricKeyWrapAlgorithmDictionaryString.Value; } }
+        public override string DefaultAsymmetricKeyWrapAlgorithm { get { return this.DefaultAsymmetricKeyWrapAlgorithmDictionaryString.Value; } }
+
+        public override string DefaultSymmetricSignatureAlgorithm { get { return DefaultSymmetricSignatureAlgorithmDictionaryString.Value; } }
+        public override string DefaultAsymmetricSignatureAlgorithm { get { return DefaultAsymmetricSignatureAlgorithmDictionaryString.Value; } }
+        public override int DefaultSignatureKeyDerivationLength { get { return 192; } }
+        public override int DefaultSymmetricKeyLength { get { return 192; } }
+        public override bool IsSymmetricKeyLengthSupported(int length) { return length >= 192 && length <= 256; }
+        public override bool IsAsymmetricKeyLengthSupported(int length) { return length >= 1024 && length <= 4096; }
+
+        internal override XmlDictionaryString DefaultCanonicalizationAlgorithmDictionaryString { get { return XD.SecurityAlgorithmDictionary.ExclusiveC14n; } }
+        internal override XmlDictionaryString DefaultDigestAlgorithmDictionaryString { get { return XD.SecurityAlgorithmDictionary.Sha1Digest; } }
+        internal override XmlDictionaryString DefaultEncryptionAlgorithmDictionaryString { get { return XD.SecurityAlgorithmDictionary.TripleDesEncryption; } }
+        internal override XmlDictionaryString DefaultSymmetricKeyWrapAlgorithmDictionaryString { get { return XD.SecurityAlgorithmDictionary.TripleDesKeyWrap; } }
+        internal override XmlDictionaryString DefaultAsymmetricKeyWrapAlgorithmDictionaryString { get { return XD.SecurityAlgorithmDictionary.RsaOaepKeyWrap; } }
+        internal override XmlDictionaryString DefaultSymmetricSignatureAlgorithmDictionaryString { get { return XD.SecurityAlgorithmDictionary.HmacSha1Signature; } }
+        internal override XmlDictionaryString DefaultAsymmetricSignatureAlgorithmDictionaryString { get { return XD.SecurityAlgorithmDictionary.RsaSha1Signature; } }
+
+        public override string ToString()
+        {
+            return "TripleDes";
         }
     }
 }

--- a/src/System.ServiceModel.Security/ref/System.ServiceModel.Security.cs
+++ b/src/System.ServiceModel.Security/ref/System.ServiceModel.Security.cs
@@ -56,6 +56,7 @@ namespace System.ServiceModel.Channels
         internal SecurityBindingElement() { }
         public System.ServiceModel.Security.Tokens.SupportingTokenParameters EndpointSupportingTokenParameters { get { return default(System.ServiceModel.Security.Tokens.SupportingTokenParameters); } }
         public bool IncludeTimestamp { get { return default(bool); } set { } }
+        public System.ServiceModel.Security.SecurityAlgorithmSuite DefaultAlgorithmSuite { get { return default(System.ServiceModel.Security.SecurityAlgorithmSuite); } set { } }
         public System.ServiceModel.Channels.LocalClientSecuritySettings LocalClientSettings { get { return default(System.ServiceModel.Channels.LocalClientSecuritySettings); } }
         public System.ServiceModel.MessageSecurityVersion MessageSecurityVersion { get { return default(System.ServiceModel.MessageSecurityVersion); } set { } }
         public System.ServiceModel.Channels.SecurityHeaderLayout SecurityHeaderLayout { get { return default(System.ServiceModel.Channels.SecurityHeaderLayout); } set { } }
@@ -97,6 +98,7 @@ namespace System.ServiceModel.Security
     }
     public abstract partial class SecurityAlgorithmSuite
     {
+        static public SecurityAlgorithmSuite TripleDes { get { return default(SecurityAlgorithmSuite); } }
         protected SecurityAlgorithmSuite() { }
         public abstract string DefaultCanonicalizationAlgorithm { get; }
         public abstract string DefaultDigestAlgorithm { get; }


### PR DESCRIPTION
* Also including adding the APIs to the public contract.
* SecurityAlgorithmSuite was already added to the S.SM.Security contract, added the static property TripleDes to this contract.
* Also adding SecurityBindingElement.DefaultAlgorithmSuite to the public surface area since that is how SecurityAlgorithmSuite.TripleDes is being set in this scenario.

This PR handles porting (from full fx) and adding types to the public contract for WSFederation project work item #3759