### PR TITLE
Use NET5 version with Http auth bug fixed

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "5.0.100-preview.8.20362.3",
+    "dotnet": "5.0.100-rc.1.20413.5",
     "runtimes": {
       "dotnet": [
         "2.1.20",
@@ -9,7 +9,7 @@
     }
   },
   "sdk": {
-    "version": "5.0.100-preview.8.20362.3"
+    "version": "5.0.100-rc.1.20413.5"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "5.0.0-beta.20411.8",


### PR DESCRIPTION
The version of .NET 5 we were using had a bug which caused Windows auth with default credentials over https to fail.