### PR TITLE
Fix some tests that would fail when running under a non en-US culture

### DIFF
--- a/src/System.Private.ServiceModel/tests/Common/Infrastructure/xunit/WcfCurrentCultureAttribute.cs
+++ b/src/System.Private.ServiceModel/tests/Common/Infrastructure/xunit/WcfCurrentCultureAttribute.cs
@@ -1,0 +1,34 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Globalization;
+using System.Reflection;
+using Xunit.Sdk;
+
+namespace Infrastructure.Common
+{
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, AllowMultiple = true, Inherited = true)]
+    public class WcfCurrentCultureAttribute : BeforeAfterTestAttribute
+    {
+        private readonly CultureInfo _cultureInfo;
+        private CultureInfo _savedCultureInfo;
+
+        public WcfCurrentCultureAttribute(string name)
+        {
+            _cultureInfo = new CultureInfo(name);
+        }
+
+        public override void Before(MethodInfo methodUnderTest)
+        {
+            _savedCultureInfo = CultureInfo.CurrentCulture;
+            CultureInfo.CurrentCulture = _cultureInfo;
+        }
+
+        public override void After(MethodInfo methodUnderTest)
+        {
+            CultureInfo.CurrentCulture = _savedCultureInfo;
+        }
+    }
+}

--- a/src/System.ServiceModel.Primitives/tests/ServiceModel/FaultExceptionTest.cs
+++ b/src/System.ServiceModel.Primitives/tests/ServiceModel/FaultExceptionTest.cs
@@ -36,6 +36,7 @@ public static class FaultExceptionTest
     }
 
     [WcfFact]
+    [WcfCurrentCulture("en-US")]
     public static void Serializable_TDetail()
     {
         // This isn't exactly what NetFx generates as the HResult is different due to CommunicationException deriving from SystemException on NetFx
@@ -57,6 +58,7 @@ public static class FaultExceptionTest
     }
 
     [WcfFact]
+    [WcfCurrentCulture("en-US")]
     public static void Serializable_Default()
     {
         string netfxBsl = @"<FaultException xmlns=""http://schemas.datacontract.org/2004/07/System.ServiceModel"" xmlns:i=""http://www.w3.org/2001/XMLSchema-instance"" xmlns:x=""http://www.w3.org/2001/XMLSchema""><ClassName i:type=""x:string"" xmlns="""">System.ServiceModel.FaultException</ClassName><Message i:type=""x:string"" xmlns="""">The creator of this fault did not specify a Reason.</Message><Data i:nil=""true"" xmlns=""""/><InnerException i:nil=""true"" xmlns=""""/><HelpURL i:nil=""true"" xmlns=""""/><StackTraceString i:nil=""true"" xmlns=""""/><RemoteStackTraceString i:nil=""true"" xmlns=""""/><RemoteStackIndex i:type=""x:int"" xmlns="""">0</RemoteStackIndex><ExceptionMethod i:nil=""true"" xmlns=""""/><HResult i:type=""x:int"" xmlns="""">-2146233088</HResult><Source i:nil=""true"" xmlns=""""/><WatsonBuckets i:nil=""true"" xmlns=""""/><code i:type=""a:ArrayOfFaultException.FaultCodeData"" xmlns="""" xmlns:a=""http://schemas.datacontract.org/2004/07/System.ServiceModel""><a:FaultException.FaultCodeData><a:name>Sender</a:name><a:ns/></a:FaultException.FaultCodeData></code><reason i:type=""a:ArrayOfFaultException.FaultReasonData"" xmlns="""" xmlns:a=""http://schemas.datacontract.org/2004/07/System.ServiceModel""><a:FaultException.FaultReasonData><a:text>The creator of this fault did not specify a Reason.</a:text><a:xmlLang>en-US</a:xmlLang></a:FaultException.FaultReasonData></reason><messageFault i:nil=""true"" xmlns=""""/><action i:nil=""true"" xmlns=""""/></FaultException>";


### PR DESCRIPTION
Before this commit, two tests would fail with this error (FaultExceptionTest.Serializable_TDetail and FaultExceptionTest.Serializable_Default):
```
Xunit.Sdk.EqualException
Assert.Equal() Failure
                                 ↓ (pos 1259)
Expected: ···:text><a:xmlLang>en-US</a:xmlLang></a:FaultException.FaultRea···
Actual:   ···:text><a:xmlLang>fr-CH</a:xmlLang></a:FaultException.FaultRea···
                                 ↑ (pos 1259)
```

Explicitly setting the expected culture with a `BeforeAfterTestAttribute` solves this issue.