### PR TITLE
Update implementation of SecureConversationSecurityTokenParameters

### DIFF
--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/Tokens/SecureConversationSecurityTokenParameters.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/Tokens/SecureConversationSecurityTokenParameters.cs
@@ -34,6 +34,7 @@ namespace System.ServiceModel.Security.Tokens
         }
 
         public SecureConversationSecurityTokenParameters()
+            : this(null, defaultRequireCancellation, null)
         {
             // empty
         }


### PR DESCRIPTION
* The default constructor needs to match what was done in Full Fx so that the default value of RequireCancellation is set correctly.