### PR TITLE
Fix for Hot Reload in .NET 6 (issue #4789) - Use MethodHandle.Value

### DIFF
--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Dispatcher/OperationSelectorBehavior.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Dispatcher/OperationSelectorBehavior.cs
@@ -35,11 +35,11 @@ namespace System.ServiceModel.Dispatcher
 
         internal class MethodInfoOperationSelector : IClientOperationSelector
         {
-            private Dictionary<object, string> _operationMap;
+            private Dictionary<IntPtr, string> _operationMap;
 
             internal MethodInfoOperationSelector(ContractDescription description, MessageDirection directionThatRequiresClientOpSelection)
             {
-                _operationMap = new Dictionary<object, string>();
+                _operationMap = new Dictionary<IntPtr, string>();
 
                 for (int i = 0; i < description.Operations.Count; i++)
                 {
@@ -48,26 +48,26 @@ namespace System.ServiceModel.Dispatcher
                     {
                         if (operation.SyncMethod != null)
                         {
-                            if (!_operationMap.ContainsKey(operation.SyncMethod))
+                            if (!_operationMap.ContainsKey(operation.SyncMethod.MethodHandle.Value))
                             {
-                                _operationMap.Add(operation.SyncMethod, operation.Name);
+                                _operationMap.Add(operation.SyncMethod.MethodHandle.Value, operation.Name);
                             }
                         }
 
                         if (operation.BeginMethod != null)
                         {
-                            if (!_operationMap.ContainsKey(operation.BeginMethod))
+                            if (!_operationMap.ContainsKey(operation.BeginMethod.MethodHandle.Value))
                             {
-                                _operationMap.Add(operation.BeginMethod, operation.Name);
-                                _operationMap.Add(operation.EndMethod, operation.Name);
+                                _operationMap.Add(operation.BeginMethod.MethodHandle.Value, operation.Name);
+                                _operationMap.Add(operation.EndMethod.MethodHandle.Value, operation.Name);
                             }
                         }
 
                         if (operation.TaskMethod != null)
                         {
-                            if (!_operationMap.ContainsKey(operation.TaskMethod))
+                            if (!_operationMap.ContainsKey(operation.TaskMethod.MethodHandle.Value))
                             {
-                                _operationMap.Add(operation.TaskMethod, operation.Name);
+                                _operationMap.Add(operation.TaskMethod.MethodHandle.Value, operation.Name);
                             }
                         }
                     }
@@ -81,9 +81,9 @@ namespace System.ServiceModel.Dispatcher
 
             public string SelectOperation(MethodBase method, object[] parameters)
             {
-                if (_operationMap.ContainsKey(method))
+                if (_operationMap.ContainsKey(method.MethodHandle.Value))
                 {
-                    return _operationMap[method];
+                    return _operationMap[method.MethodHandle.Value];
                 }
                 else
                 {

--- a/src/System.Private.ServiceModel/src/System/ServiceModel/Dispatcher/ProxyOperationRuntime.cs
+++ b/src/System.Private.ServiceModel/src/System/ServiceModel/Dispatcher/ProxyOperationRuntime.cs
@@ -257,7 +257,7 @@ namespace System.ServiceModel.Dispatcher
 
             Contract.Assert(methodCall != null);
             Contract.Assert(methodCall.MethodBase != null);
-            return methodCall.MethodBase.Equals(_syncMethod);
+            return methodCall.MethodBase.MethodHandle.Value.Equals(_syncMethod.MethodHandle.Value);
         }
 
         internal bool IsBeginCall(MethodCall methodCall)
@@ -269,7 +269,7 @@ namespace System.ServiceModel.Dispatcher
 
             Contract.Assert(methodCall != null);
             Contract.Assert(methodCall.MethodBase != null);
-            return methodCall.MethodBase.Equals(_beginMethod);
+            return methodCall.MethodBase.MethodHandle.Value.Equals(_beginMethod.MethodHandle.Value);
         }
 
         internal bool IsTaskCall(MethodCall methodCall)
@@ -281,7 +281,7 @@ namespace System.ServiceModel.Dispatcher
 
             Contract.Assert(methodCall != null);
             Contract.Assert(methodCall.MethodBase != null);
-            return methodCall.MethodBase.Equals(_taskMethod);
+            return methodCall.MethodBase.MethodHandle.Value.Equals(_taskMethod.MethodHandle.Value);
         }
 
         internal object[] MapSyncInputs(MethodCall methodCall, out object[] outs)


### PR DESCRIPTION
This fixes #4789 

Use MethodHandle.Value instead of the MethodInfo object. 

I'm not sure if anything else needs to be done, but Hot Reload is working now 🥳