### PR TITLE
Update ExtendedProtectionPolicy propagate test so it also runs on non-windows

### DIFF
--- a/src/System.ServiceModel.Http/tests/ServiceModel/BasicHttpBindingTest.cs
+++ b/src/System.ServiceModel.Http/tests/ServiceModel/BasicHttpBindingTest.cs
@@ -333,7 +333,7 @@ public static class BasicHttpBindingTest
     public static void ExtendedProtectionPolicy_Propagates_To_TransportBindingElement()
     {
         var binding = new BasicHttpBinding(BasicHttpSecurityMode.Transport);
-        var epp = new ExtendedProtectionPolicy(PolicyEnforcement.Always);
+        var epp = new ExtendedProtectionPolicy(PolicyEnforcement.WhenSupported);
         binding.Security.Transport.ExtendedProtectionPolicy = epp;
         var be = binding.CreateBindingElements();
         var htbe = be.Find<HttpTransportBindingElement>();


### PR DESCRIPTION
Start from .NET8,  System.Security.Authentication.ExtendedProtection.OSSupportsExtendedProtection returns OperatingSystem.IsWindows() instead of always returning true.

The change affected case ExtendedProtectionPolicy_Propagates_To_TransportBindingElement. 

The test is trying to set an extended protection policy with a PolicyEnforcement value of Always. The default is Never, so the binding needs to be set to something different to Never to detect that the value propagated. Changing the test to use WhenSupported instead will fix this as we can still see that the value propagated as it will have changed from Never, and we won't throw as WhenSupported is compatible with an OS not supporting extended protection.
