### PR TITLE
dotnet-svcutil: fix IsTypeSerializable to enable type reusing serializable type

### DIFF
--- a/src/dotnet-svcutil/lib/src/FrameworkFork/System.Runtime.Serialization/System/Runtime/Serialization/DataContract.cs
+++ b/src/dotnet-svcutil/lib/src/FrameworkFork/System.Runtime.Serialization/System/Runtime/Serialization/DataContract.cs
@@ -754,7 +754,7 @@ namespace System.Runtime.Serialization
             //Serializable types from Orcas needs to be supported in Silverlight 
             private static bool IsTypeSerializable(Type type)
             {
-                return (type == Globals.TypeOfDBNull);
+                return type == Globals.TypeOfDBNull || type.IsSerializable;
             }
 
             private static DataContract CreateGetOnlyCollectionDataContract(int id, RuntimeTypeHandle typeHandle, Type type)


### PR DESCRIPTION
Related issue from the VS community: https://developercommunity.visualstudio.com/t/Not-able-to-add-wcf-service-in-1786-re/10578713