### PR TITLE
Add some missed changes for svcutilcore

### DIFF
--- a/src/svcutilcore/src/Microsoft/Tools/ServiceModel/SvcUtil/Options.cs
+++ b/src/svcutilcore/src/Microsoft/Tools/ServiceModel/SvcUtil/Options.cs
@@ -415,7 +415,7 @@ namespace Microsoft.Tools.ServiceModel.SvcUtil.XmlSerializer
             private void LoadSMReferenceAssembly()
             {
                 string smReferenceArg = _arguments.GetArgument(Options.Cmd.SMReference);
-                IList<string> referencedAssembliesArgs = smReferenceArg.Split(':').ToList();
+                IList<string> referencedAssembliesArgs = smReferenceArg.Split(';').ToList();
                 if (referencedAssembliesArgs != null && referencedAssembliesArgs.Count > 0)
                 {
                     string smassembly = "";

--- a/src/svcutilcore/tests/dotnet-svcutil.xmlserializer.IntegrationTests.csproj
+++ b/src/svcutilcore/tests/dotnet-svcutil.xmlserializer.IntegrationTests.csproj
@@ -85,7 +85,7 @@
     <Message Text="$(ServiceModelPrimitivesAssemblyName) exists in $(ServiceModelPrimitivesOutputPath)" Condition="Exists('$(ServiceModelPrimitivesOutputPath)$(ServiceModelPrimitivesAssemblyName)') == 'true'" Importance="high" />
     <Error Text="$(ServiceModelPrivateAssemblyName) does not exist in $(ServiceModelPrivateOutputPath)" Condition="Exists('$(ServiceModelPrivateOutputPath)$(ServiceModelPrivateAssemblyName)') != 'true'" />
     <Error Text="$(ServiceModelPrimitivesAssemblyName) does not exist in $(ServiceModelPrimitivesOutputPath)" Condition="Exists('$(ServiceModelPrimitivesOutputPath)$(ServiceModelPrimitivesAssemblyName)') != 'true'" />
-    <Exec Command="$(DotNetExe) $(DotnetSvcutilXmlSerializerAssembly) $(InputTestAssembly) --quiet --out:$(OutputGeneratedSource) --smreference:$(ServiceModelPrimitivesAssembly):$(ServiceModelPrivateAssembly) --reference=$(depRef)" />
+    <Exec Command="$(DotNetExe) $(DotnetSvcutilXmlSerializerAssembly) $(InputTestAssembly) --quiet --out:$(OutputGeneratedSource) --smreference:$(ServiceModelPrimitivesAssembly);$(ServiceModelPrivateAssembly) --reference=$(depRef)" />
     <Warning Condition="Exists('$(OutputGeneratedSource)') != 'true'" Text="Failed to generate $(OutputGeneratedSource)"/>
     <Csc Condition="Exists('$(OutputGeneratedSource)') == 'true'"
          OutputAssembly="$(CscOutputAssembly)"


### PR DESCRIPTION
List of assemblies passed on cmd line are now semi-colon delimited instead of colon delimited.