### PR TITLE
Fix obj null reference exception when run dotnet-svcutil from directory without existing csproj 

### DIFF
--- a/src/dotnet-svcutil/lib/src/CodeDomFixup/CodeDomVisitors/AddAsyncOpenClose.cs
+++ b/src/dotnet-svcutil/lib/src/CodeDomFixup/CodeDomVisitors/AddAsyncOpenClose.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Tools.ServiceModel.Svcutil
 
         public AddAsyncOpenClose(CommandProcessorOptions options)
         {
-            if (options.Project.TargetFrameworks.Count() > 1 && options.Project.TargetFrameworks.Any(t => TargetFrameworkHelper.IsSupportedFramework(t, out FrameworkInfo netfxInfo) && !netfxInfo.IsDnx))
+            if (options.Project != null && options.Project.TargetFrameworks.Count() > 1 && options.Project.TargetFrameworks.Any(t => TargetFrameworkHelper.IsSupportedFramework(t, out FrameworkInfo netfxInfo) && !netfxInfo.IsDnx))
             {
                 _generateCloseAsync = true;
                 FrameworkInfo dnxInfo = null;


### PR DESCRIPTION
Fixing issue #5282 . 
The bug is caused by commit https://github.com/dotnet/wcf/commit/97f9f4d019df9b496052b74f291ef65c0499a961 when addressing CloseAsync() code generation for multitarget project. The fix is when there's no .csproj in the working directory, it will take the else code path as before.