### PR TITLE
Migrate to OneLocBuild

### DIFF
--- a/azure-pipelines-arcade.yml
+++ b/azure-pipelines-arcade.yml
@@ -44,6 +44,10 @@ stages:
 - stage: Build
   displayName: Build
   jobs:
+  - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+    - template: /eng/common/templates/job/onelocbuild.yml
+      parameters:
+        CreatePr: false
   - template: /eng/common/templates/jobs/jobs.yml
     parameters:
       enableMicrobuild: true

--- a/azure-pipelines-arcade.yml
+++ b/azure-pipelines-arcade.yml
@@ -48,6 +48,8 @@ stages:
     - template: /eng/common/templates/job/onelocbuild.yml
       parameters:
         CreatePr: false
+        LclSource: lclFilesfromPackage
+        LclPackageId: 'LCL-JUNO-PROD-WCF'
   - template: /eng/common/templates/jobs/jobs.yml
     parameters:
       enableMicrobuild: true


### PR DESCRIPTION
Documentation (pending merge into arcade) can be found [here](https://github.com/jonfortescue/arcade/blob/OneLocBuildDoc/Documentation/OneLocBuild.md).

Sample of this task working in a build [here](https://dev.azure.com/dnceng/internal/_build/results?buildId=1048347&view=results).