### PR TITLE
Remove System.Security.Principal.Windows reference

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -24,7 +24,6 @@
   <!-- CoreFx dependencies -->
   <PropertyGroup>
     <SystemReflectionDispatchProxyPackageVersion>4.7.1</SystemReflectionDispatchProxyPackageVersion>
-    <SystemSecurityPrincipalWindowsPackageVersion>5.0.0</SystemSecurityPrincipalWindowsPackageVersion>
     <SystemSecurityCryptographyXmlPackageVersion>6.0.1</SystemSecurityCryptographyXmlPackageVersion>
     <MicrosoftExtensionsObjectPoolVersion>6.0.16</MicrosoftExtensionsObjectPoolVersion>
   </PropertyGroup>

--- a/src/System.ServiceModel.NetFramingBase/src/System.ServiceModel.NetFramingBase.csproj
+++ b/src/System.ServiceModel.NetFramingBase/src/System.ServiceModel.NetFramingBase.csproj
@@ -6,7 +6,6 @@
     <CLSCompliant>true</CLSCompliant>
     <IsPackable>true</IsPackable>
     <IsShipping>$(Ship_WcfPackages)</IsShipping>
-    <!-- TODO: Make this net462 and netstandard2.0 after it's multi-targetting .NET Framework -->
     <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>System.ServiceModel</RootNamespace>
     <DebugType>full</DebugType>

--- a/src/System.ServiceModel.NetFramingBase/src/System.ServiceModel.NetFramingBase.csproj
+++ b/src/System.ServiceModel.NetFramingBase/src/System.ServiceModel.NetFramingBase.csproj
@@ -6,7 +6,7 @@
     <CLSCompliant>true</CLSCompliant>
     <IsPackable>true</IsPackable>
     <IsShipping>$(Ship_WcfPackages)</IsShipping>
-	<!-- TODO: Make this net462 and netstandard2.0 after it's multi-targetting .NET Framework -->
+    <!-- TODO: Make this net462 and netstandard2.0 after it's multi-targetting .NET Framework -->
     <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>System.ServiceModel</RootNamespace>
     <DebugType>full</DebugType>
@@ -16,10 +16,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\System.ServiceModel.Primitives\src\System.ServiceModel.Primitives.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="System.Security.Principal.Windows" Version="$(SystemSecurityPrincipalWindowsPackageVersion)" />
   </ItemGroup>
 
   <!--The default source produced by the Arcade SDK does not work with the checked-in source file SR.cs (class/namespace/filename)-->


### PR DESCRIPTION
System.Security.Principal.Windows's package shouldn't be referenced anymore as it got ingested into the .NETCoreApp shared framework with .NET 6.