### PR TITLE
#4766 - Support netstandard2.0 when using net6.0 utility

### DIFF
--- a/src/dotnet-svcutil/lib/src/Bootstrapper/SvcutilBootstrapper.cs
+++ b/src/dotnet-svcutil/lib/src/Bootstrapper/SvcutilBootstrapper.cs
@@ -151,6 +151,9 @@ namespace Microsoft.Tools.ServiceModel.Svcutil
             // Don't treat warnings as errors so the bootstrapper will succeed as often as possible.
             this.MSBuildProj.ClearWarningsAsErrors();
 
+            // Nullable requires newer lang versions.
+            this.MSBuildProj.SetLangVersion();
+
             await this.MSBuildProj.SaveAsync(logger, cancellationToken).ConfigureAwait(false);
         }
 

--- a/src/dotnet-svcutil/lib/src/Shared/MSBuildProj.cs
+++ b/src/dotnet-svcutil/lib/src/Shared/MSBuildProj.cs
@@ -521,6 +521,12 @@ namespace Microsoft.Tools.ServiceModel.Svcutil
             SetPropertyValue("WarningsAsErrors", string.Empty);
         }
 
+        public void SetLangVersion()
+        {
+            // netstandard2.0 will throw an error saying default 7.3 lang version is too low, requiring 8 or higher. 
+            SetPropertyValue("LangVersion", "latest");
+        }
+
         private void UpdateTargetFramework(string targetFramework)
         {
             if (_targetFramework != targetFramework && !string.IsNullOrWhiteSpace(targetFramework))


### PR DESCRIPTION
When targeting netstandard2.0, using 2.0.3 dotnet-svcutil under net6.0, the generation process will fail stating the following error:  

`SC : error CS8630: Invalid 'nullable' value: 'Enable' for C# 7.3. Please use language version '8.0' or greater`

Using `latest` tag to target what is latest available on the developers machine. 

This edit only modifies the csproj file used during the generation process