### PR TITLE
Add more apis for generic xml security token

### DIFF
--- a/src/System.ServiceModel.Primitives/ref/System.ServiceModel.Primitives.cs
+++ b/src/System.ServiceModel.Primitives/ref/System.ServiceModel.Primitives.cs
@@ -186,6 +186,10 @@ namespace System.IdentityModel.Tokens
         public abstract System.Collections.ObjectModel.ReadOnlyCollection<System.IdentityModel.Tokens.SecurityKey> SecurityKeys { get; }
         public abstract DateTime ValidFrom { get; }
         public abstract DateTime ValidTo { get; }
+        public virtual bool CanCreateKeyIdentifierClause<T>() where T : SecurityKeyIdentifierClause => default;
+        public virtual T CreateKeyIdentifierClause<T>() where T : SecurityKeyIdentifierClause => default;
+        public virtual bool MatchesKeyIdentifierClause(SecurityKeyIdentifierClause keyIdentifierClause) => default;
+        public virtual SecurityKey ResolveKeyIdentifierClause(SecurityKeyIdentifierClause keyIdentifierClause) => default;
     }
     public abstract partial class SymmetricSecurityKey : SecurityKey
     {

--- a/src/System.ServiceModel.Security/ref/System.ServiceModel.Security.cs
+++ b/src/System.ServiceModel.Security/ref/System.ServiceModel.Security.cs
@@ -234,10 +234,19 @@ namespace System.IdentityModel.Tokens
             SecurityKeyIdentifierClause internalTokenReference,
             SecurityKeyIdentifierClause externalTokenReference,
             System.Collections.ObjectModel.ReadOnlyCollection<System.IdentityModel.Policy.IAuthorizationPolicy> authorizationPolicies) {}
-        public override string Id { get; }
-        public override DateTime ValidFrom { get; }
-        public override DateTime ValidTo { get; }
-        public override System.Collections.ObjectModel.ReadOnlyCollection<System.IdentityModel.Tokens.SecurityKey> SecurityKeys { get; }
+        public override string Id => default;
+        public override DateTime ValidFrom => default;
+        public override DateTime ValidTo => default;
+        public SecurityKeyIdentifierClause InternalTokenReference => default;
+        public SecurityKeyIdentifierClause ExternalTokenReference => default;
+        public System.Xml.XmlElement TokenXml => default;
+        public SecurityToken ProofToken => default;
+        public System.Collections.ObjectModel.ReadOnlyCollection<System.IdentityModel.Policy.IAuthorizationPolicy> AuthorizationPolicies => default;
+        public override System.Collections.ObjectModel.ReadOnlyCollection<System.IdentityModel.Tokens.SecurityKey> SecurityKeys => default;
+        public override bool CanCreateKeyIdentifierClause<T>() => default;
+        public override T CreateKeyIdentifierClause<T>() => default;
+        public override bool MatchesKeyIdentifierClause(SecurityKeyIdentifierClause keyIdentifierClause) => default;
+        public override string ToString() => default;
     }
     public enum SecurityKeyType
     {
@@ -247,18 +256,9 @@ namespace System.IdentityModel.Tokens
     }
     public partial class GenericXmlSecurityKeyIdentifierClause : SecurityKeyIdentifierClause
     {
-        public GenericXmlSecurityKeyIdentifierClause(System.Xml.XmlElement referenceXml)
-            : this(referenceXml, null, 0)
-        {
-        }
-
-        public GenericXmlSecurityKeyIdentifierClause(System.Xml.XmlElement referenceXml, byte[] derivationNonce, int derivationLength)
-            : base(null, derivationNonce, derivationLength)
-        {
-        }
-
-        public System.Xml.XmlElement ReferenceXml { get { return default; } }
-
-        public override bool Matches(SecurityKeyIdentifierClause keyIdentifierClause){ return default; }
+        public GenericXmlSecurityKeyIdentifierClause(System.Xml.XmlElement referenceXml) : this(referenceXml, null, 0) { }
+        public GenericXmlSecurityKeyIdentifierClause(System.Xml.XmlElement referenceXml, byte[] derivationNonce, int derivationLength) : base(null, derivationNonce, derivationLength) { }
+        public System.Xml.XmlElement ReferenceXml => default;
+        public override bool Matches(SecurityKeyIdentifierClause keyIdentifierClause) => default;
     }
 }

--- a/src/System.ServiceModel.Security/tests/IdentityModel/GenericXmlSecurityKeyIdentifierClauseTest.cs
+++ b/src/System.ServiceModel.Security/tests/IdentityModel/GenericXmlSecurityKeyIdentifierClauseTest.cs
@@ -1,0 +1,66 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.IdentityModel.Tokens;
+using System.Text;
+using System.Xml;
+using Infrastructure.Common;
+using Xunit;
+
+public static class GenericXmlSecurityKeyIdentifierClauseTest
+{
+    [WcfFact]
+    public static void Ctor_Default_Properties()
+    {
+        var exception = Assert.Throws<ArgumentNullException>(() => new GenericXmlSecurityKeyIdentifierClause(null));
+        Assert.Equal("referenceXml", exception.ParamName);
+        XmlElement tokenReference = CreateTokenReference(Guid.NewGuid());
+        var genericXmlSecurityKeyIdentifierClause = new GenericXmlSecurityKeyIdentifierClause(tokenReference);
+        Assert.Null(genericXmlSecurityKeyIdentifierClause.Id);
+        Assert.False(genericXmlSecurityKeyIdentifierClause.CanCreateKey);
+        Assert.Null(genericXmlSecurityKeyIdentifierClause.ClauseType);
+        Assert.Throws<NotSupportedException>(() => genericXmlSecurityKeyIdentifierClause.CreateKey());
+        Assert.Null(genericXmlSecurityKeyIdentifierClause.GetDerivationNonce());
+        Assert.Equal(0, genericXmlSecurityKeyIdentifierClause.DerivationLength);
+        Assert.Equal(tokenReference, genericXmlSecurityKeyIdentifierClause.ReferenceXml);
+    }
+
+    [WcfFact]
+    public static void Ctor_Deriviation_Properties()
+    {
+        XmlElement tokenReference = CreateTokenReference(Guid.NewGuid());
+        byte[] derivationNonce = new byte[] { 1, 2, 3, 4, 5, 6 };
+        int derivationLength = 128;
+        var genericXmlSecurityKeyIdentifierClause = new GenericXmlSecurityKeyIdentifierClause(tokenReference, (byte[])derivationNonce.Clone(), derivationLength);
+        Assert.Equal(derivationNonce, genericXmlSecurityKeyIdentifierClause.GetDerivationNonce());
+        Assert.Equal(derivationLength, genericXmlSecurityKeyIdentifierClause.DerivationLength);
+    }
+
+    [WcfFact]
+    public static void Matches()
+    {
+        Guid guid = Guid.NewGuid();
+        XmlElement tokenReference = CreateTokenReference(guid);
+        var genericXmlSecurityKeyIdentifierClause = new GenericXmlSecurityKeyIdentifierClause(tokenReference);
+        tokenReference = CreateTokenReference(guid); // Create equivalant but different instance
+        var genericXmlSecurityKeyIdentifierClause2 = new GenericXmlSecurityKeyIdentifierClause(tokenReference);
+        Assert.True(genericXmlSecurityKeyIdentifierClause.Matches(genericXmlSecurityKeyIdentifierClause2));
+        tokenReference = CreateTokenReference(Guid.NewGuid());
+        genericXmlSecurityKeyIdentifierClause2 = new GenericXmlSecurityKeyIdentifierClause(tokenReference);
+        Assert.False(genericXmlSecurityKeyIdentifierClause.Matches(genericXmlSecurityKeyIdentifierClause2));
+    }
+
+    private static XmlElement CreateTokenReference(Guid guid)
+    {
+        XmlDocument doc = new XmlDocument();
+        XmlElement tokenReference = doc.CreateElement("wsse", "KeyIdentifier", "http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd");
+        XmlAttribute attr = doc.CreateAttribute("ValueType");
+        attr.Value = "http://docs.oasis-open.org/wss/oasis-wss-saml-token-profile-1.1#SAMLID";
+        tokenReference.Attributes.Append(attr);
+        tokenReference.InnerText = "_" + guid.ToString("D");
+        return tokenReference;
+    }
+}

--- a/src/System.ServiceModel.Security/tests/IdentityModel/GenericXmlSecurityTokenTest.cs
+++ b/src/System.ServiceModel.Security/tests/IdentityModel/GenericXmlSecurityTokenTest.cs
@@ -23,7 +23,6 @@ public static class GenericXmlSecurityTokenTest
         attr.Value = attrValue;
         tokenXml.Attributes.Append(attr);
         UserNameSecurityToken proofToken = new UserNameSecurityToken("user", "password");
-        
         GenericXmlSecurityToken gxst = new GenericXmlSecurityToken(tokenXml, proofToken, DateTime.UtcNow, DateTime.MaxValue, null, null, null);
         Assert.NotNull(gxst);
         Assert.NotNull(gxst.Id);
@@ -32,13 +31,45 @@ public static class GenericXmlSecurityTokenTest
         Assert.Equal(DateTime.MaxValue.Date, gxst.ValidTo.Date);
         Assert.NotNull(gxst.SecurityKeys);
         Assert.Equal(proofToken.SecurityKeys, gxst.SecurityKeys);
-
+        Assert.Equal(tokenXml, gxst.TokenXml);
+        Assert.Equal(proofToken, gxst.ProofToken);
+        Assert.False(gxst.CanCreateKeyIdentifierClause<GenericXmlSecurityKeyIdentifierClause>());
         //ProofToken is null
         GenericXmlSecurityToken gxst2 = new GenericXmlSecurityToken(tokenXml, null, DateTime.MinValue, DateTime.MaxValue, null, null, null);
         Assert.NotNull(gxst2.SecurityKeys);
         Assert.Equal(new ReadOnlyCollection<SecurityKey>(new List<SecurityKey>()), gxst2.SecurityKeys);
+        Assert.Null(gxst2.ProofToken);
 
         //TokenXml is null
         Assert.Throws<System.ArgumentNullException>(() => new GenericXmlSecurityToken(null, null, DateTime.MinValue, DateTime.MaxValue, null, null, null));
-    }    
+    }
+
+    [WcfFact]
+    public static void KeyIdentifierClauseMethods()
+    {
+        XmlDocument doc = new XmlDocument();
+        XmlElement tokenXml = doc.CreateElement("ElementName");
+        XmlAttribute attr = doc.CreateAttribute("Id", "http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd");
+        string attrValue = "Value for Attribute Name Id";
+        attr.Value = attrValue;
+        tokenXml.Attributes.Append(attr);
+        UserNameSecurityToken proofToken = new UserNameSecurityToken("user", "password");
+        var keyIdentifierGuid = Guid.NewGuid();
+        var internalTokenReference = CreateGenericKeyIdentifierClause(keyIdentifierGuid);
+        GenericXmlSecurityToken gxst = new GenericXmlSecurityToken(tokenXml, proofToken, DateTime.UtcNow, DateTime.MaxValue, internalTokenReference, null, null);
+        Assert.True(gxst.CanCreateKeyIdentifierClause<GenericXmlSecurityKeyIdentifierClause>());
+        Assert.Equal(internalTokenReference, gxst.CreateKeyIdentifierClause<GenericXmlSecurityKeyIdentifierClause>());
+        Assert.True(gxst.MatchesKeyIdentifierClause(CreateGenericKeyIdentifierClause(keyIdentifierGuid)));
+    }
+
+    private static GenericXmlSecurityKeyIdentifierClause CreateGenericKeyIdentifierClause(Guid guid)
+    {
+        XmlDocument doc = new XmlDocument();
+        XmlElement tokenReference = doc.CreateElement("wsse", "KeyIdentifier", "http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd");
+        XmlAttribute attr = doc.CreateAttribute("ValueType");
+        attr.Value = "http://docs.oasis-open.org/wss/oasis-wss-saml-token-profile-1.1#SAMLID";
+        tokenReference.Attributes.Append(attr);
+        tokenReference.InnerText = "_" + guid.ToString("D");
+        return new GenericXmlSecurityKeyIdentifierClause(tokenReference);
+    }
 }


### PR DESCRIPTION
Adding api's which are missing from the contract for GenericXmlSecurityToken and GenericXmlSecurityKeyIdentifierClause. This is needed to support the WSTrustChannelFactory usage case where customers will need to access the returned security token's TokenXml property in some cases.