### PR TITLE
Fix xUnit warning #2009 in test projects.

### DIFF
--- a/src/System.ServiceModel.Duplex/tests/System.ServiceModel.Duplex.Tests.csproj
+++ b/src/System.ServiceModel.Duplex/tests/System.ServiceModel.Duplex.Tests.csproj
@@ -6,7 +6,7 @@
     <IsPackable>false</IsPackable>
     <!--[todo:arcade] Re-enable these warnings and fix them.-->
     <!-- https://xunit.github.io/xunit.analyzers/rules/ -->
-    <NoWarn>$(NoWarn);xUnit2010;xUnit2009</NoWarn>
+    <NoWarn>$(NoWarn);xUnit2010</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/System.ServiceModel.Http/tests/System.ServiceModel.Http.Tests.csproj
+++ b/src/System.ServiceModel.Http/tests/System.ServiceModel.Http.Tests.csproj
@@ -6,7 +6,7 @@
     <IsPackable>false</IsPackable>
     <!--[todo:arcade] Re-enable these warnings and fix them.-->
     <!-- https://xunit.github.io/xunit.analyzers/rules/ -->
-    <NoWarn>$(NoWarn);xUnit2010;xUnit2009</NoWarn>
+    <NoWarn>$(NoWarn);xUnit2010</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/System.ServiceModel.NetTcp/tests/System.ServiceModel.NetTcp.Tests.csproj
+++ b/src/System.ServiceModel.NetTcp/tests/System.ServiceModel.NetTcp.Tests.csproj
@@ -6,7 +6,7 @@
     <IsPackable>false</IsPackable>
     <!--[todo:arcade] Re-enable these warnings and fix them.-->
     <!-- https://xunit.github.io/xunit.analyzers/rules/ -->
-    <NoWarn>$(NoWarn);xUnit2010;xUnit2009</NoWarn>
+    <NoWarn>$(NoWarn);xUnit2010</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/System.ServiceModel.Primitives/tests/Description/OperationContractAttributeTest.cs
+++ b/src/System.ServiceModel.Primitives/tests/Description/OperationContractAttributeTest.cs
@@ -31,7 +31,7 @@ public static class OperationContractAttributeTest
         {
             channelFactory.CreateChannel();
         });
-        Assert.True(exception.Message.Contains("INonInitiatingNonTerminatingService"));
+        Assert.Contains("INonInitiatingNonTerminatingService", exception.Message);
     }
 
     [WcfFact]
@@ -44,7 +44,7 @@ public static class OperationContractAttributeTest
         {
             channelFactory.CreateChannel();
         });
-        Assert.True(exception.Message.Contains("IInitiatingTerminatingService"));
+        Assert.Contains("IInitiatingTerminatingService", exception.Message);
     }
 
     static ChannelFactory<T> CreateChannelFactoryHelper<T>(string url)

--- a/src/System.ServiceModel.Primitives/tests/System.ServiceModel.Primitives.Tests.csproj
+++ b/src/System.ServiceModel.Primitives/tests/System.ServiceModel.Primitives.Tests.csproj
@@ -7,7 +7,7 @@
     <IsPackable>false</IsPackable>
     <!--[todo:arcade] Re-enable these warnings and fix them.-->
     <!-- https://xunit.github.io/xunit.analyzers/rules/ -->
-    <NoWarn>$(NoWarn);xUnit2010;xUnit2009</NoWarn>
+    <NoWarn>$(NoWarn);xUnit2010</NoWarn>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/System.ServiceModel.Security/tests/System.ServiceModel.Security.Tests.csproj
+++ b/src/System.ServiceModel.Security/tests/System.ServiceModel.Security.Tests.csproj
@@ -6,7 +6,7 @@
     <IsPackable>false</IsPackable>
     <!--[todo:arcade] Re-enable these warnings and fix them.-->
     <!-- https://xunit.github.io/xunit.analyzers/rules/ -->
-    <NoWarn>$(NoWarn);xUnit2010;xUnit2009</NoWarn>
+    <NoWarn>$(NoWarn);xUnit2010</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
[Detail](http://xunit.net/xunit.analyzers/rules/xUnit2009.html): Check substrings with Assert string methods like string.Contains, string.StartsWith and string.EndsWith, instread of Assert.True or Assert.False.

For #4006 .