### PR TITLE
Update HttpTransportBindingElement with Proxy property to enable client to specify IWebProxy

### DIFF
--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/HttpChannelFactory.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/HttpChannelFactory.cs
@@ -101,7 +101,9 @@ namespace System.ServiceModel.Channels
             _keepAliveEnabled = bindingElement.KeepAliveEnabled;
 
             if (bindingElement.Proxy != null)
+            {
                 _proxy = bindingElement.Proxy;
+            }
             else if (bindingElement.ProxyAddress != null)
             {
                 if (bindingElement.UseDefaultWebProxy)

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/HttpChannelFactory.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/HttpChannelFactory.cs
@@ -100,7 +100,9 @@ namespace System.ServiceModel.Channels
             TransferMode = bindingElement.TransferMode;
             _keepAliveEnabled = bindingElement.KeepAliveEnabled;
 
-            if (bindingElement.ProxyAddress != null)
+            if (bindingElement.Proxy != null)
+                _proxy = bindingElement.Proxy;
+            else if (bindingElement.ProxyAddress != null)
             {
                 if (bindingElement.UseDefaultWebProxy)
                 {

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/HttpTransportBindingElement.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/HttpTransportBindingElement.cs
@@ -45,6 +45,7 @@ namespace System.ServiceModel.Channels
             _maxPendingAccepts = HttpTransportDefaults.DefaultMaxPendingAccepts;
             _method = string.Empty;
             _proxyAuthenticationScheme = HttpTransportDefaults.ProxyAuthenticationScheme;
+            Proxy = HttpTransportDefaults.Proxy;
             ProxyAddress = HttpTransportDefaults.ProxyAddress;
             _realm = HttpTransportDefaults.Realm;
             _requestInitializationTimeout = HttpTransportDefaults.RequestInitializationTimeout;
@@ -68,6 +69,7 @@ namespace System.ServiceModel.Channels
             _maxBufferSizeInitialized = elementToBeCloned._maxBufferSizeInitialized;
             _maxPendingAccepts = elementToBeCloned._maxPendingAccepts;
             _method = elementToBeCloned._method;
+            Proxy = elementToBeCloned.Proxy;
             ProxyAddress = elementToBeCloned.ProxyAddress;
             _proxyAuthenticationScheme = elementToBeCloned._proxyAuthenticationScheme;
             _realm = elementToBeCloned._realm;
@@ -233,6 +235,7 @@ namespace System.ServiceModel.Channels
         }
 
         // fully specified proxy by client
+        [DefaultValue(HttpTransportDefaults.Proxy)]
         public IWebProxy Proxy { get; set; }
         
         [DefaultValue(HttpTransportDefaults.ProxyAddress)]

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/HttpTransportBindingElement.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/HttpTransportBindingElement.cs
@@ -232,6 +232,9 @@ namespace System.ServiceModel.Channels
             }
         }
 
+        // fully specified proxy by client
+        public IWebProxy Proxy { get; set; }
+        
         [DefaultValue(HttpTransportDefaults.ProxyAddress)]
         [TypeConverter(typeof(UriTypeConverter))]
         public Uri ProxyAddress { get; set; }

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/TransportDefaults.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/TransportDefaults.cs
@@ -257,6 +257,7 @@ namespace System.ServiceModel.Channels
         internal const bool DecompressionEnabled = true;
         internal const HostNameComparisonMode HostNameComparisonMode = System.ServiceModel.HostNameComparisonMode.StrongWildcard;
         internal const bool KeepAliveEnabled = true;
+        internal const IWebProxy Proxy = null; 
         internal const Uri ProxyAddress = null;
         internal const AuthenticationSchemes ProxyAuthenticationScheme = AuthenticationSchemes.Anonymous;
         internal const string Realm = "";


### PR DESCRIPTION
Fix #4562
- update HttpTransportBindingElement with Proxy property 
- update HttpChannelFactory to enable _proxy configuring with bindingElement.Proxy 

this commit enables clients to configure binding with fully specified IWebProxy object:
- address , 
- credentials 
- etc.