### PR TITLE
Add support for AuthenticationSchemes.IntegratedWindowsAuthentication

### DIFF
--- a/src/System.Private.ServiceModel/src/Resources/Strings.resx
+++ b/src/System.Private.ServiceModel/src/Resources/Strings.resx
@@ -862,10 +862,10 @@
     <value>Cannot resolve the host name of URI "{0}" using DNS.</value>
   </data>
   <data name="HttpRequiresSingleAuthScheme" xml:space="preserve">
-    <value>The '{0}' authentication scheme has been specified on the HTTP factory. However, the factory only supports specification of exactly one authentication scheme. Valid authentication schemes are Digest, Negotiate, NTLM, Basic, or Anonymous.</value>
+    <value>The '{0}' authentication scheme has been specified on the HTTP factory. However, the factory only supports specification of exactly one authentication scheme. Valid authentication schemes are Digest, Negotiate, NTLM, Basic, IntegratedWindowsAuthentication, or Anonymous.</value>
   </data>
   <data name="HttpAuthSchemeCannotBeNone" xml:space="preserve">
-    <value>The value specified for the AuthenticationScheme property on the HttpTransportBindingElement ('{0}') is not allowed when building a ChannelFactory. If you used a standard binding, ensure the ClientCredentialType is not set to HttpClientCredentialType.InheritedFromHost, a value which is invalid on a client. If you set the value to '{0}' directly on the HttpTransportBindingElement, please set it to Digest, Negotiate, NTLM, Basic, or Anonymous.</value>
+    <value>The value specified for the AuthenticationScheme property on the HttpTransportBindingElement ('{0}') is not allowed when building a ChannelFactory. If you used a standard binding, ensure the ClientCredentialType is not set to HttpClientCredentialType.InheritedFromHost, a value which is invalid on a client. If you set the value to '{0}' directly on the HttpTransportBindingElement, please set it to Digest, Negotiate, NTLM, Basic, IntegratedWindowsAuthentication, or Anonymous.</value>
   </data>
   <data name="HttpAuthorizationFailed" xml:space="preserve">
     <value>The HTTP request is unauthorized with client authentication scheme '{0}'. The authentication header received from the server was '{1}'.</value>

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/HttpChannelHelpers.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/HttpChannelHelpers.cs
@@ -96,6 +96,7 @@ namespace System.ServiceModel.Channels
                     break;
 
                 case AuthenticationSchemes.Ntlm:
+                case AuthenticationSchemes.IntegratedWindowsAuthentication: // IWA could use NTLM
                     result = await TransportSecurityHelpers.GetSspiCredentialAsync(credentialProvider,
                         impersonationLevelWrapper, authenticationLevelWrapper, timeout);
                     if (authenticationLevelWrapper.Value == AuthenticationLevel.MutualAuthRequired)

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/HttpTransportBindingElement.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/HttpTransportBindingElement.cs
@@ -442,7 +442,7 @@ namespace System.ServiceModel.Channels
                 throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgument("value", SR.Format(SR.HttpAuthSchemeCannotBeNone,
                     AuthenticationScheme));
             }
-            else if (!AuthenticationScheme.IsSingleton())
+            else if (!AuthenticationScheme.IsSingleton() && AuthenticationScheme != AuthenticationSchemes.IntegratedWindowsAuthentication)
             {
                 throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgument("value", SR.Format(SR.HttpRequiresSingleAuthScheme,
                     AuthenticationScheme));

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/HttpClientCredentialType.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/HttpClientCredentialType.cs
@@ -82,6 +82,7 @@ namespace System.ServiceModel
                     result = HttpClientCredentialType.Ntlm;
                     break;
                 case AuthenticationSchemes.Negotiate:
+                case AuthenticationSchemes.IntegratedWindowsAuthentication:
                     result = HttpClientCredentialType.Windows;
                     break;
                 default:

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/ClientCredentialsSecurityTokenManager.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/ClientCredentialsSecurityTokenManager.cs
@@ -52,7 +52,7 @@ namespace System.ServiceModel
             {
                 AuthenticationSchemes authScheme = (AuthenticationSchemes)requirement.Properties[ServiceModelSecurityTokenRequirement.HttpAuthenticationSchemeProperty];
 
-                if (!authScheme.IsSingleton())
+                if (!authScheme.IsSingleton() && authScheme != AuthenticationSchemes.IntegratedWindowsAuthentication)
                 {
                     throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgument("authScheme", string.Format(SR.HttpRequiresSingleAuthScheme, authScheme));
                 }

--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Http/ClientCredentialTypeTests.4.1.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Http/ClientCredentialTypeTests.4.1.0.cs
@@ -2,18 +2,15 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-// 
-
 using System;
 using System.Collections.Generic;
 using System.Net;
 using System.ServiceModel;
 using System.ServiceModel.Channels;
 using Infrastructure.Common;
-
 using Xunit;
 
-public static class Http_ClientCredentialTypeTests
+public class Http_ClientCredentialTypeTests : ConditionalWcfTest
 {
     [WcfFact]
     [OuterLoop]
@@ -138,5 +135,30 @@ public static class Http_ClientCredentialTypeTests
             // *** ENSURE CLEANUP *** \\
             ScenarioTestHelpers.CloseCommunicationObjects((ICommunicationObject)serviceProxy, factory);
         }
+    }
+
+    [WcfFact]
+    [Condition(nameof(Windows_Authentication_Available), nameof(Is_Windows))]
+    [OuterLoop]
+    public static void WindowsAuthentication_RoundTrips_Echo()
+    {
+        BasicHttpBinding basicHttpBinding = new BasicHttpBinding(BasicHttpSecurityMode.TransportCredentialOnly);
+        basicHttpBinding.Security.Transport.ClientCredentialType = HttpClientCredentialType.Windows;
+
+        ScenarioTestHelpers.RunBasicEchoTest(basicHttpBinding, Endpoints.Http_WindowsAuth_Address, "BasicHttpBinding with Windows authentication", null);
+    }
+
+    [WcfFact]
+    [Condition(nameof(Windows_Authentication_Available), nameof(Is_Windows))]
+    [OuterLoop]
+    public static void IntegratedWindowsAuthentication_Negotiate_RoundTrips_Echo()
+    {
+        BasicHttpBinding basicHttpBinding = new BasicHttpBinding(BasicHttpSecurityMode.TransportCredentialOnly);
+        basicHttpBinding.Security.Transport.ClientCredentialType = HttpClientCredentialType.Windows;
+        var binding = new CustomBinding(basicHttpBinding);
+        var htbe = binding.Elements.Find<HttpTransportBindingElement>();
+        htbe.AuthenticationScheme = System.Net.AuthenticationSchemes.IntegratedWindowsAuthentication;
+
+        ScenarioTestHelpers.RunBasicEchoTest(binding, Endpoints.Http_WindowsAuth_Address, "BasicHttpBinding with IntegratedWindowsAuthentication authentication and Negotiate endpoint", null);
     }
 }

--- a/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Https/ClientCredentialTypeTests.4.1.0.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Security/TransportSecurity/Https/ClientCredentialTypeTests.4.1.0.cs
@@ -238,13 +238,16 @@ public class Https_ClientCredentialTypeTests : ConditionalWcfTest
     }
 
     [WcfFact]
-    [Condition(nameof(Windows_Authentication_Available), nameof(Is_Windows))]
+    [Condition(nameof(NTLM_Available), nameof(Root_Certificate_Installed))]
     [OuterLoop]
-    public static void WindowsAuthentication_RoundTrips_Echo()
+    public static void IntegratedWindowsAuthentication_Ntlm_RoundTrips_Echo()
     {
-        BasicHttpBinding basicHttpBinding = new BasicHttpBinding(BasicHttpSecurityMode.TransportCredentialOnly);
+        BasicHttpBinding basicHttpBinding = new BasicHttpBinding(BasicHttpSecurityMode.Transport);
         basicHttpBinding.Security.Transport.ClientCredentialType = HttpClientCredentialType.Windows;
+        var binding = new CustomBinding(basicHttpBinding);
+        var htbe = binding.Elements.Find<HttpsTransportBindingElement>();
+        htbe.AuthenticationScheme = System.Net.AuthenticationSchemes.IntegratedWindowsAuthentication;
 
-        ScenarioTestHelpers.RunBasicEchoTest(basicHttpBinding, Endpoints.Http_WindowsAuth_Address, "BasicHttpBinding with Windows authentication", null);
+        ScenarioTestHelpers.RunBasicEchoTest(binding, Endpoints.Https_NtlmAuth_Address, "BasicHttpBinding with IntegratedWindowsAuthentication authentication and Ntlm endpoint", null);
     }
 }


### PR DESCRIPTION
When the server responds with both Negotiate and NTLM as supported authentication types, HttpClient will look in the credential cache for Negotiate credentials but not NTLM. This change allows specifying AuthenticationSchemes.IntegratedWindowsAuthentication on the HttpTransportBindingElement.AuthenticationScheme and WCF will add the credentials to the CredentialCache for Negotiate and NTLM.
Fixes #3694 