### PR TITLE
Skip 5 failing and unspport test on UAP runs.

### DIFF
--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/ExpectedExceptions/ExpectedExceptionTests.4.0.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/ExpectedExceptions/ExpectedExceptionTests.4.0.0.cs
@@ -216,6 +216,7 @@ public partial class ExpectedExceptionTests : ConditionalWcfTest
 
     [WcfFact]
     [OuterLoop]
+    [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "Issue: unstable test, skip only applies to UWP.")]
     public static void Abort_During_Implicit_Open_Closes_Async_Waiters()
     {
         // This test is a regression test of an issue with CallOnceManager.

--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Http/ClientCredentialTypeTests.4.1.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Http/ClientCredentialTypeTests.4.1.0.cs
@@ -17,6 +17,7 @@ public static class Http_ClientCredentialTypeTests
 {
     [WcfFact]
     [OuterLoop]
+    [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "Issue: https://github.com/dotnet/wcf/issues/3333")]
     public static void DigestAuthentication_Echo_RoundTrips_String_No_Domain()
     {
         ChannelFactory<IWcfService> factory = null;
@@ -79,6 +80,7 @@ public static class Http_ClientCredentialTypeTests
 
     [WcfFact]
     [OuterLoop]
+    [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "Issue: Expect100Continue header is not supported in UWP.")]
     public static void HttpExpect100Continue_DigestAuthentication_True()
     {
         ChannelFactory<IWcfService> factory = null;

--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Https/HttpsTests.4.1.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Https/HttpsTests.4.1.0.cs
@@ -270,6 +270,7 @@ public partial class HttpsTests : ConditionalWcfTest
            nameof(Server_Accepts_Certificates),
            nameof(SSL_Available))]
     [OuterLoop]
+    [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "Issue: Expect100Continue header is not supported in UWP.")]
     public static void HttpExpect100Continue_ClientCertificate_True()
     {
         string clientCertThumb = null;

--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Https/HttpsTests.4.1.1.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Https/HttpsTests.4.1.1.cs
@@ -68,6 +68,7 @@ public partial class HttpsTests : ConditionalWcfTest
                nameof(SSL_Available))]
     [Issue(1945, OS = OSID.AnyOSX)] // OSX doesn't support the TrustedPeople certificate store
     [OuterLoop]
+    [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "Issue: https://github.com/dotnet/wcf/issues/3112")]
     // Asking for PeerTrust alone should throw SecurityNegotiationException
     // if the certificate is not in the TrustedPeople store.  For this test
     // we use a valid chain-trusted certificate that we know is not in the


### PR DESCRIPTION
@HongGit , This is to skip the 4 failing tests for UWP run. Please review.