### PR TITLE
Update README.md to correct link to .NET Foundation projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ There are many .NET related projects on GitHub.
 [.NET home repo](https://github.com/Microsoft/dotnet) links to 100s of .NET projects, from Microsoft and the community.
 - The [.NET Core repo](https://github.com/dotnet/core) links to .NET Core related projects from Microsoft.
 - The [ASP.NET home repo](https://github.com/aspnet/home) is the best place to start learning about ASP.NET Core.
-- [dotnet.github.io](http://dotnet.github.io) is a good place to discover .NET Foundation projects.
+- [https://dotnetfoundation.org/projects](https://dotnetfoundation.org/projects) is a good place to discover .NET Foundation projects.
 
 ## The Windows Communication Foundation Story
 


### PR DESCRIPTION
Update README.md to correct link to .NET Foundation projects, because dotnet.github.io is pointing to dotnet.microsoft.com instead of dotnetfoundation.org project page.