### PR TITLE
Make SecureConversation inner channel factory share the same HttpClient as outer factory

### DIFF
--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/HttpChannelFactory.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/HttpChannelFactory.cs
@@ -131,6 +131,7 @@ namespace System.ServiceModel.Channels
             WebSocketSettings = WebSocketHelper.GetRuntimeWebSocketSettings(bindingElement.WebSocketSettings);
             _clientWebSocketFactory = ClientWebSocketFactory.GetFactory();
             _webSocketSoapContentType = new Lazy<string>(() => MessageEncoderFactory.CreateSessionEncoder().ContentType, LazyThreadSafetyMode.ExecutionAndPublication);
+            _httpClientCache = bindingElement.GetProperty<MruCache<string, HttpClient>>(context);
         }
 
         public bool AllowCookies { get; }
@@ -254,17 +255,6 @@ namespace System.ServiceModel.Channels
             var authenticationLevelWrapper = new OutWrapper<AuthenticationLevel>();
             NetworkCredential credential = await HttpChannelUtilities.GetCredentialAsync(AuthenticationScheme,
                 tokenProvider, impersonationLevelWrapper, authenticationLevelWrapper, timeout);
-
-            if (_httpClientCache == null)
-            {
-                lock (ThisLock)
-                {
-                    if (_httpClientCache == null)
-                    {
-                        _httpClientCache = new MruCache<string, HttpClient>(10);
-                    }
-                }
-            }
 
             HttpClient httpClient;
 

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/HttpTransportBindingElement.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/HttpTransportBindingElement.cs
@@ -415,13 +415,9 @@ namespace System.ServiceModel.Channels
 
         private MruCache<string, HttpClient> EnsureHttpClientCache()
         {
-            if (_httpClientCache == null || _httpClientCache.IsDisposed)
+            if (_httpClientCache == null || !_httpClientCache.AddRef())
             {
                 _httpClientCache = new MruCache<string, HttpClient>(10);
-            }
-            else
-            {
-                _httpClientCache.AddRef();
             }
 
             return _httpClientCache;


### PR DESCRIPTION
When using SecureConversation, an inner channel factory is used to obtain the Secure Conversation token. When using a load balancer, this can result in the session establishment and service request being made to different backend hosts resulting in the service call failing.