### PR TITLE
Fixing branch name logic.

### DIFF
--- a/eng/UpdatePRService.yml
+++ b/eng/UpdatePRService.yml
@@ -44,7 +44,11 @@ steps:
       :branch
       echo Set the repo branch to be what build.SourceBranchName is: %BUILD_SOURCEBRANCHNAME%
       REM The following vso call sets a variable that is accessible further down in the PowerShell script to Sync the PR Service.
-      echo ##vso[task.setvariable variable=branchNameorPrId]origin/%BUILD_SOURCEBRANCHNAME%
+      IF '%BUILD_SOURCEBRANCHNAME%'=='master' (
+          echo ##vso[task.setvariable variable=branchNameorPrId]origin/%BUILD_SOURCEBRANCHNAME%
+      ) ELSE (
+          echo ##vso[task.setvariable variable=branchNameorPrId]origin/release/%BUILD_SOURCEBRANCHNAME%
+      )
       goto done
 
       :done
@@ -74,7 +78,11 @@ steps:
         echo "Operation mode has been set to: $_OPERATION"
         echo "##vso[task.setvariable variable=operation]$_OPERATION"
         echo "Set the repo branch to be what build.SourceBranchName is: $BUILD_SOURCEBRANCHNAME"
-        echo "##vso[task.setvariable variable=branchNameorPrId]origin/$BUILD_SOURCEBRANCHNAME"
+        if [[ $BUILD_SOURCEBRANCHNAME = master ]]; then
+          echo "##vso[task.setvariable variable=branchNameorPrId]origin/$BUILD_SOURCEBRANCHNAME"
+        else
+          echo "##vso[task.setvariable variable=branchNameorPrId]origin/release/$BUILD_SOURCEBRANCHNAME"
+        fi
       fi
 
     displayName: Set_Operation_PR_or_Branch_Unix


### PR DESCRIPTION
* The existing logic didn't account for a branch name being "release/3.1.0"
* We leveraged the azure devops variable 'Build.SourceBranchName' which returned the "last path segment in the ref string".