### PR TITLE
Update public pool names

### DIFF
--- a/azure-pipelines-arcade.yml
+++ b/azure-pipelines-arcade.yml
@@ -63,7 +63,7 @@ stages:
         timeoutInMinutes: 90
         pool:
           ${{ if eq(variables._RunAsPublic, True) }}:
-            name: NetCore1ESPool-Public
+            name: NetCore-Public
             demands: ImageOverride -equals build.windows.10.amd64.vs2017.open
           ${{ if eq(variables._RunAsInternal, True) }}:
             name: NetCore1ESPool-Internal
@@ -164,7 +164,7 @@ stages:
           timeoutInMinutes: 90
           container: ubuntu_2004_20211215
           pool:
-            name:  NetCore1ESPool-Public
+            name:  NetCore-Public
             demands: ImageOverride -equals build.Ubuntu.1804.Amd64.Open
           variables:
           - _TestArgs: /p:ServiceUri=$(_serviceUri) /p:Root_Certificate_Installed=true /p:Client_Certificate_Installed=true /p:SSL_Available=true
@@ -223,7 +223,7 @@ stages:
         - job: MacOS
           timeoutInMinutes: 90
           pool:
-            name: NetCore1ESPool-Public
+            name: NetCore-Public
             demands: ImageOverride -equals build.windows.10.amd64.vs2017.open
           variables:
           - _TestArgs: /p:ServiceUri=$(_serviceUri) /p:Root_Certificate_Installed=true /p:Client_Certificate_Installed=true /p:SSL_Available=true

--- a/eng/common/templates/job/source-build.yml
+++ b/eng/common/templates/job/source-build.yml
@@ -46,7 +46,7 @@ jobs:
     # source-build builds run in Docker, including the default managed platform.
     pool:
       ${{ if eq(variables['System.TeamProject'], 'public') }}:
-        name: NetCore1ESPool-Public
+        name: NetCore-Public
         demands: ImageOverride -equals Build.Ubuntu.1804.Amd64.Open
       ${{ if eq(variables['System.TeamProject'], 'internal') }}:
         name: NetCore1ESPool-Internal

--- a/eng/common/templates/job/source-index-stage1.yml
+++ b/eng/common/templates/job/source-index-stage1.yml
@@ -28,7 +28,7 @@ jobs:
   ${{ if eq(parameters.pool, '') }}:
     pool:
       ${{ if eq(variables['System.TeamProject'], 'public') }}:
-        name: NetCore1ESPool-Public
+        name: NetCore-Public
         demands: ImageOverride -equals windows.vs2019.amd64.open
       ${{ if eq(variables['System.TeamProject'], 'internal') }}:
         name: NetCore1ESPool-Internal


### PR DESCRIPTION
This change is required to continue building PRs in the dotnet public repo.  The agents and images used in the new project / organization are identical and build regressions are not expected.  Updating files under eng/common is intentional to move as much as possible over to viable build agents (normally this is not done).

For questions / concerns, please stop by the .NET Core Engineering Services [First Responders Teams Channel](https://teams.microsoft.com/l/channel/19%3aafba3d1545dd45d7b79f34c1821f6055%40thread.skype/First%2520Responders?groupId=4d73664c-9f2f-450d-82a5-c2f02756606d&tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47).
