### PR TITLE
Modifications to sync with M.IM.WsTrust.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -24,7 +24,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <MicrosoftIdentityModelProtocolsWsTrustPackageVersion>6.7.2-preview-10803222715</MicrosoftIdentityModelProtocolsWsTrustPackageVersion>
+    <MicrosoftIdentityModelProtocolsWsTrustPackageVersion>6.8.0-preview-11016030239</MicrosoftIdentityModelProtocolsWsTrustPackageVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/NuGet.config
+++ b/NuGet.config
@@ -2,6 +2,7 @@
 <configuration>
   <packageSources>
     <clear />
+    <add key="myget" value ="https://www.myget.org/F/azureadwebstacknightly/api/v3/index.json" />
     <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />
     <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />

--- a/src/System.Private.ServiceModel/tests/Scenarios/Binding/WS/FederationHttp/WSFederationHttpBindingTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Binding/WS/FederationHttp/WSFederationHttpBindingTests.cs
@@ -32,7 +32,6 @@ public class WSFederationHttpBindingTests : ConditionalWcfTest
         {
             // *** SETUP *** \\
             issuerAddress = new EndpointAddress(new Uri(Endpoints.WSFederationAuthorityLocalSTS));
-            tokenTargetAddress = Endpoints.Https_SecModeTransWithMessCred_ClientCredTypeIssuedTokenSaml2;
             serviceEndpointAddress = new EndpointAddress(new Uri(tokenTargetAddress));
             var issuerBinding = new WSHttpBinding(SecurityMode.Transport);
             issuerBinding.Security.Transport.ClientCredentialType = HttpClientCredentialType.Basic;
@@ -43,10 +42,8 @@ public class WSFederationHttpBindingTests : ConditionalWcfTest
                     IssuerAddress = issuerAddress,
                     IssuerBinding = issuerBinding,
                     KeyType = SecurityKeyType.BearerKey,
-                    Target = tokenTargetAddress,
                     TokenType = Saml2Constants.OasisWssSaml2TokenProfile11
                 });
-            //federationBinding.Security.Message.EstablishSecurityContext = false;
             var customBinding = new CustomBinding(federationBinding);
             var sbe = customBinding.Elements.Find<SecurityBindingElement>();
             sbe.MessageSecurityVersion = MessageSecurityVersion.WSSecurity10WSTrust13WSSecureConversation13WSSecurityPolicy12BasicSecurityProfile10;

--- a/src/System.Private.ServiceModel/tests/Scenarios/Binding/WS/FederationHttp/WSFederationHttpBindingTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Binding/WS/FederationHttp/WSFederationHttpBindingTests.cs
@@ -32,6 +32,7 @@ public class WSFederationHttpBindingTests : ConditionalWcfTest
         {
             // *** SETUP *** \\
             issuerAddress = new EndpointAddress(new Uri(Endpoints.WSFederationAuthorityLocalSTS));
+            tokenTargetAddress = Endpoints.Https_SecModeTransWithMessCred_ClientCredTypeIssuedTokenSaml2;
             serviceEndpointAddress = new EndpointAddress(new Uri(tokenTargetAddress));
             var issuerBinding = new WSHttpBinding(SecurityMode.Transport);
             issuerBinding.Security.Transport.ClientCredentialType = HttpClientCredentialType.Basic;

--- a/src/System.ServiceModel.Federation/src/System/ServiceModel/Federation/LogHelper.cs
+++ b/src/System.ServiceModel.Federation/src/System/ServiceModel/Federation/LogHelper.cs
@@ -1,0 +1,31 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Globalization;
+
+namespace System.ServiceModel.Federation
+{
+    /// <summary>
+    /// Helper class for logging.
+    /// </summary>
+    internal class LogHelper
+    {
+        /// <summary>
+        /// Formats the string using InvariantCulture
+        /// </summary>
+        /// <param name="format">Format string.</param>
+        /// <param name="args">Format arguments.</param>
+        /// <returns>Formatted string.</returns>
+        internal static string FormatInvariant(string format, params object[] args)
+        {
+            if (format == null)
+                return string.Empty;
+
+            if (args == null)
+                return format;
+
+            return string.Format(CultureInfo.InvariantCulture, format, args);
+        }
+    }
+}

--- a/src/System.ServiceModel.Federation/src/System/ServiceModel/Federation/WSTrustChannelSecurityTokenProvider.cs
+++ b/src/System.ServiceModel.Federation/src/System/ServiceModel/Federation/WSTrustChannelSecurityTokenProvider.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#pragma warning disable 1591
-
 using System.ComponentModel;
 using System.IdentityModel.Selectors;
 using System.IdentityModel.Tokens;
@@ -14,7 +12,6 @@ using System.ServiceModel.Security;
 using System.ServiceModel.Security.Tokens;
 using System.Text;
 using System.Xml;
-using Microsoft.IdentityModel.Logging;
 using Microsoft.IdentityModel.Protocols;
 using Microsoft.IdentityModel.Protocols.WsAddressing;
 using Microsoft.IdentityModel.Protocols.WsPolicy;
@@ -27,7 +24,8 @@ namespace System.ServiceModel.Federation
 {
 
     /// <summary>
-    /// Custom WSTrustChannelSecurityTokenProvider that returns a SAML assertion
+    /// <see cref="WSTrustChannelSecurityTokenProvider"/> has been designed to work with <see cref="WSFederationHttpBinding"/> to that will send a WsTrust message to obtain a token from an STS and add the token as
+    /// an issued token when communicating with a WCF relying party.
     /// </summary>
     public class WSTrustChannelSecurityTokenProvider : SecurityTokenProvider
     {
@@ -38,7 +36,6 @@ namespace System.ServiceModel.Federation
         private const string SecurityBindingElementProperty = Namespace + "/SecurityBindingElement";
         private const string TargetAddressProperty = Namespace + "/TargetAddress";
 
-        //private readonly WSTrustTokenParameters _issuedTokenParameters;
         private SecurityKeyEntropyMode _keyEntropyMode;
         private ChannelFactory<IRequestChannel> _channelFactory;
         private readonly SecurityAlgorithmSuite _securityAlgorithmSuite;
@@ -67,11 +64,11 @@ namespace System.ServiceModel.Federation
 
 
         /// <summary>
-        /// Gets or sets the cached security token response
+        /// Gets or sets the cached security token response.
         /// </summary>
         private WsTrustResponse CachedResponse
         {
-            // TODO : At some point, it may be valuable to replace this with a cache (Microsoft.Extensions.Caching.Distributed.IDistributedCache, perhaps)
+            // FUTURE : At some point, it may be valuable to replace this with a cache (Microsoft.Extensions.Caching.Distributed.IDistributedCache, perhaps)
             //        so that caches can be shared between token providers. For the time being, this is just an in-memory WsTrustResponse since a
             //        WSTrustChannelSecurityTokenProvider will only ever use a single WsTrustRequest. If caches can be shared, though, then this would
             //        be replaced with a more full-featured cache allowing multiple providers to cache tokens in a single cache object.
@@ -114,6 +111,10 @@ namespace System.ServiceModel.Federation
 
         internal ClientCredentials ClientCredentials { get; set; }
 
+        /// <summary>
+        /// Creates a <see cref="WsTrustRequest"/> from the <see cref="WSTrustTokenParameters"/>
+        /// </summary>
+        /// <returns></returns>
         protected virtual WsTrustRequest CreateWsTrustRequest()
         {
             EndpointAddress target = SecurityTokenRequirement.GetProperty<EndpointAddress>(TargetAddressProperty);
@@ -136,7 +137,7 @@ namespace System.ServiceModel.Federation
                     keyType = _requestSerializationContext.TrustKeyTypes.Bearer;
                     break;
                 default:
-                    throw LogHelper.LogExceptionMessage(new NotSupportedException($"KeyType is not supported: '{0}'"));
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelper(new NotSupportedException(LogHelper.FormatInvariant("KeyType is not supported: {0}", WSTrustTokenParameters.KeyType)), System.Diagnostics.Tracing.EventLevel.Error);
             }
 
             Entropy entropy = null;
@@ -208,13 +209,13 @@ namespace System.ServiceModel.Federation
             // Encrypted keys and encrypted entropy are not supported, currently, as they should
             // only be needed by unsupported message security scenarios.
             if (response.RequestedProofToken?.EncryptedKey != null)
-                throw new NotSupportedException("Encrypted keys for proof tokens are not supported.");
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelper(new NotSupportedException("Encrypted keys for proof tokens are not supported."), System.Diagnostics.Tracing.EventLevel.Error);
 
             // Bearer scenarios have no proof token
             if (string.Equals(keyType, _requestSerializationContext.TrustKeyTypes.Bearer, StringComparison.Ordinal))
             {
                 if (response.RequestedProofToken != null || response.Entropy != null)
-                    throw new InvalidOperationException("Bearer key scenarios should not include a proof token or issuer entropy in the response.");
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelper(new InvalidOperationException("Bearer key scenarios should not include a proof token or issuer entropy in the response."), System.Diagnostics.Tracing.EventLevel.Error);
 
                 return null;
             }
@@ -225,7 +226,7 @@ namespace System.ServiceModel.Federation
             {
                 // Confirm that a computed key algorithm isn't also specified
                 if (!string.IsNullOrEmpty(response.RequestedProofToken.ComputedKeyAlgorithm) || response.Entropy != null)
-                    throw new InvalidOperationException("An RSTR containing a proof token should not also have a computed key algorithm or issuer entropy.");
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelper(new InvalidOperationException("An RSTR containing a proof token should not also have a computed key algorithm or issuer entropy."), System.Diagnostics.Tracing.EventLevel.Error);
 
                 return new BinarySecretSecurityToken(response.RequestedProofToken.BinarySecret.Data);
             }
@@ -234,9 +235,7 @@ namespace System.ServiceModel.Federation
             else if (response.RequestedProofToken?.ComputedKeyAlgorithm != null)
             {
                 if (!string.Equals(keyType, _requestSerializationContext.TrustKeyTypes.Symmetric, StringComparison.Ordinal))
-                {
-                    throw new InvalidOperationException("Computed key proof tokens are only supported with symmetric key types.");
-                }
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelper(new InvalidOperationException("Computed key proof tokens are only supported with symmetric key types."), System.Diagnostics.Tracing.EventLevel.Error);
 
                 if (string.Equals(response.RequestedProofToken.ComputedKeyAlgorithm, _requestSerializationContext.TrustKeyTypes.PSHA1, StringComparison.Ordinal))
                 {
@@ -244,16 +243,16 @@ namespace System.ServiceModel.Federation
                     // If we wish to support it in the future, most of the work will be in the WSTrust serializer;
                     // this code would just have to use protected key's .Secret property to get the key material.
                     if (response.Entropy?.ProtectedKey != null || request.Entropy?.ProtectedKey != null)
-                        throw new NotSupportedException("Protected key entropy is not supported.");
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelper( new NotSupportedException("Protected key entropy is not supported."), System.Diagnostics.Tracing.EventLevel.Error);
 
                     // Get issuer and requestor entropy
                     byte[] issuerEntropy = response.Entropy?.BinarySecret?.Data;
                     if (issuerEntropy == null)
-                        throw new InvalidOperationException("Computed key proof tokens require issuer to supply key material via entropy.");
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelper(new InvalidOperationException("Computed key proof tokens require issuer to supply key material via entropy."), System.Diagnostics.Tracing.EventLevel.Error);
 
                     byte[] requestorEntropy = request.Entropy?.BinarySecret?.Data;
                     if (requestorEntropy == null)
-                        throw new InvalidOperationException("Computed key proof tokens require requestor to supply key material via entropy.");
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelper(new InvalidOperationException("Computed key proof tokens require requestor to supply key material via entropy."), System.Diagnostics.Tracing.EventLevel.Error);
 
                     // Get key size
                     int keySizeInBits = response.KeySizeInBits ?? 0; // RSTR key size has precedence
@@ -264,13 +263,13 @@ namespace System.ServiceModel.Federation
                         keySizeInBits = _securityAlgorithmSuite?.DefaultSymmetricKeyLength ?? 0; // Symmetric keys should default to a length cooresponding to the algorithm in use
 
                     if (keySizeInBits == 0)
-                        throw new InvalidOperationException("No key size provided.");
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelper(new InvalidOperationException("No key size provided."), System.Diagnostics.Tracing.EventLevel.Error);
 
                     return new BinarySecretSecurityToken(Psha1KeyGenerator.ComputeCombinedKey(issuerEntropy, requestorEntropy, keySizeInBits));
                 }
                 else
                 {
-                    throw new NotSupportedException("Only PSHA1 computed keys are supported.");
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelper(new NotSupportedException("Only PSHA1 computed keys are supported."), System.Diagnostics.Tracing.EventLevel.Error);
                 }
             }
             // If the response does not have a proof token or computed key value, but the request proposed entropy,
@@ -278,7 +277,7 @@ namespace System.ServiceModel.Federation
             else if (request.Entropy != null)
             {
                 if (request.Entropy.ProtectedKey != null)
-                    throw new NotSupportedException("Protected key entropy is not supported.");
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelper(new NotSupportedException("Protected key entropy is not supported."), System.Diagnostics.Tracing.EventLevel.Error);
 
                 if (request.Entropy.BinarySecret != null)
                     return new BinarySecretSecurityToken(request.Entropy.BinarySecret.Data);
@@ -293,21 +292,18 @@ namespace System.ServiceModel.Federation
             if (securityTokenReference == null)
                 return null;
 
-            // this is tricky.
-            // the SecurityTokenReference must be in the wsse namespace of the security binding that will communicate with the relying party.
-            // the 'TokenType must be in wsse 1.1
-            // TODO - need to create to obtain the actual security version that will be used for the relying party.
-            // even though the MessageSecurityVersion is 1.1, the security header is written with 1.0
-            return new GenericXmlSecurityKeyIdentifierClause(WsSecuritySerializer.GetXmlElement(securityTokenReference, new WsSerializationContext(WsTrustVersion.TrustFeb2005)));
+            return new GenericXmlSecurityKeyIdentifierClause(WsSecuritySerializer.CreateXmlElement(securityTokenReference));
         }
 
         /// <summary>
-        /// Calls out to the STS, if necessary to get a token
+        /// Makes a WSTrust call to the STS to obtain a <see cref="SecurityToken"/> first checking if the token is available in the cache.
         /// </summary>
+        /// <returns>A <see cref="GenericXmlSecurityToken"/>.</returns>
         protected override SecurityToken GetTokenCore(TimeSpan timeout)
         {
             WsTrustRequest request = CreateWsTrustRequest();
             WsTrustResponse trustResponse = GetCachedResponse(request);
+
             if (trustResponse is null)
             {
                 using (var memeoryStream = new MemoryStream())
@@ -319,8 +315,8 @@ namespace System.ServiceModel.Federation
                     var reader = XmlDictionaryReader.CreateTextReader(memeoryStream.ToArray(), XmlDictionaryReaderQuotas.Max);
                     IRequestChannel channel = ChannelFactory.CreateChannel();
                     Message reply = channel.Request(Message.CreateMessage(MessageVersion.Soap12WSAddressing10, _requestSerializationContext.TrustActions.IssueRequest, reader));
+                    SecurityUtils.ThrowIfNegotiationFault(reply, channel.RemoteAddress);
                     trustResponse = serializer.ReadResponse(reply.GetReaderAtBodyContents());
-                    // TODO - we need to handle faults.
                     CacheSecurityTokenResponse(request, trustResponse);
                 }
             }
@@ -357,28 +353,6 @@ namespace System.ServiceModel.Federation
             }
         }
 
-        private WsAddressingVersion GetWsAddressingVersion(MessageSecurityVersion messageSecurityVersion)
-        {
-            if (messageSecurityVersion.SecurityVersion == SecurityVersion.WSSecurity10)
-                return WsAddressingVersion.Addressing200408;
-
-            if (messageSecurityVersion.SecurityVersion == SecurityVersion.WSSecurity11)
-                return WsAddressingVersion.Addressing10;
-
-            throw new NotSupportedException($"Unsupported SecurityVersion: '{MessageSecurityVersion.SecurityVersion}'.");
-        }
-
-        private WsSecurityVersion GetWsSecurityVersion(MessageSecurityVersion messageSecurityVersion)
-        {
-            if (messageSecurityVersion.SecurityVersion == SecurityVersion.WSSecurity10)
-                return WsSecurityVersion.Security10;
-
-            if (messageSecurityVersion.SecurityVersion == SecurityVersion.WSSecurity11)
-                return WsSecurityVersion.Security11;
-
-            throw new NotSupportedException($"Unsupported SecurityVersion: '{MessageSecurityVersion.SecurityVersion}'.");
-        }
-
         private WsTrustVersion GetWsTrustVersion(MessageSecurityVersion messageSecurityVersion)
         {
             if (messageSecurityVersion.TrustVersion == TrustVersion.WSTrust13)
@@ -387,7 +361,7 @@ namespace System.ServiceModel.Federation
             if (messageSecurityVersion.TrustVersion == TrustVersion.WSTrustFeb2005)
                 return WsTrustVersion.TrustFeb2005;
 
-            throw new NotSupportedException($"Unsupported TrustVersion: '{MessageSecurityVersion.TrustVersion}'.");
+            throw DiagnosticUtility.ExceptionUtility.ThrowHelper(new NotSupportedException(LogHelper.FormatInvariant("Unsupported TrustVersion: '{0}'.", MessageSecurityVersion.TrustVersion)), System.Diagnostics.Tracing.EventLevel.Error);
         }
 
         private void InitializeKeyEntropyMode()
@@ -449,7 +423,7 @@ namespace System.ServiceModel.Federation
             set
             {
                 if (!Enum.IsDefined(typeof(SecurityKeyEntropyMode), value))
-                    throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(SecurityKeyEntropyMode));
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelper(new InvalidEnumArgumentException(nameof(value), (int)value, typeof(SecurityKeyEntropyMode)), System.Diagnostics.Tracing.EventLevel.Error);
 
                 _keyEntropyMode = value;
             }
@@ -479,10 +453,10 @@ namespace System.ServiceModel.Federation
 
         /// <summary>
         /// Set initial MessageSecurityVersion based on (in priority order):
-        ///  1. The message security version of the issuer binding's security binding element.
-        ///  2. The provided DefaultMessageSecurityVersion from issued token parameters.
-        ///  3. The message security version of the outer security binding element (from the security token requirement).
-        ///  4. MessageSecurityVersion.WSSecurity11WSTrustFebruary2005WSSecureConversationFebruary2005WSSecurityPolicy11
+        ///  <para>1. The message security version of the issuer binding's security binding element.</para>
+        ///  <para>2. The provided DefaultMessageSecurityVersion from issued token parameters.</para>
+        ///  <para>3. The message security version of the outer security binding element (from the security token requirement).</para>
+        ///  <para>4. MessageSecurityVersion.WSSecurity11WSTrustFebruary2005WSSecureConversationFebruary2005WSSecurityPolicy11.</para>
         /// </summary>
         private void SetInboundSerializationContext()
         {
@@ -504,7 +478,7 @@ namespace System.ServiceModel.Federation
 
             MessageSecurityVersion = messageSecurityVersion;
 
-            _requestSerializationContext = new WsSerializationContext(GetWsTrustVersion(messageSecurityVersion), GetWsAddressingVersion(messageSecurityVersion), GetWsSecurityVersion(messageSecurityVersion));
+            _requestSerializationContext = new WsSerializationContext(GetWsTrustVersion(messageSecurityVersion));
         }
 
         public override bool SupportsTokenCancellation => false;

--- a/src/System.ServiceModel.Federation/src/System/ServiceModel/Federation/WsFederationHttpBinding.cs
+++ b/src/System.ServiceModel.Federation/src/System/ServiceModel/Federation/WsFederationHttpBinding.cs
@@ -2,23 +2,37 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#pragma warning disable 1591
-
 using System.IdentityModel.Tokens;
 using System.ServiceModel.Channels;
 using System.ServiceModel.Security.Tokens;
 
 namespace System.ServiceModel.Federation
 {
+    /// <summary>
+    /// The <see cref="WSFederationHttpBinding"/> is designed to send a WSTrust message to an STS and attach the token received as
+    /// an IssuedToken in the message to a WCF RelyingParty.
+    /// </summary>
     public class WSFederationHttpBinding : WSHttpBinding
     {
-        // binding is always TransportWithMessageCredentialy
-        public WSFederationHttpBinding(WSTrustTokenParameters wsTrustTokenParameters) : base(SecurityMode.TransportWithMessageCredential)
+        /// <summary>
+        /// Creates a <see cref="WSFederationHttpBinding"/> to send a WSTrust message to an STS and attach the token received as
+        /// an IssuedToken in the message to a WCF RelyingParty.
+        /// </summary>
+        /// <param name="wsTrustTokenParameters">the <see cref="WSTrustTokenParameters"/> that describe the WSTrust request.</param>
+        /// <remarks>The <see cref="SecurityMode"/> (for the RelyingParty), is set to <see cref="SecurityMode.TransportWithMessageCredential"/>.
+        /// <para>The ClientCredentialType (for the RelyingParty), is set to: <see cref="MessageCredentialType.IssuedToken"/>.</para></remarks>
+        /// <exception cref="ArgumentNullException">if <paramref name="wsTrustTokenParameters"/> is null.</exception>
+        public WSFederationHttpBinding(WSTrustTokenParameters wsTrustTokenParameters)
+            : base(SecurityMode.TransportWithMessageCredential)
         {
             WSTrustTokenParameters = wsTrustTokenParameters ?? throw new ArgumentNullException(nameof(wsTrustTokenParameters));
             Security.Message.ClientCredentialType = MessageCredentialType.IssuedToken;
         }
 
+        /// <summary>
+        /// The WSTrustTokenParameters describe the WsTrust request that will be sent to the STS.
+        /// </summary>
+        /// <remarks>see: http://docs.oasis-open.org/ws-sx/ws-trust/200512/ws-trust-1.3-os.html </remarks>
         public WSTrustTokenParameters WSTrustTokenParameters
         {
             get;
@@ -26,6 +40,13 @@ namespace System.ServiceModel.Federation
 
         private SecurityBindingElement SecurityBindingElement { get; set; }
 
+        /// <summary>
+        /// Builds the <see cref="SecurityBindingElement"/> for the RelyingParty channel.
+        /// </summary>
+        /// <returns>a <see cref="SecurityBindingElement"/> for the RelyingParty channel.</returns>
+        /// <remarks>Creates a new <see cref="TransportBindingElement"/> and adds <see cref="WSTrustTokenParameters"/> to the appropriate EndpointSupportingTokenParameters (Endorsing or Signed).
+        /// <para>Sets: <see cref="MessageSecurityVersion"/> == <see cref="WSTrustTokenParameters.MessageSecurityVersion"/>.</para></para>
+        /// <para>Sets: <see cref="IncludeTimestamp"/> == true.</para></remarks>
         protected override SecurityBindingElement CreateMessageSecurity()
         {
             WSTrustTokenParameters.RequireDerivedKeys = false;
@@ -44,7 +65,7 @@ namespace System.ServiceModel.Federation
                 result.EndpointSupportingTokenParameters.Endorsing.Add(WSTrustTokenParameters);
             }
 
-            if (WSTrustTokenParameters.EstablishSecurityContext)
+            if (Security.Message.EstablishSecurityContext)
             {
                 var securityContextWrappingElement = new TransportSecurityBindingElement
                 {
@@ -67,18 +88,16 @@ namespace System.ServiceModel.Federation
             return result;
         }
 
+        /// <summary>
+        /// Builds the <see cref="BindingElementCollection"/> for the channnel.
+        /// </summary>
+        /// <returns><see cref="BindingElementCollection"/> for the channel.</returns>
+        /// <remarks>Adds a <see cref="WSFederationBindingElement"/> in first position to the <see cref="BindingElementCollection"/> returned from base.CreateBindingElements().</remarks>
         public override BindingElementCollection CreateBindingElements()
         {
             var bindingElementCollection = base.CreateBindingElements();
             bindingElementCollection.Insert(0, new WSFederationBindingElement(WSTrustTokenParameters, SecurityBindingElement));
             return bindingElementCollection;
-        }
-
-
-        protected override TransportBindingElement GetTransport()
-        {
-            var transportBindingElement = base.GetTransport();
-            return transportBindingElement;
         }
     }
 }

--- a/src/System.ServiceModel.Federation/src/System/ServiceModel/Federation/WsTrustChannelClientCredentials.cs
+++ b/src/System.ServiceModel.Federation/src/System/ServiceModel/Federation/WsTrustChannelClientCredentials.cs
@@ -2,21 +2,19 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#pragma warning disable 1591
-
 using System.IdentityModel.Selectors;
 using System.ServiceModel.Description;
 
 namespace System.ServiceModel.Federation
 {
     /// <summary>
-    /// These client credentials class that will serve up a SecurityTokenManager that will use a TrustChannel to get a token from an STS
+    /// <see cref="WSTrustChannelClientCredentials"/> are designed to work with <see cref="WSFederationHttpBinding"/> to that will send a WsTrust message to obtain a token from an STS and add the token as
+    /// an issued token when communicating with a WCF relying party.
     /// </summary>
     public class WSTrustChannelClientCredentials : ClientCredentials
     {
         /// <summary>
         /// Default constructor
-        /// TODO - do we need this ctor
         /// </summary>
         public WSTrustChannelClientCredentials()
             : base()
@@ -24,9 +22,9 @@ namespace System.ServiceModel.Federation
         }
 
         /// <summary>
-        /// Copy constructor
+        /// Creates a shallow copy of 'other'.
         /// </summary>
-        /// <param name="other">The WSTrustChannelClientCredentials to create a copy of</param>
+        /// <param name="other">The WSTrustChannelClientCredentials to copy.</param>
         protected WSTrustChannelClientCredentials(WSTrustChannelClientCredentials other)
             : base(other)
         {
@@ -35,13 +33,13 @@ namespace System.ServiceModel.Federation
         }
 
         /// <summary>
-        ///
+        /// Crates an instance of <see cref="WSTrustChannelClientCredentials"/> with specifying a <see cref="ClientCredentials"/>
         /// </summary>
-        /// <param name="clientCredentials"></param>
+        /// <param name="clientCredentials">The <see cref="SecurityTokenManager"/> from this parameter will be used to
+        /// create the <see cref="SecurityTokenProvider"/> in the case the <see cref="SecurityTokenParameters"/> in the channel are not a <see cref="WSTrustTokenParameters"/></para></remarks>
         public WSTrustChannelClientCredentials(ClientCredentials clientCredentials)
             : base(clientCredentials)
         {
-            // TODO - throw on null
             ClientCredentials = clientCredentials;
         }
 
@@ -51,15 +49,21 @@ namespace System.ServiceModel.Federation
         /// </summary>
         public ClientCredentials ClientCredentials { get; private set; }
 
+        /// <summary>
+        /// Creates a shallow clone of this.
+        /// </summary>
         protected override ClientCredentials CloneCore()
         {
             return new WSTrustChannelClientCredentials(this);
         }
 
         /// <summary>
-        /// Extensibility point for serving up the WSTrustChannelSecurityTokenManager
+        /// Returns a <see cref="SecurityTokenManager"/> to use on this channel.
         /// </summary>
-        /// <returns>WSTrustChannelSecurityTokenManager</returns>
+        /// <remarks>The <see cref="SecurityTokenManager"/> is responsible to return the <see cref="SecurityTokenProvider"/> to obtain the issued token.
+        /// <para>If <see cref="ClientCredentials"/> was passed to the constructor, then that <see cref="SecurityTokenManager"/> will be used to
+        /// create the <see cref="SecurityTokenProvider"/> in the case the <see cref="SecurityTokenParameters"/> in the channel are not a <see cref="WSTrustTokenParameters"/></para></remarks>
+        /// <returns>An instance of <see cref="WSTrustChannelSecurityTokenManager" />.</returns>
         public override SecurityTokenManager CreateSecurityTokenManager()
         {
             if (ClientCredentials != null)

--- a/src/System.ServiceModel.Federation/src/System/ServiceModel/Federation/WsTrustChannelSecurityTokenManager.cs
+++ b/src/System.ServiceModel.Federation/src/System/ServiceModel/Federation/WsTrustChannelSecurityTokenManager.cs
@@ -18,7 +18,7 @@ namespace System.ServiceModel.Federation
         private WSTrustChannelClientCredentials _wsTrustChannelClientCredentials;
 
         /// <summary>
-        /// Instaintiates a <see cref="WSTrustChannelSecurityTokenManager"/>.
+        /// Instantiates a <see cref="WSTrustChannelSecurityTokenManager"/>.
         /// </summary>
         /// <param name="wsTrustChannelClientCredentials"> the WSTrustChannelClientCredentials that can serve up a SecurityTokenProvider to use.</param>
         public WSTrustChannelSecurityTokenManager(WSTrustChannelClientCredentials wsTrustChannelClientCredentials)

--- a/src/System.ServiceModel.Federation/src/System/ServiceModel/Federation/WsTrustChannelSecurityTokenManager.cs
+++ b/src/System.ServiceModel.Federation/src/System/ServiceModel/Federation/WsTrustChannelSecurityTokenManager.cs
@@ -2,11 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#pragma warning disable 1591
-
 using System.IdentityModel.Selectors;
 using System.ServiceModel.Security.Tokens;
-using Microsoft.IdentityModel.Logging;
 
 namespace System.ServiceModel.Federation
 {
@@ -21,13 +18,13 @@ namespace System.ServiceModel.Federation
         private WSTrustChannelClientCredentials _wsTrustChannelClientCredentials;
 
         /// <summary>
-        ///
+        /// Instaintiates a <see cref="WSTrustChannelSecurityTokenManager"/>.
         /// </summary>
-        /// <param name="wsTrustChannelClientCredentials"></param>
+        /// <param name="wsTrustChannelClientCredentials"> the WSTrustChannelClientCredentials that can serve up a SecurityTokenProvider to use.</param>
         public WSTrustChannelSecurityTokenManager(WSTrustChannelClientCredentials wsTrustChannelClientCredentials)
             : base(wsTrustChannelClientCredentials)
         {
-            _wsTrustChannelClientCredentials = wsTrustChannelClientCredentials ?? throw LogHelper.LogArgumentNullException(nameof(wsTrustChannelClientCredentials));
+            _wsTrustChannelClientCredentials = wsTrustChannelClientCredentials ?? throw DiagnosticUtility.ExceptionUtility.ThrowHelper(new ArgumentNullException(nameof(wsTrustChannelClientCredentials)), System.Diagnostics.Tracing.EventLevel.Error);
         }
 
         /// <summary>
@@ -38,7 +35,7 @@ namespace System.ServiceModel.Federation
         public override SecurityTokenProvider CreateSecurityTokenProvider(SecurityTokenRequirement tokenRequirement)
         {
             if (tokenRequirement == null)
-                throw LogHelper.LogArgumentNullException(nameof(tokenRequirement));
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelper(new ArgumentNullException(nameof(tokenRequirement)), System.Diagnostics.Tracing.EventLevel.Error);
 
             // If the token requirement includes an issued security token parameter of type
             // WSTrustTokenParameters, then tokens should be provided by a WSTrustChannelSecurityTokenProvider.

--- a/src/System.ServiceModel.Federation/src/System/ServiceModel/Federation/WsTrustTokenParameters.cs
+++ b/src/System.ServiceModel.Federation/src/System/ServiceModel/Federation/WsTrustTokenParameters.cs
@@ -27,7 +27,7 @@ namespace System.ServiceModel.Federation
         private int _issuedTokenRenewalThresholdPercentage = DefaultIssuedTokenRenewalThresholdPercentage;
 
         /// <summary>
-        /// Instantiates aa <see cref="wsTrustTokenParameters"/> that describe the parameters for a WSTrust request.
+        /// Instantiates a <see cref="wsTrustTokenParameters"/> that describe the parameters for a WSTrust request.
         /// </summary>
         /// <remarks><see cref="KeyType"/> == <see cref="SecurityKeyType.SymmetricKey"/>.
         /// <para><see cref="MessageSecurityVersion"/> == <see cref="MessageSecurityVersion.WSSecurity11WSTrust13WSSecureConversation13WSSecurityPolicy12BasicSecurityProfile10"/></para></remarks>

--- a/src/System.ServiceModel.Federation/src/System/ServiceModel/Federation/WsTrustTokenParameters.cs
+++ b/src/System.ServiceModel.Federation/src/System/ServiceModel/Federation/WsTrustTokenParameters.cs
@@ -2,20 +2,21 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#pragma warning disable 1591
-
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IdentityModel.Tokens;
 using System.ServiceModel.Security.Tokens;
 using System.Xml;
-using Microsoft.IdentityModel.Protocols.WsFed;
+using Microsoft.IdentityModel.Protocols.WsTrust;
 
 namespace System.ServiceModel.Federation
 {
+    /// <summary>
+    /// <see cref="WSTrustTokenParameters"/> is designed to be used with the <see cref="WSFederationHttpBinding"/> to send a WSTrust message to an STS and attach the token received as
+    /// an IssuedToken in the message to a WCF RelyingParty.
+    /// </summary>
     public class WSTrustTokenParameters : IssuedSecurityTokenParameters
     {
-        internal const bool DefaultEstablishSecurityContext = true;
         public static readonly bool DefaultCacheIssuedTokens = true;
         public static readonly int DefaultIssuedTokenRenewalThresholdPercentage = 60;
         public static readonly TimeSpan DefaultMaxIssuedTokenCachingTime = TimeSpan.MaxValue;
@@ -24,20 +25,25 @@ namespace System.ServiceModel.Federation
         private TimeSpan _maxIssuedTokenCachingTime = DefaultMaxIssuedTokenCachingTime;
         private MessageSecurityVersion _messageSecurityVersion;
         private int _issuedTokenRenewalThresholdPercentage = DefaultIssuedTokenRenewalThresholdPercentage;
-        private string _target;
 
         /// <summary>
-        /// Values that are used to obtain a token from an IdentityProvider
+        /// Instantiates aa <see cref="wsTrustTokenParameters"/> that describe the parameters for a WSTrust request.
         /// </summary>
+        /// <remarks><see cref="KeyType"/> == <see cref="SecurityKeyType.SymmetricKey"/>.
+        /// <para><see cref="MessageSecurityVersion"/> == <see cref="MessageSecurityVersion.WSSecurity11WSTrust13WSSecureConversation13WSSecurityPolicy12BasicSecurityProfile10"/></para></remarks>
         public WSTrustTokenParameters()
         {
             KeyType = DefaultSecurityKeyType;
-            EstablishSecurityContext = DefaultEstablishSecurityContext;
             DefaultMessageSecurityVersion = MessageSecurityVersion.WSSecurity11WSTrust13WSSecureConversation13WSSecurityPolicy12BasicSecurityProfile10;
             MessageSecurityVersion = MessageSecurityVersion.WSSecurity11WSTrust13WSSecureConversation13WSSecurityPolicy12BasicSecurityProfile10;
         }
 
-        protected WSTrustTokenParameters(WSTrustTokenParameters other) : base(other)
+        /// <summary>
+        /// Creates a shallow copy of 'other'.
+        /// </summary>
+        /// <param name="other">The WSTrustTokenParameters to copy.</param>
+        protected WSTrustTokenParameters(WSTrustTokenParameters other)
+            : base(other)
         {
             foreach (var parameter in other.AdditionalRequestParameters)
                 AdditionalRequestParameters.Add(parameter);
@@ -50,21 +56,32 @@ namespace System.ServiceModel.Federation
             KeySize = other.KeySize;
             _maxIssuedTokenCachingTime = other.MaxIssuedTokenCachingTime;
             _messageSecurityVersion = other.MessageSecurityVersion;
-            RequestContext = other.RequestContext;
-            _target = other.Target;
-            EstablishSecurityContext = other.EstablishSecurityContext;
         }
 
+        /// <summary>
+        /// Creates a shallow clone of this.
+        /// </summary>
         protected override SecurityTokenParameters CloneCore()
         {
             return new WSTrustTokenParameters(this);
         }
 
+        /// <summary>
+        /// Allows the addition of custom <see cref="XmlElement"/>s to the WSTrust request
+        /// <para>see: http://docs.oasis-open.org/ws-sx/ws-trust/200512/ws-trust-1.3-os.html </para>
+        /// </summary>
         public ICollection<XmlElement> AdditionalRequestParameters { get; } = new Collection<XmlElement>();
 
+        /// <summary>
+        /// Gets or set a bool that controls if tokens received from that STS should be cached.
+        /// </summary>
         public bool CacheIssuedTokens { get; set; } = DefaultCacheIssuedTokens;
 
-        public ICollection<ClaimType> ClaimTypes { get; } = new Collection<ClaimType>();
+        /// <summary>
+        /// Allows the addition of <see cref="Claims"/> to the WSTrust request
+        /// <para>see: http://docs.oasis-open.org/ws-sx/ws-trust/200512/ws-trust-1.3-os.html </para>
+        /// </summary>
+        public ICollection<Claims> ClaimTypes { get; } = new Collection<Claims>();
 
         /// <summary>
         /// Gets or sets the percentage of the issued token's lifetime at which it should be renewed instead of cached.
@@ -73,10 +90,13 @@ namespace System.ServiceModel.Federation
         {
             get => _issuedTokenRenewalThresholdPercentage;
             set => _issuedTokenRenewalThresholdPercentage = (value <= 0 || value > 100)
-                ? throw new ArgumentOutOfRangeException(nameof(value), $"IssuedTokenRenewalThresholdPercentage  must be greater than or equal to 1 and less than or equal to 100. Was: '{value}'")
+                ? throw DiagnosticUtility.ExceptionUtility.ThrowHelper(new ArgumentOutOfRangeException(nameof(value), LogHelper.FormatInvariant("IssuedTokenRenewalThresholdPercentage  must be greater than or equal to 1 and less than or equal to 100. Was: '{0}'.", value)), System.Diagnostics.Tracing.EventLevel.Error)
                 : value;
         }
 
+        /// <summary>
+        /// Gets or sets the keysize to request from the STS
+        /// </summary>
         public int? KeySize { get; set; }
 
         /// <summary>
@@ -86,24 +106,23 @@ namespace System.ServiceModel.Federation
         {
             get => _maxIssuedTokenCachingTime;
             set => _maxIssuedTokenCachingTime = value <= TimeSpan.Zero
-                ? throw new ArgumentOutOfRangeException(nameof(value), "MaxIssuedTokenCachingTime must be greater than TimeSpan.Zero. Was: '{value}'") // TODO - Get exception messages from resources
+                ? throw DiagnosticUtility.ExceptionUtility.ThrowHelper(new ArgumentOutOfRangeException(nameof(value), LogHelper.FormatInvariant("MaxIssuedTokenCachingTime must be greater than TimeSpan.Zero. Was: '{0}'.", value)), System.Diagnostics.Tracing.EventLevel.Error)
                 : value;
         }
 
+        /// <summary>
+        /// Gets or sets the <see cref="MessageSecurityVersion"/> to use.
+        /// </summary>
         public MessageSecurityVersion MessageSecurityVersion
         {
             get => _messageSecurityVersion;
-            set => _messageSecurityVersion = value ?? throw new ArgumentNullException(nameof(value));
+            set => _messageSecurityVersion = value ?? throw DiagnosticUtility.ExceptionUtility.ThrowHelper(new ArgumentNullException(nameof(value)), System.Diagnostics.Tracing.EventLevel.Error);
         }
 
+        /// <summary>
+        /// Gets or sets a string to put in the WSTrust request as a 'context' that helps in tracking request / response pairs.
+        /// <para>see: http://docs.oasis-open.org/ws-sx/ws-trust/200512/ws-trust-1.3-os.html </para>
+        /// </summary>
         public string RequestContext { get; set; }
-
-        public string Target
-        {
-            get => _target;
-            set => _target = !string.IsNullOrEmpty(value) ? value : throw new ArgumentNullException(nameof(value));
-        }
-
-        public bool EstablishSecurityContext { get; set; }
     }
 }


### PR DESCRIPTION
WSFederationHttpBinding.CreateMessgeSecurity uses Security.Message.EstablishSecurityContext to control SCT bootstrap
Remove Target and EstablishSecurityContest properties from WSTrustTokenParameters
Use DiagnosticUtility to trace exceptions
Remove M.IM.Logging direct dependency
Add comments to Federation classes
Format comments using InvariantCulture