### PR TITLE
Enable source indexing for internal builds

### DIFF
--- a/azure-pipelines-arcade.yml
+++ b/azure-pipelines-arcade.yml
@@ -58,6 +58,7 @@ extends:
           enablePublishBuildAssets: true
           enablePublishUsingPipelines: $(_PublishUsingPipelines)
           enableTelemetry: true
+          enableSourceIndex: ${{ eq(variables['Build.SourceBranch'], 'refs/heads/main') }}
           helixRepo: dotnet/wcf
           jobs:
           - job: Windows


### PR DESCRIPTION
Currently WCF source isn't appearing on https://source.dot.net. This change should hopefully get it indexing again. We won't be able to verify until after an internal build has completed.