### PR TITLE
Fix xUnit warning #2010 in test projects.

### DIFF
--- a/src/System.ServiceModel.Duplex/tests/System.ServiceModel.Duplex.Tests.csproj
+++ b/src/System.ServiceModel.Duplex/tests/System.ServiceModel.Duplex.Tests.csproj
@@ -6,7 +6,7 @@
     <IsPackable>false</IsPackable>
     <!--[todo:arcade] Re-enable these warnings and fix them.-->
     <!-- https://xunit.github.io/xunit.analyzers/rules/ -->
-    <NoWarn>$(NoWarn);xUnit2010</NoWarn>
+    <NoWarn>$(NoWarn)</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/System.ServiceModel.Http/tests/System.ServiceModel.Http.Tests.csproj
+++ b/src/System.ServiceModel.Http/tests/System.ServiceModel.Http.Tests.csproj
@@ -6,7 +6,7 @@
     <IsPackable>false</IsPackable>
     <!--[todo:arcade] Re-enable these warnings and fix them.-->
     <!-- https://xunit.github.io/xunit.analyzers/rules/ -->
-    <NoWarn>$(NoWarn);xUnit2010</NoWarn>
+    <NoWarn>$(NoWarn)</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/System.ServiceModel.NetTcp/tests/System.ServiceModel.NetTcp.Tests.csproj
+++ b/src/System.ServiceModel.NetTcp/tests/System.ServiceModel.NetTcp.Tests.csproj
@@ -6,7 +6,7 @@
     <IsPackable>false</IsPackable>
     <!--[todo:arcade] Re-enable these warnings and fix them.-->
     <!-- https://xunit.github.io/xunit.analyzers/rules/ -->
-    <NoWarn>$(NoWarn);xUnit2010</NoWarn>
+    <NoWarn>$(NoWarn)</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/System.ServiceModel.Primitives/tests/Description/ContractDescriptionTest.cs
+++ b/src/System.ServiceModel.Primitives/tests/Description/ContractDescriptionTest.cs
@@ -198,7 +198,7 @@ public static class ContractDescriptionTest
     {
         // Simple validation of the newly exposed "public ContractDescription GetContract(Type contractType);" method
         ContractDescription contractDescription = ContractDescription.GetContract(typeof(IDescriptionTestsService));
-        Assert.True(String.Equals(typeof(IDescriptionTestsService).Name, contractDescription.ContractType.Name));
-        Assert.True(String.Equals("http://tempuri.org/", contractDescription.Namespace));
+        Assert.Equal(typeof(IDescriptionTestsService).Name, contractDescription.ContractType.Name);
+        Assert.Equal("http://tempuri.org/", contractDescription.Namespace);
     }
 }

--- a/src/System.ServiceModel.Primitives/tests/Description/OperationBehaviorTest.cs
+++ b/src/System.ServiceModel.Primitives/tests/Description/OperationBehaviorTest.cs
@@ -81,11 +81,11 @@ public static class OperationBehaviorTest
 
             if (String.Equals(description.Name, nameof(IXmlTestingType.XmlSerializerFormatAttribute_Set_StyleSetTo_Rpc)) || (String.Equals(description.Name, nameof(IXmlTestingType.XmlSerializerFormatAttribute_NotSet_Two))))
             {
-                Assert.True(String.Equals(serializerBehavior.XmlSerializerFormatAttribute.Style.ToString(), "Rpc"));
+                Assert.Equal("Rpc", serializerBehavior.XmlSerializerFormatAttribute.Style.ToString());
             }
             else
             {
-                Assert.True(String.Equals(serializerBehavior.XmlSerializerFormatAttribute.Style.ToString(), "Document"));
+                Assert.Equal("Document", serializerBehavior.XmlSerializerFormatAttribute.Style.ToString());
             }
         }
     }

--- a/src/System.ServiceModel.Primitives/tests/Security/SecurityNegotiationExceptionTest.cs
+++ b/src/System.ServiceModel.Primitives/tests/Security/SecurityNegotiationExceptionTest.cs
@@ -21,9 +21,9 @@ public static class SecurityNegotiationExceptionTest
         SecurityNegotiationException exception1 = new SecurityNegotiationException();
 
         SecurityNegotiationException exception2 = new SecurityNegotiationException(exceptionMessage);
-        Assert.True(String.Equals(exceptionMessage, exception2.Message));
+        Assert.Equal(exceptionMessage, exception2.Message);
 
         SecurityNegotiationException exception3 = new SecurityNegotiationException(exceptionMessage, innerException);
-        Assert.True(String.Equals(exceptionMessage, exception3.InnerException.Message));
+        Assert.Equal(exceptionMessage, exception3.InnerException.Message);
     }
 }

--- a/src/System.ServiceModel.Primitives/tests/System.ServiceModel.Primitives.Tests.csproj
+++ b/src/System.ServiceModel.Primitives/tests/System.ServiceModel.Primitives.Tests.csproj
@@ -7,7 +7,7 @@
     <IsPackable>false</IsPackable>
     <!--[todo:arcade] Re-enable these warnings and fix them.-->
     <!-- https://xunit.github.io/xunit.analyzers/rules/ -->
-    <NoWarn>$(NoWarn);xUnit2010</NoWarn>
+    <NoWarn>$(NoWarn)</NoWarn>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/System.ServiceModel.Security/tests/System.ServiceModel.Security.Tests.csproj
+++ b/src/System.ServiceModel.Security/tests/System.ServiceModel.Security.Tests.csproj
@@ -6,7 +6,7 @@
     <IsPackable>false</IsPackable>
     <!--[todo:arcade] Re-enable these warnings and fix them.-->
     <!-- https://xunit.github.io/xunit.analyzers/rules/ -->
-    <NoWarn>$(NoWarn);xUnit2010</NoWarn>
+    <NoWarn>$(NoWarn)</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
For #4006 .

**Warning detail:** Do not use boolean check to check for string equality. Assert.Equal should be used because it give more detailed information upon failure.