### PR TITLE
Add MtomMessageEncodingBindingElement to reference assembly

### DIFF
--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/MtomMessageEncodingBindingElement.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Channels/MtomMessageEncodingBindingElement.cs
@@ -10,12 +10,12 @@ namespace System.ServiceModel.Channels
 {
     public sealed class MtomMessageEncodingBindingElement : MessageEncodingBindingElement
     {
-        int _maxReadPoolSize;
-        int _maxWritePoolSize;
-        XmlDictionaryReaderQuotas _readerQuotas;
-        int _maxBufferSize;
-        Encoding _writeEncoding;
-        MessageVersion _messageVersion;
+        private int _maxReadPoolSize;
+        private int _maxWritePoolSize;
+        private XmlDictionaryReaderQuotas _readerQuotas;
+        private int _maxBufferSize;
+        private Encoding _writeEncoding;
+        private MessageVersion _messageVersion;
 
         public MtomMessageEncodingBindingElement() : this(MessageVersion.Default, TextEncoderDefaults.Encoding) { }
 
@@ -40,7 +40,7 @@ namespace System.ServiceModel.Channels
             _writeEncoding = writeEncoding;
         }
 
-        MtomMessageEncodingBindingElement(MtomMessageEncodingBindingElement elementToBeCloned)
+        private MtomMessageEncodingBindingElement(MtomMessageEncodingBindingElement elementToBeCloned)
             : base(elementToBeCloned)
         {
             _maxReadPoolSize = elementToBeCloned._maxReadPoolSize;

--- a/src/System.ServiceModel.Primitives/ref/System.ServiceModel.Primitives.cs
+++ b/src/System.ServiceModel.Primitives/ref/System.ServiceModel.Primitives.cs
@@ -1468,6 +1468,25 @@ namespace System.ServiceModel.Channels
         public override int GetHashCode() { return default; }
         public override string ToString() { return default; }
     }
+    public sealed class MtomMessageEncodingBindingElement : MessageEncodingBindingElement
+    {
+        public MtomMessageEncodingBindingElement() { }
+        public MtomMessageEncodingBindingElement(MessageVersion messageVersion, System.Text.Encoding writeEncoding) { }
+        [System.ComponentModel.DefaultValueAttribute(64)]
+        public int MaxReadPoolSize { get; set; }
+        [System.ComponentModel.DefaultValueAttribute(16)]
+        public int MaxWritePoolSize { get; set; }
+        public System.Xml.XmlDictionaryReaderQuotas ReaderQuotas { get; set; }
+        [System.ComponentModel.DefaultValueAttribute(65536)]
+        public int MaxBufferSize { get; set; }
+        public System.Text.Encoding WriteEncoding { get; set; }
+        public override MessageVersion MessageVersion { get; set; }
+        public override IChannelFactory<TChannel> BuildChannelFactory<TChannel>(BindingContext context) { return default; }
+        public override bool CanBuildChannelFactory<TChannel>(BindingContext context) { return default; }
+        public override BindingElement Clone() { return default; }
+        public override MessageEncoderFactory CreateMessageEncoderFactory() { return default; }
+        public override T GetProperty<T>(BindingContext context) { return default; }
+    }
     public sealed class ReliableSessionBindingElement : System.ServiceModel.Channels.BindingElement
     {
         public ReliableSessionBindingElement() { }


### PR DESCRIPTION
Fixes #1810
Specifically the comment [here](https://github.com/dotnet/wcf/issues/1810#issuecomment-930535649).