### PR TITLE
Exposing GenericXmlSecurityKeyIdentifierClause and virtual CloneCore().

### DIFF
--- a/src/System.ServiceModel.Security/ref/System.ServiceModel.Security.cs
+++ b/src/System.ServiceModel.Security/ref/System.ServiceModel.Security.cs
@@ -5,8 +5,6 @@
 // ------------------------------------------------------------------------------
 
 
-using System.Xml;
-
 namespace System.ServiceModel
 {
     public partial class DnsEndpointIdentity : System.ServiceModel.EndpointIdentity
@@ -236,14 +234,16 @@ namespace System.IdentityModel.Tokens
     }
     public partial class GenericXmlSecurityKeyIdentifierClause : SecurityKeyIdentifierClause
     {
-        public GenericXmlSecurityKeyIdentifierClause(XmlElement referenceXml)
+        public GenericXmlSecurityKeyIdentifierClause(System.Xml.XmlElement referenceXml)
             : this(referenceXml, null, 0)
         {
         }
 
-        public GenericXmlSecurityKeyIdentifierClause(XmlElement referenceXml, byte[] derivationNonce, int derivationLength)
+        public GenericXmlSecurityKeyIdentifierClause(System.Xml.XmlElement referenceXml, byte[] derivationNonce, int derivationLength)
             : base(null, derivationNonce, derivationLength)
         {
         }
+
+        public override bool Matches(SecurityKeyIdentifierClause keyIdentifierClause){ return default; }
     }
 }

--- a/src/System.ServiceModel.Security/ref/System.ServiceModel.Security.cs
+++ b/src/System.ServiceModel.Security/ref/System.ServiceModel.Security.cs
@@ -5,6 +5,8 @@
 // ------------------------------------------------------------------------------
 
 
+using System.Xml;
+
 namespace System.ServiceModel
 {
     public partial class DnsEndpointIdentity : System.ServiceModel.EndpointIdentity
@@ -164,6 +166,7 @@ namespace System.ServiceModel.Security.Tokens
     {
         protected IssuedSecurityTokenParameters(IssuedSecurityTokenParameters other) { }
         public IssuedSecurityTokenParameters() { }
+        protected override SecurityTokenParameters CloneCore() { return default; }
         public MessageSecurityVersion DefaultMessageSecurityVersion { get { return default; } set { } }
         public EndpointAddress IssuerAddress { get { return default; } set { } }
         public Channels.Binding IssuerBinding { get { return default; } set { } }
@@ -175,11 +178,13 @@ namespace System.ServiceModel.Security.Tokens
         public SecureConversationSecurityTokenParameters() { }
         public SecureConversationSecurityTokenParameters(System.ServiceModel.Channels.SecurityBindingElement bootstrapSecurityBindingElement) { }
         public System.ServiceModel.Channels.SecurityBindingElement BootstrapSecurityBindingElement { get { return default; } set { } }
+        protected override SecurityTokenParameters CloneCore() { return default; }
         public bool RequireCancellation { get { return default; } set { } }
     }
     public abstract partial class SecurityTokenParameters
     {
         internal SecurityTokenParameters() { }
+        protected abstract SecurityTokenParameters CloneCore();
         public bool RequireDerivedKeys { get { return default; } set { } }
         public System.ServiceModel.Security.Tokens.SecurityTokenParameters Clone() { return default; }
     }
@@ -199,6 +204,8 @@ namespace System.ServiceModel.Security.Tokens
     public partial class UserNameSecurityTokenParameters : System.ServiceModel.Security.Tokens.SecurityTokenParameters
     {
         public UserNameSecurityTokenParameters() { }
+        protected override SecurityTokenParameters CloneCore() { return default; }
+
     }
 }
 namespace System.IdentityModel.Policy
@@ -226,5 +233,17 @@ namespace System.IdentityModel.Tokens
         SymmetricKey,
         AsymmetricKey,
         BearerKey
+    }
+    public partial class GenericXmlSecurityKeyIdentifierClause : SecurityKeyIdentifierClause
+    {
+        public GenericXmlSecurityKeyIdentifierClause(XmlElement referenceXml)
+            : this(referenceXml, null, 0)
+        {
+        }
+
+        public GenericXmlSecurityKeyIdentifierClause(XmlElement referenceXml, byte[] derivationNonce, int derivationLength)
+            : base(null, derivationNonce, derivationLength)
+        {
+        }
     }
 }

--- a/src/System.ServiceModel.Security/ref/System.ServiceModel.Security.cs
+++ b/src/System.ServiceModel.Security/ref/System.ServiceModel.Security.cs
@@ -244,6 +244,8 @@ namespace System.IdentityModel.Tokens
         {
         }
 
+        public System.Xml.XmlElement ReferenceXml { get { return default; } }
+
         public override bool Matches(SecurityKeyIdentifierClause keyIdentifierClause){ return default; }
     }
 }


### PR DESCRIPTION
Exposing GenericXmlSecurityKeyIdentitfierClause is needed for WsFederationSecurityBinding effort as WsTrustChannelSecurityTokenProvider needs to set this clause type.

Exposing CloneCore() is needed so the derived WsTrustClientCredentails.CloneCore() will be called.