### PR TITLE
Update helix queue name for internal builds

### DIFF
--- a/eng/SendToHelix.proj
+++ b/eng/SendToHelix.proj
@@ -25,7 +25,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TestJob)' == 'Windows' AND '$(RunAsInternal)'" >
-    <HelixTargetQueue Include="windows.11.amd64" />
+    <HelixTargetQueue Include="windows.11.amd64.client" />
     <HelixTargetQueue Include="(Debian.11.Amd64)ubuntu.2004.amd64@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-11-helix-amd64-20220511124750-0ece9b3" />
     <HelixTargetQueue Include="RedHat.7.Amd64" />
   </ItemGroup>


### PR DESCRIPTION
I'm going to merge with skipping the regular checks as this only affects internal builds.