### PR TITLE
Changes the ValidateContentTypeAsync to handle Content-Type header with multiple values to prevent a null content-type exception.

### DIFF
--- a/src/System.ServiceModel.Http/src/System/ServiceModel/Channels/HttpResponseMessageHelper.cs
+++ b/src/System.ServiceModel.Http/src/System/ServiceModel/Channels/HttpResponseMessageHelper.cs
@@ -5,8 +5,10 @@
 
 using System.Diagnostics.Contracts;
 using System.IO;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Runtime;
 using System.ServiceModel.Security;
 using System.Threading;

--- a/src/System.ServiceModel.Http/src/System/ServiceModel/Channels/HttpResponseMessageHelper.cs
+++ b/src/System.ServiceModel.Http/src/System/ServiceModel/Channels/HttpResponseMessageHelper.cs
@@ -133,6 +133,23 @@ namespace System.ServiceModel.Channels
             if (content != null)
             {
                 var mediaValueContentType = content.Headers.ContentType;
+
+                // If the content type header is null because the response contains 
+                // content-type header with a multiple values, like this: 
+                // Content-Type: text/xml; charset=UTF-8, text/xml; charset=ISO-8051-1
+                // tries to get the "Content-Type" header from HttpResponseMesage.Content.Headers.TryGetValues approach.
+                if (
+                    mediaValueContentType == null
+                    && content.Headers.TryGetValues("Content-Type", out var values)
+                    && values?.Count() > 0)
+                {
+                    values = values.First().Split(",", StringSplitOptions.RemoveEmptyEntries);
+                    if (values?.Count() > 0)
+                    {
+                        mediaValueContentType = MediaTypeHeaderValue.Parse(values.First());
+                    }
+                }
+
                 _contentType = mediaValueContentType == null ? string.Empty : mediaValueContentType.ToString();
                 _contentLength = content.Headers.ContentLength.HasValue ? content.Headers.ContentLength.Value : -1;
             }


### PR DESCRIPTION
In issue #5425 reported an error occurred when the content-type header had multiple values.

Because in our day-by-day we need to call third-party services when we don't have control over their process, we need to have the ability to handle messages with this content-type.