### PR TITLE
Add "encodingStyle" attribute to generated SOAP message.

### DIFF
--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Dispatcher/XmlSerializerOperationFormatter.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Dispatcher/XmlSerializerOperationFormatter.cs
@@ -20,6 +20,7 @@ namespace System.ServiceModel.Dispatcher
         private const string soap11Encoding = "http://schemas.xmlsoap.org/soap/encoding/";
         private const string soap12Encoding = "http://www.w3.org/2003/05/soap-encoding";
 
+        private bool _isEncoded;
         private MessageInfo _requestMessageInfo;
         private MessageInfo _replyMessageInfo;
 
@@ -27,6 +28,12 @@ namespace System.ServiceModel.Dispatcher
             MessageInfo requestMessageInfo, MessageInfo replyMessageInfo) :
             base(description, xmlSerializerFormatAttribute.Style == OperationFormatStyle.Rpc, xmlSerializerFormatAttribute.IsEncoded)
         {
+            if (xmlSerializerFormatAttribute.IsEncoded && xmlSerializerFormatAttribute.Style != OperationFormatStyle.Rpc)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.SFxDocEncodedNotSupported, description.Name)));
+            }
+
+            _isEncoded = xmlSerializerFormatAttribute.IsEncoded;
             _requestMessageInfo = requestMessageInfo;
             _replyMessageInfo = replyMessageInfo;
         }
@@ -83,13 +90,12 @@ namespace System.ServiceModel.Dispatcher
                     MemoryStream memoryStream = new MemoryStream();
                     XmlDictionaryWriter bufferWriter = XmlDictionaryWriter.CreateTextWriter(memoryStream);
                     bufferWriter.WriteStartElement("root");
-                    serializer.Serialize(bufferWriter, headerValues, null);
+                    serializer.Serialize(bufferWriter, headerValues, null, _isEncoded ? GetEncoding(message.Version.Envelope) : null);
                     bufferWriter.WriteEndElement();
                     bufferWriter.Flush();
                     XmlDocument doc = new XmlDocument();
                     memoryStream.Position = 0;
                     doc.Load(memoryStream);
-                    //doc.Save(Console.Out);
                     foreach (XmlElement element in doc.DocumentElement.ChildNodes)
                     {
                         MessageHeaderDescription matchingHeaderDescription = headerDescriptionTable.Get(element.LocalName, element.NamespaceURI);
@@ -236,7 +242,7 @@ namespace System.ServiceModel.Dispatcher
                 if (!bufferReader.IsEmptyElement)
                 {
                     bufferReader.ReadStartElement();
-                    object[] headerValues = (object[])serializer.Deserialize(bufferReader);
+                    object[] headerValues = (object[])serializer.Deserialize(bufferReader, _isEncoded ? GetEncoding(message.Version.Envelope) : null);
                     int headerIndex = 0;
                     foreach (MessageHeaderDescription headerDescription in messageDescription.Headers)
                     {
@@ -285,6 +291,12 @@ namespace System.ServiceModel.Dispatcher
 
         protected override void WriteBodyAttributes(XmlDictionaryWriter writer, MessageVersion version)
         {
+            if (_isEncoded && version.Envelope == EnvelopeVersion.Soap11)
+            {
+                string encoding = GetEncoding(version.Envelope);
+                writer.WriteAttributeString("encodingStyle", version.Envelope.Namespace, encoding);
+            }
+
             writer.WriteAttributeString("xmlns", "xsi", null, XmlUtil.XmlSerializerSchemaInstanceNamespace);
             writer.WriteAttributeString("xmlns", "xsd", null, XmlUtil.XmlSerializerSchemaNamespace);
         }
@@ -374,6 +386,7 @@ namespace System.ServiceModel.Dispatcher
                 bodyParameters[paramIndex++] = parameters[bodyParts[i].Index];
             }
 
+            string encoding = _isEncoded ? GetEncoding(version.Envelope) : null;
             serializer.Serialize(writer, bodyParameters, null);
         }
 
@@ -444,7 +457,7 @@ namespace System.ServiceModel.Dispatcher
                     return null;
                 }
 
-                object[] bodyParameters = (object[])serializer.Deserialize(reader);
+                object[] bodyParameters = (object[])serializer.Deserialize(reader, _isEncoded ? GetEncoding(version.Envelope) : null);
                 int paramIndex = 0;
                 if (IsValidReturnValue(returnPart))
                 {
@@ -568,7 +581,9 @@ namespace System.ServiceModel.Dispatcher
                     if (_attributes[headerDescription.Index] == null)
                     {
                         _attributes[headerDescription.Index] = new List<MessageHeader<object>>();
-                    } ((List<MessageHeader<object>>)_attributes[headerDescription.Index]).Add(new MessageHeader<object>(null, mustUnderstand, actor, relay));
+                    }
+                    
+                    ((List<MessageHeader<object>>)_attributes[headerDescription.Index]).Add(new MessageHeader<object>(null, mustUnderstand, actor, relay));
                 }
                 else
                 {


### PR DESCRIPTION
* This fix was initially produced by @maheshnlrb with PR #3891 but the commit history got sufficiently scrambled that is was easier to reproduce his changes in a clean up-to-date branch.