### PR TITLE
Add reference assembly to System.ServiceModel.Primitives package

### DIFF
--- a/src/System.ServiceModel.Primitives/src/System.ServiceModel.Primitives.csproj
+++ b/src/System.ServiceModel.Primitives/src/System.ServiceModel.Primitives.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyVersion>$(WcfAssemblyVersion)</AssemblyVersion>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
@@ -13,17 +13,11 @@
   </PropertyGroup>
 
   <!-- DesignTimeBuild requires all the TargetFramework Derived Properties to not be present in the first property group. -->
-
-  <!--<ItemGroup>
-    --><!-- bring in the System.ServiceModel shim for desktop compat --><!--
-    <ProjectReference Include="..\..\System.ServiceModel.Shim\System.ServiceModel.Shim.csproj"
-                      ReferenceOutputAssembly="false"
-                      OutputItemType="TfmSpecificPackageFile"
-                      PackagePath="ref/$(TargetFramework);lib/$(TargetFramework)" />
-  </ItemGroup>-->
-
+  <PropertyGroup>
+    <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
+  </PropertyGroup>
+  
   <ItemGroup>
-    <!-- , PublicKey=b03f5f7f11d50a3a -->
     <InternalsVisibleTo Include="System.ServiceModel.Http" />
     <InternalsVisibleTo Include="System.ServiceModel.Federation" />
     <InternalsVisibleTo Include="System.ServiceModel.NetFramingBase" />
@@ -47,9 +41,6 @@
     <Compile Include="..\..\Common\src\System\__HResults.cs">
       <Link>Common\System\__HResults.cs</Link>
     </Compile>
-    <!--<Compile Include="..\..\Common\src\System\SR.cs">
-      <Link>Common\System\SR.cs</Link>
-    </Compile>-->
     <Compile Include="..\..\Common\src\System\ServiceModel\**\*.cs">
       <Visible>true</Visible>
       <Link>Common\System\ServiceModel\%(RecursiveDir)%(Filename)%(Extension)</Link>


### PR DESCRIPTION
The primitives package wasn't shipping a reference assembly which resulted in over exposing implementation api's.