### PR TITLE
Expose ConcurrencyMode property in CallBackBehaviorAttribute.

### DIFF
--- a/src/System.Private.ServiceModel/src/System/ServiceModel/CallbackBehaviorAttribute.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/CallbackBehaviorAttribute.cs
@@ -17,6 +17,19 @@ namespace System.ServiceModel
 
         public bool AutomaticSessionShutdown { get; set; } = true;
 
+        public ConcurrencyMode ConcurrencyMode
+        {
+            get { return _concurrencyMode; }
+            set
+            {
+                if (!ConcurrencyModeHelper.IsDefined(value))
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("value"));
+                }
+
+                _concurrencyMode = value;
+            }
+        }
 
         public bool UseSynchronizationContext
         {

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/CallbackBehaviorAttribute.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/CallbackBehaviorAttribute.cs
@@ -24,7 +24,7 @@ namespace System.ServiceModel
             {
                 if (!ConcurrencyModeHelper.IsDefined(value))
                 {
-                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("value"));
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException(nameof(value)));
                 }
 
                 _concurrencyMode = value;

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Description/TypeLoader.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Description/TypeLoader.cs
@@ -608,8 +608,14 @@ namespace System.ServiceModel.Description
         {
             foreach (IEndpointBehavior behaviorAttribute in ServiceReflector.GetCustomAttributes(implementationType, typeof(IEndpointBehavior), false))
             {
-                // 
-                throw ExceptionHelper.PlatformNotSupported();
+                if(behaviorAttribute is CallbackBehaviorAttribute)
+                {
+                    serviceEndpoint.Behaviors.Insert(0, behaviorAttribute);
+                }
+                else
+                {
+                    serviceEndpoint.Behaviors.Add(behaviorAttribute);
+                }
             }
             foreach (IContractBehavior behaviorAttribute in ServiceReflector.GetCustomAttributes(implementationType, typeof(IContractBehavior), false))
             {

--- a/src/System.Private.ServiceModel/tests/Common/Scenarios/Endpoints.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Scenarios/Endpoints.cs
@@ -721,6 +721,11 @@ public static partial class Endpoints
             return GetEndpointAddress("TcpTransSecMessCredsUserName.svc//tcp-message-credentials-username", protocol: "net.tcp");
         }
     }
+
+    public static string DuplexCallbackConcurrencyMode_Address
+    {
+        get { return GetEndpointAddress("DuplexCallbackConcurrencyMode.svc/tcp", protocol: "net.tcp"); }
+    }
     #endregion net.tcp Addresses
 }
 

--- a/src/System.Private.ServiceModel/tests/Common/Scenarios/ServiceInterfaces.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Scenarios/ServiceInterfaces.cs
@@ -379,6 +379,19 @@ public interface IWcfDuplexService_Xml_Callback
     void OnXmlPingCallback(XmlCompositeTypeDuplexCallbackOnly xmlCompositeType);
 }
 
+[ServiceContract(CallbackContract = typeof(IWcfDuplexService_CallbackConcurrencyMode_Callback))]
+public interface IWcfDuplexService_CallbackConcurrencyMode
+{
+    [OperationContract(IsOneWay = true)]
+    Task DoWork();
+}
+
+public interface IWcfDuplexService_CallbackConcurrencyMode_Callback
+{
+    [OperationContract(IsOneWay = true)]
+    Task CallWithWaitAsync(int delayTime);
+}
+
 // WebSocket Interfaces
 
 [ServiceContract]

--- a/src/System.Private.ServiceModel/tests/Common/Scenarios/ServiceInterfaces.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Scenarios/ServiceInterfaces.cs
@@ -383,7 +383,7 @@ public interface IWcfDuplexService_Xml_Callback
 public interface IWcfDuplexService_CallbackConcurrencyMode
 {
     [OperationContract(IsOneWay = true)]
-    Task DoWork();
+    Task DoWorkAsync();
 }
 
 public interface IWcfDuplexService_CallbackConcurrencyMode_Callback

--- a/src/System.Private.ServiceModel/tests/Common/Scenarios/ServiceInterfaces.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Scenarios/ServiceInterfaces.cs
@@ -382,13 +382,13 @@ public interface IWcfDuplexService_Xml_Callback
 [ServiceContract(CallbackContract = typeof(IWcfDuplexService_CallbackConcurrencyMode_Callback))]
 public interface IWcfDuplexService_CallbackConcurrencyMode
 {
-    [OperationContract(IsOneWay = true)]
+    [OperationContract]
     Task DoWorkAsync();
 }
 
 public interface IWcfDuplexService_CallbackConcurrencyMode_Callback
 {
-    [OperationContract(IsOneWay = true)]
+    [OperationContract]
     Task CallWithWaitAsync(int delayTime);
 }
 

--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/ChannelLayer/DuplexChannelShapeTests.4.0.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/ChannelLayer/DuplexChannelShapeTests.4.0.0.cs
@@ -140,30 +140,22 @@ public partial class DuplexChannelShapeTests : ConditionalWcfTest
         InstanceContext instanceContext;
         DuplexChannelFactory<IWcfDuplexService_CallbackConcurrencyMode> factory = null;
         IWcfDuplexService_CallbackConcurrencyMode channel = null;
-        try
-        {
-            // *** SETUP *** \\
-            binding = new NetTcpBinding(SecurityMode.None);
-            instanceContext = new InstanceContext(new CallbackHandler_ConcurrencyMode_Single());
-            factory = new DuplexChannelFactory<IWcfDuplexService_CallbackConcurrencyMode>(instanceContext, binding, Endpoints.DuplexCallbackConcurrencyMode_Address);
 
-            // *** EXECUTE *** \\
-            channel = factory.CreateChannel();
-            channel.DoWork();
+        // *** SETUP *** \\
+        binding = new NetTcpBinding(SecurityMode.None);
+        instanceContext = new InstanceContext(new CallbackHandler_ConcurrencyMode_Single());
+        factory = new DuplexChannelFactory<IWcfDuplexService_CallbackConcurrencyMode>(instanceContext, binding, Endpoints.DuplexCallbackConcurrencyMode_Address);
 
-            // *** VALIDATE *** \\
-            Assert.True(CallbackHandler_ConcurrencyMode_Single.s_manualResetEvent.WaitOne(20000));
-            Assert.Equal(1, CallbackHandler_ConcurrencyMode_Single.s_counter);
+        // *** EXECUTE *** \\
+        channel = factory.CreateChannel();
+        channel.DoWork();
 
-            // *** CLEANUP *** \\
-            factory.Close();
-            ((ICommunicationObject)channel).Close();
-        }
-        finally
-        {
-            // *** ENSURE CLEANUP *** \\
-            ScenarioTestHelpers.CloseCommunicationObjects((ICommunicationObject)channel, factory);
-        }
+        // *** VALIDATE *** \\
+        Assert.True(CallbackHandler_ConcurrencyMode_Single.s_manualResetEvent.WaitOne(20000));
+        Assert.Equal(1, CallbackHandler_ConcurrencyMode_Single.s_counter);
+
+        // *** ENSURE CLEANUP *** \\
+        ScenarioTestHelpers.CloseCommunicationObjects((ICommunicationObject)channel, factory);
     }
 
     [WcfFact]
@@ -174,30 +166,22 @@ public partial class DuplexChannelShapeTests : ConditionalWcfTest
         InstanceContext instanceContext;
         DuplexChannelFactory<IWcfDuplexService_CallbackConcurrencyMode> factory = null;
         IWcfDuplexService_CallbackConcurrencyMode channel = null;
-        try
-        {           
-            // *** SETUP *** \\
-            binding = new NetTcpBinding(SecurityMode.None);
-            instanceContext = new InstanceContext(new CallbackHandler_ConcurrencyMode_Multiple());
-            factory = new DuplexChannelFactory<IWcfDuplexService_CallbackConcurrencyMode>(instanceContext, binding, Endpoints.DuplexCallbackConcurrencyMode_Address);
 
-            // *** EXECUTE *** \\
-            channel = factory.CreateChannel();
-            channel.DoWork();
+        // *** SETUP *** \\
+        binding = new NetTcpBinding(SecurityMode.None);
+        instanceContext = new InstanceContext(new CallbackHandler_ConcurrencyMode_Multiple());
+        factory = new DuplexChannelFactory<IWcfDuplexService_CallbackConcurrencyMode>(instanceContext, binding, Endpoints.DuplexCallbackConcurrencyMode_Address);
 
-            // *** VALIDATE *** \\
-            Assert.True(CallbackHandler_ConcurrencyMode_Multiple.s_manualResetEvent.WaitOne(20000));
-            Assert.Equal(2, CallbackHandler_ConcurrencyMode_Multiple.s_counter);
+        // *** EXECUTE *** \\
+        channel = factory.CreateChannel();
+        channel.DoWork();
 
-            // *** CLEANUP *** \\
-            factory.Close();
-            ((ICommunicationObject)channel).Close();
-        }
-        finally
-        {
-            // *** ENSURE CLEANUP *** \\
-            ScenarioTestHelpers.CloseCommunicationObjects((ICommunicationObject)channel, factory);
-        }
+        // *** VALIDATE *** \\
+        Assert.True(CallbackHandler_ConcurrencyMode_Multiple.s_manualResetEvent.WaitOne(20000));
+        Assert.Equal(2, CallbackHandler_ConcurrencyMode_Multiple.s_counter);
+
+        // *** ENSURE CLEANUP *** \\
+        ScenarioTestHelpers.CloseCommunicationObjects((ICommunicationObject)channel, factory);
     }
 
     [CallbackBehavior(ConcurrencyMode = ConcurrencyMode.Single)]

--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/ChannelLayer/DuplexChannelShapeTests.4.0.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/ChannelLayer/DuplexChannelShapeTests.4.0.0.cs
@@ -138,25 +138,32 @@ public partial class DuplexChannelShapeTests : ConditionalWcfTest
     {
         NetTcpBinding binding;
         InstanceContext instanceContext;
-        DuplexChannelFactory<IWcfDuplexService_CallbackConcurrencyMode> factory;
-        IWcfDuplexService_CallbackConcurrencyMode channel;
+        DuplexChannelFactory<IWcfDuplexService_CallbackConcurrencyMode> factory = null;
+        IWcfDuplexService_CallbackConcurrencyMode channel = null;
+        try
+        {
+            // *** SETUP *** \\
+            binding = new NetTcpBinding(SecurityMode.None);
+            instanceContext = new InstanceContext(new CallbackHandler_ConcurrencyMode_Single());
+            factory = new DuplexChannelFactory<IWcfDuplexService_CallbackConcurrencyMode>(instanceContext, binding, Endpoints.DuplexCallbackConcurrencyMode_Address);
 
-        // *** SETUP *** \\
-        binding = new NetTcpBinding(SecurityMode.None);
-        instanceContext = new InstanceContext(new CallbackHandler_ConcurrencyMode_Single());
-        factory = new DuplexChannelFactory<IWcfDuplexService_CallbackConcurrencyMode>(instanceContext, binding, Endpoints.DuplexCallbackConcurrencyMode_Address);
+            // *** EXECUTE *** \\
+            channel = factory.CreateChannel();
+            channel.DoWork();
 
-        // *** EXECUTE *** \\
-        channel = factory.CreateChannel();
-        channel.DoWork();
+            // *** VALIDATE *** \\
+            Assert.True(CallbackHandler_ConcurrencyMode_Single.s_manualResetEvent.WaitOne(20000));
+            Assert.Equal(1, CallbackHandler_ConcurrencyMode_Single.s_counter);
 
-        // *** VALIDATE *** \\
-        Assert.True(CallbackHandler_ConcurrencyMode_Single.s_manualResetEvent.WaitOne(20000));
-        Assert.Equal(1, CallbackHandler_ConcurrencyMode_Single.s_counter);
-
-        // *** CLEANUP *** \\
-        factory.Close();
-        ((ICommunicationObject)channel).Close();
+            // *** CLEANUP *** \\
+            factory.Close();
+            ((ICommunicationObject)channel).Close();
+        }
+        finally
+        {
+            // *** ENSURE CLEANUP *** \\
+            ScenarioTestHelpers.CloseCommunicationObjects((ICommunicationObject)channel, factory);
+        }
     }
 
     [WcfFact]
@@ -165,25 +172,32 @@ public partial class DuplexChannelShapeTests : ConditionalWcfTest
     {
         NetTcpBinding binding;
         InstanceContext instanceContext;
-        DuplexChannelFactory<IWcfDuplexService_CallbackConcurrencyMode> factory;
-        IWcfDuplexService_CallbackConcurrencyMode channel;
+        DuplexChannelFactory<IWcfDuplexService_CallbackConcurrencyMode> factory = null;
+        IWcfDuplexService_CallbackConcurrencyMode channel = null;
+        try
+        {           
+            // *** SETUP *** \\
+            binding = new NetTcpBinding(SecurityMode.None);
+            instanceContext = new InstanceContext(new CallbackHandler_ConcurrencyMode_Multiple());
+            factory = new DuplexChannelFactory<IWcfDuplexService_CallbackConcurrencyMode>(instanceContext, binding, Endpoints.DuplexCallbackConcurrencyMode_Address);
 
-        // *** SETUP *** \\
-        binding = new NetTcpBinding(SecurityMode.None);
-        instanceContext = new InstanceContext(new CallbackHandler_ConcurrencyMode_Multiple());
-        factory = new DuplexChannelFactory<IWcfDuplexService_CallbackConcurrencyMode>(instanceContext, binding, Endpoints.DuplexCallbackConcurrencyMode_Address);
+            // *** EXECUTE *** \\
+            channel = factory.CreateChannel();
+            channel.DoWork();
 
-        // *** EXECUTE *** \\
-        channel = factory.CreateChannel();
-        channel.DoWork();
+            // *** VALIDATE *** \\
+            Assert.True(CallbackHandler_ConcurrencyMode_Multiple.s_manualResetEvent.WaitOne(20000));
+            Assert.Equal(2, CallbackHandler_ConcurrencyMode_Multiple.s_counter);
 
-        // *** VALIDATE *** \\
-        Assert.True(CallbackHandler_ConcurrencyMode_Multiple.s_manualResetEvent.WaitOne(20000));
-        Assert.Equal(2, CallbackHandler_ConcurrencyMode_Multiple.s_counter);
-
-        // *** CLEANUP *** \\
-        factory.Close();
-        ((ICommunicationObject)channel).Close();
+            // *** CLEANUP *** \\
+            factory.Close();
+            ((ICommunicationObject)channel).Close();
+        }
+        finally
+        {
+            // *** ENSURE CLEANUP *** \\
+            ScenarioTestHelpers.CloseCommunicationObjects((ICommunicationObject)channel, factory);
+        }
     }
 
     [CallbackBehavior(ConcurrencyMode = ConcurrencyMode.Single)]

--- a/src/System.Private.ServiceModel/tests/Scenarios/Client/ChannelLayer/DuplexChannelShapeTests.4.0.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Client/ChannelLayer/DuplexChannelShapeTests.4.0.0.cs
@@ -144,7 +144,6 @@ public partial class DuplexChannelShapeTests : ConditionalWcfTest
         // *** SETUP *** \\
         binding = new NetTcpBinding(SecurityMode.None);
         instanceContext = new InstanceContext(new CallbackHandler_ConcurrencyMode_Single());
-        Assert.Equal("net.tcp://localhost:809/DuplexCallbackConcurrencyMode.svc/tcp", Endpoints.DuplexCallbackConcurrencyMode_Address);
         factory = new DuplexChannelFactory<IWcfDuplexService_CallbackConcurrencyMode>(instanceContext, binding, Endpoints.DuplexCallbackConcurrencyMode_Address);
 
         // *** EXECUTE *** \\
@@ -172,7 +171,6 @@ public partial class DuplexChannelShapeTests : ConditionalWcfTest
         // *** SETUP *** \\
         binding = new NetTcpBinding(SecurityMode.None);
         instanceContext = new InstanceContext(new CallbackHandler_ConcurrencyMode_Multiple());
-        Assert.Equal("net.tcp://localhost:809/DuplexCallbackConcurrencyMode.svc/tcp", Endpoints.DuplexCallbackConcurrencyMode_Address);
         factory = new DuplexChannelFactory<IWcfDuplexService_CallbackConcurrencyMode>(instanceContext, binding, Endpoints.DuplexCallbackConcurrencyMode_Address);
 
         // *** EXECUTE *** \\

--- a/src/System.Private.ServiceModel/tools/IISHostedWcfService/App_code/IWcfDuplexService.cs
+++ b/src/System.Private.ServiceModel/tools/IISHostedWcfService/App_code/IWcfDuplexService.cs
@@ -91,7 +91,7 @@ namespace WcfService
     public interface IWcfDuplexService_CallbackConcurrencyMode
     {
         [OperationContract(IsOneWay = true)]
-        Task DoWork();
+        Task DoWorkAsync();
     }
 
     public interface IWcfDuplexService_CallbackConcurrencyMode_Callback

--- a/src/System.Private.ServiceModel/tools/IISHostedWcfService/App_code/IWcfDuplexService.cs
+++ b/src/System.Private.ServiceModel/tools/IISHostedWcfService/App_code/IWcfDuplexService.cs
@@ -90,13 +90,13 @@ namespace WcfService
     [ServiceContract(CallbackContract = typeof(IWcfDuplexService_CallbackConcurrencyMode_Callback))]
     public interface IWcfDuplexService_CallbackConcurrencyMode
     {
-        [OperationContract(IsOneWay = true)]
+        [OperationContract]
         Task DoWorkAsync();
     }
 
     public interface IWcfDuplexService_CallbackConcurrencyMode_Callback
     {
-        [OperationContract(IsOneWay = true)]
+        [OperationContract]
         Task CallWithWaitAsync(int delayTime);
     }
 }

--- a/src/System.Private.ServiceModel/tools/IISHostedWcfService/App_code/IWcfDuplexService.cs
+++ b/src/System.Private.ServiceModel/tools/IISHostedWcfService/App_code/IWcfDuplexService.cs
@@ -86,4 +86,17 @@ namespace WcfService
         [OperationContract]
         void OnDataContractPingCallback(ComplexCompositeTypeDuplexCallbackOnly complexCompositeType);
     }
+
+    [ServiceContract(CallbackContract = typeof(IWcfDuplexService_CallbackConcurrencyMode_Callback))]
+    public interface IWcfDuplexService_CallbackConcurrencyMode
+    {
+        [OperationContract(IsOneWay = true)]
+        Task DoWork();
+    }
+
+    public interface IWcfDuplexService_CallbackConcurrencyMode_Callback
+    {
+        [OperationContract(IsOneWay = true)]
+        Task CallWithWaitAsync(int delayTime);
+    }
 }

--- a/src/System.Private.ServiceModel/tools/IISHostedWcfService/App_code/WcfDuplexService.cs
+++ b/src/System.Private.ServiceModel/tools/IISHostedWcfService/App_code/WcfDuplexService.cs
@@ -85,7 +85,7 @@ namespace WcfService
 
     public class WcfDuplexService_CallbackConcurrenyMode : IWcfDuplexService_CallbackConcurrencyMode
     {
-        public async Task DoWork()
+        public async Task DoWorkAsync()
         {
             Task t1 = Callback.CallWithWaitAsync(4000);
             Task t2 = Callback.CallWithWaitAsync(500);

--- a/src/System.Private.ServiceModel/tools/IISHostedWcfService/App_code/WcfDuplexService.cs
+++ b/src/System.Private.ServiceModel/tools/IISHostedWcfService/App_code/WcfDuplexService.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.IO;
 using System.ServiceModel;
 using System.Threading.Tasks;
 
@@ -79,6 +80,24 @@ namespace WcfService
                 throw new FaultException<FaultDetail>(ex.Detail, ex.Message, ex.Code);
             }
             return retval;
+        }
+    }
+
+    public class WcfDuplexService_CallbackConcurrenyMode : IWcfDuplexService_CallbackConcurrencyMode
+    {
+        public async Task DoWork()
+        {
+            Task t1 = Callback.CallWithWaitAsync(4000);
+            Task t2 = Callback.CallWithWaitAsync(500);
+            await Task.WhenAll(t1, t2);   
+        }
+
+        public IWcfDuplexService_CallbackConcurrencyMode_Callback Callback
+        {
+            get
+            {
+                return OperationContext.Current.GetCallbackChannel<IWcfDuplexService_CallbackConcurrencyMode_Callback>();
+            }
         }
     }
 }

--- a/src/System.Private.ServiceModel/tools/IISHostedWcfService/App_code/WcfDuplexService.cs
+++ b/src/System.Private.ServiceModel/tools/IISHostedWcfService/App_code/WcfDuplexService.cs
@@ -83,6 +83,7 @@ namespace WcfService
         }
     }
 
+    [ServiceBehavior(ConcurrencyMode = ConcurrencyMode.Multiple)]
     public class WcfDuplexService_CallbackConcurrenyMode : IWcfDuplexService_CallbackConcurrencyMode
     {
         public async Task DoWorkAsync()

--- a/src/System.Private.ServiceModel/tools/IISHostedWcfService/App_code/testhosts/DuplexTestServiceHosts.cs
+++ b/src/System.Private.ServiceModel/tools/IISHostedWcfService/App_code/testhosts/DuplexTestServiceHosts.cs
@@ -120,4 +120,20 @@ namespace WcfService
         {
         }
     }
+
+    [TestServiceDefinition(Schema = ServiceSchema.NETTCP, BasePath = "DuplexCallbackConcurrencyMode.svc")]
+    public class DuplexCallbackConcurrencyModeServiceHost : TestServiceHostBase<IWcfDuplexService_CallbackConcurrencyMode>
+    {
+        protected override string Address { get { return "tcp"; } }
+
+        protected override Binding GetBinding()
+        {
+            return new NetTcpBinding(SecurityMode.None) { PortSharingEnabled = false };
+        }
+
+        public DuplexCallbackConcurrencyModeServiceHost(params Uri[] baseAddresses)
+            : base(typeof(WcfDuplexService_CallbackConcurrenyMode), baseAddresses)
+        {
+        }
+    }
 }

--- a/src/System.ServiceModel.Duplex/tests/ServiceModel/CallbackBehaviorAttributeTest.cs
+++ b/src/System.ServiceModel.Duplex/tests/ServiceModel/CallbackBehaviorAttributeTest.cs
@@ -36,4 +36,15 @@ public static class CallbackBehaviorAttributeTest
         cba.UseSynchronizationContext = value;
         Assert.Equal(value, cba.UseSynchronizationContext);
     }
+
+    [WcfTheory]
+    [InlineData(ConcurrencyMode.Single)]
+    [InlineData(ConcurrencyMode.Multiple)]
+    [InlineData(ConcurrencyMode.Reentrant)]
+    public static void ConcurrencyMode_Property_Is_Settable(ConcurrencyMode value)
+    {
+        CallbackBehaviorAttribute cba = new CallbackBehaviorAttribute();
+        cba.ConcurrencyMode = value;       
+        Assert.Equal(value, cba.ConcurrencyMode);
+    }
 }

--- a/src/dotnet-svcutil/lib/src/FrameworkFork/System.ServiceModel/System/ServiceModel/Description/TypeLoader.cs
+++ b/src/dotnet-svcutil/lib/src/FrameworkFork/System.ServiceModel/System/ServiceModel/Description/TypeLoader.cs
@@ -594,8 +594,14 @@ namespace System.ServiceModel.Description
         {
             foreach (IEndpointBehavior behaviorAttribute in ServiceReflector.GetCustomAttributes(implementationType, typeof(IEndpointBehavior), false))
             {
-                // 
-                throw ExceptionHelper.PlatformNotSupported();
+                if(behaviorAttribute is CallbackBehaviorAttribute)
+                {
+                    serviceEndpoint.Behaviors.Insert(0, behaviorAttribute);
+                }
+                else
+                {
+                    serviceEndpoint.Behaviors.Add(behaviorAttribute);
+                }
             }
             foreach (IContractBehavior behaviorAttribute in ServiceReflector.GetCustomAttributes(implementationType, typeof(IContractBehavior), false))
             {


### PR DESCRIPTION
For issue #1959.

@mconnew I've added the public property, it seems the feature should work as it's applied in the attribute implementation:
```
 void IEndpointBehavior.ApplyClientBehavior(ServiceEndpoint serviceEndpoint, ClientRuntime clientRuntime)
        {
           ...
            dispatchRuntime.ConcurrencyMode = _concurrencyMode;
           ...
        }
```
Regarding test scenario, I need your guidance on how to test it, what kind of combination for instance mode and concurrency mode would you suggest to use to test the feature? Thank you.