### PR TITLE
dotnet-svcutil NetNamedPipeBinding support

### DIFF
--- a/src/dotnet-svcutil/lib/src/CodeDomFixup/CodeDomVisitors/AddAsyncOpenClose.cs
+++ b/src/dotnet-svcutil/lib/src/CodeDomFixup/CodeDomVisitors/AddAsyncOpenClose.cs
@@ -20,15 +20,24 @@ namespace Microsoft.Tools.ServiceModel.Svcutil
             {
                 if (TargetFrameworkHelper.NetCoreVersionReferenceTable.TryGetValue(options.TargetFramework.Version, out var referenceTable))
                 {
-                    string version = referenceTable.FirstOrDefault().Version;
-                    string[] vers = version.Split('.');
-                    if (vers.Length > 1)
+                    string version = referenceTable.FirstOrDefault().Version.Trim(new char[] { '(', ')', '[', ']'} );
+                    var versions = version.Split(',');
+                    foreach(var v in versions)
                     {
-                        Version v = new Version(int.Parse(vers[0]), int.Parse(vers[1]));
-                        // For .NETCore targetframework found in the referenced table, generate CloseAsync() when WCF package version is less than 4.10
-                        if (v.CompareTo(new Version(4, 10)) < 0)
+                        if (!string.IsNullOrEmpty(v))
                         {
-                            _generateCloseAsync = true;
+                            string[] vers = version.Split('.');
+                            if (vers.Length > 1)
+                            {
+                                Version ver = new Version(int.Parse(vers[0]), int.Parse(vers[1]));
+                                // For .NETCore targetframework found in the referenced table, generate CloseAsync() when WCF package version is less than 4.10
+                                if (ver.CompareTo(new Version(4, 10)) < 0)
+                                {
+                                    _generateCloseAsync = true;
+                                }
+                            }
+
+                            break;
                         }
                     }
                 }

--- a/src/dotnet-svcutil/lib/src/CodeDomFixup/EndpointSelector.cs
+++ b/src/dotnet-svcutil/lib/src/CodeDomFixup/EndpointSelector.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Tools.ServiceModel.Svcutil
         {
             s_bindingValidationErrors.Clear();
 
-            if (!(binding is BasicHttpBinding || binding is NetHttpBinding || binding is WSHttpBinding || binding is NetTcpBinding || binding is WSFederationHttpBinding || binding is CustomBinding))
+            if (!(binding is BasicHttpBinding || binding is NetHttpBinding || binding is WSHttpBinding || binding is NetTcpBinding || binding is WSFederationHttpBinding || binding is NetNamedPipeBinding || binding is CustomBinding))
             {
                 s_bindingValidationErrors.Add(string.Format(SR.BindingTypeNotSupportedFormat, binding.GetType().FullName,
                     typeof(BasicHttpBinding).FullName, typeof(NetHttpBinding).FullName, typeof(WSHttpBinding).FullName, typeof(NetTcpBinding).FullName, typeof(CustomBinding).FullName));
@@ -124,7 +124,7 @@ namespace Microsoft.Tools.ServiceModel.Svcutil
             {
                 if (bindingElement is TransportBindingElement)
                 {
-                    if (!(bindingElement is HttpTransportBindingElement || bindingElement is HttpsTransportBindingElement || bindingElement is TcpTransportBindingElement))
+                    if (!(bindingElement is HttpTransportBindingElement || bindingElement is HttpsTransportBindingElement || bindingElement is TcpTransportBindingElement || bindingElement is NamedPipeTransportBindingElement))
                     {
                         s_bindingValidationErrors.Add(string.Format(SR.BindingTransportTypeNotSupportedFormat, bindingElement.GetType().FullName,
                             typeof(HttpTransportBindingElement).FullName, typeof(HttpsTransportBindingElement).FullName, typeof(TcpTransportBindingElement).FullName));

--- a/src/dotnet-svcutil/lib/src/CodeDomFixup/MethodCreationHelper.cs
+++ b/src/dotnet-svcutil/lib/src/CodeDomFixup/MethodCreationHelper.cs
@@ -1296,7 +1296,7 @@ namespace Microsoft.Tools.ServiceModel.Svcutil
         {
             NamedPipeTransportBindingElement defaultBindingElement = new NamedPipeTransportBindingElement();
             CodeVariableDeclarationStatement namedPipeBindingElement = new CodeVariableDeclarationStatement(
-                typeof(TcpTransportBindingElement),
+                typeof(NamedPipeTransportBindingElement),
                 "namedPipeBindingElement",
                 new CodeObjectCreateExpression(typeof(NamedPipeTransportBindingElement)));
             statements.Add(namedPipeBindingElement);

--- a/src/dotnet-svcutil/lib/src/CodeDomFixup/WcfCodeGenerationExtension.cs
+++ b/src/dotnet-svcutil/lib/src/CodeDomFixup/WcfCodeGenerationExtension.cs
@@ -4,7 +4,9 @@
 
 using System;
 using System.Collections.ObjectModel;
+using System.Linq;
 using System.Runtime.Serialization;
+using System.ServiceModel;
 using System.ServiceModel.Channels;
 using System.ServiceModel.Description;
 
@@ -55,6 +57,18 @@ namespace Microsoft.Tools.ServiceModel.Svcutil
                 if (!importer.Errors.Contains(error))
                 {
                     importer.Errors.Add(error);
+                }
+            }
+
+            foreach(var binding in bindings)
+            {
+                if(binding is NetNamedPipeBinding && _options.Project!=null && !_options.Project.TargetFrameworks.FirstOrDefault().ToLower().Contains("windows"))
+                {
+                    MetadataConversionError error = new MetadataConversionError(SR.TargetFrameworkNotSupported_NetNamedPipe, isWarning: true);
+                    if (!importer.Errors.Contains(error))
+                    {
+                        importer.Errors.Add(error);
+                    }
                 }
             }
 

--- a/src/dotnet-svcutil/lib/src/FrameworkFork/System.ServiceModel/Resources/SRServiceModel.resx
+++ b/src/dotnet-svcutil/lib/src/FrameworkFork/System.ServiceModel/Resources/SRServiceModel.resx
@@ -324,10 +324,10 @@
   <data name="EffectiveGreaterThanExpiration" xml:space="preserve">
     <value>The valid from time is greater than the valid to time.</value>
   </data>
-	<data name="LengthMustBeGreaterThanZero" xml:space="preserve">
+  <data name="LengthMustBeGreaterThanZero" xml:space="preserve">
     <value>The length of this argument must be greater than 0.</value>
   </data>
-	<data name="KeyLengthMustBeMultipleOfEight" xml:space="preserve">
+  <data name="KeyLengthMustBeMultipleOfEight" xml:space="preserve">
     <value>Key length '{0}' is not a multiple of 8 for symmetric keys.</value>
   </data>
   <data name="InvalidX509RawData" xml:space="preserve">
@@ -990,7 +990,7 @@
   <data name="BadKeyEncryptionAlgorithm" xml:space="preserve">
     <value>Invalid key encryption algorithm {0}.</value>
   </data>
-	<data name="SPS_InvalidAsyncResult" xml:space="preserve">
+  <data name="SPS_InvalidAsyncResult" xml:space="preserve">
     <value>The asynchronous result object used to end this operation was not the object that was returned when the operation was initiated.</value>
   </data>
   <data name="UnableToCreateTokenReference" xml:space="preserve">
@@ -2016,7 +2016,7 @@
   <data name="SFxXmlArrayNotAllowedForMultiple" xml:space="preserve">
     <value>XmlArrayAttribute cannot be used in repeating part {1}:{0}.</value>
   </data>
-    <data name="SFxXmlSerializerIsNotFound" xml:space="preserve">
+  <data name="SFxXmlSerializerIsNotFound" xml:space="preserve">
     <value>Could not find XmlSerializer for type {0}.</value>
   </data>
   <data name="SFxChannelFactoryEndpointAddressUri" xml:space="preserve">
@@ -2250,12 +2250,12 @@
   <data name="DuplicateContractQNameNameOnExport" xml:space="preserve">
     <value>Duplicate contract XmlQualifiedNames are not supported.\r\nAnother ContractDescription with the Name: {0} and Namespace: {1} has already been exported.</value>
   </data>
-	<data name="WarnDuplicateBindingQNameNameOnExport" xml:space="preserve">
+  <data name="WarnDuplicateBindingQNameNameOnExport" xml:space="preserve">
     <value>Similar ServiceEndpoints were exported. The WSDL export process was forced to suffix wsdl:binding names to avoid naming conflicts.\r\n Similar ServiceEndpoints means different binding instances having the Name: {0} and Namespace: {1} and either the same ContractDescription or at least the same contract Name: {2}.</value>
-	</data>
+  </data>
   <data name="WarnSkippingOpertationWithWildcardAction" xml:space="preserve">
-     <value>An operation was skipped during export because it has a wildcard action. This is not supported in WSDL.\r\nContract Name:{0}\r\nContract Namespace:{1}\r\nOperation Name:{2}</value>
- </data>
+    <value>An operation was skipped during export because it has a wildcard action. This is not supported in WSDL.\r\nContract Name:{0}\r\nContract Namespace:{1}\r\nOperation Name:{2}</value>
+  </data>
   <data name="WarnSkippingOpertationWithSessionOpenNotificationEnabled" xml:space="preserve">
     <value>An operation was skipped during export because the property '{0}' is set to '{1}'. This operation should be used for server only and should not be exposed from WSDL. \r\nContract Name:{2}\r\nContract Namespace:{3}\r\nOperation Name:{4}</value>
   </data>
@@ -2508,7 +2508,7 @@
   <data name="ArgumentOutOfRange" xml:space="preserve">
     <value>value must be &gt;= {0} and &lt;= {1}.</value>
   </data>
-	<data name="ArgumentOutOfMinRange" xml:space="preserve">
+  <data name="ArgumentOutOfMinRange" xml:space="preserve">
     <value>Specified argument was out of the range of valid values.  The value must be at least {0}.</value>
   </data>
   <data name="ContextBindingElementCannotProvideChannelFactory" xml:space="preserve">
@@ -2610,7 +2610,7 @@
   <data name="SFxCannotImportAsParameters_OutputParameterAndTask" xml:space="preserve">
     <value>Generating message contract since the operation has multiple return values.</value>
   </data>
-    <data name="ID0023" xml:space="preserve">
+  <data name="ID0023" xml:space="preserve">
     <value>ID0023: Failed to create an instance of '{0}' from configuration. A custom configuration element was specified, but the method LoadCustomConfiguration was not implemented. Override LoadCustomConfiguration to handle custom configuration loading.</value>
   </data>
   <data name="AuthFailed" xml:space="preserve">
@@ -2768,5 +2768,86 @@
   </data>
   <data name="ProvidedNetworkCredentialsForKerberosHasInvalidUserName" xml:space="preserve">
     <value>The NetworkCredentials provided for the Kerberos Token does not have a valid UserName.</value>
+  </data>
+  <data name="PipeAlreadyClosing" xml:space="preserve">
+    <value>The pipe cannot be written to or read from because it is already in the process of being closed.</value>
+  </data>
+  <data name="PipeAlreadyShuttingDown" xml:space="preserve">
+    <value>The pipe cannot be written to because it is already in the process of shutting down.</value>
+  </data>
+  <data name="PipeCantCloseWithPendingWrite" xml:space="preserve">
+    <value>The pipe cannot be closed while a write to the pipe is pending.</value>
+  </data>
+  <data name="PipeClosed" xml:space="preserve">
+    <value>The operation cannot be completed because the pipe was closed.  This may have been caused by the application on the other end of the pipe exiting.</value>
+  </data>
+  <data name="PipeCloseFailed" xml:space="preserve">
+    <value>The pipe could not close gracefully.  This may be caused by the application on the other end of the pipe exiting.</value>
+  </data>
+  <data name="PipeConnectAddressFailed" xml:space="preserve">
+    <value>A pipe endpoint exists for '{0}', but the connect failed: {1}</value>
+  </data>
+  <data name="PipeConnectFailed" xml:space="preserve">
+    <value>Cannot connect to endpoint '{0}'.</value>
+  </data>
+  <data name="PipeConnectionAbortedReadTimedOut" xml:space="preserve">
+    <value>The pipe connection was aborted because an asynchronous read from the pipe did not complete within the allotted timeout of {0}. The time allotted to this operation may have been a portion of a longer timeout.</value>
+  </data>
+  <data name="PipeConnectionAbortedWriteTimedOut" xml:space="preserve">
+    <value>The pipe connection was aborted because an asynchronous write to the pipe did not complete within the allotted timeout of {0}. The time allotted to this operation may have been a portion of a longer timeout.</value>
+  </data>
+  <data name="PipeConnectTimedOut" xml:space="preserve">
+    <value>Cannot connect to endpoint '{0}' within the allotted timeout of {1}. The time allotted to this operation may have been a portion of a longer timeout.</value>
+  </data>
+  <data name="PipeConnectTimedOutServerTooBusy" xml:space="preserve">
+    <value>Cannot connect to endpoint '{0}' within the allotted timeout of {1}. The server has likely reached the MaxConnections quota and is too busy to accept new connections. The time allotted to this operation may have been a portion of a longer timeout.</value>
+  </data>
+  <data name="PipeEndpointNotFound" xml:space="preserve">
+    <value>The pipe endpoint '{0}' could not be found on your local machine.</value>
+  </data>
+  <data name="PipeKnownWin32Error" xml:space="preserve">
+    <value>{0} ({1}, 0x{2})</value>
+  </data>
+  <data name="PipeModeChangeFailed" xml:space="preserve">
+    <value>The pipe was not able to be set to message mode: {0}</value>
+  </data>
+  <data name="PipeNameCanNotBeAccessed" xml:space="preserve">
+    <value>The pipe name could not be obtained for the pipe URI: {0}</value>
+  </data>
+  <data name="PipeNameCanNotBeAccessed2" xml:space="preserve">
+    <value>The pipe name could not be obtained for {0}.</value>
+  </data>
+  <data name="PipeReadPending" xml:space="preserve">
+    <value>There is already a read in progress for the pipe.  Wait for the first operation to complete before attempting to read again.</value>
+  </data>
+  <data name="PipeShutdownReadError" xml:space="preserve">
+    <value>The shutdown indicator was not received from the pipe.  The application on the other end of the pipe may not have sent it.  The pipe will still be closed.</value>
+  </data>
+  <data name="PipeShutdownWriteError" xml:space="preserve">
+    <value>The shutdown indicator could not be written to the pipe.  The application on the other end of the pipe may not be listening for it.  The pipe will still be closed.</value>
+  </data>
+  <data name="PipeSignalExpected" xml:space="preserve">
+    <value>The read from the pipe expected just a signal, but received actual data.</value>
+  </data>
+  <data name="PipeUriSchemeWrong" xml:space="preserve">
+    <value>URIs used with pipes must use the scheme: 'net.pipe'.</value>
+  </data>
+  <data name="PipeWritePending" xml:space="preserve">
+    <value>There is already a write in progress for the pipe.  Wait for the first operation to complete before attempting to write again.</value>
+  </data>
+  <data name="PipeWriteTimedOut" xml:space="preserve">
+    <value>The write to the pipe did not complete within the allotted timeout of {0}. The time allotted to this operation may have been a portion of a longer timeout.</value>
+  </data>
+  <data name="PlatformNotSupported_NetNamedPipe" xml:space="preserve">
+    <value>NetNamedPipe is not supported on this platform.</value>
+  </data>
+  <data name="TraceCodeFailedPipeConnect" xml:space="preserve">
+    <value>An attempt to connect to the named pipe endpoint at '{1}' failed. Another attempt will be made with {0} remaining in the overall timeout.</value>
+  </data>
+  <data name="TraceCodeInitiatingNamedPipeConnection" xml:space="preserve">
+    <value>Initiating Named Pipe connection.</value>
+  </data>
+  <data name="TraceCodePipeConnectionAbort" xml:space="preserve">
+    <value>PipeConnection aborted</value>
   </data>
 </root>

--- a/src/dotnet-svcutil/lib/src/FrameworkFork/System.ServiceModel/SMDiagnostics/DiagnosticUtility.cs
+++ b/src/dotnet-svcutil/lib/src/FrameworkFork/System.ServiceModel/SMDiagnostics/DiagnosticUtility.cs
@@ -31,6 +31,10 @@ namespace System
 #pragma warning restore 618
         }
 
+        internal static void TraceHandledException(Exception exception, TraceEventType traceEventType)
+        {
+            FxTrace.Exception.TraceHandledException(exception, traceEventType);
+        }
 
         public static ExceptionUtility ExceptionUtility
         {

--- a/src/dotnet-svcutil/lib/src/FrameworkFork/System.ServiceModel/SMDiagnostics/System/ServiceModel/Diagnostics/ExceptionUtility.cs
+++ b/src/dotnet-svcutil/lib/src/FrameworkFork/System.ServiceModel/SMDiagnostics/System/ServiceModel/Diagnostics/ExceptionUtility.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections;
 using System.Diagnostics;
 using System.Diagnostics.Tracing;
@@ -104,6 +105,23 @@ namespace System
         internal Exception ThrowHelper(Exception exception, EventLevel eventLevel)
         {
             FxTrace.Exception.TraceEtwException(exception, eventLevel);
+
+            return exception;
+        }
+
+        internal Exception ThrowHelper(Exception exception, TraceEventType eventType)
+        {
+            return ThrowHelper(exception, eventType, null);
+        }
+
+        internal static void TraceHandledException(Exception exception, TraceEventType traceEventType)
+        {
+            FxTrace.Exception.TraceHandledException(exception, traceEventType);
+        }
+
+        internal Exception ThrowHelper(Exception exception, TraceEventType eventType, TraceRecord extendedData)
+        {
+            FxTrace.Exception.TraceEtwException(exception, eventType);
 
             return exception;
         }

--- a/src/dotnet-svcutil/lib/src/FrameworkFork/System.ServiceModel/System/IO/PipeException.cs
+++ b/src/dotnet-svcutil/lib/src/FrameworkFork/System.ServiceModel/System/IO/PipeException.cs
@@ -28,10 +28,10 @@ namespace System.IO
         {
         }
 
-        protected PipeException(SerializationInfo info, StreamingContext context)
-            : base(info, context)
-        {
-        }
+        //protected PipeException(SerializationInfo info, StreamingContext context)
+        //    : base(info, context)
+        //{
+        //}
 
         public virtual int ErrorCode
         {

--- a/src/dotnet-svcutil/lib/src/FrameworkFork/System.ServiceModel/System/IO/PipeException.cs
+++ b/src/dotnet-svcutil/lib/src/FrameworkFork/System.ServiceModel/System/IO/PipeException.cs
@@ -28,11 +28,6 @@ namespace System.IO
         {
         }
 
-        //protected PipeException(SerializationInfo info, StreamingContext context)
-        //    : base(info, context)
-        //{
-        //}
-
         public virtual int ErrorCode
         {
             get { return HResult; }

--- a/src/dotnet-svcutil/lib/src/FrameworkFork/System.ServiceModel/System/IO/PipeException.cs
+++ b/src/dotnet-svcutil/lib/src/FrameworkFork/System.ServiceModel/System/IO/PipeException.cs
@@ -1,0 +1,41 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.Serialization;
+
+namespace System.IO
+{
+    [Serializable]
+    public class PipeException : IOException
+    {
+        public PipeException()
+            : base()
+        {
+        }
+
+        public PipeException(string message)
+            : base(message)
+        {
+        }
+
+        public PipeException(string message, int errorCode)
+            : base(message, errorCode)
+        {
+        }
+
+        public PipeException(string message, Exception inner)
+            : base(message, inner)
+        {
+        }
+
+        protected PipeException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+        }
+
+        public virtual int ErrorCode
+        {
+            get { return HResult; }
+        }
+    }
+}

--- a/src/dotnet-svcutil/lib/src/FrameworkFork/System.ServiceModel/System/Runtime/BackoffTimeoutHelper.cs
+++ b/src/dotnet-svcutil/lib/src/FrameworkFork/System.ServiceModel/System/Runtime/BackoffTimeoutHelper.cs
@@ -1,0 +1,103 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Threading.Tasks;
+
+namespace System.Runtime
+{
+    internal sealed class BackoffTimeoutHelper
+    {
+        private static readonly int s_maxSkewMilliseconds = 15;
+        private static readonly long s_maxDriftTicks = s_maxSkewMilliseconds * TimeSpan.TicksPerMillisecond * 2;
+        private static readonly TimeSpan s_defaultInitialWaitTime = TimeSpan.FromMilliseconds(1);
+        private static readonly TimeSpan s_defaultMaxWaitTime = TimeSpan.FromMinutes(1);
+        private DateTime _deadline;
+        private readonly TimeSpan _maxWaitTime;
+        private TimeSpan _waitTime;
+        private readonly Random _random;
+
+        internal BackoffTimeoutHelper(TimeSpan timeout)
+            : this(timeout, s_defaultMaxWaitTime)
+        {
+        }
+
+        internal BackoffTimeoutHelper(TimeSpan timeout, TimeSpan maxWaitTime)
+            : this(timeout, maxWaitTime, s_defaultInitialWaitTime)
+        {
+        }
+
+        internal BackoffTimeoutHelper(TimeSpan timeout, TimeSpan maxWaitTime, TimeSpan initialWaitTime)
+        {
+            _random = new Random(GetHashCode());
+            _maxWaitTime = maxWaitTime;
+            OriginalTimeout = timeout;
+            Reset(timeout, initialWaitTime);
+        }
+
+        public TimeSpan OriginalTimeout { get; }
+
+        private void Reset(TimeSpan timeout, TimeSpan initialWaitTime)
+        {
+            if (timeout == TimeSpan.MaxValue)
+            {
+                _deadline = DateTime.MaxValue;
+            }
+            else
+            {
+                _deadline = DateTime.UtcNow + timeout;
+            }
+            _waitTime = initialWaitTime;
+        }
+
+        public bool IsExpired()
+        {
+            if (_deadline == DateTime.MaxValue)
+            {
+                return false;
+            }
+            else
+            {
+                return (DateTime.UtcNow >= _deadline);
+            }
+        }
+
+        public async Task WaitAndBackoffAsync()
+        {
+            await Task.Delay(WaitTimeWithDrift());
+            Backoff();
+        }
+
+        private TimeSpan WaitTimeWithDrift()
+        {
+            return Ticks.ToTimeSpan(Math.Max(
+                Ticks.FromTimeSpan(s_defaultInitialWaitTime),
+                Ticks.Add(Ticks.FromTimeSpan(_waitTime),
+                    (uint)_random.Next() % (2 * BackoffTimeoutHelper.s_maxDriftTicks + 1) - s_maxDriftTicks)));
+        }
+
+        private void Backoff()
+        {
+            if (_waitTime.Ticks >= (_maxWaitTime.Ticks / 2))
+            {
+                _waitTime = _maxWaitTime;
+            }
+            else
+            {
+                _waitTime = TimeSpan.FromTicks(_waitTime.Ticks * 2);
+            }
+
+            if (_deadline != DateTime.MaxValue)
+            {
+                TimeSpan remainingTime = _deadline - DateTime.UtcNow;
+                if (_waitTime > remainingTime)
+                {
+                    _waitTime = remainingTime;
+                    if (_waitTime < TimeSpan.Zero)
+                    {
+                        _waitTime = TimeSpan.Zero;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/dotnet-svcutil/lib/src/FrameworkFork/System.ServiceModel/System/ServiceModel/AddressAccessDeniedException.cs
+++ b/src/dotnet-svcutil/lib/src/FrameworkFork/System.ServiceModel/System/ServiceModel/AddressAccessDeniedException.cs
@@ -11,6 +11,6 @@ namespace System.ServiceModel
         public AddressAccessDeniedException() { }
         public AddressAccessDeniedException(string message) : base(message) { }
         public AddressAccessDeniedException(string message, Exception innerException) : base(message, innerException) { }
-        protected AddressAccessDeniedException(SerializationInfo info, StreamingContext context) : base(info, context) { }
+        //protected AddressAccessDeniedException(SerializationInfo info, StreamingContext context) : base(info, context) { }
     }
 }

--- a/src/dotnet-svcutil/lib/src/FrameworkFork/System.ServiceModel/System/ServiceModel/AddressAccessDeniedException.cs
+++ b/src/dotnet-svcutil/lib/src/FrameworkFork/System.ServiceModel/System/ServiceModel/AddressAccessDeniedException.cs
@@ -1,0 +1,16 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.Serialization;
+
+namespace System.ServiceModel
+{
+    [Serializable]
+    public class AddressAccessDeniedException : CommunicationException
+    {
+        public AddressAccessDeniedException() { }
+        public AddressAccessDeniedException(string message) : base(message) { }
+        public AddressAccessDeniedException(string message, Exception innerException) : base(message, innerException) { }
+        protected AddressAccessDeniedException(SerializationInfo info, StreamingContext context) : base(info, context) { }
+    }
+}

--- a/src/dotnet-svcutil/lib/src/FrameworkFork/System.ServiceModel/System/ServiceModel/AddressAccessDeniedException.cs
+++ b/src/dotnet-svcutil/lib/src/FrameworkFork/System.ServiceModel/System/ServiceModel/AddressAccessDeniedException.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-
-using System.Runtime.Serialization;
+// See the LICENSE file in the project root for more information.
 
 namespace System.ServiceModel
 {
@@ -11,6 +10,5 @@ namespace System.ServiceModel
         public AddressAccessDeniedException() { }
         public AddressAccessDeniedException(string message) : base(message) { }
         public AddressAccessDeniedException(string message, Exception innerException) : base(message, innerException) { }
-        //protected AddressAccessDeniedException(SerializationInfo info, StreamingContext context) : base(info, context) { }
     }
 }

--- a/src/dotnet-svcutil/lib/src/FrameworkFork/System.ServiceModel/System/ServiceModel/Channels/ApplicationContainerSettings.cs
+++ b/src/dotnet-svcutil/lib/src/FrameworkFork/System.ServiceModel/System/ServiceModel/Channels/ApplicationContainerSettings.cs
@@ -68,7 +68,7 @@ namespace System.ServiceModel.Channels
         internal string GetConnectionGroupSuffix()
         {
             string suffix = string.Empty;
-            if (/*AppContainerInfo.IsAppContainerSupported && */this.TargetingAppContainer)
+            if (this.TargetingAppContainer)
             {
                 suffix = string.Format(CultureInfo.InvariantCulture, GroupNameSuffixFormat, this.SessionId, this.PackageFullName);
             }

--- a/src/dotnet-svcutil/lib/src/FrameworkFork/System.ServiceModel/System/ServiceModel/Channels/ApplicationContainerSettings.cs
+++ b/src/dotnet-svcutil/lib/src/FrameworkFork/System.ServiceModel/System/ServiceModel/Channels/ApplicationContainerSettings.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Globalization;
+
 namespace System.ServiceModel.Channels
 {
     public sealed class ApplicationContainerSettings
@@ -61,6 +63,17 @@ namespace System.ServiceModel.Channels
         internal ApplicationContainerSettings Clone()
         {
             return new ApplicationContainerSettings(this);
+        }
+
+        internal string GetConnectionGroupSuffix()
+        {
+            string suffix = string.Empty;
+            if (/*AppContainerInfo.IsAppContainerSupported && */this.TargetingAppContainer)
+            {
+                suffix = string.Format(CultureInfo.InvariantCulture, GroupNameSuffixFormat, this.SessionId, this.PackageFullName);
+            }
+
+            return suffix;
         }
 
         internal bool IsMatch(ApplicationContainerSettings applicationContainerSettings)

--- a/src/dotnet-svcutil/lib/src/FrameworkFork/System.ServiceModel/System/ServiceModel/Channels/FramingChannels.cs
+++ b/src/dotnet-svcutil/lib/src/FrameworkFork/System.ServiceModel/System/ServiceModel/Channels/FramingChannels.cs
@@ -51,26 +51,12 @@ namespace System.ServiceModel.Channels
 
         protected override void CloseOutputSessionCore(TimeSpan timeout)
         {
-            if (Connection is PipeConnection)
-            {
-                (Connection as PipeConnection).WriteAsync(new Memory<byte>(SessionEncoder.EndBytes, 0, SessionEncoder.EndBytes.Length), true, timeout).GetAwaiter().GetResult();
-            }
-            else
-            {
-                Connection.Write(SessionEncoder.EndBytes, 0, SessionEncoder.EndBytes.Length, true, timeout);
-            }
+            Connection.Write(SessionEncoder.EndBytes, 0, SessionEncoder.EndBytes.Length, true, timeout);
         }
 
         protected override Task CloseOutputSessionCoreAsync(TimeSpan timeout)
         {
-            if (Connection is PipeConnection)
-            {
-                return (Connection as PipeConnection).WriteAsync(new Memory<byte>(SessionEncoder.EndBytes, 0, SessionEncoder.EndBytes.Length), true, timeout).AsTask();
-            }
-            else
-            {
-                return Connection.WriteAsync(SessionEncoder.EndBytes, 0, SessionEncoder.EndBytes.Length, true, timeout);
-            }
+            return Connection.WriteAsync(SessionEncoder.EndBytes, 0, SessionEncoder.EndBytes.Length, true, timeout);
         }
 
         protected override void CompleteClose(TimeSpan timeout)
@@ -94,30 +80,15 @@ namespace System.ServiceModel.Channels
 
             allowOutputBatching = message.Properties.AllowOutputBatching;
             messageData = this.EncodeMessage(message);
-            if (Connection is PipeConnection)
-            {
-                (Connection as PipeConnection).WriteAsync(new Memory<byte>(messageData.Array, messageData.Offset, messageData.Count), !allowOutputBatching,
-                timeout).GetAwaiter().GetResult();
-            }
-            else
-            {
-                this.Connection.Write(messageData.Array, messageData.Offset, messageData.Count, !allowOutputBatching,
+
+            this.Connection.Write(messageData.Array, messageData.Offset, messageData.Count, !allowOutputBatching,
                 timeout, this.BufferManager);
-            }
         }
 
         protected override AsyncCompletionResult BeginCloseOutput(TimeSpan timeout, Action<object> callback, object state)
         {
-            if (Connection is PipeConnection)
-            {
-                (Connection as PipeConnection).WriteAsync(new Memory<byte>(SessionEncoder.EndBytes, 0, SessionEncoder.EndBytes.Length), true, timeout).GetAwaiter().GetResult();
-                return AsyncCompletionResult.Completed;
-            }
-            else
-            {
-                return this.Connection.BeginWrite(SessionEncoder.EndBytes, 0, SessionEncoder.EndBytes.Length,
+            return this.Connection.BeginWrite(SessionEncoder.EndBytes, 0, SessionEncoder.EndBytes.Length,
                     true, timeout, callback, state);
-            }
         }
 
         protected override void FinishWritingMessage()
@@ -127,16 +98,8 @@ namespace System.ServiceModel.Channels
 
         protected override AsyncCompletionResult StartWritingBufferedMessage(Message message, ArraySegment<byte> messageData, bool allowOutputBatching, TimeSpan timeout, Action<object> callback, object state)
         {
-            if (Connection is PipeConnection)
-            {
-                (Connection as PipeConnection).WriteAsync(new Memory<byte>(messageData.Array, messageData.Offset, messageData.Count), true, timeout).GetAwaiter().GetResult();
-                return AsyncCompletionResult.Completed;
-            }
-            else
-            {
-                return this.Connection.BeginWrite(messageData.Array, messageData.Offset, messageData.Count,
+            return this.Connection.BeginWrite(messageData.Array, messageData.Offset, messageData.Count,
                     !allowOutputBatching, timeout, callback, state);
-            }
         }
 
         protected override AsyncCompletionResult StartWritingStreamedMessage(Message message, TimeSpan timeout, Action<object> callback, object state)
@@ -282,15 +245,7 @@ namespace System.ServiceModel.Channels
             // initialize a new decoder
             _decoder = new ClientDuplexDecoder(0);
             byte[] ackBuffer = new byte[1];
-
-            if (connection is PipeConnection)
-            {
-                await (connection as PipeConnection).WriteAsync(new Memory<byte>(preamble.Array, preamble.Offset, preamble.Count), true, timeoutHelper.RemainingTime());
-            }
-            else
-            {
-                await connection.WriteAsync(preamble.Array, preamble.Offset, preamble.Count, true, timeoutHelper.RemainingTime());
-            }
+            await connection.WriteAsync(preamble.Array, preamble.Offset, preamble.Count, true, timeoutHelper.RemainingTime());
 
             if (_upgrade != null)
             {
@@ -309,26 +264,10 @@ namespace System.ServiceModel.Channels
                 SetRemoteSecurity(upgradeInitiator);
                 await upgradeInitiator.CloseAsync(timeoutHelper.RemainingTime());
 
-                if (connection is PipeConnection)
-                {
-                    await (Connection as PipeConnection).WriteAsync(new Memory<byte>(ClientDuplexEncoder.PreambleEndBytes, 0, ClientDuplexEncoder.PreambleEndBytes.Length), true, timeoutHelper.RemainingTime());
-                }
-                else
-                {
-                    await connection.WriteAsync(ClientDuplexEncoder.PreambleEndBytes, 0, ClientDuplexEncoder.PreambleEndBytes.Length, true, timeoutHelper.RemainingTime());
-                }
+                await connection.WriteAsync(ClientDuplexEncoder.PreambleEndBytes, 0, ClientDuplexEncoder.PreambleEndBytes.Length, true, timeoutHelper.RemainingTime());
             }
 
-            int ackBytesRead = 0;
-
-            if (connection is PipeConnection)
-            {
-                ackBytesRead = await (connection as PipeConnection).ReadAsync(new Memory<byte>(ackBuffer, 0, ackBuffer.Length), timeoutHelper.RemainingTime());
-            }
-            else
-            {
-                ackBytesRead = await connection.ReadAsync(ackBuffer, 0, ackBuffer.Length, timeoutHelper.RemainingTime());
-            }
+            int ackBytesRead = await connection.ReadAsync(ackBuffer, 0, ackBuffer.Length, timeoutHelper.RemainingTime());
 
             if (!ConnectionUpgradeHelper.ValidatePreambleResponse(ackBuffer, ackBytesRead, _decoder, Via))
             {
@@ -345,15 +284,7 @@ namespace System.ServiceModel.Channels
             // initialize a new decoder
             _decoder = new ClientDuplexDecoder(0);
             byte[] ackBuffer = new byte[1];
-
-            if (connection is PipeConnection)
-            {
-                (connection as PipeConnection).WriteAsync(new Memory<byte>(preamble.Array, preamble.Offset, preamble.Count), true, timeoutHelper.RemainingTime()).GetAwaiter().GetResult();
-            }
-            else
-            {
-                connection.Write(preamble.Array, preamble.Offset, preamble.Count, true, timeoutHelper.RemainingTime());
-            }
+            connection.Write(preamble.Array, preamble.Offset, preamble.Count, true, timeoutHelper.RemainingTime());
 
             if (_upgrade != null)
             {
@@ -367,28 +298,11 @@ namespace System.ServiceModel.Channels
 
                 SetRemoteSecurity(upgradeInitiator);
                 upgradeInitiator.Close(timeoutHelper.RemainingTime());
-
-                if (connection is PipeConnection)
-                {
-                    (connection as PipeConnection).WriteAsync(new Memory<byte>(ClientDuplexEncoder.PreambleEndBytes, 0, ClientDuplexEncoder.PreambleEndBytes.Length), true, timeoutHelper.RemainingTime()).GetAwaiter().GetResult();
-                }
-                else
-                {
-                    connection.Write(ClientDuplexEncoder.PreambleEndBytes, 0, ClientDuplexEncoder.PreambleEndBytes.Length, true, timeoutHelper.RemainingTime());
-                }
+                connection.Write(ClientDuplexEncoder.PreambleEndBytes, 0, ClientDuplexEncoder.PreambleEndBytes.Length, true, timeoutHelper.RemainingTime());
             }
 
             // read ACK
-            int ackBytesRead;
-            if (connection is PipeConnection)
-            {
-                ackBytesRead = (connection as PipeConnection).ReadAsync(new Memory<byte>(ackBuffer, 0, ackBuffer.Length), timeoutHelper.RemainingTime()).GetAwaiter().GetResult();
-            }
-            else
-            {
-                ackBytesRead = connection.Read(ackBuffer, 0, ackBuffer.Length, timeoutHelper.RemainingTime());
-            }
-
+            int ackBytesRead = connection.Read(ackBuffer, 0, ackBuffer.Length, timeoutHelper.RemainingTime());
             if (!ConnectionUpgradeHelper.ValidatePreambleResponse(ackBuffer, ackBytesRead, _decoder, Via))
             {
                 ConnectionUpgradeHelper.DecodeFramingFault(_decoder, connection, Via,
@@ -578,16 +492,7 @@ namespace System.ServiceModel.Channels
 
             int offset = 0;
             byte[] faultBuffer = Fx.AllocateByteArray(FaultStringDecoder.FaultSizeQuota);
-
-            int size;
-            if (connection is PipeConnection)
-            {
-                size = (connection as PipeConnection).ReadAsync(new Memory<byte>(faultBuffer, offset, faultBuffer.Length), timeoutHelper.RemainingTime()).GetAwaiter().GetResult();
-            }
-            else
-            {
-                size = connection.Read(faultBuffer, offset, faultBuffer.Length, timeoutHelper.RemainingTime());
-            }
+            int size = connection.Read(faultBuffer, offset, faultBuffer.Length, timeoutHelper.RemainingTime());
 
             while (size > 0)
             {
@@ -610,14 +515,7 @@ namespace System.ServiceModel.Channels
                     if (size == 0)
                     {
                         offset = 0;
-                        if (connection is PipeConnection)
-                        {
-                            size = (connection as PipeConnection).ReadAsync(new Memory<byte>(faultBuffer, offset, faultBuffer.Length), timeoutHelper.RemainingTime()).GetAwaiter().GetResult();
-                        }
-                        else
-                        {
-                            size = connection.Read(faultBuffer, offset, faultBuffer.Length, timeoutHelper.RemainingTime());
-                        }
+                        size = connection.Read(faultBuffer, offset, faultBuffer.Length, timeoutHelper.RemainingTime());
                     }
                 }
             }
@@ -637,16 +535,8 @@ namespace System.ServiceModel.Channels
                 connection.Write(encodedUpgrade.EncodedBytes, 0, encodedUpgrade.EncodedBytes.Length, true, timeoutHelper.RemainingTime());
                 byte[] buffer = new byte[1];
 
-                // read upgrade response framing
-                int size;
-                if (connection is PipeConnection)
-                {
-                    size = (connection as PipeConnection).ReadAsync(new Memory<byte>(buffer, 0, buffer.Length), timeoutHelper.RemainingTime()).GetAwaiter().GetResult();
-                }
-                else
-                {
-                    size = connection.Read(buffer, 0, buffer.Length, timeoutHelper.RemainingTime());
-                }
+                // read upgrade response framing 
+                int size = connection.Read(buffer, 0, buffer.Length, timeoutHelper.RemainingTime());
 
                 if (!ValidateUpgradeResponse(buffer, size, decoder)) // we have a problem
                 {
@@ -676,28 +566,11 @@ namespace System.ServiceModel.Channels
             {
                 EncodedUpgrade encodedUpgrade = new EncodedUpgrade(upgradeContentType);
                 // write upgrade request framing for synchronization
-                if (connection is PipeConnection)
-                {
-                    await (connection as PipeConnection).WriteAsync(new Memory<byte>(encodedUpgrade.EncodedBytes, 0, encodedUpgrade.EncodedBytes.Length), true, timeout);
-                }
-                else
-                {
-                    await connection.WriteAsync(encodedUpgrade.EncodedBytes, 0, encodedUpgrade.EncodedBytes.Length, true, timeout);
-                }
-
+                await connection.WriteAsync(encodedUpgrade.EncodedBytes, 0, encodedUpgrade.EncodedBytes.Length, true, timeout);
                 byte[] buffer = new byte[1];
 
-                // read upgrade response framing
-                int size;
-
-                if (connection is PipeConnection)
-                {
-                    size = await (connection as PipeConnection).ReadAsync(new Memory<byte>(buffer, 0, buffer.Length), timeout);
-                }
-                else
-                {
-                    size = await connection.ReadAsync(buffer, 0, buffer.Length, timeout);
-                }
+                // read upgrade response framing 
+                int size = await connection.ReadAsync(buffer, 0, buffer.Length, timeout);
 
                 if (!ValidateUpgradeResponse(buffer, size, decoder)) // we have a problem
                 {

--- a/src/dotnet-svcutil/lib/src/FrameworkFork/System.ServiceModel/System/ServiceModel/Channels/NamedPipeChannelFactory.cs
+++ b/src/dotnet-svcutil/lib/src/FrameworkFork/System.ServiceModel/System/ServiceModel/Channels/NamedPipeChannelFactory.cs
@@ -40,12 +40,6 @@ namespace System.ServiceModel.Channels
 
         internal override IConnectionInitiator GetConnectionInitiator()
         {
-//            IConnectionInitiator pipeConnectionInitiator =
-//                new PipeConnectionInitiator(ConnectionBufferSize, this);
-//#if CONNECTIONDUMP
-//            pipeConnectionInitiator = new ConnectionDumpInitiator(pipeConnectionInitiator);
-//#endif
-//            return new BufferedConnectionInitiator(pipeConnectionInitiator, MaxOutputDelay, ConnectionBufferSize);
             return new PipeConnectionInitiator(ConnectionBufferSize);
         }
 

--- a/src/dotnet-svcutil/lib/src/FrameworkFork/System.ServiceModel/System/ServiceModel/Channels/NamedPipeChannelFactory.cs
+++ b/src/dotnet-svcutil/lib/src/FrameworkFork/System.ServiceModel/System/ServiceModel/Channels/NamedPipeChannelFactory.cs
@@ -1,0 +1,68 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.ServiceModel.Channels
+{
+    class NamedPipeChannelFactory<TChannel> : ConnectionOrientedTransportChannelFactory<TChannel>, IPipeTransportFactorySettings
+    {
+        static NamedPipeConnectionPoolRegistry s_connectionPoolRegistry = new NamedPipeConnectionPoolRegistry();
+
+        public NamedPipeChannelFactory(NamedPipeTransportBindingElement bindingElement, BindingContext context)
+            : base(bindingElement, context,
+            GetConnectionGroupName(bindingElement),
+            bindingElement.ConnectionPoolSettings.IdleTimeout,
+            bindingElement.ConnectionPoolSettings.MaxOutboundConnectionsPerEndpoint,
+            false)
+        {
+            if (bindingElement.PipeSettings != null)
+            {
+                this.PipeSettings = bindingElement.PipeSettings.Clone();
+            }
+        }
+
+        public override string Scheme
+        {
+            get { return Uri.UriSchemeNetPipe; }
+        }
+
+
+        public NamedPipeSettings PipeSettings
+        {
+            get;
+            private set;
+        }
+
+        static string GetConnectionGroupName(NamedPipeTransportBindingElement bindingElement)
+        {
+            return bindingElement.ConnectionPoolSettings.GroupName + bindingElement.PipeSettings.ApplicationContainerSettings.GetConnectionGroupSuffix();
+        }
+
+//        internal override IConnectionInitiator GetConnectionInitiator()
+//        {
+//            IConnectionInitiator pipeConnectionInitiator =
+//                new PipeConnectionInitiator(ConnectionBufferSize, this);
+//#if CONNECTIONDUMP
+//            pipeConnectionInitiator = new ConnectionDumpInitiator(pipeConnectionInitiator);
+//#endif
+//            return new BufferedConnectionInitiator(pipeConnectionInitiator, MaxOutputDelay, ConnectionBufferSize);
+//        }
+
+        internal override ConnectionPool GetConnectionPool()
+        {
+            return s_connectionPoolRegistry.Lookup(this);
+        }
+
+        internal override void ReleaseConnectionPool(ConnectionPool pool, TimeSpan timeout)
+        {
+            s_connectionPoolRegistry.Release(pool, timeout);
+        }
+
+        protected override bool SupportsUpgrade(StreamUpgradeBindingElement upgradeBindingElement)
+        {
+            return !(upgradeBindingElement is SslStreamSecurityBindingElement);
+        }
+
+        internal override IConnectionInitiator GetConnectionInitiator() => throw new NotImplementedException();
+    }
+}

--- a/src/dotnet-svcutil/lib/src/FrameworkFork/System.ServiceModel/System/ServiceModel/Channels/NamedPipeChannelFactory.cs
+++ b/src/dotnet-svcutil/lib/src/FrameworkFork/System.ServiceModel/System/ServiceModel/Channels/NamedPipeChannelFactory.cs
@@ -38,15 +38,16 @@ namespace System.ServiceModel.Channels
             return bindingElement.ConnectionPoolSettings.GroupName + bindingElement.PipeSettings.ApplicationContainerSettings.GetConnectionGroupSuffix();
         }
 
-//        internal override IConnectionInitiator GetConnectionInitiator()
-//        {
+        internal override IConnectionInitiator GetConnectionInitiator()
+        {
 //            IConnectionInitiator pipeConnectionInitiator =
 //                new PipeConnectionInitiator(ConnectionBufferSize, this);
 //#if CONNECTIONDUMP
 //            pipeConnectionInitiator = new ConnectionDumpInitiator(pipeConnectionInitiator);
 //#endif
 //            return new BufferedConnectionInitiator(pipeConnectionInitiator, MaxOutputDelay, ConnectionBufferSize);
-//        }
+            return new PipeConnectionInitiator(ConnectionBufferSize);
+        }
 
         internal override ConnectionPool GetConnectionPool()
         {
@@ -62,7 +63,5 @@ namespace System.ServiceModel.Channels
         {
             return !(upgradeBindingElement is SslStreamSecurityBindingElement);
         }
-
-        internal override IConnectionInitiator GetConnectionInitiator() => throw new NotImplementedException();
     }
 }

--- a/src/dotnet-svcutil/lib/src/FrameworkFork/System.ServiceModel/System/ServiceModel/Channels/NamedPipeChannelFactory.cs
+++ b/src/dotnet-svcutil/lib/src/FrameworkFork/System.ServiceModel/System/ServiceModel/Channels/NamedPipeChannelFactory.cs
@@ -40,7 +40,8 @@ namespace System.ServiceModel.Channels
 
         internal override IConnectionInitiator GetConnectionInitiator()
         {
-            return new PipeConnectionInitiator(ConnectionBufferSize);
+            IConnectionInitiator pipeConnectionInitiator = new PipeConnectionInitiator(ConnectionBufferSize);
+            return new BufferedConnectionInitiator(pipeConnectionInitiator, MaxOutputDelay, ConnectionBufferSize);
         }
 
         internal override ConnectionPool GetConnectionPool()

--- a/src/dotnet-svcutil/lib/src/FrameworkFork/System.ServiceModel/System/ServiceModel/Channels/NamedPipeConnectionPool.cs
+++ b/src/dotnet-svcutil/lib/src/FrameworkFork/System.ServiceModel/System/ServiceModel/Channels/NamedPipeConnectionPool.cs
@@ -45,7 +45,7 @@ namespace System.ServiceModel.Channels
                 {
                     if (!this._pipeNameCache.TryGetValue(via, out result))
                     {
-                        result = "dumb-pipe-name";//PipeConnectionInitiator.GetPipeName(via, this._transportFactorySettings);
+                        result = PipeConnectionInitiator.GetPipeName(via);
                         this._pipeNameCache.Add(via, result);
                     }
                 }
@@ -129,5 +129,3 @@ namespace System.ServiceModel.Channels
         }
     }
 }
-
-

--- a/src/dotnet-svcutil/lib/src/FrameworkFork/System.ServiceModel/System/ServiceModel/Channels/NamedPipeConnectionPool.cs
+++ b/src/dotnet-svcutil/lib/src/FrameworkFork/System.ServiceModel/System/ServiceModel/Channels/NamedPipeConnectionPool.cs
@@ -1,0 +1,133 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Runtime;
+
+namespace System.ServiceModel.Channels
+{
+    class NamedPipeConnectionPoolRegistry : ConnectionPoolRegistry
+    {
+        public NamedPipeConnectionPoolRegistry()
+            : base()
+        {
+        }
+
+        protected override ConnectionPool CreatePool(IConnectionOrientedTransportChannelFactorySettings settings)
+        {
+            Fx.Assert(settings is IPipeTransportFactorySettings, "NamedPipeConnectionPool requires an IPipeTransportFactorySettings.");
+            return new NamedPipeConnectionPool((IPipeTransportFactorySettings)settings);
+        }
+
+        class NamedPipeConnectionPool : ConnectionPool
+        {
+            PipeNameCache _pipeNameCache;
+            IPipeTransportFactorySettings _transportFactorySettings;
+
+            public NamedPipeConnectionPool(IPipeTransportFactorySettings settings)
+                : base(settings, TimeSpan.MaxValue)
+            {
+                this._pipeNameCache = new PipeNameCache();
+                this._transportFactorySettings = settings;
+            }
+
+            protected override EndpointConnectionPool CreateEndpointConnectionPool(string key)
+            {
+                return new NamedPipeEndpointConnectionPool(this, key);
+            }
+
+            protected override string GetPoolKey(EndpointAddress address, Uri via)
+            {
+                string result;
+                lock (base.ThisLock)
+                {
+                    if (!this._pipeNameCache.TryGetValue(via, out result))
+                    {
+                        result = "dumb-pipe-name";//PipeConnectionInitiator.GetPipeName(via, this._transportFactorySettings);
+                        this._pipeNameCache.Add(via, result);
+                    }
+                }
+                return result;
+            }
+
+            protected override void OnClosed()
+            {
+                base.OnClosed();
+                this._pipeNameCache.Clear();
+            }
+
+            void OnConnectionAborted(string pipeName)
+            {
+                // the underlying pipe name may have changed; purge the old one from the cache
+                lock (base.ThisLock)
+                {
+                    this._pipeNameCache.Purge(pipeName);
+                }
+            }
+
+            protected class NamedPipeEndpointConnectionPool : IdleTimeoutEndpointConnectionPool
+            {
+                NamedPipeConnectionPool _parent;
+
+                public NamedPipeEndpointConnectionPool(NamedPipeConnectionPool parent, string key)
+                    : base(parent, key)
+                {
+                    this._parent = parent;
+                }
+
+                protected override void OnConnectionAborted()
+                {
+                    _parent.OnConnectionAborted(this.Key);
+                }
+            }
+        }
+
+        // not thread-safe
+        class PipeNameCache
+        {
+            Dictionary<Uri, string> _forwardTable = new Dictionary<Uri, string>();
+            Dictionary<string, ICollection<Uri>> _reverseTable = new Dictionary<string, ICollection<Uri>>();
+
+            public void Add(Uri uri, string pipeName)
+            {
+                this._forwardTable.Add(uri, pipeName);
+
+                ICollection<Uri> uris;
+                if (!this._reverseTable.TryGetValue(pipeName, out uris))
+                {
+                    uris = new Collection<Uri>();
+                    this._reverseTable.Add(pipeName, uris);
+                }
+                uris.Add(uri);
+            }
+
+            public void Clear()
+            {
+                this._forwardTable.Clear();
+                this._reverseTable.Clear();
+            }
+
+            public void Purge(string pipeName)
+            {
+                ICollection<Uri> uris;
+                if (this._reverseTable.TryGetValue(pipeName, out uris))
+                {
+                    this._reverseTable.Remove(pipeName);
+                    foreach (Uri uri in uris)
+                    {
+                        this._forwardTable.Remove(uri);
+                    }
+                }
+            }
+
+            public bool TryGetValue(Uri uri, out string pipeName)
+            {
+                return this._forwardTable.TryGetValue(uri, out pipeName);
+            }
+        }
+    }
+}
+
+

--- a/src/dotnet-svcutil/lib/src/FrameworkFork/System.ServiceModel/System/ServiceModel/Channels/NamedPipeConnectionPoolSettings.cs
+++ b/src/dotnet-svcutil/lib/src/FrameworkFork/System.ServiceModel/System/ServiceModel/Channels/NamedPipeConnectionPoolSettings.cs
@@ -1,0 +1,94 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.ServiceModel.Channels
+{
+    using System.Runtime;
+
+    public sealed class NamedPipeConnectionPoolSettings
+    {
+        string _groupName;
+        TimeSpan _idleTimeout;
+        int _maxOutputConnectionsPerEndpoint;
+
+        internal NamedPipeConnectionPoolSettings()
+        {
+            _groupName = ConnectionOrientedTransportDefaults.ConnectionPoolGroupName;
+            _idleTimeout = ConnectionOrientedTransportDefaults.IdleTimeout;
+            _maxOutputConnectionsPerEndpoint = ConnectionOrientedTransportDefaults.MaxOutboundConnectionsPerEndpoint;
+        }
+
+        internal NamedPipeConnectionPoolSettings(NamedPipeConnectionPoolSettings namedPipe)
+        {
+            this._groupName = namedPipe._groupName;
+            this._idleTimeout = namedPipe._idleTimeout;
+            this._maxOutputConnectionsPerEndpoint = namedPipe._maxOutputConnectionsPerEndpoint;
+        }
+
+        public string GroupName
+        {
+            get { return this._groupName; }
+            set
+            {
+                if (value == null)
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("value");
+
+                this._groupName = value;
+            }
+        }
+
+        public TimeSpan IdleTimeout
+        {
+            get { return this._idleTimeout; }
+            set
+            {
+                if (value < TimeSpan.Zero)
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("value", value,
+                        "SR.SFxTimeoutOutOfRange0"));
+                }
+
+                if (TimeoutHelper.IsTooLarge(value))
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("value", value,
+                        "SR.SFxTimeoutOutOfRangeTooBig"));
+                }
+
+                this._idleTimeout = value;
+            }
+        }
+
+        public int MaxOutboundConnectionsPerEndpoint
+        {
+            get { return this._maxOutputConnectionsPerEndpoint; }
+            set
+            {
+                if (value < 0)
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("value", value,
+                        "SR.ValueMustBeNonNegative"));
+
+                this._maxOutputConnectionsPerEndpoint = value;
+            }
+        }
+
+        internal NamedPipeConnectionPoolSettings Clone()
+        {
+            return new NamedPipeConnectionPoolSettings(this);
+        }
+
+        internal bool IsMatch(NamedPipeConnectionPoolSettings namedPipe)
+        {
+            if (this._groupName != namedPipe._groupName)
+                return false;
+
+            if (this._idleTimeout != namedPipe._idleTimeout)
+                return false;
+
+            if (this._maxOutputConnectionsPerEndpoint != namedPipe._maxOutputConnectionsPerEndpoint)
+                return false;
+
+            return true;
+        }
+    }
+}

--- a/src/dotnet-svcutil/lib/src/FrameworkFork/System.ServiceModel/System/ServiceModel/Channels/NamedPipeConnectionPoolSettings.cs
+++ b/src/dotnet-svcutil/lib/src/FrameworkFork/System.ServiceModel/System/ServiceModel/Channels/NamedPipeConnectionPoolSettings.cs
@@ -46,13 +46,13 @@ namespace System.ServiceModel.Channels
                 if (value < TimeSpan.Zero)
                 {
                     throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("value", value,
-                        "SR.SFxTimeoutOutOfRange0"));
+                        SRServiceModel.SFxTimeoutOutOfRange0));
                 }
 
                 if (TimeoutHelper.IsTooLarge(value))
                 {
                     throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("value", value,
-                        "SR.SFxTimeoutOutOfRangeTooBig"));
+                        SRServiceModel.SFxTimeoutOutOfRangeTooBig));
                 }
 
                 this._idleTimeout = value;
@@ -66,7 +66,7 @@ namespace System.ServiceModel.Channels
             {
                 if (value < 0)
                     throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("value", value,
-                        "SR.ValueMustBeNonNegative"));
+                        SRServiceModel.ValueMustBeNonNegative));
 
                 this._maxOutputConnectionsPerEndpoint = value;
             }

--- a/src/dotnet-svcutil/lib/src/FrameworkFork/System.ServiceModel/System/ServiceModel/Channels/NamedPipeTransportBindingElement.cs
+++ b/src/dotnet-svcutil/lib/src/FrameworkFork/System.ServiceModel/System/ServiceModel/Channels/NamedPipeTransportBindingElement.cs
@@ -10,6 +10,7 @@ namespace System.ServiceModel.Channels
     public class NamedPipeTransportBindingElement : ConnectionOrientedTransportBindingElement
     {
         private NamedPipeSettings _settings = new NamedPipeSettings();
+        NamedPipeConnectionPoolSettings _connectionPoolSettings = new NamedPipeConnectionPoolSettings();
 
         public NamedPipeTransportBindingElement()
             : base()
@@ -20,6 +21,11 @@ namespace System.ServiceModel.Channels
             : base(elementToBeCloned)
         {
             _settings = elementToBeCloned._settings.Clone();
+        }
+
+        public NamedPipeConnectionPoolSettings ConnectionPoolSettings
+        {
+            get { return _connectionPoolSettings; }
         }
 
         public NamedPipeSettings PipeSettings
@@ -64,7 +70,28 @@ namespace System.ServiceModel.Channels
 
         internal override bool IsMatch(BindingElement b)
         {
-            throw new NotImplementedException();
+            if (!base.IsMatch(b))
+            {
+                return false;
+            }
+
+            NamedPipeTransportBindingElement namedPipe = b as NamedPipeTransportBindingElement;
+            if (namedPipe == null)
+            {
+                return false;
+            }
+
+            if (!this.ConnectionPoolSettings.IsMatch(namedPipe.ConnectionPoolSettings))
+            {
+                return false;
+            }
+
+            if (!this.PipeSettings.IsMatch(namedPipe.PipeSettings))
+            {
+                return false;
+            }
+
+            return true;
         }
 
         private class BindingDeliveryCapabilitiesHelper : IBindingDeliveryCapabilities

--- a/src/dotnet-svcutil/lib/src/FrameworkFork/System.ServiceModel/System/ServiceModel/Channels/NamedPipeTransportBindingElement.cs
+++ b/src/dotnet-svcutil/lib/src/FrameworkFork/System.ServiceModel/System/ServiceModel/Channels/NamedPipeTransportBindingElement.cs
@@ -45,7 +45,17 @@ namespace System.ServiceModel.Channels
 
         public override IChannelFactory<TChannel> BuildChannelFactory<TChannel>(BindingContext context)
         {
-            throw new NotImplementedException();
+            if (context == null)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("context");
+            }
+
+            if (!this.CanBuildChannelFactory<TChannel>(context))
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgument("TChannel", string.Format(SRServiceModel.ChannelTypeNotSupported, typeof(TChannel)));
+            }
+
+            return (IChannelFactory<TChannel>)(object)new NamedPipeChannelFactory<TChannel>(this, context);
         }
 
         public override T GetProperty<T>(BindingContext context)

--- a/src/dotnet-svcutil/lib/src/FrameworkFork/System.ServiceModel/System/ServiceModel/Channels/PipeConnection.cs
+++ b/src/dotnet-svcutil/lib/src/FrameworkFork/System.ServiceModel/System/ServiceModel/Channels/PipeConnection.cs
@@ -19,6 +19,7 @@ namespace System.ServiceModel.Channels
         private TraceEventType _exceptionEventType;
         private static readonly byte[] s_zeroBuffer = Array.Empty<byte>();
         byte[] _asyncReadBuffer;
+        private int _asyncBytesRead;
 
         // read state
         private readonly object _readLock = new object();
@@ -145,6 +146,7 @@ namespace System.ServiceModel.Channels
                 }
 
                 int bytesRead = await _pipe.ReadAsync(buffer, cancellationToken);
+                _asyncBytesRead = bytesRead;
                 if (bytesRead == 0)
                 {
                     _isAtEOF = true;
@@ -581,7 +583,11 @@ namespace System.ServiceModel.Channels
         void IConnection.Write(byte[] buffer, int offset, int size, bool immediate, TimeSpan timeout, BufferManager bufferManager) => throw new NotImplementedException();
         int IConnection.Read(byte[] buffer, int offset, int size, TimeSpan timeout) => throw new NotImplementedException();
         AsyncCompletionResult IConnection.BeginRead(int offset, int size, TimeSpan timeout, Action<object> callback, object state) => throw new NotImplementedException();
-        int IConnection.EndRead() => throw new NotImplementedException();
+        int IConnection.EndRead()
+        {
+            return _asyncBytesRead;
+        }
+
 
         private enum CloseState
         {

--- a/src/dotnet-svcutil/lib/src/FrameworkFork/System.ServiceModel/System/ServiceModel/Channels/PipeConnection.cs
+++ b/src/dotnet-svcutil/lib/src/FrameworkFork/System.ServiceModel/System/ServiceModel/Channels/PipeConnection.cs
@@ -1,0 +1,573 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using System.IO;
+using System.IO.Pipes;
+using System.Runtime;
+using System.ServiceModel.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace System.ServiceModel.Channels
+{
+    internal sealed class PipeConnection : IConnection
+    {
+        // common state
+        private readonly NamedPipeClientStream _pipe;
+        private CloseState _closeState;
+        private bool _aborted;
+        private TraceEventType _exceptionEventType;
+        private static readonly byte[] s_zeroBuffer = Array.Empty<byte>();
+
+        // read state
+        private readonly object _readLock = new object();
+        private bool _inReadingState;     // This keeps track of the state machine (IConnection interface).
+        private readonly int _connectionBufferSize;
+        private readonly TaskCompletionSource _atEOFTask;
+        private bool _isAtEOF;
+
+        // write state
+        private readonly object _writeLock = new object();
+        private bool _inWritingState;      // This keeps track of the state machine (IConnection interface).
+        private bool _isShutdownWritten;
+
+        // timeout support
+        private string _timeoutErrorString;
+        private TransferOperation _timeoutErrorTransferOperation;
+
+        public PipeConnection(NamedPipeClientStream namedPipeClient, int connectionBufferSize)
+        {
+            _pipe = namedPipeClient ?? throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull(nameof(namedPipeClient));
+            if (namedPipeClient == null)
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull(nameof(namedPipeClient));
+            if (!namedPipeClient.IsConnected)
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull(nameof(namedPipeClient));
+
+            _pipe = namedPipeClient;
+            _closeState = CloseState.Open;
+            _exceptionEventType = TraceEventType.Error;
+            _connectionBufferSize = connectionBufferSize;
+            _atEOFTask = new TaskCompletionSource();
+        }
+
+        public int ConnectionBufferSize
+        {
+            get
+            {
+                return _connectionBufferSize;
+            }
+        }
+
+        private static byte[] ZeroBuffer
+        {
+            get
+            {
+                return s_zeroBuffer;
+            }
+        }
+
+        public TraceEventType ExceptionEventType
+        {
+            get { return _exceptionEventType; }
+            set { _exceptionEventType = value; }
+        }
+
+        public void Abort()
+        {
+            Abort(null, TransferOperation.Undefined);
+        }
+
+        private void Abort(string timeoutErrorString, TransferOperation transferOperation)
+        {
+            ClosePipe(true, timeoutErrorString, transferOperation);
+        }
+
+        private Exception ConvertPipeException(PipeException pipeException, TransferOperation transferOperation)
+        {
+            return ConvertPipeException(pipeException.Message, pipeException, transferOperation);
+        }
+
+        private Exception ConvertPipeException(string exceptionMessage, PipeException pipeException, TransferOperation transferOperation)
+        {
+            if (_timeoutErrorString != null)
+            {
+                if (transferOperation == _timeoutErrorTransferOperation)
+                {
+                    return new TimeoutException(_timeoutErrorString, pipeException);
+                }
+                else
+                {
+                    return new CommunicationException(_timeoutErrorString, pipeException);
+                }
+            }
+            else if (_aborted)
+            {
+                return new CommunicationObjectAbortedException(exceptionMessage, pipeException);
+            }
+            else
+            {
+                return new CommunicationException(exceptionMessage, pipeException);
+            }
+        }
+
+        public async Task<int> ReadAsync(Memory<byte> buffer, TimeSpan timeout)
+        {
+            ValidateBufferBounds(buffer);
+            TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
+            var cancellationToken = await timeoutHelper.GetCancellationTokenAsync();
+
+            lock (_readLock)
+            {
+                ValidateEnterReadingState(true);
+                EnterReadingState();
+            }
+
+            try
+            {
+                if (_isAtEOF)
+                {
+                    return 0;
+                }
+
+                int bytesRead = await _pipe.ReadAsync(buffer, cancellationToken);
+                if (bytesRead == 0)
+                {
+                    _isAtEOF = true;
+                    _atEOFTask.TrySetResult();
+                }
+
+                if (_closeState == CloseState.PipeClosed)
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(CreatePipeClosedException(TransferOperation.Read));
+                }
+
+                return bytesRead;
+            }
+            catch (OperationCanceledException)
+            {
+                Abort(string.Format(SRServiceModel.PipeConnectionAbortedReadTimedOut, timeout), TransferOperation.Read);
+                throw;
+            }
+            finally
+            {
+                lock (_readLock)
+                {
+                    ExitReadingState();
+                }
+            }
+        }
+
+        public async ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, bool immediate, TimeSpan timeout)
+        {
+            ValidateBufferBounds(buffer);
+            TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
+            var cancellationToken = await timeoutHelper.GetCancellationTokenAsync();
+
+            lock (_writeLock)
+            {
+                ValidateEnterWritingState(true);
+                EnterWritingState();
+            }
+
+            try
+            {
+                await _pipe.WriteAsync(buffer, cancellationToken);
+
+                if (_closeState == CloseState.PipeClosed)
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(CreatePipeClosedException(TransferOperation.Write));
+                }
+            }
+            catch(OperationCanceledException)
+            {
+                Abort(string.Format(SRServiceModel.PipeConnectionAbortedWriteTimedOut, timeout), TransferOperation.Write);
+                throw;
+            }
+            finally
+            {
+                lock (_writeLock)
+                {
+                    ExitWritingState();
+                }
+            }
+        }
+
+        public async ValueTask CloseAsync(TimeSpan timeout)
+        {
+            bool existingReadIsPending = false;
+            TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
+            var cancellationToken = await timeoutHelper.GetCancellationTokenAsync();
+
+            bool shouldClosePipe = false;
+            try
+            {
+                bool shouldReadEOF = false;
+                bool shouldWriteEOF = false;
+
+                lock (_readLock)
+                {
+                    lock (_writeLock)
+                    {
+                        if (!_isShutdownWritten && _inWritingState)
+                        {
+                            throw DiagnosticUtility.ExceptionUtility.ThrowHelper(
+                                new PipeException(SRServiceModel.PipeCantCloseWithPendingWrite), ExceptionEventType);
+                        }
+
+                        if (_closeState == CloseState.Closing || _closeState == CloseState.PipeClosed)
+                        {
+                            // already closing or closed, so just return
+                            return;
+                        }
+
+                        _closeState = CloseState.Closing;
+
+                        shouldClosePipe = true;
+
+                        if (!_isAtEOF)
+                        {
+                            if (_inReadingState)
+                            {
+                                existingReadIsPending = true;
+                            }
+                            else
+                            {
+                                shouldReadEOF = true;
+                            }
+                        }
+
+                        if (!_isShutdownWritten)
+                        {
+                            shouldWriteEOF = true;
+                            _isShutdownWritten = true;
+                        }
+                    }
+                }
+
+                ValueTask writeValueTask = default;
+                ValueTask<int> readValueTask = default;
+                if (shouldWriteEOF)
+                {
+                    writeValueTask = StartWriteZeroAsync(cancellationToken);
+                }
+
+                if (shouldReadEOF)
+                {
+                    readValueTask = StartReadZeroAsync(cancellationToken);
+                }
+
+                // wait for shutdown write to complete
+                if (shouldWriteEOF)
+                {
+                    try
+                    {
+                        await WaitForWriteZero(writeValueTask, timeout, true);
+                    }
+                    catch (TimeoutException e)
+                    {
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelper(
+                            new TimeoutException(SRServiceModel.PipeShutdownWriteError, e), ExceptionEventType);
+                    }
+                }
+
+                // ensure we have received EOF signal
+                if (shouldReadEOF)
+                {
+                    try
+                    {
+                        await WaitForReadZero(readValueTask, timeout, true);
+                    }
+                    catch (TimeoutException e)
+                    {
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelper(
+                            new TimeoutException(SRServiceModel.PipeShutdownReadError, e), ExceptionEventType);
+                    }
+                }
+                else if (existingReadIsPending)
+                {
+                    if (!await _atEOFTask.Task.AwaitWithTimeout(timeoutHelper.RemainingTime()))
+                    {
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelper(
+                            new TimeoutException(SRServiceModel.PipeShutdownReadError), ExceptionEventType);
+                    }
+                }
+                // else we had already seen EOF.
+
+                // at this point, we may get exceptions if the other side closes the pipe first
+                try
+                {
+                    // write an ack for eof
+                    writeValueTask = StartWriteZeroAsync(cancellationToken);
+
+                    // read an ack for eof
+                    readValueTask = StartReadZeroAsync(cancellationToken);
+
+                    // wait for write to complete/fail
+                    await WaitForWriteZero(writeValueTask, timeout, false);
+
+                    // wait for read to complete/fail
+                    await WaitForReadZero(readValueTask, timeout, false);
+                }
+                catch (PipeException e)
+                {
+                    int errorCode = PipeError.GetErrorFromHResult(e.ErrorCode);
+                    if (!IsBrokenPipeError(errorCode))
+                    {
+                        throw;
+                    }
+                    DiagnosticUtility.TraceHandledException(e, TraceEventType.Information);
+                }
+                catch (CommunicationException e)
+                {
+                    DiagnosticUtility.TraceHandledException(e, TraceEventType.Information);
+                }
+                catch (TimeoutException e)
+                {
+                    DiagnosticUtility.TraceHandledException(e, TraceEventType.Information);
+                }
+            }
+            catch (TimeoutException e)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelper(
+                    new TimeoutException(SRServiceModel.PipeCloseFailed, e), ExceptionEventType);
+            }
+            catch (PipeException e)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelper(
+                    ConvertPipeException(SRServiceModel.PipeCloseFailed, e, TransferOperation.Undefined), ExceptionEventType);
+            }
+            finally
+            {
+                if (shouldClosePipe)
+                {
+                    ClosePipe(false, null, TransferOperation.Undefined);
+                }
+            }
+        }
+
+        private void ClosePipe(bool abort, string timeoutErrorString, TransferOperation transferOperation)
+        {
+            lock (_readLock)
+            {
+                lock (_writeLock)
+                {
+                    if (_closeState == CloseState.PipeClosed)
+                    {
+                        return;
+                    }
+
+                    _timeoutErrorString = timeoutErrorString;
+                    _timeoutErrorTransferOperation = transferOperation;
+                    _aborted = abort;
+                    _closeState = CloseState.PipeClosed;
+                    _pipe.Close();
+                    _atEOFTask.TrySetResult();
+                }
+            }
+
+            if (abort)
+            {
+                TraceEventType traceEventType = TraceEventType.Warning;
+
+                // we could be timing out a cached connection
+                if (ExceptionEventType == TraceEventType.Information)
+                {
+                    traceEventType = ExceptionEventType;
+                }
+            }
+        }
+
+        private void EnterReadingState()
+        {
+            Fx.Assert(Monitor.IsEntered(_readLock), "_readLock must be entered");
+            _inReadingState = true;
+        }
+
+        private void EnterWritingState()
+        {
+            Fx.Assert(Monitor.IsEntered(_writeLock), "_writeLock must be entered");
+            _inWritingState = true;
+        }
+
+        private void ExitReadingState()
+        {
+            Fx.Assert(Monitor.IsEntered(_readLock), "_readLock must be entered");
+            _inReadingState = false;
+        }
+
+        private void ExitWritingState()
+        {
+            Fx.Assert(Monitor.IsEntered(_writeLock), "_writeLock must be entered");
+            _inWritingState = false;
+        }
+
+        private bool IsBrokenPipeError(int error)
+        {
+            return error == UnsafeNativeMethods.ERROR_NO_DATA ||
+                error == UnsafeNativeMethods.ERROR_BROKEN_PIPE;
+        }
+
+        private Exception CreatePipeClosedException(TransferOperation transferOperation)
+        {
+            return ConvertPipeException(new PipeException(SRServiceModel.PipeClosed), transferOperation);
+        }
+
+        private ValueTask<int> StartReadZeroAsync(CancellationToken token)
+        {
+            lock (_readLock)
+            {
+                ValidateEnterReadingState(false);
+                EnterReadingState();
+                return _pipe.ReadAsync(ZeroBuffer, token);
+            }
+        }
+
+        private ValueTask StartWriteZeroAsync(CancellationToken token)
+        {
+            lock (_writeLock)
+            {
+                ValidateEnterWritingState(false);
+                EnterWritingState();
+                return _pipe.WriteAsync(ZeroBuffer, token);
+            }
+        }
+
+        private async ValueTask WaitForReadZero(ValueTask<int> readTask, TimeSpan timeout, bool traceExceptionsAsErrors)
+        {
+            bool success = false;
+            int bytesRead = -1;
+            try
+            {
+                bytesRead = await readTask;
+                success = true;
+            }
+            finally
+            {
+                lock (_readLock)
+                {
+                    try
+                    {
+                        if (success)
+                        {
+                            if (bytesRead != 0)
+                            {
+                                Exception exception = ConvertPipeException(new PipeException(SR.PipeSignalExpected), TransferOperation.Read);
+                                TraceEventType traceEventType = TraceEventType.Information;
+                                if (traceExceptionsAsErrors)
+                                {
+                                    traceEventType = TraceEventType.Error;
+                                }
+                                throw DiagnosticUtility.ExceptionUtility.ThrowHelper(exception, traceEventType);
+                            }
+                        }
+                    }
+                    finally
+                    {
+                        ExitReadingState();
+                    }
+                }
+            }
+        }
+
+        private async ValueTask WaitForWriteZero(ValueTask writeTask, TimeSpan timeout, bool traceExceptionsAsErrors)
+        {
+            try
+            {
+                await writeTask;
+            }
+            catch(Exception)
+            {
+                Abort(string.Format(SRServiceModel.PipeConnectionAbortedWriteTimedOut, timeout), TransferOperation.Write);
+
+                Exception timeoutException = new TimeoutException(string.Format(SRServiceModel.PipeWriteTimedOut, timeout));
+                TraceEventType traceEventType = TraceEventType.Information;
+                if (traceExceptionsAsErrors)
+                {
+                    traceEventType = TraceEventType.Error;
+                }
+
+                // This intentionally doesn't reset isWriteOutstanding, because technically it still is, and we need to not free the buffer.
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelper(timeoutException, traceEventType);
+            }
+            finally
+            {
+                lock (_writeLock)
+                {
+                    ExitWritingState();
+                }
+            }
+        }
+
+        private void ValidateEnterReadingState(bool checkEOF)
+        {
+            Fx.Assert(Monitor.IsEntered(_readLock), "_readLock must be entered");
+            if (checkEOF)
+            {
+                if (_closeState == CloseState.Closing)
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelper(new PipeException(SRServiceModel.PipeAlreadyClosing), ExceptionEventType);
+                }
+            }
+
+            if (_inReadingState)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelper(new PipeException(SRServiceModel.PipeReadPending), ExceptionEventType);
+            }
+
+            if (_closeState == CloseState.PipeClosed)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelper(new PipeException(SRServiceModel.PipeClosed), ExceptionEventType);
+            }
+        }
+
+        private void ValidateEnterWritingState(bool checkShutdown)
+        {
+            Fx.Assert(Monitor.IsEntered(_writeLock), "_writeLock must be entered");
+            if (checkShutdown)
+            {
+                if (_isShutdownWritten)
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelper(new PipeException(SRServiceModel.PipeAlreadyShuttingDown), ExceptionEventType);
+                }
+
+                if (_closeState == CloseState.Closing)
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelper(new PipeException(SRServiceModel.PipeAlreadyClosing), ExceptionEventType);
+                }
+            }
+
+            if (_inWritingState)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelper(new PipeException(SRServiceModel.PipeWritePending), ExceptionEventType);
+            }
+
+            if (_closeState == CloseState.PipeClosed)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelper(new PipeException(SRServiceModel.PipeClosed), ExceptionEventType);
+            }
+        }
+
+        internal static void ValidateBufferBounds(ReadOnlyMemory<byte> buffer)
+        {
+            if (buffer.IsEmpty)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull(nameof(buffer));
+            }
+        }
+
+        private enum CloseState
+        {
+            Open,
+            Closing,
+            PipeClosed,
+        }
+
+        private enum TransferOperation
+        {
+            Write,
+            Read,
+            Undefined,
+        }
+    }
+}

--- a/src/dotnet-svcutil/lib/src/FrameworkFork/System.ServiceModel/System/ServiceModel/Channels/PipeConnectionInitiator.cs
+++ b/src/dotnet-svcutil/lib/src/FrameworkFork/System.ServiceModel/System/ServiceModel/Channels/PipeConnectionInitiator.cs
@@ -1,0 +1,431 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using System.Globalization;
+using System.IO;
+using System.IO.MemoryMappedFiles;
+using System.IO.Pipes;
+using System.Runtime;
+using System.Runtime.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+using System.Security.Principal;
+using System.ServiceModel.Diagnostics;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Tools.ServiceModel.Svcutil.FrameworkFork.System.ServiceModel.Resources;
+
+namespace System.ServiceModel.Channels
+{
+    internal class PipeConnectionInitiator : IConnectionInitiator
+    {
+        private readonly int _bufferSize;
+
+        public PipeConnectionInitiator(int bufferSize)
+        {
+            _bufferSize = bufferSize;
+        }
+
+        private Exception CreateConnectFailedException(Uri remoteUri, PipeException innerException)
+        {
+            return new CommunicationException(
+                string.Format(SRServiceModel.PipeConnectFailed, remoteUri.AbsoluteUri), innerException);
+        }
+
+        public async Task<IConnection> ConnectAsync(Uri remoteUri, TimeSpan timeout)
+        {
+            string resolvedAddress;
+            BackoffTimeoutHelper backoffHelper;
+            TimeoutHelper timeoutHelper = new TimeoutHelper(timeout);
+            PrepareConnect(remoteUri, timeoutHelper.RemainingTime(), out resolvedAddress, out backoffHelper);
+
+            IConnection connection = null;
+            while (connection == null)
+            {
+                connection =  TryConnect(remoteUri, resolvedAddress, backoffHelper);
+                if (connection == null)
+                {
+                    await backoffHelper.WaitAndBackoffAsync();
+                }
+            }
+
+            return connection;
+        }
+
+        internal const string UseBestMatchNamedPipeUriString = "wcf:useBestMatchNamedPipeUri";
+        internal static bool s_useBestMatchNamedPipeUri = AppContext.TryGetSwitch(UseBestMatchNamedPipeUriString, out bool enabled) && enabled;
+
+        internal static string GetPipeName(Uri uri)
+        {
+            // for wildcard hostName support, we first try and connect to the StrongWildcard,
+            // then the Exact HostName, and lastly the WeakWildcard
+            string[] hostChoices = new string[] { "+", uri.Host, "*" };
+            bool[] globalChoices = new bool[] { true, false };
+            string matchPath = String.Empty;
+            string matchPipeName = null;
+
+            for (int i = 0; i < hostChoices.Length; i++)
+            {
+                for (int iGlobal = 0; iGlobal < globalChoices.Length; iGlobal++)
+                {
+                    // walk up the path hierarchy, looking for match
+                    string path = PipeUri.GetPath(uri);
+
+                    while (path.Length > 0)
+                    {
+
+                        string sharedMemoryName = PipeUri.BuildSharedMemoryName(hostChoices[i], path, globalChoices[iGlobal]);
+                        try
+                        {
+                            PipeSharedMemory sharedMemory = PipeSharedMemory.Open(sharedMemoryName, uri);
+                            if (sharedMemory != null)
+                            {
+                                try
+                                {
+                                    string pipeName = sharedMemory.PipeName;
+                                    if (pipeName != null)
+                                    {
+                                        // Found a matching pipe name. 
+                                        // If the best match app setting is enabled, save the match if it is the best so far and continue.
+                                        // Otherwise, just return the first match we find.
+                                        if (s_useBestMatchNamedPipeUri)
+                                        {
+                                            if (path.Length > matchPath.Length)
+                                            {
+                                                matchPath = path;
+                                                matchPipeName = pipeName;
+                                            }
+                                        }
+                                        else
+                                        {
+                                            return pipeName;
+                                        }
+                                    }
+                                }
+                                finally
+                                {
+                                    sharedMemory.Dispose();
+                                }
+                            }
+                        }
+                        catch (AddressAccessDeniedException exception)
+                        {
+                            throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new EndpointNotFoundException(string.Format(
+                                SRServiceModel.EndpointNotFound, uri.AbsoluteUri), exception));
+                        }
+
+                        path = PipeUri.GetParentPath(path);
+                    }
+                }
+            }
+
+            if (string.IsNullOrEmpty(matchPipeName))
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(
+                    new EndpointNotFoundException(string.Format(SRServiceModel.EndpointNotFound, uri.AbsoluteUri),
+                    new PipeException(string.Format(SRServiceModel.PipeEndpointNotFound, uri.AbsoluteUri))));
+            }
+
+            return matchPipeName;
+        }
+
+        private void PrepareConnect(Uri remoteUri, TimeSpan timeout, out string resolvedAddress, out BackoffTimeoutHelper backoffHelper)
+        {
+            PipeUri.Validate(remoteUri);
+            resolvedAddress = GetPipeName(remoteUri);
+            const int backoffBufferMilliseconds = 150;
+            TimeSpan backoffTimeout;
+            if (timeout >= TimeSpan.FromMilliseconds(backoffBufferMilliseconds * 2))
+            {
+                backoffTimeout = TimeoutHelper.Add(timeout, TimeSpan.Zero - TimeSpan.FromMilliseconds(backoffBufferMilliseconds));
+            }
+            else
+            {
+                backoffTimeout = Ticks.ToTimeSpan((Ticks.FromMilliseconds(backoffBufferMilliseconds) / 2) + 1);
+            }
+
+            backoffHelper = new BackoffTimeoutHelper(backoffTimeout, TimeSpan.FromMinutes(5));
+        }
+
+        private IConnection TryConnect(Uri remoteUri, string resolvedAddress, BackoffTimeoutHelper backoffHelper)
+        {
+            bool lastAttempt = backoffHelper.IsExpired();
+            // NamedPipeClientStream opens a pipe with the name "\\{serverName}\pipe\{pipeName}". As we only connect
+            // to local pipes, we pass "." as the serverName.
+            // PipeDirection means the pipe is opened READ/WRITE
+            // PipeOptions.Asynchronous sets the flag FILE_FLAG_OVERLAPPED and binds the handle to the threadpool IOCP
+            // TokenImpersonationLevel.Anonymous sets the SECURITY_QOS_PRESENT flag and disables impersonation 
+            // HandleInheritability.None sets the security attributes to null
+            NamedPipeClientStream namedPipeClient;
+            try
+            {
+                namedPipeClient = new NamedPipeClientStream(".", resolvedAddress, PipeDirection.InOut, PipeOptions.Asynchronous, TokenImpersonationLevel.Anonymous, HandleInheritability.None);
+                // Don't use ConnectAsync as it uses Task.Factory.StartNew to call the synchronous Connect code on a background thread.
+                // We pass a timeout of 1 as NamedPipeClient might call WaitNamedPipe which synchronously blocks waiting for the service
+                // to call ConnectNamedPipe on the named pipe. NamedPipeClientStream calls CreateFile to connect, and if it can't,
+                // will call WaitNamedPipe passing in the timeout. It waits this much time for the service to call ConnectNamedPipe. If
+                // we pass a value of 0, it will use the default timeout configured on the named pipe. WCF services specify zero which
+                // means use the API default which is 50ms. As we can't prevent NamedPipeClientStream from calling WaitNamedPipe, the
+                // best we can do is pass 1ms.
+                namedPipeClient.Connect(1);
+            }
+            catch (Exception ex)
+            {
+                int error = PipeError.GetErrorFromHResult(ex.HResult);
+
+                if (error == UnsafeNativeMethods.ERROR_FILE_NOT_FOUND || error == UnsafeNativeMethods.ERROR_PIPE_BUSY)
+                {
+                    if (lastAttempt)
+                    {
+                        Exception innerException = new PipeException(string.Format(SRServiceModel.PipeConnectAddressFailed,
+                            resolvedAddress, ex.Message), ex.HResult);
+
+                        TimeoutException timeoutException;
+                        string endpoint = remoteUri.AbsoluteUri;
+
+                        if (error == UnsafeNativeMethods.ERROR_PIPE_BUSY)
+                        {
+                            timeoutException = new TimeoutException(string.Format(SRServiceModel.PipeConnectTimedOutServerTooBusy,
+                                endpoint, backoffHelper.OriginalTimeout), innerException);
+                        }
+                        else
+                        {
+                            timeoutException = new TimeoutException(string.Format(SRServiceModel.PipeConnectTimedOut,
+                                endpoint, backoffHelper.OriginalTimeout), innerException);
+                        }
+
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(timeoutException);
+                    }
+                }
+                else
+                {
+                    PipeException innerException = new PipeException(string.Format(SRServiceModel.PipeConnectAddressFailed,
+                        resolvedAddress, ex.Message), error);
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(
+                        CreateConnectFailedException(remoteUri, innerException));
+                }
+
+                return null;
+            }
+
+            try
+            {
+                namedPipeClient.ReadMode = PipeTransmissionMode.Message;
+            }
+            catch(Exception ex)
+            {
+                PipeException innerException = new PipeException(string.Format(SRServiceModel.PipeModeChangeFailed, ex.Message), ex.HResult);
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(
+                    CreateConnectFailedException(remoteUri, innerException));
+
+            }
+
+            return new PipeConnection(namedPipeClient, _bufferSize);
+        }
+
+        IConnection IConnectionInitiator.Connect(Uri uri, TimeSpan timeout) => throw new NotImplementedException();
+    }
+
+    internal unsafe class PipeSharedMemory : IDisposable
+    {
+        internal const string PipeLocalPrefix = @"Local\";
+        private MemoryMappedFile _fileMapping;
+        private string _pipeName;
+        private readonly Uri _pipeUri;
+
+        private PipeSharedMemory(MemoryMappedFile fileMapping, Uri pipeUri)
+            : this(fileMapping, pipeUri, null)
+        {
+        }
+
+        private PipeSharedMemory(MemoryMappedFile fileMapping, Uri pipeUri, string pipeName)
+        {
+            _pipeName = pipeName;
+            _fileMapping = fileMapping;
+            _pipeUri = pipeUri;
+        }
+
+        public static PipeSharedMemory Open(string sharedMemoryName, Uri pipeUri)
+        {
+            MemoryMappedFile memoryMappedFile;
+            try
+            {
+                memoryMappedFile = MemoryMappedFile.OpenExisting(sharedMemoryName, MemoryMappedFileRights.Read,
+                                                                        HandleInheritability.None);
+            }
+            catch (FileNotFoundException)
+            {
+                try
+                {
+                    memoryMappedFile = MemoryMappedFile.OpenExisting("Global\\" + sharedMemoryName, MemoryMappedFileRights.Read,
+                                                                            HandleInheritability.None);
+                }
+                catch(FileNotFoundException)
+                {
+                    return null;
+                }
+                catch(IOException ioe)
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(CreatePipeNameCannotBeAccessedException(ioe, pipeUri));
+                }
+            }
+
+            return new PipeSharedMemory(memoryMappedFile, pipeUri);
+        }
+
+        public void Dispose()
+        {
+            if (_fileMapping != null)
+            {
+                _fileMapping.Dispose();
+                _fileMapping = null;
+            }
+        }
+
+        public string PipeName
+        {
+            get
+            {
+                if (_pipeName == null)
+                {
+                    using (MemoryMappedViewStream view = GetView(false))
+                    {
+                        SharedMemoryContents contents = view.SafeMemoryMappedViewHandle.Read<SharedMemoryContents>(0);
+                        _pipeName = contents.pipeGuid.ToString();
+                    }
+                }
+
+                return _pipeName;
+            }
+        }
+
+        private static Exception CreatePipeNameCannotBeAccessedException(IOException ioe, Uri pipeUri)
+        {
+            Exception innerException = new PipeException(string.Format(SRServiceModel.PipeNameCanNotBeAccessed,
+                PipeError.GetErrorString(ioe)), ioe.HResult & 0x7FF8FFFF);
+            return new AddressAccessDeniedException(string.Format(SRServiceModel.PipeNameCanNotBeAccessed2, pipeUri.AbsoluteUri), innerException);
+        }
+
+        private MemoryMappedViewStream GetView(bool writable)
+        {
+            try
+            {
+                return _fileMapping.CreateViewStream(0, sizeof(SharedMemoryContents), writable ? MemoryMappedFileAccess.Write : MemoryMappedFileAccess.Read);
+            }
+            catch(IOException ioe)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(CreatePipeNameCannotBeAccessedException(ioe, _pipeUri));
+            }
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct SharedMemoryContents
+        {
+            public bool isInitialized;
+            public Guid pipeGuid;
+        }
+    }
+
+    internal static class PipeUri
+    {
+        public static string BuildSharedMemoryName(string hostName, string path, bool global)
+        {
+            StringBuilder builder = new StringBuilder();
+            builder.Append(Uri.UriSchemeNetPipe);
+            builder.Append("://");
+            builder.Append(hostName.ToUpperInvariant());
+            builder.Append(path);
+            string canonicalName = builder.ToString();
+
+            byte[] canonicalBytes = Encoding.UTF8.GetBytes(canonicalName);
+            byte[] hashedBytes;
+            string separator;
+
+            if (canonicalBytes.Length >= 128)
+            {
+                using (HashAlgorithm hash = GetHashAlgorithm())
+                {
+                    hashedBytes = hash.ComputeHash(canonicalBytes);
+                }
+                separator = ":H";
+            }
+            else
+            {
+                hashedBytes = canonicalBytes;
+                separator = ":E";
+            }
+
+            builder = new StringBuilder();
+            if (global)
+            {
+                // we may need to create the shared memory in the global namespace so we work with terminal services+admin 
+                builder.Append("Global\\");
+            }
+            else
+            {
+                builder.Append("Local\\");
+            }
+            builder.Append(Uri.UriSchemeNetPipe);
+            builder.Append(separator);
+            builder.Append(Convert.ToBase64String(hashedBytes));
+            return builder.ToString();
+        }
+
+        internal const string UseSha1InPipeConnectionGetHashAlgorithmString = "Switch.System.ServiceModel.UseSha1InPipeConnectionGetHashAlgorithm";
+        internal static bool s_useSha1InPipeConnectionGetHashAlgorithm = AppContext.TryGetSwitch(UseSha1InPipeConnectionGetHashAlgorithmString, out bool enabled) && enabled;
+
+        private static HashAlgorithm GetHashAlgorithm()
+        {
+            if (s_useSha1InPipeConnectionGetHashAlgorithm)
+            {
+                return SHA1.Create(); // CodeQL [SM02196] Here SHA1 is not used for cryptographic purposes, it's for compatibility.
+            }
+            else
+            {
+                return SHA256.Create();
+            }
+        }
+
+        public static string GetPath(Uri uri)
+        {
+            string path = uri.LocalPath.ToUpperInvariant();
+            if (!path.EndsWith("/", StringComparison.Ordinal))
+                path = path + "/";
+            return path;
+        }
+
+        public static string GetParentPath(string path)
+        {
+            if (path.EndsWith("/", StringComparison.Ordinal))
+                path = path.Substring(0, path.Length - 1);
+            if (path.Length == 0)
+                return path;
+            return path.Substring(0, path.LastIndexOf('/') + 1);
+        }
+
+        public static void Validate(Uri uri)
+        {
+            if (uri.Scheme != Uri.UriSchemeNetPipe)
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgument(nameof(uri), SRServiceModel.PipeUriSchemeWrong);
+        }
+    }
+
+    internal static class PipeError
+    {
+        public static string GetErrorString(IOException exception)
+        {
+            int originalErrorCode = GetErrorFromHResult(exception.HResult);
+            return string.Format(
+                SRServiceModel.PipeKnownWin32Error,
+                exception.Message,
+                originalErrorCode.ToString(CultureInfo.InvariantCulture),
+                Convert.ToString(originalErrorCode, 16));
+        }
+
+        public static int GetErrorFromHResult(int hResult)
+        {
+            return hResult & 0x7FF8FFFF;
+        }
+    }
+}

--- a/src/dotnet-svcutil/lib/src/FrameworkFork/System.ServiceModel/System/ServiceModel/Channels/StandardBindingImporter.cs
+++ b/src/dotnet-svcutil/lib/src/FrameworkFork/System.ServiceModel/System/ServiceModel/Channels/StandardBindingImporter.cs
@@ -53,6 +53,10 @@ namespace System.ServiceModel.Channels
                 {
                     SetBinding(endpointContext.Endpoint, binding);
                 }
+                else if (transport is NamedPipeTransportBindingElement && NetNamedPipeBinding.TryCreate(elements, out binding))
+                {
+                    SetBinding(endpointContext.Endpoint, binding);
+                }
             }
         }
 

--- a/src/dotnet-svcutil/lib/src/FrameworkFork/System.ServiceModel/System/ServiceModel/Channels/TransportBindingElementImporter.cs
+++ b/src/dotnet-svcutil/lib/src/FrameworkFork/System.ServiceModel/System/ServiceModel/Channels/TransportBindingElementImporter.cs
@@ -151,9 +151,8 @@ namespace System.ServiceModel.Channels
                     transportBindingElement = new TcpTransportBindingElement();
                     break;
                 case TransportPolicyConstants.NamedPipeTransportUri:
-                // Not supported on .NET Core yet.
-                //                     transportBindingElement = new NamedPipeTransportBindingElement();
-                //                     break;
+                    transportBindingElement = new NamedPipeTransportBindingElement();
+                    break;
                 case TransportPolicyConstants.PeerTransportUri:
                     throw new NotImplementedException();
                 case TransportPolicyConstants.WebSocketTransportUri:

--- a/src/dotnet-svcutil/lib/src/FrameworkFork/System.ServiceModel/System/ServiceModel/Description/MetadataExchangeBindings.cs
+++ b/src/dotnet-svcutil/lib/src/FrameworkFork/System.ServiceModel/System/ServiceModel/Description/MetadataExchangeBindings.cs
@@ -202,7 +202,10 @@ namespace System.ServiceModel.Description
 
         private static CustomBinding CreateNamedPipeBinding()
         {
-            throw new NotImplementedException();
+            CustomBinding binding = new CustomBinding(MetadataStrings.MetadataExchangeStrings.TcpBindingName, MetadataStrings.MetadataExchangeStrings.BindingNamespace);
+            TcpTransportBindingElement tcpTransport = new TcpTransportBindingElement();
+            binding.Elements.Add(tcpTransport);
+            return binding;
         }
 
         internal static bool IsSchemeSupported(string scheme)

--- a/src/dotnet-svcutil/lib/src/FrameworkFork/System.ServiceModel/System/ServiceModel/Description/MetadataExchangeBindings.cs
+++ b/src/dotnet-svcutil/lib/src/FrameworkFork/System.ServiceModel/System/ServiceModel/Description/MetadataExchangeBindings.cs
@@ -202,9 +202,9 @@ namespace System.ServiceModel.Description
 
         private static CustomBinding CreateNamedPipeBinding()
         {
-            CustomBinding binding = new CustomBinding(MetadataStrings.MetadataExchangeStrings.TcpBindingName, MetadataStrings.MetadataExchangeStrings.BindingNamespace);
-            TcpTransportBindingElement tcpTransport = new TcpTransportBindingElement();
-            binding.Elements.Add(tcpTransport);
+            CustomBinding binding = new CustomBinding(MetadataStrings.MetadataExchangeStrings.NamedPipeBindingName, MetadataStrings.MetadataExchangeStrings.BindingNamespace);
+            NamedPipeTransportBindingElement pipeTransport = new NamedPipeTransportBindingElement();
+            binding.Elements.Add(pipeTransport);
             return binding;
         }
 

--- a/src/dotnet-svcutil/lib/src/FrameworkFork/System.ServiceModel/System/ServiceModel/NamedPipeTransportSecurity.cs
+++ b/src/dotnet-svcutil/lib/src/FrameworkFork/System.ServiceModel/System/ServiceModel/NamedPipeTransportSecurity.cs
@@ -1,0 +1,49 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.ComponentModel;
+using System.Net.Security;
+using System.ServiceModel.Channels;
+using System.ServiceModel.Security;
+
+namespace System.ServiceModel
+{
+    public sealed class NamedPipeTransportSecurity
+    {
+        internal const ProtectionLevel DefaultProtectionLevel = ProtectionLevel.EncryptAndSign;
+        ProtectionLevel _protectionLevel;
+
+        public NamedPipeTransportSecurity()
+        {
+            this._protectionLevel = DefaultProtectionLevel;
+        }
+
+        [DefaultValue(ConnectionOrientedTransportDefaults.ProtectionLevel)]
+        public ProtectionLevel ProtectionLevel
+        {
+            get { return this._protectionLevel; }
+            set
+            {
+                if (!ProtectionLevelHelper.IsDefined(value))
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("value"));
+                }
+                this._protectionLevel = value;
+            }
+        }
+
+        internal WindowsStreamSecurityBindingElement CreateTransportProtectionAndAuthentication()
+        {
+            WindowsStreamSecurityBindingElement result = new WindowsStreamSecurityBindingElement();
+            result.ProtectionLevel = this._protectionLevel;
+            return result;
+        }
+
+        internal static bool IsTransportProtectionAndAuthentication(WindowsStreamSecurityBindingElement wssbe, NamedPipeTransportSecurity transportSecurity)
+        {
+            transportSecurity._protectionLevel = wssbe.ProtectionLevel;
+            return true;
+        }
+    }
+}

--- a/src/dotnet-svcutil/lib/src/FrameworkFork/System.ServiceModel/System/ServiceModel/NetNamedPipeBinding.cs
+++ b/src/dotnet-svcutil/lib/src/FrameworkFork/System.ServiceModel/System/ServiceModel/NetNamedPipeBinding.cs
@@ -1,0 +1,322 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.ComponentModel;
+using System.ServiceModel.Channels;
+using Microsoft.Xml;
+
+namespace System.ServiceModel
+{
+    public class NetNamedPipeBinding : Binding, IBindingRuntimePreferences
+    {
+        // private BindingElements
+        TransactionFlowBindingElement _context;
+        BinaryMessageEncodingBindingElement _encoding;
+        NamedPipeTransportBindingElement _namedPipe;
+        NetNamedPipeSecurity _security = new NetNamedPipeSecurity();
+
+        public NetNamedPipeBinding()
+            : base()
+        {
+            Initialize();
+        }
+
+        public NetNamedPipeBinding(NetNamedPipeSecurityMode securityMode)
+            : this()
+        {
+            this._security.Mode = securityMode;
+        }
+        //public NetNamedPipeBinding(string configurationName)
+        //    : this()
+        //{
+        //    ApplyConfiguration(configurationName);
+        //}
+        NetNamedPipeBinding(NetNamedPipeSecurity security)
+            : this()
+        {
+            this._security = security;
+        }
+
+        [DefaultValue(TransactionFlowDefaults.Transactions)]
+        public bool TransactionFlow
+        {
+            get { return _context.Transactions; }
+            set { _context.Transactions = value; }
+        }
+
+        public TransactionProtocol TransactionProtocol
+        {
+            get { return this._context.TransactionProtocol; }
+            set { this._context.TransactionProtocol = value; }
+        }
+
+        [DefaultValue(ConnectionOrientedTransportDefaults.TransferMode)]
+        public TransferMode TransferMode
+        {
+            get { return _namedPipe.TransferMode; }
+            set { _namedPipe.TransferMode = value; }
+        }
+
+        [DefaultValue(ConnectionOrientedTransportDefaults.HostNameComparisonMode)]
+        public HostNameComparisonMode HostNameComparisonMode
+        {
+            get { return _namedPipe.HostNameComparisonMode; }
+            set { _namedPipe.HostNameComparisonMode = value; }
+        }
+
+        [DefaultValue(TransportDefaults.MaxBufferPoolSize)]
+        public long MaxBufferPoolSize
+        {
+            get { return _namedPipe.MaxBufferPoolSize; }
+            set
+            {
+                _namedPipe.MaxBufferPoolSize = value;
+            }
+        }
+
+        [DefaultValue(TransportDefaults.MaxBufferSize)]
+        public int MaxBufferSize
+        {
+            get { return _namedPipe.MaxBufferSize; }
+            set { _namedPipe.MaxBufferSize = value; }
+        }
+
+        public int MaxConnections
+        {
+            //get { return _namedPipe.MaxPendingConnections; }
+            //set
+            //{
+            //    _namedPipe.MaxPendingConnections = value;
+            //    _namedPipe.ConnectionPoolSettings.MaxOutboundConnectionsPerEndpoint = value;
+            //}
+            get;set;
+        }
+
+        //internal bool IsMaxConnectionsSet
+        //{
+        //    get { return _namedPipe.IsMaxPendingConnectionsSet; }
+        //}
+
+        [DefaultValue(TransportDefaults.MaxReceivedMessageSize)]
+        public long MaxReceivedMessageSize
+        {
+            get { return _namedPipe.MaxReceivedMessageSize; }
+            set { _namedPipe.MaxReceivedMessageSize = value; }
+        }
+
+        public XmlDictionaryReaderQuotas ReaderQuotas
+        {
+            get { return _encoding.ReaderQuotas; }
+            set
+            {
+                if (value == null)
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("value");
+                value.CopyTo(_encoding.ReaderQuotas);
+            }
+        }
+
+        bool IBindingRuntimePreferences.ReceiveSynchronously
+        {
+            get { return false; }
+        }
+
+        public override string Scheme { get { return _namedPipe.Scheme; } }
+
+        public EnvelopeVersion EnvelopeVersion
+        {
+            get { return EnvelopeVersion.Soap12; }
+        }
+
+        public NetNamedPipeSecurity Security
+        {
+            get { return this._security; }
+            set
+            {
+                if (value == null)
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("value");
+                this._security = value;
+            }
+        }
+
+        static TransactionFlowBindingElement GetDefaultTransactionFlowBindingElement()
+        {
+            return new TransactionFlowBindingElement(false);
+        }
+
+        void Initialize()
+        {
+            _namedPipe = new NamedPipeTransportBindingElement();
+            _encoding = new BinaryMessageEncodingBindingElement();
+            _context = GetDefaultTransactionFlowBindingElement();
+        }
+
+        void InitializeFrom(NamedPipeTransportBindingElement namedPipe, BinaryMessageEncodingBindingElement encoding, TransactionFlowBindingElement context)
+        {
+            Initialize();
+            this.HostNameComparisonMode = namedPipe.HostNameComparisonMode;
+            this.MaxBufferPoolSize = namedPipe.MaxBufferPoolSize;
+            this.MaxBufferSize = namedPipe.MaxBufferSize;
+            //if (namedPipe.IsMaxPendingConnectionsSet)
+            //{
+            //    this.MaxConnections = namedPipe.MaxPendingConnections;    
+            //}
+            this.MaxReceivedMessageSize = namedPipe.MaxReceivedMessageSize;
+            this.TransferMode = namedPipe.TransferMode;
+
+            this.ReaderQuotas = encoding.ReaderQuotas;
+
+            this.TransactionFlow = context.Transactions;
+            this.TransactionProtocol = context.TransactionProtocol;
+        }
+
+        // check that properties of the HttpTransportBindingElement and 
+        // MessageEncodingBindingElement not exposed as properties on BasicHttpBinding 
+        // match default values of the binding elements
+        bool IsBindingElementsMatch(NamedPipeTransportBindingElement namedPipe, BinaryMessageEncodingBindingElement encoding, TransactionFlowBindingElement context)
+        {
+            if (!this._namedPipe.IsMatch(namedPipe))
+                return false;
+            if (!this._encoding.IsMatch(encoding))
+                return false;
+            if (!this._context.IsMatch(context))
+                return false;
+            return true;
+        }
+
+        //void ApplyConfiguration(string configurationName)
+        //{
+        //    NetNamedPipeBindingCollectionElement section = NetNamedPipeBindingCollectionElement.GetBindingCollectionElement();
+        //    NetNamedPipeBindingElement element = section.Bindings[configurationName];
+        //    if (element == null)
+        //    {
+        //        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ConfigurationErrorsException(
+        //            SR.GetString(SR.ConfigInvalidBindingConfigurationName,
+        //                         configurationName,
+        //                         ConfigurationStrings.NetNamedPipeBindingCollectionElementName)));
+        //    }
+        //    else
+        //    {
+        //        element.ApplyConfiguration(this);
+        //    }
+        //}
+
+        public override BindingElementCollection CreateBindingElements()
+        {   // return collection of BindingElements
+            BindingElementCollection bindingElements = new BindingElementCollection();
+            // order of BindingElements is important
+            // add context
+            bindingElements.Add(_context);
+            // add encoding
+            bindingElements.Add(_encoding);
+            // add transport security
+            WindowsStreamSecurityBindingElement transportSecurity = CreateTransportSecurity();
+            if (transportSecurity != null)
+            {
+                bindingElements.Add(transportSecurity);
+            }
+            // add transport (named pipes)
+            bindingElements.Add(this._namedPipe);
+
+            return bindingElements.Clone();
+        }
+
+        internal static bool TryCreate(BindingElementCollection elements, out Binding binding)
+        {
+            binding = null;
+            if (elements.Count > 4)
+                return false;
+
+            TransactionFlowBindingElement context = null;
+            BinaryMessageEncodingBindingElement encoding = null;
+            WindowsStreamSecurityBindingElement security = null;
+            NamedPipeTransportBindingElement namedPipe = null;
+
+            foreach (BindingElement element in elements)
+            {
+                if (element is TransactionFlowBindingElement)
+                    context = element as TransactionFlowBindingElement;
+                else if (element is BinaryMessageEncodingBindingElement)
+                    encoding = element as BinaryMessageEncodingBindingElement;
+                else if (element is WindowsStreamSecurityBindingElement)
+                    security = element as WindowsStreamSecurityBindingElement;
+                else if (element is NamedPipeTransportBindingElement)
+                    namedPipe = element as NamedPipeTransportBindingElement;
+                else
+                    return false;
+            }
+
+            if (namedPipe == null)
+                return false;
+
+            if (encoding == null)
+                return false;
+
+            if (context == null)
+                context = GetDefaultTransactionFlowBindingElement();
+
+            NetNamedPipeSecurity pipeSecurity;
+            if (!TryCreateSecurity(security, out pipeSecurity))
+                return false;
+
+            NetNamedPipeBinding netNamedPipeBinding = new NetNamedPipeBinding(pipeSecurity);
+            netNamedPipeBinding.InitializeFrom(namedPipe, encoding, context);
+
+            if (!netNamedPipeBinding.IsBindingElementsMatch(namedPipe, encoding, context))
+                return false;
+
+            binding = netNamedPipeBinding;
+            return true;
+        }
+
+        WindowsStreamSecurityBindingElement CreateTransportSecurity()
+        {
+            if (this._security.Mode == NetNamedPipeSecurityMode.Transport)
+            {
+                return this._security.CreateTransportSecurity();
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+        static bool TryCreateSecurity(WindowsStreamSecurityBindingElement wssbe, out NetNamedPipeSecurity security)
+        {
+            NetNamedPipeSecurityMode mode = wssbe == null ? NetNamedPipeSecurityMode.None : NetNamedPipeSecurityMode.Transport;
+            return NetNamedPipeSecurity.TryCreate(wssbe, mode, out security);
+        }
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public bool ShouldSerializeReaderQuotas()
+        {
+            return (!EncoderDefaults.IsDefaultReaderQuotas(this.ReaderQuotas));
+        }
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public bool ShouldSerializeSecurity()
+        {
+            if (this._security.Mode != NetNamedPipeSecurity.DefaultMode)
+            {
+                return true;
+            }
+            if (this._security.Transport.ProtectionLevel != NamedPipeTransportSecurity.DefaultProtectionLevel)
+            {
+                return true;
+            }
+            return false;
+        }
+
+        //[EditorBrowsable(EditorBrowsableState.Never)]
+        //public bool ShouldSerializeTransactionProtocol()
+        //{
+        //    return (TransactionProtocol != NetTcpDefaults.TransactionProtocol);
+        //}
+
+        //[EditorBrowsable(EditorBrowsableState.Never)]
+        //public bool ShouldSerializeMaxConnections()
+        //{
+        //    return _namedPipe.ShouldSerializeMaxPendingConnections();
+        //}
+    }
+}

--- a/src/dotnet-svcutil/lib/src/FrameworkFork/System.ServiceModel/System/ServiceModel/NetNamedPipeBinding.cs
+++ b/src/dotnet-svcutil/lib/src/FrameworkFork/System.ServiceModel/System/ServiceModel/NetNamedPipeBinding.cs
@@ -27,11 +27,7 @@ namespace System.ServiceModel
         {
             this._security.Mode = securityMode;
         }
-        //public NetNamedPipeBinding(string configurationName)
-        //    : this()
-        //{
-        //    ApplyConfiguration(configurationName);
-        //}
+        
         NetNamedPipeBinding(NetNamedPipeSecurity security)
             : this()
         {
@@ -84,19 +80,8 @@ namespace System.ServiceModel
 
         public int MaxConnections
         {
-            //get { return _namedPipe.MaxPendingConnections; }
-            //set
-            //{
-            //    _namedPipe.MaxPendingConnections = value;
-            //    _namedPipe.ConnectionPoolSettings.MaxOutboundConnectionsPerEndpoint = value;
-            //}
             get;set;
         }
-
-        //internal bool IsMaxConnectionsSet
-        //{
-        //    get { return _namedPipe.IsMaxPendingConnectionsSet; }
-        //}
 
         [DefaultValue(TransportDefaults.MaxReceivedMessageSize)]
         public long MaxReceivedMessageSize
@@ -157,10 +142,7 @@ namespace System.ServiceModel
             this.HostNameComparisonMode = namedPipe.HostNameComparisonMode;
             this.MaxBufferPoolSize = namedPipe.MaxBufferPoolSize;
             this.MaxBufferSize = namedPipe.MaxBufferSize;
-            //if (namedPipe.IsMaxPendingConnectionsSet)
-            //{
-            //    this.MaxConnections = namedPipe.MaxPendingConnections;    
-            //}
+            
             this.MaxReceivedMessageSize = namedPipe.MaxReceivedMessageSize;
             this.TransferMode = namedPipe.TransferMode;
 
@@ -183,23 +165,6 @@ namespace System.ServiceModel
                 return false;
             return true;
         }
-
-        //void ApplyConfiguration(string configurationName)
-        //{
-        //    NetNamedPipeBindingCollectionElement section = NetNamedPipeBindingCollectionElement.GetBindingCollectionElement();
-        //    NetNamedPipeBindingElement element = section.Bindings[configurationName];
-        //    if (element == null)
-        //    {
-        //        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ConfigurationErrorsException(
-        //            SR.GetString(SR.ConfigInvalidBindingConfigurationName,
-        //                         configurationName,
-        //                         ConfigurationStrings.NetNamedPipeBindingCollectionElementName)));
-        //    }
-        //    else
-        //    {
-        //        element.ApplyConfiguration(this);
-        //    }
-        //}
 
         public override BindingElementCollection CreateBindingElements()
         {   // return collection of BindingElements
@@ -306,17 +271,5 @@ namespace System.ServiceModel
             }
             return false;
         }
-
-        //[EditorBrowsable(EditorBrowsableState.Never)]
-        //public bool ShouldSerializeTransactionProtocol()
-        //{
-        //    return (TransactionProtocol != NetTcpDefaults.TransactionProtocol);
-        //}
-
-        //[EditorBrowsable(EditorBrowsableState.Never)]
-        //public bool ShouldSerializeMaxConnections()
-        //{
-        //    return _namedPipe.ShouldSerializeMaxPendingConnections();
-        //}
     }
 }

--- a/src/dotnet-svcutil/lib/src/FrameworkFork/System.ServiceModel/System/ServiceModel/NetNamedPipeSecurity.cs
+++ b/src/dotnet-svcutil/lib/src/FrameworkFork/System.ServiceModel/System/ServiceModel/NetNamedPipeSecurity.cs
@@ -1,0 +1,87 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.ComponentModel;
+using System.ServiceModel.Channels;
+
+namespace System.ServiceModel
+{
+    public sealed class NetNamedPipeSecurity
+    {
+        internal const NetNamedPipeSecurityMode DefaultMode = NetNamedPipeSecurityMode.Transport;
+        NetNamedPipeSecurityMode _mode;
+        NamedPipeTransportSecurity _transport = new NamedPipeTransportSecurity();
+
+        public NetNamedPipeSecurity()
+        {
+            this._mode = DefaultMode;
+        }
+
+        NetNamedPipeSecurity(NetNamedPipeSecurityMode mode, NamedPipeTransportSecurity transport)
+        {
+            this._mode = mode;
+            this._transport = transport == null ? new NamedPipeTransportSecurity() : transport;
+        }
+
+        [DefaultValue(DefaultMode)]
+        public NetNamedPipeSecurityMode Mode
+        {
+            get { return this._mode; }
+            set
+            {
+                if (!NetNamedPipeSecurityModeHelper.IsDefined(value))
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException("value"));
+                }
+                this._mode = value;
+            }
+        }
+
+        public NamedPipeTransportSecurity Transport
+        {
+            get { return this._transport; }
+            set
+            {
+                if (value == null)
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("value");
+                this._transport = value;
+            }
+        }
+
+        internal WindowsStreamSecurityBindingElement CreateTransportSecurity()
+        {
+            if (_mode == NetNamedPipeSecurityMode.Transport)
+            {
+                return this._transport.CreateTransportProtectionAndAuthentication();
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+        internal static bool TryCreate(WindowsStreamSecurityBindingElement wssbe, NetNamedPipeSecurityMode mode, out NetNamedPipeSecurity security)
+        {
+            security = null;
+            NamedPipeTransportSecurity transportSecurity = new NamedPipeTransportSecurity();
+            if (mode == NetNamedPipeSecurityMode.Transport)
+            {
+                if (!NamedPipeTransportSecurity.IsTransportProtectionAndAuthentication(wssbe, transportSecurity))
+                    return false;
+            }
+            security = new NetNamedPipeSecurity(mode, transportSecurity);
+            return true;
+        }
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public bool ShouldSerializeTransport()
+        {
+            if (this._transport.ProtectionLevel == ConnectionOrientedTransportDefaults.ProtectionLevel)
+            {
+                return false;
+            }
+            return true;
+        }
+    }
+}

--- a/src/dotnet-svcutil/lib/src/FrameworkFork/System.ServiceModel/System/ServiceModel/NetNamedPipeSecurityMode.cs
+++ b/src/dotnet-svcutil/lib/src/FrameworkFork/System.ServiceModel/System/ServiceModel/NetNamedPipeSecurityMode.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.ServiceModel
+{
+    public enum NetNamedPipeSecurityMode
+    {
+        None,
+        Transport
+    }
+
+    static class NetNamedPipeSecurityModeHelper
+    {
+        internal static bool IsDefined(NetNamedPipeSecurityMode value)
+        {
+            return
+                value == NetNamedPipeSecurityMode.Transport ||
+                value == NetNamedPipeSecurityMode.None;
+        }
+    }
+}

--- a/src/dotnet-svcutil/lib/src/Metadata/MetadataDocumentLoader.cs
+++ b/src/dotnet-svcutil/lib/src/Metadata/MetadataDocumentLoader.cs
@@ -262,7 +262,8 @@ namespace Microsoft.Tools.ServiceModel.Svcutil.Metadata
                     uri = uri.Trim(new char[] { '"' }).Trim();
 
                     var isUrl = uri.StartsWith(MetadataConstants.Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase) ||
-                                uri.StartsWith(MetadataConstants.Uri.UriSchemeNetTcp, StringComparison.OrdinalIgnoreCase);
+                                uri.StartsWith(MetadataConstants.Uri.UriSchemeNetTcp, StringComparison.OrdinalIgnoreCase) ||
+                                uri.StartsWith(MetadataConstants.Uri.UriSchemeNetPipe, StringComparison.OrdinalIgnoreCase);
 
                     if (Uri.TryCreate(uri, UriKind.Absolute, out serviceUri) ||
                         isUrl && Uri.TryCreate(baseUrl, UriKind.Absolute, out Uri baseUri) && Uri.TryCreate(baseUri, uri, out serviceUri) ||
@@ -271,6 +272,7 @@ namespace Microsoft.Tools.ServiceModel.Svcutil.Metadata
                         return serviceUri.Scheme == MetadataConstants.Uri.UriSchemeHttp ||
                             serviceUri.Scheme == MetadataConstants.Uri.UriSchemeHttps ||
                             serviceUri.Scheme == MetadataConstants.Uri.UriSchemeNetTcp ||
+                            serviceUri.Scheme == MetadataConstants.Uri.UriSchemeNetPipe ||
                             serviceUri.Scheme == MetadataConstants.Uri.UriSchemeFile;
                     }
                 }

--- a/src/dotnet-svcutil/lib/src/SR.resx
+++ b/src/dotnet-svcutil/lib/src/SR.resx
@@ -619,4 +619,7 @@ Your credentials will be sent to the server in clear text.</value>
   <data name="HelpAcceptCertificateFormat" xml:space="preserve">
     <value>Accept remote certificate as trusted when downloading service metadata. (Short Form: -{0})</value>
   </data>
+  <data name="TargetFrameworkNotSupported_NetNamedPipe" xml:space="preserve">
+    <value>NetNamedPipe is not supported on this .net target framework.</value>
+  </data>
 </root>

--- a/src/dotnet-svcutil/lib/src/Shared/MSBuildProj.cs
+++ b/src/dotnet-svcutil/lib/src/Shared/MSBuildProj.cs
@@ -219,7 +219,7 @@ namespace Microsoft.Tools.ServiceModel.Svcutil
                         continue;
 
                     string version = GetItemValue(reference, "Version");
-                    if (!ProjectDependency.IsValidVersion(version))
+                    if (!ProjectDependency.IsValidPackageVersion(version))
                     {
                         version = "";
                     }

--- a/src/dotnet-svcutil/lib/src/Shared/ProjectDependency.cs
+++ b/src/dotnet-svcutil/lib/src/Shared/ProjectDependency.cs
@@ -86,7 +86,7 @@ namespace Microsoft.Tools.ServiceModel.Svcutil
             {
                 packageVersion = DefaultVersion;
             }
-            else if (!IsValidVersion(packageVersion))
+            else if (!IsValidPackageVersion(packageVersion))
             {
                 throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, Shared.Resources.ErrorInvalidDependencyValue, packageVersion, nameof(packageVersion)));
             }
@@ -327,7 +327,49 @@ namespace Microsoft.Tools.ServiceModel.Svcutil
             return dependencyType;
         }
 
-        internal static bool IsValidVersion(string version)
+        internal static bool IsValidPackageVersion(string version)
+        {
+            version = version.Trim();
+            if (version.StartsWith("(") || version.StartsWith("["))
+            {
+                if (!(version.EndsWith(")") || version.EndsWith("]")))
+                {
+                    return false;
+                }
+                else
+                {
+                    version = version.Trim(new char[] { '(', ')', ']', '[' });
+                    var vers = version.Split(',');
+                    if (vers.Length == 2)
+                    {
+                        if (string.IsNullOrEmpty(vers[0]) && string.IsNullOrEmpty(vers[1]))
+                        {
+                            return false;
+                        }
+
+                        if (!string.IsNullOrEmpty(vers[0]) && !IsValidVersion(vers[0]))
+                        {
+                            return false;
+                        }
+
+                        if (!string.IsNullOrEmpty(vers[1]) && !IsValidVersion(vers[1]))
+                        {
+                            return false;
+                        }
+
+                        return true;
+                    }
+
+                    return false;
+                }
+            }
+            else
+            {
+                return IsValidVersion(version);
+            }
+        }
+
+        private static bool IsValidVersion(string version)
         {
             // https://semver.org/spec/v2.0.0.html
 

--- a/src/dotnet-svcutil/lib/src/Shared/TargetFrameworkHelper.cs
+++ b/src/dotnet-svcutil/lib/src/Shared/TargetFrameworkHelper.cs
@@ -71,6 +71,14 @@ namespace Microsoft.Tools.ServiceModel.Svcutil
                 ProjectDependency.FromPackage("System.ServiceModel.NetTcp", "4.10.*"  ),
                 ProjectDependency.FromPackage("System.ServiceModel.Security", "4.10.*"),
                 ProjectDependency.FromPackage("System.ServiceModel.Federation", "4.10.*")
+            } },
+            {new Version("7.0"), new List<ProjectDependency> {
+                ProjectDependency.FromPackage("System.ServiceModel.Duplex", "6.0.0-rc.23205.4"  ),
+                ProjectDependency.FromPackage("System.ServiceModel.Http", "6.0.0-rc.23205.4"    ),
+                ProjectDependency.FromPackage("System.ServiceModel.NetTcp", "6.0.0-rc.23205.4"  ),
+                ProjectDependency.FromPackage("System.ServiceModel.Security", "6.0.0-rc.23205.4"),
+                ProjectDependency.FromPackage("System.ServiceModel.Federation", "6.0.0-rc.23205.4"),
+                ProjectDependency.FromPackage("System.ServiceModel.NetNamedPipe", "6.0.0-rc.23205.4")
             } }
         };
 
@@ -89,7 +97,9 @@ namespace Microsoft.Tools.ServiceModel.Svcutil
             ProjectDependency.FromPackage("System.Private.ServiceModel", "*"),
             ProjectDependency.FromPackage("System.ServiceModel.Security", "*"),
             ProjectDependency.FromPackage("System.Xml.XmlSerializer", "*"),
-            ProjectDependency.FromPackage("System.ServiceModel.Federation", "*")
+            ProjectDependency.FromPackage("System.ServiceModel.Federation", "*"),
+            ProjectDependency.FromPackage("System.ServiceModel.NetNamedPipe", "*"),
+            ProjectDependency.FromPackage("System.ServiceModel.NetFramingBase", "*")
         };
 
         public static Version MinSupportedNetFxVersion { get; } = new Version("4.5");

--- a/src/dotnet-svcutil/lib/src/Shared/TargetFrameworkHelper.cs
+++ b/src/dotnet-svcutil/lib/src/Shared/TargetFrameworkHelper.cs
@@ -73,12 +73,12 @@ namespace Microsoft.Tools.ServiceModel.Svcutil
                 ProjectDependency.FromPackage("System.ServiceModel.Federation", "4.10.*")
             } },
             {new Version("7.0"), new List<ProjectDependency> {
-                ProjectDependency.FromPackage("System.ServiceModel.Duplex", "6.0.0-rc.23205.4"  ),
-                ProjectDependency.FromPackage("System.ServiceModel.Http", "6.0.0-rc.23205.4"    ),
-                ProjectDependency.FromPackage("System.ServiceModel.NetTcp", "6.0.0-rc.23205.4"  ),
-                ProjectDependency.FromPackage("System.ServiceModel.Security", "6.0.0-rc.23205.4"),
-                ProjectDependency.FromPackage("System.ServiceModel.Federation", "6.0.0-rc.23205.4"),
-                ProjectDependency.FromPackage("System.ServiceModel.NetNamedPipe", "6.0.0-rc.23205.4")
+                ProjectDependency.FromPackage("System.ServiceModel.Duplex", "(6.0.0-*,)"  ),
+                ProjectDependency.FromPackage("System.ServiceModel.Http", "(6.0.0-*,)"    ),
+                ProjectDependency.FromPackage("System.ServiceModel.NetTcp", "(6.0.0-*,)"  ),
+                ProjectDependency.FromPackage("System.ServiceModel.Security", "(6.0.0-*,)"),
+                ProjectDependency.FromPackage("System.ServiceModel.Federation", "(6.0.0-*,)"),
+                ProjectDependency.FromPackage("System.ServiceModel.NetNamedPipe", "(6.0.0-*,)")
             } }
         };
 

--- a/src/dotnet-svcutil/lib/src/Shared/Utilities/PathHelper.cs
+++ b/src/dotnet-svcutil/lib/src/Shared/Utilities/PathHelper.cs
@@ -55,7 +55,8 @@ namespace Microsoft.Tools.ServiceModel.Svcutil
                     input = input.Trim(new char[] { '"' }).Trim();
 
                     var isUrl = input.StartsWith("http", StringComparison.OrdinalIgnoreCase) ||
-                                input.StartsWith("net.tcp", StringComparison.OrdinalIgnoreCase);
+                                input.StartsWith("net.tcp", StringComparison.OrdinalIgnoreCase) ||
+                                input.StartsWith("net.pipe", StringComparison.OrdinalIgnoreCase);
 
                     if (!isUrl && (Uri.TryCreate(Path.Combine(basePath, input), UriKind.Absolute, out var uri)) && uri.Scheme == "file")
                     {

--- a/src/dotnet-svcutil/lib/src/Tool.cs
+++ b/src/dotnet-svcutil/lib/src/Tool.cs
@@ -278,6 +278,11 @@ namespace Microsoft.Tools.ServiceModel.Svcutil
                     bool needSave = false;
                     foreach (var dep in dependencies)
                     {
+                        if (dep.Name.Contains("NetNamedPipe") && !project.TargetFrameworks.First().Contains("windows"))
+                        {
+                            continue;
+                        }
+
                         needSave |= project.AddDependency(dep);
                     }
 

--- a/src/dotnet-svcutil/lib/src/dotnet-svcutil-lib.csproj
+++ b/src/dotnet-svcutil/lib/src/dotnet-svcutil-lib.csproj
@@ -1,10 +1,10 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyVersionFile>$(IntermediateOutputPath)\$(TargetFramework)\$(MSBuildProjectName).$(TargetFramework).version.cs</AssemblyVersionFile>
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <RootNamespace>Microsoft.Tools.ServiceModel.Svcutil</RootNamespace>
     <AssemblyName>$(MSBuildProjectName)</AssemblyName>
   </PropertyGroup>

--- a/src/dotnet-svcutil/lib/src/dotnet-svcutil-lib.csproj
+++ b/src/dotnet-svcutil/lib/src/dotnet-svcutil-lib.csproj
@@ -4,7 +4,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>Microsoft.Tools.ServiceModel.Svcutil</RootNamespace>
     <AssemblyName>$(MSBuildProjectName)</AssemblyName>
   </PropertyGroup>


### PR DESCRIPTION
Support mexHttpBinding and mexNamedPipeBinding for metadata retrieving.

Note: for context project with target framework doesn't support NetNamedPipe (non-net-windows), add a warning message.