### PR TITLE
Add S.IM.T.SecurityKey.KeySize to the public contract.

### DIFF
--- a/src/System.ServiceModel.Primitives/ref/System.ServiceModel.Primitives.cs
+++ b/src/System.ServiceModel.Primitives/ref/System.ServiceModel.Primitives.cs
@@ -156,6 +156,7 @@ namespace System.IdentityModel.Tokens
     public abstract partial class SecurityKey
     {
         internal SecurityKey() { }
+        public abstract int KeySize { get; }
         //public abstract byte[] DecryptKey(string algorithm, byte[] keyData) { return default(byte[]); }
         //public abstract byte[] EncryptKey(string algorithm, byte[] keyData) { return default(byte[]); }
         //public abstract bool IsAsymmetricAlgorithm(string algorithm) { return default(bool); }


### PR DESCRIPTION
* Initially we thought we only needed the class but we found a case where the KeySize is referenced outside of the WS Trust client scenario.

Related work item #3856