### PR TITLE
Change release lablel for non-shipping package to rtm.

### DIFF
--- a/src/svcutilcore/src/dotnet-svcutil.xmlserializer.csproj
+++ b/src/svcutilcore/src/dotnet-svcutil.xmlserializer.csproj
@@ -20,7 +20,7 @@
     <IsPackable>true</IsPackable>
     <MajorVersion>1</MajorVersion>
     <MinorVersion>2</MinorVersion>
-    <PreReleaseVersionLabel>preview1</PreReleaseVersionLabel>
+    <PreReleaseVersionLabel>rtm</PreReleaseVersionLabel>
     <PackageReleaseNotes>https://github.com/dotnet/wcf/blob/master/release-notes/dotnet-svcutil.xmlserializer-notes.md</PackageReleaseNotes>
     <!-- The partial facade assembly's public key token must exactly match the contract to be filled. -->
     <StrongNameKeyId>Open</StrongNameKeyId>


### PR DESCRIPTION
Changing the pre-release label in Versions.props only affects the WCF packages.
To affect the dotnet-svcutil.xmlserializer package it has to be done in the project file.
This package ships on an entirely different cadence which is why it is handled separately like this.