### PR TITLE
dotnet-svcutil: add reference to wcf 6.* library instead of 8.* for net7.0 target project.

### DIFF
--- a/src/dotnet-svcutil/lib/src/Shared/TargetFrameworkHelper.cs
+++ b/src/dotnet-svcutil/lib/src/Shared/TargetFrameworkHelper.cs
@@ -74,6 +74,15 @@ namespace Microsoft.Tools.ServiceModel.Svcutil
                 ProjectDependency.FromPackage("System.ServiceModel.UnixDomainSocket", "6.2.*"),
                 ProjectDependency.FromPackage("System.Web.Services.Description", "6.2.*")
             } },
+            {new Version("7.0"), new List<ProjectDependency> {
+                ProjectDependency.FromPackage("System.ServiceModel.Http", "6.2.*"),
+                ProjectDependency.FromPackage("System.ServiceModel.NetTcp", "6.2.*"),
+                ProjectDependency.FromPackage("System.ServiceModel.NetNamedPipe", "6.2.*"),
+                ProjectDependency.FromPackage("System.ServiceModel.Primitives", "6.2.*"),
+                ProjectDependency.FromPackage("System.ServiceModel.Federation", "6.2.*"),
+                ProjectDependency.FromPackage("System.ServiceModel.UnixDomainSocket", "6.2.*"),
+                ProjectDependency.FromPackage("System.Web.Services.Description", "6.2.*")
+            } },
             {new Version("8.0"), new List<ProjectDependency> {
                 ProjectDependency.FromPackage("System.ServiceModel.Http", "8.*"),
                 ProjectDependency.FromPackage("System.ServiceModel.NetTcp", "8.*"),


### PR DESCRIPTION
.NET7.0 is missing in the key-value table and will reference WCF 8.* packages after code generation.  This is a problem because WCF 8.* packages are not compatible with .NET 7.0, so add the mapping to reference WCF 6.2 packages for NET7.0 target to address this issue.