### PR TITLE
Add the default ctor for FaultException<TDetail>

### DIFF
--- a/src/System.ServiceModel.Primitives/ref/System.ServiceModel.Primitives.cs
+++ b/src/System.ServiceModel.Primitives/ref/System.ServiceModel.Primitives.cs
@@ -515,6 +515,7 @@ namespace System.ServiceModel
     }
     public partial class FaultException<TDetail> : System.ServiceModel.FaultException
     {
+        public FaultException(TDetail detail) { }
         public FaultException(TDetail detail, System.ServiceModel.FaultReason reason) { }
         public FaultException(TDetail detail, System.ServiceModel.FaultReason reason, System.ServiceModel.FaultCode code, string action) { }
         protected FaultException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }


### PR DESCRIPTION
@mconnew I believe we discussed this, I don't see any reason why we can't add this to the public contract.

FYI @wouterroos