### PR TITLE
Make federation implementation async and fix memory leak

### DIFF
--- a/src/Common/src/Internals/System/Runtime/Diagnostics/EventTraceActivity.cs
+++ b/src/Common/src/Internals/System/Runtime/Diagnostics/EventTraceActivity.cs
@@ -49,9 +49,6 @@ namespace System.Runtime.Diagnostics
             get { return "E2EActivity"; }
         }
 
-        [Fx.Tag.SecurityNote(Critical = "Critical because the CorrelationManager property has a link demand on UnmanagedCode.",
-            Safe = "We do not leak security data.")]
-        [SecuritySafeCritical]
         public static EventTraceActivity GetFromThreadOrCreate(bool clearIdOnThread = false)
         {
             Guid guid = Trace.CorrelationManager.ActivityId;
@@ -68,17 +65,11 @@ namespace System.Runtime.Diagnostics
             return new EventTraceActivity(guid);
         }
 
-        [Fx.Tag.SecurityNote(Critical = "Critical because the CorrelationManager property has a link demand on UnmanagedCode.",
-            Safe = "We do not leak security data.")]
-        [SecuritySafeCritical]
         public static Guid GetActivityIdFromThread()
         {
             return EventSource.CurrentThreadActivityId;
         }
 
-        [Fx.Tag.SecurityNote(Critical = "Critical because the CorrelationManager property has a link demand on UnmanagedCode.",
-                    Safe = "We do not leak security data.")]
-        [SecuritySafeCritical]
         private void SetActivityIdOnThread()
         {
             EventSource.SetCurrentThreadActivityId(ActivityId);

--- a/src/Common/src/Internals/System/Runtime/WcfEventSource.cs
+++ b/src/Common/src/Internals/System/Runtime/WcfEventSource.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Diagnostics.Tracing;
+using System.Runtime.Diagnostics;
 
 namespace System.Runtime
 {
@@ -79,10 +80,29 @@ namespace System.Runtime
             ThrowingEtwExceptionVerbose(data1, data2, SerializedException, "");
         }
 
+        [NonEvent]
+        private void TransferActivityId(EventTraceActivity eventTraceActivity)
+        {
+            if (eventTraceActivity != null)
+            {
+                Guid oldGuid;
+                SetCurrentThreadActivityId(eventTraceActivity.ActivityId, out oldGuid);
+            }
+        }
+
+        [NonEvent]
+        private void SetActivityId(EventTraceActivity eventTraceActivity)
+        {
+            if (eventTraceActivity != null)
+            {
+                SetCurrentThreadActivityId(eventTraceActivity.ActivityId);
+            }
+        }
         #region Keywords / Tasks / Opcodes
 
         public partial class EventIds
         {
+            public const int SecurityTokenProviderOpened = 3332;
             public const int EtwUnhandledException = 57408;
             public const int ThrowingEtwExceptionVerbose = 57409;
             public const int ThrowingEtwException = 57410;
@@ -90,8 +110,8 @@ namespace System.Runtime
 
         public partial class Keywords
         {
+            public const EventKeywords Security = (EventKeywords)0x10;
             public const EventKeywords Infrastructure = (EventKeywords)0x10000;
-
         }
 
         public class ChannelKeywords
@@ -100,6 +120,11 @@ namespace System.Runtime
             public const EventKeywords Operational = unchecked((EventKeywords)0x4000000000000000);
             public const EventKeywords Analytic = unchecked((EventKeywords)0x2000000000000000);
             public const EventKeywords Debug = unchecked((EventKeywords)0x1000000000000000);
+        }
+
+        public partial class Tasks
+        {
+            public const EventTask SecureMessage = (EventTask)2571;
         }
         #endregion
     }

--- a/src/Common/src/System/ServiceModel/Diagnostics/ExceptionUtility.cs
+++ b/src/Common/src/System/ServiceModel/Diagnostics/ExceptionUtility.cs
@@ -13,11 +13,20 @@ namespace System.ServiceModel.Diagnostics
             return ThrowHelper(exception, EventLevel.Error);
         }
 
+        internal Exception ThrowHelperError(Exception exception, Guid activityId, object source)
+        {
+            return exception;
+        }
+
         internal Exception ThrowHelper(Exception exception, EventLevel eventLevel)
         {
             FxTrace.Exception.TraceEtwException(exception, eventLevel);
             return exception;
         }
 
+        internal ArgumentNullException ThrowHelperArgumentNull(string paramName)
+        {
+            return (ArgumentNullException)ThrowHelperError(new ArgumentNullException(paramName));
+        }
     }
 }

--- a/src/System.Private.ServiceModel/src/Internals/WcfEventSource.cs
+++ b/src/System.Private.ServiceModel/src/Internals/WcfEventSource.cs
@@ -2062,26 +2062,6 @@ namespace System.Runtime
         {
             ThrowingExceptionVerbose(data1, data2, SerializedException, "");
         }
-
-        [NonEvent]
-        private void SetActivityId(EventTraceActivity eventTraceActivity)
-        {
-            if (eventTraceActivity != null)
-            {
-                SetCurrentThreadActivityId(eventTraceActivity.ActivityId);
-            }
-        }
-
-        [NonEvent]
-        private void TransferActivityId(EventTraceActivity eventTraceActivity)
-        {
-            if (eventTraceActivity != null)
-            {
-                Guid oldGuid;
-                SetCurrentThreadActivityId(eventTraceActivity.ActivityId, out oldGuid);
-            }
-        }
-
         #region Keywords / Tasks / Opcodes
 
         public partial class EventIds
@@ -2307,7 +2287,7 @@ namespace System.Runtime
             public const int ClientFormatterDeserializeReplyStop = 3329;
             public const int SecurityNegotiationStart = 3330;
             public const int SecurityNegotiationStop = 3331;
-            public const int SecurityTokenProviderOpened = 3332;
+            //public const int SecurityTokenProviderOpened = 3332;
             public const int OutgoingMessageSecured = 3333;
             public const int IncomingMessageVerified = 3334;
             public const int GetServiceInstanceStart = 3335;
@@ -2569,7 +2549,7 @@ namespace System.Runtime
             public const int HttpHandlerPickedForUrl = 62326;
         }
 
-        public class Tasks
+        public partial class Tasks
         {
             public const EventTask ActivationDispatchSession = (EventTask)2500;
             public const EventTask ActivationDuplicateSocket = (EventTask)2501;
@@ -2640,7 +2620,7 @@ namespace System.Runtime
             public const EventTask RuntimeTransaction = (EventTask)2568;
             public const EventTask ScheduleActivity = (EventTask)2569;
             public const EventTask ScheduleWorkItem = (EventTask)2570;
-            public const EventTask SecureMessage = (EventTask)2571;
+            //public const EventTask SecureMessage = (EventTask)2571;
             public const EventTask SecurityImpersonation = (EventTask)2572;
             public const EventTask SecurityNegotiation = (EventTask)2573;
             public const EventTask SecurityVerification = (EventTask)2574;
@@ -2841,7 +2821,7 @@ namespace System.Runtime
             public const EventKeywords Serialization = (EventKeywords)0x2;
             public const EventKeywords ServiceModel = (EventKeywords)0x4;
             public const EventKeywords Transaction = (EventKeywords)0x8;
-            public const EventKeywords Security = (EventKeywords)0x10;
+            //public const EventKeywords Security = (EventKeywords)0x10;
             public const EventKeywords WCFMessageLogging = (EventKeywords)0x20;
             public const EventKeywords WFTracking = (EventKeywords)0x40;
             public const EventKeywords WebHost = (EventKeywords)0x80;

--- a/src/System.Private.ServiceModel/src/SMDiagnostics/System/ServiceModel/Diagnostics/ExceptionUtility.cs
+++ b/src/System.Private.ServiceModel/src/SMDiagnostics/System/ServiceModel/Diagnostics/ExceptionUtility.cs
@@ -28,11 +28,6 @@ namespace System.ServiceModel.Diagnostics
             return (ArgumentException)ThrowHelperError(new ArgumentException(message, paramName));
         }
 
-        public ArgumentNullException ThrowHelperArgumentNull(string paramName)
-        {
-            return (ArgumentNullException)ThrowHelperError(new ArgumentNullException(paramName));
-        }
-
         public ArgumentNullException ThrowHelperArgumentNull(string paramName, string message)
         {
             return (ArgumentNullException)ThrowHelperError(new ArgumentNullException(paramName, message));

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SecurityProtocol.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SecurityProtocol.cs
@@ -337,7 +337,7 @@ namespace System.ServiceModel.Security
                         SecurityProtocolFactory.ExpectSupportingTokens = true;
                         foreach (SupportingTokenProviderSpecification tokenProviderSpec in ChannelSupportingTokenProviderSpecification)
                         {
-                            SecurityUtils.OpenTokenProviderIfRequired(tokenProviderSpec.TokenProvider, timeoutHelper.RemainingTime());
+                            await SecurityUtils.OpenTokenProviderIfRequiredAsync(tokenProviderSpec.TokenProvider, timeoutHelper.RemainingTime());
                             if (tokenProviderSpec.SecurityTokenAttachmentMode == SecurityTokenAttachmentMode.Endorsing || tokenProviderSpec.SecurityTokenAttachmentMode == SecurityTokenAttachmentMode.SignedEndorsing)
                             {
                                 if (tokenProviderSpec.TokenParameters.RequireDerivedKeys && !tokenProviderSpec.TokenParameters.HasAsymmetricKey)

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SecuritySessionClientSettings.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SecuritySessionClientSettings.cs
@@ -487,7 +487,7 @@ namespace System.ServiceModel.Security
             {
                 TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
                 SetupSessionTokenProvider();
-                SecurityUtils.OpenTokenProviderIfRequired(_sessionTokenProvider, timeoutHelper.RemainingTime());
+                await SecurityUtils.OpenTokenProviderIfRequiredAsync(_sessionTokenProvider, timeoutHelper.RemainingTime());
                 using (ServiceModelActivity activity = DiagnosticUtility.ShouldUseActivity ?
                     ServiceModelActivity.CreateBoundedActivity() : null)
                 {

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SecurityUtils.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Security/SecurityUtils.cs
@@ -780,7 +780,11 @@ namespace System.ServiceModel.Security
                 return OpenCommunicationObjectAsync(aco, timeout);
             }
 
-            OpenCommunicationObject(tokenProvider as ICommunicationObject, timeout);
+            if (tokenProvider is ICommunicationObject communicationObject && communicationObject != null)
+            {
+                return Task.Factory.FromAsync(communicationObject.BeginOpen, communicationObject.EndOpen, timeout, null, TaskCreationOptions.None);
+            }
+
             return Task.CompletedTask;
         }
 
@@ -802,7 +806,11 @@ namespace System.ServiceModel.Security
                 return CloseCommunicationObjectAsync(aco, false, timeout);
             }
 
-            CloseCommunicationObject(tokenProvider, false, timeout);
+            if (tokenProvider is ICommunicationObject communicationObject && communicationObject != null)
+            {
+                return Task.Factory.FromAsync(communicationObject.BeginClose, communicationObject.EndClose, timeout, null, TaskCreationOptions.None);
+            }
+
             return Task.CompletedTask;
         }
 

--- a/src/System.ServiceModel.Federation/src/Resources/Strings.resx
+++ b/src/System.ServiceModel.Federation/src/Resources/Strings.resx
@@ -123,4 +123,10 @@
   <data name="SecurityServerTooBusy" xml:space="preserve">
     <value>Server '{0}' sent back a fault indicating it is too busy to process the request. Please retry later. Please see the inner exception for fault details.</value>
   </data>
+  <data name="CommunicationObjectFaulted1" xml:space="preserve">
+    <value>The communication object, {0}, cannot be used for communication because it is in the Faulted state.</value>
+  </data>
+  <data name="CommunicationObjectCannotBeUsed" xml:space="preserve">
+    <value>The communication object, {0}, is in the {1} state.  Communication objects cannot be used for communication unless they are in the Opened state.</value>
+  </data>
 </root>

--- a/src/System.ServiceModel.Federation/src/System/IdentityModel/Security/WrapperSecurityCommunicationObject.cs
+++ b/src/System.ServiceModel.Federation/src/System/IdentityModel/Security/WrapperSecurityCommunicationObject.cs
@@ -1,0 +1,146 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime;
+using System.ServiceModel;
+using System.ServiceModel.Channels;
+using System.ServiceModel.Federation.System.Runtime;
+using System.ServiceModel.Security;
+
+namespace System.IdentityModel.Security
+{
+    internal class WrapperSecurityCommunicationObject : CommunicationObject
+    {
+        ISecurityCommunicationObject _innerCommunicationObject;
+
+        public WrapperSecurityCommunicationObject(ISecurityCommunicationObject innerCommunicationObject) : base()
+        {
+            _innerCommunicationObject = innerCommunicationObject ?? throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull(nameof(innerCommunicationObject));
+        }
+
+        protected override Type GetCommunicationObjectType()
+        {
+            return _innerCommunicationObject.GetType();
+        }
+
+        protected override TimeSpan DefaultCloseTimeout
+        {
+            get { return _innerCommunicationObject.DefaultCloseTimeout; }
+        }
+
+        protected override TimeSpan DefaultOpenTimeout
+        {
+            get { return _innerCommunicationObject.DefaultOpenTimeout; }
+        }
+
+        protected override void OnAbort()
+        {
+            _innerCommunicationObject.OnAbort();
+        }
+
+        protected override IAsyncResult OnBeginClose(TimeSpan timeout, AsyncCallback callback, object state)
+        {
+            return _innerCommunicationObject.OnCloseAsync(timeout).ToApm(callback, state);
+        }
+
+        protected override IAsyncResult OnBeginOpen(TimeSpan timeout, AsyncCallback callback, object state)
+        {
+            return _innerCommunicationObject.OnOpenAsync(timeout).ToApm(callback, state);
+        }
+
+        protected override void OnClose(TimeSpan timeout)
+        {
+            _innerCommunicationObject.OnCloseAsync(timeout).GetAwaiter().GetResult();
+        }
+
+        protected override void OnClosed()
+        {
+            _innerCommunicationObject.OnClosed();
+            base.OnClosed();
+        }
+
+        protected override void OnClosing()
+        {
+            _innerCommunicationObject.OnClosing();
+            base.OnClosing();
+        }
+
+        protected override void OnEndClose(IAsyncResult result)
+        {
+            result.ToApmEnd();
+        }
+
+        protected override void OnEndOpen(IAsyncResult result)
+        {
+            result.ToApmEnd();
+        }
+
+        protected override void OnFaulted()
+        {
+            _innerCommunicationObject.OnFaulted();
+            base.OnFaulted();
+        }
+
+        protected override void OnOpen(TimeSpan timeout)
+        {
+            _innerCommunicationObject.OnOpenAsync(timeout).GetAwaiter().GetResult();
+        }
+
+        protected override void OnOpened()
+        {
+            _innerCommunicationObject.OnOpened();
+            base.OnOpened();
+        }
+
+        protected override void OnOpening()
+        {
+            _innerCommunicationObject.OnOpening();
+            base.OnOpening();
+        }
+
+        internal void ThrowIfClosedOrNotOpen()
+        {
+            switch (State)
+            {
+                case CommunicationState.Created:
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(CreateNotOpenException(), Guid.Empty, this);
+
+                case CommunicationState.Opening:
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(CreateNotOpenException(), Guid.Empty, this);
+
+                case CommunicationState.Opened:
+                    break;
+
+                case CommunicationState.Closing:
+                    break;
+
+                case CommunicationState.Closed:
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(CreateClosedException(), Guid.Empty, this);
+
+                case CommunicationState.Faulted:
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(CreateFaultedException(), Guid.Empty, this);
+
+                default:
+                    Fx.Assert("ThrowIfClosedOrNotOpen: Unknown CommunicationObject.state");
+                    throw new Exception("ThrowIfClosedOrNotOpen: Unknown CommunicationObject.state");
+            }
+        }
+
+        private Exception CreateNotOpenException()
+        {
+            return new InvalidOperationException(SR.Format(SR.CommunicationObjectCannotBeUsed, GetCommunicationObjectType().ToString(), State.ToString()));
+        }
+
+        private Exception CreateClosedException()
+        {
+            return new ObjectDisposedException(GetCommunicationObjectType().ToString());
+        }
+
+        internal Exception CreateFaultedException()
+        {
+            string message = SR.Format(SR.CommunicationObjectFaulted1, GetCommunicationObjectType().ToString());
+            return new CommunicationObjectFaultedException(message);
+        }
+    }
+}

--- a/src/System.ServiceModel.Federation/src/System/Runtime/TaskHelpers.cs
+++ b/src/System.ServiceModel.Federation/src/System/Runtime/TaskHelpers.cs
@@ -1,0 +1,87 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace System.ServiceModel.Federation.System.Runtime
+{
+    internal static class TaskHelpers
+    {
+        // Helper method when implementing an APM wrapper around a Task based async method which returns a result. 
+        // In the BeginMethod method, you would call use ToApm to wrap a call to MethodAsync:
+        //     return MethodAsync(params).ToApm(callback, state);
+        // In the EndMethod, you would use ToApmEnd to ensure the correct exception handling
+        // This will handle throwing exceptions in the correct place and ensure the IAsyncResult contains the provided
+        // state object
+        public static Task ToApm(this Task task, AsyncCallback callback, object state)
+        {
+            // When using APM, the returned IAsyncResult must have the passed in state object stored in AsyncState. This
+            // is so the callback can regain state. If the incoming task already holds the state object, there's no need
+            // to create a TaskCompletionSource to ensure the returned (IAsyncResult)Task has the right state object.
+            // This is a performance optimization for this special case.
+            if (task.AsyncState == state)
+            {
+                if (callback != null)
+                {
+                    task.ContinueWith((antecedent, obj) =>
+                    {
+                        var callbackObj = obj as AsyncCallback;
+                        callbackObj(antecedent);
+                    }, callback, CancellationToken.None, TaskContinuationOptions.HideScheduler, TaskScheduler.Default);
+                }
+                return task;
+            }
+
+            // Need to create a TaskCompletionSource so that the returned Task object has the correct AsyncState value.
+            // As we intend to create a task with no Result value, we don't care what result type the TCS holds as we
+            // won't be using it. As Task<TResult> derives from Task, the returned Task is compatible.
+            var tcs = new TaskCompletionSource<object>(state);
+            var continuationState = Tuple.Create(tcs, callback);
+            task.ContinueWith((antecedent, obj) =>
+            {
+                var tuple = obj as Tuple<TaskCompletionSource<object>, AsyncCallback>;
+                var tcsObj = tuple.Item1;
+                var callbackObj = tuple.Item2;
+                if (antecedent.IsFaulted)
+                {
+                    tcsObj.TrySetException(antecedent.Exception.InnerException);
+                }
+                else if (antecedent.IsCanceled)
+                {
+                    tcsObj.TrySetCanceled();
+                }
+                else
+                {
+                    tcsObj.TrySetResult(null);
+                }
+
+                if (callbackObj != null)
+                {
+                    callbackObj(tcsObj.Task);
+                }
+            }, continuationState, CancellationToken.None, TaskContinuationOptions.HideScheduler, TaskScheduler.Default);
+            return tcs.Task;
+        }
+
+        // Helper method to implement the End method of an APM method pair which is wrapping a Task based
+        // async method when the Task does not return result.
+        public static void ToApmEnd(this IAsyncResult iar)
+        {
+            Task task = iar as Task;
+            task.GetAwaiter().GetResult();
+        }
+
+        // Helper method to implement the End method of an APM method pair which is wrapping a Task based
+        // async method when the Task returns a result. By using task.GetAwaiter.GetResult(), the exception
+        // handling conventions are the same as when await'ing a task, i.e. this throws the first exception
+        // and doesn't wrap it in an AggregateException. It also throws the right exception if the task was
+        // cancelled.
+        public static TResult ToApmEnd<TResult>(this IAsyncResult iar)
+        {
+            Task<TResult> task = iar as Task<TResult>;
+            return task.GetAwaiter().GetResult();
+        }
+    }
+}

--- a/src/System.ServiceModel.Federation/src/System/Runtime/WcfEventSource.cs
+++ b/src/System.ServiceModel.Federation/src/System/Runtime/WcfEventSource.cs
@@ -1,0 +1,31 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics.Tracing;
+using System.Runtime.Diagnostics;
+
+namespace System.Runtime
+{
+    internal sealed partial class WcfEventSource : EventSource
+    {
+        public bool SecurityTokenProviderOpenedIsEnabled()
+        {
+            return base.IsEnabled(EventLevel.Verbose, Keywords.Security, EventChannel.Debug);
+        }
+
+        [Event(EventIds.SecurityTokenProviderOpened, Level = EventLevel.Verbose, Channel = EventChannel.Debug, Opcode = EventOpcode.Start, Task = Tasks.SecureMessage,
+            Keywords = Keywords.Security, Message = "SecurityTokenProvider opening completed.")]
+        public void SecurityTokenProviderOpened(string AppDomain)
+        {
+            WriteEvent(EventIds.SecurityTokenProviderOpened, AppDomain);
+        }
+
+        [NonEvent]
+        public void SecurityTokenProviderOpened(EventTraceActivity eventTraceActivity)
+        {
+            SetActivityId(eventTraceActivity);
+            SecurityTokenProviderOpened("");
+        }
+    }
+}

--- a/src/System.ServiceModel.Federation/src/System/ServiceModel/Diagnostics/SecurityTraceRecordHelper.cs
+++ b/src/System.ServiceModel.Federation/src/System/ServiceModel/Diagnostics/SecurityTraceRecordHelper.cs
@@ -1,0 +1,21 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.IdentityModel.Selectors;
+using System.Runtime;
+using System.Runtime.Diagnostics;
+
+namespace System.ServiceModel.Diagnostics
+{
+    internal static class SecurityTraceRecordHelper
+    {
+        internal static void TraceTokenProviderOpened(EventTraceActivity eventTraceActivity, SecurityTokenProvider provider)
+        {
+            if (WcfEventSource.Instance.SecurityTokenProviderOpenedIsEnabled())
+            {
+                WcfEventSource.Instance.SecurityTokenProviderOpened(eventTraceActivity);
+            }
+        }
+    }
+}

--- a/src/System.ServiceModel.Federation/src/System/ServiceModel/Federation/WsTrustChannelSecurityTokenManager.cs
+++ b/src/System.ServiceModel.Federation/src/System/ServiceModel/Federation/WsTrustChannelSecurityTokenManager.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics.Tracing;
 using System.IdentityModel.Selectors;
 using System.ServiceModel.Security.Tokens;
 
@@ -24,7 +25,7 @@ namespace System.ServiceModel.Federation
         public WSTrustChannelSecurityTokenManager(WSTrustChannelClientCredentials wsTrustChannelClientCredentials)
             : base(wsTrustChannelClientCredentials)
         {
-            _wsTrustChannelClientCredentials = wsTrustChannelClientCredentials ?? throw DiagnosticUtility.ExceptionUtility.ThrowHelper(new ArgumentNullException(nameof(wsTrustChannelClientCredentials)), System.Diagnostics.Tracing.EventLevel.Error);
+            _wsTrustChannelClientCredentials = wsTrustChannelClientCredentials ?? throw DiagnosticUtility.ExceptionUtility.ThrowHelper(new ArgumentNullException(nameof(wsTrustChannelClientCredentials)), EventLevel.Error);
         }
 
         /// <summary>
@@ -35,7 +36,7 @@ namespace System.ServiceModel.Federation
         public override SecurityTokenProvider CreateSecurityTokenProvider(SecurityTokenRequirement tokenRequirement)
         {
             if (tokenRequirement == null)
-                throw DiagnosticUtility.ExceptionUtility.ThrowHelper(new ArgumentNullException(nameof(tokenRequirement)), System.Diagnostics.Tracing.EventLevel.Error);
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelper(new ArgumentNullException(nameof(tokenRequirement)), EventLevel.Error);
 
             // If the token requirement includes an issued security token parameter of type
             // WSTrustTokenParameters, then tokens should be provided by a WSTrustChannelSecurityTokenProvider.

--- a/src/System.ServiceModel.Federation/src/System/ServiceModel/Federation/WsTrustTokenParameters.cs
+++ b/src/System.ServiceModel.Federation/src/System/ServiceModel/Federation/WsTrustTokenParameters.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Diagnostics.Tracing;
 using System.IdentityModel.Tokens;
 using System.ServiceModel.Channels;
 using System.ServiceModel.Security.Tokens;
@@ -92,7 +93,7 @@ namespace System.ServiceModel.Federation
         {
             get => _issuedTokenRenewalThresholdPercentage;
             set => _issuedTokenRenewalThresholdPercentage = (value <= 0 || value > 100)
-                ? throw DiagnosticUtility.ExceptionUtility.ThrowHelper(new ArgumentOutOfRangeException(nameof(value), LogHelper.FormatInvariant("IssuedTokenRenewalThresholdPercentage  must be greater than or equal to 1 and less than or equal to 100. Was: '{0}'.", value)), System.Diagnostics.Tracing.EventLevel.Error)
+                ? throw DiagnosticUtility.ExceptionUtility.ThrowHelper(new ArgumentOutOfRangeException(nameof(value), LogHelper.FormatInvariant("IssuedTokenRenewalThresholdPercentage  must be greater than or equal to 1 and less than or equal to 100. Was: '{0}'.", value)), EventLevel.Error)
                 : value;
         }
 
@@ -108,7 +109,7 @@ namespace System.ServiceModel.Federation
         {
             get => _maxIssuedTokenCachingTime;
             set => _maxIssuedTokenCachingTime = value <= TimeSpan.Zero
-                ? throw DiagnosticUtility.ExceptionUtility.ThrowHelper(new ArgumentOutOfRangeException(nameof(value), LogHelper.FormatInvariant("MaxIssuedTokenCachingTime must be greater than TimeSpan.Zero. Was: '{0}'.", value)), System.Diagnostics.Tracing.EventLevel.Error)
+                ? throw DiagnosticUtility.ExceptionUtility.ThrowHelper(new ArgumentOutOfRangeException(nameof(value), LogHelper.FormatInvariant("MaxIssuedTokenCachingTime must be greater than TimeSpan.Zero. Was: '{0}'.", value)), EventLevel.Error)
                 : value;
         }
 
@@ -118,7 +119,7 @@ namespace System.ServiceModel.Federation
         public MessageSecurityVersion MessageSecurityVersion
         {
             get => _messageSecurityVersion;
-            set => _messageSecurityVersion = value ?? throw DiagnosticUtility.ExceptionUtility.ThrowHelper(new ArgumentNullException(nameof(value)), System.Diagnostics.Tracing.EventLevel.Error);
+            set => _messageSecurityVersion = value ?? throw DiagnosticUtility.ExceptionUtility.ThrowHelper(new ArgumentNullException(nameof(value)), EventLevel.Error);
         }
 
         /// <summary>

--- a/src/System.ServiceModel.Federation/src/System/ServiceModel/Security/ISecurityCommunicationObject.cs
+++ b/src/System.ServiceModel.Federation/src/System/ServiceModel/Security/ISecurityCommunicationObject.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading.Tasks;
+
+namespace System.ServiceModel.Security
+{
+    internal interface ISecurityCommunicationObject
+    {
+        TimeSpan DefaultOpenTimeout { get; }
+        TimeSpan DefaultCloseTimeout { get; }
+        void OnAbort();
+        Task OnCloseAsync(TimeSpan timeout);
+        Task OnOpenAsync(TimeSpan timeout);
+        void OnClosed();
+        void OnClosing();
+        void OnFaulted();
+        void OnOpened();
+        void OnOpening();
+    }
+}

--- a/src/System.ServiceModel.Federation/src/System/ServiceModel/ServiceDefaults.cs
+++ b/src/System.ServiceModel.Federation/src/System/ServiceModel/ServiceDefaults.cs
@@ -1,0 +1,12 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.ServiceModel
+{
+    internal static class ServiceDefaults
+    {
+        internal static TimeSpan CloseTimeout { get; } = TimeSpan.FromMinutes(1);
+        internal static TimeSpan OpenTimeout { get; } = TimeSpan.FromMinutes(1);
+    }
+}


### PR DESCRIPTION
Implemented BeginGetTokenCore and EndGetTokenCore to provide async implementation and fixed memory leak around ChannelFactory and channel lifetime.
Fixes #4462
Fixes #4461