### PR TITLE
Fix CG issue in UDS test proj that referenced corewcf pkg.

### DIFF
--- a/src/System.Private.ServiceModel/tests/Scenarios/Binding/UDS/Binding.UDS.IntegrationTests.csproj
+++ b/src/System.Private.ServiceModel/tests/Scenarios/Binding/UDS/Binding.UDS.IntegrationTests.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="CoreWCF.NetFramingBase" Version="1.5.2" />
     <PackageReference Include="CoreWCF.UnixDomainSocket" Version="1.5.0" />
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>


### PR DESCRIPTION
The latest release of CoreWCF.UnixDomainSocket package doesn't reference the latest release of CoreWCF.NetFramingBase, so force referencing version 1.5.2 of CoreWCF.NetFramingBase to address the security warning.