### PR TITLE
Make dotnet-svcutil tool support .net5.

### DIFF
--- a/src/dotnet-svcutil/lib/src/Shared/FrameworkInfo.cs
+++ b/src/dotnet-svcutil/lib/src/Shared/FrameworkInfo.cs
@@ -72,7 +72,7 @@ namespace Microsoft.Tools.ServiceModel.Svcutil
             fxInfo.FullName = fullFrameworkName;
             fxInfo.Name = name;
             fxInfo.Version = version;
-            fxInfo.IsDnx = name == Netstandard || name == Netcoreapp;
+            fxInfo.IsDnx = name == Netstandard || name == Netcoreapp || version.Major >= 5;
             fxInfo.IsKnownDnx = fxInfo.IsDnx &&
                         (TargetFrameworkHelper.NetStandardToNetCoreVersionMap.Keys.Any((netstdVersion) => netstdVersion == version) ||
                          TargetFrameworkHelper.NetStandardToNetCoreVersionMap.Values.Any((netcoreVersion) => netcoreVersion == version));


### PR DESCRIPTION
@HongGit, this is to split PR #4341 to contain product change only as suggested. 

Code change in this PR alone would enable the tool to support .Net5, the referenced WCF client packages would be still version 4.4.*, same as the released tool.

However, we happen to uncover a bug when publishing a WCF test project after running the tool, if the referenced WCF package version is 4.4.*, the published project binaries would be missing System.Private.ServiceModel.dll which cause the published .exe run fail, with error like below:

> Unhandled exception. System.IO.FileNotFoundException: Could not load file or assembly 'System.Private.ServiceModel, Version=4.1.2.4, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'. The system cannot find the file specified.
> File name: 'System.Private.ServiceModel, Version=4.1.2.4, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'
>    at tmp.Program.Main(String[] args)

Although we haven't heard anyone report this bug, it seems we could take this opportunity to fix it.