### PR TITLE
Enable or disable shipping different packages.

### DIFF
--- a/eng/Versioning.props
+++ b/eng/Versioning.props
@@ -1,6 +1,8 @@
 <Project>
   <PropertyGroup>
     <GenerateAssemblyInfo Condition="'$(GenerateAssemblyInfo)'==''">true</GenerateAssemblyInfo>
+    <Ship_SvcUtilXmlSerPackages Condition="'$(Ship_SvcUtilXmlSerPackages)'==''">false</Ship_SvcUtilXmlSerPackages>
+    <Ship_WcfPackages Condition="'$(Ship_WcfPackages)'==''">true</Ship_WcfPackages>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(GenerateAssemblyInfo)'=='true'">

--- a/src/System.Private.ServiceModel/src/System.Private.ServiceModel.csproj
+++ b/src/System.Private.ServiceModel/src/System.Private.ServiceModel.csproj
@@ -18,6 +18,7 @@
     <CLSCompliant>true</CLSCompliant>
     <IsImplementationAssembly>true</IsImplementationAssembly>
     <IsPackable>true</IsPackable>
+    <IsShipping>$(Ship_WcfPackages)</IsShipping>
   </PropertyGroup>
 
   <!-- [todo:arcade] Added this because our released S.P.SM package includes the "_BlockReflectionAttribute" but it is included not only in the UAP* assembly but also the other shipped assembly, should this only be in the binary built for uap? -->

--- a/src/System.ServiceModel.Duplex/src/System.ServiceModel.Duplex.Facade.csproj
+++ b/src/System.ServiceModel.Duplex/src/System.ServiceModel.Duplex.Facade.csproj
@@ -13,6 +13,7 @@
     <TargetFrameworks>$(BuildFrameworks)$(HarvestFrameworks)</TargetFrameworks>
     <IsBuilding Condition="$(BuildFrameworks.Contains('$(TargetFramework);'))">true</IsBuilding>
     <IsHarvesting Condition="$(HarvestFrameworks.Contains('$(TargetFramework);'))">true</IsHarvesting>
+    <IsShipping>$(Ship_WcfPackages)</IsShipping>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(IsBuilding)' == 'true'">

--- a/src/System.ServiceModel.Http/src/System.ServiceModel.Http.Facade.csproj
+++ b/src/System.ServiceModel.Http/src/System.ServiceModel.Http.Facade.csproj
@@ -13,6 +13,7 @@
     <TargetFrameworks>$(BuildFrameworks)$(HarvestFrameworks)</TargetFrameworks>
     <IsBuilding Condition="$(BuildFrameworks.Contains('$(TargetFramework);'))">true</IsBuilding>
     <IsHarvesting Condition="$(HarvestFrameworks.Contains('$(TargetFramework);'))">true</IsHarvesting>
+    <IsShipping>$(Ship_WcfPackages)</IsShipping>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(IsBuilding)' == 'true'">

--- a/src/System.ServiceModel.NetTcp/src/System.ServiceModel.NetTcp.Facade.csproj
+++ b/src/System.ServiceModel.NetTcp/src/System.ServiceModel.NetTcp.Facade.csproj
@@ -13,6 +13,7 @@
     <TargetFrameworks>$(BuildFrameworks)$(HarvestFrameworks)</TargetFrameworks>
     <IsBuilding Condition="$(BuildFrameworks.Contains('$(TargetFramework);'))">true</IsBuilding>
     <IsHarvesting Condition="$(HarvestFrameworks.Contains('$(TargetFramework);'))">true</IsHarvesting>
+    <IsShipping>$(Ship_WcfPackages)</IsShipping>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(IsBuilding)' == 'true'">

--- a/src/System.ServiceModel.Primitives/src/System.ServiceModel.Primitives.Facade.csproj
+++ b/src/System.ServiceModel.Primitives/src/System.ServiceModel.Primitives.Facade.csproj
@@ -13,6 +13,7 @@
     <TargetFrameworks>$(BuildFrameworks)$(HarvestFrameworks)</TargetFrameworks>
     <IsBuilding Condition="$(BuildFrameworks.Contains('$(TargetFramework);'))">true</IsBuilding>
     <IsHarvesting Condition="$(HarvestFrameworks.Contains('$(TargetFramework);'))">true</IsHarvesting>
+    <IsShipping>$(Ship_WcfPackages)</IsShipping>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(IsBuilding)' == 'true' And '$(TargetFramework)' != 'net461'">

--- a/src/System.ServiceModel.Security/src/System.ServiceModel.Security.Facade.csproj
+++ b/src/System.ServiceModel.Security/src/System.ServiceModel.Security.Facade.csproj
@@ -13,6 +13,7 @@
     <TargetFrameworks>$(BuildFrameworks)$(HarvestFrameworks)</TargetFrameworks>
     <IsBuilding Condition="$(BuildFrameworks.Contains('$(TargetFramework);'))">true</IsBuilding>
     <IsHarvesting Condition="$(HarvestFrameworks.Contains('$(TargetFramework);'))">true</IsHarvesting>
+    <IsShipping>$(Ship_WcfPackages)</IsShipping>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(IsBuilding)' == 'true'">

--- a/src/svcutilcore/src/dotnet-svcutil.xmlserializer.csproj
+++ b/src/svcutilcore/src/dotnet-svcutil.xmlserializer.csproj
@@ -12,7 +12,7 @@
     <DebugSymbols>true</DebugSymbols>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <ProjectGuid>{EAB2959D-0A16-4F60-A453-765491E1C069}</ProjectGuid>
-    <IsShipping>false</IsShipping>
+    <IsShipping>$(Ship_SvcUtilXmlSerPackages)</IsShipping>
   </PropertyGroup>
 
   <!--Package Properties-->


### PR DESCRIPTION
* By default always ship WCF packages.
* By default do not ship dotnet-svcutil.xmlserializer packages.
* Enable or disable either one by setting their respective properties to true or false, can be done from the build definition that produces final release packages.
* Fixes #3975