### PR TITLE
Adding UA to RootCert curl call to identify test variant in logs

### DIFF
--- a/src/System.Private.ServiceModel/tools/scripts/InstallRootCertificate.sh
+++ b/src/System.Private.ServiceModel/tools/scripts/InstallRootCertificate.sh
@@ -23,7 +23,7 @@ acquire_certificate()
     # Need to make a call as the original user as we need to write to the cert store for the current 
     # user, not as root
     echo "Making a call to '${__service_host}/TestHost.svc/RootCert' as user '$SUDO_USER'"
-    sudo -E -u $SUDO_USER $__curl_exe -o $__cafile "http://${__service_host}/TestHost.svc/RootCert?asPem=true" 
+    sudo -E -u $SUDO_USER $__curl_exe -o $__cafile -A "WcfCertDownloadScript/1.0 (${__os})" "http://${__service_host}/TestHost.svc/RootCert?asPem=true" 
     
     return $?
 }


### PR DESCRIPTION
Sometimes we get connectivity issues in our test infrastructure and it's difficult to know which Helix test machines are communicating with our test server. This change adds the OS name to the user agent so it can be identified in the HTTP logs on our test server.