### PR TITLE
Upgrade dependency package version to resolve security vulnerability.

### DIFF
--- a/src/System.Private.ServiceModel/tests/Scenarios/Binding/UDS/Binding.UDS.IntegrationTests.csproj
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Binding/UDS/Binding.UDS.IntegrationTests.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="CoreWCF.UnixDomainSocket" Version="1.5.0-preview1" />
+    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.0" />
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 


### PR DESCRIPTION
A security vulnerability is found in the `Microsoft.AspNetCore.Http` version **2.1.1** package.

The project `Binding.UDS.IntegrationTests.csproj` referenced `CoreWCF.UnixDomainSocket` package which has following dependencies:
```
CoreWCF.UnixDomainSocket 1.5.0-preview1 
- -> microsoft.aspnetcore.hosting >=2.1.1 
- - - -> microsoft.aspnetcore.http >=2.1.1
```

The fix here is to explicitly reference the upgraded version **2.2.0** of package `microsoft.aspnetcore.http` in the scenario project.