### PR TITLE
Update assembly version of xmlserializer tool.

### DIFF
--- a/src/svcutilcore/src/dotnet-svcutil.xmlserializer.csproj
+++ b/src/svcutilcore/src/dotnet-svcutil.xmlserializer.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <AssemblyVersion>1.1.0.0</AssemblyVersion>
+    <AssemblyVersion>1.1.1.0</AssemblyVersion>
     <AssemblyName>dotnet-svcutil.xmlserializer</AssemblyName>
     <RootNamespace>Microsoft.Tools.ServiceModel.SvcUtil.XmlSerializer</RootNamespace>
     <TargetFramework>netcoreapp2.1</TargetFramework>


### PR DESCRIPTION
Currently released package is version 1.1.0 with assembly version 1.1.0.0

The package version had already been updated to 1.2.0

I've updated the assembly 'patch' digit since the only fix/change in the assembly is #4145