### PR TITLE
Remove not violated xUnit warnings in wcf test projects.

### DIFF
--- a/src/System.Private.ServiceModel/tests/Scenarios/Binding/Custom/Binding.Custom.IntegrationTests.csproj
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Binding/Custom/Binding.Custom.IntegrationTests.csproj
@@ -7,7 +7,7 @@
     <IsPackable>false</IsPackable>
     <!--[todo:arcade] Re-enable these warnings and fix them.-->
     <!-- https://xunit.github.io/xunit.analyzers/rules/ -->
-    <NoWarn>$(NoWarn);xUnit1013;xUnit2010;xUnit2006;xUnit1014;xUnit1003;xUnit2000;xUnit2009;xUnit1006</NoWarn>
+    <NoWarn>$(NoWarn);xUnit2000;xUnit2009</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/System.Private.ServiceModel/tests/Scenarios/Binding/Http/Binding.Http.IntegrationTests.csproj
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Binding/Http/Binding.Http.IntegrationTests.csproj
@@ -7,7 +7,7 @@
     <IsPackable>false</IsPackable>
     <!--[todo:arcade] Re-enable these warnings and fix them.-->
     <!-- https://xunit.github.io/xunit.analyzers/rules/ -->
-    <NoWarn>$(NoWarn);xUnit1013;xUnit2010;xUnit2006;xUnit1014;xUnit1003;xUnit2000;xUnit2009;xUnit1006</NoWarn>
+    <NoWarn>$(NoWarn);xUnit2000;xUnit2009</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/System.Private.ServiceModel/tests/Scenarios/Binding/Tcp/Binding.Tcp.IntegrationTests.csproj
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Binding/Tcp/Binding.Tcp.IntegrationTests.csproj
@@ -6,7 +6,7 @@
     <IsPackable>false</IsPackable>
     <!--[todo:arcade] Re-enable these warnings and fix them.-->
     <!-- https://xunit.github.io/xunit.analyzers/rules/ -->
-    <NoWarn>$(NoWarn);xUnit1013;xUnit2010;xUnit2006;xUnit1014;xUnit1003;xUnit2000;xUnit2009;xUnit1006</NoWarn>
+    <NoWarn>$(NoWarn);xUnit2000;xUnit2009</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/System.Private.ServiceModel/tests/Scenarios/Binding/WS/TransportWithMessageCredentialSecurity/Binding.WS.TransportWithMessageCredentialSecurity.IntegrationTests.csproj
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Binding/WS/TransportWithMessageCredentialSecurity/Binding.WS.TransportWithMessageCredentialSecurity.IntegrationTests.csproj
@@ -6,7 +6,7 @@
     <IsPackable>false</IsPackable>
     <!--[todo:arcade] Re-enable these warnings and fix them.-->
     <!-- https://xunit.github.io/xunit.analyzers/rules/ -->
-    <NoWarn>$(NoWarn);xUnit1013;xUnit2010;xUnit2006;xUnit1014;xUnit1003;xUnit2000;xUnit2009;xUnit1006</NoWarn>
+    <NoWarn>$(NoWarn);xUnit2000;xUnit2009</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/ChannelLayer/Client.ChannelLayer.IntegrationTests.csproj
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/ChannelLayer/Client.ChannelLayer.IntegrationTests.csproj
@@ -7,7 +7,7 @@
     <IsPackable>false</IsPackable>
     <!--[todo:arcade] Re-enable these warnings and fix them.-->
     <!-- https://xunit.github.io/xunit.analyzers/rules/ -->
-    <NoWarn>$(NoWarn);xUnit1013;xUnit2010;xUnit2006;xUnit1014;xUnit1003;xUnit2000;xUnit2009;xUnit1006</NoWarn>
+    <NoWarn>$(NoWarn);xUnit2000;xUnit2009</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/ClientBase/Client.ClientBase.IntegrationTests.csproj
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/ClientBase/Client.ClientBase.IntegrationTests.csproj
@@ -7,7 +7,7 @@
     <IsPackable>false</IsPackable>
     <!--[todo:arcade] Re-enable these warnings and fix them.-->
     <!-- https://xunit.github.io/xunit.analyzers/rules/ -->
-    <NoWarn>$(NoWarn);xUnit1013;xUnit2010;xUnit2006;xUnit1014;xUnit1003;xUnit2000;xUnit2009;xUnit1006</NoWarn>
+    <NoWarn>$(NoWarn);xUnit2000;xUnit2009</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/ExpectedExceptions/Client.ExpectedExceptions.IntegrationTests.csproj
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/ExpectedExceptions/Client.ExpectedExceptions.IntegrationTests.csproj
@@ -7,7 +7,7 @@
     <IsPackable>false</IsPackable>
     <!--[todo:arcade] Re-enable these warnings and fix them.-->
     <!-- https://xunit.github.io/xunit.analyzers/rules/ -->
-    <NoWarn>$(NoWarn);xUnit1013;xUnit2010;xUnit2006;xUnit1014;xUnit1003;xUnit2000;xUnit2009;xUnit1006</NoWarn>
+    <NoWarn>$(NoWarn);xUnit2000;xUnit2009</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/TypedClient/Client.TypedClient.IntegrationTests.csproj
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/TypedClient/Client.TypedClient.IntegrationTests.csproj
@@ -6,7 +6,7 @@
     <IsPackable>false</IsPackable>
     <!--[todo:arcade] Re-enable these warnings and fix them.-->
     <!-- https://xunit.github.io/xunit.analyzers/rules/ -->
-    <NoWarn>$(NoWarn);xUnit1013;xUnit2010;xUnit2006;xUnit1014;xUnit1003;xUnit2000;xUnit2009;xUnit1006;xUnit1024</NoWarn>
+    <NoWarn>$(NoWarn);xUnit2000;xUnit2009;xUnit1024</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/System.Private.ServiceModel/tests/Scenarios/Contract/Data/Contract.Data.IntegrationTests.csproj
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Contract/Data/Contract.Data.IntegrationTests.csproj
@@ -6,7 +6,7 @@
     <IsPackable>false</IsPackable>
     <!--[todo:arcade] Re-enable these warnings and fix them.-->
     <!-- https://xunit.github.io/xunit.analyzers/rules/ -->
-    <NoWarn>$(NoWarn);xUnit1013;xUnit2010;xUnit2006;xUnit1014;xUnit1003;xUnit2000;xUnit2009;xUnit1006;xUnit2013</NoWarn>
+    <NoWarn>$(NoWarn);xUnit2000;xUnit2009;xUnit2013</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/System.Private.ServiceModel/tests/Scenarios/Contract/Fault/Contract.Fault.IntegrationTests.csproj
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Contract/Fault/Contract.Fault.IntegrationTests.csproj
@@ -6,7 +6,7 @@
     <IsPackable>false</IsPackable>
     <!--[todo:arcade] Re-enable these warnings and fix them.-->
     <!-- https://xunit.github.io/xunit.analyzers/rules/ -->
-    <NoWarn>$(NoWarn);xUnit1013;xUnit2010;xUnit2006;xUnit1014;xUnit1003;xUnit2000;xUnit2009;xUnit1006</NoWarn>
+    <NoWarn>$(NoWarn);xUnit2000;xUnit2009</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/System.Private.ServiceModel/tests/Scenarios/Contract/Message/Contract.Message.IntegrationTests.csproj
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Contract/Message/Contract.Message.IntegrationTests.csproj
@@ -6,7 +6,7 @@
     <IsPackable>false</IsPackable>
     <!--[todo:arcade] Re-enable these warnings and fix them.-->
     <!-- https://xunit.github.io/xunit.analyzers/rules/ -->
-    <NoWarn>$(NoWarn);xUnit1013;xUnit2010;xUnit2006;xUnit1014;xUnit1003;xUnit2000;xUnit2009;xUnit1006</NoWarn>
+    <NoWarn>$(NoWarn);xUnit2000;xUnit2009</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/System.Private.ServiceModel/tests/Scenarios/Contract/Service/Contract.Service.IntegrationTests.csproj
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Contract/Service/Contract.Service.IntegrationTests.csproj
@@ -6,7 +6,7 @@
     <IsPackable>false</IsPackable>
     <!--[todo:arcade] Re-enable these warnings and fix them.-->
     <!-- https://xunit.github.io/xunit.analyzers/rules/ -->
-    <NoWarn>$(NoWarn);xUnit1013;xUnit2010;xUnit2006;xUnit1014;xUnit1003;xUnit2000;xUnit2009;xUnit1006</NoWarn>
+    <NoWarn>$(NoWarn);xUnit2000;xUnit2009</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/System.Private.ServiceModel/tests/Scenarios/Contract/XmlSerializer/Contract.XmlSerializer.IntegrationTests.csproj
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Contract/XmlSerializer/Contract.XmlSerializer.IntegrationTests.csproj
@@ -6,7 +6,7 @@
     <IsPackable>false</IsPackable>
     <!--[todo:arcade] Re-enable these warnings and fix them.-->
     <!-- https://xunit.github.io/xunit.analyzers/rules/ -->
-    <NoWarn>$(NoWarn);xUnit1013;xUnit2010;xUnit2006;xUnit1014;xUnit1003;xUnit2000;xUnit2009;xUnit1006</NoWarn>
+    <NoWarn>$(NoWarn);xUnit2000;xUnit2009</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/System.Private.ServiceModel/tests/Scenarios/Encoding/Encoders/Encoding.Encoders.IntegrationTests.csproj
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Encoding/Encoders/Encoding.Encoders.IntegrationTests.csproj
@@ -6,7 +6,7 @@
     <IsPackable>false</IsPackable>
     <!--[todo:arcade] Re-enable these warnings and fix them.-->
     <!-- https://xunit.github.io/xunit.analyzers/rules/ -->
-    <NoWarn>$(NoWarn);xUnit1013;xUnit2010;xUnit2006;xUnit1014;xUnit1003;xUnit2000;xUnit2009;xUnit1006;xUnit1024</NoWarn>
+    <NoWarn>$(NoWarn);xUnit2000;xUnit2009;xUnit1024</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/System.Private.ServiceModel/tests/Scenarios/Encoding/MessageVersion/Encoding.MessageVersion.IntegrationTests.csproj
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Encoding/MessageVersion/Encoding.MessageVersion.IntegrationTests.csproj
@@ -6,7 +6,7 @@
     <IsPackable>false</IsPackable>
     <!--[todo:arcade] Re-enable these warnings and fix them.-->
     <!-- https://xunit.github.io/xunit.analyzers/rules/ -->
-    <NoWarn>$(NoWarn);xUnit1013;xUnit2010;xUnit2006;xUnit1014;xUnit1003;xUnit2000;xUnit2009;xUnit1006;xUnit1024</NoWarn>
+    <NoWarn>$(NoWarn);xUnit2000;xUnit2009;xUnit1024</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/System.Private.ServiceModel/tests/Scenarios/Extensibility/MessageEncoder/Extensibility.MessageEncoder.IntegrationTests.csproj
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Extensibility/MessageEncoder/Extensibility.MessageEncoder.IntegrationTests.csproj
@@ -6,7 +6,7 @@
     <IsPackable>false</IsPackable>
     <!--[todo:arcade] Re-enable these warnings and fix them.-->
     <!-- https://xunit.github.io/xunit.analyzers/rules/ -->
-    <NoWarn>$(NoWarn);xUnit1013;xUnit2010;xUnit2006;xUnit1014;xUnit1003;xUnit2000;xUnit2009;xUnit1006</NoWarn>
+    <NoWarn>$(NoWarn);xUnit2000;xUnit2009</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/System.Private.ServiceModel/tests/Scenarios/Extensibility/MessageInterceptor/Extensibility.MessageInterceptor.IntegrationTests.csproj
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Extensibility/MessageInterceptor/Extensibility.MessageInterceptor.IntegrationTests.csproj
@@ -6,7 +6,7 @@
     <IsPackable>false</IsPackable>
     <!--[todo:arcade] Re-enable these warnings and fix them.-->
     <!-- https://xunit.github.io/xunit.analyzers/rules/ -->
-    <NoWarn>$(NoWarn);xUnit1013;xUnit2010;xUnit2006;xUnit1014;xUnit1003;xUnit2000;xUnit2009;xUnit1006</NoWarn>
+    <NoWarn>$(NoWarn);xUnit2000;xUnit2009</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/System.Private.ServiceModel/tests/Scenarios/Extensibility/WebSockets/Extensibility.WebSockets.IntegrationTests.csproj
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Extensibility/WebSockets/Extensibility.WebSockets.IntegrationTests.csproj
@@ -7,7 +7,7 @@
     <IsPackable>false</IsPackable>
     <!--[todo:arcade] Re-enable these warnings and fix them.-->
     <!-- https://xunit.github.io/xunit.analyzers/rules/ -->
-    <NoWarn>$(NoWarn);xUnit1013;xUnit2010;xUnit2006;xUnit1014;xUnit1003;xUnit2000;xUnit2009;xUnit1006</NoWarn>
+    <NoWarn>$(NoWarn);xUnit2000;xUnit2009</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/System.Private.ServiceModel/tests/Scenarios/Infrastructure/Infrastructure.IntegrationTests.csproj
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Infrastructure/Infrastructure.IntegrationTests.csproj
@@ -7,7 +7,7 @@
     <IsPackable>false</IsPackable>
     <!--[todo:arcade] Re-enable these warnings and fix them.-->
     <!-- https://xunit.github.io/xunit.analyzers/rules/ -->
-    <NoWarn>$(NoWarn);xUnit1013;xUnit2010;xUnit2006;xUnit1014;xUnit1003;xUnit2000;xUnit2009;xUnit1006</NoWarn>
+    <NoWarn>$(NoWarn);xUnit2000;xUnit2009</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Security.TransportSecurity.IntegrationTests.csproj
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Security.TransportSecurity.IntegrationTests.csproj
@@ -7,7 +7,7 @@
     <IsPackable>false</IsPackable>
     <!--[todo:arcade] Re-enable these warnings and fix them.-->
     <!-- https://xunit.github.io/xunit.analyzers/rules/ -->
-    <NoWarn>$(NoWarn);xUnit1013;xUnit2010;xUnit2006;xUnit1014;xUnit1003;xUnit2000;xUnit2009;xUnit1006</NoWarn>
+    <NoWarn>$(NoWarn);xUnit2000;xUnit2009</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Address part of issue #4006.

WCF test projects doesn't violate below xunit warnings, so I removed the suppress config from related csproj files in this single PR. 
xUnit1003
xUnit1006
xUnit1013
xUnit1014
xUnit2006
xUnit2010



For the other violations listed below, will address each in separated PR.
xUnit2000
xUnit2009
xUnit1024
xUnit2013