### PR TITLE
DataContractSerializerOperationBehavior.SerializationSurrogateProvider fix for netstandard library

### DIFF
--- a/src/System.ServiceModel.Primitives/ref/System.ServiceModel.Primitives.Ref.csproj
+++ b/src/System.ServiceModel.Primitives/ref/System.ServiceModel.Primitives.Ref.csproj
@@ -13,11 +13,11 @@
     <Compile Include="System.ServiceModel.Primitives.cs" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1' OR '$(TargetFramework)' == 'netstandard2.0'">
     <Compile Include="System.ServiceModel.Primitives.Netcoreapp.cs" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp2.1'">
+  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp2.1' OR '$(TargetFramework)' != 'netstandard2.0'">
     <None Include="System.ServiceModel.Primitives.Netcoreapp.cs" />
   </ItemGroup>
 


### PR DESCRIPTION
Simple fix to have DataContractSerializerOperationBehavior.SerializationSurrogateProvider in netstandard library, see the Issue #3967 .
See https://github.com/FrancescoCrimi/DCSOB-Error for the error

Thanks you