### PR TITLE
Allow dotnet-svcutil referenced package name end with dll.

### DIFF
--- a/src/dotnet-svcutil/lib/src/Shared/ProjectDependency.cs
+++ b/src/dotnet-svcutil/lib/src/Shared/ProjectDependency.cs
@@ -112,12 +112,6 @@ namespace Microsoft.Tools.ServiceModel.Svcutil
                 // even when it is a Pacakge type, it may contain a valid binary, let's check.
                 fileHasKnownExtension = string.IsNullOrWhiteSpace(filePath) ? false :
                      (s_binaryExtensions.Any((ext) => String.Compare(Path.GetExtension(filePath), ext, StringComparison.OrdinalIgnoreCase) == 0));
-
-                // check that package name is not confused with assembly name.
-                if (s_binaryExtensions.Any((ext) => String.Compare(Path.GetExtension(packageName), ext, StringComparison.OrdinalIgnoreCase) == 0))
-                {
-                    throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, Shared.Resources.ErrorInvalidDependencyValue, packageName, nameof(packageName)));
-                }
             }
             else // Binary or Project.
             {

--- a/src/dotnet-svcutil/lib/src/Shared/ProjectDependency.cs
+++ b/src/dotnet-svcutil/lib/src/Shared/ProjectDependency.cs
@@ -28,6 +28,7 @@ namespace Microsoft.Tools.ServiceModel.Svcutil
 
         private static readonly IReadOnlyList<string> s_binaryExtensions = new List<string> { ".exe", ".dll" }.AsReadOnly();
         private static readonly IReadOnlyList<string> s_projectExtensions = new List<string> { ".csproj" }.AsReadOnly();
+        private static readonly IReadOnlyList<string> s_exeExtensions = new List<string> { ".exe" }.AsReadOnly();
 
         /// <summary>
         /// The dependency name.  This can be a package or assembly name.
@@ -112,6 +113,12 @@ namespace Microsoft.Tools.ServiceModel.Svcutil
                 // even when it is a Pacakge type, it may contain a valid binary, let's check.
                 fileHasKnownExtension = string.IsNullOrWhiteSpace(filePath) ? false :
                      (s_binaryExtensions.Any((ext) => String.Compare(Path.GetExtension(filePath), ext, StringComparison.OrdinalIgnoreCase) == 0));
+
+                // check that package name is not confused with executable name.
+                if (s_exeExtensions.Any((ext) => String.Compare(Path.GetExtension(packageName), ext, StringComparison.OrdinalIgnoreCase) == 0))
+                {
+                    throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, Shared.Resources.ErrorInvalidDependencyValue, packageName, nameof(packageName)));
+                }
             }
             else // Binary or Project.
             {


### PR DESCRIPTION
Fixes #4126. 