### PR TITLE
Switch to 1ES servicing pools on release/3.2

### DIFF
--- a/azure-pipelines-arcade.yml
+++ b/azure-pipelines-arcade.yml
@@ -205,6 +205,7 @@ stages:
               --integrationTest
               --projects $(Build.SourcesDirectory)/eng/SendToHelix.proj
               $(_TestArgs)
+              /p:TestJob=Linux
               /bl:$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)/SendToHelix.binlog
             displayName: Linux - Run Helix Tests
             env:

--- a/azure-pipelines-arcade.yml
+++ b/azure-pipelines-arcade.yml
@@ -144,6 +144,7 @@ stages:
             -integrationTest
             -projects $(Build.SourcesDirectory)/eng/SendToHelix.proj
             $(_TestArgs)
+            /p:TestJob=Windows
             /bl:$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)/SendToHelix.binlog
           displayName: Windows - Run Helix Tests
           env:
@@ -153,7 +154,7 @@ stages:
             RunAsPublic: $(_RunAsPublic)
             RunAsInternal: $(_RunAsInternal)
             IsWindowsBuild: true
-
+            
       # Only build and test Unix in PR and CI builds.
       - ${{ if eq(variables._RunAsPublic, True) }}:
         - job: Linux

--- a/azure-pipelines-arcade.yml
+++ b/azure-pipelines-arcade.yml
@@ -60,11 +60,11 @@ stages:
         timeoutInMinutes: 90
         pool:
           ${{ if eq(variables._RunAsPublic, True) }}:
-            name: NetCorePublic-Pool
-            queue: buildpool.windows.10.amd64.vs2017.open
+            name: NetCore1ESPool-Svc-Public
+            demands: ImageOverride -equals build.windows.10.amd64.vs2017.open
           ${{ if eq(variables._RunAsInternal, True) }}:
-            name: NetCoreInternal-Pool
-            queue: buildpool.windows.10.amd64.vs2017
+            name: NetCore1ESPool-Svc-Internal
+            demands: ImageOverride -equals build.windows.10.amd64.vs2017
         variables:
         - _InternalBuildArgs: ''
         - HelixApiAccessToken: ''
@@ -160,8 +160,8 @@ stages:
           timeoutInMinutes: 90
           container: ubuntu_1604_Powershell_62
           pool:
-            name:  NetCorePublic-Pool
-            queue: BuildPool.Ubuntu.1604.Amd64.Open
+            name:  NetCore1ESPool-Svc-Public
+            demands: ImageOverride -equals build.Ubuntu.1604.Amd64.Open
           variables:
           - _TestArgs: /p:ServiceUri=$(_serviceUri) /p:Root_Certificate_Installed=true /p:Client_Certificate_Installed=true /p:SSL_Available=true
           - _serviceUri: wcfcoresrv2.westus2.cloudapp.azure.com/WcfService$(_WcfPRServiceId)

--- a/azure-pipelines-arcade.yml
+++ b/azure-pipelines-arcade.yml
@@ -218,7 +218,8 @@ stages:
         - job: MacOS
           timeoutInMinutes: 90
           pool:
-            name: Hosted macOS
+            name: NetCore1ESPool-Public
+            demands: ImageOverride -equals build.windows.10.amd64.vs2017.open
           variables:
           - _TestArgs: /p:ServiceUri=$(_serviceUri) /p:Root_Certificate_Installed=true /p:Client_Certificate_Installed=true /p:SSL_Available=true
           - _serviceUri: wcfcoresrv2.westus2.cloudapp.azure.com/WcfService$(_WcfPRServiceId)
@@ -247,22 +248,23 @@ stages:
           - template: /eng/UpdatePRService.yml
             parameters:
               wcfPRServiceId: $(_WcfPRServiceId)
-          - script: eng/common/cibuild.sh
+          - script: eng\common\cibuild.cmd
               -configuration $(_BuildConfig)
               -preparemachine
               $(_TestArgs)
               /p:Test=false
-            displayName: Unix Build
-          - script: eng/common/build.sh
-              --configuration $(_BuildConfig)
-              --prepareMachine
-              --ci
-              --test
-              --integrationTest
-              --projects $(Build.SourcesDirectory)/eng/SendToHelix.proj
+            displayName: MacOS Build
+          - powershell: eng\common\build.ps1
+              -configuration $(_BuildConfig)
+              -prepareMachine
+              -ci
+              -test
+              -integrationTest
+              -projects $(Build.SourcesDirectory)/eng/SendToHelix.proj
               $(_TestArgs)
+              /p:TestJob=MacOS
               /bl:$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)/SendToHelix.binlog
-            displayName: Linux - Run Helix Tests
+            displayName: MacOS - Run Helix Tests
             env:
               SYSTEM_ACCESSTOKEN: $(System.AccessToken)
               ServiceHost: $(_serviceUri)

--- a/eng/SendToHelix.proj
+++ b/eng/SendToHelix.proj
@@ -19,18 +19,18 @@
     <XUnitProject Include="..\src\System.ServiceModel.*\tests\*.Tests.csproj"/>
   </ItemGroup>
 
-  <ItemGroup Condition="$(IsWindowsBuild) AND '$(RunAsPublic)' == 'true'" >
+  <ItemGroup Condition="'$(TestJob)' == 'Windows' AND '$(RunAsPublic)' == 'true'" >
     <HelixTargetQueue Include="Windows.10.Amd64.ClientRS5.Open" />
     <HelixTargetQueue Include="Windows.10.Amd64.ServerRS5.Open" />
   </ItemGroup>
 
-  <ItemGroup Condition="$(IsWindowsBuild) AND '$(RunAsInternal)'" >
+  <ItemGroup Condition="'$(TestJob)' == 'Windows' AND '$(RunAsInternal)'" >
     <HelixTargetQueue Include="Windows.10.Amd64" />
     <HelixTargetQueue Include="Debian.9.Amd64" />
     <HelixTargetQueue Include="RedHat.7.Amd64" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(AGENT_OS)' == 'Linux'" >
+  <ItemGroup Condition="'$(TestJob)' == 'Linux'" >
     <HelixTargetQueue Include="Centos.7.Amd64.Open" />
     <HelixTargetQueue Include="Debian.9.Amd64.Open" />
     <HelixTargetQueue Include="RedHat.7.Amd64.Open" />
@@ -38,7 +38,7 @@
     <HelixTargetQueue Include="Ubuntu.1804.Amd64.Open" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(AGENT_OS)' == 'Darwin'" >
+  <ItemGroup Condition="'$(TestJob)' == 'MacOS'" >
     <HelixTargetQueue Include="OSX.1014.Amd64.Open" />
   </ItemGroup>
 


### PR DESCRIPTION
Same as https://github.com/dotnet/wcf/pull/4733 but on release/3.2.