### PR TITLE
dotnet-svcutil: write generated json file with relative path for referenced assembly.

### DIFF
--- a/src/dotnet-svcutil/lib/src/Shared/Options/UpdateOptions.cs
+++ b/src/dotnet-svcutil/lib/src/Shared/Options/UpdateOptions.cs
@@ -103,6 +103,16 @@ namespace Microsoft.Tools.ServiceModel.Svcutil
                     this.Inputs[idx] = new Uri(relPath, UriKind.Relative);
                 }
             }
+
+            // Update references
+            for (int idx = 0; idx < this.References.Count; idx++)
+            {
+                var reference = this.References[idx];
+                if (reference.DependencyType == ProjectDependencyType.Project || reference.DependencyType == ProjectDependencyType.Binary)
+                {
+                    this.References[idx].ReferenceIdentity = PathHelper.GetRelativePath(reference.FullPath, optionsFileDirectory, out relPath) ? relPath : reference.FullPath;
+                }
+            }
         }
 
         public void ResolveFullPathsFrom(DirectoryInfo optionsFileDirectory)
@@ -120,6 +130,18 @@ namespace Microsoft.Tools.ServiceModel.Svcutil
                 if (!input.IsAbsoluteUri && PathHelper.IsFile(input, optionsFileDirectory.FullName, out var fileUri))
                 {
                     this.Inputs[idx] = fileUri;
+                }
+            }
+
+            // Update references full path
+            for (int idx = 0; idx < this.References.Count; idx++)
+            {
+                var reference = this.References[idx];
+                if (reference.DependencyType == ProjectDependencyType.Project || reference.DependencyType == ProjectDependencyType.Binary)
+                {
+                    string fullPath = Path.GetFullPath(Path.Combine(optionsFileDirectory.FullName, reference.ReferenceIdentity));
+                    this.References[idx].FullPath = fullPath;
+                    this.References[idx].ReferenceIdentity = fullPath;
                 }
             }
         }

--- a/src/dotnet-svcutil/lib/src/Shared/ProjectDependency.cs
+++ b/src/dotnet-svcutil/lib/src/Shared/ProjectDependency.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Tools.ServiceModel.Svcutil
         /// <summary>
         /// Assembly full path.
         /// </summary>
-        public string FullPath { get; private set; }
+        public string FullPath { get; set; }
 
         /// <summary>
         /// Assembly name.
@@ -63,7 +63,7 @@ namespace Microsoft.Tools.ServiceModel.Svcutil
         /// <summary>
         /// The package identity, used for describing the dependency passed to Svcutil.
         /// </summary>
-        public string ReferenceIdentity { get; private set; }
+        public string ReferenceIdentity { get; set; }
 
         #region instance contruction methods
         // this ctr is private to ensure the integrity of the data which can be done only by the provided static instance creation (FromXXX) methods.
@@ -153,7 +153,7 @@ namespace Microsoft.Tools.ServiceModel.Svcutil
 
             this.ReferenceIdentity = this.DependencyType == ProjectDependencyType.Package || this.DependencyType == ProjectDependencyType.Tool || !string.IsNullOrWhiteSpace(packageName) ?
                 string.Format(CultureInfo.InvariantCulture, "{0}, {{{1}, {2}}}", this.AssemblyName, this.Name, this.Version) :
-                this.FullPath;
+                filePath;
 
             this.IsFramework = this.Name == NetCoreAppPackageID || this.Name == NetStandardLibraryPackageID;
         }

--- a/src/dotnet-svcutil/lib/tests/Baselines/MultiTargetTypeReuse/TypeReuseClient/ServiceReference/dotnet-svcutil.params.json
+++ b/src/dotnet-svcutil/lib/tests/Baselines/MultiTargetTypeReuse/TypeReuseClient/ServiceReference/dotnet-svcutil.params.json
@@ -10,7 +10,7 @@
     ],
     "outputFile": "Reference.cs",
     "references": [
-      "$TEMP$MultiTargetTypeReuse//TypeReuseClient//bin//Debug//net6.0//BinLib.dll"
+      "../bin/Debug/net6.0/BinLib.dll"
     ],
     "targetFramework": "N.N",
     "typeReuseMode": "All"

--- a/src/dotnet-svcutil/lib/tests/Baselines/MultiTargetTypeReuse/TypeReuseClient/ServiceReference/dotnet-svcutil.params.json
+++ b/src/dotnet-svcutil/lib/tests/Baselines/MultiTargetTypeReuse/TypeReuseClient/ServiceReference/dotnet-svcutil.params.json
@@ -10,7 +10,7 @@
     ],
     "outputFile": "Reference.cs",
     "references": [
-      "../bin/Debug/net6.0/BinLib.dll"
+      "../bin/Debug/net10.0/BinLib.dll"
     ],
     "targetFramework": "N.N",
     "typeReuseMode": "All"

--- a/src/dotnet-svcutil/lib/tests/Baselines/MultiTargetTypeReuse/TypeReuseClient/TypeReuseClient.csproj
+++ b/src/dotnet-svcutil/lib/tests/Baselines/MultiTargetTypeReuse/TypeReuseClient/TypeReuseClient.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net10.0;net8.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="BinLib">
@@ -10,8 +10,6 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
-    <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">
     <PackageReference Include="System.ServiceModel.*", Version="N.N.N">

--- a/src/dotnet-svcutil/lib/tests/Baselines/ReuseIXmlSerializableType/ReuseIXmlSerializableType/ServiceReference/dotnet-svcutil.params.json
+++ b/src/dotnet-svcutil/lib/tests/Baselines/ReuseIXmlSerializableType/ReuseIXmlSerializableType/ServiceReference/dotnet-svcutil.params.json
@@ -10,7 +10,7 @@
     ],
     "outputFile": "Reference.cs",
     "references": [
-      "$testCasesPath$//TypeReuse//CommonTypes.dll"
+      "../../../../../../src/dotnet-svcutil/lib/tests/TestCases/TypeReuse/CommonTypes.dll"
     ],
     "targetFramework": "N.N",
     "typeReuseMode": "Specified"

--- a/src/dotnet-svcutil/lib/tests/TestCases/MultiTargetTypeReuse/TypeReuseClient/TypeReuseClient.csproj
+++ b/src/dotnet-svcutil/lib/tests/TestCases/MultiTargetTypeReuse/TypeReuseClient/TypeReuseClient.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net10.0;net8.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="BinLib">


### PR DESCRIPTION
For issue #5495.

Write referenced assembly name instead of absolute path to the generated parameters json file, corresponding to the change, recalculate references base on project dependencies for update operation, update related test as well.