### PR TITLE
Fix IOTS cleanup on non Windows

### DIFF
--- a/src/System.Private.ServiceModel/src/Internals/System/Runtime/IOThreadScheduler.cs
+++ b/src/System.Private.ServiceModel/src/Internals/System/Runtime/IOThreadScheduler.cs
@@ -487,7 +487,11 @@ namespace System.Runtime
                 {
                     throw Fx.AssertAndThrowFatal("Cleanup called on an overlapped that is in-flight.");
                 }
-                Overlapped.Free(_nativeOverlapped);
+				
+                if (!s_isWindows)
+                {
+                    Overlapped.Free(_nativeOverlapped);
+                }
             }
         }
     }


### PR DESCRIPTION
With recent changes to improve performance on Windows by bringing back use of IO completion ports, a bug was introduced on non-Windows platforms where cleaning up an IOThreadScheduler resulted in an exception due to attempting to free a null overlapped.