### PR TITLE
dotnet-svcutil: support vb and fsharp project dependencies

### DIFF
--- a/src/dotnet-svcutil/lib/src/Shared/ProjectDependency.cs
+++ b/src/dotnet-svcutil/lib/src/Shared/ProjectDependency.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Tools.ServiceModel.Svcutil
         public const string NetStandardLibraryPackageID = "NETStandard.Library";
 
         private static readonly IReadOnlyList<string> s_binaryExtensions = new List<string> { ".exe", ".dll" }.AsReadOnly();
-        private static readonly IReadOnlyList<string> s_projectExtensions = new List<string> { ".csproj" }.AsReadOnly();
+        private static readonly IReadOnlyList<string> s_projectExtensions = new List<string> { ".csproj", ".vbproj",".fsproj" }.AsReadOnly();
         private static readonly IReadOnlyList<string> s_exeExtensions = new List<string> { ".exe" }.AsReadOnly();
 
         /// <summary>


### PR DESCRIPTION
For #4947, #4785 