### PR TITLE
Add .NET 6.0 TFM to packages

### DIFF
--- a/src/System.ServiceModel.Duplex/ref/System.ServiceModel.Duplex.Ref.csproj
+++ b/src/System.ServiceModel.Duplex/ref/System.ServiceModel.Duplex.Ref.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <AssemblyVersion>$(WcfAssemblyVersion)</AssemblyVersion>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
-    <TargetFrameworks>netstandard2.0;net461;</TargetFrameworks>
+    <TargetFrameworks>net6.0;netstandard2.0;net461;</TargetFrameworks>
     <AssemblyName>System.ServiceModel.Duplex</AssemblyName>
     <RootNamespace>System.ServiceModel</RootNamespace>
     <CLSCompliant>true</CLSCompliant>

--- a/src/System.ServiceModel.Duplex/src/System.ServiceModel.Duplex.Facade.csproj
+++ b/src/System.ServiceModel.Duplex/src/System.ServiceModel.Duplex.Facade.csproj
@@ -8,7 +8,7 @@
     <!-- Workaround for https://github.com/NuGet/NuGet.Client/pull/3016 -->
     <NoWarn>$(NoWarn);NU5131</NoWarn>
 
-    <BuildFrameworks>netstandard2.0;net461;</BuildFrameworks>
+    <BuildFrameworks>net6.0;netstandard2.0;net461;</BuildFrameworks>
     <HarvestFrameworks>MonoAndroid10;MonoTouch10;net45;netcore50;netstandard1.1;netstandard1.3;portable-net45+win8;win8;xamarinios10;xamarinmac20;xamarintvos10;xamarinwatchos10;</HarvestFrameworks>
     <TargetFrameworks>$(BuildFrameworks)$(HarvestFrameworks)</TargetFrameworks>
     <IsBuilding Condition="$(BuildFrameworks.Contains('$(TargetFramework);'))">true</IsBuilding>

--- a/src/System.ServiceModel.Http/ref/System.ServiceModel.Http.Ref.csproj
+++ b/src/System.ServiceModel.Http/ref/System.ServiceModel.Http.Ref.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <AssemblyVersion>$(WcfAssemblyVersion)</AssemblyVersion>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
-    <TargetFrameworks>netstandard2.0;net461;</TargetFrameworks>
+    <TargetFrameworks>net6.0;netstandard2.0;net461;</TargetFrameworks>
     <AssemblyName>System.ServiceModel.Http</AssemblyName>
     <RootNamespace>System.ServiceModel</RootNamespace>
     <CLSCompliant>true</CLSCompliant>

--- a/src/System.ServiceModel.Http/src/System.ServiceModel.Http.Facade.csproj
+++ b/src/System.ServiceModel.Http/src/System.ServiceModel.Http.Facade.csproj
@@ -8,7 +8,7 @@
     <!-- Workaround for https://github.com/NuGet/NuGet.Client/pull/3016 -->
     <NoWarn>$(NoWarn);NU5131</NoWarn>
 
-    <BuildFrameworks>netstandard2.0;net461;</BuildFrameworks>
+    <BuildFrameworks>net6.0;netstandard2.0;net461;</BuildFrameworks>
     <HarvestFrameworks>MonoAndroid10;MonoTouch10;net45;net46;netcore50;netstandard1.0;netstandard1.1;netstandard1.3;portable-net45+win8+wp8;win8;wp8;xamarinios10;xamarinmac20;xamarintvos10;xamarinwatchos10;</HarvestFrameworks>
     <TargetFrameworks>$(BuildFrameworks)$(HarvestFrameworks)</TargetFrameworks>
     <IsBuilding Condition="$(BuildFrameworks.Contains('$(TargetFramework);'))">true</IsBuilding>

--- a/src/System.ServiceModel.NetTcp/ref/System.ServiceModel.NetTcp.Ref.csproj
+++ b/src/System.ServiceModel.NetTcp/ref/System.ServiceModel.NetTcp.Ref.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <AssemblyVersion>$(WcfAssemblyVersion)</AssemblyVersion>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
-    <TargetFrameworks>netstandard2.0;net461;</TargetFrameworks>
+    <TargetFrameworks>net6.0;netstandard2.0;net461;</TargetFrameworks>
     <AssemblyName>System.ServiceModel.NetTcp</AssemblyName>
     <RootNamespace>System.ServiceModel</RootNamespace>
     <CLSCompliant>true</CLSCompliant>

--- a/src/System.ServiceModel.NetTcp/src/System.ServiceModel.NetTcp.Facade.csproj
+++ b/src/System.ServiceModel.NetTcp/src/System.ServiceModel.NetTcp.Facade.csproj
@@ -8,7 +8,7 @@
     <!-- Workaround for https://github.com/NuGet/NuGet.Client/pull/3016 -->
     <NoWarn>$(NoWarn);NU5131</NoWarn>
 
-    <BuildFrameworks>netstandard2.0;net461;</BuildFrameworks>
+    <BuildFrameworks>net6.0;netstandard2.0;net461;</BuildFrameworks>
     <HarvestFrameworks>MonoAndroid10;MonoTouch10;net45;net46;netcore50;netstandard1.1;netstandard1.3;portable-net45+win8;win8;xamarinios10;xamarinmac20;xamarintvos10;xamarinwatchos10;</HarvestFrameworks>
     <TargetFrameworks>$(BuildFrameworks)$(HarvestFrameworks)</TargetFrameworks>
     <IsBuilding Condition="$(BuildFrameworks.Contains('$(TargetFramework);'))">true</IsBuilding>

--- a/src/System.ServiceModel.Primitives/ref/System.ServiceModel.Primitives.Ref.csproj
+++ b/src/System.ServiceModel.Primitives/ref/System.ServiceModel.Primitives.Ref.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <AssemblyVersion>$(WcfAssemblyVersion)</AssemblyVersion>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
-    <TargetFrameworks>netstandard2.0;netcoreapp2.1;net461;</TargetFrameworks>
+    <TargetFrameworks>net6.0;netstandard2.0;netcoreapp2.1;net461;</TargetFrameworks>
     <AssemblyName>System.ServiceModel.Primitives</AssemblyName>
     <RootNamespace>System.ServiceModel</RootNamespace>
     <CLSCompliant>true</CLSCompliant>
@@ -14,11 +14,11 @@
     <Compile Include="System.ServiceModel.Primitives.cs" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1' or '$(TargetFramework)' == 'net6.0'">
     <Compile Include="System.ServiceModel.Primitives.Netcoreapp.cs" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp2.1'">
+  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp2.1' and '$(TargetFramework)' != 'net6.0'">
     <None Include="System.ServiceModel.Primitives.Netcoreapp.cs" />
   </ItemGroup>
 

--- a/src/System.ServiceModel.Primitives/src/System.ServiceModel.Primitives.Facade.csproj
+++ b/src/System.ServiceModel.Primitives/src/System.ServiceModel.Primitives.Facade.csproj
@@ -8,7 +8,7 @@
     <!-- Workaround for https://github.com/NuGet/NuGet.Client/pull/3016 -->
     <NoWarn>$(NoWarn);NU5131</NoWarn>
 
-    <BuildFrameworks>netstandard2.0;netcoreapp2.1;net461;</BuildFrameworks>
+    <BuildFrameworks>net6.0;netstandard2.0;netcoreapp2.1;net461;</BuildFrameworks>
     <HarvestFrameworks>MonoAndroid10;MonoTouch10;net45;net46;netcore50;netstandard1.0;netstandard1.1;netstandard1.3;portable-net45+win8+wp8;win8;wp8;xamarinios10;xamarinmac20;xamarintvos10;xamarinwatchos10;</HarvestFrameworks>
     <TargetFrameworks>$(BuildFrameworks)$(HarvestFrameworks)</TargetFrameworks>
     <IsBuilding Condition="$(BuildFrameworks.Contains('$(TargetFramework);'))">true</IsBuilding>

--- a/src/System.ServiceModel.Security/ref/System.ServiceModel.Security.Ref.csproj
+++ b/src/System.ServiceModel.Security/ref/System.ServiceModel.Security.Ref.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <AssemblyVersion>$(WcfAssemblyVersion)</AssemblyVersion>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
-    <TargetFrameworks>netstandard2.0;net461;</TargetFrameworks>
+    <TargetFrameworks>net6.0;netstandard2.0;net461;</TargetFrameworks>
     <AssemblyName>System.ServiceModel.Security</AssemblyName>
     <RootNamespace>System.ServiceModel</RootNamespace>
     <CLSCompliant>true</CLSCompliant>

--- a/src/System.ServiceModel.Security/src/System.ServiceModel.Security.Facade.csproj
+++ b/src/System.ServiceModel.Security/src/System.ServiceModel.Security.Facade.csproj
@@ -8,7 +8,7 @@
     <!-- Workaround for https://github.com/NuGet/NuGet.Client/pull/3016 -->
     <NoWarn>$(NoWarn);NU5131</NoWarn>
 
-    <BuildFrameworks>netstandard2.0;net461;</BuildFrameworks>
+    <BuildFrameworks>net6.0;netstandard2.0;net461;</BuildFrameworks>
     <HarvestFrameworks>MonoAndroid10;MonoTouch10;net45;netcore50;netstandard1.0;netstandard1.1;netstandard1.3;portable-net45+win8+wp8;win8;wp8;xamarinios10;xamarinmac20;xamarintvos10;xamarinwatchos10;</HarvestFrameworks>
     <TargetFrameworks>$(BuildFrameworks)$(HarvestFrameworks)</TargetFrameworks>
     <IsBuilding Condition="$(BuildFrameworks.Contains('$(TargetFramework);'))">true</IsBuilding>


### PR DESCRIPTION
Fixes https://github.com/dotnet/wcf/issues/4237

See https://github.com/dotnet/designs/pull/222#issuecomment-861617052 for context.

@mconnew I verified these packages restore using the `net6.0` assets in the HelloAndroid sample from https://github.com/dotnet/maui-samples and at least a basic call to a SOAP webservice works.