### PR TITLE
Use latest docker containers

### DIFF
--- a/azure-pipelines-arcade.yml
+++ b/azure-pipelines-arcade.yml
@@ -38,7 +38,7 @@ variables:
 resources:
   containers:
   - container: ubuntu_2004_20211215
-    image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-20.04-coredeps-20211215184912-e6e3ac4
+    image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-20.04-coredeps
 
 stages:
 - stage: Build

--- a/eng/SendToHelix.proj
+++ b/eng/SendToHelix.proj
@@ -26,13 +26,13 @@
 
   <ItemGroup Condition="'$(TestJob)' == 'Windows' AND '$(RunAsInternal)'" >
     <HelixTargetQueue Include="windows.11.amd64.client" />
-    <HelixTargetQueue Include="(Debian.11.Amd64)ubuntu.2004.amd64@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-11-helix-amd64-20220511124750-0ece9b3" />
+    <HelixTargetQueue Include="(Debian.11.Amd64)ubuntu.2004.amd64@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-11-helix-amd64" />
     <HelixTargetQueue Include="RedHat.7.Amd64" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TestJob)' == 'Linux'" >
     <HelixTargetQueue Include="Centos.7.Amd64.Open" />
-    <HelixTargetQueue Include="(Debian.11.Amd64.Open)ubuntu.2004.amd64.open@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-11-helix-amd64-20220511124750-0ece9b3" />
+    <HelixTargetQueue Include="(Debian.11.Amd64.Open)ubuntu.2004.amd64.open@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-11-helix-amd64" />
     <HelixTargetQueue Include="RedHat.7.Amd64.Open" />
     <HelixTargetQueue Include="SLES.15.Amd64.Open" />
     <HelixTargetQueue Include="Ubuntu.2004.Amd64.Open" />


### PR DESCRIPTION
This change moves all of the docker images to the latest tag as part of https://github.com/dotnet/arcade/issues/10377.