### PR TITLE
Update MessageVersion ref

### DIFF
--- a/src/System.ServiceModel.Primitives/ref/System.ServiceModel.Primitives.Ref.csproj
+++ b/src/System.ServiceModel.Primitives/ref/System.ServiceModel.Primitives.Ref.csproj
@@ -14,6 +14,5 @@
     <Compile Include="System.ServiceModel.Security.cs" />
     <Compile Include="System.ServiceModel.Primitives.Netcoreapp.cs" />
     <Compile Include="System.ServiceModel.Duplex.cs" />
-    <None Include="System.ServiceModel.Primitives.netframework.cs" />
   </ItemGroup>
 </Project>

--- a/src/System.ServiceModel.Primitives/ref/System.ServiceModel.Primitives.cs
+++ b/src/System.ServiceModel.Primitives/ref/System.ServiceModel.Primitives.cs
@@ -1485,7 +1485,9 @@ namespace System.ServiceModel.Channels
         public System.ServiceModel.EnvelopeVersion Envelope { get { return default; } }
         public static System.ServiceModel.Channels.MessageVersion None { get { return default; } }
         public static System.ServiceModel.Channels.MessageVersion Soap11 { get { return default; } }
+        public static System.ServiceModel.Channels.MessageVersion Soap11WSAddressing10 { get { return default; } }
         public static System.ServiceModel.Channels.MessageVersion Soap11WSAddressingAugust2004 { get { return default; } }
+        public static System.ServiceModel.Channels.MessageVersion Soap12 { get { return default; } }
         public static System.ServiceModel.Channels.MessageVersion Soap12WSAddressing10 { get { return default; } }
         public static System.ServiceModel.Channels.MessageVersion Soap12WSAddressingAugust2004 { get { return default; } }
         public static System.ServiceModel.Channels.MessageVersion CreateVersion(System.ServiceModel.EnvelopeVersion envelopeVersion) { return default; }


### PR DESCRIPTION
The MessageVersion properties Soap11WSAddressing10 & Soap12 were missing from the ref.
Also removed the non-existing file System.ServiceModel.Primitives.netframework.cs from the project file.