### PR TITLE
Make BasicHttpsSecurity default constructor public in the contract

### DIFF
--- a/src/System.ServiceModel.Http/ref/System.ServiceModel.Http.cs
+++ b/src/System.ServiceModel.Http/ref/System.ServiceModel.Http.cs
@@ -53,7 +53,7 @@ namespace System.ServiceModel
     }
     public sealed partial class BasicHttpsSecurity
     {
-        internal BasicHttpsSecurity() { }
+        public BasicHttpsSecurity() { }
         public System.ServiceModel.BasicHttpsSecurityMode Mode { get { return default; } set { } }
         public System.ServiceModel.HttpTransportSecurity Transport { get { return default; } set { } }
         public System.ServiceModel.BasicHttpMessageSecurity Message { get { return default; } set { } }


### PR DESCRIPTION
It's already public in the implementation. This mirrors #2572 from years ago.