### PR TITLE
Make all WCF exceptions serializable

### DIFF
--- a/src/System.Private.ServiceModel/src/Internals/System/Runtime/FatalException.cs
+++ b/src/System.Private.ServiceModel/src/Internals/System/Runtime/FatalException.cs
@@ -6,14 +6,11 @@ using System.Runtime.Serialization;
 
 namespace System.Runtime
 {
+    [Serializable]
     internal class FatalException : Exception
     {
-        public FatalException()
-        {
-        }
-        public FatalException(string message) : base(message)
-        {
-        }
+        public FatalException() { }
+        public FatalException(string message) : base(message) { }
 
         public FatalException(string message, Exception innerException) : base(message, innerException)
         {
@@ -22,9 +19,6 @@ namespace System.Runtime
             Fx.Assert(innerException == null || !Fx.IsFatal(innerException), "FatalException can't be used to wrap fatal exceptions.");
         }
 
-        protected FatalException(SerializationInfo info, StreamingContext context) : base(info, context)
-        {
-            throw new PlatformNotSupportedException();
-        }
+        protected FatalException(SerializationInfo info, StreamingContext context) : base(info, context) { }
     }
 }

--- a/src/System.Private.ServiceModel/src/Internals/System/Runtime/Fx.cs
+++ b/src/System.Private.ServiceModel/src/Internals/System/Runtime/Fx.cs
@@ -971,33 +971,18 @@ namespace System.Runtime
             }
         }
 
-        internal class InternalException : Exception
+        [Serializable]
+        internal class InternalException : SystemException
         {
-            public InternalException(string description)
-                : base(InternalSR.ShipAssertExceptionMessage(description))
-            {
-            }
-
-            protected InternalException(SerializationInfo info, StreamingContext context)
-                : base(info, context)
-            {
-                throw new PlatformNotSupportedException();
-            }
+            public InternalException(string description) : base(InternalSR.ShipAssertExceptionMessage(description)) { }
+            protected InternalException(SerializationInfo info, StreamingContext context) : base(info, context) { }
         }
 
         [Serializable]
         internal class FatalInternalException : InternalException
         {
-            public FatalInternalException(string description)
-                : base(description)
-            {
-            }
-
-            protected FatalInternalException(SerializationInfo info, StreamingContext context)
-                : base(info, context)
-            {
-                throw new PlatformNotSupportedException();
-            }
+            public FatalInternalException(string description) : base(description) { }
+            protected FatalInternalException(SerializationInfo info, StreamingContext context) : base(info, context) { }
         }
     }
 }

--- a/src/System.Private.ServiceModel/src/System/IdentityModel/SecurityMessageSerializationException.cs
+++ b/src/System.Private.ServiceModel/src/System/IdentityModel/SecurityMessageSerializationException.cs
@@ -6,27 +6,17 @@ using System.Runtime.Serialization;
 
 namespace System.IdentityModel
 {
+    [Serializable]
     public class SecurityMessageSerializationException : Exception
     {
-        public SecurityMessageSerializationException()
-            : base()
-        {
-        }
+        public SecurityMessageSerializationException() : base() { }
 
-        public SecurityMessageSerializationException(String message)
-            : base(message)
-        {
-        }
+        public SecurityMessageSerializationException(string message) : base(message) { }
 
-        public SecurityMessageSerializationException(String message, Exception innerException)
-            : base(message, innerException)
-        {
-        }
+        public SecurityMessageSerializationException(string message, Exception innerException)
+            : base(message, innerException) { }
 
         protected SecurityMessageSerializationException(SerializationInfo info, StreamingContext context)
-            : base(info, context)
-        {
-            throw new PlatformNotSupportedException();
-        }
+            : base(info, context) { }
     }
 }

--- a/src/System.Private.ServiceModel/src/System/IdentityModel/Tokens/SecurityTokenException.cs
+++ b/src/System.Private.ServiceModel/src/System/IdentityModel/Tokens/SecurityTokenException.cs
@@ -6,27 +6,12 @@ using System.Runtime.Serialization;
 
 namespace System.IdentityModel.Tokens
 {
+    [Serializable]
     public class SecurityTokenException : Exception
     {
-        public SecurityTokenException()
-            : base()
-        {
-        }
-
-        public SecurityTokenException(String message)
-            : base(message)
-        {
-        }
-
-        public SecurityTokenException(String message, Exception innerException)
-            : base(message, innerException)
-        {
-        }
-
-        protected SecurityTokenException(SerializationInfo info, StreamingContext context)
-            : base(info, context)
-        {
-            throw new PlatformNotSupportedException();
-        }
+        public SecurityTokenException() : base() { }
+        public SecurityTokenException(string message) : base(message) { }
+        public SecurityTokenException(string message, Exception innerException) : base(message, innerException) { }
+        protected SecurityTokenException(SerializationInfo info, StreamingContext context) : base(info, context) { }
     }
 }

--- a/src/System.Private.ServiceModel/src/System/IdentityModel/Tokens/SecurityTokenValidationException.cs
+++ b/src/System.Private.ServiceModel/src/System/IdentityModel/Tokens/SecurityTokenValidationException.cs
@@ -6,27 +6,12 @@ using System.Runtime.Serialization;
 
 namespace System.IdentityModel.Tokens
 {
+    [Serializable]
     public class SecurityTokenValidationException : SecurityTokenException
     {
-        public SecurityTokenValidationException()
-            : base()
-        {
-        }
-
-        public SecurityTokenValidationException(String message)
-            : base(message)
-        {
-        }
-
-        public SecurityTokenValidationException(String message, Exception innerException)
-            : base(message, innerException)
-        {
-        }
-
-        protected SecurityTokenValidationException(SerializationInfo info, StreamingContext context)
-            : base(info, context)
-        {
-            throw new PlatformNotSupportedException();
-        }
+        public SecurityTokenValidationException() : base() { }
+        public SecurityTokenValidationException(string message) : base(message) { }
+        public SecurityTokenValidationException(string message, Exception innerException) : base(message, innerException) { }
+        protected SecurityTokenValidationException(SerializationInfo info, StreamingContext context) : base(info, context) { }
     }
 }

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/ActionMismatchAddressingException.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/ActionMismatchAddressingException.cs
@@ -8,38 +8,27 @@ using System.ServiceModel.Channels;
 
 namespace System.ServiceModel
 {
+    [Serializable]
     internal class ActionMismatchAddressingException : ProtocolException
     {
-        private string _soapActionHeader;
-
         public ActionMismatchAddressingException(string message, string soapActionHeader, string httpActionHeader)
             : base(message)
         {
             HttpActionHeader = httpActionHeader;
-            _soapActionHeader = soapActionHeader;
+            SoapActionHeader = soapActionHeader;
         }
 
-        protected ActionMismatchAddressingException(SerializationInfo info, StreamingContext context)
-            : base(info, context)
-        {
-            throw new PlatformNotSupportedException();
-        }
+        protected ActionMismatchAddressingException(SerializationInfo info, StreamingContext context) : base(info, context) { }
 
         public string HttpActionHeader { get; }
 
-        public string SoapActionHeader
-        {
-            get
-            {
-                return _soapActionHeader;
-            }
-        }
+        public string SoapActionHeader { get; }
 
         internal Message ProvideFault(MessageVersion messageVersion)
         {
             Fx.Assert(messageVersion.Addressing == AddressingVersion.WSAddressing10, "");
             WSAddressing10ProblemHeaderQNameFault phf = new WSAddressing10ProblemHeaderQNameFault(this);
-            Message message = System.ServiceModel.Channels.Message.CreateMessage(messageVersion, phf, messageVersion.Addressing.FaultAction);
+            Message message = Channels.Message.CreateMessage(messageVersion, phf, messageVersion.Addressing.FaultAction);
             phf.AddHeaders(message.Headers);
             return message;
         }

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/ActionNotSupportedException.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/ActionNotSupportedException.cs
@@ -2,18 +2,18 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-
 using System.Diagnostics.Contracts;
 using System.Runtime.Serialization;
 using System.ServiceModel.Channels;
 
 namespace System.ServiceModel
 {
+    [Serializable]
     public class ActionNotSupportedException : CommunicationException
     {
         public ActionNotSupportedException() { }
         public ActionNotSupportedException(string message) : base(message) { }
-        public ActionNotSupportedException(string message, Exception innerException) : base(message, innerException) { throw new PlatformNotSupportedException(); }
+        public ActionNotSupportedException(string message, Exception innerException) : base(message, innerException) { }
         protected ActionNotSupportedException(SerializationInfo info, StreamingContext context) : base(info, context) { }
 
         internal Message ProvideFault(MessageVersion messageVersion)
@@ -21,8 +21,7 @@ namespace System.ServiceModel
             Contract.Assert(messageVersion.Addressing != AddressingVersion.None);
             FaultCode code = FaultCode.CreateSenderFaultCode(AddressingStrings.ActionNotSupported, messageVersion.Addressing.Namespace);
             string reason = Message;
-            return System.ServiceModel.Channels.Message.CreateMessage(
-               messageVersion, code, reason, messageVersion.Addressing.FaultAction);
+            return Channels.Message.CreateMessage(messageVersion, code, reason, messageVersion.Addressing.FaultAction);
         }
     }
 }

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/ChannelTerminatedException.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/ChannelTerminatedException.cs
@@ -6,11 +6,12 @@ using System.Runtime.Serialization;
 
 namespace System.ServiceModel
 {
+    [Serializable]
     public class ChannelTerminatedException : CommunicationException
     {
         public ChannelTerminatedException() { }
         public ChannelTerminatedException(string message) : base(message) { }
         public ChannelTerminatedException(string message, Exception innerException) : base(message, innerException) { }
-        protected ChannelTerminatedException(SerializationInfo info, StreamingContext context) : base(info, context) { throw new PlatformNotSupportedException(); }
+        protected ChannelTerminatedException(SerializationInfo info, StreamingContext context) : base(info, context) { }
     }
 }

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/CommunicationException.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/CommunicationException.cs
@@ -6,11 +6,12 @@ using System.Runtime.Serialization;
 
 namespace System.ServiceModel
 {
+    [Serializable]
     public class CommunicationException : Exception
     {
         public CommunicationException() { }
         public CommunicationException(string message) : base(message) { }
         public CommunicationException(string message, Exception innerException) : base(message, innerException) { }
-        protected CommunicationException(SerializationInfo info, StreamingContext context) : base(info, context) { throw new PlatformNotSupportedException(); }
+        protected CommunicationException(SerializationInfo info, StreamingContext context) : base(info, context) { }
     }
 }

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/CommunicationObjectAbortedException.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/CommunicationObjectAbortedException.cs
@@ -6,11 +6,12 @@ using System.Runtime.Serialization;
 
 namespace System.ServiceModel
 {
+    [Serializable]
     public class CommunicationObjectAbortedException : CommunicationException
     {
         public CommunicationObjectAbortedException() { }
         public CommunicationObjectAbortedException(string message) : base(message) { }
         public CommunicationObjectAbortedException(string message, Exception innerException) : base(message, innerException) { }
-        protected CommunicationObjectAbortedException(SerializationInfo info, StreamingContext context) : base(info, context) { throw new PlatformNotSupportedException(); }
+        protected CommunicationObjectAbortedException(SerializationInfo info, StreamingContext context) : base(info, context) { }
     }
 }

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/CommunicationObjectFaultedException.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/CommunicationObjectFaultedException.cs
@@ -6,11 +6,12 @@ using System.Runtime.Serialization;
 
 namespace System.ServiceModel
 {
+    [Serializable]
     public class CommunicationObjectFaultedException : CommunicationException
     {
         public CommunicationObjectFaultedException() { }
         public CommunicationObjectFaultedException(string message) : base(message) { }
         public CommunicationObjectFaultedException(string message, Exception innerException) : base(message, innerException) { }
-        protected CommunicationObjectFaultedException(SerializationInfo info, StreamingContext context) : base(info, context) { throw new PlatformNotSupportedException(); }
+        protected CommunicationObjectFaultedException(SerializationInfo info, StreamingContext context) : base(info, context) { }
     }
 }

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Dispatcher/InvalidBodyAccessException.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Dispatcher/InvalidBodyAccessException.cs
@@ -6,22 +6,11 @@ using System.Runtime.Serialization;
 
 namespace System.ServiceModel.Dispatcher
 {
+    [Serializable]
     internal abstract class InvalidBodyAccessException : Exception
     {
-        protected InvalidBodyAccessException(string message)
-            : this(message, null)
-        {
-        }
-
-        protected InvalidBodyAccessException(string message, Exception innerException)
-            : base(message, innerException)
-        {
-        }
-
-        protected InvalidBodyAccessException(SerializationInfo info, StreamingContext context)
-            : base(info, context)
-        {
-            throw new PlatformNotSupportedException();
-        }
+        protected InvalidBodyAccessException(string message) : this(message, null) { }
+        protected InvalidBodyAccessException(string message, Exception innerException) : base(message, innerException) { }
+        protected InvalidBodyAccessException(SerializationInfo info, StreamingContext context) : base(info, context) { }
     }
 }

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/EndpointNotFoundException.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/EndpointNotFoundException.cs
@@ -6,11 +6,12 @@ using System.Runtime.Serialization;
 
 namespace System.ServiceModel
 {
+    [Serializable]
     public class EndpointNotFoundException : CommunicationException
     {
         public EndpointNotFoundException() { }
         public EndpointNotFoundException(string message) : base(message) { }
         public EndpointNotFoundException(string message, Exception innerException) : base(message, innerException) { }
-        protected EndpointNotFoundException(SerializationInfo info, StreamingContext context) : base(info, context) { throw new PlatformNotSupportedException(); }
+        protected EndpointNotFoundException(SerializationInfo info, StreamingContext context) : base(info, context) { }
     }
 }

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/InvalidMessageContractException.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/InvalidMessageContractException.cs
@@ -2,33 +2,17 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-
 using System.Runtime.Serialization;
 
 namespace System.ServiceModel
 {
+    [Serializable]
     public class InvalidMessageContractException : Exception
     {
-        public InvalidMessageContractException()
-            : base()
-        {
-        }
-
-        public InvalidMessageContractException(String message)
-            : base(message)
-        {
-        }
-
-        public InvalidMessageContractException(String message, Exception innerException)
-            : base(message, innerException)
-        {
-        }
-
-        protected InvalidMessageContractException(SerializationInfo info, StreamingContext context)
-            : base(info, context)
-        {
-            throw new PlatformNotSupportedException();
-        }
+        public InvalidMessageContractException() : base() { }
+        public InvalidMessageContractException(string message) : base(message) { }
+        public InvalidMessageContractException(String message, Exception innerException) : base(message, innerException) { }
+        protected InvalidMessageContractException(SerializationInfo info, StreamingContext context) : base(info, context) { }
     }
 }
 

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/MessageHeaderException.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/MessageHeaderException.cs
@@ -8,45 +8,25 @@ using System.ServiceModel.Channels;
 
 namespace System.ServiceModel
 {
+    [Serializable]
     public class MessageHeaderException : ProtocolException
     {
-        private string _headerNamespace;
-
-        public MessageHeaderException(string message)
-            : this(message, null, null)
-        {
-        }
-        public MessageHeaderException(string message, bool isDuplicate)
-            : this(message, null, null)
-        {
-        }
-        public MessageHeaderException(string message, Exception innerException)
-            : this(message, null, null, innerException)
-        {
-        }
-        public MessageHeaderException(string message, string headerName, string ns)
-            : this(message, headerName, ns, null)
-        {
-        }
-        public MessageHeaderException(string message, string headerName, string ns, bool isDuplicate)
-            : this(message, headerName, ns, isDuplicate, null)
-        {
-        }
-        public MessageHeaderException(string message, string headerName, string ns, Exception innerException)
-            : this(message, headerName, ns, false, innerException)
-        {
-        }
-        public MessageHeaderException(string message, string headerName, string ns, bool isDuplicate, Exception innerException)
-            : base(message, innerException)
+        public MessageHeaderException(string message) : this(message, null, null) { }
+        public MessageHeaderException(string message, bool isDuplicate) : this(message, null, null, isDuplicate, null) { }
+        public MessageHeaderException(string message, Exception innerException) : this(message, null, null, innerException) { }
+        public MessageHeaderException(string message, string headerName, string ns) : this(message, headerName, ns, null) { }
+        public MessageHeaderException(string message, string headerName, string ns, bool isDuplicate) : this(message, headerName, ns, isDuplicate, null) { }
+        public MessageHeaderException(string message, string headerName, string ns, Exception innerException) : this(message, headerName, ns, false, innerException) { }
+        public MessageHeaderException(string message, string headerName, string ns, bool isDuplicate, Exception innerException) : base(message, innerException)
         {
             HeaderName = headerName;
-            _headerNamespace = ns;
+            HeaderNamespace = ns;
             IsDuplicate = isDuplicate;
         }
 
         public string HeaderName { get; }
 
-        public string HeaderNamespace { get { return _headerNamespace; } }
+        public string HeaderNamespace { get; }
 
         // IsDuplicate==true means there was more than one; IsDuplicate==false means there were zero
         public bool IsDuplicate { get; }
@@ -62,6 +42,6 @@ namespace System.ServiceModel
 
         // for serialization
         public MessageHeaderException() { }
-        protected MessageHeaderException(SerializationInfo info, StreamingContext context) : base(info, context) { throw new PlatformNotSupportedException(); }
+        protected MessageHeaderException(SerializationInfo info, StreamingContext context) : base(info, context) { }
     }
 }

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/MustUnderstandSoapException.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/MustUnderstandSoapException.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-
 using System.Xml;
 using System.Globalization;
 using System.Collections.ObjectModel;
@@ -11,11 +10,12 @@ using System.ServiceModel.Channels;
 
 namespace System.ServiceModel
 {
+    [Serializable]
     internal class MustUnderstandSoapException : CommunicationException
     {
         // for serialization
         public MustUnderstandSoapException() { }
-        protected MustUnderstandSoapException(SerializationInfo info, StreamingContext context) : base(info, context) { throw new PlatformNotSupportedException(); }
+        protected MustUnderstandSoapException(SerializationInfo info, StreamingContext context) : base(info, context) { }
 
         private EnvelopeVersion _envelopeVersion;
 

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/ProtocolException.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/ProtocolException.cs
@@ -8,12 +8,13 @@ using System.ServiceModel.Channels;
 
 namespace System.ServiceModel
 {
+    [Serializable]
     public class ProtocolException : CommunicationException
     {
         public ProtocolException() { }
         public ProtocolException(string message) : base(message) { }
         public ProtocolException(string message, Exception innerException) : base(message, innerException) { }
-        protected ProtocolException(SerializationInfo info, StreamingContext context) : base(info, context) { throw new PlatformNotSupportedException(); }
+        protected ProtocolException(SerializationInfo info, StreamingContext context) : base(info, context) { }
 
         internal static ProtocolException ReceiveShutdownReturnedNonNull(Message message)
         {

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/QuotaExceededException.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/QuotaExceededException.cs
@@ -2,33 +2,17 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-
 using System.Runtime.Serialization;
 
 namespace System.ServiceModel
 {
+    [Serializable]
     public class QuotaExceededException : Exception
     {
-        public QuotaExceededException()
-            : base()
-        {
-        }
-
-        public QuotaExceededException(string message)
-            : base(message)
-        {
-        }
-
-        public QuotaExceededException(string message, Exception innerException)
-            : base(message, innerException)
-        {
-        }
-
-        protected QuotaExceededException(SerializationInfo info, StreamingContext context)
-            : base(info, context)
-        {
-            throw new PlatformNotSupportedException();
-        }
+        public QuotaExceededException() : base() { }
+        public QuotaExceededException(string message) : base(message) { }
+        public QuotaExceededException(string message, Exception innerException) : base(message, innerException) { }
+        protected QuotaExceededException(SerializationInfo info, StreamingContext context) : base(info, context) { }
     }
 }
 

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/MessageSecurityException.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/MessageSecurityException.cs
@@ -3,55 +3,15 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Runtime.Serialization;
-using System.ServiceModel.Channels;
 
 namespace System.ServiceModel.Security
 {
+    [Serializable]
     public class MessageSecurityException : CommunicationException
     {
-        private bool _isReplay = false;
-
-        public MessageSecurityException()
-            : base()
-        {
-        }
-
-        public MessageSecurityException(String message)
-            : base(message)
-        {
-        }
-
-        public MessageSecurityException(String message, Exception innerException)
-            : base(message, innerException)
-        {
-        }
-
-        protected MessageSecurityException(SerializationInfo info, StreamingContext context)
-            : base(info, context)
-        {
-            throw new PlatformNotSupportedException();
-        }
-
-        internal MessageSecurityException(string message, Exception innerException, MessageFault fault)
-            : base(message, innerException)
-        {
-            Fault = fault;
-        }
-
-        internal MessageSecurityException(String message, bool isReplay)
-            : base(message)
-        {
-            _isReplay = isReplay;
-        }
-
-        internal bool ReplayDetected
-        {
-            get
-            {
-                return _isReplay;
-            }
-        }
-
-        internal MessageFault Fault { get; }
+        public MessageSecurityException() : base() { }
+        public MessageSecurityException(string message) : base(message) { }
+        public MessageSecurityException(string message, Exception innerException) : base(message, innerException) { }
+        protected MessageSecurityException(SerializationInfo info, StreamingContext context) : base(info, context) { }
     }
 }

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SecurityAccessDeniedException.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SecurityAccessDeniedException.cs
@@ -6,22 +6,11 @@ using System.Runtime.Serialization;
 
 namespace System.ServiceModel.Security
 {
+    [Serializable]
     public class SecurityAccessDeniedException : CommunicationException
     {
-        public SecurityAccessDeniedException(String message)
-            : base(message)
-        {
-        }
-
-        public SecurityAccessDeniedException(String message, Exception innerException)
-            : base(message, innerException)
-        {
-        }
-
-        protected SecurityAccessDeniedException(SerializationInfo info, StreamingContext context)
-            : base(info, context)
-        {
-            throw new PlatformNotSupportedException();
-        }
+        public SecurityAccessDeniedException(string message) : base(message) { }
+        public SecurityAccessDeniedException(string message, Exception innerException) : base(message, innerException) { }
+        protected SecurityAccessDeniedException(SerializationInfo info, StreamingContext context) : base(info, context) { }
     }
 }

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SecurityNegotiationException.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SecurityNegotiationException.cs
@@ -6,27 +6,12 @@ using System.Runtime.Serialization;
 
 namespace System.ServiceModel.Security
 {
+    [Serializable]
     public class SecurityNegotiationException : CommunicationException
     {
-        public SecurityNegotiationException()
-            : base()
-        {
-        }
-
-        public SecurityNegotiationException(String message)
-            : base(message)
-        {
-        }
-
-        public SecurityNegotiationException(String message, Exception innerException)
-            : base(message, innerException)
-        {
-        }
-
-        protected SecurityNegotiationException(SerializationInfo info, StreamingContext context)
-            : base(info, context)
-        {
-            throw new PlatformNotSupportedException();
-        }
+        public SecurityNegotiationException() : base() { }
+        public SecurityNegotiationException(string message) : base(message) { }
+        public SecurityNegotiationException(String message, Exception innerException) : base(message, innerException) { }
+        protected SecurityNegotiationException(SerializationInfo info, StreamingContext context) : base(info, context) { }
     }
 }

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SessionKeyExpiredException.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SessionKeyExpiredException.cs
@@ -9,24 +9,9 @@ namespace System.ServiceModel.Security
     [Serializable]
     internal class SessionKeyExpiredException : MessageSecurityException
     {
-        public SessionKeyExpiredException()
-            : base()
-        {
-        }
-
-        public SessionKeyExpiredException(string message)
-            : base(message)
-        {
-        }
-
-        public SessionKeyExpiredException(string message, Exception innerException)
-            : base(message, innerException)
-        {
-        }
-
-        protected SessionKeyExpiredException(SerializationInfo info, StreamingContext context)
-            : base(info, context)
-        {
-        }
+        public SessionKeyExpiredException() : base() { }
+        public SessionKeyExpiredException(string message) : base(message) { }
+        public SessionKeyExpiredException(string message, Exception innerException) : base(message, innerException) { }
+        protected SessionKeyExpiredException(SerializationInfo info, StreamingContext context) : base(info, context) { }
     }
 }

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/Tokens/SecurityContextTokenValidationException.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/Tokens/SecurityContextTokenValidationException.cs
@@ -10,24 +10,9 @@ namespace System.ServiceModel.Security.Tokens
     [Serializable]
     class SecurityContextTokenValidationException : SecurityTokenValidationException
     {
-        public SecurityContextTokenValidationException()
-            : base()
-        {
-        }
-
-        public SecurityContextTokenValidationException(string message)
-            : base(message)
-        {
-        }
-
-        public SecurityContextTokenValidationException(string message, Exception innerException)
-            : base(message, innerException)
-        {
-        }
-
-        protected SecurityContextTokenValidationException(SerializationInfo info, StreamingContext context)
-            : base(info, context)
-        {
-        }
+        public SecurityContextTokenValidationException() : base() { }
+        public SecurityContextTokenValidationException(string message) : base(message) { }
+        public SecurityContextTokenValidationException(string message, Exception innerException) : base(message, innerException) { }
+        protected SecurityContextTokenValidationException(SerializationInfo info, StreamingContext context) : base(info, context) { }
     }
 }

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/ServerTooBusyException.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/ServerTooBusyException.cs
@@ -7,11 +7,12 @@ using System.Runtime.Serialization;
 
 namespace System.ServiceModel
 {
+    [Serializable]
     public class ServerTooBusyException : CommunicationException
     {
         public ServerTooBusyException() { }
         public ServerTooBusyException(string message) : base(message) { }
         public ServerTooBusyException(string message, Exception innerException) : base(message, innerException) { }
-        protected ServerTooBusyException(SerializationInfo info, StreamingContext context) : base(info, context) { throw new PlatformNotSupportedException(); }
+        protected ServerTooBusyException(SerializationInfo info, StreamingContext context) : base(info, context) { }
     }
 }

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/ServiceActivationException.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/ServiceActivationException.cs
@@ -2,16 +2,16 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-
 using System.Runtime.Serialization;
 
 namespace System.ServiceModel
 {
+    [Serializable]
     public class ServiceActivationException : CommunicationException
     {
         public ServiceActivationException() { }
         public ServiceActivationException(string message) : base(message) { }
         public ServiceActivationException(string message, Exception innerException) : base(message, innerException) { }
-        protected ServiceActivationException(SerializationInfo info, StreamingContext context) : base(info, context) { throw new PlatformNotSupportedException(); }
+        protected ServiceActivationException(SerializationInfo info, StreamingContext context) : base(info, context) { }
     }
 }

--- a/src/System.ServiceModel.Primitives/tests/ServiceModel/FaultExceptionTest.cs
+++ b/src/System.ServiceModel.Primitives/tests/ServiceModel/FaultExceptionTest.cs
@@ -3,6 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 
+using System;
+using System.Globalization;
 using System.IO;
 using System.Runtime.Serialization;
 using System.ServiceModel;
@@ -23,14 +25,35 @@ public static class FaultExceptionTest
         Assert.NotNull(exception.Code);
         Assert.Equal(detail, exception.Detail);
         Assert.Equal(reason, exception.Reason);
-        
+
         FaultDetail nullDetail = null;
         FaultReason nullReason = null;
         var exception2 = new FaultException<FaultDetail>(nullDetail, nullReason);
         Assert.NotNull(exception2);
         Assert.NotNull(exception2.Code);
         Assert.NotNull(exception2.Reason);
-        Assert.Null(exception2.Detail);        
+        Assert.Null(exception2.Detail);
+    }
+
+    [WcfFact]
+    public static void Serializable_TDetail()
+    {
+        // This isn't exactly what NetFx generates as the HResult is different due to CommunicationException deriving from SystemException on NetFx
+        string netfxBsl = @"<FaultExceptionOfFaultDetailInChYzgb xmlns=""http://schemas.datacontract.org/2004/07/System.ServiceModel"" xmlns:i=""http://www.w3.org/2001/XMLSchema-instance"" xmlns:x=""http://www.w3.org/2001/XMLSchema""><ClassName i:type=""x:string"" xmlns="""">System.ServiceModel.FaultException`1[FaultDetail]</ClassName><Message i:type=""x:string"" xmlns="""">The creator of this fault did not specify a Reason.</Message><Data i:nil=""true"" xmlns=""""/><InnerException i:nil=""true"" xmlns=""""/><HelpURL i:nil=""true"" xmlns=""""/><StackTraceString i:nil=""true"" xmlns=""""/><RemoteStackTraceString i:nil=""true"" xmlns=""""/><RemoteStackIndex i:type=""x:int"" xmlns="""">0</RemoteStackIndex><ExceptionMethod i:nil=""true"" xmlns=""""/><HResult i:type=""x:int"" xmlns="""">-2146233088</HResult><Source i:nil=""true"" xmlns=""""/><WatsonBuckets i:nil=""true"" xmlns=""""/><code i:type=""a:ArrayOfFaultException.FaultCodeData"" xmlns="""" xmlns:a=""http://schemas.datacontract.org/2004/07/System.ServiceModel""><a:FaultException.FaultCodeData><a:name>Sender</a:name><a:ns/></a:FaultException.FaultCodeData></code><reason i:type=""a:ArrayOfFaultException.FaultReasonData"" xmlns="""" xmlns:a=""http://schemas.datacontract.org/2004/07/System.ServiceModel""><a:FaultException.FaultReasonData><a:text>The creator of this fault did not specify a Reason.</a:text><a:xmlLang>en-US</a:xmlLang></a:FaultException.FaultReasonData></reason><messageFault i:nil=""true"" xmlns=""""/><action i:nil=""true"" xmlns=""""/><detail i:type=""a:FaultDetail"" xmlns="""" xmlns:a=""http://www.contoso.com/wcfnamespace""><a:Message>Fault Message</a:Message></detail></FaultExceptionOfFaultDetailInChYzgb>";
+        var dcs = new DataContractSerializer(typeof(FaultException<FaultDetail>));
+        using (var ms = new MemoryStream())
+        {
+            using (var sr = new StreamReader(ms))
+            {
+                dcs.WriteObject(ms, new FaultException<FaultDetail>(new FaultDetail("Fault Message")));
+                ms.Position = 0;
+                Assert.Equal(netfxBsl, sr.ReadToEnd());
+                ms.Position = 0;
+                var faultException = (FaultException<FaultDetail>)dcs.ReadObject(ms);
+                Assert.NotNull(faultException.Detail);
+                Assert.Equal("Fault Message", faultException.Detail.Message);
+            }
+        }
     }
 
     [WcfFact]
@@ -40,12 +63,28 @@ public static class FaultExceptionTest
         var dcs = new DataContractSerializer(typeof(FaultException));
 
         using (var ms = new MemoryStream())
-        using (var sr = new StreamReader(ms))
         {
-            dcs.WriteObject(ms, new FaultException());
-            ms.Position = 0;
-            Assert.Equal(netfxBsl, sr.ReadToEnd());
-        }            
+            using (var sr = new StreamReader(ms))
+            {
+                dcs.WriteObject(ms, new FaultException());
+                ms.Position = 0;
+                Assert.Equal(netfxBsl, sr.ReadToEnd());
+                ms.Position = 0;
+                var faultException = (FaultException)dcs.ReadObject(ms);
+                Assert.Equal("The creator of this fault did not specify a Reason.", faultException.Message);
+                Assert.Null(faultException.Action);
+                Assert.NotNull(faultException.Code);
+                Assert.Equal("Sender", faultException.Code.Name);
+                Assert.Equal(string.Empty, faultException.Code.Namespace);
+                Assert.Null(faultException.Code.SubCode);
+                Assert.NotNull(faultException.Reason);
+                var reasonTranslations = faultException.Reason.Translations;
+                Assert.Single(reasonTranslations);
+                var faultReasonText = reasonTranslations[0];
+                Assert.Equal(CultureInfo.CurrentCulture.Name, faultReasonText.XmlLang);
+                Assert.Equal("The creator of this fault did not specify a Reason.", faultReasonText.Text);
+            }
+        }
     }
 
     [WcfFact]


### PR DESCRIPTION
Fixes #4448
Also improves the use of DataContractSerializer with FaultException\<TDetail\> so you don't need to provide typeof(TDetail) to DataContractSerializer.