### PR TITLE
Make ServiceChannelProxy implement IAsyncDisposable

### DIFF
--- a/src/System.ServiceModel.Primitives/src/System/ServiceModel/Channels/ServiceChannelProxy.cs
+++ b/src/System.ServiceModel.Primitives/src/System/ServiceModel/Channels/ServiceChannelProxy.cs
@@ -15,7 +15,7 @@ using System.Threading.Tasks;
 
 namespace System.ServiceModel.Channels
 {
-    public class ServiceChannelProxy : DispatchProxy, ICommunicationObject, IChannel, IClientChannel, IOutputChannel, IRequestChannel, IServiceChannel, IDuplexContextChannel
+    public class ServiceChannelProxy : DispatchProxy, ICommunicationObject, IChannel, IClientChannel, IOutputChannel, IRequestChannel, IServiceChannel, IDuplexContextChannel, IAsyncDisposable
     {
         private const String activityIdSlotName = "E2ETrace.ActivityID";
         private Type _proxiedType;
@@ -671,6 +671,11 @@ namespace System.ServiceModel.Channels
         void IDisposable.Dispose()
         {
             ((IClientChannel)_serviceChannel).Dispose();
+        }
+
+        ValueTask IAsyncDisposable.DisposeAsync()
+        {
+            return ((IAsyncDisposable)_serviceChannel).DisposeAsync();
         }
 
         bool IContextChannel.AllowOutputBatching


### PR DESCRIPTION
So that channels created through a `ChannelFactory<T>` without inheriting from `ClientBase<T>` can also benefit from the asynchronous disposal improvements introduced in #4865.

Fixes #5270