### PR TITLE
Add the default ctor for FaultException<TDetail>

### DIFF
--- a/src/System.ServiceModel.Primitives/ref/System.ServiceModel.Primitives.cs
+++ b/src/System.ServiceModel.Primitives/ref/System.ServiceModel.Primitives.cs
@@ -515,6 +515,7 @@ namespace System.ServiceModel
     }
     public partial class FaultException<TDetail> : System.ServiceModel.FaultException
     {
+        public FaultException(TDetail detail) { }
         public FaultException(TDetail detail, System.ServiceModel.FaultReason reason) { }
         public FaultException(TDetail detail, System.ServiceModel.FaultReason reason, System.ServiceModel.FaultCode code, string action) { }
         protected FaultException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }


### PR DESCRIPTION
Cherry-picking this change to the release/3.1.0 branch.
Requested by @wouterroos in #3911 

This change will ship with release 3.1 GA in December.