### PR TITLE
Fix pathing issues with the dotnet-svcutil.xmlserializer tool.

### DIFF
--- a/src/svcutilcore/files/dotnet-svcutil.xmlserializer.targets
+++ b/src/svcutilcore/files/dotnet-svcutil.xmlserializer.targets
@@ -9,10 +9,23 @@
     <_SerializationAssemblyDisabledWarnings>$(NoWarn);219;162;$(SerializationAssemblyDisabledWarnings)</_SerializationAssemblyDisabledWarnings>
   </PropertyGroup>
 
+  <UsingTask TaskName="Microsoft.NET.Build.Tasks.ResolvePackageAssets"
+            AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
+
   <Target Name="SvcUtilGenerateSerializationAssembly" AfterTargets="Build">
+    <ResolvePackageAssets
+      ProjectAssetsFile="$(ProjectAssetsFile)"
+      ProjectAssetsCacheFile="$(ProjectAssetsCacheFile)"
+      ProjectPath="$(MSBuildProjectFullPath)"
+      TargetFrameworkMoniker="$(NuGetTargetMoniker)"
+      DotNetAppHostExecutableNameWithoutExtension="$(_DotNetAppHostExecutableNameWithoutExtension)">
+      <Output
+          TaskParameter="RuntimeAssemblies"
+          ItemName="WCFRuntimeAssembly"/>
+    </ResolvePackageAssets>
+
     <ItemGroup>
-      <_ReferenceAssembly Include="@(ReferencePath)"/>
-      <_ReferenceSMAssembly Include="@(_ReferenceAssembly)" Condition="$([System.String]::new('%(_ReferenceAssembly.Identity)').EndsWith('System.ServiceModel.Primitives.dll'))" />
+      <_ReferenceSMAssembly Include="@(WCFRuntimeAssembly)" />
     </ItemGroup>
     
     <Delete Condition="Exists('$(_SerializerDllIntermediateFolder)') == 'true'" Files="$(_SerializerDllIntermediateFolder)" ContinueOnError="true" />

--- a/src/svcutilcore/src/dotnet-svcutil.xmlserializer.csproj
+++ b/src/svcutilcore/src/dotnet-svcutil.xmlserializer.csproj
@@ -100,5 +100,4 @@
     <Message Importance="high" Text="The value of property 'PsCmd' is: $(PsCmd)" />
     <Exec Command="$(PsCmd) -ExecutionPolicy UnRestricted -File $(WcfRootFolder)/src/svcutilcore/tools/scripts/UpdateSvcutilDotXmlSerializerPackage.ps1 $(PackageOutputPath)"/>
   </Target>
-
 </Project>

--- a/src/svcutilcore/tests/dotnet-svcutil.xmlserializer.IntegrationTests.csproj
+++ b/src/svcutilcore/tests/dotnet-svcutil.xmlserializer.IntegrationTests.csproj
@@ -20,7 +20,7 @@
     <!-- We're building netcoreap, run on the test CLI
          Reuse the same runtimeconfig that the tests use. -->
     <GeneratorRuntimeConfig>$(ArtifactsBinDir)\dotnet-svcutil.xmlserializer\$(Configuration)\$(TargetFramework)\dotnet-svcutil.xmlserializer.runtimeconfig.json</GeneratorRuntimeConfig>
-    <GeneratorCliPath>$(DOTNET_INSTALL_DIR)</GeneratorCliPath>
+    <GeneratorCliPath>$(DOTNET_INSTALL_DIR)/</GeneratorCliPath>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' != 'netcoreapp2.1'">
@@ -65,20 +65,27 @@
     </FindInList>
     
     <PropertyGroup>
-      <WcfSMOutputPath>$(ArtifactsBinDir)System.Private.ServiceModel\$(Configuration)\netstandard2.0</WcfSMOutputPath>
-      <ServiceModelAssemblyName>System.Private.ServiceModel.dll</ServiceModelAssemblyName>
-      <DotNetExe>$(GeneratorCliPath)\dotnet</DotNetExe>
+      <ServiceModelPrivateOutputPath>$(ArtifactsBinDir)System.Private.ServiceModel/$(Configuration)/netstandard2.0/</ServiceModelPrivateOutputPath>
+      <ServiceModelPrivateAssemblyName>System.Private.ServiceModel.dll</ServiceModelPrivateAssemblyName>
+      <ServiceModelPrimitivesOutputPath>$(ArtifactsBinDir)System.ServiceModel.Primitives.Facade/$(Configuration)/netstandard2.0/</ServiceModelPrimitivesOutputPath>
+      <ServiceModelPrimitivesAssemblyName>System.ServiceModel.Primitives.dll</ServiceModelPrimitivesAssemblyName>
+      <DotNetExe>$(GeneratorCliPath)dotnet</DotNetExe>
       <DotnetSvcutilXmlSerializerAssembly>$(OutputPath)dotnet-svcutil.xmlserializer.dll</DotnetSvcutilXmlSerializerAssembly>
       <InputTestAssembly>$(OutputPath)ScenarioTests.Common.Tests.dll</InputTestAssembly>
       <OutputGeneratedSource>$(OutputPath)ScenarioTests.Common.Tests.XmlSerializers.cs</OutputGeneratedSource>
       <CscOutputAssembly>$(OutputPath)ScenarioTests.Common.Tests.XmlSerializers.dll</CscOutputAssembly>
+      <ServiceModelPrivateAssembly>$(ServiceModelPrivateOutputPath)$(ServiceModelPrivateAssemblyName)</ServiceModelPrivateAssembly>
+      <ServiceModelPrimitivesAssembly>$(ServiceModelPrimitivesOutputPath)$(ServiceModelPrimitivesAssemblyName)</ServiceModelPrimitivesAssembly>
+      
     </PropertyGroup>
     <Message Text="Running Serialization Tool" Importance="normal" />
     
-    <Message Text="Run XmlSerializer: $(DotNetExe) $(DotnetSvcutilXmlSerializerAssembly) $(InputTestAssembly) --quiet --out:$(OutputGeneratedSource) --smreference:$(WcfSMOutputPath)\$(ServiceModelAssemblyName)  --reference=$(depRef)" Importance="high" />
-    <Message Text="$(ServiceModelAssemblyName) exists in $(WcfSMOutputPath)" Condition="Exists('$(WcfSMOutputPath)\$(ServiceModelAssemblyName)') == 'true'" Importance="high" />
-    <Error Text="$(ServiceModelAssemblyName) does not exist in $(WcfSMOutputPath)" Condition="Exists('$(WcfSMOutputPath)\$(ServiceModelAssemblyName)') != 'true'" />
-    <Exec Command="$(DotNetExe) $(DotnetSvcutilXmlSerializerAssembly) $(InputTestAssembly) --quiet --out:$(OutputGeneratedSource) --smreference:$(WcfSMOutputPath)\$(ServiceModelAssemblyName) --reference=$(depRef)" />
+    <Message Text="Run XmlSerializer: $(DotNetExe) $(DotnetSvcutilXmlSerializerAssembly) $(InputTestAssembly) --quiet --out:$(OutputGeneratedSource) --smreference:$(ServiceModelPrimitivesAssembly);$(ServiceModelPrivateAssembly) --reference=$(depRef)" Importance="high" />
+    <Message Text="$(ServiceModelPrivateAssemblyName) exists in $(ServiceModelPrivateOutputPath)" Condition="Exists('$(ServiceModelPrivateOutputPath)$(ServiceModelPrivateAssemblyName)') == 'true'" Importance="high" />
+    <Message Text="$(ServiceModelPrimitivesAssemblyName) exists in $(ServiceModelPrimitivesOutputPath)" Condition="Exists('$(ServiceModelPrimitivesOutputPath)$(ServiceModelPrimitivesAssemblyName)') == 'true'" Importance="high" />
+    <Error Text="$(ServiceModelPrivateAssemblyName) does not exist in $(ServiceModelPrivateOutputPath)" Condition="Exists('$(ServiceModelPrivateOutputPath)$(ServiceModelPrivateAssemblyName)') != 'true'" />
+    <Error Text="$(ServiceModelPrimitivesAssemblyName) does not exist in $(ServiceModelPrimitivesOutputPath)" Condition="Exists('$(ServiceModelPrimitivesOutputPath)$(ServiceModelPrimitivesAssemblyName)') != 'true'" />
+    <Exec Command="$(DotNetExe) $(DotnetSvcutilXmlSerializerAssembly) $(InputTestAssembly) --quiet --out:$(OutputGeneratedSource) --smreference:$(ServiceModelPrimitivesAssembly):$(ServiceModelPrivateAssembly) --reference=$(depRef)" />
     <Warning Condition="Exists('$(OutputGeneratedSource)') != 'true'" Text="Failed to generate $(OutputGeneratedSource)"/>
     <Csc Condition="Exists('$(OutputGeneratedSource)') == 'true'"
          OutputAssembly="$(CscOutputAssembly)"


### PR DESCRIPTION
Instead of making assumptions and parsing strings I get the location of the needed assemblies from the built-in msbuild 'ResolvePackageAssets' Task.

Fixes #4090

Cherry-pick this to the 3.1 servicing branch once it has been fully tested.