### PR TITLE
Unit test for SecurityToken class.

### DIFF
--- a/src/System.ServiceModel.Primitives/ref/System.ServiceModel.Primitives.cs
+++ b/src/System.ServiceModel.Primitives/ref/System.ServiceModel.Primitives.cs
@@ -199,7 +199,7 @@ namespace System.IdentityModel.Tokens
         public abstract DateTime ValidFrom { get; }
         public abstract DateTime ValidTo { get; }
         //public virtual bool CanCreateKeyIdentifierClause<T>() where T : System.IdentityModel.Tokens.SecurityKeyIdentifierClause { return default(bool); }
-        //public virtual T CreateKeyIdentifierClause<T>() where T : System.IdentityModel.Tokens.SecurityKeyIdentifierClause { return default(T); }
+        public virtual T CreateKeyIdentifierClause<T>() where T : System.IdentityModel.Tokens.SecurityKeyIdentifierClause { return default(T); }
         //public virtual bool MatchesKeyIdentifierClause(System.IdentityModel.Tokens.SecurityKeyIdentifierClause keyIdentifierClause) { return default(bool); }
         //public virtual System.IdentityModel.Tokens.SecurityKey ResolveKeyIdentifierClause(System.IdentityModel.Tokens.SecurityKeyIdentifierClause keyIdentifierClause) { return default(System.IdentityModel.Tokens.SecurityKey); }
     }

--- a/src/System.ServiceModel.Primitives/tests/Security/SecurityTokenTest.cs
+++ b/src/System.ServiceModel.Primitives/tests/Security/SecurityTokenTest.cs
@@ -1,0 +1,59 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+
+using System;
+using System.Collections.ObjectModel;
+using System.IdentityModel.Tokens;
+using Infrastructure.Common;
+using Xunit;
+
+public static class SecurityTokenTest
+{
+    [WcfFact]
+    public static void Method_CreateKeyIdentifierClause()
+    {
+        MockSecurityToken mst = new MockSecurityToken();
+        LocalIdKeyIdentifierClause idClause = mst.CreateKeyIdentifierClause<LocalIdKeyIdentifierClause>();
+        Assert.NotNull(idClause);
+        Assert.Equal(mst.Id, idClause.LocalId);
+
+        Assert.Throws<NotSupportedException>(() => mst.CreateKeyIdentifierClause<GenericXmlSecurityKeyIdentifierClause>());
+    }
+}
+
+public class MockSecurityToken : SecurityToken
+{
+    public override string Id
+    {
+        get
+        {
+            return "Id";
+        }
+    }
+
+    public override ReadOnlyCollection<SecurityKey> SecurityKeys
+    {
+        get
+        {
+            return null;
+        }
+    }
+
+    public override DateTime ValidFrom
+    {
+        get
+        {
+            return DateTime.UtcNow;
+        }
+    }
+
+    public override DateTime ValidTo
+    {
+        get
+        {
+            return DateTime.MaxValue;
+        }
+    }
+}


### PR DESCRIPTION
For issue #3857, regarding unit tests for APIs listed in table:

1. I didn't find ctor internal SecurityToken() but find ctor internal SecurityKey() in the public contract, and I didn't find implementation for ctor SecurityKey() in "System.Private.ServiceModel" project. I have no idea how to add unit test for this.

2. The properties validation was covered in test added for BinarySecretSecurityToken which derived from SecurityToken. No extra test added for this.

3. The only test not covered is for "virtual method T CreateKeyIdentifierClause<T>() where T : SecurityKeyIdentifierClause" , and it's not added as public contract. I updated that and added unit test for it via mocking the abstract SecurityToken class. 

@StephenBonikowsky , @mconnew , @HongGit 
I am not sure if I missed something above, please help confirm. Thanks!