### PR TITLE
dotnet-svcutil: add reference to wcf package 8.0 for client project

### DIFF
--- a/src/dotnet-svcutil/lib/src/CodeDomFixup/CodeDomVisitors/AddAsyncOpenClose.cs
+++ b/src/dotnet-svcutil/lib/src/CodeDomFixup/CodeDomVisitors/AddAsyncOpenClose.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Tools.ServiceModel.Svcutil
                         string[] vers = version.Split('.');
                         if (vers.Length > 1)
                         {
-                            Version v = new Version(int.Parse(vers[0]), int.Parse(vers[1]));
+                            Version v = new Version(int.Parse(vers[0]), int.TryParse(vers[1], out int minor) ? minor : 0);
                             // For .NETCore targetframework found in the referenced table, generate CloseAsync() when WCF package version is less than 4.10
                             if (v.CompareTo(new Version(4, 10)) < 0)
                             {

--- a/src/dotnet-svcutil/lib/src/Shared/TargetFrameworkHelper.cs
+++ b/src/dotnet-svcutil/lib/src/Shared/TargetFrameworkHelper.cs
@@ -66,19 +66,22 @@ namespace Microsoft.Tools.ServiceModel.Svcutil
                 ProjectDependency.FromPackage("System.ServiceModel.Federation", "4.8.*")
             } },
             {new Version("6.0"), new List<ProjectDependency> {
-                ProjectDependency.FromPackage("System.ServiceModel.Duplex", "6.0.*"  ),
-                ProjectDependency.FromPackage("System.ServiceModel.Http", "6.0.*"    ),
-                ProjectDependency.FromPackage("System.ServiceModel.NetTcp", "6.0.*"  ),
-                ProjectDependency.FromPackage("System.ServiceModel.Security", "6.0.*"),
-                ProjectDependency.FromPackage("System.ServiceModel.Federation", "6.0.*"),
-                ProjectDependency.FromPackage("System.ServiceModel.NetNamedPipe", "6.0.*")
+                ProjectDependency.FromPackage("System.ServiceModel.Http", "6.2.*"),
+                ProjectDependency.FromPackage("System.ServiceModel.NetTcp", "6.2.*"),
+                ProjectDependency.FromPackage("System.ServiceModel.NetNamedPipe", "6.2.*"),
+                ProjectDependency.FromPackage("System.ServiceModel.Primitives", "6.2.*"),
+                ProjectDependency.FromPackage("System.ServiceModel.Federation", "6.2.*"),
+                ProjectDependency.FromPackage("System.ServiceModel.UnixDomainSocket", "6.2.*"),
+                ProjectDependency.FromPackage("System.Web.Services.Description", "6.2.*")
             } },
             {new Version("8.0"), new List<ProjectDependency> {
-                ProjectDependency.FromPackage("System.ServiceModel.Primitives", "8.0.*"  ),
-                ProjectDependency.FromPackage("System.ServiceModel.Http", "8.0.*"    ),
-                ProjectDependency.FromPackage("System.ServiceModel.NetTcp", "8.0.*"  ),
-                ProjectDependency.FromPackage("System.ServiceModel.Federation", "8.0.*"),
-                ProjectDependency.FromPackage("System.ServiceModel.NetNamedPipe", "8.0.*")
+                ProjectDependency.FromPackage("System.ServiceModel.Http", "8.*"),
+                ProjectDependency.FromPackage("System.ServiceModel.NetTcp", "8.*"),
+                ProjectDependency.FromPackage("System.ServiceModel.NetNamedPipe", "8.*"),
+                ProjectDependency.FromPackage("System.ServiceModel.Primitives", "8.*"),
+                ProjectDependency.FromPackage("System.ServiceModel.Federation", "8.*"),
+                ProjectDependency.FromPackage("System.ServiceModel.UnixDomainSocket", "8.*"),
+                ProjectDependency.FromPackage("System.Web.Services.Description", "8.*")
             } }
         };
 

--- a/src/dotnet-svcutil/lib/src/Shared/TargetFrameworkHelper.cs
+++ b/src/dotnet-svcutil/lib/src/Shared/TargetFrameworkHelper.cs
@@ -72,6 +72,13 @@ namespace Microsoft.Tools.ServiceModel.Svcutil
                 ProjectDependency.FromPackage("System.ServiceModel.Security", "6.0.*"),
                 ProjectDependency.FromPackage("System.ServiceModel.Federation", "6.0.*"),
                 ProjectDependency.FromPackage("System.ServiceModel.NetNamedPipe", "6.0.*")
+            } },
+            {new Version("8.0"), new List<ProjectDependency> {
+                ProjectDependency.FromPackage("System.ServiceModel.Primitives", "8.0.*"  ),
+                ProjectDependency.FromPackage("System.ServiceModel.Http", "8.0.*"    ),
+                ProjectDependency.FromPackage("System.ServiceModel.NetTcp", "8.0.*"  ),
+                ProjectDependency.FromPackage("System.ServiceModel.Federation", "8.0.*"),
+                ProjectDependency.FromPackage("System.ServiceModel.NetNamedPipe", "8.0.*")
             } }
         };
 

--- a/src/dotnet-svcutil/lib/tests/Baselines/Collections/array/array.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/Collections/array/array.csproj
@@ -3,12 +3,14 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>N.N</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="dotnet-svcutil-lib" Version="99.99.99" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/content/internalAssets/**" Link="internalAssets/%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">

--- a/src/dotnet-svcutil/lib/tests/Baselines/Collections/array/array.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/Collections/array/array.csproj
@@ -15,5 +15,7 @@
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/Collections/arrayList/arrayList.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/Collections/arrayList/arrayList.csproj
@@ -3,12 +3,14 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>N.N</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="dotnet-svcutil-lib" Version="99.99.99" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/content/internalAssets/**" Link="internalAssets/%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">

--- a/src/dotnet-svcutil/lib/tests/Baselines/Collections/arrayList/arrayList.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/Collections/arrayList/arrayList.csproj
@@ -15,5 +15,7 @@
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/Collections/collection/collection.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/Collections/collection/collection.csproj
@@ -3,12 +3,14 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>N.N</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="dotnet-svcutil-lib" Version="99.99.99" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/content/internalAssets/**" Link="internalAssets/%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">

--- a/src/dotnet-svcutil/lib/tests/Baselines/Collections/collection/collection.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/Collections/collection/collection.csproj
@@ -15,5 +15,7 @@
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/Collections/dictionary/dictionary.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/Collections/dictionary/dictionary.csproj
@@ -3,12 +3,14 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>N.N</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="dotnet-svcutil-lib" Version="99.99.99" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/content/internalAssets/**" Link="internalAssets/%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">

--- a/src/dotnet-svcutil/lib/tests/Baselines/Collections/dictionary/dictionary.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/Collections/dictionary/dictionary.csproj
@@ -15,5 +15,7 @@
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/Collections/hashTable/hashTable.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/Collections/hashTable/hashTable.csproj
@@ -3,12 +3,14 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>N.N</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="dotnet-svcutil-lib" Version="99.99.99" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/content/internalAssets/**" Link="internalAssets/%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">

--- a/src/dotnet-svcutil/lib/tests/Baselines/Collections/hashTable/hashTable.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/Collections/hashTable/hashTable.csproj
@@ -15,5 +15,7 @@
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/Collections/hybridDictionary/hybridDictionary.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/Collections/hybridDictionary/hybridDictionary.csproj
@@ -3,12 +3,14 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>N.N</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="dotnet-svcutil-lib" Version="99.99.99" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/content/internalAssets/**" Link="internalAssets/%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">

--- a/src/dotnet-svcutil/lib/tests/Baselines/Collections/hybridDictionary/hybridDictionary.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/Collections/hybridDictionary/hybridDictionary.csproj
@@ -15,5 +15,7 @@
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/Collections/linkedList/linkedList.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/Collections/linkedList/linkedList.csproj
@@ -3,12 +3,14 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>N.N</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="dotnet-svcutil-lib" Version="99.99.99" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/content/internalAssets/**" Link="internalAssets/%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">

--- a/src/dotnet-svcutil/lib/tests/Baselines/Collections/linkedList/linkedList.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/Collections/linkedList/linkedList.csproj
@@ -15,5 +15,7 @@
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/Collections/list/list.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/Collections/list/list.csproj
@@ -3,12 +3,14 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>N.N</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="dotnet-svcutil-lib" Version="99.99.99" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/content/internalAssets/**" Link="internalAssets/%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">

--- a/src/dotnet-svcutil/lib/tests/Baselines/Collections/list/list.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/Collections/list/list.csproj
@@ -15,5 +15,7 @@
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/Collections/listDictionary/listDictionary.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/Collections/listDictionary/listDictionary.csproj
@@ -3,12 +3,14 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>N.N</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="dotnet-svcutil-lib" Version="99.99.99" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/content/internalAssets/**" Link="internalAssets/%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">

--- a/src/dotnet-svcutil/lib/tests/Baselines/Collections/listDictionary/listDictionary.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/Collections/listDictionary/listDictionary.csproj
@@ -15,5 +15,7 @@
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/Collections/observableCollection/observableCollection.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/Collections/observableCollection/observableCollection.csproj
@@ -3,12 +3,14 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>N.N</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="dotnet-svcutil-lib" Version="99.99.99" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/content/internalAssets/**" Link="internalAssets/%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">

--- a/src/dotnet-svcutil/lib/tests/Baselines/Collections/observableCollection/observableCollection.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/Collections/observableCollection/observableCollection.csproj
@@ -15,5 +15,7 @@
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/Collections/orderedDictionary/orderedDictionary.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/Collections/orderedDictionary/orderedDictionary.csproj
@@ -3,12 +3,14 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>N.N</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="dotnet-svcutil-lib" Version="99.99.99" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/content/internalAssets/**" Link="internalAssets/%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">

--- a/src/dotnet-svcutil/lib/tests/Baselines/Collections/orderedDictionary/orderedDictionary.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/Collections/orderedDictionary/orderedDictionary.csproj
@@ -15,5 +15,7 @@
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/Collections/sortedDictionary/sortedDictionary.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/Collections/sortedDictionary/sortedDictionary.csproj
@@ -3,12 +3,14 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>N.N</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="dotnet-svcutil-lib" Version="99.99.99" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/content/internalAssets/**" Link="internalAssets/%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">

--- a/src/dotnet-svcutil/lib/tests/Baselines/Collections/sortedDictionary/sortedDictionary.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/Collections/sortedDictionary/sortedDictionary.csproj
@@ -15,5 +15,7 @@
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/Collections/sortedList/sortedList.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/Collections/sortedList/sortedList.csproj
@@ -3,12 +3,14 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>N.N</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="dotnet-svcutil-lib" Version="99.99.99" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/content/internalAssets/**" Link="internalAssets/%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">

--- a/src/dotnet-svcutil/lib/tests/Baselines/Collections/sortedList/sortedList.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/Collections/sortedList/sortedList.csproj
@@ -15,5 +15,7 @@
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/Collections/sortedListNonGeneric/sortedListNonGeneric.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/Collections/sortedListNonGeneric/sortedListNonGeneric.csproj
@@ -3,12 +3,14 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>N.N</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="dotnet-svcutil-lib" Version="99.99.99" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/content/internalAssets/**" Link="internalAssets/%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">

--- a/src/dotnet-svcutil/lib/tests/Baselines/Collections/sortedListNonGeneric/sortedListNonGeneric.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/Collections/sortedListNonGeneric/sortedListNonGeneric.csproj
@@ -15,5 +15,7 @@
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/MetadataQuery/mexParam/mexParam.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/MetadataQuery/mexParam/mexParam.csproj
@@ -3,12 +3,14 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>N.N</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="dotnet-svcutil-lib" Version="99.99.99" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/content/internalAssets/**" Link="internalAssets/%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">

--- a/src/dotnet-svcutil/lib/tests/Baselines/MetadataQuery/mexParam/mexParam.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/MetadataQuery/mexParam/mexParam.csproj
@@ -15,5 +15,7 @@
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/MetadataQuery/noQuery/noQuery.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/MetadataQuery/noQuery/noQuery.csproj
@@ -3,12 +3,14 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>N.N</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="dotnet-svcutil-lib" Version="99.99.99" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/content/internalAssets/**" Link="internalAssets/%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">

--- a/src/dotnet-svcutil/lib/tests/Baselines/MetadataQuery/noQuery/noQuery.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/MetadataQuery/noQuery/noQuery.csproj
@@ -15,5 +15,7 @@
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/MetadataQuery/singleWsdlQuery/singleWsdlQuery.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/MetadataQuery/singleWsdlQuery/singleWsdlQuery.csproj
@@ -3,12 +3,14 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>N.N</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="dotnet-svcutil-lib" Version="99.99.99" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/content/internalAssets/**" Link="internalAssets/%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">

--- a/src/dotnet-svcutil/lib/tests/Baselines/MetadataQuery/singleWsdlQuery/singleWsdlQuery.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/MetadataQuery/singleWsdlQuery/singleWsdlQuery.csproj
@@ -15,5 +15,7 @@
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/MetadataQuery/wsdlQuery/wsdlQuery.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/MetadataQuery/wsdlQuery/wsdlQuery.csproj
@@ -3,12 +3,14 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>N.N</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="dotnet-svcutil-lib" Version="99.99.99" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/content/internalAssets/**" Link="internalAssets/%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">

--- a/src/dotnet-svcutil/lib/tests/Baselines/MetadataQuery/wsdlQuery/wsdlQuery.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/MetadataQuery/wsdlQuery/wsdlQuery.csproj
@@ -15,5 +15,7 @@
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/MultiTargetCloseAsyncGeneration/net60/net60.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/MultiTargetCloseAsyncGeneration/net60/net60.csproj
@@ -12,5 +12,6 @@
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/MultiTargetCloseAsyncGeneration/net60net48/net60net48.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/MultiTargetCloseAsyncGeneration/net60net48/net60net48.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
   <ItemGroup>
     <Reference Condition="'$(TargetFramework)' == 'net48'" Include="System.ServiceModel">

--- a/src/dotnet-svcutil/lib/tests/Baselines/TFM/net90/net90.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/TFM/net90/net90.csproj
@@ -3,12 +3,14 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>N.N</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="dotnet-svcutil-lib" Version="99.99.99" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/content/internalAssets/**" Link="internalAssets/%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">

--- a/src/dotnet-svcutil/lib/tests/Baselines/TFM/net90/net90.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/TFM/net90/net90.csproj
@@ -15,5 +15,7 @@
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/TFM/tfm100/tfm100.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/TFM/tfm100/tfm100.csproj
@@ -3,12 +3,14 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>N.N</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="dotnet-svcutil-lib" Version="99.99.99" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/content/internalAssets/**" Link="internalAssets/%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">

--- a/src/dotnet-svcutil/lib/tests/Baselines/TFM/tfm100/tfm100.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/TFM/tfm100/tfm100.csproj
@@ -15,5 +15,7 @@
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/TFM/tfm20/tfm20.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/TFM/tfm20/tfm20.csproj
@@ -3,12 +3,14 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>N.N</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="dotnet-svcutil-lib" Version="99.99.99" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/content/internalAssets/**" Link="internalAssets/%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">

--- a/src/dotnet-svcutil/lib/tests/Baselines/TFM/tfm20/tfm20.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/TFM/tfm20/tfm20.csproj
@@ -15,5 +15,7 @@
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/TFM/tfm45/tfm45.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/TFM/tfm45/tfm45.csproj
@@ -3,12 +3,14 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>N.N</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="dotnet-svcutil-lib" Version="99.99.99" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/content/internalAssets/**" Link="internalAssets/%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">

--- a/src/dotnet-svcutil/lib/tests/Baselines/TFM/tfm45/tfm45.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/TFM/tfm45/tfm45.csproj
@@ -15,5 +15,7 @@
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/TFM/tfmDefault/tfmDefault.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/TFM/tfmDefault/tfmDefault.csproj
@@ -3,12 +3,14 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>N.N</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="dotnet-svcutil-lib" Version="99.99.99" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/content/internalAssets/**" Link="internalAssets/%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">

--- a/src/dotnet-svcutil/lib/tests/Baselines/TFM/tfmDefault/tfmDefault.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/TFM/tfmDefault/tfmDefault.csproj
@@ -15,5 +15,7 @@
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateNetPipeServiceRef/UpdateNetPipeServiceRefBootstrapping/UpdateNetPipeServiceRefBootstrapping.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateNetPipeServiceRef/UpdateNetPipeServiceRefBootstrapping/UpdateNetPipeServiceRefBootstrapping.csproj
@@ -8,10 +8,10 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="dotnet-svcutil-lib" Version="99.99.99" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/content/internalAssets/**" Link="internalAssets/%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.ServiceModel.Primitives " Version="8.0.*" />
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateNetPipeServiceRef/UpdateNetPipeServiceRefBootstrapping/UpdateNetPipeServiceRefBootstrapping.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateNetPipeServiceRef/UpdateNetPipeServiceRefBootstrapping/UpdateNetPipeServiceRefBootstrapping.csproj
@@ -11,9 +11,11 @@
     <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/content/internalAssets/**" Link="internalAssets/%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.ServiceModel.Primitives " Version="8.0.*" />
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateNetPipeServiceRef/UpdateNetPipeServiceRefDefault/UpdateNetPipeServiceRefDefault.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateNetPipeServiceRef/UpdateNetPipeServiceRefDefault/UpdateNetPipeServiceRefDefault.csproj
@@ -8,10 +8,10 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="dotnet-svcutil-lib" Version="99.99.99" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/content/internalAssets/**" Link="internalAssets/%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.ServiceModel.Primitives " Version="8.0.*" />
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateNetPipeServiceRef/UpdateNetPipeServiceRefDefault/UpdateNetPipeServiceRefDefault.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateNetPipeServiceRef/UpdateNetPipeServiceRefDefault/UpdateNetPipeServiceRefDefault.csproj
@@ -11,9 +11,11 @@
     <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/content/internalAssets/**" Link="internalAssets/%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.ServiceModel.Primitives " Version="8.0.*" />
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefBasic/UpdateServiceRefBootstrapping/UpdateServiceRefBootstrapping.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefBasic/UpdateServiceRefBootstrapping/UpdateServiceRefBootstrapping.csproj
@@ -11,9 +11,11 @@
     <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/content/internalAssets/**" Link="internalAssets/%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.ServiceModel.Primitives " Version="8.0.*" />
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefBasic/UpdateServiceRefBootstrapping/UpdateServiceRefBootstrapping.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefBasic/UpdateServiceRefBootstrapping/UpdateServiceRefBootstrapping.csproj
@@ -3,13 +3,15 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>N.N</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="dotnet-svcutil-lib" Version="99.99.99" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/content/internalAssets/**" Link="internalAssets/%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.ServiceModel.Primitives " Version="8.0.*" />
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefBasic/UpdateServiceRefDefault/UpdateServiceRefDefault.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefBasic/UpdateServiceRefDefault/UpdateServiceRefDefault.csproj
@@ -11,9 +11,11 @@
     <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/content/internalAssets/**" Link="internalAssets/%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.ServiceModel.Primitives " Version="8.0.*" />
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefBasic/UpdateServiceRefDefault/UpdateServiceRefDefault.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefBasic/UpdateServiceRefDefault/UpdateServiceRefDefault.csproj
@@ -3,13 +3,15 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>N.N</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="dotnet-svcutil-lib" Version="99.99.99" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/content/internalAssets/**" Link="internalAssets/%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.ServiceModel.Primitives " Version="8.0.*" />
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateRefLevels/UpdateRefLevels.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateRefLevels/UpdateRefLevels.csproj
@@ -11,9 +11,11 @@
     <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/content/internalAssets/**" Link="internalAssets/%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.ServiceModel.Primitives " Version="8.0.*" />
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateRefLevels/UpdateRefLevels.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateRefLevels/UpdateRefLevels.csproj
@@ -3,13 +3,15 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>N.N</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="dotnet-svcutil-lib" Version="99.99.99" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/content/internalAssets/**" Link="internalAssets/%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.ServiceModel.Primitives " Version="8.0.*" />
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateRefLevelsFull/UpdateRefLevelsFull.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateRefLevelsFull/UpdateRefLevelsFull.csproj
@@ -11,9 +11,11 @@
     <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/content/internalAssets/**" Link="internalAssets/%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.ServiceModel.Primitives " Version="8.0.*" />
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateRefLevelsFull/UpdateRefLevelsFull.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateRefLevelsFull/UpdateRefLevelsFull.csproj
@@ -3,13 +3,15 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>N.N</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="dotnet-svcutil-lib" Version="99.99.99" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/content/internalAssets/**" Link="internalAssets/%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.ServiceModel.Primitives " Version="8.0.*" />
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptionsDefault/UpdateServiceRefOptionsDefault.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptionsDefault/UpdateServiceRefOptionsDefault.csproj
@@ -11,9 +11,11 @@
     <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/content/internalAssets/**" Link="internalAssets/%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.ServiceModel.Primitives " Version="8.0.*" />
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptionsDefault/UpdateServiceRefOptionsDefault.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptionsDefault/UpdateServiceRefOptionsDefault.csproj
@@ -3,13 +3,15 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>N.N</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="dotnet-svcutil-lib" Version="99.99.99" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/content/internalAssets/**" Link="internalAssets/%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.ServiceModel.Primitives " Version="8.0.*" />
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptionsExtraOptions/UpdateServiceRefOptionsExtraOptions.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptionsExtraOptions/UpdateServiceRefOptionsExtraOptions.csproj
@@ -11,9 +11,11 @@
     <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/content/internalAssets/**" Link="internalAssets/%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.ServiceModel.Primitives " Version="8.0.*" />
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptionsExtraOptions/UpdateServiceRefOptionsExtraOptions.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptionsExtraOptions/UpdateServiceRefOptionsExtraOptions.csproj
@@ -3,13 +3,15 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>N.N</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="dotnet-svcutil-lib" Version="99.99.99" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/content/internalAssets/**" Link="internalAssets/%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.ServiceModel.Primitives " Version="8.0.*" />
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptionsExtraOptionsWarn/UpdateServiceRefOptionsExtraOptionsWarn.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptionsExtraOptionsWarn/UpdateServiceRefOptionsExtraOptionsWarn.csproj
@@ -11,9 +11,11 @@
     <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/content/internalAssets/**" Link="internalAssets/%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.ServiceModel.Primitives " Version="8.0.*" />
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptionsExtraOptionsWarn/UpdateServiceRefOptionsExtraOptionsWarn.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptionsExtraOptionsWarn/UpdateServiceRefOptionsExtraOptionsWarn.csproj
@@ -3,13 +3,15 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>N.N</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="dotnet-svcutil-lib" Version="99.99.99" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/content/internalAssets/**" Link="internalAssets/%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.ServiceModel.Primitives " Version="8.0.*" />
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptionsFilePath/UpdateServiceRefOptionsFilePath.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptionsFilePath/UpdateServiceRefOptionsFilePath.csproj
@@ -11,9 +11,11 @@
     <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/content/internalAssets/**" Link="internalAssets/%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.ServiceModel.Primitives " Version="8.0.*" />
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptionsFilePath/UpdateServiceRefOptionsFilePath.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptionsFilePath/UpdateServiceRefOptionsFilePath.csproj
@@ -3,13 +3,15 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>N.N</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="dotnet-svcutil-lib" Version="99.99.99" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/content/internalAssets/**" Link="internalAssets/%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.ServiceModel.Primitives " Version="8.0.*" />
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptionsFullPath/UpdateServiceRefOptionsFullPath.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptionsFullPath/UpdateServiceRefOptionsFullPath.csproj
@@ -11,9 +11,11 @@
     <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/content/internalAssets/**" Link="internalAssets/%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.ServiceModel.Primitives " Version="8.0.*" />
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptionsFullPath/UpdateServiceRefOptionsFullPath.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptionsFullPath/UpdateServiceRefOptionsFullPath.csproj
@@ -3,13 +3,15 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>N.N</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="dotnet-svcutil-lib" Version="99.99.99" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/content/internalAssets/**" Link="internalAssets/%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.ServiceModel.Primitives " Version="8.0.*" />
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptionsRef/UpdateServiceRefOptionsRef.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptionsRef/UpdateServiceRefOptionsRef.csproj
@@ -11,9 +11,11 @@
     <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/content/internalAssets/**" Link="internalAssets/%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.ServiceModel.Primitives " Version="8.0.*" />
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptionsRef/UpdateServiceRefOptionsRef.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptionsRef/UpdateServiceRefOptionsRef.csproj
@@ -3,13 +3,15 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>N.N</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="dotnet-svcutil-lib" Version="99.99.99" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/content/internalAssets/**" Link="internalAssets/%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.ServiceModel.Primitives " Version="8.0.*" />
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptionsRef2/UpdateServiceRefOptionsRef2.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptionsRef2/UpdateServiceRefOptionsRef2.csproj
@@ -11,9 +11,11 @@
     <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/content/internalAssets/**" Link="internalAssets/%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.ServiceModel.Primitives " Version="8.0.*" />
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptionsRef2/UpdateServiceRefOptionsRef2.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptionsRef2/UpdateServiceRefOptionsRef2.csproj
@@ -3,13 +3,15 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>N.N</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="dotnet-svcutil-lib" Version="99.99.99" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/content/internalAssets/**" Link="internalAssets/%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.ServiceModel.Primitives " Version="8.0.*" />
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptions_Folder_With_Spaces/UpdateServiceRefOptions_Folder_With_Spaces.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptions_Folder_With_Spaces/UpdateServiceRefOptions_Folder_With_Spaces.csproj
@@ -11,9 +11,11 @@
     <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/content/internalAssets/**" Link="internalAssets/%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.ServiceModel.Primitives " Version="8.0.*" />
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptions_Folder_With_Spaces/UpdateServiceRefOptions_Folder_With_Spaces.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptions_Folder_With_Spaces/UpdateServiceRefOptions_Folder_With_Spaces.csproj
@@ -3,13 +3,15 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>N.N</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="dotnet-svcutil-lib" Version="99.99.99" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/content/internalAssets/**" Link="internalAssets/%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.ServiceModel.Primitives " Version="8.0.*" />
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptions_Folder_With_Spaces_Full/UpdateServiceRefOptions_Folder_With_Spaces_Full.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptions_Folder_With_Spaces_Full/UpdateServiceRefOptions_Folder_With_Spaces_Full.csproj
@@ -11,9 +11,11 @@
     <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/content/internalAssets/**" Link="internalAssets/%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.ServiceModel.Primitives " Version="8.0.*" />
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptions_Folder_With_Spaces_Full/UpdateServiceRefOptions_Folder_With_Spaces_Full.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefOptions/UpdateServiceRefOptions_Folder_With_Spaces_Full/UpdateServiceRefOptions_Folder_With_Spaces_Full.csproj
@@ -3,13 +3,15 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>N.N</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="dotnet-svcutil-lib" Version="99.99.99" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/content/internalAssets/**" Link="internalAssets/%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.ServiceModel.Primitives " Version="8.0.*" />
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefWCFCS/CSServiceReference/CSServiceReference.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefWCFCS/CSServiceReference/CSServiceReference.csproj
@@ -11,9 +11,11 @@
     <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/content/internalAssets/**" Link="internalAssets/%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.ServiceModel.Primitives " Version="8.0.*" />
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefWCFCS/CSServiceReference/CSServiceReference.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefWCFCS/CSServiceReference/CSServiceReference.csproj
@@ -3,13 +3,15 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>N.N</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="dotnet-svcutil-lib" Version="99.99.99" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/content/internalAssets/**" Link="internalAssets/%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.ServiceModel.Primitives " Version="8.0.*" />
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefWCFCS/CSServiceReferenceRoundtrip/CSServiceReferenceRoundtrip.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefWCFCS/CSServiceReferenceRoundtrip/CSServiceReferenceRoundtrip.csproj
@@ -11,9 +11,11 @@
     <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/content/internalAssets/**" Link="internalAssets/%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.ServiceModel.Primitives " Version="8.0.*" />
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.Web.Services.Description", Version="N.N.N">
   </ItemGroup>
 </Project>

--- a/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefWCFCS/CSServiceReferenceRoundtrip/CSServiceReferenceRoundtrip.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/UpdateServiceRefWCFCS/CSServiceReferenceRoundtrip/CSServiceReferenceRoundtrip.csproj
@@ -3,13 +3,15 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>N.N</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="dotnet-svcutil-lib" Version="99.99.99" />
+    <Content CopyToOutputDirectory="always" Include="$(NuGetPackageRoot)dotnet-svcutil-lib/99.99.99/content/internalAssets/**" Link="internalAssets/%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
+    <PackageReference Include="System.ServiceModel.Primitives " Version="8.0.*" />
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">

--- a/src/dotnet-svcutil/lib/tests/src/FixupUtil.cs
+++ b/src/dotnet-svcutil/lib/tests/src/FixupUtil.cs
@@ -48,7 +48,8 @@ namespace SvcutilTest
                 new ReplaceInfo(@"<TargetFramework>netcoreapp\d+\.\d+</TargetFramework>", "<TargetFramework>N.N</TargetFramework>") { UseRegex = true }, //new    
                 new ReplaceInfo(@"""targetFramework"": ""net\d+\.\d+""", "\"targetFramework\": \"N.N\"") { UseRegex = true }, //new    
                 new ReplaceInfo(@"<TargetFramework>net\d+\.\d+</TargetFramework>", "<TargetFramework>N.N</TargetFramework>") { UseRegex = true }, //new    
-                new ReplaceInfo(@"<PackageReference Include=""System\.ServiceModel\.\w+"" Version="".+"" />", @"<PackageReference Include=""System.ServiceModel.*"", Version=""N.N.N"">") { UseRegex = true } //new
+                new ReplaceInfo(@"<PackageReference Include=""System\.ServiceModel\.\w+"" Version="".+"" />", @"<PackageReference Include=""System.ServiceModel.*"", Version=""N.N.N"">") { UseRegex = true }, //new
+                new ReplaceInfo(@"<PackageReference Include=""System\.Web\.Services\.Description"" Version="".+"" />", @"<PackageReference Include=""System.Web.Services.Description"", Version=""N.N.N"">") { UseRegex = true } //new
             };
 
             // The result path passed in includes the directory name. Instead replace the parent.


### PR DESCRIPTION
1. update referenced wcf package to latest RTM version 8.0 for client project after code generated.
2. wcf 8.0 & 6.2 combines `System.ServiceModel.Security` & `System.ServiceModel.Duplex` into `System.ServiceModel.Primitives`, update to reflect that change, and add reference to all supported wcf pkgs including `System.Web.Services.Description` & `System.ServiceModel.UnixDomainSocket` for 6.0 and 8.0 targets.
3. update test baselines affected by the above changes.