### PR TITLE
Fix NullReferenceException when using BasicHttpBinding and NTLM web proxy authentication

### DIFF
--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/HttpChannelFactory.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/HttpChannelFactory.cs
@@ -96,6 +96,7 @@ namespace System.ServiceModel.Channels
             }
 
             AuthenticationScheme = bindingElement.AuthenticationScheme;
+            ProxyAuthenticationScheme = bindingElement.ProxyAuthenticationScheme;
             MaxBufferSize = bindingElement.MaxBufferSize;
             TransferMode = bindingElement.TransferMode;
             _keepAliveEnabled = bindingElement.KeepAliveEnabled;
@@ -137,6 +138,7 @@ namespace System.ServiceModel.Channels
         public bool AllowCookies { get; }
 
         public AuthenticationSchemes AuthenticationScheme { get; }
+        public AuthenticationSchemes ProxyAuthenticationScheme { get; }
 
         public virtual bool IsChannelBindingSupportEnabled
         {
@@ -556,7 +558,7 @@ namespace System.ServiceModel.Channels
 
         protected virtual bool IsSecurityTokenManagerRequired()
         {
-            return AuthenticationScheme != AuthenticationSchemes.Anonymous;
+            return ProxyAuthenticationScheme != AuthenticationSchemes.Anonymous || AuthenticationScheme != AuthenticationSchemes.Anonymous;
         }
 
         protected override IAsyncResult OnBeginOpen(TimeSpan timeout, AsyncCallback callback, object state)

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/HttpChannelFactory.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/HttpChannelFactory.cs
@@ -96,7 +96,6 @@ namespace System.ServiceModel.Channels
             }
 
             AuthenticationScheme = bindingElement.AuthenticationScheme;
-            ProxyAuthenticationScheme = bindingElement.ProxyAuthenticationScheme;
             MaxBufferSize = bindingElement.MaxBufferSize;
             TransferMode = bindingElement.TransferMode;
             _keepAliveEnabled = bindingElement.KeepAliveEnabled;
@@ -138,7 +137,6 @@ namespace System.ServiceModel.Channels
         public bool AllowCookies { get; }
 
         public AuthenticationSchemes AuthenticationScheme { get; }
-        public AuthenticationSchemes ProxyAuthenticationScheme { get; }
 
         public virtual bool IsChannelBindingSupportEnabled
         {
@@ -356,7 +354,7 @@ namespace System.ServiceModel.Channels
                     httpClient.DefaultRequestHeaders.ExpectContinue = true;
                 }
 
-                // We provide our own CancellationToken for each request. Setting HttpClient.Timeout to -1 
+                // We provide our own CancellationToken for each request. Setting HttpClient.Timeout to -1
                 // prevents a call to CancellationToken.CancelAfter that HttpClient does internally which
                 // causes TimerQueue contention at high load.
                 httpClient.Timeout = Timeout.InfiniteTimeSpan;
@@ -558,7 +556,18 @@ namespace System.ServiceModel.Channels
 
         protected virtual bool IsSecurityTokenManagerRequired()
         {
-            return ProxyAuthenticationScheme != AuthenticationSchemes.Anonymous || AuthenticationScheme != AuthenticationSchemes.Anonymous;
+            if (AuthenticationScheme != AuthenticationSchemes.Anonymous)
+            {
+                return true;
+            }
+            if (_proxyFactory != null && _proxyFactory.AuthenticationScheme != AuthenticationSchemes.Anonymous)
+            {
+                return true;
+            }
+            else
+            {
+                return false;
+            }
         }
 
         protected override IAsyncResult OnBeginOpen(TimeSpan timeout, AsyncCallback callback, object state)
@@ -1000,7 +1009,7 @@ namespace System.ServiceModel.Channels
                     {
                         if (_channel.State != CommunicationState.Opened)
                         {
-                            // if we were aborted while getting our request or doing correlation, 
+                            // if we were aborted while getting our request or doing correlation,
                             // we need to abort the request and bail
                             Cleanup();
                             _channel.ThrowIfDisposedOrNotOpen();
@@ -1282,7 +1291,7 @@ namespace System.ServiceModel.Channels
                         }
                     }
 
-                    // since we don't get the output stream in send when retVal == true, 
+                    // since we don't get the output stream in send when retVal == true,
                     // we need to disable chunking for some verbs (DELETE/PUT)
                     if (suppressEntityBody)
                     {
@@ -1318,7 +1327,7 @@ namespace System.ServiceModel.Channels
                     }
 
                     var requestUri = _httpRequestMessage.RequestUri;
-                    // sends a HEAD request to the specificed requestUri for authentication purposes 
+                    // sends a HEAD request to the specificed requestUri for authentication purposes
                     Contract.Assert(requestUri != null);
 
                     HttpRequestMessage headHttpRequestMessage = new HttpRequestMessage()
@@ -1373,7 +1382,7 @@ namespace System.ServiceModel.Channels
                             SR.ProxyImpersonationLevelMismatch, impersonationLevelWrapper.Value, requestImpersonationLevel)));
                     }
 
-                    // The authentication level for target auth is also used for proxy auth (by System.Net).  
+                    // The authentication level for target auth is also used for proxy auth (by System.Net).
                     // Therefore, fail if proxy auth requires mutual authentication but target auth does not.
                     if ((authenticationLevelWrapper.Value == AuthenticationLevel.MutualAuthRequired) &&
                         (requestAuthenticationLevel != AuthenticationLevel.MutualAuthRequired))


### PR DESCRIPTION
Fixed Check for SecurityTokenManager initialization for web proxies with NTLM authentication: 
When using BasicHttpClient Bindings with additional authentication for enterprise style web proxies, a NullReferenceException was raised because of missing initialization of SecurityTokenManager (resulting member field was NULL). 

By extracting the AuthenticationScheme passed by the used binding and using it for deciding  whether SecurityTokenManager is needed or not, the NRE is removed and NTLM auth can be used successfully within the HTTP channel factory.