### PR TITLE
wcfcs tool add service failed with 0 endpoints found error if type-reuse enabled

### DIFF
--- a/src/dotnet-svcutil/lib/src/FrameworkFork/System.Runtime.Serialization/System/Runtime/Serialization/DataContract.cs
+++ b/src/dotnet-svcutil/lib/src/FrameworkFork/System.Runtime.Serialization/System/Runtime/Serialization/DataContract.cs
@@ -1710,18 +1710,10 @@ namespace System.Runtime.Serialization
             string clrNs = type.Namespace;
             if (clrNs == null)
                 clrNs = String.Empty;
-            string ns = null;
-            try
-            {
-                ns = GetGlobalDataContractNamespace(clrNs, type.GetTypeInfo().Module.GetCustomAttributes(typeof(ContractNamespaceAttribute)).ToArray());
-                if (ns == null)
-                    ns = GetGlobalDataContractNamespace(clrNs, type.GetTypeInfo().Assembly.GetCustomAttributes(typeof(ContractNamespaceAttribute)).ToArray());
-            }
-            catch
-            {
-                //reflect type to GetCustomAttributes could throw dependency file loading error (e.g. fail to load System.Runtime 4.2.2.0)
-            }
-            
+            string ns = GetGlobalDataContractNamespace(clrNs, type.GetTypeInfo().Module.GetCustomAttributes(typeof(ContractNamespaceAttribute)).ToArray());
+            if (ns == null)
+                ns = GetGlobalDataContractNamespace(clrNs, type.GetTypeInfo().Assembly.GetCustomAttributes(typeof(ContractNamespaceAttribute)).ToArray());
+
             if (ns == null)
                 ns = GetDefaultStableNamespace(type);
             else

--- a/src/dotnet-svcutil/lib/src/FrameworkFork/System.Runtime.Serialization/System/Runtime/Serialization/DataContract.cs
+++ b/src/dotnet-svcutil/lib/src/FrameworkFork/System.Runtime.Serialization/System/Runtime/Serialization/DataContract.cs
@@ -1714,13 +1714,13 @@ namespace System.Runtime.Serialization
             string ns = null;
             try
             {
-                ns = GetGlobalDataContractNamespace(clrNs, type.GetTypeInfo().Module.GetCustomAttributes(typeof(ContractNamespaceAttribute)).ToArray());
+                ns = GetGlobalDataContractNamespace(clrNs, type.Module.GetCustomAttributes(typeof(ContractNamespaceAttribute)).ToArray());
                 if (ns == null)
-                    ns = GetGlobalDataContractNamespace(clrNs, type.GetTypeInfo().Assembly.GetCustomAttributes(typeof(ContractNamespaceAttribute)).ToArray());
+                    ns = GetGlobalDataContractNamespace(clrNs, type.Assembly.GetCustomAttributes(typeof(ContractNamespaceAttribute)).ToArray());
             }
-            catch
+            catch(System.IO.FileNotFoundException)
             {
-                //reflect type to GetCustomAttributes could throw file loading error due to the exact assembly version not restored
+                //type.Module or type.Assembly could throw if multiple assembly with same name get referenced but only one version get restored.
             }
 
             if (ns == null)

--- a/src/dotnet-svcutil/lib/src/FrameworkFork/System.Runtime.Serialization/System/Runtime/Serialization/DataContract.cs
+++ b/src/dotnet-svcutil/lib/src/FrameworkFork/System.Runtime.Serialization/System/Runtime/Serialization/DataContract.cs
@@ -1710,10 +1710,18 @@ namespace System.Runtime.Serialization
             string clrNs = type.Namespace;
             if (clrNs == null)
                 clrNs = String.Empty;
-            string ns = GetGlobalDataContractNamespace(clrNs, type.GetTypeInfo().Module.GetCustomAttributes(typeof(ContractNamespaceAttribute)).ToArray());
-            if (ns == null)
-                ns = GetGlobalDataContractNamespace(clrNs, type.GetTypeInfo().Assembly.GetCustomAttributes(typeof(ContractNamespaceAttribute)).ToArray());
-
+            string ns = null;
+            try
+            {
+                ns = GetGlobalDataContractNamespace(clrNs, type.GetTypeInfo().Module.GetCustomAttributes(typeof(ContractNamespaceAttribute)).ToArray());
+                if (ns == null)
+                    ns = GetGlobalDataContractNamespace(clrNs, type.GetTypeInfo().Assembly.GetCustomAttributes(typeof(ContractNamespaceAttribute)).ToArray());
+            }
+            catch
+            {
+                //reflect type to GetCustomAttributes could throw dependency file loading error (e.g. fail to load System.Runtime 4.2.2.0)
+            }
+            
             if (ns == null)
                 ns = GetDefaultStableNamespace(type);
             else

--- a/src/dotnet-svcutil/lib/src/FrameworkFork/System.Runtime.Serialization/System/Runtime/Serialization/DataContract.cs
+++ b/src/dotnet-svcutil/lib/src/FrameworkFork/System.Runtime.Serialization/System/Runtime/Serialization/DataContract.cs
@@ -1710,9 +1710,18 @@ namespace System.Runtime.Serialization
             string clrNs = type.Namespace;
             if (clrNs == null)
                 clrNs = String.Empty;
-            string ns = GetGlobalDataContractNamespace(clrNs, type.GetTypeInfo().Module.GetCustomAttributes(typeof(ContractNamespaceAttribute)).ToArray());
-            if (ns == null)
-                ns = GetGlobalDataContractNamespace(clrNs, type.GetTypeInfo().Assembly.GetCustomAttributes(typeof(ContractNamespaceAttribute)).ToArray());
+
+            string ns = null;
+            try
+            {
+                ns = GetGlobalDataContractNamespace(clrNs, type.GetTypeInfo().Module.GetCustomAttributes(typeof(ContractNamespaceAttribute)).ToArray());
+                if (ns == null)
+                    ns = GetGlobalDataContractNamespace(clrNs, type.GetTypeInfo().Assembly.GetCustomAttributes(typeof(ContractNamespaceAttribute)).ToArray());
+            }
+            catch
+            {
+                //reflect type to GetCustomAttributes could throw file loading error due to the exact assembly version not restored
+            }
 
             if (ns == null)
                 ns = GetDefaultStableNamespace(type);

--- a/src/dotnet-svcutil/lib/src/TypeLoader.cs
+++ b/src/dotnet-svcutil/lib/src/TypeLoader.cs
@@ -77,7 +77,6 @@ namespace Microsoft.Tools.ServiceModel.Svcutil
                         }
                     }
                 }
-                types = new Type[] { };
             }
             return types;
         }

--- a/src/dotnet-svcutil/lib/src/TypeLoader.cs
+++ b/src/dotnet-svcutil/lib/src/TypeLoader.cs
@@ -77,6 +77,7 @@ namespace Microsoft.Tools.ServiceModel.Svcutil
                         }
                     }
                 }
+                types = new Type[] { };
             }
             return types;
         }


### PR DESCRIPTION
This is to fix below error thrown from WCF Connected Service tool when add some service with type reuse feature enabled:
```
Importing web service metadata ...
Scaffolding service reference code ...
Number of service endpoints found: 0
ErrorNo code was generated.
If you were trying to generate a client, this could be because the metadata documents did not contain any valid contracts or services, or because all contracts/services were discovered to exist in --reference assemblies. Verify that you passed all the metadata documents to the tool.
Done.
ErrorFailed adding service reference(s). Index (zero based) must be greater than or equal to zero and less than the size of the argument list.
```

The error message is not very specific, root cause is that the referenced package has dependency file failed to be loaded in the WCFCS execution context, for example System.Runtime version 4.2.2.0 can't be loaded when reusing type SqlClientFactory in Microsoft.Data.SqlClient package version 4.1.0.