### PR TITLE
Fix release build, WSFed is case sensitive on URI's

### DIFF
--- a/azure-pipelines-arcade.yml
+++ b/azure-pipelines-arcade.yml
@@ -88,7 +88,7 @@ stages:
                 /p:DotNetArtifactsCategory=$(_DotNetArtifactsCategory)
                 /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
             # Service uri needed for integration tests in official builds
-            - _serviceUri: wcfcoresrv5.cloudapp.net/wcftestservice1
+            - _serviceUri: wcfcoresrv5.cloudapp.net/WcfTestService1
 
         # Public/PR & CI Build Variables
         - ${{ if eq(variables._RunAsPublic, True) }}:


### PR DESCRIPTION
This was causing problems with release build due to the AudienceUri not matching in case.