### PR TITLE
Fix xUnit warning #2006 for test projects.

### DIFF
--- a/src/System.ServiceModel.Duplex/tests/System.ServiceModel.Duplex.Tests.csproj
+++ b/src/System.ServiceModel.Duplex/tests/System.ServiceModel.Duplex.Tests.csproj
@@ -6,7 +6,7 @@
     <IsPackable>false</IsPackable>
     <!--[todo:arcade] Re-enable these warnings and fix them.-->
     <!-- https://xunit.github.io/xunit.analyzers/rules/ -->
-    <NoWarn>$(NoWarn);xUnit2010;xUnit2006;xUnit2009</NoWarn>
+    <NoWarn>$(NoWarn);xUnit2010;xUnit2009</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/System.ServiceModel.Http/tests/Channels/HttpRequestMessagePropertyTest.cs
+++ b/src/System.ServiceModel.Http/tests/Channels/HttpRequestMessagePropertyTest.cs
@@ -16,8 +16,8 @@ public static class HttpRequestMessagePropertyTest
         HttpRequestMessageProperty requestMsgProperty = new HttpRequestMessageProperty();
 
         Assert.NotNull(requestMsgProperty.Headers);
-        Assert.Equal<string>("POST", requestMsgProperty.Method);
-        Assert.Equal<string>(string.Empty, requestMsgProperty.QueryString);
+        Assert.Equal("POST", requestMsgProperty.Method);
+        Assert.Equal(string.Empty, requestMsgProperty.QueryString);
         Assert.False(requestMsgProperty.SuppressEntityBody);
     }
 
@@ -38,17 +38,17 @@ public static class HttpRequestMessagePropertyTest
         Assert.IsType<HttpRequestMessageProperty>(copyMessageProperty);
         HttpRequestMessageProperty copy = (HttpRequestMessageProperty)copyMessageProperty;
 
-        Assert.Equal<string>(original.QueryString, copy.QueryString);
-        Assert.Equal<string>(original.Method, copy.Method);
+        Assert.Equal(original.QueryString, copy.QueryString);
+        Assert.Equal(original.Method, copy.Method);
         Assert.Equal<bool>(original.SuppressEntityBody, copy.SuppressEntityBody);
         Assert.Equal<int>(original.Headers.Count, copy.Headers.Count);
-        Assert.Equal<string>(original.Headers[testKeyName], copy.Headers[testKeyName]);
+        Assert.Equal(original.Headers[testKeyName], copy.Headers[testKeyName]);
     }
 
     [WcfFact]
     public static void Name_Property()
     {
-        Assert.Equal<string>("httpRequest", HttpRequestMessageProperty.Name);
+        Assert.Equal("httpRequest", HttpRequestMessageProperty.Name);
     }
 
     [WcfFact]
@@ -57,7 +57,7 @@ public static class HttpRequestMessagePropertyTest
         const string newMethod = "PUT";
         HttpRequestMessageProperty requestMsgProperty = new HttpRequestMessageProperty();
         requestMsgProperty.Method = newMethod;
-        Assert.Equal<string>(newMethod, requestMsgProperty.Method);
+        Assert.Equal(newMethod, requestMsgProperty.Method);
     }
 
     [WcfFact]
@@ -73,7 +73,7 @@ public static class HttpRequestMessagePropertyTest
         const string newQueryString = "name=Mary";
         HttpRequestMessageProperty requestMsgProperty = new HttpRequestMessageProperty();
         requestMsgProperty.QueryString = newQueryString;
-        Assert.Equal<string>(newQueryString, requestMsgProperty.QueryString);
+        Assert.Equal(newQueryString, requestMsgProperty.QueryString);
     }
 
     [WcfFact]

--- a/src/System.ServiceModel.Http/tests/ServiceModel/BasicHttpBindingTest.cs
+++ b/src/System.ServiceModel.Http/tests/ServiceModel/BasicHttpBindingTest.cs
@@ -20,11 +20,11 @@ public static class BasicHttpBindingTest
     public static void Default_Ctor_Initializes_Properties()
     {
         var binding = new BasicHttpBinding();
-        Assert.Equal<string>("BasicHttpBinding", binding.Name);
-        Assert.Equal<string>("http://tempuri.org/", binding.Namespace);
-        Assert.Equal<string>("http", binding.Scheme);
+        Assert.Equal("BasicHttpBinding", binding.Name);
+        Assert.Equal("http://tempuri.org/", binding.Namespace);
+        Assert.Equal("http", binding.Scheme);
         Assert.Equal<Encoding>(Encoding.GetEncoding("utf-8"), binding.TextEncoding);
-        Assert.Equal<string>(Encoding.GetEncoding("utf-8").WebName, binding.TextEncoding.WebName);
+        Assert.Equal(Encoding.GetEncoding("utf-8").WebName, binding.TextEncoding.WebName);
         Assert.False(binding.AllowCookies);
         Assert.Equal<TimeSpan>(TimeSpan.FromMinutes(1), binding.CloseTimeout);
         Assert.Equal<TimeSpan>(TimeSpan.FromMinutes(1), binding.OpenTimeout);
@@ -45,11 +45,11 @@ public static class BasicHttpBindingTest
     {
         var binding = new BasicHttpBinding(BasicHttpSecurityMode.Transport);
 
-        Assert.Equal<string>("BasicHttpBinding", binding.Name);
-        Assert.Equal<string>("http://tempuri.org/", binding.Namespace);
-        Assert.Equal<string>("https", binding.Scheme);
+        Assert.Equal("BasicHttpBinding", binding.Name);
+        Assert.Equal("http://tempuri.org/", binding.Namespace);
+        Assert.Equal("https", binding.Scheme);
         Assert.Equal<Encoding>(Encoding.GetEncoding("utf-8"), binding.TextEncoding);
-        Assert.Equal<string>(Encoding.GetEncoding("utf-8").WebName, binding.TextEncoding.WebName);
+        Assert.Equal(Encoding.GetEncoding("utf-8").WebName, binding.TextEncoding.WebName);
         Assert.False(binding.AllowCookies);
         Assert.Equal<TimeSpan>(TimeSpan.FromMinutes(1), binding.CloseTimeout);
         Assert.Equal<TimeSpan>(TimeSpan.FromMinutes(1), binding.OpenTimeout);
@@ -69,11 +69,11 @@ public static class BasicHttpBindingTest
     public static void Ctor_With_BasicHttpSecurityMode_TransportCredentialOnly_Initializes_Properties()
     {
         var binding = new BasicHttpBinding(BasicHttpSecurityMode.TransportCredentialOnly);
-        Assert.Equal<string>("BasicHttpBinding", binding.Name);
-        Assert.Equal<string>("http://tempuri.org/", binding.Namespace);
-        Assert.Equal<string>("http", binding.Scheme);
+        Assert.Equal("BasicHttpBinding", binding.Name);
+        Assert.Equal("http://tempuri.org/", binding.Namespace);
+        Assert.Equal("http", binding.Scheme);
         Assert.Equal<Encoding>(Encoding.GetEncoding("utf-8"), binding.TextEncoding);
-        Assert.Equal<string>(Encoding.GetEncoding("utf-8").WebName, binding.TextEncoding.WebName);
+        Assert.Equal(Encoding.GetEncoding("utf-8").WebName, binding.TextEncoding.WebName);
         Assert.False(binding.AllowCookies);
         Assert.Equal<TimeSpan>(TimeSpan.FromMinutes(1), binding.CloseTimeout);
         Assert.Equal<TimeSpan>(TimeSpan.FromMinutes(1), binding.OpenTimeout);
@@ -165,7 +165,7 @@ public static class BasicHttpBindingTest
     {
         var binding = new BasicHttpBinding();
         binding.Name = value;
-        Assert.Equal<string>(value, binding.Name);
+        Assert.Equal(value, binding.Name);
     }
 
     [WcfTheory]
@@ -185,7 +185,7 @@ public static class BasicHttpBindingTest
     {
         var binding = new BasicHttpBinding();
         binding.Namespace = value;
-        Assert.Equal<string>(value, binding.Namespace);
+        Assert.Equal(value, binding.Namespace);
     }
 
     [WcfTheory]

--- a/src/System.ServiceModel.Http/tests/ServiceModel/BasicHttpsBindingTest.cs
+++ b/src/System.ServiceModel.Http/tests/ServiceModel/BasicHttpsBindingTest.cs
@@ -18,11 +18,11 @@ public class BasicHttpsBindingTest : ConditionalWcfTest
     public static void Default_Ctor_Initializes_Properties()
     {
         var binding = new BasicHttpsBinding();
-        Assert.Equal<string>("BasicHttpsBinding", binding.Name);
-        Assert.Equal<string>("http://tempuri.org/", binding.Namespace);
-        Assert.Equal<string>("https", binding.Scheme);
+        Assert.Equal("BasicHttpsBinding", binding.Name);
+        Assert.Equal("http://tempuri.org/", binding.Namespace);
+        Assert.Equal("https", binding.Scheme);
         Assert.Equal<Encoding>(Encoding.GetEncoding("utf-8"), binding.TextEncoding);
-        Assert.Equal<string>(Encoding.GetEncoding("utf-8").WebName, binding.TextEncoding.WebName);
+        Assert.Equal(Encoding.GetEncoding("utf-8").WebName, binding.TextEncoding.WebName);
         Assert.False(binding.AllowCookies);
         Assert.Equal<TimeSpan>(TimeSpan.FromMinutes(1), binding.CloseTimeout);
         Assert.Equal<TimeSpan>(TimeSpan.FromMinutes(1), binding.OpenTimeout);
@@ -43,11 +43,11 @@ public class BasicHttpsBindingTest : ConditionalWcfTest
     {
         var binding = new BasicHttpsBinding(BasicHttpsSecurityMode.Transport);
 
-        Assert.Equal<string>("BasicHttpsBinding", binding.Name);
-        Assert.Equal<string>("http://tempuri.org/", binding.Namespace);
-        Assert.Equal<string>("https", binding.Scheme);
+        Assert.Equal("BasicHttpsBinding", binding.Name);
+        Assert.Equal("http://tempuri.org/", binding.Namespace);
+        Assert.Equal("https", binding.Scheme);
         Assert.Equal<Encoding>(Encoding.GetEncoding("utf-8"), binding.TextEncoding);
-        Assert.Equal<string>(Encoding.GetEncoding("utf-8").WebName, binding.TextEncoding.WebName);
+        Assert.Equal(Encoding.GetEncoding("utf-8").WebName, binding.TextEncoding.WebName);
         Assert.False(binding.AllowCookies);
         Assert.Equal<TimeSpan>(TimeSpan.FromMinutes(1), binding.CloseTimeout);
         Assert.Equal<TimeSpan>(TimeSpan.FromMinutes(1), binding.OpenTimeout);
@@ -153,7 +153,7 @@ public class BasicHttpsBindingTest : ConditionalWcfTest
     {
         var binding = new BasicHttpsBinding();
         binding.Name = value;
-        Assert.Equal<string>(value, binding.Name);
+        Assert.Equal(value, binding.Name);
     }
 
     [WcfTheory]
@@ -173,7 +173,7 @@ public class BasicHttpsBindingTest : ConditionalWcfTest
     {
         var binding = new BasicHttpsBinding();
         binding.Namespace = value;
-        Assert.Equal<string>(value, binding.Namespace);
+        Assert.Equal(value, binding.Namespace);
     }
 
     [WcfTheory]

--- a/src/System.ServiceModel.Http/tests/System.ServiceModel.Http.Tests.csproj
+++ b/src/System.ServiceModel.Http/tests/System.ServiceModel.Http.Tests.csproj
@@ -6,7 +6,7 @@
     <IsPackable>false</IsPackable>
     <!--[todo:arcade] Re-enable these warnings and fix them.-->
     <!-- https://xunit.github.io/xunit.analyzers/rules/ -->
-    <NoWarn>$(NoWarn);xUnit2010;xUnit2006;xUnit2009</NoWarn>
+    <NoWarn>$(NoWarn);xUnit2010;xUnit2009</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/System.ServiceModel.NetTcp/tests/Channels/TcpConnectionPoolSettingsTest.cs
+++ b/src/System.ServiceModel.NetTcp/tests/Channels/TcpConnectionPoolSettingsTest.cs
@@ -20,7 +20,7 @@ public static class TcpConnectionPoolSettingsTest
         TcpTransportBindingElement element = new TcpTransportBindingElement();
         TcpConnectionPoolSettings settings = element.ConnectionPoolSettings;
         settings.GroupName = groupName;
-        Assert.Equal<string>(groupName, settings.GroupName);
+        Assert.Equal(groupName, settings.GroupName);
     }
 
     [WcfFact]

--- a/src/System.ServiceModel.NetTcp/tests/ServiceModel/NetTcpBindingTest.cs
+++ b/src/System.ServiceModel.NetTcp/tests/ServiceModel/NetTcpBindingTest.cs
@@ -22,7 +22,7 @@ public static class NetTcpBindingTest
         Assert.Equal<long>(512 * 1024, binding.MaxBufferPoolSize);
         Assert.Equal<long>(65536, binding.MaxBufferSize);
         Assert.True(TestHelpers.XmlDictionaryReaderQuotasAreEqual(binding.ReaderQuotas, new XmlDictionaryReaderQuotas()), "XmlDictionaryReaderQuotas");
-        Assert.Equal<string>("net.tcp", binding.Scheme);
+        Assert.Equal("net.tcp", binding.Scheme);
         Assert.Equal<TransferMode>(TransferMode.Buffered, binding.TransferMode);
         Assert.Equal<SecurityMode>(securityMode, binding.Security.Mode);
     }

--- a/src/System.ServiceModel.NetTcp/tests/System.ServiceModel.NetTcp.Tests.csproj
+++ b/src/System.ServiceModel.NetTcp/tests/System.ServiceModel.NetTcp.Tests.csproj
@@ -6,7 +6,7 @@
     <IsPackable>false</IsPackable>
     <!--[todo:arcade] Re-enable these warnings and fix them.-->
     <!-- https://xunit.github.io/xunit.analyzers/rules/ -->
-    <NoWarn>$(NoWarn);xUnit2010;xUnit2006;xUnit2009</NoWarn>
+    <NoWarn>$(NoWarn);xUnit2010;xUnit2009</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/System.ServiceModel.Primitives/tests/Channels/CustomBindingTest.cs
+++ b/src/System.ServiceModel.Primitives/tests/Channels/CustomBindingTest.cs
@@ -44,7 +44,7 @@ public static class CustomBindingTest
         CustomBinding customBinding = new CustomBinding();
         customBinding.Name = bindingName;
         string actualBindingName = customBinding.Name;
-        Assert.Equal<string>(bindingName, actualBindingName);
+        Assert.Equal(bindingName, actualBindingName);
     }
 
     [WcfTheory]

--- a/src/System.ServiceModel.Primitives/tests/Channels/MessageTest.cs
+++ b/src/System.ServiceModel.Primitives/tests/Channels/MessageTest.cs
@@ -26,7 +26,7 @@ public static class MessageTest
     {
         var message = Message.CreateMessage(MessageVersion.Soap12WSAddressing10, s_action);
         Assert.Equal<MessageVersion>(MessageVersion.Soap12WSAddressing10, message.Version);
-        Assert.Equal<string>(s_action, message.Headers.Action);
+        Assert.Equal(s_action, message.Headers.Action);
         Assert.True(message.IsEmpty);
     }
 
@@ -38,13 +38,13 @@ public static class MessageTest
         var message = Message.CreateMessage(MessageVersion.Soap12WSAddressing10, s_action, body);
 
         Assert.Equal<MessageVersion>(MessageVersion.Soap12WSAddressing10, message.Version);
-        Assert.Equal<string>(s_action, message.Headers.Action);
+        Assert.Equal(s_action, message.Headers.Action);
         Assert.False(message.IsEmpty);
 
         var reader = message.GetReaderAtBodyContents();
         var messageBody = reader.ReadElementContentAsString();
 
-        Assert.Equal<string>(content, messageBody);
+        Assert.Equal(content, messageBody);
     }
 
     [WcfFact]
@@ -53,13 +53,13 @@ public static class MessageTest
         var message = Message.CreateMessage(MessageVersion.Soap12WSAddressing10, s_action, new CustomBodyWriter());
 
         Assert.Equal<MessageVersion>(MessageVersion.Soap12WSAddressing10, message.Version);
-        Assert.Equal<string>(s_action, message.Headers.Action);
+        Assert.Equal(s_action, message.Headers.Action);
         Assert.False(message.IsEmpty);
 
         var reader = message.GetReaderAtBodyContents();
         var messageBody = reader.ReadContentAsString();
 
-        Assert.Equal<string>(string.Empty, messageBody);
+        Assert.Equal(string.Empty, messageBody);
     }
 
     [WcfFact]
@@ -75,6 +75,6 @@ public static class MessageTest
 
         string expected = "Soap12 (http://www.w3.org/2003/05/soap-envelope) Addressing10 (http://www.w3.org/2005/08/addressing)";
         string actual = version.ToString();
-        Assert.Equal<string>(expected, actual);
+        Assert.Equal(expected, actual);
     }
 }

--- a/src/System.ServiceModel.Primitives/tests/Description/OperationBehaviorTest.cs
+++ b/src/System.ServiceModel.Primitives/tests/Description/OperationBehaviorTest.cs
@@ -116,7 +116,7 @@ public static class OperationBehaviorTest
 
             for (int i = 0; i < 2; i++)
             {
-                Assert.StrictEqual(obj.Members[i].Name, deserialized.Members[i].Name);
+                Assert.Equal(obj.Members[i].Name, deserialized.Members[i].Name);
                 Assert.StrictEqual(obj.Members[i].Index, deserialized.Members[i].Index);
             }
         }

--- a/src/System.ServiceModel.Primitives/tests/ServiceModel/ChannelFactoryTest.cs
+++ b/src/System.ServiceModel.Primitives/tests/ServiceModel/ChannelFactoryTest.cs
@@ -46,7 +46,7 @@ public class ChannelFactoryTest
             // Validate ToString()
             string toStringResult = channel.ToString();
             string toStringExpected = "System.ServiceModel.Channels.IRequestChannel";
-            Assert.Equal<string>(toStringExpected, toStringResult);
+            Assert.Equal(toStringExpected, toStringResult);
 
             // Validate Equals()
             Assert.StrictEqual<IRequestChannel>(channel, channel);
@@ -103,7 +103,7 @@ public class ChannelFactoryTest
             // Validate ToString()
             string toStringResult = channel.ToString();
             string toStringExpected = "System.ServiceModel.Channels.IRequestChannel";
-            Assert.Equal<string>(toStringExpected, toStringResult);
+            Assert.Equal(toStringExpected, toStringResult);
 
             // Validate Equals()
             Assert.StrictEqual<IRequestChannel>(channel, channel);
@@ -156,7 +156,7 @@ public class ChannelFactoryTest
             // Validate ToString()
             string toStringResult = channel.ToString();
             string toStringExpected = "System.ServiceModel.Channels.IRequestChannel";
-            Assert.Equal<string>(toStringExpected, toStringResult);
+            Assert.Equal(toStringExpected, toStringResult);
 
             factory.Close();
             Assert.Equal(CommunicationState.Closed, factory.State);

--- a/src/System.ServiceModel.Primitives/tests/ServiceModel/DuplexChannelFactoryTest.cs
+++ b/src/System.ServiceModel.Primitives/tests/ServiceModel/DuplexChannelFactoryTest.cs
@@ -202,7 +202,7 @@ public class DuplexChannelFactoryTest
             // Validate ToString()
             string toStringResult = channel.ToString();
             string toStringExpected = "IWcfDuplexService";
-            Assert.Equal<string>(toStringExpected, toStringResult);
+            Assert.Equal(toStringExpected, toStringResult);
 
             // Validate Equals()
             Assert.StrictEqual<IWcfDuplexService>(channel, channel);

--- a/src/System.ServiceModel.Primitives/tests/System.ServiceModel.Primitives.Tests.csproj
+++ b/src/System.ServiceModel.Primitives/tests/System.ServiceModel.Primitives.Tests.csproj
@@ -7,7 +7,7 @@
     <IsPackable>false</IsPackable>
     <!--[todo:arcade] Re-enable these warnings and fix them.-->
     <!-- https://xunit.github.io/xunit.analyzers/rules/ -->
-    <NoWarn>$(NoWarn);xUnit2010;xUnit2006;xUnit2009</NoWarn>
+    <NoWarn>$(NoWarn);xUnit2010;xUnit2009</NoWarn>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/System.ServiceModel.Security/tests/System.ServiceModel.Security.Tests.csproj
+++ b/src/System.ServiceModel.Security/tests/System.ServiceModel.Security.Tests.csproj
@@ -6,7 +6,7 @@
     <IsPackable>false</IsPackable>
     <!--[todo:arcade] Re-enable these warnings and fix them.-->
     <!-- https://xunit.github.io/xunit.analyzers/rules/ -->
-    <NoWarn>$(NoWarn);xUnit2010;xUnit2006;xUnit2009</NoWarn>
+    <NoWarn>$(NoWarn);xUnit2010;xUnit2009</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Warning detail:  the generic overloads of Assert.Equal or Assert.StrictEqual are used with string. There is an optimized overload of both Assert.Equal and Assert.StrictEqual for string arguments.

For #4006 .