### PR TITLE
Remove configuration api.

### DIFF
--- a/src/System.ServiceModel.Http/src/System/ServiceModel/NetHttpBinding.cs
+++ b/src/System.ServiceModel.Http/src/System/ServiceModel/NetHttpBinding.cs
@@ -32,12 +32,6 @@ namespace System.ServiceModel
             ReliableSession.Enabled = reliableSessionEnabled;
         }
 
-        public NetHttpBinding(string configurationName)
-            : base()
-        {
-            Initialize();
-        }
-
         private NetHttpBinding(BasicHttpSecurity security)
             : base()
         {

--- a/src/System.ServiceModel.NetTcp/src/System/ServiceModel/NetTcpBinding.cs
+++ b/src/System.ServiceModel.NetTcp/src/System/ServiceModel/NetTcpBinding.cs
@@ -32,15 +32,6 @@ namespace System.ServiceModel
             ReliableSession.Enabled = reliableSessionEnabled;
         }
 
-        public NetTcpBinding(string configurationName)
-            : this()
-        {
-            if (!string.IsNullOrEmpty(configurationName))
-            {
-                throw new PlatformNotSupportedException();
-            }
-        }
-
         [DefaultValue(ConnectionOrientedTransportDefaults.TransferMode)]
         public TransferMode TransferMode
         {

--- a/src/System.ServiceModel.Primitives/ref/System.ServiceModel.Duplex.cs
+++ b/src/System.ServiceModel.Primitives/ref/System.ServiceModel.Duplex.cs
@@ -36,10 +36,6 @@ namespace System.ServiceModel
         public DuplexChannelFactory(System.ServiceModel.InstanceContext callbackInstance, System.ServiceModel.Channels.Binding binding) : base(default(System.Type)) { }
         public DuplexChannelFactory(System.ServiceModel.InstanceContext callbackInstance, System.ServiceModel.Channels.Binding binding, System.ServiceModel.EndpointAddress remoteAddress) : base(default(System.Type)) { }
         public DuplexChannelFactory(System.ServiceModel.InstanceContext callbackInstance, System.ServiceModel.Channels.Binding binding, string remoteAddress) : base(default(System.Type)) { }
-        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
-        public DuplexChannelFactory(System.ServiceModel.InstanceContext callbackInstance, string endpointConfigurationName) : base(default(System.Type)) { }
-        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
-        public DuplexChannelFactory(System.ServiceModel.InstanceContext callbackInstance, string endpointConfigurationName, System.ServiceModel.EndpointAddress remoteAddress) : base(default(System.Type)) { }
         public override TChannel CreateChannel(System.ServiceModel.EndpointAddress address, System.Uri via) { return default(TChannel); }
         public TChannel CreateChannel(System.ServiceModel.InstanceContext callbackInstance) { return default(TChannel); }
         public TChannel CreateChannel(System.ServiceModel.InstanceContext callbackInstance, System.ServiceModel.EndpointAddress address) { return default(TChannel); }
@@ -49,11 +45,5 @@ namespace System.ServiceModel
     {
         protected DuplexClientBase(System.ServiceModel.InstanceContext callbackInstance) { }
         protected DuplexClientBase(System.ServiceModel.InstanceContext callbackInstance, System.ServiceModel.Channels.Binding binding, System.ServiceModel.EndpointAddress remoteAddress) { }
-        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
-        protected DuplexClientBase(System.ServiceModel.InstanceContext callbackInstance, string endpointConfigurationName) { }
-        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
-        protected DuplexClientBase(System.ServiceModel.InstanceContext callbackInstance, string endpointConfigurationName, System.ServiceModel.EndpointAddress remoteAddress) { }
-        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
-        protected DuplexClientBase(System.ServiceModel.InstanceContext callbackInstance, string endpointConfigurationName, string remoteAddress) { }
     }
 }

--- a/src/System.ServiceModel.Primitives/ref/System.ServiceModel.Primitives.cs
+++ b/src/System.ServiceModel.Primitives/ref/System.ServiceModel.Primitives.cs
@@ -236,16 +236,12 @@ namespace System.ServiceModel
         protected override System.TimeSpan DefaultCloseTimeout { get { return default; } }
         protected override System.TimeSpan DefaultOpenTimeout { get { return default; } }
         public System.ServiceModel.Description.ServiceEndpoint Endpoint { get { return default; } }
-        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
-        protected virtual void ApplyConfiguration(string configurationName) { }
         protected abstract System.ServiceModel.Description.ServiceEndpoint CreateDescription();
         protected virtual System.ServiceModel.Channels.IChannelFactory CreateFactory() { return default; }
         protected internal void EnsureOpened() { }
         public T GetProperty<T>() where T : class { return default; }
         protected void InitializeEndpoint(System.ServiceModel.Channels.Binding binding, System.ServiceModel.EndpointAddress address) { }
         protected void InitializeEndpoint(System.ServiceModel.Description.ServiceEndpoint endpoint) { }
-        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
-        protected void InitializeEndpoint(string configurationName, System.ServiceModel.EndpointAddress address) { }
         protected override void OnAbort() { }
         protected override System.IAsyncResult OnBeginClose(System.TimeSpan timeout, System.AsyncCallback callback, object state) { return default; }
         protected override System.IAsyncResult OnBeginOpen(System.TimeSpan timeout, System.AsyncCallback callback, object state) { return default; }
@@ -262,10 +258,6 @@ namespace System.ServiceModel
         public ChannelFactory(System.ServiceModel.Channels.Binding binding) { }
         public ChannelFactory(System.ServiceModel.Channels.Binding binding, System.ServiceModel.EndpointAddress remoteAddress) { }
         public ChannelFactory(System.ServiceModel.Description.ServiceEndpoint endpoint) { }
-        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
-        public ChannelFactory(string endpointConfigurationName) { }
-        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
-        public ChannelFactory(string endpointConfigurationName, System.ServiceModel.EndpointAddress remoteAddress) { }
         protected ChannelFactory(System.Type channelType) { }
         public TChannel CreateChannel() { return default; }
         public TChannel CreateChannel(System.ServiceModel.EndpointAddress address) { return default; }
@@ -284,12 +276,6 @@ namespace System.ServiceModel
         protected ClientBase() { }
         protected ClientBase(System.ServiceModel.Channels.Binding binding, System.ServiceModel.EndpointAddress remoteAddress) { }
         protected ClientBase(System.ServiceModel.Description.ServiceEndpoint endpoint) { }
-        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
-        protected ClientBase(string endpointConfigurationName) { }
-        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
-        protected ClientBase(string endpointConfigurationName, System.ServiceModel.EndpointAddress remoteAddress) { }
-        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
-        protected ClientBase(string endpointConfigurationName, string remoteAddress) { }
         protected TChannel Channel { get { return default; } }
         public static CacheSetting CacheSetting { get { return default; } set { } }
         public System.ServiceModel.ChannelFactory<TChannel> ChannelFactory { get { return default; } }

--- a/src/System.ServiceModel.Primitives/src/System/ServiceModel/ClientBase.cs
+++ b/src/System.ServiceModel.Primitives/src/System/ServiceModel/ClientBase.cs
@@ -55,21 +55,6 @@ namespace System.ServiceModel
             throw new PlatformNotSupportedException(SRP.ConfigurationFilesNotSupported);
         }
 
-        protected ClientBase(string endpointConfigurationName)
-        {
-            throw new PlatformNotSupportedException(SRP.ConfigurationFilesNotSupported);
-        }
-
-        protected ClientBase(string endpointConfigurationName, string remoteAddress)
-        {
-            throw new PlatformNotSupportedException(SRP.ConfigurationFilesNotSupported);
-        }
-
-        protected ClientBase(string endpointConfigurationName, EndpointAddress remoteAddress)
-        {
-            throw new PlatformNotSupportedException(SRP.ConfigurationFilesNotSupported);
-        }
-
         protected ClientBase(Binding binding, EndpointAddress remoteAddress)
         {
             if (binding == null)

--- a/src/System.ServiceModel.Primitives/src/System/ServiceModel/DuplexChannelFactory.cs
+++ b/src/System.ServiceModel.Primitives/src/System/ServiceModel/DuplexChannelFactory.cs
@@ -24,12 +24,6 @@ namespace System.ServiceModel
         public DuplexChannelFactory(Type callbackInstanceType, Binding binding)
             : this((object)callbackInstanceType, binding)
         { }
-        public DuplexChannelFactory(Type callbackInstanceType, string endpointConfigurationName, EndpointAddress remoteAddress)
-            : this((object)callbackInstanceType, endpointConfigurationName, remoteAddress)
-        { }
-        public DuplexChannelFactory(Type callbackInstanceType, string endpointConfigurationName)
-            : this((object)callbackInstanceType, endpointConfigurationName)
-        { }
         public DuplexChannelFactory(Type callbackInstanceType, ServiceEndpoint endpoint)
             : this((object)callbackInstanceType, endpoint)
         { }
@@ -46,12 +40,6 @@ namespace System.ServiceModel
         { }
         public DuplexChannelFactory(InstanceContext callbackInstance, Binding binding)
             : this((object)callbackInstance, binding)
-        { }
-        public DuplexChannelFactory(InstanceContext callbackInstance, string endpointConfigurationName, EndpointAddress remoteAddress)
-            : this((object)callbackInstance, endpointConfigurationName, remoteAddress)
-        { }
-        public DuplexChannelFactory(InstanceContext callbackInstance, string endpointConfigurationName)
-            : this((object)callbackInstance, endpointConfigurationName)
         { }
         public DuplexChannelFactory(InstanceContext callbackInstance, ServiceEndpoint endpoint)
             : this((object)callbackInstance, endpoint)
@@ -73,38 +61,7 @@ namespace System.ServiceModel
                 }
 
                 CheckAndAssignCallbackInstance(callbackObject);
-                InitializeEndpoint((string)null, (EndpointAddress)null);
-            }
-        }
-
-        // TChannel provides ContractDescription, attr/config [TChannel,name] provides Address,Binding
-        public DuplexChannelFactory(object callbackObject, string endpointConfigurationName)
-            : this(callbackObject, endpointConfigurationName, null)
-        {
-        }
-
-        // TChannel provides ContractDescription, attr/config [TChannel,name] provides Binding, provide Address explicitly
-        public DuplexChannelFactory(object callbackObject, string endpointConfigurationName, EndpointAddress remoteAddress)
-            : base(typeof(TChannel))
-        {
-            using (ServiceModelActivity activity = DiagnosticUtility.ShouldUseActivity ? ServiceModelActivity.CreateBoundedActivity() : null)
-            {
-                if (DiagnosticUtility.ShouldUseActivity)
-                {
-                    ServiceModelActivity.Start(activity, SRP.Format(SRP.ActivityConstructChannelFactory, TraceUtility.CreateSourceString(this)), ActivityType.Construct);
-                }
-                if (callbackObject == null)
-                {
-                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull(nameof(callbackObject));
-                }
-
-                if (endpointConfigurationName == null)
-                {
-                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull(nameof(endpointConfigurationName));
-                }
-
-                CheckAndAssignCallbackInstance(callbackObject);
-                InitializeEndpoint(endpointConfigurationName, remoteAddress);
+                InitializeEndpoint((EndpointAddress)null);
             }
         }
 
@@ -262,11 +219,6 @@ namespace System.ServiceModel
             return new InstanceContext(callbackObject);
         }
 
-        public static TChannel CreateChannel(object callbackObject, String endpointConfigurationName)
-        {
-            return CreateChannel(GetInstanceContextForObject(callbackObject), endpointConfigurationName);
-        }
-
         public static TChannel CreateChannel(object callbackObject, Binding binding, EndpointAddress endpointAddress)
         {
             return CreateChannel(GetInstanceContextForObject(callbackObject), binding, endpointAddress);
@@ -275,14 +227,6 @@ namespace System.ServiceModel
         public static TChannel CreateChannel(object callbackObject, Binding binding, EndpointAddress endpointAddress, Uri via)
         {
             return CreateChannel(GetInstanceContextForObject(callbackObject), binding, endpointAddress, via);
-        }
-
-        public static TChannel CreateChannel(InstanceContext callbackInstance, String endpointConfigurationName)
-        {
-            DuplexChannelFactory<TChannel> channelFactory = new DuplexChannelFactory<TChannel>(callbackInstance, endpointConfigurationName);
-            TChannel channel = channelFactory.CreateChannel();
-            SetFactoryToAutoClose(channel);
-            return channel;
         }
 
         public static TChannel CreateChannel(InstanceContext callbackInstance, Binding binding, EndpointAddress endpointAddress)

--- a/src/System.ServiceModel.Primitives/src/System/ServiceModel/DuplexClientBase.cs
+++ b/src/System.ServiceModel.Primitives/src/System/ServiceModel/DuplexClientBase.cs
@@ -10,22 +10,6 @@ namespace System.ServiceModel
     public abstract class DuplexClientBase<TChannel> : ClientBase<TChannel>
         where TChannel : class
     {
-        protected DuplexClientBase(InstanceContext callbackInstance)
-        {
-            throw new PlatformNotSupportedException(SRP.ConfigurationFilesNotSupported);
-        }
-        protected DuplexClientBase(InstanceContext callbackInstance, string endpointConfigurationName)
-        {
-            throw new PlatformNotSupportedException(SRP.ConfigurationFilesNotSupported);
-        }
-        protected DuplexClientBase(InstanceContext callbackInstance, string endpointConfigurationName, string remoteAddress)
-        {
-            throw new PlatformNotSupportedException(SRP.ConfigurationFilesNotSupported);
-        }
-        protected DuplexClientBase(InstanceContext callbackInstance, string endpointConfigurationName, EndpointAddress remoteAddress)
-        {
-            throw new PlatformNotSupportedException(SRP.ConfigurationFilesNotSupported);
-        }
         protected DuplexClientBase(InstanceContext callbackInstance, Binding binding, EndpointAddress remoteAddress)
             : base(callbackInstance, binding, remoteAddress)
         {


### PR DESCRIPTION
Shall we remove the [ConfigurationName](https://github.com/dotnet/wcf/blob/f229469c67dc1d46978833f72332d3ef16b3a75a/src/System.ServiceModel.Primitives/src/System/ServiceModel/ServiceContractAttribute.cs#L21C6-L21C6) property from ServiceContractAttribute as well?
