### PR TITLE
Remove netcoreapp2.1 usage and fix test compile error for obsolete crypto type

### DIFF
--- a/src/System.ServiceModel.Primitives/ref/System.ServiceModel.Primitives.Ref.csproj
+++ b/src/System.ServiceModel.Primitives/ref/System.ServiceModel.Primitives.Ref.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <AssemblyVersion>$(WcfAssemblyVersion)</AssemblyVersion>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
-    <TargetFrameworks>net6.0;netstandard2.0;netcoreapp2.1;net461;</TargetFrameworks>
+    <TargetFrameworks>net6.0;netstandard2.0;netcoreapp3.1;net461;</TargetFrameworks>
     <AssemblyName>System.ServiceModel.Primitives</AssemblyName>
     <RootNamespace>System.ServiceModel</RootNamespace>
     <CLSCompliant>true</CLSCompliant>
@@ -14,11 +14,11 @@
     <Compile Include="System.ServiceModel.Primitives.cs" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1' or '$(TargetFramework)' == 'net6.0'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1' or '$(TargetFramework)' == 'net6.0'">
     <Compile Include="System.ServiceModel.Primitives.Netcoreapp.cs" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp2.1' and '$(TargetFramework)' != 'net6.0'">
+  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.1' and '$(TargetFramework)' != 'net6.0'">
     <None Include="System.ServiceModel.Primitives.Netcoreapp.cs" />
   </ItemGroup>
 

--- a/src/System.ServiceModel.Primitives/src/System.ServiceModel.Primitives.Facade.csproj
+++ b/src/System.ServiceModel.Primitives/src/System.ServiceModel.Primitives.Facade.csproj
@@ -8,7 +8,7 @@
     <!-- Workaround for https://github.com/NuGet/NuGet.Client/pull/3016 -->
     <NoWarn>$(NoWarn);NU5131</NoWarn>
 
-    <BuildFrameworks>net6.0;netstandard2.0;netcoreapp2.1;net461;</BuildFrameworks>
+    <BuildFrameworks>net6.0;netstandard2.0;netcoreapp3.1;net461;</BuildFrameworks>
     <HarvestFrameworks>MonoAndroid10;MonoTouch10;net45;net46;netcore50;netstandard1.0;netstandard1.1;netstandard1.3;portable-net45+win8+wp8;win8;wp8;xamarinios10;xamarinmac20;xamarintvos10;xamarinwatchos10;</HarvestFrameworks>
     <TargetFrameworks>$(BuildFrameworks)$(HarvestFrameworks)</TargetFrameworks>
     <IsBuilding Condition="$(BuildFrameworks.Contains('$(TargetFramework);'))">true</IsBuilding>

--- a/src/System.ServiceModel.Primitives/tests/IdentityModel/SymmetricSecurityKeyTest.cs
+++ b/src/System.ServiceModel.Primitives/tests/IdentityModel/SymmetricSecurityKeyTest.cs
@@ -25,7 +25,7 @@ public static class SymmetricSecurityKeyTest
         string algorit = "DES";
         MockGetSymmetricAlgorithm mgsaalg = new MockGetSymmetricAlgorithm();
         Assert.NotNull(mgsaalg.GetSymmetricAlgorithm(algorit));
-        Assert.IsAssignableFrom<DESCryptoServiceProvider>(mgsaalg.GetSymmetricAlgorithm(algorit));
+        Assert.IsAssignableFrom<DES>(mgsaalg.GetSymmetricAlgorithm(algorit));
     }
 }
 
@@ -70,7 +70,7 @@ public class MockGetSymmetricAlgorithm : SymmetricSecurityKey
 
     public override SymmetricAlgorithm GetSymmetricAlgorithm(string algorithm)
     {
-        return new DESCryptoServiceProvider();
+        return DES.Create(algorithm);
     }
 
     public override byte[] GetSymmetricKey()


### PR DESCRIPTION
This is to enable merging of PR using latest arcade versions which purposefully breaks builds using netcoreapp2.1