### PR TITLE
Fix RST generation issues in WsFederation

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -24,7 +24,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <MicrosoftIdentityModelProtocolsWsTrustPackageVersion>6.6.1-preview-10617201806</MicrosoftIdentityModelProtocolsWsTrustPackageVersion>
+    <MicrosoftIdentityModelProtocolsWsTrustPackageVersion>6.7.2-preview-10803222715</MicrosoftIdentityModelProtocolsWsTrustPackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/System.ServiceModel.Federation/src/System/ServiceModel/Federation/WSTrustChannelSecurityTokenProvider.cs
+++ b/src/System.ServiceModel.Federation/src/System/ServiceModel/Federation/WSTrustChannelSecurityTokenProvider.cs
@@ -165,6 +165,7 @@ namespace System.ServiceModel.Federation
             if (entropy != null)
             {
                 trustRequest.Entropy = entropy;
+                trustRequest.ComputedKeyAlgorithm = _requestSerializationContext.TrustKeyTypes.PSHA1;
             }
 
             return trustRequest;

--- a/src/System.ServiceModel.Federation/src/System/ServiceModel/Federation/WSTrustChannelSecurityTokenProvider.cs
+++ b/src/System.ServiceModel.Federation/src/System/ServiceModel/Federation/WSTrustChannelSecurityTokenProvider.cs
@@ -154,12 +154,18 @@ namespace System.ServiceModel.Federation
                 Context = RequestContext,
                 KeySizeInBits = keySize,
                 KeyType = keyType,
-                TokenType = SecurityTokenRequirement.TokenType,
                 WsTrustVersion = _requestSerializationContext.TrustVersion
             };
 
+            if (SecurityTokenRequirement.TokenType != null)
+            {
+                trustRequest.TokenType = SecurityTokenRequirement.TokenType;
+            }
+
             if (entropy != null)
+            {
                 trustRequest.Entropy = entropy;
+            }
 
             return trustRequest;
         }

--- a/src/System.ServiceModel.Federation/src/System/ServiceModel/Federation/WsTrustChannelSecurityTokenManager.cs
+++ b/src/System.ServiceModel.Federation/src/System/ServiceModel/Federation/WsTrustChannelSecurityTokenManager.cs
@@ -41,7 +41,8 @@ namespace System.ServiceModel.Federation
             // TODO - we should check the value of the IssuedTokenType on WsTrustTokenParameters
             if (Saml2Constants.OasisWssSaml2TokenProfile11.Equals(tokenRequirement.TokenType) ||
                 Saml2Constants.Saml2TokenProfile11.Equals(tokenRequirement.TokenType) ||
-                SamlConstants.OasisWssSamlTokenProfile11.Equals(tokenRequirement.TokenType))
+                SamlConstants.OasisWssSamlTokenProfile11.Equals(tokenRequirement.TokenType) ||
+                tokenRequirement.TokenType is null) // Treat unspecified token types as being SAML
             {
                 // pass issuedtokenRequirements
                 return new WsTrustChannelSecurityTokenProvider(tokenRequirement)

--- a/src/System.ServiceModel.Federation/src/System/ServiceModel/Federation/WsTrustChannelSecurityTokenManager.cs
+++ b/src/System.ServiceModel.Federation/src/System/ServiceModel/Federation/WsTrustChannelSecurityTokenManager.cs
@@ -5,9 +5,8 @@
 #pragma warning disable 1591
 
 using System.IdentityModel.Selectors;
+using System.ServiceModel.Security.Tokens;
 using Microsoft.IdentityModel.Logging;
-using Microsoft.IdentityModel.Tokens.Saml;
-using Microsoft.IdentityModel.Tokens.Saml2;
 
 namespace System.ServiceModel.Federation
 {
@@ -16,6 +15,9 @@ namespace System.ServiceModel.Federation
     /// </summary>
     public class WsTrustChannelSecurityTokenManager : ClientCredentialsSecurityTokenManager
     {
+        private const string Namespace = "http://schemas.microsoft.com/ws/2006/05/servicemodel/securitytokenrequirement";
+        private const string IssuedSecurityTokenParametersProperty = Namespace + "/IssuedSecurityTokenParameters";
+
         private WsTrustChannelClientCredentials _wsTrustChannelClientCredentials;
 
         /// <summary>
@@ -38,11 +40,10 @@ namespace System.ServiceModel.Federation
             if (tokenRequirement == null)
                 throw LogHelper.LogArgumentNullException(nameof(tokenRequirement));
 
-            // TODO - we should check the value of the IssuedTokenType on WsTrustTokenParameters
-            if (Saml2Constants.OasisWssSaml2TokenProfile11.Equals(tokenRequirement.TokenType) ||
-                Saml2Constants.Saml2TokenProfile11.Equals(tokenRequirement.TokenType) ||
-                SamlConstants.OasisWssSamlTokenProfile11.Equals(tokenRequirement.TokenType) ||
-                tokenRequirement.TokenType is null) // Treat unspecified token types as being SAML
+            // If the token requirement includes an issued security token parameter of type
+            // WsTrustTokenParameters, then tokens should be provided by a WsTrustChannelSecurityTokenProvider.
+            if (tokenRequirement.TryGetProperty(IssuedSecurityTokenParametersProperty, out SecurityTokenParameters issuedSecurityTokenParameters) &&
+                issuedSecurityTokenParameters is WsTrustTokenParameters)
             {
                 // pass issuedtokenRequirements
                 return new WsTrustChannelSecurityTokenProvider(tokenRequirement)


### PR DESCRIPTION
This allows RSTs to be generated with null token types (to match NetFx behavior) and includes a requested ComputedKeyAlgorithm in combined entropy scenarios.