### PR TITLE
Support running dotnet-svcutil on machine with only .net5 installed

### DIFF
--- a/src/dotnet-svcutil/src/dotnet-svcutil.csproj
+++ b/src/dotnet-svcutil/src/dotnet-svcutil.csproj
@@ -19,7 +19,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
     <RootNamespace>Microsoft.Tools.ServiceModel.Svcutil</RootNamespace>
 
     <PackAsTool>true</PackAsTool>


### PR DESCRIPTION
@HongGit, @mconnew 

On machine with .net5 installed only, dotnet-svcutil throw error like below:

![image](https://user-images.githubusercontent.com/14886586/100577473-48983400-331b-11eb-80f6-ade848192d07.png)

This PR fixed the issue.