### PR TITLE
Suppress credscan error for fake credentials

### DIFF
--- a/src/System.Private.ServiceModel/tests/Scenarios/Binding/WS/FederationHttp/WSFederationHttpBindingTests.cs
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Binding/WS/FederationHttp/WSFederationHttpBindingTests.cs
@@ -103,6 +103,7 @@ public class WSFederationHttpBindingTests : ConditionalWcfTest
             factory = new ChannelFactory<IWcfService>(federationBinding, serviceEndpointAddress);
 
             factory.Credentials.UserName.UserName = "AUser";
+			// [SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Not a real secret")]
             factory.Credentials.UserName.Password = "MyPassword";
             serviceProxy = factory.CreateChannel();
 
@@ -153,6 +154,7 @@ public class WSFederationHttpBindingTests : ConditionalWcfTest
             factory = new ChannelFactory<IWcfService>(federationBinding, serviceEndpointAddress);
 
             factory.Credentials.UserName.UserName = "AUser";
+			// [SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Not a real secret")]
             factory.Credentials.UserName.Password = "MyPassword";
             serviceProxy = factory.CreateChannel();
 


### PR DESCRIPTION
Internal build system does a credscan check to prevent accidentally committing real credentials. Recent tests added fake credentials in the code. This suppresses the resulting error.