### PR TITLE
remove RestoreSources and update release notes

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -45,10 +45,4 @@
     <!-- Needed by Infrastructure.Common.csproj -->
     <MicrosoftDotNetPlatformAbstractionsVersion>2.1.0</MicrosoftDotNetPlatformAbstractionsVersion>
   </PropertyGroup>
-  <PropertyGroup>
-    <RestoreSources>
-      $(RestoreSources);
-      https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
-    </RestoreSources>
-  </PropertyGroup>
 </Project>

--- a/release-notes/System.ServiceModel.Duplex.md
+++ b/release-notes/System.ServiceModel.Duplex.md
@@ -8,6 +8,11 @@
 
 ## Version History
 
+### 4.10.0
+
+* [NuGet Package](https://www.nuget.org/packages/System.ServiceModel.Duplex/4.10.0)
+* [Release tag](https://github.com/dotnet/wcf/releases/tag/v3.4.0-rtm)
+
 ### 4.9.0
 
 * [NuGet Package](https://www.nuget.org/packages/System.ServiceModel.Duplex/4.9.0)

--- a/release-notes/System.ServiceModel.Federation.md
+++ b/release-notes/System.ServiceModel.Federation.md
@@ -8,6 +8,11 @@
 
 ## Version History
 
+### 4.10.0
+
+* [NuGet Package](https://www.nuget.org/packages/System.ServiceModel.Federation/4.10.0)
+* [Release tag](https://github.com/dotnet/wcf/releases/tag/v3.4.0-rtm)
+
 ### 4.9.0
 
 * [NuGet Package](https://www.nuget.org/packages/System.ServiceModel.Federation/4.9.0)

--- a/release-notes/System.ServiceModel.Http.md
+++ b/release-notes/System.ServiceModel.Http.md
@@ -8,6 +8,11 @@
 
 ## Version History
 
+### 4.10.0
+
+* [NuGet Package](https://www.nuget.org/packages/System.ServiceModel.Http/4.10.0)
+* [Release tag](https://github.com/dotnet/wcf/releases/tag/v3.4.0-rtm)
+
 ### 4.9.0
 
 * [NuGet Package](https://www.nuget.org/packages/System.ServiceModel.Http/4.9.0)

--- a/release-notes/System.ServiceModel.NetTcp.md
+++ b/release-notes/System.ServiceModel.NetTcp.md
@@ -8,6 +8,11 @@
 
 ## Version History
 
+### 4.10.0
+
+* [NuGet Package](https://www.nuget.org/packages/System.ServiceModel.NetTcp/4.10.0)
+* [Release tag](https://github.com/dotnet/wcf/releases/tag/v3.4.0-rtm)
+
 ### 4.9.0
 
 * [NuGet Package](https://www.nuget.org/packages/System.ServiceModel.NetTcp/4.9.0)

--- a/release-notes/System.ServiceModel.Primitives.md
+++ b/release-notes/System.ServiceModel.Primitives.md
@@ -8,6 +8,11 @@
 
 ## Version History
 
+### 4.10.0
+
+* [NuGet Package](https://www.nuget.org/packages/System.ServiceModel.Primitives/4.10.0)
+* [Release tag](https://github.com/dotnet/wcf/releases/tag/v3.4.0-rtm)
+
 ### 4.9.0
 
 * [NuGet Package](https://www.nuget.org/packages/System.ServiceModel.Primitives/4.9.0)

--- a/release-notes/System.ServiceModel.Security.md
+++ b/release-notes/System.ServiceModel.Security.md
@@ -8,6 +8,11 @@
 
 ## Version History
 
+### 4.10.0
+
+* [NuGet Package](https://www.nuget.org/packages/System.ServiceModel.Security/4.10.0)
+* [Release tag](https://github.com/dotnet/wcf/releases/tag/v3.4.0-rtm)
+
 ### 4.9.0
 
 * [NuGet Package](https://www.nuget.org/packages/System.ServiceModel.Security/4.9.0)

--- a/release-notes/System.Web.Services.Description.md
+++ b/release-notes/System.Web.Services.Description.md
@@ -8,6 +8,11 @@
 
 ## Version History
 
+### 4.10.0
+
+* [NuGet Package](https://www.nuget.org/packages/System.Web.Services.Description/4.10.0)
+* [Release tag](https://github.com/dotnet/wcf/releases/tag/v3.4.0-rtm)
+
 ### 4.9.0
 
 * [NuGet Package](https://www.nuget.org/packages/System.Web.Services.Description/4.9.0)


### PR DESCRIPTION
According to [this article](https://github.com/dotnet/arcade/blob/e7ede87875f41a9b3df898ae08da5ebc96e24f56/Documentation/RestoreSourcesUpdateStatus.md), RestoreSources is already replaced by Nuget.config. 

Also update release notes to WCF Core 4.10 release.