### PR TITLE
Adding support for WSTrustChannelFactory and WSTrustChannel

### DIFF
--- a/src/System.ServiceModel.Federation/src/Resources/Strings.resx
+++ b/src/System.ServiceModel.Federation/src/Resources/Strings.resx
@@ -171,4 +171,16 @@
   <data name="RSTRProofTokenShouldNotHaveAComputedKeyAlgorithmOrIssuerEntropy" xml:space="preserve">
     <value>An RSTR containing a proof token should not also have a computed key algorithm or issuer entropy.</value>
   </data>
+  <data name="IRequestChannelMustBeCreated" xml:space="preserve">
+    <value>The IRequestChannel must be in the created state. Was: '{0}'.</value>
+  </data>
+  <data name="IssuedSecurityTokenParametersIncorrectType" xml:space="preserve">
+    <value>tokenRequirement.GetProperty&lt;IssuedSecurityTokenParameters&gt; must be of type: WSTrustTokenParameters. Was: '{0}.</value>
+  </data>
+  <data name="IssuedTokenRenewalThresholdPercentageIncorrect" xml:space="preserve">
+    <value>IssuedTokenRenewalThresholdPercentage  must be greater than or equal to 1 and less than or equal to 100. Was: '{0}'.</value>
+  </data>
+  <data name="MaxIssuedTokenCachingTimeMustBeGreaterThanTimeSpanZero" xml:space="preserve">
+    <value>MaxIssuedTokenCachingTime must be greater than TimeSpan.Zero. Was: '{0}'.</value>
+  </data>
 </root>

--- a/src/System.ServiceModel.Federation/src/Resources/Strings.resx
+++ b/src/System.ServiceModel.Federation/src/Resources/Strings.resx
@@ -129,4 +129,46 @@
   <data name="CommunicationObjectCannotBeUsed" xml:space="preserve">
     <value>The communication object, {0}, is in the {1} state.  Communication objects cannot be used for communication unless they are in the Opened state.</value>
   </data>
+  <data name="RequestTypeNotSupported" xml:space="preserve">
+    <value>The RequestType '{0}', is not supported.</value>
+  </data>
+  <data name="TokenProviderUnableToGetToken" xml:space="preserve">
+    <value>The token provider '{0}' was unable to provide a security token.</value>
+  </data>
+  <data name="UseKeysAreNotSupported" xml:space="preserve">
+    <value>UseKeys are not supported</value>
+  </data>
+  <data name="WsTrustVersionNotSupported" xml:space="preserve">
+    <value>The WsTrust wersion '{0}' is not supported.</value>
+  </data>
+  <data name="ChannelFactoryMustSupportIRequestChannel" xml:space="preserve">
+    <value>ChannnelFactory must support 'System.ServiceModel.Channels.IRequestChannel' interface.</value>
+  </data>
+  <data name="BearerKeyShouldNotIincludeAProofToken" xml:space="preserve">
+    <value>Bearer key scenarios should not include a proof token or issuer entropy in the response.</value>
+  </data>
+  <data name="ComputedKeyProofTokensAreOnlySupportedWithSymmetricKeyTypes" xml:space="preserve">
+    <value>Computed key proof tokens are only supported with symmetric key types.</value>
+  </data>
+  <data name="ComputedKeyProofTokensRequireIssuerToSupplyKeyMaterialViaEntropy" xml:space="preserve">
+    <value>Computed key proof tokens require issuer to supply key material via entropy.</value>
+  </data>
+  <data name="ComputedKeyProofTokensRequireRequesterToSupplyKeyMaterialViaEntropy" xml:space="preserve">
+    <value>Computed key proof tokens require requester to supply key material via entropy.</value>
+  </data>
+  <data name="EncryptedKeysForProofTokensNotSupported" xml:space="preserve">
+    <value>Encrypted keys for proof tokens are not supported.</value>
+  </data>
+  <data name="NoKeySizeProvided" xml:space="preserve">
+    <value>No key size provided.</value>
+  </data>
+  <data name="OnlyPSHA1ComputedKeysAreSupported" xml:space="preserve">
+    <value>Only PSHA1 computed keys are supported.</value>
+  </data>
+  <data name="ProtectedKeyEntropyIsNotSupported" xml:space="preserve">
+    <value>Protected key entropy is not supported.</value>
+  </data>
+  <data name="RSTRProofTokenShouldNotHaveAComputedKeyAlgorithmOrIssuerEntropy" xml:space="preserve">
+    <value>An RSTR containing a proof token should not also have a computed key algorithm or issuer entropy.</value>
+  </data>
 </root>

--- a/src/System.ServiceModel.Federation/src/Resources/xlf/Strings.cs.xlf
+++ b/src/System.ServiceModel.Federation/src/Resources/xlf/Strings.cs.xlf
@@ -42,6 +42,26 @@
         <target state="new">Encrypted keys for proof tokens are not supported.</target>
         <note />
       </trans-unit>
+      <trans-unit id="IRequestChannelMustBeCreated">
+        <source>The IRequestChannel must be in the created state. Was: '{0}'.</source>
+        <target state="new">The IRequestChannel must be in the created state. Was: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IssuedSecurityTokenParametersIncorrectType">
+        <source>tokenRequirement.GetProperty&lt;IssuedSecurityTokenParameters&gt; must be of type: WSTrustTokenParameters. Was: '{0}.</source>
+        <target state="new">tokenRequirement.GetProperty&lt;IssuedSecurityTokenParameters&gt; must be of type: WSTrustTokenParameters. Was: '{0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IssuedTokenRenewalThresholdPercentageIncorrect">
+        <source>IssuedTokenRenewalThresholdPercentage  must be greater than or equal to 1 and less than or equal to 100. Was: '{0}'.</source>
+        <target state="new">IssuedTokenRenewalThresholdPercentage  must be greater than or equal to 1 and less than or equal to 100. Was: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MaxIssuedTokenCachingTimeMustBeGreaterThanTimeSpanZero">
+        <source>MaxIssuedTokenCachingTime must be greater than TimeSpan.Zero. Was: '{0}'.</source>
+        <target state="new">MaxIssuedTokenCachingTime must be greater than TimeSpan.Zero. Was: '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoKeySizeProvided">
         <source>No key size provided.</source>
         <target state="new">No key size provided.</target>

--- a/src/System.ServiceModel.Federation/src/Resources/xlf/Strings.cs.xlf
+++ b/src/System.ServiceModel.Federation/src/Resources/xlf/Strings.cs.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../Strings.resx">
     <body>
+      <trans-unit id="BearerKeyShouldNotIincludeAProofToken">
+        <source>Bearer key scenarios should not include a proof token or issuer entropy in the response.</source>
+        <target state="new">Bearer key scenarios should not include a proof token or issuer entropy in the response.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ChannelFactoryMustSupportIRequestChannel">
+        <source>ChannnelFactory must support 'System.ServiceModel.Channels.IRequestChannel' interface.</source>
+        <target state="new">ChannnelFactory must support 'System.ServiceModel.Channels.IRequestChannel' interface.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CommunicationObjectCannotBeUsed">
         <source>The communication object, {0}, is in the {1} state.  Communication objects cannot be used for communication unless they are in the Opened state.</source>
         <target state="translated">Objekt komunikace {0} je ve stavu {1}. Pokud objekty komunikace nejsou ve stavu Opened, nelze je použít ke komunikaci.</target>
@@ -12,6 +22,51 @@
         <target state="translated">Objekt komunikace {0} nelze použít ke komunikaci, protože je ve stavu Faulted.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ComputedKeyProofTokensAreOnlySupportedWithSymmetricKeyTypes">
+        <source>Computed key proof tokens are only supported with symmetric key types.</source>
+        <target state="new">Computed key proof tokens are only supported with symmetric key types.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ComputedKeyProofTokensRequireIssuerToSupplyKeyMaterialViaEntropy">
+        <source>Computed key proof tokens require issuer to supply key material via entropy.</source>
+        <target state="new">Computed key proof tokens require issuer to supply key material via entropy.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ComputedKeyProofTokensRequireRequesterToSupplyKeyMaterialViaEntropy">
+        <source>Computed key proof tokens require requester to supply key material via entropy.</source>
+        <target state="new">Computed key proof tokens require requester to supply key material via entropy.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EncryptedKeysForProofTokensNotSupported">
+        <source>Encrypted keys for proof tokens are not supported.</source>
+        <target state="new">Encrypted keys for proof tokens are not supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoKeySizeProvided">
+        <source>No key size provided.</source>
+        <target state="new">No key size provided.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OnlyPSHA1ComputedKeysAreSupported">
+        <source>Only PSHA1 computed keys are supported.</source>
+        <target state="new">Only PSHA1 computed keys are supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProtectedKeyEntropyIsNotSupported">
+        <source>Protected key entropy is not supported.</source>
+        <target state="new">Protected key entropy is not supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RSTRProofTokenShouldNotHaveAComputedKeyAlgorithmOrIssuerEntropy">
+        <source>An RSTR containing a proof token should not also have a computed key algorithm or issuer entropy.</source>
+        <target state="new">An RSTR containing a proof token should not also have a computed key algorithm or issuer entropy.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RequestTypeNotSupported">
+        <source>The RequestType '{0}', is not supported.</source>
+        <target state="new">The RequestType '{0}', is not supported.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SecurityEndpointNotFound">
         <source>Server '{0}' sent back a fault indicating it is in the process of shutting down. Please see the inner exception for fault details.</source>
         <target state="translated">Server {0} odeslal zpět chybu, která udává, že probíhá jeho vypínání. Podrobné informace o chybě naleznete v popisu vnitřní výjimky.</target>
@@ -20,6 +75,21 @@
       <trans-unit id="SecurityServerTooBusy">
         <source>Server '{0}' sent back a fault indicating it is too busy to process the request. Please retry later. Please see the inner exception for fault details.</source>
         <target state="translated">Server {0} odeslal zpět chybu, která udává, že je příliš zaneprázdněn a nemůže zpracovat požadavek. Podrobné informace o chybě naleznete v popisu vnitřní výjimky.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TokenProviderUnableToGetToken">
+        <source>The token provider '{0}' was unable to provide a security token.</source>
+        <target state="new">The token provider '{0}' was unable to provide a security token.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseKeysAreNotSupported">
+        <source>UseKeys are not supported</source>
+        <target state="new">UseKeys are not supported</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WsTrustVersionNotSupported">
+        <source>The WsTrust wersion '{0}' is not supported.</source>
+        <target state="new">The WsTrust wersion '{0}' is not supported.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/System.ServiceModel.Federation/src/Resources/xlf/Strings.de.xlf
+++ b/src/System.ServiceModel.Federation/src/Resources/xlf/Strings.de.xlf
@@ -42,6 +42,26 @@
         <target state="new">Encrypted keys for proof tokens are not supported.</target>
         <note />
       </trans-unit>
+      <trans-unit id="IRequestChannelMustBeCreated">
+        <source>The IRequestChannel must be in the created state. Was: '{0}'.</source>
+        <target state="new">The IRequestChannel must be in the created state. Was: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IssuedSecurityTokenParametersIncorrectType">
+        <source>tokenRequirement.GetProperty&lt;IssuedSecurityTokenParameters&gt; must be of type: WSTrustTokenParameters. Was: '{0}.</source>
+        <target state="new">tokenRequirement.GetProperty&lt;IssuedSecurityTokenParameters&gt; must be of type: WSTrustTokenParameters. Was: '{0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IssuedTokenRenewalThresholdPercentageIncorrect">
+        <source>IssuedTokenRenewalThresholdPercentage  must be greater than or equal to 1 and less than or equal to 100. Was: '{0}'.</source>
+        <target state="new">IssuedTokenRenewalThresholdPercentage  must be greater than or equal to 1 and less than or equal to 100. Was: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MaxIssuedTokenCachingTimeMustBeGreaterThanTimeSpanZero">
+        <source>MaxIssuedTokenCachingTime must be greater than TimeSpan.Zero. Was: '{0}'.</source>
+        <target state="new">MaxIssuedTokenCachingTime must be greater than TimeSpan.Zero. Was: '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoKeySizeProvided">
         <source>No key size provided.</source>
         <target state="new">No key size provided.</target>

--- a/src/System.ServiceModel.Federation/src/Resources/xlf/Strings.de.xlf
+++ b/src/System.ServiceModel.Federation/src/Resources/xlf/Strings.de.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../Strings.resx">
     <body>
+      <trans-unit id="BearerKeyShouldNotIincludeAProofToken">
+        <source>Bearer key scenarios should not include a proof token or issuer entropy in the response.</source>
+        <target state="new">Bearer key scenarios should not include a proof token or issuer entropy in the response.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ChannelFactoryMustSupportIRequestChannel">
+        <source>ChannnelFactory must support 'System.ServiceModel.Channels.IRequestChannel' interface.</source>
+        <target state="new">ChannnelFactory must support 'System.ServiceModel.Channels.IRequestChannel' interface.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CommunicationObjectCannotBeUsed">
         <source>The communication object, {0}, is in the {1} state.  Communication objects cannot be used for communication unless they are in the Opened state.</source>
         <target state="translated">Das Kommunikationsobjekt {0} befindet sich im {1}-Zustand. Die Kommunikationsobjekte können nicht zur Kommunikation verwendet werden, wenn sie sich nicht im Opened-Zustand befinden.</target>
@@ -12,6 +22,51 @@
         <target state="translated">Das Kommunikationsobjekt {0} kann nicht zur Kommunikation verwendet werden, weil es sich im Faulted-Zustand befindet.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ComputedKeyProofTokensAreOnlySupportedWithSymmetricKeyTypes">
+        <source>Computed key proof tokens are only supported with symmetric key types.</source>
+        <target state="new">Computed key proof tokens are only supported with symmetric key types.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ComputedKeyProofTokensRequireIssuerToSupplyKeyMaterialViaEntropy">
+        <source>Computed key proof tokens require issuer to supply key material via entropy.</source>
+        <target state="new">Computed key proof tokens require issuer to supply key material via entropy.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ComputedKeyProofTokensRequireRequesterToSupplyKeyMaterialViaEntropy">
+        <source>Computed key proof tokens require requester to supply key material via entropy.</source>
+        <target state="new">Computed key proof tokens require requester to supply key material via entropy.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EncryptedKeysForProofTokensNotSupported">
+        <source>Encrypted keys for proof tokens are not supported.</source>
+        <target state="new">Encrypted keys for proof tokens are not supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoKeySizeProvided">
+        <source>No key size provided.</source>
+        <target state="new">No key size provided.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OnlyPSHA1ComputedKeysAreSupported">
+        <source>Only PSHA1 computed keys are supported.</source>
+        <target state="new">Only PSHA1 computed keys are supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProtectedKeyEntropyIsNotSupported">
+        <source>Protected key entropy is not supported.</source>
+        <target state="new">Protected key entropy is not supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RSTRProofTokenShouldNotHaveAComputedKeyAlgorithmOrIssuerEntropy">
+        <source>An RSTR containing a proof token should not also have a computed key algorithm or issuer entropy.</source>
+        <target state="new">An RSTR containing a proof token should not also have a computed key algorithm or issuer entropy.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RequestTypeNotSupported">
+        <source>The RequestType '{0}', is not supported.</source>
+        <target state="new">The RequestType '{0}', is not supported.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SecurityEndpointNotFound">
         <source>Server '{0}' sent back a fault indicating it is in the process of shutting down. Please see the inner exception for fault details.</source>
         <target state="translated">Der Server "{0}" hat einen Fehler zurückgesendet, der darauf hinweist, dass der Server gerade heruntergefahren wird. Detaillierte Fehlerinformationen finden Sie in der inneren Ausnahme.</target>
@@ -20,6 +75,21 @@
       <trans-unit id="SecurityServerTooBusy">
         <source>Server '{0}' sent back a fault indicating it is too busy to process the request. Please retry later. Please see the inner exception for fault details.</source>
         <target state="translated">Der Server "{0}" hat einen Fehler zurückgesendet, der darauf hinweist, dass er zu ausgelastet ist, um die Anforderung zu verarbeiten. Versuchen Sie es später noch mal. Detaillierte Fehlerinformationen finden Sie in der inneren Ausnahme.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TokenProviderUnableToGetToken">
+        <source>The token provider '{0}' was unable to provide a security token.</source>
+        <target state="new">The token provider '{0}' was unable to provide a security token.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseKeysAreNotSupported">
+        <source>UseKeys are not supported</source>
+        <target state="new">UseKeys are not supported</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WsTrustVersionNotSupported">
+        <source>The WsTrust wersion '{0}' is not supported.</source>
+        <target state="new">The WsTrust wersion '{0}' is not supported.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/System.ServiceModel.Federation/src/Resources/xlf/Strings.es.xlf
+++ b/src/System.ServiceModel.Federation/src/Resources/xlf/Strings.es.xlf
@@ -42,6 +42,26 @@
         <target state="new">Encrypted keys for proof tokens are not supported.</target>
         <note />
       </trans-unit>
+      <trans-unit id="IRequestChannelMustBeCreated">
+        <source>The IRequestChannel must be in the created state. Was: '{0}'.</source>
+        <target state="new">The IRequestChannel must be in the created state. Was: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IssuedSecurityTokenParametersIncorrectType">
+        <source>tokenRequirement.GetProperty&lt;IssuedSecurityTokenParameters&gt; must be of type: WSTrustTokenParameters. Was: '{0}.</source>
+        <target state="new">tokenRequirement.GetProperty&lt;IssuedSecurityTokenParameters&gt; must be of type: WSTrustTokenParameters. Was: '{0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IssuedTokenRenewalThresholdPercentageIncorrect">
+        <source>IssuedTokenRenewalThresholdPercentage  must be greater than or equal to 1 and less than or equal to 100. Was: '{0}'.</source>
+        <target state="new">IssuedTokenRenewalThresholdPercentage  must be greater than or equal to 1 and less than or equal to 100. Was: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MaxIssuedTokenCachingTimeMustBeGreaterThanTimeSpanZero">
+        <source>MaxIssuedTokenCachingTime must be greater than TimeSpan.Zero. Was: '{0}'.</source>
+        <target state="new">MaxIssuedTokenCachingTime must be greater than TimeSpan.Zero. Was: '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoKeySizeProvided">
         <source>No key size provided.</source>
         <target state="new">No key size provided.</target>

--- a/src/System.ServiceModel.Federation/src/Resources/xlf/Strings.es.xlf
+++ b/src/System.ServiceModel.Federation/src/Resources/xlf/Strings.es.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../Strings.resx">
     <body>
+      <trans-unit id="BearerKeyShouldNotIincludeAProofToken">
+        <source>Bearer key scenarios should not include a proof token or issuer entropy in the response.</source>
+        <target state="new">Bearer key scenarios should not include a proof token or issuer entropy in the response.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ChannelFactoryMustSupportIRequestChannel">
+        <source>ChannnelFactory must support 'System.ServiceModel.Channels.IRequestChannel' interface.</source>
+        <target state="new">ChannnelFactory must support 'System.ServiceModel.Channels.IRequestChannel' interface.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CommunicationObjectCannotBeUsed">
         <source>The communication object, {0}, is in the {1} state.  Communication objects cannot be used for communication unless they are in the Opened state.</source>
         <target state="translated">El objeto de comunicación, {0}, se encuentra en el estado {1}. Los objetos de comunicación no se pueden usar para la comunicación a menos que se encuentren en el estado Opened.</target>
@@ -12,6 +22,51 @@
         <target state="translated">El objeto de comunicación, {0}, no se puede usar para la comunicación porque se encuentra en el estado Faulted.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ComputedKeyProofTokensAreOnlySupportedWithSymmetricKeyTypes">
+        <source>Computed key proof tokens are only supported with symmetric key types.</source>
+        <target state="new">Computed key proof tokens are only supported with symmetric key types.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ComputedKeyProofTokensRequireIssuerToSupplyKeyMaterialViaEntropy">
+        <source>Computed key proof tokens require issuer to supply key material via entropy.</source>
+        <target state="new">Computed key proof tokens require issuer to supply key material via entropy.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ComputedKeyProofTokensRequireRequesterToSupplyKeyMaterialViaEntropy">
+        <source>Computed key proof tokens require requester to supply key material via entropy.</source>
+        <target state="new">Computed key proof tokens require requester to supply key material via entropy.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EncryptedKeysForProofTokensNotSupported">
+        <source>Encrypted keys for proof tokens are not supported.</source>
+        <target state="new">Encrypted keys for proof tokens are not supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoKeySizeProvided">
+        <source>No key size provided.</source>
+        <target state="new">No key size provided.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OnlyPSHA1ComputedKeysAreSupported">
+        <source>Only PSHA1 computed keys are supported.</source>
+        <target state="new">Only PSHA1 computed keys are supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProtectedKeyEntropyIsNotSupported">
+        <source>Protected key entropy is not supported.</source>
+        <target state="new">Protected key entropy is not supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RSTRProofTokenShouldNotHaveAComputedKeyAlgorithmOrIssuerEntropy">
+        <source>An RSTR containing a proof token should not also have a computed key algorithm or issuer entropy.</source>
+        <target state="new">An RSTR containing a proof token should not also have a computed key algorithm or issuer entropy.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RequestTypeNotSupported">
+        <source>The RequestType '{0}', is not supported.</source>
+        <target state="new">The RequestType '{0}', is not supported.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SecurityEndpointNotFound">
         <source>Server '{0}' sent back a fault indicating it is in the process of shutting down. Please see the inner exception for fault details.</source>
         <target state="translated">El servidor '{0}' devolvió un error que indica que está en proceso de cerrarse. Consulte la excepción interna para obtener más información del error.</target>
@@ -20,6 +75,21 @@
       <trans-unit id="SecurityServerTooBusy">
         <source>Server '{0}' sent back a fault indicating it is too busy to process the request. Please retry later. Please see the inner exception for fault details.</source>
         <target state="translated">El servidor "{0}" devolvió un error que indica que está demasiado ocupado para procesar la solicitud. Inténtelo de nuevo más adelante. Consulte la excepción interna para obtener más información del error.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TokenProviderUnableToGetToken">
+        <source>The token provider '{0}' was unable to provide a security token.</source>
+        <target state="new">The token provider '{0}' was unable to provide a security token.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseKeysAreNotSupported">
+        <source>UseKeys are not supported</source>
+        <target state="new">UseKeys are not supported</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WsTrustVersionNotSupported">
+        <source>The WsTrust wersion '{0}' is not supported.</source>
+        <target state="new">The WsTrust wersion '{0}' is not supported.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/System.ServiceModel.Federation/src/Resources/xlf/Strings.fr.xlf
+++ b/src/System.ServiceModel.Federation/src/Resources/xlf/Strings.fr.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../Strings.resx">
     <body>
+      <trans-unit id="BearerKeyShouldNotIincludeAProofToken">
+        <source>Bearer key scenarios should not include a proof token or issuer entropy in the response.</source>
+        <target state="new">Bearer key scenarios should not include a proof token or issuer entropy in the response.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ChannelFactoryMustSupportIRequestChannel">
+        <source>ChannnelFactory must support 'System.ServiceModel.Channels.IRequestChannel' interface.</source>
+        <target state="new">ChannnelFactory must support 'System.ServiceModel.Channels.IRequestChannel' interface.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CommunicationObjectCannotBeUsed">
         <source>The communication object, {0}, is in the {1} state.  Communication objects cannot be used for communication unless they are in the Opened state.</source>
         <target state="translated">L'objet de communication {0} est dans l'état {1}. Les objets de communication ne peuvent pas être utilisés à moins d'être dans l'état Opened.</target>
@@ -12,6 +22,51 @@
         <target state="translated">L'objet de communication {0} ne peut pas être utilisé pour la communication, car il est dans l'état Faulted.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ComputedKeyProofTokensAreOnlySupportedWithSymmetricKeyTypes">
+        <source>Computed key proof tokens are only supported with symmetric key types.</source>
+        <target state="new">Computed key proof tokens are only supported with symmetric key types.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ComputedKeyProofTokensRequireIssuerToSupplyKeyMaterialViaEntropy">
+        <source>Computed key proof tokens require issuer to supply key material via entropy.</source>
+        <target state="new">Computed key proof tokens require issuer to supply key material via entropy.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ComputedKeyProofTokensRequireRequesterToSupplyKeyMaterialViaEntropy">
+        <source>Computed key proof tokens require requester to supply key material via entropy.</source>
+        <target state="new">Computed key proof tokens require requester to supply key material via entropy.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EncryptedKeysForProofTokensNotSupported">
+        <source>Encrypted keys for proof tokens are not supported.</source>
+        <target state="new">Encrypted keys for proof tokens are not supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoKeySizeProvided">
+        <source>No key size provided.</source>
+        <target state="new">No key size provided.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OnlyPSHA1ComputedKeysAreSupported">
+        <source>Only PSHA1 computed keys are supported.</source>
+        <target state="new">Only PSHA1 computed keys are supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProtectedKeyEntropyIsNotSupported">
+        <source>Protected key entropy is not supported.</source>
+        <target state="new">Protected key entropy is not supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RSTRProofTokenShouldNotHaveAComputedKeyAlgorithmOrIssuerEntropy">
+        <source>An RSTR containing a proof token should not also have a computed key algorithm or issuer entropy.</source>
+        <target state="new">An RSTR containing a proof token should not also have a computed key algorithm or issuer entropy.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RequestTypeNotSupported">
+        <source>The RequestType '{0}', is not supported.</source>
+        <target state="new">The RequestType '{0}', is not supported.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SecurityEndpointNotFound">
         <source>Server '{0}' sent back a fault indicating it is in the process of shutting down. Please see the inner exception for fault details.</source>
         <target state="translated">Le serveur '{0}' a renvoyé une erreur indiquant qu'il est en cours d'arrêt. Consultez l'exception interne pour obtenir des détails sur l'erreur.</target>
@@ -20,6 +75,21 @@
       <trans-unit id="SecurityServerTooBusy">
         <source>Server '{0}' sent back a fault indicating it is too busy to process the request. Please retry later. Please see the inner exception for fault details.</source>
         <target state="translated">Le serveur '{0}' a envoyé une erreur indiquant qu'il est trop occupé pour traiter la requête. Réessayez plus tard. Consultez l'exception interne pour obtenir des détails sur l'erreur.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TokenProviderUnableToGetToken">
+        <source>The token provider '{0}' was unable to provide a security token.</source>
+        <target state="new">The token provider '{0}' was unable to provide a security token.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseKeysAreNotSupported">
+        <source>UseKeys are not supported</source>
+        <target state="new">UseKeys are not supported</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WsTrustVersionNotSupported">
+        <source>The WsTrust wersion '{0}' is not supported.</source>
+        <target state="new">The WsTrust wersion '{0}' is not supported.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/System.ServiceModel.Federation/src/Resources/xlf/Strings.fr.xlf
+++ b/src/System.ServiceModel.Federation/src/Resources/xlf/Strings.fr.xlf
@@ -42,6 +42,26 @@
         <target state="new">Encrypted keys for proof tokens are not supported.</target>
         <note />
       </trans-unit>
+      <trans-unit id="IRequestChannelMustBeCreated">
+        <source>The IRequestChannel must be in the created state. Was: '{0}'.</source>
+        <target state="new">The IRequestChannel must be in the created state. Was: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IssuedSecurityTokenParametersIncorrectType">
+        <source>tokenRequirement.GetProperty&lt;IssuedSecurityTokenParameters&gt; must be of type: WSTrustTokenParameters. Was: '{0}.</source>
+        <target state="new">tokenRequirement.GetProperty&lt;IssuedSecurityTokenParameters&gt; must be of type: WSTrustTokenParameters. Was: '{0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IssuedTokenRenewalThresholdPercentageIncorrect">
+        <source>IssuedTokenRenewalThresholdPercentage  must be greater than or equal to 1 and less than or equal to 100. Was: '{0}'.</source>
+        <target state="new">IssuedTokenRenewalThresholdPercentage  must be greater than or equal to 1 and less than or equal to 100. Was: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MaxIssuedTokenCachingTimeMustBeGreaterThanTimeSpanZero">
+        <source>MaxIssuedTokenCachingTime must be greater than TimeSpan.Zero. Was: '{0}'.</source>
+        <target state="new">MaxIssuedTokenCachingTime must be greater than TimeSpan.Zero. Was: '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoKeySizeProvided">
         <source>No key size provided.</source>
         <target state="new">No key size provided.</target>

--- a/src/System.ServiceModel.Federation/src/Resources/xlf/Strings.it.xlf
+++ b/src/System.ServiceModel.Federation/src/Resources/xlf/Strings.it.xlf
@@ -42,6 +42,26 @@
         <target state="new">Encrypted keys for proof tokens are not supported.</target>
         <note />
       </trans-unit>
+      <trans-unit id="IRequestChannelMustBeCreated">
+        <source>The IRequestChannel must be in the created state. Was: '{0}'.</source>
+        <target state="new">The IRequestChannel must be in the created state. Was: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IssuedSecurityTokenParametersIncorrectType">
+        <source>tokenRequirement.GetProperty&lt;IssuedSecurityTokenParameters&gt; must be of type: WSTrustTokenParameters. Was: '{0}.</source>
+        <target state="new">tokenRequirement.GetProperty&lt;IssuedSecurityTokenParameters&gt; must be of type: WSTrustTokenParameters. Was: '{0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IssuedTokenRenewalThresholdPercentageIncorrect">
+        <source>IssuedTokenRenewalThresholdPercentage  must be greater than or equal to 1 and less than or equal to 100. Was: '{0}'.</source>
+        <target state="new">IssuedTokenRenewalThresholdPercentage  must be greater than or equal to 1 and less than or equal to 100. Was: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MaxIssuedTokenCachingTimeMustBeGreaterThanTimeSpanZero">
+        <source>MaxIssuedTokenCachingTime must be greater than TimeSpan.Zero. Was: '{0}'.</source>
+        <target state="new">MaxIssuedTokenCachingTime must be greater than TimeSpan.Zero. Was: '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoKeySizeProvided">
         <source>No key size provided.</source>
         <target state="new">No key size provided.</target>

--- a/src/System.ServiceModel.Federation/src/Resources/xlf/Strings.it.xlf
+++ b/src/System.ServiceModel.Federation/src/Resources/xlf/Strings.it.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../Strings.resx">
     <body>
+      <trans-unit id="BearerKeyShouldNotIincludeAProofToken">
+        <source>Bearer key scenarios should not include a proof token or issuer entropy in the response.</source>
+        <target state="new">Bearer key scenarios should not include a proof token or issuer entropy in the response.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ChannelFactoryMustSupportIRequestChannel">
+        <source>ChannnelFactory must support 'System.ServiceModel.Channels.IRequestChannel' interface.</source>
+        <target state="new">ChannnelFactory must support 'System.ServiceModel.Channels.IRequestChannel' interface.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CommunicationObjectCannotBeUsed">
         <source>The communication object, {0}, is in the {1} state.  Communication objects cannot be used for communication unless they are in the Opened state.</source>
         <target state="translated">L'oggetto comunicazione {0} si trova nello stato {1}. Non è possibile usare oggetti comunicazione per la comunicazione a meno che non siano nello stato Opened.</target>
@@ -12,6 +22,51 @@
         <target state="translated">Non è possibile usare l'oggetto comunicazione {0} per la comunicazione perché si trova nello stato Faulted.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ComputedKeyProofTokensAreOnlySupportedWithSymmetricKeyTypes">
+        <source>Computed key proof tokens are only supported with symmetric key types.</source>
+        <target state="new">Computed key proof tokens are only supported with symmetric key types.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ComputedKeyProofTokensRequireIssuerToSupplyKeyMaterialViaEntropy">
+        <source>Computed key proof tokens require issuer to supply key material via entropy.</source>
+        <target state="new">Computed key proof tokens require issuer to supply key material via entropy.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ComputedKeyProofTokensRequireRequesterToSupplyKeyMaterialViaEntropy">
+        <source>Computed key proof tokens require requester to supply key material via entropy.</source>
+        <target state="new">Computed key proof tokens require requester to supply key material via entropy.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EncryptedKeysForProofTokensNotSupported">
+        <source>Encrypted keys for proof tokens are not supported.</source>
+        <target state="new">Encrypted keys for proof tokens are not supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoKeySizeProvided">
+        <source>No key size provided.</source>
+        <target state="new">No key size provided.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OnlyPSHA1ComputedKeysAreSupported">
+        <source>Only PSHA1 computed keys are supported.</source>
+        <target state="new">Only PSHA1 computed keys are supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProtectedKeyEntropyIsNotSupported">
+        <source>Protected key entropy is not supported.</source>
+        <target state="new">Protected key entropy is not supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RSTRProofTokenShouldNotHaveAComputedKeyAlgorithmOrIssuerEntropy">
+        <source>An RSTR containing a proof token should not also have a computed key algorithm or issuer entropy.</source>
+        <target state="new">An RSTR containing a proof token should not also have a computed key algorithm or issuer entropy.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RequestTypeNotSupported">
+        <source>The RequestType '{0}', is not supported.</source>
+        <target state="new">The RequestType '{0}', is not supported.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SecurityEndpointNotFound">
         <source>Server '{0}' sent back a fault indicating it is in the process of shutting down. Please see the inner exception for fault details.</source>
         <target state="translated">Il server '{0}' ha restituito un errore che indica che è in fase di arresto. Per ulteriori informazioni sull'errore, vedere l'eccezione interna.</target>
@@ -20,6 +75,21 @@
       <trans-unit id="SecurityServerTooBusy">
         <source>Server '{0}' sent back a fault indicating it is too busy to process the request. Please retry later. Please see the inner exception for fault details.</source>
         <target state="translated">Il server '{0}' ha restituito un errore che indica che è troppo occupato per elaborare la richiesta. Riprovare più tardi. Per dettagli sull'errore, vedere l'eccezione interna.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TokenProviderUnableToGetToken">
+        <source>The token provider '{0}' was unable to provide a security token.</source>
+        <target state="new">The token provider '{0}' was unable to provide a security token.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseKeysAreNotSupported">
+        <source>UseKeys are not supported</source>
+        <target state="new">UseKeys are not supported</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WsTrustVersionNotSupported">
+        <source>The WsTrust wersion '{0}' is not supported.</source>
+        <target state="new">The WsTrust wersion '{0}' is not supported.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/System.ServiceModel.Federation/src/Resources/xlf/Strings.ja.xlf
+++ b/src/System.ServiceModel.Federation/src/Resources/xlf/Strings.ja.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../Strings.resx">
     <body>
+      <trans-unit id="BearerKeyShouldNotIincludeAProofToken">
+        <source>Bearer key scenarios should not include a proof token or issuer entropy in the response.</source>
+        <target state="new">Bearer key scenarios should not include a proof token or issuer entropy in the response.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ChannelFactoryMustSupportIRequestChannel">
+        <source>ChannnelFactory must support 'System.ServiceModel.Channels.IRequestChannel' interface.</source>
+        <target state="new">ChannnelFactory must support 'System.ServiceModel.Channels.IRequestChannel' interface.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CommunicationObjectCannotBeUsed">
         <source>The communication object, {0}, is in the {1} state.  Communication objects cannot be used for communication unless they are in the Opened state.</source>
         <target state="translated">通信オブジェクト {0} は {1} 状態です。通信オブジェクトは、Opened 状態でないと通信に使用できません。</target>
@@ -12,6 +22,51 @@
         <target state="translated">通信オブジェクト {0} は、状態が Faulted であるため通信に使用できません。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ComputedKeyProofTokensAreOnlySupportedWithSymmetricKeyTypes">
+        <source>Computed key proof tokens are only supported with symmetric key types.</source>
+        <target state="new">Computed key proof tokens are only supported with symmetric key types.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ComputedKeyProofTokensRequireIssuerToSupplyKeyMaterialViaEntropy">
+        <source>Computed key proof tokens require issuer to supply key material via entropy.</source>
+        <target state="new">Computed key proof tokens require issuer to supply key material via entropy.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ComputedKeyProofTokensRequireRequesterToSupplyKeyMaterialViaEntropy">
+        <source>Computed key proof tokens require requester to supply key material via entropy.</source>
+        <target state="new">Computed key proof tokens require requester to supply key material via entropy.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EncryptedKeysForProofTokensNotSupported">
+        <source>Encrypted keys for proof tokens are not supported.</source>
+        <target state="new">Encrypted keys for proof tokens are not supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoKeySizeProvided">
+        <source>No key size provided.</source>
+        <target state="new">No key size provided.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OnlyPSHA1ComputedKeysAreSupported">
+        <source>Only PSHA1 computed keys are supported.</source>
+        <target state="new">Only PSHA1 computed keys are supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProtectedKeyEntropyIsNotSupported">
+        <source>Protected key entropy is not supported.</source>
+        <target state="new">Protected key entropy is not supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RSTRProofTokenShouldNotHaveAComputedKeyAlgorithmOrIssuerEntropy">
+        <source>An RSTR containing a proof token should not also have a computed key algorithm or issuer entropy.</source>
+        <target state="new">An RSTR containing a proof token should not also have a computed key algorithm or issuer entropy.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RequestTypeNotSupported">
+        <source>The RequestType '{0}', is not supported.</source>
+        <target state="new">The RequestType '{0}', is not supported.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SecurityEndpointNotFound">
         <source>Server '{0}' sent back a fault indicating it is in the process of shutting down. Please see the inner exception for fault details.</source>
         <target state="translated">サーバー '{0}' は、シャットダウンの処理中であることを示すフォールトを返信しました。詳細については、内部例外を参照してください。</target>
@@ -20,6 +75,21 @@
       <trans-unit id="SecurityServerTooBusy">
         <source>Server '{0}' sent back a fault indicating it is too busy to process the request. Please retry later. Please see the inner exception for fault details.</source>
         <target state="translated">サーバー '{0}' は、ビジー状態のため要求を処理できないことを示すフォールトを送り返しました。後で再試行してください。フォールトの詳細については、内部例外を参照してください。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TokenProviderUnableToGetToken">
+        <source>The token provider '{0}' was unable to provide a security token.</source>
+        <target state="new">The token provider '{0}' was unable to provide a security token.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseKeysAreNotSupported">
+        <source>UseKeys are not supported</source>
+        <target state="new">UseKeys are not supported</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WsTrustVersionNotSupported">
+        <source>The WsTrust wersion '{0}' is not supported.</source>
+        <target state="new">The WsTrust wersion '{0}' is not supported.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/System.ServiceModel.Federation/src/Resources/xlf/Strings.ja.xlf
+++ b/src/System.ServiceModel.Federation/src/Resources/xlf/Strings.ja.xlf
@@ -42,6 +42,26 @@
         <target state="new">Encrypted keys for proof tokens are not supported.</target>
         <note />
       </trans-unit>
+      <trans-unit id="IRequestChannelMustBeCreated">
+        <source>The IRequestChannel must be in the created state. Was: '{0}'.</source>
+        <target state="new">The IRequestChannel must be in the created state. Was: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IssuedSecurityTokenParametersIncorrectType">
+        <source>tokenRequirement.GetProperty&lt;IssuedSecurityTokenParameters&gt; must be of type: WSTrustTokenParameters. Was: '{0}.</source>
+        <target state="new">tokenRequirement.GetProperty&lt;IssuedSecurityTokenParameters&gt; must be of type: WSTrustTokenParameters. Was: '{0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IssuedTokenRenewalThresholdPercentageIncorrect">
+        <source>IssuedTokenRenewalThresholdPercentage  must be greater than or equal to 1 and less than or equal to 100. Was: '{0}'.</source>
+        <target state="new">IssuedTokenRenewalThresholdPercentage  must be greater than or equal to 1 and less than or equal to 100. Was: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MaxIssuedTokenCachingTimeMustBeGreaterThanTimeSpanZero">
+        <source>MaxIssuedTokenCachingTime must be greater than TimeSpan.Zero. Was: '{0}'.</source>
+        <target state="new">MaxIssuedTokenCachingTime must be greater than TimeSpan.Zero. Was: '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoKeySizeProvided">
         <source>No key size provided.</source>
         <target state="new">No key size provided.</target>

--- a/src/System.ServiceModel.Federation/src/Resources/xlf/Strings.ko.xlf
+++ b/src/System.ServiceModel.Federation/src/Resources/xlf/Strings.ko.xlf
@@ -42,6 +42,26 @@
         <target state="new">Encrypted keys for proof tokens are not supported.</target>
         <note />
       </trans-unit>
+      <trans-unit id="IRequestChannelMustBeCreated">
+        <source>The IRequestChannel must be in the created state. Was: '{0}'.</source>
+        <target state="new">The IRequestChannel must be in the created state. Was: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IssuedSecurityTokenParametersIncorrectType">
+        <source>tokenRequirement.GetProperty&lt;IssuedSecurityTokenParameters&gt; must be of type: WSTrustTokenParameters. Was: '{0}.</source>
+        <target state="new">tokenRequirement.GetProperty&lt;IssuedSecurityTokenParameters&gt; must be of type: WSTrustTokenParameters. Was: '{0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IssuedTokenRenewalThresholdPercentageIncorrect">
+        <source>IssuedTokenRenewalThresholdPercentage  must be greater than or equal to 1 and less than or equal to 100. Was: '{0}'.</source>
+        <target state="new">IssuedTokenRenewalThresholdPercentage  must be greater than or equal to 1 and less than or equal to 100. Was: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MaxIssuedTokenCachingTimeMustBeGreaterThanTimeSpanZero">
+        <source>MaxIssuedTokenCachingTime must be greater than TimeSpan.Zero. Was: '{0}'.</source>
+        <target state="new">MaxIssuedTokenCachingTime must be greater than TimeSpan.Zero. Was: '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoKeySizeProvided">
         <source>No key size provided.</source>
         <target state="new">No key size provided.</target>

--- a/src/System.ServiceModel.Federation/src/Resources/xlf/Strings.ko.xlf
+++ b/src/System.ServiceModel.Federation/src/Resources/xlf/Strings.ko.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../Strings.resx">
     <body>
+      <trans-unit id="BearerKeyShouldNotIincludeAProofToken">
+        <source>Bearer key scenarios should not include a proof token or issuer entropy in the response.</source>
+        <target state="new">Bearer key scenarios should not include a proof token or issuer entropy in the response.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ChannelFactoryMustSupportIRequestChannel">
+        <source>ChannnelFactory must support 'System.ServiceModel.Channels.IRequestChannel' interface.</source>
+        <target state="new">ChannnelFactory must support 'System.ServiceModel.Channels.IRequestChannel' interface.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CommunicationObjectCannotBeUsed">
         <source>The communication object, {0}, is in the {1} state.  Communication objects cannot be used for communication unless they are in the Opened state.</source>
         <target state="translated">통신 개체 {0}이(가) {1} 상태입니다. 통신 개체는 열림 상태가 아닌 경우 통신에 사용할 수 없습니다.</target>
@@ -12,6 +22,51 @@
         <target state="translated">통신 개체 {0}은(는) Faulted 상태이기 때문에 통신에 사용할 수 없습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ComputedKeyProofTokensAreOnlySupportedWithSymmetricKeyTypes">
+        <source>Computed key proof tokens are only supported with symmetric key types.</source>
+        <target state="new">Computed key proof tokens are only supported with symmetric key types.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ComputedKeyProofTokensRequireIssuerToSupplyKeyMaterialViaEntropy">
+        <source>Computed key proof tokens require issuer to supply key material via entropy.</source>
+        <target state="new">Computed key proof tokens require issuer to supply key material via entropy.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ComputedKeyProofTokensRequireRequesterToSupplyKeyMaterialViaEntropy">
+        <source>Computed key proof tokens require requester to supply key material via entropy.</source>
+        <target state="new">Computed key proof tokens require requester to supply key material via entropy.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EncryptedKeysForProofTokensNotSupported">
+        <source>Encrypted keys for proof tokens are not supported.</source>
+        <target state="new">Encrypted keys for proof tokens are not supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoKeySizeProvided">
+        <source>No key size provided.</source>
+        <target state="new">No key size provided.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OnlyPSHA1ComputedKeysAreSupported">
+        <source>Only PSHA1 computed keys are supported.</source>
+        <target state="new">Only PSHA1 computed keys are supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProtectedKeyEntropyIsNotSupported">
+        <source>Protected key entropy is not supported.</source>
+        <target state="new">Protected key entropy is not supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RSTRProofTokenShouldNotHaveAComputedKeyAlgorithmOrIssuerEntropy">
+        <source>An RSTR containing a proof token should not also have a computed key algorithm or issuer entropy.</source>
+        <target state="new">An RSTR containing a proof token should not also have a computed key algorithm or issuer entropy.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RequestTypeNotSupported">
+        <source>The RequestType '{0}', is not supported.</source>
+        <target state="new">The RequestType '{0}', is not supported.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SecurityEndpointNotFound">
         <source>Server '{0}' sent back a fault indicating it is in the process of shutting down. Please see the inner exception for fault details.</source>
         <target state="translated">종료하는 중이라는 것을 나타내는 오류를 '{0}' 서버가 다시 보냈습니다. 자세한 오류 내용은 내부 예외를 참조하십시오.</target>
@@ -20,6 +75,21 @@
       <trans-unit id="SecurityServerTooBusy">
         <source>Server '{0}' sent back a fault indicating it is too busy to process the request. Please retry later. Please see the inner exception for fault details.</source>
         <target state="translated">사용 중이어서 요청을 처리할 수 없다는 것을 나타내는 오류를 '{0}' 서버가 다시 보냈습니다. 나중에 다시 시도하세요. 자세한 오류 내용은 내부 예외를 참조하세요.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TokenProviderUnableToGetToken">
+        <source>The token provider '{0}' was unable to provide a security token.</source>
+        <target state="new">The token provider '{0}' was unable to provide a security token.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseKeysAreNotSupported">
+        <source>UseKeys are not supported</source>
+        <target state="new">UseKeys are not supported</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WsTrustVersionNotSupported">
+        <source>The WsTrust wersion '{0}' is not supported.</source>
+        <target state="new">The WsTrust wersion '{0}' is not supported.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/System.ServiceModel.Federation/src/Resources/xlf/Strings.pl.xlf
+++ b/src/System.ServiceModel.Federation/src/Resources/xlf/Strings.pl.xlf
@@ -42,6 +42,26 @@
         <target state="new">Encrypted keys for proof tokens are not supported.</target>
         <note />
       </trans-unit>
+      <trans-unit id="IRequestChannelMustBeCreated">
+        <source>The IRequestChannel must be in the created state. Was: '{0}'.</source>
+        <target state="new">The IRequestChannel must be in the created state. Was: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IssuedSecurityTokenParametersIncorrectType">
+        <source>tokenRequirement.GetProperty&lt;IssuedSecurityTokenParameters&gt; must be of type: WSTrustTokenParameters. Was: '{0}.</source>
+        <target state="new">tokenRequirement.GetProperty&lt;IssuedSecurityTokenParameters&gt; must be of type: WSTrustTokenParameters. Was: '{0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IssuedTokenRenewalThresholdPercentageIncorrect">
+        <source>IssuedTokenRenewalThresholdPercentage  must be greater than or equal to 1 and less than or equal to 100. Was: '{0}'.</source>
+        <target state="new">IssuedTokenRenewalThresholdPercentage  must be greater than or equal to 1 and less than or equal to 100. Was: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MaxIssuedTokenCachingTimeMustBeGreaterThanTimeSpanZero">
+        <source>MaxIssuedTokenCachingTime must be greater than TimeSpan.Zero. Was: '{0}'.</source>
+        <target state="new">MaxIssuedTokenCachingTime must be greater than TimeSpan.Zero. Was: '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoKeySizeProvided">
         <source>No key size provided.</source>
         <target state="new">No key size provided.</target>

--- a/src/System.ServiceModel.Federation/src/Resources/xlf/Strings.pl.xlf
+++ b/src/System.ServiceModel.Federation/src/Resources/xlf/Strings.pl.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../Strings.resx">
     <body>
+      <trans-unit id="BearerKeyShouldNotIincludeAProofToken">
+        <source>Bearer key scenarios should not include a proof token or issuer entropy in the response.</source>
+        <target state="new">Bearer key scenarios should not include a proof token or issuer entropy in the response.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ChannelFactoryMustSupportIRequestChannel">
+        <source>ChannnelFactory must support 'System.ServiceModel.Channels.IRequestChannel' interface.</source>
+        <target state="new">ChannnelFactory must support 'System.ServiceModel.Channels.IRequestChannel' interface.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CommunicationObjectCannotBeUsed">
         <source>The communication object, {0}, is in the {1} state.  Communication objects cannot be used for communication unless they are in the Opened state.</source>
         <target state="translated">Obiekt komunikacyjny {0} jest w stanie {1}. Obiektów komunikacyjnych nie można używać do komunikacji, jeśli nie są w stanie Opened.</target>
@@ -12,6 +22,51 @@
         <target state="translated">Obiektu komunikacyjnego {0} nie można używać do komunikacji, ponieważ jest w stanie Faulted.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ComputedKeyProofTokensAreOnlySupportedWithSymmetricKeyTypes">
+        <source>Computed key proof tokens are only supported with symmetric key types.</source>
+        <target state="new">Computed key proof tokens are only supported with symmetric key types.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ComputedKeyProofTokensRequireIssuerToSupplyKeyMaterialViaEntropy">
+        <source>Computed key proof tokens require issuer to supply key material via entropy.</source>
+        <target state="new">Computed key proof tokens require issuer to supply key material via entropy.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ComputedKeyProofTokensRequireRequesterToSupplyKeyMaterialViaEntropy">
+        <source>Computed key proof tokens require requester to supply key material via entropy.</source>
+        <target state="new">Computed key proof tokens require requester to supply key material via entropy.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EncryptedKeysForProofTokensNotSupported">
+        <source>Encrypted keys for proof tokens are not supported.</source>
+        <target state="new">Encrypted keys for proof tokens are not supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoKeySizeProvided">
+        <source>No key size provided.</source>
+        <target state="new">No key size provided.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OnlyPSHA1ComputedKeysAreSupported">
+        <source>Only PSHA1 computed keys are supported.</source>
+        <target state="new">Only PSHA1 computed keys are supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProtectedKeyEntropyIsNotSupported">
+        <source>Protected key entropy is not supported.</source>
+        <target state="new">Protected key entropy is not supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RSTRProofTokenShouldNotHaveAComputedKeyAlgorithmOrIssuerEntropy">
+        <source>An RSTR containing a proof token should not also have a computed key algorithm or issuer entropy.</source>
+        <target state="new">An RSTR containing a proof token should not also have a computed key algorithm or issuer entropy.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RequestTypeNotSupported">
+        <source>The RequestType '{0}', is not supported.</source>
+        <target state="new">The RequestType '{0}', is not supported.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SecurityEndpointNotFound">
         <source>Server '{0}' sent back a fault indicating it is in the process of shutting down. Please see the inner exception for fault details.</source>
         <target state="translated">Serwer „{0}” zwrócił błąd wskazujący, że właśnie trwa jego zamykanie. Szczegółowe informacje o błędzie można znaleźć w wewnętrznym wyjątku.</target>
@@ -20,6 +75,21 @@
       <trans-unit id="SecurityServerTooBusy">
         <source>Server '{0}' sent back a fault indicating it is too busy to process the request. Please retry later. Please see the inner exception for fault details.</source>
         <target state="translated">Serwer „{0}” zwrócił błąd wskazujący, że jest zbyt obciążony, aby obsłużyć żądanie. Spróbuj ponownie później. Szczegółowe informacje o błędzie można znaleźć w wewnętrznym wyjątku.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TokenProviderUnableToGetToken">
+        <source>The token provider '{0}' was unable to provide a security token.</source>
+        <target state="new">The token provider '{0}' was unable to provide a security token.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseKeysAreNotSupported">
+        <source>UseKeys are not supported</source>
+        <target state="new">UseKeys are not supported</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WsTrustVersionNotSupported">
+        <source>The WsTrust wersion '{0}' is not supported.</source>
+        <target state="new">The WsTrust wersion '{0}' is not supported.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/System.ServiceModel.Federation/src/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/System.ServiceModel.Federation/src/Resources/xlf/Strings.pt-BR.xlf
@@ -42,6 +42,26 @@
         <target state="new">Encrypted keys for proof tokens are not supported.</target>
         <note />
       </trans-unit>
+      <trans-unit id="IRequestChannelMustBeCreated">
+        <source>The IRequestChannel must be in the created state. Was: '{0}'.</source>
+        <target state="new">The IRequestChannel must be in the created state. Was: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IssuedSecurityTokenParametersIncorrectType">
+        <source>tokenRequirement.GetProperty&lt;IssuedSecurityTokenParameters&gt; must be of type: WSTrustTokenParameters. Was: '{0}.</source>
+        <target state="new">tokenRequirement.GetProperty&lt;IssuedSecurityTokenParameters&gt; must be of type: WSTrustTokenParameters. Was: '{0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IssuedTokenRenewalThresholdPercentageIncorrect">
+        <source>IssuedTokenRenewalThresholdPercentage  must be greater than or equal to 1 and less than or equal to 100. Was: '{0}'.</source>
+        <target state="new">IssuedTokenRenewalThresholdPercentage  must be greater than or equal to 1 and less than or equal to 100. Was: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MaxIssuedTokenCachingTimeMustBeGreaterThanTimeSpanZero">
+        <source>MaxIssuedTokenCachingTime must be greater than TimeSpan.Zero. Was: '{0}'.</source>
+        <target state="new">MaxIssuedTokenCachingTime must be greater than TimeSpan.Zero. Was: '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoKeySizeProvided">
         <source>No key size provided.</source>
         <target state="new">No key size provided.</target>

--- a/src/System.ServiceModel.Federation/src/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/System.ServiceModel.Federation/src/Resources/xlf/Strings.pt-BR.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../Strings.resx">
     <body>
+      <trans-unit id="BearerKeyShouldNotIincludeAProofToken">
+        <source>Bearer key scenarios should not include a proof token or issuer entropy in the response.</source>
+        <target state="new">Bearer key scenarios should not include a proof token or issuer entropy in the response.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ChannelFactoryMustSupportIRequestChannel">
+        <source>ChannnelFactory must support 'System.ServiceModel.Channels.IRequestChannel' interface.</source>
+        <target state="new">ChannnelFactory must support 'System.ServiceModel.Channels.IRequestChannel' interface.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CommunicationObjectCannotBeUsed">
         <source>The communication object, {0}, is in the {1} state.  Communication objects cannot be used for communication unless they are in the Opened state.</source>
         <target state="translated">O objeto de comunicação, {0}, está no estado {1}. Objetos de comunicação não poderão ser usados para comunicação, a não ser que estejam no estado Aberto.</target>
@@ -12,6 +22,51 @@
         <target state="translated">O objeto de comunicação, {0}, não pode ser usado para comunicação porque está no estado Com Falha.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ComputedKeyProofTokensAreOnlySupportedWithSymmetricKeyTypes">
+        <source>Computed key proof tokens are only supported with symmetric key types.</source>
+        <target state="new">Computed key proof tokens are only supported with symmetric key types.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ComputedKeyProofTokensRequireIssuerToSupplyKeyMaterialViaEntropy">
+        <source>Computed key proof tokens require issuer to supply key material via entropy.</source>
+        <target state="new">Computed key proof tokens require issuer to supply key material via entropy.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ComputedKeyProofTokensRequireRequesterToSupplyKeyMaterialViaEntropy">
+        <source>Computed key proof tokens require requester to supply key material via entropy.</source>
+        <target state="new">Computed key proof tokens require requester to supply key material via entropy.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EncryptedKeysForProofTokensNotSupported">
+        <source>Encrypted keys for proof tokens are not supported.</source>
+        <target state="new">Encrypted keys for proof tokens are not supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoKeySizeProvided">
+        <source>No key size provided.</source>
+        <target state="new">No key size provided.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OnlyPSHA1ComputedKeysAreSupported">
+        <source>Only PSHA1 computed keys are supported.</source>
+        <target state="new">Only PSHA1 computed keys are supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProtectedKeyEntropyIsNotSupported">
+        <source>Protected key entropy is not supported.</source>
+        <target state="new">Protected key entropy is not supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RSTRProofTokenShouldNotHaveAComputedKeyAlgorithmOrIssuerEntropy">
+        <source>An RSTR containing a proof token should not also have a computed key algorithm or issuer entropy.</source>
+        <target state="new">An RSTR containing a proof token should not also have a computed key algorithm or issuer entropy.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RequestTypeNotSupported">
+        <source>The RequestType '{0}', is not supported.</source>
+        <target state="new">The RequestType '{0}', is not supported.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SecurityEndpointNotFound">
         <source>Server '{0}' sent back a fault indicating it is in the process of shutting down. Please see the inner exception for fault details.</source>
         <target state="translated">O servidor '{0}' retornou uma falha indicando que ele está desligando. Consulte a exceção interna para obter os detalhes da falha.</target>
@@ -20,6 +75,21 @@
       <trans-unit id="SecurityServerTooBusy">
         <source>Server '{0}' sent back a fault indicating it is too busy to process the request. Please retry later. Please see the inner exception for fault details.</source>
         <target state="translated">O servidor '{0}' retornou uma falha indicando que ele está muito ocupado para processar a solicitação. Tente novamente mais tarde. Consulte a exceção interna para obter os detalhes da falha.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TokenProviderUnableToGetToken">
+        <source>The token provider '{0}' was unable to provide a security token.</source>
+        <target state="new">The token provider '{0}' was unable to provide a security token.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseKeysAreNotSupported">
+        <source>UseKeys are not supported</source>
+        <target state="new">UseKeys are not supported</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WsTrustVersionNotSupported">
+        <source>The WsTrust wersion '{0}' is not supported.</source>
+        <target state="new">The WsTrust wersion '{0}' is not supported.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/System.ServiceModel.Federation/src/Resources/xlf/Strings.ru.xlf
+++ b/src/System.ServiceModel.Federation/src/Resources/xlf/Strings.ru.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../Strings.resx">
     <body>
+      <trans-unit id="BearerKeyShouldNotIincludeAProofToken">
+        <source>Bearer key scenarios should not include a proof token or issuer entropy in the response.</source>
+        <target state="new">Bearer key scenarios should not include a proof token or issuer entropy in the response.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ChannelFactoryMustSupportIRequestChannel">
+        <source>ChannnelFactory must support 'System.ServiceModel.Channels.IRequestChannel' interface.</source>
+        <target state="new">ChannnelFactory must support 'System.ServiceModel.Channels.IRequestChannel' interface.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CommunicationObjectCannotBeUsed">
         <source>The communication object, {0}, is in the {1} state.  Communication objects cannot be used for communication unless they are in the Opened state.</source>
         <target state="translated">Объект связи {0} находится в состоянии {1}. Объекты связи можно использовать для связи только в состоянии Opened.</target>
@@ -12,6 +22,51 @@
         <target state="translated">Объект связи {0} нельзя использовать для связи, так как он находится в состоянии Faulted.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ComputedKeyProofTokensAreOnlySupportedWithSymmetricKeyTypes">
+        <source>Computed key proof tokens are only supported with symmetric key types.</source>
+        <target state="new">Computed key proof tokens are only supported with symmetric key types.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ComputedKeyProofTokensRequireIssuerToSupplyKeyMaterialViaEntropy">
+        <source>Computed key proof tokens require issuer to supply key material via entropy.</source>
+        <target state="new">Computed key proof tokens require issuer to supply key material via entropy.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ComputedKeyProofTokensRequireRequesterToSupplyKeyMaterialViaEntropy">
+        <source>Computed key proof tokens require requester to supply key material via entropy.</source>
+        <target state="new">Computed key proof tokens require requester to supply key material via entropy.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EncryptedKeysForProofTokensNotSupported">
+        <source>Encrypted keys for proof tokens are not supported.</source>
+        <target state="new">Encrypted keys for proof tokens are not supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoKeySizeProvided">
+        <source>No key size provided.</source>
+        <target state="new">No key size provided.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OnlyPSHA1ComputedKeysAreSupported">
+        <source>Only PSHA1 computed keys are supported.</source>
+        <target state="new">Only PSHA1 computed keys are supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProtectedKeyEntropyIsNotSupported">
+        <source>Protected key entropy is not supported.</source>
+        <target state="new">Protected key entropy is not supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RSTRProofTokenShouldNotHaveAComputedKeyAlgorithmOrIssuerEntropy">
+        <source>An RSTR containing a proof token should not also have a computed key algorithm or issuer entropy.</source>
+        <target state="new">An RSTR containing a proof token should not also have a computed key algorithm or issuer entropy.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RequestTypeNotSupported">
+        <source>The RequestType '{0}', is not supported.</source>
+        <target state="new">The RequestType '{0}', is not supported.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SecurityEndpointNotFound">
         <source>Server '{0}' sent back a fault indicating it is in the process of shutting down. Please see the inner exception for fault details.</source>
         <target state="translated">Сервер "{0}" отправил обратно сообщение об ошибке, указывающее, что он находится в процессе отключения. Дополнительные сведения об ошибке см. внутреннее исключение.</target>
@@ -20,6 +75,21 @@
       <trans-unit id="SecurityServerTooBusy">
         <source>Server '{0}' sent back a fault indicating it is too busy to process the request. Please retry later. Please see the inner exception for fault details.</source>
         <target state="translated">Сервер "{0}" отправил обратно сообщение об ошибке, указывающее, что он перегружен и не может обработать запрос. Повторите попытку позже. Дополнительные сведения об ошибке см. в описании внутреннего исключения.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TokenProviderUnableToGetToken">
+        <source>The token provider '{0}' was unable to provide a security token.</source>
+        <target state="new">The token provider '{0}' was unable to provide a security token.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseKeysAreNotSupported">
+        <source>UseKeys are not supported</source>
+        <target state="new">UseKeys are not supported</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WsTrustVersionNotSupported">
+        <source>The WsTrust wersion '{0}' is not supported.</source>
+        <target state="new">The WsTrust wersion '{0}' is not supported.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/System.ServiceModel.Federation/src/Resources/xlf/Strings.ru.xlf
+++ b/src/System.ServiceModel.Federation/src/Resources/xlf/Strings.ru.xlf
@@ -42,6 +42,26 @@
         <target state="new">Encrypted keys for proof tokens are not supported.</target>
         <note />
       </trans-unit>
+      <trans-unit id="IRequestChannelMustBeCreated">
+        <source>The IRequestChannel must be in the created state. Was: '{0}'.</source>
+        <target state="new">The IRequestChannel must be in the created state. Was: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IssuedSecurityTokenParametersIncorrectType">
+        <source>tokenRequirement.GetProperty&lt;IssuedSecurityTokenParameters&gt; must be of type: WSTrustTokenParameters. Was: '{0}.</source>
+        <target state="new">tokenRequirement.GetProperty&lt;IssuedSecurityTokenParameters&gt; must be of type: WSTrustTokenParameters. Was: '{0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IssuedTokenRenewalThresholdPercentageIncorrect">
+        <source>IssuedTokenRenewalThresholdPercentage  must be greater than or equal to 1 and less than or equal to 100. Was: '{0}'.</source>
+        <target state="new">IssuedTokenRenewalThresholdPercentage  must be greater than or equal to 1 and less than or equal to 100. Was: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MaxIssuedTokenCachingTimeMustBeGreaterThanTimeSpanZero">
+        <source>MaxIssuedTokenCachingTime must be greater than TimeSpan.Zero. Was: '{0}'.</source>
+        <target state="new">MaxIssuedTokenCachingTime must be greater than TimeSpan.Zero. Was: '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoKeySizeProvided">
         <source>No key size provided.</source>
         <target state="new">No key size provided.</target>

--- a/src/System.ServiceModel.Federation/src/Resources/xlf/Strings.tr.xlf
+++ b/src/System.ServiceModel.Federation/src/Resources/xlf/Strings.tr.xlf
@@ -42,6 +42,26 @@
         <target state="new">Encrypted keys for proof tokens are not supported.</target>
         <note />
       </trans-unit>
+      <trans-unit id="IRequestChannelMustBeCreated">
+        <source>The IRequestChannel must be in the created state. Was: '{0}'.</source>
+        <target state="new">The IRequestChannel must be in the created state. Was: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IssuedSecurityTokenParametersIncorrectType">
+        <source>tokenRequirement.GetProperty&lt;IssuedSecurityTokenParameters&gt; must be of type: WSTrustTokenParameters. Was: '{0}.</source>
+        <target state="new">tokenRequirement.GetProperty&lt;IssuedSecurityTokenParameters&gt; must be of type: WSTrustTokenParameters. Was: '{0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IssuedTokenRenewalThresholdPercentageIncorrect">
+        <source>IssuedTokenRenewalThresholdPercentage  must be greater than or equal to 1 and less than or equal to 100. Was: '{0}'.</source>
+        <target state="new">IssuedTokenRenewalThresholdPercentage  must be greater than or equal to 1 and less than or equal to 100. Was: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MaxIssuedTokenCachingTimeMustBeGreaterThanTimeSpanZero">
+        <source>MaxIssuedTokenCachingTime must be greater than TimeSpan.Zero. Was: '{0}'.</source>
+        <target state="new">MaxIssuedTokenCachingTime must be greater than TimeSpan.Zero. Was: '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoKeySizeProvided">
         <source>No key size provided.</source>
         <target state="new">No key size provided.</target>

--- a/src/System.ServiceModel.Federation/src/Resources/xlf/Strings.tr.xlf
+++ b/src/System.ServiceModel.Federation/src/Resources/xlf/Strings.tr.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../Strings.resx">
     <body>
+      <trans-unit id="BearerKeyShouldNotIincludeAProofToken">
+        <source>Bearer key scenarios should not include a proof token or issuer entropy in the response.</source>
+        <target state="new">Bearer key scenarios should not include a proof token or issuer entropy in the response.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ChannelFactoryMustSupportIRequestChannel">
+        <source>ChannnelFactory must support 'System.ServiceModel.Channels.IRequestChannel' interface.</source>
+        <target state="new">ChannnelFactory must support 'System.ServiceModel.Channels.IRequestChannel' interface.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CommunicationObjectCannotBeUsed">
         <source>The communication object, {0}, is in the {1} state.  Communication objects cannot be used for communication unless they are in the Opened state.</source>
         <target state="translated">{0} iletişim nesnesi {1} durumunda. Opened durumunda olmadıkları sürece, iletişim nesneleri iletişim için kullanılamaz.</target>
@@ -12,6 +22,51 @@
         <target state="translated">{0} iletişim nesnesi, Faulted durumunda olduğundan iletişim için kullanılamıyor.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ComputedKeyProofTokensAreOnlySupportedWithSymmetricKeyTypes">
+        <source>Computed key proof tokens are only supported with symmetric key types.</source>
+        <target state="new">Computed key proof tokens are only supported with symmetric key types.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ComputedKeyProofTokensRequireIssuerToSupplyKeyMaterialViaEntropy">
+        <source>Computed key proof tokens require issuer to supply key material via entropy.</source>
+        <target state="new">Computed key proof tokens require issuer to supply key material via entropy.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ComputedKeyProofTokensRequireRequesterToSupplyKeyMaterialViaEntropy">
+        <source>Computed key proof tokens require requester to supply key material via entropy.</source>
+        <target state="new">Computed key proof tokens require requester to supply key material via entropy.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EncryptedKeysForProofTokensNotSupported">
+        <source>Encrypted keys for proof tokens are not supported.</source>
+        <target state="new">Encrypted keys for proof tokens are not supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoKeySizeProvided">
+        <source>No key size provided.</source>
+        <target state="new">No key size provided.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OnlyPSHA1ComputedKeysAreSupported">
+        <source>Only PSHA1 computed keys are supported.</source>
+        <target state="new">Only PSHA1 computed keys are supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProtectedKeyEntropyIsNotSupported">
+        <source>Protected key entropy is not supported.</source>
+        <target state="new">Protected key entropy is not supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RSTRProofTokenShouldNotHaveAComputedKeyAlgorithmOrIssuerEntropy">
+        <source>An RSTR containing a proof token should not also have a computed key algorithm or issuer entropy.</source>
+        <target state="new">An RSTR containing a proof token should not also have a computed key algorithm or issuer entropy.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RequestTypeNotSupported">
+        <source>The RequestType '{0}', is not supported.</source>
+        <target state="new">The RequestType '{0}', is not supported.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SecurityEndpointNotFound">
         <source>Server '{0}' sent back a fault indicating it is in the process of shutting down. Please see the inner exception for fault details.</source>
         <target state="translated">'{0}' sunucusu, kapanmakta olduğunu belirten bir hata gönderdi. Hata ayrıntıları için iç özel duruma bakın.</target>
@@ -20,6 +75,21 @@
       <trans-unit id="SecurityServerTooBusy">
         <source>Server '{0}' sent back a fault indicating it is too busy to process the request. Please retry later. Please see the inner exception for fault details.</source>
         <target state="translated">'{0}' sunucusu bir hata geri göndererek, isteği işleyemeyecek kadar meşgul olduğunu belirtti. Lütfen daha sonra yeniden deneyin. Hata ayrıntıları için iç özel duruma bakın.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TokenProviderUnableToGetToken">
+        <source>The token provider '{0}' was unable to provide a security token.</source>
+        <target state="new">The token provider '{0}' was unable to provide a security token.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseKeysAreNotSupported">
+        <source>UseKeys are not supported</source>
+        <target state="new">UseKeys are not supported</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WsTrustVersionNotSupported">
+        <source>The WsTrust wersion '{0}' is not supported.</source>
+        <target state="new">The WsTrust wersion '{0}' is not supported.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/System.ServiceModel.Federation/src/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/System.ServiceModel.Federation/src/Resources/xlf/Strings.zh-Hans.xlf
@@ -42,6 +42,26 @@
         <target state="new">Encrypted keys for proof tokens are not supported.</target>
         <note />
       </trans-unit>
+      <trans-unit id="IRequestChannelMustBeCreated">
+        <source>The IRequestChannel must be in the created state. Was: '{0}'.</source>
+        <target state="new">The IRequestChannel must be in the created state. Was: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IssuedSecurityTokenParametersIncorrectType">
+        <source>tokenRequirement.GetProperty&lt;IssuedSecurityTokenParameters&gt; must be of type: WSTrustTokenParameters. Was: '{0}.</source>
+        <target state="new">tokenRequirement.GetProperty&lt;IssuedSecurityTokenParameters&gt; must be of type: WSTrustTokenParameters. Was: '{0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IssuedTokenRenewalThresholdPercentageIncorrect">
+        <source>IssuedTokenRenewalThresholdPercentage  must be greater than or equal to 1 and less than or equal to 100. Was: '{0}'.</source>
+        <target state="new">IssuedTokenRenewalThresholdPercentage  must be greater than or equal to 1 and less than or equal to 100. Was: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MaxIssuedTokenCachingTimeMustBeGreaterThanTimeSpanZero">
+        <source>MaxIssuedTokenCachingTime must be greater than TimeSpan.Zero. Was: '{0}'.</source>
+        <target state="new">MaxIssuedTokenCachingTime must be greater than TimeSpan.Zero. Was: '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoKeySizeProvided">
         <source>No key size provided.</source>
         <target state="new">No key size provided.</target>

--- a/src/System.ServiceModel.Federation/src/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/System.ServiceModel.Federation/src/Resources/xlf/Strings.zh-Hans.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../Strings.resx">
     <body>
+      <trans-unit id="BearerKeyShouldNotIincludeAProofToken">
+        <source>Bearer key scenarios should not include a proof token or issuer entropy in the response.</source>
+        <target state="new">Bearer key scenarios should not include a proof token or issuer entropy in the response.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ChannelFactoryMustSupportIRequestChannel">
+        <source>ChannnelFactory must support 'System.ServiceModel.Channels.IRequestChannel' interface.</source>
+        <target state="new">ChannnelFactory must support 'System.ServiceModel.Channels.IRequestChannel' interface.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CommunicationObjectCannotBeUsed">
         <source>The communication object, {0}, is in the {1} state.  Communication objects cannot be used for communication unless they are in the Opened state.</source>
         <target state="translated">通信对象 {0} 处于 {1} 状态。除非通信对象处于“已打开”状态，否则无法将其用于通信。</target>
@@ -12,6 +22,51 @@
         <target state="translated">通信对象 {0} 无法用于通信，因为其处于“出错”状态。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ComputedKeyProofTokensAreOnlySupportedWithSymmetricKeyTypes">
+        <source>Computed key proof tokens are only supported with symmetric key types.</source>
+        <target state="new">Computed key proof tokens are only supported with symmetric key types.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ComputedKeyProofTokensRequireIssuerToSupplyKeyMaterialViaEntropy">
+        <source>Computed key proof tokens require issuer to supply key material via entropy.</source>
+        <target state="new">Computed key proof tokens require issuer to supply key material via entropy.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ComputedKeyProofTokensRequireRequesterToSupplyKeyMaterialViaEntropy">
+        <source>Computed key proof tokens require requester to supply key material via entropy.</source>
+        <target state="new">Computed key proof tokens require requester to supply key material via entropy.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EncryptedKeysForProofTokensNotSupported">
+        <source>Encrypted keys for proof tokens are not supported.</source>
+        <target state="new">Encrypted keys for proof tokens are not supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoKeySizeProvided">
+        <source>No key size provided.</source>
+        <target state="new">No key size provided.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OnlyPSHA1ComputedKeysAreSupported">
+        <source>Only PSHA1 computed keys are supported.</source>
+        <target state="new">Only PSHA1 computed keys are supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProtectedKeyEntropyIsNotSupported">
+        <source>Protected key entropy is not supported.</source>
+        <target state="new">Protected key entropy is not supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RSTRProofTokenShouldNotHaveAComputedKeyAlgorithmOrIssuerEntropy">
+        <source>An RSTR containing a proof token should not also have a computed key algorithm or issuer entropy.</source>
+        <target state="new">An RSTR containing a proof token should not also have a computed key algorithm or issuer entropy.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RequestTypeNotSupported">
+        <source>The RequestType '{0}', is not supported.</source>
+        <target state="new">The RequestType '{0}', is not supported.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SecurityEndpointNotFound">
         <source>Server '{0}' sent back a fault indicating it is in the process of shutting down. Please see the inner exception for fault details.</source>
         <target state="translated">服务器“{0}”发回错误，指示其正在关机。有关错误的详细信息，请参见内部异常。</target>
@@ -20,6 +75,21 @@
       <trans-unit id="SecurityServerTooBusy">
         <source>Server '{0}' sent back a fault indicating it is too busy to process the request. Please retry later. Please see the inner exception for fault details.</source>
         <target state="translated">服务器“{0}”发回错误，指示其太忙，无法处理请求。请稍后重试。有关错误的详细信息，请参见内部异常。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TokenProviderUnableToGetToken">
+        <source>The token provider '{0}' was unable to provide a security token.</source>
+        <target state="new">The token provider '{0}' was unable to provide a security token.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseKeysAreNotSupported">
+        <source>UseKeys are not supported</source>
+        <target state="new">UseKeys are not supported</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WsTrustVersionNotSupported">
+        <source>The WsTrust wersion '{0}' is not supported.</source>
+        <target state="new">The WsTrust wersion '{0}' is not supported.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/System.ServiceModel.Federation/src/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/System.ServiceModel.Federation/src/Resources/xlf/Strings.zh-Hant.xlf
@@ -42,6 +42,26 @@
         <target state="new">Encrypted keys for proof tokens are not supported.</target>
         <note />
       </trans-unit>
+      <trans-unit id="IRequestChannelMustBeCreated">
+        <source>The IRequestChannel must be in the created state. Was: '{0}'.</source>
+        <target state="new">The IRequestChannel must be in the created state. Was: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IssuedSecurityTokenParametersIncorrectType">
+        <source>tokenRequirement.GetProperty&lt;IssuedSecurityTokenParameters&gt; must be of type: WSTrustTokenParameters. Was: '{0}.</source>
+        <target state="new">tokenRequirement.GetProperty&lt;IssuedSecurityTokenParameters&gt; must be of type: WSTrustTokenParameters. Was: '{0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IssuedTokenRenewalThresholdPercentageIncorrect">
+        <source>IssuedTokenRenewalThresholdPercentage  must be greater than or equal to 1 and less than or equal to 100. Was: '{0}'.</source>
+        <target state="new">IssuedTokenRenewalThresholdPercentage  must be greater than or equal to 1 and less than or equal to 100. Was: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MaxIssuedTokenCachingTimeMustBeGreaterThanTimeSpanZero">
+        <source>MaxIssuedTokenCachingTime must be greater than TimeSpan.Zero. Was: '{0}'.</source>
+        <target state="new">MaxIssuedTokenCachingTime must be greater than TimeSpan.Zero. Was: '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoKeySizeProvided">
         <source>No key size provided.</source>
         <target state="new">No key size provided.</target>

--- a/src/System.ServiceModel.Federation/src/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/System.ServiceModel.Federation/src/Resources/xlf/Strings.zh-Hant.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../Strings.resx">
     <body>
+      <trans-unit id="BearerKeyShouldNotIincludeAProofToken">
+        <source>Bearer key scenarios should not include a proof token or issuer entropy in the response.</source>
+        <target state="new">Bearer key scenarios should not include a proof token or issuer entropy in the response.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ChannelFactoryMustSupportIRequestChannel">
+        <source>ChannnelFactory must support 'System.ServiceModel.Channels.IRequestChannel' interface.</source>
+        <target state="new">ChannnelFactory must support 'System.ServiceModel.Channels.IRequestChannel' interface.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CommunicationObjectCannotBeUsed">
         <source>The communication object, {0}, is in the {1} state.  Communication objects cannot be used for communication unless they are in the Opened state.</source>
         <target state="translated">通訊物件 {0} 為 {1} 狀態。除非通訊物件為「已開啟」狀態，否則無法用於通訊。</target>
@@ -12,6 +22,51 @@
         <target state="translated">因為通訊物件 {0} 為「出錯」狀態，所以無法用於通訊。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ComputedKeyProofTokensAreOnlySupportedWithSymmetricKeyTypes">
+        <source>Computed key proof tokens are only supported with symmetric key types.</source>
+        <target state="new">Computed key proof tokens are only supported with symmetric key types.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ComputedKeyProofTokensRequireIssuerToSupplyKeyMaterialViaEntropy">
+        <source>Computed key proof tokens require issuer to supply key material via entropy.</source>
+        <target state="new">Computed key proof tokens require issuer to supply key material via entropy.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ComputedKeyProofTokensRequireRequesterToSupplyKeyMaterialViaEntropy">
+        <source>Computed key proof tokens require requester to supply key material via entropy.</source>
+        <target state="new">Computed key proof tokens require requester to supply key material via entropy.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EncryptedKeysForProofTokensNotSupported">
+        <source>Encrypted keys for proof tokens are not supported.</source>
+        <target state="new">Encrypted keys for proof tokens are not supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoKeySizeProvided">
+        <source>No key size provided.</source>
+        <target state="new">No key size provided.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OnlyPSHA1ComputedKeysAreSupported">
+        <source>Only PSHA1 computed keys are supported.</source>
+        <target state="new">Only PSHA1 computed keys are supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProtectedKeyEntropyIsNotSupported">
+        <source>Protected key entropy is not supported.</source>
+        <target state="new">Protected key entropy is not supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RSTRProofTokenShouldNotHaveAComputedKeyAlgorithmOrIssuerEntropy">
+        <source>An RSTR containing a proof token should not also have a computed key algorithm or issuer entropy.</source>
+        <target state="new">An RSTR containing a proof token should not also have a computed key algorithm or issuer entropy.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RequestTypeNotSupported">
+        <source>The RequestType '{0}', is not supported.</source>
+        <target state="new">The RequestType '{0}', is not supported.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SecurityEndpointNotFound">
         <source>Server '{0}' sent back a fault indicating it is in the process of shutting down. Please see the inner exception for fault details.</source>
         <target state="translated">伺服器 '{0}' 傳回錯誤，指出正在進行關機。如需錯誤詳細資訊，請參閱內部例外狀況。</target>
@@ -20,6 +75,21 @@
       <trans-unit id="SecurityServerTooBusy">
         <source>Server '{0}' sent back a fault indicating it is too busy to process the request. Please retry later. Please see the inner exception for fault details.</source>
         <target state="translated">伺服器 '{0}' 傳回錯誤，指出因過於忙碌，無法處理要求。請稍後重試。請參考內部例外狀況，以取得錯誤詳細資料。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TokenProviderUnableToGetToken">
+        <source>The token provider '{0}' was unable to provide a security token.</source>
+        <target state="new">The token provider '{0}' was unable to provide a security token.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseKeysAreNotSupported">
+        <source>UseKeys are not supported</source>
+        <target state="new">UseKeys are not supported</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WsTrustVersionNotSupported">
+        <source>The WsTrust wersion '{0}' is not supported.</source>
+        <target state="new">The WsTrust wersion '{0}' is not supported.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/System.ServiceModel.Federation/src/System/ServiceModel/Federation/IWSTrustChannelContract.cs
+++ b/src/System.ServiceModel.Federation/src/System/ServiceModel/Federation/IWSTrustChannelContract.cs
@@ -1,0 +1,26 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.IdentityModel.Tokens;
+using System.Threading.Tasks;
+using Microsoft.IdentityModel.Protocols.WsTrust;
+
+namespace System.ServiceModel.Federation
+{
+    /// <summary>
+    /// A service contract that defines the Issue request.
+    /// </summary>
+    [ServiceContract]
+    public interface IWSTrustChannelContract
+    {
+        /// <summary>
+        /// Sends a WS-Trust Issue request to a STS.
+        /// </summary>
+        /// <param name="request">The <see cref="WsTrustRequest" /> to send to the STS.</param>
+        /// <returns>A <see cref="SecurityToken" /> issued by the STS.</returns>
+        /// <summary>
+        [OperationContract(Name = "Issue", Action = "*", ReplyAction = "*")]
+        Task<SecurityToken> IssueAsync(WsTrustRequest request);
+    }
+}

--- a/src/System.ServiceModel.Federation/src/System/ServiceModel/Federation/WSTrustChannel.cs
+++ b/src/System.ServiceModel.Federation/src/System/ServiceModel/Federation/WSTrustChannel.cs
@@ -28,6 +28,9 @@ namespace System.ServiceModel.Federation
         public WSTrustChannel(IRequestChannel requestChannel)
         {
             RequestChannel = requestChannel ?? throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull(nameof(requestChannel));
+            if (requestChannel.State != CommunicationState.Created)
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(LogHelper.FormatInvariant(SR.GetResourceString(SR.IRequestChannelMustBeCreated), requestChannel.State)));
+
             MessageVersion = RequestChannel.GetProperty<MessageVersion>();
             if (MessageVersion == null || MessageVersion == MessageVersion.None)
                 MessageVersion = MessageVersion.Default;

--- a/src/System.ServiceModel.Federation/src/System/ServiceModel/Federation/WSTrustChannel.cs
+++ b/src/System.ServiceModel.Federation/src/System/ServiceModel/Federation/WSTrustChannel.cs
@@ -1,0 +1,374 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.ServiceModel.Channels;
+using System.Threading.Tasks;
+using Microsoft.IdentityModel.Protocols;
+using Microsoft.IdentityModel.Protocols.WsTrust;
+using Microsoft.IdentityModel.Tokens;
+using WCFSecurityToken = System.IdentityModel.Tokens.SecurityToken;
+
+namespace System.ServiceModel.Federation
+{
+    /// <summary>
+    /// A channel that is used to send WS-Trust messages to an STS.
+    /// </summary>
+    public class WSTrustChannel : IWSTrustChannelContract, IChannel, ICommunicationObject
+    {
+        private const int FaultMaxBufferSize = 20 * 1024;
+        private WsSerializationContext _wsSerializationContextTrustFeb2005;
+        private WsSerializationContext _wsSerializationContextTrust1_3;
+        private WsSerializationContext _wsSerializationContextTrust1_4;
+
+        /// <summary>
+        /// Constructs a <see cref="WSTrustChannel" />.
+        /// </summary>
+        /// <param name="requestChannel">The <see cref="IRequestChannel" /> this channel will be used to send a <see cref="WsTrustRequest" /> to the STS.</param>
+        public WSTrustChannel(IRequestChannel requestChannel)
+        {
+            RequestChannel = requestChannel ?? throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull(nameof(requestChannel));
+            MessageVersion = RequestChannel.GetProperty<MessageVersion>();
+            if (MessageVersion == null || MessageVersion == MessageVersion.None)
+                MessageVersion = MessageVersion.Default;
+
+            EndpointAddress endpointAddress = RequestChannel.GetProperty<EndpointAddress>();
+            if (endpointAddress != null)
+                Address = endpointAddress.Uri?.AbsoluteUri;
+        }
+
+        private string Address { get; }
+
+        /// <summary>
+        /// The <see cref="IRequestChannel" /> this class uses for sending and receiving <see cref="Message" /> objects.
+        /// </summary>
+        private IRequestChannel RequestChannel { get; }
+
+        /// <summary>
+        /// Gets the version of WS-Trust this channel will use for serializing <see cref="Message" /> objects.
+        /// </summary>
+        private MessageVersion MessageVersion { get; }
+
+        /// <summary>
+        /// Gets the version of WS-Trust this channel will use for serializing <see cref="Message" /> objects.
+        /// </summary>
+        //private WsSerializationContext SerializationContext
+        //{
+        //    get; set;
+        //}
+
+        ///// <summary>
+        ///// Gets the <see cref="WsTrustSerializer" /> this channel will used for serializing WS-Trust request messages.
+        ///// </summary>
+        private WsTrustSerializer TrustSerializer { get; } = new WsTrustSerializer();
+
+        /// <summary>
+        /// Creates a <see cref="Message"/> that represents a the <see cref="WsTrustRequest"/>.
+        /// </summary>
+        /// <param name="trustRequest">The <see cref="WsTrustRequest"/> to serialize into the message.</param>
+        /// <returns>The <see cref="Message" /> that represents the <see cref="WsTrustRequest"/>.</returns>
+        protected virtual Message CreateRequest(WsTrustRequest trustRequest)
+        {
+            _ = trustRequest ?? throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull(nameof(trustRequest));
+            return Message.CreateMessage(MessageVersion,
+                                         GetRequestAction(trustRequest),
+                                         new WSTrustRequestBodyWriter(trustRequest, TrustSerializer));
+        }
+
+        /// <summary>
+        /// Gets the WS-Addressing SOAP action that corresponds to the <see cref="WsTrustRequest"/>.RequestType and <see cref="WsTrustRequest"/>.WsTrustVersion.
+        /// </summary>
+        /// <param name="trustRequest">The <see cref="WsTrustRequest"/> to generate the WS-Addressing action.
+        /// <returns>The WS-Addressing action to use.</returns>
+        public static string GetRequestAction(WsTrustRequest trustRequest)
+        {
+            _ = trustRequest ?? throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull(nameof(trustRequest));
+
+            WsTrustActions wsTrustActions;
+            if (trustRequest.WsTrustVersion == WsTrustVersion.Trust13)
+                wsTrustActions = WsTrustActions.Trust13;
+            else if (trustRequest.WsTrustVersion == WsTrustVersion.TrustFeb2005)
+                wsTrustActions = WsTrustActions.TrustFeb2005;
+            else if (trustRequest.WsTrustVersion == WsTrustVersion.Trust14)
+                wsTrustActions = WsTrustActions.Trust14;
+            else
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new NotSupportedException(SR.GetResourceString(SR.WsTrustVersionNotSupported, trustRequest.WsTrustVersion.ToString())));
+
+            if (trustRequest.RequestType.Equals(wsTrustActions.Issue))
+                return wsTrustActions.IssueRequest;
+            else if (trustRequest.RequestType.Equals(wsTrustActions.Cancel))
+                return wsTrustActions.CancelRequest;
+            else if (trustRequest.RequestType.Equals(wsTrustActions.Renew))
+                return wsTrustActions.RenewRequest;
+            else if (trustRequest.RequestType.Equals(wsTrustActions.Validate))
+                return wsTrustActions.ValidateRequest;
+            else
+               throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new NotSupportedException(SR.GetResourceString(SR.RequestTypeNotSupported, trustRequest.RequestType)));
+        }
+
+        /// <summary>
+        /// Gets the <see cref="WsSerializationContext"/> to use when serializing the <see cref="WsTrustRequest"/>.
+        /// </summary>
+        /// <param name="trustRequest">The <see cref="WsTrustRequest"/> that will be serialized.
+        /// <returns>The <see cref="WsSerializationContext"/> for the <see cref="WsTrustRequest"/>.</returns>
+        private WsSerializationContext GetSerializationContext(WsTrustRequest trustRequest)
+        {
+            _ = trustRequest ?? throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull(nameof(trustRequest));
+            if (trustRequest.WsTrustVersion == WsTrustVersion.TrustFeb2005)
+            {
+                if (_wsSerializationContextTrustFeb2005 == null)
+                    _wsSerializationContextTrustFeb2005 = new WsSerializationContext(trustRequest.WsTrustVersion);
+
+                return _wsSerializationContextTrustFeb2005;
+            }
+            else if (trustRequest.WsTrustVersion == WsTrustVersion.Trust13)
+            {
+                if (_wsSerializationContextTrust1_3 == null)
+                    _wsSerializationContextTrust1_3 = new WsSerializationContext(trustRequest.WsTrustVersion);
+
+                return _wsSerializationContextTrust1_3;
+            }
+            else if (trustRequest.WsTrustVersion == WsTrustVersion.Trust14)
+            {
+                if (_wsSerializationContextTrust1_4 == null)
+                    _wsSerializationContextTrust1_4 = new WsSerializationContext(trustRequest.WsTrustVersion);
+
+                return _wsSerializationContextTrust1_4;
+            }
+
+            throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new NotSupportedException(SR.GetResourceString(SR.WsTrustVersionNotSupported, trustRequest.WsTrustVersion.ToString())));
+        }
+
+        #region IChannel Members
+        /// <summary>
+        /// Returns a typed object requested, if present, from the appropriate layer in the channel stack.
+        /// </summary>
+        /// <typeparam name="T">The typed object for which the method is querying.</typeparam>
+        /// <returns>The typed object <typeparamref name="T"/> requested if present, null if not found.</returns>
+        public T GetProperty<T>() where T : class
+        {
+            return RequestChannel.GetProperty<T>();
+        }
+        #endregion
+
+        #region ICommunicationObject Members
+        /// <summary>
+        /// Occurs when the communication object completes its transition from the closing state into the closed state.
+        /// </summary>
+        event EventHandler ICommunicationObject.Closed
+        {
+            add { RequestChannel.Closed += value; }
+            remove { RequestChannel.Closed -= value; }
+        }
+
+        /// <summary>
+        /// Occurs when the communication object first enters the closing state.
+        /// </summary>
+        event EventHandler ICommunicationObject.Closing
+        {
+            add { RequestChannel.Closing += value; }
+            remove { RequestChannel.Closing -= value; }
+        }
+
+        /// <summary>
+        /// Occurs when the communication object first enters the faulted state.
+        /// </summary>
+        event EventHandler ICommunicationObject.Faulted
+        {
+            add { RequestChannel.Faulted += value; }
+            remove { RequestChannel.Faulted -= value; }
+        }
+
+        /// <summary>
+        /// Occurs when the communication object completes its transition from the opening state into the opened state.
+        /// </summary>
+        event EventHandler ICommunicationObject.Opened
+        {
+            add { RequestChannel.Opened += value; }
+            remove { RequestChannel.Opened -= value; }
+        }
+
+        /// <summary>
+        /// Occurs when the communication object first enters the opening state.
+        /// </summary>
+        event EventHandler ICommunicationObject.Opening
+        {
+            add { RequestChannel.Opening += value; }
+            remove { RequestChannel.Opening -= value; }
+        }
+
+        /// <summary>
+        /// Causes a communication object to transition immediately from its current state into the closed state. 
+        /// </summary>
+        void ICommunicationObject.Abort()
+        {
+            RequestChannel.Abort();
+        }
+
+        /// <summary>
+        /// Begins an asynchronous operation to close a communication object with a specified timeout.
+        /// </summary>
+        /// <param name="timeout">
+        /// The <see cref="TimeSpan" /> that specifies how long the close operation has to complete before timing out.
+        /// </param>
+        /// <param name="callback">
+        /// The <see cref="AsyncCallback" /> delegate that receives notification of the completion of the asynchronous 
+        /// close operation.
+        /// </param>
+        /// <param name="state">
+        /// An object, specified by the application, that contains state information associated with the asynchronous 
+        /// close operation.
+        /// </param>
+        /// <returns>The <see cref="IAsyncResult" /> that references the asynchronous close operation.</returns>
+        IAsyncResult ICommunicationObject.BeginClose(TimeSpan timeout, AsyncCallback callback, object state)
+        {
+            return RequestChannel.BeginClose(timeout, callback, state);
+        }
+
+        /// <summary>
+        /// Begins an asynchronous operation to close a communication object.
+        /// </summary>
+        /// <param name="callback">
+        /// The <see cref="AsyncCallback" /> delegate that receives notification of the completion of the asynchronous 
+        /// close operation.
+        /// </param>
+        /// <param name="state">
+        /// An object, specified by the application, that contains state information associated with the asynchronous 
+        /// close operation.
+        /// </param>
+        /// <returns>The <see cref="IAsyncResult" /> that references the asynchronous close operation.</returns>
+        IAsyncResult ICommunicationObject.BeginClose(AsyncCallback callback, object state)
+        {
+            return RequestChannel.BeginClose(callback, state);
+        }
+
+        /// <summary>
+        /// Begins an asynchronous operation to open a communication object within a specified interval of time.
+        /// </summary>
+        /// <param name="timeout">
+        /// The <see cref="TimeSpan" /> that specifies how long the open operation has to complete before timing out.
+        /// </param>
+        /// <param name="callback">
+        /// The <see cref="AsyncCallback" /> delegate that receives notification of the completion of the asynchronous 
+        /// close operation.
+        /// </param>
+        /// <param name="state">
+        /// An object, specified by the application, that contains state information associated with the asynchronous 
+        /// close operation.
+        /// </param>
+        /// <returns>The <see cref="IAsyncResult" /> that references the asynchronous open operation.</returns>
+        IAsyncResult ICommunicationObject.BeginOpen(TimeSpan timeout, AsyncCallback callback, object state)
+        {
+            return RequestChannel.BeginOpen(timeout, callback, state);
+        }
+
+        /// <summary>
+        /// Begins an asynchronous operation to open a communication object.
+        /// </summary>
+        /// <param name="callback">
+        /// The <see cref="AsyncCallback" /> delegate that receives notification of the completion of the asynchronous 
+        /// close operation.
+        /// </param>
+        /// <param name="state">
+        /// An object, specified by the application, that contains state information associated with the asynchronous 
+        /// close operation.
+        /// </param>
+        /// <returns>The <see cref="IAsyncResult" /> that references the asynchronous open operation.</returns>
+        IAsyncResult ICommunicationObject.BeginOpen(AsyncCallback callback, object state)
+        {
+            return RequestChannel.BeginOpen(callback, state);
+        }
+
+        /// <summary>
+        /// Causes a communication object to transition from its current state into the closed state.
+        /// </summary>
+        /// <param name="timeout">
+        /// The <see cref="TimeSpan" /> that specifies how long the open operation has to complete before timing out.
+        /// </param>
+        void ICommunicationObject.Close(TimeSpan timeout)
+        {
+            RequestChannel.Close(timeout);
+        }
+
+        /// <summary>
+        /// Causes a communication object to transition from its current state into the closed state.
+        /// </summary>
+        void ICommunicationObject.Close()
+        {
+            RequestChannel.Close();
+        }
+
+        /// <summary>
+        /// Completes an asynchronous operation to close a communication object.
+        /// </summary>
+        /// <param name="result">The <see cref="IAsyncResult" /> that is returned by a call to the BeginClose() method.</param>
+        void ICommunicationObject.EndClose(IAsyncResult result)
+        {
+            RequestChannel.EndClose(result);
+        }
+
+        /// <summary>
+        /// Completes an asynchronous operation to open a communication object.
+        /// </summary>
+        /// <param name="result">The <see cref="IAsyncResult" /> that is returned by a call to the BeginClose() method.</param>
+        void ICommunicationObject.EndOpen(IAsyncResult result)
+        {
+            RequestChannel.EndOpen(result);
+        }
+
+        /// <summary>
+        /// Causes a communication object to transition from the created state into the opened state within a specified interval of time.
+        /// </summary>
+        /// <param name="timeout">
+        /// The <see cref="TimeSpan" /> that specifies how long the open operation has to complete before timing out.
+        /// </param>
+        void ICommunicationObject.Open(TimeSpan timeout)
+        {
+            RequestChannel.Open(timeout);
+        }
+
+        /// <summary>
+        /// Causes a communication object to transition from the created state into the opened state. 
+        /// </summary>
+        void ICommunicationObject.Open()
+        {
+            RequestChannel.Open();
+        }
+
+        /// <summary>
+        /// Gets the current state of the communication-oriented object.
+        /// </summary>
+        CommunicationState ICommunicationObject.State
+        {
+            get { return RequestChannel.State; }
+        }
+        #endregion
+
+        #region IWSTrustChannelContract Members
+        /// <summary>
+        /// Sends a <see cref="WsTrustRequest"/> to a STS to obtain a <see cref="WCFSecurityToken"/>.
+        /// </summary>
+        /// <param name="trustRequest">The <see cref="WsTrustRequest" /> sent to the STS.</param>
+        /// <returns>A <see cref="WCFSecurityToken" /> issued by the STS.</returns>
+        public async virtual Task<WCFSecurityToken> IssueAsync(WsTrustRequest trustRequest)
+        {
+            _ = trustRequest ?? throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull(nameof(trustRequest));
+
+            Message requestMessage = CreateRequest(trustRequest);
+            Message response = await Task.Factory.FromAsync(RequestChannel.BeginRequest, RequestChannel.EndRequest, requestMessage, null, TaskCreationOptions.None).ConfigureAwait(false);
+            if (response.IsFault)
+            {
+                MessageFault fault = MessageFault.CreateFault(response, FaultMaxBufferSize);
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(FaultException.CreateFault(fault, response.Headers?.Action));
+            }
+
+            WsTrustResponse trustResponse = TrustSerializer.ReadResponse(response.GetReaderAtBodyContents());
+            WCFSecurityToken token = WSTrustUtilities.CreateGenericXmlSecurityToken(trustRequest, trustResponse, GetSerializationContext(trustRequest), null);
+            if (token == null)
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new SecurityTokenException(SR.Format(SR.TokenProviderUnableToGetToken, string.IsNullOrEmpty(Address) ? ToString() : Address)));
+            
+            return token;
+        }
+        #endregion
+    }
+}

--- a/src/System.ServiceModel.Federation/src/System/ServiceModel/Federation/WSTrustChannelFactory.cs
+++ b/src/System.ServiceModel.Federation/src/System/ServiceModel/Federation/WSTrustChannelFactory.cs
@@ -1,0 +1,65 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.ServiceModel.Channels;
+using System.ServiceModel.Description;
+using Microsoft.IdentityModel.Protocols.WsTrust;
+
+namespace System.ServiceModel.Federation
+{
+    /// <summary>
+    /// A <see cref="WSTrustChannelFactory" /> that creates a <see cref="WSTrustChannel" /> to send a <see cref="WsTrustRequest"/> to a STS.
+    /// </summary>
+    public class WSTrustChannelFactory : ChannelFactory<IWSTrustChannelContract>
+    {
+        /// <summary>
+        /// Initializes a new instance of a <see cref="WSTrustChannelFactory" /> specifying the <see cref="ServiceEndpoint"/>.
+        /// </summary>
+        /// <param name="serviceEndpoint">The <see cref="ServiceEndpoint" /> used by the channels created by the factory.</param>
+        public WSTrustChannelFactory(ServiceEndpoint serviceEndpoint)
+            : base(serviceEndpoint)
+        {
+            _ = serviceEndpoint ?? throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull(nameof(serviceEndpoint));
+            EndpointAddress = serviceEndpoint.Address;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of a <see cref="WSTrustChannelFactory" /> specifying the <see cref="Binding"/> and <see cref="EndpointAddress"/>.
+        /// </summary>
+        /// <param name="binding">The <see cref="Binding" /> used by channels created by the factory.</param>
+        /// <param name="endpointAddress">The <see cref="EndpointAddress" /> that specifies the address of the STS.</param>
+        public WSTrustChannelFactory(Binding binding, EndpointAddress endpointAddress)
+            : base(binding, endpointAddress)
+        {
+            _ = binding ?? throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull(nameof(binding));
+
+            EndpointAddress = endpointAddress ?? throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull(nameof(endpointAddress));
+        }
+
+        /// <summary>
+        /// Creates a <see cref="IWSTrustChannelContract" /> that is used to send an Issue request to a STS.
+        /// </summary>
+        /// <param name="endpointAddress">The <see cref="EndpointAddress"/> that specifies the address of the STS.</param>
+        /// <param name="via">The <see cref="Uri" /> that address that the channel uses to send messages.</param>
+        /// <returns>A <see cref="IChannel"/> that can be used to send an Issue request to a STS.</returns>
+        public override IWSTrustChannelContract CreateChannel(EndpointAddress endpointAddress, Uri via)
+        {
+            _ = endpointAddress ?? throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull(nameof(endpointAddress));
+            _ = via ?? throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull(nameof(via));
+
+            return new WSTrustChannel(base.CreateChannel(endpointAddress, via) as IRequestChannel);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="IWSTrustChannelContract" /> that is used to send an Issue request to a STS.
+        /// </summary>
+        /// <returns>A <see cref="IChannel"/> that can be used to send an Issue request to a STS.</returns>
+        public IWSTrustChannelContract CreateTrustChannel()
+        {
+            return new WSTrustChannel(base.CreateChannel(EndpointAddress, EndpointAddress.Uri) as IRequestChannel);
+        }
+
+        private EndpointAddress EndpointAddress { get; }
+    }
+}

--- a/src/System.ServiceModel.Federation/src/System/ServiceModel/Federation/WSTrustChannelSecurityTokenProvider.cs
+++ b/src/System.ServiceModel.Federation/src/System/ServiceModel/Federation/WSTrustChannelSecurityTokenProvider.cs
@@ -61,7 +61,7 @@ namespace System.ServiceModel.Federation
             WSTrustTokenParameters = issuedSecurityTokenParameters as WSTrustTokenParameters;
             if (WSTrustTokenParameters == null)
             {
-                throw DiagnosticUtility.ExceptionUtility.ThrowHelper(new ArgumentException(LogHelper.FormatInvariant("tokenRequirement.GetProperty<IssuedSecurityTokenParameters> must be of type: WSTrustTokenParameters. Was: '{0}.", issuedSecurityTokenParameters), nameof(tokenRequirement)), EventLevel.Error);
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelper(new ArgumentException(LogHelper.FormatInvariant(SR.GetResourceString(SR.IssuedSecurityTokenParametersIncorrectType), issuedSecurityTokenParameters), nameof(tokenRequirement)), EventLevel.Error);
             }
 
             _communicationObject = new WrapperSecurityCommunicationObject(this);
@@ -295,7 +295,7 @@ namespace System.ServiceModel.Federation
             if (messageSecurityVersion.TrustVersion == TrustVersion.WSTrustFeb2005)
                 return WsTrustVersion.TrustFeb2005;
 
-            throw DiagnosticUtility.ExceptionUtility.ThrowHelper(new NotSupportedException(LogHelper.FormatInvariant("Unsupported TrustVersion: '{0}'.", MessageSecurityVersion.TrustVersion)), EventLevel.Error);
+            throw DiagnosticUtility.ExceptionUtility.ThrowHelper(new NotSupportedException(LogHelper.FormatInvariant(SR.GetResourceString(SR.WsTrustVersionNotSupported), MessageSecurityVersion.TrustVersion)), EventLevel.Error);
         }
 
         private void InitializeKeyEntropyMode()

--- a/src/System.ServiceModel.Federation/src/System/ServiceModel/Federation/WSTrustChannelSecurityTokenProvider.cs
+++ b/src/System.ServiceModel.Federation/src/System/ServiceModel/Federation/WSTrustChannelSecurityTokenProvider.cs
@@ -197,116 +197,6 @@ namespace System.ServiceModel.Federation
         }
 
         /// <summary>
-        /// Gets the WsTrustVersion for the current MessageSecurityVersion.
-        /// </summary>        /// <summary>
-        /// Get a proof token from a WsTrust request/response pair based on section 4.4.3 of the WS-Trust 1.3 spec.
-        /// How the proof token is retrieved depends on whether the requestor or issuer provide key material:
-        /// Requestor   |   Issuer                  | Results
-        /// -------------------------------------------------
-        /// Entropy     | No key material           | No proof token returned, requestor entropy used
-        /// Entropy     | Entropy                   | Computed key algorithm returned and key computed based on request and response entropy
-        /// Entropy     | Rejects requestor entropy | Proof token in response used as key
-        /// No entropy  | Issues key                | Proof token in response used as key
-        /// No entropy  | No key material           | No proof token
-        /// </summary>
-        /// <param name="request">The WS-Trust request (RST).</param>
-        /// <param name="response">The WS-Trust response (RSTR).</param>
-        /// <returns>The proof token or null if there is no proof token.</returns>
-        private BinarySecretSecurityToken GetProofToken(WsTrustRequest request, RequestSecurityTokenResponse response)
-        {
-            // According to the WS-Trust 1.3 spec, symmetric is the default key type
-            string keyType = response.KeyType ?? request.KeyType ?? _requestSerializationContext.TrustKeyTypes.Symmetric;
-
-            // Encrypted keys and encrypted entropy are not supported, currently, as they should
-            // only be needed by unsupported message security scenarios.
-            if (response.RequestedProofToken?.EncryptedKey != null)
-                throw DiagnosticUtility.ExceptionUtility.ThrowHelper(new NotSupportedException("Encrypted keys for proof tokens are not supported."), EventLevel.Error);
-
-            // Bearer scenarios have no proof token
-            if (string.Equals(keyType, _requestSerializationContext.TrustKeyTypes.Bearer, StringComparison.Ordinal))
-            {
-                if (response.RequestedProofToken != null || response.Entropy != null)
-                    throw DiagnosticUtility.ExceptionUtility.ThrowHelper(new InvalidOperationException("Bearer key scenarios should not include a proof token or issuer entropy in the response."), EventLevel.Error);
-
-                return null;
-            }
-
-            // If the response includes a proof token, use it as the security token's proof.
-            // This scenario will occur if the request does not include entropy or if the issuer rejects the requestor's entropy.
-            if (response.RequestedProofToken?.BinarySecret != null)
-            {
-                // Confirm that a computed key algorithm isn't also specified
-                if (!string.IsNullOrEmpty(response.RequestedProofToken.ComputedKeyAlgorithm) || response.Entropy != null)
-                    throw DiagnosticUtility.ExceptionUtility.ThrowHelper(new InvalidOperationException("An RSTR containing a proof token should not also have a computed key algorithm or issuer entropy."), EventLevel.Error);
-
-                return new BinarySecretSecurityToken(response.RequestedProofToken.BinarySecret.Data);
-            }
-            // If the response includes a computed key algorithm, compute the proof token based on requestor and issuer entropy.
-            // This scenario will occur if the requestor and issuer both provide key material.
-            else if (response.RequestedProofToken?.ComputedKeyAlgorithm != null)
-            {
-                if (!string.Equals(keyType, _requestSerializationContext.TrustKeyTypes.Symmetric, StringComparison.Ordinal))
-                    throw DiagnosticUtility.ExceptionUtility.ThrowHelper(new InvalidOperationException("Computed key proof tokens are only supported with symmetric key types."), EventLevel.Error);
-
-                if (string.Equals(response.RequestedProofToken.ComputedKeyAlgorithm, _requestSerializationContext.TrustKeyTypes.PSHA1, StringComparison.Ordinal))
-                {
-                    // Confirm that no encrypted entropy was provided as that is currently not supported.
-                    // If we wish to support it in the future, most of the work will be in the WSTrust serializer;
-                    // this code would just have to use protected key's .Secret property to get the key material.
-                    if (response.Entropy?.ProtectedKey != null || request.Entropy?.ProtectedKey != null)
-                        throw DiagnosticUtility.ExceptionUtility.ThrowHelper( new NotSupportedException("Protected key entropy is not supported."), EventLevel.Error);
-
-                    // Get issuer and requestor entropy
-                    byte[] issuerEntropy = response.Entropy?.BinarySecret?.Data;
-                    if (issuerEntropy == null)
-                        throw DiagnosticUtility.ExceptionUtility.ThrowHelper(new InvalidOperationException("Computed key proof tokens require issuer to supply key material via entropy."), EventLevel.Error);
-
-                    byte[] requestorEntropy = request.Entropy?.BinarySecret?.Data;
-                    if (requestorEntropy == null)
-                        throw DiagnosticUtility.ExceptionUtility.ThrowHelper(new InvalidOperationException("Computed key proof tokens require requestor to supply key material via entropy."), EventLevel.Error);
-
-                    // Get key size
-                    int keySizeInBits = response.KeySizeInBits ?? 0; // RSTR key size has precedence
-                    if (keySizeInBits == 0)
-                        keySizeInBits = request.KeySizeInBits ?? 0; // Followed by RST
-
-                    if (keySizeInBits == 0)
-                        keySizeInBits = _securityAlgorithmSuite?.DefaultSymmetricKeyLength ?? 0; // Symmetric keys should default to a length cooresponding to the algorithm in use
-
-                    if (keySizeInBits == 0)
-                        throw DiagnosticUtility.ExceptionUtility.ThrowHelper(new InvalidOperationException("No key size provided."), EventLevel.Error);
-
-                    return new BinarySecretSecurityToken(Psha1KeyGenerator.ComputeCombinedKey(issuerEntropy, requestorEntropy, keySizeInBits));
-                }
-                else
-                {
-                    throw DiagnosticUtility.ExceptionUtility.ThrowHelper(new NotSupportedException("Only PSHA1 computed keys are supported."), EventLevel.Error);
-                }
-            }
-            // If the response does not have a proof token or computed key value, but the request proposed entropy,
-            // then the requestor's entropy is used as the proof token.
-            else if (request.Entropy != null)
-            {
-                if (request.Entropy.ProtectedKey != null)
-                    throw DiagnosticUtility.ExceptionUtility.ThrowHelper(new NotSupportedException("Protected key entropy is not supported."), EventLevel.Error);
-
-                if (request.Entropy.BinarySecret != null)
-                    return new BinarySecretSecurityToken(request.Entropy.BinarySecret.Data);
-            }
-
-            // If we get here, then no key material has been supplied (by either issuer or requestor), so there is no proof token.
-            return null;
-        }
-
-        private GenericXmlSecurityKeyIdentifierClause GetSecurityKeyIdentifierForTokenReference(SecurityTokenReference securityTokenReference)
-        {
-            if (securityTokenReference == null)
-                return null;
-
-            return new GenericXmlSecurityKeyIdentifierClause(WsSecuritySerializer.CreateXmlElement(securityTokenReference));
-        }
-
-        /// <summary>
         /// Begins a WSTrust call to the STS to obtain a <see cref="SecurityToken"/> first checking if the token is available in the cache.
         /// </summary>
         /// <returns>A <see cref="IAsyncResult"/>.</returns>
@@ -356,7 +246,7 @@ namespace System.ServiceModel.Federation
                 }
             }
 
-            return CreateGenericXmlSecurityToken(request, trustResponse);
+            return WSTrustUtilities.CreateGenericXmlSecurityToken(request, trustResponse, _requestSerializationContext, _securityAlgorithmSuite);
         }
 
         /// <summary>
@@ -394,38 +284,7 @@ namespace System.ServiceModel.Federation
                 }
             }
 
-            return CreateGenericXmlSecurityToken(request, trustResponse);
-        }
-
-        private SecurityToken CreateGenericXmlSecurityToken(WsTrustRequest request, WsTrustResponse trustResponse)
-        {
-            // Create GenericXmlSecurityToken
-            // Assumes that token is first and Saml2SecurityToken.
-            RequestSecurityTokenResponse response = trustResponse.RequestSecurityTokenResponseCollection[0];
-
-            // Get attached and unattached references
-            GenericXmlSecurityKeyIdentifierClause internalSecurityKeyIdentifierClause = null;
-            if (response.AttachedReference != null)
-                internalSecurityKeyIdentifierClause = GetSecurityKeyIdentifierForTokenReference(response.AttachedReference);
-
-            GenericXmlSecurityKeyIdentifierClause externalSecurityKeyIdentifierClause = null;
-            if (response.UnattachedReference != null)
-                externalSecurityKeyIdentifierClause = GetSecurityKeyIdentifierForTokenReference(response.UnattachedReference);
-
-            // Get proof token
-            IdentityModel.Tokens.SecurityToken proofToken = GetProofToken(request, response);
-
-            // Get lifetime
-            DateTime created = response.Lifetime?.Created ?? DateTime.UtcNow;
-            DateTime expires = response.Lifetime?.Expires ?? created.AddDays(1);
-
-            return new GenericXmlSecurityToken(response.RequestedSecurityToken.TokenElement,
-                                               proofToken,
-                                               created,
-                                               expires,
-                                               internalSecurityKeyIdentifierClause,
-                                               externalSecurityKeyIdentifierClause,
-                                               null);
+            return WSTrustUtilities.CreateGenericXmlSecurityToken(request, trustResponse, _requestSerializationContext, _securityAlgorithmSuite);
         }
 
         private WsTrustVersion GetWsTrustVersion(MessageSecurityVersion messageSecurityVersion)

--- a/src/System.ServiceModel.Federation/src/System/ServiceModel/Federation/WSTrustRequestBodyWriter.cs
+++ b/src/System.ServiceModel.Federation/src/System/ServiceModel/Federation/WSTrustRequestBodyWriter.cs
@@ -1,0 +1,40 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.ServiceModel.Channels;
+using System.Xml;
+using Microsoft.IdentityModel.Protocols.WsTrust;
+
+namespace System.ServiceModel.Federation
+{
+    /// <summary>
+    /// Defines a <see cref="BodyWriter"/> that writes a <see cref="WsTrustRequest"/> into a <see cref="XmlDictionaryWriter"/>.
+    /// </summary>
+    internal class WSTrustRequestBodyWriter : BodyWriter
+    {
+        /// <summary>
+        /// Constructor for the WSTrustRequestBodyWriter.
+        /// </summary>
+        /// <param name="trustRequest">The <see cref="WsTrustRequest"/> to be serialized in a outgoing Message.</param>
+        /// <param name="trustSerializer">The <see cref="WsTrustSerializer"/> used to write the <see cref="WsTrustRequest"/> into a <see cref="XmlDictionaryWriter"/>.</param>
+        public WSTrustRequestBodyWriter(WsTrustRequest trustRequest, WsTrustSerializer trustSerializer) : base(true)
+        {
+            TrustRequest = trustRequest ?? throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull(nameof(trustRequest));
+            TrustSerializer = trustSerializer ?? throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull(nameof(trustSerializer));
+        }
+
+        /// <summary>
+        /// Override of the base class method. Serializes the <see cref="WsTrustRequest"/> into the <see cref="XmlDictionaryWriter"/>.
+        /// </summary>
+        /// <param name="writer"> The <see cref="XmlDictionaryWriter"/> to serialize the <see cref="WsTrustRequest"/> into.</param>
+        protected override void OnWriteBodyContents(XmlDictionaryWriter writer)
+        {
+            TrustSerializer.WriteRequest(writer, TrustRequest.WsTrustVersion, TrustRequest);
+        }
+
+        protected WsTrustRequest TrustRequest { get; }
+
+        protected WsTrustSerializer TrustSerializer { get; }
+    }
+}

--- a/src/System.ServiceModel.Federation/src/System/ServiceModel/Federation/WSTrustUtilities.cs
+++ b/src/System.ServiceModel.Federation/src/System/ServiceModel/Federation/WSTrustUtilities.cs
@@ -1,0 +1,161 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics.Tracing;
+using System.IdentityModel.Tokens;
+using System.ServiceModel.Security;
+using System.ServiceModel.Security.Tokens;
+using Microsoft.IdentityModel.Protocols;
+using Microsoft.IdentityModel.Protocols.WsSecurity;
+using Microsoft.IdentityModel.Protocols.WsTrust;
+using WCFSecurityToken = System.IdentityModel.Tokens.SecurityToken;
+
+namespace System.ServiceModel.Federation
+{
+    /// <summary>
+    /// WSTrustUtilities are shared between <see cref="WSTrustChannelSecurityTokenProvider"/> with <see cref="WSFederationHttpBinding"/>
+    /// and <see cref="WSTrustChannelFactory"/> and <see cref="WSTrustChannel"/> to send a WsTrust message to obtain a SecurityToken from a STS.
+    /// The SecurityToken can be added as an IssuedToken on the outbound WCF message OR be used to call a WebAPI.
+    /// </summary>
+    internal static class WSTrustUtilities
+    {
+        /// Get a proof token from a WsTrust request/response pair based on section 4.4.3 of the WS-Trust 1.3 spec.
+        /// How the proof token is retrieved depends on whether the requester or issuer provide key material:
+        /// Requester   |   Issuer                  | Results
+        /// -------------------------------------------------
+        /// Entropy     | No key material           | No proof token returned, requester entropy used
+        /// Entropy     | Entropy                   | Computed key algorithm returned and key computed based on request and response entropy
+        /// Entropy     | Rejects requester entropy | Proof token in response used as key
+        /// No entropy  | Issues key                | Proof token in response used as key
+        /// No entropy  | No key material           | No proof token
+        /// </summary>
+        /// <param name="request">The WS-Trust request (RST).</param>
+        /// <param name="response">The WS-Trust response (RSTR).</param>
+        /// <returns>The proof token or null if there is no proof token.</returns>
+        internal static BinarySecretSecurityToken GetProofToken(WsTrustRequest request, RequestSecurityTokenResponse response, WsSerializationContext serializationContext, SecurityAlgorithmSuite algorithmSuite)
+        {
+            // According to the WS-Trust 1.3 spec, symmetric is the default key type
+            string keyType = response.KeyType ?? request.KeyType ?? serializationContext.TrustKeyTypes.Symmetric;
+
+            // Encrypted keys and encrypted entropy are not supported, currently, as they should
+            // only be needed by unsupported message security scenarios.
+            if (response.RequestedProofToken?.EncryptedKey != null)
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelper(new NotSupportedException(SR.GetResourceString(SR.EncryptedKeysForProofTokensNotSupported)), EventLevel.Error);
+
+            // Bearer scenarios have no proof token
+            if (string.Equals(keyType, serializationContext.TrustKeyTypes.Bearer, StringComparison.Ordinal))
+            {
+                if (response.RequestedProofToken != null || response.Entropy != null)
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelper(new InvalidOperationException(SR.GetResourceString(SR.BearerKeyShouldNotIincludeAProofToken)), EventLevel.Error);
+
+                return null;
+            }
+
+            // If the response includes a proof token, use it as the security token's proof.
+            // This scenario will occur if the request does not include entropy or if the issuer rejects the requester's entropy.
+            if (response.RequestedProofToken?.BinarySecret != null)
+            {
+                // Confirm that a computed key algorithm isn't also specified
+                if (!string.IsNullOrEmpty(response.RequestedProofToken.ComputedKeyAlgorithm) || response.Entropy != null)
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelper(new InvalidOperationException(SR.GetResourceString(SR.RSTRProofTokenShouldNotHaveAComputedKeyAlgorithmOrIssuerEntropy)), EventLevel.Error);
+
+                return new BinarySecretSecurityToken(response.RequestedProofToken.BinarySecret.Data);
+            }
+            // If the response includes a computed key algorithm, compute the proof token based on requester and issuer entropy.
+            // This scenario will occur if the requester and issuer both provide key material.
+            else if (response.RequestedProofToken?.ComputedKeyAlgorithm != null)
+            {
+                if (!string.Equals(keyType, serializationContext.TrustKeyTypes.Symmetric, StringComparison.Ordinal))
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelper(new InvalidOperationException(SR.GetResourceString(SR.ComputedKeyProofTokensAreOnlySupportedWithSymmetricKeyTypes)), EventLevel.Error);
+
+                if (string.Equals(response.RequestedProofToken.ComputedKeyAlgorithm, serializationContext.TrustKeyTypes.PSHA1, StringComparison.Ordinal))
+                {
+                    // Confirm that no encrypted entropy was provided as that is currently not supported.
+                    // If we wish to support it in the future, most of the work will be in the WSTrust serializer;
+                    // this code would just have to use protected key's .Secret property to get the key material.
+                    if (response.Entropy?.ProtectedKey != null || request.Entropy?.ProtectedKey != null)
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelper( new NotSupportedException(SR.GetResourceString(SR.ProtectedKeyEntropyIsNotSupported)), EventLevel.Error);
+
+                    // Get issuer and requester entropy
+                    byte[] issuerEntropy = response.Entropy?.BinarySecret?.Data;
+                    if (issuerEntropy == null)
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelper(new InvalidOperationException(SR.GetResourceString(SR.ComputedKeyProofTokensRequireIssuerToSupplyKeyMaterialViaEntropy)), EventLevel.Error);
+
+                    byte[] requestorEntropy = request.Entropy?.BinarySecret?.Data;
+                    if (requestorEntropy == null)
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelper(new InvalidOperationException(SR.GetResourceString(SR.ComputedKeyProofTokensRequireRequesterToSupplyKeyMaterialViaEntropy)), EventLevel.Error);
+
+                    // Get key size
+                    int keySizeInBits = response.KeySizeInBits ?? 0; // RSTR key size has precedence
+                    if (keySizeInBits == 0)
+                        keySizeInBits = request.KeySizeInBits ?? 0; // Followed by RST
+
+                    if (keySizeInBits == 0)
+                        keySizeInBits = algorithmSuite?.DefaultSymmetricKeyLength ?? 0; // Symmetric keys should default to a length corresponding to the algorithm in use
+
+                    if (keySizeInBits == 0)
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelper(new InvalidOperationException(SR.GetResourceString(SR.NoKeySizeProvided)), EventLevel.Error);
+
+                    return new BinarySecretSecurityToken(Psha1KeyGenerator.ComputeCombinedKey(issuerEntropy, requestorEntropy, keySizeInBits));
+                }
+                else
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelper(new NotSupportedException(SR.GetResourceString(SR.OnlyPSHA1ComputedKeysAreSupported)), EventLevel.Error);
+                }
+            }
+            // If the response does not have a proof token or computed key value, but the request proposed entropy,
+            // then the requester's entropy is used as the proof token.
+            else if (request.Entropy != null)
+            {
+                if (request.Entropy.ProtectedKey != null)
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelper(new NotSupportedException(SR.GetResourceString(SR.ProtectedKeyEntropyIsNotSupported)), EventLevel.Error);
+
+                if (request.Entropy.BinarySecret != null)
+                    return new BinarySecretSecurityToken(request.Entropy.BinarySecret.Data);
+            }
+
+            // If we get here, then no key material has been supplied (by either issuer or requester), so there is no proof token.
+            return null;
+        }
+
+        internal static GenericXmlSecurityKeyIdentifierClause GetSecurityKeyIdentifierForTokenReference(SecurityTokenReference securityTokenReference)
+        {
+            if (securityTokenReference == null)
+                return null;
+
+            return new GenericXmlSecurityKeyIdentifierClause(WsSecuritySerializer.CreateXmlElement(securityTokenReference));
+        }
+
+        internal static WCFSecurityToken CreateGenericXmlSecurityToken(WsTrustRequest request, WsTrustResponse trustResponse, WsSerializationContext serializationContext, SecurityAlgorithmSuite algorithmSuite)
+        {
+            // Create GenericXmlSecurityToken
+            // Assumes that token is first and Saml2SecurityToken.
+            RequestSecurityTokenResponse response = trustResponse.RequestSecurityTokenResponseCollection[0];
+
+            // Get attached and unattached references
+            GenericXmlSecurityKeyIdentifierClause internalSecurityKeyIdentifierClause = null;
+            if (response.AttachedReference != null)
+                internalSecurityKeyIdentifierClause = GetSecurityKeyIdentifierForTokenReference(response.AttachedReference);
+
+            GenericXmlSecurityKeyIdentifierClause externalSecurityKeyIdentifierClause = null;
+            if (response.UnattachedReference != null)
+                externalSecurityKeyIdentifierClause = GetSecurityKeyIdentifierForTokenReference(response.UnattachedReference);
+
+            // Get proof token
+            WCFSecurityToken proofToken = GetProofToken(request, response, serializationContext, algorithmSuite);
+
+            // Get lifetime
+            DateTime created = response.Lifetime?.Created ?? DateTime.UtcNow;
+            DateTime expires = response.Lifetime?.Expires ?? created.AddDays(1);
+
+            return new GenericXmlSecurityToken(response.RequestedSecurityToken.TokenElement,
+                                               proofToken,
+                                               created,
+                                               expires,
+                                               internalSecurityKeyIdentifierClause,
+                                               externalSecurityKeyIdentifierClause,
+                                               null);
+        }
+    }
+}

--- a/src/System.ServiceModel.Federation/src/System/ServiceModel/Federation/WsTrustTokenParameters.cs
+++ b/src/System.ServiceModel.Federation/src/System/ServiceModel/Federation/WsTrustTokenParameters.cs
@@ -93,7 +93,7 @@ namespace System.ServiceModel.Federation
         {
             get => _issuedTokenRenewalThresholdPercentage;
             set => _issuedTokenRenewalThresholdPercentage = (value <= 0 || value > 100)
-                ? throw DiagnosticUtility.ExceptionUtility.ThrowHelper(new ArgumentOutOfRangeException(nameof(value), LogHelper.FormatInvariant("IssuedTokenRenewalThresholdPercentage  must be greater than or equal to 1 and less than or equal to 100. Was: '{0}'.", value)), EventLevel.Error)
+                ? throw DiagnosticUtility.ExceptionUtility.ThrowHelper(new ArgumentOutOfRangeException(nameof(value), LogHelper.FormatInvariant(SR.GetResourceString(SR.IssuedTokenRenewalThresholdPercentageIncorrect), value)), EventLevel.Error)
                 : value;
         }
 
@@ -109,7 +109,7 @@ namespace System.ServiceModel.Federation
         {
             get => _maxIssuedTokenCachingTime;
             set => _maxIssuedTokenCachingTime = value <= TimeSpan.Zero
-                ? throw DiagnosticUtility.ExceptionUtility.ThrowHelper(new ArgumentOutOfRangeException(nameof(value), LogHelper.FormatInvariant("MaxIssuedTokenCachingTime must be greater than TimeSpan.Zero. Was: '{0}'.", value)), EventLevel.Error)
+                ? throw DiagnosticUtility.ExceptionUtility.ThrowHelper(new ArgumentOutOfRangeException(nameof(value), LogHelper.FormatInvariant(SR.GetResourceString(SR.MaxIssuedTokenCachingTimeMustBeGreaterThanTimeSpanZero), value)), EventLevel.Error)
                 : value;
         }
 

--- a/src/System.ServiceModel.Federation/tests/System.ServiceModel.Federation.Tests.csproj
+++ b/src/System.ServiceModel.Federation/tests/System.ServiceModel.Federation.Tests.csproj
@@ -8,7 +8,13 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\System.ServiceModel.Federation\src\System.ServiceModel.Federation.csproj" />
+    <ProjectReference Include="..\..\System.Private.ServiceModel\src\System.Private.ServiceModel.csproj" />
     <ProjectReference Include="$(WcfUnitTestCommonProj)" />
     <ProjectReference Include="$(WcfInfrastructureCommonProj)" />
   </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.WsTrust" Version="$(MicrosoftIdentityModelProtocolsWsTrustPackageVersion)" />
+  </ItemGroup>
+
 </Project>

--- a/src/System.ServiceModel.Federation/tests/System.ServiceModel.Federation.Tests.csproj
+++ b/src/System.ServiceModel.Federation/tests/System.ServiceModel.Federation.Tests.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\System.ServiceModel.Federation\src\System.ServiceModel.Federation.csproj" />
-    <ProjectReference Include="..\..\System.Private.ServiceModel\src\System.Private.ServiceModel.csproj" />
+    <ProjectReference Include="..\..\System.ServiceModel.Primitives\src\System.ServiceModel.Primitives.Facade.csproj" />
     <ProjectReference Include="$(WcfUnitTestCommonProj)" />
     <ProjectReference Include="$(WcfInfrastructureCommonProj)" />
   </ItemGroup>

--- a/src/System.ServiceModel.Federation/tests/WSTrustChannelFactoryTest.cs
+++ b/src/System.ServiceModel.Federation/tests/WSTrustChannelFactoryTest.cs
@@ -1,0 +1,17 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Infrastructure.Common;
+
+namespace System.ServiceModel.Federation.Tests
+{
+    public static class WSTrustChannelFactoryTest
+    {
+        [WcfFact]
+        public static void DefaultWSTrustChannelFactory()
+        {
+            WSTrustChannelFactory trustChannelFactory = new WSTrustChannelFactory(null, null);
+        }
+    }
+}

--- a/src/System.ServiceModel.Federation/tests/WSTrustChannelFactoryTest.cs
+++ b/src/System.ServiceModel.Federation/tests/WSTrustChannelFactoryTest.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Infrastructure.Common;
+using Xunit;
 
 namespace System.ServiceModel.Federation.Tests
 {
@@ -11,7 +12,14 @@ namespace System.ServiceModel.Federation.Tests
         [WcfFact]
         public static void DefaultWSTrustChannelFactory()
         {
-            WSTrustChannelFactory trustChannelFactory = new WSTrustChannelFactory(null, null);
+            try
+            {
+                WSTrustChannelFactory trustChannelFactory = new WSTrustChannelFactory(null, null);
+            }
+            catch(Exception ex)
+            {
+                Assert.Equal(typeof(ArgumentNullException), ex.GetType());
+            }
         }
     }
 }

--- a/src/System.ServiceModel.Federation/tests/WSTrustChannelTest.cs
+++ b/src/System.ServiceModel.Federation/tests/WSTrustChannelTest.cs
@@ -1,0 +1,18 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Infrastructure.Common;
+using Microsoft.IdentityModel.Protocols.WsTrust;
+
+namespace System.ServiceModel.Federation.Tests
+{
+    public static class WSTrustChannelTest
+    {
+        [WcfFact]
+        public static void DefaultWSTrustChannel()
+        {
+            WSTrustChannel trustChannel = new WSTrustChannel(null);
+        }
+    }
+}

--- a/src/System.ServiceModel.Federation/tests/WSTrustChannelTest.cs
+++ b/src/System.ServiceModel.Federation/tests/WSTrustChannelTest.cs
@@ -3,16 +3,23 @@
 // See the LICENSE file in the project root for more information.
 
 using Infrastructure.Common;
-using Microsoft.IdentityModel.Protocols.WsTrust;
+using Xunit;
 
 namespace System.ServiceModel.Federation.Tests
 {
     public static class WSTrustChannelTest
     {
         [WcfFact]
-        public static void DefaultWSTrustChannel()
+        public static void WSTrustChannelParameters()
         {
-            WSTrustChannel trustChannel = new WSTrustChannel(null);
+            try
+            {
+                WSTrustChannel trustChannel = new WSTrustChannel(null);
+            }
+            catch(Exception ex)
+            {
+                Assert.Equal(typeof(ArgumentNullException), ex.GetType());
+            }
         }
     }
 }


### PR DESCRIPTION
This is similar to what existed in .net framework with some small changes.
WSTrustChannel ctor takes a ChannelFactory rather than a WSTrustChannelFactory.
The new Async model has replaced the Begin / End model found in the original WCF release.
Common methods that were used in WSTrustSecurityTokenProvider and WSTrustChannel were moved to WSTrustUtilities.
An additional constructor was added that takes a separate IRequestChannel.


