### PR TITLE
dotnet svcutil - add example for update option usage

### DIFF
--- a/src/dotnet-svcutil/lib/src/CommandProcessorOptions.cs
+++ b/src/dotnet-svcutil/lib/src/CommandProcessorOptions.cs
@@ -328,7 +328,7 @@ namespace Microsoft.Tools.ServiceModel.Svcutil
                     }
                     else if (projects.Length == 0)
                     {
-                        if (this.ToolContext == OperationalContext.Project)
+                        if (this.ToolContext == OperationalContext.Project || this.ToolContext == OperationalContext.Global)
                         {
                             throw new ToolArgumentException(string.Format(CultureInfo.CurrentCulture, SR.ErrInvalidOperationNoProjectFileFoundUnderFolderFormat, workingDirectory));
                         }

--- a/src/dotnet-svcutil/lib/src/CommandProcessorOptions.cs
+++ b/src/dotnet-svcutil/lib/src/CommandProcessorOptions.cs
@@ -328,7 +328,8 @@ namespace Microsoft.Tools.ServiceModel.Svcutil
                     }
                     else if (projects.Length == 0)
                     {
-                        if (this.ToolContext == OperationalContext.Project || this.ToolContext == OperationalContext.Global)
+                        if (this.ToolContext == OperationalContext.Project || (this.ToolContext == OperationalContext.Global && IsUpdateOperation))
+
                         {
                             throw new ToolArgumentException(string.Format(CultureInfo.CurrentCulture, SR.ErrInvalidOperationNoProjectFileFoundUnderFolderFormat, workingDirectory));
                         }

--- a/src/dotnet-svcutil/lib/src/CommandProcessorOptions.cs
+++ b/src/dotnet-svcutil/lib/src/CommandProcessorOptions.cs
@@ -328,8 +328,7 @@ namespace Microsoft.Tools.ServiceModel.Svcutil
                     }
                     else if (projects.Length == 0)
                     {
-                        if (this.ToolContext == OperationalContext.Project || (this.ToolContext == OperationalContext.Global && IsUpdateOperation))
-
+                        if (this.ToolContext == OperationalContext.Project)
                         {
                             throw new ToolArgumentException(string.Format(CultureInfo.CurrentCulture, SR.ErrInvalidOperationNoProjectFileFoundUnderFolderFormat, workingDirectory));
                         }

--- a/src/dotnet-svcutil/lib/src/HelpGenerator.cs
+++ b/src/dotnet-svcutil/lib/src/HelpGenerator.cs
@@ -82,6 +82,7 @@ namespace Microsoft.Tools.ServiceModel.Svcutil
 
             WriteExample(SR.HelpExamples2, SR.HelpExamples3);
             WriteExample(SR.HelpExamples8, SR.HelpExamples9);
+            WriteExample(SR.HelpExamples10, SR.HelpExamples11);
         }
 
         private static void WriteExample(string syntax, string explanation)

--- a/src/dotnet-svcutil/lib/src/SR.resx
+++ b/src/dotnet-svcutil/lib/src/SR.resx
@@ -607,4 +607,10 @@ Your credentials will be sent to the server in clear text.</value>
   <data name="ParametersProjectFile" xml:space="preserve">
     <value>&lt;project file&gt;</value>
   </data>
+  <data name="HelpExamples10" xml:space="preserve">
+    <value>dotnet-svcutil -u ServiceReference</value>
+  </data>
+  <data name="HelpExamples11" xml:space="preserve">
+    <value>- Update existing web service reference named ServiceReference. The command need to be executed under directory which contains the project file.</value>
+  </data>
 </root>

--- a/src/dotnet-svcutil/lib/src/xlf/SR.cs.xlf
+++ b/src/dotnet-svcutil/lib/src/xlf/SR.cs.xlf
@@ -467,6 +467,16 @@ Document Identifier: '{0}'.</target>
         <target state="new">-= EXAMPLES =-</target>
         <note />
       </trans-unit>
+      <trans-unit id="HelpExamples10">
+        <source>dotnet-svcutil -u ServiceReference</source>
+        <target state="new">dotnet-svcutil -u ServiceReference</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HelpExamples11">
+        <source>- Update existing web service reference named ServiceReference. The command need to be executed under directory which contains the project file.</source>
+        <target state="new">- Update existing web service reference named ServiceReference. The command need to be executed under directory which contains the project file.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HelpExamples2">
         <source>dotnet-svcutil http://example.com/service.svc?wsdl</source>
         <target state="new">dotnet-svcutil http://example.com/service.svc?wsdl</target>

--- a/src/dotnet-svcutil/lib/src/xlf/SR.de.xlf
+++ b/src/dotnet-svcutil/lib/src/xlf/SR.de.xlf
@@ -467,6 +467,16 @@ Document Identifier: '{0}'.</target>
         <target state="new">-= EXAMPLES =-</target>
         <note />
       </trans-unit>
+      <trans-unit id="HelpExamples10">
+        <source>dotnet-svcutil -u ServiceReference</source>
+        <target state="new">dotnet-svcutil -u ServiceReference</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HelpExamples11">
+        <source>- Update existing web service reference named ServiceReference. The command need to be executed under directory which contains the project file.</source>
+        <target state="new">- Update existing web service reference named ServiceReference. The command need to be executed under directory which contains the project file.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HelpExamples2">
         <source>dotnet-svcutil http://example.com/service.svc?wsdl</source>
         <target state="new">dotnet-svcutil http://example.com/service.svc?wsdl</target>

--- a/src/dotnet-svcutil/lib/src/xlf/SR.es.xlf
+++ b/src/dotnet-svcutil/lib/src/xlf/SR.es.xlf
@@ -467,6 +467,16 @@ Document Identifier: '{0}'.</target>
         <target state="new">-= EXAMPLES =-</target>
         <note />
       </trans-unit>
+      <trans-unit id="HelpExamples10">
+        <source>dotnet-svcutil -u ServiceReference</source>
+        <target state="new">dotnet-svcutil -u ServiceReference</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HelpExamples11">
+        <source>- Update existing web service reference named ServiceReference. The command need to be executed under directory which contains the project file.</source>
+        <target state="new">- Update existing web service reference named ServiceReference. The command need to be executed under directory which contains the project file.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HelpExamples2">
         <source>dotnet-svcutil http://example.com/service.svc?wsdl</source>
         <target state="new">dotnet-svcutil http://example.com/service.svc?wsdl</target>

--- a/src/dotnet-svcutil/lib/src/xlf/SR.fr.xlf
+++ b/src/dotnet-svcutil/lib/src/xlf/SR.fr.xlf
@@ -467,6 +467,16 @@ Document Identifier: '{0}'.</target>
         <target state="new">-= EXAMPLES =-</target>
         <note />
       </trans-unit>
+      <trans-unit id="HelpExamples10">
+        <source>dotnet-svcutil -u ServiceReference</source>
+        <target state="new">dotnet-svcutil -u ServiceReference</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HelpExamples11">
+        <source>- Update existing web service reference named ServiceReference. The command need to be executed under directory which contains the project file.</source>
+        <target state="new">- Update existing web service reference named ServiceReference. The command need to be executed under directory which contains the project file.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HelpExamples2">
         <source>dotnet-svcutil http://example.com/service.svc?wsdl</source>
         <target state="new">dotnet-svcutil http://example.com/service.svc?wsdl</target>

--- a/src/dotnet-svcutil/lib/src/xlf/SR.it.xlf
+++ b/src/dotnet-svcutil/lib/src/xlf/SR.it.xlf
@@ -467,6 +467,16 @@ Document Identifier: '{0}'.</target>
         <target state="new">-= EXAMPLES =-</target>
         <note />
       </trans-unit>
+      <trans-unit id="HelpExamples10">
+        <source>dotnet-svcutil -u ServiceReference</source>
+        <target state="new">dotnet-svcutil -u ServiceReference</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HelpExamples11">
+        <source>- Update existing web service reference named ServiceReference. The command need to be executed under directory which contains the project file.</source>
+        <target state="new">- Update existing web service reference named ServiceReference. The command need to be executed under directory which contains the project file.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HelpExamples2">
         <source>dotnet-svcutil http://example.com/service.svc?wsdl</source>
         <target state="new">dotnet-svcutil http://example.com/service.svc?wsdl</target>

--- a/src/dotnet-svcutil/lib/src/xlf/SR.ja.xlf
+++ b/src/dotnet-svcutil/lib/src/xlf/SR.ja.xlf
@@ -467,6 +467,16 @@ Document Identifier: '{0}'.</target>
         <target state="new">-= EXAMPLES =-</target>
         <note />
       </trans-unit>
+      <trans-unit id="HelpExamples10">
+        <source>dotnet-svcutil -u ServiceReference</source>
+        <target state="new">dotnet-svcutil -u ServiceReference</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HelpExamples11">
+        <source>- Update existing web service reference named ServiceReference. The command need to be executed under directory which contains the project file.</source>
+        <target state="new">- Update existing web service reference named ServiceReference. The command need to be executed under directory which contains the project file.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HelpExamples2">
         <source>dotnet-svcutil http://example.com/service.svc?wsdl</source>
         <target state="new">dotnet-svcutil http://example.com/service.svc?wsdl</target>

--- a/src/dotnet-svcutil/lib/src/xlf/SR.ko.xlf
+++ b/src/dotnet-svcutil/lib/src/xlf/SR.ko.xlf
@@ -467,6 +467,16 @@ Document Identifier: '{0}'.</target>
         <target state="new">-= EXAMPLES =-</target>
         <note />
       </trans-unit>
+      <trans-unit id="HelpExamples10">
+        <source>dotnet-svcutil -u ServiceReference</source>
+        <target state="new">dotnet-svcutil -u ServiceReference</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HelpExamples11">
+        <source>- Update existing web service reference named ServiceReference. The command need to be executed under directory which contains the project file.</source>
+        <target state="new">- Update existing web service reference named ServiceReference. The command need to be executed under directory which contains the project file.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HelpExamples2">
         <source>dotnet-svcutil http://example.com/service.svc?wsdl</source>
         <target state="new">dotnet-svcutil http://example.com/service.svc?wsdl</target>

--- a/src/dotnet-svcutil/lib/src/xlf/SR.pl.xlf
+++ b/src/dotnet-svcutil/lib/src/xlf/SR.pl.xlf
@@ -467,6 +467,16 @@ Document Identifier: '{0}'.</target>
         <target state="new">-= EXAMPLES =-</target>
         <note />
       </trans-unit>
+      <trans-unit id="HelpExamples10">
+        <source>dotnet-svcutil -u ServiceReference</source>
+        <target state="new">dotnet-svcutil -u ServiceReference</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HelpExamples11">
+        <source>- Update existing web service reference named ServiceReference. The command need to be executed under directory which contains the project file.</source>
+        <target state="new">- Update existing web service reference named ServiceReference. The command need to be executed under directory which contains the project file.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HelpExamples2">
         <source>dotnet-svcutil http://example.com/service.svc?wsdl</source>
         <target state="new">dotnet-svcutil http://example.com/service.svc?wsdl</target>

--- a/src/dotnet-svcutil/lib/src/xlf/SR.pt-BR.xlf
+++ b/src/dotnet-svcutil/lib/src/xlf/SR.pt-BR.xlf
@@ -467,6 +467,16 @@ Document Identifier: '{0}'.</target>
         <target state="new">-= EXAMPLES =-</target>
         <note />
       </trans-unit>
+      <trans-unit id="HelpExamples10">
+        <source>dotnet-svcutil -u ServiceReference</source>
+        <target state="new">dotnet-svcutil -u ServiceReference</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HelpExamples11">
+        <source>- Update existing web service reference named ServiceReference. The command need to be executed under directory which contains the project file.</source>
+        <target state="new">- Update existing web service reference named ServiceReference. The command need to be executed under directory which contains the project file.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HelpExamples2">
         <source>dotnet-svcutil http://example.com/service.svc?wsdl</source>
         <target state="new">dotnet-svcutil http://example.com/service.svc?wsdl</target>

--- a/src/dotnet-svcutil/lib/src/xlf/SR.ru.xlf
+++ b/src/dotnet-svcutil/lib/src/xlf/SR.ru.xlf
@@ -467,6 +467,16 @@ Document Identifier: '{0}'.</target>
         <target state="new">-= EXAMPLES =-</target>
         <note />
       </trans-unit>
+      <trans-unit id="HelpExamples10">
+        <source>dotnet-svcutil -u ServiceReference</source>
+        <target state="new">dotnet-svcutil -u ServiceReference</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HelpExamples11">
+        <source>- Update existing web service reference named ServiceReference. The command need to be executed under directory which contains the project file.</source>
+        <target state="new">- Update existing web service reference named ServiceReference. The command need to be executed under directory which contains the project file.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HelpExamples2">
         <source>dotnet-svcutil http://example.com/service.svc?wsdl</source>
         <target state="new">dotnet-svcutil http://example.com/service.svc?wsdl</target>

--- a/src/dotnet-svcutil/lib/src/xlf/SR.tr.xlf
+++ b/src/dotnet-svcutil/lib/src/xlf/SR.tr.xlf
@@ -467,6 +467,16 @@ Document Identifier: '{0}'.</target>
         <target state="new">-= EXAMPLES =-</target>
         <note />
       </trans-unit>
+      <trans-unit id="HelpExamples10">
+        <source>dotnet-svcutil -u ServiceReference</source>
+        <target state="new">dotnet-svcutil -u ServiceReference</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HelpExamples11">
+        <source>- Update existing web service reference named ServiceReference. The command need to be executed under directory which contains the project file.</source>
+        <target state="new">- Update existing web service reference named ServiceReference. The command need to be executed under directory which contains the project file.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HelpExamples2">
         <source>dotnet-svcutil http://example.com/service.svc?wsdl</source>
         <target state="new">dotnet-svcutil http://example.com/service.svc?wsdl</target>

--- a/src/dotnet-svcutil/lib/src/xlf/SR.zh-Hans.xlf
+++ b/src/dotnet-svcutil/lib/src/xlf/SR.zh-Hans.xlf
@@ -467,6 +467,16 @@ Document Identifier: '{0}'.</target>
         <target state="new">-= EXAMPLES =-</target>
         <note />
       </trans-unit>
+      <trans-unit id="HelpExamples10">
+        <source>dotnet-svcutil -u ServiceReference</source>
+        <target state="new">dotnet-svcutil -u ServiceReference</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HelpExamples11">
+        <source>- Update existing web service reference named ServiceReference. The command need to be executed under directory which contains the project file.</source>
+        <target state="new">- Update existing web service reference named ServiceReference. The command need to be executed under directory which contains the project file.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HelpExamples2">
         <source>dotnet-svcutil http://example.com/service.svc?wsdl</source>
         <target state="new">dotnet-svcutil http://example.com/service.svc?wsdl</target>

--- a/src/dotnet-svcutil/lib/src/xlf/SR.zh-Hant.xlf
+++ b/src/dotnet-svcutil/lib/src/xlf/SR.zh-Hant.xlf
@@ -467,6 +467,16 @@ Document Identifier: '{0}'.</target>
         <target state="new">-= EXAMPLES =-</target>
         <note />
       </trans-unit>
+      <trans-unit id="HelpExamples10">
+        <source>dotnet-svcutil -u ServiceReference</source>
+        <target state="new">dotnet-svcutil -u ServiceReference</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HelpExamples11">
+        <source>- Update existing web service reference named ServiceReference. The command need to be executed under directory which contains the project file.</source>
+        <target state="new">- Update existing web service reference named ServiceReference. The command need to be executed under directory which contains the project file.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HelpExamples2">
         <source>dotnet-svcutil http://example.com/service.svc?wsdl</source>
         <target state="new">dotnet-svcutil http://example.com/service.svc?wsdl</target>


### PR DESCRIPTION
@HongGit , @mconnew,  

Fixing issue #4359,  to throw meaningful error when running dotnet-svcutil to update service reference in global tool context but from unexpected working directory (projectFile not found under the dir).