### PR TITLE
Add support for ClientBase<T>.CacheSetting

### DIFF
--- a/src/System.Private.ServiceModel/src/Internals/WcfEventSource.cs
+++ b/src/System.Private.ServiceModel/src/Internals/WcfEventSource.cs
@@ -9,6 +9,10 @@ namespace System.Runtime
 {
     internal sealed partial class WcfEventSource : EventSource
     {
+        // All events from NetFx can be found here:
+        // https://github.com/dotnet/wcf/blob/6d515edfbdc2aa408d1ad1b40eb7f30f726039d2/src/System.Private.ServiceModel/src/Internals/WcfEventSource.cs
+        // When adding more functionality which emits ETW events, this is the easiest place to get it from.
+
         public bool BufferPoolAllocationIsEnabled()
         {
             return base.IsEnabled(EventLevel.Verbose, Keywords.Infrastructure, EventChannel.Debug);
@@ -839,6 +843,86 @@ namespace System.Runtime
         public void WritePoolMiss(string itemTypeName)
         {
             WritePoolMiss(itemTypeName, "");
+        }
+
+        public bool ClientBaseCachedChannelFactoryCountIsEnabled()
+        {
+            return base.IsEnabled(EventLevel.Informational, Keywords.ServiceModel, EventChannel.Debug);
+        }
+
+        [Event(EventIds.ClientBaseCachedChannelFactoryCount, Level = EventLevel.Informational, Channel = EventChannel.Debug, Opcode = EventOpcode.Info, Task = Tasks.ChannelFactoryCaching,
+            Keywords = Keywords.ServiceModel,
+            Message = "Number of cached channel factories is: '{0}'.  At most '{1}' channel factories can be cached.")]
+        public void ClientBaseCachedChannelFactoryCount(int Count, int MaxNum, string EventSource, string AppDomain)
+        {
+            WriteEvent(EventIds.ClientBaseCachedChannelFactoryCount, Count, MaxNum, EventSource, AppDomain);
+        }
+
+        [NonEvent]
+        public void ClientBaseCachedChannelFactoryCount(int Count, int MaxNum, object source)
+        {
+            TracePayload payload = FxTrace.Trace.GetSerializedPayload(source, null, null);
+            ClientBaseCachedChannelFactoryCount(Count, MaxNum, payload.EventSource, "");
+        }
+
+        public bool ClientBaseChannelFactoryAgedOutofCacheIsEnabled()
+        {
+            return base.IsEnabled(EventLevel.Informational, Keywords.ServiceModel, EventChannel.Debug);
+        }
+
+        [Event(EventIds.ClientBaseChannelFactoryAgedOutofCache, Level = EventLevel.Informational, Channel = EventChannel.Debug, Opcode = EventOpcode.Info, Task = Tasks.ChannelFactoryCaching,
+            Keywords = Keywords.ServiceModel,
+            Message = "A channel factory has been aged out of the cache because the cache has reached its limit of '{0}'.")]
+        public void ClientBaseChannelFactoryAgedOutofCache(int Count, string EventSource, string AppDomain)
+        {
+            WriteEvent(EventIds.ClientBaseChannelFactoryAgedOutofCache, Count, EventSource, AppDomain);
+        }
+
+        [NonEvent]
+        public void ClientBaseChannelFactoryAgedOutofCache(int Count, object source)
+        {
+            TracePayload payload = FxTrace.Trace.GetSerializedPayload(source, null, null);
+            ClientBaseChannelFactoryAgedOutofCache(Count, payload.EventSource, "");
+        }
+
+        public bool ClientBaseChannelFactoryCacheHitIsEnabled()
+        {
+            return base.IsEnabled(EventLevel.Informational, Keywords.ServiceModel, EventChannel.Debug);
+        }
+
+        [Event(EventIds.ClientBaseChannelFactoryCacheHit, Level = EventLevel.Informational, Channel = EventChannel.Debug, Opcode = EventOpcode.Info, Task = Tasks.ChannelFactoryCaching,
+            Keywords = Keywords.ServiceModel,
+            Message = "Used matching channel factory found in cache.")]
+        public void ClientBaseChannelFactoryCacheHit(string EventSource, string AppDomain)
+        {
+            WriteEvent(EventIds.ClientBaseChannelFactoryCacheHit, EventSource, AppDomain);
+        }
+
+        [NonEvent]
+        public void ClientBaseChannelFactoryCacheHit(object source)
+        {
+            TracePayload payload = FxTrace.Trace.GetSerializedPayload(source, null, null);
+            ClientBaseChannelFactoryCacheHit(payload.EventSource, "");
+        }
+
+        public bool ClientBaseUsingLocalChannelFactoryIsEnabled()
+        {
+            return base.IsEnabled(EventLevel.Informational, Keywords.ServiceModel, EventChannel.Debug);
+        }
+
+        [Event(EventIds.ClientBaseUsingLocalChannelFactory, Level = EventLevel.Informational, Channel = EventChannel.Debug, Opcode = EventOpcode.Info, Task = Tasks.ChannelFactoryCaching,
+            Keywords = Keywords.ServiceModel,
+            Message = "Not using channel factory from cache, i.e. caching disabled for instance.")]
+        public void ClientBaseUsingLocalChannelFactory(string EventSource, string AppDomain)
+        {
+            WriteEvent(EventIds.ClientBaseUsingLocalChannelFactory, EventSource, AppDomain);
+        }
+
+        [NonEvent]
+        public void ClientBaseUsingLocalChannelFactory(object source)
+        {
+            TracePayload payload = FxTrace.Trace.GetSerializedPayload(source, null, null);
+            ClientBaseUsingLocalChannelFactory(payload.EventSource, "");
         }
 
         public bool MessageReadByEncoderIsEnabled()

--- a/src/System.Private.ServiceModel/src/Resources/Strings.resx
+++ b/src/System.Private.ServiceModel/src/Resources/Strings.resx
@@ -2991,4 +2991,7 @@
   <data name="SFxErrorCreatingMtomReader" xml:space="preserve">
     <value>Error creating a reader for the MTOM message</value>
   </data>
+  <data name="SFxImmutableClientBaseCacheSetting" xml:space="preserve">
+    <value>This value cannot be changed after the first ClientBase of type '{0}' has been created.</value>
+  </data>
 </root>

--- a/src/System.Private.ServiceModel/src/Resources/xlf/Strings.cs.xlf
+++ b/src/System.Private.ServiceModel/src/Resources/xlf/Strings.cs.xlf
@@ -2917,6 +2917,11 @@
         <target state="translated">Tuto hodnotu po otevření třídy ChannelFactory nelze změnit.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SFxImmutableClientBaseCacheSetting">
+        <source>This value cannot be changed after the first ClientBase of type '{0}' has been created.</source>
+        <target state="new">This value cannot be changed after the first ClientBase of type '{0}' has been created.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SFxImmutableServiceHostBehavior0">
         <source>This value cannot be changed after the ServiceHost has opened.</source>
         <target state="translated">Tuto hodnotu po otevření třídy ServiceHost nelze změnit.</target>

--- a/src/System.Private.ServiceModel/src/Resources/xlf/Strings.de.xlf
+++ b/src/System.Private.ServiceModel/src/Resources/xlf/Strings.de.xlf
@@ -2917,6 +2917,11 @@
         <target state="translated">Dieser Wert kann nicht geändert werden, nachdem die ChannelFactory geöffnet wurde.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SFxImmutableClientBaseCacheSetting">
+        <source>This value cannot be changed after the first ClientBase of type '{0}' has been created.</source>
+        <target state="new">This value cannot be changed after the first ClientBase of type '{0}' has been created.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SFxImmutableServiceHostBehavior0">
         <source>This value cannot be changed after the ServiceHost has opened.</source>
         <target state="translated">Dieser Wert kann nicht geändert werden, nachdem der ServiceHost geöffnet wurde.</target>

--- a/src/System.Private.ServiceModel/src/Resources/xlf/Strings.es.xlf
+++ b/src/System.Private.ServiceModel/src/Resources/xlf/Strings.es.xlf
@@ -2917,6 +2917,11 @@
         <target state="translated">Este valor no se puede cambiar una vez abierto ChannelFactory.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SFxImmutableClientBaseCacheSetting">
+        <source>This value cannot be changed after the first ClientBase of type '{0}' has been created.</source>
+        <target state="new">This value cannot be changed after the first ClientBase of type '{0}' has been created.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SFxImmutableServiceHostBehavior0">
         <source>This value cannot be changed after the ServiceHost has opened.</source>
         <target state="translated">Este valor no se puede cambiar una vez abierto ServiceHost.</target>

--- a/src/System.Private.ServiceModel/src/Resources/xlf/Strings.fr.xlf
+++ b/src/System.Private.ServiceModel/src/Resources/xlf/Strings.fr.xlf
@@ -2917,6 +2917,11 @@
         <target state="translated">Impossible de changer cette valeur après l'ouverture de ChannelFactory.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SFxImmutableClientBaseCacheSetting">
+        <source>This value cannot be changed after the first ClientBase of type '{0}' has been created.</source>
+        <target state="new">This value cannot be changed after the first ClientBase of type '{0}' has been created.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SFxImmutableServiceHostBehavior0">
         <source>This value cannot be changed after the ServiceHost has opened.</source>
         <target state="translated">Impossible de changer cette valeur après l'ouverture de ServiceHost.</target>

--- a/src/System.Private.ServiceModel/src/Resources/xlf/Strings.it.xlf
+++ b/src/System.Private.ServiceModel/src/Resources/xlf/Strings.it.xlf
@@ -2917,6 +2917,11 @@
         <target state="translated">Non è possibile modificare questo valore dopo l'apertura di ChannelFactory.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SFxImmutableClientBaseCacheSetting">
+        <source>This value cannot be changed after the first ClientBase of type '{0}' has been created.</source>
+        <target state="new">This value cannot be changed after the first ClientBase of type '{0}' has been created.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SFxImmutableServiceHostBehavior0">
         <source>This value cannot be changed after the ServiceHost has opened.</source>
         <target state="translated">Non è possibile modificare questo valore dopo l'apertura di ServiceHost.</target>

--- a/src/System.Private.ServiceModel/src/Resources/xlf/Strings.ja.xlf
+++ b/src/System.Private.ServiceModel/src/Resources/xlf/Strings.ja.xlf
@@ -2917,6 +2917,11 @@
         <target state="translated">ChannelFactory が開かれた後に、この値を変更することはできません。</target>
         <note />
       </trans-unit>
+      <trans-unit id="SFxImmutableClientBaseCacheSetting">
+        <source>This value cannot be changed after the first ClientBase of type '{0}' has been created.</source>
+        <target state="new">This value cannot be changed after the first ClientBase of type '{0}' has been created.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SFxImmutableServiceHostBehavior0">
         <source>This value cannot be changed after the ServiceHost has opened.</source>
         <target state="translated">ServiceHost が開かれた後に、この値を変更することはできません。</target>

--- a/src/System.Private.ServiceModel/src/Resources/xlf/Strings.ko.xlf
+++ b/src/System.Private.ServiceModel/src/Resources/xlf/Strings.ko.xlf
@@ -2917,6 +2917,11 @@
         <target state="translated">ChannelFactory가 열리고 나면 이 값을 변경할 수 없습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SFxImmutableClientBaseCacheSetting">
+        <source>This value cannot be changed after the first ClientBase of type '{0}' has been created.</source>
+        <target state="new">This value cannot be changed after the first ClientBase of type '{0}' has been created.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SFxImmutableServiceHostBehavior0">
         <source>This value cannot be changed after the ServiceHost has opened.</source>
         <target state="translated">ServiceHost가 열리고 나면 이 값을 변경할 수 없습니다.</target>

--- a/src/System.Private.ServiceModel/src/Resources/xlf/Strings.pl.xlf
+++ b/src/System.Private.ServiceModel/src/Resources/xlf/Strings.pl.xlf
@@ -2917,6 +2917,11 @@
         <target state="translated">Ta wartość nie może zostać zmieniona po otwarciu elementu ChannelFactory.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SFxImmutableClientBaseCacheSetting">
+        <source>This value cannot be changed after the first ClientBase of type '{0}' has been created.</source>
+        <target state="new">This value cannot be changed after the first ClientBase of type '{0}' has been created.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SFxImmutableServiceHostBehavior0">
         <source>This value cannot be changed after the ServiceHost has opened.</source>
         <target state="translated">Ta wartość nie może zostać zmieniona po otwarciu elementu ServiceHost.</target>

--- a/src/System.Private.ServiceModel/src/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/System.Private.ServiceModel/src/Resources/xlf/Strings.pt-BR.xlf
@@ -2917,6 +2917,11 @@
         <target state="translated">Não é possível alterar este valor após abrir a ChannelFactory.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SFxImmutableClientBaseCacheSetting">
+        <source>This value cannot be changed after the first ClientBase of type '{0}' has been created.</source>
+        <target state="new">This value cannot be changed after the first ClientBase of type '{0}' has been created.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SFxImmutableServiceHostBehavior0">
         <source>This value cannot be changed after the ServiceHost has opened.</source>
         <target state="translated">Não é possível alterar este valor após abrir o ServiceHost.</target>

--- a/src/System.Private.ServiceModel/src/Resources/xlf/Strings.ru.xlf
+++ b/src/System.Private.ServiceModel/src/Resources/xlf/Strings.ru.xlf
@@ -2917,6 +2917,11 @@
         <target state="translated">Это значение нельзя изменить после открытия ChannelFactory.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SFxImmutableClientBaseCacheSetting">
+        <source>This value cannot be changed after the first ClientBase of type '{0}' has been created.</source>
+        <target state="new">This value cannot be changed after the first ClientBase of type '{0}' has been created.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SFxImmutableServiceHostBehavior0">
         <source>This value cannot be changed after the ServiceHost has opened.</source>
         <target state="translated">Это значение нельзя изменить после открытия ServiceHost.</target>

--- a/src/System.Private.ServiceModel/src/Resources/xlf/Strings.tr.xlf
+++ b/src/System.Private.ServiceModel/src/Resources/xlf/Strings.tr.xlf
@@ -2917,6 +2917,11 @@
         <target state="translated">ChannelFactory açıldıktan sonra bu değer değiştirilemez.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SFxImmutableClientBaseCacheSetting">
+        <source>This value cannot be changed after the first ClientBase of type '{0}' has been created.</source>
+        <target state="new">This value cannot be changed after the first ClientBase of type '{0}' has been created.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SFxImmutableServiceHostBehavior0">
         <source>This value cannot be changed after the ServiceHost has opened.</source>
         <target state="translated">ServiceHost açıldıktan sonra bu değer değiştirilemez.</target>

--- a/src/System.Private.ServiceModel/src/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/System.Private.ServiceModel/src/Resources/xlf/Strings.zh-Hans.xlf
@@ -2917,6 +2917,11 @@
         <target state="translated">打开 ChannelFactory 后，无法更改此值。</target>
         <note />
       </trans-unit>
+      <trans-unit id="SFxImmutableClientBaseCacheSetting">
+        <source>This value cannot be changed after the first ClientBase of type '{0}' has been created.</source>
+        <target state="new">This value cannot be changed after the first ClientBase of type '{0}' has been created.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SFxImmutableServiceHostBehavior0">
         <source>This value cannot be changed after the ServiceHost has opened.</source>
         <target state="translated">打开 ServiceHost 后，无法更改此值。</target>

--- a/src/System.Private.ServiceModel/src/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/System.Private.ServiceModel/src/Resources/xlf/Strings.zh-Hant.xlf
@@ -2917,6 +2917,11 @@
         <target state="translated">開啟 ChannelFactory 之後，便不能更改此值。</target>
         <note />
       </trans-unit>
+      <trans-unit id="SFxImmutableClientBaseCacheSetting">
+        <source>This value cannot be changed after the first ClientBase of type '{0}' has been created.</source>
+        <target state="new">This value cannot be changed after the first ClientBase of type '{0}' has been created.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SFxImmutableServiceHostBehavior0">
         <source>This value cannot be changed after the ServiceHost has opened.</source>
         <target state="translated">開啟 ServiceHost 之後，便不能更改此值。</target>

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/CacheSetting.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/CacheSetting.cs
@@ -1,0 +1,14 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+
+namespace System.ServiceModel
+{
+    public enum CacheSetting
+    {
+        Default,
+        AlwaysOn,
+        AlwaysOff
+    }
+}

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/ChannelFactoryRefCache.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/ChannelFactoryRefCache.cs
@@ -1,0 +1,120 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+
+using System.Collections.Generic;
+using System.Runtime;
+
+namespace System.ServiceModel
+{
+    internal sealed class ChannelFactoryRef<TChannel> where TChannel : class
+    {
+        private ChannelFactory<TChannel> _channelFactory;
+        private int _refCount = 1;
+
+        public ChannelFactoryRef(ChannelFactory<TChannel> channelFactory)
+        {
+            _channelFactory = channelFactory;
+        }
+
+        public void AddRef()
+        {
+            _refCount++;
+        }
+
+        // The caller should call Close/Abort when the return value is true.
+        public bool Release()
+        {
+            --_refCount;
+            Fx.Assert(_refCount >= 0, "RefCount should not be less than zero.");
+
+            if (_refCount == 0)
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        public void Close(TimeSpan timeout)
+        {
+            _channelFactory.Close(timeout);
+        }
+
+        public void Abort()
+        {
+            _channelFactory.Abort();
+        }
+
+        public ChannelFactory<TChannel> ChannelFactory
+        {
+            get
+            {
+                return _channelFactory;
+            }
+        }
+    }
+
+    internal class ChannelFactoryRefCache<TChannel> : MruCache<EndpointTrait<TChannel>, ChannelFactoryRef<TChannel>>
+       where TChannel : class
+    {
+        private static EndpointTraitComparer DefaultEndpointTraitComparer = new EndpointTraitComparer();
+        private readonly int _watermark;
+
+        private class EndpointTraitComparer : IEqualityComparer<EndpointTrait<TChannel>>
+        {
+            public bool Equals(EndpointTrait<TChannel> x, EndpointTrait<TChannel> y)
+            {
+                if (x != null)
+                {
+                    if (y != null)
+                        return x.Equals(y);
+
+                    return false;
+                }
+
+                if (y != null)
+                    return false;
+
+                return true;
+            }
+
+            public int GetHashCode(EndpointTrait<TChannel> obj)
+            {
+                if (obj == null)
+                    return 0;
+
+                return obj.GetHashCode();
+            }
+        }
+
+        public ChannelFactoryRefCache(int watermark)
+            : base(watermark * 4 / 5, watermark, DefaultEndpointTraitComparer)
+        {
+            _watermark = watermark;
+        }
+
+        protected override void OnSingleItemRemoved(ChannelFactoryRef<TChannel> item)
+        {
+            // Remove from cache.
+            if (item.Release())
+            {
+                item.Abort();
+            }
+
+            if (WcfEventSource.Instance.ClientBaseCachedChannelFactoryCountIsEnabled())
+            {
+                WcfEventSource.Instance.ClientBaseCachedChannelFactoryCount(Count, _watermark, this);
+            }
+        }
+
+        protected override void OnItemAgedOutOfCache(ChannelFactoryRef<TChannel> item)
+        {
+            if (WcfEventSource.Instance.ClientBaseChannelFactoryAgedOutofCacheIsEnabled())
+            {
+                WcfEventSource.Instance.ClientBaseChannelFactoryAgedOutofCache(_watermark, this);
+            }
+        }
+    }
+}

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/EndpointTrait.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/EndpointTrait.cs
@@ -1,0 +1,13 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+
+namespace System.ServiceModel
+{
+    internal abstract class EndpointTrait<TChannel>
+        where TChannel : class
+    {
+        public abstract ChannelFactory<TChannel> CreateChannelFactory();
+    }
+}

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/ProgrammaticEndpointTrait.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/ProgrammaticEndpointTrait.cs
@@ -1,0 +1,88 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime;
+using System.ServiceModel.Channels;
+
+namespace System.ServiceModel
+{
+    internal sealed class ProgrammaticEndpointTrait<TChannel> : EndpointTrait<TChannel>
+        where TChannel : class
+    {
+        private EndpointAddress _remoteAddress;
+        private Binding _binding;
+        private InstanceContext _callbackInstance;
+
+        public ProgrammaticEndpointTrait(Binding binding,
+            EndpointAddress remoteAddress,
+            InstanceContext callbackInstance)
+            : base()
+        {
+            _binding = binding;
+            _remoteAddress = remoteAddress;
+            _callbackInstance = callbackInstance;
+        }
+
+        public override bool Equals(object obj)
+        {
+            ProgrammaticEndpointTrait<TChannel> trait1 = obj as ProgrammaticEndpointTrait<TChannel>;
+            if (trait1 == null)
+                return false;
+
+            if (!ReferenceEquals(_callbackInstance, trait1._callbackInstance))
+                return false;
+
+            // EndpointAddress.Equals is used.
+            if (_remoteAddress != trait1._remoteAddress)
+                return false;
+
+            if (!ReferenceEquals(_binding, trait1._binding))
+                return false;
+
+            return true;
+        }
+
+        public override int GetHashCode()
+        {
+            int hashCode = 0;
+            if (_callbackInstance != null)
+            {
+                hashCode ^= _callbackInstance.GetHashCode();
+            }
+
+            Fx.Assert(_remoteAddress != null, "remoteAddress should not be null.");
+            hashCode ^= _remoteAddress.GetHashCode();
+
+
+            Fx.Assert(_binding != null, "binding should not be null.");
+            hashCode ^= _binding.GetHashCode();
+
+            return hashCode;
+        }
+
+        public override ChannelFactory<TChannel> CreateChannelFactory()
+        {
+            if (_callbackInstance != null)
+                return CreateDuplexFactory();
+
+            return CreateSimplexFactory();
+        }
+
+        private DuplexChannelFactory<TChannel> CreateDuplexFactory()
+        {
+            Fx.Assert(_remoteAddress != null, "remoteAddress should not be null.");
+            Fx.Assert(_binding != null, "binding should not be null.");
+
+            return new DuplexChannelFactory<TChannel>(_callbackInstance, _binding, _remoteAddress);
+        }
+
+        private ChannelFactory<TChannel> CreateSimplexFactory()
+        {
+            Fx.Assert(_remoteAddress != null, "remoteAddress should not be null.");
+            Fx.Assert(_binding != null, "binding should not be null.");
+
+            return new ChannelFactory<TChannel>(_binding, _remoteAddress);
+        }
+    }
+}

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/ServiceEndpointTrait.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/ServiceEndpointTrait.cs
@@ -1,0 +1,72 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime;
+using System.ServiceModel.Description;
+
+namespace System.ServiceModel
+{
+    internal sealed class ServiceEndpointTrait<TChannel> : EndpointTrait<TChannel> where TChannel : class
+    {
+        private InstanceContext _callbackInstance;
+        private ServiceEndpoint _serviceEndpoint;
+
+        public ServiceEndpointTrait(ServiceEndpoint endpoint,
+            InstanceContext callbackInstance)
+        {
+            _serviceEndpoint = endpoint;
+            _callbackInstance = callbackInstance;
+        }
+
+        public override bool Equals(object obj)
+        {
+            ServiceEndpointTrait<TChannel> trait1 = obj as ServiceEndpointTrait<TChannel>;
+            if (trait1 == null)
+                return false;
+
+            if (!ReferenceEquals(_callbackInstance, trait1._callbackInstance))
+                return false;
+
+            if (!ReferenceEquals(_serviceEndpoint, trait1._serviceEndpoint))
+                return false;
+
+            return true;
+        }
+
+        public override int GetHashCode()
+        {
+            int hashCode = 0;
+
+            if (_callbackInstance != null)
+            {
+                hashCode ^= _callbackInstance.GetHashCode();
+            }
+
+            Fx.Assert(_serviceEndpoint != null, "endpoint should not be null.");
+            hashCode ^= _serviceEndpoint.GetHashCode();
+
+            return hashCode;
+        }
+
+        public override ChannelFactory<TChannel> CreateChannelFactory()
+        {
+            if (_callbackInstance != null)
+                return CreateDuplexFactory();
+
+            return CreateSimplexFactory();
+        }
+
+        private DuplexChannelFactory<TChannel> CreateDuplexFactory()
+        {
+            Fx.Assert(_serviceEndpoint != null, "endpoint should not be null.");
+            return new DuplexChannelFactory<TChannel>(_callbackInstance, _serviceEndpoint);
+        }
+
+        private ChannelFactory<TChannel> CreateSimplexFactory()
+        {
+            Fx.Assert(_serviceEndpoint != null, "endpoint should not be null.");
+            return new ChannelFactory<TChannel>(_serviceEndpoint);
+        }
+    }
+}

--- a/src/System.ServiceModel.Primitives/ref/System.ServiceModel.Primitives.cs
+++ b/src/System.ServiceModel.Primitives/ref/System.ServiceModel.Primitives.cs
@@ -202,6 +202,12 @@ namespace System.ServiceModel
         public ActionNotSupportedException(string message, System.Exception innerException) { }
         protected ActionNotSupportedException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
+    public enum CacheSetting
+    {
+        Default,
+        AlwaysOn,
+        AlwaysOff
+    }
     public abstract partial class ChannelFactory : System.ServiceModel.Channels.CommunicationObject, System.IDisposable, System.ServiceModel.Channels.IChannelFactory, System.ServiceModel.ICommunicationObject
     {
         protected ChannelFactory() { }
@@ -263,6 +269,7 @@ namespace System.ServiceModel
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         protected ClientBase(string endpointConfigurationName, string remoteAddress) { }
         protected TChannel Channel { get { return default; } }
+        public static CacheSetting CacheSetting { get { return default; } set { } }
         public System.ServiceModel.ChannelFactory<TChannel> ChannelFactory { get { return default; } }
         public System.ServiceModel.Description.ClientCredentials ClientCredentials { get { return default; } }
         public System.ServiceModel.Description.ServiceEndpoint Endpoint { get { return default; } }

--- a/src/System.ServiceModel.Primitives/tests/ServiceModel/ClientBaseTest.cs
+++ b/src/System.ServiceModel.Primitives/tests/ServiceModel/ClientBaseTest.cs
@@ -2,13 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-
 using System;
-using System.Collections.Generic;
 using System.ServiceModel;
 using System.ServiceModel.Description;
 using System.ServiceModel.Channels;
-using System.Text;
 using Infrastructure.Common;
 using Xunit;
 
@@ -29,10 +26,161 @@ public static class ClientBaseTest
         Assert.Equal(CommunicationState.Closed, client.State);
     }
 
+    [WcfFact]
+    public static void ClientBaseChannelFactoryDefaultCachingBindingEndpointAddress()
+    {
+        Assert.Equal(CacheSetting.Default, MyClientBase.CacheSetting);
+        BasicHttpBinding binding = new BasicHttpBinding();
+        EndpointAddress endpointAddress = new EndpointAddress("http://myendpoint");
+        MyClientBase client1 = new MyClientBase(binding, endpointAddress);
+        client1.Open();
+        MyClientBase client2 = new MyClientBase(binding, endpointAddress);
+        client2.Open();
+        Assert.NotEqual(client1.ChannelFactory, client2.ChannelFactory);
+        client1.Close();
+        client2.Close();
+        // Validate setting to same value doesn't throw
+        MyClientBase.CacheSetting = CacheSetting.Default;
+        // Validate instantiated caching throws when changing setting
+        Assert.Throws<InvalidOperationException>(() => MyClientBase.CacheSetting = CacheSetting.AlwaysOn);
+    }
+
+    [WcfFact]
+    public static void ClientBaseChannelFactoryDefaultCachingServiceEndpoint()
+    {
+        Assert.Equal(CacheSetting.Default, MyClientBase.CacheSetting);
+        BasicHttpBinding binding = new BasicHttpBinding();
+        EndpointAddress endpointAddress = new EndpointAddress("http://myendpoint");
+        ChannelFactory<ITestService> tempFactory = new ChannelFactory<ITestService>(binding, endpointAddress);
+        ServiceEndpoint serviceEndpoint = tempFactory.Endpoint;
+        MyClientBase client1 = new MyClientBase(serviceEndpoint);
+        client1.Open();
+        MyClientBase client2 = new MyClientBase(serviceEndpoint);
+        client2.Open();
+        Assert.NotEqual(client1.ChannelFactory, client2.ChannelFactory);
+        client1.Close();
+        client2.Close();
+        // Validate setting to same value doesn't throw
+        MyClientBase.CacheSetting = CacheSetting.Default;
+        // Validate instantiated caching throws when changing setting
+        Assert.Throws<InvalidOperationException>(() => MyClientBase.CacheSetting = CacheSetting.AlwaysOn);
+    }
+
+    [WcfFact]
+    public static void ClientBaseChannelFactoryAlwaysOnCachingBindingEndpointAddress()
+    {
+        MyClientBase2.CacheSetting = CacheSetting.AlwaysOn;
+        BasicHttpBinding binding = new BasicHttpBinding();
+        EndpointAddress endpointAddress = new EndpointAddress("http://myendpoint");
+        MyClientBase2 client1 = new MyClientBase2(binding, endpointAddress);
+        client1.Open();
+        MyClientBase2 client2 = new MyClientBase2(binding, endpointAddress);
+        client2.Open();
+        // Validate using the same ChannelFactory when constructor args are the same
+        Assert.Equal(client1.ChannelFactory, client2.ChannelFactory);
+        MyClientBase2 client3 = new MyClientBase2(binding, new EndpointAddress("http://myendpoint"));
+        client3.Open();
+        // Validate using the same ChannelFactory when constructor args are equivalent
+        Assert.Equal(client1.ChannelFactory, client3.ChannelFactory);
+        MyClientBase2 client4 = new MyClientBase2(binding, new EndpointAddress("http://myotherendpoint"));
+        // Validate using different ChannelFactory when constructor args are not equivalent
+        Assert.NotEqual(client1.ChannelFactory, client4.ChannelFactory);
+        client1.Close();
+        client2.Close();
+        client3.Close();
+        client4.Close();
+        // Validate setting to same value doesn't throw
+        MyClientBase2.CacheSetting = CacheSetting.AlwaysOn;
+        // Validate instantiated caching throws when changing setting
+        Assert.Throws<InvalidOperationException>(() => MyClientBase2.CacheSetting = CacheSetting.Default);
+    }
+
+    [WcfFact]
+    public static void ClientBaseChannelFactoryAlwaysOnServiceEndpoint()
+    {
+        MyClientBase2.CacheSetting = CacheSetting.AlwaysOn;
+        BasicHttpBinding binding = new BasicHttpBinding();
+        EndpointAddress endpointAddress = new EndpointAddress("http://myendpoint");
+        ChannelFactory<ITestService2> tempFactory = new ChannelFactory<ITestService2>(binding, endpointAddress);
+        ServiceEndpoint serviceEndpoint = tempFactory.Endpoint;
+        MyClientBase2 client1 = new MyClientBase2(serviceEndpoint);
+        client1.Open();
+        MyClientBase2 client2 = new MyClientBase2(serviceEndpoint);
+        client2.Open();
+        // Validate using the same ChannelFactory when constructor args are the same
+        Assert.Equal(client1.ChannelFactory, client2.ChannelFactory);
+        tempFactory = new ChannelFactory<ITestService2>(binding, endpointAddress);
+        ServiceEndpoint serviceEndpoint2 = tempFactory.Endpoint;
+        MyClientBase2 client3 = new MyClientBase2(serviceEndpoint2);
+        client3.Open();
+        // Validate using different ChannelFactory when constructor args are not the same
+        Assert.NotEqual(client1.ChannelFactory, client3.ChannelFactory);
+        var existingChannelFactory = client1.ChannelFactory;
+        client1.Close();
+        client2.Close();
+        client3.Close();
+        // Validate that ChannelFactory is replaced if existing one is closed
+        existingChannelFactory.Close();
+        Assert.Equal(CommunicationState.Closed, existingChannelFactory.State);
+        MyClientBase2 client4 = new MyClientBase2(serviceEndpoint);
+        client4.Open();
+        Assert.NotEqual(existingChannelFactory, client4.ChannelFactory);
+        // Validate setting to same value doesn't throw
+        MyClientBase2.CacheSetting = CacheSetting.AlwaysOn;
+        // Validate instantiated caching throws when changing setting
+        Assert.Throws<InvalidOperationException>(() => MyClientBase2.CacheSetting = CacheSetting.Default);
+    }
+
+
+    [WcfFact]
+    public static void ClientBaseChannelFactoryAlwaysOffCachingBindingEndpointAddress()
+    {
+        MyClientBase3.CacheSetting = CacheSetting.AlwaysOff;
+        BasicHttpBinding binding = new BasicHttpBinding();
+        EndpointAddress endpointAddress = new EndpointAddress("http://myendpoint");
+        MyClientBase3 client1 = new MyClientBase3(binding, endpointAddress);
+        client1.Open();
+        MyClientBase3 client2 = new MyClientBase3(binding, endpointAddress);
+        client2.Open();
+        Assert.NotEqual(client1.ChannelFactory, client2.ChannelFactory);
+        client1.Close();
+        client2.Close();
+        // Validate setting to same value doesn't throw
+        MyClientBase3.CacheSetting = CacheSetting.AlwaysOff;
+        // Validate instantiated caching throws when changing setting
+        Assert.Throws<InvalidOperationException>(() => MyClientBase.CacheSetting = CacheSetting.AlwaysOn);
+    }
+
+    [WcfFact]
+    public static void ClientBaseChannelFactoryAlwaysOffCachingServiceEndpoint()
+    {
+        MyClientBase3.CacheSetting = CacheSetting.AlwaysOff;
+        BasicHttpBinding binding = new BasicHttpBinding();
+        EndpointAddress endpointAddress = new EndpointAddress("http://myendpoint");
+        ChannelFactory<ITestService3> tempFactory = new ChannelFactory<ITestService3>(binding, endpointAddress);
+        ServiceEndpoint serviceEndpoint = tempFactory.Endpoint;
+        MyClientBase3 client1 = new MyClientBase3(serviceEndpoint);
+        client1.Open();
+        MyClientBase3 client2 = new MyClientBase3(serviceEndpoint);
+        client2.Open();
+        Assert.NotEqual(client1.ChannelFactory, client2.ChannelFactory);
+        client1.Close();
+        client2.Close();
+        // Validate setting to same value doesn't throw
+        MyClientBase3.CacheSetting = CacheSetting.AlwaysOff;
+        // Validate instantiated caching throws when changing setting
+        Assert.Throws<InvalidOperationException>(() => MyClientBase.CacheSetting = CacheSetting.AlwaysOn);
+    }
+
     public class MyClientBase : ClientBase<ITestService>
     {
         public MyClientBase(Binding binding, EndpointAddress endpointAddress)
             : base(binding, endpointAddress)
+        {
+        }
+
+        public MyClientBase(ServiceEndpoint serviceEndpoint)
+            : base(serviceEndpoint)
         {
         }
 
@@ -42,10 +190,49 @@ public static class ClientBaseTest
         }
     }
 
+    // 3 ClientBase types are needed as once you set the CacheSetting and instantiated a ClientBase<T>,
+    // you can't modify the CacheSetting. We have tests which require a CacheSetting different from default
+    // so need a 3 different types to test the 3 CacheSettings modes.
+    public class MyClientBase2 : ClientBase<ITestService2>
+    {
+        public MyClientBase2(Binding binding, EndpointAddress endpointAddress)
+            : base(binding, endpointAddress)
+        {
+        }
+
+        public MyClientBase2(ServiceEndpoint serviceEndpoint)
+            : base(serviceEndpoint)
+        {
+        }
+    }
+
+    public class MyClientBase3 : ClientBase<ITestService3>
+    {
+        public MyClientBase3(Binding binding, EndpointAddress endpointAddress)
+            : base(binding, endpointAddress)
+        {
+        }
+
+        public MyClientBase3(ServiceEndpoint serviceEndpoint)
+            : base(serviceEndpoint)
+        {
+        }
+    }
+
     [ServiceContract]
     public interface ITestService
     {
         [OperationContract]
         string Echo(string message);
+    }
+
+    [ServiceContract]
+    public interface ITestService2 : ITestService
+    {
+    }
+
+    [ServiceContract]
+    public interface ITestService3 : ITestService
+    {
     }
 }


### PR DESCRIPTION
This will help with #4186. We should do some follow-up work to have dotnet-svcutil emit the code to turn on caching as the only constructor on ClientBase\<TChannel\> that has caching turned on by default is the configuration based constructors which we don't support.