### PR TITLE
Remove UAP from test attribute skipping logic.

### DIFF
--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/ExpectedExceptions/ExpectedExceptionTests.4.1.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/ExpectedExceptions/ExpectedExceptionTests.4.1.0.cs
@@ -52,7 +52,6 @@ public partial class ExpectedExceptionTests : ConditionalWcfTest
     }
 
     [WcfFact]
-    [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "Issue: https://github.com/dotnet/wcf/issues/1717")]
     [OuterLoop]
     public static void ServiceRestart_Throws_CommunicationException()
     {

--- a/src/System.Private.ServiceModel/tests/Scenarios/Extensibility/WebSockets/WebSocketTests.4.1.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Extensibility/WebSockets/WebSocketTests.4.1.0.cs
@@ -14,7 +14,6 @@ using Infrastructure.Common;
 public class WebSocketTests : ConditionalWcfTest
 {
     [WcfFact]
-    [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "Issue: https://github.com/dotnet/wcf/issues/526")]
     [Issue(1438, OS = OSID.Windows_7)]  // not supported on Win7
     [OuterLoop]
     public static void WebSocket_Http_RequestReply_BinaryStreamed()
@@ -78,7 +77,6 @@ public class WebSocketTests : ConditionalWcfTest
 
     [WcfFact]
     [OuterLoop]
-    [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "Issue: https://github.com/dotnet/wcf/issues/526")]
     [Issue(1438, OS = OSID.Windows_7)]  // not supported on Win7
     public static void WebSocket_Http_Duplex_BinaryStreamed()
     {
@@ -171,7 +169,6 @@ public class WebSocketTests : ConditionalWcfTest
 
     [WcfFact]
     [Condition(nameof(Root_Certificate_Installed))]
-    [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "Issue: https://github.com/dotnet/wcf/issues/526")]
     [Issue(3572, OS = OSID.OSX_10_14)]
     [Issue(1438, OS = OSID.Windows_7)]  // not supported on Win7
     [OuterLoop]
@@ -268,7 +265,6 @@ public class WebSocketTests : ConditionalWcfTest
     }
 
     [WcfFact]
-    [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "Issue: https://github.com/dotnet/wcf/issues/526")]
     [Issue(3572, OS = OSID.OSX_10_14)]
     [Issue(1438, OS = OSID.Windows_7)]  // not supported on Win7
     [OuterLoop]
@@ -365,7 +361,6 @@ public class WebSocketTests : ConditionalWcfTest
     }
 
     [WcfFact]
-    [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "Issue: https://github.com/dotnet/wcf/issues/526")]
     [Issue(1438, OS = OSID.Windows_7)]  // not supported on Win7
     [OuterLoop]
     public static void WebSocket_Http_Duplex_TextStreamed()
@@ -458,7 +453,6 @@ public class WebSocketTests : ConditionalWcfTest
     }
 
     [WcfFact]
-    [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "Issue: https://github.com/dotnet/wcf/issues/526")]
     [Issue(1438, OS = OSID.Windows_7)]  // not supported on Win7
     [OuterLoop]
     public static void WebSocket_Http_RequestReply_TextStreamed()
@@ -646,7 +640,6 @@ public class WebSocketTests : ConditionalWcfTest
 
     [WcfFact]
     [Condition(nameof(Root_Certificate_Installed))]
-    [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "Issue: https://github.com/dotnet/wcf/issues/526")]
     [Issue(3572, OS = OSID.OSX_10_14)]
     [Issue(1438, OS = OSID.Windows_7)]  // not supported on Win7
     [OuterLoop]
@@ -700,7 +693,6 @@ public class WebSocketTests : ConditionalWcfTest
 
     [WcfFact]
     [Condition(nameof(Root_Certificate_Installed))]
-    [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "Issue: https://github.com/dotnet/wcf/issues/526")]
     [Issue(3572, OS = OSID.OSX_10_14)]
     [Issue(1438, OS = OSID.Windows_7)]  // not supported on Win7
     [OuterLoop]
@@ -756,7 +748,6 @@ public class WebSocketTests : ConditionalWcfTest
 
     [WcfFact]
     [Condition(nameof(Root_Certificate_Installed))]
-    [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "Issue: https://github.com/dotnet/wcf/issues/526")]
     [Issue(3572, OS = OSID.OSX_10_14)]
     [Issue(1438, OS = OSID.Windows_7)]  // not supported on Win7
     [OuterLoop]
@@ -825,7 +816,6 @@ public class WebSocketTests : ConditionalWcfTest
 
     [WcfFact]
     [Condition(nameof(Root_Certificate_Installed))]
-    [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "Issue: https://github.com/dotnet/wcf/issues/526")]
     [Issue(3572, OS = OSID.OSX_10_14)]
     [Issue(1438, OS = OSID.Windows_7)]  // not supported on Win7
     [OuterLoop]
@@ -893,7 +883,6 @@ public class WebSocketTests : ConditionalWcfTest
     }
 
     [WcfFact]
-    [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "Issue: https://github.com/dotnet/wcf/issues/526")]
     [Issue(1438, OS = OSID.Windows_7)]  // not supported on Win7
     [OuterLoop]
     public static void WebSocket_Http_RequestReply_TextBuffered()
@@ -943,7 +932,6 @@ public class WebSocketTests : ConditionalWcfTest
     }
 
     [WcfFact]
-    [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "Issue: https://github.com/dotnet/wcf/issues/526")]
     [Issue(1438, OS = OSID.Windows_7)]  // not supported on Win7
     [OuterLoop]
     public static void WebSocket_Http_RequestReply_BinaryBuffered_KeepAlive()
@@ -994,7 +982,6 @@ public class WebSocketTests : ConditionalWcfTest
     }
 
     [WcfFact]
-    [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "Issue: https://github.com/dotnet/wcf/issues/526")]
     [Issue(1438, OS = OSID.Windows_7)]  // not supported on Win7
     [OuterLoop]
     public static void WebSocket_Http_Duplex_TextBuffered_KeepAlive()
@@ -1058,7 +1045,6 @@ public class WebSocketTests : ConditionalWcfTest
     }
 
     [WcfFact]
-    [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "Issue: https://github.com/dotnet/wcf/issues/526")]
     [Issue(1438, OS = OSID.Windows_7)]  // not supported on Win7
     [OuterLoop]
     public static void WebSocket_Http_Duplex_BinaryBuffered()
@@ -1124,7 +1110,6 @@ public class WebSocketTests : ConditionalWcfTest
     // When not using a callback you can still force WCF to use WebSockets.
     // This test verifies that it actually uses WebSockets when not using a callback.
     [WcfFact]
-    [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "Issue: https://github.com/dotnet/wcf/issues/526")]
     [Issue(1438, OS = OSID.Windows_7)]  // not supported on Win7
     [OuterLoop]
     public static void WebSocket_Http_VerifyWebSocketsUsed()

--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Http/ClientCredentialTypeTests.4.1.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Http/ClientCredentialTypeTests.4.1.0.cs
@@ -17,7 +17,6 @@ public static class Http_ClientCredentialTypeTests
 {
     [WcfFact]
     [OuterLoop]
-    [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "Issue: https://github.com/dotnet/wcf/issues/3333")]
     public static void DigestAuthentication_Echo_RoundTrips_String_No_Domain()
     {
         ChannelFactory<IWcfService> factory = null;
@@ -80,7 +79,6 @@ public static class Http_ClientCredentialTypeTests
 
     [WcfFact]
     [OuterLoop]
-    [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "Issue: Expect100Continue header is not supported in UWP.")]
     public static void HttpExpect100Continue_DigestAuthentication_True()
     {
         ChannelFactory<IWcfService> factory = null;

--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Https/HttpsTests.4.1.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Https/HttpsTests.4.1.0.cs
@@ -277,7 +277,6 @@ public partial class HttpsTests : ConditionalWcfTest
            nameof(Server_Accepts_Certificates),
            nameof(SSL_Available))]
     [OuterLoop]
-    [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "Issue: Expect100Continue header is not supported in UWP.")]
     public static void HttpExpect100Continue_ClientCertificate_True()
     {
         string clientCertThumb = null;

--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Https/HttpsTests.4.1.1.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Https/HttpsTests.4.1.1.cs
@@ -67,7 +67,6 @@ public partial class HttpsTests : ConditionalWcfTest
                nameof(Peer_Certificate_Installed),
                nameof(SSL_Available))]
     [Issue(1945, OS = OSID.AnyOSX)] // OSX doesn't support the TrustedPeople certificate store
-    [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "Issue: https://github.com/dotnet/wcf/issues/3112")]
     [OuterLoop]
     // Asking for PeerTrust alone should throw SecurityNegotiationException
     // if the certificate is not in the TrustedPeople store.  For this test


### PR DESCRIPTION
* Uap was removed from TargetFrameworkMonikers in Arcade.
* Since we no longer run tests on this TFm we can just remove these conditional skips.