### PR TITLE
Make dotnet-svcutil-lib InternalsVisibleTo MS.VS.WCF.ServiceReferences

### DIFF
--- a/src/dotnet-svcutil/lib/src/dotnet-svcutil-lib.csproj
+++ b/src/dotnet-svcutil/lib/src/dotnet-svcutil-lib.csproj
@@ -47,6 +47,9 @@
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
       <_Parameter1>dotnet-svcutil-lib.Tests, PublicKey='0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9'</_Parameter1>
     </AssemblyAttribute>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+      <_Parameter1>Microsoft.VisualStudio.WCF.ServiceReferences, PublicKey ='002400000480000094000000060200000024000052534131000400000100010007d1fa57c4aed9f0a32e84aa0faefd0de9e8fd6aec8f87fb03766c834c99921eb23be79ad9d5dcc1dd9ad236132102900b723cf980957fc4e177108fc607774f29e8320e92ea05ece4e821c0a5efe8f1645c4c0c93c1ab99285d622caa652c1dfad63d745d6f2de5f17e5eaf0fc4963d261c8a12436518206dc093344d5ad293'</_Parameter1>
+    </AssemblyAttribute>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
CC: @ZhaodongTian , @HongGit 