### PR TITLE
[main] Update xlf files for dotnet-svcutil.XmlSerializer.csproj

### DIFF
--- a/src/svcutilcore/src/Resources/xlf/Strings.cs.xlf
+++ b/src/svcutilcore/src/Resources/xlf/Strings.cs.xlf
@@ -237,7 +237,7 @@
     Source: {0}
     Line: {1} Column: {2}
    Validation Error: {3}</source>
-        <target state="translated">Došlo k chybě ověření schématu vygenerovaného během exportu: 
+        <target state="needs-review-translation">Došlo k chybě ověření schématu vygenerovaného během exportu: 
     Zdroj: {0}
     Řádek: {1}, sloupec: {2}
    Chyba ověření: {3}</target>
@@ -276,7 +276,7 @@
       <trans-unit id="ErrUnableToLoadReferenceType">
         <source>There was an error loading a referenced contract type. This type will be ignored.
     Type: {0}</source>
-        <target state="translated">Při načítání odkazovaného typu kontraktu došlo k chybě. Tento typ bude ignorován.
+        <target state="needs-review-translation">Při načítání odkazovaného typu kontraktu došlo k chybě. Tento typ bude ignorován.
     Typ: {0}</target>
         <note />
       </trans-unit>
@@ -635,7 +635,7 @@
 [{1}]
 {2}
 </source>
-        <target state="translated">Nástroj Microsoft (R) dotnet-svcutil.xmlserializer, verze {0}.
+        <target state="needs-review-translation">Nástroj Microsoft (R) dotnet-svcutil.xmlserializer, verze {0}.
 [{1}]
 {2}
 </target>
@@ -650,7 +650,7 @@
         <source>No code was generated.
 If you were trying to generate a client, this could be because the metadata documents did not contain any valid contracts or services
 or because all contracts/services were discovered to exist in /reference assemblies. Verify that you passed all the metadata documents to the tool.</source>
-        <target state="translated">Nebyl vygenerován žádný kód.
+        <target state="needs-review-translation">Nebyl vygenerován žádný kód.
 Pokud jste se pokoušeli vygenerovat klienta, může k tomuto dojít v případě, že dokumenty metadat neobsahovaly žádné platné kontrakty ani služby,
 nebo bylo zjištěno, že všechny kontrakty nebo služby existují v sestaveních /reference. Ověřte, že jste nástroji předali všechny dokumenty metadat.</target>
         <note />
@@ -749,7 +749,7 @@ nebo bylo zjištěno, že všechny kontrakty nebo služby existují v sestavení
         <source>There was an error loading a contract type. Cannot generate XmlSerializer types for this contract.
     Type: {0}
     Details:{1}</source>
-        <target state="translated">Při načítání typu kontraktu došlo k chybě. Nelze generovat typy XmlSerializer pro tento kontrakt.
+        <target state="needs-review-translation">Při načítání typu kontraktu došlo k chybě. Nelze generovat typy XmlSerializer pro tento kontrakt.
     Typ: {0}
     Podrobnosti: {1}</target>
         <note />

--- a/src/svcutilcore/src/Resources/xlf/Strings.de.xlf
+++ b/src/svcutilcore/src/Resources/xlf/Strings.de.xlf
@@ -237,7 +237,7 @@
     Source: {0}
     Line: {1} Column: {2}
    Validation Error: {3}</source>
-        <target state="translated">Validierungsfehler bei einem Schema, das während des Exports generiert wurde: 
+        <target state="needs-review-translation">Validierungsfehler bei einem Schema, das während des Exports generiert wurde: 
     Quelle: {0}
     Zeile: {1} Spalte: {2}
    Validierungsfehler: {3}</target>
@@ -276,7 +276,7 @@
       <trans-unit id="ErrUnableToLoadReferenceType">
         <source>There was an error loading a referenced contract type. This type will be ignored.
     Type: {0}</source>
-        <target state="translated">Fehler beim Laden eines referenzierten Vertragstyps. Dieser Typ wird ignoriert.
+        <target state="needs-review-translation">Fehler beim Laden eines referenzierten Vertragstyps. Dieser Typ wird ignoriert.
     Typ: {0}</target>
         <note />
       </trans-unit>
@@ -635,7 +635,7 @@
 [{1}]
 {2}
 </source>
-        <target state="translated">Microsoft (R) dotnet-svcutil.xmlserializer-Tool, Version {0}.
+        <target state="needs-review-translation">Microsoft (R) dotnet-svcutil.xmlserializer-Tool, Version {0}.
 [{1}]
 {2}
 </target>
@@ -650,7 +650,7 @@
         <source>No code was generated.
 If you were trying to generate a client, this could be because the metadata documents did not contain any valid contracts or services
 or because all contracts/services were discovered to exist in /reference assemblies. Verify that you passed all the metadata documents to the tool.</source>
-        <target state="translated">Es wurde kein Code generiert.
+        <target state="needs-review-translation">Es wurde kein Code generiert.
 Wenn Sie versucht haben, einen Client zu generieren, könnte die Ursache hierfür sein, dass die Metadatendokumente keine gültigen Verträge oder Dienste enthielten
 oder dass erkannt wurde, dass sich alle Verträge/Dienste in /reference-Assemblys befinden. Stellen Sie sicher, dass alle Metadatendokumente an das Tool übergeben wurden.</target>
         <note />
@@ -749,7 +749,7 @@ oder dass erkannt wurde, dass sich alle Verträge/Dienste in /reference-Assembly
         <source>There was an error loading a contract type. Cannot generate XmlSerializer types for this contract.
     Type: {0}
     Details:{1}</source>
-        <target state="translated">Fehler beim Laden eines Vertragstyps. XmlSerializer-Typen für diesen Vertrag können nicht generiert werden.
+        <target state="needs-review-translation">Fehler beim Laden eines Vertragstyps. XmlSerializer-Typen für diesen Vertrag können nicht generiert werden.
     Typ: {0}
     Details: {1}</target>
         <note />

--- a/src/svcutilcore/src/Resources/xlf/Strings.es.xlf
+++ b/src/svcutilcore/src/Resources/xlf/Strings.es.xlf
@@ -237,7 +237,7 @@
     Source: {0}
     Line: {1} Column: {2}
    Validation Error: {3}</source>
-        <target state="translated">Error de validación en un esquema generado durante la exportación:
+        <target state="needs-review-translation">Error de validación en un esquema generado durante la exportación:
     Origen: {0}
     Línea: {1} Columna: {2}
    Error de validación: {3}</target>
@@ -276,7 +276,7 @@
       <trans-unit id="ErrUnableToLoadReferenceType">
         <source>There was an error loading a referenced contract type. This type will be ignored.
     Type: {0}</source>
-        <target state="translated">Error al cargar un tipo de contrato al que se hace referencia. Este tipo se omitirá.
+        <target state="needs-review-translation">Error al cargar un tipo de contrato al que se hace referencia. Este tipo se omitirá.
     Tipo: {0}</target>
         <note />
       </trans-unit>
@@ -635,7 +635,7 @@
 [{1}]
 {2}
 </source>
-        <target state="translated">Herramienta dotnet-svcutil.xmlserializer de Microsoft (R), versión {0}.
+        <target state="needs-review-translation">Herramienta dotnet-svcutil.xmlserializer de Microsoft (R), versión {0}.
 [{1}]
 {2}
 </target>
@@ -650,7 +650,7 @@
         <source>No code was generated.
 If you were trying to generate a client, this could be because the metadata documents did not contain any valid contracts or services
 or because all contracts/services were discovered to exist in /reference assemblies. Verify that you passed all the metadata documents to the tool.</source>
-        <target state="translated">No se generó código.
+        <target state="needs-review-translation">No se generó código.
 Si intentaba generar un cliente, es posible que se deba a que los documentos de metadatos no contenían contratos o servicios válidos, 
 o bien porque se detectó que todos los contratos y servicios existen en los /ensamblados de referencia. Compruebe que pasó todos los documentos de metadatos a la herramienta.</target>
         <note />
@@ -749,7 +749,7 @@ o bien porque se detectó que todos los contratos y servicios existen en los /en
         <source>There was an error loading a contract type. Cannot generate XmlSerializer types for this contract.
     Type: {0}
     Details:{1}</source>
-        <target state="translated">Error al cargar un tipo de contrato. No se pueden generar tipos XmlSerializer para este contrato.
+        <target state="needs-review-translation">Error al cargar un tipo de contrato. No se pueden generar tipos XmlSerializer para este contrato.
     Tipo: {0}
     Detalles:{1}</target>
         <note />

--- a/src/svcutilcore/src/Resources/xlf/Strings.fr.xlf
+++ b/src/svcutilcore/src/Resources/xlf/Strings.fr.xlf
@@ -237,7 +237,7 @@
     Source: {0}
     Line: {1} Column: {2}
    Validation Error: {3}</source>
-        <target state="translated">Une erreur de validation s’est produite sur un schéma généré lors de l’exportation :
+        <target state="needs-review-translation">Une erreur de validation s’est produite sur un schéma généré lors de l’exportation :
     Source : {0}
     Ligne {1} Colonne : {2}
    Erreur de validation : {3}</target>
@@ -276,7 +276,7 @@
       <trans-unit id="ErrUnableToLoadReferenceType">
         <source>There was an error loading a referenced contract type. This type will be ignored.
     Type: {0}</source>
-        <target state="translated">Une erreur s’est produite lors du chargement d’un type de contrat référencé. Ce type sera ignoré.
+        <target state="needs-review-translation">Une erreur s’est produite lors du chargement d’un type de contrat référencé. Ce type sera ignoré.
     Type : {0}</target>
         <note />
       </trans-unit>
@@ -635,7 +635,7 @@
 [{1}]
 {2}
 </source>
-        <target state="translated">Microsoft (R) dotnet-svcutil.xmlserializer tool, Version {0}.
+        <target state="needs-review-translation">Microsoft (R) dotnet-svcutil.xmlserializer tool, Version {0}.
 [{1}]
 {2}
 </target>
@@ -650,7 +650,7 @@
         <source>No code was generated.
 If you were trying to generate a client, this could be because the metadata documents did not contain any valid contracts or services
 or because all contracts/services were discovered to exist in /reference assemblies. Verify that you passed all the metadata documents to the tool.</source>
-        <target state="translated">Aucun code n'a été généré.
+        <target state="needs-review-translation">Aucun code n'a été généré.
 Si vous essayiez de générer un client, cela peut être dû au fait que les documents de métadonnées ne contenaient aucun service ou contrat valide
 ou que les contrats/services existaient déjà dans des assemblys de référence. Vérifiez que vous avez indiqué tous les documents de métadonnées à l'outil.</target>
         <note />
@@ -749,7 +749,7 @@ ou que les contrats/services existaient déjà dans des assemblys de référence
         <source>There was an error loading a contract type. Cannot generate XmlSerializer types for this contract.
     Type: {0}
     Details:{1}</source>
-        <target state="translated">Une erreur s’est produite lors du chargement d’un type de contrat. Impossible de générer des types XmlSerializer pour ce contrat.
+        <target state="needs-review-translation">Une erreur s’est produite lors du chargement d’un type de contrat. Impossible de générer des types XmlSerializer pour ce contrat.
     Type : {0}
     Détails : {1}</target>
         <note />

--- a/src/svcutilcore/src/Resources/xlf/Strings.it.xlf
+++ b/src/svcutilcore/src/Resources/xlf/Strings.it.xlf
@@ -237,7 +237,7 @@
     Source: {0}
     Line: {1} Column: {2}
    Validation Error: {3}</source>
-        <target state="translated">Errore di convalida in uno schema generato durante l'esportazione:
+        <target state="needs-review-translation">Errore di convalida in uno schema generato durante l'esportazione:
     Origine: {0}
     Riga: {1} Colonna: {2}
    Errore di convalida: {3}</target>
@@ -276,7 +276,7 @@
       <trans-unit id="ErrUnableToLoadReferenceType">
         <source>There was an error loading a referenced contract type. This type will be ignored.
     Type: {0}</source>
-        <target state="translated">Si è verificato un errore durante il caricamento di un tipo di contratto di riferimento. Questo tipo verrà ignorato.
+        <target state="needs-review-translation">Si è verificato un errore durante il caricamento di un tipo di contratto di riferimento. Questo tipo verrà ignorato.
     Tipo: {0}</target>
         <note />
       </trans-unit>
@@ -635,7 +635,7 @@
 [{1}]
 {2}
 </source>
-        <target state="translated">Strumento Microsoft (R) dotnet-svcutil.xmlserializer, versione {0}.
+        <target state="needs-review-translation">Strumento Microsoft (R) dotnet-svcutil.xmlserializer, versione {0}.
 [{1}]
 {2}
 </target>
@@ -650,7 +650,7 @@
         <source>No code was generated.
 If you were trying to generate a client, this could be because the metadata documents did not contain any valid contracts or services
 or because all contracts/services were discovered to exist in /reference assemblies. Verify that you passed all the metadata documents to the tool.</source>
-        <target state="translated">Nessun codice generato.
+        <target state="needs-review-translation">Nessun codice generato.
 Se si sta tentando di creare un client, ciò può essere dovuto al fatto che i documenti dei metadati non contengono contratti o servizi validi
 oppure tutti i contratti/servizi sono presenti negli assembly /reference. Verificare di aver passato tutti i documenti dei metadati allo strumento.</target>
         <note />
@@ -749,7 +749,7 @@ oppure tutti i contratti/servizi sono presenti negli assembly /reference. Verifi
         <source>There was an error loading a contract type. Cannot generate XmlSerializer types for this contract.
     Type: {0}
     Details:{1}</source>
-        <target state="translated">Si è verificato un errore durante il caricamento di un tipo di contratto. Non è possibile generare tipi XmlSerializer per questo contratto.
+        <target state="needs-review-translation">Si è verificato un errore durante il caricamento di un tipo di contratto. Non è possibile generare tipi XmlSerializer per questo contratto.
     Tipo: {0}
     Dettagli:{1}</target>
         <note />

--- a/src/svcutilcore/src/Resources/xlf/Strings.ja.xlf
+++ b/src/svcutilcore/src/Resources/xlf/Strings.ja.xlf
@@ -237,7 +237,7 @@
     Source: {0}
     Line: {1} Column: {2}
    Validation Error: {3}</source>
-        <target state="translated">
+        <target state="needs-review-translation">
  のエクスポート中に生成されたスキーマで検証エラーが発生しました。
    ソース: {0}
    行: {1} 列: {2}
@@ -277,7 +277,7 @@
       <trans-unit id="ErrUnableToLoadReferenceType">
         <source>There was an error loading a referenced contract type. This type will be ignored.
     Type: {0}</source>
-        <target state="translated">参照されたコントラクト型の読み込み中にエラーが発生しました。この種類は無視されます。
+        <target state="needs-review-translation">参照されたコントラクト型の読み込み中にエラーが発生しました。この種類は無視されます。
    種類: {0}</target>
         <note />
       </trans-unit>
@@ -636,7 +636,7 @@
 [{1}]
 {2}
 </source>
-        <target state="translated">Microsoft (R) dotnet-svcutil.xmlserializer ツール、バージョン {0}.
+        <target state="needs-review-translation">Microsoft (R) dotnet-svcutil.xmlserializer ツール、バージョン {0}.
 [{1}]
 {2}
 </target>
@@ -651,7 +651,7 @@
         <source>No code was generated.
 If you were trying to generate a client, this could be because the metadata documents did not contain any valid contracts or services
 or because all contracts/services were discovered to exist in /reference assemblies. Verify that you passed all the metadata documents to the tool.</source>
-        <target state="translated">コードは生成されませんでした。
+        <target state="needs-review-translation">コードは生成されませんでした。
 クライアントを生成しようとしていた場合は、メタデータ ドキュメントに有効なコントラクトまたはサービスが含まれていなかったか、
 すべてのコントラクト/サービスが /reference アセンブリ内に存在することが検出された可能性があります。すべてのメタデータ ドキュメントをツールに渡したことを確認してください。</target>
         <note />
@@ -750,7 +750,7 @@ or because all contracts/services were discovered to exist in /reference assembl
         <source>There was an error loading a contract type. Cannot generate XmlSerializer types for this contract.
     Type: {0}
     Details:{1}</source>
-        <target state="translated">コントラクト型の読み込み中にエラーが発生しました。このコントラクトの XmlSerializer 型を生成できません。
+        <target state="needs-review-translation">コントラクト型の読み込み中にエラーが発生しました。このコントラクトの XmlSerializer 型を生成できません。
    型: {0}
    詳細: {1}</target>
         <note />

--- a/src/svcutilcore/src/Resources/xlf/Strings.ko.xlf
+++ b/src/svcutilcore/src/Resources/xlf/Strings.ko.xlf
@@ -237,7 +237,7 @@
     Source: {0}
     Line: {1} Column: {2}
    Validation Error: {3}</source>
-        <target state="translated">내보내는 동안 생성된 스키마에 유효성 검사 오류가 발생: 
+        <target state="needs-review-translation">내보내는 동안 생성된 스키마에 유효성 검사 오류가 발생: 
     원본: {0}
     줄: {1} 열: {2}
    유효성 검사 오류: {3}</target>
@@ -276,7 +276,7 @@
       <trans-unit id="ErrUnableToLoadReferenceType">
         <source>There was an error loading a referenced contract type. This type will be ignored.
     Type: {0}</source>
-        <target state="translated">참조된 계약 형식을 로드하는 동안 오류가 발생했습니다. 이 형식은 무시됩니다.
+        <target state="needs-review-translation">참조된 계약 형식을 로드하는 동안 오류가 발생했습니다. 이 형식은 무시됩니다.
     형식: {0}</target>
         <note />
       </trans-unit>
@@ -635,7 +635,7 @@
 [{1}]
 {2}
 </source>
-        <target state="translated">Microsoft (R) dotnet-svcutil.xmlserializer 도구, 버전 {0}.
+        <target state="needs-review-translation">Microsoft (R) dotnet-svcutil.xmlserializer 도구, 버전 {0}.
 [{1}]
 {2}
 </target>
@@ -650,7 +650,7 @@
         <source>No code was generated.
 If you were trying to generate a client, this could be because the metadata documents did not contain any valid contracts or services
 or because all contracts/services were discovered to exist in /reference assemblies. Verify that you passed all the metadata documents to the tool.</source>
-        <target state="translated">코드가 생성되지 않았습니다.
+        <target state="needs-review-translation">코드가 생성되지 않았습니다.
 클라이언트를 생성하려고 하는 경우 메타데이터 문서에 올바른 계약 또는 서비스가 포함되지 않았거나
 모든 계약/서비스가 /reference assemblies에 있기 때문일 수 있습니다. 모든 메타데이터 문서를 도구에 전달했는지 확인하십시오.</target>
         <note />
@@ -749,7 +749,7 @@ or because all contracts/services were discovered to exist in /reference assembl
         <source>There was an error loading a contract type. Cannot generate XmlSerializer types for this contract.
     Type: {0}
     Details:{1}</source>
-        <target state="translated">계약 형식을 로드하는 동안 오류가 발생했습니다. 이 계약에 대한 XmlSerializer 형식을 생성할 수 없습니다.
+        <target state="needs-review-translation">계약 형식을 로드하는 동안 오류가 발생했습니다. 이 계약에 대한 XmlSerializer 형식을 생성할 수 없습니다.
     형식: {0}
     세부 정보:{1}</target>
         <note />

--- a/src/svcutilcore/src/Resources/xlf/Strings.pl.xlf
+++ b/src/svcutilcore/src/Resources/xlf/Strings.pl.xlf
@@ -237,7 +237,7 @@
     Source: {0}
     Line: {1} Column: {2}
    Validation Error: {3}</source>
-        <target state="translated">Wystąpił błąd weryfikacji schematu wygenerowanego podczas eksportowania:
+        <target state="needs-review-translation">Wystąpił błąd weryfikacji schematu wygenerowanego podczas eksportowania:
     Źródło: {0}
     Wiersz: {1}, kolumna: {2}
    Błąd walidacji: {3}</target>
@@ -276,7 +276,7 @@
       <trans-unit id="ErrUnableToLoadReferenceType">
         <source>There was an error loading a referenced contract type. This type will be ignored.
     Type: {0}</source>
-        <target state="translated">Wystąpił błąd podczas ładowania przywoływanego typu kontraktu. Ten typ zostanie zignorowany.
+        <target state="needs-review-translation">Wystąpił błąd podczas ładowania przywoływanego typu kontraktu. Ten typ zostanie zignorowany.
     Typ: {0}</target>
         <note />
       </trans-unit>
@@ -635,7 +635,7 @@
 [{1}]
 {2}
 </source>
-        <target state="translated">Narzędzie Microsoft (R) dotnet-svcutil.xmlserializer, wersja {0}.
+        <target state="needs-review-translation">Narzędzie Microsoft (R) dotnet-svcutil.xmlserializer, wersja {0}.
 [{1}]
 {2}
 </target>
@@ -650,7 +650,7 @@
         <source>No code was generated.
 If you were trying to generate a client, this could be because the metadata documents did not contain any valid contracts or services
 or because all contracts/services were discovered to exist in /reference assemblies. Verify that you passed all the metadata documents to the tool.</source>
-        <target state="translated">Nie wygenerowano żadnego kodu.
+        <target state="needs-review-translation">Nie wygenerowano żadnego kodu.
 Jeśli próbowano wygenerować klienta, może być to spowodowane przez dokumenty metadanych, które nie zawierały żadnych prawidłowych kontraktów lub usług,
 albo przez to, że wszystkie kontrakty/usługi zostały odnalezione jako istniejące w zestawach /reference. Upewnij się, że do narzędzia przekazano wszystkie dokumenty metadanych.</target>
         <note />
@@ -749,7 +749,7 @@ albo przez to, że wszystkie kontrakty/usługi zostały odnalezione jako istniej
         <source>There was an error loading a contract type. Cannot generate XmlSerializer types for this contract.
     Type: {0}
     Details:{1}</source>
-        <target state="translated">Wystąpił błąd podczas ładowania typu kontraktu. Nie można wygenerować typów XmlSerializer dla tego kontraktu.
+        <target state="needs-review-translation">Wystąpił błąd podczas ładowania typu kontraktu. Nie można wygenerować typów XmlSerializer dla tego kontraktu.
     Typ: {0}
     Szczegóły: {1}</target>
         <note />

--- a/src/svcutilcore/src/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/svcutilcore/src/Resources/xlf/Strings.pt-BR.xlf
@@ -237,7 +237,7 @@
     Source: {0}
     Line: {1} Column: {2}
    Validation Error: {3}</source>
-        <target state="translated">Ocorreu um erro de validação em um esquema gerado durante a exportação:
+        <target state="needs-review-translation">Ocorreu um erro de validação em um esquema gerado durante a exportação:
     Origem: {0}
     Linha: {1} Coluna: {2}
    Erro de Validação: {3}</target>
@@ -276,7 +276,7 @@
       <trans-unit id="ErrUnableToLoadReferenceType">
         <source>There was an error loading a referenced contract type. This type will be ignored.
     Type: {0}</source>
-        <target state="translated">Ocorreu um erro ao carregar um tipo de contrato referenciado. Esse tipo será ignorado.
+        <target state="needs-review-translation">Ocorreu um erro ao carregar um tipo de contrato referenciado. Esse tipo será ignorado.
     Tipo: {0}</target>
         <note />
       </trans-unit>
@@ -635,7 +635,7 @@
 [{1}]
 {2}
 </source>
-        <target state="translated">Ferramenta Microsoft (R) dotnet-svcutil.xmlserializer, Versão {0}.
+        <target state="needs-review-translation">Ferramenta Microsoft (R) dotnet-svcutil.xmlserializer, Versão {0}.
 [{1}]
 {2}
 </target>
@@ -650,7 +650,7 @@
         <source>No code was generated.
 If you were trying to generate a client, this could be because the metadata documents did not contain any valid contracts or services
 or because all contracts/services were discovered to exist in /reference assemblies. Verify that you passed all the metadata documents to the tool.</source>
-        <target state="translated">Nenhum código foi gerado.
+        <target state="needs-review-translation">Nenhum código foi gerado.
 Se você estivesse tentando gerar um cliente, isso poderia ocorrer porque os documentos de metadados não continham nenhum contrato nem serviço válido
 ou porque descobriu-se que todos os contratos/serviços existiam em assemblies /reference. Verifique se você passou todos os documentos de metadados à ferramenta.</target>
         <note />
@@ -749,7 +749,7 @@ ou porque descobriu-se que todos os contratos/serviços existiam em assemblies /
         <source>There was an error loading a contract type. Cannot generate XmlSerializer types for this contract.
     Type: {0}
     Details:{1}</source>
-        <target state="translated">Erro ao carregar um tipo de contrato. Não é possível gerar tipos XmlSerializer para este contrato.
+        <target state="needs-review-translation">Erro ao carregar um tipo de contrato. Não é possível gerar tipos XmlSerializer para este contrato.
     Tipo: {0}
     Detalhes:{1}</target>
         <note />

--- a/src/svcutilcore/src/Resources/xlf/Strings.ru.xlf
+++ b/src/svcutilcore/src/Resources/xlf/Strings.ru.xlf
@@ -237,7 +237,7 @@
     Source: {0}
     Line: {1} Column: {2}
    Validation Error: {3}</source>
-        <target state="translated">Произошла ошибка проверки схемы, созданной во время экспорта:
+        <target state="needs-review-translation">Произошла ошибка проверки схемы, созданной во время экспорта:
     Источник: {0}
     Строка: {1} столбец: {2}
    Ошибка проверки: {3}</target>
@@ -276,7 +276,7 @@
       <trans-unit id="ErrUnableToLoadReferenceType">
         <source>There was an error loading a referenced contract type. This type will be ignored.
     Type: {0}</source>
-        <target state="translated">Произошла ошибка при загрузке указанного типа контракта. Этот тип будет пропущен.
+        <target state="needs-review-translation">Произошла ошибка при загрузке указанного типа контракта. Этот тип будет пропущен.
     Тип: {0}</target>
         <note />
       </trans-unit>
@@ -635,7 +635,7 @@
 [{1}]
 {2}
 </source>
-        <target state="translated">Средство Microsoft (R) dotnet-svcutil.xmlserializer, версия{0}.
+        <target state="needs-review-translation">Средство Microsoft (R) dotnet-svcutil.xmlserializer, версия{0}.
 [{1}]
 {2}
 </target>
@@ -650,7 +650,7 @@
         <source>No code was generated.
 If you were trying to generate a client, this could be because the metadata documents did not contain any valid contracts or services
 or because all contracts/services were discovered to exist in /reference assemblies. Verify that you passed all the metadata documents to the tool.</source>
-        <target state="translated">Код не сгенерирован.
+        <target state="needs-review-translation">Код не сгенерирован.
 Если вы пытались сгенерировать клиент, причиной этого может быть то, что документы метаданных не содержат допустимых контрактов или служб,
 или все контракты и службы были обнаружены в сборках, указанных в параметре /reference. Убедитесь, что в программное средство переданы все документы метаданных.</target>
         <note />
@@ -749,7 +749,7 @@ or because all contracts/services were discovered to exist in /reference assembl
         <source>There was an error loading a contract type. Cannot generate XmlSerializer types for this contract.
     Type: {0}
     Details:{1}</source>
-        <target state="translated">Произошла ошибка при загрузке типа контракта. Не удается сформировать типы XmlSerializer для этого контракта.
+        <target state="needs-review-translation">Произошла ошибка при загрузке типа контракта. Не удается сформировать типы XmlSerializer для этого контракта.
     Тип: {0}
     Сведения:{1}</target>
         <note />

--- a/src/svcutilcore/src/Resources/xlf/Strings.tr.xlf
+++ b/src/svcutilcore/src/Resources/xlf/Strings.tr.xlf
@@ -237,7 +237,7 @@
     Source: {0}
     Line: {1} Column: {2}
    Validation Error: {3}</source>
-        <target state="translated">Dışarı aktarma sırasında oluşturulan şemada doğrulama hatası oluştu:
+        <target state="needs-review-translation">Dışarı aktarma sırasında oluşturulan şemada doğrulama hatası oluştu:
     Kaynak: {0}
     Satır: {1} Sütun: {2}
    Doğrulama Hatası: {3}</target>
@@ -276,7 +276,7 @@
       <trans-unit id="ErrUnableToLoadReferenceType">
         <source>There was an error loading a referenced contract type. This type will be ignored.
     Type: {0}</source>
-        <target state="translated">Başvurulan anlaşma türü yüklenirken bir hata oluştu. Bu tür yoksayılır.
+        <target state="needs-review-translation">Başvurulan anlaşma türü yüklenirken bir hata oluştu. Bu tür yoksayılır.
     Tür: {0}</target>
         <note />
       </trans-unit>
@@ -635,7 +635,7 @@
 [{1}]
 {2}
 </source>
-        <target state="translated">Microsoft (R) dotnet-svcutil.xmlserializer aracı, Sürüm {0}.
+        <target state="needs-review-translation">Microsoft (R) dotnet-svcutil.xmlserializer aracı, Sürüm {0}.
 [{1}]
 {2}
 </target>
@@ -650,7 +650,7 @@
         <source>No code was generated.
 If you were trying to generate a client, this could be because the metadata documents did not contain any valid contracts or services
 or because all contracts/services were discovered to exist in /reference assemblies. Verify that you passed all the metadata documents to the tool.</source>
-        <target state="translated">Kod oluşturulmadı.
+        <target state="needs-review-translation">Kod oluşturulmadı.
 İstemci oluşturmaya çalışıyorsanız bunun nedeni meta veri belgelerinin geçerli anlaşma veya hizmetler içermemesi
 ya da bulunan tüm anlaşma ve hizmetlerin /reference bütünleştirilmiş kodlarında yer alması olabilir. Araca tüm meta veri belgelerini geçirdiğinizi doğrulayın.</target>
         <note />
@@ -749,7 +749,7 @@ ya da bulunan tüm anlaşma ve hizmetlerin /reference bütünleştirilmiş kodla
         <source>There was an error loading a contract type. Cannot generate XmlSerializer types for this contract.
     Type: {0}
     Details:{1}</source>
-        <target state="translated">Anlaşma türü yüklenirken bir hata oluştu. Bu anlaşma için XmlSerializer türleri oluşturulamıyor.
+        <target state="needs-review-translation">Anlaşma türü yüklenirken bir hata oluştu. Bu anlaşma için XmlSerializer türleri oluşturulamıyor.
     Tür: {0}
     Ayrıntılar:{1}</target>
         <note />

--- a/src/svcutilcore/src/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/svcutilcore/src/Resources/xlf/Strings.zh-Hans.xlf
@@ -237,7 +237,7 @@
     Source: {0}
     Line: {1} Column: {2}
    Validation Error: {3}</source>
-        <target state="translated">导出期间生成的架构出现验证错误:
+        <target state="needs-review-translation">导出期间生成的架构出现验证错误:
    源:{0}
    行: {1} 列: {2}
   验证错误: {3}</target>
@@ -276,7 +276,7 @@
       <trans-unit id="ErrUnableToLoadReferenceType">
         <source>There was an error loading a referenced contract type. This type will be ignored.
     Type: {0}</source>
-        <target state="translated">加载引用的协定类型时出错。将忽略此类型。
+        <target state="needs-review-translation">加载引用的协定类型时出错。将忽略此类型。
    类型: {0}</target>
         <note />
       </trans-unit>
@@ -635,7 +635,7 @@
 [{1}]
 {2}
 </source>
-        <target state="translated">Microsoft (R) dotnet-svcutil.xmlserializer 工具，版本 {0}。
+        <target state="needs-review-translation">Microsoft (R) dotnet-svcutil.xmlserializer 工具，版本 {0}。
 [{1}]
 {2}
 </target>
@@ -650,7 +650,7 @@
         <source>No code was generated.
 If you were trying to generate a client, this could be because the metadata documents did not contain any valid contracts or services
 or because all contracts/services were discovered to exist in /reference assemblies. Verify that you passed all the metadata documents to the tool.</source>
-        <target state="translated">未生成任何代码。
+        <target state="needs-review-translation">未生成任何代码。
 如果尝试生成客户端，此问题可能是由于元数据文档中未包含任何有效的约定或服务所致，
 或者由于发现所有约定/服务均存在于 /reference 程序集中所致。请验证是否已将所有元数据文档传递给工具。</target>
         <note />
@@ -749,7 +749,7 @@ or because all contracts/services were discovered to exist in /reference assembl
         <source>There was an error loading a contract type. Cannot generate XmlSerializer types for this contract.
     Type: {0}
     Details:{1}</source>
-        <target state="translated">加载合约类型时出错。无法为此合约生成 XmlSerializer 类型。
+        <target state="needs-review-translation">加载合约类型时出错。无法为此合约生成 XmlSerializer 类型。
    类型: {0}
    详细信息:{1}</target>
         <note />

--- a/src/svcutilcore/src/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/svcutilcore/src/Resources/xlf/Strings.zh-Hant.xlf
@@ -237,7 +237,7 @@
     Source: {0}
     Line: {1} Column: {2}
    Validation Error: {3}</source>
-        <target state="translated">匯出期間產生的結構描述上發生驗證錯誤:
+        <target state="needs-review-translation">匯出期間產生的結構描述上發生驗證錯誤:
    來源: {0}
    行: {1} 資料行: {2}
   驗證錯誤: {3}</target>
@@ -276,7 +276,7 @@
       <trans-unit id="ErrUnableToLoadReferenceType">
         <source>There was an error loading a referenced contract type. This type will be ignored.
     Type: {0}</source>
-        <target state="translated">載入參考的合約類型時發生錯誤。將忽略此類型。
+        <target state="needs-review-translation">載入參考的合約類型時發生錯誤。將忽略此類型。
    類型: {0}</target>
         <note />
       </trans-unit>
@@ -635,7 +635,7 @@
 [{1}]
 {2}
 </source>
-        <target state="translated">Microsoft (R) dotnet-svcutil.xmlserializer 工具，版本 {0}。
+        <target state="needs-review-translation">Microsoft (R) dotnet-svcutil.xmlserializer 工具，版本 {0}。
 [{1}]
 {2}
 </target>
@@ -650,7 +650,7 @@
         <source>No code was generated.
 If you were trying to generate a client, this could be because the metadata documents did not contain any valid contracts or services
 or because all contracts/services were discovered to exist in /reference assemblies. Verify that you passed all the metadata documents to the tool.</source>
-        <target state="translated">未產生任何程式碼。
+        <target state="needs-review-translation">未產生任何程式碼。
 若嘗試產生用戶端，這可能是因為中繼資料文件未包含任何有效的合約或服務，或因為所有
 合約/服務被發現存在於 /reference 組件中。請確認您已將所有中繼資料文件傳遞給工具。</target>
         <note />
@@ -749,7 +749,7 @@ or because all contracts/services were discovered to exist in /reference assembl
         <source>There was an error loading a contract type. Cannot generate XmlSerializer types for this contract.
     Type: {0}
     Details:{1}</source>
-        <target state="translated">載入合約類型時發生錯誤。無法產生此合約的 XmlSerializer 類型。
+        <target state="needs-review-translation">載入合約類型時發生錯誤。無法產生此合約的 XmlSerializer 類型。
    類型: {0}
    詳細資料: {1}</target>
         <note />


### PR DESCRIPTION

The new resource file including Xlf files have been added and merged, but CI build for shipping dotnet-svcutil.XmlSerializer still failed with error: 
```
Microsoft.DotNet.XliffTasks.targets(84,5): error : 'Resources\xlf\Strings.cs.xlf' is out-of-date with 'Resources\Strings.resx'. 

Run `msbuild /t:UpdateXlf` to update .xlf files or set UpdateXlfOnBuild=true to update them.
```

As suggested in the error message, I have run the build command locally with the option "/p:UpdateXlfOnBuild=true" which created the source code changes in this PR. All changes are multi-line strings. I'm not sure if this is part of the work item of the overall localization process.